### PR TITLE
fix(keeper): treat explicit autoboot base as materializable

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -1,14 +1,9 @@
 [keeper]
-# base.toml is a loader template referenced by other keeper TOMLs via
-# `base = "base.toml"` (see lib/keeper/keeper_types_profile.ml:846-855 +
-# loader_level_keeper_toml_key_names at line 652). It is not an
-# autoboot target — it has no persona_name, no goal, and no
-# mention_targets, so validate_keeper_inputs (keeper_tool_persona_runtime.ml:109)
-# rejects it with "goal is required" every autoboot cycle.
-# Suppress the failed materialize attempt (142 events/24h triplet) by
-# disabling autoboot for this file. discover_keepers_toml still loads it
-# as a profile-defaults source for downstream keepers.
-autoboot_enabled = false
+# base.toml is both the shared defaults source referenced by other keeper TOMLs
+# via `base = "base.toml"` and the default base keeper. Explicit autoboot keeps
+# the base keeper in the durable keepalive fleet; TOML overlays still inherit the
+# defaults below.
+autoboot_enabled = true
 # persona⊥{model,runtime}: keeper TOML no longer carries a runtime/model
 # selection (the parser now fail-loud rejects `runtime_id`/`model` keys).
 # keeper→runtime assignment is the sole responsibility of runtime.toml

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -44,9 +44,16 @@ let keeper_count (config : Workspace.config) : int =
   List.length (keeper_names config)
 
 let configured_runtime_keeper_names config =
-  let loader_level_names = Keeper_types_profile.loader_level_keeper_toml_key_names in
   Keeper_meta_store.configured_keeper_names config
-  |> List.filter (fun name -> not (List.exists (String.equal name) loader_level_names))
+  |> List.filter (fun name ->
+    try
+      Keeper_types_profile.load_keeper_profile_defaults_for_base_path
+        ~base_path:config.Workspace.base_path
+        name
+      |> Keeper_types_profile.keeper_profile_defaults_materializable
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> true)
 
 let configured_keeper_count (config : Workspace.config) : int =
   List.length (configured_runtime_keeper_names config)

--- a/lib/dashboard/dashboard_http_keeper.mli
+++ b/lib/dashboard/dashboard_http_keeper.mli
@@ -35,8 +35,9 @@ val keeper_count : Workspace.config -> int
 (** Total keepers visible in [config.base_path] meta. *)
 
 val configured_keeper_count : Workspace.config -> int
-(** Total declarative runtime keeper profiles discovered from keeper TOML.
-    Loader-level templates such as [base.toml] are excluded. *)
+(** Total materializable declarative runtime keeper profiles discovered from
+    keeper TOML. Loader-level templates are excluded only when they do not opt
+    into runtime materialization, e.g. via [autoboot_enabled=true]. *)
 
 val keeper_names : Workspace.config -> string list
 (** Keeper names visible in [config.base_path] meta. *)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -143,6 +143,17 @@ let persona_operator_todo_placeholder_fields
       ("keeper.goal", defaults.goal);
     ]
 
+let keeper_profile_defaults_materializable (defaults : keeper_profile_defaults) =
+  let has_runtime_identity =
+    Option.is_some defaults.persona_name
+    || Option.is_some defaults.goal
+    || defaults.mention_targets <> []
+  in
+  match defaults.autoboot_enabled with
+  | Some true -> true
+  | Some false | None -> has_runtime_identity
+;;
+
 let keeper_toml_path_opt name =
   Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
   Config_dir_resolver.keeper_toml_path_opt name

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -56,6 +56,7 @@ val json_operator_todo_placeholder_paths : Yojson.Safe.t -> string list
 val reject_placeholder_persona_profile : label:string -> path:string -> Yojson.Safe.t -> bool
 val operator_todo_placeholder_fields : (string * string option) list -> string list
 val persona_operator_todo_placeholder_fields : persona_summary -> keeper_profile_defaults -> string list
+val keeper_profile_defaults_materializable : keeper_profile_defaults -> bool
 val normalize_per_provider_timeout_opt : source:string -> float option -> float option
 
 val per_provider_timeout_of_declared_float_opt :

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -533,13 +533,17 @@ let string_set_of_list values =
 
 let json_string_list values = Json_util.json_string_list values
 
-let configured_keeper_is_materializable name =
+let configured_keeper_is_materializable ?base_path name =
   try
-    let defaults = Keeper_types_profile.load_keeper_profile_defaults name in
-    (* Exclude loader-only TOMLs such as base.toml from identity drift. *)
-    Option.is_some defaults.persona_name
-    || Option.is_some defaults.goal
-    || defaults.mention_targets <> []
+    let defaults =
+      match base_path with
+      | Some base_path ->
+        Keeper_types_profile.load_keeper_profile_defaults_for_base_path
+          ~base_path
+          name
+      | None -> Keeper_types_profile.load_keeper_profile_defaults name
+    in
+    Keeper_types_profile.keeper_profile_defaults_materializable defaults
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | _ -> true
@@ -553,7 +557,8 @@ let keeper_identity_drift_scan config =
   in
   let materializable_configured_names =
     configured_names
-    |> List.filter configured_keeper_is_materializable
+    |> List.filter
+         (configured_keeper_is_materializable ~base_path:config.Workspace.base_path)
     |> sorted_unique_strings
   in
   let configured_set = string_set_of_list materializable_configured_names in

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -65,7 +65,7 @@ val sort_paused_keeper_details :
 val keeper_fleet_meta_scan :
   ?include_paused_details:bool ->
   Workspace.config -> keeper_fleet_meta_scan
-val configured_keeper_is_materializable : string -> bool
+val configured_keeper_is_materializable : ?base_path:string -> string -> bool
 val keeper_identity_drift_scan : Workspace.config -> keeper_identity_drift_scan
 val keeper_identity_drift_health_json_of_scan :
   keeper_identity_drift_scan -> Yojson.Safe.t

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1180,7 +1180,18 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
       Alcotest.(check int)
         "counts.persisted_keepers mirrors top-level persisted_keepers"
         0
-        (json |> member "counts" |> member "persisted_keepers" |> to_int))
+        (json |> member "counts" |> member "persisted_keepers" |> to_int);
+      write_file
+        (Filename.concat keepers_dir "base.toml")
+        "[keeper]\nautoboot_enabled = true\n";
+      Config_dir_resolver.reset ();
+      let json =
+        Server_dashboard_http_core.dashboard_shell_http_json ~light:true config
+      in
+      Alcotest.(check int)
+        "configured_keepers includes explicit autoboot base keeper"
+        3
+        (json |> member "configured_keepers" |> to_int))
 
 let test_dashboard_shell_light_counts_agents_from_summary_fields () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1367,6 +1367,45 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
           (health |> member "keeper_identity_drift" |> member "status"
            |> to_string)))
 
+let test_keeper_identity_drift_treats_explicit_autoboot_base_as_materializable
+    () =
+  with_temp_dir "keeper-identity-drift-base-autoboot" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    write_file
+      (Filename.concat (Filename.concat config_root "keepers") "base.toml")
+      "[keeper]\nautoboot_enabled = true\ninstructions = \"default keeper\"\n";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        write_keeper_meta_exn config
+          (make_keeper_meta ~name:"base" ~trace_id:"trace-base" ());
+        let json =
+          Server_routes_http_runtime_fleet_scan.keeper_identity_drift_health_json
+            config
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "drift status" "ok"
+          (json |> member "status" |> to_string);
+        Alcotest.(check bool) "base meta does not block drift" false
+          (json |> member "blocking" |> to_bool);
+        Alcotest.(check (list string)) "materializable configured names"
+          [ "base" ]
+          (json |> member "materializable_configured_keeper_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check (list string)) "meta without config"
+          []
+          (json |> member "meta_without_config_names" |> to_list
+           |> List.map to_string)))
+
 let test_health_json_keeps_timeout_pause_without_policy_manual () =
   with_temp_dir "health-timeout-paused-without-policy" (fun dir ->
     let config_root = make_config_root dir in
@@ -4138,6 +4177,10 @@ let () =
             "health json surfaces keeper identity config/meta drift"
             `Quick
             test_keeper_identity_drift_health_json_surfaces_config_meta_split;
+          Alcotest.test_case
+            "health json treats explicit autoboot base as materializable"
+            `Quick
+            test_keeper_identity_drift_treats_explicit_autoboot_base_as_materializable;
           Alcotest.test_case
             "health json keeps timeout pause without policy manual"
             `Quick test_health_json_keeps_timeout_pause_without_policy_manual;


### PR DESCRIPTION
## Summary
- Keep `base.toml` as an explicit autoboot default keeper while preserving its shared-defaults role.
- Centralize materializable keeper detection so health drift and dashboard counts agree.
- Stop flagging explicit-autoboot `base` runtime meta as stale drift.

## Validation
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe test/test_dashboard_http_core.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test --show-errors --bail bootstrap 23,24`
- `./_build/default/test/test_dashboard_http_core.exe test --show-errors --bail executor_pool 34`
