### PR TITLE
[codex] fix main build broken by OAS SDK bump

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -77,6 +77,7 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.ApprovalRequired -> "approval_required"
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
+  | Agent_sdk.Hooks.HookFailed _ -> "hook_failed"
 
 let json_value_shape_for_log = function
   | `Assoc fields -> Printf.sprintf "object:%d" (List.length fields)

--- a/lib/runtime/runtime_wire_overlay.ml
+++ b/lib/runtime/runtime_wire_overlay.ml
@@ -65,6 +65,8 @@ let agent_capabilities_of_llm_capabilities
   ; supports_code_execution = caps.supports_code_execution
   ; emits_usage_tokens = caps.emits_usage_tokens
   ; supported_models = caps.supported_models
+  ; preserve_thinking_control_format = caps.preserve_thinking_control_format
+  ; reasoning_replay_override = caps.reasoning_replay_override
   }
 ;;
 

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -65,6 +65,7 @@ let decision_kind (d : Agent_sdk.Hooks.hook_decision) : string =
   | AdjustParams _ -> "AdjustParams"
   | ElicitInput _ -> "ElicitInput"
   | Nudge _ -> "Nudge"
+  | HookFailed _ -> "HookFailed"
 
 let override_text (d : Agent_sdk.Hooks.hook_decision) : string =
   match d with


### PR DESCRIPTION
Fixes the build errors caused by missing `preserve_thinking_control_format` / `reasoning_replay_override` and unhandled `HookFailed` match arms.