### PR TITLE
fix(dashboard): chunk D — 모바일 하단바 reserve + 반응형 surface 패딩

### DIFF
--- a/dashboard/src/styles/keeper-v2/craft.css
+++ b/dashboard/src/styles/keeper-v2/craft.css
@@ -47,6 +47,18 @@
   --gap-row:     6px;
 }
 
+/* Mobile (single-column shell, ≤900px — same breakpoint the bottom tab bar
+   uses): the desktop surface padding (up to 42px each side on spacious)
+   eats ~27% of a 406px viewport once the 12px shell pad is added. Compress
+   the horizontal pad per density tier; keep the vertical rhythm. Only
+   `--pad-surface` is touched, so every surface on `.ov-scroll`/`.surf-scroll`/
+   `.cp-main` (overview, work, approvals, schedule, cockpit) tightens together. */
+@media (max-width: 900px) {
+  .v2-app[data-density="spacious"] { --pad-surface: 24px 16px 48px; }
+  .v2-app[data-density="regular"]  { --pad-surface: 18px 13px 36px; }
+  .v2-app[data-density="compact"]  { --pad-surface: 14px 11px 28px; }
+}
+
 /* ── Chat console — spacious (the headline surface) ── */
 .v2-app[data-density="spacious"] .chat-head   { padding: 18px 28px 16px; gap: 16px; }
 .v2-app[data-density="spacious"] .thread      { padding: 34px 0 14px; }

--- a/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
+++ b/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+// Contract guard for the mobile shell regression fixed in the dashboard polish
+// pass: the reskin dropped the `data-mpane` shell attribute but left the
+// `.v2-body[data-mpane="chat"]` rules in v2.css as dead selectors. The bottom
+// reserve (`padding-bottom: 58px`) was gated on `:not([data-mpane="chat"])`,
+// which — with the attribute gone — was always true, so the 58px band stayed
+// reserved even in keeper chat reading mode (nav hidden) and the composer
+// floated above the viewport bottom. The reserve is now keyed off the live
+// `.v2-app[data-reading="true"]` attribute instead.
+
+const v2Css = readFileSync(resolve(__dirname, 'v2.css'), 'utf-8')
+const craftCss = readFileSync(resolve(__dirname, 'craft.css'), 'utf-8')
+
+const SHELL_MOBILE_CHROME_BREAKPOINT = '900px'
+
+function mediaRuleDecls(source: string, selector: string, maxWidth: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  parse(source).walkAtRules('media', (atRule) => {
+    if (!atRule.params.includes(`max-width: ${maxWidth}`)) return
+    atRule.walkRules((rule) => {
+      if (!rule.selectors.includes(selector)) return
+      rule.walkDecls((decl) => {
+        declarations[decl.prop] = decl.value.trim()
+      })
+    })
+  })
+  return declarations
+}
+
+// `--pad-surface: <top> <inline> <bottom>` shorthand → the inline (L/R) token.
+function inlinePad(padSurface: string): string {
+  const parts = padSurface.split(/\s+/)
+  return parts[1] ?? parts[0] ?? ''
+}
+const px = (v: string): number => Number.parseFloat(v)
+
+describe('mobile bottom-bar reserve (data-reading, not dead data-mpane)', () => {
+  it('has no selector gated on the dropped data-mpane attribute', () => {
+    // `data-mpane` is never set by the app (the reskin dropped it). Any rule
+    // gated on it is a dead selector — regressions hide here. (The word may
+    // still appear in an explanatory comment; we only forbid it in selectors.)
+    const deadSelectors: string[] = []
+    parse(v2Css).walkRules((rule) => {
+      if (rule.selector.includes('data-mpane')) deadSelectors.push(rule.selector)
+    })
+    expect(deadSelectors).toEqual([])
+  })
+
+  it('reserves the bottom-bar band only when NOT in reading mode', () => {
+    const decls = mediaRuleDecls(
+      v2Css,
+      '.v2-app:not([data-reading="true"]) .v2-body',
+      SHELL_MOBILE_CHROME_BREAKPOINT,
+    )
+    expect(decls['padding-bottom']).toBeDefined()
+    expect(decls['padding-bottom']).toContain('58px')
+  })
+})
+
+describe('mobile surface padding compresses per density tier (≤900px)', () => {
+  // Desktop tiers (craft.css): spacious 42px / regular 26px / compact 18px
+  // inline padding. On the single-column mobile shell these are disproportionate
+  // (spacious 42px + 12px shell pad ≈ 27% of a 406px viewport).
+  const DESKTOP_INLINE: Record<string, number> = { spacious: 42, regular: 26, compact: 18 }
+
+  for (const tier of ['spacious', 'regular', 'compact'] as const) {
+    it(`tightens --pad-surface inline padding for data-density="${tier}"`, () => {
+      const decls = mediaRuleDecls(craftCss, `.v2-app[data-density="${tier}"]`, SHELL_MOBILE_CHROME_BREAKPOINT)
+      const pad = decls['--pad-surface']
+      expect(pad).toBeDefined()
+      expect(px(inlinePad(pad))).toBeLessThan(DESKTOP_INLINE[tier])
+    })
+  }
+})

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1416,8 +1416,13 @@
   .nav-item:hover, .nav-item.on { background: transparent; }
   .nav-item.on::before { left: 26%; right: 26%; top: 0; bottom: auto; width: auto; height: 3px; border-radius: 0 0 3px 3px; box-shadow: none; }
 
-  /* hide the bottom bar while reading a thread (full-screen chat) */
-  .v2-body[data-mpane="chat"] .v2-nav { display: none; }
+  /* The bottom tab bar is hidden in keeper chat reading mode via
+     `.v2-app[data-reading="true"]` (keeper-workspace.css). The shell
+     `data-mpane` attribute that used to gate these rules was dropped in the
+     reskin and is never set, so the old `.v2-body[data-mpane="chat"]`
+     nav-hide and master-detail rules here never fired (dead selectors,
+     removed). The bottom reserve below is re-keyed off the live
+     `data-reading` attribute. */
 
   /* co-view FAB is redundant on a phone — the top-bar Chat button already
      opens the dock, and a floating FAB collides with the bottom tab bar */
@@ -1425,13 +1430,10 @@
 
   /* single column; JS already sets gridTemplateColumns:1fr, this is the guard */
   .v2-body { grid-template-columns: 1fr !important; }
-  /* reserve room so surface content clears the fixed bottom tab bar. Every
-     surface scrolls inside .v2-body; chat hides the bar so it needs no pad. */
-  .v2-body:not([data-mpane="chat"]) { padding-bottom: calc(58px + env(safe-area-inset-bottom, 0px)); }
-
-  /* master-detail: show one pane at a time */
-  .v2-body[data-mpane="chat"] .roster { display: none; }
-  .v2-body[data-mpane="roster"] .chat-wrap { display: none; }
+  /* reserve room so surface content clears the fixed bottom tab bar. Reading
+     mode hides the bar, so it must NOT reserve the band — otherwise the
+     composer floats 58px above the viewport bottom (the empty band bug). */
+  .v2-app:not([data-reading="true"]) .v2-body { padding-bottom: calc(58px + env(safe-area-inset-bottom, 0px)); }
 
   .roster { border-right: none; }
   .roster-list { padding-bottom: 16px; }


### PR DESCRIPTION
## 무엇을

대시보드 폴리싱 감사의 **Chunk D — 모바일 레이아웃/밀도**. Chrome 확장으로 406px 뷰포트에서 직접 진단·검증한 회귀 2건.

| # | 결함 | 수정 |
|---|------|------|
| ②①  | **키퍼 채팅 하단 빈 띠** — 리스킨이 `data-mpane` shell 속성을 제거했으나 `v2.css`에 `.v2-body[data-mpane="chat"]` 규칙이 dead selector로 잔존. 하단 58px reserve가 `:not([data-mpane="chat"])`(속성이 없어 항상 참)에 묶여, nav가 숨는 채팅 reading 모드에서도 reserve가 남아 composer가 바닥에서 58px 떠 있었음 | reserve를 살아있는 `.v2-app[data-reading="true"]` 속성 기준으로 재배선. dead nav-hide / master-detail 규칙 제거 |
| ③ | **메인 영역 좌우 패딩 과다** — `--pad-surface`(spacious 티어 좌우 42px)가 뷰포트와 무관하게 고정. 12px shell 패딩과 합쳐 406px 화면의 ~27%(108px)를 잠식 | `≤900px`(shell 모바일 브레이크포인트) 오버라이드로 density 티어별 좌우 패딩 압축(세로 리듬 유지). SSOT 토큰 `--pad-surface`만 조정 → overview/work/approvals/schedule/cockpit 일괄 적용 |

## 왜 root fix (telemetry/workaround 아님)

증상을 가리는 게 아니라 **죽은 셀렉터를 살아있는 속성으로 교체**하는 근본 수정입니다. `data-mpane`은 앱이 절대 세팅하지 않으므로(리스킨이 drop), 관련 규칙은 전부 dead였습니다. nav 숨김 자체는 이미 `keeper-workspace.css`의 `data-reading`이 담당하고 있었고, 빠진 건 reserve 회수뿐이었습니다.

## 검증 (406px 뷰포트, 현재 소스 dev server)

| 상태 | `data-reading` | `.v2-body` reserve | nav |
|---|---|---|---|
| overview (non-reading) | false | **58px 유지** (콘텐츠가 보이는 nav 뒤로 안 숨음) | 표시 |
| 키퍼 채팅 (reading) | true | **0px** (composer 바닥 도달) | 숨김 |

- overview surface 좌우 패딩 42px → **16px** (총 inset 108px → 56px, 27%→14%)
- 신규 계약 테스트 `mobile-bottom-reserve.test.ts` 5건 — dead `data-mpane` selector 부재 + reserve가 `data-reading` 기준 + density 티어별 모바일 패딩 압축 단언
- `tsc --noEmit` clean, styles 테스트 120/120, craft-v2/app/mobile 계약 테스트 green

## 범위 밖

- overview KPI 그리드 모바일 3열의 trailing 빈 셀(밀도 nit) — 별도.
- 데스크톱 density 값(사용자 선택형)은 미변경. 모바일 오버라이드만 추가.
- RFC 대상 아님 (dashboard 스타일, credential/keeper-sandbox/operator 무관).
