### PR TITLE
fix(core): refactor code smells violating new agent guidelines

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -327,7 +327,7 @@ let host_fd_pressure_state_file_env_key = "MASC_HOST_FD_PRESSURE_STATE_FILE"
 let legacy_host_fd_pressure_state_file_env_key = "MASC_SYSMON_PRESSURE_STATE"
 let host_fd_pressure_poller_disabled_env_key = "MASC_HOST_FD_PRESSURE_POLLER_DISABLED"
 let host_fd_pressure_poll_interval_sec_env_key = "MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC"
-let default_host_fd_pressure_state_file_path = "/tmp/masc-host-pressure.state"
+let default_host_fd_pressure_state_file_path = Filename.get_temp_dir_name () ^ "/masc-host-pressure.state"
 
 let host_fd_pressure_state_file_path_opt () =
   raw_value_opt host_fd_pressure_state_file_env_key |> trim_opt

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -269,7 +269,13 @@ let next_round ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string
                   let json = Yojson.Safe.from_string line in
                   let entry_turn = (match Json_util.assoc_member_opt "turn" json with Some (`Int n) -> n | _ -> 0) in
                   if entry_turn = turn then acc + 1 else acc
-                with _ -> acc
+                with
+                | Yojson.Json_error msg ->
+                    Log.Keeper.warn "Failed to parse trajectory JSON during next_round (trace_id=%s): %s" trace_id msg;
+                    acc
+                | exn ->
+                    Log.Keeper.warn "Unexpected error reading trajectory line (trace_id=%s): %s" trace_id (Printexc.to_string exn);
+                    acc
               ) 0
     in
     let next = current + 1 in


### PR DESCRIPTION
- **trajectory.ml**: Fix silent failure when parsing JSON trajectory entries. Exception is now properly logged instead of swallowed via `with _ -> acc`.
- **env_config_core.ml**: Replace hardcoded `/tmp/` path with `Filename.get_temp_dir_name ()` to respect base path guidelines.
- Note: `alignment_score.ml` contains heavy mathematical heuristic logic that violates the *LLM Judgment Boundary* guideline. This is noted as an architectural smell but left out of this quick fix PR as it requires a feature-level LLM prompt rewrite.
- Note: `file_lock_eio.ml` and `shutdown.ml` use `Unix.sleepf`, but these were verified to be running safely within `Eio_guard.run_in_systhread` or a dedicated standard `Thread`, meaning they do *not* block the Eio domain. They are safe.