### PR TITLE
fix(dashboard): 모바일 shell gutter 실수정 — #22675 px-2 no-op 교체 (12→6px)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -316,7 +316,7 @@ export function App() {
             class="v2-surface-host"
             style=${{ minWidth: 0, minHeight: 0, overflowY: 'auto' }}
           >
-            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : 'dashboard-main-scroll h-full p-4 max-[900px]:px-2 max-[900px]:pb-16'}>
+            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : 'dashboard-main-scroll h-full p-4 max-[900px]:pb-16'}>
               <div class="v2-surface" key=${currentTab}>
                 <${DashboardMain} />
               </div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -267,6 +267,19 @@ tbody tr:hover {
   padding: var(--spacing-card);
 }
 
+/* The rule above is ID-specificity (1,0,1), so it outranks the shell's
+   `p-4`/`max-[900px]:px-2` utility classes — those never reach this element.
+   On the single-column mobile shell the 12px gutter (--spacing-card) stacks on
+   top of the surface inner padding (--pad-surface), wasting horizontal space.
+   Step the inline gutter down one semantic tier (card 12px → element 6px); the
+   surface padding owns the content inset, so the outer gutter only needs to
+   clear the #main-content border. Block (top/bottom) padding is left untouched. */
+@media (max-width: 900px) {
+  #main-content > div {
+    padding-inline: var(--spacing-element);
+  }
+}
+
 /* Tone border utilities — applied via toneClass() helper */
 @utility ok { border-color: var(--ok-22); }
 @utility warn { border-color: var(--warn-soft); }

--- a/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
+++ b/dashboard/src/styles/keeper-v2/mobile-bottom-reserve.test.ts
@@ -14,7 +14,18 @@ import { parse } from 'postcss'
 
 const v2Css = readFileSync(resolve(__dirname, 'v2.css'), 'utf-8')
 const craftCss = readFileSync(resolve(__dirname, 'craft.css'), 'utf-8')
+const globalCss = readFileSync(resolve(__dirname, '../global.css'), 'utf-8')
+const variablesCss = readFileSync(resolve(__dirname, '../variables.css'), 'utf-8')
 const appSource = readFileSync(resolve(__dirname, '../../app.ts'), 'utf-8')
+
+// Resolve a `--token: <Npx>;` declaration from variables.css to its pixel number.
+function tokenPx(prop: string): number {
+  let value = ''
+  parse(variablesCss).walkDecls((decl) => {
+    if (decl.prop === prop) value = decl.value.trim()
+  })
+  return Number.parseFloat(value)
+}
 
 const SHELL_MOBILE_CHROME_BREAKPOINT = '900px'
 
@@ -63,17 +74,28 @@ describe('mobile bottom-bar reserve (data-reading, not dead data-mpane)', () => 
 })
 
 describe('mobile shell gutter is tightened (≤900px)', () => {
-  it('overrides the shell horizontal padding on the mobile branch', () => {
-    // The surface scroll container owns the inner card padding (--pad-surface);
-    // the shell `dashboard-main-scroll p-4` adds the outer gutter. On desktop
-    // both read 12px+; on mobile the outer gutter is tightened via
-    // `max-[900px]:px-2` so card surfaces sit closer to the screen edge while
-    // bare surfaces (e.g. board `.bd-body`, which relies on the shell gutter)
-    // keep a minimal inset. Asserted on the shell branch className.
+  // The shell gutter is owned by the ID-specificity rule `#main-content > div
+  // { padding: var(--spacing-card) }` in global.css — NOT by the shell's
+  // `dashboard-main-scroll p-4` utility classes, which lose the cascade to the
+  // ID selector and never reach the element. An earlier attempt tightened the
+  // gutter via `max-[900px]:px-2` on the shell className; that class generates
+  // but is overridden by the ID rule, so it was a no-op at runtime. The real
+  // lever is a mobile override on `#main-content > div`.
+
+  it('does not rely on the dead max-[900px]:px-2 shell class (loses to the ID rule)', () => {
     const shellBranch = appSource.match(/dashboard-main-scroll[^'"`]*/)?.[0] ?? ''
-    expect(shellBranch).toContain('p-4')
-    expect(shellBranch).toContain('max-[900px]:px-2')
-    expect(shellBranch).toContain('max-[900px]:pb-16')
+    expect(shellBranch).not.toContain('px-2')
+  })
+
+  it('tightens #main-content > div inline padding on the mobile branch', () => {
+    const decls = mediaRuleDecls(globalCss, '#main-content > div', SHELL_MOBILE_CHROME_BREAKPOINT)
+    expect(decls['padding-inline']).toBe('var(--spacing-element)')
+  })
+
+  it('the mobile gutter token is smaller than the desktop --spacing-card', () => {
+    // Desktop: `#main-content > div { padding: var(--spacing-card) }`.
+    // Mobile steps down one semantic tier to --spacing-element.
+    expect(tokenPx('--spacing-element')).toBeLessThan(tokenPx('--spacing-card'))
   })
 })
 


### PR DESCRIPTION
## 배경

PR #22675는 모바일 shell gutter를 `max-[900px]:px-2`(7.5px)로 줄이려 했으나, **런타임에서 적용되지 않는 no-op**였습니다.

shell gutter의 실제 주인은 ID specificity 규칙입니다:

```css
#main-content > div { padding: var(--spacing-card); }   /* (1,0,1) */
```

이 ID 셀렉터(1,0,1)는 shell의 `p-4`/`max-[900px]:px-2` 유틸리티(0,1,0)와 `.v2-app[data-density] .dashboard-main-scroll`(0,3,0)을 모두 cascade에서 이깁니다. 따라서 `px-2`는 클래스로 생성은 되지만 이 요소에 도달하지 못합니다.

**검증 (getComputedStyle, 406px 모바일):** `px-2`를 className에서 제거해도 `padding-left`는 12px 그대로. `!important`만이 ID 규칙을 이김. tsc/contract test는 "클래스 존재"만 증명했고, 런타임 무효는 시각/계산값 검증으로만 드러났습니다.

## 변경

1. **죽은 클래스 제거** — `app.ts` shell className에서 `max-[900px]:px-2` 제거 (구조적 no-op).
2. **진짜 메커니즘에 override 추가** — `global.css`의 `#main-content > div`에 모바일(≤900px) inline padding override:

   ```css
   @media (max-width: 900px) {
     #main-content > div { padding-inline: var(--spacing-element); }
   }
   ```

   gutter를 한 semantic 티어 낮춤 (`--spacing-card` 12px → `--spacing-element` 6px). magic number 대신 기존 토큰 사용. block(top/bottom) padding은 건드리지 않음 — surface `--pad-surface`가 콘텐츠 inset을 담당하므로 바깥 gutter는 `#main-content` border만 비우면 됨.
3. **계약 테스트 갱신** — 기존의 "className에 px-2 포함" 거짓 단언을 (a) px-2 미포함(재추가 회귀 가드), (b) global.css 모바일 override 존재, (c) `--spacing-element` < `--spacing-card` 수치 검증으로 교체.

## 검증

- `tsc --noEmit`: exit 0
- `vitest` (`mobile-bottom-reserve.test.ts` + `app.test.ts`): 38 passed
- Chrome getComputedStyle @406px: `padding-inline` 12px → **6px**, `padding-top/bottom` 12px 유지, className에 px-2 없음
- 시각 확인: 콘텐츠가 가로폭을 더 활용, clipping/cramping 없음

RFC-WAIVED: dashboard CSS gutter 토큰 티어 조정. credential/keeper/operator/hooks/workflow 서브시스템과 무관 (RFC 게이트 대상 아님).
