### PR TITLE
[codex] Retain OAS stream message metadata

### DIFF
--- a/dashboard/src/keeper-message.test.ts
+++ b/dashboard/src/keeper-message.test.ts
@@ -168,12 +168,15 @@ describe('normalizeKeeperConversationDetails', () => {
         input_tokens: 100,
         output_tokens: 50,
         total_tokens: 150,
+        cache_creation_input_tokens: 7,
+        cache_read_input_tokens: 11,
+        cost_usd: 0.04,
       },
     })
     expect(result).not.toBeNull()
     expect(result!.traceId).toBe('trace-123')
     expect(result!.generation).toBe(5)
-    expect(result!.modelUsed).toBeNull()
+    expect(result!.modelUsed).toBe('gpt-4')
     expect(result!.latencyMs).toBe(1500)
     expect(result!.costUsd).toBe(0.05)
     expect(result!.skillPrimary).toBe('router')
@@ -183,6 +186,9 @@ describe('normalizeKeeperConversationDetails', () => {
       inputTokens: 100,
       outputTokens: 50,
       totalTokens: 150,
+      cacheCreationInputTokens: 7,
+      cacheReadInputTokens: 11,
+      costUsd: 0.04,
     })
   })
 

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -58,6 +58,26 @@ function normalizeKeeperTurnOutcome(value: unknown): KeeperTurnOutcome | null {
   }
 }
 
+function normalizeKeeperUsage(raw: unknown): NonNullable<KeeperConversationDetails['usage']> | null {
+  if (!isRecord(raw)) return null
+  const usage: NonNullable<KeeperConversationDetails['usage']> = {
+    inputTokens: asNumber(raw.input_tokens) ?? null,
+    outputTokens: asNumber(raw.output_tokens) ?? null,
+    totalTokens: asNumber(raw.total_tokens) ?? null,
+  }
+  const cacheCreationInputTokens = asNumber(raw.cache_creation_input_tokens)
+  const cacheReadInputTokens = asNumber(raw.cache_read_input_tokens)
+  const costUsd = asNumber(raw.cost_usd)
+  if (cacheCreationInputTokens !== undefined) {
+    usage.cacheCreationInputTokens = cacheCreationInputTokens
+  }
+  if (cacheReadInputTokens !== undefined) {
+    usage.cacheReadInputTokens = cacheReadInputTokens
+  }
+  if (costUsd !== undefined) usage.costUsd = costUsd
+  return usage
+}
+
 export function keeperTurnOutcomeSuppressesReply(
   outcome: KeeperTurnOutcome | null | undefined,
 ): boolean {
@@ -74,21 +94,17 @@ export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversa
 
   const reply = asString(payload.reply) ?? ''
   const stateBlock = reply ? extractStateBlock(reply) : null
-  const usage = isRecord(payload.usage)
-    ? {
-        inputTokens: asNumber(payload.usage.input_tokens) ?? null,
-        outputTokens: asNumber(payload.usage.output_tokens) ?? null,
-        totalTokens: asNumber(payload.usage.total_tokens) ?? null,
-      }
-    : null
+  const usage = normalizeKeeperUsage(payload.usage)
 
   return {
     traceId: asString(payload.trace_id) ?? null,
     turnRef: asString(payload.turn_ref) ?? null,
+    providerMessageId: asString(payload.provider_message_id) ?? null,
     generation: asNumber(payload.generation) ?? null,
-    modelUsed: null,
+    modelUsed: asString(payload.model_used) ?? asString(payload.model) ?? null,
+    stopReason: asString(payload.stop_reason) ?? null,
     latencyMs: asNumber(payload.latency_ms) ?? null,
-    costUsd: asNumber(payload.cost_usd) ?? null,
+    costUsd: asNumber(payload.cost_usd) ?? usage?.costUsd ?? null,
     usage,
     skillPrimary: asString(payload.skill_primary) ?? null,
     skillReason: asString(payload.skill_reason) ?? null,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -231,6 +231,62 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.details?.turnRef).toBe('trace-live#42')
   })
 
+  it('keeps OAS stream message metadata through reply details', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_MESSAGE_START',
+      value: {
+        provider_message_id: 'msg-oas-1',
+        model: 'gpt-5.5',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 1,
+          total_tokens: 11,
+        },
+      },
+    })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_MESSAGE_DELTA',
+      value: {
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 2,
+          total_tokens: 12,
+          cache_creation_input_tokens: 3,
+          cache_read_input_tokens: 4,
+          cost_usd: 0.125,
+        },
+      },
+    })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        reply: 'done',
+        turn_ref: 'trace-live#43',
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('done')
+    expect(entry?.turnRef).toBe('trace-live#43')
+    expect(entry?.details?.providerMessageId).toBe('msg-oas-1')
+    expect(entry?.details?.modelUsed).toBe('gpt-5.5')
+    expect(entry?.details?.stopReason).toBe('end_turn')
+    expect(entry?.details?.costUsd).toBe(0.125)
+    expect(entry?.details?.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      cacheCreationInputTokens: 3,
+      cacheReadInputTokens: 4,
+      costUsd: 0.125,
+    })
+  })
+
   it('suppresses a declared checkpoint regardless of reply text', () => {
     assistantEntry()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -5,6 +5,7 @@ import {
 } from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
 import type { KeeperChatStreamEvent } from './api'
+import type { KeeperConversationDetails } from './types'
 import {
   appendAssistantDelta,
   appendAssistantThinkingDelta,
@@ -25,7 +26,7 @@ import {
   keeperStreamStartedAt,
   setRecordValue,
 } from './keeper-state'
-import { isRecord, asString } from './components/common/normalize'
+import { isRecord, asNumber, asString } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
@@ -62,6 +63,42 @@ function recordStreamProtocolError(
       error: message,
     }
   })
+}
+
+function normalizeStreamUsage(raw: unknown): NonNullable<KeeperConversationDetails['usage']> | null {
+  if (!isRecord(raw)) return null
+  const usage: NonNullable<KeeperConversationDetails['usage']> = {
+    inputTokens: asNumber(raw.input_tokens) ?? null,
+    outputTokens: asNumber(raw.output_tokens) ?? null,
+    totalTokens: asNumber(raw.total_tokens) ?? null,
+  }
+  const cacheCreationInputTokens = asNumber(raw.cache_creation_input_tokens)
+  const cacheReadInputTokens = asNumber(raw.cache_read_input_tokens)
+  const costUsd = asNumber(raw.cost_usd)
+  if (cacheCreationInputTokens !== undefined) {
+    usage.cacheCreationInputTokens = cacheCreationInputTokens
+  }
+  if (cacheReadInputTokens !== undefined) {
+    usage.cacheReadInputTokens = cacheReadInputTokens
+  }
+  if (costUsd !== undefined) usage.costUsd = costUsd
+  return usage
+}
+
+function mergeAssistantStreamDetails(
+  keeperName: string,
+  assistantEntryId: string,
+  patch: Partial<KeeperConversationDetails>,
+): void {
+  updateThreadEntry(keeperName, assistantEntryId, entry => ({
+    ...entry,
+    details: {
+      ...(entry.details ?? {}),
+      ...patch,
+      usage: patch.usage ?? entry.details?.usage ?? null,
+      rawPayload: entry.details?.rawPayload,
+    },
+  }))
 }
 
 export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult | null {
@@ -189,6 +226,40 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'CUSTOM':
+      if (event.name === 'KEEPER_STREAM_MESSAGE_START') {
+        const value = isRecord(event.value) ? event.value : null
+        const patch: Partial<KeeperConversationDetails> = {}
+        const providerMessageId = asString(value?.provider_message_id)
+        const modelUsed = asString(value?.model)
+        const usage = normalizeStreamUsage(value?.usage)
+        if (providerMessageId) patch.providerMessageId = providerMessageId
+        if (modelUsed) patch.modelUsed = modelUsed
+        if (usage) patch.usage = usage
+        if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
+        if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
+        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_STREAM_MESSAGE_DELTA') {
+        const value = isRecord(event.value) ? event.value : null
+        const patch: Partial<KeeperConversationDetails> = {}
+        const stopReason = asString(value?.stop_reason)
+        const usage = normalizeStreamUsage(value?.usage)
+        if (stopReason) patch.stopReason = stopReason
+        if (usage) patch.usage = usage
+        if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
+        if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
+        if (stopReason) setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_STREAM_PING') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        return null
+      }
       if (event.name === 'KEEPER_THINKING_DELTA') {
         const delta = isRecord(event.value)
           ? (typeof event.value.delta === 'string'
@@ -284,15 +355,24 @@ export function applyKeeperStreamEvent(
         const details = normalizeKeeperConversationDetails(event.value)
         if (details) {
           updateThreadEntry(keeperName, assistantEntryId, entry => {
-            const rawText = details.replyText ?? entry.rawText ?? entry.text
-            if (keeperTurnOutcomeSuppressesReply(details.turnOutcome)) {
+            const mergedDetails: KeeperConversationDetails = {
+              ...(entry.details ?? {}),
+              ...details,
+              providerMessageId: details.providerMessageId ?? entry.details?.providerMessageId ?? null,
+              modelUsed: details.modelUsed ?? entry.details?.modelUsed ?? null,
+              stopReason: details.stopReason ?? entry.details?.stopReason ?? null,
+              costUsd: details.costUsd ?? entry.details?.costUsd ?? null,
+              usage: details.usage ?? entry.details?.usage ?? null,
+            }
+            const rawText = mergedDetails.replyText ?? entry.rawText ?? entry.text
+            if (keeperTurnOutcomeSuppressesReply(mergedDetails.turnOutcome)) {
               return {
                 ...entry,
-                details,
-                turnRef: details.turnRef ?? entry.turnRef,
+                details: mergedDetails,
+                turnRef: mergedDetails.turnRef ?? entry.turnRef,
                 rawText,
                 text: '',
-                delivery: details.turnOutcome === 'no_visible_reply' ? 'no_reply' : 'queued',
+                delivery: mergedDetails.turnOutcome === 'no_visible_reply' ? 'no_reply' : 'queued',
                 streamState: null,
               }
             }
@@ -300,8 +380,8 @@ export function applyKeeperStreamEvent(
             const blocks = entry.blocks?.length ? entry.blocks : parseTextToChatBlocks(text)
             return {
               ...entry,
-              details,
-              turnRef: details.turnRef ?? entry.turnRef,
+              details: mergedDetails,
+              turnRef: mergedDetails.turnRef ?? entry.turnRef,
               rawText,
               text,
               blocks,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -717,6 +717,9 @@ interface KeeperConversationUsage {
   inputTokens?: number | null
   outputTokens?: number | null
   totalTokens?: number | null
+  cacheCreationInputTokens?: number | null
+  cacheReadInputTokens?: number | null
+  costUsd?: number | null
 }
 
 // RFC-0232 P2: producer-typed turn outcome carried in the reply payload
@@ -731,8 +734,10 @@ export type KeeperTurnOutcome =
 export interface KeeperConversationDetails {
   traceId?: string | null
   turnRef?: string | null
+  providerMessageId?: string | null
   generation?: number | null
   modelUsed?: string | null
+  stopReason?: string | null
   latencyMs?: number | null
   costUsd?: number | null
   usage?: KeeperConversationUsage | null

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -675,6 +675,18 @@ let json_opt key value =
   | None -> []
   | Some value -> [ (key, value) ]
 
+let keeper_stream_usage_json (usage : Agent_sdk.Types.api_usage) =
+  `Assoc
+    ([
+       ("input_tokens", `Int usage.input_tokens);
+       ("output_tokens", `Int usage.output_tokens);
+       ("total_tokens", `Int (Agent_sdk.Types.total_tokens usage));
+       ("cache_creation_input_tokens", `Int usage.cache_creation_input_tokens);
+       ("cache_read_input_tokens", `Int usage.cache_read_input_tokens);
+     ]
+     @ json_opt "cost_usd"
+         (Option.map (fun value -> `Float value) usage.cost_usd))
+
 let keeper_stream_protocol_error ?index ?event_type ?reason ?raw_bytes kind =
   let fields =
     [ ("kind", `String kind) ]
@@ -695,6 +707,42 @@ let translate_oas_stream_event ~redact_text ~text_accum bridge_state
       { bridge_state;
         chat_events =
           [ Custom { name = "KEEPER_CONNECTED"; value = `Null } ]
+      }
+  | MessageStart { id; model; usage } ->
+      { bridge_state;
+        chat_events =
+          [ Custom
+              { name = "KEEPER_STREAM_MESSAGE_START";
+                value =
+                  `Assoc
+                    ([ ("provider_message_id", `String id); ("model", `String model) ]
+                     @ json_opt "usage"
+                         (Option.map keeper_stream_usage_json usage)) } ]
+      }
+  | MessageDelta { stop_reason; usage } ->
+      { bridge_state;
+        chat_events =
+          [ Custom
+              { name = "KEEPER_STREAM_MESSAGE_DELTA";
+                value =
+                  `Assoc
+                    (json_opt "stop_reason"
+                       (Option.map
+                          (fun reason ->
+                            `String (Agent_sdk.Types.stop_reason_to_string reason))
+                          stop_reason)
+                     @ json_opt "usage"
+                         (Option.map keeper_stream_usage_json usage)) } ]
+      }
+  | MessageStop ->
+      { bridge_state;
+        chat_events =
+          [ Custom { name = "KEEPER_STREAM_MESSAGE_STOP"; value = `Null } ]
+      }
+  | Ping ->
+      { bridge_state;
+        chat_events =
+          [ Custom { name = "KEEPER_STREAM_PING"; value = `Null } ]
       }
   | Timeout reason ->
       { bridge_state;
@@ -833,7 +881,6 @@ let translate_oas_stream_event ~redact_text ~text_accum bridge_state
               { message =
                   redact_text ("Provider stream incomplete: " ^ reason) } ]
       }
-  | MessageStart _ | MessageDelta _ | MessageStop | Ping -> no_events
 
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~client_disconnects

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -60,6 +60,11 @@ let assoc_int key fields =
   | Some (`Int value) -> Some value
   | _ -> None
 
+let assoc_assoc key fields =
+  match List.assoc_opt key fields with
+  | Some (`Assoc value) -> Some value
+  | _ -> None
+
 let test_agent_name_for_channel_actor () =
   let agent_name =
     Gate_keeper_backend.agent_name_for_channel_actor
@@ -539,6 +544,60 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
                 | Keeper_chat_events.Event_error _ -> "error"
                 | _ -> "other")
               events))
+
+let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
+  let open Agent_sdk.Types in
+  let usage_start =
+    { input_tokens = 10;
+      output_tokens = 1;
+      cache_creation_input_tokens = 3;
+      cache_read_input_tokens = 4;
+      cost_usd = None }
+  in
+  let usage_delta =
+    { usage_start with output_tokens = 2; cost_usd = Some 0.125 }
+  in
+  let events =
+    translate_oas_stream_events
+      [
+        MessageStart
+          { id = "msg-oas-1"; model = "gpt-5.5"; usage = Some usage_start };
+        MessageDelta { stop_reason = Some EndTurn; usage = Some usage_delta };
+        MessageStop;
+        Ping;
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_MESSAGE_START"; value = `Assoc start };
+      Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_MESSAGE_DELTA"; value = `Assoc delta };
+      Keeper_chat_events.Custom
+        { name = "KEEPER_STREAM_MESSAGE_STOP"; value = `Null };
+      Keeper_chat_events.Custom { name = "KEEPER_STREAM_PING"; value = `Null } ] ->
+      let start_usage =
+        assoc_assoc "usage" start |> Option.value ~default:[]
+      in
+      let delta_usage =
+        assoc_assoc "usage" delta |> Option.value ~default:[]
+      in
+      check (option string) "provider message id" (Some "msg-oas-1")
+        (assoc_string "provider_message_id" start);
+      check (option string) "model" (Some "gpt-5.5")
+        (assoc_string "model" start);
+      check (option int) "start input tokens" (Some 10)
+        (assoc_int "input_tokens" start_usage);
+      check (option int) "start total tokens" (Some 11)
+        (assoc_int "total_tokens" start_usage);
+      check (option int) "cache creation tokens" (Some 3)
+        (assoc_int "cache_creation_input_tokens" start_usage);
+      check (option string) "stop reason" (Some "end_turn")
+        (assoc_string "stop_reason" delta);
+      check (option int) "delta output tokens" (Some 2)
+        (assoc_int "output_tokens" delta_usage);
+      check (option int) "delta total tokens" (Some 12)
+        (assoc_int "total_tokens" delta_usage)
+  | _ -> fail "expected OAS message lifecycle metadata events"
 
 let test_keeper_stream_bridge_rejects_tool_args_without_start () =
   let open Agent_sdk.Types in
@@ -1333,6 +1392,8 @@ let () =
             test_keeper_stream_args_preserve_user_blocks;
           test_case "stream bridge preserves interleaved thinking and tool" `Quick
             test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool;
+          test_case "stream bridge surfaces OAS message metadata" `Quick
+            test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge rejects tool args without start" `Quick
             test_keeper_stream_bridge_rejects_tool_args_without_start;
           test_case "stream bridge surfaces unknown and incomplete events" `Quick


### PR DESCRIPTION
## Summary

- Retain OAS `MessageStart`, `MessageDelta`, `MessageStop`, and `Ping` instead of dropping them in the MASC keeper stream bridge.
- Carry provider message id, model, stop reason, usage, cache-token usage, and usage-level cost into dashboard `KeeperConversationDetails`.
- Keep stream metadata when later `KEEPER_REPLY_DETAILS` arrives, so final reply hydration does not wipe the OAS facts already observed live.

## OAS Boundary

- MASC consumes typed OAS lifecycle facts and uses OAS helpers for derived values:
  - `Agent_sdk.Types.stop_reason_to_string`
  - `Agent_sdk.Types.total_tokens`
- MASC still does not parse provider wire payloads or assemble final OAS responses. This is UI/stream projection only.

## Validation

- `dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-message.test.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1` (73 tests)
- `dashboard/node_modules/.bin/tsc --noEmit --pretty`
- `ocamlformat --check lib/server/server_routes_http_keeper_stream.ml lib/server/server_routes_http_keeper_stream.mli test/test_gate_keeper_backend.ml`
- `git diff --check origin/main...HEAD`

## Local Dune Note

- `gtimeout 90 ./scripts/dune-local.sh build test/test_gate_keeper_backend.exe` entered the focused Dune build after confirming the OAS pin, but hit the 90s timeout with no compiler error output.
- Treat PR CI as the latest OCaml build authority for this follow-up.

## Relation

- Follow-up to #22682, which merged before this metadata-retention commit was included.
