### PR TITLE
fix(runtime): default preserve-thinking to thinking-support — restore dashboard thinking interleaving

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -447,8 +447,17 @@ let parse_model (id : string) (tbl : Otoml.t)
     let thinking_support =
       Otoml.find_or ~default:false tbl Otoml.get_boolean [ "thinking-support" ]
     in
+    (* Default preserve-thinking to thinking-support: a model that can think
+       should preserve its thinking trace for the dashboard interleaving unless
+       it explicitly opts out. Previously this defaulted to false, so 28/30
+       thinking-capable models in the catalog left it unset and the dashboard
+       thinking-interleaving wiring stayed dormant (oas requests the provider
+       without preserve/clear_thinking=false, so the provider clears or omits
+       thinking and no ThinkingDelta reaches the SSE stream). Explicit
+       preserve-thinking=false still opts out (e.g. Gemma4's own <|think|>
+       chat-template path). *)
     let preserve_thinking =
-      Otoml.find_or ~default:false tbl Otoml.get_boolean [ "preserve-thinking" ]
+      Otoml.find_or ~default:thinking_support tbl Otoml.get_boolean [ "preserve-thinking" ]
     in
     let max_thinking_budget =
       Otoml.find_opt tbl Otoml.get_integer [ "max-thinking-budget" ]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -521,11 +521,21 @@ tools-support = true
 thinking-support = false
 streaming = true
 
+[models.thinkdefault]
+api-name = "thinkdefault"
+max-context = 128000
+tools-support = true
+thinking-support = true
+streaming = true
+
 [ollama_cloud.think]
 is-default = true
 max-concurrent = 1
 
 [ollama_cloud.nothink]
+max-concurrent = 1
+
+[ollama_cloud.thinkdefault]
 max-concurrent = 1
 |}
 ;;
@@ -549,6 +559,15 @@ let test_thinking_support_true_enables_thinking_and_preserves () =
       seed.Runtime_inference.thinking_enabled;
     Alcotest.(check (option bool))
       "preserve-thinking true emits Some true"
+      (Some true)
+      seed.Runtime_inference.preserve_thinking)
+;;
+
+let test_thinking_support_true_defaults_preserve_when_unset () =
+  with_runtime_thinking (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"ollama_cloud.thinkdefault" in
+    Alcotest.(check (option bool))
+      "thinking-support true without preserve-thinking defaults preserve to Some true"
       (Some true)
       seed.Runtime_inference.preserve_thinking)
 ;;
@@ -658,6 +677,10 @@ let () =
             "thinking-support=true enables thinking and preserve-thinking"
             `Quick
             test_thinking_support_true_enables_thinking_and_preserves
+        ; Alcotest.test_case
+            "thinking-support=true w/o preserve-thinking defaults preserve on"
+            `Quick
+            test_thinking_support_true_defaults_preserve_when_unset
         ; Alcotest.test_case
             "thinking-support=false forces thinking off (Some false)"
             `Quick


### PR DESCRIPTION
## What was broken

The dashboard keeper-chat **Thinking interleaving** (think ↔ tool ↔ text in the turn timeline) was dormant for most models — "broken for a long time" as flagged.

## Root cause (manifesto audit, 2026-06-29)

Traced the full pipeline end-to-end; every stage is healthy:
- oas streams `ContentBlockDelta { delta = ThinkingDelta _ }` (`lib/llm_provider/streaming.ml`).
- mascot emits `KEEPER_THINKING_DELTA` SSE on `ThinkingDelta` (`server_routes_http_keeper_stream.ml:894`).
- FE maps `KEEPER_THINKING_DELTA` → `traceSteps` `kind:'think'` (`keeper-stream.ts:150`).
- `interleaveTraceAndTools` preserves think↔tool order (`primitives.ts:2573`, test-verified).

The gap was at the **front of the pipe**: `preserve-thinking` is the request-side flag that tells oas to keep thinking (GLM `clear_thinking=false`, qwen3 `chat_template_kwargs.preserve_thinking`). `config/runtime.toml` has **30 thinking-capable models but only 2 set `preserve-thinking=true`**; the rest defaulted to `false` (`runtime_toml.ml:450`). So providers cleared/omitted thinking, no `ThinkingDelta` was streamed, and `KEEPER_THINKING_DELTA` never fired — the dashboard showed no think steps despite a healthy pipeline.

## Fix

Default `preserve-thinking` to `thinking-support` in `runtime_toml.ml`. A model that can think preserves its trace for the dashboard unless it explicitly opts out — no per-model N-of-M flag churn (manifesto). Explicit `preserve-thinking=false` still opts out (Gemma4's own `<|think|>` chat-template path is unchanged).

## Test

New case `thinking-support=true w/o preserve-thinking defaults preserve on` asserts `Some true`. Existing `preserve-thinking=true` (explicit) and `thinking-support=false` cases unchanged.

## Notes

- This is the front-of-pipe switch fix. The recent 12h thinking/reasoning PRs (#2222 infinite-Thinking P0, #2227/#2228/#2229 reasoning preserve axis) land on top of this cleanly — they shape *how* thinking streams, this fix ensures it streams at all.
- Dashboard FE wiring (interleave/traceSteps) needed no change; verified test-covered.
- Per manifesto ("build in CI, don't over-fixate on local CI"), local `ocamlformat --check` clean; full build/test delegated to CI.

Co-Authored-By: Claude <noreply@anthropic.com>