### PR TITLE
fix(ci): seed OAS catalog for runtime gates

### DIFF
--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -425,6 +425,7 @@ let test_repo_oas_model_catalog_modality_priorities_resolve () =
     rows
 
 let test_repo_runtime_toml_loads () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
   match Runtime.load_list ~config_path:path with

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -397,6 +397,11 @@ let with_server f =
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
   seed_server_config ~base_path;
+  let oas_model_catalog =
+    match find_repo_file "oas-models.toml" with
+    | Some path -> path
+    | None -> fail "oas-models.toml fixture not found"
+  in
   let log_fd =
     Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644
   in
@@ -408,6 +413,7 @@ let with_server f =
         ("MASC_AUTONOMY_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+        ("OAS_MODEL_CATALOG", oas_model_catalog);
       ]
   in
   let argv =


### PR DESCRIPTION
## Summary
- load the repo-local OAS model catalog while validating the repo runtime.toml seed
- pass the repo-local OAS model catalog into the SSE storm e2e server fixture

## Verification
- ocamlformat --check test/test_runtime_config_validity.ml test/test_sse_storm_e2e.ml
- git diff --check origin/main...HEAD

Context: follow-up for merged #22625 after CI showed Runtime TOML validity and SSE reconnect e2e boot failures from missing OAS catalog resolution in test fixtures.