### PR TITLE
fix(dashboard): chunk A polish — route card stack, KPI grid, reaction align

### DIFF
--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -92,7 +92,7 @@ export function ReactionBar({
           <button
             key=${emoji}
             type="button"
-            class=${`v2-workspace-action ${compact ? 'h-6 min-w-7 px-1.5 text-2xs' : 'h-7 min-w-8 px-2 text-xs'} rounded-[var(--r-1)] border transition-colors duration-[var(--t-med)] ${
+            class=${`v2-workspace-action inline-flex items-center justify-center gap-1 leading-none ${compact ? 'h-6 min-w-7 px-1.5 text-2xs' : 'h-7 min-w-8 px-2 text-xs'} rounded-[var(--r-1)] border transition-colors duration-[var(--t-med)] ${
               reacted
                 ? 'bg-[var(--accent-12)] text-[var(--color-accent-fg)] border-[var(--accent-20)]'
                 : 'bg-transparent text-[var(--color-fg-muted)] border-[var(--color-border-divider)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)]'
@@ -103,7 +103,7 @@ export function ReactionBar({
             onClick=${() => { void handleToggle(emoji) }}
           >
             <span aria-hidden="true">${emoji}</span>
-            ${count > 0 ? html`<span class="ml-1 tabular-nums">${count}</span>` : null}
+            ${count > 0 ? html`<span class="tabular-nums">${count}</span>` : null}
           </button>
         `
       })}

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -179,7 +179,7 @@ function PlaneSection({ plane, entries }: { plane: CockpitPlane; entries: Cockpi
             aria-label=${`Open ${displayLabel(entrypoint)} in ${routeCaption(entrypoint)}`}
           >
             <div class="cp-route-top">
-              <span class="min-w-0">
+              <span class="cp-route-label">
                 <span class="rl">${displayLabel(entrypoint)}</span>
                 <span class="rc">${routeCaption(entrypoint)}</span>
               </span>

--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -408,6 +408,16 @@
   min-width: 0;
 }
 
+/* The label wrapper must be a block-level flex column: as a bare inline <span>
+ * its children .rl/.rc laid out inline, so .rc margin-top and both spans'
+ * text-overflow:ellipsis were ignored and the caption glued onto the label on
+ * one line, overflowing the card (audit #1). */
+.cp-route .cp-route-label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .cp-route .rl {
   font-size: 12.5px;
   font-weight: 600;

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -290,13 +290,18 @@
   letter-spacing: 0.14em;
 }
 
-/* keeper-v2/overview.jsx renders 7 KPI cells (overview.jsx:106-114) into a
- * 6-column grid as the prototype specifies (surfaces.css:88 `repeat(6, 1fr)`).
- * The 7th cell ("진행 심의") wraps to a second row, matching prototype intent.
- * All other values mirror surfaces.css:88. */
+/* OverviewKpiStrip renders exactly 7 KPI cells (overview.ts:744-752) into a
+ * 1px-gap hairline grid: the container background shows through the gaps as
+ * dividers. With repeat(6) the 7th cell wrapped to a second row, leaving 5
+ * empty tracks that exposed the container --border-soft as a solid band
+ * (audit #2). 7 is prime, so only 1 or 7 columns tile 7 cells with no empty
+ * trailing area. Desktop uses 7 (one clean row); below 1280px it stacks to a
+ * single column (see the media query). A 2–3-col tablet tier would need a
+ * per-cell border divider instead of gap-bleed — deferred to the responsive
+ * chunk. */
 .ov-kpis {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(7, 1fr);
   gap: 1px;
   background: var(--border-soft);
   border: 1px solid var(--border-main);
@@ -1025,7 +1030,9 @@
 
 /* responsive */
 @media (max-width: 1280px) {
-  .ov-kpis { grid-template-columns: repeat(3, 1fr); }
+  /* repeat(3) re-introduced the orphan band (7 % 3 = 1). Stack to a single
+   * band-free column below 1280px (see the .ov-kpis note above). */
+  .ov-kpis { grid-template-columns: 1fr; }
   .ov-grid { grid-template-columns: 1fr; }
 }
 


### PR DESCRIPTION
## 무엇을

대시보드 디자인 폴리싱 감사(154 findings, 고심각도 8건)의 **Chunk A — 정렬·렌더 깨짐** 3건. CSS/마크업만, 토큰 값 변경 없음.

| # | 서피스 | 결함(근본 원인) | 수정 |
|---|--------|----------------|------|
| 1 | cockpit | route card label wrapper가 bare inline `<span>` → `.rl`/`.rc`가 inline으로 흘러 `.rc`의 `margin-top`·`text-overflow:ellipsis` 무시, 라벨+경로가 한 줄로 붙어 카드 overflow | wrapper에 `.cp-route-label`(flex column, `min-width:0`) 부여 → 캡션 스택 + 말줄임 작동 |
| 2 | overview | KPI 스트립은 `gap:1px`+`background:--border-soft` hairline 그리드. 6-col에서 7개 중 7번째 셀이 2행으로 wrap → 빈 5트랙이 `--border-soft`를 **밴드**로 노출 | 7은 소수 → 1·7만 빈 트랙 없이 타일링. 데스크탑 7-col(1행), `≤1280px` 1-col stack |
| 3 | board | 리액션 버튼이 flex 컨테이너가 아니라 이모지가 텍스트 baseline에 얹혀 세로·가로 정렬이 들쭉날쭉("삐뚤빼뚤") | 버튼 `inline-flex items-center justify-center leading-none`, 카운트 `ml-1`→`gap-1` |

## 왜

근본 원인 수정입니다(워크어라운드 아님): inline→block-flex 스택, prime-7 타일링, inline-flex 중앙정렬. 각 수정의 "왜"를 코드 주석에 남겼습니다. `#2`의 기존 "프로토타입 의도" 주석은 그 의도가 곧 시각 결함이라 정정했습니다.

## 검증

- 테스트: board 66 (reaction-bar + a11y + board-surface) + overview/cockpit 97 통과
- `tsc --noEmit`, `pnpm tokens:check`, `eslint`(변경 파일) clean
- 시각 before: cockpit 캡처로 #1 확증
- 시각 after: 헤드리스가 worktree dev server(unbundled 서빙)에서 timeout — **미확인**. Chrome 확장/로컬 5174로 별도 시각 검증 권장

## 범위

- 디자인 폴리싱 백로그의 첫 청크. 후속: B(타이포 토큰 codemod) / C(dead-ui 숙청) / D(반응형) / E(a11y) / F(일관성) / G(설정 write 배선=FEATURE+RFC, 분리)
- 건드리지 않음: 토큰 값, 로직, 백엔드, credential/operator/sandbox
- RFC 대상 아님 (dashboard 프론트엔드 정렬 CSS만)
