### PR TITLE
feat(keeper): consume SDK stream progress predicates

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -239,6 +239,7 @@ export interface KeeperChatStreamEvent {
   messageId?: string
   role?: string
   delta?: string
+  snapshot?: string
   name?: string
   value?: unknown
   timestamp?: number

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -996,6 +996,33 @@ export function appendAssistantToolTraceArgsDelta(
   if (!found) warnMissingToolTrace('args patch', name, entryId, id)
 }
 
+export function setAssistantToolTraceArgsSnapshot(
+  name: string,
+  entryId: string,
+  toolCallId: string,
+  snapshot: string,
+): void {
+  const id = toolCallId.trim()
+  if (!id) return
+  let found = false
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const traceSteps = existing.map((trace) => {
+      if (trace.kind !== 'tool' || trace.toolCallId !== id) return trace
+      found = true
+      return {
+        ...trace,
+        args: snapshot,
+      }
+    })
+    return {
+      ...entry,
+      traceSteps,
+    }
+  })
+  if (!found) warnMissingToolTrace('args snapshot', name, entryId, id)
+}
+
 export function markAssistantToolTraceEnded(
   name: string,
   entryId: string,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -434,6 +434,40 @@ describe('applyKeeperStreamEvent tool calls', () => {
     expect(finished?.streamState).toBeNull()
   })
 
+  it('replaces tool-call args when OAS emits argument snapshots', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-snapshot',
+      toolCallName: 'keeper_board_list',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 'tc-snapshot',
+      snapshot: '{"limit":1}',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 'tc-snapshot',
+      snapshot: '{"limit":2}',
+    })
+
+    const tool = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-snapshot')
+    expect(tool?.text).toBe('{"limit":2}')
+    expect(tool?.rawText).toBe('{"limit":2}')
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'keeper_board_list',
+        toolCallId: 'tc-snapshot',
+        status: 'pending',
+        args: '{"limit":2}',
+        ts: expect.any(String),
+      },
+    ])
+  })
+
   it('records tool calls in the assistant trace between thinking deltas', () => {
     assistantEntry()
     applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -10,6 +10,7 @@ import {
   appendAssistantDelta,
   appendAssistantThinkingDelta,
   appendAssistantToolTraceArgsDelta,
+  setAssistantToolTraceArgsSnapshot,
   appendAssistantToolTraceStep,
   setAssistantStreamState,
   updateThreadEntry,
@@ -195,7 +196,15 @@ export function applyKeeperStreamEvent(
         )
         return null
       }
-      if (toolCallId && typeof event.delta === 'string' && event.delta) {
+      const snapshot = event.snapshot
+      if (toolCallId && typeof snapshot === 'string') {
+        setAssistantToolTraceArgsSnapshot(keeperName, assistantEntryId, toolCallId, snapshot)
+        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
+          ...entry,
+          text: snapshot,
+          rawText: snapshot,
+        }))
+      } else if (toolCallId && typeof event.delta === 'string' && event.delta) {
         appendAssistantToolTraceArgsDelta(keeperName, assistantEntryId, toolCallId, event.delta)
         updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
           ...entry,

--- a/dune-project
+++ b/dune-project
@@ -55,9 +55,10 @@
   ; (upstream piaf 0.2.0 missing conf-libssl dependency on macOS arm64).
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
-  ;; Pinned to OAS v0.207.27, including InputJsonSnapshot tool-argument
-  ;; snapshots emitted by provider stream adapters. MASC also consumes the
-  ;; canonical stream/tool surfaces and fail-closed media source carriers
+  ;; Pinned to OAS v0.207.27 plus the latest main follow-up fixes after
+  ;; #2291 locked the GLM clear_thinking=false/non-preserve behavior. MASC also
+  ;; consumes the canonical stream/tool surfaces introduced in the v0.207.25
+  ;; line and the fail-closed media source carrier expansion
   ;; (Base64/Url/File_id).
   (agent_sdk (>= 0.207.27))
   (uri (>= 4.4))

--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,9 @@
   (piaf (>= 0.2.0))
   (eio-ssl (>= 0.3.0))
   ;; Pinned to OAS v0.207.27, including InputJsonSnapshot tool-argument
-  ;; snapshots emitted by provider stream adapters.
+  ;; snapshots emitted by provider stream adapters. MASC also consumes the
+  ;; canonical stream/tool surfaces and fail-closed media source carriers
+  ;; (Base64/Url/File_id).
   (agent_sdk (>= 0.207.27))
   (uri (>= 4.4))
   (tls (>= 2.0))

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -1,5 +1,7 @@
 (** Prompt metrics and adaptive inference helpers for keeper Agent.run turns. *)
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 let adaptive_thinking_budget
       ~enabled
       ~is_retry
@@ -147,20 +149,27 @@ let metric_of_block
     ~(role : Agent_sdk.Types.role)
     (block : Agent_sdk.Types.content_block) : prompt_segment_metrics =
   let bytes =
-    match block with
+    match Canonical_tool.tool_result_of_block block with
+    | Some result ->
+        String.length
+          (Inference_utils.sanitize_text_utf8 result.Canonical_tool.call_id)
+        + String.length
+            (Inference_utils.sanitize_text_utf8 result.Canonical_tool.content)
+        + (match result.Canonical_tool.structured_content with
+           | Some value -> String.length (Yojson.Safe.to_string value)
+           | None -> 0)
+    | None -> (
+      match block with
     | Agent_sdk.Types.Text text ->
         String.length (Inference_utils.sanitize_text_utf8 text)
     | Agent_sdk.Types.ToolUse { id; name; input } ->
         String.length (Inference_utils.sanitize_text_utf8 id)
         + String.length (Inference_utils.sanitize_text_utf8 name)
         + String.length (Yojson.Safe.to_string input)
-    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
-        String.length (Inference_utils.sanitize_text_utf8 tool_use_id)
-        + String.length (Inference_utils.sanitize_text_utf8 content)
-        + (match json with
-           | Some value -> String.length (Yojson.Safe.to_string value)
-           | None -> 0)
-    | _ -> 0
+    | Agent_sdk.Types.ToolResult _ ->
+        invalid_arg
+          "keeper_agent_prompt_metrics: OAS canonical tool-result projection unavailable"
+    | _ -> 0)
   in
   let msg : Agent_sdk.Types.message =
     {

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -65,6 +65,8 @@ let normalize_response_text_for_finalization
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
+  let sse_event_watchdog_progress_kind =
+    Turn_helpers.sse_event_watchdog_progress_kind
   let registry_progress_on_event = Turn_helpers.registry_progress_on_event
   let progress_keeper_tool_names_for_contract =
     Contract_helpers.progress_keeper_tool_names_for_contract

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -20,6 +20,8 @@ val completion_contract_result_for_progress_evidence
 
 module For_testing : sig
   val sse_event_progress_kind : Agent_sdk.Types.sse_event -> string option
+  val sse_event_watchdog_progress_kind :
+    Agent_sdk.Types.sse_event -> string option
   val registry_progress_on_event
     :  record_turn_progress:(string -> unit)
     -> (Agent_sdk.Types.sse_event -> unit) option

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -75,21 +75,34 @@ let per_provider_timeout_for_turn
 
 [@@@warning "-11"]
 
+let sdk_stream_event_is_first_token =
+  Agent_sdk.Llm_provider.Streaming.sse_event_is_first_token_signal
+
+let sdk_stream_event_is_deliverable =
+  Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal
+
 let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
   match event with
   | Agent_sdk.Types.MessageStart _ -> Some "sse_message_start"
-  | Agent_sdk.Types.ContentBlockStart { tool_name = Some _; _ } ->
+  | Agent_sdk.Types.ContentBlockStart _ when sdk_stream_event_is_deliverable event ->
       Some "sse_tool_block_start"
   | Agent_sdk.Types.ContentBlockStart _ -> Some "sse_content_block_start"
-  | Agent_sdk.Types.ContentBlockDelta { delta = Agent_sdk.Types.TextDelta _; _ } ->
+  | Agent_sdk.Types.ContentBlockDelta { delta = Agent_sdk.Types.TextDelta _; _ }
+    when sdk_stream_event_is_deliverable event ->
       Some "sse_text_delta"
-  | Agent_sdk.Types.ContentBlockDelta { delta = Agent_sdk.Types.ThinkingDelta _; _ } ->
+  | Agent_sdk.Types.ContentBlockDelta
+      { delta = Agent_sdk.Types.ThinkingDelta _; _ }
+    when sdk_stream_event_is_first_token event ->
       Some "sse_thinking_delta"
   | Agent_sdk.Types.ContentBlockDelta
-      { delta = (Agent_sdk.Types.InputJsonDelta _ | Agent_sdk.Types.InputJsonSnapshot _)
+      { delta = Agent_sdk.Types.InputJsonDelta _ | Agent_sdk.Types.InputJsonSnapshot _
       ; _
-      } ->
+      }
+    when sdk_stream_event_is_deliverable event ->
       Some "sse_tool_arg_delta"
+  | Agent_sdk.Types.ContentBlockDelta { delta = Agent_sdk.Types.MediaDelta _; _ }
+    when sdk_stream_event_is_deliverable event ->
+      Some "sse_media_delta"
   | Agent_sdk.Types.ContentBlockDelta _ ->
       (* Future OAS carrier deltas, such as provider-private reasoning signatures,
          are progress evidence only. They must not be promoted to text/tool

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -95,9 +95,7 @@ let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
     when sdk_stream_event_is_first_token event ->
       Some "sse_thinking_delta"
   | Agent_sdk.Types.ContentBlockDelta
-      { delta = Agent_sdk.Types.InputJsonDelta _ | Agent_sdk.Types.InputJsonSnapshot _
-      ; _
-      }
+      { delta = Agent_sdk.Types.InputJsonDelta _ | Agent_sdk.Types.InputJsonSnapshot _; _ }
     when sdk_stream_event_is_deliverable event ->
       Some "sse_tool_arg_delta"
   | Agent_sdk.Types.ContentBlockDelta { delta = Agent_sdk.Types.MediaDelta _; _ }

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -103,8 +103,8 @@ let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
       Some "sse_media_delta"
   | Agent_sdk.Types.ContentBlockDelta _ ->
       (* Future OAS carrier deltas, such as provider-private reasoning signatures,
-         are progress evidence only. They must not be promoted to text/tool
-         progress or keeper-visible output. *)
+         are diagnostic stream evidence only. They must not be promoted to
+         text/tool progress, keeper-visible output, or watchdog progress. *)
       Some "sse_content_delta"
   | Agent_sdk.Types.ContentBlockStop _ -> Some "sse_content_block_stop"
   | Agent_sdk.Types.MessageDelta _ -> Some "sse_message_delta"
@@ -119,8 +119,13 @@ let sse_event_progress_kind (event : Agent_sdk.Types.sse_event) =
 
 [@@@warning "+11"]
 
+let sse_event_watchdog_progress_kind event =
+  match sse_event_progress_kind event with
+  | Some kind when sdk_stream_event_is_deliverable event -> Some kind
+  | _ -> None
+
 let registry_progress_on_event ~record_turn_progress downstream event =
-  Option.iter record_turn_progress (sse_event_progress_kind event);
+  Option.iter record_turn_progress (sse_event_watchdog_progress_kind event);
   Option.iter (fun cb -> cb event) downstream
 
 

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -13,6 +13,8 @@ val per_provider_timeout_for_turn :
   float option
 
 val sse_event_progress_kind : Agent_sdk.Types.sse_event -> string option
+val sse_event_watchdog_progress_kind :
+  Agent_sdk.Types.sse_event -> string option
 
 val registry_progress_on_event :
   record_turn_progress:(string -> unit) ->

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -1,5 +1,7 @@
 let default_keep_recent = 3
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 let keep_recent_from_env () =
   match Sys.getenv_opt "MASC_TOOL_HYDRATE_RECENT" with
   | None -> default_keep_recent
@@ -27,21 +29,32 @@ let try_hydrate ~store ~sha256 ~marker =
 
 let hydrate_block ~store ~remaining
     (block : Agent_sdk.Types.content_block) : Agent_sdk.Types.content_block =
-  match block with
-  | Agent_sdk.Types.ToolResult
-      { tool_use_id; content; is_error; json; content_blocks } ->
+  match Canonical_tool.tool_result_of_block block with
+  | Some result ->
       if !remaining = 0 then block
       else
-        (match Tool_output.decode_from_oas content with
+        (match Tool_output.decode_from_oas result.Canonical_tool.content with
          | Tool_output.Stored { sha256; _ } ->
-             (match try_hydrate ~store ~sha256 ~marker:content with
+             (match
+                try_hydrate ~store ~sha256 ~marker:result.Canonical_tool.content
+              with
               | Some bytes ->
                   decr remaining;
                   Agent_sdk.Types.ToolResult
-                    { tool_use_id; content = bytes; is_error; json; content_blocks }
+                    { tool_use_id = result.Canonical_tool.call_id
+                    ; content = bytes
+                    ; is_error = result.Canonical_tool.is_error
+                    ; json = result.Canonical_tool.structured_content
+                    ; content_blocks = result.Canonical_tool.content_blocks
+                    }
               | None -> block)
          | Tool_output.Inline _ -> block)
-  | _ -> block
+  | None -> (
+      match block with
+      | Agent_sdk.Types.ToolResult _ ->
+          invalid_arg
+            "keeper_artifact_hydrator: OAS canonical tool-result projection unavailable"
+      | _ -> block)
 
 let hydrate_messages ~store ~keep_recent
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -453,6 +453,9 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
     | Tool_call_args { tool_call_id = _; delta = _ } ->
         (* Args stream is not visualized — only start/end matters. *)
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
+    | Tool_call_args_snapshot { tool_call_id = _; snapshot = _ } ->
+        (* Args stream is not visualized — only start/end matters. *)
+        loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_call_end { tool_call_id } ->
         (match find_tool_msg tool_msgs tool_call_id with
          | Some entry ->

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -56,6 +56,7 @@ type keeper_chat_event =
   | Oas_stream_protocol_error of stream_protocol_error
   | Tool_call_start of { tool_call_id : string; tool_call_name : string }
   | Tool_call_args of { tool_call_id : string; delta : string }
+  | Tool_call_args_snapshot of { tool_call_id : string; snapshot : string }
   | Tool_call_end of { tool_call_id : string }
   | Link_block of
       { url : string

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -66,6 +66,7 @@ type keeper_chat_event =
   | Oas_stream_protocol_error of stream_protocol_error
   | Tool_call_start of { tool_call_id : string; tool_call_name : string }
   | Tool_call_args of { tool_call_id : string; delta : string }
+  | Tool_call_args_snapshot of { tool_call_id : string; snapshot : string }
   | Tool_call_end of { tool_call_id : string }
   | Link_block of
       { url : string

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -54,6 +54,25 @@ let content_block_start_event ~index ~content_type ~tool_id ~tool_name =
 let content_block_stop_event ~index =
   Keeper_chat_events.Oas_content_block_stop { index }
 
+let tool_args_event ~redact_text ~snapshot bridge_state index args =
+  let open Keeper_chat_events in
+  match stream_tool_for_index bridge_state index with
+  | Some tool ->
+      let args = redact_text args in
+      let chat_event =
+        if snapshot then
+          Tool_call_args_snapshot { tool_call_id = tool.tool_call_id; snapshot = args }
+        else Tool_call_args { tool_call_id = tool.tool_call_id; delta = args }
+      in
+      { bridge_state; chat_events = [ chat_event ] }
+  | None ->
+      { bridge_state;
+        chat_events =
+          [ protocol_error ~index
+              ~reason:"tool argument event arrived before tool start"
+              Tool_args_without_start ]
+      }
+
 let translate ~redact_text ~on_text_delta bridge_state
     (evt : Agent_sdk.Types.sse_event) =
   let open Agent_sdk.Types in
@@ -148,21 +167,10 @@ let translate ~redact_text ~on_text_delta bridge_state
                 Tool_start_missing_identity ]
         }
       else { bridge_state; chat_events = [ block_start ] }
-  | ContentBlockDelta { index; delta = (InputJsonDelta args | InputJsonSnapshot args) } -> (
-      match stream_tool_for_index bridge_state index with
-      | Some tool ->
-          { bridge_state;
-            chat_events =
-              [ Tool_call_args
-                  { tool_call_id = tool.tool_call_id; delta = redact_text args } ]
-          }
-      | None ->
-          { bridge_state;
-            chat_events =
-              [ protocol_error ~index
-                  ~reason:"tool argument delta arrived before tool start"
-                  Tool_args_without_start ]
-          })
+  | ContentBlockDelta { index; delta = InputJsonDelta args } ->
+      tool_args_event ~redact_text ~snapshot:false bridge_state index args
+  | ContentBlockDelta { index; delta = InputJsonSnapshot args } ->
+      tool_args_event ~redact_text ~snapshot:true bridge_state index args
   | ContentBlockStop { index } -> (
       let block_stop = content_block_stop_event ~index in
       match stream_tool_for_index bridge_state index with

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -26,6 +26,19 @@ let remove_tool bridge_state index =
 let tool_start_is_replay existing tool =
   String.equal existing.tool_call_id tool.tool_call_id
 
+let sdk_stream_event_is_deliverable =
+  Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal
+
+let stream_start_is_tool ~index ~content_type ~tool_id ~tool_name =
+  sdk_stream_event_is_deliverable
+    (Agent_sdk.Types.ContentBlockStart
+       { index; content_type; tool_id; tool_name })
+
+let has_any_tool_identity ~tool_id ~tool_name =
+  match tool_id, tool_name with
+  | None, None -> false
+  | _ -> true
+
 let protocol_error ?index ?event_type ?reason ?raw_bytes kind =
   Keeper_chat_events.Oas_stream_protocol_error
     { kind; index; event_type; reason; raw_bytes }
@@ -89,9 +102,11 @@ let translate ~redact_text ~on_text_delta bridge_state
           [ Oas_media_delta
               { index; media_type; source_type; bytes = String.length data } ]
       }
-  | ContentBlockStart
-      { index; content_type; tool_id = Some tid; tool_name = Some tname }
-    when String.trim tid <> "" && String.trim tname <> "" ->
+  | ContentBlockStart { index; content_type; tool_id; tool_name }
+    when stream_start_is_tool ~index ~content_type ~tool_id ~tool_name -> (
+      match tool_id, tool_name with
+      | Some tid, Some tname
+        when String.trim tid <> "" && String.trim tname <> "" ->
       let tool = { tool_call_id = tid; tool_call_name = tname } in
       let existing_tool = stream_tool_for_index bridge_state index in
       let block_start =
@@ -109,21 +124,27 @@ let translate ~redact_text ~on_text_delta bridge_state
            | None ->
                [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ])
       }
+      | _ ->
+          let block_start =
+            content_block_start_event ~index ~content_type ~tool_id ~tool_name
+          in
+          { bridge_state;
+            chat_events =
+              [ block_start;
+                protocol_error ~index
+                  ~reason:"tool-use block start missed tool id or name"
+                  Tool_start_missing_identity ]
+          })
   | ContentBlockStart { index; content_type; tool_id; tool_name } ->
       let block_start =
         content_block_start_event ~index ~content_type ~tool_id ~tool_name
       in
-      let partial_tool_identity =
-        match tool_id, tool_name with
-        | None, None -> false
-        | _ -> true
-      in
-      if partial_tool_identity then
+      if has_any_tool_identity ~tool_id ~tool_name then
         { bridge_state;
           chat_events =
             [ block_start;
               protocol_error ~index
-                ~reason:"tool content block start missed tool id or name"
+                ~reason:"non-tool content block carried tool id or name"
                 Tool_start_missing_identity ]
         }
       else { bridge_state; chat_events = [ block_start ] }

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -295,7 +295,7 @@ let adapter_loop ~token ~channel ~events ?base_url () =
                 ^ Keeper_chat_events.stream_protocol_error_summary error)
             : (unit, error) result);
         loop ~acc_text ~acc_blocks ~run_id_opt
-    | Tool_call_start _ | Tool_call_args _ | Tool_call_end _ ->
+    | Tool_call_start _ | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Link_block { url; title; description; image = _ } ->
         let block = link_block_json ~url ~title ~description in

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -49,7 +49,8 @@ val adapter_loop :
     Rich events ([Link_block], [Image_block], [Audio_block],
     [Tool_context_block]) are rendered as Slack Block Kit sections and
     included alongside the final message. [Tool_call_start],
-    [Tool_call_args], and [Tool_call_end] are ignored for live streaming.
+    [Tool_call_args], [Tool_call_args_snapshot], and [Tool_call_end] are
+    ignored for live streaming.
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -10,6 +10,8 @@ open Keeper_types_profile
 
 include Keeper_context_core_accessors
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 let add_checkpoint_sanitize_stats
     (a : checkpoint_sanitize_stats)
     (b : checkpoint_sanitize_stats) : checkpoint_sanitize_stats =
@@ -232,7 +234,17 @@ let sanitize_checkpoint_message
                    dropped_blocks = 1;
                    dropped_chars = String.length text;
                  } )
-         | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
+         | Agent_sdk.Types.ToolResult _ ->
+             let result =
+               match Canonical_tool.tool_result_of_block block with
+               | Some result -> result
+               | None ->
+                   invalid_arg
+                     "keeper_context_core: OAS canonical tool-result projection unavailable"
+             in
+             let tool_use_id = result.Canonical_tool.call_id in
+             let content = result.Canonical_tool.content in
+             let is_error = result.Canonical_tool.is_error in
              let tool_chars = String.length content in
              if kept_tool_results
                 >= default_max_checkpoint_tool_results_per_message
@@ -345,12 +357,18 @@ let sanitize_checkpoint_message
         { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
   else (Some { msg with content = kept }, stats)
 
-let checkpoint_content_chars_of_block = function
-  | Agent_sdk.Types.Text text -> String.length text
-  | Agent_sdk.Types.Thinking { content; _ } -> String.length content
-  | Agent_sdk.Types.RedactedThinking text -> String.length text
-  | Agent_sdk.Types.ToolResult { content; _ } -> String.length content
-  | _ -> 0
+let checkpoint_content_chars_of_block block =
+  match Canonical_tool.tool_result_of_block block with
+  | Some result -> String.length result.Canonical_tool.content
+  | None -> (
+      match block with
+      | Agent_sdk.Types.Text text -> String.length text
+      | Agent_sdk.Types.Thinking { content; _ } -> String.length content
+      | Agent_sdk.Types.RedactedThinking text -> String.length text
+      | Agent_sdk.Types.ToolResult _ ->
+          invalid_arg
+            "keeper_context_core: OAS canonical tool-result projection unavailable"
+      | _ -> 0)
 
 let checkpoint_content_chars_of_message (msg : Agent_sdk.Types.message) : int =
   List.fold_left
@@ -414,13 +432,24 @@ let cap_checkpoint_message_to_remaining_content
            match block with
            | Agent_sdk.Types.Text text ->
                cap_content (fun text -> Agent_sdk.Types.Text text) text
-           | Agent_sdk.Types.ToolResult
-               { tool_use_id; content; is_error; content_blocks; _ } ->
+           | Agent_sdk.Types.ToolResult _ ->
+               let result =
+                 match Canonical_tool.tool_result_of_block block with
+                 | Some result -> result
+                 | None ->
+                     invalid_arg
+                       "keeper_context_core: OAS canonical tool-result projection unavailable"
+               in
                cap_content
                  (fun content ->
                    Agent_sdk.Types.ToolResult
-                     { tool_use_id; content; is_error; json = None; content_blocks })
-                 content
+                     { tool_use_id = result.Canonical_tool.call_id
+                     ; content
+                     ; is_error = result.Canonical_tool.is_error
+                     ; json = None
+                     ; content_blocks = result.Canonical_tool.content_blocks
+                     })
+                 result.Canonical_tool.content
            | Agent_sdk.Types.Thinking t ->
                cap_content
                  (fun text -> Agent_sdk.Types.Thinking { t with content = text })

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -13,6 +13,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 
 module Message_json = Keeper_context_core_message_json
+module Canonical_tool = Agent_sdk.Canonical_tool
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -276,6 +277,16 @@ let record_dropped_tool_result stats tool_use_id =
       ; dropped_tool_result_ids = [ tool_use_id ]
       }
 
+let canonical_tool_result_of_block block =
+  match Canonical_tool.tool_result_of_block block with
+  | Some result -> Some result
+  | None -> (
+      match block with
+      | Agent_sdk.Types.ToolResult _ ->
+          invalid_arg
+            "keeper_context_core_accessors: OAS canonical tool-result projection unavailable"
+      | _ -> None)
+
 let pair_repair_metadata_kind stats =
   match stats.dropped_tool_uses > 0, stats.dropped_tool_results > 0 with
   | true, true -> "dropped_tool_pair_blocks"
@@ -330,17 +341,20 @@ let filter_group_message_content
                    || not (List.mem id matched_tool_result_ids)) ->
             record_dropped_tool_use stats id name;
             None
-        | Agent_sdk.Types.ToolResult { tool_use_id; _ } as block
-          when mode.drop_orphan_results ->
-            let allowed = List.mem tool_use_id allowed_tool_use_ids in
-            let duplicate = List.mem tool_use_id !seen_tool_result_ids in
-            if allowed && not duplicate
-            then (
-              seen_tool_result_ids := tool_use_id :: !seen_tool_result_ids;
-              Some block)
-            else (
-              record_dropped_tool_result stats tool_use_id;
-              None)
+        | Agent_sdk.Types.ToolResult _ as block when mode.drop_orphan_results -> (
+            match canonical_tool_result_of_block block with
+            | Some result ->
+                let tool_use_id = result.Canonical_tool.call_id in
+                let allowed = List.mem tool_use_id allowed_tool_use_ids in
+                let duplicate = List.mem tool_use_id !seen_tool_result_ids in
+                if allowed && not duplicate
+                then (
+                  seen_tool_result_ids := tool_use_id :: !seen_tool_result_ids;
+                  Some block)
+                else (
+                  record_dropped_tool_result stats tool_use_id;
+                  None)
+            | None -> Some block)
         | other -> Some other)
       msg.content
   in
@@ -360,10 +374,12 @@ let filter_orphan_result_message_content
     let content =
       List.filter_map
         (function
-          | Agent_sdk.Types.ToolResult { tool_use_id; _ }
-            when mode.drop_orphan_results ->
-              record_dropped_tool_result stats tool_use_id;
-              None
+          | Agent_sdk.Types.ToolResult _ as block when mode.drop_orphan_results -> (
+              match canonical_tool_result_of_block block with
+              | Some result ->
+                  record_dropped_tool_result stats result.Canonical_tool.call_id;
+                  None
+              | None -> Some block)
           | Agent_sdk.Types.ToolUse { id; name; _ } when drop_non_assistant_tool_use ->
               record_dropped_tool_use stats id name;
               None

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -1,9 +1,4 @@
-let role_to_string (r : Agent_sdk.Types.role) =
-  match r with
-  | System -> "system"
-  | User -> "user"
-  | Assistant -> "assistant"
-  | Tool -> "tool"
+let role_to_string = Agent_sdk.Types.role_to_string
 
 (* Issue #8623: returns [Some] only for the 4 wire-format names.
    Callers must handle [None] explicitly — the previous Variant
@@ -12,12 +7,7 @@ let role_to_string (r : Agent_sdk.Types.role) =
    "user" causes the LLM to treat tool output as user instructions,
    echo prior assistant replies as user input, or downgrade system
    prompt privileges. Same anti-pattern class as #8605/#8615. *)
-let role_of_string_opt = function
-  | "system" -> Some Agent_sdk.Types.System
-  | "user" -> Some Agent_sdk.Types.User
-  | "assistant" -> Some Agent_sdk.Types.Assistant
-  | "tool" -> Some Agent_sdk.Types.Tool
-  | _ -> None
+let role_of_string_opt = Agent_sdk.Types.role_of_string
 
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -15,35 +15,11 @@ let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
   `List (List.map Agent_sdk.Api.content_block_to_json blocks)
 
-let thinking_signature_of_json (json : Yojson.Safe.t) =
-  match Json_util.get_string json "signature" with
-  | Some _ as signature -> signature
-  | None ->
-    (* DET-OK: older context/checkpoint JSON predates the OAS canonical
-       [signature] carrier and stored the same value under [thinking_type]. *)
-    Json_util.get_string json "thinking_type"
-
 let content_blocks_of_json
     (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
   match Json_util.assoc_member_opt "content_blocks" json with
   | Some (`List blocks) ->
-      let parse_block = function
-        | `Assoc _ as j ->
-          (match Json_util.get_string j "type" with
-           | Some "thinking" ->
-             (match Json_util.get_string j "thinking" with
-              | Some content ->
-                let signature = thinking_signature_of_json j in
-                Some (Agent_sdk.Types.Thinking { content; signature })
-              | None -> None)
-           | Some "redacted_thinking" ->
-             (match Json_util.get_string j "data" with
-              | Some text -> Some (Agent_sdk.Types.RedactedThinking text)
-              | None -> None)
-           | _ -> Agent_sdk.Api.content_block_of_json j)
-        | _ -> None
-      in
-      let parsed = List.filter_map parse_block blocks in
+      let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
       if List.length parsed = List.length blocks then Some parsed else None
   | _ -> None
 

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -1,3 +1,5 @@
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 let role_to_string = Agent_sdk.Types.role_to_string
 
 (* Issue #8623: returns [Some] only for the 4 wire-format names.
@@ -64,17 +66,9 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
         match m.role with
         | Agent_sdk.Types.Tool ->
             List.find_map
-              (function
-                | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
-                    Some tool_use_id
-                (* Other content_block variants do not carry a tool_use_id. *)
-                | Agent_sdk.Types.Text _
-                | Agent_sdk.Types.Thinking _
-                | Agent_sdk.Types.RedactedThinking _
-                | Agent_sdk.Types.ToolUse _
-                | Agent_sdk.Types.Image _
-                | Agent_sdk.Types.Document _
-                | Agent_sdk.Types.Audio _ -> None)
+              (fun block ->
+                Canonical_tool.tool_result_of_block block
+                |> Option.map (fun result -> result.Canonical_tool.call_id))
               m.content
         (* Non-Tool roles never own a tool_call_id. *)
         | Agent_sdk.Types.System

--- a/lib/keeper/keeper_context_tool_message_pairs.ml
+++ b/lib/keeper/keeper_context_tool_message_pairs.ml
@@ -1,8 +1,10 @@
 (* Tool-use / tool-result block pair invariants for keeper messages.
 
-   Extracted from [Keeper_context_core] (godfile decomp). All
-   functions are pure projections over the message-content variant
-   and total over [Agent_sdk.Types] (exhaustive matches, no catch-all). *)
+   Extracted from [Keeper_context_core] (godfile decomp). ToolResult
+   projections delegate to [Agent_sdk.Canonical_tool]; ToolUse projections stay
+   local until OAS exposes the matching call projection. *)
+
+module Canonical_tool = Agent_sdk.Canonical_tool
 
 let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   match msg.role with
@@ -40,31 +42,15 @@ let has_tool_use_block (msg : Agent_sdk.Types.message) : bool =
 
 let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map
-    (function
-      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
+    (fun block ->
+      Canonical_tool.tool_result_of_block block
+      |> Option.map (fun result -> result.Canonical_tool.call_id))
     msg.content
 ;;
 
 let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
   List.exists
-    (function
-      | Agent_sdk.Types.ToolResult _ -> true
-      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> false)
+    (fun block -> Canonical_tool.tool_result_of_block block |> Option.is_some)
     msg.content
 ;;
 

--- a/lib/keeper/keeper_hooks_oas_response_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_response_metrics.ml
@@ -2,6 +2,8 @@
 
 open Keeper_hooks_oas_types
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 (* #9919: counter for post_tool_use_failure events.
 
    Replaces an earlier low-signal metric emit that produced
@@ -78,15 +80,25 @@ let resolve_after_turn_model ~keeper_name
    stop_reason_label_* SSOT constants by inlining their literals.  [open
    Keeper_hooks_oas_types] above brings stop_reason_to_label into scope. *)
 
-let content_block_has_visible_or_tool_progress = function
-  | Agent_sdk.Types.Text text -> String.trim text <> ""
-  | Agent_sdk.Types.ToolResult { content; json; _ } ->
-      String.trim content <> "" || Option.is_some json
-  | Agent_sdk.Types.ToolUse _
-  | Agent_sdk.Types.Image _
-  | Agent_sdk.Types.Document _
-  | Agent_sdk.Types.Audio _ -> true
-  | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> false
+let content_block_has_visible_or_tool_progress block =
+  match Canonical_tool.tool_result_of_block block with
+  | Some result ->
+      String.trim result.Canonical_tool.content <> ""
+      || Option.is_some result.Canonical_tool.structured_content
+      || (match result.Canonical_tool.content_blocks with
+          | Some (_ :: _) -> true
+          | Some [] | None -> false)
+  | None -> (
+      match block with
+      | Agent_sdk.Types.Text text -> String.trim text <> ""
+      | Agent_sdk.Types.ToolResult _ ->
+          invalid_arg
+            "keeper_hooks_oas_response_metrics: OAS canonical tool-result projection unavailable"
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> true
+      | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> false)
 
 let shape_empty = "empty"
 let shape_thinking_only = "thinking_only"

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -2,6 +2,8 @@
 
 open Keeper_memory_os_types
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 type input =
   { trace_id : string
   ; generation : int
@@ -30,27 +32,28 @@ let trim_nonempty s =
   if String.equal s "" then None else Some s
 ;;
 
-let role_to_string = function
-  | Agent_sdk.Types.User -> "user"
-  | Agent_sdk.Types.Assistant -> "assistant"
-  | Agent_sdk.Types.System -> "system"
-  | Agent_sdk.Types.Tool -> "tool"
-;;
+let role_to_string = Agent_sdk.Types.role_to_string
 
-let text_of_content = function
-  | Agent_sdk.Types.Text s -> trim_nonempty s
-  | Agent_sdk.Types.ToolUse { id; name; _ } ->
-    Some (Printf.sprintf "[tool use omitted: id=%s name=%s]" id name)
-  | Agent_sdk.Types.ToolResult { tool_use_id; is_error; _ } ->
+let text_of_content block =
+  match Canonical_tool.tool_result_of_block block with
+  | Some result ->
     Some
       (Printf.sprintf
          "[tool result omitted: id=%s is_error=%b]"
-         tool_use_id
-         is_error)
+         result.Canonical_tool.call_id
+         result.Canonical_tool.is_error)
+  | None -> (
+    match block with
+  | Agent_sdk.Types.Text s -> trim_nonempty s
+  | Agent_sdk.Types.ToolUse { id; name; _ } ->
+    Some (Printf.sprintf "[tool use omitted: id=%s name=%s]" id name)
+  | Agent_sdk.Types.ToolResult _ ->
+    invalid_arg
+      "keeper_librarian: OAS canonical tool-result projection unavailable"
   | Agent_sdk.Types.Thinking _ | Agent_sdk.Types.RedactedThinking _ -> None
   | Agent_sdk.Types.Image _ -> Some "[image omitted]"
   | Agent_sdk.Types.Document _ -> Some "[document omitted]"
-  | Agent_sdk.Types.Audio _ -> Some "[audio omitted]"
+  | Agent_sdk.Types.Audio _ -> Some "[audio omitted]")
 ;;
 
 let message_to_text ~turn (m : Agent_sdk.Types.message) : string =

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -115,11 +115,11 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
   | Agent_sdk.Types.Image { media_type; data; source_type } ->
     (match source_type with
      | Agent_sdk.Types.Url | Agent_sdk.Types.File_id ->
-      record_eviction ~mode ~result:"error" ~reason:"invalid_source_type";
-      Agent_sdk.Types.Text
-        (image_store_failed_placeholder ~reason:"unsupported image source")
+       record_eviction ~mode ~result:"error" ~reason:"invalid_source_type";
+       Agent_sdk.Types.Text
+         (image_store_failed_placeholder ~reason:"unsupported image source")
      | Agent_sdk.Types.Base64 ->
-      match raw_bytes_of_image_data data with
+       match raw_bytes_of_image_data data with
       | Error _ ->
         record_eviction ~mode ~result:"error" ~reason:"bad_base64";
         Agent_sdk.Types.Text

--- a/lib/keeper/keeper_wake_telemetry.ml
+++ b/lib/keeper/keeper_wake_telemetry.ml
@@ -15,6 +15,8 @@
     [~goal], so downstream p95 analysis matches the wire-level view
     the LLM actually receives. *)
 
+module Canonical_tool = Agent_sdk.Canonical_tool
+
 type sizes = {
   system_prompt_bytes : int;
   tool_defs_bytes : int;
@@ -25,24 +27,27 @@ type sizes = {
   tool_count : int;
 }
 
-let role_key : Agent_sdk.Types.role -> string = function
-  | Agent_sdk.Types.System -> "system"
-  | Agent_sdk.Types.User -> "user"
-  | Agent_sdk.Types.Assistant -> "assistant"
-  | Agent_sdk.Types.Tool -> "tool"
+let role_key : Agent_sdk.Types.role -> string = Agent_sdk.Types.role_to_string
 
-let bytes_of_content_block : Agent_sdk.Types.content_block -> int = function
+let bytes_of_content_block (block : Agent_sdk.Types.content_block) : int =
+  match Canonical_tool.tool_result_of_block block with
+  | Some result ->
+    String.length result.Canonical_tool.call_id
+    + String.length result.Canonical_tool.content
+  | None -> (
+    match block with
   | Agent_sdk.Types.Text s -> String.length s
   | Agent_sdk.Types.Thinking { content; _ } -> String.length content
   | Agent_sdk.Types.RedactedThinking s -> String.length s
   | Agent_sdk.Types.ToolUse { id; name; input } ->
     String.length id + String.length name
     + String.length (Yojson.Safe.to_string input)
-  | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
-    String.length tool_use_id + String.length content
+  | Agent_sdk.Types.ToolResult _ ->
+    invalid_arg
+      "keeper_wake_telemetry: OAS canonical tool-result projection unavailable"
   | Agent_sdk.Types.Image { data; _ }
   | Agent_sdk.Types.Document { data; _ }
-  | Agent_sdk.Types.Audio { data; _ } -> String.length data
+  | Agent_sdk.Types.Audio { data; _ } -> String.length data)
 
 let bytes_of_message (m : Agent_sdk.Types.message) : int =
   List.fold_left

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1216,6 +1216,18 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                     ~delta:(Some delta)
                     Tool_call_args)
             then loop ()
+        | Tool_call_args_snapshot { tool_call_id; snapshot } ->
+            (* [snapshot] is already redacted at publish. OAS
+               [InputJsonSnapshot] is a whole replacement value, not an
+               append fragment, so preserve that distinction on the wire. *)
+            if
+              keeper_stream_send_event ~on_closed writer mutex closed
+                Ag_ui.(
+                  make_event ~thread_id:!current_thread_id ~run_id:!current_run_id
+                    ~tool_call_id:(Some tool_call_id)
+                    ~snapshot:(Some (`String snapshot))
+                    Tool_call_args)
+            then loop ()
         | Tool_call_end { tool_call_id } ->
             if
               keeper_stream_send_event ~on_closed writer mutex closed

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.207.25"}
+  "agent_sdk" {= "0.207.26"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -217,8 +217,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.207.25"
-  "git+https://github.com/jeong-sik/oas.git#b6b2ae6c887afbdce7dd069fc03f6ac1bba721e0"
+  "agent_sdk.0.207.26"
+  "git+https://github.com/jeong-sik/oas.git#c8c3f7f44894837b318b0f30ea52280ca72dc0c9"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.207.26"}
+  "agent_sdk" {= "0.207.27"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -217,8 +217,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.207.26"
-  "git+https://github.com/jeong-sik/oas.git#c8c3f7f44894837b318b0f30ea52280ca72dc0c9"
+  "agent_sdk.0.207.27"
+  "git+https://github.com/jeong-sik/oas.git#279870eb0ac84f55d163ba291293e7c44cb01eca"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -95,7 +95,7 @@ let test_empty_response_detail_summarizes_shape () =
     ; model = "m"
     ; stop_reason = Agent_sdk.Types.MaxTokens
     ; content =
-        [ Agent_sdk.Types.Thinking { content = "secret chain"; signature = None } ]
+        [ Agent_sdk.Types.Thinking { signature = None; content = "secret chain" } ]
     ; usage =
         Some
           { input_tokens = 21

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -543,6 +543,79 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
                 | Keeper_chat_events.Oas_thinking_delta _ -> "oas_thinking"
                 | Keeper_chat_events.Tool_call_start _ -> "tool_start"
                 | Keeper_chat_events.Tool_call_args _ -> "tool_args"
+                | Keeper_chat_events.Tool_call_args_snapshot _ ->
+                    "tool_args_snapshot"
+                | Keeper_chat_events.Tool_call_end _ -> "tool_end"
+                | Keeper_chat_events.Text_delta _ -> "text"
+                | Keeper_chat_events.Event_error _ -> "error"
+                | _ -> "other")
+              events))
+
+let test_keeper_stream_bridge_preserves_tool_args_snapshot () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = ThinkingDelta "think A" };
+        ContentBlockStart
+          { index = 1;
+            content_type = "tool_use";
+            tool_id = Some "tc-snapshot";
+            tool_name = Some "keeper_board_list" };
+        ContentBlockDelta
+          { index = 1; delta = InputJsonSnapshot "{\"limit\":1}" };
+        ContentBlockDelta
+          { index = 1; delta = InputJsonSnapshot "{\"limit\":2}" };
+        ContentBlockStop { index = 1 };
+        ContentBlockDelta { index = 2; delta = ThinkingDelta "think B" };
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Oas_thinking_delta { index = first_index; delta = first };
+      Keeper_chat_events.Oas_content_block_start
+        { index = tool_index;
+          content_type;
+          tool_call_id = Some block_tool_id;
+          tool_call_name = Some block_tool_name };
+      Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
+      Keeper_chat_events.Tool_call_args_snapshot
+        { tool_call_id = snapshot_id_a; snapshot = snapshot_a };
+      Keeper_chat_events.Tool_call_args_snapshot
+        { tool_call_id = snapshot_id_b; snapshot = snapshot_b };
+      Keeper_chat_events.Oas_content_block_stop { index = stop_index };
+      Keeper_chat_events.Tool_call_end { tool_call_id = end_id };
+      Keeper_chat_events.Oas_thinking_delta { index = last_index; delta = last } ] ->
+      check int "first thinking index" 0 first_index;
+      check string "first thinking" "think A" first;
+      check int "tool block index" 1 tool_index;
+      check string "content type" "tool_use" content_type;
+      check string "block tool id" "tc-snapshot" block_tool_id;
+      check string "block tool name" "keeper_board_list" block_tool_name;
+      check string "tool id" "tc-snapshot" tool_call_id;
+      check string "tool name" "keeper_board_list" tool_call_name;
+      check string "snapshot id a" "tc-snapshot" snapshot_id_a;
+      check string "snapshot id b" "tc-snapshot" snapshot_id_b;
+      check string "snapshot a" "{\"limit\":1}" snapshot_a;
+      check string "snapshot b" "{\"limit\":2}" snapshot_b;
+      check int "tool stop index" 1 stop_index;
+      check string "end id" "tc-snapshot" end_id;
+      check int "last thinking index" 2 last_index;
+      check string "last thinking" "think B" last
+  | _ ->
+      failf "unexpected stream bridge snapshot events: %s"
+        (String.concat ", "
+           (List.map
+              (function
+                | Keeper_chat_events.Custom { name; _ } -> "custom:" ^ name
+                | Keeper_chat_events.Oas_content_block_start _ ->
+                    "oas_block_start"
+                | Keeper_chat_events.Oas_content_block_stop _ ->
+                    "oas_block_stop"
+                | Keeper_chat_events.Oas_thinking_delta _ -> "oas_thinking"
+                | Keeper_chat_events.Tool_call_start _ -> "tool_start"
+                | Keeper_chat_events.Tool_call_args _ -> "tool_args"
+                | Keeper_chat_events.Tool_call_args_snapshot _ ->
+                    "tool_args_snapshot"
                 | Keeper_chat_events.Tool_call_end _ -> "tool_end"
                 | Keeper_chat_events.Text_delta _ -> "text"
                 | Keeper_chat_events.Event_error _ -> "error"
@@ -826,6 +899,7 @@ let test_keeper_stream_bridge_rejects_tool_args_without_start () =
            (List.exists
               (function
                 | Keeper_chat_events.Tool_call_args _ -> true
+                | Keeper_chat_events.Tool_call_args_snapshot _ -> true
                 | _ -> false)
               events))
   | _ -> fail "expected a stream protocol error for missing tool start"
@@ -1651,6 +1725,8 @@ let () =
             test_keeper_stream_args_preserve_user_blocks;
           test_case "stream bridge preserves interleaved thinking and tool" `Quick
             test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool;
+          test_case "stream bridge preserves tool args snapshots" `Quick
+            test_keeper_stream_bridge_preserves_tool_args_snapshot;
           test_case "stream bridge ignores replayed tool starts" `Quick
             test_keeper_stream_bridge_ignores_replayed_tool_start;
           test_case "stream bridge closes tool when index is reused" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -740,6 +740,74 @@ let test_keeper_stream_bridge_preserves_non_tool_block_lifecycle () =
       check int "stop index" 4 stop_index
   | _ -> fail "expected non-tool OAS block start and stop events"
 
+let test_keeper_stream_bridge_rejects_tool_start_missing_identity () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 5;
+            content_type = "tool_use";
+            tool_id = None;
+            tool_name = None };
+      ]
+  in
+  match events with
+  | [
+      Keeper_chat_events.Oas_content_block_start
+        { index = block_index; content_type; tool_call_id; tool_call_name };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind; index = Some error_index; reason = Some reason; _ };
+    ] ->
+      check int "block index" 5 block_index;
+      check string "content type" "tool_use" content_type;
+      check (option string) "tool id" None tool_call_id;
+      check (option string) "tool name" None tool_call_name;
+      check string "kind" "tool_start_missing_identity"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string kind);
+      check int "error index" 5 error_index;
+      check string "reason" "tool-use block start missed tool id or name" reason
+  | _ -> fail "expected tool-use start without identity to fail closed"
+
+let test_keeper_stream_bridge_rejects_non_tool_start_with_tool_identity () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 6;
+            content_type = "text";
+            tool_id = Some "tc-not-tool";
+            tool_name = Some "keeper_memory_search" };
+      ]
+  in
+  let has_tool_start =
+    List.exists
+      (function
+        | Keeper_chat_events.Tool_call_start _ -> true
+        | _ -> false)
+      events
+  in
+  check bool "non-tool block is not promoted to tool call" false has_tool_start;
+  match events with
+  | [
+      Keeper_chat_events.Oas_content_block_start
+        { index = block_index; content_type; tool_call_id; tool_call_name };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind; index = Some error_index; reason = Some reason; _ };
+    ] ->
+      check int "block index" 6 block_index;
+      check string "content type" "text" content_type;
+      check (option string) "tool id" (Some "tc-not-tool") tool_call_id;
+      check (option string) "tool name" (Some "keeper_memory_search")
+        tool_call_name;
+      check string "kind" "tool_start_missing_identity"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string kind);
+      check int "error index" 6 error_index;
+      check string "reason" "non-tool content block carried tool id or name"
+        reason
+  | _ -> fail "expected non-tool start with tool identity to fail closed"
+
 let test_keeper_stream_bridge_rejects_tool_args_without_start () =
   let open Agent_sdk.Types in
   let events =
@@ -1593,6 +1661,10 @@ let () =
             test_keeper_stream_bridge_preserves_typed_media_source;
           test_case "stream bridge preserves non-tool block lifecycle" `Quick
             test_keeper_stream_bridge_preserves_non_tool_block_lifecycle;
+          test_case "stream bridge rejects tool start missing identity" `Quick
+            test_keeper_stream_bridge_rejects_tool_start_missing_identity;
+          test_case "stream bridge rejects non-tool start with tool identity" `Quick
+            test_keeper_stream_bridge_rejects_non_tool_start_with_tool_identity;
           test_case "stream bridge rejects tool args without start" `Quick
             test_keeper_stream_bridge_rejects_tool_args_without_start;
           test_case "stream protocol error summary includes diagnostics" `Quick

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -177,8 +177,8 @@ let test_roundtrip_preserves_thinking_signature () =
       T.role = T.Assistant;
       content =
         [
-          T.Thinking { content = "chain"; signature = None };
-          T.Thinking { content = "signed"; signature = Some "anthropic-signature" };
+          T.Thinking { signature = None; content = "chain" };
+          T.Thinking { signature = Some "anthropic-signature"; content = "signed" };
           T.RedactedThinking "encrypted";
           T.Text "done";
         ];
@@ -196,11 +196,11 @@ let test_roundtrip_preserves_thinking_signature () =
    T.RedactedThinking blob;
    T.Text text;
   ] ->
-      Alcotest.(check (option string)) "first thinking signature" None first_signature;
+      Alcotest.(check (option string)) "first thinking signature" None
+        first_signature;
       Alcotest.(check string) "first thinking content" "chain" first_content;
       Alcotest.(check (option string))
-        "second thinking signature"
-        (Some "anthropic-signature")
+        "second thinking signature" (Some "anthropic-signature")
         second_signature;
       Alcotest.(check string) "second thinking content" "signed" second_content;
       Alcotest.(check string) "redacted thinking" "encrypted" blob;
@@ -212,7 +212,7 @@ let test_thinking_block_json_uses_oas_signature () =
     {
       T.role = T.Assistant;
       content =
-        [ T.Thinking { content = "signed"; signature = Some "anthropic-signature" } ];
+        [ T.Thinking { signature = Some "anthropic-signature"; content = "signed" } ];
       name = None;
       tool_call_id = None;
       metadata = [];
@@ -236,7 +236,7 @@ let test_thinking_block_json_uses_oas_signature () =
       | _ -> Alcotest.fail "expected one content block")
   | _ -> Alcotest.fail "expected message object"
 
-let test_legacy_thinking_type_still_reads () =
+let test_legacy_thinking_type_is_not_promoted_to_signature () =
   let json : Yojson.Safe.t =
     `Assoc
       [
@@ -256,9 +256,7 @@ let test_legacy_thinking_type_still_reads () =
   let parsed = C.message_of_json json in
   match parsed.content with
   | [ T.Thinking { signature; content } ] ->
-      Alcotest.(check (option string))
-        "legacy thinking_type reads as signature"
-        (Some "legacy-signature")
+      Alcotest.(check (option string)) "legacy thinking type ignored" None
         signature;
       Alcotest.(check string) "content" "signed" content
   | _ -> Alcotest.fail "expected legacy thinking block"
@@ -285,8 +283,8 @@ let () =
             test_roundtrip_preserves_thinking_signature;
           Alcotest.test_case "thinking block JSON uses OAS signature" `Quick
             test_thinking_block_json_uses_oas_signature;
-          Alcotest.test_case "legacy thinking_type still reads" `Quick
-            test_legacy_thinking_type_still_reads;
+          Alcotest.test_case "legacy thinking_type is not promoted" `Quick
+            test_legacy_thinking_type_is_not_promoted_to_signature;
         ] );
       ( "text_of_history_jsonl_json",
         [

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -27,8 +27,8 @@ let test_tool_arg_shapes_keep_field_names () =
    These pin that policy output across all classifier cases so the delegation
    stays behavior-preserving. *)
 
-let thinking content =
-  Agent_sdk.Types.Thinking { content; signature = None }
+let thinking ?signature content =
+  Agent_sdk.Types.Thinking { signature; content }
 
 let check_thinking_summary ~msg ~present ~blocks ~chars ~redacted ~kind content =
   let { Keeper_hooks_oas_types.thinking_present

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -468,7 +468,8 @@ let test_librarian_prompt_omits_private_blocks () =
     { role = Agent_sdk.Types.Assistant
     ; content =
         [ Agent_sdk.Types.Text "[STATE]\nsecret runtime marker\n[/STATE]\nvisible fact"
-        ; Agent_sdk.Types.Thinking { content = "hidden chain of thought"; signature = None }
+        ; Agent_sdk.Types.Thinking
+            { signature = None; content = "hidden chain of thought" }
         ; Agent_sdk.Types.RedactedThinking "redacted reasoning blob"
         ; Agent_sdk.Types.ToolResult
             { tool_use_id = "call_1"
@@ -1169,7 +1170,8 @@ let test_librarian_runtime_appends_episode_bundle () =
           ; content =
               [ Agent_sdk.Types.Text
                   "[STATE]\nruntime secret sentinel\n[/STATE]\nvisible durable fact"
-              ; Agent_sdk.Types.Thinking { content = "hidden chain of thought"; signature = None }
+              ; Agent_sdk.Types.Thinking
+                  { signature = None; content = "hidden chain of thought" }
               ; Agent_sdk.Types.ToolResult
                   { tool_use_id = "call_runtime"
                   ; content = "secret tool payload"

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -242,7 +242,8 @@ let test_reject_reason_describes_thinking_only_response () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "abcde"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "abcde" };
            ]
          ())
   in
@@ -344,7 +345,8 @@ let test_runtime_error_mapping_preserves_no_progress_accept_rejection () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in
@@ -469,7 +471,8 @@ let test_accept_reason_includes_last_tool_context () =
          ~checkpoint
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in
@@ -534,7 +537,8 @@ let test_thinking_only_after_mutation_then_read_does_not_try_next_candidate () =
          ~checkpoint
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in
@@ -603,7 +607,8 @@ let test_historical_mutation_does_not_block_current_read_only_retry () =
          ~checkpoint
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in
@@ -667,7 +672,8 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
          ~checkpoint
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in
@@ -739,7 +745,8 @@ let test_thinking_only_after_workspace_mutation_stays_terminal () =
               ~checkpoint
               ~content:
                 [
-                  Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+                  Agent_sdk.Types.Thinking
+                    { signature = None; content = "internal chain" };
                 ]
               ())
        in
@@ -1484,7 +1491,8 @@ let test_thinking_with_text_is_accepted () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
              Agent_sdk.Types.Text "final answer";
            ]
          ())
@@ -1504,7 +1512,8 @@ let test_thinking_with_tool_use_is_accepted () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
              Agent_sdk.Types.ToolUse
                { id = "tool-1"; name = "keeper_board_search"; input = `Assoc [] };
            ]
@@ -1534,7 +1543,8 @@ let test_accept_contract_delegates_to_oas_response_shape () =
   check_accept_matches_oas_shape
     "thinking only"
     [
-      Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+      Agent_sdk.Types.Thinking
+        { signature = None; content = "internal chain" };
     ];
   check_accept_matches_oas_shape "blank text" [ Agent_sdk.Types.Text " \n\t " ];
   check_accept_matches_oas_shape "text" [ Agent_sdk.Types.Text "visible answer" ];
@@ -1574,7 +1584,8 @@ let test_thinking_only_non_end_turn_response_is_rejected () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ~stop_reason:Agent_sdk.Types.StopSequence
          ())
@@ -1601,7 +1612,8 @@ let test_thinking_only_no_tool_can_try_next_candidate () =
       (run_result
          ~content:
            [
-             Agent_sdk.Types.Thinking { content = "internal chain"; signature = None };
+             Agent_sdk.Types.Thinking
+               { signature = None; content = "internal chain" };
            ]
          ())
   in

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1889,6 +1889,9 @@ let test_reject_reason_describes_mixed_non_progress_response () =
 let test_sse_event_progress_kind_classifies_known_deltas () =
   let open Agent_sdk.Types in
   let kind event = Masc.Keeper_agent_run_turn_helpers.sse_event_progress_kind event in
+  let watchdog_kind event =
+    Masc.Keeper_agent_run_turn_helpers.sse_event_watchdog_progress_kind event
+  in
   Alcotest.(check (option string))
     "tool block start follows SDK stream classifier"
     (Some "sse_tool_block_start")
@@ -1927,9 +1930,113 @@ let test_sse_event_progress_kind_classifies_known_deltas () =
     (Some "sse_content_delta")
     (kind (ContentBlockDelta { index = 0; delta = TextDelta "" }));
   Alcotest.(check (option string))
+    "empty text delta is not watchdog progress"
+    None
+    (watchdog_kind (ContentBlockDelta { index = 0; delta = TextDelta "" }));
+  Alcotest.(check (option string))
+    "thinking delta is diagnostic but not watchdog progress"
+    None
+    (watchdog_kind (ContentBlockDelta { index = 0; delta = ThinkingDelta "hidden" }));
+  Alcotest.(check (option string))
+    "visible text delta is watchdog progress"
+    (Some "sse_text_delta")
+    (watchdog_kind (ContentBlockDelta { index = 0; delta = TextDelta "visible" }));
+  Alcotest.(check (option string))
     "stream incomplete"
     (Some "sse_stream_incomplete")
     (kind (StreamIncomplete { reason = "max_output_tokens" }))
+
+let registry_recorded_progress events =
+  let recorded = ref [] in
+  let downstream_count = ref 0 in
+  let on_event =
+    Masc.Keeper_agent_run_turn_helpers.registry_progress_on_event
+      ~record_turn_progress:(fun kind -> recorded := kind :: !recorded)
+      (Some (fun _ -> incr downstream_count))
+  in
+  List.iter on_event events;
+  (List.rev !recorded, !downstream_count)
+
+let test_registry_progress_on_event_records_only_watchdog_progress () =
+  let open Agent_sdk.Types in
+  let recorded, downstream_count =
+    registry_recorded_progress
+      [ ContentBlockDelta { index = 0; delta = TextDelta "" }
+      ; ContentBlockDelta { index = 0; delta = ThinkingDelta "hidden" }
+      ; ContentBlockStop { index = 0 }
+      ; MessageDelta { stop_reason = None; usage = None }
+      ; ContentBlockDelta { index = 0; delta = TextDelta "visible" }
+      ; ContentBlockStart
+          { index = 1; content_type = "tool_use"; tool_id = None; tool_name = None }
+      ]
+  in
+  Alcotest.(check (list string))
+    "carrier/control events do not reset watchdog progress"
+    [ "sse_text_delta"; "sse_tool_block_start" ]
+    recorded;
+  Alcotest.(check int) "downstream still sees every event" 6 downstream_count
+
+let test_carrier_only_stream_does_not_suppress_mid_turn_no_progress () =
+  let open Agent_sdk.Types in
+  let recorded, downstream_count =
+    registry_recorded_progress
+      [ ContentBlockDelta { index = 0; delta = TextDelta "" }
+      ; ContentBlockDelta { index = 0; delta = ThinkingDelta "hidden" }
+      ; ContentBlockStop { index = 0 }
+      ; MessageDelta { stop_reason = None; usage = None }
+      ; MessageStop
+      ]
+  in
+  Alcotest.(check (list string))
+    "carrier-only stream does not record watchdog progress"
+    []
+    recorded;
+  Alcotest.(check int) "diagnostic downstream receives carrier stream" 5 downstream_count;
+  let turn_observation =
+    let open Masc.Keeper_registry_types in
+    ({ turn_id = 1
+     ; started_at = 0.0
+     ; last_progress_at = 0.0
+     ; last_progress_kind = Some "turn_started"
+     ; active_tool_count = 0
+     ; turn_phase = Packed Turn_prompting
+     ; decision_stage = Packed Decision_undecided
+     ; measurement = None
+     ; measurement_bind_count = 0
+     ; selected_model = None
+     }
+      : Masc.Keeper_registry_types.turn_observation)
+  in
+  match
+    Masc.Keeper_supervisor.assess_in_turn_progress
+      ~phase:Masc.Keeper_state_machine.Running
+      ~in_turn:(Some turn_observation)
+      ~now:45.0
+      ~progress_timeout:30.0
+  with
+  | Some
+      (Masc.Keeper_registry.Stale_turn_timeout
+         (Masc.Keeper_registry.Mid_turn_no_progress
+            { since_progress_seconds
+            ; progress_timeout_threshold
+            ; last_progress_kind
+            ; _
+            })) ->
+    Alcotest.(check int)
+      "carrier-only stream stays stale"
+      45
+      (int_of_float since_progress_seconds);
+    Alcotest.(check int)
+      "progress timeout threshold preserved"
+      30
+      (int_of_float progress_timeout_threshold);
+    Alcotest.(check (option string))
+      "last watchdog progress remains turn start"
+      (Some "turn_started")
+      last_progress_kind
+  | _ ->
+    Alcotest.fail
+      "carrier-only stream must not suppress Mid_turn_no_progress"
 
 let test_per_provider_timeout_not_forwarded_to_oas_hard_deadline () =
   (* RFC-0129 (§62, 2026-05-17 fleet incident): per_provider_timeout_s must NOT
@@ -2050,6 +2157,14 @@ let () =
             test_reject_reason_describes_mixed_non_progress_response;
           Alcotest.test_case "sse progress classifies known deltas" `Quick
             test_sse_event_progress_kind_classifies_known_deltas;
+          Alcotest.test_case
+            "sse watchdog progress records deliverable events only"
+            `Quick
+            test_registry_progress_on_event_records_only_watchdog_progress;
+          Alcotest.test_case
+            "carrier-only stream still trips mid-turn no-progress"
+            `Quick
+            test_carrier_only_stream_does_not_suppress_mid_turn_no_progress;
           Alcotest.test_case
             "keeper timeout is not forwarded to OAS hard deadline (RFC-0129)"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1878,6 +1878,12 @@ let test_sse_event_progress_kind_classifies_known_deltas () =
   let open Agent_sdk.Types in
   let kind event = Masc.Keeper_agent_run_turn_helpers.sse_event_progress_kind event in
   Alcotest.(check (option string))
+    "tool block start follows SDK stream classifier"
+    (Some "sse_tool_block_start")
+    (kind
+       (ContentBlockStart
+          { index = 0; content_type = "tool_use"; tool_id = None; tool_name = None }));
+  Alcotest.(check (option string))
     "text delta"
     (Some "sse_text_delta")
     (kind (ContentBlockDelta { index = 0; delta = TextDelta "visible" }));
@@ -1893,6 +1899,21 @@ let test_sse_event_progress_kind_classifies_known_deltas () =
     "tool arg snapshot"
     (Some "sse_tool_arg_delta")
     (kind (ContentBlockDelta { index = 0; delta = InputJsonSnapshot "{}" }));
+  Alcotest.(check (option string))
+    "media delta"
+    (Some "sse_media_delta")
+    (kind
+       (ContentBlockDelta
+          {
+            index = 0;
+            delta =
+              MediaDelta
+                { media_type = "image/png"; source_type = Base64; data = "abcd" };
+          }));
+  Alcotest.(check (option string))
+    "empty text delta falls back to carrier progress"
+    (Some "sse_content_delta")
+    (kind (ContentBlockDelta { index = 0; delta = TextDelta "" }));
   Alcotest.(check (option string))
     "stream incomplete"
     (Some "sse_stream_incomplete")

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2009,7 +2009,7 @@ let test_carrier_only_stream_does_not_suppress_mid_turn_no_progress () =
   in
   match
     Masc.Keeper_supervisor.assess_in_turn_progress
-      ~phase:Masc.Keeper_state_machine.Running
+      ~phase:Keeper_state_machine.Running
       ~in_turn:(Some turn_observation)
       ~now:45.0
       ~progress_timeout:30.0

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -808,25 +808,37 @@ let test_delegate_eviction_bad_base64_surfaces_redacted_text_error () =
     assert (not (contains_substring placeholder "bad base64"))
   | _ -> failwith "bad base64 must surface as a redacted text placeholder"
 
-let test_delegate_eviction_rejects_non_base64_source_types () =
-  let check_source source_type =
-    match
-      Vi.evict_blocks
-        ~mode:Vi.Store_only
-        ~policy:Masc.Keeper_types_profile.Mm_delegate
-        ~keeper_name:"vision-ingest-source-kind"
-        [ Agent_sdk.Types.Image
-            { media_type = "image/png"; data = "not-inline-base64"; source_type }
-        ]
-    with
-    | [ Agent_sdk.Types.Text placeholder ] ->
-      assert (contains_substring placeholder "could not store");
-      assert (contains_substring placeholder "unsupported image source")
-    | _ -> failwith "non-base64 image source must surface as a text placeholder"
-  in
-  check_source Agent_sdk.Types.Url;
-  check_source Agent_sdk.Types.File_id
-;;
+let test_delegate_eviction_rejects_non_base64_source_before_store () =
+  List.iter
+    (fun source_type ->
+      let source_name = Agent_sdk.Types.media_source_kind_to_string source_type in
+      let metric_labels =
+        [ "mode", "store_only"; "result", "error"; "reason", "invalid_source_type" ]
+      in
+      let before =
+        metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels
+      in
+      match
+        Vi.evict_blocks
+          ~mode:Vi.Store_only
+          ~policy:Masc.Keeper_types_profile.Mm_delegate
+          ~keeper_name:("vision-ingest-source-" ^ source_name)
+          [ Agent_sdk.Types.Image
+              { media_type = "image/png"
+              ; data = "https://example.invalid/image.png"
+              ; source_type
+              }
+          ]
+      with
+      | [ Agent_sdk.Types.Text placeholder ] ->
+        assert (contains_substring placeholder "could not store");
+        assert (contains_substring placeholder "unsupported image source");
+        assert_metric_increment
+          ("vision_ingest invalid_source_type " ^ source_name)
+          before
+          (metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels)
+      | _ -> failwith "non-base64 image source must surface as a text placeholder")
+    [ Agent_sdk.Types.Url; Agent_sdk.Types.File_id ]
 
 let test_non_delegate_eviction_preserves_inline_image () =
   let bytes = "raw-image" in
@@ -908,7 +920,7 @@ let () =
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();
   test_delegate_eviction_bad_base64_surfaces_redacted_text_error ();
-  test_delegate_eviction_rejects_non_base64_source_types ();
+  test_delegate_eviction_rejects_non_base64_source_before_store ();
   test_non_delegate_eviction_preserves_inline_image ();
   test_evicted_history_has_no_image_modality ();
   print_endline "test_keeper_vision_tool: all assertions passed"

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -56,7 +56,7 @@ let test_thinking_and_redacted () =
       role = Types.Assistant;
       content =
         [
-          Types.Thinking { content = "ponder"; signature = None };
+          Types.Thinking { signature = None; content = "ponder" };
           Types.RedactedThinking "redacted-blob";
         ];
       name = None;

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -676,8 +676,8 @@ let test_persist_response_content_per_turn_full () =
     (* acc.turn stays 0; the hook passes ~turn:11 — assert ~turn wins. *)
     let big = String.make 5000 'a' in
     let content = [
-      Agent_sdk.Types.Thinking { content = big; signature = None };
-      Agent_sdk.Types.Thinking { content = "second block"; signature = None };
+      Agent_sdk.Types.Thinking { signature = None; content = big };
+      Agent_sdk.Types.Thinking { signature = None; content = "second block" };
     ] in
     Keeper_agent_run_thinking_trajectory.persist_response_content
       ~keeper_name:"k" ~trajectory_acc:(Some acc) ~turn:11 content;


### PR DESCRIPTION
## Summary

- route keeper SSE progress classification through the SDK stream predicates for first-token and deliverable progress
- stop inferring tool-block progress from `tool_name`; tool-use block starts now follow the SDK classifier
- make the keeper chat stream bridge use the same SDK classifier before emitting `Tool_call_start`
- fail closed when a tool-use block is missing identity or a non-tool block carries tool identity
- use the SDK role codec for keeper checkpoint/librarian/wake telemetry role labels instead of duplicating role string mappings
- use `Agent_sdk.Canonical_tool.tool_result_of_block` for keeper ToolResult projections in message JSON, pair repair, prompt metrics, wake telemetry, librarian prompts, artifact hydration, checkpoint sanitization, and response-content metrics
- bump the OAS pin to `agent_sdk 0.207.27`
- consume OAS `InputJsonSnapshot` as a replacement tool-args event instead of appending it as a delta; dashboard `TOOL_CALL_ARGS.snapshot` now replaces accumulated args
- consume OAS `Thinking { content; signature }` directly and delegate content-block JSON decoding back to `Agent_sdk.Api.content_block_of_json`
- handle the expanded `media_source_kind` contract (`Base64 | Url | File_id`) by preserving Base64 handling and failing closed for unsupported URL/file-id image carriers
- add coverage for tool-use starts with partial identity, media deltas, empty text carrier fallback, canonical ToolResult projection paths, artifact hydration, unsupported media-source carriers, stream arg snapshots, and OAS thinking signatures

## Base

#22711 is merged into `main`; this branch was rebased onto `origin/main` and now carries only the keeper-side OAS consumption follow-up commits.

## Verification

- `bash scripts/check-oas-pin.sh --local-only`
- `ocamlformat --inplace lib/keeper/keeper_chat_events.mli lib/keeper/keeper_chat_events.ml lib/keeper/keeper_chat_oas_stream_bridge.ml lib/keeper/keeper_agent_run_turn_helpers.ml lib/server/server_routes_http_keeper_stream.ml lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_slack.mli lib/keeper/keeper_chat_discord.ml lib/keeper/keeper_context_core_message_json.ml test/test_gate_keeper_backend.ml test/test_keeper_turn_driver_accept.ml test/test_keeper_context_core_dedup.ml test/test_trajectory.ml test/test_keeper_wake_telemetry.ml test/test_fusion_oas_error_detail.ml test/test_keeper_memory_os.ml test/test_keeper_hooks_oas_log_shape.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe test/test_keeper_turn_driver_accept.exe test/test_keeper_context_core_dedup.exe test/test_keeper_hooks_oas_log_shape.exe test/test_trajectory.exe test/test_fusion_oas_error_detail.exe test/test_keeper_wake_telemetry.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_memory_os.exe`
- `./_build/default/test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_keeper_turn_driver_accept.exe`
- `./_build/default/test/test_keeper_context_core_dedup.exe`
- `./_build/default/test/test_keeper_hooks_oas_log_shape.exe`
- `./_build/default/test/test_trajectory.exe`
- `./_build/default/test/test_fusion_oas_error_detail.exe`
- `./_build/default/test/test_keeper_wake_telemetry.exe`
- `./_build/default/test/test_keeper_memory_os.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `git diff --check`
