### PR TITLE
fix dashboard stream duplicate tool indexes

### DIFF
--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -23,6 +23,9 @@ let replace_tool bridge_state index tool =
 let remove_tool bridge_state index =
   { tools_by_index = List.remove_assoc index bridge_state.tools_by_index }
 
+let tool_start_is_replay existing tool =
+  String.equal existing.tool_call_id tool.tool_call_id
+
 let protocol_error ?index ?event_type ?reason ?raw_bytes kind =
   Keeper_chat_events.Oas_stream_protocol_error
     { kind; index; event_type; reason; raw_bytes }
@@ -78,18 +81,16 @@ let translate ~redact_text ~on_text_delta bridge_state
   | ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ }
     when String.trim tid <> "" && String.trim tname <> "" ->
       let tool = { tool_call_id = tid; tool_call_name = tname } in
-      let duplicate_event =
-        match stream_tool_for_index bridge_state index with
-        | None -> []
-        | Some _ ->
-            [ protocol_error ~index
-                ~reason:"content block start reused an active stream index"
-                Tool_start_duplicate_index ]
-      in
+      let existing_tool = stream_tool_for_index bridge_state index in
       { bridge_state = replace_tool bridge_state index tool;
         chat_events =
-          duplicate_event
-          @ [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
+          (match existing_tool with
+           | Some existing when tool_start_is_replay existing tool -> []
+           | Some existing ->
+               [ Tool_call_end { tool_call_id = existing.tool_call_id };
+                 Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
+           | None ->
+               [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ])
       }
   | ContentBlockStart { index; tool_id; tool_name; _ } ->
       let partial_tool_identity =

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -48,6 +48,13 @@ let translate_oas_stream_events events =
   in
   loop Keeper_chat_oas_stream_bridge.empty_state [] events
 
+let has_stream_protocol_error events =
+  List.exists
+    (function
+      | Keeper_chat_events.Oas_stream_protocol_error _ -> true
+      | _ -> false)
+    events
+
 let test_agent_name_for_channel_actor () =
   let agent_name =
     Gate_keeper_backend.agent_name_for_channel_actor
@@ -524,6 +531,77 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
                 | Keeper_chat_events.Event_error _ -> "error"
                 | _ -> "other")
               events))
+
+let test_keeper_stream_bridge_ignores_replayed_tool_start () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-repeat";
+            tool_name = Some "keeper_memory_search" };
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-repeat";
+            tool_name = Some "keeper_memory_search" };
+        ContentBlockDelta { index = 2; delta = InputJsonDelta "{\"q\":\"loop\"}" };
+        ContentBlockStop { index = 2 };
+      ]
+  in
+  check bool "no protocol error for replayed start" false
+    (has_stream_protocol_error events);
+  match events with
+  | [ Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
+      Keeper_chat_events.Tool_call_args { tool_call_id = args_id; delta };
+      Keeper_chat_events.Tool_call_end { tool_call_id = end_id } ] ->
+      check string "tool id" "tc-repeat" tool_call_id;
+      check string "tool name" "keeper_memory_search" tool_call_name;
+      check string "args id" "tc-repeat" args_id;
+      check string "args" "{\"q\":\"loop\"}" delta;
+      check string "end id" "tc-repeat" end_id
+  | _ -> fail "expected one start, one args delta, and one end"
+
+let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-first";
+            tool_name = Some "keeper_memory_search" };
+        ContentBlockDelta { index = 2; delta = InputJsonDelta "{\"q\":\"first\"}" };
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-second";
+            tool_name = Some "keeper_memory_search" };
+        ContentBlockDelta { index = 2; delta = InputJsonDelta "{\"q\":\"second\"}" };
+        ContentBlockStop { index = 2 };
+      ]
+  in
+  check bool "no protocol error for recoverable reused index" false
+    (has_stream_protocol_error events);
+  match events with
+  | [ Keeper_chat_events.Tool_call_start { tool_call_id = first_start; _ };
+      Keeper_chat_events.Tool_call_args { tool_call_id = first_args; delta = args_a };
+      Keeper_chat_events.Tool_call_end { tool_call_id = first_end };
+      Keeper_chat_events.Tool_call_start { tool_call_id = second_start; _ };
+      Keeper_chat_events.Tool_call_args { tool_call_id = second_args; delta = args_b };
+      Keeper_chat_events.Tool_call_end { tool_call_id = second_end } ] ->
+      check string "first start" "tc-first" first_start;
+      check string "first args id" "tc-first" first_args;
+      check string "first args" "{\"q\":\"first\"}" args_a;
+      check string "first implicit end" "tc-first" first_end;
+      check string "second start" "tc-second" second_start;
+      check string "second args id" "tc-second" second_args;
+      check string "second args" "{\"q\":\"second\"}" args_b;
+      check string "second end" "tc-second" second_end
+  | _ -> fail "expected previous tool to close before reused-index tool starts"
 
 let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
   let open Agent_sdk.Types in
@@ -1392,6 +1470,10 @@ let () =
             test_keeper_stream_args_preserve_user_blocks;
           test_case "stream bridge preserves interleaved thinking and tool" `Quick
             test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool;
+          test_case "stream bridge ignores replayed tool starts" `Quick
+            test_keeper_stream_bridge_ignores_replayed_tool_start;
+          test_case "stream bridge closes tool when index is reused" `Quick
+            test_keeper_stream_bridge_closes_tool_when_index_is_reused;
           test_case "stream bridge surfaces OAS message metadata" `Quick
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge rejects tool args without start" `Quick


### PR DESCRIPTION
## Summary
- Treat replayed OAS tool starts on the same stream index as idempotent in the keeper chat OAS stream bridge
- Close the prior tool implicitly when a provider reuses an active tool index for a different tool call
- Add regression coverage so duplicate/reused tool indexes no longer surface as visible stream protocol chat text

## Verification
- ocamlformat --check lib/keeper/keeper_chat_oas_stream_bridge.ml lib/server/server_routes_http_keeper_stream.ml test/test_gate_keeper_backend.ml
- git diff --cached --check
- scripts/dune-local.sh build test/test_gate_keeper_backend.exe
- ./_build/default/test/test_gate_keeper_backend.exe