### PR TITLE
fix(keeper): classify internal broadcast name as Board_activity (#22042)

### DIFF
--- a/lib/keeper/keeper_tool_capability_axis.ml
+++ b/lib/keeper/keeper_tool_capability_axis.ml
@@ -31,9 +31,24 @@ let claim_task_tool_names =
 ;;
 
 let board_activity_tool_names =
+  (* #22042 / RFC-0299 Phase 4 — canonical-form membership.
+
+     [supports]/[candidate_names] canonicalize the *incoming* name before
+     [List.mem], so every entry here must be a canonical form the runtime can
+     actually present. [broadcast] has an asymmetric registration: the
+     descriptor (keeper.task.broadcast) carries the internal name
+     "keeper_broadcast", while "masc_broadcast" is a
+     [public_mcp_non_descriptor_name] (routing_table miss -> known_runtime
+     identity, stays unchanged). The two representations therefore canonicalize
+     to two different strings, so both must be listed or the internal form
+     classifies as Passive_status and silently resets the RFC-0239 anti-thrash
+     streak. [keeper_msg] is symmetric (public_name = internal_name =
+     "masc_keeper_msg" via [masc_keeper_descriptor]) so its single entry
+     already covers every representation. *)
   [ Keeper_tool_name.(to_string Board_post)
   ; Keeper_tool_name.(to_string Board_comment)
-  ; "masc_broadcast"
+  ; Keeper_tool_name.(to_string Broadcast) (* internal canonical = "keeper_broadcast" *)
+  ; "masc_broadcast" (* non-descriptor public form; canonicalizes to itself *)
   ; "masc_keeper_msg"
   ]
 ;;

--- a/test/test_keeper_tool_capability_axis.ml
+++ b/test/test_keeper_tool_capability_axis.ml
@@ -2,10 +2,22 @@ open Alcotest
 
 module Axis = Masc.Keeper_tool_capability_axis
 module Resolution = Masc.Keeper_tool_descriptor_resolution
+module Progress = Masc.Keeper_tool_progress
+module Tool_resolution = Masc.Keeper_tool_resolution
 module Tool_catalog = Tool_catalog
 
 let check_support capability name expected =
   check bool name expected (Axis.supports capability name)
+;;
+
+let is_execution name =
+  match Progress.classify_tool_progress name with
+  | Progress.Execution -> true
+  | Progress.Passive_status | Progress.Claim_context | Progress.Completion -> false
+;;
+
+let check_execution name =
+  check bool (name ^ " classifies as Execution (Board_activity)") true (is_execution name)
 ;;
 
 let test_claim_task_supports_keeper_and_public_projection () =
@@ -20,6 +32,30 @@ let test_board_activity_supports_keeper_and_public_projection () =
   check_support Axis.Board_activity "mcp__masc__masc_broadcast" true;
   check_support Axis.Board_activity "masc_keeper_msg" true;
   check_support Axis.Board_activity "keeper_board_list" false
+;;
+
+(* #22042 / RFC-0239 ground truth — a board/broadcast/keeper_msg turn must
+   classify as Execution so the anti-thrash streak accrues, for *every*
+   representation the runtime can present: the public MCP name, the
+   mcp-prefixed name, and the internal canonical name that
+   [Keeper_agent_result.tool_names_of_calls] produces via
+   [Keeper_tool_resolution.canonical_tool_name]. Broadcast's registration is
+   asymmetric (descriptor internal "keeper_broadcast" vs non-descriptor public
+   "masc_broadcast" canonicalizing to itself), so both forms are exercised;
+   keeper_msg is symmetric. Before the canonical-form fix the internal
+   "keeper_broadcast" representation fell through to Passive_status. *)
+let test_board_activity_classification_ground_truth () =
+  check_execution "masc_broadcast";
+  check_execution "mcp__masc__masc_broadcast";
+  check_execution "keeper_broadcast";
+  check_execution "masc_keeper_msg";
+  check_execution "mcp__masc__masc_keeper_msg";
+  check_execution "keeper_board_post";
+  check_execution "keeper_board_comment";
+  check bool "canonicalized public broadcast supports Board_activity" true
+    (Axis.supports Axis.Board_activity (Tool_resolution.canonical_tool_name "masc_broadcast"));
+  check bool "canonicalized internal broadcast supports Board_activity" true
+    (Axis.supports Axis.Board_activity (Tool_resolution.canonical_tool_name "keeper_broadcast"))
 ;;
 
 let test_polling_read_supports_descriptor_projection () =
@@ -61,6 +97,10 @@ let () =
             "board activity supports keeper and public projection names"
             `Quick
             test_board_activity_supports_keeper_and_public_projection
+        ; test_case
+            "board activity classification ground truth (#22042 all representations)"
+            `Quick
+            test_board_activity_classification_ground_truth
         ; test_case
             "polling read supports descriptor projection names"
             `Quick


### PR DESCRIPTION
## 목적

`#22042` (P1) 의 실체를 코드로 검증하고 닫는다. broadcast 단독 턴이 RFC-0239 anti-thrash streak 를 리셋하는 latent gap 의 **정확한 범위**를 확정하고, canonical-form 으로 수정한다.

## 적대적 검증으로 좁힌 실체

이슈는 broadcast/keeper_msg 둘 다 샌다고 봤으나, 현 `main` 을 직접 그라운딩한 결과:

- **broadcast = 비대칭 등록**. descriptor `keeper.task.broadcast` 의 internal_name 은 `keeper_broadcast` 이고, `masc_broadcast` 는 `public_mcp_non_descriptor_names` 항목(routing_table miss → known_runtime identity, 그대로 유지)이다. 두 표현이 서로 다른 canonical 로 정규화된다. `board_activity_tool_names` 가 public 형 `masc_broadcast` 만 가지고 있어, **internal 형 `keeper_broadcast` 표현은 `List.mem` 에 걸리지 않고 `Passive_status` 로 fall-through** → streak 리셋. 이게 #22042 의 실제 구멍이다.
- **keeper_msg = 대칭 등록**. `masc_keeper_descriptor "msg" "masc_keeper_msg"` 는 `in_process_descriptor ~public_name:name ~internal_name:name` 로 public_name = internal_name = `masc_keeper_msg`. 모든 표현이 같은 canonical 로 가므로 기존 단일 엔트리가 이미 전부 커버한다. **keeper_msg 는 새지 않는다** (이슈의 가정 정정).

따라서 broken site 는 broadcast 의 internal 표현 **한 곳**뿐이다 (N-of-M 아님 — keeper_msg 는 검증상 정상).

## 변경

1. `lib/keeper/keeper_tool_capability_axis.ml` — `board_activity_tool_names` 에 typed canonical `Keeper_tool_name.(to_string Broadcast)` (= `keeper_broadcast`) 추가. 비대칭 때문에 non-descriptor public 형 `masc_broadcast` 도 유지. 두 표현 모두 Board_activity 로 분류된다. 비대칭의 근거를 주석으로 명시.
2. `test/test_keeper_tool_capability_axis.ml` — 모든 표현(public / mcp-prefixed / internal canonical)을 실제 런타임 경로(`Keeper_tool_resolution.canonical_tool_name` → `classify_tool_progress`)로 검증하는 결정론적 테스트 추가. 수정 전에는 `keeper_broadcast` 케이스가 실패한다.

## 검증 방법

빌드/테스트는 CI 에서 확인한다 (`test_keeper_tool_capability_axis`). `classify_tool_progress` 가 모든 broadcast/keeper_msg 표현에 대해 `Execution` 을 반환해야 통과한다.

## 범위 밖 (정직한 한계)

이 PR 은 라이브 albini(qwen36) "no actionable work" 60s 재방송 루프의 **드라이버가 아니다**. 그 루프는 broadcast 를 *tool call* 로 호출하지 않고 keeper 의 *text response* 가 `message.broadcast` 로 posting 되는 경로이며, completion-contract disposition (`operator_broadcast_required`) 이 매 idle cycle 페이징을 생성하는 별개 root 다. 이 PR 은 #22042 가 기술한 capability-axis 분류 gap 만 닫는다.

## RFC

RFC-0299 Phase 4 (tool capability axis: canonical-form closed-sum, public-alias 리터럴 폐기) 의 방향과 정합. 본 변경은 분류 site 의 canonical-form membership 만 수정하며 anti-thrash 의미론 변경은 없다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
