### PR TITLE
[codex] harden server base-path provenance

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -489,6 +489,12 @@ let base_path =
   in
   Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
 
+let run_base_path =
+  let doc =
+    "Workspace root for MASC data. Runtime state lives under <base-path>/.masc; do not pass the .masc directory itself."
+  in
+  Arg.(value & opt (some string) None & info ["base-path"] ~docv:"PATH" ~doc)
+
 let login_json =
   let doc = "Emit machine-readable JSON instead of text output" in
   Arg.(value & flag & info ["json"] ~doc)
@@ -567,41 +573,23 @@ let acquire_base_path_lock base_path =
            pid base_path pid);
       exit 1
 
-let run_cmd host port base_path =
+let run_cmd host port cli_base_path =
   Printexc.record_backtrace true;
-  let raw_base_path = String.trim base_path in
-  let normalized_base_path =
-    Env_config.normalize_masc_base_path_input base_path
+  let resolved_base_path =
+    Server_base_path_guard.resolve_startup_base_path ~cli_base_path
+      ~default_base_path ()
   in
+  Server_base_path_guard.exit_on_violation
+    (Server_base_path_guard.enforce resolved_base_path);
+  let raw_base_path = resolved_base_path.raw_base_path in
+  let normalized_base_path = resolved_base_path.normalized_base_path in
   let resolution_source =
-    match Sys.getenv_opt "MASC_BASE_PATH_RESOLUTION_SOURCE" with
-    | Some source when String.trim source <> "" -> String.trim source
-    | _ ->
-        let inherited_env_matches =
-          match Sys.getenv_opt "MASC_BASE_PATH" with
-          | Some existing ->
-              String.equal
-                (Env_config.normalize_masc_base_path_input existing)
-                normalized_base_path
-          | None -> false
-        in
-        if inherited_env_matches then
-          "explicit_env"
-        else
-          let default_path =
-            Env_config.normalize_masc_base_path_input (default_base_path ())
-          in
-          if String.equal default_path normalized_base_path then
-            Server_base_path_guard.implicit_base_path_resolution_source
-          else
-            "explicit_cli"
+    Server_base_path_guard.resolution_source_label
+      resolved_base_path.resolution_source
   in
   let stripped_base_path =
-    Env_config.strip_path_trailing_slashes (String.trim base_path)
+    Env_config.strip_path_trailing_slashes (String.trim raw_base_path)
   in
-  Server_base_path_guard.guard_self_repo_base_path normalized_base_path;
-  Server_base_path_guard.guard_implicit_base_path ~resolution_source
-    ~normalized_base_path;
   let masc_dir = Filename.concat normalized_base_path Common.masc_dirname in
   Fs_compat.mkdir_p masc_dir;
   acquire_pid_lock port;
@@ -617,7 +605,7 @@ let run_cmd host port base_path =
   then
     Log.Server.warn
       "Normalizing --base-path from %s to %s because runtime base paths must point at the workspace root, not the .masc directory."
-      base_path normalized_base_path;
+      raw_base_path normalized_base_path;
   Unix.putenv "MASC_BASE_PATH_INPUT" raw_base_path;
   Unix.putenv "MASC_BASE_PATH" normalized_base_path;
   Workspace_utils_backend_setup.cache_resolved_base_path normalized_base_path;
@@ -774,7 +762,7 @@ let run_cmd host port base_path =
             ()
             in
             Eio.Fiber.first
-            (fun () -> run_server ~sw ~env ~host ~port ~base_path)
+            (fun () -> run_server ~sw ~env ~host ~port ~base_path:normalized_base_path)
             await_shutdown_signal;
             (* Server stopped; close SSE connections after server is down. *)
             (try close_all_sse_connections ()
@@ -988,7 +976,7 @@ let setup_gc () =
 let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc" ~version:Masc.Version.version ~doc in
-  Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ base_path)
+  Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ run_base_path)
     info [ init_cmd; login_cmd; memory_os_gc_dry_run_cmd ]
 
 let () =

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -14,29 +14,22 @@ let base_path =
   let doc =
     "Workspace root for MASC data. Runtime state lives under <base-path>/.masc; do not pass the .masc directory itself."
   in
-  Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
+  Arg.(value & opt (some string) None & info ["base-path"] ~docv:"PATH" ~doc)
 
-let run_cmd base_path =
+let run_cmd cli_base_path =
   Printexc.record_backtrace true;
-  let normalized_base_path =
-    Env_config.normalize_masc_base_path_input base_path
+  let resolved_base_path =
+    Server_base_path_guard.resolve_startup_base_path ~cli_base_path
+      ~default_base_path ()
   in
-  let resolution_source =
-    match Sys.getenv_opt "MASC_BASE_PATH_RESOLUTION_SOURCE" with
-    | Some source when String.trim source <> "" -> String.trim source
-    | _ ->
-      (match Sys.getenv_opt "MASC_BASE_PATH" with
-       | Some existing
-         when String.equal
-                (Env_config.normalize_masc_base_path_input existing)
-                normalized_base_path -> "explicit_env"
-       | _ -> "explicit_cli")
-  in
-  Server_base_path_guard.guard_self_repo_base_path normalized_base_path;
-  Server_base_path_guard.guard_implicit_base_path
-    ~resolution_source
-    ~normalized_base_path;
-  Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE" resolution_source;
+  Server_base_path_guard.exit_on_violation
+    (Server_base_path_guard.enforce resolved_base_path);
+  let base_path = resolved_base_path.normalized_base_path in
+  Unix.putenv "MASC_BASE_PATH_INPUT" resolved_base_path.raw_base_path;
+  Unix.putenv "MASC_BASE_PATH" base_path;
+  Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE"
+    (Server_base_path_guard.resolution_source_label
+       resolved_base_path.resolution_source);
   Eio_main.run @@ fun env ->
   Mirage_crypto_rng_unix.use_default ();
   Eio_guard.enable ();

--- a/lib/exec_policy/sandbox_backend.ml
+++ b/lib/exec_policy/sandbox_backend.ml
@@ -4,11 +4,15 @@ type exec_result = {
   exit_code : int;
 }
 
-let unsupported_stderr =
-  "masc.exec_policy Sandbox_backend.run is not a production sandbox executor; use \
+type error = Unsupported_backend of string
+
+let unsupported_message =
+  "masc.exec_policy Sandbox_backend.run is disabled; use \
    Masc.Keeper_sandbox_runner/Keeper_sandbox_docker"
-;;
+
+let error_message = function
+  | Unsupported_backend message -> message
 
 let run (_ : Typed_capabilities.safe Typed_capabilities.verified_ir)
-    (_env : Eio_unix.Stdenv.base) : exec_result =
-  { stdout = ""; stderr = unsupported_stderr; exit_code = 126 }
+    (_env : Eio_unix.Stdenv.base) : (exec_result, error) result =
+  Error (Unsupported_backend unsupported_message)

--- a/lib/exec_policy/sandbox_backend.mli
+++ b/lib/exec_policy/sandbox_backend.mli
@@ -4,4 +4,11 @@ type exec_result = {
   exit_code : int;
 }
 
-val run : Typed_capabilities.safe Typed_capabilities.verified_ir -> Eio_unix.Stdenv.base -> exec_result
+type error = Unsupported_backend of string
+
+val error_message : error -> string
+
+val run :
+  Typed_capabilities.safe Typed_capabilities.verified_ir ->
+  Eio_unix.Stdenv.base ->
+  (exec_result, error) result

--- a/lib/server/server_base_path_guard.ml
+++ b/lib/server/server_base_path_guard.ml
@@ -74,17 +74,12 @@ let source_repo_markers base_path =
   let markers = [ Git_metadata; Dune_project; Masc_opam ] in
   if List.for_all (path_exists base_path) markers then markers else []
 
-let has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value > prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
-
 let executable_under_base_build base_path =
   match realpath_opt Sys.executable_name with
   | None -> None
   | Some executable ->
       let build_prefix = Filename.concat (realpath_or_input base_path) "_build" ^ "/" in
-      if has_prefix ~prefix:build_prefix executable then Some executable else None
+      if String.starts_with ~prefix:build_prefix executable then Some executable else None
 
 let enforce resolved =
   match resolved.resolution_source with
@@ -107,8 +102,8 @@ let format_violation = function
          Resolution source: %s\n\
          Resolved path: %s\n\n\
          Start the server with an explicit base path:\n\
-         \\  --base-path /path/to/workspace     (CLI flag)\n\
-         \\  MASC_BASE_PATH=/path/to/workspace  (environment variable)\n\n\
+         --base-path /path/to/workspace     (CLI flag)\n\
+         MASC_BASE_PATH=/path/to/workspace  (environment variable)\n\n\
          Use a workspace root, not the repository checkout or $HOME directly.\n"
         (resolution_source_label resolved.resolution_source)
         resolved.normalized_base_path
@@ -128,8 +123,8 @@ let format_violation = function
          Source markers: %s\n\
          Executable: %s\n\
          Runtime state would pollute the repo. Use a workspace root instead:\n\
-         \\  --base-path $MASC_BASE_PATH    (recommended)\n\
-         \\  --base-path /path/to/workspace (explicit workspace root)\n\
+         --base-path $MASC_BASE_PATH    (recommended)\n\
+         --base-path /path/to/workspace (explicit workspace root)\n\
          Or start via: sb mcp masc start\n"
         base_path marker_text executable_text
 

--- a/lib/server/server_base_path_guard.ml
+++ b/lib/server/server_base_path_guard.ml
@@ -1,49 +1,140 @@
-(** Shared server entrypoint guards for runtime base paths. *)
+(** Shared startup guard for server runtime base paths. *)
 
-let implicit_base_path_resolution_source = "implicit_base_path"
+type resolution_source =
+  | Explicit_cli
+  | Explicit_env
+  | Implicit_default
 
-let guard_self_repo_base_path base_path =
-  let base_path = Env_config.normalize_masc_base_path_input base_path in
-  let abs_base =
-    try Unix.realpath base_path with
-    | Unix.Unix_error _ -> base_path
-  in
-  let abs_exe =
-    try Unix.realpath Sys.executable_name with
-    | Unix.Unix_error _ -> ""
-  in
-  let build_prefix = abs_base ^ "/_build/" in
-  let is_self_repo =
-    abs_exe <> ""
-    && String.length abs_exe > String.length build_prefix
-    && String.sub abs_exe 0 (String.length build_prefix) = build_prefix
-  in
-  if is_self_repo
-  then (
-    Printf.eprintf
-      "[FATAL] --base-path points to the server's own source repo: %s\n\
-       (executable: %s)\n\
-       Runtime state would pollute the repo. Use a workspace root instead:\n\
-       \\  --base-path $MASC_BASE_PATH    (recommended)\n\
-       \\  --base-path /path/to/workspace (explicit workspace root)\n\
-       Or start via: sb mcp masc start\n"
-      base_path
-      abs_exe;
-    exit 1)
-;;
+type resolved = {
+  raw_base_path : string;
+  normalized_base_path : string;
+  resolution_source : resolution_source;
+}
 
-let guard_implicit_base_path ~resolution_source ~normalized_base_path =
-  if String.equal resolution_source implicit_base_path_resolution_source
-  then (
-    Printf.eprintf
-      "[FATAL] Server refused to start with an implicit base path.\n\
-       Resolution source: %s\n\
-       Resolved path: %s\n\n\
-       Start the server with an explicit base path:\n\
-       \\  --base-path /path/to/workspace     (CLI flag)\n\
-       \\  MASC_BASE_PATH=/path/to/workspace  (environment variable)\n\n\
-       Use a workspace root, not the repository checkout or $HOME directly.\n"
-      resolution_source
-      normalized_base_path;
-    exit 1)
-;;
+type repo_marker =
+  | Git_metadata
+  | Dune_project
+  | Masc_opam
+
+type violation =
+  | Implicit_base_path of resolved
+  | Source_repo_base_path of {
+      base_path : string;
+      executable : string option;
+      markers : repo_marker list;
+    }
+
+let resolution_source_label = function
+  | Explicit_cli -> "explicit_cli"
+  | Explicit_env -> "explicit_env"
+  | Implicit_default -> "implicit_base_path"
+
+let repo_marker_path = function
+  | Git_metadata -> ".git"
+  | Dune_project -> "dune-project"
+  | Masc_opam -> "masc.opam"
+
+let non_blank value =
+  match value with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let normalize raw =
+  Env_config.normalize_masc_base_path_input raw
+
+let resolve_startup_base_path ?(getenv = Sys.getenv_opt) ~cli_base_path
+    ~default_base_path () =
+  let raw_base_path, resolution_source =
+    match non_blank cli_base_path with
+    | Some raw -> raw, Explicit_cli
+    | None -> (
+        match non_blank (getenv "MASC_BASE_PATH") with
+        | Some raw -> raw, Explicit_env
+        | None -> default_base_path (), Implicit_default)
+  in
+  { raw_base_path;
+    normalized_base_path = normalize raw_base_path;
+    resolution_source;
+  }
+
+let realpath_opt path =
+  try Some (Unix.realpath path) with Unix.Unix_error _ -> None
+
+let realpath_or_input path =
+  match realpath_opt path with
+  | Some path -> path
+  | None -> path
+
+let path_exists base marker =
+  Sys.file_exists (Filename.concat base (repo_marker_path marker))
+
+let source_repo_markers base_path =
+  let markers = [ Git_metadata; Dune_project; Masc_opam ] in
+  if List.for_all (path_exists base_path) markers then markers else []
+
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value > prefix_len
+  && String.equal (String.sub value 0 prefix_len) prefix
+
+let executable_under_base_build base_path =
+  match realpath_opt Sys.executable_name with
+  | None -> None
+  | Some executable ->
+      let build_prefix = Filename.concat (realpath_or_input base_path) "_build" ^ "/" in
+      if has_prefix ~prefix:build_prefix executable then Some executable else None
+
+let enforce resolved =
+  match resolved.resolution_source with
+  | Implicit_default -> Error (Implicit_base_path resolved)
+  | Explicit_cli | Explicit_env ->
+      let base_path = resolved.normalized_base_path in
+      let markers = source_repo_markers base_path in
+      let executable = executable_under_base_build base_path in
+      if markers <> [] || Option.is_some executable then
+        Error (Source_repo_base_path { base_path; executable; markers })
+      else
+        Ok ()
+
+let format_marker marker = repo_marker_path marker
+
+let format_violation = function
+  | Implicit_base_path resolved ->
+      Printf.sprintf
+        "[FATAL] Server refused to start with an implicit base path.\n\
+         Resolution source: %s\n\
+         Resolved path: %s\n\n\
+         Start the server with an explicit base path:\n\
+         \\  --base-path /path/to/workspace     (CLI flag)\n\
+         \\  MASC_BASE_PATH=/path/to/workspace  (environment variable)\n\n\
+         Use a workspace root, not the repository checkout or $HOME directly.\n"
+        (resolution_source_label resolved.resolution_source)
+        resolved.normalized_base_path
+  | Source_repo_base_path { base_path; executable; markers } ->
+      let marker_text =
+        match markers with
+        | [] -> "(executable is under _build)"
+        | markers -> String.concat ", " (List.map format_marker markers)
+      in
+      let executable_text =
+        match executable with
+        | Some executable -> executable
+        | None -> "(not under base _build)"
+      in
+      Printf.sprintf
+        "[FATAL] --base-path points to the MASC source repo: %s\n\
+         Source markers: %s\n\
+         Executable: %s\n\
+         Runtime state would pollute the repo. Use a workspace root instead:\n\
+         \\  --base-path $MASC_BASE_PATH    (recommended)\n\
+         \\  --base-path /path/to/workspace (explicit workspace root)\n\
+         Or start via: sb mcp masc start\n"
+        base_path marker_text executable_text
+
+let exit_on_violation = function
+  | Ok () -> ()
+  | Error violation ->
+      Printf.eprintf "%s" (format_violation violation);
+      exit 1

--- a/lib/server/server_base_path_guard.mli
+++ b/lib/server/server_base_path_guard.mli
@@ -1,14 +1,40 @@
-(** Startup guards for runtime base-path selection. *)
+(** Shared startup guard for server runtime base paths. *)
 
-val implicit_base_path_resolution_source : string
-(** Resolution marker used when no explicit base path was provided. *)
+type resolution_source =
+  | Explicit_cli
+  | Explicit_env
+  | Implicit_default
 
-val guard_self_repo_base_path : string -> unit
-(** [guard_self_repo_base_path base_path] aborts process startup when
-    [base_path] points at the server source repository that produced the
-    running executable. *)
+type resolved = {
+  raw_base_path : string;
+  normalized_base_path : string;
+  resolution_source : resolution_source;
+}
 
-val guard_implicit_base_path :
-  resolution_source:string -> normalized_base_path:string -> unit
-(** [guard_implicit_base_path ~resolution_source ~normalized_base_path]
-    aborts process startup when the base path was selected implicitly. *)
+type repo_marker =
+  | Git_metadata
+  | Dune_project
+  | Masc_opam
+
+type violation =
+  | Implicit_base_path of resolved
+  | Source_repo_base_path of {
+      base_path : string;
+      executable : string option;
+      markers : repo_marker list;
+    }
+
+val resolution_source_label : resolution_source -> string
+
+val resolve_startup_base_path :
+  ?getenv:(string -> string option) ->
+  cli_base_path:string option ->
+  default_base_path:(unit -> string) ->
+  unit ->
+  resolved
+
+val enforce : resolved -> (unit, violation) result
+
+val format_violation : violation -> string
+
+val exit_on_violation : (unit, violation) result -> unit

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -698,7 +698,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-BASE_PATH_RESOLUTION_SOURCE="implicit_repo_root"
+BASE_PATH_RESOLUTION_SOURCE="implicit_base_path"
 if [ "$BASE_PATH_EXPLICIT" = "1" ]; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_cli"
 elif [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && is_absolute_path "$BASE_PATH"; then

--- a/test/dune
+++ b/test/dune
@@ -856,6 +856,7 @@
   test_server_runtime_bootstrap
   test_server_hibernation
   test_server_base_path_diagnostics
+  test_server_base_path_guard
   test_server_timing
   test_server_startup_takeover
   test_keeper_meta_cas_retry
@@ -1045,6 +1046,7 @@
   test_server_runtime_bootstrap
   test_server_hibernation
   test_server_base_path_diagnostics
+  test_server_base_path_guard
   test_server_timing
   test_server_startup_takeover
   test_keeper_meta_cas_retry

--- a/test/test_exec_policy_path_arg_descriptor.ml
+++ b/test/test_exec_policy_path_arg_descriptor.ml
@@ -17,36 +17,6 @@
 open Masc
 module D = Exec_policy_path_arg_descriptor
 
-let source_root () =
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root -> root
-  | None -> Sys.getcwd ()
-
-let source_file path = Filename.concat (source_root ()) path
-
-let read_file path =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> In_channel.input_all ic)
-
-let contains_substring ~needle value =
-  let needle_len = String.length needle in
-  let value_len = String.length value in
-  if needle_len = 0
-  then true
-  else if needle_len > value_len
-  then false
-  else (
-    let rec loop i =
-      if i + needle_len > value_len
-      then false
-      else if String.equal (String.sub value i needle_len) needle
-      then true
-      else loop (i + 1)
-    in
-    loop 0)
-
 let test_is_path_flag_closed_set () =
   List.iter
     (fun flag ->
@@ -155,16 +125,30 @@ let test_grep_context_flags_are_not_path_args () =
   Alcotest.(check bool) "grep context count skipped" false
     (List.mem "3" values)
 
-let test_sandbox_backend_is_not_fake_success () =
-  let source = read_file (source_file "lib/exec_policy/sandbox_backend.ml") in
-  Alcotest.(check bool)
-    "no simulated success text"
-    false
-    (contains_substring ~needle:"Structured sandbox run" source);
-  Alcotest.(check bool)
-    "unsupported marker is explicit"
-    true
-    (contains_substring ~needle:"not a production sandbox executor" source)
+let test_sandbox_backend_fails_loud () =
+  let simple : Masc_exec.Shell_ir.simple =
+    { bin = Masc_exec.Exec_program.of_known Masc_exec.Exec_program.Ls
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let safe_ir =
+    Typed_capabilities.Safe_IR (Masc_exec.Shell_ir.Simple simple)
+  in
+  Eio_main.run @@ fun env ->
+  match Sandbox_backend.run safe_ir env with
+  | Error error ->
+      Alcotest.(check string)
+        "unsupported backend is explicit"
+        "masc.exec_policy Sandbox_backend.run is disabled; use \
+         Masc.Keeper_sandbox_runner/Keeper_sandbox_docker"
+        (Sandbox_backend.error_message error)
+  | Ok result ->
+      Alcotest.failf "unexpected sandbox success: exit_code=%d stdout=%S"
+        result.exit_code result.stdout
 
 let () =
   Alcotest.run "exec_policy_path_arg_descriptor"
@@ -194,7 +178,7 @@ let () =
             test_grep_context_flags_are_not_path_args
         ] )
     ; ( "sandbox backend"
-      , [ Alcotest.test_case "no fake success" `Quick
-            test_sandbox_backend_is_not_fake_success
+      , [ Alcotest.test_case "fails loud instead of fake success" `Quick
+            test_sandbox_backend_fails_loud
         ] )
     ]

--- a/test/test_server_base_path_guard.ml
+++ b/test/test_server_base_path_guard.ml
@@ -1,0 +1,114 @@
+open Alcotest
+
+let getenv_none _ = None
+
+let getenv_base value name =
+  if String.equal name "MASC_BASE_PATH" then Some value else None
+
+let default_base_path () = "/tmp/masc-default"
+
+let check_source label expected actual =
+  check string label expected
+    (Server_base_path_guard.resolution_source_label actual)
+
+let with_env name value f =
+  let prior = Sys.getenv_opt name in
+  (match value with
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "")
+    f
+
+let test_implicit_default_ignores_spoofed_resolution_env () =
+  with_env "MASC_BASE_PATH_RESOLUTION_SOURCE" (Some "explicit_cli") @@ fun () ->
+  let resolved =
+    Server_base_path_guard.resolve_startup_base_path ~getenv:getenv_none
+      ~cli_base_path:None ~default_base_path ()
+  in
+  check_source "source" "implicit_base_path" resolved.resolution_source;
+  match Server_base_path_guard.enforce resolved with
+  | Error (Server_base_path_guard.Implicit_base_path _) -> ()
+  | Ok () -> fail "expected implicit default to fail closed"
+  | Error _ -> fail "expected implicit base-path violation"
+
+let test_cli_source_wins_over_env () =
+  let resolved =
+    Server_base_path_guard.resolve_startup_base_path
+      ~getenv:(getenv_base "/tmp/from-env")
+      ~cli_base_path:(Some "/tmp/from-cli")
+      ~default_base_path ()
+  in
+  check_source "source" "explicit_cli" resolved.resolution_source;
+  check string "base path" "/tmp/from-cli" resolved.normalized_base_path
+
+let test_env_source_without_cli () =
+  let resolved =
+    Server_base_path_guard.resolve_startup_base_path
+      ~getenv:(getenv_base "/tmp/from-env")
+      ~cli_base_path:None ~default_base_path ()
+  in
+  check_source "source" "explicit_env" resolved.resolution_source;
+  check string "base path" "/tmp/from-env" resolved.normalized_base_path
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let test_source_repo_markers_fail_closed () =
+  with_temp_dir "masc-source-repo-" @@ fun dir ->
+  Unix.mkdir (Filename.concat dir ".git") 0o755;
+  write_file (Filename.concat dir "dune-project") "(name masc)\n";
+  write_file (Filename.concat dir "masc.opam") "opam-version: \"2.0\"\n";
+  let resolved =
+    Server_base_path_guard.resolve_startup_base_path ~getenv:getenv_none
+      ~cli_base_path:(Some dir) ~default_base_path ()
+  in
+  match Server_base_path_guard.enforce resolved with
+  | Error (Server_base_path_guard.Source_repo_base_path { markers; _ }) ->
+      check int "marker count" 3 (List.length markers)
+  | Ok () -> fail "expected source repo path to fail closed"
+  | Error _ -> fail "expected source repo violation"
+
+let test_plain_workspace_allowed () =
+  with_temp_dir "masc-workspace-" @@ fun dir ->
+  let resolved =
+    Server_base_path_guard.resolve_startup_base_path ~getenv:getenv_none
+      ~cli_base_path:(Some dir) ~default_base_path ()
+  in
+  match Server_base_path_guard.enforce resolved with
+  | Ok () -> ()
+  | Error violation ->
+      fail (Server_base_path_guard.format_violation violation)
+
+let () =
+  Alcotest.run "Server_base_path_guard"
+    [ ( "resolution"
+      , [ test_case "implicit default ignores spoofed resolution env" `Quick
+            test_implicit_default_ignores_spoofed_resolution_env
+        ; test_case "cli source wins over env" `Quick test_cli_source_wins_over_env
+        ; test_case "env source without cli" `Quick test_env_source_without_cli
+        ] )
+    ; ( "guard"
+      , [ test_case "source repo markers fail closed" `Quick
+            test_source_repo_markers_fail_closed
+        ; test_case "plain workspace allowed" `Quick test_plain_workspace_allowed
+        ] )
+    ]

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1008,10 +1008,11 @@ let test_default_build_lock_is_worktree_local () =
 
 let test_stdio_entrypoint_uses_shared_base_path_guard () =
   let source = read_file (source_file "bin/main_stdio_eio.ml") in
-  check bool "stdio guards self repo base path" true
-    (contains_substring source "Server_base_path_guard.guard_self_repo_base_path");
-  check bool "stdio rejects implicit base path" true
-    (contains_substring source "Server_base_path_guard.guard_implicit_base_path")
+  check bool "stdio resolves base path through shared guard" true
+    (contains_substring source
+       "Server_base_path_guard.resolve_startup_base_path");
+  check bool "stdio enforces shared base path guard" true
+    (contains_substring source "Server_base_path_guard.enforce")
 
 let test_stdio_skips_dashboard_build_and_http_preflight () =
   with_temp_dir "start-masc-script-stdio" (fun dir ->


### PR DESCRIPTION
## Summary
- Replace startup base-path provenance guessing with a typed resolver: Explicit_cli, Explicit_env, or Implicit_default.
- Share the guard across HTTP and stdio entrypoints so implicit defaults fail closed in both paths.
- Reject explicit MASC source-repo base paths via source markers, not only executable build-directory location.
- Disable the legacy exec-policy sandbox backend fake-success path with an explicit typed error.

## Why
This extracts the production-relevant pieces from PR #22625 without carrying its stale version, docs, auth, and broad keeper churn. The goal is to close the concrete bypasses found in review: ambient MASC_BASE_PATH_RESOLUTION_SOURCE spoofing, stdio default misclassification, launcher and OCaml source-label drift, and sandbox simulated success.

## RFC Trace
- RFC-0127 (`docs/rfc/RFC-0127-runtime-fast-fail-and-termination-provenance.md`) covers runtime provenance and fail-closed termination/provenance discipline.
- RFC-0213 (`docs/rfc/RFC-0213-keeper-sandbox-isolation.md`), RFC-0070 (`docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md`), and RFC-0006 (`docs/rfc/RFC-0006-keeper-surface-and-sandbox.md`) cover keeper sandbox isolation, pure edge separation, and surface/sandbox boundaries.

## Validation
- git diff --check
- ocamlformat --check lib/server/server_base_path_guard.ml
- Local compile and tests intentionally skipped per operator request; GitHub CI is the build and test authority for this PR.
