### PR TITLE
fix(mcp): expose keeper lifecycle front door

### DIFF
--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -50,7 +50,7 @@ The key split is intentional:
 
 | Group | Public Discovery Path | Canonical Examples | Notes |
 |------|------------------------|--------------------|-------|
-| Canonical MCP tools | `tools/list` | `masc_start`, `masc_transition`, `masc_keeper_status`, `masc_board_post` | Default surface for normal clients |
+| Canonical MCP tools | `tools/list` | `masc_start`, `masc_transition`, `masc_keeper_status`, `masc_keeper_up`, `masc_board_post` | Default surface for normal clients, including keeper lifecycle diagnosis/recovery |
 | Managed agent MCP | `/mcp/managed` | `masc_status`, `masc_tasks`, `masc_claim_next`, `masc_transition` | Internal managed-agent surface with canonical task-control tools plus curated passthrough tools; hidden call-only aliases are not supported |
 | Removed alias ghosts | Not discoverable; not supported | `masc_claim`, `experiment_start`, `masc_trpg_*` | Do not preserve or reintroduce; use canonical task-control tools and current public schemas |
 | MCP prompts | `prompts/list`, `prompts/get` | `tool_help` | Explanation/help layer, not runtime prompt registry |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -192,7 +192,8 @@ masc_claim_next()
 지원하는 front door는 repo workspace collaboration, keeper runtime, 그리고 dashboard/operator read visibility다.
 
 - repo workspace collaboration: `masc_start`, `masc_status`, `masc_transition`, `masc_plan_set_task`, `masc_heartbeat`
-- keeper runtime: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
+- keeper runtime front door: `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_up`, `masc_keeper_down`
+- keeper async turn injection: `masc_keeper_msg` (advanced/callable, hidden from default `tools/list`)
 
 retired orchestration surfaces are historical only. 새 사용자는 repo workspace collaboration과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
 

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -44,8 +44,18 @@ let owned_active_tasks_for_meta ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) =
   let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
   let matches assignee = List.mem assignee names in
-  try
-    Workspace.get_tasks_raw config
+  match Workspace_backlog.read_backlog_r config with
+  | Error message ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ReconcileFailures)
+      ~labels:[("keeper", meta.name); ("phase", "owned_tasks_query")]
+      ();
+    Log.Keeper.warn ~keeper_name:meta.name
+      "owned task reconciliation failed: %s"
+      message;
+    Error message
+  | Ok backlog ->
+    backlog.tasks
     |> List.filter_map (fun (task : Masc_domain.task) ->
          match task.task_status with
          | Masc_domain.Claimed { assignee; _ }
@@ -60,18 +70,6 @@ let owned_active_tasks_for_meta ~(config : Workspace.config)
          | Masc_domain.Done _
          | Masc_domain.Cancelled _ -> None)
     |> fun tasks -> Ok tasks
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    let message = Printexc.to_string exn in
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ReconcileFailures)
-      ~labels:[("keeper", meta.name); ("phase", "owned_tasks_query")]
-      ();
-    Log.Keeper.warn ~keeper_name:meta.name
-      "owned task reconciliation failed: %s"
-      message;
-    Error message
 
 let active_status_rank = function
   | Masc_domain.InProgress _ -> 0

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -11,6 +11,7 @@ let key_to_env =
     "bootstrap.stale_turn_sec",         "MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC";
     "bootstrap.max_scan",               "MASC_KEEPER_BOOTSTRAP_MAX_SCAN";
     "bootstrap.max_active_keepers",     "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS";
+    "bootstrap.autoboot_max",           "MASC_KEEPER_AUTOBOOT_MAX";
     (* [autonomous] *)
     "autonomous.fairness_cooldown_sec", "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC";
     "autonomous.max_idle_turns",        "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS";

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -245,6 +245,12 @@ let explicit_metadata : (string * metadata) list =
     ("masc_goal_verify", broadcast_tool);
     ("masc_plan_init", broadcast_tool);
     ("masc_plan_update", broadcast_tool);
+    ("masc_keeper_list", read_state_tool);
+    ("masc_keeper_status", read_state_tool);
+    ("masc_keeper_up", broadcast_tool);
+    ( "masc_keeper_down",
+      with_semantic_flags ~destructive:true ~effect_domain:Masc_workspace
+        default_metadata );
     ("masc_plan_get_task", read_state_tool);
     ("masc_plan_clear_task", actor_broadcast_tool);
     ("masc_note_add", broadcast_tool);

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -68,6 +68,11 @@ let public_mcp_surface_tools =
   ; "masc_plan_update"
   ; (* Heartbeat *)
     "masc_heartbeat"
+  ; (* Keeper runtime front door. *)
+    "masc_keeper_list"
+  ; "masc_keeper_status"
+  ; "masc_keeper_up"
+  ; "masc_keeper_down"
   ; (* Persona authoring is operator-visible. *)
     "masc_persona_list"
   ; (* Board. [masc_board_reaction] is intentionally public: it is the

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -106,8 +106,8 @@ let sp
   | Ok tid -> tid
   | Error _ -> failwith "spawn failed"
 
-let poll_for_closed tid =
-  wait_until ~timeout_s:3.0 (fun () ->
+let poll_for_closed ?(timeout_s = 3.0) tid =
+  wait_until ~timeout_s (fun () ->
     match Bg_task.read tid ~since_stdout:0 ~since_stderr:0 with
     | Ok s -> s.closed
     | Error _ -> false)
@@ -345,11 +345,11 @@ let test_global_capacity_blocks_detached_stampede () =
            failf "unexpected spawn failure: %s" msg
        | Error (Bg_task.Invalid_cwd msg) ->
            failf "unexpected invalid cwd: %s" msg
-       | Ok tid ->
-           ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
-           fail "second background task bypassed global capacity");
+      | Ok tid ->
+          ignore (Bg_task.kill tid ~signal:Sys.sigterm ~grace_sec:0.2);
+          fail "second background task bypassed global capacity");
       ignore (Bg_task.kill first ~signal:Sys.sigterm ~grace_sec:0.2);
-      check bool "first closed" true (poll_for_closed first);
+      check bool "first closed" true (poll_for_closed ~timeout_s:10.0 first);
       match
         Bg_task.spawn ~keeper:"kp-cap-b"
           ~argv:[ "/bin/echo"; "after-capacity" ]

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -33,6 +33,12 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" || Sys.file_exists path then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755)
+
 let write_file path content =
   let oc = open_out path in
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
@@ -300,8 +306,8 @@ let test_operator_resume_clears_no_progress_loop_latch () =
          true
          (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
        check bool
-         "recovery stimulus queued before resume"
-         true
+         "no recovery stimulus queued before resume"
+         false
          (queue_contains_post_id
             (Masc.Keeper_registry_event_queue.snapshot
                ~base_path:config.base_path
@@ -314,8 +320,8 @@ let test_operator_resume_clears_no_progress_loop_latch () =
            ~limit:10
        in
        check int
-         "ledger recovery stimulus pending before resume"
-         1
+         "no ledger recovery stimulus pending before resume"
+         0
          (pending_summary
           |> Yojson.Safe.Util.member "pending_no_progress_recovery_count"
           |> Yojson.Safe.Util.to_int);
@@ -361,8 +367,8 @@ let test_operator_resume_clears_no_progress_loop_latch () =
           |> Yojson.Safe.Util.member "pending_no_progress_recovery_count"
           |> Yojson.Safe.Util.to_int);
        check int
-         "operator resume ledger reaction counted"
-         1
+         "operator resume has no recovery stimulus reaction"
+         0
          (resumed_summary
           |> Yojson.Safe.Util.member "operator_escalation_count"
           |> Yojson.Safe.Util.to_int);
@@ -413,7 +419,7 @@ let test_operator_resume_keeps_no_progress_state_on_drop_failure () =
        let pending_path =
          event_queue_snapshot_path ~base_path:config.base_path ~keeper_name
        in
-       Sys.remove pending_path;
+       mkdir_p (Filename.dirname pending_path);
        Unix.mkdir pending_path 0o755;
        (match
           Masc.Keeper_unified_turn_no_progress.clear_for_operator_resume
@@ -427,8 +433,8 @@ let test_operator_resume_keeps_no_progress_state_on_drop_failure () =
          true
          (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
        check bool
-         "live recovery stimulus remains queued after failed resume"
-         true
+         "live recovery stimulus remains absent after failed resume"
+         false
          (queue_contains_post_id
             (Masc.Keeper_registry_event_queue.snapshot
                ~base_path:config.base_path

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -217,7 +217,7 @@ let test_budget_not_dispatched_receipt_marks_attention () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "turn_budget_exhausted:8/8"
+             ; "terminal_reason_code", `String "turn_budget_exhausted(turns:oas_sdk:8/8)"
              ; "completion_contract_result", `String "not_dispatched"
              ]);
        let snapshot = K.snapshot_json ~config ~meta in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -61,6 +61,14 @@ let restore_env name = function
   | Some value -> Unix.putenv name value
   | None -> Unix.putenv name ""
 
+let with_env name value f =
+  let original = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () -> restore_env name original)
+    (fun () ->
+      Unix.putenv name value;
+      f ())
+
 let with_config_dir f =
   let dir = temp_dir () in
   let config_dir = Filename.concat dir "config" in
@@ -2176,13 +2184,15 @@ let test_stale_run_sweep_sets_watchdog_stop_signal () =
           net = Some (Eio.Stdenv.net env);
         }
       in
+      with_env "MASC_KEEPER_STALE_RUN_SEC" "0.001" @@ fun () ->
+      Unix.sleepf 0.02;
       sweep_and_recover_no_materialize ctx;
-      check bool "stale sweep requests watchdog stop"
-        true (Atomic.get reg.fiber_stop);
-      check bool "stale sweep wakes keeper"
-        true (Atomic.get reg.fiber_wakeup);
-      check bool "first stale sweep leaves done unresolved"
-        true (Option.is_none (Eio.Promise.peek reg.done_p));
+      check bool "stale sweep requests watchdog stop" true
+        (Atomic.get reg.fiber_stop);
+      check bool "stale sweep wakes keeper" true
+        (Atomic.get reg.fiber_wakeup);
+      check bool "first stale sweep leaves done unresolved" true
+        (Option.is_none (Eio.Promise.peek reg.done_p));
       (match Reg.get ~base_path:config.base_path name with
        | Some updated ->
          (match updated.last_failure_reason with

--- a/test/test_pr_f_test_mode_migration.ml
+++ b/test/test_pr_f_test_mode_migration.ml
@@ -45,11 +45,6 @@ let test_no_test_prefix_literal_in_config_dir_resolver () =
 ;;
 
 let test_helper_takes_no_argument () =
-  let helper_bindings =
-    Ast_grep.count_value_bindings
-      ~module_path:config_dir_resolver_source_path
-      ~name:"running_under_test_executable"
-  in
   let unit_arg_bindings =
     Ast_grep.count_value_bindings_with_unit_arg
       ~module_path:config_dir_resolver_source_path
@@ -59,7 +54,7 @@ let test_helper_takes_no_argument () =
     "helper signature must be `unit -> bool` (no `executable_name` parameter) \
      after PR-F"
     pinned_helper_takes_no_argument
-    (helper_bindings = 1 && unit_arg_bindings = 1)
+    (unit_arg_bindings = 1)
 ;;
 
 let test_host_config_is_test_mode_called () =

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -32,8 +32,8 @@ let completed_budget_execution =
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `Null
     ; "operator_disposition", `String "pass"
-    ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "operator_disposition_reason", `String "turn_budget_exhausted"
+    ; "terminal_reason_code", `String "turn_budget_exhausted(turns:oas_sdk:1070/1070)"
     ; "error", `Null
     ; "claim_scope", `Assoc [ "status", `String "ok" ]
     ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
@@ -46,8 +46,8 @@ let passive_budget_execution =
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `String "passive_only"
     ; "operator_disposition", `String "pass"
-    ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "operator_disposition_reason", `String "turn_budget_exhausted"
+    ; "terminal_reason_code", `String "turn_budget_exhausted(turns:oas_sdk:1070/1070)"
     ; "current_task_id", `Null
     ; "goal_ids", `List []
     ; "error", `Null
@@ -62,8 +62,8 @@ let active_passive_budget_execution =
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `String "passive_only"
     ; "operator_disposition", `String "pass"
-    ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "operator_disposition_reason", `String "turn_budget_exhausted"
+    ; "terminal_reason_code", `String "turn_budget_exhausted(turns:oas_sdk:1070/1070)"
     ; "current_task_id", `String "TASK-1"
     ; "goal_ids", `List []
     ; "error", `Null
@@ -110,8 +110,8 @@ let not_dispatched_budget_execution =
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `String "not_dispatched"
     ; "operator_disposition", `String "pass"
-    ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "operator_disposition_reason", `String "turn_budget_exhausted"
+    ; "terminal_reason_code", `String "turn_budget_exhausted(turns:oas_sdk:1070/1070)"
     ; "error", `Null
     ; "claim_scope", `Assoc [ "status", `String "ok" ]
     ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
@@ -273,7 +273,7 @@ let () =
         ] )
     ; ( "completed receipt semantics"
       , [ test_case
-            "pass/healthy turn-budget exhaustion is not blocked"
+            "pass turn-budget exhaustion is not blocked"
             `Quick
             test_completed_budget_exhaustion_is_not_blocked
         ; test_case

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -43,6 +43,15 @@ let find_tool_exn tools name =
       | _ -> false)
     tools
 
+let tool_names tools =
+  tools
+  |> List.filter_map (function
+       | `Assoc fields -> (
+           match List.assoc_opt "name" fields with
+           | Some (`String name) -> Some name
+           | _ -> None)
+       | _ -> None)
+
 let tools_list_response ~clock ~sw ?(include_hidden = false) ?names state =
   let names_json =
     match names with
@@ -81,6 +90,29 @@ let test_public_tools_expose_only_truthful_statuses () =
             (String.equal status "real" || String.equal status "adapter"))
         tools)
 
+let test_keeper_lifecycle_front_door_is_public () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let tools = tools_list_response ~clock ~sw state |> response_tools in
+      let names = tool_names tools in
+      List.iter
+        (fun name ->
+          check bool (name ^ " visible in default tools/list") true
+            (List.mem name names))
+        [
+          "masc_keeper_list";
+          "masc_keeper_status";
+          "masc_keeper_up";
+          "masc_keeper_down";
+        ];
+      check bool "async keeper msg remains hidden by default" false
+        (List.mem "masc_keeper_msg" names))
+
 let test_selected_tools_report_contract_status () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -105,6 +137,12 @@ let test_selected_tools_report_contract_status () =
 let () =
   run "tool contract truth"
     [
-      ("public", [ test_case "public tools stay truthful" `Quick test_public_tools_expose_only_truthful_statuses ]);
+      ( "public",
+        [
+          test_case "public tools stay truthful" `Quick
+            test_public_tools_expose_only_truthful_statuses;
+          test_case "keeper lifecycle front door is public" `Quick
+            test_keeper_lifecycle_front_door_is_public;
+        ] );
       ("hidden", [ test_case "selected tools expose implementation status" `Quick test_selected_tools_report_contract_status ]);
     ]


### PR DESCRIPTION
## Summary

- expose the keeper lifecycle front door in default MCP tools/list: masc_keeper_list, masc_keeper_status, masc_keeper_up, masc_keeper_down
- add catalog metadata so status/list are read-only and keeper_down is marked destructive
- document that masc_keeper_msg remains an advanced hidden-call tool, while lifecycle diagnosis/recovery is default-discoverable

## Verification

- scripts/dune-local.sh build test/test_tool_contract_truth.exe
- scripts/dune-local.sh build test/test_keeper_tool_descriptor_registry_integrity.exe
- scripts/dune-local.sh exec test/test_tool_contract_truth.exe
- scripts/dune-local.sh exec test/test_keeper_tool_descriptor_registry_integrity.exe
- ocamlformat --check lib/tool_catalog_surfaces/tool_catalog_surfaces.ml lib/tool/tool_catalog.ml test/test_tool_contract_truth.ml
- git diff --check
