### PR TITLE
fix(config): malformed env values are loud (warn + opt-in strict), consolidate otel bool parser

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -42,7 +42,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 499 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 500 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 443 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 515 | Whether to log parse warnings. Default: false. |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 563 | Whether malformed env parses fail fast. Default: false. |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 448 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 539 | PubSub max messages per read. Default: 1000. |
 | `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 470 | Whether relay token calibration is enabled. Default: true. |

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -29,6 +29,36 @@ let raw_value_opt name =
     | Some _ as value -> value
     | None -> Config_boot_overrides.get_opt name
 
+(* [MASC_PARSE_WARN] governs strict mode below. Defined here (rather than with
+   the other env-key constants further down) so the malformed handler can see
+   it. *)
+let parse_warn_env_key = "MASC_PARSE_WARN"
+
+(* Strict mode: when [MASC_PARSE_WARN] is truthy a malformed env value becomes a
+   hard [Config_error] (fail-fast boot) instead of warn + default. Read with a
+   primitive truthy check rather than [get_bool] so a malformed value for this
+   very key cannot recurse back into [reject_malformed_env]. *)
+let parse_strict_mode () =
+  match raw_value_opt parse_warn_env_key with
+  | Some v ->
+    (match String.trim v |> String.lowercase_ascii with
+     | "true" | "1" | "yes" | "on" -> true
+     | _ -> false)
+  | None -> false
+
+(* A non-empty env value that does not parse to the expected type is an operator
+   misconfiguration, not a silent fallback. Loud by default: warn and use
+   [default]. [MASC_PARSE_WARN] escalates to [Config_error] for fail-fast boot.
+   The empty string is handled by each caller as "unset" (silent default) — an
+   empty env var is a common intentional no-op. *)
+let reject_malformed_env ~name ~raw ~type_name =
+  Log.Misc.warn "malformed env %s=%S (expected %s); using default" name raw
+    type_name;
+  if parse_strict_mode () then
+    raise
+      (Config_error
+         (Printf.sprintf "malformed env %s=%S (expected %s)" name raw type_name))
+
 (** Safe getters with defaults *)
 let get_string ~default name =
   match raw_value_opt name with
@@ -37,13 +67,27 @@ let get_string ~default name =
 
 let get_int ~default name =
   match raw_value_opt name with
-  | Some v -> Safe_ops.int_of_string_with_default ~default v
   | None -> default
+  | Some v ->
+    if String.trim v = "" then default
+    else (
+      match Safe_ops.int_of_string_safe v with
+      | Some n -> n
+      | None ->
+        reject_malformed_env ~name ~raw:v ~type_name:"int";
+        default)
 
 let get_float ~default name =
   match raw_value_opt name with
-  | Some v -> Safe_ops.float_of_string_with_default ~default v
   | None -> default
+  | Some v ->
+    if String.trim v = "" then default
+    else (
+      match Safe_ops.float_of_string_safe v with
+      | Some f -> f
+      | None ->
+        reject_malformed_env ~name ~raw:v ~type_name:"float";
+        default)
 
 (** Variants that floor at zero.  An operator who sets a negative
     value (e.g. [MASC_KEEPER_ALERT_MAX_RETRIES=-5]) gets the default
@@ -97,13 +141,15 @@ let get_ratio ~default name =
 
 let get_bool ~default name =
   match raw_value_opt name with
+  | None -> default
   | Some v ->
       (match String.trim v |> String.lowercase_ascii with
        | "true" | "1" | "yes" | "on" -> true
        | "false" | "0" | "no" | "off" -> false
        | "" -> default
-       | _ -> default)
-  | None -> default
+       | _ ->
+           reject_malformed_env ~name ~raw:v ~type_name:"bool";
+           default)
 
 let trim_opt = function
   | Some raw ->
@@ -499,7 +545,8 @@ let git_fetch_timeout_sec () =
 let log_level_env_key = "MASC_LOG_LEVEL"
 let log_routine_level_env_key = "MASC_LOG_ROUTINE_LEVEL"
 let telemetry_enabled_env_key = "MASC_TELEMETRY_ENABLED"
-let parse_warn_env_key = "MASC_PARSE_WARN"
+(* [parse_warn_env_key] is defined near the top of this module (next to the
+   malformed handler that consumes it). *)
 let governance_level_env_key = "MASC_GOVERNANCE_LEVEL"
 
 (** Log level string (e.g. "debug", "info", "warn", "error"). *)
@@ -510,9 +557,10 @@ let log_level_opt () =
 let telemetry_enabled () =
   get_bool ~default:true telemetry_enabled_env_key
 
-(** Whether to log parse warnings. Default: false. *)
-let parse_warn_enabled () =
-  get_bool ~default:false parse_warn_env_key
+(** Whether malformed env parses are escalated to a hard [Config_error]
+    (fail-fast boot) instead of a warn + default. Controlled by
+    [MASC_PARSE_WARN]. Default: false (warn + use default). *)
+let parse_warn_enabled () = parse_strict_mode ()
 
 (** Governance level. Set at runtime by server_runtime_bootstrap.
     Valid: "production", "development", etc. Default: "production". *)

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -197,10 +197,17 @@ val git_fetch_timeout_sec : unit -> float
 val log_level_env_key : string
 val log_routine_level_env_key : string
 val telemetry_enabled_env_key : string
+
+(** [MASC_PARSE_WARN]. Malformed env values always warn; this flag escalates
+    them to a hard {!Config_error} (fail-fast boot). *)
 val parse_warn_env_key : string
+
 val governance_level_env_key : string
 val log_level_opt : unit -> string option
 val telemetry_enabled : unit -> bool
+
+(** Whether malformed env parses are escalated to {!Config_error} (fail-fast)
+    instead of warn + default. Controlled by [MASC_PARSE_WARN]. Default: false. *)
 val parse_warn_enabled : unit -> bool
 val governance_level : unit -> string
 val disable_hitl_env_key : string

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -42,7 +42,8 @@ let runtime_entries =
     entry ~default:"(auto)" Env_config_core.log_level_env_key "Log level override";
     entry ~default:"debug" Env_config_core.log_routine_level_env_key
       "Routine telemetry log level override (debug|info|warn|error|off)";
-    entry ~default:"false" Env_config_core.parse_warn_env_key "Enable JSON parse warnings";
+    entry ~default:"false" Env_config_core.parse_warn_env_key
+      "Escalate malformed env parses to Config_error";
     entry ~default:"production" Env_config_core.governance_level_env_key
       "Governance enforcement level";
     entry ~default:"(none)" "MASC_SLOT_YIELD_ENABLED"
@@ -800,7 +801,7 @@ let telemetry_entries =
     entry ~default:"debug" Env_config_core.log_routine_level_env_key
       "Routine telemetry level (debug|info|warn|error|off)";
     entry ~default:"false" Env_config_core.parse_warn_env_key
-      "Whether to log parse warnings";
+      "Whether malformed env parses fail fast";
     entry ~default:"(none)" "MASC_OTEL_ENABLED"
       "Enable OpenTelemetry span collection";
   ]

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -70,7 +70,7 @@ let all_flags : flag list = [
     lifecycle = Active; since = "2.90.0" };
 
   { env_name = Env_config_core.parse_warn_env_key;
-    description = "Log JSON parse warnings";
+    description = "Escalate malformed env parses to Config_error";
     default = false; category = "tool";
     lifecycle = Active; since = "2.60.0" };
 

--- a/lib/otel_spans/otel_config.ml
+++ b/lib/otel_spans/otel_config.ml
@@ -7,10 +7,11 @@
     resolution racing with Docker's IPv4-only port binding during startup.
     Override via [OTEL_EXPORTER_OTLP_ENDPOINT] if needed. *)
 
-let enabled =
-  match Sys.getenv_opt "MASC_OTEL_ENABLED" with
-  | Some "false" | Some "0" -> false
-  | _ -> true
+(* Delegates to the shared env parser instead of an ad-hoc match so
+   [MASC_OTEL_ENABLED] follows the same truthy/falsy vocabulary as every other
+   MASC bool flag (case-insensitive true/1/yes/on vs false/0/no/off) and a
+   malformed value warns rather than silently enabling. *)
+let enabled = Env_config_core.get_bool ~default:true "MASC_OTEL_ENABLED"
 
 let endpoint =
   let raw =

--- a/test/test_env_config_nonneg.ml
+++ b/test/test_env_config_nonneg.ml
@@ -129,6 +129,61 @@ let test_gc_space_overhead_garbage_uses_default () =
   check_int "MASC_GC_SPACE_OVERHEAD garbage -> default 100" 100
     (C.get_int_nonneg ~default:100 "MASC_GC_SPACE_OVERHEAD")
 
+(* ── loud malformed handling (warn by default, strict raises) ──────────
+   A non-empty env value that does not parse is an operator misconfiguration,
+   not a silent fallback. By default the helpers warn and use [default];
+   [MASC_PARSE_WARN] escalates to [Config_error] (fail-fast boot). An empty
+   value stays "unset" (silent default). *)
+
+let raises_config_error f =
+  try
+    ignore (f ());
+    false
+  with C.Config_error _ -> true
+
+let test_get_bool_malformed_uses_default () =
+  with_env "MASC_TEST_PARSE_BOOL_BAD" "flase" @@ fun () ->
+  Alcotest.(check bool) "malformed bool → default true" true
+    (C.get_bool ~default:true "MASC_TEST_PARSE_BOOL_BAD");
+  Alcotest.(check bool) "malformed bool → default false" false
+    (C.get_bool ~default:false "MASC_TEST_PARSE_BOOL_BAD")
+
+let test_get_bool_case_insensitive_synonyms () =
+  with_env "MASC_TEST_PARSE_BOOL_ON" "ON" @@ fun () ->
+  Alcotest.(check bool) "ON → true" true
+    (C.get_bool ~default:false "MASC_TEST_PARSE_BOOL_ON");
+  with_env "MASC_TEST_PARSE_BOOL_OFF" "Off" @@ fun () ->
+  Alcotest.(check bool) "Off → false" false
+    (C.get_bool ~default:true "MASC_TEST_PARSE_BOOL_OFF")
+
+let test_empty_value_is_unset_default () =
+  with_env "MASC_TEST_PARSE_EMPTY_INT" "" @@ fun () ->
+  check_int "empty int → default (silent)" 5
+    (C.get_int ~default:5 "MASC_TEST_PARSE_EMPTY_INT");
+  with_env "MASC_TEST_PARSE_EMPTY_BOOL" "" @@ fun () ->
+  Alcotest.(check bool) "empty bool → default (silent)" true
+    (C.get_bool ~default:true "MASC_TEST_PARSE_EMPTY_BOOL")
+
+(* Non-vacuous: on the pre-fix code [get_int]/[get_bool] silently return the
+   default on a malformed value, so [raises_config_error] would be [false] and
+   these turn red. Strict mode is the behavioral change under test. *)
+let test_strict_mode_raises_on_malformed () =
+  with_env "MASC_PARSE_WARN" "1" @@ fun () ->
+  ( with_env "MASC_TEST_PARSE_STRICT_INT" "notanint" @@ fun () ->
+    Alcotest.(check bool) "strict + malformed int raises Config_error" true
+      (raises_config_error (fun () ->
+           C.get_int ~default:0 "MASC_TEST_PARSE_STRICT_INT")) );
+  with_env "MASC_TEST_PARSE_STRICT_BOOL" "definitely-not-bool" @@ fun () ->
+  Alcotest.(check bool) "strict + malformed bool raises Config_error" true
+    (raises_config_error (fun () ->
+         C.get_bool ~default:true "MASC_TEST_PARSE_STRICT_BOOL"))
+
+let test_non_strict_malformed_does_not_raise () =
+  with_env "MASC_PARSE_WARN" "0" @@ fun () ->
+  with_env "MASC_TEST_PARSE_NONSTRICT_INT" "notanint" @@ fun () ->
+  check_int "non-strict malformed int → default, no raise" 9
+    (C.get_int ~default:9 "MASC_TEST_PARSE_NONSTRICT_INT")
+
 (* ── runner ───────────────────────────────────────────────────────── *)
 
 let () =
@@ -172,5 +227,18 @@ let () =
             `Quick test_snapshot_interval_garbage_uses_default;
           Alcotest.test_case "MASC_GC_SPACE_OVERHEAD garbage → default"
             `Quick test_gc_space_overhead_garbage_uses_default;
+        ] );
+      ( "loud_malformed_handling",
+        [
+          Alcotest.test_case "malformed bool → default" `Quick
+            test_get_bool_malformed_uses_default;
+          Alcotest.test_case "bool case-insensitive synonyms" `Quick
+            test_get_bool_case_insensitive_synonyms;
+          Alcotest.test_case "empty value → default (silent)" `Quick
+            test_empty_value_is_unset_default;
+          Alcotest.test_case "strict mode raises on malformed" `Quick
+            test_strict_mode_raises_on_malformed;
+          Alcotest.test_case "non-strict malformed does not raise" `Quick
+            test_non_strict_malformed_does_not_raise;
         ] );
     ]


### PR DESCRIPTION
## 목적 (ENV-3)

`Env_config_core`의 env 파서 패밀리가 malformed 값을 **조용히 default로 삼키는** silent failure를 SSOT에서 닫고, otel_config의 4번째 ad-hoc bool 파서를 통합합니다.

## 근본 원인

- `get_bool`(`_ -> default`), `get_int`/`get_float`(silent `Safe_ops.*_with_default` 경유) 모두 malformed → silent default. `MASC_DISABLE_HITL=ture`, `MASC_GC_SPACE_OVERHEAD=abc` 같은 오타가 무신호로 사라집니다.
- 의도됐던 경고 메커니즘 `MASC_PARSE_WARN` / `parse_warn_enabled`(둘 다 **public** .mli)은 **dead code** — 어디서도 소비되지 않음.
- `otel_config.ml`은 `Some "false" | "0" -> false | _ -> true`로 **bool 파싱을 재구현**(4번째 ad-hoc 파서).

## 수정

| 변경 | 내용 |
|------|------|
| **loud by default** | non-empty malformed → `Log.Misc.warn` + default. 빈 문자열은 "unset"(silent default) 유지 — 빈 env는 흔한 의도적 no-op. |
| **MASC_PARSE_WARN repurpose** | dead flag → strict gate. truthy면 malformed가 `Config_error` raise(fail-fast boot). `get_bool` 우회 primitive read로 **자기참조 재귀 차단**. |
| **otel 통합** | `otel_config.enabled` → `Env_config_core.get_bool ~default:true`. case-insensitive 동의어(no/off/FALSE) + 동일 malformed 처리 획득. |

## 경계/안티패턴 self-check

- **N-of-M 회피**: bool/int/float 세 getter를 **동시에** 수정(한 사이트만 고치는 "K of M" 시그니처 회피).
- **telemetry-as-fix 아님**: malformed에 sensible default는 12-factor 의도된 동작이고 유일 결함은 *침묵*. warn은 그 침묵을 고치고 strict는 hard-fail 경로 제공 → CLAUDE.md 안티패턴 #2 "unknown→Error/None" 부합.
- **완전 typed 대안 명시**: getter가 Result를 반환해 모든 caller가 malformed를 명시 처리하는 방식은 40-callsite 변경이라 **별도 작업으로 deferred**.

## 테스트

`test_env_config_nonneg.ml`(이미 등록) 확장: malformed bool→default, case-insensitive 동의어, empty-is-unset, **strict-mode raise**. strict 케이스는 **non-vacuous** — 구 코드는 silent default 반환·raise 안 함 → 이 변경 없이는 RED.

## Follow-up (별도)

`Safe_ops.get_env_int_logged`는 `Sys.getenv_opt`를 직접 읽어 `Env_config_core.raw_value_opt`(Unix.getenv + Config_boot_overrides)를 우회하는 **두 번째 env-resolution 경로** — SSOT 중복으로 reconcile 필요.

## 범위

- masc.config는 otel_spans 의존성에 이미 포함 → 경계위반/순환 없음(masc_config→masc_log 기존 의존).
- 기본 모드(MASC_PARSE_WARN unset): 반환 *값* 변화 없음, warn 로그만 추가 → caller 안전.

RFC-WAIVED: lib/config (env parsing) is not in the gated subsystem list (credential/gh/host_config/sandbox/shell/repo_manager/operator_control/dashboard-credential/hooks/workflow). No architectural change; additive observability + opt-in strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
