### PR TITLE
[codex] Improve runtime settings catalog

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -10,7 +10,13 @@ import {
   logRowStatus,
   normalizeSettingsSection,
 } from './settings-surface'
-import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard'
+import type {
+  DashboardRuntimeProviderSnapshot,
+  DashboardRuntimeProvidersResponse,
+  DashboardToolInventoryItem,
+  LogEntry,
+  RuntimeDefaultsResponse,
+} from '../api/dashboard'
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
@@ -24,6 +30,7 @@ const apiMock = vi.hoisted(() => ({
   fetchLogs: vi.fn(),
   fetchDashboardTools: vi.fn(),
   fetchRuntimeDefaults: vi.fn(),
+  fetchRuntimeProviders: vi.fn(),
 }))
 
 const promptApiMock = vi.hoisted(() => ({
@@ -59,6 +66,7 @@ vi.mock('../api/dashboard.js', async () => {
     fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
+    fetchRuntimeProviders: apiMock.fetchRuntimeProviders,
   }
 })
 
@@ -132,6 +140,69 @@ function makeRuntimeDefaults(
   }
 }
 
+function makeRuntimeProvider(
+  overrides: Partial<DashboardRuntimeProviderSnapshot> = {},
+): DashboardRuntimeProviderSnapshot {
+  return {
+    provider: 'rt-a',
+    runtime_id: 'rt-a',
+    provider_id: 'provider-a',
+    provider_display_name: 'Provider A',
+    model_id: 'm1',
+    model_api_name: 'm1',
+    protocol: 'openai-http',
+    transport: 'http',
+    kind: 'cloud',
+    runtime_kind: 'cloud',
+    auth_kind: 'env',
+    status: 'configured',
+    available: true,
+    is_default_runtime: true,
+    max_context: 128000,
+    tools_support: true,
+    thinking_support: false,
+    streaming: true,
+    model_count: 1,
+    models: ['m1'],
+    source: 'runtime.toml',
+    endpoint_url: 'https://runtime.example/v1',
+    note: null,
+    discovery: null,
+    ...overrides,
+  }
+}
+
+function makeRuntimeProviders(
+  overrides: Partial<DashboardRuntimeProvidersResponse> = {},
+): DashboardRuntimeProvidersResponse {
+  return {
+    updated_at: '2026-06-21T00:00:00Z',
+    summary: {
+      providers: 1,
+      runtimes: 2,
+      local_models: 0,
+      cloud_models: 2,
+      cli_models: 0,
+      default_runtime_id: 'rt-a',
+    },
+    providers: [
+      makeRuntimeProvider(),
+      makeRuntimeProvider({
+        provider: 'rt-b',
+        runtime_id: 'rt-b',
+        provider_display_name: 'Provider B',
+        model_id: 'm2',
+        model_api_name: 'm2',
+        is_default_runtime: false,
+        thinking_support: true,
+      }),
+    ],
+    assignment_governance: null,
+    config_path: '/cfg/runtime.toml',
+    ...overrides,
+  }
+}
+
 function stubRuntimeDefaults(value: RuntimeDefaultsResponse = makeRuntimeDefaults()) {
   apiMock.fetchRuntimeDefaults.mockResolvedValue(value)
 }
@@ -140,6 +211,7 @@ function stubEmptyApi() {
   apiMock.fetchLogs.mockResolvedValue({ total: 0, entries: [] })
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
   stubRuntimeDefaults()
+  apiMock.fetchRuntimeProviders.mockResolvedValue(makeRuntimeProviders())
 }
 
 const navigate = vi.fn()
@@ -163,6 +235,7 @@ describe('SettingsSurface', () => {
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.fetchRuntimeProviders.mockReset()
     promptApiMock.clearPromptOverride.mockClear()
     promptApiMock.fetchDashboardPrompts.mockClear()
     promptApiMock.savePromptOverride.mockClear()
@@ -281,57 +354,92 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="set-verify"]')).toBeNull()
   })
 
-  it('keeps preview toggle controls read-only instead of mutating local state', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
-    await fireEvent.click(runtimeNav)
-
-    const toggle = () => container.querySelector('[data-testid="set-toggle"]') as HTMLButtonElement
-    expect(toggle().getAttribute('aria-checked')).toBe('true')
-    expect(toggle().disabled).toBe(true)
-    expect(toggle().getAttribute('aria-disabled')).toBe('true')
-
-    await fireEvent.click(toggle())
-    expect(toggle().getAttribute('aria-checked')).toBe('true')
-  })
-
-  it('keeps preview segmented controls read-only instead of mutating local state', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
-    await fireEvent.click(runtimeNav)
-
-    const seg = () => container.querySelector('[data-testid="set-seg"]') as HTMLElement
-    // The Default runtime segmented control renders from resolved runtime config.
-    await waitFor(() => expect(seg()).not.toBeNull())
-    const buttons = () => Array.from(seg().querySelectorAll('button'))
-    expect(buttons().length).toBeGreaterThanOrEqual(3)
-    expect(buttons()[0]!.getAttribute('data-active')).toBe('true')
-    expect(buttons()[0]!.disabled).toBe(true)
-    expect(buttons()[2]!.disabled).toBe(true)
-
-    await fireEvent.click(buttons()[2]!)
-    expect(buttons()[0]!.getAttribute('data-active')).toBe('true')
-    expect(buttons()[2]!.getAttribute('data-active')).toBe('false')
-  })
-
-  it('Default runtime/model options come from the resolved runtime config', async () => {
+  it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
     await fireEvent.click(runtimeNav)
 
     await waitFor(() => {
-      const segLabels = Array.from(
-        container.querySelectorAll('[data-testid="set-seg"] button'),
-      ).map(b => b.textContent?.trim())
-      // runtime ids from the mocked registry, not the old hardcoded oas-* strings
-      expect(segLabels).toContain('rt-a')
-      expect(segLabels).toContain('rt-b')
-      expect(segLabels).toContain('rt-c')
-      expect(segLabels).not.toContain('oas·seoul-1')
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
+      expect(container.querySelector('[data-testid="runtime-settings-live"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-settings-edit"]')).not.toBeNull()
     })
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
+    expect(container.querySelector('[data-testid="set-toggle"]')).toBeNull()
+    expect(container.querySelector('[data-testid="set-seg"]')).toBeNull()
+  })
+
+  it('opens runtime management from the runtime overview entry point', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: unknown) => {
+      const requestUrl =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : typeof (input as { url?: unknown }).url === 'string'
+              ? (input as { url: string }).url
+              : ''
+      const path = requestUrl.startsWith('http')
+        ? new URL(requestUrl).pathname
+        : requestUrl.split('?')[0] ?? requestUrl
+      if (path === '/api/v1/dashboard/dev-token') {
+        return new Response(JSON.stringify({ token: 'dev-token', actor: 'dashboard' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (path === '/api/v1/runtime/config/raw') {
+        return new Response(JSON.stringify({
+          ok: true,
+          path: MOCK_RUNTIME_PATH,
+          file_name: 'runtime.toml',
+          source_text: '[runtime]\ndefault = "rt-a"\n',
+          reloaded: false,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ message: `unexpected ${path}` }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
+    await fireEvent.click(runtimeNav)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-settings-edit"]')).not.toBeNull()
+    })
+    await fireEvent.click(container.querySelector('[data-testid="runtime-settings-edit"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임 관리')
+    expect(navigate).toHaveBeenLastCalledWith('settings', { section: 'runtimes' })
+  })
+
+  it('runtime overview shows resolved defaults and the live provider catalog', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
+    await fireEvent.click(runtimeNav)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-default-runtime"]')?.textContent).toBe('rt-a')
+      expect(container.querySelector('[data-testid="runtime-default-model"]')?.textContent).toBe('m1')
+      expect(container.querySelector('[data-testid="runtime-settings-config-path"]')?.textContent).toContain('/cfg/runtime.toml')
+      const cards = Array.from(container.querySelectorAll('[data-testid="runtime-catalog-card"]'))
+      expect(cards.length).toBe(2)
+      expect(cards.map(card => card.textContent)).toEqual([
+        expect.stringContaining('Provider A'),
+        expect.stringContaining('Provider B'),
+      ])
+      expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')
+    })
+    expect(container.textContent).not.toContain('oas·seoul-1')
   })
 
   it('routing section shows resolved keeper assignments read-only', async () => {
@@ -615,6 +723,7 @@ describe('SettingsSurface shell route', () => {
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.fetchRuntimeProviders.mockReset()
     stubEmptyApi()
     dashboardLoading.value = false
     connected.value = true

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -10,8 +10,14 @@ import {
   type SettingsRouteSectionId,
 } from '../config/navigation'
 import { navigate, route } from '../router'
-import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults } from '../api/dashboard.js'
-import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard.js'
+import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults, fetchRuntimeProviders } from '../api/dashboard.js'
+import type {
+  DashboardRuntimeProviderSnapshot,
+  DashboardRuntimeProvidersResponse,
+  DashboardToolInventoryItem,
+  LogEntry,
+  RuntimeDefaultsResponse,
+} from '../api/dashboard.js'
 import { envBool } from '../config/env'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
@@ -312,10 +318,83 @@ function RolePill({ children }: { children: ComponentChildren }) {
   return html`<span class="set-rolepill">${children}</span>`
 }
 
+function formatRuntimeContext(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'ctx 미수집'
+  if (value >= 1_000_000) return `${Number.parseFloat((value / 1_000_000).toFixed(1))}M ctx`
+  if (value >= 1_000) return `${Math.round(value / 1_000)}K ctx`
+  return `${value} ctx`
+}
+
+function runtimeCatalogKey(item: DashboardRuntimeProviderSnapshot): string {
+  return item.runtime_id?.trim() || item.provider.trim()
+}
+
+function findRuntimeCatalogSnapshot(
+  catalog: readonly DashboardRuntimeProviderSnapshot[],
+  runtimeId: string | null | undefined,
+): DashboardRuntimeProviderSnapshot | null {
+  const needle = runtimeId?.trim() ?? ''
+  if (needle === '') return null
+  return catalog.find(item => runtimeCatalogKey(item) === needle || item.provider_id === needle) ?? null
+}
+
+function RuntimeCatalogCapability({ label, value }: { label: string; value: boolean | undefined }) {
+  const isOn = value === true
+  return html`<span class=${`rt-cap ${isOn ? 'on' : ''}`}>${isOn ? '✓' : '·'} ${label}</span>`
+}
+
+function RuntimeCatalogCard({
+  item,
+  defaultRuntimeId,
+}: {
+  item: DashboardRuntimeProviderSnapshot
+  defaultRuntimeId: string | null | undefined
+}) {
+  const runtimeId = runtimeCatalogKey(item)
+  const providerName = item.provider_display_name ?? item.provider_id ?? item.provider
+  const modelName = item.model_api_name ?? item.model_id ?? item.models[0] ?? 'model 미수집'
+  const transport = item.endpoint_url ?? item.transport ?? item.kind ?? 'transport 미수집'
+  const status = item.available === false ? 'unavailable' : item.status ?? 'configured'
+  const isDefault = runtimeId === (defaultRuntimeId ?? '')
+
+  return html`
+    <div class="set-rt" data-testid="runtime-catalog-card">
+      <div class="set-rt-top">
+        <span class="set-rt-name mono">${runtimeId}</span>
+        <span class="set-rt-kind">${item.runtime_kind ?? item.kind ?? 'runtime'}</span>
+        ${isDefault ? html`<span class="set-rt-kind" data-testid="runtime-catalog-default">default</span>` : null}
+        <span class="set-rt-keepers">${status}</span>
+      </div>
+      <div class="set-rt-row">
+        <span class="sub-k">provider</span>
+        <span class="mono">${providerName}</span>
+      </div>
+      <div class="set-rt-row">
+        <span class="sub-k">model</span>
+        <span class="mono">${modelName}</span>
+      </div>
+      <div class="set-rt-row">
+        <span class="sub-k">context</span>
+        <span class="mono">${formatRuntimeContext(item.max_context)}</span>
+      </div>
+      <div class="rt-caps">
+        <${RuntimeCatalogCapability} label="tools" value=${item.tools_support} />
+        <${RuntimeCatalogCapability} label="thinking" value=${item.thinking_support} />
+        <${RuntimeCatalogCapability} label="streaming" value=${item.streaming} />
+      </div>
+      <div class="set-rt-row">
+        <span class="sub-k">transport</span>
+        <span class="mono set-runtime-transport">${transport}</span>
+      </div>
+    </div>
+  `
+}
+
 function settingsSectionState(
   section: SectionId,
   fusionSettingsWritable: boolean,
 ): { live: boolean; label: string } {
+  if (section === 'runtime') return { live: true, label: 'runtime.toml live-backed' }
   if (section === 'runtimes') return { live: true, label: 'runtime.toml live-backed' }
   if (section === 'prompts') return { live: true, label: 'prompt registry live-backed' }
   if (section === 'fusion' && fusionSettingsWritable) {
@@ -479,11 +558,8 @@ export function SettingsSurface() {
 
   // runtime defaults / model routing — resolved from runtime.toml (SSOT)
   const [runtimeDefaults, setRuntimeDefaults] = useState<RuntimeDefaultsResponse | null>(null)
-  const [defRuntime, setDefRuntime] = useState('')
-  const [defModel, setDefModel] = useState('')
-  const [maxPar, setMaxPar] = useState(6)
-  const [compactAt, setCompactAt] = useState(85)
-  const [autoCompact, setAutoCompact] = useState(true)
+  const [runtimeProviders, setRuntimeProviders] = useState<DashboardRuntimeProvidersResponse | null>(null)
+  const [runtimeCatalogStatus, setRuntimeCatalogStatus] = useState<'loading' | 'ready' | 'error'>('loading')
 
   useEffect(() => {
     let active = true
@@ -492,13 +568,27 @@ export function SettingsSurface() {
         const resp = await fetchRuntimeDefaults()
         if (!active) return
         setRuntimeDefaults(resp)
-        // Seed the selectors with the resolved defaults (unknown → left blank,
-        // never a fabricated default).
-        if (resp.default_runtime_id) setDefRuntime(resp.default_runtime_id)
-        if (resp.default_model) setDefModel(resp.default_model)
       } catch {
         if (!active) return
         setRuntimeDefaults(null)
+      }
+    })()
+    return () => { active = false }
+  }, [])
+
+  useEffect(() => {
+    let active = true
+    setRuntimeCatalogStatus('loading')
+    void (async () => {
+      try {
+        const resp = await fetchRuntimeProviders()
+        if (!active) return
+        setRuntimeProviders(resp)
+        setRuntimeCatalogStatus('ready')
+      } catch {
+        if (!active) return
+        setRuntimeProviders(null)
+        setRuntimeCatalogStatus('error')
       }
     })()
     return () => { active = false }
@@ -591,9 +681,17 @@ export function SettingsSurface() {
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
-  const runtimeIdOptions = runtimeEntries.map(r => r.id)
-  const runtimeModelOptions = [...new Set(runtimeEntries.map(r => r.model))]
+  const runtimeCatalogEntries = runtimeProviders?.providers ?? []
+  const runtimeConfigPath = runtimeProviders?.config_path ?? runtimeDefaults?.config_path ?? null
+  const defaultRuntimeId = runtimeDefaults?.default_runtime_id ?? runtimeProviders?.summary?.default_runtime_id ?? null
+  const defaultCatalogEntry = findRuntimeCatalogSnapshot(runtimeCatalogEntries, defaultRuntimeId)
   const keeperAssignments = runtimeDefaults?.model_routing.keeper_assignments ?? []
+  const runtimeCount = runtimeEntries.length > 0
+    ? runtimeEntries.length
+    : runtimeProviders?.summary?.runtimes ?? runtimeCatalogEntries.length
+  const keeperAssignmentCount = keeperAssignments.length > 0
+    ? keeperAssignments.length
+    : runtimeProviders?.assignment_governance?.assignment_count ?? 0
   const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
   const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
 
@@ -645,7 +743,7 @@ export function SettingsSurface() {
           </header>
 
           <div
-            class=${`set-card-b mx-6 my-6 ${sec === 'runtimes' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
+            class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
             data-preview-locked=${sectionState.live ? 'false' : 'true'}
           >
             ${sec === 'account' && html`
@@ -707,27 +805,74 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtime' && html`
-              <${SetRow} label="Default runtime" hint="Resolved from runtime.toml [runtime].default">
-                ${runtimeIdOptions.length === 0
-                  ? html`<span class="set-hint" data-testid="runtime-default-empty">런타임 설정을 불러오지 못했습니다.</span>`
-                  : html`<${SetSeg} value=${defRuntime} options=${runtimeIdOptions} onChange=${setDefRuntime} />`}
-              <//>
-              <${SetRow} label="Default model" hint="API model of the default runtime">
-                ${runtimeModelOptions.length === 0
-                  ? html`<span class="set-hint">—</span>`
-                  : html`<${SetSeg} value=${defModel} options=${runtimeModelOptions} onChange=${setDefModel} />`}
-              <//>
-              <${SetRow} label="Max concurrent keepers" hint="In this namespace">
-                <${SetStepper} v=${maxPar} set=${setMaxPar} min=${1} max=${12} />
-              <//>
-              <${SetRow} label="Auto compaction" hint=${`Compact at ${compactAt}% context`}>
-                <${SetToggle} on=${autoCompact} onChange=${setAutoCompact} />
-              <//>
-              ${autoCompact && html`
-                <${SetRow} label="Compaction threshold" hint="Window usage basis">
-                  <${SetSlider} value=${compactAt} min=${60} max=${95} suffix="%" onChange=${setCompactAt} />
-                <//>
-              `}
+              <div class="settings-runtime-live" data-testid="runtime-settings-live">
+                <div class="settings-runtime-live-h">
+                  <div>
+                    <div class="set-sub-h">runtime.toml</div>
+                    <div class="set-hint">현재 서버가 해석한 런타임 기본값과 provider 카탈로그입니다.</div>
+                  </div>
+                  <button
+                    type="button"
+                    class="set-rt-open"
+                    data-testid="runtime-settings-edit"
+                    onClick=${() => openSection('runtimes')}
+                  >
+                    런타임 관리 열기
+                  </button>
+                </div>
+                <div class="settings-runtime-live-source mono" data-testid="runtime-settings-config-path">
+                  ${runtimeConfigPath ?? 'runtime.toml 경로 미확인'}
+                </div>
+
+                <div class="set-rt-launch" data-testid="runtime-settings-summary">
+                  <div class="set-rt-launch-stats">
+                    <div class="set-rt-launch-stat">
+                      <span class="v mono">${runtimeCount}</span>
+                      <span class="k">resolved runtimes</span>
+                    </div>
+                    <div class="set-rt-launch-stat">
+                      <span class="v mono">${runtimeCatalogEntries.length}</span>
+                      <span class="k">catalog entries</span>
+                    </div>
+                    <div class="set-rt-launch-stat">
+                      <span class="v mono">${keeperAssignmentCount}</span>
+                      <span class="k">keeper assignments</span>
+                    </div>
+                  </div>
+                  <${SetRow} label="Default runtime" hint="[runtime].default">
+                    ${defaultRuntimeId
+                      ? html`<span class="mono" data-testid="runtime-default-runtime">${defaultRuntimeId}</span>`
+                      : html`<span class="set-hint" data-testid="runtime-default-empty">런타임 설정을 불러오지 못했습니다.</span>`}
+                  <//>
+                  <${SetRow} label="Default model" hint="Resolved model API name">
+                    <span class="mono" data-testid="runtime-default-model">${runtimeDefaults?.default_model ?? defaultCatalogEntry?.model_api_name ?? '—'}</span>
+                  <//>
+                  <${SetRow} label="Default context" hint="Resolved context window">
+                    <span class="mono" data-testid="runtime-default-context">
+                      ${formatRuntimeContext(runtimeDefaults?.default_max_context ?? defaultCatalogEntry?.max_context ?? null)}
+                    </span>
+                  <//>
+                </div>
+
+                <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
+                ${runtimeCatalogStatus === 'loading'
+                  ? html`<div class="set-hint" data-testid="runtime-catalog-loading">runtime catalog 불러오는 중...</div>`
+                  : runtimeCatalogStatus === 'error'
+                    ? html`<div class="set-hint" data-testid="runtime-catalog-error">runtime catalog를 불러오지 못했습니다.</div>`
+                    : runtimeCatalogEntries.length === 0
+                      ? html`<div class="set-hint" data-testid="runtime-catalog-empty">표시할 runtime catalog entry가 없습니다.</div>`
+                      : html`
+                        <div class="settings-runtime-catalog" data-testid="runtime-catalog-summary">
+                          ${runtimeCatalogEntries.map(item => html`
+                            <${RuntimeCatalogCard}
+                              key=${runtimeCatalogKey(item)}
+                              item=${item}
+                              defaultRuntimeId=${defaultRuntimeId}
+                            />
+                          `)}
+                        </div>
+                      `}
+              </div>
             `}
 
             ${sec === 'runtimes' && html`

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -270,6 +270,25 @@
   padding: 6px 8px;
 }
 
+.settings-runtime-catalog {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.settings-runtime-catalog .set-rt {
+  margin-top: 0;
+  min-width: 0;
+}
+
+.set-runtime-transport {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 900px) {
   .settings-surf .set-card-b.set-card-b-wide {
     max-width: 100%;
@@ -449,6 +468,54 @@
 
 .set-rt-row .set-input {
   flex: 1;
+}
+
+.set-rt-launch {
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: 16px 18px;
+}
+
+.set-rt-launch-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+  margin-bottom: 12px;
+}
+
+.set-rt-launch-stat .v {
+  display: block;
+  font-size: 17px;
+  color: var(--text-bright);
+}
+
+.set-rt-launch-stat .k {
+  display: block;
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.set-rt-open {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 9px 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt);
+  cursor: pointer;
+  transition: 0.14s;
+  white-space: nowrap;
+}
+
+.set-rt-open:hover {
+  background: var(--volt);
+  color: var(--volt-ink);
 }
 
 /* system log viewer */


### PR DESCRIPTION
## What changed

- Reworked Settings > Runtime defaults from disabled preview controls into a live-backed runtime overview.
- Added runtime catalog cards sourced from `/api/v1/providers`, including provider, model, context, capabilities, transport, and default marker.
- Added a clear entry point from the overview into the existing `runtime.toml` management editor.
- Added responsive CSS for the runtime summary/catalog and updated settings tests around the new behavior.

## Why

The previous Runtime defaults tab looked editable but was only local preview state, while the actual writer lived under Runtime management. The catalog data also was not visible on the Settings runtime surface, so operators had to infer configured runtimes from other screens.

## Impact

Operators now see the live runtime.toml-derived defaults and catalog in Settings, then jump directly to the real runtime.toml editor for changes. The existing write path remains centralized in Runtime management.

## Validation

- `git diff --check HEAD~1 HEAD`
- `env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit`
- `env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/settings-surface.ts`
- `env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run src/components/settings-surface.test.ts src/components/runtime-toml-editor.test.ts src/components/keeper-runtime-model-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- Playwright rendered check against local dashboard: desktop/mobile Settings runtime overview, 9 catalog cards, default runtime visible, Runtime management navigation works, no console/page errors.

Build is left to CI.