### PR TITLE
fix(ci): seed OAS catalog for operator MCP e2e

### DIFF
--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -367,6 +367,9 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let project_root = Masc_test_deps.find_project_root () in
   let config_dir = Filename.concat project_root "config" in
   let personas_dir = Filename.concat config_dir "personas" in
+  let oas_model_catalog = Filename.concat project_root "oas-models.toml" in
+  if not (Sys.file_exists oas_model_catalog) then
+    fail "oas-models.toml fixture not found";
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc.Workspace.default_config base_path in
@@ -440,6 +443,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
         ("MASC_CONFIG_DIR", config_dir);
         ("MASC_PERSONAS_DIR", personas_dir);
         ("MASC_BOARD_BACKEND", "jsonl");
+        ("OAS_MODEL_CATALOG", oas_model_catalog);
       ]
   in
   let argv =


### PR DESCRIPTION
## Summary
- seed repo-local oas-models.toml into test_operator_mcp_e2e child server env
- keep production strict runtime catalog validation unchanged
- fix quick-suite operator_mcp_e2e bootstrap failure after strict OAS catalog gate

## Evidence
- CI artifact from run 28346272668 showed test_operator_mcp_e2e canonical agent discovery route failing because Runtime.init_default_strict found no OAS model catalog
- focused Runtime TOML validity gate and SSE reconnect e2e passed on de990977 before this follow-up

## Local checks
- ocamlformat --check test/test_operator_mcp_e2e.ml
- git diff --check

No local Dune build/test run; CI is the build authority for this task.