### PR TITLE
fix(keeper): stop event-queue persistence mutex poisoning on disk failure

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -11,10 +11,32 @@
 let eio_write_mu = Eio.Mutex.create ()
 let fallback_write_mu = Stdlib.Mutex.create ()
 
-let with_write_lock f =
-  match Eio_context.get_switch_opt () with
-  | Some _ -> Eio.Mutex.use_rw ~protect:true eio_write_mu f
-  | None -> Stdlib.Mutex.protect fallback_write_mu f
+(* [eio_write_mu] is process-global, so a poisoned mutex blocks durable
+   event-queue snapshots for EVERY keeper for the lifetime of the process
+   (audit 2026-06-29). [Eio.Mutex.use_rw] poisons the mutex permanently if the
+   critical section raises, so the failure must never cross the [use_rw]
+   boundary: a non-cancellation exception is captured inside the critical
+   section and re-raised — with its original backtrace — only after the lock is
+   released, leaving the mutex usable for the next keeper. [Eio.Cancel.Cancelled]
+   is re-raised in place so cancellation/shutdown is honoured and never swallowed
+   (CancelledNeverAbsorbed). The external contract is unchanged: [with_write_lock]
+   still returns [f ()] or re-raises its exception. *)
+let with_write_lock : type a. (unit -> a) -> a =
+ fun f ->
+  let guarded () =
+    match f () with
+    | v -> Ok v
+    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+    | exception exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  let outcome =
+    match Eio_context.get_switch_opt () with
+    | Some _ -> Eio.Mutex.use_rw ~protect:true eio_write_mu guarded
+    | None -> Stdlib.Mutex.protect fallback_write_mu guarded
+  in
+  match outcome with
+  | Ok v -> v
+  | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
 
 let valid_keeper_name name =
   let valid_char = function
@@ -23,12 +45,25 @@ let valid_keeper_name name =
   in
   (not (String.equal name "")) && String.for_all valid_char name
 
+(* [Fs_compat.mkdir_p] raises (Sys_error / Unix_error) on ENOSPC/EROFS/ENOTDIR
+   instead of returning a result, so route it through the same [(unit, string)
+   result] channel as [save_file_atomic]. This keeps [save_json_atomic] total:
+   it never raises for a disk failure, so the enclosing [with_write_lock]
+   critical section returns normally and the shared mutex is not poisoned.
+   [Eio.Cancel.Cancelled] is re-raised so cancellation is not flattened into a
+   string error. *)
 let save_json_atomic path json =
-  Fs_compat.mkdir_p (Filename.dirname path);
-  json
-  |> Safe_ops.sanitize_json_utf8
-  |> Yojson.Safe.pretty_to_string
-  |> Fs_compat.save_file_atomic path
+  match
+    (try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Printexc.to_string exn))
+  with
+  | Error _ as err -> err
+  | Ok () ->
+    json
+    |> Safe_ops.sanitize_json_utf8
+    |> Yojson.Safe.pretty_to_string
+    |> Fs_compat.save_file_atomic path
 
 let snapshot_path ~base_path ~keeper_name =
   if valid_keeper_name keeper_name

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,7 @@
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
+  test_keeper_event_queue_persist_poison
   test_keeper_relevance_check
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
@@ -652,6 +653,7 @@
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
+  test_keeper_event_queue_persist_poison
   test_keeper_relevance_check
   test_actionable_path_action
   test_workspace_routes_keeper

--- a/test/test_keeper_event_queue_persist_poison.ml
+++ b/test/test_keeper_event_queue_persist_poison.ml
@@ -1,0 +1,68 @@
+(** Regression: durable event-queue persistence must not poison its shared,
+    process-global Eio mutex on a disk write failure (audit 2026-06-29).
+
+    Before the fix, [save_json_atomic] called [Fs_compat.mkdir_p] — which raises
+    (Sys_error / Unix_error) on ENOTDIR/ENOSPC/EROFS — inside the
+    [Eio.Mutex.use_rw] critical section. [use_rw] poisons the mutex permanently
+    on a raised exception, so a single disk error blocked durable snapshots for
+    EVERY keeper for the lifetime of the process.
+
+    This test drives the Eio path (so [Eio_context.get_switch_opt] returns
+    [Some], selecting the poison-prone [eio_write_mu]) and asserts that a failed
+    persist leaves the mutex usable for a subsequent valid persist. On the
+    unfixed code the second persist's [with_write_lock] raises
+    [Eio.Mutex.Poisoned], [persist] swallows it, the snapshot file is never
+    written, and the [Sys.file_exists] assertion fails (RED). *)
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+
+let () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw @@ fun () ->
+  (* Exercise the Eio mutex (poison-prone path), not the Stdlib fallback. *)
+  assert (Eio_context.get_switch_opt () <> None);
+
+  let keeper_name = "poison_probe" in
+  let queue = Keeper_event_queue.empty in
+
+  (* 1) Force mkdir_p to raise inside the critical section: a base path whose
+        ancestor is a regular file yields ENOTDIR. [persist] logs the failure as
+        a warning and returns; pre-fix it ALSO poisoned the shared mutex. *)
+  let blocker_file = Filename.temp_file "kqp_poison_blocker" "" in
+  let bad_base = Filename.concat blocker_file "base" in
+  Keeper_event_queue_persistence.persist ~base_path:bad_base ~keeper_name queue;
+
+  (* 2) A valid persist on a real directory. If step 1 poisoned the mutex,
+        [with_write_lock] raises [Eio.Mutex.Poisoned], [persist] swallows it, and
+        the snapshot is never written -> the assertion below fails. *)
+  let good_base = Filename.temp_dir "kqp_poison_ok" "" in
+  Keeper_event_queue_persistence.persist ~base_path:good_base ~keeper_name queue;
+  let path = snapshot_path ~base_path:good_base ~keeper_name in
+  assert (Sys.file_exists path);
+
+  (* 3) The lock still serializes correctly after recovery: load round-trips the
+        persisted (empty) queue without raising. *)
+  let restored =
+    Keeper_event_queue_persistence.load ~base_path:good_base ~keeper_name
+  in
+  assert (Keeper_event_queue.is_empty restored);
+
+  rm_rf good_base;
+  (try Sys.remove blocker_file with _ -> ());
+  print_endline "test_keeper_event_queue_persist_poison: OK"


### PR DESCRIPTION
## What

`keeper_event_queue_persistence` serializes durable snapshot writes with a single process-global Eio mutex (`eio_write_mu`). `save_json_atomic` called `Fs_compat.mkdir_p`, which raises (`Sys_error`/`Unix_error`) on ENOSPC/EROFS/ENOTDIR, **inside** the `Eio.Mutex.use_rw` critical section. `use_rw` poisons the mutex permanently on a raised exception, so the first disk error blocked durable event-queue snapshots for **every** keeper for the process lifetime (`Eio.Mutex.Poisoned`). The outer `try/with` in `persist`/`persist_snapshot` logged the failure but ran after the mutex was already poisoned.

This is finding **OAS-EIO-03** from the 2026-06-29 keeper-runtime deep audit — the highest-blast-radius live defect (one disk failure disables persistence for the whole fleet).

## Root fix (two layers, no call-site patching)

1. `with_write_lock` captures any non-cancellation exception **inside** the critical section and re-raises it (backtrace preserved) only after the lock is released. The shared mutex can no longer be poisoned by a critical-section failure — structurally, for any current or future writer. `Eio.Cancel.Cancelled` is re-raised in place (CancelledNeverAbsorbed). The external contract is unchanged: `with_write_lock` still returns `f ()` or re-raises.
2. `save_json_atomic` routes `mkdir_p` through the existing `(unit, string) result` channel, removing the known raise vector at the source and producing a clean "failed to persist" warning.

## Test

`test_keeper_event_queue_persist_poison` drives the Eio path (`get_switch_opt = Some`, so the poison-prone `eio_write_mu` is selected), forces a `mkdir` ENOTDIR failure, then asserts a subsequent valid persist still writes its snapshot. Red on the unfixed code: the poisoned mutex makes the second `persist` swallow its write.

## Verification

- Local build intentionally not run; verified by CI per repo policy.
- Self-review (best-programmer): goal = remove the process-wide persistence outage triggered by the first disk error; changed files = `lib/keeper_runtime/keeper_event_queue_persistence.ml` (+ new test, `test/dune`); not-verified-locally = full `dune build` + `dune test` (delegated to CI).

## Scope / boundaries

- Not in an RFC-gated subsystem (credential / repo_manager / operator_control / keeper_sandbox / dashboard-credential / hooks / workflow). No RFC required.
- No `.mli` / external API change (`with_write_lock` and `save_json_atomic` are internal).
- `Eio.Mutex` poisoning semantics: https://ocaml-multicore.github.io/eio/eio/Eio/Mutex/index.html

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
