### PR TITLE
fix(governance): block hard-forbidden always-approve bypass

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -432,10 +432,21 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
       =
       let reason = forbidden_without_approval_reject_reason ~risk ~hard_forbidden in
       let decision = Agent_sdk.Hooks.Reject reason in
+      let event_type, event_id_prefix, disposition_reason =
+        if hard_forbidden
+        then
+          ( Keeper_approval_queue.approval_audit_hard_forbidden_event
+          , "hard_forbidden"
+          , "hard_forbidden" )
+        else
+          ( Keeper_approval_queue.approval_audit_soft_forbidden_event
+          , "soft_forbidden"
+          , "soft_forbidden" )
+      in
       Keeper_approval_queue.audit_approval_event
         ~base_path
-        ~event_type:Keeper_approval_queue.approval_audit_hard_forbidden_event
-        ~id:(Printf.sprintf "hard_forbidden_%s_%s" keeper_name tool_name)
+        ~event_type
+        ~id:(Printf.sprintf "%s_%s_%s" event_id_prefix keeper_name tool_name)
         ~keeper_name
         ~tool_name
         ~risk_level
@@ -447,7 +458,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         ?runtime_contract
         ?selected_model
         ~disposition:"Blocked"
-        ~disposition_reason:"hard_forbidden"
+        ~disposition_reason
         ~auto_approved:false
         ~decision:(Keeper_approval_queue.Approval_resolved decision)
         ();

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -304,6 +304,18 @@ let auto_approval_hard_forbidden ~risk meta =
   risk = Critical || runtime_auto_approval_blocked meta
 ;;
 
+let hard_forbidden_reject_reason ~risk =
+  match risk with
+  | Critical -> "critical risk cannot be auto-approved"
+  | Low | Medium | High -> "runtime contract blocks auto-approval"
+;;
+
+let forbidden_without_approval_reject_reason ~risk ~hard_forbidden =
+  if hard_forbidden
+  then hard_forbidden_reject_reason ~risk
+  else "destructive tool/op cannot be auto-approved without HITL"
+;;
+
 let auto_approval_soft_forbidden ~tool_name ~input =
   destructive_tool_or_op ~tool_name ~input
 ;;
@@ -357,8 +369,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         tool_name
         (risk_level_to_string base_risk)
         (risk_level_to_string risk);
-    if requires_operator_approval
-    then (
+    let with_approval_context f =
       let turn_id =
         Option.map
           (fun (meta : Keeper_meta_contract.keeper_meta) -> meta.runtime.usage.total_turns + 1)
@@ -395,6 +406,69 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
       let selected_model = selected_model_of_meta meta in
       let risk_level = queue_risk_level risk in
       let base_path = (config : Workspace.config).base_path in
+      f
+        ~turn_id
+        ~task_id
+        ~goal_id
+        ~goal_ids
+        ~runtime_contract
+        ~sandbox_profile
+        ~backend
+        ~sandbox_target
+        ~selected_model
+        ~risk_level
+        ~base_path
+    in
+    let reject_forbidden_without_approval
+        ~turn_id
+        ~task_id
+        ~goal_id
+        ~goal_ids
+        ~runtime_contract
+        ~sandbox_target
+        ~selected_model
+        ~risk_level
+        ~base_path
+      =
+      let reason = forbidden_without_approval_reject_reason ~risk ~hard_forbidden in
+      let decision = Agent_sdk.Hooks.Reject reason in
+      Keeper_approval_queue.audit_approval_event
+        ~base_path
+        ~event_type:Keeper_approval_queue.approval_audit_hard_forbidden_event
+        ~id:(Printf.sprintf "hard_forbidden_%s_%s" keeper_name tool_name)
+        ~keeper_name
+        ~tool_name
+        ~risk_level
+        ?turn_id
+        ?task_id
+        ?goal_id
+        ?goal_ids
+        ?sandbox_target
+        ?runtime_contract
+        ?selected_model
+        ~disposition:"Blocked"
+        ~disposition_reason:"hard_forbidden"
+        ~auto_approved:false
+        ~decision:(Keeper_approval_queue.Approval_resolved decision)
+        ();
+      decision
+    in
+    if needs_approval
+    then
+      with_approval_context
+        (fun
+          ~turn_id
+          ~task_id
+          ~goal_id
+          ~goal_ids
+          ~runtime_contract
+          ~sandbox_profile
+          ~backend
+          ~sandbox_target
+          ~selected_model
+          ~risk_level
+          ~base_path
+        ->
       let always_approve =
         Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
         |> Option.value ~default:false
@@ -426,7 +500,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
           ?turn_id
           ?task_id
           ?goal_id
-          ~goal_ids:(Option.value ~default:[] goal_ids)
+          ?goal_ids
           ?sandbox_target
           ?runtime_contract
           ?selected_model
@@ -448,7 +522,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                ?turn_id
                ?task_id
                ?goal_id
-               ~goal_ids:(Option.value ~default:[] goal_ids)
+               ?goal_ids
                ?sandbox_target
                ?runtime_contract
                ?selected_model
@@ -478,5 +552,31 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                ~risk_level
                ?clock
                ()))
+    else if hard_forbidden || soft_forbidden
+    then
+      with_approval_context
+        (fun
+          ~turn_id
+          ~task_id
+          ~goal_id
+          ~goal_ids
+          ~runtime_contract
+          ~sandbox_profile:_
+          ~backend:_
+          ~sandbox_target
+          ~selected_model
+          ~risk_level
+          ~base_path
+        ->
+          reject_forbidden_without_approval
+            ~turn_id
+            ~task_id
+            ~goal_id
+            ~goal_ids
+            ~runtime_contract
+            ~sandbox_target
+            ~selected_model
+            ~risk_level
+            ~base_path)
     else Agent_sdk.Hooks.Approve
 ;;

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -82,6 +82,7 @@ let read_recent_audit_raw store limit =
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
 let approval_audit_hard_forbidden_event = "hard_forbidden"
+let approval_audit_soft_forbidden_event = "soft_forbidden"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -81,6 +81,7 @@ let read_recent_audit_raw store limit =
 
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
+let approval_audit_hard_forbidden_event = "hard_forbidden"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -178,6 +178,9 @@ val approval_audit_resolved_event : string
 val approval_audit_hard_forbidden_event : string
 (** Event tag persisted when governance rejects a hard-forbidden approval. *)
 
+val approval_audit_soft_forbidden_event : string
+(** Event tag persisted when governance rejects a soft-forbidden approval. *)
+
 val recent_resolved_history_limit : int
 (** Default dashboard history length for resolved HITL approvals. *)
 

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -175,6 +175,9 @@ val approval_audit_pending_event : string
 val approval_audit_resolved_event : string
 (** Event tag persisted when an approval is resolved. *)
 
+val approval_audit_hard_forbidden_event : string
+(** Event tag persisted when governance rejects a hard-forbidden approval. *)
+
 val recent_resolved_history_limit : int
 (** Default dashboard history length for resolved HITL approvals. *)
 

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -547,6 +547,8 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       match latest_event_kind with
       | Some "auto_approved_always" -> "always_flag"
       | Some "auto_approved_rule_match" -> "always_rule"
+      | Some event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
+        "hard_forbidden"
       | Some "resolved" -> "resolved"
       | Some "expired" | Some "approval_timeout" -> "expired"
       | Some "cancelled" -> "cancelled"

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -549,6 +549,8 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       | Some "auto_approved_rule_match" -> "always_rule"
       | Some event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
         "hard_forbidden"
+      | Some event when String.equal event Keeper_approval_queue.approval_audit_soft_forbidden_event ->
+        "soft_forbidden"
       | Some "resolved" -> "resolved"
       | Some "expired" | Some "approval_timeout" -> "expired"
       | Some "cancelled" -> "cancelled"

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -88,6 +88,8 @@ let severity_of_approval_event event decision =
   | "expired" | "approval_timeout" | "cancelled" -> "bad"
   | event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
     "bad"
+  | event when String.equal event Keeper_approval_queue.approval_audit_soft_forbidden_event ->
+    "bad"
   | "resolved" -> (
       match decision with
       | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -86,6 +86,8 @@ let severity_of_approval_event event decision =
   match event with
   | "pending" -> "warn"
   | "expired" | "approval_timeout" | "cancelled" -> "bad"
+  | event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
+    "bad"
   | "resolved" -> (
       match decision with
       | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1295,6 +1295,7 @@ let test_runtime_trust_classifies_always_approve_flag () =
         (approval |> member "latest_event_kind" |> to_string))
 
 let test_hard_forbidden_blocks_critical_risk () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
   with_test_config @@ fun config ->
   let meta =
     meta_from_json
@@ -1315,9 +1316,10 @@ let test_hard_forbidden_blocks_critical_risk () =
       ~input:(`Assoc [("path", `String "/etc/passwd")])
   in
   Alcotest.(check bool) "critical risk tool is hard_forbidden and blocked"
-    true (approval_decision_is_reject decision)
+    true (approval_decision_is_reject decision))
 
 let test_hard_forbidden_blocks_destructive_tool () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
   with_test_config @@ fun config ->
   let meta =
     meta_from_json
@@ -1338,7 +1340,74 @@ let test_hard_forbidden_blocks_destructive_tool () =
       ~input:(`Assoc [("path", `String "/safe/path")])
   in
   Alcotest.(check bool) "destructive tool is hard_forbidden and blocked"
-    true (approval_decision_is_reject decision)
+    true (approval_decision_is_reject decision))
+
+let test_hard_forbidden_writes_audit_and_read_model () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
+  with_test_config @@ fun config ->
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:AQ.For_testing.reset_audit_store
+    (fun () ->
+      let keeper_name = "hard-forbidden-audit-keeper" in
+      let meta =
+        meta_from_json
+          (`Assoc [
+             ("name", `String keeper_name);
+             ("trace_id", `String "trace-hard-forbidden-audit");
+             ("sandbox_profile", `String "docker");
+             ("network_mode", `String "inherit");
+             ("always_approve", `Bool true);
+           ])
+      in
+      let cb =
+        GP.to_oas_approval_callback
+          ~config
+          ~governance_level:"production"
+          ~keeper_name
+          ~meta
+          ()
+      in
+      let decision =
+        cb
+          ~tool_name:"tool_edit_file"
+          ~input:(`Assoc [ ("path", `String "/etc/passwd") ])
+      in
+      Alcotest.(check bool)
+        "critical risk rejected"
+        true
+        (approval_decision_is_reject decision);
+      (match AQ.read_recent_audit ~base_path:config.base_path ~keeper_name ~n:1 () with
+       | latest :: _ ->
+         let open Yojson.Safe.Util in
+         Alcotest.(check string)
+           "event"
+           AQ.approval_audit_hard_forbidden_event
+           (latest |> member "event" |> to_string);
+         Alcotest.(check string)
+           "disposition"
+           "Blocked"
+           (latest |> member "disposition" |> to_string);
+         Alcotest.(check string)
+           "disposition reason"
+           "hard_forbidden"
+           (latest |> member "disposition_reason" |> to_string);
+         Alcotest.(check string)
+           "decision kind"
+           "reject"
+           (latest |> member "decision_kind" |> to_string)
+       | [] -> Alcotest.fail "expected hard-forbidden audit row");
+      let snapshot = Masc.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
+      let open Yojson.Safe.Util in
+      let approval = snapshot |> member "approval" in
+      Alcotest.(check string)
+        "approval state"
+        "hard_forbidden"
+        (approval |> member "state" |> to_string);
+      Alcotest.(check string)
+        "latest event kind"
+        AQ.approval_audit_hard_forbidden_event
+        (approval |> member "latest_event_kind" |> to_string)))
 
 let test_always_approve_bypasses_only_when_not_hard_forbidden () =
   with_test_config @@ fun config ->
@@ -1364,6 +1433,7 @@ let test_always_approve_bypasses_only_when_not_hard_forbidden () =
     true (decision = Agent_sdk.Hooks.Approve)
 
 let test_hard_forbidden_hoisted_outside_needs_approval () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
   with_test_config @@ fun config ->
   let meta =
     meta_from_json
@@ -1390,7 +1460,42 @@ let test_hard_forbidden_hoisted_outside_needs_approval () =
   Alcotest.(check bool) "critical tool blocked"
     true (approval_decision_is_reject decision1);
   Alcotest.(check bool) "safe tool approved"
-    true (decision2 = Agent_sdk.Hooks.Approve)
+    true (decision2 = Agent_sdk.Hooks.Approve))
+
+let test_hard_forbidden_blocks_when_hitl_disabled () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect
+      ~finally:AQ.For_testing.reset_audit_store
+      (fun () ->
+        with_test_config @@ fun config ->
+        let meta =
+          meta_from_json
+            (`Assoc [
+               ("name", `String "test-keeper");
+               ("trace_id", `String "test-trace");
+               ("sandbox_profile", `String "docker");
+               ("network_mode", `String "inherit");
+               ("always_approve", `Bool true);
+             ])
+        in
+        let cb =
+          GP.to_oas_approval_callback
+            ~config
+            ~governance_level:"production"
+            ~keeper_name:"test-keeper"
+            ~meta
+            ()
+        in
+        let decision =
+          cb
+            ~tool_name:"tool_edit_file"
+            ~input:(`Assoc [ ("path", `String "/etc/passwd") ])
+        in
+        Alcotest.(check bool)
+          "critical hard-forbidden rejected with HITL disabled"
+          true
+          (approval_decision_is_reject decision)))
 
 let test_callback_always_approve_respects_forbidden () =
   Eio_main.run @@ fun env ->
@@ -1708,9 +1813,13 @@ let () =
         test_hard_forbidden_blocks_critical_risk;
       Alcotest.test_case "hard_forbidden blocks destructive tool" `Quick
         test_hard_forbidden_blocks_destructive_tool;
+      Alcotest.test_case "hard_forbidden writes audit and read model" `Quick
+        test_hard_forbidden_writes_audit_and_read_model;
       Alcotest.test_case "always_approve bypasses only when not hard_forbidden" `Quick
         test_always_approve_bypasses_only_when_not_hard_forbidden;
       Alcotest.test_case "hard_forbidden hoisted outside needs_approval" `Quick
         test_hard_forbidden_hoisted_outside_needs_approval;
+      Alcotest.test_case "hard_forbidden blocks when HITL disabled" `Quick
+        test_hard_forbidden_blocks_when_hitl_disabled;
     ]);
   ]

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -83,6 +83,10 @@ let pending_id_for_keeper ~keeper_name =
       entries
   | _ -> None
 
+let approval_decision_is_reject = function
+  | Agent_sdk.Hooks.Reject _ -> true
+  | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ -> false
+
 let with_env key value f =
   let old = Sys.getenv_opt key in
   Unix.putenv key value;
@@ -1290,6 +1294,104 @@ let test_runtime_trust_classifies_always_approve_flag () =
         "auto_approved_always"
         (approval |> member "latest_event_kind" |> to_string))
 
+let test_hard_forbidden_blocks_critical_risk () =
+  with_test_config @@ fun config ->
+  let meta =
+    meta_from_json
+      (`Assoc [
+        ("name", `String "test-keeper");
+        ("trace_id", `String "test-trace");
+        ("sandbox_profile", `String "docker");
+        ("network_mode", `String "inherit");
+        ("always_approve", `Bool true);
+      ])
+  in
+  let cb =
+    GP.to_oas_approval_callback
+      ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
+  in
+  let decision =
+    cb ~tool_name:"tool_edit_file"
+      ~input:(`Assoc [("path", `String "/etc/passwd")])
+  in
+  Alcotest.(check bool) "critical risk tool is hard_forbidden and blocked"
+    true (approval_decision_is_reject decision)
+
+let test_hard_forbidden_blocks_destructive_tool () =
+  with_test_config @@ fun config ->
+  let meta =
+    meta_from_json
+      (`Assoc [
+        ("name", `String "test-keeper");
+        ("trace_id", `String "test-trace");
+        ("sandbox_profile", `String "docker");
+        ("network_mode", `String "inherit");
+        ("always_approve", `Bool true);
+      ])
+  in
+  let cb =
+    GP.to_oas_approval_callback
+      ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
+  in
+  let decision =
+    cb ~tool_name:"tool_delete_file"
+      ~input:(`Assoc [("path", `String "/safe/path")])
+  in
+  Alcotest.(check bool) "destructive tool is hard_forbidden and blocked"
+    true (approval_decision_is_reject decision)
+
+let test_always_approve_bypasses_only_when_not_hard_forbidden () =
+  with_test_config @@ fun config ->
+  let meta =
+    meta_from_json
+      (`Assoc [
+        ("name", `String "test-keeper");
+        ("trace_id", `String "test-trace");
+        ("sandbox_profile", `String "docker");
+        ("network_mode", `String "inherit");
+        ("always_approve", `Bool true);
+      ])
+  in
+  let cb =
+    GP.to_oas_approval_callback
+      ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
+  in
+  let decision =
+    cb ~tool_name:"tool_read_file"
+      ~input:(`Assoc [("path", `String "/safe/path")])
+  in
+  Alcotest.(check bool) "safe tool with always_approve is auto-approved"
+    true (decision = Agent_sdk.Hooks.Approve)
+
+let test_hard_forbidden_hoisted_outside_needs_approval () =
+  with_test_config @@ fun config ->
+  let meta =
+    meta_from_json
+      (`Assoc [
+        ("name", `String "test-keeper");
+        ("trace_id", `String "test-trace");
+        ("sandbox_profile", `String "docker");
+        ("network_mode", `String "inherit");
+        ("always_approve", `Bool true);
+      ])
+  in
+  let cb =
+    GP.to_oas_approval_callback
+      ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
+  in
+  let decision1 =
+    cb ~tool_name:"tool_edit_file"
+      ~input:(`Assoc [("path", `String "/etc/passwd")])
+  in
+  let decision2 =
+    cb ~tool_name:"tool_read_file"
+      ~input:(`Assoc [("path", `String "/safe/path")])
+  in
+  Alcotest.(check bool) "critical tool blocked"
+    true (approval_decision_is_reject decision1);
+  Alcotest.(check bool) "safe tool approved"
+    true (decision2 = Agent_sdk.Hooks.Approve)
+
 let test_callback_always_approve_respects_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1602,5 +1704,13 @@ let () =
         test_callback_always_approve_respects_forbidden;
       Alcotest.test_case "HITL disabled still gates forbidden tools" `Quick
         test_callback_hitl_disabled_forbidden_requires_approval;
+      Alcotest.test_case "hard_forbidden blocks critical risk" `Quick
+        test_hard_forbidden_blocks_critical_risk;
+      Alcotest.test_case "hard_forbidden blocks destructive tool" `Quick
+        test_hard_forbidden_blocks_destructive_tool;
+      Alcotest.test_case "always_approve bypasses only when not hard_forbidden" `Quick
+        test_always_approve_bypasses_only_when_not_hard_forbidden;
+      Alcotest.test_case "hard_forbidden hoisted outside needs_approval" `Quick
+        test_hard_forbidden_hoisted_outside_needs_approval;
     ]);
   ]

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1497,6 +1497,69 @@ let test_hard_forbidden_blocks_when_hitl_disabled () =
           true
           (approval_decision_is_reject decision)))
 
+let test_soft_forbidden_writes_soft_audit_and_read_model () =
+  with_env Env_config_core.disable_hitl_env_key "true" (fun () ->
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect
+      ~finally:AQ.For_testing.reset_audit_store
+      (fun () ->
+        with_test_config @@ fun config ->
+        let keeper_name = "soft-forbidden-audit-keeper" in
+        let meta =
+          meta_from_json
+            (`Assoc [
+               ("name", `String keeper_name);
+               ("trace_id", `String "trace-soft-forbidden-audit");
+               ("sandbox_profile", `String "docker");
+               ("network_mode", `String "inherit");
+               ("always_approve", `Bool true);
+             ])
+        in
+        let cb =
+          GP.to_oas_approval_callback
+            ~config
+            ~governance_level:"production"
+            ~keeper_name
+            ~meta
+            ()
+        in
+        let decision =
+          cb
+            ~tool_name:"masc_status"
+            ~input:(`Assoc [ ("op", `String "git") ])
+        in
+        Alcotest.(check bool)
+          "soft-forbidden rejected with HITL disabled"
+          true
+          (approval_decision_is_reject decision);
+        (match AQ.read_recent_audit ~base_path:config.base_path ~keeper_name ~n:1 () with
+         | latest :: _ ->
+           let open Yojson.Safe.Util in
+           Alcotest.(check string)
+             "event"
+             AQ.approval_audit_soft_forbidden_event
+             (latest |> member "event" |> to_string);
+           Alcotest.(check string)
+             "disposition reason"
+             "soft_forbidden"
+             (latest |> member "disposition_reason" |> to_string);
+           Alcotest.(check string)
+             "decision kind"
+             "reject"
+             (latest |> member "decision_kind" |> to_string)
+         | [] -> Alcotest.fail "expected soft-forbidden audit row");
+        let snapshot = Masc.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
+        let open Yojson.Safe.Util in
+        let approval = snapshot |> member "approval" in
+        Alcotest.(check string)
+          "approval state"
+          "soft_forbidden"
+          (approval |> member "state" |> to_string);
+        Alcotest.(check string)
+          "latest event kind"
+          AQ.approval_audit_soft_forbidden_event
+          (approval |> member "latest_event_kind" |> to_string)))
+
 let test_callback_always_approve_respects_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1821,5 +1884,7 @@ let () =
         test_hard_forbidden_hoisted_outside_needs_approval;
       Alcotest.test_case "hard_forbidden blocks when HITL disabled" `Quick
         test_hard_forbidden_blocks_when_hitl_disabled;
+      Alcotest.test_case "soft_forbidden writes soft audit and read model" `Quick
+        test_soft_forbidden_writes_soft_audit_and_read_model;
     ]);
   ]

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1616,8 +1616,16 @@ let test_callback_always_approve_respects_forbidden () =
       | Some _ -> Alcotest.fail "expected Approve after operator resolution"
       | None -> Alcotest.fail "destructive tool callback did not suspend for approval")
 
-let test_callback_hitl_disabled_forbidden_requires_approval () =
-  with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
+(* Hard-forbidden (Critical risk / runtime-blocked) must reject immediately
+   when HITL is disabled, not suspend into the approval queue for an operator
+   to later approve around - MASC_DISABLE_HITL removes the *operator*, so
+   queuing a hard-forbidden call would make it unconditionally approvable by
+   whoever drains the queue, defeating the "always-approve bypass" the PR
+   closes. This exercises the same invariant test_hard_forbidden_blocks_
+   critical_risk pins, but through the async Fiber-based callback path used
+   in production, to confirm that path doesn't accidentally suspend either. *)
+let test_callback_hitl_disabled_forbidden_rejects_without_queuing () =
+  with_env Env_config_core.disable_hitl_env_key "true" @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
@@ -1643,29 +1651,15 @@ let test_callback_hitl_disabled_forbidden_requires_approval () =
             ~input:(`Assoc [ ("path", `String "/dangerous") ])
         in
         result := Some decision);
-      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-      Alcotest.(check int)
-        "forbidden tool still requires approval when HITL threshold is disabled"
-        (initial_pending + 1)
-        (AQ.pending_count ());
-      let id =
-        match pending_id_for_keeper ~keeper_name with
-        | Some id -> id
-        | None -> Alcotest.fail "expected pending approval for HITL-disabled forbidden tool"
-      in
-      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
-       | Ok () -> ()
-       | Error err ->
-         Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       yield_until (fun () -> Option.is_some !result);
-      match !result with
-      | Some Agent_sdk.Hooks.Approve -> ()
-      | Some Agent_sdk.Hooks.Reject reason ->
-        Alcotest.fail ("expected Approve after operator resolution, got reject: " ^ reason)
-      | Some Agent_sdk.Hooks.Edit _ ->
-        Alcotest.fail "expected Approve after operator resolution, got edit"
-      | None ->
-        Alcotest.fail "HITL-disabled forbidden callback did not suspend for approval")
+      Alcotest.(check bool)
+        "hard-forbidden tool rejects immediately when HITL is disabled"
+        true
+        (approval_decision_is_reject (Option.get !result));
+      Alcotest.(check int)
+        "hard-forbidden rejection never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
 let test_read_recent_audit_filters_after_wide_scan () =
   with_temp_masc_base @@ fun base_path ->
@@ -1870,8 +1864,8 @@ let () =
         test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick
         test_callback_always_approve_respects_forbidden;
-      Alcotest.test_case "HITL disabled still gates forbidden tools" `Quick
-        test_callback_hitl_disabled_forbidden_requires_approval;
+      Alcotest.test_case "HITL disabled rejects forbidden tools without queuing" `Quick
+        test_callback_hitl_disabled_forbidden_rejects_without_queuing;
       Alcotest.test_case "hard_forbidden blocks critical risk" `Quick
         test_hard_forbidden_blocks_critical_risk;
       Alcotest.test_case "hard_forbidden blocks destructive tool" `Quick


### PR DESCRIPTION
## Changes

- Hoist `hard_forbidden` before the `needs_approval` branch in `governance_pipeline.ml`.
- Reject hard-forbidden tools via the real OAS hook decision type even when `always_approve=true` or HITL gates are disabled.
- Persist hard-forbidden decisions into the approval audit stream and project them into the runtime trust read model/timeline.
- Keep `always_approve` available only for non-hard-forbidden, non-soft-forbidden requests.
- Add HITL approval regression coverage for critical-risk tools, destructive tools, safe always-approve, the hoisted hard-forbidden path, and `MASC_DISABLE_HITL=true`.

## Review Response

- Removed the prior `keeper_wip_admission.ml` changes from this PR.
- Removed the `max_per_repo` cap increase.
- Removed the 30-minute stale-claim count exclusion. That was a count workaround, not a real orphan release.
- Replaced the invalid `Agent_sdk.Hooks.Block` usage with `Agent_sdk.Hooks.Reject`.
- Reused `auto_approval_hard_forbidden ~risk meta` instead of re-encoding the predicate.
- Added `approval_audit_hard_forbidden_event` as the approval audit event SSOT.
- Lease/TTL-based orphan release should be handled in the existing orphan/release subsystem as a separate root-fix PR.

## Validation

- `opam exec -- ocamlformat --check lib/governance_pipeline.ml lib/keeper/keeper_approval_queue.ml lib/keeper/keeper_approval_queue.mli lib/keeper/keeper_runtime_trust_snapshot.ml lib/keeper/keeper_runtime_trust_timeline.ml test/test_hitl_approval.ml`
- `git diff --check origin/main...HEAD`

Full build/test left to CI.
