### PR TITLE
test(keeper): update peer-surface axis-drift guard for keeper_broadcast (#22708)

### DIFF
--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -318,6 +318,12 @@ let test_classify_delivery_mapping () =
   let expected_peer_tools =
     [ "keeper_board_comment"
     ; "keeper_board_post"
+    (* #22708/#22042: broadcast registers asymmetrically, so the axis lists both
+       canonical forms — the descriptor internal name [keeper_broadcast] and the
+       non-descriptor public name [masc_broadcast]. Both are peer-surface tools;
+       a broadcast-only turn (either form) accrues the RFC-0239 anti-thrash
+       streak rather than resetting it. *)
+    ; "keeper_broadcast"
     ; "masc_broadcast"
     ; "masc_keeper_msg"
     ]


### PR DESCRIPTION
## 무엇

masc main의 `[FAIL] RFC-0276 delivery decouple / classify_delivery maps observed facts` (`test_no_progress_loop_detector.ml:325`) 회귀를 수정합니다.

## 근본 원인 (#22708 머지 후 발생)

`test_classify_delivery_mapping`은 `board_activity_tool_names`의 정확한 내용을 `expected_peer_tools` 리터럴로 pin하는 **axis-drift guard**입니다(주석: "If axis adds a Board_activity tool, this assertion fails and forces a conscious decision about its no-progress impact").

#22708(#22042)이 broadcast 비대칭 등록 fix로 `board_activity_tool_names`에 descriptor internal form `Keeper_tool_name.(to_string Broadcast)` (= `keeper_broadcast`)을 **5번째 엔트리로 추가**했습니다. 그러나 이 드리프트 가드 테스트의 `expected_peer_tools`(4 엔트리)는 갱신되지 않아 `slist` 동등 비교가 실패합니다. (드리프트 가드가 설계대로 작동해 누락을 잡은 것.)

main 로그(run 28380916900, head c1661c015c3):
```
test/test_no_progress_loop_detector.ml:325 character 2
Called from ...test_classify_delivery_mapping
```

## 변경

`expected_peer_tools`에 `"keeper_broadcast"` 추가 — #22708의 의도(broadcast의 internal/public 두 형태 모두 peer-surface 도구, broadcast-only 턴이 RFC-0239 anti-thrash streak을 reset이 아닌 accrue)를 드리프트 가드에 명시적으로 반영. 아래 `List.iter`가 자동으로 `keeper_broadcast → peer_only`도 검증합니다. (+6/-0, 1 file)

## 적대적 판단

- 불필요 테스트 아님 — 이 드리프트 가드는 axis↔no-progress policy 결합을 silent→guarded로 만드는 실제 invariant. 제거가 아니라 **pin을 의도된 현실에 맞춤**.
- 워크어라운드 아님 — #22708이 만든 의도적 axis 성장을 승인하는 conscious decision(가드가 요구한 바로 그것).

## 반경 (별개 이슈)

같은 quick-suite 스텝이 `exit code 124`(타임아웃, ~22분)도 동반합니다. 이건 classify_delivery와 별개의 CI 성능/타임아웃 문제(DUNE_JOBS=1 추정)로, 이 PR로 해소되지 않습니다 — `.github` 인프라 영역. 이 PR은 assertion 회귀만 닫습니다.

빌드/테스트는 CI 확인. 머지는 운영자 판단.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
