### PR TITLE
[codex] Preserve OAS thinking signatures in keeper context

### DIFF
--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -21,22 +21,19 @@ let role_of_string_opt = function
 
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
-  `List
-    (List.map
-       (function
-        | Agent_sdk.Types.Thinking { thinking_type; content } ->
-          `Assoc
-            [ ("type", `String "thinking")
-            ; ("thinking", `String content)
-            ; ("thinking_type", `String thinking_type)
-            ]
-        | Agent_sdk.Types.RedactedThinking text ->
-          `Assoc
-            [ ("type", `String "redacted_thinking")
-            ; ("data", `String text)
-            ]
-        | block -> Agent_sdk.Api.content_block_to_json block)
-       blocks)
+  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
+
+let thinking_type_of_json (json : Yojson.Safe.t) =
+  match Json_util.get_string json "signature" with
+  | Some signature -> signature
+  | None -> (
+      match Json_util.get_string json "thinking_type" with
+      | Some thinking_type -> thinking_type
+      | None ->
+          (* DET-OK: older context/checkpoint JSON predates the OAS
+             canonical [signature] carrier; "thinking" is the historical wire
+             value for those persisted rows. *)
+          "thinking")
 
 let content_blocks_of_json
     (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
@@ -48,15 +45,7 @@ let content_blocks_of_json
            | Some "thinking" ->
              (match Json_util.get_string j "thinking" with
               | Some content ->
-                let thinking_type =
-                  match Json_util.get_string j "thinking_type" with
-                  | Some thinking_type -> thinking_type
-                  | None ->
-                    (* DET-OK: older context/checkpoint JSON predates the
-                       explicit carrier tag; "thinking" is the historical
-                       wire value for those persisted rows. *)
-                    "thinking"
-                in
+                let thinking_type = thinking_type_of_json j in
                 Some (Agent_sdk.Types.Thinking { thinking_type; content })
               | None -> None)
            | Some "redacted_thinking" ->

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -206,6 +206,59 @@ let test_roundtrip_preserves_thinking_type () =
       Alcotest.(check string) "text" "done" text
   | _ -> Alcotest.fail "expected thinking, thinking, redacted thinking, text"
 
+let test_thinking_block_json_uses_oas_signature () =
+  let original : T.message =
+    {
+      T.role = T.Assistant;
+      content =
+        [ T.Thinking { thinking_type = "anthropic-signature"; content = "signed" } ];
+      name = None;
+      tool_call_id = None;
+      metadata = [];
+    }
+  in
+  match C.message_to_json original with
+  | `Assoc fields -> (
+      match List.assoc_opt "content_blocks" fields with
+      | Some (`List [ `Assoc block_fields ]) ->
+          Alcotest.(check bool)
+            "uses OAS canonical signature carrier" true
+            (List.mem_assoc "signature" block_fields);
+          Alcotest.(check bool)
+            "does not emit legacy thinking_type carrier" false
+            (List.mem_assoc "thinking_type" block_fields);
+          Alcotest.(check string)
+            "signature preserved"
+            "anthropic-signature"
+            (Yojson.Safe.Util.member "signature" (`Assoc block_fields)
+             |> Yojson.Safe.Util.to_string)
+      | _ -> Alcotest.fail "expected one content block")
+  | _ -> Alcotest.fail "expected message object"
+
+let test_legacy_thinking_type_still_reads () =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [
+        ("role", `String "assistant");
+        ( "content_blocks",
+          `List
+            [
+              `Assoc
+                [
+                  ("type", `String "thinking");
+                  ("thinking", `String "signed");
+                  ("thinking_type", `String "legacy-signature");
+                ];
+            ] );
+      ]
+  in
+  let parsed = C.message_of_json json in
+  match parsed.content with
+  | [ T.Thinking { thinking_type; content } ] ->
+      Alcotest.(check string) "legacy thinking type" "legacy-signature" thinking_type;
+      Alcotest.(check string) "content" "signed" content
+  | _ -> Alcotest.fail "expected legacy thinking block"
+
 let () =
   Alcotest.run "keeper_context_core_dedup"
     [
@@ -226,6 +279,10 @@ let () =
             test_roundtrip_text_preserved;
           Alcotest.test_case "round-trip thinking type preserved" `Quick
             test_roundtrip_preserves_thinking_type;
+          Alcotest.test_case "thinking block JSON uses OAS signature" `Quick
+            test_thinking_block_json_uses_oas_signature;
+          Alcotest.test_case "legacy thinking_type still reads" `Quick
+            test_legacy_thinking_type_still_reads;
         ] );
       ( "text_of_history_jsonl_json",
         [


### PR DESCRIPTION
Summary:
- delegate keeper content-block JSON writes to Agent_sdk.Api.content_block_to_json
- read OAS canonical thinking signature first, with legacy thinking_type fallback for old rows
- add regression coverage for canonical signature output and legacy input compatibility

Validation:
- ocamlformat --check lib/keeper/keeper_context_core_message_json.ml test/test_keeper_context_core_dedup.ml
- ./scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe
- ./_build/default/test/test_keeper_context_core_dedup.exe
- git diff --check