### PR TITLE
refactor(thinking-summary): consume OAS Response_shape.summarize_blocks (F2)

### DIFF
--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
@@ -207,28 +207,31 @@ type thinking_log_summary =
   }
 
 let summarize_thinking_blocks content =
-  let thinking_blocks = ref 0 in
-  let thinking_chars = ref 0 in
-  let redacted_thinking_blocks = ref 0 in
-  List.iter
-    (function
-      | Agent_sdk.Types.Thinking { content; _ } ->
-          incr thinking_blocks;
-          thinking_chars := !thinking_chars + String.length content
-      | Agent_sdk.Types.RedactedThinking _ -> incr redacted_thinking_blocks
-      | _ -> ())
-    content;
+  (* F2 canonical projection consumption: delegate block counting to the OAS
+     [Response_shape.summarize_blocks] (exhaustive per-variant fold) instead of
+     re-iterating with a [_ -> ()] catch-all that silently drops a new
+     thinking-bearing content_block variant. MASC keeps only the policy shaping
+     (thinking_present + thinking_kind classifier). The leading qualified field
+     anchors the pattern to [Response_shape.t] to disambiguate the shared
+     thinking_* field names. *)
+  let { Agent_sdk.Response_shape.thinking_blocks
+      ; thinking_chars
+      ; redacted_thinking_blocks
+      ; _
+      } =
+    Agent_sdk.Response_shape.summarize_blocks content
+  in
   let thinking_kind =
-    match !thinking_blocks > 0, !redacted_thinking_blocks > 0 with
+    match thinking_blocks > 0, redacted_thinking_blocks > 0 with
     | false, false -> "none"
     | true, false -> "thinking"
     | false, true -> "redacted"
     | true, true -> "mixed"
   in
-  { thinking_present = !thinking_blocks > 0 || !redacted_thinking_blocks > 0
-  ; thinking_blocks = !thinking_blocks
-  ; thinking_chars = !thinking_chars
-  ; redacted_thinking_blocks = !redacted_thinking_blocks
+  { thinking_present = thinking_blocks > 0 || redacted_thinking_blocks > 0
+  ; thinking_blocks
+  ; thinking_chars
+  ; redacted_thinking_blocks
   ; thinking_kind
   }
 

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -21,6 +21,55 @@ let test_tool_arg_shapes_keep_field_names () =
   check string "keys preserve input order" "argv,cwd,executable"
     (Under_test.tool_input_keys_for_log input)
 
+(* F2 canonical projection consumption: block counting in
+   [summarize_thinking_blocks] is delegated to OAS [Response_shape.summarize_blocks];
+   MASC keeps the policy shaping (thinking_present + thinking_kind classifier).
+   These pin that policy output across all classifier cases so the delegation
+   stays behavior-preserving. *)
+
+let thinking ?(thinking_type = "thinking") content =
+  Agent_sdk.Types.Thinking { thinking_type; content }
+
+let check_thinking_summary ~msg ~present ~blocks ~chars ~redacted ~kind content =
+  let { Keeper_hooks_oas_types.thinking_present
+      ; thinking_blocks
+      ; thinking_chars
+      ; redacted_thinking_blocks
+      ; thinking_kind
+      } =
+    Keeper_hooks_oas_types.summarize_thinking_blocks content
+  in
+  check bool (msg ^ ": present") present thinking_present;
+  check int (msg ^ ": blocks") blocks thinking_blocks;
+  check int (msg ^ ": chars") chars thinking_chars;
+  check int (msg ^ ": redacted") redacted redacted_thinking_blocks;
+  check string (msg ^ ": kind") kind thinking_kind
+
+let test_thinking_summary_none_empty () =
+  check_thinking_summary ~msg:"empty" ~present:false ~blocks:0 ~chars:0
+    ~redacted:0 ~kind:"none" []
+
+let test_thinking_summary_none_text_only () =
+  check_thinking_summary ~msg:"text-only" ~present:false ~blocks:0 ~chars:0
+    ~redacted:0 ~kind:"none" [ Agent_sdk.Types.Text "hello" ]
+
+let test_thinking_summary_thinking_counts_chars () =
+  check_thinking_summary ~msg:"thinking" ~present:true ~blocks:1 ~chars:5
+    ~redacted:0 ~kind:"thinking" [ thinking "abcde" ]
+
+let test_thinking_summary_redacted_only () =
+  check_thinking_summary ~msg:"redacted" ~present:true ~blocks:0 ~chars:0
+    ~redacted:1 ~kind:"redacted" [ Agent_sdk.Types.RedactedThinking "opaque" ]
+
+let test_thinking_summary_mixed_sums () =
+  check_thinking_summary ~msg:"mixed" ~present:true ~blocks:2 ~chars:7
+    ~redacted:1 ~kind:"mixed"
+    [ thinking "abcd"
+    ; Agent_sdk.Types.RedactedThinking "x"
+    ; thinking "efg"
+    ; Agent_sdk.Types.Text "ignored"
+    ]
+
 let () =
   run "keeper_hooks_oas_log_shape"
     [ ( "tool-input-log-shape"
@@ -28,5 +77,16 @@ let () =
             test_empty_tool_args_are_explicit_object_shape
         ; test_case "field shapes are explicit" `Quick
             test_tool_arg_shapes_keep_field_names
+        ] )
+    ; ( "thinking-summary-classifier"
+      , [ test_case "empty -> none" `Quick test_thinking_summary_none_empty
+        ; test_case "text-only -> none" `Quick
+            test_thinking_summary_none_text_only
+        ; test_case "thinking -> thinking, chars counted" `Quick
+            test_thinking_summary_thinking_counts_chars
+        ; test_case "redacted -> redacted" `Quick
+            test_thinking_summary_redacted_only
+        ; test_case "mixed -> mixed, chars sum, text ignored" `Quick
+            test_thinking_summary_mixed_sums
         ] )
     ]


### PR DESCRIPTION
## 목적

OAS canonical projection `Agent_sdk.Response_shape.summarize_blocks` 를 MASC가 **소비**하도록 전환한다. 기존 `summarize_thinking_blocks` 는 `content_block` 리스트를 직접 순회하며 `| _ -> ()` catch-all 로 thinking/redacted 만 카운트했다 — OAS가 새로운 thinking류 variant 를 추가하면 컴파일러가 잡지 못하고 **silent 누락**되는 FSM sparse-match 안티패턴(CLAUDE.md AI 안티패턴 #4).

방향은 로드맵대로 MASC→OAS. OAS는 variant별 exhaustive fold(`summarize_blocks`)를 소유하고, MASC는 **정책 shaping 만** 유지한다(`thinking_present` + `thinking_kind` 분류자).

근거: oas `docs/design/2026-06-29-canonical-projection-ssot.md` 의 **F2**.

## 변경

`lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml` `summarize_thinking_blocks`:
- `_ -> ()` catch-all 제거 → `Agent_sdk.Response_shape.summarize_blocks` (exhaustive) 위임.
- mutable ref 3개(`ref 0`/`incr`/`:=`) 제거 → 순수 fold-결과 레코드 destructure (Immutable).
- 첫 필드를 `Agent_sdk.Response_shape.` 로 한정해 공유 `thinking_*` 라벨 모호성 회피.

## 동작 보존 (byte-identical)

| 항목 | before | OAS summarize_blocks |
|---|---|---|
| thinking 카운트 | `Thinking {content;_} -> +1` | 동일 |
| thinking_chars | `String.length content` (비-trim) | 동일 (비-trim) |
| redacted 카운트 | `RedactedThinking _ -> +1` | 동일 |

`thinking_kind`/`thinking_present` 는 동일 카운트에서 파생 → 출력 무변경. 반환 타입 `thinking_log_summary` 유지 → callers(`fusion_oas.ml`, `keeper_hooks_oas.ml`) 무영향.

## 빌드 안전

- `summarize_blocks` + `t` 필드(thinking_blocks/thinking_chars/redacted_thinking_blocks) 가 lock된 `agent_sdk 0.207.21`(= oas `39a7d139`, **CI 빌드 대상**) `response_shape.mli:10-12,34` 에 존재. 로컬 `0.207.22` 도 동일.
- `Agent_sdk.Response_shape` 는 masc에서 이미 사용 중(`keeper_tool_response.ml`).

## 테스트

`test/test_keeper_hooks_oas_log_shape.ml` 에 분류자 정책 출력 pin 추가 (dune 변경 없음 — 기존 wired 파일, `masc_test_deps` 가 `agent_sdk`/`keeper_hooks_oas_types` re-export):
- none(empty/text-only) / thinking(+char count) / redacted / mixed(+char sum, text 무시) 5 케이스.

## 로컬 검증 / 미검증

- 로컬: diff 검토 + 심볼/필드 존재(locked·local agent_sdk) + 카운팅 로직 byte-identical 대조.
- 미검증(CI 위임): full `dune build`/test — 정책상 CI에서 확인.

RFC-WAIVED: RFC-gated subsystem 아님. 순수 SSOT 중복 제거 + catch-all 안티패턴 제거 + OAS 로드맵(F2) 정합 소비.
