### PR TITLE
test(dashboard): align keeper-detail-page rail test with removed 처리량 section (main green-restore)

### DIFF
--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -80,14 +80,14 @@ describe('KeeperWorkspaceRail', () => {
     tasks.value = [makeTask()]
     const container = renderInto(html`<${KeeperWorkspaceRail} keeper=${makeKeeper()} onToggleDetail=${() => {}} />`)
 
-    // v2 rail split the old combined '런타임 · 처리량' card into separate
-    // 런타임 (RuntimeSection / .rtc-card) and 처리량 (ThroughputSection) sections,
-    // each with its own .ctx-sec h4 header. The 처리량 header is now a collapse
-    // toggle (.ctx-h-toggle) whose text bundles the caret + an idle/rate summary
-    // (e.g. '▸처리량유휴'), so match it by substring rather than exact text.
+    // v2 rail renders 런타임 (RuntimeSection / .rtc-card), 컨텍스트, and 소유 태스크
+    // sections, each with its own .ctx-sec h4 header. The standalone 처리량
+    // (ThroughputSection) header was removed from the keeper rail (see
+    // keeper-workspace-rail.test.ts, which asserts textContent no longer contains
+    // '처리량'), so it must not appear as a .ctx-sec h4 here either.
     const sectionHeaders = Array.from(container.querySelectorAll('.ctx-sec h4')).map(h => h.textContent)
     expect(sectionHeaders).toContain('런타임')
-    expect(sectionHeaders.some(h => h?.includes('처리량'))).toBe(true)
+    expect(sectionHeaders.some(h => h?.includes('처리량'))).toBe(false)
     expect(container.textContent).toContain('claude-sonnet-4')
     expect(container.textContent).toContain('oas-seoul-1')
     expect(container.textContent).toContain('62%')


### PR DESCRIPTION
## 목적

masc `main`(현 `334366f8`)의 **Dashboard > Run dashboard tests**를 green으로 회복합니다.

## 증상 (CI)

```
FAIL  src/components/keeper-detail-page.test.ts > KeeperWorkspaceRail > renders current keeper runtime, context, and owned task
AssertionError: expected false to be true
  90| expect(sectionHeaders.some(h => h?.includes('처리량'))).toBe(true)
Tests  1 failed | 8075 passed (8076)
```

## 근본 원인 (stale test, N-of-2 누락)

`#22687`(키퍼 레일에서 처리량 섹션/카드 제거)이 keeper rail의 standalone **처리량(ThroughputSection)** 헤더를 제거하고, 같은 rail을 검증하는 `keeper-workspace-rail.test.ts`는 갱신했습니다(`expect(container.textContent).not.toContain('처리량')`, line 118-120·192). 그러나 **같은 rail을 렌더하는 다른 테스트 파일** `keeper-detail-page.test.ts:90`은 여전히 처리량 `.ctx-sec h4`가 **존재한다고**(`toBe(true)`) 단언해, 컴포넌트(주의/런타임/컨텍스트/소유태스크만 렌더)와 어긋나 main이 red가 되었습니다.

- 컴포넌트 `keeper-workspace-rail.ts`의 현재 `.ctx-sec` 섹션: 주의 / 런타임 / 컨텍스트 / 소유 태스크 — 처리량 없음.
- 즉 이 단언은 이제 *제거된 섹션이 존재한다*고 잘못 주장하는 stale 상태입니다.

## 변경 (test-only, surgical)

`keeper-detail-page.test.ts:90`의 처리량 단언을 현실(섹션 제거)에 맞춰 `toBe(false)`로 교정하고 stale 주석을 갱신했습니다. 적대적 판단: 이 테스트는 vacuous가 아니라 rail 렌더(런타임/컨텍스트/태스크)를 검증하므로 **전체 삭제가 아니라 처리량 단언만 교정**하고 `런타임` 단언과 나머지(claude-sonnet-4 / oas-seoul-1 / 62% / T-1)는 유지했습니다.

## 검증

- 로컬 편집은 surgical(6/6, 단언 1줄 + 주석). 빌드/테스트는 CI에서 확인.
- 영향 범위: `keeper-detail-page.test.ts` 단일 파일. open PR(#22689 docs / #22690 stream / #22688 memory-os) 어느 것도 이 파일을 건드리지 않아 충돌 없음.

## 관계

- `#22687` 후속 보완(누락된 2번째 테스트 파일 정렬).
- `#22689`(docs) 등 base가 broken main인 PR들의 Dashboard collateral-fail도 이 머지 후 회복됩니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>