### PR TITLE
fix(keeper): gate backlog triggers on claimable work

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -638,7 +638,7 @@ Unified keeper의 내부 decision record는 `{keeper_dir}/{name}.decisions.jsonl
 
 각 레코드에는:
 - `id`: 고유 결정 ID (`dec-{timestamp_ms}-{hash}`)
-- `trigger_signals`: turn 시점에 관찰된 트리거 후보 (`direct_mention`, `board_activity`, `new_unclaimed_task` 등)
+- `trigger_signals`: turn 시점에 관찰된 트리거 후보 (`direct_mention`, `board_activity`, `claimable_task` 등)
 - `observed_affordances`: 당시 가능한 액션 후보 (`task_claim`, `reply_in_workspace`, `board_post_or_comment` 등)
 - `turn_mode`: 실제 최종 결과 분류 (`tool_use`, `text_response`, `skip_text`, `noop`). 에러 여부는 `outcome`이 담당한다.
 - `tools_used`: 실제 호출된 tool 목록

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -60,6 +60,25 @@ let replay_suffix_prune_reason
   else None
 ;;
 
+let stop_reason_requests_resume_merge = function
+  | Runtime_agent.TurnBudgetExhausted _ -> true
+  | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+;;
+
+let should_resume_merge
+      ~pre_dispatch_compacted
+      ~state_snapshot_source
+      ~stop_reason
+      ~completion_contract_result
+  =
+  if completion_contract_drops_current_turn_replay completion_contract_result
+  then false
+  else
+    pre_dispatch_compacted
+    || Keeper_memory_policy.state_snapshot_source_is_synthetic state_snapshot_source
+    || stop_reason_requests_resume_merge stop_reason
+;;
+
 let rec messages_prefix_equal expected actual =
   match expected, actual with
   | [], _ -> true
@@ -187,6 +206,7 @@ module For_testing = struct
     replay_suffix_prune_reason_to_string
 
   let checkpoint_for_replay_persistence = checkpoint_for_replay_persistence
+  let should_resume_merge = should_resume_merge
 end
 
 let finalize
@@ -260,14 +280,12 @@ let finalize
      reminder, or the model emitted no structured state at all (synthesized). On
      a normal model-authored state turn the snapshot is authoritative, so a
      dropped loop still clears. *)
-  let is_budget_exhausted = function
-    | Runtime_agent.TurnBudgetExhausted _ -> true
-    | _ -> false
-  in
   let resume_merge =
-    pre_dispatch_compacted
-    || Keeper_memory_policy.state_snapshot_source_is_synthetic state_snapshot_source
-    || is_budget_exhausted result.stop_reason
+    should_resume_merge
+      ~pre_dispatch_compacted
+      ~state_snapshot_source
+      ~stop_reason:result.stop_reason
+      ~completion_contract_result
   in
   let { Keeper_agent_run_sidecar.working_state = _
       ; state_snapshot_saved = _

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -148,6 +148,26 @@ let keepalive_keeper_names config =
       None)
 ;;
 
+let paused_reconcile_keeper_names config =
+  configured_keeper_names config
+  |> List.filter_map (fun name ->
+    match read_meta_file_path (keeper_meta_path config name) with
+    | Ok (Some meta) when meta.paused && effective_autoboot_enabled config name meta ->
+      Some meta.name
+    | Ok (Some _)
+    | Ok None -> None
+    | Error msg ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string MetaReadFailures)
+        ~labels:[("keeper", name); ("site", "paused_reconcile_read")]
+        ();
+      Log.Keeper.warn
+        "paused_reconcile_keeper_names: meta read failed for %s, dropping from paused reconcile set: %s"
+        name
+        msg;
+      None)
+;;
+
 (** Names of keepers that should be running across sessions.
     A keeper is "persistent" when its on-disk meta has autoboot enabled
     and is not currently paused - i.e. the operator expects the runtime

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -53,6 +53,12 @@ val declarative_autoboot_enabled_by_default : Workspace.config -> string -> bool
     (issue #8377). *)
 val keepalive_keeper_names : Workspace.config -> string list
 
+(** Names of paused keepers whose durable meta should still be inspected
+    during supervisor reconciliation. These keepers are not keepalive
+    execution candidates, but a previous runtime may have left them paused
+    while still owning an active backlog task. *)
+val paused_reconcile_keeper_names : Workspace.config -> string list
+
 (** Names of keepers expected to persist across sessions. Mirrors
     [keepalive_keeper_names] for readers caring about durability
     rather than the keepalive fiber. *)

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -138,6 +138,62 @@ let clear_current_task_id_after_successful_pause_release ~config ~meta ~reason_t
        false)
 ;;
 
+let blocker_class_releases_owned_tasks_on_pause = function
+  | Turn_timeout | Turn_livelock_blocked | No_progress_loop -> true
+  | Runtime_exhausted _
+  | Capacity_backpressure
+  | Ambiguous_post_commit_timeout
+  | Ambiguous_post_commit_failure
+  | Admission_queue_wait_timeout
+  | Turn_timeout_after_queue_wait
+  | Completion_contract_violation
+  | Fiber_unresolved
+  | Stale_turn_timeout
+  | Stale_fleet_batch
+  | Oas_agent_execution_timeout
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met
+  | Sdk_input_required -> false
+;;
+
+let reconcile_persisted_auto_pause_task_release ~config ~meta =
+  let release_required =
+    meta.paused
+    &&
+    match meta.runtime.last_blocker with
+    | Some { klass; _ } -> blocker_class_releases_owned_tasks_on_pause klass
+    | None -> false
+  in
+  if not release_required
+  then Ok meta
+  else (
+    let reason_tag = "persisted_auto_pause_reconcile" in
+    let release_ok = release_owned_active_tasks_after_pause ~config ~meta ~reason_tag in
+    if not release_ok
+    then
+      Error
+        (Printf.sprintf
+           "%s: persisted auto-pause task release failed"
+           meta.name)
+    else if
+      clear_current_task_id_after_successful_pause_release
+        ~config
+        ~meta
+        ~reason_tag
+    then Ok { meta with current_task_id = None; updated_at = now_iso () }
+    else
+      Error
+        (Printf.sprintf
+           "%s: persisted auto-pause current_task_id clear failed"
+           meta.name))
+;;
+
 let handle_crash_auto_pause
       ~publish_phase_lifecycle
       (ctx : _ context)

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -93,6 +93,16 @@ val handle_auto_pause_from_meta
   -> unit
   -> (Keeper_meta_contract.keeper_meta, string) result
 
+(** [reconcile_persisted_auto_pause_task_release ~config ~meta] repairs
+    durable paused meta left behind by an earlier runtime before the pause
+    policy could clear task ownership. It only acts on typed blocker classes
+    whose pause path already owns task release semantics; operator/manual
+    pauses without such a blocker are left untouched. *)
+val reconcile_persisted_auto_pause_task_release
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> (Keeper_meta_contract.keeper_meta, string) result
+
 (** [failure_reason_policy_decision reason] maps a persisted
     [Keeper_registry.failure_reason] back to a
     [Keeper_failure_policy.decision]. Returns [None] for non-policy

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -81,12 +81,27 @@ let reconcile_keepalive_keepers
           ();
         Log.Keeper.info "%s: reconciled durable keeper" meta.name))
   in
+  let reconcile_paused_meta meta =
+    match
+      Keeper_supervisor_pause_policy.reconcile_persisted_auto_pause_task_release
+        ~config:ctx.config
+        ~meta
+    with
+    | Ok _meta -> ()
+    | Error err ->
+      inc_reconcile_failure ~name:meta.name ~operation:"paused_task_release";
+      Log.Keeper.warn
+        "reconcile: paused keeper %s task release repair failed: %s"
+        meta.name
+        err
+  in
   let reconcile_one name =
     try
       match read_effective_meta ctx.config name with
       | Ok (Some meta) when not meta.paused ->
         reconcile_meta meta
-      | Ok (Some _meta) -> () (* paused, skip *)
+      | Ok (Some meta) ->
+        reconcile_paused_meta meta
       | Ok None ->
         (match load_or_materialize_keeper_meta ctx name with
          | Ok (Some meta) when not meta.paused ->
@@ -94,9 +109,10 @@ let reconcile_keepalive_keepers
            then
              Log.Keeper.info
                "%s: materialized durable keeper during reconcile"
-               meta.name
+             meta.name
            else reconcile_meta meta
-         | Ok (Some _meta) -> ()
+         | Ok (Some meta) ->
+           reconcile_paused_meta meta
          | Ok None ->
            Log.Keeper.debug
              "reconcile: configured keeper %s has no materialized meta"

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -15,10 +15,14 @@ let reconcile_keepalive_keepers
       ~publish_lifecycle
       ~supervise_keepalive
       ~load_or_materialize_keeper_meta
-      (ctx : _ context)
+  (ctx : _ context)
   =
   let base_path = ctx.config.base_path in
-  let names = Keeper_meta_store.keepalive_keeper_names ctx.config in
+  let names =
+    Keeper_meta_store.keepalive_keeper_names ctx.config
+    @ Keeper_meta_store.paused_reconcile_keeper_names ctx.config
+    |> List.sort_uniq String.compare
+  in
   Log.Keeper.debug
     "reconcile_keepalive_keepers: started (candidates=%d)"
     (List.length names);

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -438,29 +438,43 @@ let turn_mode_of_result (result : Keeper_agent_run.run_result) : turn_mode =
 let turn_mode_of_json = Turn_mode_codec.turn_mode_of_json
 let work_kind_of_json = Turn_mode_codec.work_kind_of_json
 
+let claim_backlog_actionable
+    (observation : Keeper_world_observation.world_observation) : bool =
+  observation.claimable_task_count > 0
+  && observation.provider_capacity_blocked_task_count = 0
+
+let singleton_when condition label =
+  if condition then [ label ] else []
+
 let observed_triggers_of_observation
     ?meta
     (observation : Keeper_world_observation.world_observation) : string list =
-  let triggers = ref [] in
-  let add trigger = triggers := trigger :: !triggers in
-  if observation.pending_mentions <> [] then add "direct_mention";
-  if observation.pending_board_events <> [] then add "board_activity";
-  if observation.pending_scope_messages <> [] then add "scope_message";
-  if observation.unclaimed_task_count > 0 then add "new_unclaimed_task";
-  if observation.claimable_task_count > 0 then add "claimable_task";
-  if observation.provider_capacity_blocked_task_count > 0 then
-    add "provider_capacity_blocked_backlog";
-  if observation.failed_task_count > 0 then add "failed_task";
   let _ = meta in
-  if observation.pending_verification_count > 0 then
-    add "pending_verification";
-  if observation.scheduled_automation.due_ready_count > 0 then
-    add "scheduled_automation_due_ready";
-  if observation.scheduled_automation.blocked_approval_count > 0 then
-    add "scheduled_automation_blocked_approval";
-  if observation.active_goals <> [] && observation.idle_seconds > 0 then
-    add "idle_timeout_candidate";
-  List.rev !triggers
+  let actionable_backlog = claim_backlog_actionable observation in
+  List.concat
+    [
+      singleton_when (observation.pending_mentions <> []) "direct_mention";
+      singleton_when (observation.pending_board_events <> []) "board_activity";
+      singleton_when (observation.pending_scope_messages <> []) "scope_message";
+      singleton_when actionable_backlog "new_unclaimed_task";
+      singleton_when actionable_backlog "claimable_task";
+      singleton_when
+        (observation.provider_capacity_blocked_task_count > 0)
+        "provider_capacity_blocked_backlog";
+      singleton_when (observation.failed_task_count > 0) "failed_task";
+      singleton_when
+        (observation.pending_verification_count > 0)
+        "pending_verification";
+      singleton_when
+        (observation.scheduled_automation.due_ready_count > 0)
+        "scheduled_automation_due_ready";
+      singleton_when
+        (observation.scheduled_automation.blocked_approval_count > 0)
+        "scheduled_automation_blocked_approval";
+      singleton_when
+        (observation.active_goals <> [] && observation.idle_seconds > 0)
+        "idle_timeout_candidate";
+    ]
 
 let observed_affordances_of_observation
     ?meta
@@ -473,11 +487,7 @@ let observed_affordances_of_observation
   if observation.pending_scope_messages <> [] then add "message_sweep";
   if observation.provider_capacity_blocked_task_count > 0 then
     add "provider_capacity_blocked";
-  if
-    observation.claimable_task_count > 0
-    && observation.provider_capacity_blocked_task_count = 0
-  then
-    add "task_claim";
+  if claim_backlog_actionable observation then add "task_claim";
   if observation.failed_task_count > 0 then add "task_audit";
   if observation.pending_verification_count > 0 then
     add "task_verify";

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -38,11 +38,20 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
     meta
   in
   match
-    Keeper_turn_runtime_budget.sync_keeper_paused_state_with_resume_policy
+    Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
       ~config
       ~meta:blocked_meta
-      ~paused:true
+      ~reason_tag:failure_reason_code
+      ~lifecycle_detail:detail
+      ~log_message:
+        (Printf.sprintf
+           "no_progress loop escalated to blocker and operator-resume pause \
+            (streak=%d threshold=%d)"
+           streak
+           threshold)
+      ~blocker_class:(Some Keeper_meta_contract.No_progress_loop)
       ~resume_policy:Keeper_supervisor_pause_policy.Manual_resume_required
+      ()
   with
   | Ok paused_meta ->
     Log.Keeper.warn

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -15,6 +15,7 @@ module KT = Keeper_types
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
 module Keeper_meta_json = Masc.Keeper_meta_json
+module Keeper_meta_store = Masc.Keeper_meta_store
 module MC = Masc.Keeper_meta_contract
 
 let temp_dir prefix =
@@ -211,6 +212,49 @@ let queue_contains_post_id queue post_id =
   |> List.exists (fun stimulus ->
     String.equal stimulus.Keeper_event_queue.post_id post_id)
 
+let task_id_of_created_task (created : Masc.Workspace.add_task_success) =
+  match Keeper_id.Task_id.of_string created.task_id with
+  | Ok task_id -> task_id
+  | Error err -> fail err
+
+let create_owned_active_task config meta =
+  let created =
+    match
+      Masc.Workspace.add_task_with_result
+        config
+        ~title:"no-progress release regression"
+        ~priority:1
+        ~description:"owned active task must release when no-progress pause latches"
+    with
+    | Ok created -> created
+    | Error err -> fail (Masc.Workspace.add_task_error_to_string err)
+  in
+  (match
+     Masc.Workspace.claim_task_r
+       config
+       ~agent_name:meta.Keeper_meta_contract.agent_name
+       ~task_id:created.task_id
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Masc_domain.masc_error_to_string err));
+  (match
+     Masc.Workspace.transition_task_r
+       config
+       ~agent_name:meta.Keeper_meta_contract.agent_name
+       ~task_id:created.task_id
+       ~action:Masc_domain.Start
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Masc_domain.masc_error_to_string err));
+  created
+
+let task_status_by_id config task_id =
+  Masc.Workspace.get_tasks_raw config
+  |> List.find (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+  |> fun task -> task.Masc_domain.task_status
+
 let event_queue_snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
@@ -270,6 +314,49 @@ let test_no_progress_loop_detection_pauses_keeper () =
 	                 ~base_path:config.base_path
 	                 keeper_name))
 	       | None -> fail "expected registered keeper")
+
+let test_no_progress_loop_detection_releases_owned_active_task () =
+  let base_path = temp_dir "masc-no-progress-release-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       let _init_msg = Masc.Workspace.init config ~agent_name:(Some "operator") in
+       let keeper_name = "no-progress-owner" in
+       let meta = make_meta keeper_name in
+       let created = create_owned_active_task config meta in
+       let current_task_id = task_id_of_created_task created in
+       let meta = { meta with current_task_id = Some current_task_id } in
+       Masc.Keeper_registry.clear ();
+       (match Keeper_meta_store.write_meta config meta with
+        | Ok () -> ()
+        | Error err -> fail err);
+       let _entry =
+         Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta
+       in
+       let paused_meta =
+         Masc.Keeper_unified_turn_no_progress.mark_loop_detected
+           ~config
+           meta
+           ~streak:10
+           ~threshold:10
+       in
+       check (option string) "returned meta current_task_id cleared" None
+         (Option.map Keeper_id.Task_id.to_string paused_meta.current_task_id);
+       (match task_status_by_id config created.task_id with
+        | Masc_domain.Todo -> ()
+        | status ->
+          fail
+            (Printf.sprintf
+               "expected no-progress pause to release task to todo, got %s"
+               (Masc_domain.task_status_to_string status)));
+       match Keeper_meta_store.read_meta config keeper_name with
+       | Ok (Some persisted) ->
+         check bool "persisted meta paused" true persisted.paused;
+         check (option string) "persisted current_task_id cleared" None
+           (Option.map Keeper_id.Task_id.to_string persisted.current_task_id)
+       | Ok None -> fail "expected persisted keeper meta"
+       | Error err -> fail err)
 
 let test_operator_resume_clears_no_progress_loop_latch () =
   Eio_main.run
@@ -1085,6 +1172,8 @@ let () =
         [
           test_case "loop detection pauses keeper for manual resume" `Quick
             test_no_progress_loop_detection_pauses_keeper;
+          test_case "loop detection releases owned active task" `Quick
+            test_no_progress_loop_detection_releases_owned_active_task;
           test_case "operator resume clears no-progress latch" `Quick
             test_operator_resume_clears_no_progress_loop_latch;
           test_case

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -11,6 +11,7 @@
 module KMP = Masc.Keeper_memory_policy
 module KCC = Masc.Keeper_context_core
 module KRT = Masc.Keeper_agent_run_response_text
+module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
 module Receipt = Masc.Keeper_execution_receipt
 
 let contains_substring text needle =
@@ -811,6 +812,30 @@ let test_budget_finalizer_drops_synthetic_response_text () =
     []
     finalized.state_snapshot.decisions
 
+let test_attention_contract_does_not_resume_working_state_digest () =
+  let attention_resume =
+    Finalize.should_resume_merge
+      ~pre_dispatch_compacted:false
+      ~state_snapshot_source:KMP.Synthesized
+      ~stop_reason:Runtime_agent.Completed
+      ~completion_contract_result:Receipt.Contract_passive_only
+  in
+  Alcotest.(check bool)
+    "attention contract does not restore prior prompt-digest loops"
+    false
+    attention_resume;
+  let budget_resume =
+    Finalize.should_resume_merge
+      ~pre_dispatch_compacted:false
+      ~state_snapshot_source:KMP.Synthesized
+      ~stop_reason:(Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 })
+      ~completion_contract_result:Receipt.Contract_satisfied_completion
+  in
+  Alcotest.(check bool)
+    "budget checkpoint still resumes prior prompt-digest loops"
+    true
+    budget_resume
+
 let test_synthetic_finalizer_drops_generated_response_text () =
   let raw_response_text =
     String.concat
@@ -968,6 +993,10 @@ let () =
             "budget finalizer drops synthetic response text"
             `Quick
             test_budget_finalizer_drops_synthetic_response_text;
+          Alcotest.test_case
+            "attention result does not resume working-state digest"
+            `Quick
+            test_attention_contract_does_not_resume_working_state_digest;
           Alcotest.test_case
             "synthetic finalizer drops generated response text"
             `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -469,6 +469,44 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 
+let create_started_task_for_meta config (meta : Keeper_meta_contract.keeper_meta) ~title =
+  let created =
+    match
+      Masc.Workspace.add_task_with_result
+        config
+        ~title
+        ~priority:1
+        ~description:"test task"
+    with
+    | Ok created -> created
+    | Error err -> fail (Masc.Workspace.add_task_error_to_string err)
+  in
+  (match
+     Masc.Workspace.claim_task_r
+       config
+       ~agent_name:meta.agent_name
+       ~task_id:created.task_id
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Masc_domain.masc_error_to_string err));
+  (match
+     Masc.Workspace.transition_task_r
+       config
+       ~agent_name:meta.agent_name
+       ~task_id:created.task_id
+       ~action:Masc_domain.Start
+       ()
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Masc_domain.masc_error_to_string err));
+  created
+
+let task_status_for_id config task_id =
+  Masc.Workspace.get_tasks_raw config
+  |> List.find (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+  |> fun (task : Masc_domain.task) -> task.task_status
+
 let noop_load_or_materialize_keeper_meta _ctx _name = Ok None
 
 let sweep_and_recover_no_materialize ctx =
@@ -786,6 +824,131 @@ let test_reconcile_does_not_double_start_materialized_keeper () =
     (List.rev !supervised);
   check bool "materialized keeper registered" true
     (Reg.is_registered ~base_path:config.base_path name)
+
+let test_reconcile_repairs_persisted_no_progress_paused_task_owner () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "paused-no-progress-owner" in
+  write_keeper_toml config_dir ~name;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+  let ctx = keeper_runtime_context env sw config in
+  let base_meta = make_meta name in
+  let created =
+    create_started_task_for_meta
+      config
+      base_meta
+      ~title:"persisted no-progress owner release"
+  in
+  let task_id =
+    match Keeper_id.Task_id.of_string created.task_id with
+    | Ok task_id -> task_id
+    | Error err -> fail err
+  in
+  let meta =
+    {
+      base_meta with
+      paused = true;
+      current_task_id = Some task_id;
+      runtime =
+        {
+          base_meta.runtime with
+          last_blocker =
+            Some
+              (Keeper_meta_contract.blocker_info_of_class
+                 ~detail:"no_progress loop detected"
+                 Keeper_meta_contract.No_progress_loop);
+        };
+    }
+  in
+  (match Keeper_meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error err -> fail err);
+  let supervised = ref [] in
+  let publish_lifecycle ~event:_ _name _detail () = () in
+  let supervise_keepalive ~proactive_warmup_sec:_ _ctx
+      (meta : Keeper_meta_contract.keeper_meta) =
+    supervised := meta.name :: !supervised
+  in
+  KSR.reconcile_keepalive_keepers
+    ~publish_lifecycle
+    ~supervise_keepalive
+    ~load_or_materialize_keeper_meta:noop_load_or_materialize_keeper_meta
+    ctx;
+  check (list string) "paused keeper is not supervised" [] (List.rev !supervised);
+  (match task_status_for_id config created.task_id with
+   | Masc_domain.Todo -> ()
+   | status ->
+     fail
+       (Printf.sprintf
+          "expected paused owner task to be released, got %s"
+          (Masc_domain.task_status_to_string status)));
+  match Keeper_meta_store.read_meta config name with
+  | Ok (Some persisted) ->
+    check bool "keeper remains paused" true persisted.paused;
+    check (option string) "stale current_task_id cleared" None
+      (Option.map Keeper_id.Task_id.to_string persisted.current_task_id)
+  | Ok None -> fail "expected persisted keeper meta"
+  | Error err -> fail err
+
+let test_reconcile_keeps_manual_paused_task_owner () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun env ->
+  ensure_test_runtime ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = Filename.dirname config_dir in
+  let name = "manual-paused-owner" in
+  write_keeper_toml config_dir ~name;
+  Eio.Switch.on_release sw (fun () ->
+      Reg.clear ();
+      KR.reset_test_state base_dir);
+  let config = Masc.Workspace.default_config base_dir in
+  let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+  let ctx = keeper_runtime_context env sw config in
+  let base_meta = make_meta name in
+  let created =
+    create_started_task_for_meta config base_meta ~title:"manual paused owner"
+  in
+  let task_id =
+    match Keeper_id.Task_id.of_string created.task_id with
+    | Ok task_id -> task_id
+    | Error err -> fail err
+  in
+  let meta = { base_meta with paused = true; current_task_id = Some task_id } in
+  (match Keeper_meta_store.write_meta config meta with
+   | Ok () -> ()
+   | Error err -> fail err);
+  let publish_lifecycle ~event:_ _name _detail () = () in
+  let supervise_keepalive ~proactive_warmup_sec:_ _ctx _meta = () in
+  KSR.reconcile_keepalive_keepers
+    ~publish_lifecycle
+    ~supervise_keepalive
+    ~load_or_materialize_keeper_meta:noop_load_or_materialize_keeper_meta
+    ctx;
+  (match task_status_for_id config created.task_id with
+   | Masc_domain.InProgress { assignee; _ } ->
+     check string "manual pause keeps active owner" base_meta.agent_name assignee
+   | status ->
+     fail
+       (Printf.sprintf
+          "expected manual paused owner task to stay in_progress, got %s"
+          (Masc_domain.task_status_to_string status)));
+  match Keeper_meta_store.read_meta config name with
+  | Ok (Some persisted) ->
+    check bool "keeper remains paused" true persisted.paused;
+    check (option string) "current_task_id preserved"
+      (Some created.task_id)
+      (Option.map Keeper_id.Task_id.to_string persisted.current_task_id)
+  | Ok None -> fail "expected persisted keeper meta"
+  | Error err -> fail err
 
 let test_reconcile_materialize_failure_continues_with_metric () =
   with_config_dir @@ fun config_dir ->
@@ -3139,6 +3302,10 @@ let () =
         test_reconcile_materializes_configured_keeper_without_meta;
       test_case "reconcile does not double-start materialized keeper" `Quick
         test_reconcile_does_not_double_start_materialized_keeper;
+      test_case "reconcile repairs persisted no-progress paused task owner" `Quick
+        test_reconcile_repairs_persisted_no_progress_paused_task_owner;
+      test_case "reconcile keeps manual paused task owner" `Quick
+        test_reconcile_keeps_manual_paused_task_owner;
       test_case "reconcile materialize failure is isolated and metriced" `Quick
         test_reconcile_materialize_failure_continues_with_metric;
       test_case "reconcile supervise exception is isolated" `Quick

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -250,9 +250,19 @@ let test_backlog_trigger_split () =
     { base_observation with unclaimed_task_count = 3; claimable_task_count = 1 }
   in
   let triggers = UM.observed_triggers_of_observation obs in
-  check bool "absolute backlog trigger remains visible" true
+  check bool "claimable backlog trigger remains visible" true
     (List.mem "new_unclaimed_task" triggers);
   check bool "matched backlog trigger is explicit" true
+    (List.mem "claimable_task" triggers)
+
+let test_unclaimable_backlog_is_not_a_claim_trigger () =
+  let obs =
+    { base_observation with unclaimed_task_count = 3; claimable_task_count = 0 }
+  in
+  let triggers = UM.observed_triggers_of_observation obs in
+  check bool "unclaimable backlog is not a new task trigger" false
+    (List.mem "new_unclaimed_task" triggers);
+  check bool "unclaimable backlog is not a claimable task trigger" false
     (List.mem "claimable_task" triggers)
 
 let test_provider_capacity_blocked_trigger () =
@@ -265,6 +275,10 @@ let test_provider_capacity_blocked_trigger () =
     }
   in
   let triggers = UM.observed_triggers_of_observation obs in
+  check bool "provider-blocked backlog is not a new task trigger" false
+    (List.mem "new_unclaimed_task" triggers);
+  check bool "provider-blocked backlog is not a claimable task trigger" false
+    (List.mem "claimable_task" triggers);
   check bool "provider capacity trigger is explicit" true
     (List.mem "provider_capacity_blocked_backlog" triggers)
 
@@ -347,6 +361,8 @@ let () =
             `Quick test_task_claim_suppressed_for_provider_blocked_backlog;
           test_case "trigger: absolute and matched backlog split" `Quick
             test_backlog_trigger_split;
+          test_case "trigger: unclaimable backlog is not claimable work" `Quick
+            test_unclaimable_backlog_is_not_a_claim_trigger;
           test_case "trigger: provider capacity blocked backlog" `Quick
             test_provider_capacity_blocked_trigger;
           test_case "trigger: keeper sees pending_verification" `Quick


### PR DESCRIPTION
## Summary
- Gate backlog trigger labels on claimable, provider-unblocked work.
- Reuse the same claimability predicate for trigger labels and task-claim affordance.
- Route no-progress loop auto-pause through the keeper supervisor pause policy so owned active tasks are released and current_task_id is cleared.
- Add regressions for unclaimable/provider-blocked backlog trigger labels and for no-progress pause releasing owned active work.

## Evidence
- Live Albini decisions showed trigger_signals contained new_unclaimed_task while claimable_task_count=0.
- Live health showed Albini paused with current_task_id=task-1582 and fleet degraded as active_task_owner_without_executable_fiber.
- MASC already had a supervisor pause policy that releases owned active tasks, but no-progress loop detection bypassed it via direct paused-state sync.

## Validation
- opam exec -- ocamlformat --check lib/keeper/keeper_unified_turn_no_progress.ml test/test_keeper_auto_pause_blocker_persist_12683.ml lib/keeper/keeper_unified_metrics_support.ml test/test_keeper_unified_verification_surface.ml
- git diff --check

## Notes
- Full build/test intentionally left to CI per operator instruction.
