### PR TITLE
fix(dashboard): narrow indexed access in mobile-bottom-reserve test (main Dashboard red)

### DIFF
--- a/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
+++ b/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
@@ -65,13 +65,18 @@ describe('mobile surface padding compresses per density tier (≤900px)', () => 
   // Desktop tiers (craft.css): spacious 42px / regular 26px / compact 18px
   // inline padding. On the single-column mobile shell these are disproportionate
   // (spacious 42px + 12px shell pad ≈ 27% of a 406px viewport).
-  const DESKTOP_INLINE: Record<string, number> = { spacious: 42, regular: 26, compact: 18 }
+  const DESKTOP_INLINE: Record<'spacious' | 'regular' | 'compact', number> = {
+    spacious: 42,
+    regular: 26,
+    compact: 18,
+  }
 
   for (const tier of ['spacious', 'regular', 'compact'] as const) {
     it(`tightens --pad-surface inline padding for data-density="${tier}"`, () => {
       const decls = mediaRuleDecls(craftCss, `.v2-app[data-density="${tier}"]`, SHELL_MOBILE_CHROME_BREAKPOINT)
       const pad = decls['--pad-surface']
-      expect(pad).toBeDefined()
+      if (pad === undefined)
+        throw new Error(`--pad-surface declaration missing for data-density="${tier}"`)
       expect(px(inlinePad(pad))).toBeLessThan(DESKTOP_INLINE[tier])
     })
   }


### PR DESCRIPTION
## 목적
main(`fe7e0b8c`)의 **Dashboard** check red를 회복합니다. #22672가 자체 test의 tsc 에러와 함께 머지되어 `tsc --noEmit`이 실패 중입니다:

```
mobile-bottom-reserve.test.ts(75,27): TS2345 'string | undefined' not assignable to 'string'
mobile-bottom-reserve.test.ts(75,47): TS2345 'number | undefined' not assignable to 'number | bigint'
```

`noUncheckedIndexedAccess`에서 indexed access가 `| undefined`를 더하는데 line 75가 미가드였습니다.

## 변경 (타입 레벨 narrowing, `!` 미사용)
1. `DESKTOP_INLINE: Record<string, number>` → `Record<'spacious' | 'regular' | 'compact', number>`. mapped type(유한 키)이라 `DESKTOP_INLINE[tier]`가 `number`(index signature가 아니므로 undefined 없음). `tier`는 `['spacious','regular','compact'] as const` 순회 union이라 정확히 매칭.
2. `expect(pad).toBeDefined()` → `if (pad === undefined) throw ...`. vitest의 `toBeDefined()`는 타입을 narrow하지 않으므로, throw-guard로 `pad`를 `string`으로 좁히고 동시에 명확한 메시지로 단언.

## 검증
`tsc --noEmit`은 CI에서 확인(로컬 빌드 안 함). Dashboard check green 확인 후 Ready.

## 반경
main은 현재 **이중 red**입니다:
- **Dashboard** = 이 PR(#22672 tsc 회귀)
- **Lint** = #22669 keeper or-pattern break, fix는 **#22671**(green·MERGEABLE, 머지 대기)

두 PR 모두 머지되어야 masc main이 완전 회복됩니다.
