### PR TITLE
fix: add per-keeper claimed_by filter to WIP admission (task-1572)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -498,7 +498,7 @@ let handle_keeper_task_tool
         Keeper_wip_admission.active_items_of_tasks
           ~task_goal_index
           ~default_repo:wip_default_repo
-          active_tasks
+          ~claimed_by:(Some meta.agent_name) active_tasks
       in
       let scope =
         Keeper_wip_admission.scope_of_task ~task_goal_index ~default_repo:wip_default_repo task

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -87,9 +87,9 @@ type active_item = {
   scope : scope;
 }
 
-let task_is_active_wip (task : Masc_domain.task) =
+let task_is_active_wip ?(claimed_by : string option) (task : Masc_domain.task) =
   match task.task_status with
-  | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> true
+  | Masc_domain.Claimed agent_name | Masc_domain.InProgress agent_name -> (match claimed_by with Some name -> String.equal name agent_name | None -> true)
   | Masc_domain.Todo
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
@@ -98,9 +98,9 @@ let task_is_active_wip (task : Masc_domain.task) =
 let active_item_of_task ?task_goal_index ~default_repo (task : Masc_domain.task) =
   { id = task.id; scope = scope_of_task ?task_goal_index ~default_repo task }
 
-let active_items_of_tasks ?task_goal_index ~default_repo tasks =
+let active_items_of_tasks ?task_goal_index ?claimed_by ~default_repo tasks =
   tasks
-  |> List.filter task_is_active_wip
+  |> List.filter (task_is_active_wip ?claimed_by)
   |> List.map (active_item_of_task ?task_goal_index ~default_repo)
 
 type reject_reason =

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -37,10 +37,10 @@ type active_item = {
   scope : scope;
 }
 
-val task_is_active_wip : Masc_domain.task -> bool
+val task_is_active_wip : ?claimed_by:string option -> Masc_domain.task -> bool
 val active_item_of_task :
   ?task_goal_index:(string, string list) Hashtbl.t -> default_repo:string -> Masc_domain.task -> active_item
-val active_items_of_tasks :
+val active_items_of_tasks : ?claimed_by:string option ->
   ?task_goal_index:(string, string list) Hashtbl.t -> default_repo:string -> Masc_domain.task list -> active_item list
 
 type reject_reason =


### PR DESCRIPTION
## Problem

keeper_wip_admission.ml task_is_active_wip counts all keepers globally. masc_tasks filters per-keeper. Mismatch causes WIP cap overcount.

## Fix

- task_is_active_wip: ~claimed_by param, filters by agent when provided
- active_items_of_tasks: same param, passes through
- Call site: meta.agent_name -> ~claimed_by:(Some meta.agent_name)
- .mli updated

## Files

- lib/keeper/keeper_wip_admission.ml
- lib/keeper/keeper_wip_admission.mli
- lib/keeper/keeper_tool_task_runtime.ml