### PR TITLE
fix(keeper): surface stream protocol errors in connectors

### DIFF
--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -425,8 +425,13 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
     | Oas_stream_ping
     | Oas_thinking_delta _
     | Oas_thinking_signature_delta _
-    | Oas_media_delta _
-    | Oas_stream_protocol_error _ ->
+    | Oas_media_delta _ ->
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+    | Oas_stream_protocol_error error ->
+        send_message ~token ~channel_id
+          ~content:
+            ("Keeper stream protocol: "
+             ^ Keeper_chat_events.stream_protocol_error_summary error);
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_call_start { tool_call_id; tool_call_name } ->
         let tool_msgs =

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -102,6 +102,19 @@ let stream_protocol_error_kind_to_string = function
   | Sse_unknown_event_type -> "sse_unknown_event_type"
   | Sse_stream_incomplete -> "sse_stream_incomplete"
 
+let stream_protocol_error_summary error =
+  let parts =
+    [
+      Some (stream_protocol_error_kind_to_string error.kind);
+      Option.map (Printf.sprintf "index=%d") error.index;
+      Option.map (Printf.sprintf "event_type=%s") error.event_type;
+      error.reason;
+      Option.map (Printf.sprintf "raw_bytes=%d") error.raw_bytes;
+    ]
+    |> List.filter_map Fun.id
+  in
+  String.concat " | " parts
+
 let stream_protocol_error_to_json error =
   let fields =
     [

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -94,4 +94,5 @@ val subscribe : keeper_chat_event Eio.Stream.t -> keeper_chat_event
 
 val api_usage_to_json : Agent_sdk.Types.api_usage -> Yojson.Safe.t
 val stream_protocol_error_kind_to_string : stream_protocol_error_kind -> string
+val stream_protocol_error_summary : stream_protocol_error -> string
 val stream_protocol_error_to_json : stream_protocol_error -> Yojson.Safe.t

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -283,8 +283,15 @@ let adapter_loop ~token ~channel ~events ?base_url () =
     | Oas_stream_ping
     | Oas_thinking_delta _
     | Oas_thinking_signature_delta _
-    | Oas_media_delta _
-    | Oas_stream_protocol_error _ ->
+    | Oas_media_delta _ ->
+        loop ~acc_text ~acc_blocks ~run_id_opt
+    | Oas_stream_protocol_error error ->
+        ignore
+          (send_message ~token ~channel
+             ~content:
+               ("Keeper stream protocol: "
+                ^ Keeper_chat_events.stream_protocol_error_summary error)
+            : (unit, error) result);
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Tool_call_start _ | Tool_call_args _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -590,6 +590,25 @@ let test_keeper_stream_bridge_rejects_tool_args_without_start () =
               events))
   | _ -> fail "expected a stream protocol error for missing tool start"
 
+let test_stream_protocol_error_summary_includes_diagnostics () =
+  let summary =
+    Keeper_chat_events.stream_protocol_error_summary
+      {
+        kind = Keeper_chat_events.Tool_args_without_start;
+        index = Some 2;
+        event_type = Some "response.future";
+        reason = Some "tool argument delta arrived before tool start";
+        raw_bytes = Some 7;
+      }
+  in
+  check bool "kind" true (string_contains summary "tool_args_without_start");
+  check bool "index" true (string_contains summary "index=2");
+  check bool "event type" true
+    (string_contains summary "event_type=response.future");
+  check bool "reason" true
+    (string_contains summary "tool argument delta arrived before tool start");
+  check bool "raw bytes" true (string_contains summary "raw_bytes=7")
+
 let test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events () =
   let open Agent_sdk.Types in
   let events =
@@ -1396,6 +1415,8 @@ let () =
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge rejects tool args without start" `Quick
             test_keeper_stream_bridge_rejects_tool_args_without_start;
+          test_case "stream protocol error summary includes diagnostics" `Quick
+            test_stream_protocol_error_summary_includes_diagnostics;
           test_case "stream bridge surfaces unknown and incomplete events" `Quick
             test_keeper_stream_bridge_surfaces_unknown_and_incomplete_events;
           test_case "chat history persists attachment refs not raw media" `Quick


### PR DESCRIPTION
## Summary
- follow up after #22700: make `Oas_stream_protocol_error` visible on Slack and Discord adapters instead of silently ignoring connector-side protocol diagnostics
- add a shared `stream_protocol_error_summary` formatter owned by `Keeper_chat_events`
- keep dashboard `KEEPER_STREAM_PROTOCOL_ERROR` JSON projection unchanged

## Validation
- `ocamlformat --check lib/keeper/keeper_chat_events.ml lib/keeper/keeper_chat_events.mli lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_discord.ml test/test_gate_keeper_backend.ml`
- `git diff --check origin/main...HEAD`

Full build/test left to CI per repo workflow.
