### PR TITLE
test(runtime): seed OAS catalog in per-keeper thinking-gate cases

### DIFF
--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -551,7 +551,48 @@ max-concurrent = 1
 |}
 ;;
 
+(* Resolve the repo root (containing the vendored OAS catalog) by walking up
+   from the test's cwd to the nearest [dune-project] — same resolution
+   test_runtime_config_validity.ml uses for its catalog-backed cases. *)
+let rec repo_root_from dir =
+  let dune_project = Filename.concat dir "dune-project" in
+  if Sys.file_exists dune_project
+  then dir
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir
+    then Alcotest.failf "unable to locate repo root from cwd=%s" (Sys.getcwd ())
+    else repo_root_from parent)
+;;
+
+let repo_root () = repo_root_from (Sys.getcwd ())
+
+(* The per-model thinking gate derives preserve-thinking defaults from the OAS
+   capability catalog: [Runtime.default_preserve_thinking_for_model] runs a live
+   [capabilities_for_runtime] lookup against [Model_catalog.global ()].
+   Production seeds that global catalog at boot (server bootstrap /
+   [init_default_strict]); the routing-only [init_default] used here is
+   intentionally catalog-independent (runtime.ml: "kept out of load_list so unit
+   tests stay catalog-independent"), so without an explicit seed the lookup
+   returns [None] and the preserve-thinking default collapses to [None].  Seed
+   the vendored [oas-models.toml] — the same SSOT the server loads — so the
+   capability-derived default (qwen36-35b-a3b-mtp ->
+   chat_template_kwargs_preserve_thinking -> Some true) is exercised against the
+   committed catalog instead of a host-dependent
+   ~/.masc/config/capability-manifest.json.  Cleared via [Fun.protect] so the
+   process-global catalog never leaks into the sibling test groups in this same
+   binary. *)
 let with_runtime_thinking f =
+  let catalog_path = Filename.concat (repo_root ()) "oas-models.toml" in
+  if not (Sys.file_exists catalog_path)
+  then Alcotest.failf "repo oas-models.toml missing at %s" catalog_path;
+  let catalog =
+    match Llm_provider.Model_catalog.load_file catalog_path with
+    | Ok catalog -> catalog
+    | Error msg -> Alcotest.failf "repo oas-models.toml should load: %s" msg
+  in
+  Fun.protect ~finally:Llm_provider.Model_catalog.clear_global @@ fun () ->
+  Llm_provider.Model_catalog.set_global catalog;
   with_temp_dir "runtime-thinking-gate" @@ fun dir ->
   let path = Filename.concat dir "runtime.toml" in
   write_file path runtime_config_thinking;


### PR DESCRIPTION
## 목표
`per-model thinking gate` 테스트 그룹의 `request-side preserve capability defaults preserve on` 케이스가 main에서 결정론적으로 실패하던 것을 수정한다 (Expected `Some true`, Received `None`).

## 근본 원인
`Runtime.default_preserve_thinking_for_model`은 preserve-thinking 기본값을 OAS capability 카탈로그(`Model_catalog.global ()` 대상 live `capabilities_for_runtime` lookup)에서 도출한다. `with_runtime_thinking` 헬퍼는 routing 전용 `Runtime.init_default`만 호출하는데, 이 경로는 의도적으로 catalog-independent다(`runtime.ml`: "kept out of load_list so unit tests stay catalog-independent"). 따라서 global 카탈로그가 seed되지 않은 상태에서 lookup이 `None`을 반환하고 preserve-thinking 기본값이 `None`으로 붕괴한다.

이전까지 일부 환경에서 통과한 이유는 OAS가 host의 `~/.masc/config/capability-manifest.json`을 우연히 읽을 수 있던 경우뿐이며, 그 파일이 없는 CI(및 임의의 host)에서는 항상 실패한다 — 즉 host-dependent한 비결정성이었다.

## 변경
`with_runtime_thinking`이 vendored `oas-models.toml`(서버 부팅이 로드하는 동일 SSOT)을 seed하도록 한다. `Fun.protect ~finally:Model_catalog.clear_global`로 감싸 프로세스 전역 카탈로그가 같은 바이너리의 sibling 테스트 그룹(`runtime-assignment routing` / `driver lookup`)으로 누설되지 않게 한다.

`qwen36-35b-a3b-mtp`가 `chat_template_kwargs_preserve_thinking` → `Some true`로 해석되어 프로덕션과 일치하며, 케이스는 더 이상 host-dependent하지 않다. 이 패턴은 `test_runtime_config_validity.ml`의 `with_repo_oas_model_catalog`(이미 green)를 그대로 미러링한다.

## 검증
- 변경 범위: `test/test_runtime_per_keeper_routing.ml` 1파일 (헬퍼 + `repo_root` 유틸 추가, 기존 6개 thinking-gate 케이스 동작 유지).
- 로컬 빌드는 현재 머신의 무관한 OAS pin drift(로컬 switch가 codex dev 브랜치 0.207.25)로 막혀 있어, **이 PR의 CI(lock된 agent_sdk 0.207.22)로 컴파일·테스트를 검증**한다.
- sibling green 테스트(`test_runtime_capability_gate_uses_provider_qualified_catalog`)가 동일 경로(catalog seed → `preserve_thinking_of_runtime_id` = `Some true`)를 이미 증명한다.

RFC: 해당 없음 (test/ 만 변경, credential/operator/sandbox/dashboard-credential/hooks/workflow subsystem 미접촉).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
