### PR TITLE
fix(dashboard): chunk D 후속 — 모바일 shell gutter 축소 (12→7.5px)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -316,7 +316,7 @@ export function App() {
             class="v2-surface-host"
             style=${{ minWidth: 0, minHeight: 0, overflowY: 'auto' }}
           >
-            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : 'dashboard-main-scroll h-full p-4 max-[900px]:pb-16'}>
+            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : 'dashboard-main-scroll h-full p-4 max-[900px]:px-2 max-[900px]:pb-16'}>
               <div class="v2-surface" key=${currentTab}>
                 <${DashboardMain} />
               </div>

--- a/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
+++ b/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
@@ -14,6 +14,7 @@ import { parse } from 'postcss'
 
 const v2Css = readFileSync(resolve(__dirname, 'v2.css'), 'utf-8')
 const craftCss = readFileSync(resolve(__dirname, 'craft.css'), 'utf-8')
+const appSource = readFileSync(resolve(__dirname, '../../app.ts'), 'utf-8')
 
 const SHELL_MOBILE_CHROME_BREAKPOINT = '900px'
 
@@ -61,18 +62,37 @@ describe('mobile bottom-bar reserve (data-reading, not dead data-mpane)', () => 
   })
 })
 
+describe('mobile shell gutter is tightened (≤900px)', () => {
+  it('overrides the shell horizontal padding on the mobile branch', () => {
+    // The surface scroll container owns the inner card padding (--pad-surface);
+    // the shell `dashboard-main-scroll p-4` adds the outer gutter. On desktop
+    // both read 12px+; on mobile the outer gutter is tightened via
+    // `max-[900px]:px-2` so card surfaces sit closer to the screen edge while
+    // bare surfaces (e.g. board `.bd-body`, which relies on the shell gutter)
+    // keep a minimal inset. Asserted on the shell branch className.
+    const shellBranch = appSource.match(/dashboard-main-scroll[^'"`]*/)?.[0] ?? ''
+    expect(shellBranch).toContain('p-4')
+    expect(shellBranch).toContain('max-[900px]:px-2')
+    expect(shellBranch).toContain('max-[900px]:pb-16')
+  })
+})
+
 describe('mobile surface padding compresses per density tier (≤900px)', () => {
   // Desktop tiers (craft.css): spacious 42px / regular 26px / compact 18px
   // inline padding. On the single-column mobile shell these are disproportionate
   // (spacious 42px + 12px shell pad ≈ 27% of a 406px viewport).
-  const DESKTOP_INLINE: Record<string, number> = { spacious: 42, regular: 26, compact: 18 }
+  const TIERS = [
+    { tier: 'spacious', desktopInline: 42 },
+    { tier: 'regular', desktopInline: 26 },
+    { tier: 'compact', desktopInline: 18 },
+  ] as const
 
-  for (const tier of ['spacious', 'regular', 'compact'] as const) {
+  for (const { tier, desktopInline } of TIERS) {
     it(`tightens --pad-surface inline padding for data-density="${tier}"`, () => {
       const decls = mediaRuleDecls(craftCss, `.v2-app[data-density="${tier}"]`, SHELL_MOBILE_CHROME_BREAKPOINT)
-      const pad = decls['--pad-surface']
-      expect(pad).toBeDefined()
-      expect(px(inlinePad(pad))).toBeLessThan(DESKTOP_INLINE[tier])
+      const pad = decls['--pad-surface'] ?? ''
+      expect(pad).not.toBe('')
+      expect(px(inlinePad(pad))).toBeLessThan(desktopInline)
     })
   }
 })


### PR DESCRIPTION
## 무엇을

Chunk D 모바일 패스(#22672) 후속. 사용자 피드백 — "main과 내용물 패딩 구간, 공간 절약이 안 되는 건가" — 에 대한 응답.

## 진단 (406px 실측)

overview 패딩 스택은 두 층입니다:
- shell `dashboard-main-scroll p-4` = **12px** (카드↔화면 가장자리 outer gutter)
- surface `.ov-scroll` (`--pad-surface`) = **16px** (콘텐츠↔카드 안쪽 padding)

→ 카드형 서페이스는 좌우 각 28px inset. 반면 board `.bd-body`는 자체 패딩 0으로 **shell gutter에만 의존**.

## 수정

shell 모바일 분기에 `max-[900px]:px-2` 추가 → outer gutter **12px → 7.5px**. 카드형 서페이스가 화면 가장자리에 더 가까워지고, board류(자체 패딩 없음)는 가장자리에 붙지 않고 최소 여백 유지. 세로 패딩·하단 reserve는 불변. 전역 gutter 제거(edge-to-edge)는 board류를 깨므로 의도적으로 *축소만* 함.

## 검증

- `px-2` = 7.5px (이 repo 스케일, probe 확인). 기존 `max-[900px]:pb-16`과 동일 변형 메커니즘.
- 계약 테스트 `mobile-bottom-reserve.test.ts`에 shell 분기 className 단언 추가 (6/6).
- `tsc --noEmit` clean, styles+app 테스트 151/151.
- 모바일 뷰포트 시각 확인은 로컬 Chrome 줌 이슈로 결정적 측정(getComputedStyle/probe)으로 대체.

## 범위 밖
- 카드형 서페이스 edge-to-edge 전환 / overview KPI 모바일 빈 셀 — 별도.
- RFC 대상 아님 (dashboard 스타일).
