### PR TITLE
feat(oas): consume typed media and stream blocks

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -669,10 +669,20 @@ describe('thread history merge & persistence', () => {
 
   it('preserves accumulated tool trace state when TOOL_CALL_START repeats', () => {
     appendThreadEntry('echo', entry({ id: 'reply-1', role: 'assistant', source: 'direct_assistant' }))
-    appendAssistantToolTraceStep('echo', 'reply-1', { toolCallId: 'tc-1', name: 'lookup', ts: '2026-06-25T00:00:00.000Z' })
+    appendAssistantToolTraceStep('echo', 'reply-1', {
+      toolCallId: 'tc-1',
+      name: 'lookup',
+      ts: '2026-06-25T00:00:00.000Z',
+      oasBlockIndex: 5,
+    })
     appendAssistantToolTraceArgsDelta('echo', 'reply-1', 'tc-1', '{"a":1}')
     markAssistantToolTraceEnded('echo', 'reply-1', 'tc-1')
-    appendAssistantToolTraceStep('echo', 'reply-1', { toolCallId: 'tc-1', name: 'lookup-again', ts: '2026-06-25T00:00:01.000Z' })
+    appendAssistantToolTraceStep('echo', 'reply-1', {
+      toolCallId: 'tc-1',
+      name: 'lookup-again',
+      ts: '2026-06-25T00:00:01.000Z',
+      oasBlockIndex: 6,
+    })
 
     const reply = keeperThreads.value.echo?.find(e => e.id === 'reply-1')
     expect(reply?.traceSteps).toEqual([
@@ -683,6 +693,7 @@ describe('thread history merge & persistence', () => {
         status: 'ok',
         args: '{"a":1}',
         ts: '2026-06-25T00:00:00.000Z',
+        oasBlockIndex: 5,
       },
     ])
   })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -285,7 +285,14 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
   const kind = asString(raw.kind)
   if (kind === 'think') {
     const text = asString(raw.text)
-    return text !== undefined ? withoutUndefined({ kind, text, ts: asString(raw.ts) }) : null
+    return text !== undefined
+      ? withoutUndefined({
+          kind,
+          text,
+          ts: asString(raw.ts),
+          oasBlockIndex: asNumber(raw.oasBlockIndex) ?? asNumber(raw.oas_block_index) ?? undefined,
+        })
+      : null
   }
   if (kind === 'reason') {
     const text = asString(raw.text)
@@ -308,6 +315,7 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
       args: normalizeTracePayload(raw.args),
       result: normalizeTracePayload(raw.result),
       ts: asString(raw.ts) ?? undefined,
+      oasBlockIndex: asNumber(raw.oasBlockIndex) ?? asNumber(raw.oas_block_index) ?? undefined,
     })
   }
   return null
@@ -855,24 +863,45 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
   }))
 }
 
-export function appendAssistantThinkingDelta(name: string, entryId: string, delta: string): void {
+export function appendAssistantThinkingDelta(
+  name: string,
+  entryId: string,
+  delta: string,
+  meta: { oasBlockIndex?: number } = {},
+): void {
   if (!delta.trim()) return
+  const oasBlockIndex = meta.oasBlockIndex
   updateThreadEntry(name, entryId, entry => {
     const existing = entry.traceSteps ?? []
     const last = existing[existing.length - 1]
+    const sameThinkingBlock =
+      last?.kind === 'think'
+      && (oasBlockIndex === undefined
+        ? last.oasBlockIndex === undefined
+        : last.oasBlockIndex === oasBlockIndex)
     // Stamp the occurrence time on a NEW think step so the work-trace card can
     // interleave it with tool entries by occurrence order. When consecutive
     // deltas merge into the same step, the first stamp is preserved: the step
     // began at that time, not when the latest fragment arrived.
     const traceSteps: ChatTraceStep[] =
-      last?.kind === 'think'
+      sameThinkingBlock
         ? [
             ...existing.slice(0, -1),
-            { kind: 'think', text: `${last.text}${delta}`, ts: last.ts },
+            withoutUndefined({
+              kind: 'think',
+              text: `${last.text}${delta}`,
+              ts: last.ts,
+              oasBlockIndex: last.oasBlockIndex,
+            }),
           ]
         : [
             ...existing,
-            { kind: 'think', text: delta.trimStart(), ts: new Date().toISOString() },
+            withoutUndefined({
+              kind: 'think',
+              text: delta.trimStart(),
+              ts: new Date().toISOString(),
+              oasBlockIndex,
+            }),
           ]
     return {
       ...entry,
@@ -895,7 +924,7 @@ function warnMissingToolTrace(
 export function appendAssistantToolTraceStep(
   name: string,
   entryId: string,
-  step: { toolCallId: string; name: string; ts?: string },
+  step: { toolCallId: string; name: string; ts?: string; oasBlockIndex?: number },
 ): void {
   const toolCallId = step.toolCallId.trim()
   const toolName = step.name.trim()
@@ -908,25 +937,27 @@ export function appendAssistantToolTraceStep(
     const index = existing.findIndex(
       trace => trace.kind === 'tool' && trace.toolCallId === toolCallId,
     )
-    const nextStep: ChatTraceStep = {
+    const nextStep = withoutUndefined({
       kind: 'tool',
       toolCallId,
       name: toolName,
       status: 'pending',
       ts: step.ts ?? new Date().toISOString(),
-    }
+      oasBlockIndex: step.oasBlockIndex,
+    })
     const traceSteps =
       index === -1
         ? [...existing, nextStep]
         : existing.map((trace, i) =>
             i === index && trace.kind === 'tool'
-              ? {
+              ? withoutUndefined({
                   ...trace,
                   name: trace.name || toolName,
                   toolCallId,
                   status: trace.status ?? 'pending',
                   ts: trace.ts ?? nextStep.ts,
-                }
+                  oasBlockIndex: trace.oasBlockIndex ?? nextStep.oasBlockIndex,
+                })
               : trace,
           )
     return {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -362,6 +362,31 @@ describe('applyKeeperStreamEvent', () => {
       { kind: 'think', text: 'checking tools', ts: expect.any(String) },
     ])
   })
+
+  it('splits thinking trace steps by OAS content block index', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { index: 1, delta: 'checking ' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { index: 1, delta: 'tools' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { index: 2, delta: 'next block' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'checking tools', ts: expect.any(String), oasBlockIndex: 1 },
+      { kind: 'think', text: 'next block', ts: expect.any(String), oasBlockIndex: 2 },
+    ])
+  })
 })
 
 describe('applyKeeperStreamEvent tool calls', () => {
@@ -448,6 +473,52 @@ describe('applyKeeperStreamEvent tool calls', () => {
         ts: expect.any(String),
       },
       { kind: 'think', text: 'think B', ts: expect.any(String) },
+    ])
+  })
+
+  it('preserves OAS content block index on tool trace steps', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTENT_BLOCK_START',
+      value: {
+        index: 7,
+        content_type: 'tool_use',
+        tool_call_id: 'tc-oas',
+        tool_call_name: 'keeper_board_list',
+      },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-oas',
+      toolCallName: 'keeper_board_list',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 'tc-oas',
+      delta: '{"limit":1}',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_END',
+      toolCallId: 'tc-oas',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTENT_BLOCK_STOP',
+      value: { index: 7 },
+    })
+
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'keeper_board_list',
+        toolCallId: 'tc-oas',
+        status: 'ok',
+        args: '{"limit":1}',
+        ts: expect.any(String),
+        oasBlockIndex: 7,
+      },
     ])
   })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -260,17 +260,40 @@ export function applyKeeperStreamEvent(
         setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
         return null
       }
+      if (event.name === 'KEEPER_CONTENT_BLOCK_START') {
+        const value = isRecord(event.value) ? event.value : null
+        const oasBlockIndex = asNumber(value?.index) ?? asNumber(value?.block_index)
+        const toolCallId = asString(value?.tool_call_id)
+        const toolName = asString(value?.tool_call_name)
+        if (toolCallId && toolName) {
+          appendAssistantToolTraceStep(keeperName, assistantEntryId, {
+            toolCallId,
+            name: toolName,
+            oasBlockIndex,
+          })
+        }
+        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        return null
+      }
+      if (event.name === 'KEEPER_CONTENT_BLOCK_STOP') {
+        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        return null
+      }
       if (event.name === 'KEEPER_THINKING_DELTA') {
-        const delta = isRecord(event.value)
-          ? (typeof event.value.delta === 'string'
-              ? event.value.delta
-              : typeof event.value.text === 'string'
-                ? event.value.text
+        const value = isRecord(event.value) ? event.value : null
+        const delta = value
+          ? (typeof value.delta === 'string'
+              ? value.delta
+              : typeof value.text === 'string'
+                ? value.text
                 : undefined)
           : typeof event.value === 'string'
             ? event.value
             : undefined
-        if (delta) appendAssistantThinkingDelta(keeperName, assistantEntryId, delta)
+        const oasBlockIndex = value
+          ? asNumber(value.index) ?? asNumber(value.block_index)
+          : undefined
+        if (delta) appendAssistantThinkingDelta(keeperName, assistantEntryId, delta, { oasBlockIndex })
         else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
         return null
       }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -841,7 +841,7 @@ export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string 
 // `ts` (ISO-8601) records when the trace event arrived. Live streams preserve
 // think/tool order structurally in this array; persisted legacy rows may omit
 // timestamps and still render in stored order.
-export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string }
+export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string; oasBlockIndex?: number }
 export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string; ts?: string }
 export type ChatTraceToolStep = {
   kind: 'tool'
@@ -852,6 +852,7 @@ export type ChatTraceToolStep = {
   args?: string
   result?: string
   ts?: string
+  oasBlockIndex?: number
 }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep
 export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -423,6 +423,8 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
     | Oas_stream_message_delta _
     | Oas_stream_message_stop
     | Oas_stream_ping
+    | Oas_content_block_start _
+    | Oas_content_block_stop _
     | Oas_thinking_delta _
     | Oas_thinking_signature_delta _
     | Oas_media_delta _ ->

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -42,7 +42,7 @@ type keeper_chat_event =
   | Oas_thinking_signature_delta of { signature_bytes : int }
   | Oas_media_delta of
       { media_type : string
-      ; source_type : string
+      ; source_type : Agent_sdk.Types.media_source_kind
       ; bytes : int
       }
   | Oas_stream_protocol_error of stream_protocol_error

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -38,10 +38,18 @@ type keeper_chat_event =
       }
   | Oas_stream_message_stop
   | Oas_stream_ping
-  | Oas_thinking_delta of { delta : string }
-  | Oas_thinking_signature_delta of { signature_bytes : int }
+  | Oas_content_block_start of
+      { index : int
+      ; content_type : string
+      ; tool_call_id : string option
+      ; tool_call_name : string option
+      }
+  | Oas_content_block_stop of { index : int }
+  | Oas_thinking_delta of { index : int; delta : string }
+  | Oas_thinking_signature_delta of { index : int; signature_bytes : int }
   | Oas_media_delta of
-      { media_type : string
+      { index : int
+      ; media_type : string
       ; source_type : Agent_sdk.Types.media_source_kind
       ; bytes : int
       }

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -52,7 +52,7 @@ type keeper_chat_event =
   | Oas_thinking_signature_delta of { signature_bytes : int }
   | Oas_media_delta of
       { media_type : string
-      ; source_type : string
+      ; source_type : Agent_sdk.Types.media_source_kind
       ; bytes : int
       }
   | Oas_stream_protocol_error of stream_protocol_error

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -48,10 +48,18 @@ type keeper_chat_event =
       }
   | Oas_stream_message_stop
   | Oas_stream_ping
-  | Oas_thinking_delta of { delta : string }
-  | Oas_thinking_signature_delta of { signature_bytes : int }
+  | Oas_content_block_start of
+      { index : int
+      ; content_type : string
+      ; tool_call_id : string option
+      ; tool_call_name : string option
+      }
+  | Oas_content_block_stop of { index : int }
+  | Oas_thinking_delta of { index : int; delta : string }
+  | Oas_thinking_signature_delta of { index : int; signature_bytes : int }
   | Oas_media_delta of
-      { media_type : string
+      { index : int
+      ; media_type : string
       ; source_type : Agent_sdk.Types.media_source_kind
       ; bytes : int
       }

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -30,11 +30,21 @@ let protocol_error ?index ?event_type ?reason ?raw_bytes kind =
   Keeper_chat_events.Oas_stream_protocol_error
     { kind; index; event_type; reason; raw_bytes }
 
+let content_block_start_event ~index ~content_type ~tool_id ~tool_name =
+  Keeper_chat_events.Oas_content_block_start
+    { index
+    ; content_type
+    ; tool_call_id = tool_id
+    ; tool_call_name = tool_name
+    }
+
+let content_block_stop_event ~index =
+  Keeper_chat_events.Oas_content_block_stop { index }
+
 let translate ~redact_text ~on_text_delta bridge_state
     (evt : Agent_sdk.Types.sse_event) =
   let open Agent_sdk.Types in
   let open Keeper_chat_events in
-  let no_events = { bridge_state; chat_events = [] } in
   match evt with
   | Connected ->
       { bridge_state; chat_events = [ Oas_stream_connected ] }
@@ -61,33 +71,37 @@ let translate ~redact_text ~on_text_delta bridge_state
       }
   | ContentBlockDelta { delta = TextDelta text; _ } ->
       { bridge_state; chat_events = [ Text_delta (on_text_delta text) ] }
-  | ContentBlockDelta { delta = ThinkingDelta text; _ } ->
+  | ContentBlockDelta { index; delta = ThinkingDelta text } ->
       { bridge_state;
         chat_events =
-          [ Oas_thinking_delta { delta = redact_text text } ]
+          [ Oas_thinking_delta { index; delta = redact_text text } ]
       }
-  | ContentBlockDelta { delta = ThinkingSignatureDelta signature; _ } ->
+  | ContentBlockDelta { index; delta = ThinkingSignatureDelta signature } ->
       { bridge_state;
         chat_events =
           [ Oas_thinking_signature_delta
-              { signature_bytes = String.length signature } ]
+              { index; signature_bytes = String.length signature } ]
       }
-  | ContentBlockDelta { delta = MediaDelta { media_type; source_type; data }; _ } ->
+  | ContentBlockDelta
+      { index; delta = MediaDelta { media_type; source_type; data } } ->
       { bridge_state;
         chat_events =
           [ Oas_media_delta
-              { media_type;
-                source_type = media_source_kind_to_string source_type;
-                bytes = String.length data
-              } ]
+              { index; media_type; source_type; bytes = String.length data } ]
       }
-  | ContentBlockStart { index; tool_id = Some tid; tool_name = Some tname; _ }
+  | ContentBlockStart
+      { index; content_type; tool_id = Some tid; tool_name = Some tname }
     when String.trim tid <> "" && String.trim tname <> "" ->
       let tool = { tool_call_id = tid; tool_call_name = tname } in
       let existing_tool = stream_tool_for_index bridge_state index in
+      let block_start =
+        content_block_start_event ~index ~content_type ~tool_id:(Some tid)
+          ~tool_name:(Some tname)
+      in
       { bridge_state = replace_tool bridge_state index tool;
         chat_events =
-          (match existing_tool with
+          block_start
+          :: (match existing_tool with
            | Some existing when tool_start_is_replay existing tool -> []
            | Some existing ->
                [ Tool_call_end { tool_call_id = existing.tool_call_id };
@@ -95,7 +109,10 @@ let translate ~redact_text ~on_text_delta bridge_state
            | None ->
                [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ])
       }
-  | ContentBlockStart { index; tool_id; tool_name; _ } ->
+  | ContentBlockStart { index; content_type; tool_id; tool_name } ->
+      let block_start =
+        content_block_start_event ~index ~content_type ~tool_id ~tool_name
+      in
       let partial_tool_identity =
         match tool_id, tool_name with
         | None, None -> false
@@ -104,11 +121,12 @@ let translate ~redact_text ~on_text_delta bridge_state
       if partial_tool_identity then
         { bridge_state;
           chat_events =
-            [ protocol_error ~index
+            [ block_start;
+              protocol_error ~index
                 ~reason:"tool content block start missed tool id or name"
                 Tool_start_missing_identity ]
         }
-      else no_events
+      else { bridge_state; chat_events = [ block_start ] }
   | ContentBlockDelta { index; delta = InputJsonDelta args } -> (
       match stream_tool_for_index bridge_state index with
       | Some tool ->
@@ -125,18 +143,15 @@ let translate ~redact_text ~on_text_delta bridge_state
                   Tool_args_without_start ]
           })
   | ContentBlockStop { index } -> (
+      let block_stop = content_block_stop_event ~index in
       match stream_tool_for_index bridge_state index with
       | Some tool ->
           { bridge_state = remove_tool bridge_state index;
-            chat_events = [ Tool_call_end { tool_call_id = tool.tool_call_id } ]
+            chat_events =
+              [ block_stop; Tool_call_end { tool_call_id = tool.tool_call_id } ]
           }
       | None ->
-          { bridge_state;
-            chat_events =
-              [ protocol_error ~index
-                  ~reason:"tool block stop arrived before tool start"
-                  Tool_stop_without_start ]
-          })
+          { bridge_state; chat_events = [ block_stop ] })
   | SSEError { message; error_type; raw = _ } ->
       let reason =
         match error_type with

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -281,6 +281,8 @@ let adapter_loop ~token ~channel ~events ?base_url () =
     | Oas_stream_message_delta _
     | Oas_stream_message_stop
     | Oas_stream_ping
+    | Oas_content_block_start _
+    | Oas_content_block_stop _
     | Oas_thinking_delta _
     | Oas_thinking_signature_delta _
     | Oas_media_delta _ ->

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -32,7 +32,7 @@ val evict_blocks
   -> Agent_sdk.Types.content_block list
 (** Site 1. Evict every [Image] in the list when [policy = Mm_delegate]; return
     the list unchanged otherwise. Images are fail-closed before store on
-    source_type, base64 payload, size, and media type. [Eager] consults the
+    base64 payload, size, and media type. [Eager] consults the
     fiber-local Eio context for one bounded sub-call; with none present (tests)
     it falls back to an unread placeholder, so eviction still holds. *)
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1159,7 +1159,10 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                 (`Assoc
                   [
                     ("media_type", `String media_type);
-                    ("source_type", `String source_type);
+                    ( "source_type",
+                      `String
+                        (Agent_sdk.Types.media_source_kind_to_string source_type)
+                    );
                     ("bytes", `Int bytes);
                   ])
             then loop ()

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1143,21 +1143,45 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             if send_custom "KEEPER_STREAM_MESSAGE_STOP" `Null then loop ()
         | Oas_stream_ping ->
             if send_custom "KEEPER_STREAM_PING" `Null then loop ()
-        | Oas_thinking_delta { delta } ->
+        | Oas_content_block_start
+            { index; content_type; tool_call_id; tool_call_name } ->
+            if
+              send_custom "KEEPER_CONTENT_BLOCK_START"
+                (`Assoc
+                  ([
+                     ("index", `Int index);
+                     ("content_type", `String content_type);
+                   ]
+                  @ json_opt "tool_call_id"
+                      (Option.map (fun value -> `String value) tool_call_id)
+                  @ json_opt "tool_call_name"
+                      (Option.map (fun value -> `String value) tool_call_name)))
+            then loop ()
+        | Oas_content_block_stop { index } ->
+            if
+              send_custom "KEEPER_CONTENT_BLOCK_STOP"
+                (`Assoc [ ("index", `Int index) ])
+            then loop ()
+        | Oas_thinking_delta { index; delta } ->
             if
               send_custom "KEEPER_THINKING_DELTA"
-                (`Assoc [ ("delta", `String delta) ])
+                (`Assoc [ ("index", `Int index); ("delta", `String delta) ])
             then loop ()
-        | Oas_thinking_signature_delta { signature_bytes } ->
+        | Oas_thinking_signature_delta { index; signature_bytes } ->
             if
               send_custom "KEEPER_THINKING_SIGNATURE_DELTA"
-                (`Assoc [ ("signature_bytes", `Int signature_bytes) ])
+                (`Assoc
+                  [
+                    ("index", `Int index);
+                    ("signature_bytes", `Int signature_bytes);
+                  ])
             then loop ()
-        | Oas_media_delta { media_type; source_type; bytes } ->
+        | Oas_media_delta { index; media_type; source_type; bytes } ->
             if
               send_custom "KEEPER_MEDIA_DELTA"
                 (`Assoc
                   [
+                    ("index", `Int index);
                     ("media_type", `String media_type);
                     ( "source_type",
                       `String

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -296,8 +296,7 @@ let test_keeper_multimodal_input_converts_user_blocks_to_oas_blocks () =
       ] ->
       check string "media type" "image/png" media_type;
       check string "data" "abc123" data;
-      check string "source type" "base64"
-        (Agent_sdk.Types.media_source_kind_to_string source_type);
+      check bool "source type" true (source_type = Agent_sdk.Types.Base64);
       check string "text" "describe this" text
   | Ok _ -> fail "expected image then text OAS blocks"
   | Error err -> fail ("expected OAS block conversion: " ^ err)
@@ -330,8 +329,7 @@ let test_keeper_multimodal_input_accepts_mixed_case_data_url () =
   | Ok [ Agent_sdk.Types.Image { media_type; data; source_type } ] ->
       check string "media type" "image/png" media_type;
       check string "data" "abc123" data;
-      check string "source type" "base64"
-        (Agent_sdk.Types.media_source_kind_to_string source_type)
+      check bool "source type" true (source_type = Agent_sdk.Types.Base64)
   | Ok _ -> fail "expected image OAS block"
   | Error err -> fail ("expected mixed-case data URL conversion: " ^ err)
 
@@ -363,8 +361,7 @@ let test_keeper_multimodal_input_normalizes_inferred_data_url_mime () =
   | Ok [ Agent_sdk.Types.Image { media_type; data; source_type } ] ->
       check string "media type" "image/png" media_type;
       check string "data" "abc123" data;
-      check string "source type" "base64"
-        (Agent_sdk.Types.media_source_kind_to_string source_type)
+      check bool "source type" true (source_type = Agent_sdk.Types.Base64)
   | Ok _ -> fail "expected image OAS block"
   | Error err -> fail ("expected inferred data URL MIME conversion: " ^ err)
 
@@ -648,6 +645,34 @@ let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
       check int "delta total tokens" 12
         (Agent_sdk.Types.total_tokens delta_usage)
   | _ -> fail "expected OAS message lifecycle metadata events"
+
+let test_keeper_stream_bridge_preserves_typed_media_source () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockDelta
+          {
+            index = 0;
+            delta =
+              MediaDelta
+                {
+                  media_type = "image/png";
+                  source_type = Base64;
+                  data = "abcd";
+                };
+          };
+      ]
+  in
+  match events with
+  | [
+      Keeper_chat_events.Oas_media_delta
+        { media_type; source_type; bytes };
+    ] ->
+      check string "media type" "image/png" media_type;
+      check bool "source type" true (source_type = Base64);
+      check int "bytes" 4 bytes
+  | _ -> fail "expected typed OAS media delta"
 
 let test_keeper_stream_bridge_rejects_tool_args_without_start () =
   let open Agent_sdk.Types in
@@ -937,8 +962,7 @@ let test_runtime_run_blocks_appends_multimodal_input_to_oas_agent () =
               check string "text preserved" "Inspect this" text;
               check string "image media type" "image/png" media_type;
               check string "image data" "img" data;
-              check string "source type" "base64"
-                (Agent_sdk.Types.media_source_kind_to_string source_type)
+              check bool "source type" true (source_type = Agent_sdk.Types.Base64)
           | _ -> fail "stored user input lost multimodal block shape")
       | _ -> fail "missing appended OAS user message")
 
@@ -1499,6 +1523,8 @@ let () =
             test_keeper_stream_bridge_closes_tool_when_index_is_reused;
           test_case "stream bridge surfaces OAS message metadata" `Quick
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
+          test_case "stream bridge preserves typed media source" `Quick
+            test_keeper_stream_bridge_preserves_typed_media_source;
           test_case "stream bridge rejects tool args without start" `Quick
             test_keeper_stream_bridge_rejects_tool_args_without_start;
           test_case "stream protocol error summary includes diagnostics" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -502,20 +502,33 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
       ]
   in
   match events with
-  | [ Keeper_chat_events.Oas_thinking_delta { delta = first };
+  | [ Keeper_chat_events.Oas_thinking_delta { index = first_index; delta = first };
+      Keeper_chat_events.Oas_content_block_start
+        { index = tool_index;
+          content_type;
+          tool_call_id = Some block_tool_id;
+          tool_call_name = Some block_tool_name };
       Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id_a; delta = args_a };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id_b; delta = args_b };
+      Keeper_chat_events.Oas_content_block_stop { index = stop_index };
       Keeper_chat_events.Tool_call_end { tool_call_id = end_id };
-      Keeper_chat_events.Oas_thinking_delta { delta = last } ] ->
+      Keeper_chat_events.Oas_thinking_delta { index = last_index; delta = last } ] ->
+      check int "first thinking index" 0 first_index;
       check string "first thinking" "think A" first;
+      check int "tool block index" 1 tool_index;
+      check string "content type" "tool_use" content_type;
+      check string "block tool id" "tc-1" block_tool_id;
+      check string "block tool name" "keeper_board_list" block_tool_name;
       check string "tool id" "tc-1" tool_call_id;
       check string "tool name" "keeper_board_list" tool_call_name;
       check string "args id a" "tc-1" args_id_a;
       check string "args id b" "tc-1" args_id_b;
       check string "args a" "{\"limit\":" args_a;
       check string "args b" "1}" args_b;
+      check int "tool stop index" 1 stop_index;
       check string "end id" "tc-1" end_id;
+      check int "last thinking index" 2 last_index;
       check string "last thinking" "think B" last
   | _ ->
       failf "unexpected stream bridge events: %s"
@@ -523,6 +536,10 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
            (List.map
               (function
                 | Keeper_chat_events.Custom { name; _ } -> "custom:" ^ name
+                | Keeper_chat_events.Oas_content_block_start _ ->
+                    "oas_block_start"
+                | Keeper_chat_events.Oas_content_block_stop _ ->
+                    "oas_block_stop"
                 | Keeper_chat_events.Oas_thinking_delta _ -> "oas_thinking"
                 | Keeper_chat_events.Tool_call_start _ -> "tool_start"
                 | Keeper_chat_events.Tool_call_args _ -> "tool_args"
@@ -554,15 +571,27 @@ let test_keeper_stream_bridge_ignores_replayed_tool_start () =
   check bool "no protocol error for replayed start" false
     (has_stream_protocol_error events);
   match events with
-  | [ Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
+  | [ Keeper_chat_events.Oas_content_block_start
+        { index = first_index; tool_call_id = Some first_block_id; _ };
+      Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
+      Keeper_chat_events.Oas_content_block_start
+        { index = replay_index; tool_call_id = Some replay_block_id; _ };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id; delta };
+      Keeper_chat_events.Oas_content_block_stop { index = stop_index };
       Keeper_chat_events.Tool_call_end { tool_call_id = end_id } ] ->
+      check int "first block index" 2 first_index;
+      check string "first block tool id" "tc-repeat" first_block_id;
       check string "tool id" "tc-repeat" tool_call_id;
       check string "tool name" "keeper_memory_search" tool_call_name;
+      check int "replay block index" 2 replay_index;
+      check string "replay block tool id" "tc-repeat" replay_block_id;
       check string "args id" "tc-repeat" args_id;
       check string "args" "{\"q\":\"loop\"}" delta;
+      check int "stop index" 2 stop_index;
       check string "end id" "tc-repeat" end_id
-  | _ -> fail "expected one start, one args delta, and one end"
+  | _ ->
+      fail
+        "expected replayed block start, one tool start, one args delta, and one end"
 
 let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
   let open Agent_sdk.Types in
@@ -587,19 +616,29 @@ let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
   check bool "no protocol error for recoverable reused index" false
     (has_stream_protocol_error events);
   match events with
-  | [ Keeper_chat_events.Tool_call_start { tool_call_id = first_start; _ };
+  | [ Keeper_chat_events.Oas_content_block_start
+        { index = first_block_index; tool_call_id = Some first_block_id; _ };
+      Keeper_chat_events.Tool_call_start { tool_call_id = first_start; _ };
       Keeper_chat_events.Tool_call_args { tool_call_id = first_args; delta = args_a };
+      Keeper_chat_events.Oas_content_block_start
+        { index = second_block_index; tool_call_id = Some second_block_id; _ };
       Keeper_chat_events.Tool_call_end { tool_call_id = first_end };
       Keeper_chat_events.Tool_call_start { tool_call_id = second_start; _ };
       Keeper_chat_events.Tool_call_args { tool_call_id = second_args; delta = args_b };
+      Keeper_chat_events.Oas_content_block_stop { index = stop_index };
       Keeper_chat_events.Tool_call_end { tool_call_id = second_end } ] ->
+      check int "first block index" 2 first_block_index;
+      check string "first block id" "tc-first" first_block_id;
       check string "first start" "tc-first" first_start;
       check string "first args id" "tc-first" first_args;
       check string "first args" "{\"q\":\"first\"}" args_a;
+      check int "second block index" 2 second_block_index;
+      check string "second block id" "tc-second" second_block_id;
       check string "first implicit end" "tc-first" first_end;
       check string "second start" "tc-second" second_start;
       check string "second args id" "tc-second" second_args;
       check string "second args" "{\"q\":\"second\"}" args_b;
+      check int "stop index" 2 stop_index;
       check string "second end" "tc-second" second_end
   | _ -> fail "expected previous tool to close before reused-index tool starts"
 
@@ -667,12 +706,39 @@ let test_keeper_stream_bridge_preserves_typed_media_source () =
   match events with
   | [
       Keeper_chat_events.Oas_media_delta
-        { media_type; source_type; bytes };
+        { index; media_type; source_type; bytes };
     ] ->
+      check int "block index" 0 index;
       check string "media type" "image/png" media_type;
       check bool "source type" true (source_type = Base64);
       check int "bytes" 4 bytes
   | _ -> fail "expected typed OAS media delta"
+
+let test_keeper_stream_bridge_preserves_non_tool_block_lifecycle () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 4;
+            content_type = "text";
+            tool_id = None;
+            tool_name = None };
+        ContentBlockStop { index = 4 };
+      ]
+  in
+  check bool "no protocol error for non-tool block stop" false
+    (has_stream_protocol_error events);
+  match events with
+  | [ Keeper_chat_events.Oas_content_block_start
+        { index = start_index; content_type; tool_call_id; tool_call_name };
+      Keeper_chat_events.Oas_content_block_stop { index = stop_index } ] ->
+      check int "start index" 4 start_index;
+      check string "content type" "text" content_type;
+      check (option string) "tool id" None tool_call_id;
+      check (option string) "tool name" None tool_call_name;
+      check int "stop index" 4 stop_index
+  | _ -> fail "expected non-tool OAS block start and stop events"
 
 let test_keeper_stream_bridge_rejects_tool_args_without_start () =
   let open Agent_sdk.Types in
@@ -1525,6 +1591,8 @@ let () =
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge preserves typed media source" `Quick
             test_keeper_stream_bridge_preserves_typed_media_source;
+          test_case "stream bridge preserves non-tool block lifecycle" `Quick
+            test_keeper_stream_bridge_preserves_non_tool_block_lifecycle;
           test_case "stream bridge rejects tool args without start" `Quick
             test_keeper_stream_bridge_rejects_tool_args_without_start;
           test_case "stream protocol error summary includes diagnostics" `Quick


### PR DESCRIPTION
## What changed

- Keep MASC on the current `main` OAS pin:
  - `agent_sdk` `0.207.25`
  - OAS `main@b6b2ae6c887afbdce7dd069fc03f6ac1bba721e0`
- Carry OAS media source encoding as `Agent_sdk.Types.media_source_kind` inside keeper chat events instead of a raw string.
- Preserve OAS stream content block lifecycle in MASC keeper chat events:
  - `ContentBlockStart` -> `Oas_content_block_start`
  - `ContentBlockStop` -> `Oas_content_block_stop`
  - thinking/signature/media deltas now keep the OAS content block `index`
- Project the block lifecycle/index through the keeper SSE route into dashboard stream handling.
- Keep dashboard thinking/tool trace steps linked to `oasBlockIndex` so interleaved thinking/tool blocks are not collapsed into arrival-order-only UI state.
- Convert typed OAS values to wire strings only at the external SSE/JSON boundary.

## Why

MASC should consume OAS public SDK types and stream structure directly instead of maintaining stringly shadow state.

This keeps the boundary clean:

- MASC consumes OAS public types.
- OAS remains unaware of MASC.
- JSON/string projection happens only at MASC's external wire boundary.
- Tool/thinking/media interleaving remains observable by OAS content block index instead of dashboard-only arrival order.

## Validation

- `bash scripts/check-oas-pin.sh --local-only` -> pass for `main@b6b2ae6c887afbdce7dd069fc03f6ac1bba721e0`.
- `git diff --check` -> pass.
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe` -> pass.
- `./_build/default/test/test_gate_keeper_backend.exe` -> pass, 75 tests.
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-stream.test.ts src/keeper-state.test.ts` -> pass, 76 tests.
- `pnpm typecheck` in `dashboard/` -> pass.

Local build note: the first Dune attempt refused to run because another bare `dune build .` process was active on the machine. I reran via the repo wrapper with `MASC_DUNE_ALLOW_BARE_DUNE=1`; the wrapper still verified the `agent_sdk` pin before building.
