### PR TITLE
[codex] Align keeper tool-pair repair with OAS role semantics

### DIFF
--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -211,6 +211,7 @@ let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 let tool_use_ids_of_message = Keeper_context_tool_message_pairs.tool_use_ids_of_message
 let tool_result_ids_of_message = Keeper_context_tool_message_pairs.tool_result_ids_of_message
 let has_tool_result_block = Keeper_context_tool_message_pairs.has_tool_result_block
+let has_tool_use_block = Keeper_context_tool_message_pairs.has_tool_use_block
 let trim_messages_preserving_pairs = Keeper_context_tool_message_pairs.trim_messages_preserving_pairs
 
 (* Tool block text renderers extracted to
@@ -325,7 +326,8 @@ let filter_group_message_content
       (function
         | Agent_sdk.Types.ToolUse { id; name; _ }
           when mode.drop_dangling_uses
-               && not (List.mem id matched_tool_result_ids) ->
+               && (msg.role <> Agent_sdk.Types.Assistant
+                   || not (List.mem id matched_tool_result_ids)) ->
             record_dropped_tool_use stats id name;
             None
         | Agent_sdk.Types.ToolResult { tool_use_id; _ } as block
@@ -348,15 +350,22 @@ let filter_orphan_result_message_content
     mode
     (msg : Agent_sdk.Types.message)
     : Agent_sdk.Types.content_block list * tool_pair_repair_stats =
-  if not mode.drop_orphan_results
+  let drop_non_assistant_tool_use =
+    mode.drop_dangling_uses && msg.role <> Agent_sdk.Types.Assistant
+  in
+  if (not mode.drop_orphan_results) && not drop_non_assistant_tool_use
   then msg.content, empty_tool_pair_repair_stats
   else
     let stats = ref empty_tool_pair_repair_stats in
     let content =
       List.filter_map
         (function
-          | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+          | Agent_sdk.Types.ToolResult { tool_use_id; _ }
+            when mode.drop_orphan_results ->
               record_dropped_tool_result stats tool_use_id;
+              None
+          | Agent_sdk.Types.ToolUse { id; name; _ } when drop_non_assistant_tool_use ->
+              record_dropped_tool_use stats id name;
               None
           | other -> Some other)
         msg.content
@@ -458,6 +467,9 @@ let repair_tool_call_pairs_with_stats
           in
           loop acc_stats acc rest
         else if has_tool_result_block msg
+                || (mode.drop_dangling_uses
+                    && msg.role <> Agent_sdk.Types.Assistant
+                    && has_tool_use_block msg)
         then
           let content, stats = filter_orphan_result_message_content mode msg in
           let acc = append_repaired acc stats msg content in

--- a/lib/keeper/keeper_context_tool_message_pairs.ml
+++ b/lib/keeper/keeper_context_tool_message_pairs.ml
@@ -5,17 +5,36 @@
    and total over [Agent_sdk.Types] (exhaustive matches, no catch-all). *)
 
 let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
+  match msg.role with
+  | Agent_sdk.Types.Assistant ->
+    List.filter_map
+      (function
+        | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+        (* Only assistant [ToolUse] blocks are provider tool-call anchors. *)
+        | Agent_sdk.Types.Text _
+        | Agent_sdk.Types.Thinking _
+        | Agent_sdk.Types.RedactedThinking _
+        | Agent_sdk.Types.ToolResult _
+        | Agent_sdk.Types.Image _
+        | Agent_sdk.Types.Document _
+        | Agent_sdk.Types.Audio _ -> None)
+      msg.content
+  | Agent_sdk.Types.System
+  | Agent_sdk.Types.User
+  | Agent_sdk.Types.Tool -> []
+;;
+
+let has_tool_use_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
     (function
-      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
-      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
+      | Agent_sdk.Types.ToolUse _ -> true
       | Agent_sdk.Types.Text _
       | Agent_sdk.Types.Thinking _
       | Agent_sdk.Types.RedactedThinking _
       | Agent_sdk.Types.ToolResult _
       | Agent_sdk.Types.Image _
       | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
+      | Agent_sdk.Types.Audio _ -> false)
     msg.content
 ;;
 

--- a/lib/keeper/keeper_context_tool_message_pairs.mli
+++ b/lib/keeper/keeper_context_tool_message_pairs.mli
@@ -3,6 +3,7 @@
 val tool_use_ids_of_message : Agent_sdk.Types.message -> string list
 val tool_result_ids_of_message : Agent_sdk.Types.message -> string list
 val has_tool_result_block : Agent_sdk.Types.message -> bool
+val has_tool_use_block : Agent_sdk.Types.message -> bool
 
 (** Trim messages to at most [max_count] preserving ToolUse/ToolResult
     pairing.  Drops from the front; advances the drop boundary by 1

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -230,6 +230,14 @@ let assistant_tool_use ?(input = `Null) id name : Agent_sdk.Types.message =
   ; metadata = []
   }
 
+let user_tool_use ?(input = `Null) id name : Agent_sdk.Types.message =
+  { role = Agent_sdk.Types.User
+  ; content = [ Agent_sdk.Types.ToolUse { id; name; input } ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
 let assistant_text_and_tool_use ?(input = `Null) text id name : Agent_sdk.Types.message =
   { role = Agent_sdk.Types.Assistant
   ; content =
@@ -497,6 +505,35 @@ let test_pair_repair_preserves_contiguous_result_span () =
   Alcotest.(check (pair int int))
     "contiguous span ToolUse and ToolResult blocks preserved"
     (2, 2)
+    (count_tool_blocks repaired)
+
+let test_pair_repair_rejects_non_assistant_tool_use_anchor () =
+  let messages =
+    [ user_tool_use "toolu_user" "lookup"
+    ; tool_result_message ~role:Agent_sdk.Types.Tool "toolu_user" "ok"
+    ]
+  in
+  let repaired, stats = KC.repair_broken_tool_call_pairs_with_stats messages in
+  Alcotest.(check int)
+    "non-assistant ToolUse is dropped"
+    1
+    stats.dropped_tool_uses;
+  Alcotest.(check int)
+    "matching result is still orphan"
+    1
+    stats.dropped_tool_results;
+  Alcotest.(check (list (pair string string)))
+    "invalid ToolUse sample preserved"
+    [ "toolu_user", "lookup" ]
+    stats.dropped_tool_use_samples;
+  Alcotest.(check (list string))
+    "orphan result id preserved"
+    [ "toolu_user" ]
+    stats.dropped_tool_result_ids;
+  Alcotest.(check int) "structural messages removed" 0 (List.length repaired);
+  Alcotest.(check (pair int int))
+    "no malformed tool blocks survive"
+    (0, 0)
     (count_tool_blocks repaired)
 
 let test_pair_repair_moves_late_results_before_interstitial_turns () =
@@ -789,6 +826,8 @@ let () =
         test_pair_repair_preserves_same_message_tool_pair;
       Alcotest.test_case "pair repair preserves contiguous result span" `Quick
         test_pair_repair_preserves_contiguous_result_span;
+      Alcotest.test_case "pair repair rejects non-assistant tool-use anchor" `Quick
+        test_pair_repair_rejects_non_assistant_tool_use_anchor;
       Alcotest.test_case "pair repair moves late results before interstitial turns" `Quick
         test_pair_repair_moves_late_results_before_interstitial_turns;
       Alcotest.test_case "pair repair drops only invalid span blocks" `Quick


### PR DESCRIPTION
Summary:
- treat only assistant ToolUse blocks as provider tool-call anchors, matching OAS Tool_message_pairs semantics
- drop non-assistant ToolUse blocks through the existing typed pair-repair stats instead of preserving malformed anchors
- add regression coverage for non-assistant ToolUse plus matching ToolResult being repaired as invalid/orphaned blocks

Validation:
- ./scripts/dune-local.sh build test/test_pbt_context_overflow.exe
- ./_build/default/test/test_pbt_context_overflow.exe
- ocamlformat --check lib/keeper/keeper_context_core_accessors.ml lib/keeper/keeper_context_tool_message_pairs.ml lib/keeper/keeper_context_tool_message_pairs.mli test/test_pbt_context_overflow.ml
- git diff --check