### PR TITLE
[codex] Fix dashboard empty keeper replies

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -25,7 +25,7 @@ const {
     || result.status === 'cancelled'
   )),
   queuedKeeperMessageError: vi.fn((result: { status: string }) => `request ${result.status}`),
-  queuedKeeperMessageToReply: vi.fn((result: { result?: { reply?: string } }) => ({
+  queuedKeeperMessageToReply: vi.fn((result: { result?: { reply?: string } }): KeeperToolReply => ({
     text: result.result?.reply ?? '(empty reply)',
     details: null,
   })),
@@ -92,6 +92,7 @@ import {
   toolCallOutputsCoveredThroughMs,
 } from './tool-call-output-store'
 import type { KeeperChatStreamEvent } from './api'
+import type { KeeperToolReply } from './api/keeper'
 import type { ToolCallEntry } from './api/dashboard'
 import type { KeeperConversationAttachment, KeeperStatusDetail } from './types'
 
@@ -261,7 +262,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     queuedKeeperMessageError.mockClear()
     queuedKeeperMessageToReply.mockClear()
     queuedKeeperMessageError.mockImplementation((result: { status: string }) => `request ${result.status}`)
-    queuedKeeperMessageToReply.mockImplementation((result: { result?: { reply?: string } }) => ({
+    queuedKeeperMessageToReply.mockImplementation((result: { result?: { reply?: string } }): KeeperToolReply => ({
       text: result.result?.reply ?? '(empty reply)',
       details: null,
     }))
@@ -753,6 +754,30 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
   })
 
+  it('marks a terminal no-visible reply as error instead of empty reply text', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_REPLY_DETAILS',
+        value: {
+          runtime_class: 'keeper',
+          reply: '',
+          turn_outcome: 'no_visible_reply',
+        },
+      },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '뭐함')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('error')
+    expect(reply?.text).toContain('표시할 답변')
+    expect(reply?.text).not.toBe('(empty reply)')
+    expect(keeperActionErrors.value.echo).toContain('표시할 답변')
+  })
+
   it('derives text and media user blocks when only attachments are supplied', async () => {
     streamKeeperMessage.mockImplementation(emitting([
       { type: 'RUN_STARTED' },
@@ -920,6 +945,60 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['assistant', '여기까지 했습니다.', 'delivered'],
     ])
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+  })
+
+  it('resumes a no-visible pending request as error instead of blank assistant text', async () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: '뭐함',
+      submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+    })
+    fetchQueuedKeeperMessageResult.mockResolvedValue({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      status: 'done',
+      ok: true,
+      result: {
+        reply: '',
+        turn_outcome: 'no_visible_reply',
+      },
+    })
+    queuedKeeperMessageToReply.mockImplementation(() => ({
+      text: '',
+      details: {
+        traceId: null,
+        turnRef: null,
+        providerMessageId: null,
+        generation: null,
+        modelUsed: null,
+        stopReason: null,
+        latencyMs: null,
+        costUsd: null,
+        usage: null,
+        skillPrimary: null,
+        skillReason: null,
+        stateBlock: null,
+        replyText: null,
+        turnOutcome: 'no_visible_reply',
+        rawPayload: {
+          reply: '',
+          turn_outcome: 'no_visible_reply',
+        },
+      },
+    }))
+    fetchKeeperChatHistory.mockResolvedValue([])
+
+    await resumePendingKeeperChatRequests('echo')
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', '뭐함', 'error'],
+      ['assistant', expect.stringContaining('표시할 답변'), 'error'],
+    ])
+    expect(thread.find(entry => entry.role === 'assistant')?.text).not.toBe('(empty reply)')
+    expect(keeperActionErrors.value.echo).toContain('표시할 답변')
   })
 
   it('resumes repeated same-message sends as distinct request ids', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -75,6 +75,8 @@ import {
 type KeeperInterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
 
 const TOOL_ONLY_EMPTY_REPLY_TEXT = 'Tool-only turn ended without a final reply.'
+const EMPTY_VISIBLE_REPLY_TEXT =
+  'Keeper가 thinking만 반환하고 표시할 답변을 만들지 못했습니다. 다시 보내주세요.'
 const pendingKeeperThreadCancels = new Map<string, Promise<boolean>>()
 const KEEPER_THREAD_CANCEL_TIMEOUT_MS = 5_000
 const KEEPER_THREAD_CANCEL_SETTLE_GRACE_MS = 500
@@ -517,8 +519,13 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       const isNoVisibleReply = reply.details?.turnOutcome === 'no_visible_reply'
       const suppressReply = keeperTurnOutcomeSuppressesReply(reply.details?.turnOutcome)
       const isCancelled = result.status === 'cancelled'
-      const isError = !isCancelled && (result.status !== 'done' || result.ok === false)
-      const errorMessage = isError ? queuedKeeperMessageError(result) : null
+      const isError = !isCancelled && (isNoVisibleReply || result.status !== 'done' || result.ok === false)
+      let errorMessage: string | null = null
+      if (isNoVisibleReply) {
+        errorMessage = EMPTY_VISIBLE_REPLY_TEXT
+      } else if (isError) {
+        errorMessage = queuedKeeperMessageError(result)
+      }
       let userDelivery: KeeperConversationDelivery = 'delivered'
       if (isCancelled) {
         userDelivery = 'cancelled'
@@ -531,7 +538,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       } else if (isCheckpoint) {
         assistantDelivery = 'queued'
       } else if (isNoVisibleReply) {
-        assistantDelivery = 'no_reply'
+        assistantDelivery = 'error'
       } else if (isError) {
         assistantDelivery = 'error'
       }
@@ -539,9 +546,17 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         delivery: userDelivery,
         error: errorMessage,
       })
+      let assistantText = reply.text
+      let assistantRawText = reply.details?.replyText ?? reply.text
+      if (isNoVisibleReply) {
+        assistantText = EMPTY_VISIBLE_REPLY_TEXT
+        assistantRawText = EMPTY_VISIBLE_REPLY_TEXT
+      } else if (suppressReply) {
+        assistantText = ''
+      }
       finalizeAssistantEntry(request.keeperName, assistantId, {
-        text: suppressReply ? '' : reply.text,
-        rawText: reply.details?.replyText ?? reply.text,
+        text: assistantText,
+        rawText: assistantRawText,
         delivery: assistantDelivery,
         streamState: null,
         timestamp: new Date().toISOString(),
@@ -898,10 +913,24 @@ export async function sendKeeperThreadMessage(
       !finalText && finalEntry?.delivery === 'queued'
         ? 'queued' as KeeperConversationDelivery
         : 'delivered' as KeeperConversationDelivery
-    let emptyTerminalText = '(empty reply)'
-    if (finalDelivery === 'queued') {
-      emptyTerminalText = ''
-    } else if (toolCallEnded) {
+    if (!finalText && finalDelivery !== 'queued' && !toolCallEnded) {
+      finalizeAssistantEntry(keeperName, assistantId, {
+        text: EMPTY_VISIBLE_REPLY_TEXT,
+        rawText: finalEntry?.rawText || EMPTY_VISIBLE_REPLY_TEXT,
+        delivery: 'error',
+        streamState: null,
+        timestamp: new Date().toISOString(),
+        error: EMPTY_VISIBLE_REPLY_TEXT,
+      })
+      setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
+      if (requestId) {
+        removePendingKeeperChatRequest(requestId)
+        releaseActiveStreamRequestId(requestId)
+      }
+      return
+    }
+    let emptyTerminalText = ''
+    if (toolCallEnded) {
       emptyTerminalText = TOOL_ONLY_EMPTY_REPLY_TEXT
     }
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -619,6 +619,17 @@ let persisted_error_reply err =
   in
   "Keeper request failed: " ^ detail
 
+let empty_direct_reply_error =
+  "Keeper completed without a visible reply; the runtime returned only thinking or internal state."
+
+let direct_reply_terminal_error payload_json_opt visible_reply =
+  let turn_outcome = Keeper_turn_outcome.of_reply_payload payload_json_opt in
+  match (turn_outcome, String_util.trim_to_option visible_reply) with
+  | Keeper_turn_outcome.Continuation_checkpoint, _ -> None
+  | Keeper_turn_outcome.No_visible_reply, _ -> Some empty_direct_reply_error
+  | Keeper_turn_outcome.Visible_reply, None -> Some empty_direct_reply_error
+  | Keeper_turn_outcome.Visible_reply, Some _ -> None
+
 let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
     ?(message = "") () =
   let fields =
@@ -1022,31 +1033,41 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
               Keeper_turn_outcome.turn_ref_of_reply_payload payload_json_opt
             in
             let visible_reply = String.trim visible_reply in
-            (match
-               ( Keeper_turn_outcome.of_reply_payload payload_json_opt,
-                 String_util.trim_to_option visible_reply )
-             with
-            | Keeper_turn_outcome.Continuation_checkpoint, _
-            | Keeper_turn_outcome.No_visible_reply, _ ->
-                persist_user_message_only ()
-            | Keeper_turn_outcome.Visible_reply, None -> persist_user_message_only ()
-            | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
-                Keeper_chat_store.append_turn
-                  ~base_dir:base_path
-                  ~keeper_name:payload.name
-                  ~user_content:payload.message
-                  ~user_attachments:payload.attachments
-                  ~surface:chat_surface
-                  ~speaker:chat_speaker
-                  ~assistant_content:visible_reply
-                  ?turn_ref
-                  ();
-                Keeper_chat_broadcast.chat_appended
-                  ~keeper_name:payload.name ~source:chat_source
-                  ~content:visible_reply
-                  ());
-            push_worker_event (Stream_terminal { ok = true; status = "done"; body });
-            Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
+            (match direct_reply_terminal_error payload_json_opt visible_reply with
+             | Some err ->
+                 persist_failure_reply err;
+                 push_worker_event
+                   (Stream_terminal { ok = false; status = "error"; body = err });
+                 Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
+             | None ->
+                 (match
+                    ( Keeper_turn_outcome.of_reply_payload payload_json_opt,
+                      String_util.trim_to_option visible_reply )
+                  with
+                 | Keeper_turn_outcome.Continuation_checkpoint, _ ->
+                     persist_user_message_only ()
+                 | Keeper_turn_outcome.No_visible_reply, _ ->
+                     persist_user_message_only ()
+                 | Keeper_turn_outcome.Visible_reply, None ->
+                     persist_user_message_only ()
+                 | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
+                     Keeper_chat_store.append_turn
+                       ~base_dir:base_path
+                       ~keeper_name:payload.name
+                       ~user_content:payload.message
+                       ~user_attachments:payload.attachments
+                       ~surface:chat_surface
+                       ~speaker:chat_speaker
+                       ~assistant_content:visible_reply
+                       ?turn_ref
+                       ();
+                     Keeper_chat_broadcast.chat_appended
+                       ~keeper_name:payload.name ~source:chat_source
+                       ~content:visible_reply
+                       ());
+                 push_worker_event
+                   (Stream_terminal { ok = true; status = "done"; body });
+                 Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body)
         | Ok (false, err) ->
             persist_failure_reply err;
             push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
@@ -1407,6 +1428,7 @@ module For_testing = struct
   let args_of_request = args_of_request
   let modalities_for_request = modalities_for_request
   let extract_visible_reply = extract_visible_reply
+  let direct_reply_terminal_error = direct_reply_terminal_error
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
   let empty_stream_bridge_state = empty_keeper_stream_bridge_state

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -185,6 +185,7 @@ module For_testing : sig
   val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
   val modalities_for_request : keeper_chat_stream_request -> string list
   val extract_visible_reply : string -> Yojson.Safe.t option * string
+  val direct_reply_terminal_error : Yojson.Safe.t option -> string -> string option
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   val empty_stream_bridge_state : keeper_stream_bridge_state

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -776,6 +776,37 @@ let test_extract_visible_reply_uses_typed_reply_field_only () =
   check bool "structured envelope parsed" true (Option.is_some payload_json_opt);
   check string "visible reply comes from reply field" "Done." visible_reply
 
+let test_direct_reply_terminal_error_rejects_no_visible_reply () =
+  let payload_json =
+    `Assoc
+      [
+        ("runtime_class", `String "keeper");
+        ("turn_outcome", `String "no_visible_reply");
+        ("reply", `String "");
+      ]
+  in
+  let err =
+    Server_routes_http_keeper_stream.For_testing.direct_reply_terminal_error
+      (Some payload_json) ""
+  in
+  check bool "thinking-only direct reply is terminal error" true
+    (Option.is_some err)
+
+let test_direct_reply_terminal_error_allows_checkpoint () =
+  let payload_json =
+    `Assoc
+      [
+        ("runtime_class", `String "keeper");
+        ("turn_outcome", `String "continuation_checkpoint");
+        ("reply", `String "");
+      ]
+  in
+  let err =
+    Server_routes_http_keeper_stream.For_testing.direct_reply_terminal_error
+      (Some payload_json) ""
+  in
+  check bool "checkpoint can stay user-only" true (Option.is_none err)
+
 let vision_provider_cfg () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -1406,6 +1437,10 @@ let () =
             test_extract_visible_reply_drops_empty_structured_envelope;
           test_case "visible reply uses typed reply field only" `Quick
             test_extract_visible_reply_uses_typed_reply_field_only;
+          test_case "direct reply rejects no visible reply" `Quick
+            test_direct_reply_terminal_error_rejects_no_visible_reply;
+          test_case "direct reply allows continuation checkpoint" `Quick
+            test_direct_reply_terminal_error_allows_checkpoint;
           test_case "runtime run_blocks appends multimodal input to OAS agent" `Quick
             test_runtime_run_blocks_appends_multimodal_input_to_oas_agent;
           test_case "runtime multimodal gate lists required modalities" `Quick


### PR DESCRIPTION
## Summary
- Treat direct keeper chat turns with no visible reply as transport failures instead of successful empty replies.
- Make the dashboard render a clear error state for terminal `no_visible_reply` results from both live streams and pending-request resume.
- Add focused dashboard and backend regression coverage for the empty-reply path.

## Root Cause
OAS could complete a turn with only thinking/internal state and no visible answer. MASC classified that as `no_visible_reply` but still returned a successful terminal result, so the dashboard finalized the assistant bubble as `(empty reply)` and the server transcript persisted only the user message.

## Validation
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/keeper-actions.ts src/keeper-actions.test.ts`
- `scripts/dune-local.sh build test/test_gate_keeper_backend.exe`
- `scripts/dune-local.sh exec ./test/test_gate_keeper_backend.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vite build`