### PR TITLE
fix(keeper): classify empty runtime replies as non-visible

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -220,6 +220,25 @@ describe('fetchQueuedKeeperMessageResult', () => {
       'Continuation checkpoint saved; keeper remains scheduled for the next cycle.',
     )
   })
+
+  it('suppresses queued no-visible replies as non-visible replies', () => {
+    const result = {
+      requestId: 'kmsg_sangsu_4',
+      keeperName: 'sangsu',
+      status: 'done' as const,
+      ok: true,
+      result: {
+        reply: '',
+        turn_outcome: 'no_visible_reply',
+      },
+    }
+
+    const reply = queuedKeeperMessageToReply(result)
+
+    expect(reply.text).toBe('')
+    expect(reply.details?.turnOutcome).toBe('no_visible_reply')
+    expect(reply.details?.replyText).toBeNull()
+  })
 })
 
 describe('streamKeeperMessage', () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -3,6 +3,7 @@
 import { asString, isRecord } from '../components/common/normalize'
 import {
   formatKeeperVisibleReply,
+  keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
 } from '../keeper-message'
 import type { KeeperConversationDetails, KeeperUserInputBlock } from '../types'
@@ -362,7 +363,7 @@ export function queuedKeeperMessageToReply(result: QueuedKeeperMessageResult): K
   const payload = isRecord(result.result) ? result.result : null
   const rawReply = asString(payload?.reply, '').trim()
   const details = normalizeKeeperConversationDetails(payload ?? result.result)
-  if (result.status === 'done' && details?.turnOutcome === 'continuation_checkpoint') {
+  if (result.status === 'done' && keeperTurnOutcomeSuppressesReply(details?.turnOutcome)) {
     return {
       text: '',
       details,

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -196,6 +196,8 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
       return 'timeout'
     case 'cancelled':
       return 'cancelled'
+    case 'no_reply':
+      return 'no reply'
     case 'error':
       return 'error'
     case 'interrupted':
@@ -1910,6 +1912,15 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   showSourceBadge?: boolean
   action?: ChatTranscriptAction
 }) {
+  if (
+    entry.delivery === 'no_reply'
+    && !entry.text.trim()
+    && !entry.blocks?.length
+    && !entry.attachments?.length
+  ) {
+    return null
+  }
+
   const [expandedRaw, setExpandedRaw] = useState(false)
   const [rawExpandedRaw, setRawExpandedRaw] = useState(false)
   const [messageCollapsed, setMessageCollapsed] = useState(true)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -17,6 +17,7 @@ import {
   recordToolCallOutputs,
 } from './tool-call-output-store'
 import { asString, isRecord } from './components/common/normalize'
+import { keeperTurnOutcomeSuppressesReply } from './keeper-message'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import { isAbortError } from './lib/async-state'
 import type {
@@ -513,6 +514,8 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
 
       const reply = queuedKeeperMessageToReply(result)
       const isCheckpoint = reply.details?.turnOutcome === 'continuation_checkpoint'
+      const isNoVisibleReply = reply.details?.turnOutcome === 'no_visible_reply'
+      const suppressReply = keeperTurnOutcomeSuppressesReply(reply.details?.turnOutcome)
       const isCancelled = result.status === 'cancelled'
       const isError = !isCancelled && (result.status !== 'done' || result.ok === false)
       const errorMessage = isError ? queuedKeeperMessageError(result) : null
@@ -527,6 +530,8 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         assistantDelivery = 'cancelled'
       } else if (isCheckpoint) {
         assistantDelivery = 'queued'
+      } else if (isNoVisibleReply) {
+        assistantDelivery = 'no_reply'
       } else if (isError) {
         assistantDelivery = 'error'
       }
@@ -535,7 +540,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
       })
       finalizeAssistantEntry(request.keeperName, assistantId, {
-        text: isCheckpoint ? '' : reply.text,
+        text: suppressReply ? '' : reply.text,
         rawText: reply.details?.replyText ?? reply.text,
         delivery: assistantDelivery,
         streamState: null,

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -51,9 +51,17 @@ function normalizeKeeperTurnOutcome(value: unknown): KeeperTurnOutcome | null {
       return 'visible_reply'
     case 'continuation_checkpoint':
       return 'continuation_checkpoint'
+    case 'no_visible_reply':
+      return 'no_visible_reply'
     default:
       return null
   }
+}
+
+export function keeperTurnOutcomeSuppressesReply(
+  outcome: KeeperTurnOutcome | null | undefined,
+): boolean {
+  return outcome === 'continuation_checkpoint' || outcome === 'no_visible_reply'
 }
 
 export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversationDetails | null {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -231,6 +231,24 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.delivery).toBe('queued')
   })
 
+  it('suppresses a declared no-visible reply without marking it queued', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        reply: 'hidden runtime-only observation',
+        turn_outcome: 'no_visible_reply',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('')
+    expect(entry?.rawText).toBe('hidden runtime-only observation')
+    expect(entry?.delivery).toBe('no_reply')
+    expect(entry?.streamState).toBeNull()
+  })
+
   it('extracts error messages from events', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'RUN_ERROR',

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -1,4 +1,8 @@
-import { normalizeKeeperConversationDetails, formatKeeperVisibleReply } from './keeper-message'
+import {
+  formatKeeperVisibleReply,
+  keeperTurnOutcomeSuppressesReply,
+  normalizeKeeperConversationDetails,
+} from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
 import type { KeeperChatStreamEvent } from './api'
 import {
@@ -223,13 +227,13 @@ export function applyKeeperStreamEvent(
         if (details) {
           updateThreadEntry(keeperName, assistantEntryId, entry => {
             const rawText = details.replyText ?? entry.rawText ?? entry.text
-            if (details.turnOutcome === 'continuation_checkpoint') {
+            if (keeperTurnOutcomeSuppressesReply(details.turnOutcome)) {
               return {
                 ...entry,
                 details,
                 rawText,
                 text: '',
-                delivery: 'queued',
+                delivery: details.turnOutcome === 'no_visible_reply' ? 'no_reply' : 'queued',
                 streamState: null,
               }
             }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -705,6 +705,7 @@ export type KeeperConversationDelivery =
   | 'sending'
   | 'streaming'
   | 'delivered'
+  | 'no_reply'
   | 'timeout'
   | 'cancelled'
   | 'error'
@@ -720,8 +721,12 @@ interface KeeperConversationUsage {
 
 // RFC-0232 P2: producer-typed turn outcome carried in the reply payload
 // (`turn_outcome`). `continuation_checkpoint` marks the synthetic
-// resume-next-cycle notice; everything else is model output.
-export type KeeperTurnOutcome = 'visible_reply' | 'continuation_checkpoint'
+// resume-next-cycle notice; `no_visible_reply` marks a completed runtime
+// turn with no assistant text for the chat surface.
+export type KeeperTurnOutcome =
+  | 'visible_reply'
+  | 'continuation_checkpoint'
+  | 'no_visible_reply'
 
 export interface KeeperConversationDetails {
   traceId?: string | null

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -563,6 +563,7 @@ let direct_reply_visible_text body =
     let json = Yojson.Safe.from_string body in
     match Keeper_turn_outcome.of_reply_payload (Some json) with
     | Keeper_turn_outcome.Continuation_checkpoint -> None
+    | Keeper_turn_outcome.No_visible_reply -> None
     | Keeper_turn_outcome.Visible_reply -> (
         match Json_util.get_string json "reply" with
         | None -> None

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1291,7 +1291,8 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                   ( Keeper_turn_outcome.wire_key,
                     `String
                       (Keeper_turn_outcome.to_label
-                         (Keeper_turn_outcome.of_stop_reason
+                         (Keeper_turn_outcome.of_result_surface
+                            ~response_text:result.response_text
                             result.stop_reason)) );
                   ("model", `String surface_model_used);
                   ("model_used_raw", `String surface_model_used);

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -5,21 +5,25 @@
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | No_visible_reply
 
 let equal a b =
   match (a, b) with
   | Visible_reply, Visible_reply
+  | No_visible_reply, No_visible_reply
   | Continuation_checkpoint, Continuation_checkpoint ->
       true
-  | (Visible_reply | Continuation_checkpoint), _ -> false
+  | (Visible_reply | Continuation_checkpoint | No_visible_reply), _ -> false
 
 let to_label = function
   | Visible_reply -> "visible_reply"
   | Continuation_checkpoint -> "continuation_checkpoint"
+  | No_visible_reply -> "no_visible_reply"
 
 let of_label = function
   | "visible_reply" -> Some Visible_reply
   | "continuation_checkpoint" -> Some Continuation_checkpoint
+  | "no_visible_reply" -> Some No_visible_reply
   | _ -> None
 
 let wire_key = "turn_outcome"
@@ -28,6 +32,12 @@ let turn_ref_wire_key = "turn_ref"
 
 let of_stop_reason = function
   | Runtime_agent.Completed -> Visible_reply
+  | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
+  | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
+
+let of_result_surface ~response_text = function
+  | Runtime_agent.Completed ->
+      if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
 

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -1,21 +1,24 @@
 (** RFC-0232 P2 — producer-typed turn outcome.
 
     The keeper reply payload declares at the write boundary whether its
-    [reply] text is model output ([Visible_reply]) or the synthetic
-    continuation notice substituted when a run stops at a budget /
-    mutation boundary ([Continuation_checkpoint]).  Consumers (lane
-    persistence, stream terminal, direct-reply surface, dashboard)
-    match on the decoded variant; the legacy
-    ["Continuation checkpoint saved;"] prefix sniff is deleted. *)
+    [reply] text is model output ([Visible_reply]), absent from the
+    visible surface ([No_visible_reply]), or the synthetic continuation
+    notice substituted when a run stops at a budget / mutation boundary
+    ([Continuation_checkpoint]).  Consumers (lane persistence, stream
+    terminal, direct-reply surface, dashboard) match on the decoded
+    variant; the legacy ["Continuation checkpoint saved;"] prefix sniff
+    is deleted. *)
 
 type t =
   | Visible_reply
   | Continuation_checkpoint
+  | No_visible_reply
 
 val equal : t -> t -> bool
 
 val to_label : t -> string
-(** Closed wire labels: ["visible_reply"] / ["continuation_checkpoint"]. *)
+(** Closed wire labels: ["visible_reply"] / ["continuation_checkpoint"] /
+    ["no_visible_reply"]. *)
 
 val of_label : string -> t option
 (** Inverse of {!to_label}; [None] on any other string. *)
@@ -31,20 +34,31 @@ val turn_ref_wire_key : string
     ({!turn_ref_of_reply_payload}) so the wire name cannot drift. *)
 
 val of_stop_reason : Runtime_agent.stop_reason -> t
-(** [Completed] is the only stop reason whose reply text is model
-    output.  [TurnBudgetExhausted] replaces the reply with the synthetic
-    continuation notice ({!Runtime_agent} MaxTurnsExceeded arm);
-    [MutationBoundaryReached] shares the resume-next-cycle contract
-    (currently unreachable: no production caller passes
-    [exit_condition_result]). *)
+(** Stop-reason-only legacy classifier.  [Completed] is the only stop
+    reason whose reply text may be model output.  Use
+    {!of_result_surface} at payload production sites where the actual
+    [response_text] is available.  [TurnBudgetExhausted] replaces the
+    reply with the synthetic continuation notice ({!Runtime_agent}
+    MaxTurnsExceeded arm); [MutationBoundaryReached] shares the
+    resume-next-cycle contract (currently unreachable: no production
+    caller passes [exit_condition_result]). *)
+
+val of_result_surface : response_text:string -> Runtime_agent.stop_reason -> t
+(** Classify the reply-surface contract for a completed keeper run.
+    [Completed] with blank [response_text] is [No_visible_reply], not
+    [Visible_reply].  This keeps hidden read-only/tool-only runtime turns
+    from being reported as user-visible replies while preserving the
+    explicit continuation checkpoint outcome for budget and mutation
+    boundaries. *)
 
 val of_reply_payload : Yojson.Safe.t option -> t
-(** Decode from a parsed keeper reply payload.  Absent payload, absent
-    field, or unknown label decodes to [Visible_reply] (unknown labels
-    are logged at WARN): the bitten failure mode (#20870) was a reply
-    silently {e not} persisted — the lane watermark stalled and the
-    keeper re-answered the same message — so decode failure must fail
-    toward persisting, never toward dropping. *)
+(** Decode from a parsed keeper reply payload.  Known labels decode to
+    their declared variant.  Absent payload, absent field, or unknown
+    label decodes to [Visible_reply] (unknown labels are logged at WARN):
+    the bitten failure mode (#20870) was a reply silently {e not}
+    persisted — the lane watermark stalled and the keeper re-answered
+    the same message — so decode failure must fail toward persisting,
+    never toward dropping. *)
 
 val turn_ref_of_reply_payload : Yojson.Safe.t option -> Ids.Turn_ref.t option
 (** Decode the turn's join key ([turn_ref_wire_key]) from a parsed keeper

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -41,7 +41,8 @@ let append_decision_record
     | Some r
       when String.trim r.response_text <> ""
            && Keeper_turn_outcome.equal
-                (Keeper_turn_outcome.of_stop_reason r.stop_reason)
+                (Keeper_turn_outcome.of_result_surface
+                   ~response_text:r.response_text r.stop_reason)
                 Keeper_turn_outcome.Visible_reply ->
         Some (short_preview r.response_text)
     | _ -> None

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -63,7 +63,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
      still drives the visible/noop/autonomous counters unchanged. *)
   let is_visible_reply =
     Keeper_turn_outcome.equal
-      (Keeper_turn_outcome.of_stop_reason result.stop_reason)
+      (Keeper_turn_outcome.of_result_surface
+         ~response_text:result.response_text result.stop_reason)
       Keeper_turn_outcome.Visible_reply
   in
   let validated_evidence = visible_run_validation result in

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -367,13 +367,14 @@ let validated_evidence_preview
         (String.concat ", " names)
 
 (* RFC-0232: the scheduled-autonomous "what is this keeper doing" preview, by
-   precedence. [is_visible_reply] is the typed turn outcome
-   ([Keeper_turn_outcome.of_stop_reason]) — a budget-exhausted turn substitutes
-   a synthetic continuation notice for the reply text, which is display-only and
-   must not be sniffed as model output, so visible model text only wins when the
-   outcome is [Visible_reply]. Then substantive tool calls, then validated
-   evidence, else the prior preview is kept (never overwritten with a synthetic
-   filler). Pure so the precedence is unit-testable without a keeper_meta. *)
+   precedence. [is_visible_reply] is the typed reply-surface outcome
+   ([Keeper_turn_outcome.of_result_surface]) — a budget-exhausted turn
+   substitutes a synthetic continuation notice for the reply text, and a
+   completed runtime turn may still have no visible reply. Neither case may be
+   sniffed as model output, so visible model text only wins when the outcome is
+   [Visible_reply]. Then substantive tool calls, then validated evidence, else
+   the prior preview is kept (never overwritten with a synthetic filler). Pure
+   so the precedence is unit-testable without a keeper_meta. *)
 let select_proactive_preview
     ~(previous : string)
     ~(has_text : bool)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -788,7 +788,9 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                ( Keeper_turn_outcome.of_reply_payload payload_json_opt,
                  String_util.trim_to_option visible_reply )
              with
-            | Keeper_turn_outcome.Continuation_checkpoint, _ -> persist_user_message_only ()
+            | Keeper_turn_outcome.Continuation_checkpoint, _
+            | Keeper_turn_outcome.No_visible_reply, _ ->
+                persist_user_message_only ()
             | Keeper_turn_outcome.Visible_reply, None -> persist_user_message_only ()
             | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                 Keeper_chat_store.append_turn
@@ -928,13 +930,18 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
             | _ -> visible_reply
           in
           let visible_reply = redact_text visible_reply in
-          let is_checkpoint =
-            match Keeper_turn_outcome.of_reply_payload payload_json_opt with
-            | Keeper_turn_outcome.Continuation_checkpoint -> true
+          let turn_outcome =
+            Keeper_turn_outcome.of_reply_payload payload_json_opt
+          in
+          let suppress_terminal_reply =
+            match turn_outcome with
+            | Keeper_turn_outcome.Continuation_checkpoint
+            | Keeper_turn_outcome.No_visible_reply ->
+                true
             | Keeper_turn_outcome.Visible_reply -> false
           in
           if
-            (not is_checkpoint)
+            (not suppress_terminal_reply)
             && not (Keeper_stream_text_accum.suppress_terminal_resend text_accum)
           then
             split_keeper_reply_chunks visible_reply
@@ -947,7 +954,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
                     { name = "KEEPER_REPLY_DETAILS";
                       value = redact_json payload_json })
            | None -> ());
-          if is_checkpoint then
+          if
+            Keeper_turn_outcome.equal turn_outcome
+              Keeper_turn_outcome.Continuation_checkpoint
+          then
             Keeper_chat_events.publish events
               (Custom
                  { name = "KEEPER_CONTINUATION_CHECKPOINT";

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -1,10 +1,11 @@
 (* RFC-0232 P2: producer-typed turn outcome.
 
    The reply payload's [turn_outcome] field is the only carrier of the
-   checkpoint/visible distinction; the legacy "Continuation checkpoint
-   saved;" prefix sniff is deleted.  These tests pin:
+   checkpoint/visible/no-visible distinction; the legacy "Continuation
+   checkpoint saved;" prefix sniff is deleted.  These tests pin:
    - the closed label codec (round-trip, unknown -> None),
    - the stop_reason -> outcome mapping (single mapping site),
+   - response_text-aware result-surface classification,
    - payload decode policy: absent/unknown fails toward Visible_reply
      (the bitten failure mode, #20870, was silent non-persistence),
    - prefix deadness: checkpoint-shaped reply TEXT alone never
@@ -20,7 +21,7 @@ let outcome : TO.t testable =
     (fun fmt t -> Format.pp_print_string fmt (TO.to_label t))
     TO.equal
 
-let all = [ TO.Visible_reply; TO.Continuation_checkpoint ]
+let all = [ TO.Visible_reply; TO.Continuation_checkpoint; TO.No_visible_reply ]
 
 let test_label_round_trip () =
   List.iter
@@ -47,6 +48,16 @@ let test_of_stop_reason () =
        (Runtime_agent.MutationBoundaryReached
           { turns_used = 2; tool_name = Some "masc_add_task" }))
 
+let test_of_result_surface () =
+  check outcome "completed with text -> visible" TO.Visible_reply
+    (TO.of_result_surface ~response_text:"done" Runtime_agent.Completed);
+  check outcome "completed with empty text -> no visible reply"
+    TO.No_visible_reply
+    (TO.of_result_surface ~response_text:"   " Runtime_agent.Completed);
+  check outcome "budget exhausted -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_result_surface ~response_text:"done"
+       (Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 }))
+
 let payload fields = Some (`Assoc fields)
 
 let test_payload_decode () =
@@ -60,6 +71,9 @@ let test_payload_decode () =
   check outcome "visible label" TO.Visible_reply
     (TO.of_reply_payload
        (payload [ (TO.wire_key, `String "visible_reply") ]));
+  check outcome "no visible reply label" TO.No_visible_reply
+    (TO.of_reply_payload
+       (payload [ (TO.wire_key, `String "no_visible_reply") ]));
   check outcome "unknown label -> visible (report-and-persist)"
     TO.Visible_reply
     (TO.of_reply_payload (payload [ (TO.wire_key, `String "deferred") ]))
@@ -83,8 +97,15 @@ let test_prefix_is_dead () =
     TO.Continuation_checkpoint
     (TO.of_reply_payload
        (payload
+         [ ("reply", `String "all done");
+           (TO.wire_key, `String "continuation_checkpoint")
+          ]));
+  check outcome "ordinary text, declared no visible reply"
+    TO.No_visible_reply
+    (TO.of_reply_payload
+       (payload
           [ ("reply", `String "all done");
-            (TO.wire_key, `String "continuation_checkpoint")
+            (TO.wire_key, `String "no_visible_reply")
           ]))
 
 let turn_ref_t : Ids.Turn_ref.t testable =
@@ -129,6 +150,12 @@ let test_direct_reply_visible_text () =
           [ ("reply", `String checkpoint_text);
             ("turn_outcome", `String "continuation_checkpoint")
           ]));
+  check (option string) "declared no visible reply -> None" None
+    (Ops.direct_reply_visible_text
+       (body
+          [ ("reply", `String "all done");
+            ("turn_outcome", `String "no_visible_reply")
+          ]));
   check (option string) "checkpoint-shaped text without field -> visible"
     (Some checkpoint_text)
     (Ops.direct_reply_visible_text
@@ -155,7 +182,10 @@ let () =
           test_case "unknown label is None" `Quick test_unknown_label_is_none;
         ] );
       ( "mapping",
-        [ test_case "of_stop_reason" `Quick test_of_stop_reason ] );
+        [
+          test_case "of_stop_reason" `Quick test_of_stop_reason;
+          test_case "of_result_surface" `Quick test_of_result_surface;
+        ] );
       ( "payload_decode",
         [
           test_case "decode policy" `Quick test_payload_decode;


### PR DESCRIPTION
## Summary
- add a closed `no_visible_reply` keeper turn outcome for completed runtime turns with blank response text
- propagate the outcome through stream persistence, direct replies, metrics previews, and dashboard decoding/rendering
- keep continuation checkpoints distinct from no-visible runtime turns so queued semantics are not reused

## Evidence
- `git diff --check`
- no local build/test run after user request: build will be handled by user/CI