### PR TITLE
fix(dashboard): 보드 스레드 pane 최대 폭 520→760

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -299,6 +299,9 @@ describe('BoardSurface Component', () => {
     expect(normalizeBoardDetailWidth(333.6)).toBe(334)
     expect(normalizeBoardDetailWidth(800)).toBe(BOARD_DETAIL_WIDTH_MAX)
     expect(normalizeBoardDetailWidth('bad')).toBe(BOARD_DETAIL_WIDTH_DEFAULT)
+    // The widened range now admits 700px (was clamped to the old 520 max).
+    expect(BOARD_DETAIL_WIDTH_MAX).toBeGreaterThanOrEqual(700)
+    expect(normalizeBoardDetailWidth(700)).toBe(700)
   })
 
   it('hydrates the persisted Board detail rail width into the grid and resize handle', () => {
@@ -333,7 +336,8 @@ describe('BoardSurface Component', () => {
     expect(handle).toHaveAttribute('aria-valuenow', '440')
     expect(getLocalStorageItem(BOARD_DETAIL_WIDTH_STORAGE_KEY)).toBe('440')
 
-    fireEvent.pointerMove(window, { clientX: 760 })
+    // Drag well past the cap (360 + (1000 - 500) = 860) → clamps to MAX (760).
+    fireEvent.pointerMove(window, { clientX: 500 })
     expect(surface?.getAttribute('data-detail-width')).toBe(String(BOARD_DETAIL_WIDTH_MAX))
     fireEvent.pointerCancel(window)
 

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -94,7 +94,10 @@ import type { BoardPost, ContentCategory, ParsedStateBlock } from './board-state
 export const BOARD_DETAIL_WIDTH_STORAGE_KEY = 'dashboard:board-detail-width'
 export const BOARD_DETAIL_WIDTH_DEFAULT = 360
 export const BOARD_DETAIL_WIDTH_MIN = 290
-export const BOARD_DETAIL_WIDTH_MAX = 520
+// Raised 520 → 760: threads carry root-cause analyses with code blocks that
+// read poorly at 520px. The feed column is minmax(0, 1fr) so the user drives
+// the trade-off via the resize handle; the cap just lets it go wider.
+export const BOARD_DETAIL_WIDTH_MAX = 760
 
 export function normalizeBoardDetailWidth(value: unknown): number {
   const numeric = typeof value === 'number' ? value : Number(value)


### PR DESCRIPTION
## 배경

사용자: "우측 스레드창을 더 넓게도 보고싶을때가 있음."

조사 결과 스레드 pane(`bd-detail`)에는 **이미 리사이즈 핸들이 존재**(드래그 + 화살표키 + 더블클릭, 폭 localStorage 영속화). 진짜 제약은 **`BOARD_DETAIL_WIDTH_MAX = 520`** — 더 넓게 못 가는 상한.

## 변경

- `BOARD_DETAIL_WIDTH_MAX` **520 → 760**. 스레드는 root-cause 분석 + 코드 블록을 담아 520px에서 가독성이 떨어짐.
- grid는 `200px minmax(0,1fr) var(--bd-detail-width)` 그대로 — feed 컬럼이 `minmax(0,1fr)`라 사용자가 핸들로 트레이드오프를 직접 조절. 상한만 넓힘.

## 검증

- `tsc --noEmit`: 0
- `board-surface.test.ts` (59 passed): 범위가 700px를 허용함을 단언 + pointer-drag clamp 테스트를 새 max 초과로 조정해 MAX clamp 검증.

RFC-WAIVED: dashboard board layout constant. credential/keeper/operator/hooks/workflow 무관.
