### PR TITLE
fix(keeper): gate passive-only healthy carve-out on world-observation signal (#22710)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -380,7 +380,6 @@ let run_turn
             ("context_digest", `String context_digest);
           ]))
     Keeper_runtime_manifest.Context_injected;
-  let _world_observation_is_advisory = world_observation in
   (* 7. Set up agent — delegated to Keeper_run_tools *)
   let setup =
     Keeper_run_tools.prepare_agent_setup
@@ -626,6 +625,18 @@ let run_turn
                  in
                  let contract_status = completion_contract_status () in
                  acc.receipt_completion_contract_result <- contract_status;
+                 (* Root B (#22710): capture the world-observation actionable
+                    signal alongside the contract status so the receipt carries
+                    the real "is there anything to do" signal. [operator_disposition]
+                    uses it to replace the [goal_ids = []] proxy. [None] when no
+                    observation was threaded (disposition stays broadcast-required;
+                    conservative). *)
+                 acc.receipt_actionable_signal <-
+                   Option.map
+                     (fun obs ->
+                       Keeper_contract_classifier.classify_actionable_signal
+                         (Keeper_contract_classifier.of_keeper_world_observation obs))
+                     world_observation;
                      (match
                         normalize_response_text_for_finalization
                           ~runtime_id:runtime_id_string

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -154,6 +154,7 @@ let finalize
     ; response_text_present = !receipt_response_text_present_ref
     ; model_used = !receipt_model_used_ref
     ; completion_contract_result
+    ; actionable_signal = acc.receipt_actionable_signal
     ; tool_surface =
         { turn_lane = acc.tool_surface.turn_lane }
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -170,9 +170,21 @@ let completion_contract_unsatisfied = function
 ;;
 
 let passive_only_without_work_scope receipt =
+  (* Root B (#22710): a passive-only turn is healthy iff the keeper held no
+     claimed task AND the world genuinely offered nothing actionable. The old
+     [goal_ids = []] proxy conflated "has no goals" with "has nothing to do":
+     a coordination keeper always carries goals, so it could never pass this
+     carve-out and re-emitted [operator_broadcast_required] every idle turn.
+     [actionable_signal] is the real per-turn signal (no unclaimed tasks, no
+     board activity). [None] (no world observation threaded) is treated as not
+     healthy-passive, preserving the prior broadcast-required behavior. *)
   receipt.completion_contract_result = Contract_passive_only
   && Option.is_none receipt.current_task_id
-  && receipt.goal_ids = []
+  && (match receipt.actionable_signal with
+      | Some Keeper_contract_classifier.No_actionable_signal -> true
+      | Some Keeper_contract_classifier.Has_unclaimed_tasks
+      | Some Keeper_contract_classifier.Has_board_activity
+      | None -> false)
 ;;
 
 let terminal_reason_is_success receipt =
@@ -474,6 +486,10 @@ let to_json (receipt : t) =
     ; "model_used", `Null
     ; ( "completion_contract_result"
       , `String (completion_contract_result_to_string receipt.completion_contract_result) )
+    ; ( "actionable_signal"
+      , match receipt.actionable_signal with
+        | Some signal -> `String (Keeper_contract_classifier.actionable_signal_label signal)
+        | None -> `Null )
     ; ( "tool_surface"
       , `Assoc
           [ ( "turn_lane"
@@ -787,6 +803,10 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "runtime_outcome", `String (runtime_outcome_to_string receipt.runtime_outcome)
     ; ( "completion_contract_result"
       , `String (completion_contract_result_to_string receipt.completion_contract_result) )
+    ; ( "actionable_signal"
+      , match receipt.actionable_signal with
+        | Some signal -> `String (Keeper_contract_classifier.actionable_signal_label signal)
+        | None -> `Null )
     ; ( "contract_violation_detail"
       , match decode_contract_violation_reason terminal_reason_code with
         | None -> `Null

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -178,6 +178,12 @@ type t =
   ; response_text_present : bool
   ; model_used : string option
   ; completion_contract_result : completion_contract_result
+  ; actionable_signal : Keeper_contract_classifier.actionable_signal option
+    (** Root B (#22710): world-observation actionable signal captured at turn
+        time, consumed by [operator_disposition] to replace the [goal_ids = []]
+        proxy in [passive_only_without_work_scope]. [None] when no world
+        observation was threaded (disposition falls back to broadcast-required;
+        conservative, never silently suppressed). *)
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -277,6 +277,15 @@ type t =
   ; response_text_present : bool
   ; model_used : string option
   ; completion_contract_result : completion_contract_result
+  ; actionable_signal : Keeper_contract_classifier.actionable_signal option
+    (* Root B (#22710): the world-observation actionable signal captured at
+       turn time, consumed by [operator_disposition] to decide whether a
+       passive-only turn is healthy. Replaces the [goal_ids = []] structural
+       proxy in [passive_only_without_work_scope]: a coordination keeper always
+       carries goals yet may legitimately have nothing actionable in a given
+       turn. [None] when no world observation was threaded, in which case the
+       disposition falls back to the prior broadcast-required behavior
+       (conservative; a needed broadcast is never silently suppressed). *)
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -79,6 +79,12 @@ type t = {
   response_text_present : bool;
   model_used : string option;
   completion_contract_result : completion_contract_result;
+  actionable_signal : Keeper_contract_classifier.actionable_signal option;
+    (** Root B (#22710): world-observation actionable signal captured at turn
+        time, consumed by [operator_disposition]. Replaces the [goal_ids = []]
+        proxy in [passive_only_without_work_scope]. [None] when no world
+        observation was threaded (disposition falls back to broadcast-required;
+        conservative, never silently suppressed). *)
   tool_surface : tool_surface;
   sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile;
   sandbox_root : string option;

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -28,6 +28,8 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
@@ -42,6 +44,8 @@ type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
   ; out_requested_tool_names : string list
   ; out_receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; out_receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   }
 
 let freeze = Keeper_run_tools_hook_accumulator.freeze

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -26,6 +26,8 @@ type hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
@@ -41,6 +43,8 @@ type hook_outputs =
   ; out_requested_tool_names : string list
   ; out_receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; out_receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -26,6 +26,12 @@ type hook_accumulator =
        before_turn_params hook, read at the receipt/TurnRecord write site
        in run_turn. Last-write-wins matches the turn-context cell
        semantics the receipt already uses. *)
+  ; mutable receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
+    (* Root B (#22710): world-observation actionable signal computed from the
+       turn's [world_observation] in run_turn, carried into the receipt so
+       [operator_disposition] can replace the [goal_ids = []] proxy. [None]
+       until the contract-status write site sets it. *)
   ; mutable prompt_blocks : Turn_record.prompt_block list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
@@ -40,6 +46,8 @@ type hook_outputs =
   ; out_requested_tool_names : string list
   ; out_receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; out_receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   }
 
 let freeze (acc : hook_accumulator) : hook_outputs =
@@ -50,6 +58,7 @@ let freeze (acc : hook_accumulator) : hook_outputs =
   ; out_tool_surface = acc.tool_surface
   ; out_requested_tool_names = acc.requested_tool_names
   ; out_receipt_completion_contract_result = acc.receipt_completion_contract_result
+  ; out_receipt_actionable_signal = acc.receipt_actionable_signal
   }
 ;;
 

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -10,6 +10,8 @@ type hook_accumulator =
   ; mutable requested_tool_names : string list
   ; mutable receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; mutable receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   ; mutable prompt_blocks : Turn_record.prompt_block list
   ; mutable extra_system_context_digest : string option
   ; mutable extra_system_context_size : int option
@@ -24,6 +26,8 @@ type hook_outputs =
   ; out_requested_tool_names : string list
   ; out_receipt_completion_contract_result :
       Keeper_execution_receipt.completion_contract_result
+  ; out_receipt_actionable_signal :
+      Keeper_contract_classifier.actionable_signal option
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -80,6 +80,7 @@ let prepare_agent_setup
     ; requested_tool_names = []
     ; receipt_completion_contract_result =
         Keeper_execution_receipt.Contract_unknown
+    ; receipt_actionable_signal = None
     ; prompt_blocks = []
     ; extra_system_context_digest = None
     ; extra_system_context_size = None

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -237,6 +237,10 @@ let record_pre_dispatch_terminal_observation
     ; response_text_present = false
     ; model_used = None
     ; completion_contract_result = Keeper_execution_receipt.Contract_not_dispatched
+    ; actionable_signal = None
+      (* Pre-dispatch receipt: the turn never ran, so no world observation was
+         captured. [Contract_not_dispatched] never reaches the
+         [passive_only_without_work_scope] carve-out, so [None] is inert here. *)
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -17,6 +17,7 @@
       is caught here. *)
 
 module R = Masc.Keeper_execution_receipt
+module C = Masc.Keeper_contract_classifier
 module Tr = Keeper_terminal_reason
 
 let failures = ref []
@@ -319,6 +320,10 @@ let base_receipt : R.t =
   ; response_text_present = false
   ; model_used = None
   ; completion_contract_result = R.Contract_unknown
+  ; actionable_signal = Some C.No_actionable_signal
+    (* Root B (#22710): the base receipt represents an idle keeper with nothing
+       actionable, the same "no-work" baseline the prior [goal_ids = []] default
+       expressed. The passive-only carve-out now reads this signal. *)
   ; tool_surface = base_tool_surface
   ; sandbox_kind = Keeper_types_profile_sandbox.Local
   ; sandbox_root = None
@@ -399,7 +404,7 @@ let intentional_passive_only_no_work_policy_change (receipt : R.t) got =
   if
     receipt.completion_contract_result = R.Contract_passive_only
     && Option.is_none receipt.current_task_id
-    && receipt.goal_ids = []
+    && receipt.actionable_signal = Some C.No_actionable_signal
   then (
     let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
     match terminal_reason, receipt.outcome, got with
@@ -607,6 +612,58 @@ let () =
   check
     (Printf.sprintf
        "completed active passive-only receipt want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want)
+;;
+
+(* Root B (#22710) regression: a coordination keeper always carries goals
+   (goal_ids <> []), yet may have nothing actionable in a given turn. The
+   passive-only carve-out must key on the world-observation [actionable_signal],
+   not on goal presence; otherwise such a keeper fails the healthy carve-out and
+   re-emits [operator_broadcast_required] every idle turn (albini, 85/day). *)
+let () =
+  let coordination_passive ?(actionable_signal = Some C.No_actionable_signal) () =
+    { base_receipt with
+      terminal_reason_code = "completed"
+    ; outcome = `Ok
+    ; runtime_outcome = R.Runtime_completed
+    ; completion_contract_result = R.Contract_passive_only
+    ; goal_ids = [ "GOAL-1" ]
+    ; actionable_signal
+    }
+  in
+  let got = R.operator_disposition (coordination_passive ()) in
+  let want = R.Disp_pass, R.Reason_healthy in
+  check
+    (Printf.sprintf
+       "coordination keeper with goals + no actionable signal is healthy want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  check
+    "healthy idle coordination turn does not need an operator broadcast"
+    (not (R.needs_operator_broadcast (fst got)));
+  let got =
+    R.operator_disposition
+      (coordination_passive ~actionable_signal:(Some C.Has_unclaimed_tasks) ())
+  in
+  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  check
+    (Printf.sprintf
+       "coordination keeper with unclaimed tasks still pages an operator want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  check
+    "unclaimed-task passive turn needs an operator broadcast"
+    (R.needs_operator_broadcast (fst got));
+  let got = R.operator_disposition (coordination_passive ~actionable_signal:None ()) in
+  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  check
+    (Printf.sprintf
+       "coordination keeper with no observation falls back to broadcast-required \
+        want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want)


### PR DESCRIPTION
## 문제 (#22710)

completion-contract disposition의 healthy carve-out(`passive_only_without_work_scope`)이 "할 일 없음"을 `goal_ids = []`라는 구조적 proxy로 판정한다. 그러나 coordination keeper는 *항상* 목표를 보유하므로 이 carve-out을 영구히 통과하지 못한다. 결과적으로 idle passive turn마다:

```
Contract_passive_only
  → passive_only_without_work_scope = false  (goal_ids ≠ [])
  → completion_contract_unsatisfied = true
  → Disp_pause_human, Reason_completion_contract_unsatisfied
  → needs_operator_broadcast = true
  → operator_broadcast_required emit  (이 reason은 dedup 대상이 아님)
```

라이브 측정: albini ~85건/일, fleet ~565건/일. 같은 idle 상태가 매 사이클 운영자에게 페이징된다.

## 근본 수정

`goal_ids = []` proxy를 turn-time `actionable_signal`(`No_actionable_signal` / `Has_unclaimed_tasks` / `Has_board_activity`)로 교체한다. 이 신호는 turn의 `world_observation`에서 파생되며, "claim한 task가 없고 + 세계에 actionable한 것이 없음"일 때만 passive turn을 healthy로 본다.

- proxy(목표 보유 여부)가 아니라 실제 의미 신호(할 일 존재 여부)를 본다 — Parse, don't validate.
- `world_observation`이 threading되지 않은 경로는 `None` → 기존 broadcast-required 동작 유지(보수적, 필요한 broadcast를 조용히 누락하지 않음).
- 신호를 receipt에 영속시켜 live append와 dashboard/replay가 동일 disposition을 계산(SSOT). disposition은 receipt만으로 재현 가능.

## 변경 파일

- `keeper_execution_receipt_types.{ml,mli}` — receipt에 `actionable_signal` 필드 추가 (additive, write-only JSON. receipt에 deserializer가 없어 마이그레이션 불요).
- `keeper_run_tools_hook_accumulator.ml` / `keeper_run_tools.ml` — hook accumulator + outputs(두 type-equality 재export) + freeze, `keeper_run_tools_setup.ml` init.
- `keeper_agent_run.ml` — `world_observation`에서 신호 파생해 contract status와 함께 set. 소비되므로 advisory binding 제거.
- `keeper_turn_helpers.ml` — pre-dispatch receipt는 `None`(관측 미수집, carve-out에 도달 안 함).
- `keeper_execution_receipt.ml` — carve-out이 exhaustive match로 신호를 읽음(catch-all 없음). `to_json` + `operator_broadcast_payload`에 직렬화.
- `test_keeper_terminal_reason_typed.ml` — coordination keeper(목표 보유)의 3가지 신호값 ground-truth + 기존 passive 단언/drift-guard proxy를 신호 기준으로 갱신.

## 검증

빌드/테스트는 CI에서 확인한다. 핵심 회귀는 `test_keeper_terminal_reason_typed`:
- 목표 보유 + `No_actionable_signal` → `Disp_pass, Reason_healthy` (`needs_operator_broadcast = false`) — 수정의 핵심.
- 목표 보유 + `Has_unclaimed_tasks` → `Disp_pause_human` (할 일이 있을 때는 여전히 페이징).
- 목표 보유 + `None` → `Disp_pause_human` (보수적 fallback).

## P0 / 워크어라운드 self-check

- P0(제약 지옥 아님): carve-out을 *완화*한다(거짓 broadcast 감소). 제약 추가 없음.
- P0(한 keeper 정지가 전체 정지 아님): per-receipt/per-keeper. 공유 게이트 없음.
- 워크어라운드 시그니처 7항목 해당 없음: telemetry-as-fix 아님(분류 자체를 수정), string classifier 아님(proxy 제거 + typed exhaustive match), N-of-M 아님(carve-out 1곳 + 전 리터럴 3곳 원자적 갱신), catch-all 추가 아님, dedup 확장 아님(분류 root를 수정).

Refs #22710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
