### PR TITLE
fix(keeper): retry no-tool thinking-only turns

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -276,6 +276,7 @@ type degraded_retry_reason =
   | Auth_error
   | Read_only_no_progress
   | Empty_no_progress
+  | Thinking_only_no_progress
 
 let degraded_retry_reason_to_string = function
   | Hard_quota -> "hard_quota"
@@ -291,6 +292,7 @@ let degraded_retry_reason_to_string = function
   | Auth_error -> "auth_error"
   | Read_only_no_progress -> "read_only_no_progress"
   | Empty_no_progress -> "empty_no_progress"
+  | Thinking_only_no_progress -> "thinking_only_no_progress"
 
 let accept_rejection_degraded_retry_reason err =
   match Keeper_turn_driver.classify_masc_internal_error err with
@@ -298,13 +300,18 @@ let accept_rejection_degraded_retry_reason err =
     (match Keeper_turn_driver.accept_no_progress_retry_kind internal_error with
      | Some `Empty_no_progress -> Some Empty_no_progress
      | Some `Read_only_no_progress -> Some Read_only_no_progress
+     | Some `Thinking_only_no_progress -> Some Thinking_only_no_progress
      | None -> None)
   | None -> None
 
 let is_recoverable_no_progress_accept_rejection
     (err : Agent_sdk.Error.sdk_error) : bool =
   match accept_rejection_degraded_retry_reason err with
-  | Some (Empty_no_progress | Read_only_no_progress) -> true
+  | Some
+      ( Empty_no_progress
+      | Read_only_no_progress
+      | Thinking_only_no_progress ) ->
+    true
   | Some _ | None -> false
 
 type degraded_retry =
@@ -553,7 +560,7 @@ let default_degraded_rotation_candidates
   in
   let default_candidates = [ normalized_base; default_runtime; phase_recovery_runtime ] in
   match fallback_reason with
-  | Some (Read_only_no_progress | Empty_no_progress) ->
+  | Some (Read_only_no_progress | Empty_no_progress | Thinking_only_no_progress) ->
     let tool_capable =
       Runtime.get_runtimes ()
       |> List.filter (fun (runtime : Runtime.t) -> runtime.model.tools_support)
@@ -657,7 +664,11 @@ let is_completion_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
     false
 
 let degraded_reason_allows_candidate_cycle = function
-  | Hard_quota | Rate_limit | Read_only_no_progress | Empty_no_progress -> false
+  | Hard_quota
+  | Rate_limit
+  | Read_only_no_progress
+  | Empty_no_progress
+  | Thinking_only_no_progress -> false
   | Resumable_cli_session
   | Admission_queue_timeout
   | Provider_timeout
@@ -704,6 +715,7 @@ let degraded_rotation_after_recoverable_error
         | Hard_quota
         | Read_only_no_progress
         | Empty_no_progress
+        | Thinking_only_no_progress
         | Resumable_cli_session
         | Admission_queue_timeout
         | Provider_timeout

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -110,6 +110,7 @@ type degraded_retry_reason =
   | Auth_error
   | Read_only_no_progress
   | Empty_no_progress
+  | Thinking_only_no_progress
 
 val degraded_retry_reason_to_string : degraded_retry_reason -> string
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -341,12 +341,12 @@ module For_testing = struct
   let surface_context_to_instructions = surface_context_to_instructions
   let clear_direct_success_no_progress_pause =
     clear_direct_success_no_progress_pause
-  let direct_empty_no_progress_retry_reason =
-    Keeper_turn_runtime_budget.direct_empty_no_progress_retry_reason
-  let direct_empty_no_progress_retry_decision =
-    Keeper_turn_runtime_budget.direct_empty_no_progress_retry_decision
-  let run_direct_empty_no_progress_retry_loop =
-    Keeper_turn_runtime_budget.run_direct_empty_no_progress_retry_loop
+  let direct_no_progress_retry_reason =
+    Keeper_turn_runtime_budget.direct_no_progress_retry_reason
+  let direct_no_progress_retry_decision =
+    Keeper_turn_runtime_budget.direct_no_progress_retry_decision
+  let run_direct_no_progress_retry_loop =
+    Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
 end
 
 let resolve_turn_runtime_id (meta : keeper_meta) =
@@ -1010,7 +1010,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                    ~keeper_name:meta.name
 		                    ~turn_id:keeper_turn_id
 		                    (fun () ->
-		                       Keeper_turn_runtime_budget.run_direct_empty_no_progress_retry_loop
+		                       Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
 		                         ~keeper_name:meta.name
 		                         ~base_runtime:turn_runtime_id
 		                         ~initial_runtime:turn_runtime_id
@@ -1046,7 +1046,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                  retry.fallback_reason
 		                              in
 		                              Log.Keeper.warn
-		                                "%s: direct keeper_msg empty response \
+		                                "%s: direct keeper_msg no-progress response \
 		                                 from runtime=%s suggested retry to %s \
 		                                 (reason=%s), but retry setup failed: %s"
 		                                meta.name
@@ -1069,7 +1069,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                      .terminal_reason_code_of_sdk_error
 		                                        fail_open_err))
 		                                ~activity_kind:
-		                                  "direct_empty_no_progress_retry_setup"
+		                                  "direct_no_progress_retry_setup"
 		                                ~trajectory_outcome:
 		                                  (Trajectory.Failed
 		                                     (Agent_sdk.Error.to_string
@@ -1089,7 +1089,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                ())
 		                         ~before_retry:
 		                           Keeper_turn_runtime_budget
-		                           .yield_before_empty_no_progress_retry
+		                           .yield_before_direct_no_progress_retry
 		                         ~run_once:
 		                           (fun ~runtime_id ~max_context ~is_retry
 		                                ~degraded_retry_runtime ~fallback_reason

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -51,12 +51,12 @@ module For_testing : sig
   (** Apply the direct-message success recovery that clears a no-progress
       forced pause without running a live LLM turn. *)
 
-  val direct_empty_no_progress_retry_reason :
+  val direct_no_progress_retry_reason :
     Agent_sdk.Error.sdk_error -> Keeper_error_classify.degraded_retry_reason option
-  (** Return [Some Empty_no_progress] only for direct-message accept rejections
+  (** Return a direct-message no-progress retry reason for accept rejections
       that are safe to rotate before surfacing an error. *)
 
-  val direct_empty_no_progress_retry_decision :
+  val direct_no_progress_retry_decision :
     base_runtime:string ->
     effective_runtime:string ->
     attempted_runtimes:string list ->
@@ -65,10 +65,11 @@ module For_testing : sig
     remaining_turn_budget_s:float ->
     Agent_sdk.Error.sdk_error ->
     Keeper_turn_runtime_budget.degraded_retry_budget_decision
-  (** Shared-budget retry decision for direct-message empty no-progress accept
-      rejections. Non-empty/read-only accept rejections remain terminal here. *)
+  (** Shared-budget retry decision for direct-message no-progress accept
+      rejections. Read-only no-progress remains terminal here because it
+      already consumed tool execution in the current attempt. *)
 
-  val run_direct_empty_no_progress_retry_loop :
+  val run_direct_no_progress_retry_loop :
     keeper_name:string ->
     base_runtime:string ->
     initial_runtime:string ->
@@ -111,7 +112,7 @@ module For_testing : sig
        ('a, Agent_sdk.Error.sdk_error) result) ->
     unit ->
     ('a * int, Agent_sdk.Error.sdk_error) result
-  (** Execute the direct-message empty-response retry loop with injected side
+  (** Execute the direct-message no-progress retry loop with injected side
       effects. Exposed only to verify that fallback selection reaches the next
       keeper run attempt. *)
 end

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -89,7 +89,7 @@ let accept_rejected_result_should_try_next ~is_last err =
 
 let checkpoint_for_accept_rejected_retry ~resume_checkpoint ~checkpoint_after err =
   match accept_no_progress_retry_kind err with
-  | Some `Empty_no_progress -> resume_checkpoint
+  | Some (`Empty_no_progress | `Thinking_only_no_progress) -> resume_checkpoint
   | Some `Read_only_no_progress -> checkpoint_after
   | None -> checkpoint_after
 

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -250,22 +250,23 @@ let plan_degraded_retry_step
     Degraded_retry_step_slot_phase_exhausted { retry; reason }
   | Degraded_retry_slot_phase_exhausted _ -> Degraded_retry_step_not_allowed
 
-let yield_before_empty_no_progress_retry () = Eio.Fiber.yield ()
+let yield_before_direct_no_progress_retry () = Eio.Fiber.yield ()
 
-let direct_empty_no_progress_retry_reason err =
+let direct_no_progress_retry_reason err =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some internal_error ->
     (match Keeper_turn_driver.accept_no_progress_retry_kind internal_error with
      | Some `Empty_no_progress -> Some EC.Empty_no_progress
+     | Some `Thinking_only_no_progress -> Some EC.Thinking_only_no_progress
      | Some `Read_only_no_progress | None -> None)
   | None -> None
 
-let retry_reason_is_empty_no_progress (retry : EC.degraded_retry) =
+let retry_reason_is_direct_no_progress (retry : EC.degraded_retry) =
   match retry.fallback_reason with
-  | EC.Empty_no_progress -> true
+  | EC.Empty_no_progress | EC.Thinking_only_no_progress -> true
   | _ -> false
 
-let direct_empty_no_progress_retry_decision
+let direct_no_progress_retry_decision
     ~base_runtime
     ~effective_runtime
     ~attempted_runtimes
@@ -273,9 +274,9 @@ let direct_empty_no_progress_retry_decision
     ?time_spent_in_turn_s
     ~remaining_turn_budget_s
     err =
-  match direct_empty_no_progress_retry_reason err with
+  match direct_no_progress_retry_reason err with
   | None -> No_degraded_retry
-  | Some EC.Empty_no_progress ->
+  | Some (EC.Empty_no_progress | EC.Thinking_only_no_progress) ->
     (match
        next_fail_open_runtime_for_turn_with_budget
          ~base_runtime
@@ -286,15 +287,15 @@ let direct_empty_no_progress_retry_decision
          ~remaining_turn_budget_s
          err
      with
-     | Degraded_retry_allowed retry when retry_reason_is_empty_no_progress retry
+     | Degraded_retry_allowed retry when retry_reason_is_direct_no_progress retry
        -> Degraded_retry_allowed retry
      | Degraded_retry_slot_phase_exhausted retry
-       when retry_reason_is_empty_no_progress retry ->
+       when retry_reason_is_direct_no_progress retry ->
        Degraded_retry_slot_phase_exhausted retry
      | _ -> No_degraded_retry)
   | Some _ -> No_degraded_retry
 
-let run_direct_empty_no_progress_retry_loop
+let run_direct_no_progress_retry_loop
       ~keeper_name
       ~base_runtime
       ~initial_runtime
@@ -360,7 +361,7 @@ let run_direct_empty_no_progress_retry_loop
            ~remaining_turn_budget_s:(remaining_turn_budget_s ())
            ~attempt
            ~err
-           ~allow_retry:retry_reason_is_empty_no_progress
+           ~allow_retry:retry_reason_is_direct_no_progress
            ~publish_cascade_resolution
            ~emit_runtime_selected
            ~emit_runtime_rotation
@@ -368,7 +369,7 @@ let run_direct_empty_no_progress_retry_loop
        with
        | Degraded_retry_step_not_allowed ->
          let reason =
-           match direct_empty_no_progress_retry_reason err with
+           match direct_no_progress_retry_reason err with
            | Some retry_reason ->
              Printf.sprintf
                "terminal_%s_no_degraded_retry"
@@ -385,7 +386,7 @@ let run_direct_empty_no_progress_retry_loop
          error
        | Degraded_retry_step_slot_phase_exhausted { retry; reason } ->
          Log.Keeper.warn
-           "%s: direct keeper_msg empty response from runtime=%s suggested \
+           "%s: direct keeper_msg no-progress response from runtime=%s suggested \
             retry to %s (reason=%s), but productive slot phase budget %.1fs \
             is exhausted after %.1fs"
            keeper_name
@@ -437,7 +438,7 @@ let run_direct_empty_no_progress_retry_loop
          in
          let retry_resolution = next_execution.max_context_resolution in
          Log.Keeper.warn
-           "%s: direct keeper_msg empty response from runtime=%s; retrying \
+           "%s: direct keeper_msg no-progress response from runtime=%s; retrying \
             runtime=%s reason=%s max_context=%d context_budget=%d \
             primary_budget=%d requested_override=%s"
            keeper_name

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -165,21 +165,21 @@ val plan_degraded_retry_step :
   setup_runtime:(string -> ('a, Agent_sdk.Error.sdk_error) result) ->
   'a degraded_retry_step
 (** Shared degraded-runtime retry step for unified turns and direct
-    empty-response turns. Callers supply their acceptance policy
+    no-progress turns. Callers supply their acceptance policy
     ([allow_retry]) and retain ownership of terminal-error handling. *)
 
-val yield_before_empty_no_progress_retry : unit -> unit
-(** Cooperative spacing used between direct empty-response retry attempts.
-    Empty accept rejection is a response-contract miss rather than a transport
-    retry, so it intentionally yields without borrowing transient-network
-    backoff. *)
+val yield_before_direct_no_progress_retry : unit -> unit
+(** Cooperative spacing used between direct no-progress retry attempts.
+    No-progress accept rejection is a response-contract miss rather than a
+    transport retry, so it intentionally yields without borrowing
+    transient-network backoff. *)
 
-val direct_empty_no_progress_retry_reason :
+val direct_no_progress_retry_reason :
   Agent_sdk.Error.sdk_error -> EC.degraded_retry_reason option
-(** Return [Some Empty_no_progress] only for direct-message accept rejections
-    that are safe to rotate before surfacing an error. *)
+(** Return a direct-message no-progress retry reason for accept rejections that
+    are safe to rotate before surfacing an error. *)
 
-val direct_empty_no_progress_retry_decision :
+val direct_no_progress_retry_decision :
   base_runtime:string ->
   effective_runtime:string ->
   attempted_runtimes:string list ->
@@ -188,10 +188,11 @@ val direct_empty_no_progress_retry_decision :
   remaining_turn_budget_s:float ->
   Agent_sdk.Error.sdk_error ->
   degraded_retry_budget_decision
-(** Shared-budget retry decision for direct-message empty no-progress accept
-    rejections. Non-empty/read-only accept rejections remain terminal here. *)
+(** Shared-budget retry decision for direct-message no-progress accept
+    rejections. Read-only no-progress remains terminal here because it already
+    consumed tool execution in the current attempt. *)
 
-val run_direct_empty_no_progress_retry_loop :
+val run_direct_no_progress_retry_loop :
   keeper_name:string ->
   base_runtime:string ->
   initial_runtime:string ->
@@ -231,7 +232,7 @@ val run_direct_empty_no_progress_retry_loop :
      ('a, Agent_sdk.Error.sdk_error) result) ->
   unit ->
   ('a * int, Agent_sdk.Error.sdk_error) result
-(** Execute the direct-message empty-response retry loop with injected side
+(** Execute the direct-message no-progress retry loop with injected side
     effects. This keeps direct-message retry orchestration on the same budget
     and cascade path as unified degraded-runtime retries. *)
 

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -539,6 +539,18 @@ let accept_rejection_is_empty_no_progress
   && Option.is_none any_mutating_tool
   && tool_effects_seen = []
 
+let accept_rejection_is_thinking_only_no_progress
+    ~reason_kind
+    ~response_shape
+    ~last_tool_effect
+    ~any_mutating_tool
+    ~tool_effects_seen =
+  reason_kind = Some Accept_no_usable_progress
+  && response_shape = Some Accept_response_thinking_only
+  && Option.is_none last_tool_effect
+  && Option.is_none any_mutating_tool
+  && tool_effects_seen = []
+
 let accept_rejection_is_read_only_no_progress
     ~reason_kind
     ~response_shape
@@ -615,6 +627,26 @@ let summary_of_masc_internal_error = function
     Some
       (Printf.sprintf
          "Provider returned an empty assistant turn for runtime %s; no text or tool progress was produced."
+         (nonempty_or_unknown scope))
+  | Accept_rejected
+      {
+        scope;
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
+        tool_effects_seen = [];
+        _;
+      }
+    when accept_rejection_is_thinking_only_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen:[] ->
+    Some
+      (Printf.sprintf
+         "Provider returned a thinking-only assistant turn for runtime %s; no text or tool progress was produced."
          (nonempty_or_unknown scope))
   | Accept_rejected
       {
@@ -724,6 +756,22 @@ let accept_no_progress_retry_kind = function
     Some `Empty_no_progress
   | Accept_rejected
       {
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
+        tool_effects_seen;
+        _;
+      }
+    when accept_rejection_is_thinking_only_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen ->
+    Some `Thinking_only_no_progress
+  | Accept_rejected
+      {
         tool_effects_seen;
         reason_kind;
         response_shape;
@@ -756,13 +804,16 @@ let accept_no_progress_retry_kind = function
 let accept_rejection_has_read_only_no_progress_retry_hint err =
   match accept_no_progress_retry_kind err with
   | Some `Read_only_no_progress -> true
-  | Some `Empty_no_progress
+  | Some (`Empty_no_progress | `Thinking_only_no_progress)
   | None ->
     false
 
 let accept_rejection_has_no_progress_retry_hint err =
   match accept_no_progress_retry_kind err with
-  | Some (`Empty_no_progress | `Read_only_no_progress) ->
+  | Some
+      ( `Empty_no_progress
+      | `Read_only_no_progress
+      | `Thinking_only_no_progress ) ->
     true
   | None -> false
 

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -154,7 +154,7 @@ val runtime_id_of_masc_internal_error : masc_internal_error -> string
 
 val accept_no_progress_retry_kind :
   masc_internal_error ->
-  [ `Empty_no_progress | `Read_only_no_progress ] option
+  [ `Empty_no_progress | `Read_only_no_progress | `Thinking_only_no_progress ] option
 
 val accept_rejection_has_no_progress_retry_hint : masc_internal_error -> bool
 

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -74,13 +74,14 @@ let accept_no_progress_retry_kind_string err =
   Option.map
     (function
       | `Empty_no_progress -> "empty_no_progress"
-      | `Read_only_no_progress -> "read_only_no_progress")
+      | `Read_only_no_progress -> "read_only_no_progress"
+      | `Thinking_only_no_progress -> "thinking_only_no_progress")
     kind
 
-let direct_empty_no_progress_retry_reason_string err =
+let direct_no_progress_retry_reason_string err =
   Option.map
     Masc.Keeper_error_classify.degraded_retry_reason_to_string
-    (Masc.Keeper_turn_runtime_budget.direct_empty_no_progress_retry_reason err)
+    (Masc.Keeper_turn_runtime_budget.direct_no_progress_retry_reason err)
 
 let write_file path content =
   let oc = open_out path in
@@ -122,8 +123,8 @@ let with_direct_retry_runtime f =
        | Ok () -> f ()
        | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e)
 
-let direct_empty_no_progress_retry_decision ?time_spent_in_turn_s err =
-  Masc.Keeper_turn_runtime_budget.direct_empty_no_progress_retry_decision
+let direct_no_progress_retry_decision ?time_spent_in_turn_s err =
+  Masc.Keeper_turn_runtime_budget.direct_no_progress_retry_decision
     ~base_runtime:"test_provider.test_model"
     ~effective_runtime:"runtime.direct-empty"
     ~attempted_runtimes:[ "runtime.direct-empty" ]
@@ -280,14 +281,18 @@ let test_reject_reason_describes_thinking_only_response () =
     false
     (Masc.Keeper_error_classify.is_runtime_exhausted_error err);
   Alcotest.(check bool)
-    "thinking-only without read-only tool does not try next candidate"
+    "thinking-only without read-only tool is not a read-only retry"
     false
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
        err);
+  Alcotest.(check bool)
+    "thinking-only without tool can try next candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
   Alcotest.(check (option string))
-    "thinking-only without read-only tool is not runtime-recoverable"
-    None
+    "thinking-only without tool is runtime-recoverable"
+    (Some "thinking_only_no_progress")
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
        (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
@@ -793,7 +798,7 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
   Alcotest.(check (option string))
     "direct keeper_msg does not rotate read-only no-progress"
     None
-    (direct_empty_no_progress_retry_reason_string typed_err);
+    (direct_no_progress_retry_reason_string typed_err);
   let string_only_err =
     accept_rejected_sdk_error
       ~response_shape:None
@@ -816,7 +821,7 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
 	       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason
 	          string_only_err))
 
-let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
+let test_direct_no_progress_retry_uses_shared_budget_decision () =
   with_direct_retry_runtime (fun () ->
     let empty_err =
       accept_rejected_sdk_error
@@ -825,7 +830,7 @@ let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
         ~reason:"shape=empty"
         ()
     in
-    (match direct_empty_no_progress_retry_decision empty_err with
+    (match direct_no_progress_retry_decision empty_err with
      | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
        Alcotest.(check string)
          "allowed reason"
@@ -840,7 +845,7 @@ let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
       Masc.Keeper_turn_runtime_budget.degraded_retry_slot_phase_budget_sec +. 1.0
     in
     (match
-       direct_empty_no_progress_retry_decision
+       direct_no_progress_retry_decision
          ~time_spent_in_turn_s:exhausted_after
          empty_err
      with
@@ -855,6 +860,25 @@ let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
        Alcotest.fail "exhausted direct empty retry should not rotate"
      | Masc.Keeper_turn_runtime_budget.No_degraded_retry ->
        Alcotest.fail "exhausted direct empty retry should report slot exhaustion");
+    let thinking_only_err =
+      accept_rejected_sdk_error
+        ~response_shape:(Some Keeper_internal_error.Accept_response_thinking_only)
+        ~last_tool_effect:None
+        ~reason:"shape=thinking_only"
+        ()
+    in
+    (match direct_no_progress_retry_decision thinking_only_err with
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
+       Alcotest.(check string)
+         "thinking-only allowed reason"
+         "thinking_only_no_progress"
+         (Masc.Keeper_error_classify.degraded_retry_reason_to_string
+            retry.fallback_reason)
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
+       Alcotest.fail
+         "fresh direct thinking-only retry should not exhaust slot phase"
+     | Masc.Keeper_turn_runtime_budget.No_degraded_retry ->
+       Alcotest.fail "fresh direct thinking-only retry should rotate");
     let read_only_err =
       accept_rejected_sdk_error
         ~response_shape:(Some Keeper_internal_error.Accept_response_thinking_only)
@@ -867,7 +891,7 @@ let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
     Alcotest.(check bool)
       "direct read-only no-progress remains terminal"
       true
-      (match direct_empty_no_progress_retry_decision read_only_err with
+      (match direct_no_progress_retry_decision read_only_err with
        | Masc.Keeper_turn_runtime_budget.No_degraded_retry -> true
 	       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed _
 	       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
@@ -1039,7 +1063,7 @@ let test_plan_degraded_retry_step_covers_direct_outcomes () =
         ()
     in
     let expected_retry_runtime =
-      match direct_empty_no_progress_retry_decision empty_err with
+      match direct_no_progress_retry_decision empty_err with
       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
         retry.next_runtime
       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
@@ -1209,7 +1233,7 @@ let test_plan_degraded_retry_step_covers_direct_outcomes () =
        Alcotest.failf "expected one slot-exhausted cascade event, got %d"
          (List.length rows)))
 
-let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
+let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
   with_direct_retry_runtime (fun () ->
     let empty_err =
       accept_rejected_sdk_error
@@ -1219,7 +1243,7 @@ let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
         ()
     in
     let expected_retry_runtime =
-      match direct_empty_no_progress_retry_decision empty_err with
+      match direct_no_progress_retry_decision empty_err with
       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
         retry.next_runtime
       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
@@ -1253,7 +1277,7 @@ let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
       }
     in
     let result =
-      Masc.Keeper_turn_runtime_budget.run_direct_empty_no_progress_retry_loop
+      Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
         ~keeper_name:"keeper-test"
         ~base_runtime:"test_provider.test_model"
         ~initial_runtime:"runtime.direct-empty"
@@ -1398,7 +1422,7 @@ let test_direct_retry_loop_publishes_non_retry_terminal_cascade () =
   let published = ref [] in
   let run_count = ref 0 in
   let result =
-    Masc.Keeper_turn_runtime_budget.run_direct_empty_no_progress_retry_loop
+    Masc.Keeper_turn_runtime_budget.run_direct_no_progress_retry_loop
       ~keeper_name:"keeper-test"
       ~base_runtime:"runtime.initial"
       ~initial_runtime:"runtime.initial"
@@ -1577,6 +1601,65 @@ let test_thinking_only_non_end_turn_response_is_rejected () =
     true
     (contains ~needle:"stop_reason=stop_sequence" reason)
 
+let test_thinking_only_no_tool_can_try_next_candidate () =
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.thinking-only-no-tool"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~content:
+           [
+             Agent_sdk.Types.Thinking
+               { thinking_type = "reasoning"; content = "internal chain" };
+           ]
+         ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason identifies thinking-only shape"
+    true
+    (contains ~needle:"shape=thinking_only" reason);
+  Alcotest.(check bool)
+    "thinking-only no-tool can try next provider candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
+  Alcotest.(check bool)
+    "non-last thinking-only no-tool advances provider candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:false
+       err);
+  Alcotest.(check bool)
+    "last thinking-only no-tool stays in same-attempt loop terminal"
+    false
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:true
+       err);
+  Alcotest.(check bool)
+    "thinking-only no-tool is not a read-only retry"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err);
+  Alcotest.(check (option string))
+    "thinking-only no-tool classified by internal-error SSOT"
+    (Some "thinking_only_no_progress")
+    (accept_no_progress_retry_kind_string err);
+  Alcotest.(check (option string))
+    "thinking-only no-tool is runtime-recoverable"
+    (Some "thinking_only_no_progress")
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err));
+  Alcotest.(check (option string))
+    "direct keeper_msg rotates thinking-only no-progress"
+    (Some "thinking_only_no_progress")
+    (direct_no_progress_retry_reason_string err)
+
 let test_empty_non_end_turn_response_is_rejected () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -1658,7 +1741,7 @@ let test_empty_non_end_turn_response_is_rejected () =
   Alcotest.(check (option string))
     "direct keeper_msg rotates empty no-progress"
     (Some "empty_no_progress")
-    (direct_empty_no_progress_retry_reason_string err)
+    (direct_no_progress_retry_reason_string err)
 
 let test_empty_after_workspace_mutation_stays_terminal () =
   let checkpoint =
@@ -1706,7 +1789,7 @@ let test_empty_after_workspace_mutation_stays_terminal () =
   Alcotest.(check (option string))
     "direct keeper_msg does not rotate after mutation"
     None
-    (direct_empty_no_progress_retry_reason_string err)
+    (direct_no_progress_retry_reason_string err)
 
 let test_blank_text_non_end_turn_response_is_rejected () =
   let result =
@@ -1874,9 +1957,9 @@ let () =
             `Quick
             test_read_only_retry_uses_typed_context_not_reason_tokens;
 	          Alcotest.test_case
-	            "direct empty no-progress retry uses shared budget decision"
+	            "direct no-progress retry uses shared budget decision"
 	            `Quick
-	            test_direct_empty_no_progress_retry_uses_shared_budget_decision;
+	            test_direct_no_progress_retry_uses_shared_budget_decision;
           Alcotest.test_case
             "degraded retry rejects empty runtime target"
             `Quick
@@ -1890,9 +1973,9 @@ let () =
             `Quick
             test_plan_degraded_retry_step_covers_direct_outcomes;
 	          Alcotest.test_case
-	            "direct empty no-progress retry runs fallback attempt"
+	            "direct no-progress retry runs fallback attempt"
 	            `Quick
-	            test_direct_empty_no_progress_retry_loop_runs_fallback_attempt;
+	            test_direct_no_progress_retry_loop_runs_fallback_attempt;
           Alcotest.test_case
             "direct retry publishes terminal non-retry cascade"
             `Quick
@@ -1905,6 +1988,10 @@ let () =
             test_accept_contract_delegates_to_oas_response_shape;
           Alcotest.test_case "thinking-only non-end-turn response is rejected" `Quick
             test_thinking_only_non_end_turn_response_is_rejected;
+          Alcotest.test_case
+            "thinking-only no-tool response rotates typed no-progress"
+            `Quick
+            test_thinking_only_no_tool_can_try_next_candidate;
           Alcotest.test_case "empty non-end-turn response is rejected" `Quick
             test_empty_non_end_turn_response_is_rejected;
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- classify no-tool `thinking_only` accept rejections as typed `Thinking_only_no_progress`
- allow provider-candidate and direct-message degraded retry for that typed no-progress class
- keep read-only/mutating tool cases constrained: read-only direct retry remains terminal, mutating cases remain non-retryable
- reuse the resume checkpoint for no-tool thinking-only provider retry so the thinking-only assistant turn is not carried into the next candidate

## Why
Live runtime on `a796d9c82df` paused `nick0cave` after repeated `accept_rejected` errors from `runpod_mtp.qwen36-35b-a3b-mtp` with `response_shape=thinking_only`, `last_tool_effect=null`.

This is not provider-name-specific and should be handled through the existing typed no-progress SSOT rather than reason string matching.

## Verification
- `ocamlformat --check lib/keeper_runtime/keeper_internal_error.ml lib/keeper_runtime/keeper_internal_error.mli lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_turn_runtime_budget.ml lib/keeper/keeper_turn_runtime_budget.mli lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/keeper/keeper_turn_driver_try_runtime.ml test/test_keeper_turn_driver_accept.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_turn_driver_accept.exe`
- `./_build/default/test/test_keeper_turn_driver_accept.exe` (31 tests)
