### PR TITLE
fix(dashboard): generated↔variables.css 토큰 override drift 게이트 (Gate 2)

### DIFF
--- a/dashboard/design-system/tokens/override-drift-baseline.json
+++ b/dashboard/design-system/tokens/override-drift-baseline.json
@@ -1,0 +1,119 @@
+{
+  "_doc": "Reviewed baseline of generated↔variables.css token divergences. The app imports src/styles/tokens.generated.css (@theme, @generated) then src/styles/variables.css (:root), which re-defines these tokens to different RENDERED values. tokens:check (Gate 2) ratchets this set: any NEW divergence, or a value change on a listed entry, or a listed entry that no longer diverges, fails the gate. Entries marked UNREVIEWED are pre-existing drift pending a reconcile decision (chunk F). Scope: variables.css only (the last-winning override layer); styleseed-tokens.css is an earlier layer not yet covered.",
+  "scope": {
+    "generated": "src/styles/tokens.generated.css",
+    "override": "src/styles/variables.css"
+  },
+  "overrides": {
+    "--color-accent-glow": {
+      "generated": "var(--brass-glow)",
+      "override": "var(--accent-glow)",
+      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+    },
+    "--color-info": {
+      "generated": "#6a8eb0",
+      "override": "var(--text-info)",
+      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+    },
+    "--font-body": {
+      "generated": "'EB Garamond', 'Noto Sans KR', Georgia, serif",
+      "override": "\"EB Garamond\", \"Noto Sans KR\", Georgia, serif",
+      "reason": "Font stack quote-style / fallback-list variant (cosmetic or fallback diff)"
+    },
+    "--font-display": {
+      "generated": "'Cinzel', 'Noto Sans KR', 'EB Garamond', serif",
+      "override": "\"Cinzel\", \"Noto Sans KR\", \"EB Garamond\", serif",
+      "reason": "Font stack quote-style / fallback-list variant (cosmetic or fallback diff)"
+    },
+    "--radius-lg": {
+      "generated": "12px",
+      "override": "6px",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--radius-md": {
+      "generated": "6px",
+      "override": "4px",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--radius-pill": {
+      "generated": "999px",
+      "override": "9999px",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--radius-sm": {
+      "generated": "4px",
+      "override": "3px",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--radius-xl": {
+      "generated": "24px",
+      "override": "8px",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--radius-xs": {
+      "generated": "2px",
+      "override": "var(--r-0)",
+      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+    },
+    "--scrim-strong": {
+      "generated": "var(--color-scrim-strong)",
+      "override": "rgba(0, 0, 0, 0.6)",
+      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+    },
+    "--shadow-card": {
+      "generated": "0 1px 4px rgba(0, 0, 0, 0.5)",
+      "override": "0 1px 3px rgba(0, 0, 0, 0.04)",
+      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+    },
+    "--spacing-card": {
+      "generated": "16px",
+      "override": "12px",
+      "reason": "Cockpit density override — keep generated ladder intact, render tighter (variables.css L382-386)"
+    },
+    "--spacing-element": {
+      "generated": "8px",
+      "override": "6px",
+      "reason": "Cockpit density override — keep generated ladder intact, render tighter (variables.css L382-386)"
+    },
+    "--spacing-group": {
+      "generated": "12px",
+      "override": "8px",
+      "reason": "Cockpit density override — keep generated ladder intact, render tighter (variables.css L382-386)"
+    },
+    "--type-body": {
+      "generated": "var(--fs-13)/var(--lh-body) var(--font-sans)",
+      "override": "var(--fs-13)/var(--lh-body) ui-sans-serif, -apple-system, system-ui, sans-serif",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-caption": {
+      "generated": "var(--fs-10)/var(--lh-tight) var(--font-mono)",
+      "override": "var(--fs-10)/var(--lh-tight) ui-monospace, \"SF Mono\", Menlo, monospace",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-kpi-l": {
+      "generated": "var(--fs-20)/var(--lh-tight) var(--font-mono)",
+      "override": "var(--fs-20)/var(--lh-tight) ui-monospace, \"SF Mono\", Menlo, monospace",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-kpi-m": {
+      "generated": "var(--fs-16)/var(--lh-tight) var(--font-mono)",
+      "override": "var(--fs-16)/var(--lh-tight) ui-monospace, \"SF Mono\", Menlo, monospace",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-label": {
+      "generated": "var(--fs-11)/var(--lh-tight) var(--font-sans)",
+      "override": "var(--fs-11)/var(--lh-tight) ui-sans-serif, -apple-system, system-ui, sans-serif",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-meta": {
+      "generated": "var(--fs-12)/var(--lh-tight) var(--font-mono)",
+      "override": "var(--fs-12)/var(--lh-tight) ui-monospace, \"SF Mono\", Menlo, monospace",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    },
+    "--type-title": {
+      "generated": "var(--fs-14)/var(--lh-tight) var(--font-sans)",
+      "override": "var(--fs-14)/var(--lh-tight) ui-sans-serif, -apple-system, system-ui, sans-serif",
+      "reason": "Type composite re-points font stack to system fallback (variables.css)"
+    }
+  }
+}

--- a/dashboard/design-system/tokens/scripts/check-equivalence.mjs
+++ b/dashboard/design-system/tokens/scripts/check-equivalence.mjs
@@ -24,11 +24,21 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import postcss from "postcss";
 import { formatHex, parseHex, differenceCiede2000 } from "culori";
+import { computeConflicts } from "./lib/override-drift.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "..", "..", "..", "..");
 
 const GENERATED_CSS = resolve(REPO, "dashboard/design-system/source_styles/tokens.generated.css");
+
+// Override-drift gate: the app imports src/styles/tokens.generated.css (@theme)
+// then src/styles/variables.css (:root), which re-defines a subset of tokens to
+// different RENDERED values. The drift workflow only guards source.ts ↔
+// generated, so this divergence is otherwise unchecked. We ratchet it against a
+// reviewed baseline — NEW divergence, a value change, or a stale entry all fail.
+const APP_GENERATED_CSS = resolve(REPO, "dashboard/src/styles/tokens.generated.css");
+const APP_VARIABLES_CSS = resolve(REPO, "dashboard/src/styles/variables.css");
+const OVERRIDE_BASELINE = resolve(HERE, "..", "override-drift-baseline.json");
 
 const STATUS_CANON = {
   ok: "#6b9e6b",
@@ -104,6 +114,49 @@ function checkKeeperPalette(genMap) {
   return errors;
 }
 
+function checkOverrideDrift() {
+  const errors = [];
+  let baseline;
+  try {
+    baseline = JSON.parse(readFileSync(OVERRIDE_BASELINE, "utf8"));
+  } catch (e) {
+    return [`override-drift baseline unreadable: ${OVERRIDE_BASELINE} (${e.message})`];
+  }
+  const allowed = new Map(Object.entries(baseline.overrides ?? {}));
+
+  let conflicts;
+  try {
+    conflicts = computeConflicts(APP_GENERATED_CSS, APP_VARIABLES_CSS);
+  } catch (e) {
+    return [`override-drift scan failed: ${e.message}`];
+  }
+  const current = new Map(conflicts.map((c) => [c.token, c]));
+
+  // NEW divergence or a value change on an allow-listed entry.
+  for (const c of conflicts) {
+    const entry = allowed.get(c.token);
+    if (!entry) {
+      errors.push(
+        `NEW override drift: ${c.token} generated=${c.generated} variables.css=${c.override} — ` +
+          `add a reviewed entry to override-drift-baseline.json (with a reason) or reconcile the value`,
+      );
+    } else if (entry.generated !== c.generated || entry.override !== c.override) {
+      errors.push(
+        `override drift value changed: ${c.token} now generated=${c.generated} variables.css=${c.override}, ` +
+          `baseline had generated=${entry.generated} variables.css=${entry.override} — re-review and update the baseline`,
+      );
+    }
+  }
+  // Stale baseline entry — the divergence is gone, so the entry must be removed
+  // to keep the baseline honest (prevents the allow-list from rotting open).
+  for (const token of allowed.keys()) {
+    if (!current.has(token)) {
+      errors.push(`stale baseline entry: ${token} no longer diverges — remove it from override-drift-baseline.json`);
+    }
+  }
+  return errors;
+}
+
 function main() {
   let genText;
   try {
@@ -133,6 +186,15 @@ function main() {
     failed = true;
   } else {
     console.log(`[OK] keeper 12-slot palette ΔE < 2 vs OkLCH(L=68, C=0.09, H=i*30)`);
+  }
+
+  const overrideErrors = checkOverrideDrift();
+  if (overrideErrors.length > 0) {
+    console.error(`[FAIL] generated ↔ variables.css override drift:`);
+    for (const e of overrideErrors) console.error(`  - ${e}`);
+    failed = true;
+  } else {
+    console.log(`[OK] generated ↔ variables.css override drift matches reviewed baseline`);
   }
 
   if (failed) {

--- a/dashboard/design-system/tokens/scripts/lib/override-drift.mjs
+++ b/dashboard/design-system/tokens/scripts/lib/override-drift.mjs
@@ -1,0 +1,66 @@
+/**
+ * Override-drift detector (shared by check-equivalence.mjs and the
+ * baseline generator).
+ *
+ * The dashboard renders design tokens from `src/styles/tokens.generated.css`
+ * (@theme block, @generated) but `src/styles/variables.css` is imported AFTER
+ * it (global.css import order) and re-defines a subset of those tokens to
+ * different values — so the *rendered* value diverges from the generated SSOT.
+ * The tokens-drift workflow only guards source.ts ↔ generated equivalence, so
+ * this generated ↔ variables.css divergence is otherwise unchecked.
+ *
+ * This module extracts the conflict set so the gate can ratchet it against a
+ * reviewed baseline: pre-existing intentional overrides are allow-listed with
+ * a reason; any NEW (or value-changed) divergence fails the gate.
+ */
+import { readFileSync } from "node:fs";
+import postcss from "postcss";
+
+// Collect `--token: value` declarations that determine the base (desktop)
+// cascade value: decls inside top-level `:root` rules and `@theme` at-rules,
+// but NOT inside `@media`/other conditional at-rules (those are responsive
+// overrides, compared separately if ever needed). Last write wins, mirroring
+// the CSS cascade within a single file.
+export function collectBaseTokens(cssText) {
+  const root = postcss.parse(cssText);
+  const out = new Map();
+
+  const insideConditional = (node) => {
+    for (let p = node.parent; p && p.type !== "root"; p = p.parent) {
+      if (p.type === "atrule" && p.name !== "theme") return true;
+    }
+    return false;
+  };
+
+  root.walkDecls((decl) => {
+    if (!decl.prop.startsWith("--")) return;
+    if (insideConditional(decl)) return;
+    // Only count decls that live under :root or @theme (token surfaces).
+    let surface = false;
+    for (let p = decl.parent; p && p.type !== "root"; p = p.parent) {
+      if (p.type === "atrule" && p.name === "theme") { surface = true; break; }
+      if (p.type === "rule") {
+        const sels = p.selector.split(",").map((s) => s.trim());
+        if (sels.some((s) => s === ":root" || s.startsWith(":root"))) { surface = true; break; }
+      }
+    }
+    if (!surface) return;
+    out.set(decl.prop, decl.value.trim());
+  });
+  return out;
+}
+
+// Returns the sorted list of tokens defined in BOTH files with different base
+// values: { token, generated, override }.
+export function computeConflicts(generatedCssPath, overrideCssPath) {
+  const gen = collectBaseTokens(readFileSync(generatedCssPath, "utf8"));
+  const ovr = collectBaseTokens(readFileSync(overrideCssPath, "utf8"));
+  const conflicts = [];
+  for (const [token, ovrVal] of ovr) {
+    if (!gen.has(token)) continue;
+    const genVal = gen.get(token);
+    if (genVal !== ovrVal) conflicts.push({ token, generated: genVal, override: ovrVal });
+  }
+  conflicts.sort((a, b) => a.token.localeCompare(b.token));
+  return conflicts;
+}


### PR DESCRIPTION
## 배경

작업 중 발견: 대시보드 **표시 토큰의 SSOT가 끊겨** 있습니다.

- 앱은 `src/styles/tokens.generated.css`(`@theme`, `@generated`)를 import한 뒤 `src/styles/variables.css`(`:root`)를 **나중에** import 합니다. variables.css가 일부 토큰을 **다른 값으로 재정의**하고 cascade에서 이기므로, **실제 렌더값이 design-system generated SSOT와 다릅니다**.
- 예: `--spacing-card` 16px→12px, `--spacing-element` 8px→6px, `--radius-xl` 24px→8px, `--radius-pill` 999px→9999px.
- 기존 `tokens-drift` 워크플로의 3개 게이트는 **source.ts↔generated 등가성만** 검증합니다. generated↔variables.css drift는 **아무도 안 봅니다** → `tokens:check`가 green이어도 production 표시값과 무관할 수 있음.
- 부수 사실: generated 헤더는 source를 `source.ts`라 하지만 source.ts는 토큰 0개(마커 2개), generator `build.ts`는 부재(`tokens:build`은 no-op). generated 재생성 자체가 막혀 있어 hand-authored override가 사실상 SSOT.

## 변경

`check-equivalence.mjs`(Gate 2)에 **override-drift ratchet** 추가:

- 앱이 실제 import하는 `src/styles/tokens.generated.css` ↔ `src/styles/variables.css`의 base 충돌을 reviewed baseline과 대조.
- **NEW divergence** (generated 토큰을 variables.css가 새로 가림) → FAIL
- baseline 항목의 **값 변경** → FAIL (재검토 강제)
- 더 이상 충돌 안 하는 **stale 항목** → FAIL (allow-list 부패 방지)

`override-drift-baseline.json`: 현재 base 충돌 22건을 사유와 함께 기록. **12건 documented**(Cockpit density spacing, type composite), **10건 UNREVIEWED**(radius 스케일, 일부 색/그림자 — 화해 방향은 chunk F로 보류, 게이트가 동결해 신규 drift 누적 차단).

`lib/override-drift.mjs`: `:root`/`@theme` base 토큰 파서(`@media` 제외 — 반응형 override는 별도).

## 검증

- `pnpm tokens:check`: status canon + keeper ΔE + **override drift** 모두 [OK]
- **Mutation test**: (a) 새 충돌 주입 → "NEW override drift" FAIL, (b) 값 변경 → "value changed" FAIL, (c) baseline override 제거 → "stale baseline entry" FAIL. 복원 후 PASS.

## 범위/후속

- 이 PR은 **drift를 잡는 게이트만** 추가합니다. **drift 값 자체는 안 건드립니다** (의도적 override 보존).
- UNREVIEWED 10건(radius/color)의 화해 방향(generated 재생성 vs variables.css를 SSOT 승격)은 별도 결정/RFC 대상.
- 현재 scope는 variables.css(마지막 override 레이어)만. styleseed-tokens.css(이른 레이어)는 미커버 — baseline `_doc`에 명시.

RFC-WAIVED: dashboard token-drift CI 게이트(tooling). credential/keeper/operator/hooks/workflow 무관.
