### PR TITLE
fix(keeper): resume keeps authoritative unpause when cosmetic no-progress clear fails (KLV-2)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -288,21 +288,31 @@ let set_keeper_paused_state ~agent_name paused =
       log_directive_agent_not_in_registry ~agent_name ~action)
     (fun entry ->
        let previous_failure_reason = entry.last_failure_reason in
-       let directive_source_meta_result =
-         if paused then Ok entry.meta else clear_no_progress_loop_for_operator_resume entry
+       (* On resume, dropping the no-progress recovery stimulus is a cosmetic
+          cleanup that must NOT gate the authoritative unpause. A disk failure in
+          [clear_no_progress_loop_for_operator_resume] used to short-circuit the
+          resume and leave the keeper paused forever: no_progress pause is
+          [Manual_resume_required], so there is no other recovery path. Run it
+          best-effort and always fall through to the paused-state write below;
+          the authoritative [persist_directive_meta_update] stays fail-closed.
+          KLV-2 / RFC-0152. *)
+       let directive_source_meta =
+         if paused then entry.meta
+         else (
+           match clear_no_progress_loop_for_operator_resume entry with
+           | Ok cleared_meta -> cleared_meta
+           | Error err ->
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string DirectiveFailures)
+               ~labels:[ "keeper", entry.name; "site", "no_progress_resume_clear" ]
+               ();
+             Log.Keeper.warn
+               "directive resume: best-effort no_progress clear failed for %s; \
+                proceeding with unpause: %s"
+               entry.name
+               err;
+             entry.meta)
        in
-       match directive_source_meta_result with
-       | Error err ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string DirectiveFailures)
-           ~labels:
-             [ "keeper", entry.name; "site", "no_progress_resume_clear" ]
-           ();
-         Log.Keeper.error
-           "directive resume: no_progress clear failed for %s: %s"
-           entry.name
-           err
-       | Ok directive_source_meta ->
        let cleared_completion_contract =
          if paused then directive_source_meta
        else

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -193,6 +193,53 @@ let test_no_progress_clear_failure_observable () =
   check bool "directive no-progress clear failure is observable" true
     (count_occurrences ~needle:"no_progress_resume_clear" src >= 2)
 
+let test_klv2_directive_resume_no_progress_clear_best_effort () =
+  (* KLV-2 / RFC-0152: on operator resume, dropping the no-progress recovery
+     stimulus is a cosmetic cleanup. A transient disk failure there must NOT
+     gate the authoritative unpause. Previously the [Error] arm logged at
+     [error] level and short-circuited the whole [set_keeper_paused_state]
+     body, so the keeper never reached [persist_directive_meta_update] and
+     stayed paused forever (no_progress pause is [Manual_resume_required] — no
+     other recovery path exists). After the fix the clear result is bound into
+     [directive_source_meta] best-effort and execution always falls through to
+     the authoritative persist, which stays fail-closed.
+
+     Structural guard: the existing rationale for source-pattern over
+     integration applies (injecting a clear failure needs the full server +
+     event-queue harness). Non-vacuous — reverting the fix restores the
+     [..._result] binding name and the [error]-level short-circuit log, so both
+     the [let directive_source_meta =] and ["proceeding with unpause"] markers
+     disappear and these checks turn red. *)
+  let src = load_source "lib/keeper/keeper_keepalive.ml" in
+  check bool "resume no-progress clear is bound best-effort (not a gate)" true
+    (count_occurrences ~needle:"let directive_source_meta =" src >= 1);
+  check bool "resume clear failure proceeds with unpause (no short-circuit)"
+    true
+    (count_occurrences ~needle:"proceeding with unpause" src >= 1);
+  check int "fail-closed short-circuit error log on clear removed" 0
+    (count_occurrences
+       ~needle:"directive resume: no_progress clear failed for"
+       src);
+  check bool "authoritative unpause persist is still reached" true
+    (count_occurrences
+       ~needle:"persist_directive_meta_update entry ~updated_meta"
+       src
+     >= 1);
+  (* The cosmetic clear site is handled strictly before the authoritative
+     persist site, proving the two carry distinct failure policies. *)
+  (match
+     ( first_index ~needle:"no_progress_resume_clear" src,
+       first_index ~needle:"pause_resume_persist" src )
+   with
+   | Some clear_pos, Some persist_pos ->
+       check bool "best-effort clear site precedes fail-closed persist site"
+         true (clear_pos < persist_pos)
+   | _ -> Alcotest.failf "missing KLV-2 site markers in keeper_keepalive.ml");
+  (* Fail-closed preserved: the authoritative persist still rolls the registry
+     failure reason back on [Error] rather than swallowing it. *)
+  check bool "authoritative persist stays fail-closed (rolls back reason)" true
+    (count_occurrences ~needle:"previous_failure_reason" src >= 1)
+
 let test_counter_inc_calls () =
   let src = target_source () in
   (* The metric must actually be incremented at least 6 times: 2 in
@@ -332,6 +379,8 @@ let () =
             test_write_error_branch_observable
         ; test_case "no-progress clear failure observable" `Quick
             test_no_progress_clear_failure_observable
+        ; test_case "KLV-2 directive resume no-progress clear best-effort"
+            `Quick test_klv2_directive_resume_no_progress_clear_best_effort
         ; test_case "counter inc calls present" `Quick
             test_counter_inc_calls
         ; test_case "resume paths clear no-progress latch" `Quick


### PR DESCRIPTION
## 목적 (KLV-2)

operator resume가 **cosmetic cleanup 실패에 fail-closed**되어 keeper가 영구 paused 상태로 갇히는 버그를 수정합니다.

## 근본 원인

`set_keeper_paused_state`(`lib/keeper/keeper_keepalive.ml`)는 resume 시 no-progress recovery stimulus(disk op)를 **먼저** drop한 뒤 권위적 unpause를 기록합니다. 그 clear가 fail-closed였습니다:

```
| Error err -> Log.Keeper.error "... no_progress clear failed"; (* directive body 전체 short-circuit *)
```

→ `persist_directive_meta_update`에 도달하지 못해 keeper가 unpause되지 않음. no-progress pause는 `Manual_resume_required`라 다른 복구 경로가 없습니다. 즉 **저가치 cleanup의 일시적 disk 오류가 keeper를 영구 정지**시킵니다.

## 수정

clear 결과를 `directive_source_meta`에 **best-effort**로 바인딩:

- `Error` → 기존 `DirectiveFailures` counter(`site=no_progress_resume_clear`) + warn 로그 → `entry.meta`로 fall-through → 권위적 persist 항상 도달.
- 권위적 `persist_directive_meta_update`는 **fail-closed 유지**(Error 시 registry failure reason rollback).

best-effort 진행이 flapping을 유발하지 않음: stale stimulus가 남아도 그건 "recovery nudge"지 "pause"가 아니므로, 최악의 경우 1회 중복 nudge일 뿐 — "영구 paused"보다 엄격히 낫습니다.

## 경계: 증상 fix vs 구조 fix

이건 KLV-1 liveness fragmentation(**RFC-0297**, PR #22620)의 한 증상에 대한 tactical fix입니다. 근본은 resume가 N개 저장소에 N번 write해야 하는 구조 — 첫 cosmetic write가 마지막 authoritative write를 막을 수 있음. RFC-0297이 단일 closed-sum 타입으로 이를 구조적으로 제거합니다. RFC-0152가 auto-resume/pause 경로를 관장합니다.

## 테스트

`test_keeper_pause_silent_failure_source.ml`(issue #8391 구조 가드)에 KLV-2 케이스 추가. **non-vacuous**: fix를 revert하면 `..._result` 바인딩과 error-level short-circuit 로그가 복원되어 `let directive_source_meta =` / `proceeding with unpause` 마커가 사라지고 RED가 됩니다. best-effort 사이트가 fail-closed persist 사이트보다 앞서 등장하는 순서도 검사해 두 사이트의 정책 분리를 못박습니다.

## 범위 외 (보호 대상)

- 권위적 `persist_directive_meta_update` fail-closed 정책 — 그대로 유지.
- pause 경로(`if paused then entry.meta`) — 변경 없음.

RFC-WAIVED: keeper_keepalive.ml is not in the gated subsystem list (credential/gh/host_config/sandbox/shell/repo_manager/operator_control/dashboard-credential/hooks/workflow); cites governing RFC-0152 and structural RFC-0297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
