### PR TITLE
fix(workspace): remove shadowing broad arm in base_path test-override branch

### DIFF
--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -178,15 +178,16 @@ let resolve_masc_base_path path =
     match (Host_config.from_env ()).base_path with
     | Some explicit
       when running_under_test_executable ()
-           && not (test_base_path_override_enabled ()) ->
-        log_once_info
-          "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
-          explicit path;
-        requested
-    | Some explicit
-      when running_under_test_executable ()
            && not (test_base_path_override_enabled ())
            && not (String.equal explicit requested) ->
+        (* Test executable, override not opted in, and the inherited
+           [MASC_BASE_PATH] diverges from the requested path: ignore it. A
+           matching override ([explicit = requested]) is intentionally left to
+           fall through to the [Some explicit] arm below, which keeps it — the
+           docstring's "ignored unless it matches the requested path". The
+           former broad arm (same body, no equality guard) shadowed this
+           narrower one, leaving it unreachable; OCaml does not flag
+           [when]-guard redundancy, so the dead arm compiled silently. *)
         log_once_info
           "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
           explicit path;


### PR DESCRIPTION
## 무엇을

`resolve_masc_base_path`(`lib/workspace/workspace_utils_backend_setup.ml`)의 **도달 불가능한 match arm**을 제거합니다.

## 근본 원인

test executable + override 미opt-in 케이스에서 `Some explicit`를 두 번 매칭했습니다:
- arm1 guard: `running_under_test_executable () && not (test_base_path_override_enabled ())`
- arm2 guard: `running_under_test_executable () && not (test_base_path_override_enabled ()) && not (String.equal explicit requested)`

arm2 guard는 arm1의 strict subset이고 **body가 완전히 동일**하므로, OCaml이 위에서부터 매칭하는 특성상 arm1이 항상 선점 → **arm2는 영원히 도달 불가**. OCaml은 `when`-guard arm의 redundancy를 경고하지 않아(가드 만족성은 결정 불가) 컴파일러가 잡지 못하고 조용히 컴파일됐습니다.

## 변경

함수 docstring의 의도는 "test에서 inherited override는 **requested와 일치하지 않으면** 무시"입니다. 정작 이 의도를 담은 건 narrow한 arm2였고, broad한 arm1이 *일치하는* override까지 "Ignoring"으로 처리하고 있었습니다.

broad arm1을 삭제하고 narrow arm만 남깁니다. 일치하는 override(`explicit = requested`)는 아래 `Some explicit` arm으로 fall-through되어 **유지**됩니다 — docstring과 기존 테스트 `test_resolve_masc_base_path_keeps_matching_explicit_env`("matching explicit env preserved")의 의미와 일치.

## 검증 (behavior-preserving 증명)

narrow arm은 `String.equal explicit requested`일 때만 bypass되며, 그 경우 `explicit`와 `requested`가 동일 문자열이라 반환값이 불변입니다. 일치 케이스의 **로그 메시지만** `"Ignoring ..."` → `"MASC base ... (explicit MASC_BASE_PATH)"`로 정확해집니다(어떤 테스트도 로그 문자열을 단언하지 않음).

기존 회귀 테스트가 양쪽 경로를 이미 커버:
- `test_resolve_masc_base_path_ignores_base_path_override_without_opt_in`: diverging override → ignored(returns requested) = narrow arm.
- `test_resolve_masc_base_path_keeps_matching_explicit_env`: matching override → kept = fall-through arm.

빌드/전체 테스트는 CI에서 확인.

RFC-WAIVED: workspace base_path 해석은 credential/identity/operator-control/sandbox/hooks/workflow 게이트 subsystem이 아님. 도달 불가 match arm 제거(행동 무변화, 로그 정확화)로 아키텍처/보안 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
