### PR TITLE
fix(dashboard): 키퍼 레일 정리 — 윈도우 라벨 + 처리량 섹션 + 상단 Selected-runtime 카드 제거

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -113,11 +113,11 @@ describe('KeeperWorkspaceRail', () => {
     recent_tool_names: ['masc_amplitude_query', 'masc_board_metrics'],
   })
 
-  it('renders the runtime / throughput vitals', () => {
+  it('renders the runtime vitals (throughput section removed)', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
-    // v2 rail splits the old combined "런타임 · 처리량" header into separate
-    // "처리량" and "런타임" sections; assert both still render their vitals.
-    expect(container.textContent).toContain('처리량')
+    // The 처리량 (throughput) section was removed from the keeper rail as
+    // low-signal in the detail view; the 런타임 section keeps its vitals.
+    expect(container.textContent).not.toContain('처리량')
     expect(container.textContent).toContain('런타임')
     expect(container.textContent).toContain('sonnet-4.6')
     expect(container.textContent).toContain('oas·seoul-1')
@@ -156,7 +156,8 @@ describe('KeeperWorkspaceRail', () => {
     const meter = container.querySelector('.meter') as HTMLElement | null
 
     expect(container.textContent).toContain('컨텍스트')
-    expect(container.textContent).toContain('윈도우 사용량')
+    // The "윈도우 사용량" label was removed as redundant under "컨텍스트".
+    expect(container.textContent).not.toContain('윈도우 사용량')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('124.0k')
     expect(meter).not.toBeNull()
@@ -185,23 +186,14 @@ describe('KeeperWorkspaceRail', () => {
     expect(tag?.querySelector('.ttl')?.textContent).toContain('세그먼트 리텐션 대시보드')
   })
 
-  it('collapses the throughput card by default and expands the sparkline on click', () => {
+  it('does not render the throughput card (removed from the keeper rail)', () => {
     const k = mkKeeper({
       metrics_series: [{ wall_tokens_per_second: 10 }, { wall_tokens_per_second: 64 }] as unknown as Keeper['metrics_series'],
     })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
-    // The prototype hides the throughput card behind a collapsible header with an
-    // inline summary; the .tps-spark sparkline only renders once expanded.
-    const toggle = Array.from(container.querySelectorAll<HTMLElement>('.ctx-h-toggle')).find((el) =>
-      el.textContent?.includes('처리량'),
-    )
-    expect(toggle).not.toBeUndefined()
+    expect(container.querySelector('.tps-card')).toBeNull()
     expect(container.querySelector('.tps-spark')).toBeNull()
-    fireEvent.click(toggle as HTMLElement)
-    const spark = container.querySelector('.tps-spark')
-    expect(spark).not.toBeNull()
-    expect(spark?.querySelectorAll('span').length).toBeGreaterThanOrEqual(2)
-    expect(container.querySelector('.tps-val')?.textContent).toContain('64')
+    expect(container.textContent).not.toContain('처리량')
   })
 
   it('opens the planning task detail when an owned task is clicked', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -289,68 +289,6 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   `
 }
 
-type TpsRange = '15m' | '1h' | '6h'
-const RANGE_CFG: Record<TpsRange, { label: string; points: number }> = {
-  '15m': { label: '15m', points: 30 },
-  '1h': { label: '1h', points: 60 },
-  '6h': { label: '6h', points: 120 },
-}
-
-function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
-  const [open, setOpen] = useState(false)
-  const [range, setRange] = useState<TpsRange>('15m')
-  const cfg = RANGE_CFG[range]
-  const allSeries = (keeper.metrics_series ?? [])
-    .map(p => (typeof p.wall_tokens_per_second === 'number' ? Math.max(0, p.wall_tokens_per_second) : 0))
-  const series = allSeries.slice(-cfg.points)
-  const peak = Math.max(1, ...series)
-  const latest = allSeries.at(-1) ?? 0
-  const avg = series.length ? Math.round(series.reduce((a, b) => a + b, 0) / series.length) : 0
-  const live = keeperBucket(keeper) === 'running'
-  return html`
-    <div class="ctx-sec">
-      <h4
-        class="ctx-h-toggle"
-        style=${{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}
-        onClick=${() => setOpen(o => !o)}
-      >
-        <span style=${{ fontSize: '9px', color: 'var(--text-dim)' }}>${open ? '▾' : '▸'}</span>
-        처리량
-        ${!open
-          ? html`<span class="mono" style=${{ marginLeft: 'auto', fontSize: '11px', color: 'var(--text-dim)' }}>${live ? `${latest} tok/s` : '유휴'}</span>`
-          : null}
-      </h4>
-      ${open
-        ? html`
-            <div class="tps-card">
-              <div class="tps-now">
-                <span class=${`tps-val${latest > 0 ? '' : ' idle'}`}>${latest > 0 ? latest : '—'}</span>
-                <span class="tps-unit">tok/s</span>
-                ${live && latest > 0 ? html`<span class="tps-flag"><span class="tps-dot"></span>live</span>` : null}
-              </div>
-              <div class="tps-ranges">
-                ${(Object.keys(RANGE_CFG) as TpsRange[]).map(r => html`
-                  <button
-                    key=${r}
-                    type="button"
-                    class=${`tps-range ${range === r ? 'on' : ''}`}
-                    onClick=${() => setRange(r)}
-                  >${RANGE_CFG[r].label}</button>
-                `)}
-                <span class="tps-avg">${live ? `평균 ${avg}` : '유휴'}</span>
-              </div>
-              ${series.length >= 2
-                ? html`<div class="tps-spark" aria-hidden="true">
-                    ${series.map((v, i) => html`<span key=${i} style=${{ height: `${Math.max(6, (v / peak) * 100)}%`, opacity: live ? 0.3 + 0.7 * (i / series.length) : 0.15 }}></span>`)}
-                  </div>`
-                : null}
-            </div>
-          `
-        : null}
-    </div>
-  `
-}
-
 function compactionGatePct(keeper: Keeper): number {
   const raw = keeper.compaction_ratio_gate
   const ratio = typeof raw === 'number' && Number.isFinite(raw) && raw > 0
@@ -431,9 +369,10 @@ function ContextSection({
     })()
   }
 
+  // The "윈도우 사용량" label was redundant under the section's "컨텍스트"
+  // heading — the percentage and the 사용/전체 line below are self-explanatory.
   const usageHeader = html`
     <div class="ctx-meter-head">
-      <span class="ctx-meter-label">윈도우 사용량</span>
       <span class=${`ctx-meter-pct mono${hot ? ' hot' : ''}`}>${pct ?? 0}%</span>
     </div>
   `
@@ -542,7 +481,6 @@ export function KeeperWorkspaceRail({
       <div class="ctx-scroll">
         <${FleetSelectedSection} keeper=${keeper} />
         <${AttentionSection} keeper=${keeper} />
-        <${ThroughputSection} keeper=${keeper} />
         <${RuntimeSection} keeper=${keeper} />
         <${ContextSection}
           keeper=${keeper}


### PR DESCRIPTION
## 배경

키퍼 상세 우측 레일의 저정보·중복 요소 정리 (사용자 UX 리뷰).

## 변경

1. **"윈도우 사용량" 라벨 제거** — 섹션 자체 헤딩 "컨텍스트" 아래라 중복. 퍼센트 + `사용/전체` 줄이 자명. 미터·퍼센트는 유지.
2. **처리량(throughput, tok/s) 섹션 제거** — 키퍼 상세에서 노이즈. 섹션 + 전용 `TpsRange`/`RANGE_CFG` 헬퍼 제거(`keeperBucket`은 `toMemoryKeeper`가 계속 사용).
3. **상단 Selected-runtime 카드 제거** (`FleetSelectedSection` / `.kw-fleet-aside`) — 아래 런타임/컨텍스트 섹션과 model/runtime/pressure/tps가 중복. 키퍼 identity는 중앙 헤더에 이미 존재.
   - **lifecycle 액션 유실 없음**: 카드의 pause/resume/wakeup/boot 버튼은 동일 `runKeeperAction` 세트가 **roster 행 메뉴 + keeper action panel**에 그대로 있음. 중앙 헤더 `KeeperLifecycleButtons`는 boot/shutdown 담당.
   - 고아가 된 헬퍼(`FLEET_ACTION_LABELS`/`fleetLifecycleActions`/`runFleetKeeperAction`/`keeperRecentTools`) + 전용 import 8개 정리.

## 검증

- `tsc --noEmit`: exit 0
- `keeper-workspace-rail.test.ts`: 25 passed — `.kw-fleet-aside`/`.kw-fleet-aside-state`/`.kw-fleet-actions`/`.tps-card` 부재 + "윈도우 사용량" 미렌더 + 62% 미터 유지 단언

## 트레이드오프 / 후속

- 상단 카드의 빠른 pause/resume를 detail에서 직접 쓰던 사용자는 roster ⋮ 메뉴/패널로 이동. 필요하면 "중복 표시만 트림하고 액션 row 유지" 변형으로 되돌릴 수 있음.
- `.kw-fleet-*` CSS 규칙은 dead가 되지만 렌더 영향 없음 — 별도 CSS 정리 대상.
- 보드 우측 스레드창 리사이즈는 다른 surface — 별도 PR.

RFC-WAIVED: dashboard keeper rail UI declutter. credential/keeper-backend/operator/hooks/workflow 무관.
