### PR TITLE
fix(keeper): suppress contract-attention response replay

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -47,6 +47,21 @@ let finalize
     Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted
       result.stop_reason
   in
+  let completion_contract_result = acc.receipt_completion_contract_result in
+  let contract_requires_attention =
+    Keeper_execution_receipt.completion_contract_result_requires_attention
+      completion_contract_result
+  in
+  let suppress_visible_response = budget_exhausted || contract_requires_attention in
+  let raw_response_text_present =
+    (not budget_exhausted) && String.trim raw_response_text <> ""
+  in
+  if contract_requires_attention && raw_response_text_present
+  then
+    Log.Keeper.info ~keeper_name:meta.name
+      "suppressing keeper-visible response for completion_contract_result=%s"
+      (Keeper_execution_receipt.completion_contract_result_to_string
+         completion_contract_result);
   let reported_state_snapshot =
     reported_state_snapshot_from_checkpoint result.checkpoint
   in
@@ -61,6 +76,7 @@ let finalize
       ~keeper_name:meta.name
       ~goal:meta.goal
       ~actual_keeper_tool_names
+      ~completion_contract_result
       ~stop_reason:result.stop_reason
       ~raw_response_text
       ()
@@ -97,9 +113,9 @@ let finalize
     ~append_manifest
     ()
   in
-  receipt_response_text_present_ref := String.trim response_text <> "";
+  receipt_response_text_present_ref := raw_response_text_present;
   let assistant_msg =
-    if budget_exhausted
+    if suppress_visible_response || String.trim response_text = ""
     then None
     else
       Some
@@ -121,15 +137,12 @@ let finalize
     match result.checkpoint with
     | Some checkpoint ->
       let patched =
-        if budget_exhausted
-        then checkpoint
-        else
-          Keeper_context_core.patch_checkpoint_last_assistant
-            checkpoint
-            ~session_id:
-              (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-            ~response_text
-            ~snapshot:state_snapshot
+        Keeper_context_core.patch_checkpoint_last_assistant
+          checkpoint
+          ~session_id:
+            (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~response_text
+          ~snapshot:state_snapshot
       in
       (match
          Keeper_checkpoint_store.save_oas_classified

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -77,11 +77,16 @@ let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
 ;;
 
 let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
-      ~stop_reason ~raw_response_text
+      ~completion_contract_result ~stop_reason ~raw_response_text
       ()
   =
   let budget_exhausted = stop_reason_is_turn_budget_exhausted stop_reason in
-  let raw_response_text = if budget_exhausted then "" else raw_response_text in
+  let contract_requires_attention =
+    Keeper_execution_receipt.completion_contract_result_requires_attention
+      completion_contract_result
+  in
+  let suppress_response_text = budget_exhausted || contract_requires_attention in
+  let raw_response_text = if suppress_response_text then "" else raw_response_text in
   let state_snapshot, state_snapshot_source =
     state_snapshot
       ~reported_state_snapshot
@@ -97,6 +102,6 @@ let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_nam
   in
   { state_snapshot
   ; state_snapshot_source
-  ; response_text = if budget_exhausted then "" else response_text
+  ; response_text = if suppress_response_text then "" else response_text
   }
 ;;

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -18,6 +18,7 @@ val finalize :
   keeper_name:string ->
   goal:string ->
   actual_keeper_tool_names:string list ->
+  completion_contract_result:Keeper_execution_receipt.completion_contract_result ->
   stop_reason:Runtime_agent.stop_reason ->
   raw_response_text:string ->
   unit ->

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -11,6 +11,7 @@
 module KMP = Masc.Keeper_memory_policy
 module KCC = Masc.Keeper_context_core
 module KRT = Masc.Keeper_agent_run_response_text
+module Receipt = Masc.Keeper_execution_receipt
 
 let contains_substring text needle =
   let text_len = String.length text in
@@ -178,6 +179,7 @@ let test_finalizer_uses_structured_state_source () =
       ~keeper_name:"test"
       ~goal:"Fix structured state"
       ~actual_keeper_tool_names:[ "masc_tasks" ]
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:raw
       ()
@@ -232,6 +234,7 @@ let test_finalizer_prefers_reported_state_snapshot () =
       ~keeper_name:"test"
       ~goal:"Fallback goal"
       ~actual_keeper_tool_names:[ "keeper_report_state" ]
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text:"Visible reply"
       ()
@@ -431,6 +434,7 @@ let test_budget_finalizer_drops_synthetic_response_text () =
       ~keeper_name:"test"
       ~goal:"Fix task"
       ~actual_keeper_tool_names:[]
+      ~completion_contract_result:Receipt.Contract_satisfied_completion
       ~stop_reason:(Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 })
       ~raw_response_text:
         "Continuation checkpoint saved; keeper remains scheduled"
@@ -467,6 +471,7 @@ let test_synthetic_finalizer_drops_raw_response_text () =
       ~keeper_name:"test"
       ~goal:"Monitor keeper work"
       ~actual_keeper_tool_names:["keeper_tasks_list"]
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text
       ()
@@ -483,6 +488,38 @@ let test_synthetic_finalizer_drops_raw_response_text () =
     "raw repeated text not persisted as response"
     false
     (contains_substring finalized.response_text "What should I do next?")
+
+let test_contract_attention_finalizer_drops_raw_response_text () =
+  let raw_response_text =
+    "Good. I will read the code, edit it, and commit it now.\n\
+     \n\
+     Good. I will read the code, edit it, and commit it now."
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"albini"
+      ~goal:"PM flow"
+      ~actual_keeper_tool_names:["keeper_context_status"]
+      ~completion_contract_result:Receipt.Contract_passive_only
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text
+      ()
+  in
+  Alcotest.(check string)
+    "contract attention suppresses visible response"
+    ""
+    finalized.response_text;
+  Alcotest.(check string)
+    "synthetic state source"
+    "synthesized"
+    (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
+  Alcotest.(check bool)
+    "raw repeated text not persisted as decision"
+    false
+    (List.exists
+       (fun text -> contains_substring text "edit it, and commit")
+       finalized.state_snapshot.decisions)
 
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
@@ -541,5 +578,9 @@ let () =
             "synthetic finalizer drops raw response text"
             `Quick
             test_synthetic_finalizer_drops_raw_response_text;
+          Alcotest.test_case
+            "contract attention finalizer drops raw response text"
+            `Quick
+            test_contract_attention_finalizer_drops_raw_response_text;
         ] );
     ]

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -15,6 +15,7 @@ module Dispatch = Masc.Keeper_tool_dispatch_runtime
 module Boundary = Masc.Keeper_tools_oas_failure_boundary
 module Response_text = Masc.Keeper_agent_run_response_text
 module State = Masc.Keeper_memory_policy
+module Receipt = Masc.Keeper_execution_receipt
 module U = Yojson.Safe.Util
 (* Tool_result lives in the leaf [masc_tool_types] lib (wrapped false), so
    it is referenced bare — not under [Masc.] — matching existing tests. *)
@@ -137,6 +138,7 @@ let test_state_block_reply_returns_state_snapshot () =
       ~keeper_name:"keeper-task-create-test"
       ~goal:"Keep runtime visible"
       ~actual_keeper_tool_names:[]
+      ~completion_contract_result:Receipt.Contract_satisfied_completion
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text
       ()


### PR DESCRIPTION
## Summary
- Suppress keeper-visible response text when the typed completion contract requires attention.
- Keep receipt evidence (`response_text_present`, `completion_contract_result`) while preventing raw passive-only text from entering chat/history/checkpoints.
- Add regression coverage for `Contract_passive_only` finalizer suppression.

## Evidence
- Live Albini after restart on `17996e7de60`: turn 79 ended `passive_only`, `pause_human`, `completion_contract_unsatisfied`, but still surfaced repeated chat text.
- The fix uses `Keeper_execution_receipt.completion_contract_result_requires_attention`, not string matching.

## Tests
- `scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe test/test_keeper_validation_breaker_exempt.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_validation_breaker_exempt.exe`
- `git diff --check`
