### PR TITLE
refactor(keeper): remove WORKAROUND-CARRYOVER symptom suppressions

### DIFF
--- a/lib/keeper/keeper_reconcile_state.mli
+++ b/lib/keeper/keeper_reconcile_state.mli
@@ -12,7 +12,7 @@
     - [`First]: first failure for this (keeper, error fingerprint).
       Caller should keep the existing WARN log (behaviour preservation).
     - [`Repeated]: same (keeper, fingerprint) seen again. Caller should
-      demote the WARN to DEBUG. The counter still increments.
+      log the WARN again without silent suppression. The counter still increments.
     - [`Threshold_disable]: consecutive failures reached
       [disable_threshold] (default 10). Caller should ERROR-log once and
       mark the keeper as disabled. Subsequent sweeps skip until
@@ -20,10 +20,7 @@
 
     Note: in-process state, [Hashtbl.t] guarded by a [Mutex]. No
     cross-process synchronisation — each server replica maintains its own
-    counters. Threshold defaults are conservative; the dedup/demote tier
-    is a [WORKAROUND-CARRYOVER §Symptom-억제] band-aid for invalid TOML
-    drift, not a structural fix. Root fix: invalid keeper TOML cleanup +
-    [keeper_assignable=false] policy decision (separate RFC). *)
+    counters. Threshold defaults are conservative. *)
 
 (** Outcome of recording a reconcile failure. *)
 type record_outcome =

--- a/lib/keeper/keeper_registry_error_recording.ml
+++ b/lib/keeper/keeper_registry_error_recording.ml
@@ -22,39 +22,25 @@ let record ~base_path ?details name err =
      emitting at ERROR up to 96× in 30-min slices on production
      (system_log_2026-05-16 sample, 299 events/day; verifier
      sandbox_docker ~48%). First occurrence keeps ERROR — operators
-     must still see *new* failure modes. Repeated occurrences demote
-     to DEBUG and bump a Otel_metric_store counter so the dashboard still
-     reflects the retry rate without paging operators.
-
-     WORKAROUND-CARRYOVER: this is symptom suppression. The root fix
-     is the underlying error source (verifier sandbox docker exec,
-     path-syntax guard, stale-turn timeouts). Tracked as separate PRs
-     keyed on the [Keeper_recording_error_state.error_kind] buckets. *)
+     must still see *new* failure modes. Repeated occurrences log at
+     ERROR again (symptom suppression removed). *)
   let kind, outcome =
     Keeper_recording_error_state.classify_outcome ~keeper:name ~error:err
   in
   let kind_label = Keeper_recording_error_state.error_kind_to_string kind in
-  (match outcome with
-   | `First ->
-     (match details with
-      | Some details ->
-        Log.Keeper.emit
-          Log.Error
-          ~details
-          (Printf.sprintf "registry: recording error name=%s error=%s" name err)
-      | None ->
-        Log.Keeper.error "registry: recording error name=%s error=%s" name err)
-   | `Repeated count ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string RecordingErrorDedup)
-       ~labels:[ "keeper", name; "error_kind", kind_label ]
-       ();
-     Log.Keeper.debug
-       "registry: recording error name=%s error=%s (repeated×%d, kind=%s, demoted)"
-       name
-       err
-       count
-       kind_label);
+  (match details with
+   | Some details ->
+     Log.Keeper.emit
+       Log.Error
+       ~details
+       (Printf.sprintf "registry: recording error name=%s error=%s" name err)
+   | None ->
+     Log.Keeper.error "registry: recording error name=%s error=%s" name err);
+  if outcome <> `First then
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string RecordingErrorDedup)
+      ~labels:[ "keeper", name; "error_kind", kind_label ]
+      ();
   Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
   Keeper_registry.set_last_error_entry ~base_path ~name err
 ;;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -884,11 +884,6 @@ let start_supervisor_sweep ctx =
                               Log.Keeper.warn "TOML reconcile failed for %s: %s"
                                 entry.name e
                           | `Repeated ->
-                              (* WORKAROUND-CARRYOVER §Symptom-억제: demote
-                                 repeats to DEBUG so the system_log isn't
-                                 flooded by invalid TOML drift. Root fix is
-                                 keeper TOML correction + runtime.toml
-                                 [keeper_assignable] policy (separate RFC). *)
                               Otel_metric_store.inc_counter
                                 Keeper_metrics.(to_string TomlReconcileDedup)
                                 ~labels:
@@ -896,7 +891,7 @@ let start_supervisor_sweep ctx =
                                   ; "outcome", "repeated"
                                   ]
                                 ();
-                              Log.Keeper.debug
+                              Log.Keeper.warn
                                 "TOML reconcile still failing for %s (dedup): %s"
                                 entry.name e
                           | `Threshold_disable ->

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -291,22 +291,7 @@ let execute_with_observers
             (2026-05-19): the same (tool, normalized detail)
             tuple recurs as the supervisor walks the 1->2->3
             retry ladder, so a single transient failure
-            emits at ERROR three times. Route the log
-            surface through [Keeper_tool_retry_state] so
-            attempts 2+ within the same retry cycle and
-            identical failures across cycles are demoted to
-            DEBUG, with one durable ERROR plus a Otel_metric_store
-            counter when the silence threshold trips.
-
-            [WORKAROUND-CARRYOVER]: this is a noise-dedupe
-            layer. Tracked by
-            docs/rfc/RFC-0144-workaround-sunset-keeper-dedup-carryover.md.
-            Removal: whole-layer sunset criteria (RFC §4):
-            aggregate retry ERROR rate <10/day for 7 days
-            rolling AND threshold_silence counter == 0.
-            The root fix is upstream (reduce the rate of
-            tool-call failures themselves — args validation,
-            container reuse RFC-0097, etc.). *)
+            emits at ERROR three times. *)
          let error_signature =
            Keeper_tool_retry_state.normalize detail
          in
@@ -325,7 +310,7 @@ let execute_with_observers
               max_consecutive_failures
               detail
           | `Repeated n ->
-            Log.Keeper.debug
+            Log.Keeper.warn
               "tool %s repeated retry log (%d/%d, total=%d, \
                dedup): %s"
               name


### PR DESCRIPTION
Removes silent failures / demotions to DEBUG for repeated errors in TOML reconcile, registry recording, and tool retry loops. Conforms to the explicit 'No Silent Failure' architectural standard.