### PR TITLE
test(dashboard): align keeper detail rail assertions

### DIFF
--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -80,14 +80,10 @@ describe('KeeperWorkspaceRail', () => {
     tasks.value = [makeTask()]
     const container = renderInto(html`<${KeeperWorkspaceRail} keeper=${makeKeeper()} onToggleDetail=${() => {}} />`)
 
-    // v2 rail split the old combined '런타임 · 처리량' card into separate
-    // 런타임 (RuntimeSection / .rtc-card) and 처리량 (ThroughputSection) sections,
-    // each with its own .ctx-sec h4 header. The 처리량 header is now a collapse
-    // toggle (.ctx-h-toggle) whose text bundles the caret + an idle/rate summary
-    // (e.g. '▸처리량유휴'), so match it by substring rather than exact text.
+    // The rail no longer renders the old low-signal throughput section; keep
+    // this test focused on the detail page's runtime, context, and task facts.
     const sectionHeaders = Array.from(container.querySelectorAll('.ctx-sec h4')).map(h => h.textContent)
     expect(sectionHeaders).toContain('런타임')
-    expect(sectionHeaders.some(h => h?.includes('처리량'))).toBe(true)
     expect(container.textContent).toContain('claude-sonnet-4')
     expect(container.textContent).toContain('oas-seoul-1')
     expect(container.textContent).toContain('62%')


### PR DESCRIPTION
## Summary
- Remove the stale keeper detail page assertion that still expected the removed rail throughput section.
- Keep the test aligned with keeper-workspace-rail.test.ts, where the throughput section removal is already the canonical contract.

## Evidence
- CI failure source: masc #22688 Dashboard, src/components/keeper-detail-page.test.ts:90 expected a 처리량 section.
- Local: pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail-page.test.ts --no-file-parallelism --maxWorkers=1
- Local: pnpm run typecheck