### PR TITLE
fix(keeper): demote TOML-only overlay log to debug

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -376,7 +376,7 @@ let emit_keeper_meta_overlay_drift ~keeper_name categories =
   match categories with
   | [] -> ()
   | cats ->
-    Log.Keeper.info
+    Log.Keeper.debug
       "ensure_keeper_meta: overlaying TOML-only [%s] for %s without writing \
        runtime meta JSON"
       (String.concat "," cats)


### PR DESCRIPTION
Fixes operator noise where expected TOML-only metadata overlays logged as INFO on every reconcile.