### PR TITLE
Align no-progress peer surface pin

### DIFF
--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -309,15 +309,17 @@ let test_classify_delivery_mapping () =
 
      vs the removed social-model [inferred_tool_surface] set
      {keeper_board_comment, keeper_board_post, keeper_broadcast}: this set adds
-     [masc_keeper_msg] (keeper->keeper message; [masc_broadcast] is the public
-     name of the same [keeper_broadcast] tool). That is an intentional, more
-     complete peer-surface definition (RFC-0276 §2.4 / §3.2 behavior change): a
-     turn that only sends a peer message with no durable evidence now accrues
-     the streak, matching RFC-0239's "only posts to peers without evidence"
-     intent, where the old social model let a bare keeper-msg turn reset it. *)
+     [masc_keeper_msg] (keeper->keeper message) and keeps both
+     [keeper_broadcast] (internal canonical) and [masc_broadcast] (public MCP
+     alias). That is an intentional, more complete peer-surface definition
+     (RFC-0276 §2.4 / §3.2 behavior change): a turn that only sends a peer
+     message with no durable evidence now accrues the streak, matching
+     RFC-0239's "only posts to peers without evidence" intent, where the old
+     social model let a bare keeper-msg turn reset it. *)
   let expected_peer_tools =
     [ "keeper_board_comment"
     ; "keeper_board_post"
+    ; "keeper_broadcast"
     ; "masc_broadcast"
     ; "masc_keeper_msg"
     ]


### PR DESCRIPTION
## Summary

Fixes #22042.

Align the RFC-0276 no-progress peer-surface axis guard with the canonical/public broadcast forms now present in `Keeper_tool_capability_axis.board_activity_tool_names`.

The implementation already classifies both:

- `keeper_broadcast` as the internal canonical broadcast surface
- `masc_broadcast` as the public MCP alias

This PR updates the pinned test expectation and comment so the quick suite no longer fails on the intentional fifth peer-surface entry.

## Product impact

Restores the CI guard for #22042 without changing runtime behavior. The no-progress detector continues to treat internal `keeper_broadcast`, public `masc_broadcast`, and `masc_keeper_msg` as peer-only surfaces that require durable evidence.

## Evidence

- `ocamlformat --check test/test_no_progress_loop_detector.ml`
- `git diff --check`
- `scripts/dune-local.sh exec ./test/test_no_progress_loop_detector.exe -- --compact`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — main CI run `28387941820` quick-suite diagnostics showed the stale `test_no_progress_loop_detector` peer-surface pin failing.
- [x] Orient — mapped to #22042 broadcast/keeper-msg Board_activity axis drift.
- [x] Decide — scoped to the stale test guard because runtime axis membership already includes both canonical/public broadcast forms.
- [x] Act — updated only `test/test_no_progress_loop_detector.ml` pinned expectation and comment.
- [x] Verify — focused local test command passes.
- [x] Loop — no follow-up needed for this bounded test guard alignment.

## Review evidence

- Main CI run `28387941820` quick-suite diagnostics showed `test_runtime_per_keeper_routing` passing, then `test_no_progress_loop_detector` failing on the stale peer-surface pin.
- Focused local reproduction target now passes after adding `keeper_broadcast` to the pinned expectation.

## Linked issue

- Fixes #22042

## Variant addition checklist

- [ ] **OCaml** — N/A, no variant added/removed.
- [ ] **TypeScript** — N/A, no TypeScript union change.
- [ ] **TLA+ spec** — N/A, no TLA+ domain change.
- [ ] **Event / JSON schema** — N/A, no event or JSON schema enum change.
- [ ] **`make check-variants` passes** — N/A, no variant/schema change.

## CI Context

`main` CI run `28387941820` failed in `Run tests (quick suite)` with:

```text
FAIL peer-surface set is exactly the pinned list (axis-drift guard)
Expected: ["keeper_board_comment"; "keeper_board_post"; "masc_broadcast"; "masc_keeper_msg"]
Received: ["keeper_board_post"; "keeper_board_comment"; "keeper_broadcast"; "masc_broadcast"; "masc_keeper_msg"]
```

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/22042-keeper-broadcast-axis-20260629` → `main` · 1 commit(s) · synced 2026-06-29T17:37:50Z

| sha | subject | date |
|---|---|---|
| `b8cfd12b5` | test: align no-progress peer surface pin | 2026-06-29 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->