### PR TITLE
fix(dashboard): dead :root --radius-lg/md/sm 제거 [RFC-0300 P3]

### DIFF
--- a/dashboard/design-system/tokens/override-drift-baseline.json
+++ b/dashboard/design-system/tokens/override-drift-baseline.json
@@ -25,35 +25,20 @@
       "override": "\"Cinzel\", \"Noto Sans KR\", \"EB Garamond\", serif",
       "reason": "Font stack quote-style / fallback-list variant (cosmetic or fallback diff)"
     },
-    "--radius-lg": {
-      "generated": "12px",
-      "override": "6px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
-    },
-    "--radius-md": {
-      "generated": "6px",
-      "override": "4px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
-    },
     "--radius-pill": {
       "generated": "999px",
       "override": "9999px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
-    },
-    "--radius-sm": {
-      "generated": "4px",
-      "override": "3px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (getComputedStyle 2026-06-30): .gd-board sets --radius-pill:9999px on the element (LIVE via self-declaration). :root renders 999px (skin-v2/generated). Not :root drift."
     },
     "--radius-xl": {
       "generated": "24px",
       "override": "8px",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (getComputedStyle 2026-06-30): LIVE in app and preview — neither skin-v2 nor generated defines --radius-xl, so the :root 8px renders. Intentional kept-distinct, not drift."
     },
     "--radius-xs": {
       "generated": "2px",
       "override": "var(--r-0)",
-      "reason": "UNREVIEWED: radius scale predates generated tokens; reconcile direction TBD (chunk F)"
+      "reason": "DIAGNOSED (getComputedStyle 2026-06-30): .gd-board sets --radius-xs:2px on the element (LIVE via self-declaration); var(--r-0) alias resolves to 2px. Not :root drift."
     },
     "--scrim-strong": {
       "generated": "var(--color-scrim-strong)",

--- a/dashboard/src/styles/radius-ssot.test.ts
+++ b/dashboard/src/styles/radius-ssot.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+// Guards the --radius-* cascade after the dead :root decl removal in
+// variables.css. Rendered values measured with getComputedStyle on the dev
+// server (2026-06-30):
+//
+//   app (html[data-skin=v2]) : xs 3 / sm 4 / md 6 / lg 10 / xl 8 / pill 999
+//   preview (no data-skin)   : xs 2 / sm 4 / md 6 / lg 12 / xl 8 / pill 999
+//   .gd-board (any theme)    : xs 2 / pill 9999  (own, LIVE via self-decl)
+//
+// The :root lg6/md4/sm3 (removed) never rendered: skin-v2.css (specificity
+// 0,3,1) wins for the app and generated tokens.generated.css wins with no
+// skin. The :root xl8 IS live (neither skin-v2 nor generated defines --radius-xl)
+// and is kept. This test pins the structural invariants; it does not re-run
+// the browser (jsdom does not compute the cascade).
+
+function declsFor(css: string, match: (selector: string) => boolean): Record<string, string> {
+  const out: Record<string, string> = {}
+  parse(css).walkRules((rule) => {
+    if (rule.parent?.type === 'atrule') return
+    if (!rule.selectors.some(match)) return
+    rule.walkDecls((decl) => {
+      out[decl.prop] = decl.value.trim()
+    })
+  })
+  return out
+}
+
+const variables = readFileSync(resolve(__dirname, 'variables.css'), 'utf-8')
+const skinV2 = readFileSync(resolve(__dirname, 'skin-v2.css'), 'utf-8')
+
+describe('--radius-* SSOT (getComputedStyle-verified 2026-06-30)', () => {
+  it(':root drops dead --radius-lg/md/sm (skin-v2 / generated win)', () => {
+    const root = declsFor(variables, (s) => s === ':root')
+    expect(root['--radius-lg']).toBeUndefined()
+    expect(root['--radius-md']).toBeUndefined()
+    expect(root['--radius-sm']).toBeUndefined()
+  })
+
+  it(':root keeps --radius-xl: 8px (LIVE — neither skin-v2 nor generated defines xl)', () => {
+    const root = declsFor(variables, (s) => s === ':root')
+    expect(root['--radius-xl']).toBe('8px')
+  })
+
+  it('.gd-board self-declares --radius-xs/pill (LIVE: self-declaration beats inheritance)', () => {
+    const gd = declsFor(variables, (s) => s === '.gd-board')
+    expect(gd['--radius-xs']).toBe('2px')
+    expect(gd['--radius-pill']).toBe('9999px')
+  })
+
+  it('skin-v2.css is the canonical radius scale for the app', () => {
+    const skin = declsFor(
+      skinV2,
+      (s) =>
+        s.includes('[data-skin="v2"]') &&
+        s.includes(':not([data-theme="paper"]') &&
+        !s.includes('[data-volt'),
+    )
+    expect(skin['--radius-xs']).toBe('3px')
+    expect(skin['--radius-sm']).toBe('4px')
+    expect(skin['--radius-md']).toBe('6px')
+    expect(skin['--radius-lg']).toBe('10px')
+  })
+})

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -361,10 +361,14 @@
   --border-highlight: var(--line-2);
 
   /* Layout & Sizing */
-  --radius-xl: 8px;
-  --radius-lg: 6px;
-  --radius-md: 4px;
-  --radius-sm: 3px;
+  --radius-xl: 8px; /* LIVE: neither skin-v2 nor generated defines --radius-xl,
+                     * so this :root value renders in both app and preview. */
+  /* --radius-lg/md/sm removed from :root — dead in app and preview.
+   * Verified via getComputedStyle (2026-06-30): skin-v2.css (html[data-skin=v2],
+   * spec 0,3,1) wins for the app (lg10/md6/sm4); generated tokens.generated.css
+   * wins with no skin (lg12/md6/sm4). The :root lg6/md4/sm3 never render. SSOT
+   * is skin-v2.css (app) / generated (preview). .gd-board sets its own xs/pill
+   * on the element (LIVE). Do not re-add :root --radius-lg/md/sm. */
   --header-h: 72px;
 
   /* Font-size scale — aliases to the canonical Tailwind v4 @theme tokens


### PR DESCRIPTION
## P3 (radius) — dead `:root --radius-lg/md/sm` 제거 [RFC-0300]

### 실측 근거 (getComputedStyle, 2026-06-30 dev server)

| 컨텍스트 | xs | sm | md | lg | xl | pill | 승자 |
|---|---|---|---|---|---|---|---|
| app (`data-skin=v2`) | 3 | 4 | 6 | **10** | 8 | 999 | skin-v2.css |
| preview (skin off) | 2 | 4 | 6 | **12** | 8 | 999 | generated |
| `.gd-board` (전 theme) | **2** | — | — | — | — | **9999** | 자기-선언 (LIVE) |

`variables.css :root` 의 `--radius-lg:6px / md:4px / sm:3px`는 **app·preview 어디서도 렌더되지 않음 = dead**. app은 skin-v2(lg10/md6/sm4), preview는 generated(lg12/md6/sm4)가 이깁니다.

### 변경 (3 파일)

- `variables.css`: `:root --radius-lg/md/sm` 제거(dead) + 가드 주석. **`--radius-xl:8px`는 유지** — skin-v2도 generated도 xl을 정의하지 않아 `:root`가 live source(app=preview=8px 실측 확인).
- `radius-ssot.test.ts`(신규): cascade 불변(skin-v2 canonical, `.gd-board` LIVE, xl live) postcss 정적 검증.
- `override-drift-baseline.json`: stale lg/md/sm entry 제거. xl/pill/xs는 LIVE로 확정돼 reason을 `DIAGNOSED`로 정정(intentional kept-distinct, drift 아님).

### 검증

- `tokens:check` PASS · `tsc --noEmit` 0 · `radius-ssot.test.ts` 4/4
- 렌더 픽셀 무변경 (절대 렌더되지 않는 dead decl만 제거)

### RFC-0300 §9.1 결정 반영

canonical = **현 렌더값 보존**(사용자 결정). app radius(skin-v2: xs3/sm4/md6/lg10/xl8/pill999)를 그대로 두고 dead `:root` 중복만 제거. `.gd-board`·keeper-v2 flatten(0)은 의도적 override로 보존.

RFC-WAIVED: dashboard 디자인 토큰 정리. credential/keeper/operator/hooks/workflow subsystem 무관.
