### PR TITLE
fix(reputation): canonical keeper identity로 task 집계 (full actor id 과소집계 수정)

### DIFF
--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -124,11 +124,38 @@ let load_jsonl_safe (path : string) : Yojson.Safe.t list =
 
 (** {1 Task Counting from Workspace State} *)
 
+(** Canonical keeper name used for identity comparison.  Shared with
+    {!accountability_metrics} so both metrics fold an identity the same way:
+    via [Keeper_identity.canonical_keeper_name_from_agent_name], which unwraps
+    the full actor id and resolves a generated-nickname alias to its agent
+    type, falling back to the trimmed input for non-keeper principals.
+
+    Known residual: this canonicalizer collapses 3+-part hyphenated non-keeper
+    ids (e.g. "codex-mcp-client" -> "client") onto their last segment, so such
+    principals can share a canonical form.  Resolving that needs registry-aware
+    typed identity (RFC-0038 Phase 2); it does not affect single-token keeper
+    names, which are the subject of the undercount fixed below. *)
+let keeper_name_of_agent agent_name =
+  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
+  | Some keeper_name -> keeper_name
+  | None -> String.trim agent_name
+
 (** Count tasks claimed and completed by an agent from the task backlog.
     Reads the canonical Workspace backlog so reputation follows the same storage
-    path as task transitions. *)
+    path as task transitions.
+
+    Identity is compared on the canonical keeper name (see
+    {!keeper_name_of_agent}).  Previously a raw [String.equal assignee
+    agent_name] was used: because the backlog persists [assignee] as the full
+    actor id the claiming keeper used ("keeper-taskmaster-agent") while
+    reputation is computed per short handle ("taskmaster"), every full-actor-id
+    row was silently dropped, undercounting a keeper's claims/completions. *)
 let count_tasks_from_backlog (config : Workspace.config) ~(agent_name : string)
     : int * int =
+  let owner = keeper_name_of_agent agent_name in
+  let assignee_is_owner assignee =
+    String.equal (keeper_name_of_agent assignee) owner
+  in
   let claimed = ref 0 in
   let completed = ref 0 in
   Workspace.get_tasks_safe config
@@ -137,9 +164,9 @@ let count_tasks_from_backlog (config : Workspace.config) ~(agent_name : string)
          | Masc_domain.Claimed { assignee; _ }
          | Masc_domain.InProgress { assignee; _ }
          | Masc_domain.AwaitingVerification { assignee; _ }
-           when String.equal assignee agent_name ->
+           when assignee_is_owner assignee ->
              Stdlib.incr claimed
-         | Masc_domain.Done { assignee; _ } when String.equal assignee agent_name ->
+         | Masc_domain.Done { assignee; _ } when assignee_is_owner assignee ->
              Stdlib.incr claimed;
              Stdlib.incr completed
          | Masc_domain.Todo
@@ -261,11 +288,6 @@ let compute_overall_score ~completion_rate ~response_rate
   +. (weight_thompson *. thompson_confidence)
 
 (** {1 Accountability Penalty} *)
-
-let keeper_name_of_agent agent_name =
-  match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
-  | Some keeper_name -> keeper_name
-  | None -> String.trim agent_name
 
 let accountability_metrics (config : Workspace.config) ~(agent_name : string) =
   let keeper_name = keeper_name_of_agent agent_name in

--- a/test/dune
+++ b/test/dune
@@ -193,6 +193,7 @@
   test_keeper_accountability
   test_reputation_ledger_v2
   test_reputation_multi_dim
+  test_reputation_identity_undercount
   test_accountability_emit_skip_10314
   test_keeper_adaptive_thinking
   test_keeper_lifecycle_registry_dispatch
@@ -518,6 +519,7 @@
   test_keeper_accountability
   test_reputation_ledger_v2
   test_reputation_multi_dim
+  test_reputation_identity_undercount
   test_accountability_emit_skip_10314
   test_keeper_adaptive_thinking
   test_keeper_lifecycle_registry_dispatch

--- a/test/test_reputation_identity_undercount.ml
+++ b/test/test_reputation_identity_undercount.ml
@@ -1,0 +1,93 @@
+open Alcotest
+open Masc
+
+(* Regression for the reputation task-count undercount: a keeper claims and
+   completes tasks under its full actor id ("keeper-<h>-agent") — the form the
+   backlog persists — while reputation is computed per short handle. The count
+   must fold both sides to the canonical keeper name so the keeper's own rows
+   are not dropped. Before the fix [count_tasks_from_backlog] compared the raw
+   short handle against the stored full actor id and returned zero. *)
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_reputation_identity_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  rm dir
+
+let with_workspace ?(agent_name = "keeper-repkeeper-agent") f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some agent_name));
+      f config)
+
+let claim_and_complete config ~agent_name ~task_id =
+  ignore (Workspace.claim_task config ~agent_name ~task_id);
+  match
+    Workspace.transition_task_r config ~agent_name ~task_id
+      ~action:Masc_domain.Done_action ()
+  with
+  | Ok _ -> ()
+  | Error err ->
+      Alcotest.failf "done transition failed: %s"
+        (Masc_domain.masc_error_to_string err)
+
+(* The keeper claims under the full actor id; reputation queried by the short
+   handle must still see the completed task. *)
+let test_full_actor_id_counted_for_short_handle () =
+  with_workspace ~agent_name:"keeper-repkeeper-agent" (fun config ->
+      ignore
+        (Workspace.add_task config ~title:"reputation task" ~priority:1
+           ~description:"d");
+      claim_and_complete config ~agent_name:"keeper-repkeeper-agent"
+        ~task_id:"task-001";
+      let rep = Reputation.compute_reputation config ~agent_name:"repkeeper" in
+      check int "completed task counted via short handle" 1
+        rep.Reputation.tasks_completed;
+      check int "claimed task counted via short handle" 1
+        rep.Reputation.tasks_claimed)
+
+(* The canonical fold widens matching, it must not merge distinct keepers:
+   a task owned by repkeeper must not surface when reputation is queried for an
+   unrelated handle. *)
+let test_unrelated_handle_not_counted () =
+  with_workspace ~agent_name:"keeper-repkeeper-agent" (fun config ->
+      ignore
+        (Workspace.add_task config ~title:"reputation task" ~priority:1
+           ~description:"d");
+      claim_and_complete config ~agent_name:"keeper-repkeeper-agent"
+        ~task_id:"task-001";
+      let rep = Reputation.compute_reputation config ~agent_name:"otherkeeper" in
+      check int "unrelated handle sees no completed task" 0
+        rep.Reputation.tasks_completed;
+      check int "unrelated handle sees no claimed task" 0
+        rep.Reputation.tasks_claimed)
+
+let () =
+  Alcotest.run "Reputation identity undercount"
+    [
+      ( "task-count",
+        [
+          test_case "full actor id counted for short handle" `Quick
+            test_full_actor_id_counted_for_short_handle;
+          test_case "unrelated handle not counted" `Quick
+            test_unrelated_handle_not_counted;
+        ] );
+    ]


### PR DESCRIPTION
## 무엇을

`Reputation.count_tasks_from_backlog`가 keeper의 task claim/completion 수를 **최대 약 92% 과소집계**하던 문제를 수정합니다. 대시보드/평판 지표가 keeper의 실제 작업량을 크게 적게 표시했습니다.

## 근본 원인

task backlog는 `assignee`를 claim한 keeper의 **full actor id**(`keeper-taskmaster-agent`) 형식으로 저장합니다. 반면 reputation은 **short handle**(`taskmaster`)로 계산됩니다. `count_tasks_from_backlog`가 둘을 raw `String.equal`로 비교했기에 full actor id로 저장된 행이 전부 누락됐습니다.

라이브 backlog 실측: `keeper-taskmaster-agent` 163건 vs `taskmaster` 14건 → taskmaster의 task count가 177 중 14만 집계(약 92% 누락).

## 변경

- assignee와 조회 handle을 **이미 존재하는** `keeper_name_of_agent` canonicalizer(`accountability_metrics`가 이미 사용)로 양쪽 다 정규화한 뒤 비교합니다. 새 분류기를 추가하는 것이 아니라 파일 내 식별자 정규화를 단일 헬퍼로 통일한 것입니다. 헬퍼를 `count_tasks_from_backlog` 위로 이동해 공유합니다(중복 정의 제거).
- 회귀 테스트 추가: full actor id로 claim/complete 후 short handle로 조회해 count=1을 단언하고, 무관한 handle은 0을 단언(canonical fold가 서로 다른 keeper를 병합하지 않음을 증명).

## 검증

- 신규 회귀 테스트(`test_reputation_identity_undercount`). 빌드/전체 테스트는 CI에서 확인.

## 범위 밖 (별도 추적)

- `canonical_keeper_name_from_agent_name`는 3+ 하이픈 파트 비-keeper id(`codex-mcp-client` → `client`)를 마지막 세그먼트로 접어 서로 다른 비-keeper principal이 같은 canonical을 공유할 수 있습니다. `accountability_metrics`도 동일 헬퍼를 쓰므로 같은 잔여 특성을 공유합니다. registry-aware typed identity로의 근본 해결은 **RFC-0038 Phase 2**가 추적합니다. 단일 토큰 keeper 이름(본 PR이 고치는 과소집계 대상)에는 영향 없습니다.

RFC-WAIVED: reputation 은 credential/identity/operator-control/sandbox/hooks/workflow 게이트 subsystem 이 아님. read-model 지표 집계 수정으로 아키텍처/보안 영향 없음. keeper 식별자 typed canonical 의 근본 작업은 RFC-0038 Phase 2 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
