### PR TITLE
fix(dashboard): chunk E a11y — dock picker keyboard access, toggle aria-pressed

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -169,6 +169,8 @@ export function AgentLiveTimeline({ name }: { name: string }) {
             class="v2-monitoring-action px-2 py-0.5 rounded-[var(--r-1)] text-3xs border cursor-pointer transition-[background-color,border-color,box-shadow] duration-[var(--t-med)] ${autoScroll.value
               ? 'border-[var(--ok-border)] text-[var(--color-status-ok)] bg-[var(--color-bg-elevated)]'
               : 'border-[var(--color-border-default)] text-[var(--color-fg-disabled)] bg-[var(--color-bg-elevated)]'}"
+            aria-pressed=${autoScroll.value}
+            aria-label="자동 스크롤"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
             title=${autoScroll.value ? '자동 스크롤 ON' : '자동 스크롤 OFF'}
           >

--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -352,7 +352,13 @@ describe('CopilotDock', () => {
 
     const rows = container.querySelectorAll('.dock-menu-row')
     expect(rows.length).toBeGreaterThan(1)
-    ;(rows[1] as HTMLDivElement).click()
+    // a11y (audit #6): rows are keyboard-operable native <button>s with an
+    // accessible name; the current keeper row is marked aria-current.
+    rows.forEach(r => expect(r.tagName).toBe('BUTTON'))
+    expect((rows[0] as HTMLButtonElement).getAttribute('aria-label')).toContain('전환')
+    const onRow = container.querySelector('.dock-menu-row.on')
+    if (onRow) expect(onRow.getAttribute('aria-current')).toBe('true')
+    ;(rows[1] as HTMLButtonElement).click()
 
     expect(dock.state.value.keeperId).not.toBe('masc-improver')
   })

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -497,9 +497,12 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
             ? html`
                 <div class="dock-menu" onMouseDown=${(e: MouseEvent) => e.stopPropagation()}>
                   ${keeperRows.map(k => html`
-                    <div
+                    <button
+                      type="button"
                       key=${k.id}
                       class=${`dock-menu-row ${k.id === keeper.id ? 'on' : ''}`}
+                      aria-current=${k.id === keeper.id ? 'true' : undefined}
+                      aria-label=${`${k.kr}로 전환`}
                       onClick=${() => { dock.setKeeper(k.id); setPickOpen(false) }}
                     >
                       <${KeeperBadge} id=${k.id} name=${k.kr} variant="sigil" size="lg" beat=${statusLooksRunning(k.status)} />
@@ -507,7 +510,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
                         <div class="nm">${k.kr} <span class="h">${k.id}</span></div>
                         <div class="sub"><${StatusDot} status=${k.status} />${k.phase} · ${k.ns}</div>
                       </div>
-                    </div>
+                    </button>
                   `)}
                 </div>
               `

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -69,13 +69,18 @@
   background: var(--bg-panel); border: 1px solid var(--border-highlight);
   border-radius: var(--radius-md); box-shadow: var(--shadow-pop); z-index: 8; padding: 6px;
 }
-.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; }
+/* Native <button> (keyboard + screen-reader accessible). Reset button chrome
+   so the row renders identically to the former <div>. */
+.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; width: 100%; text-align: left; background: transparent; border: 0; color: inherit; font: inherit; }
 .dock-menu-row:hover { background: var(--bg-card); }
 .dock-menu-row.on { background: var(--bg-card); box-shadow: inset 0 0 0 1px var(--volt-wash); }
 .dock-menu-row .minfo { min-width: 0; flex: 1; }
 .dock-menu-row .nm { font-size: 12px; color: var(--text-bright); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dock-menu-row .nm .h { color: var(--text-dim); font-weight: 400; font-size: 10px; }
 .dock-menu-row .sub { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
+/* Keyboard focus ring (placed after .on so it wins on the current row). */
+.dock-menu-row:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.dock-picker-btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
 /* ── co-view context card ── */
 .dock-coview {


### PR DESCRIPTION
## 무엇을

대시보드 폴리싱 감사의 **Chunk E — a11y**. 키보드/스크린리더 접근성 결함 2건.

| # | 결함 | 수정 |
|---|------|------|
| 6 (high) | copilot dock 키퍼 picker **메뉴 행이 click-only `<div>`** — 마우스 전용, 키보드/SR 도달 불가 (picker 트리거·starter prompt는 이미 `<button>`, 스위처 행만 누락) | 행을 native `<button>`으로 (Enter/Space·focus·implicit role) + `aria-label` + 현재 키퍼 `aria-current`. CSS에 button chrome 리셋(렌더 동일) + `--focus-ring` `:focus-visible` |
| 27 | live-timeline auto-scroll 토글에 pressed 상태 없음 | `aria-pressed` + `aria-label` 추가 (SR이 ON/OFF 안내) |

## 왜 native button (role=button div 아님)

`<div role="button" tabindex onKeyDown>`보다 native `<button>`이 정석(implicit role·키보드·focus 무료). 행 내부에 중첩 인터랙티브 요소가 없음을 확인했고, CSS 리셋(`background/border/font/color/width/text-align`)으로 기존 `<div>`와 픽셀 동일하게 렌더됩니다.

## 제외 — audit #26 (overview attention row)

감사는 attention 행이 onClick-only div라 키보드 불가라고 했으나, **행 내부에 이미 키보드 접근 가능한 `<button class="ov-attn-act">`**가 동일 `navigate()`를 수행합니다. 행을 button으로 바꾸면 button-in-button(무효 HTML)이 되고, 키보드 사용자는 이미 접근 경로가 있으므로 행의 onClick은 마우스 편의 중복일 뿐 — 변경하지 않았습니다. (적대 검증으로 감사 항목을 정정)

## 검증

- copilot-dock 18 tests pass — **신규 단언**: picker 행이 `<button>` + `aria-label`(전환) + 현재 행 `aria-current="true"`
- `tsc --noEmit` clean, `pnpm tokens:check` clean, eslint(소스) clean
- focus-visible는 `--focus-ring` 토큰 사용(하드코딩 없음)

## 범위 밖

- #23 (btn 아톰 공유 focus-visible): btn.ts가 의도적으로 inline-style(클래스 미사용)이라 `:focus-visible` 부착에 inline↔class 충돌 검토 필요 → 별도 처리.
- RFC 대상 아님.
