### PR TITLE
refactor(usage): consume OAS canonical api_usage projections (F4/F12)

### DIFF
--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -23,17 +23,18 @@ let int_of_env_default name ~default ~min_v ~max_v =
 (* Usage helpers                                                     *)
 (* ================================================================ *)
 
-(** Compute total tokens from OAS api_usage. *)
-let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens
+(** Total tokens — delegates to OAS [Agent_sdk.Types.total_tokens] (F12 canonical
+    projection consumption: OAS owns api_usage arithmetic, MASC consumes). *)
+let total_tokens = Agent_sdk.Types.total_tokens
 
 (** CJK-aware token estimate delegated to OAS Context_reducer. *)
 let estimate_tokens (s : string) : int =
   if s = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens s
 
-(** Zero usage marker — delegates to OAS Masc_domain.zero_api_usage.
+(** Zero usage marker — delegates to OAS [Agent_sdk.Types.zero_api_usage] (F4
+    canonical projection consumption: removes re-spelled record literal).
     @since 2.123.0 — delegated to OAS *)
-let zero_usage : Agent_sdk.Types.api_usage =
-  { input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0; cost_usd = None }
+let zero_usage = Agent_sdk.Types.zero_api_usage
 
 (** Extract usage from an api_response, defaulting to zero.
     @since 2.123.0 *)

--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
@@ -276,14 +276,9 @@ let stop_reason_to_label : Agent_sdk.Types.stop_reason -> string = function
   | Agent_sdk.Types.ContextWindowExceeded -> "model_context_window_exceeded"
   | Agent_sdk.Types.Unknown _ -> stop_reason_label_unknown
 
-let zero_usage : Agent_sdk.Types.api_usage =
-  {
-    input_tokens = 0;
-    output_tokens = 0;
-    cache_creation_input_tokens = 0;
-    cache_read_input_tokens = 0;
-    cost_usd = None;
-  }
+(* F4 canonical projection consumption: delegate to OAS instead of re-spelling
+   the api_usage record literal (SSOT — OAS owns the zero marker). *)
+let zero_usage = Agent_sdk.Types.zero_api_usage
 
 let telemetry_has_canonical_model_id
     (telemetry : Agent_sdk.Types.inference_telemetry option) =

--- a/test/test_inference_utils.ml
+++ b/test/test_inference_utils.ml
@@ -16,6 +16,34 @@ let test_elapsed_duration_ms_rejects_non_finite () =
   check int "nan" 0 (Inference_utils.elapsed_duration_ms nan);
   check int "infinity" 0 (Inference_utils.elapsed_duration_ms infinity)
 
+(* Canonical-projection consumption drift-guards (oas roadmap F4 / F12).
+   MASC delegates its zero-usage markers and token arithmetic to OAS so the
+   api_usage SSOT lives in one place. These trip if a divergent re-spelled
+   literal is ever re-introduced on the MASC side. *)
+
+let test_zero_usage_tracks_oas_canonical () =
+  check bool "Inference_utils.zero_usage = OAS zero_api_usage" true
+    (Inference_utils.zero_usage = Agent_sdk.Types.zero_api_usage);
+  check bool "Keeper_hooks_oas_types.zero_usage = OAS zero_api_usage" true
+    (Keeper_hooks_oas_types.zero_usage = Agent_sdk.Types.zero_api_usage)
+
+let test_total_tokens_parity_and_excludes_cache () =
+  let sample : Agent_sdk.Types.api_usage =
+    {
+      Agent_sdk.Types.input_tokens = 7;
+      output_tokens = 5;
+      cache_creation_input_tokens = 3;
+      cache_read_input_tokens = 2;
+      cost_usd = Some 0.01;
+    }
+  in
+  (* input + output only — cache tokens are excluded by the projection. *)
+  check int "total_tokens excludes cache tokens" 12
+    (Inference_utils.total_tokens sample);
+  check int "total_tokens parity with OAS projection"
+    (Agent_sdk.Types.total_tokens sample)
+    (Inference_utils.total_tokens sample)
+
 let () =
   Alcotest.run "Inference_utils"
     [
@@ -29,5 +57,12 @@ let () =
             test_elapsed_duration_ms_keeps_non_positive_zero;
           test_case "non-finite intervals stay zero" `Quick
             test_elapsed_duration_ms_rejects_non_finite;
+        ] );
+      ( "canonical projection consumption",
+        [
+          test_case "zero_usage markers track OAS canonical" `Quick
+            test_zero_usage_tracks_oas_canonical;
+          test_case "total_tokens parity, excludes cache tokens" `Quick
+            test_total_tokens_parity_and_excludes_cache;
         ] );
     ]


### PR DESCRIPTION
## 목적

OAS가 노출하는 canonical projection(`Agent_sdk.Types.{zero_api_usage,total_tokens}`)을 MASC가 **소비**하도록 전환한다. 기존에는 MASC가 동일한 `api_usage` 레코드 리터럴/연산을 직접 재작성(re-spell)해 SSOT를 위반하고 drift 위험이 있었다. 방향은 로드맵대로 MASC→OAS (OAS는 MASC를 참조하지 않는다).

근거: oas `docs/design/2026-06-29-canonical-projection-ssot.md` 의 **F4**(`zero_usage` ×2 제거)·**F12**(`total_tokens` 제거).

## 변경

| 사이트 | before | after |
|---|---|---|
| `lib/inference_utils.ml` total_tokens | `fun u -> u.input + u.output` 리터럴 | `Agent_sdk.Types.total_tokens` (F12) |
| `lib/inference_utils.ml` zero_usage | 5-field 레코드 리터럴 | `Agent_sdk.Types.zero_api_usage` (F4) |
| `lib/keeper_hooks_oas_types/…` zero_usage | 5-field 레코드 리터럴 | `Agent_sdk.Types.zero_api_usage` (F4) |

## 타입 안전 / 빌드

- `.mli` 시그니처 무변경: `total_tokens : api_usage -> int`, `zero_usage : api_usage` 가 위임 대상과 byte-identical.
- 심볼 존재 검증: lock된 `agent_sdk 0.207.21` (= oas `39a7d139`, **CI 빌드 대상**) 의 `types.mli:425/433` 에 `zero_api_usage`/`total_tokens` 존재. 로컬 switch `0.207.22` 도 동일.
- 동작 무변경: 위임은 값/함수가 동일하므로 zero-behavior-change.

## N-of-M 회피 (전수 분류)

`zero_usage`/`total_tokens` 전 정의를 스캔해 분류:
- **위임 대상(완료)**: `inference_utils`·`keeper_hooks_oas_types` 의 5-field api_usage 마커.
- **다른 타입(제외)**: `fusion_types.ml`(2-field 로컬 `@@deriving` 타입), `keeper_meta_contract.ml`(`usage_metrics` 타입).
- **다른 관심사(제외)**: `make_usage`/`usage_for_trust`(파라미터화 생성자 — 명시 리터럴이 schema 변경 시 컴파일 강제), dashboard `total_tokens`(JSON 파싱/누산 ref).
- **re-export(자동 추종)**: `keeper_context_core_accessors`·`keeper_context_runtime`.

## 테스트

`test/test_inference_utils.ml` 에 drift-guard 추가 (dune 변경 없음 — `masc_test_deps` 가 `agent_sdk` re-export):
- MASC zero 마커 2개가 OAS `zero_api_usage` 를 추종하는지 구조적 등치 검증.
- `total_tokens` 가 input+output 만 합산(cache 제외) + OAS projection 과 parity.
- 의미: 미래에 발산 리터럴 재도입 시 실패하는 revert-tripwire.

## 로컬 검증 / 미검증

- 로컬: diff 검토 + 심볼 존재(locked/local agent_sdk) + .mli parity 확인.
- 미검증(CI 위임): full `dune build`/test 실행 — 정책상 CI에서 확인.

RFC-WAIVED: RFC-gated subsystem 아님 (credential/keeper_gh/host_config/repo_manager/operator_control/dashboard credential/hooks/workflow 미해당). 순수 SSOT 중복 제거 + OAS 로드맵(F4/F12) 정합 소비.
