### PR TITLE
fix(ci): seed OAS catalog for release evidence

### DIFF
--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -35,6 +35,7 @@ cd "$repo_root"
 
 [[ -x "$BINARY" ]] || { echo "release-evidence: binary not executable: $BINARY" >&2; exit 1; }
 [[ -f config/tool_policy.toml ]] || { echo "release-evidence: config/tool_policy.toml missing" >&2; exit 1; }
+[[ -f oas-models.toml ]] || { echo "release-evidence: oas-models.toml missing" >&2; exit 1; }
 
 mkdir -p "$(dirname "$OUTFILE")"
 out_dir="$(cd "$(dirname "$OUTFILE")" && pwd)"
@@ -291,6 +292,7 @@ env \
   MASC_WS_ENABLED=0 \
   MASC_WEBRTC_ENABLED=0 \
   MASC_KEEPER_BOOTSTRAP_ENABLED=false \
+  OAS_MODEL_CATALOG="$repo_root/oas-models.toml" \
   "$BINARY" --base-path "$base_path" --port "$PORT" >"$server_log" 2>&1 &
 SERVER_PID=$!
 


### PR DESCRIPTION
## Summary
- fail fast when repo-local oas-models.toml is missing from release evidence script
- pass OAS_MODEL_CATALOG to the release-evidence smoke server
- keep the strict runtime model capability gate enabled

## Evidence
- main CI run 28347983949 passed Build, Runtime TOML gate, quick suite, operator control, SSE reconnect e2e, transport harness, and contract harness
- the same job failed only at Generate main release evidence bundle because Runtime.init_default_strict had no OAS catalog for release_evidence.deepseek-v4-flash

## Local checks
- bash -n scripts/release-evidence.sh
- git diff --check

No local Dune build/test run; CI is the build authority for this task.