### PR TITLE
[codex] Fix settings local preview controls

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -368,6 +368,54 @@ describe('SettingsSurface', () => {
     expect(never?.getAttribute('data-active')).toBe('true')
   })
 
+  it('local preview text inputs are editable and reflected in dependent text', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
+
+    const input = container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')
+    expect(input).toBeTruthy()
+    expect(input?.readOnly).toBe(false)
+
+    await fireEvent.input(input as HTMLInputElement, {
+      target: { value: 'http://127.0.0.1:7777/mcp' },
+    })
+
+    expect(input?.value).toBe('http://127.0.0.1:7777/mcp')
+    expect(container.querySelector('.set-mcp-detail')?.textContent).toContain('POST http://127.0.0.1:7777/mcp')
+    expect(container.querySelector('[data-testid="settings-preview-badge"]')?.textContent).toBe('local only')
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
+
+    expect(container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')?.value).toBe('http://127.0.0.1:7777/mcp')
+  })
+
+  it('sandbox allowlist and gate base local inputs are editable', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-sandbox"]') as HTMLElement)
+
+    const allowlistInput = container.querySelector<HTMLInputElement>('[data-testid="settings-allowed-domains-input"]')
+    expect(allowlistInput).toBeTruthy()
+    expect(allowlistInput?.readOnly).toBe(false)
+
+    await fireEvent.input(allowlistInput as HTMLInputElement, {
+      target: { value: 'github.com, example.test' },
+    })
+    expect(allowlistInput?.value).toBe('github.com, example.test')
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    const gateInput = container.querySelector<HTMLInputElement>('[data-testid="settings-gate-base-input"]')
+    expect(gateInput).toBeTruthy()
+    expect(gateInput?.readOnly).toBe(false)
+
+    await fireEvent.input(gateInput as HTMLInputElement, {
+      target: { value: 'https://gate.example.test' },
+    })
+    expect(gateInput?.value).toBe('https://gate.example.test')
+  })
+
   it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -5,6 +5,9 @@ import { html } from 'htm/preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import {
   SettingsSurface,
+  checkSettingsMcpEndpoint,
+  checkSettingsStoreUrl,
+  checkSettingsWorktreeBase,
   mcpExposedToolNames,
   logEntryToSysRow,
   logRowStatus,
@@ -414,6 +417,35 @@ describe('SettingsSurface', () => {
       target: { value: 'https://gate.example.test' },
     })
     expect(gateInput?.value).toBe('https://gate.example.test')
+  })
+
+  it('paths local preview values can be format-checked without claiming live verification', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
+
+    expect(container.textContent).toContain('format-checked only')
+    expect(container.textContent).not.toContain('Each item can be verified')
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-mcp"]') as HTMLElement)
+    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-store"]') as HTMLElement)
+    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-worktree"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="settings-path-check-result-mcp"]')?.textContent).toBe('valid MCP URL')
+    expect(container.querySelector('[data-testid="settings-path-check-result-mcp"]')?.getAttribute('data-ok')).toBe('true')
+    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.textContent).toBe('valid store URL')
+    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.getAttribute('data-ok')).toBe('true')
+    expect(container.querySelector('[data-testid="settings-path-check-result-worktree"]')?.textContent).toBe('valid local path')
+    expect(container.querySelector('[data-testid="settings-path-check-result-worktree"]')?.getAttribute('data-ok')).toBe('true')
+
+    const storeInput = container.querySelector<HTMLInputElement>('[data-testid="settings-store-url-input"]')
+    await fireEvent.input(storeInput as HTMLInputElement, {
+      target: { value: 'not-a-url' },
+    })
+    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-store"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.textContent).toBe('invalid URL')
+    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.getAttribute('data-ok')).toBe('false')
   })
 
   it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
@@ -850,6 +882,39 @@ describe('SettingsSurface shell route', () => {
 })
 
 describe('settings read-surface helpers', () => {
+  it('checks Settings path preview values by format only', () => {
+    expect(checkSettingsMcpEndpoint('https://masc.local/mcp')).toEqual({
+      ok: true,
+      message: 'valid MCP URL',
+    })
+    expect(checkSettingsMcpEndpoint('ftp://masc.local/mcp')).toEqual({
+      ok: false,
+      message: 'expected http(s) URL',
+    })
+    expect(checkSettingsMcpEndpoint('https://masc.local/api')).toEqual({
+      ok: false,
+      message: 'path should include /mcp',
+    })
+
+    expect(checkSettingsStoreUrl('postgres://masc.local:5432/masc')).toEqual({
+      ok: true,
+      message: 'valid store URL',
+    })
+    expect(checkSettingsStoreUrl('https://masc.local/db')).toEqual({
+      ok: false,
+      message: 'expected postgres URL',
+    })
+
+    expect(checkSettingsWorktreeBase('~/wt')).toEqual({
+      ok: true,
+      message: 'valid local path',
+    })
+    expect(checkSettingsWorktreeBase('http://masc.local/wt')).toEqual({
+      ok: false,
+      message: 'expected filesystem path',
+    })
+  })
+
   it('mcpExposedToolNames keeps only public_mcp tools, sorted', () => {
     const names = mcpExposedToolNames([
       makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -334,11 +334,12 @@ describe('SettingsSurface', () => {
     })
   })
 
-  it('marks unbacked settings sections as previews instead of fake saved actions', async () => {
+  it('marks unbacked settings sections as local preview controls instead of fake saved actions', async () => {
     render(html`<${SettingsSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('preview only')
-    expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('true')
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.textContent).not.toContain('Save changes')
     expect(container.textContent).not.toContain('Reissue')
     expect(container.textContent).not.toContain('Log out')
@@ -348,10 +349,23 @@ describe('SettingsSurface', () => {
     const gateNav = container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement
     await fireEvent.click(gateNav)
 
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('preview only')
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
     expect(container.textContent).not.toContain('＋ Add gate')
     expect(container.querySelector('[data-testid="settings-preview-badge"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="set-verify"]')).toBeNull()
+  })
+
+  it('local preview segmented controls update visible state when clicked', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const never = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
+      .find(button => button.textContent === '안 함')
+    expect(never).toBeTruthy()
+    expect(never?.disabled).toBe(false)
+
+    await fireEvent.click(never as HTMLButtonElement)
+
+    expect(never?.getAttribute('data-active')).toBe('true')
   })
 
   it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
@@ -562,6 +576,37 @@ describe('SettingsSurface', () => {
       // internal-only tools are not exposed over public MCP.
       expect(labels).not.toContain('internal_only')
     })
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('live inventory + local controls')
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
+  })
+
+  it('MCP exposed-tool toggles are clickable local controls', async () => {
+    apiMock.fetchDashboardTools.mockResolvedValue({
+      tool_inventory: {
+        count: 2,
+        tools: [
+          makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp'] }),
+          makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
+        ],
+      },
+    })
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
+    await waitFor(() => {
+      expect(container.textContent).toContain('Exposed tools (2/2)')
+    })
+
+    const toggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
+    expect(toggles.length).toBe(2)
+    expect(toggles[0]!.disabled).toBe(false)
+    expect(toggles[0]!.getAttribute('aria-checked')).toBe('true')
+
+    await fireEvent.click(toggles[0]!)
+
+    expect(toggles[0]!.getAttribute('aria-checked')).toBe('false')
+    expect(container.textContent).toContain('Exposed tools (1/2)')
   })
 
   it('renders the fusion preset section (panel families + judge) read-only', async () => {
@@ -578,7 +623,8 @@ describe('SettingsSurface', () => {
     expect(models).toContain('glm-coding.glm-5-turbo')
     expect(models).toContain('ollama_cloud.minimax-m3')
     expect(container.querySelector('.set-fus-model.judge')?.textContent).toBe('deepseek.deepseek-v4-pro')
-    expect(container.querySelector('[data-testid="set-toggle"]')?.getAttribute('aria-disabled')).toBe('true')
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
+    expect((container.querySelector('[data-testid="set-toggle"]') as HTMLButtonElement).disabled).toBe(false)
     expect(container.querySelector('[data-testid="fusion-settings-editor"]')).toBeNull()
     expect(container.textContent).not.toContain('per_hour_budget')
   })
@@ -650,9 +696,14 @@ describe('SettingsSurface', () => {
     expect(triggers().length).toBe(4)
     const vals = triggers().map(t => t.querySelector('.mono')?.textContent)
     expect(vals).toEqual(['mention_or_thread', 'mention_only', 'all', 'user_only'])
-    // default selection is mention_or_thread; controls are read-only previews.
+    // default selection is mention_or_thread; local preview radios can be changed.
     expect(triggers()[0]!.classList.contains('on')).toBe(true)
-    expect((triggers()[0] as HTMLButtonElement).disabled).toBe(true)
+    expect((triggers()[0] as HTMLButtonElement).disabled).toBe(false)
+
+    await fireEvent.click(triggers()[2] as HTMLButtonElement)
+
+    expect(triggers()[0]!.getAttribute('data-active')).toBe('false')
+    expect(triggers()[2]!.getAttribute('data-active')).toBe('true')
   })
 
   it('opens the live runtime.toml editor from runtime management', async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -29,6 +29,7 @@ type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
+const SETTINGS_LOCAL_STORAGE_PREFIX = 'masc.settings.local.'
 
 const SET_SECTIONS: [SectionId, string, string][] = [
   ['account', 'Account', '계정'],
@@ -80,6 +81,33 @@ export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]
     .filter(item => item.surfaces.includes(MCP_PUBLIC_SURFACE))
     .map(item => item.name)
     .sort((a, b) => a.localeCompare(b))
+}
+
+function readLocalPreviewString(key: string, fallback: string): string {
+  try {
+    if (typeof sessionStorage === 'undefined') return fallback
+    return sessionStorage.getItem(`${SETTINGS_LOCAL_STORAGE_PREFIX}${key}`) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+function writeLocalPreviewString(key: string, value: string) {
+  try {
+    if (typeof sessionStorage === 'undefined') return
+    sessionStorage.setItem(`${SETTINGS_LOCAL_STORAGE_PREFIX}${key}`, value)
+  } catch {
+    // Local preview settings are best-effort; blocked storage should not break Settings.
+  }
+}
+
+function useLocalPreviewString(key: string, initialValue: string): [string, (next: string) => void] {
+  const [value, setValue] = useState(() => readLocalPreviewString(key, initialValue))
+  const setStoredValue = (next: string) => {
+    setValue(next)
+    writeLocalPreviewString(key, next)
+  }
+  return [value, setStoredValue]
 }
 
 // [fusion] preset shape from config/runtime.toml [fusion] — keeper-v2
@@ -298,7 +326,7 @@ function SetSlider({
   `
 }
 
-function PreviewBadge({ label = 'API 미연결' }: { label?: string }) {
+function PreviewBadge({ label = 'local only' }: { label?: string }) {
   return html`
     <span
       class="set-preview-badge"
@@ -529,7 +557,7 @@ export function SettingsSurface() {
   const [sessionExpiry, setSessionExpiry] = useState('8시간')
 
   // mcp — exposed tools come from the live capability registry (public_mcp surface)
-  const [mcpUrl, setMcpUrl] = useState('https://masc.local/mcp')
+  const [mcpUrl, setMcpUrl] = useLocalPreviewString('mcpUrl', 'https://masc.local/mcp')
   const [transport, setTransport] = useState('http')
   const [mcpTools, setMcpTools] = useState<string[]>([])
   const [tools, setTools] = useState<Record<string, boolean>>({})
@@ -617,20 +645,20 @@ export function SettingsSurface() {
   const [onOverflow, setOnOverflow] = useState('자동 compact')
 
   // gate / paths
-  const [gateBase, setGateBase] = useState('https://gate.masc.local')
+  const [gateBase, setGateBase] = useLocalPreviewString('gateBase', 'https://gate.masc.local')
   const [gateOn, setGateOn] = useState<Record<string, boolean>>({
     Slack: true,
     Discord: true,
     Amplitude: true,
     GitHub: false,
   })
-  const [wtBase, setWtBase] = useState('~/wt')
-  const [storeUrl, setStoreUrl] = useState('postgres://masc.local:5432/masc')
+  const [wtBase, setWtBase] = useLocalPreviewString('wtBase', '~/wt')
+  const [storeUrl, setStoreUrl] = useLocalPreviewString('storeUrl', 'postgres://masc.local:5432/masc')
 
   // sandbox
   const [isolation, setIsolation] = useState('container')
   const [egress, setEgress] = useState('허용목록')
-  const [allowlist, setAllowlist] = useState('github.com, opam.ocaml.org, *.masc.local')
+  const [allowlist, setAllowlist] = useLocalPreviewString('allowlist', 'github.com, opam.ocaml.org, *.masc.local')
   const [fsScope, setFsScope] = useState('worktree')
   const [shellOn, setShellOn] = useState(true)
   const [blockRisky, setBlockRisky] = useState(true)
@@ -653,7 +681,7 @@ export function SettingsSurface() {
   const [annoAutoLink, setAnnoAutoLink] = useState(true)
   const [embedTerminal, setEmbedTerminal] = useState(true)
   const [searchIndex, setSearchIndex] = useState(true)
-  const [ideRepo, setIdeRepo] = useState('masc/masc-mcp')
+  const [ideRepo, setIdeRepo] = useLocalPreviewString('ideRepo', 'masc/masc-mcp')
 
   // logs
   const [traceKeep, setTraceKeep] = useState('30일')
@@ -777,7 +805,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-mcp-endpoint-input"
                     value=${mcpUrl}
                     onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
                   />
@@ -1023,7 +1051,7 @@ export function SettingsSurface() {
                 <${SetRow} label="Allowed domains" hint="Comma-separated">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-allowed-domains-input"
                     style=${{ width: '260px' }}
                     value=${allowlist}
                     onInput=${(e: Event) => setAllowlist((e.target as HTMLInputElement).value)}
@@ -1109,7 +1137,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-ide-repo-input"
                     value=${ideRepo}
                     onInput=${(e: Event) => setIdeRepo((e.target as HTMLInputElement).value)}
                   />
@@ -1133,7 +1161,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-gate-base-input"
                     value=${gateBase}
                     onInput=${(e: Event) => setGateBase((e.target as HTMLInputElement).value)}
                   />
@@ -1178,7 +1206,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-mcp-endpoint-input"
                     value=${mcpUrl}
                     onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
                   />
@@ -1189,7 +1217,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-store-url-input"
                     value=${storeUrl}
                     onInput=${(e: Event) => setStoreUrl((e.target as HTMLInputElement).value)}
                   />
@@ -1200,7 +1228,7 @@ export function SettingsSurface() {
                 <div class="set-path">
                   <input
                     class="set-input mono"
-                    readOnly
+                    data-testid="settings-worktree-base-input"
                     value=${wtBase}
                     onInput=${(e: Event) => setWtBase((e.target as HTMLInputElement).value)}
                   />

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -201,8 +201,6 @@ function SetToggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => vo
       class=${`set-toggle ${on ? 'on' : ''}`}
       role="switch"
       aria-checked=${on}
-      aria-disabled="true"
-      disabled
       data-testid="set-toggle"
       onClick=${() => onChange(!on)}
     >
@@ -228,8 +226,7 @@ function SetSeg({
           key=${o}
           class=${`set-seg-b ${value === o ? 'on' : ''}`}
           data-active=${value === o ? 'true' : 'false'}
-          aria-disabled="true"
-          disabled
+          aria-pressed=${value === o}
           onClick=${() => onChange(o)}
         >
           ${o}
@@ -264,9 +261,9 @@ function SetStepper({
 }) {
   return html`
     <div class="set-stepper" data-testid="set-stepper">
-      <button type="button" aria-disabled="true" disabled onClick=${() => set(Math.max(min, v - 1))}>−</button>
+      <button type="button" disabled=${v <= min} onClick=${() => set(Math.max(min, v - 1))}>−</button>
       <span class="mono">${v}</span>
-      <button type="button" aria-disabled="true" disabled onClick=${() => set(Math.min(max, v + 1))}>+</button>
+      <button type="button" disabled=${v >= max} onClick=${() => set(Math.min(max, v + 1))}>+</button>
     </div>
   `
 }
@@ -294,8 +291,6 @@ function SetSlider({
         max=${max}
         step=${step ?? 1}
         value=${value}
-        disabled
-        aria-disabled="true"
         onInput=${(e: Event) => onChange(Number((e.target as HTMLInputElement).value))}
       />
       <span class="mono">${value}${suffix ?? ''}</span>
@@ -390,17 +385,22 @@ function RuntimeCatalogCard({
   `
 }
 
+type SettingsSectionMode = 'live' | 'local'
+
 function settingsSectionState(
   section: SectionId,
   fusionSettingsWritable: boolean,
-): { live: boolean; label: string } {
-  if (section === 'runtime') return { live: true, label: 'runtime.toml live-backed' }
-  if (section === 'runtimes') return { live: true, label: 'runtime.toml live-backed' }
-  if (section === 'prompts') return { live: true, label: 'prompt registry live-backed' }
+): { mode: SettingsSectionMode; label: string } {
+  if (section === 'runtime') return { mode: 'live', label: 'runtime.toml live-backed' }
+  if (section === 'runtimes') return { mode: 'live', label: 'runtime.toml live-backed' }
+  if (section === 'routing') return { mode: 'live', label: 'runtime.toml live-backed' }
+  if (section === 'prompts') return { mode: 'live', label: 'prompt registry live-backed' }
   if (section === 'fusion' && fusionSettingsWritable) {
-    return { live: true, label: 'runtime.toml live-backed' }
+    return { mode: 'live', label: 'runtime.toml live-backed' }
   }
-  return { live: false, label: 'preview only' }
+  if (section === 'mcp') return { mode: 'local', label: 'live inventory + local controls' }
+  if (section === 'logs') return { mode: 'local', label: 'live logs + local controls' }
+  return { mode: 'local', label: 'local preview only' }
 }
 
 function LogFilter({
@@ -728,14 +728,14 @@ export function SettingsSurface() {
             </div>
           `)}
           <!-- keeper-v2 settings.jsx:262 — KO nav-note copy. -->
-          <div class="set-nav-note">프로토타입 — 변경은 로컬에만 적용됩니다.</div>
+          <div class="set-nav-note">live-backed 섹션은 API에 저장됩니다. local preview 섹션은 이 브라우저 세션에서만 바뀝니다.</div>
         </nav>
 
         <div class="set-content">
           <header class="set-content-h">
             <h1 data-testid="settings-section-title">${cur[2]}</h1>
             <span
-              class=${`set-section-state ${sectionState.live ? 'live' : 'preview'}`}
+              class=${`set-section-state ${sectionState.mode}`}
               data-testid="settings-section-state"
             >
               ${sectionState.label}
@@ -744,7 +744,8 @@ export function SettingsSurface() {
 
           <div
             class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
-            data-preview-locked=${sectionState.live ? 'false' : 'true'}
+            data-preview-locked="false"
+            data-settings-mode=${sectionState.mode}
           >
             ${sec === 'account' && html`
               <${SetRow} label="Operator" hint="Currently logged-in operator">
@@ -1156,8 +1157,7 @@ export function SettingsSurface() {
                     class=${`set-trigger ${discordTrigger === val ? 'on' : ''}`}
                     data-testid="set-trigger"
                     data-active=${discordTrigger === val ? 'true' : 'false'}
-                    aria-disabled="true"
-                    disabled
+                    aria-pressed=${discordTrigger === val}
                     onClick=${() => setDiscordTrigger(val)}
                   >
                     <span class="set-trigger-radio"></span>

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -28,6 +28,11 @@ import type { ComponentChildren } from 'preact'
 type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
+type PathCheckTarget = 'mcp' | 'store' | 'worktree'
+type PathCheckResult = {
+  readonly ok: boolean
+  readonly message: string
+}
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const SETTINGS_LOCAL_STORAGE_PREFIX = 'masc.settings.local.'
 
@@ -81,6 +86,57 @@ export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]
     .filter(item => item.surfaces.includes(MCP_PUBLIC_SURFACE))
     .map(item => item.name)
     .sort((a, b) => a.localeCompare(b))
+}
+
+export function checkSettingsMcpEndpoint(value: string): PathCheckResult {
+  const trimmed = value.trim()
+  if (trimmed === '') return { ok: false, message: 'URL required' }
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return { ok: false, message: 'expected http(s) URL' }
+    }
+    if (url.hostname.trim() === '') return { ok: false, message: 'host required' }
+    if (!url.pathname.toLowerCase().includes('mcp')) {
+      return { ok: false, message: 'path should include /mcp' }
+    }
+    return { ok: true, message: 'valid MCP URL' }
+  } catch {
+    return { ok: false, message: 'invalid URL' }
+  }
+}
+
+export function checkSettingsStoreUrl(value: string): PathCheckResult {
+  const trimmed = value.trim()
+  if (trimmed === '') return { ok: false, message: 'URL required' }
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+      return { ok: false, message: 'expected postgres URL' }
+    }
+    if (url.hostname.trim() === '') return { ok: false, message: 'host required' }
+    return { ok: true, message: 'valid store URL' }
+  } catch {
+    return { ok: false, message: 'invalid URL' }
+  }
+}
+
+export function checkSettingsWorktreeBase(value: string): PathCheckResult {
+  const trimmed = value.trim()
+  if (trimmed === '') return { ok: false, message: 'path required' }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return { ok: false, message: 'expected filesystem path' }
+  }
+  if (
+    trimmed.startsWith('~/') ||
+    trimmed === '~' ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../')
+  ) {
+    return { ok: true, message: 'valid local path' }
+  }
+  return { ok: false, message: 'use absolute, ./, ../, or ~/' }
 }
 
 function readLocalPreviewString(key: string, fallback: string): string {
@@ -333,6 +389,25 @@ function PreviewBadge({ label = 'local only' }: { label?: string }) {
       data-testid="settings-preview-badge"
     >
       ${label}
+    </span>
+  `
+}
+
+function PathCheckBadge({
+  result,
+  target,
+}: {
+  result: PathCheckResult | undefined
+  target: PathCheckTarget
+}) {
+  if (!result) return null
+  return html`
+    <span
+      class=${`set-path-check-result ${result.ok ? 'ok' : 'fail'}`}
+      data-testid=${`settings-path-check-result-${target}`}
+      data-ok=${result.ok ? 'true' : 'false'}
+    >
+      ${result.message}
     </span>
   `
 }
@@ -654,6 +729,23 @@ export function SettingsSurface() {
   })
   const [wtBase, setWtBase] = useLocalPreviewString('wtBase', '~/wt')
   const [storeUrl, setStoreUrl] = useLocalPreviewString('storeUrl', 'postgres://masc.local:5432/masc')
+  const [pathChecks, setPathChecks] = useState<Partial<Record<PathCheckTarget, PathCheckResult>>>({})
+
+  function runPathCheck(target: PathCheckTarget) {
+    let result: PathCheckResult
+    switch (target) {
+      case 'mcp':
+        result = checkSettingsMcpEndpoint(mcpUrl)
+        break
+      case 'store':
+        result = checkSettingsStoreUrl(storeUrl)
+        break
+      case 'worktree':
+        result = checkSettingsWorktreeBase(wtBase)
+        break
+    }
+    setPathChecks(current => ({ ...current, [target]: result }))
+  }
 
   // sandbox
   const [isolation, setIsolation] = useState('container')
@@ -1200,7 +1292,7 @@ export function SettingsSurface() {
 
             ${sec === 'paths' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Server·store basepaths and keeper worktree root. Each item can be verified.
+                Server·store basepaths and keeper worktree root. Local preview values can be format-checked only.
               </div>
               <${SetRow} label="MCP endpoint" hint="/mcp HTTP entrypoint">
                 <div class="set-path">
@@ -1211,6 +1303,15 @@ export function SettingsSurface() {
                     onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
                   />
                   <${PreviewBadge} />
+                  <button
+                    type="button"
+                    class="set-verify"
+                    data-testid="settings-path-check-mcp"
+                    onClick=${() => runPathCheck('mcp')}
+                  >
+                    Check
+                  </button>
+                  <${PathCheckBadge} target="mcp" result=${pathChecks.mcp} />
                 </div>
               <//>
               <${SetRow} label="Store (DB)" hint="trace·audit persistence">
@@ -1222,6 +1323,15 @@ export function SettingsSurface() {
                     onInput=${(e: Event) => setStoreUrl((e.target as HTMLInputElement).value)}
                   />
                   <${PreviewBadge} />
+                  <button
+                    type="button"
+                    class="set-verify"
+                    data-testid="settings-path-check-store"
+                    onClick=${() => runPathCheck('store')}
+                  >
+                    Check
+                  </button>
+                  <${PathCheckBadge} target="store" result=${pathChecks.store} />
                 </div>
               <//>
               <${SetRow} label="Default worktree basepath" hint="keeper worktree root — e.g. ~/wt/<keeper>">
@@ -1233,6 +1343,15 @@ export function SettingsSurface() {
                     onInput=${(e: Event) => setWtBase((e.target as HTMLInputElement).value)}
                   />
                   <${PreviewBadge} />
+                  <button
+                    type="button"
+                    class="set-verify"
+                    data-testid="settings-path-check-worktree"
+                    onClick=${() => runPathCheck('worktree')}
+                  >
+                    Check
+                  </button>
+                  <${PathCheckBadge} target="worktree" result=${pathChecks.worktree} />
                 </div>
               <//>
             `}

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -222,6 +222,11 @@
   border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
 }
 
+.set-section-state.local {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
+}
+
 .set-preview-badge {
   padding: 6px 12px;
   border-style: dashed;

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -403,11 +403,27 @@
 .set-path {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
 .set-path .set-input {
   width: 260px;
+  max-width: 100%;
+}
+
+.set-path-check-result {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  line-height: 1;
+}
+
+.set-path-check-result.ok {
+  color: var(--status-ok);
+}
+
+.set-path-check-result.fail {
+  color: var(--status-fail);
 }
 
 .set-rolepill {


### PR DESCRIPTION
## What

- Makes Settings local-preview controls actually respond to clicks instead of rendering disabled buttons with inert handlers.
- Makes local-preview text fields editable instead of rendering `readOnly` inputs with dead `onInput` handlers.
- Persists local-preview text values in `sessionStorage` so section navigation does not reset edits during the browser session.
- Adds honest local format checks for the Paths section (`MCP endpoint`, `Store (DB)`, `Default worktree basepath`) instead of implying live verification.
- Marks non-persistent sections as `local preview only`, `live inventory + local controls`, or `live logs + local controls` instead of the old locked preview state.
- Keeps live-backed runtime/prompt/runtime.toml sections distinct from browser-session-only settings.

## Why

The Settings surface still had many controls with state handlers wired but also rendered as disabled/read-only, so users saw buttons, menus, and text fields that looked like settings but could not be operated. This keeps the persistence boundary honest while making the visible local controls behave.

## Validation

- `git diff --check`
- `npx tsc --noEmit --pretty false`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/settings-surface.ts`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run src/components/settings-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run src/components/settings-surface.test.ts src/components/runtime-toml-editor.test.ts src/components/keeper-runtime-model-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- Rendered smoke via Python Playwright on `http://127.0.0.1:5175/dashboard/#settings`:
  - desktop: Account `안 함`, Gate `all`, Sandbox `microVM` all became `data-active=true`
  - desktop: MCP endpoint, Sandbox allowed domains, and Gate base URL were editable and retained expected values across Settings section navigation
  - desktop: Paths `Check` buttons produced valid MCP/store/worktree results, then invalid Store URL produced `invalid URL` with `data-ok=false`
  - mobile: Sandbox `microVM` became `data-active=true`
  - mobile: MCP endpoint input was editable and retained the typed value
  - mobile: Paths `Check` buttons and invalid Store result rendered without console/page errors
  - screenshots: `/private/tmp/masc-settings-path-checks-20260630.png`, `/private/tmp/masc-settings-path-checks-mobile-20260630.png`

## Notes

This is a continuation after #22726 was already merged. Build remains for CI.
