### PR TITLE
[codex] Preserve typed OAS stream interleaving

### DIFF
--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -84,6 +84,7 @@ export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversa
 
   return {
     traceId: asString(payload.trace_id) ?? null,
+    turnRef: asString(payload.turn_ref) ?? null,
     generation: asNumber(payload.generation) ?? null,
     modelUsed: null,
     latencyMs: asNumber(payload.latency_ms) ?? null,

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -255,24 +255,12 @@ describe('thread history merge & persistence', () => {
     expect(traceTextOf('hist-b')).toBe('second turn reasoning')
   })
 
-  it('observes trace cross when finalize order inverts append order (#21950, pre-R3)', () => {
+  it('uses turnRef to keep multiturn traces attached when finalize order inverts', () => {
     // Reverse-finalize scenario: local-a is appended FIRST but finalizes
     // LATER (ts=02); local-b is appended SECOND but finalizes EARLIER (ts=01).
     // The server sends history chronological (earliest first): [hist-b(01), hist-a(02)].
-    //
-    // consumed Set still guarantees the 1:1 invariant — each local trace source
-    // is claimed at most once, so no row duplicates another row's trace. What
-    // it CANNOT guarantee is the *correct-row* mapping: mergeLocalAssistantTraceSteps
-    // matches by append order (appendThreadEntry push-to-end, keeper-state.ts:769)
-    // while server history is chronological, and finalize stamps `timestamp: new Date().toISOString()`
-    // at COMPLETION time (keeper-actions.ts:447 etc.), not append time. When those
-    // two orders diverge, the trace CROSSES.
-    //
-    // This is a known limitation tracked in #21950, NOT a regression: the
-    // pre-#21932 code duplicated the FIRST trace on BOTH rows (strictly worse).
-    // R3 server-minted id handshake will remove the role+text fallback and make
-    // the pairing deterministic — when it lands, flip the two `toBe` expectations
-    // below to the correct pairing (hist-a <-> 'turn-a reasoning', hist-b <-> 'turn-b').
+    // turnRef is the producer-assigned join key, so the trace follows the turn
+    // instead of append order or timestamp order.
     appendThreadEntry('echo', entry({
       id: 'local-a',
       role: 'assistant',
@@ -281,6 +269,7 @@ describe('thread history merge & persistence', () => {
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:02.000Z', // appended first, finalized LATER
+      turnRef: 'trace-x#42',
     }))
     appendThreadEntry('echo', entry({
       id: 'local-b',
@@ -290,13 +279,14 @@ describe('thread history merge & persistence', () => {
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:01.000Z', // appended second, finalized EARLIER
+      turnRef: 'trace-x#41',
     }))
     appendAssistantThinkingDelta('echo', 'local-a', 'turn-a reasoning')
     appendAssistantThinkingDelta('echo', 'local-b', 'turn-b reasoning')
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
-      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z', turnRef: 'trace-x#41' }),
+      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', turnRef: 'trace-x#42' }),
     ])
 
     const thread = keeperThreads.value.echo ?? []
@@ -304,13 +294,9 @@ describe('thread history merge & persistence', () => {
       const step = thread.find(e => e.id === id)?.traceSteps?.[0]
       return step && 'text' in step ? step.text : undefined
     }
-    // 1:1 invariant holds even under inverted finalize order: each row carries
-    // a DISTINCT trace (no row duplicates the other).
     expect(traceTextOf('hist-a')).not.toBe(traceTextOf('hist-b'))
-    // KNOWN CROSS (#21950): under inverted finalize order the pairing inverts.
-    // The correct pairing (hist-a <-> 'turn-a reasoning') is blocked pre-R3.
-    expect(traceTextOf('hist-a')).toBe('turn-b reasoning')
-    expect(traceTextOf('hist-b')).toBe('turn-a reasoning')
+    expect(traceTextOf('hist-a')).toBe('turn-a reasoning')
+    expect(traceTextOf('hist-b')).toBe('turn-b reasoning')
   })
 
   it('keeps local entries the server has not persisted yet', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1037,22 +1037,36 @@ function mergeLocalAssistantTraceSteps(
   historyEntry: KeeperConversationEntry,
   localEntries: KeeperConversationEntry[],
   // Tracks local trace sources already claimed by an earlier history row.
-  // Without it, two identical-text assistant history rows both match the FIRST
-  // local source via the role+text fallback in sameConversationEntry, so the
-  // second turn inherits the first turn's trace (#21748). Each source is
-  // consumed at most once → 1:1 distribution.
-  // Contract: localEntries are in append order, which mirrors the chronological
-  // order of historyEntries, so the Nth identical-text history row maps to the
-  // Nth local source. A server-minted id handshake (R3, not yet landed) would
-  // make this exact without the ordering assumption; until then local
-  // optimistic entries carry no turn_ref, so id-keyed matching is not possible.
+  // When OAS/MASC provides turn_ref on both the live reply details and the
+  // persisted history row, that value is the exact join key. The role+text
+  // fallback remains only for legacy rows without turn_ref; `consumed` keeps
+  // those fallback matches 1:1 instead of letting duplicate assistant text reuse
+  // the first local trace source (#21748).
   consumed: Set<string>,
 ): KeeperConversationEntry {
   if (historyEntry.role !== 'assistant') return historyEntry
+  const historyTurnRef = historyEntry.turnRef?.trim()
+  const localTraceSourceByTurnRef = historyTurnRef
+    ? localEntries.find(
+        entry =>
+          entry.role === 'assistant'
+          && (entry.traceSteps?.length ?? 0) > 0
+          && !consumed.has(entry.id)
+          && entry.turnRef?.trim() === historyTurnRef,
+      )
+    : undefined
+  if (localTraceSourceByTurnRef?.traceSteps?.length) {
+    consumed.add(localTraceSourceByTurnRef.id)
+    return {
+      ...historyEntry,
+      traceSteps: localTraceSourceByTurnRef.traceSteps,
+    }
+  }
   const localTraceSource = localEntries.find(
     entry =>
       entry.role === 'assistant'
       && (entry.traceSteps?.length ?? 0) > 0
+      && !(entry.turnRef?.trim())
       && !consumed.has(entry.id)
       && sameConversationEntry(entry, historyEntry),
   )

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -215,6 +215,22 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.delivery).toBe('sending')
   })
 
+  it('keeps the producer turnRef from reply details for history rehydrate joins', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        reply: 'done',
+        turn_ref: 'trace-live#42',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.turnRef).toBe('trace-live#42')
+    expect(entry?.details?.turnRef).toBe('trace-live#42')
+  })
+
   it('suppresses a declared checkpoint regardless of reply text', () => {
     assistantEntry()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -379,19 +379,42 @@ describe('applyKeeperStreamEvent tool calls', () => {
     ])
   })
 
-  it('routes args to the last started tool call when toolCallId is missing', () => {
+  it('records a protocol error instead of guessing the tool when toolCallId is missing', () => {
     assistantEntry()
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_START',
-      toolCallId: 'tc-fallback',
+      toolCallId: 'tc-no-fallback',
       toolCallName: 'keeper_board_post',
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_ARGS', delta: '{"post_id":"p-1"}' })
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_END' })
 
-    const tool = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-fallback')
-    expect(tool?.text).toBe('{"post_id":"p-1"}')
-    expect(tool?.delivery).toBe('delivered')
+    const tool = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-no-fallback')
+    expect(tool?.text).toBe('')
+    expect(tool?.delivery).toBe('streaming')
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.rawText).toContain('[stream protocol] TOOL_CALL_ARGS missing toolCallId')
+    expect(reply?.rawText).toContain('[stream protocol] TOOL_CALL_END missing toolCallId')
+    expect(reply?.error).toBe('TOOL_CALL_END missing toolCallId')
+  })
+
+  it('records server stream protocol errors on the assistant entry', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_PROTOCOL_ERROR',
+      value: {
+        kind: 'tool_args_without_start',
+        index: 2,
+        reason: 'tool argument delta arrived before tool start',
+      },
+    })
+
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.error).toBe(
+      'tool_args_without_start | index=2 | tool argument delta arrived before tool start',
+    )
+    expect(reply?.rawText).toContain('[stream protocol] tool_args_without_start')
   })
 
   it('keeps duplicate TOOL_CALL_START events idempotent', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -31,15 +31,37 @@ import { toolEntryIdFromCallId } from './tool-call-output-store'
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
 
-// Most recent TOOL_CALL_START id per keeper — fallback target for
-// TOOL_CALL_ARGS / TOOL_CALL_END events that omit toolCallId.
-const lastToolCallIds = new Map<string, string>()
-
 export interface KeeperThreadAbortResult {
   readonly keeperName: string
   readonly entryId: string | null
   readonly requestId: string | null
   readonly controllerAborted: boolean
+}
+
+function streamProtocolMessage(value: unknown, fallback: string): string {
+  if (!isRecord(value)) return fallback
+  const kind = asString(value.kind, '').trim()
+  const reason = asString(value.reason, '').trim()
+  const eventType = asString(value.event_type, '').trim()
+  const index = typeof value.index === 'number' ? `index=${value.index}` : ''
+  return [kind || fallback, eventType ? `event=${eventType}` : '', index, reason]
+    .filter(part => part.trim() !== '')
+    .join(' | ')
+}
+
+function recordStreamProtocolError(
+  keeperName: string,
+  assistantEntryId: string,
+  message: string,
+): void {
+  updateThreadEntry(keeperName, assistantEntryId, entry => {
+    const line = `[stream protocol] ${message}`
+    return {
+      ...entry,
+      rawText: entry.rawText?.trim() ? `${entry.rawText}\n${line}` : line,
+      error: message,
+    }
+  })
 }
 
 export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult | null {
@@ -96,9 +118,16 @@ export function applyKeeperStreamEvent(
       setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
       return null
     case 'TOOL_CALL_START': {
-      const toolCallId = event.toolCallId ?? `tc-${keeperName}-${Date.now()}`
-      lastToolCallIds.set(keeperName, toolCallId)
-      const toolName = event.toolCallName ?? event.name ?? 'tool'
+      const toolCallId = event.toolCallId?.trim()
+      const toolName = (event.toolCallName ?? event.name)?.trim()
+      if (!toolCallId || !toolName) {
+        recordStreamProtocolError(
+          keeperName,
+          assistantEntryId,
+          'TOOL_CALL_START missing toolCallId or toolCallName',
+        )
+        return null
+      }
       appendAssistantToolTraceStep(keeperName, assistantEntryId, {
         toolCallId,
         name: toolName,
@@ -120,7 +149,15 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TOOL_CALL_ARGS': {
-      const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
+      const toolCallId = event.toolCallId?.trim()
+      if (!toolCallId) {
+        recordStreamProtocolError(
+          keeperName,
+          assistantEntryId,
+          'TOOL_CALL_ARGS missing toolCallId',
+        )
+        return null
+      }
       if (toolCallId && typeof event.delta === 'string' && event.delta) {
         appendAssistantToolTraceArgsDelta(keeperName, assistantEntryId, toolCallId, event.delta)
         updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
@@ -132,7 +169,15 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TOOL_CALL_END': {
-      const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
+      const toolCallId = event.toolCallId?.trim()
+      if (!toolCallId) {
+        recordStreamProtocolError(
+          keeperName,
+          assistantEntryId,
+          'TOOL_CALL_END missing toolCallId',
+        )
+        return null
+      }
       if (toolCallId) {
         markAssistantToolTraceEnded(keeperName, assistantEntryId, toolCallId)
         updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
@@ -140,9 +185,6 @@ export function applyKeeperStreamEvent(
           delivery: 'delivered',
           streamState: null,
         }))
-        if (lastToolCallIds.get(keeperName) === toolCallId) {
-          lastToolCallIds.delete(keeperName)
-        }
       }
       return null
     }
@@ -159,6 +201,22 @@ export function applyKeeperStreamEvent(
             : undefined
         if (delta) appendAssistantThinkingDelta(keeperName, assistantEntryId, delta)
         else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_STREAM_PROTOCOL_ERROR') {
+        recordStreamProtocolError(
+          keeperName,
+          assistantEntryId,
+          streamProtocolMessage(event.value, 'stream protocol error'),
+        )
+        return null
+      }
+      if (event.name === 'KEEPER_THINKING_SIGNATURE_DELTA') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_MEDIA_DELTA') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -289,6 +289,7 @@ export function applyKeeperStreamEvent(
               return {
                 ...entry,
                 details,
+                turnRef: details.turnRef ?? entry.turnRef,
                 rawText,
                 text: '',
                 delivery: details.turnOutcome === 'no_visible_reply' ? 'no_reply' : 'queued',
@@ -300,6 +301,7 @@ export function applyKeeperStreamEvent(
             return {
               ...entry,
               details,
+              turnRef: details.turnRef ?? entry.turnRef,
               rawText,
               text,
               blocks,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -730,6 +730,7 @@ export type KeeperTurnOutcome =
 
 export interface KeeperConversationDetails {
   traceId?: string | null
+  turnRef?: string | null
   generation?: number | null
   modelUsed?: string | null
   latencyMs?: number | null

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -644,6 +644,197 @@ type keeper_stream_worker_event =
       ; body : string
       }
 
+type keeper_stream_tool_ref =
+  { tool_call_id : string
+  ; tool_call_name : string
+  }
+
+type keeper_stream_bridge_state =
+  { tools_by_index : (int * keeper_stream_tool_ref) list }
+
+type translated_keeper_stream_event =
+  { bridge_state : keeper_stream_bridge_state
+  ; chat_events : Keeper_chat_events.keeper_chat_event list
+  }
+
+let empty_keeper_stream_bridge_state = { tools_by_index = [] }
+
+let stream_tool_for_index bridge_state index =
+  List.assoc_opt index bridge_state.tools_by_index
+
+let stream_bridge_replace_tool bridge_state index tool =
+  { tools_by_index =
+      (index, tool) :: List.remove_assoc index bridge_state.tools_by_index
+  }
+
+let stream_bridge_remove_tool bridge_state index =
+  { tools_by_index = List.remove_assoc index bridge_state.tools_by_index }
+
+let json_opt key value =
+  match value with
+  | None -> []
+  | Some value -> [ (key, value) ]
+
+let keeper_stream_protocol_error ?index ?event_type ?reason ?raw_bytes kind =
+  let fields =
+    [ ("kind", `String kind) ]
+    @ json_opt "index" (Option.map (fun value -> `Int value) index)
+    @ json_opt "event_type" (Option.map (fun value -> `String value) event_type)
+    @ json_opt "reason" (Option.map (fun value -> `String value) reason)
+    @ json_opt "raw_bytes" (Option.map (fun value -> `Int value) raw_bytes)
+  in
+  Keeper_chat_events.Custom
+    { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc fields }
+
+let translate_oas_stream_event ~redact_text ~text_accum bridge_state
+    (evt : Agent_sdk.Types.sse_event) =
+  let open Agent_sdk.Types in
+  let no_events = { bridge_state; chat_events = [] } in
+  match evt with
+  | Connected ->
+      { bridge_state;
+        chat_events =
+          [ Custom { name = "KEEPER_CONNECTED"; value = `Null } ]
+      }
+  | Timeout reason ->
+      { bridge_state;
+        chat_events =
+          [ Event_error { message = redact_text ("Timeout: " ^ reason) } ]
+      }
+  | ContentBlockDelta { delta = TextDelta text; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Text_delta
+              (Keeper_stream_text_accum.on_delta text_accum
+                 ~redact:redact_text text)
+          ]
+      }
+  | ContentBlockDelta { delta = ThinkingDelta text; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Custom
+              { name = "KEEPER_THINKING_DELTA";
+                value = `Assoc [ ("delta", `String (redact_text text)) ] }
+          ]
+      }
+  | ContentBlockDelta { delta = ThinkingSignatureDelta signature; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Custom
+              { name = "KEEPER_THINKING_SIGNATURE_DELTA";
+                value =
+                  `Assoc [ ("signature_bytes", `Int (String.length signature)) ] }
+          ]
+      }
+  | ContentBlockDelta { delta = MediaDelta { media_type; source_type; data }; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Custom
+              { name = "KEEPER_MEDIA_DELTA";
+                value =
+                  `Assoc
+                    [ ("media_type", `String media_type);
+                      ("source_type", `String source_type);
+                      ("bytes", `Int (String.length data)) ] }
+          ]
+      }
+  | ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ }
+    when String.trim tid <> "" && String.trim tname <> "" ->
+      let tool = { tool_call_id = tid; tool_call_name = tname } in
+      let duplicate_event =
+        match stream_tool_for_index bridge_state index with
+        | None -> []
+        | Some _ ->
+            [ keeper_stream_protocol_error ~index
+                ~reason:"content block start reused an active stream index"
+                "tool_start_duplicate_index" ]
+      in
+      { bridge_state = stream_bridge_replace_tool bridge_state index tool;
+        chat_events =
+          duplicate_event
+          @ [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
+      }
+  | ContentBlockStart { index; tool_id; tool_name; _ } ->
+      let partial_tool_identity =
+        match tool_id, tool_name with
+        | None, None -> false
+        | _ -> true
+      in
+      if partial_tool_identity then
+        { bridge_state;
+          chat_events =
+            [ keeper_stream_protocol_error ~index
+                ~reason:"tool content block start missed tool id or name"
+                "tool_start_missing_identity" ]
+        }
+      else no_events
+  | ContentBlockDelta { index; delta = InputJsonDelta args } -> (
+      match stream_tool_for_index bridge_state index with
+      | Some tool ->
+          { bridge_state;
+            chat_events =
+              [ Tool_call_args
+                  { tool_call_id = tool.tool_call_id; delta = redact_text args } ]
+          }
+      | None ->
+          { bridge_state;
+            chat_events =
+              [ keeper_stream_protocol_error ~index
+                  ~reason:"tool argument delta arrived before tool start"
+                  "tool_args_without_start" ]
+          })
+  | ContentBlockStop { index } -> (
+      match stream_tool_for_index bridge_state index with
+      | Some tool ->
+          { bridge_state = stream_bridge_remove_tool bridge_state index;
+            chat_events = [ Tool_call_end { tool_call_id = tool.tool_call_id } ]
+          }
+      | None ->
+          { bridge_state;
+            chat_events =
+              [ keeper_stream_protocol_error ~index
+                  ~reason:"tool block stop arrived before tool start"
+                  "tool_stop_without_start" ]
+          })
+  | SSEError { message; error_type; raw = _ } ->
+      let reason =
+        match error_type with
+        | None -> message
+        | Some error_type -> error_type ^ ": " ^ message
+      in
+      { bridge_state;
+        chat_events =
+          [ keeper_stream_protocol_error ?event_type:error_type
+              ~reason:(redact_text message) "sse_error";
+            Event_error
+              { message = redact_text ("Provider stream error: " ^ reason) } ]
+      }
+  | SSEParseFailed { raw; reason } ->
+      { bridge_state;
+        chat_events =
+          [ keeper_stream_protocol_error ~reason:(redact_text reason)
+              ~raw_bytes:(String.length raw) "sse_parse_failed";
+            Event_error
+              { message =
+                  redact_text ("Provider stream parse failed: " ^ reason) } ]
+      }
+  | SSEUnknownEventType { event_type; raw } ->
+      { bridge_state;
+        chat_events =
+          [ keeper_stream_protocol_error ~event_type
+              ~raw_bytes:(String.length raw) "sse_unknown_event_type" ]
+      }
+  | StreamIncomplete { reason } ->
+      { bridge_state;
+        chat_events =
+          [ keeper_stream_protocol_error ~reason:(redact_text reason)
+              "sse_stream_incomplete";
+            Event_error
+              { message =
+                  redact_text ("Provider stream incomplete: " ^ reason) } ]
+      }
+  | MessageStart _ | MessageDelta _ | MessageStop | Ping -> no_events
+
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name
@@ -874,40 +1065,16 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
       Keeper_chat_events.publish events
         (Custom { name = "KEEPER_REQUEST_TERMINAL"; value = payload_json })
   in
-  let index_to_tool_id = Hashtbl.create 4 in
-  let rec consume_worker_events () =
+  let rec consume_worker_events bridge_state =
     if Atomic.get client_disconnected then ()
     else match Eio.Stream.take worker_events with
     | Stream_client_disconnected -> ()
     | Stream_event evt ->
-        (match evt with
-         | Agent_sdk.Types.Connected ->
-             Keeper_chat_events.publish events (Custom { name = "KEEPER_CONNECTED"; value = `Null })
-         | Agent_sdk.Types.Timeout reason ->
-             Keeper_chat_events.publish events
-               (Event_error { message = redact_text ("Timeout: " ^ reason) })
-         | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } ->
-             Keeper_chat_events.publish events
-               (Text_delta
-                  (Keeper_stream_text_accum.on_delta text_accum
-                     ~redact:redact_text text))
-         | Agent_sdk.Types.ContentBlockDelta { delta = ThinkingDelta text; _ } ->
-             Keeper_chat_events.publish events
-               (Custom
-                  { name = "KEEPER_THINKING_DELTA";
-                    value = `Assoc [ ("delta", `String (redact_text text)) ] })
-         | Agent_sdk.Types.ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ } ->
-             Hashtbl.replace index_to_tool_id index tid;
-             Keeper_chat_events.publish events (Tool_call_start { tool_call_id = tid; tool_call_name = tname })
-         | Agent_sdk.Types.ContentBlockDelta { index; delta = InputJsonDelta args } ->
-             let tid = Hashtbl.find_opt index_to_tool_id index |> Option.value ~default:"" in
-             Keeper_chat_events.publish events
-               (Tool_call_args { tool_call_id = tid; delta = redact_text args })
-         | Agent_sdk.Types.ContentBlockStop { index } ->
-             let tid = Hashtbl.find_opt index_to_tool_id index |> Option.value ~default:"" in
-             Keeper_chat_events.publish events (Tool_call_end { tool_call_id = tid })
-         | _ -> ());
-        consume_worker_events ()
+        let translated =
+          translate_oas_stream_event ~redact_text ~text_accum bridge_state evt
+        in
+        List.iter (Keeper_chat_events.publish events) translated.chat_events;
+        consume_worker_events translated.bridge_state
     | Stream_terminal { ok = false; status = "cancelled"; body = message } ->
         let message = redact_text message in
         publish_terminal ~status:"cancelled" ~ok:false ~message ();
@@ -977,7 +1144,7 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
             Keeper_chat_events.publish events
               (Event_error { message }))
   in
-  consume_worker_events ()
+  consume_worker_events empty_keeper_stream_bridge_state
 
 
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
@@ -1195,4 +1362,6 @@ module For_testing = struct
   let extract_visible_reply = extract_visible_reply
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
+  let empty_stream_bridge_state = empty_keeper_stream_bridge_state
+  let translate_oas_stream_event = translate_oas_stream_event
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -164,6 +164,16 @@ val process_single_turn :
 
 (** {1 Testing helpers} *)
 
+type keeper_stream_bridge_state
+(** Per-stream OAS event bridge state. Abstract outside tests so callers cannot
+    construct synthetic stream correlation state. *)
+
+type translated_keeper_stream_event = {
+  bridge_state : keeper_stream_bridge_state;
+  chat_events : Keeper_chat_events.keeper_chat_event list;
+}
+(** Result of translating one typed OAS stream event into keeper chat events. *)
+
 module For_testing : sig
   val parse_request : string -> (keeper_chat_stream_request, string) result
   val has_connector_context : keeper_chat_stream_request -> bool
@@ -177,4 +187,11 @@ module For_testing : sig
   val extract_visible_reply : string -> Yojson.Safe.t option * string
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
+  val empty_stream_bridge_state : keeper_stream_bridge_state
+  val translate_oas_stream_event :
+    redact_text:(string -> string) ->
+    text_accum:Keeper_stream_text_accum.t ->
+    keeper_stream_bridge_state ->
+    Agent_sdk.Types.sse_event ->
+    translated_keeper_stream_event
 end

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -33,6 +33,33 @@ let string_contains haystack needle =
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
+let translate_oas_stream_events events =
+  let redact_text text = text in
+  let text_accum = Keeper_stream_text_accum.create () in
+  let rec loop bridge_state acc = function
+    | [] -> List.rev acc
+    | event :: rest ->
+        let translated =
+          Server_routes_http_keeper_stream.For_testing.translate_oas_stream_event
+            ~redact_text ~text_accum bridge_state event
+        in
+        loop translated.bridge_state
+          (List.rev_append translated.chat_events acc) rest
+  in
+  loop
+    Server_routes_http_keeper_stream.For_testing.empty_stream_bridge_state []
+    events
+
+let assoc_string key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Some value
+  | _ -> None
+
+let assoc_int key fields =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Some value
+  | _ -> None
+
 let test_agent_name_for_channel_actor () =
   let agent_name =
     Gate_keeper_backend.agent_name_for_channel_actor
@@ -461,6 +488,103 @@ let test_keeper_stream_args_preserve_user_blocks () =
              | _ -> None)
       | _ -> fail "expected user_blocks and attachment payload in keeper args")
   | _ -> fail "expected keeper args object"
+
+let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = ThinkingDelta "think A" };
+        ContentBlockStart
+          { index = 1;
+            content_type = "tool_use";
+            tool_id = Some "tc-1";
+            tool_name = Some "keeper_board_list" };
+        ContentBlockDelta { index = 1; delta = InputJsonDelta "{\"limit\":" };
+        ContentBlockDelta { index = 1; delta = InputJsonDelta "1}" };
+        ContentBlockStop { index = 1 };
+        ContentBlockDelta { index = 2; delta = ThinkingDelta "think B" };
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Custom
+        { name = "KEEPER_THINKING_DELTA"; value = `Assoc first };
+      Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
+      Keeper_chat_events.Tool_call_args { tool_call_id = args_id_a; delta = args_a };
+      Keeper_chat_events.Tool_call_args { tool_call_id = args_id_b; delta = args_b };
+      Keeper_chat_events.Tool_call_end { tool_call_id = end_id };
+      Keeper_chat_events.Custom
+        { name = "KEEPER_THINKING_DELTA"; value = `Assoc last } ] ->
+      check (option string) "first thinking" (Some "think A")
+        (assoc_string "delta" first);
+      check string "tool id" "tc-1" tool_call_id;
+      check string "tool name" "keeper_board_list" tool_call_name;
+      check string "args id a" "tc-1" args_id_a;
+      check string "args id b" "tc-1" args_id_b;
+      check string "args a" "{\"limit\":" args_a;
+      check string "args b" "1}" args_b;
+      check string "end id" "tc-1" end_id;
+      check (option string) "last thinking" (Some "think B")
+        (assoc_string "delta" last)
+  | _ ->
+      failf "unexpected stream bridge events: %s"
+        (String.concat ", "
+           (List.map
+              (function
+                | Keeper_chat_events.Custom { name; _ } -> "custom:" ^ name
+                | Keeper_chat_events.Tool_call_start _ -> "tool_start"
+                | Keeper_chat_events.Tool_call_args _ -> "tool_args"
+                | Keeper_chat_events.Tool_call_end _ -> "tool_end"
+                | Keeper_chat_events.Text_delta _ -> "text"
+                | Keeper_chat_events.Event_error _ -> "error"
+                | _ -> "other")
+              events))
+
+let test_keeper_stream_bridge_rejects_tool_args_without_start () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [ ContentBlockDelta { index = 7; delta = InputJsonDelta "{\"x\":1}" } ]
+  in
+  match events with
+  | [ Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc fields } ] ->
+      check (option string) "kind" (Some "tool_args_without_start")
+        (assoc_string "kind" fields);
+      check (option int) "index" (Some 7) (assoc_int "index" fields);
+      check bool "no tool event forged" true
+        (not
+           (List.exists
+              (function
+                | Keeper_chat_events.Tool_call_args _ -> true
+                | _ -> false)
+              events))
+  | _ -> fail "expected a stream protocol error for missing tool start"
+
+let test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        SSEUnknownEventType { event_type = "response.future"; raw = "{\"x\":1}" };
+        StreamIncomplete { reason = "max_output_tokens" };
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc unknown };
+      Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc incomplete };
+      Keeper_chat_events.Event_error { message } ] ->
+      check (option string) "unknown kind" (Some "sse_unknown_event_type")
+        (assoc_string "kind" unknown);
+      check (option string) "unknown event type" (Some "response.future")
+        (assoc_string "event_type" unknown);
+      check (option string) "incomplete kind" (Some "sse_stream_incomplete")
+        (assoc_string "kind" incomplete);
+      check string "incomplete is visible error"
+        "Provider stream incomplete: max_output_tokens" message
+  | _ -> fail "expected visible events for unknown/incomplete provider stream"
 
 let test_keeper_chat_history_persists_attachment_refs_not_raw_media () =
   let base_dir = temp_base_path "gate-keeper-media-history" in
@@ -1207,6 +1331,12 @@ let () =
             test_keeper_multimodal_input_rejects_malformed_data_url;
           test_case "stream args preserve user blocks" `Quick
             test_keeper_stream_args_preserve_user_blocks;
+          test_case "stream bridge preserves interleaved thinking and tool" `Quick
+            test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool;
+          test_case "stream bridge rejects tool args without start" `Quick
+            test_keeper_stream_bridge_rejects_tool_args_without_start;
+          test_case "stream bridge surfaces unknown and incomplete events" `Quick
+            test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events;
           test_case "chat history persists attachment refs not raw media" `Quick
             test_keeper_chat_history_persists_attachment_refs_not_raw_media;
           test_case "user-only chat history persists attachment refs not raw media" `Quick


### PR DESCRIPTION
## Summary

- Project OAS `Agent_sdk.Types.sse_event` into keeper chat stream events without string-scraping provider payloads.
- Preserve Thinking/Tool/Media interleaving in the dashboard stream surface, including explicit protocol errors instead of silent fallback ids.
- Carry producer `turn_ref` from reply details into live assistant entries so history rehydration joins traces by the exact OAS/MASC turn identity.
- Retain OAS message lifecycle metadata (`MessageStart`, `MessageDelta`, `MessageStop`, `Ping`) including provider message id, model, stop reason, usage, cache tokens, and usage-level cost.

## OAS Boundary

- MASC consumes OAS typed stream facts (`TextDelta`, `ThinkingDelta`, `ThinkingSignatureDelta`, `InputJsonDelta`, `MediaDelta`, `MessageStart`, `MessageDelta`, `MessageStop`, `Ping`, `SSEError`, `SSEParseFailed`, `SSEUnknownEventType`, `StreamIncomplete`).
- MASC does not reimplement provider parsing or final response accumulation. OAS remains responsible for stream parsing/finalization; MASC only keeps the minimal per-stream block-index projection state needed to render live tool args/stops.
- The dashboard no longer guesses missing tool ids from the previous tool call. Missing ids surface as stream protocol errors.
- `stop_reason` and `total_tokens` are derived through OAS helpers (`stop_reason_to_string`, `total_tokens`) rather than MASC-local token/string policy.

## Validation

- `dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-message.test.ts src/keeper-state.test.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1` (124 tests)
- `dashboard/node_modules/.bin/tsc --noEmit --pretty`
- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml lib/server/server_routes_http_keeper_stream.mli test/test_gate_keeper_backend.ml`
- `git diff --check`

## Local Dune Note

- Earlier in this branch, `./scripts/dune-local.sh build test/test_gate_keeper_backend.exe` and `./_build/default/test/test_gate_keeper_backend.exe` passed before the final OAS message-metadata extension.
- The latest local focused Dune rerun was intentionally not forced because `scripts/dune-local.sh` detected live bare Dune processes in another OAS worktree and refused to bypass the machine-wide lock. PR CI should be treated as the latest OCaml build authority for the final commit.

## Notes

- This is the MASC consumer-side hardening for the OAS PR #2232 direction. It does not move OAS provider policy, catalog rows, or `Complete_stream_acc` internals into MASC.
