### PR TITLE
fix(dashboard): dead :root --shadow-card 제거 [RFC-0300 P2]

### DIFF
--- a/dashboard/design-system/tokens/override-drift-baseline.json
+++ b/dashboard/design-system/tokens/override-drift-baseline.json
@@ -60,11 +60,6 @@
       "override": "rgba(0, 0, 0, 0.6)",
       "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
     },
-    "--shadow-card": {
-      "generated": "0 1px 4px rgba(0, 0, 0, 0.5)",
-      "override": "0 1px 3px rgba(0, 0, 0, 0.04)",
-      "reason": "UNREVIEWED: color/shadow override; some a11y-driven (variables.css L598); reconcile direction TBD (chunk F)"
-    },
     "--spacing-card": {
       "generated": "16px",
       "override": "12px",

--- a/dashboard/src/styles/shadow-card-ssot.test.ts
+++ b/dashboard/src/styles/shadow-card-ssot.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+// Guards the --shadow-card cascade after the dead-decl removal in
+// variables.css. The rendered values below were measured with
+// getComputedStyle across data-theme × data-volt on 2026-06-30 (dev server,
+// html[data-skin="v2"]):
+//
+//   theme=default/dark-fantasy : :root --shadow-card = 0 1px 3px /.5  (skin-v2)
+//   theme=paper                : :root --shadow-card = 0 1px 2px /.06 (paper)
+//   theme=styleseed            : :root --shadow-card = 0 1px 3px /.5
+//   .gd-board (any theme)      :       --shadow-card = 0 2px 8px /.35 (own)
+//
+// The variables.css :root --shadow-card (0 1px 3px /.04) never appeared in any
+// measured root — it is dead because skin-v2.css (specificity 0,3,1) outranks
+// :root. This test pins the structural invariants that keep that true; it does
+// not re-run the browser (jsdom does not compute the cascade).
+
+function declsFor(css: string, match: (selector: string) => boolean): Record<string, string> {
+  const out: Record<string, string> = {}
+  parse(css).walkRules((rule) => {
+    // base-layer rules only; skip @media/@supports nesting
+    if (rule.parent?.type === 'atrule') return
+    if (!rule.selectors.some(match)) return
+    rule.walkDecls((decl) => {
+      out[decl.prop] = decl.value.trim()
+    })
+  })
+  return out
+}
+
+const variables = readFileSync(resolve(__dirname, 'variables.css'), 'utf-8')
+const skinV2 = readFileSync(resolve(__dirname, 'skin-v2.css'), 'utf-8')
+
+describe('--shadow-card SSOT (getComputedStyle-verified 2026-06-30)', () => {
+  it(':root in variables.css declares no --shadow-card (dead — skin-v2 wins)', () => {
+    const root = declsFor(variables, (s) => s === ':root')
+    expect(root['--shadow-card']).toBeUndefined()
+  })
+
+  it(':root keeps shadow-elevated/modal (skin-v2 does not redefine them — LIVE)', () => {
+    const root = declsFor(variables, (s) => s === ':root')
+    expect(root['--shadow-elevated']).toBe('0 4px 12px rgba(0, 0, 0, 0.08)')
+    expect(root['--shadow-modal']).toBe('0 8px 24px rgba(0, 0, 0, 0.12)')
+  })
+
+  it('.gd-board keeps its own --shadow-card (LIVE: self-declaration beats inheritance)', () => {
+    const gd = declsFor(variables, (s) => s === '.gd-board')
+    expect(gd['--shadow-card']).toBe('0 2px 8px rgba(0, 0, 0, 0.35)')
+  })
+
+  it('skin-v2.css is the SSOT card shadow for default/dark-fantasy themes', () => {
+    const skin = declsFor(
+      skinV2,
+      (s) =>
+        s.includes('[data-skin="v2"]') &&
+        s.includes(':not([data-theme="paper"]') &&
+        !s.includes('[data-volt'),
+    )
+    expect(skin['--shadow-card']).toBe('0 1px 3px rgba(0,0,0,0.5)')
+  })
+})

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -589,7 +589,15 @@
   --color-icon-default:   var(--icon-default);
   --color-border:         var(--border-border);
   --color-alert-badge:    var(--bg-alert-badge);
-  --shadow-card:          0 1px 3px rgba(0, 0, 0, 0.04);
+  /* --shadow-card removed from :root — dead in every reachable theme.
+   * Verified via getComputedStyle across data-theme × data-volt (2026-06-30):
+   * the :root value never renders. skin-v2.css (html[data-skin=v2], specificity
+   * 0,3,1) wins :root for default/dark-fantasy (0 1px 3px/.5); paper and
+   * styleseed set their own; .gd-board declares its own on the element
+   * (0 2px 8px/.35, LIVE via self-declaration beating inheritance). The SSOT
+   * for card shadow is skin-v2.css — do not re-add a :root --shadow-card.
+   * shadow-elevated/modal stay: skin-v2 does not redefine them, so :root is
+   * the live source. */
   --shadow-elevated:      0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-modal:         0 8px 24px rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
## P2 (shadow) — dead `:root --shadow-card` 제거 [RFC-0300]

### 실측 근거 (getComputedStyle, 2026-06-30 dev server)

`data-theme × data-volt` 전 조합을 브라우저에서 측정:

| 컨텍스트 | `--shadow-card` 렌더값 | 승자 |
|---|---|---|
| default / dark-fantasy (`:root`) | `0 1px 3px /.5` | skin-v2.css (spec 0,3,1) |
| paper (`:root`) | `0 1px 2px /.06` | paper-theme |
| styleseed (`:root`) | `0 1px 3px /.5` | — |
| `.gd-board` (전 theme) | `0 2px 8px /.35` | 자기-선언 (LIVE) |

`variables.css :root --shadow-card`(`0 1px 3px /.04`)는 **어느 root에도 나타나지 않음 = dead**. skin-v2(specificity 0,3,1)가 같은 `html` 요소에서 `:root`를 이기기 때문.

### 변경 (3 파일)

- `variables.css`: `:root --shadow-card` 제거(dead) + 가드 주석. `shadow-elevated`/`modal`은 유지 — skin-v2가 재정의하지 않아 `:root`가 live source.
- `shadow-card-ssot.test.ts`(신규): cascade 불변(`.gd-board` LIVE, skin-v2 SSOT, elevated/modal live)을 postcss 정적 검증으로 고정.
- `override-drift-baseline.json`: 더 이상 diverge하지 않는 stale `--shadow-card` entry 제거.

### RFC-0300 §2.2 정정

RFC 초안은 "`variables.css`의 두 shadow-card decl이 모두 dead"라 기술했으나, **실측 결과 `.gd-board` 0.35는 LIVE**입니다 — custom property는 자기-요소 선언이 상속을 이기므로(`.gd-board`는 `html`의 후손이 아니라 자기 자신에 set), specificity 비교 대상이 아닙니다. 정적 cascade 추론의 오류를 실측이 정정했습니다. RFC 본문 정정은 #22725에서 반영합니다.

### 검증

- `tokens:check` PASS · `tsc --noEmit` 0 · `shadow-card-ssot.test.ts` 4/4
- 렌더 픽셀 무변경 (절대 렌더되지 않는 dead decl만 제거)

RFC-WAIVED: dashboard 디자인 토큰 정리. credential/keeper/operator/hooks/workflow subsystem 무관.
