### PR TITLE
Fix runtime thinking preserve test catalog

### DIFF
--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -44,6 +44,22 @@ let write_file path content =
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 ;;
 
+let with_model_catalog_content content f =
+  let path = Filename.temp_file "runtime-thinking-oas-models" ".toml" in
+  Fun.protect
+    ~finally:(fun () ->
+      Llm_provider.Model_catalog.clear_global ();
+      try Sys.remove path with
+      | _ -> ())
+    (fun () ->
+      write_file path content;
+      match Llm_provider.Model_catalog.load_file path with
+      | Error msg -> Alcotest.failf "test OAS model catalog should load: %s" msg
+      | Ok catalog ->
+        Llm_provider.Model_catalog.set_global catalog;
+        f ())
+;;
+
 let string_contains haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -551,14 +567,36 @@ max-concurrent = 1
 |}
 ;;
 
+let runtime_thinking_model_catalog =
+  {|
+[[models]]
+id_prefix = "qwen36-35b-a3b-mtp"
+base = "openai_chat"
+max_context_tokens = 131072
+supports_tools = true
+supports_tool_choice = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "chat_template_kwargs"
+preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+supports_native_streaming = true
+|}
+;;
+
 let with_runtime_thinking f =
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
   with_temp_dir "runtime-thinking-gate" @@ fun dir ->
-  let path = Filename.concat dir "runtime.toml" in
-  write_file path runtime_config_thinking;
-  (match Runtime.init_default ~config_path:path with
-   | Ok () -> ()
-   | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
-  f ()
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+      with_model_catalog_content runtime_thinking_model_catalog @@ fun () ->
+      let path = Filename.concat dir "runtime.toml" in
+      write_file path runtime_config_thinking;
+      (match Runtime.init_default ~config_path:path with
+       | Ok () -> ()
+       | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
+      f ())
 ;;
 
 let test_thinking_support_true_enables_thinking_and_preserves () =


### PR DESCRIPTION
## Summary

- Make the per-model thinking gate test install the OAS capability row it asserts against.
- Restore the runtime singleton after the thinking-gate fixture so the test does not leak process-global runtime state.

## Product impact

- User-visible change: none.
- CI impact: the `test_runtime_per_keeper_routing` fixture no longer depends on ambient/repo-discovered OAS model catalog state when asserting request-side thinking preservation defaults.

## Evidence

- PASS: `ocamlformat --check test/test_runtime_per_keeper_routing.ml`
- PASS: `git diff --check`
- BLOCKED: `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh exec ./test/test_runtime_per_keeper_routing.exe -- --compact`
  - The focused test did not run. Local compile stopped first because the shared opam switch is pinned to a newer OAS `agent_sdk` than this branch SSOT, producing unrelated `media_source_kind` type errors in `lib/keeper/keeper_chat_oas_stream_bridge.ml`, `lib/keeper/keeper_vision_tool.ml`, and `lib/keeper/keeper_vision_ingest.ml`.
  - `scripts/check-oas-pin.sh --local-only` also reports the local pin source `3d886a1f4debe2cc1ddd04cd18cbbdb5dcfc1302` vs branch expected `c74132468414bf0663b32722be74c9c4acd7f8c1`; `scripts/opam-pin-external-deps.sh --install` refused to downgrade below recorded floor `0.207.25`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/3
provenance: direct
stages:
  - command: "ocamlformat --check test/test_runtime_per_keeper_routing.ml"
    result: pass
  - command: "git diff --check"
    result: pass
  - command: "scripts/dune-local.sh exec ./test/test_runtime_per_keeper_routing.exe -- --compact"
    result: blocked
    blocker: "shared local OAS agent_sdk pin is newer than branch SSOT and breaks unrelated media_source_kind compile sites before this test runs"
```

## GOAL LOOP ACT checklist

- [x] Observe - #22702 identifies the deterministic main quick-suite failure: expected `Some true`, got `None`.
- [x] Orient - root cause is test hermeticity: `Runtime.init_default` intentionally does not load or gate the OAS catalog, but the test asserted a catalog-derived default.
- [x] Decide - smallest bounded fix is to install a minimal test catalog row instead of depending on repo catalog discovery or changing runtime behavior.
- [x] Act - changed only `test/test_runtime_per_keeper_routing.ml`; rollback is reverting this commit.
- [ ] Verify - local Dune verification is blocked by shared OAS pin drift; PR CI should verify with the branch-pinned dependency set.
- [x] Loop - linked to #22702; no new follow-up from this test-fixture fix.

## Review evidence

- Cross-model review not run; this is a narrow test-fixture hermeticity fix. CI is the intended review/evidence surface for the branch-pinned dependency set.

## Linked issue

- Closes #22702

## Variant addition checklist

- [ ] **OCaml** - N/A, no variant added/removed.
- [ ] **TypeScript** - N/A, no TypeScript union change.
- [ ] **TLA+ spec** - N/A, no TLA+ domain change.
- [ ] **Event / JSON schema** - N/A, no event/schema enum change.
- [ ] **`make check-variants` passes** - N/A for this test-fixture-only change.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/22702-thinking-default-preserve-20260629` → `main` · 1 commit(s) · synced 2026-06-29T16:38:42Z

| sha | subject | date |
|---|---|---|
| `b330b51fb` | fix runtime thinking preserve test catalog | 2026-06-29 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->