### PR TITLE
fix(keeper): canonicalize replay checkpoint history

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -28,11 +28,13 @@ let completion_contract_drops_current_turn_replay
 type replay_suffix_prune_reason =
   | Completion_contract_requires_attention
   | Synthetic_empty_state_snapshot
+  | Canonical_success_replay
 
 let replay_suffix_prune_reason_to_string = function
   | Completion_contract_requires_attention ->
     "completion_contract_requires_attention"
   | Synthetic_empty_state_snapshot -> "synthetic_empty_state_snapshot"
+  | Canonical_success_replay -> "canonical_success_replay"
 ;;
 
 let synthetic_empty_state_drops_current_turn_replay
@@ -86,6 +88,56 @@ let prune_current_turn_replay
   else None
 ;;
 
+let canonical_success_replay_checkpoint
+      ~(history_messages : Agent_sdk.Types.message list)
+      ~(session_id : string)
+      ~(response_text : string)
+      ~(state_snapshot : Keeper_memory_policy.keeper_state_snapshot option)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  if messages_prefix_equal history_messages checkpoint.Agent_sdk.Checkpoint.messages
+  then
+    let dropped_current_turn_replay =
+      List.length checkpoint.Agent_sdk.Checkpoint.messages
+      > List.length history_messages
+    in
+    let history_messages =
+      Keeper_context_core.repair_broken_tool_call_pairs history_messages
+    in
+    let checkpoint =
+      if String.trim response_text = ""
+      then
+        { checkpoint with
+          Agent_sdk.Checkpoint.session_id
+        ; messages = history_messages
+        ; working_context = None
+        }
+      else
+        let replay_assistant =
+          Agent_sdk.Types.make_message
+            ~role:Agent_sdk.Types.Assistant
+            [ Agent_sdk.Types.Text response_text ]
+        in
+        Keeper_context_core.patch_checkpoint_last_assistant
+          { checkpoint with
+            Agent_sdk.Checkpoint.messages =
+              history_messages @ [ replay_assistant ]
+          }
+          ~session_id
+          ~response_text
+          ?snapshot:state_snapshot
+    in
+    Ok
+      ( checkpoint
+      , if dropped_current_turn_replay
+        then Some Canonical_success_replay
+        else None )
+  else
+    Error
+      "refusing to save checkpoint: canonical replay persistence requires \
+       checkpoint messages to match pre-turn history prefix"
+;;
+
 let checkpoint_for_replay_persistence
       ~(history_messages : Agent_sdk.Types.message list)
       ~(pre_turn_working_context : Yojson.Safe.t option)
@@ -119,13 +171,12 @@ let checkpoint_for_replay_persistence
             checkpoint messages do not match pre-turn history prefix"
            (replay_suffix_prune_reason_to_string reason)))
   | None ->
-    Ok
-      ( Keeper_context_core.patch_checkpoint_last_assistant
-          checkpoint
-          ~session_id
-          ~response_text
-          ?snapshot:state_snapshot
-      , None )
+    canonical_success_replay_checkpoint
+      ~history_messages
+      ~session_id
+      ~response_text
+      ~state_snapshot
+      checkpoint
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -971,22 +971,10 @@ let synthesize_state_from_run_result
     else None
   in
   let decisions =
-    if budget_exhausted
-    then []
-    else (
-      let response_hint =
-        let trimmed = String.trim response_text in
-        if trimmed = ""
-        then None
-        else
-          Some
-            (String_util.utf8_safe ~max_bytes:103 ~suffix:"..." trimmed
-             |> String_util.to_string)
-      in
-      match response_hint with
-      | Some hint ->
-        [ Keeper_synthetic_marker.tag (Printf.sprintf "Last output: %s" hint) ]
-      | None -> [ Keeper_synthetic_marker.tag "No visible output this generation" ])
+    (* The visible reply is persisted as an assistant message. Synthetic state
+       must not replay an unstructured preview as a durable decision. *)
+    ignore response_text;
+    []
   in
   { priority = None;
     goal = (let g = String.trim goal in if g = "" then None else Some g);

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -658,7 +658,7 @@ let test_synthetic_empty_checkpoint_prunes_current_turn_suffix () =
     false
     (List.exists has_tool_use patched.messages)
 
-let test_satisfied_checkpoint_keeps_tool_suffix_and_patches_final () =
+let test_satisfied_checkpoint_drops_tool_suffix_and_persists_final () =
   let open Agent_sdk.Types in
   let old_user = checkpoint_msg User [ Text "old user" ] in
   let old_assistant = checkpoint_msg Assistant [ Text "old answer" ] in
@@ -703,12 +703,16 @@ let test_satisfied_checkpoint_keeps_tool_suffix_and_patches_final () =
       cp
     |> expect_checkpoint_for_replay
   in
-  Alcotest.(check (option string)) "suffix kept" None
+  Alcotest.(check (option string))
+    "suffix canonicalized"
+    (Some "canonical_success_replay")
     (prune_reason_to_string pruned);
-  Alcotest.(check int) "turn transcript remains" 6
+  Alcotest.(check int) "prior history plus final assistant remains" 3
     (List.length patched.messages);
-  Alcotest.(check bool) "tool use remains" true
+  Alcotest.(check bool) "tool use dropped from replay checkpoint" false
     (List.exists has_tool_use patched.messages);
+  Alcotest.(check bool) "working context cleared" true
+    (patched.working_context = None);
   match List.rev patched.messages with
   | last :: _ ->
       Alcotest.(check string) "final assistant patched" "visible answer"
@@ -775,7 +779,11 @@ let test_no_tool_synthesis_does_not_invent_progress_text () =
   Alcotest.(check (option string))
     "no synthetic no-tool done summary"
     None
-    snapshot.done_summary
+    snapshot.done_summary;
+  Alcotest.(check (list string))
+    "no synthetic no-tool decisions"
+    []
+    snapshot.decisions
 
 let test_budget_finalizer_drops_synthetic_response_text () =
   let finalized =
@@ -837,7 +845,11 @@ let test_synthetic_finalizer_drops_generated_response_text () =
   Alcotest.(check bool)
     "raw repeated text not persisted as response"
     false
-    (contains_substring finalized.response_text "What should I do next?")
+    (contains_substring finalized.response_text "What should I do next?");
+  Alcotest.(check (list string))
+    "raw repeated text not persisted as synthetic decisions"
+    []
+    finalized.state_snapshot.decisions
 
 let test_contract_attention_finalizer_drops_raw_response_text () =
   let raw_response_text =
@@ -933,9 +945,9 @@ let () =
             `Quick
             test_synthetic_empty_checkpoint_prunes_current_turn_suffix;
           Alcotest.test_case
-            "satisfied result keeps tool replay suffix"
+            "satisfied result drops tool replay suffix"
             `Quick
-            test_satisfied_checkpoint_keeps_tool_suffix_and_patches_final;
+            test_satisfied_checkpoint_drops_tool_suffix_and_persists_final;
           Alcotest.test_case
             "drops persisted empty replay snapshot suffix"
             `Quick


### PR DESCRIPTION
## Summary

- canonicalize satisfied keeper replay checkpoints to pre-turn history plus one final visible assistant reply
- drop the raw current-turn user/tool/tool-result/tool-use suffix from OAS replay persistence
- stop synthetic keeper state from persisting raw `Last output` / no-visible-output prose as durable decisions
- update replay regression coverage and run neighboring synthetic-state + stream interleaving tests

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_agent_run_finalize_response.ml lib/keeper/keeper_memory_policy.ml test/test_keeper_state_snapshot_json.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_working_state.exe test/test_keeper_memory_write.exe`
- `./_build/default/test/test_keeper_working_state.exe`
- `./_build/default/test/test_keeper_memory_write.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_stream_text_accum.exe test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_keeper_stream_text_accum.exe`
- `./_build/default/test/test_gate_keeper_backend.exe`

## Notes

- `MASC_DUNE_ALLOW_BARE_DUNE=1` was used only because an unrelated root checkout `dune runtest --root .` was already active; all validation targets used this worktree's `_build`.
