### PR TITLE
Bridge OAS stream events into keeper chat

### DIFF
--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -418,6 +418,16 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
         Log.Keeper.debug
           "keeper_chat_discord: custom event %s" name;
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+    | Oas_stream_connected
+    | Oas_stream_message_start _
+    | Oas_stream_message_delta _
+    | Oas_stream_message_stop
+    | Oas_stream_ping
+    | Oas_thinking_delta _
+    | Oas_thinking_signature_delta _
+    | Oas_media_delta _
+    | Oas_stream_protocol_error _ ->
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_call_start { tool_call_id; tool_call_name } ->
         let tool_msgs =
           match send_tool_running ~token ~channel_id ~tool_call_name with

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -1,5 +1,23 @@
 type role = User | Assistant
 
+type stream_protocol_error_kind =
+  | Tool_start_duplicate_index
+  | Tool_start_missing_identity
+  | Tool_args_without_start
+  | Tool_stop_without_start
+  | Sse_error
+  | Sse_parse_failed
+  | Sse_unknown_event_type
+  | Sse_stream_incomplete
+
+type stream_protocol_error = {
+  kind : stream_protocol_error_kind;
+  index : int option;
+  event_type : string option;
+  reason : string option;
+  raw_bytes : int option;
+}
+
 type keeper_chat_event =
   | Run_started of { run_id : string; thread_id : string }
   | Text_message_start of { message_id : string; role : role }
@@ -8,6 +26,26 @@ type keeper_chat_event =
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }
+  | Oas_stream_connected
+  | Oas_stream_message_start of
+      { provider_message_id : string
+      ; model : string
+      ; usage : Agent_sdk.Types.api_usage option
+      }
+  | Oas_stream_message_delta of
+      { stop_reason : Agent_sdk.Types.stop_reason option
+      ; usage : Agent_sdk.Types.api_usage option
+      }
+  | Oas_stream_message_stop
+  | Oas_stream_ping
+  | Oas_thinking_delta of { delta : string }
+  | Oas_thinking_signature_delta of { signature_bytes : int }
+  | Oas_media_delta of
+      { media_type : string
+      ; source_type : string
+      ; bytes : int
+      }
+  | Oas_stream_protocol_error of stream_protocol_error
   | Tool_call_start of { tool_call_id : string; tool_call_name : string }
   | Tool_call_args of { tool_call_id : string; delta : string }
   | Tool_call_end of { tool_call_id : string }
@@ -36,3 +74,44 @@ let create () = Eio.Stream.create 512
 let publish stream event = Eio.Stream.add stream event
 
 let subscribe stream = Eio.Stream.take stream
+
+let json_opt key value =
+  match value with
+  | None -> []
+  | Some value -> [ (key, value) ]
+
+let api_usage_to_json (usage : Agent_sdk.Types.api_usage) =
+  `Assoc
+    ([
+       ("input_tokens", `Int usage.input_tokens);
+       ("output_tokens", `Int usage.output_tokens);
+       ("total_tokens", `Int (Agent_sdk.Types.total_tokens usage));
+       ("cache_creation_input_tokens", `Int usage.cache_creation_input_tokens);
+       ("cache_read_input_tokens", `Int usage.cache_read_input_tokens);
+     ]
+     @ json_opt "cost_usd"
+         (Option.map (fun value -> `Float value) usage.cost_usd))
+
+let stream_protocol_error_kind_to_string = function
+  | Tool_start_duplicate_index -> "tool_start_duplicate_index"
+  | Tool_start_missing_identity -> "tool_start_missing_identity"
+  | Tool_args_without_start -> "tool_args_without_start"
+  | Tool_stop_without_start -> "tool_stop_without_start"
+  | Sse_error -> "sse_error"
+  | Sse_parse_failed -> "sse_parse_failed"
+  | Sse_unknown_event_type -> "sse_unknown_event_type"
+  | Sse_stream_incomplete -> "sse_stream_incomplete"
+
+let stream_protocol_error_to_json error =
+  let fields =
+    [
+      ( "kind",
+        `String (stream_protocol_error_kind_to_string error.kind) );
+    ]
+    @ json_opt "index" (Option.map (fun value -> `Int value) error.index)
+    @ json_opt "event_type"
+        (Option.map (fun value -> `String value) error.event_type)
+    @ json_opt "reason" (Option.map (fun value -> `String value) error.reason)
+    @ json_opt "raw_bytes" (Option.map (fun value -> `Int value) error.raw_bytes)
+  in
+  `Assoc fields

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -10,6 +10,24 @@
 
 type role = User | Assistant
 
+type stream_protocol_error_kind =
+  | Tool_start_duplicate_index
+  | Tool_start_missing_identity
+  | Tool_args_without_start
+  | Tool_stop_without_start
+  | Sse_error
+  | Sse_parse_failed
+  | Sse_unknown_event_type
+  | Sse_stream_incomplete
+
+type stream_protocol_error = {
+  kind : stream_protocol_error_kind;
+  index : int option;
+  event_type : string option;
+  reason : string option;
+  raw_bytes : int option;
+}
+
 type keeper_chat_event =
   | Run_started of { run_id : string; thread_id : string }
   | Text_message_start of { message_id : string; role : role }
@@ -18,6 +36,26 @@ type keeper_chat_event =
   | Run_finished of { run_id : string }
   | Event_error of { message : string }
   | Custom of { name : string; value : Yojson.Safe.t }
+  | Oas_stream_connected
+  | Oas_stream_message_start of
+      { provider_message_id : string
+      ; model : string
+      ; usage : Agent_sdk.Types.api_usage option
+      }
+  | Oas_stream_message_delta of
+      { stop_reason : Agent_sdk.Types.stop_reason option
+      ; usage : Agent_sdk.Types.api_usage option
+      }
+  | Oas_stream_message_stop
+  | Oas_stream_ping
+  | Oas_thinking_delta of { delta : string }
+  | Oas_thinking_signature_delta of { signature_bytes : int }
+  | Oas_media_delta of
+      { media_type : string
+      ; source_type : string
+      ; bytes : int
+      }
+  | Oas_stream_protocol_error of stream_protocol_error
   | Tool_call_start of { tool_call_id : string; tool_call_name : string }
   | Tool_call_args of { tool_call_id : string; delta : string }
   | Tool_call_end of { tool_call_id : string }
@@ -53,3 +91,7 @@ val publish : keeper_chat_event Eio.Stream.t -> keeper_chat_event -> unit
 
 (** [subscribe stream] blocks until an event is available, then returns it. *)
 val subscribe : keeper_chat_event Eio.Stream.t -> keeper_chat_event
+
+val api_usage_to_json : Agent_sdk.Types.api_usage -> Yojson.Safe.t
+val stream_protocol_error_kind_to_string : stream_protocol_error_kind -> string
+val stream_protocol_error_to_json : stream_protocol_error -> Yojson.Safe.t

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -1,0 +1,171 @@
+type tool_ref = {
+  tool_call_id : string;
+  tool_call_name : string;
+}
+
+type state = { tools_by_index : (int * tool_ref) list }
+
+type translated_event = {
+  bridge_state : state;
+  chat_events : Keeper_chat_events.keeper_chat_event list;
+}
+
+let empty_state = { tools_by_index = [] }
+
+let stream_tool_for_index bridge_state index =
+  List.assoc_opt index bridge_state.tools_by_index
+
+let replace_tool bridge_state index tool =
+  { tools_by_index =
+      (index, tool) :: List.remove_assoc index bridge_state.tools_by_index
+  }
+
+let remove_tool bridge_state index =
+  { tools_by_index = List.remove_assoc index bridge_state.tools_by_index }
+
+let protocol_error ?index ?event_type ?reason ?raw_bytes kind =
+  Keeper_chat_events.Oas_stream_protocol_error
+    { kind; index; event_type; reason; raw_bytes }
+
+let translate ~redact_text ~on_text_delta bridge_state
+    (evt : Agent_sdk.Types.sse_event) =
+  let open Agent_sdk.Types in
+  let open Keeper_chat_events in
+  let no_events = { bridge_state; chat_events = [] } in
+  match evt with
+  | Connected ->
+      { bridge_state; chat_events = [ Oas_stream_connected ] }
+  | MessageStart { id; model; usage } ->
+      { bridge_state;
+        chat_events =
+          [
+            Oas_stream_message_start
+              { provider_message_id = id; model; usage };
+          ]
+      }
+  | MessageDelta { stop_reason; usage } ->
+      { bridge_state;
+        chat_events = [ Oas_stream_message_delta { stop_reason; usage } ]
+      }
+  | MessageStop ->
+      { bridge_state; chat_events = [ Oas_stream_message_stop ] }
+  | Ping ->
+      { bridge_state; chat_events = [ Oas_stream_ping ] }
+  | Timeout reason ->
+      { bridge_state;
+        chat_events =
+          [ Event_error { message = redact_text ("Timeout: " ^ reason) } ]
+      }
+  | ContentBlockDelta { delta = TextDelta text; _ } ->
+      { bridge_state; chat_events = [ Text_delta (on_text_delta text) ] }
+  | ContentBlockDelta { delta = ThinkingDelta text; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Oas_thinking_delta { delta = redact_text text } ]
+      }
+  | ContentBlockDelta { delta = ThinkingSignatureDelta signature; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Oas_thinking_signature_delta
+              { signature_bytes = String.length signature } ]
+      }
+  | ContentBlockDelta { delta = MediaDelta { media_type; source_type; data }; _ } ->
+      { bridge_state;
+        chat_events =
+          [ Oas_media_delta
+              { media_type; source_type; bytes = String.length data } ]
+      }
+  | ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ }
+    when String.trim tid <> "" && String.trim tname <> "" ->
+      let tool = { tool_call_id = tid; tool_call_name = tname } in
+      let duplicate_event =
+        match stream_tool_for_index bridge_state index with
+        | None -> []
+        | Some _ ->
+            [ protocol_error ~index
+                ~reason:"content block start reused an active stream index"
+                Tool_start_duplicate_index ]
+      in
+      { bridge_state = replace_tool bridge_state index tool;
+        chat_events =
+          duplicate_event
+          @ [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
+      }
+  | ContentBlockStart { index; tool_id; tool_name; _ } ->
+      let partial_tool_identity =
+        match tool_id, tool_name with
+        | None, None -> false
+        | _ -> true
+      in
+      if partial_tool_identity then
+        { bridge_state;
+          chat_events =
+            [ protocol_error ~index
+                ~reason:"tool content block start missed tool id or name"
+                Tool_start_missing_identity ]
+        }
+      else no_events
+  | ContentBlockDelta { index; delta = InputJsonDelta args } -> (
+      match stream_tool_for_index bridge_state index with
+      | Some tool ->
+          { bridge_state;
+            chat_events =
+              [ Tool_call_args
+                  { tool_call_id = tool.tool_call_id; delta = redact_text args } ]
+          }
+      | None ->
+          { bridge_state;
+            chat_events =
+              [ protocol_error ~index
+                  ~reason:"tool argument delta arrived before tool start"
+                  Tool_args_without_start ]
+          })
+  | ContentBlockStop { index } -> (
+      match stream_tool_for_index bridge_state index with
+      | Some tool ->
+          { bridge_state = remove_tool bridge_state index;
+            chat_events = [ Tool_call_end { tool_call_id = tool.tool_call_id } ]
+          }
+      | None ->
+          { bridge_state;
+            chat_events =
+              [ protocol_error ~index
+                  ~reason:"tool block stop arrived before tool start"
+                  Tool_stop_without_start ]
+          })
+  | SSEError { message; error_type; raw = _ } ->
+      let reason =
+        match error_type with
+        | None -> message
+        | Some error_type -> error_type ^ ": " ^ message
+      in
+      { bridge_state;
+        chat_events =
+          [ protocol_error ?event_type:error_type ~reason:(redact_text message)
+              Sse_error;
+            Event_error
+              { message = redact_text ("Provider stream error: " ^ reason) } ]
+      }
+  | SSEParseFailed { raw; reason } ->
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~reason:(redact_text reason)
+              ~raw_bytes:(String.length raw) Sse_parse_failed;
+            Event_error
+              { message =
+                  redact_text ("Provider stream parse failed: " ^ reason) } ]
+      }
+  | SSEUnknownEventType { event_type; raw } ->
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~event_type ~raw_bytes:(String.length raw)
+              Sse_unknown_event_type ]
+      }
+  | StreamIncomplete { reason } ->
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~reason:(redact_text reason) Sse_stream_incomplete;
+            Event_error
+              { message =
+                  redact_text ("Provider stream incomplete: " ^ reason) } ]
+      }

--- a/lib/keeper/keeper_chat_oas_stream_bridge.mli
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.mli
@@ -1,0 +1,23 @@
+(** Translate OAS typed stream events into keeper chat events.
+
+    MASC owns the channel event surface, but the upstream stream semantics come
+    from OAS' closed {!Agent_sdk.Types.sse_event} sum. This module is the
+    boundary adapter between those two domains. *)
+
+type state
+(** Per-stream correlation state for OAS content block indices. *)
+
+type translated_event = {
+  bridge_state : state;
+  chat_events : Keeper_chat_events.keeper_chat_event list;
+}
+(** Result of translating one typed OAS stream event. *)
+
+val empty_state : state
+
+val translate :
+  redact_text:(string -> string) ->
+  on_text_delta:(string -> string) ->
+  state ->
+  Agent_sdk.Types.sse_event ->
+  translated_event

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -276,6 +276,16 @@ let adapter_loop ~token ~channel ~events ?base_url () =
     | Custom { name; value = _ } ->
         Log.Keeper.debug "keeper_chat_slack: custom event %s" name;
         loop ~acc_text ~acc_blocks ~run_id_opt
+    | Oas_stream_connected
+    | Oas_stream_message_start _
+    | Oas_stream_message_delta _
+    | Oas_stream_message_stop
+    | Oas_stream_ping
+    | Oas_thinking_delta _
+    | Oas_thinking_signature_delta _
+    | Oas_media_delta _
+    | Oas_stream_protocol_error _ ->
+        loop ~acc_text ~acc_blocks ~run_id_opt
     | Tool_call_start _ | Tool_call_args _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Link_block { url; title; description; image = _ } ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -655,243 +655,16 @@ type keeper_stream_worker_event =
       ; body : string
       }
 
-type keeper_stream_tool_ref =
-  { tool_call_id : string
-  ; tool_call_name : string
-  }
-
-type keeper_stream_bridge_state =
-  { tools_by_index : (int * keeper_stream_tool_ref) list }
+type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
 type translated_keeper_stream_event =
+  Keeper_chat_oas_stream_bridge.translated_event =
   { bridge_state : keeper_stream_bridge_state
   ; chat_events : Keeper_chat_events.keeper_chat_event list
   }
 
-let empty_keeper_stream_bridge_state = { tools_by_index = [] }
-
-let stream_tool_for_index bridge_state index =
-  List.assoc_opt index bridge_state.tools_by_index
-
-let stream_bridge_replace_tool bridge_state index tool =
-  { tools_by_index =
-      (index, tool) :: List.remove_assoc index bridge_state.tools_by_index
-  }
-
-let stream_bridge_remove_tool bridge_state index =
-  { tools_by_index = List.remove_assoc index bridge_state.tools_by_index }
-
-let json_opt key value =
-  match value with
-  | None -> []
-  | Some value -> [ (key, value) ]
-
-let keeper_stream_usage_json (usage : Agent_sdk.Types.api_usage) =
-  `Assoc
-    ([
-       ("input_tokens", `Int usage.input_tokens);
-       ("output_tokens", `Int usage.output_tokens);
-       ("total_tokens", `Int (Agent_sdk.Types.total_tokens usage));
-       ("cache_creation_input_tokens", `Int usage.cache_creation_input_tokens);
-       ("cache_read_input_tokens", `Int usage.cache_read_input_tokens);
-     ]
-     @ json_opt "cost_usd"
-         (Option.map (fun value -> `Float value) usage.cost_usd))
-
-let keeper_stream_protocol_error ?index ?event_type ?reason ?raw_bytes kind =
-  let fields =
-    [ ("kind", `String kind) ]
-    @ json_opt "index" (Option.map (fun value -> `Int value) index)
-    @ json_opt "event_type" (Option.map (fun value -> `String value) event_type)
-    @ json_opt "reason" (Option.map (fun value -> `String value) reason)
-    @ json_opt "raw_bytes" (Option.map (fun value -> `Int value) raw_bytes)
-  in
-  Keeper_chat_events.Custom
-    { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc fields }
-
-let translate_oas_stream_event ~redact_text ~text_accum bridge_state
-    (evt : Agent_sdk.Types.sse_event) =
-  let open Agent_sdk.Types in
-  let no_events = { bridge_state; chat_events = [] } in
-  match evt with
-  | Connected ->
-      { bridge_state;
-        chat_events =
-          [ Custom { name = "KEEPER_CONNECTED"; value = `Null } ]
-      }
-  | MessageStart { id; model; usage } ->
-      { bridge_state;
-        chat_events =
-          [ Custom
-              { name = "KEEPER_STREAM_MESSAGE_START";
-                value =
-                  `Assoc
-                    ([ ("provider_message_id", `String id); ("model", `String model) ]
-                     @ json_opt "usage"
-                         (Option.map keeper_stream_usage_json usage)) } ]
-      }
-  | MessageDelta { stop_reason; usage } ->
-      { bridge_state;
-        chat_events =
-          [ Custom
-              { name = "KEEPER_STREAM_MESSAGE_DELTA";
-                value =
-                  `Assoc
-                    (json_opt "stop_reason"
-                       (Option.map
-                          (fun reason ->
-                            `String (Agent_sdk.Types.stop_reason_to_string reason))
-                          stop_reason)
-                     @ json_opt "usage"
-                         (Option.map keeper_stream_usage_json usage)) } ]
-      }
-  | MessageStop ->
-      { bridge_state;
-        chat_events =
-          [ Custom { name = "KEEPER_STREAM_MESSAGE_STOP"; value = `Null } ]
-      }
-  | Ping ->
-      { bridge_state;
-        chat_events =
-          [ Custom { name = "KEEPER_STREAM_PING"; value = `Null } ]
-      }
-  | Timeout reason ->
-      { bridge_state;
-        chat_events =
-          [ Event_error { message = redact_text ("Timeout: " ^ reason) } ]
-      }
-  | ContentBlockDelta { delta = TextDelta text; _ } ->
-      { bridge_state;
-        chat_events =
-          [ Text_delta
-              (Keeper_stream_text_accum.on_delta text_accum
-                 ~redact:redact_text text)
-          ]
-      }
-  | ContentBlockDelta { delta = ThinkingDelta text; _ } ->
-      { bridge_state;
-        chat_events =
-          [ Custom
-              { name = "KEEPER_THINKING_DELTA";
-                value = `Assoc [ ("delta", `String (redact_text text)) ] }
-          ]
-      }
-  | ContentBlockDelta { delta = ThinkingSignatureDelta signature; _ } ->
-      { bridge_state;
-        chat_events =
-          [ Custom
-              { name = "KEEPER_THINKING_SIGNATURE_DELTA";
-                value =
-                  `Assoc [ ("signature_bytes", `Int (String.length signature)) ] }
-          ]
-      }
-  | ContentBlockDelta { delta = MediaDelta { media_type; source_type; data }; _ } ->
-      { bridge_state;
-        chat_events =
-          [ Custom
-              { name = "KEEPER_MEDIA_DELTA";
-                value =
-                  `Assoc
-                    [ ("media_type", `String media_type);
-                      ("source_type", `String source_type);
-                      ("bytes", `Int (String.length data)) ] }
-          ]
-      }
-  | ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ }
-    when String.trim tid <> "" && String.trim tname <> "" ->
-      let tool = { tool_call_id = tid; tool_call_name = tname } in
-      let duplicate_event =
-        match stream_tool_for_index bridge_state index with
-        | None -> []
-        | Some _ ->
-            [ keeper_stream_protocol_error ~index
-                ~reason:"content block start reused an active stream index"
-                "tool_start_duplicate_index" ]
-      in
-      { bridge_state = stream_bridge_replace_tool bridge_state index tool;
-        chat_events =
-          duplicate_event
-          @ [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
-      }
-  | ContentBlockStart { index; tool_id; tool_name; _ } ->
-      let partial_tool_identity =
-        match tool_id, tool_name with
-        | None, None -> false
-        | _ -> true
-      in
-      if partial_tool_identity then
-        { bridge_state;
-          chat_events =
-            [ keeper_stream_protocol_error ~index
-                ~reason:"tool content block start missed tool id or name"
-                "tool_start_missing_identity" ]
-        }
-      else no_events
-  | ContentBlockDelta { index; delta = InputJsonDelta args } -> (
-      match stream_tool_for_index bridge_state index with
-      | Some tool ->
-          { bridge_state;
-            chat_events =
-              [ Tool_call_args
-                  { tool_call_id = tool.tool_call_id; delta = redact_text args } ]
-          }
-      | None ->
-          { bridge_state;
-            chat_events =
-              [ keeper_stream_protocol_error ~index
-                  ~reason:"tool argument delta arrived before tool start"
-                  "tool_args_without_start" ]
-          })
-  | ContentBlockStop { index } -> (
-      match stream_tool_for_index bridge_state index with
-      | Some tool ->
-          { bridge_state = stream_bridge_remove_tool bridge_state index;
-            chat_events = [ Tool_call_end { tool_call_id = tool.tool_call_id } ]
-          }
-      | None ->
-          { bridge_state;
-            chat_events =
-              [ keeper_stream_protocol_error ~index
-                  ~reason:"tool block stop arrived before tool start"
-                  "tool_stop_without_start" ]
-          })
-  | SSEError { message; error_type; raw = _ } ->
-      let reason =
-        match error_type with
-        | None -> message
-        | Some error_type -> error_type ^ ": " ^ message
-      in
-      { bridge_state;
-        chat_events =
-          [ keeper_stream_protocol_error ?event_type:error_type
-              ~reason:(redact_text message) "sse_error";
-            Event_error
-              { message = redact_text ("Provider stream error: " ^ reason) } ]
-      }
-  | SSEParseFailed { raw; reason } ->
-      { bridge_state;
-        chat_events =
-          [ keeper_stream_protocol_error ~reason:(redact_text reason)
-              ~raw_bytes:(String.length raw) "sse_parse_failed";
-            Event_error
-              { message =
-                  redact_text ("Provider stream parse failed: " ^ reason) } ]
-      }
-  | SSEUnknownEventType { event_type; raw } ->
-      { bridge_state;
-        chat_events =
-          [ keeper_stream_protocol_error ~event_type
-              ~raw_bytes:(String.length raw) "sse_unknown_event_type" ]
-      }
-  | StreamIncomplete { reason } ->
-      { bridge_state;
-        chat_events =
-          [ keeper_stream_protocol_error ~reason:(redact_text reason)
-              "sse_stream_incomplete";
-            Event_error
-              { message =
-                  redact_text ("Provider stream incomplete: " ^ reason) } ]
-      }
+let empty_keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.empty_state
+let translate_oas_stream_event = Keeper_chat_oas_stream_bridge.translate
 
 let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     ~client_disconnects
@@ -1139,7 +912,10 @@ let process_single_turn ~state ~clock ~sw ~auth_token ~thread_id ~closed
     | Stream_client_disconnected -> ()
     | Stream_event evt ->
         let translated =
-          translate_oas_stream_event ~redact_text ~text_accum bridge_state evt
+          translate_oas_stream_event ~redact_text
+            ~on_text_delta:
+              (Keeper_stream_text_accum.on_delta text_accum ~redact:redact_text)
+            bridge_state evt
         in
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
@@ -1284,6 +1060,19 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                    ~custom_value:(Some (`Assoc [ ("message", `String message) ]))
                    Run_error))
     in
+    let json_opt key value =
+      match value with
+      | None -> []
+      | Some value -> [ (key, value) ]
+    in
+    let send_custom name value =
+      keeper_stream_send_event ~on_closed writer mutex closed
+        Ag_ui.(
+          make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+            ~custom_name:(Some name)
+            ~custom_value:(Some (redact_json value))
+            Custom)
+    in
     let rec loop () =
       if not !closed then
         match Keeper_chat_events.subscribe events with
@@ -1325,15 +1114,62 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                   make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
                     ~message_id:!current_message_id Text_message_end)
             then loop ()
-        | Custom { name; value } ->
+        | Oas_stream_connected ->
+            if send_custom "KEEPER_CONNECTED" `Null then loop ()
+        | Oas_stream_message_start { provider_message_id; model; usage } ->
+            let value =
+              `Assoc
+                ([
+                   ("provider_message_id", `String provider_message_id);
+                   ("model", `String model);
+                 ]
+                @ json_opt "usage"
+                    (Option.map Keeper_chat_events.api_usage_to_json usage))
+            in
+            if send_custom "KEEPER_STREAM_MESSAGE_START" value then loop ()
+        | Oas_stream_message_delta { stop_reason; usage } ->
+            let value =
+              `Assoc
+                (json_opt "stop_reason"
+                   (Option.map
+                      (fun reason ->
+                        `String (Agent_sdk.Types.stop_reason_to_string reason))
+                      stop_reason)
+                @ json_opt "usage"
+                    (Option.map Keeper_chat_events.api_usage_to_json usage))
+            in
+            if send_custom "KEEPER_STREAM_MESSAGE_DELTA" value then loop ()
+        | Oas_stream_message_stop ->
+            if send_custom "KEEPER_STREAM_MESSAGE_STOP" `Null then loop ()
+        | Oas_stream_ping ->
+            if send_custom "KEEPER_STREAM_PING" `Null then loop ()
+        | Oas_thinking_delta { delta } ->
             if
-              keeper_stream_send_event ~on_closed writer mutex closed
-                Ag_ui.(
-                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
-                    ~custom_name:(Some name)
-                    ~custom_value:(Some (redact_json value))
-                    Custom)
+              send_custom "KEEPER_THINKING_DELTA"
+                (`Assoc [ ("delta", `String delta) ])
             then loop ()
+        | Oas_thinking_signature_delta { signature_bytes } ->
+            if
+              send_custom "KEEPER_THINKING_SIGNATURE_DELTA"
+                (`Assoc [ ("signature_bytes", `Int signature_bytes) ])
+            then loop ()
+        | Oas_media_delta { media_type; source_type; bytes } ->
+            if
+              send_custom "KEEPER_MEDIA_DELTA"
+                (`Assoc
+                  [
+                    ("media_type", `String media_type);
+                    ("source_type", `String source_type);
+                    ("bytes", `Int bytes);
+                  ])
+            then loop ()
+        | Oas_stream_protocol_error error ->
+            if
+              send_custom "KEEPER_STREAM_PROTOCOL_ERROR"
+                (Keeper_chat_events.stream_protocol_error_to_json error)
+            then loop ()
+        | Custom { name; value } ->
+            if send_custom name value then loop ()
         | Tool_call_start { tool_call_id; tool_call_name } ->
             if
               keeper_stream_send_event ~on_closed writer mutex closed

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -164,11 +164,12 @@ val process_single_turn :
 
 (** {1 Testing helpers} *)
 
-type keeper_stream_bridge_state
+type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 (** Per-stream OAS event bridge state. Abstract outside tests so callers cannot
     construct synthetic stream correlation state. *)
 
-type translated_keeper_stream_event = {
+type translated_keeper_stream_event =
+  Keeper_chat_oas_stream_bridge.translated_event = {
   bridge_state : keeper_stream_bridge_state;
   chat_events : Keeper_chat_events.keeper_chat_event list;
 }
@@ -191,7 +192,7 @@ module For_testing : sig
   val empty_stream_bridge_state : keeper_stream_bridge_state
   val translate_oas_stream_event :
     redact_text:(string -> string) ->
-    text_accum:Keeper_stream_text_accum.t ->
+    on_text_delta:(string -> string) ->
     keeper_stream_bridge_state ->
     Agent_sdk.Types.sse_event ->
     translated_keeper_stream_event

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -35,35 +35,18 @@ let read_file path =
 
 let translate_oas_stream_events events =
   let redact_text text = text in
-  let text_accum = Keeper_stream_text_accum.create () in
+  let on_text_delta text = text in
   let rec loop bridge_state acc = function
     | [] -> List.rev acc
     | event :: rest ->
         let translated =
-          Server_routes_http_keeper_stream.For_testing.translate_oas_stream_event
-            ~redact_text ~text_accum bridge_state event
+          Keeper_chat_oas_stream_bridge.translate ~redact_text ~on_text_delta
+            bridge_state event
         in
         loop translated.bridge_state
           (List.rev_append translated.chat_events acc) rest
   in
-  loop
-    Server_routes_http_keeper_stream.For_testing.empty_stream_bridge_state []
-    events
-
-let assoc_string key fields =
-  match List.assoc_opt key fields with
-  | Some (`String value) -> Some value
-  | _ -> None
-
-let assoc_int key fields =
-  match List.assoc_opt key fields with
-  | Some (`Int value) -> Some value
-  | _ -> None
-
-let assoc_assoc key fields =
-  match List.assoc_opt key fields with
-  | Some (`Assoc value) -> Some value
-  | _ -> None
+  loop Keeper_chat_oas_stream_bridge.empty_state [] events
 
 let test_agent_name_for_channel_actor () =
   let agent_name =
@@ -512,16 +495,13 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
       ]
   in
   match events with
-  | [ Keeper_chat_events.Custom
-        { name = "KEEPER_THINKING_DELTA"; value = `Assoc first };
+  | [ Keeper_chat_events.Oas_thinking_delta { delta = first };
       Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id_a; delta = args_a };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id_b; delta = args_b };
       Keeper_chat_events.Tool_call_end { tool_call_id = end_id };
-      Keeper_chat_events.Custom
-        { name = "KEEPER_THINKING_DELTA"; value = `Assoc last } ] ->
-      check (option string) "first thinking" (Some "think A")
-        (assoc_string "delta" first);
+      Keeper_chat_events.Oas_thinking_delta { delta = last } ] ->
+      check string "first thinking" "think A" first;
       check string "tool id" "tc-1" tool_call_id;
       check string "tool name" "keeper_board_list" tool_call_name;
       check string "args id a" "tc-1" args_id_a;
@@ -529,14 +509,14 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
       check string "args a" "{\"limit\":" args_a;
       check string "args b" "1}" args_b;
       check string "end id" "tc-1" end_id;
-      check (option string) "last thinking" (Some "think B")
-        (assoc_string "delta" last)
+      check string "last thinking" "think B" last
   | _ ->
       failf "unexpected stream bridge events: %s"
         (String.concat ", "
            (List.map
               (function
                 | Keeper_chat_events.Custom { name; _ } -> "custom:" ^ name
+                | Keeper_chat_events.Oas_thinking_delta _ -> "oas_thinking"
                 | Keeper_chat_events.Tool_call_start _ -> "tool_start"
                 | Keeper_chat_events.Tool_call_args _ -> "tool_args"
                 | Keeper_chat_events.Tool_call_end _ -> "tool_end"
@@ -568,35 +548,24 @@ let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
       ]
   in
   match events with
-  | [ Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_MESSAGE_START"; value = `Assoc start };
-      Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_MESSAGE_DELTA"; value = `Assoc delta };
-      Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_MESSAGE_STOP"; value = `Null };
-      Keeper_chat_events.Custom { name = "KEEPER_STREAM_PING"; value = `Null } ] ->
-      let start_usage =
-        assoc_assoc "usage" start |> Option.value ~default:[]
-      in
-      let delta_usage =
-        assoc_assoc "usage" delta |> Option.value ~default:[]
-      in
-      check (option string) "provider message id" (Some "msg-oas-1")
-        (assoc_string "provider_message_id" start);
-      check (option string) "model" (Some "gpt-5.5")
-        (assoc_string "model" start);
-      check (option int) "start input tokens" (Some 10)
-        (assoc_int "input_tokens" start_usage);
-      check (option int) "start total tokens" (Some 11)
-        (assoc_int "total_tokens" start_usage);
-      check (option int) "cache creation tokens" (Some 3)
-        (assoc_int "cache_creation_input_tokens" start_usage);
-      check (option string) "stop reason" (Some "end_turn")
-        (assoc_string "stop_reason" delta);
-      check (option int) "delta output tokens" (Some 2)
-        (assoc_int "output_tokens" delta_usage);
-      check (option int) "delta total tokens" (Some 12)
-        (assoc_int "total_tokens" delta_usage)
+  | [ Keeper_chat_events.Oas_stream_message_start
+        { provider_message_id; model; usage = Some start_usage };
+      Keeper_chat_events.Oas_stream_message_delta
+        { stop_reason = Some stop_reason; usage = Some delta_usage };
+      Keeper_chat_events.Oas_stream_message_stop;
+      Keeper_chat_events.Oas_stream_ping ] ->
+      check string "provider message id" "msg-oas-1" provider_message_id;
+      check string "model" "gpt-5.5" model;
+      check int "start input tokens" 10 start_usage.input_tokens;
+      check int "start total tokens" 11
+        (Agent_sdk.Types.total_tokens start_usage);
+      check int "cache creation tokens" 3
+        start_usage.cache_creation_input_tokens;
+      check string "stop reason" "end_turn"
+        (Agent_sdk.Types.stop_reason_to_string stop_reason);
+      check int "delta output tokens" 2 delta_usage.output_tokens;
+      check int "delta total tokens" 12
+        (Agent_sdk.Types.total_tokens delta_usage)
   | _ -> fail "expected OAS message lifecycle metadata events"
 
 let test_keeper_stream_bridge_rejects_tool_args_without_start () =
@@ -606,11 +575,12 @@ let test_keeper_stream_bridge_rejects_tool_args_without_start () =
       [ ContentBlockDelta { index = 7; delta = InputJsonDelta "{\"x\":1}" } ]
   in
   match events with
-  | [ Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc fields } ] ->
-      check (option string) "kind" (Some "tool_args_without_start")
-        (assoc_string "kind" fields);
-      check (option int) "index" (Some 7) (assoc_int "index" fields);
+  | [ Keeper_chat_events.Oas_stream_protocol_error
+        { kind; index = Some index; event_type = _; reason = _; raw_bytes = _ }
+    ] ->
+      check string "kind" "tool_args_without_start"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string kind);
+      check int "index" 7 index;
       check bool "no tool event forged" true
         (not
            (List.exists
@@ -630,17 +600,16 @@ let test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events () =
       ]
   in
   match events with
-  | [ Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc unknown };
-      Keeper_chat_events.Custom
-        { name = "KEEPER_STREAM_PROTOCOL_ERROR"; value = `Assoc incomplete };
+  | [ Keeper_chat_events.Oas_stream_protocol_error
+        { kind = unknown_kind; event_type = Some event_type; _ };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind = incomplete_kind; _ };
       Keeper_chat_events.Event_error { message } ] ->
-      check (option string) "unknown kind" (Some "sse_unknown_event_type")
-        (assoc_string "kind" unknown);
-      check (option string) "unknown event type" (Some "response.future")
-        (assoc_string "event_type" unknown);
-      check (option string) "incomplete kind" (Some "sse_stream_incomplete")
-        (assoc_string "kind" incomplete);
+      check string "unknown kind" "sse_unknown_event_type"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string unknown_kind);
+      check string "unknown event type" "response.future" event_type;
+      check string "incomplete kind" "sse_stream_incomplete"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string incomplete_kind);
       check string "incomplete is visible error"
         "Provider stream incomplete: max_output_tokens" message
   | _ -> fail "expected visible events for unknown/incomplete provider stream"


### PR DESCRIPTION
## Summary
- add a keeper-level OAS stream bridge that translates `Agent_sdk.Types.sse_event` into typed keeper chat events
- preserve thinking, tool, text, metadata, media, and protocol-error interleaving without internal Custom string matching
- keep AG-UI Custom event names at the server wire-projection boundary only

## Validation
- `ocamlformat --check lib/keeper/keeper_chat_events.ml lib/keeper/keeper_chat_events.mli lib/keeper/keeper_chat_oas_stream_bridge.ml lib/keeper/keeper_chat_oas_stream_bridge.mli lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_discord.ml lib/server/server_routes_http_keeper_stream.ml lib/server/server_routes_http_keeper_stream.mli test/test_gate_keeper_backend.ml`
- `git diff --check`
- `./scripts/dune-local.sh build test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_gate_keeper_backend.exe` (70 tests)