### PR TITLE
fix(keeper): stop leaking state metadata as replies

### DIFF
--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -51,30 +51,11 @@ let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_to
           (synth, Keeper_memory_policy.Synthesized)))
 ;;
 
-let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
-  let is_structured_reply, is_synthesized =
-    match (state_snapshot_source : Keeper_memory_policy.state_snapshot_source) with
-    | Structured_state_reply -> true, false
-    | Synthesized -> false, true
-    | Structured_state_tool | State_block -> false, false
-  in
-  let fallback =
-    match
-      Keeper_text_processing.state_snapshot_reply_fallback (Some state_snapshot)
-    with
-    | Some _ as fallback -> fallback
-    | None when is_structured_reply ->
-      Some "State updated."
-    | None -> None
-  in
-  if is_synthesized then ""
-  else if is_structured_reply then
-    Keeper_text_processing.user_visible_reply_text ?fallback ""
-  else
-    match fallback with
-    | Some fallback ->
-      Keeper_text_processing.user_visible_reply_text ~fallback raw_response_text
-    | None -> Keeper_text_processing.user_visible_reply_text raw_response_text
+let response_text ~state_snapshot_source ~raw_response_text =
+  match (state_snapshot_source : Keeper_memory_policy.state_snapshot_source) with
+  | Synthesized | Structured_state_reply -> ""
+  | Structured_state_tool | State_block ->
+    Keeper_text_processing.strip_internal_reply_markup raw_response_text
 ;;
 
 let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
@@ -99,7 +80,7 @@ let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_nam
       ()
   in
   let response_text =
-    response_text ~state_snapshot ~state_snapshot_source ~raw_response_text
+    response_text ~state_snapshot_source ~raw_response_text
   in
   { state_snapshot
   ; state_snapshot_source

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -202,8 +202,8 @@ let test_finalizer_uses_structured_state_source () =
     (Some "Structured progress")
     state_snapshot.progress;
   Alcotest.(check string)
-    "visible response"
-    "Structured progress"
+    "structured state is not a visible reply"
+    ""
     response_text;
   Alcotest.(check (list string))
     "decisions"
@@ -215,6 +215,62 @@ let test_finalizer_uses_structured_state_source () =
     (List.exists
        (fun text -> contains_substring text "[SYNTHETIC]")
        state_snapshot.decisions)
+
+let test_finalizer_keeps_visible_text_outside_state_block () =
+  let raw =
+    "Visible work summary.\n\
+     \n\
+     [STATE]\n\
+     Goal: Keep metadata\n\
+     DONE: Stored in metadata\n\
+     [/STATE]"
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"test"
+      ~goal:"Keep metadata"
+      ~actual_keeper_tool_names:[]
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:raw
+      ()
+  in
+  Alcotest.(check string)
+    "state block source"
+    "model_state_block"
+    (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
+  Alcotest.(check string)
+    "visible response"
+    "Visible work summary."
+    finalized.response_text
+
+let test_finalizer_drops_state_only_visible_fallback () =
+  let raw =
+    "[STATE]\n\
+     Goal: Keep metadata\n\
+     DONE: No tools used this generation\n\
+     [/STATE]"
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"test"
+      ~goal:"Keep metadata"
+      ~actual_keeper_tool_names:[]
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:raw
+      ()
+  in
+  Alcotest.(check string)
+    "state block source"
+    "model_state_block"
+    (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
+  Alcotest.(check string)
+    "state-only metadata is not visible reply"
+    ""
+    finalized.response_text
 
 let test_finalizer_prefers_reported_state_snapshot () =
   let reported_state_snapshot =
@@ -846,6 +902,14 @@ let () =
             "finalizer keeps structured source"
             `Quick
             test_finalizer_uses_structured_state_source;
+          Alcotest.test_case
+            "finalizer keeps visible text outside state block"
+            `Quick
+            test_finalizer_keeps_visible_text_outside_state_block;
+          Alcotest.test_case
+            "finalizer drops state-only visible fallback"
+            `Quick
+            test_finalizer_drops_state_only_visible_fallback;
           Alcotest.test_case
             "finalizer prefers reported state"
             `Quick

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -151,7 +151,7 @@ let test_state_block_reply_returns_state_snapshot () =
     state_snapshot.next_items;
   check (list string) "state keeps constraints" [ "Use worktrees" ]
     state_snapshot.constraints;
-  check string "visible response falls back to goal" "Keep runtime visible"
+  check string "state-only block is not a visible response" ""
     response_text
 
 (* RFC-0239 / audit D1: a rejected keeper_task_done must carry a typed


### PR DESCRIPTION
## Summary
- stop treating structured keeper state as user-visible reply text
- keep real text outside [STATE] blocks visible
- add regressions for state-only replies that used to surface as "No tools used this generation" or "Used: ..."

## Evidence
- live Albini history contains durable direct_assistant rows whose content is state metadata, including "No tools used this generation" and "Used: keeper_context_status"
- root cause is state snapshot progress fallback in Keeper_agent_run_response_text

## Validation
- git diff --check origin/main..HEAD
- local Dune build intentionally not run; CI is the build authority for this change