### PR TITLE
fix no-progress peer surface guard

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -109,14 +109,15 @@ type reply_delivery =
    a multi-signal turn cannot flip the anti-thrash verdict to exempt.
 
    Behavior change (RFC-0276 §2.4): the [Board_activity] capability set is
-   {keeper_board_post, keeper_board_comment, masc_broadcast, masc_keeper_msg} —
-   wider than the old social-model peer set {board_post, board_comment,
-   broadcast} by [masc_keeper_msg] (keeper->keeper message). A turn that only
-   sends a peer message with no durable evidence now accrues the no-progress
-   streak (it previously reset it). This is intentional: a bare peer message is
-   exactly the "posts to peers without evidence" case RFC-0239 targets. The set
-   is pinned in test_no_progress_loop_detector so any axis change forces a
-   conscious no-progress review. *)
+   {keeper_board_post, keeper_board_comment, keeper_broadcast, masc_broadcast,
+   masc_keeper_msg} — wider than the old social-model peer set {board_post,
+   board_comment, broadcast} by the public broadcast form and
+   [masc_keeper_msg] (keeper->keeper message). A turn that only sends a peer
+   message with no durable evidence now accrues the no-progress streak (it
+   previously reset it). This is intentional: a bare peer message is exactly the
+   "posts to peers without evidence" case RFC-0239 targets. The set is pinned
+   in test_no_progress_loop_detector so any axis change forces a conscious
+   no-progress review. *)
 let classify_delivery ~is_autonomous ~reply_delivery ~tools ~has_visible_text =
   if Keeper_tool_capability_axis.(supports_any Board_activity tools)
   then Peer_only

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -302,22 +302,23 @@ let test_classify_delivery_mapping () =
   (* Pin the EXACT peer-surface set that the no-progress classifier treats as
      evidence-requiring. Intentionally an explicit literal, NOT
      [Cap.board_activity_tool_names] iterated: iterating the axis would be
-     tautological (it could never detect the axis growing a 5th tool). If
+     tautological (it could never detect the axis growing a 6th tool). If
      [Keeper_tool_capability_axis] adds a Board_activity tool, this assertion
      fails and forces a conscious decision about its no-progress impact —
      converting the policy<->taxonomy coupling from silent to guarded.
 
      vs the removed social-model [inferred_tool_surface] set
      {keeper_board_comment, keeper_board_post, keeper_broadcast}: this set adds
-     [masc_keeper_msg] (keeper->keeper message; [masc_broadcast] is the public
-     name of the same [keeper_broadcast] tool). That is an intentional, more
-     complete peer-surface definition (RFC-0276 §2.4 / §3.2 behavior change): a
-     turn that only sends a peer message with no durable evidence now accrues
-     the streak, matching RFC-0239's "only posts to peers without evidence"
-     intent, where the old social model let a bare keeper-msg turn reset it. *)
+     [masc_broadcast] (public broadcast form) and [masc_keeper_msg]
+     (keeper->keeper message). That is an intentional, more complete
+     peer-surface definition (RFC-0276 §2.4 / §3.2 behavior change): a turn
+     that only sends a peer message with no durable evidence now accrues the
+     streak, matching RFC-0239's "only posts to peers without evidence" intent,
+     where the old social model let a bare keeper-msg turn reset it. *)
   let expected_peer_tools =
-    [ "keeper_board_comment"
-    ; "keeper_board_post"
+    [ "keeper_board_post"
+    ; "keeper_board_comment"
+    ; "keeper_broadcast"
     ; "masc_broadcast"
     ; "masc_keeper_msg"
     ]


### PR DESCRIPTION
Update the RFC-0276 delivery-decouple guard to match the current Board_activity capability axis, including both the internal keeper_broadcast and public masc_broadcast peer surfaces.

The stale pinned literal broke the quick suite at test_no_progress_loop_detector classify_delivery maps observed facts.

Verification:

- ocamlformat --check test/test_no_progress_loop_detector.ml lib/keeper/keeper_unified_turn_success.ml

- git diff --check

- MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_no_progress_loop_detector.exe

- ./_build/default/test/test_no_progress_loop_detector.exe
