### PR TITLE
test(runtime): seed OAS_MODEL_CATALOG in per-keeper thinking gate test

### DIFF
--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -18,6 +18,20 @@ open Masc
 module J = Yojson.Safe.Util
 module KMC = Keeper_meta_contract
 
+(* Test hermeticity: the per-model thinking gate resolves capabilities through
+   the OAS [Model_catalog], which is loaded once (memoized via Atomic) from the
+   [OAS_MODEL_CATALOG] env var.  Production seeds this in
+   server_runtime_bootstrap; without it [Model_catalog.global ()] is [None], so
+   qwen36's [preserve_thinking_control_format] misses the catalog row and the
+   gate defaults [preserve_thinking] to [None] instead of [Some true].  Set at
+   module top so it precedes the first [global ()] access regardless of test
+   ordering, and only when unset so an external/CI value is honored. *)
+let () =
+  match Sys.getenv_opt "OAS_MODEL_CATALOG" with
+  | Some _ -> ()
+  | None ->
+    Unix.putenv "OAS_MODEL_CATALOG" (Masc_test_deps.source_path "oas-models.toml")
+
 (* ---- temp config-dir + keeper TOML fixtures
    (helper shape mirrors test_keeper_runtime_denylist.ml) ---- *)
 


### PR DESCRIPTION
## 무엇

`test/test_runtime_per_keeper_routing.ml`의 per-model thinking gate 테스트(`test_thinking_support_true_defaults_preserve_when_unset`, line 577)가 main에서 실패 중인 원인은 **테스트 hermeticity**입니다. CI Gate에서 Build & Test만 red, 나머지 gate(LINT/DASHBOARD/HEALTH/STRUCTURE_RATCHET/SHELL_IR) 전부 green — #22662 이후 잔존.

## 근본 원인

- 이 테스트는 모델 `thinkdefault`(api-name `qwen36-35b-a3b-mtp`, provider `ollama_cloud`, preserve-thinking 미설정)에서 `seed.preserve_thinking = Some true`를 기대하는데 `None`을 받습니다.
- thinking gate는 capability를 OAS `Model_catalog`를 통해 해소하는데, 이 카탈로그는 `OAS_MODEL_CATALOG` env에서 **한 번 로드(Atomic 메모이즈)**됩니다.
- 기존 harness `with_runtime_thinking`은 `MASC_CONFIG_DIR`만 set하고 `OAS_MODEL_CATALOG`는 set하지 않음 → `Model_catalog.global () = None` → qwen36의 capability 조회가 카탈로그 행(`chat_template_kwargs_preserve_thinking` → `Some true`로 매핑)을 놓치고 기본값 `None`으로 떨어짐.
- **프로덕션 무결성**: `server_runtime_bootstrap`이 이 env를 seed하므로 프로덕션은 정상. 테스트 환경 누락 문제입니다.

## 변경

module-top에서 `OAS_MODEL_CATALOG`를 repo-pinned `oas-models.toml`로 set:
- 첫 `Model_catalog.global ()` 접근 전 보장(테스트 순서 무관) — harness 내부가 아닌 module-top 배치 이유.
- 외부/CI 값이 이미 set돼 있으면 존중(clobber 방지).
- 형제 테스트 `test_operator_mcp_e2e` / `test_sse_storm_e2e`와 동일 패턴(`Masc_test_deps.source_path`).
- dune 변경 불요(`test_runtime_per_keeper_routing`는 이미 `masc_test_deps unix` 의존).

## 적대적 검토 (불필요 테스트 / 워크어라운드 판정)

- **제거 대상 아님**: 잠그는 invariant(thinking-support 모델이 preserve-thinking 미설정 시 카탈로그 capability를 따른다)는 실제 정책이며 vacuous하지 않음. hermeticity만 보강.
- **워크어라운드 아님**: 테스트를 프로덕션 동작(env seed)에 정렬하는 fix. telemetry-as-fix / string-classifier / N-of-M / cap-cooldown-dedup-repair 시그니처 무해당. 오히려 hidden coupling(테스트가 ambient 카탈로그에 암묵 의존)을 명시화.
- **#22707과 독립**: qwen36 카탈로그 행은 현재 pin(0.207.22 `c7413246`)과 #22707 타겟(`d8395b9a`) 양쪽 동일 → sdk pin bump는 이 테스트를 고치지 않음. 별개 fix.

## 검증

빌드는 CI에서 확인. (로컬 worktree 미빌드 — ocamllsp unbound 경고는 `_build` 부재 아티팩트, 실제 오류 아님)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
