### PR TITLE
fix(masc): use immutable set for keeper trace deduplication

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -5,27 +5,38 @@ let line_ts = function
   | Trajectory.Thinking entry -> entry.ts
 ;;
 
+module Thinking_key = struct
+  type t = float * bool * string
+
+  let compare (ts1, r1, c1) (ts2, r2, c2) =
+    let c_ts = Float.compare ts1 ts2 in
+    if c_ts <> 0
+    then c_ts
+    else
+      let c_r = Bool.compare r1 r2 in
+      if c_r <> 0 then c_r else String.compare c1 c2
+  ;;
+end
+
+module Thinking_set = Set.Make (Thinking_key)
+
 let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
   : Trajectory.trajectory_line list
   =
-  let seen = Hashtbl.create 32 in
-  List.filter
-    (function
-      | Trajectory.Tool_call _ -> true
-      | Trajectory.Thinking entry ->
-        let key =
-          Printf.sprintf
-            "%.6f\x1f%b\x1f%s"
-            entry.ts
-            entry.redacted
-            entry.content
-        in
-        if Hashtbl.mem seen key
-        then false
-        else (
-          Hashtbl.add seen key ();
-          true))
-    lines
+  let _, rev_deduped =
+    List.fold_left
+      (fun (seen, acc) line ->
+         match line with
+         | Trajectory.Tool_call _ -> seen, line :: acc
+         | Trajectory.Thinking entry ->
+           let key = entry.ts, entry.redacted, entry.content in
+           if Thinking_set.mem key seen
+           then seen, acc
+           else Thinking_set.add key seen, line :: acc)
+      (Thinking_set.empty, [])
+      lines
+  in
+  List.rev rev_deduped
 ;;
 
 let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string)
@@ -36,14 +47,16 @@ let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string
      subset of lines decode to [trajectory_line]. *)
   Fs_compat.fold_jsonl_lines
     ~init:[]
-    ~f:(fun acc ~line_no:_ json ->
+    ~f:(fun acc ~line_no json ->
        match
          Server_dashboard_http_keeper_api_types
          .internal_history_json_to_trajectory_line
            json
        with
        | Some line -> line :: acc
-       | None -> acc)
+       | None ->
+         Log.Dashboard.warn "Skipped invalid internal history trace row (trace=%s, line=%d)" trace_id line_no;
+         acc)
     path
   |> List.rev
 ;;

--- a/test/dune
+++ b/test/dune
@@ -106,6 +106,7 @@
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
   test_server_dashboard_http_legacy_keeper_inventory
+  test_server_dashboard_http_keeper_api_trace
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -429,6 +430,7 @@
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
   test_server_dashboard_http_legacy_keeper_inventory
+  test_server_dashboard_http_keeper_api_trace
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/test_keeper_tool_access_validation.ml
+++ b/test/test_keeper_tool_access_validation.ml
@@ -6,8 +6,43 @@
 module P = Server_dashboard_http_keeper_api_post
 
 let check_names msg expected actual = Alcotest.(check (list string)) msg expected actual
+let check_labels msg expected actual = Alcotest.(check (list string)) msg expected actual
 
 let candidates = [ "masc_status"; "WebSearch"; "WebFetch"; "masc_board_post" ]
+
+let thinking ?(ts = 1.0) ?(redacted = false) content =
+  Trajectory.Thinking
+    { ts
+    ; ts_iso = "2026-06-29T00:00:00Z"
+    ; turn = 1
+    ; content
+    ; content_length = String.length content
+    ; redacted
+    }
+;;
+
+let tool_call ?(ts = 1.5) tool_name =
+  Trajectory.Tool_call
+    { ts
+    ; ts_iso = "2026-06-29T00:00:01Z"
+    ; turn = 1
+    ; round = 1
+    ; tool_name
+    ; args_json = "{}"
+    ; gate_decision = Trajectory.Pass
+    ; result = None
+    ; duration_ms = 0
+    ; error = None
+    ; cost_usd = 0.0
+    ; execution_id = None
+    }
+;;
+
+let line_label = function
+  | Trajectory.Thinking entry ->
+    Printf.sprintf "thinking:%s:%b" entry.content entry.redacted
+  | Trajectory.Tool_call entry -> "tool:" ^ entry.tool_name
+;;
 
 let test_all_known_accepted () =
   check_names "all known -> nothing rejected" []
@@ -44,13 +79,54 @@ let test_multiple_unknown_reported_in_order () =
     (P.unknown_added_tool_names ~candidate_names:candidates ~existing:[]
        ~requested:[ "masc_status"; "z_bad"; "WebFetch"; "a_bad" ])
 
+let test_dedupe_thinking_lines_preserves_order_and_tool_calls () =
+  let lines =
+    [ thinking "same"
+    ; tool_call "keeper_board_post"
+    ; thinking "same"
+    ; thinking ~redacted:true "same"
+    ; thinking "other"
+    ]
+  in
+  let deduped = P.dedupe_thinking_lines lines in
+  check_labels "drops exact duplicate thinking only"
+    [ "thinking:same:false"
+    ; "tool:keeper_board_post"
+    ; "thinking:same:true"
+    ; "thinking:other:false"
+    ]
+    (List.map line_label deduped)
+
+let test_dedupe_thinking_lines_keeps_distinct_float_timestamps () =
+  let lines =
+    [ thinking ~ts:1.0000001 "same"; thinking ~ts:1.0000002 "same" ]
+  in
+  Alcotest.(check int)
+    "sub-microsecond-distinct timestamps stay distinct"
+    2
+    (P.dedupe_thinking_lines lines |> List.length)
+
 let () =
   Alcotest.run "keeper_tool_access_validation"
-    [ ( "delta",
-        [ Alcotest.test_case "all known accepted" `Quick test_all_known_accepted;
-          Alcotest.test_case "unknown rejected" `Quick test_unknown_rejected;
-          Alcotest.test_case "legacy grandfathered" `Quick test_legacy_grandfathered;
-          Alcotest.test_case "new unknown amid legacy" `Quick test_new_unknown_amid_legacy;
-          Alcotest.test_case "removal allowed" `Quick test_removal_allowed;
-          Alcotest.test_case "multiple unknown in order" `Quick
-            test_multiple_unknown_reported_in_order ] ) ]
+    [ ( "delta"
+      , [ Alcotest.test_case "all known accepted" `Quick test_all_known_accepted
+        ; Alcotest.test_case "unknown rejected" `Quick test_unknown_rejected
+        ; Alcotest.test_case "legacy grandfathered" `Quick test_legacy_grandfathered
+        ; Alcotest.test_case "new unknown amid legacy" `Quick test_new_unknown_amid_legacy
+        ; Alcotest.test_case "removal allowed" `Quick test_removal_allowed
+        ; Alcotest.test_case
+            "multiple unknown in order"
+            `Quick
+            test_multiple_unknown_reported_in_order
+        ] )
+    ; ( "runtime_trace"
+      , [ Alcotest.test_case
+            "thinking dedupe preserves order and tool calls"
+            `Quick
+            test_dedupe_thinking_lines_preserves_order_and_tool_calls
+        ; Alcotest.test_case
+            "thinking dedupe keeps distinct float timestamps"
+            `Quick
+            test_dedupe_thinking_lines_keeps_distinct_float_timestamps
+        ] )
+    ]

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -1,0 +1,96 @@
+open Alcotest
+open Masc
+module Trace = Server_dashboard_http_keeper_api_trace
+module T = Trajectory
+
+let mk_thinking ~ts ~redacted ~content =
+  T.Thinking
+    { ts
+    ; ts_iso = "2026-06-29T00:00:00Z"
+    ; turn = 1
+    ; content
+    ; content_length = String.length content
+    ; redacted
+    }
+;;
+
+let test_dedupe_preserves_first_order () =
+  let t1 = mk_thinking ~ts:1.0 ~redacted:false ~content:"A" in
+  let t2 = mk_thinking ~ts:2.0 ~redacted:false ~content:"B" in
+  let t1_dup = mk_thinking ~ts:1.0 ~redacted:false ~content:"A" in
+  let input = [ t1; t2; t1_dup ] in
+  let result = Trace.dedupe_thinking_lines input in
+  check int "length" 2 (List.length result);
+  match result with
+  | [ T.Thinking a; T.Thinking b ] ->
+    check string "first" "A" a.content;
+    check string "second" "B" b.content
+  | _ -> fail "expected two thinking lines"
+;;
+
+let test_dedupe_precision () =
+  let t1 = mk_thinking ~ts:1.1234561 ~redacted:false ~content:"A" in
+  let t2 = mk_thinking ~ts:1.1234562 ~redacted:false ~content:"A" in
+  let input = [ t1; t2 ] in
+  let result = Trace.dedupe_thinking_lines input in
+  (* Without the fix, Printf.sprintf "%.6f" would truncate both to 1.123456 and drop t2 *)
+  check int "length" 2 (List.length result)
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_file "trace-test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let test_read_invalid_json_skips () =
+  with_temp_dir (fun dir ->
+    let config = Workspace.default_config dir in
+    let trace_file = Keeper_types_support.keeper_internal_history_path config "test_trace" in
+    let trace_dir = Filename.dirname trace_file in
+    Unix.system (Printf.sprintf "mkdir -p '%s'" trace_dir) |> ignore;
+    let oc = open_out trace_file in
+    (* 1 valid line, 1 invalid line (missing ts/timestamp), 1 valid line *)
+    Printf.fprintf
+      oc
+      "{\"source\":\"internal_assistant\",\"content\":\"A\",\"ts_unix\":1.0}\n\
+       {\"source\":\"internal_assistant\",\"content\":\"B\"}\n\
+       {\"source\":\"internal_assistant\",\"content\":\"C\",\"ts_unix\":3.0}\n";
+    close_out oc;
+    let result = Trace.read_internal_history_lines ~config ~trace_id:"test_trace" in
+    (* Should skip the invalid line ("B") without failing *)
+    check int "length" 2 (List.length result);
+    match result with
+    | [ T.Thinking a; T.Thinking c ] ->
+      check string "first" "A" a.content;
+      check (float 0.0) "first_ts" 1.0 a.ts;
+      check string "second" "C" c.content;
+      check (float 0.0) "second_ts" 3.0 c.ts
+    | _ -> fail "expected two valid thinking lines")
+;;
+
+let () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  run
+    "Server_dashboard_http_keeper_api_trace"
+    [ ( "dedupe_thinking_lines"
+      , [ test_case "preserves first order" `Quick test_dedupe_preserves_first_order
+        ; test_case "preserves sub-microsecond precision" `Quick test_dedupe_precision
+        ] )
+    ; ( "read_internal_history_lines"
+      , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips ] )
+    ]
+;;

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -577,6 +577,54 @@ let test_read_entries_since_no_dir () =
     let entries = Trajectory.read_entries_since ~masc_root:dir ~keeper_name:"nonexistent" ~since:0.0 in
     Alcotest.(check int) "no dir" 0 (List.length entries))
 
+let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
+  Trajectory.Thinking
+    {
+      ts;
+      ts_iso = "2026-06-29T00:00:00Z";
+      turn = 1;
+      content;
+      content_length = String.length content;
+      redacted;
+    }
+
+let check_thinking_content label expected = function
+  | Trajectory.Thinking entry ->
+      Alcotest.(check string) label expected entry.Trajectory.content
+  | Trajectory.Tool_call _ -> Alcotest.fail (label ^ ": expected thinking line")
+
+let check_tool_call label expected = function
+  | Trajectory.Tool_call entry ->
+      Alcotest.(check string) label expected entry.Trajectory.tool_name
+  | Trajectory.Thinking _ -> Alcotest.fail (label ^ ": expected tool call line")
+
+let test_dedupe_thinking_lines_uses_structural_key () =
+  let tool_call =
+    Trajectory.Tool_call
+      (mk_entry ~ts:1000.5 "tool_execute" 20 0.0 "2026-06-29T00:00:00Z")
+  in
+  let lines =
+    [
+      thinking_line ~ts:1000.0 "same";
+      tool_call;
+      thinking_line ~ts:1000.0 "same";
+      thinking_line ~ts:1001.0 "same";
+      thinking_line ~ts:1000.0 ~redacted:true "same";
+    ]
+  in
+  let deduped =
+    Server_dashboard_http_keeper_api_trace.dedupe_thinking_lines lines
+  in
+  Alcotest.(check int) "one exact duplicate removed" 4 (List.length deduped);
+  check_thinking_content "first thinking preserved" "same" (List.nth deduped 0);
+  check_tool_call "tool call preserved" "tool_execute" (List.nth deduped 1);
+  check_thinking_content "same content at a new timestamp preserved" "same"
+    (List.nth deduped 2);
+  (match List.nth deduped 3 with
+   | Trajectory.Thinking entry ->
+       Alcotest.(check bool) "redacted variant preserved" true entry.Trajectory.redacted
+   | Trajectory.Tool_call _ -> Alcotest.fail "expected redacted thinking line")
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -703,6 +751,10 @@ let () =
       Alcotest.test_case "parses persisted gate summary" `Quick
         test_read_entries_since_result_parses_gate_summary;
       Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
+    ]);
+    ("keeper_trace", [
+      Alcotest.test_case "dedupe_thinking_lines uses structural key" `Quick
+        test_dedupe_thinking_lines_uses_structural_key;
     ]);
     ("thinking_trajectory", [
       Alcotest.test_case "append_thinking persists full untruncated text" `Quick


### PR DESCRIPTION
Fix deduplication in keeper trace history by using Set.Make and tuple comparison instead of Hashtbl and Printf string matching. Also logs invalid lines in internal history JSON.