### PR TITLE
fix(keeper): avoid same-pool hard quota rotation

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -623,7 +623,7 @@ let degraded_rotation_candidates
   |> List.filter (fun candidate ->
          not (String.equal candidate normalized_effective))
 
-let filter_rate_limit_rotation_candidates
+let filter_quota_pool_rotation_candidates
       ~credential_pool_of_runtime_id
       ~effective_runtime
       candidates
@@ -707,12 +707,12 @@ let degraded_rotation_after_recoverable_error
       in
       let candidates =
         match fallback_reason with
+        | Hard_quota
         | Rate_limit ->
-          filter_rate_limit_rotation_candidates
+          filter_quota_pool_rotation_candidates
             ~credential_pool_of_runtime_id
             ~effective_runtime
             candidates
-        | Hard_quota
         | Read_only_no_progress
         | Empty_no_progress
         | Thinking_only_no_progress

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -172,16 +172,16 @@ val degraded_retry_after_recoverable_error :
     any other candidate; if it duplicates the effective runtime or has
     already been attempted, the next legal candidate is returned.
 
-    For ["rate_limit"], candidates sharing the effective runtime's credential
-    pool, as reported by [credential_pool_of_runtime_id], are excluded before
-    attempt filtering, preserving independent-provider failover while avoiding
-    same-account fan-out. If no pool function is supplied, no credential-pool
-    filtering is applied. Non-contract transient infrastructure errors
-    (provider timeout, server error, capacity backpressure) allow cycling
-    through candidates again when all are exhausted, because the same runtime may
-    succeed on a subsequent attempt. Contract violations, read-only no-progress
-    accept rejections, and quota/rate-limit classes cap rotation after the
-    candidate set is exhausted.
+    For ["hard_quota"] and ["rate_limit"], candidates sharing the effective
+    runtime's credential pool, as reported by [credential_pool_of_runtime_id],
+    are excluded before attempt filtering, preserving independent-provider
+    failover while avoiding same-account fan-out. If no pool function is
+    supplied, no credential-pool filtering is applied. Non-contract transient
+    infrastructure errors (provider timeout, server error, capacity
+    backpressure) allow cycling through candidates again when all are exhausted,
+    because the same runtime may succeed on a subsequent attempt. Contract
+    violations, read-only no-progress accept rejections, and quota/rate-limit
+    classes cap rotation after the candidate set is exhausted.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?credential_pool_of_runtime_id:(string -> string option) ->

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -411,6 +411,17 @@ let soft_rate_limit_err =
        { retry_after = Some 30.0; message = "rate limited, retry later" })
 ;;
 
+let hard_quota_err =
+  SdkE.Api
+    (Retry.RateLimited
+       {
+         retry_after = None;
+         message =
+           "you (yousleepwhen) have reached your session usage limit, add extra \
+            usage: https://ollama.com/settings";
+       })
+;;
+
 let server_error_500 =
   SdkE.Api
     (Retry.ServerError { status = 500; message = "Internal Server Error" })
@@ -519,6 +530,47 @@ let test_soft_rate_limit_preserves_independent_pool_failover () =
   | Some { fallback_reason; next_runtime } ->
     Alcotest.failf
       "expected rate_limit -> other.c, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None -> Alcotest.fail "expected independent credential pool failover"
+;;
+
+let test_hard_quota_skips_same_credential_pool () =
+  init_rate_limit_pool_runtime ();
+  let retry =
+    EC.degraded_rotation_after_recoverable_error
+      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+      ~fallback_hint:"same.b"
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:[ "same.a" ]
+      hard_quota_err
+  in
+  Alcotest.(check bool)
+    "hard quota does not fan out to the same credential pool"
+    false
+    (Option.is_some retry)
+;;
+
+let test_hard_quota_preserves_independent_pool_failover () =
+  init_rate_limit_pool_runtime ();
+  match
+    EC.degraded_rotation_after_recoverable_error
+      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+      ~fallback_hint:"other.c"
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:[ "same.a" ]
+      hard_quota_err
+  with
+  | Some { EC.next_runtime; fallback_reason = EC.Hard_quota } ->
+    Alcotest.(check string)
+      "independent credential pool remains eligible"
+      "other.c"
+      next_runtime
+  | Some { fallback_reason; next_runtime } ->
+    Alcotest.failf
+      "expected hard_quota -> other.c, got %s -> %s"
       (EC.degraded_retry_reason_to_string fallback_reason)
       next_runtime
   | None -> Alcotest.fail "expected independent credential pool failover"
@@ -712,6 +764,14 @@ let () =
             "soft rate limits preserve independent credential-pool failover"
             `Quick
             test_soft_rate_limit_preserves_independent_pool_failover
+        ; Alcotest.test_case
+            "hard quota skips same credential-pool candidates"
+            `Quick
+            test_hard_quota_skips_same_credential_pool
+        ; Alcotest.test_case
+            "hard quota preserves independent credential-pool failover"
+            `Quick
+            test_hard_quota_preserves_independent_pool_failover
         ; Alcotest.test_case
             "500 classifies as recoverable server_error"
             `Quick


### PR DESCRIPTION
## Summary
- stop degraded hard-quota rotation from selecting candidates in the same credential pool
- keep independent-provider failover available for hard-quota cases
- add regression coverage next to the existing soft rate-limit pool filter tests

## Evidence
- live logs showed repeated `reached your session usage limit` hard-quota failures rotating across Ollama Cloud runtimes in the same account pool
- `provider_error_parse` unmapped warnings were from the pre-#22697 window and are already fixed on main

## Validation
- `ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli test/test_keeper_sdk_error_typed_bridge.ml`
- `git diff --check`

Local Dune build/test intentionally not run; CI is the build authority for this pass.