### PR TITLE
fix(keeper): parenthesize readonly guard decision match

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -722,7 +722,7 @@ let readonly_observation_duplicate_guard
       let keeper_name = (!meta_ref).name in
       if not (read_only_snapshot_observation ~tool_name ~input) then
         Agent_sdk.Hooks.Continue
-      else
+      else (
         let key = readonly_observation_key ~tool_name ~input in
         match readonly_observation_record_pre_tool_use state ~turn ~schedule key with
         | Readonly_observation_duplicate ->
@@ -757,7 +757,7 @@ let readonly_observation_duplicate_guard
                ~source_path ~source_line
                ~tool_name ~reason_code:"readonly_observation_duplicate"
                ~reason_text)
-        | Readonly_observation_continue -> Agent_sdk.Hooks.Continue
+        | Readonly_observation_continue -> Agent_sdk.Hooks.Continue)
     | _ -> Agent_sdk.Hooks.Continue
   in
   let post_tool_use event =

--- a/test/test_keeper_tool_capability_axis.ml
+++ b/test/test_keeper_tool_capability_axis.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Axis = Masc.Keeper_tool_capability_axis
+module Descriptor = Masc.Keeper_tool_descriptor
 module Resolution = Masc.Keeper_tool_descriptor_resolution
 module Tool_catalog = Tool_catalog
 
@@ -28,6 +29,22 @@ let test_polling_read_supports_descriptor_projection () =
   check_support Axis.Polling_read "masc_keeper_msg_result" true;
   check_support Axis.Polling_read "mcp__masc__masc_keeper_msg_result" true;
   check_support Axis.Polling_read "keeper_tasks_list" false
+;;
+
+let test_polling_read_axis_matches_descriptor_policy () =
+  let descriptor_projection = Descriptor.polling_read_internal_names () in
+  check (list string) "axis polling list is descriptor projection"
+    descriptor_projection Axis.polling_read_tool_names;
+  Descriptor.all_descriptors ()
+  |> List.iter (fun descriptor ->
+    let expected = descriptor.Descriptor.policy.polling_read in
+    Descriptor.internal_names descriptor
+    @ Descriptor.public_names_of_descriptor descriptor
+    |> List.iter (fun tool_name ->
+      check bool
+        (tool_name ^ " polling axis matches descriptor policy")
+        expected
+        (Axis.supports Axis.Polling_read tool_name)))
 ;;
 
 let test_polling_read_projection_is_descriptor_read_only () =
@@ -65,6 +82,10 @@ let () =
             "polling read supports descriptor projection names"
             `Quick
             test_polling_read_supports_descriptor_projection
+        ; test_case
+            "polling read axis matches descriptor policy"
+            `Quick
+            test_polling_read_axis_matches_descriptor_policy
         ; test_case
             "polling read projection is descriptor read-only"
             `Quick


### PR DESCRIPTION
## Summary
- parenthesize the readonly observation pre-tool decision match so the hook-event fallback remains attached to the outer event match
- keep the total hook-event fallback from the merged PR while avoiding OCaml warning-as-error parse ambiguity

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_guards.ml
- git diff --check origin/main..HEAD
- scripts/lint/no-provider-name-hardcoding.sh
- scripts/lint/no-actionable-signal-bool-context.sh
- scripts/lint/no-keeper-behavior-hardcoding.sh (prints existing missing lib/tool_task*.ml rg messages, exits OK)

Local build intentionally not run; CI is the build authority for this workflow.