### PR TITLE
docs(dashboard): radius cascade 진단을 토큰 drift baseline에 기록 (chunk F)

### DIFF
--- a/dashboard/design-system/tokens/override-drift-baseline.json
+++ b/dashboard/design-system/tokens/override-drift-baseline.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Reviewed baseline of generated↔variables.css token divergences. The app imports src/styles/tokens.generated.css (@theme, @generated) then src/styles/variables.css (:root), which re-defines these tokens to different RENDERED values. tokens:check (Gate 2) ratchets this set: any NEW divergence, or a value change on a listed entry, or a listed entry that no longer diverges, fails the gate. Entries marked UNREVIEWED are pre-existing drift pending a reconcile decision (chunk F). Scope: variables.css only (the last-winning override layer); styleseed-tokens.css is an earlier layer not yet covered.",
+  "_doc": "Reviewed baseline of generated↔variables.css token divergences. The app imports src/styles/tokens.generated.css (@theme, @generated) then src/styles/variables.css (:root), which re-defines these tokens to different RENDERED values. tokens:check (Gate 2) ratchets this set: any NEW divergence, or a value change on a listed entry, or a listed entry that no longer diverges, fails the gate. Entries marked UNREVIEWED are pre-existing drift pending a reconcile decision (chunk F). Scope: this baseline compares generated vs variables.css :root ONLY. CAVEAT (discovered chunk F): variables.css is NOT always the last-winning layer — scoped blocks ([data-theme=dark-fantasy], html[data-skin=v2] in skin-v2.css, .gd-board, .wk-surface, keeper-v2) carry higher specificity than :root and override it for some tokens (radius is the documented case: skin-v2 wins). So a listed 'override' value is the variables.css :root decl, not necessarily the rendered value. styleseed-tokens.css is an earlier layer not yet covered.",
   "scope": {
     "generated": "src/styles/tokens.generated.css",
     "override": "src/styles/variables.css"
@@ -8,12 +8,12 @@
     "--color-accent-glow": {
       "generated": "var(--brass-glow)",
       "override": "var(--accent-glow)",
-      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+      "reason": "DEFERRED (chunk F, pending design pass): real color/value diff between generated and the variables.css :root re-point; value kept gated. Reconcile direction is a design decision (which value is canonical), not a mechanical token edit, so it is intentionally left to a dedicated color/contrast review."
     },
     "--color-info": {
       "generated": "#6a8eb0",
       "override": "var(--text-info)",
-      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+      "reason": "DEFERRED (chunk F, pending design pass): real color/value diff between generated and the variables.css :root re-point; value kept gated. Reconcile direction is a design decision (which value is canonical), not a mechanical token edit, so it is intentionally left to a dedicated color/contrast review."
     },
     "--font-body": {
       "generated": "'EB Garamond', 'Noto Sans KR', Georgia, serif",
@@ -28,42 +28,42 @@
     "--radius-lg": {
       "generated": "12px",
       "override": "6px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--radius-md": {
       "generated": "6px",
       "override": "4px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--radius-pill": {
       "generated": "999px",
       "override": "9999px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--radius-sm": {
       "generated": "4px",
       "override": "3px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--radius-xl": {
       "generated": "24px",
       "override": "8px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--radius-xs": {
       "generated": "2px",
       "override": "var(--r-0)",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (chunk F): this generated-vs-variables :root drift is SHADOWED in the default app, so it has no in-app render effect. The active skin layer html[data-skin=v2] (skin-v2.css, specificity 0,3,1 > :root 0,1,0) wins for xs/sm/md/lg, rendering 3/4/6/10px (neither generated nor variables.css). xl/pill fall to variables.css :root (8px/9999px) since skin-v2 omits them; generated :root never renders. Changing generated (source.ts) would not change in-app rendering and would only diverge the preview surfaces (which load generated alone). True reconcile = consolidating radius across 6+ scopes (generated/:root + variables :root + [data-theme=dark-fantasy] + html[data-skin=v2] + .gd-board/.wk-surface + keeper-v2) — a design-system task, not a token value edit. Value kept gated."
     },
     "--scrim-strong": {
       "generated": "var(--color-scrim-strong)",
       "override": "rgba(0, 0, 0, 0.6)",
-      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+      "reason": "DEFERRED (chunk F, pending design pass): real color/value diff between generated and the variables.css :root re-point; value kept gated. Reconcile direction is a design decision (which value is canonical), not a mechanical token edit, so it is intentionally left to a dedicated color/contrast review."
     },
     "--shadow-card": {
       "generated": "0 1px 4px rgba(0, 0, 0, 0.5)",
       "override": "0 1px 3px rgba(0, 0, 0, 0.04)",
-      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
+      "reason": "DEFERRED (chunk F, pending design pass): real visual diff, value kept gated. CASCADE NOTE: --shadow-card is declared TWICE in variables.css (L592 = 0 1px 3px rgba(0,0,0,0.04); L662 = 0 2px 8px rgba(0,0,0,0.35)) plus scoped theme/skin layers; the collector captured the L592 decl but the actually-rendered value depends on selector/source order and needs getComputedStyle confirmation before any reconcile."
     },
     "--spacing-card": {
       "generated": "16px",


### PR DESCRIPTION
## 배경

청크 F의 radius drift 6건 reconcile을 조사하던 중, 선택된 방향("override 스케일을 source.ts로 흡수, app-invisible + preview 정합")의 **전제가 거짓**임을 발견했습니다.

## 발견 (cascade 진단)

기본 앱은 `<html data-skin="v2">`로 렌더되고, `skin-v2.css`의 `html[data-skin=v2]:not(...)` (specificity 0,3,1)가 `:root`(0,1,0)를 이깁니다.

| 토큰 | generated `:root` | variables `:root` | **실제 렌더 (default app)** |
|---|---|---|---|
| radius-xs | 2px | var(--r-0)=2px | **skin-v2 3px** |
| radius-sm | 4px | 3px | **skin-v2 4px** |
| radius-md | 6px | 4px | **skin-v2 6px** |
| radius-lg | 12px | 6px | **skin-v2 10px** |
| radius-xl | 24px | 8px | **variables 8px** (skin-v2 미정의) |
| radius-pill | 999px | 9999px | **variables 9999px** (skin-v2 미정의) |

즉 baseline이 "rendered"라 기록한 variables.css 값은 xs/sm/md/lg에서 **틀렸고**, generated `:root`는 어느 토큰에서도 렌더되지 않습니다. source.ts radius를 바꿔도 **앱 렌더 0 영향** + preview만 어긋납니다.

## 변경 (값 불변, 문서만)

- radius 6건 reason → `DIAGNOSED`: skin-v2가 :root drift를 shadow, 실제 렌더 스케일 명시, 진짜 reconcile은 6+ 스코프 consolidation(별도 design-system 작업)임을 기록.
- color/shadow 4건 reason → `DEFERRED`: design pass 대기. 특히 `--shadow-card`는 variables.css에 **2회 정의**(L592 0.04 / L662 0.35)되어 실제 렌더값은 getComputedStyle 확인 필요함을 명시.
- `_doc`의 "variables.css = last-winning override layer" 오기 정정: scoped 블록이 :root보다 specificity 우위.

## 검증

- JSON 유효, 22 엔트리 불변.
- `pnpm tokens:check` PASS — 토큰 **값 변경 0**이라 게이트는 동일 집합을 그대로 ratchet.

## 트레이드오프

- drift를 *제거*하지 않고 *진단 기록*만 합니다. radius 통합은 637 소비처 + 6+ 스코프라 RFC급 별도 작업이며, 이 PR은 그 헛수고를 반복하지 않도록 근거를 남기는 것이 목적입니다.

# ci:skip-test-coverage
근거: doc-only baseline 주석. 신규 로직 0, 유닛테스트 대상 없음. drift 값은 tokens:check가 계속 게이트(통과).

RFC-WAIVED: dashboard 디자인 토큰 drift baseline 문서 갱신(값 불변). credential/keeper-backend/operator/hooks/workflow 무관.
