### PR TITLE
fix(keeper): restore exhaustive event match in readonly observation guard (P0 main build)

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -722,7 +722,7 @@ let readonly_observation_duplicate_guard
       let keeper_name = (!meta_ref).name in
       if not (read_only_snapshot_observation ~tool_name ~input) then
         Agent_sdk.Hooks.Continue
-      else
+      else begin
         let key = readonly_observation_key ~tool_name ~input in
         match readonly_observation_record_pre_tool_use state ~turn ~schedule key with
         | Readonly_observation_duplicate ->
@@ -758,6 +758,7 @@ let readonly_observation_duplicate_guard
                ~tool_name ~reason_code:"readonly_observation_duplicate"
                ~reason_text)
         | Readonly_observation_continue -> Agent_sdk.Hooks.Continue
+      end
     | _ -> Agent_sdk.Hooks.Continue
   in
   let post_tool_use event =


### PR DESCRIPTION
## P0 — main 빌드 차단 hotfix

#22646 (`bfb74e23079`) 머지 후 main `dune build .` 실패:
```
lib/keeper/keeper_guards.ml:761  warning 11 [redundant-case]
lib/keeper/keeper_guards.ml:718-761  warning 8 [partial-match]
  (BeforeTurn|BeforeTurnParams|AfterTurn|PostToolUse|...|OnContextCompacted) 미매칭
```
`-warn-error +a`로 빌드 차단.

## 근본 원인 (dangling match)
`readonly_observation_duplicate_guard`의 inner `match readonly_observation_record_pre_tool_use ... with`가 괄호/`begin..end`로 감싸지지 않아, `| _ -> Continue`가 outer `event` match가 아닌 **inner 2-variant match의 arm**으로 파싱됨:
- inner: `Readonly_observation_duplicate | Readonly_observation_continue | _` → `_` redundant (**warning 11**)
- outer: `PreToolUse` 하나만 → 나머지 13개 hook variant 누락 (**warning 8**)

두 경고가 동시에 뜨는 게 dangling-match의 특징.

## 수정
inner match를 `begin ... end`로 감싸 `| _ -> Continue`가 outer event match에 다시 바인딩되도록 (2 insert / 1 delete). 로직 무변경 — PreToolUse만 처리하고 나머지 event는 Continue하는 의도 그대로 복원.

## 검증
- `ocamlformat --check lib/keeper/keeper_guards.ml`: pass
- CI Build/Lint가 warning 8/11 해소 확인 (로컬 전체 빌드도 병행 검증 중)

RFC-WAIVED: P0 main 빌드 차단 hotfix. `keeper_guards.ml`은 hook guard로 credential/identity/sandbox subsystem과 무관, 1줄 구조 수정(로직 불변).
