### PR TITLE
fix(tools): share masc_run schema SSOT

### DIFF
--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -112,76 +112,7 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   | "masc_run_list" -> lift (handle_run_list ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
-let schemas : Masc_domain.tool_schema list = [
-  (* masc_run_init *)
-  {
-    name = "masc_run_init";
-    description = "Create an execution memory directory (.masc/runs/{task_id}/) to track the run plan. \
-Call when starting work on a claimed task to enable structured progress tracking. \
-After init, use masc_run_plan to set approach and masc_run_get to review.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID to track");
-        ]);
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Agent working on the task");
-        ]);
-      ]);
-      ("required", `List [`String "task_id"; `String "agent_name"]);
-    ];
-  };
-
-  (* masc_run_plan *)
-  {
-    name = "masc_run_plan";
-    description = "Set or update the execution plan (markdown) for a task run; each update creates a new revision. \\nCall after masc_run_init to document your approach before starting implementation. \\nOther agents can view plans via masc_run_get for workspace and handoff context.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID");
-        ]);
-        ("plan", `Assoc [
-          ("type", `String "string");
-          ("description", `String "The plan (markdown supported)");
-        ]);
-      ]);
-      ("required", `List [`String "task_id"; `String "plan"]);
-    ];
-  };
-
-  (* masc_run_get *)
-  {
-    name = "masc_run_get";
-    description = "Retrieve the run record and execution plan for a task. \\nIf the task has no run record yet, create an empty run scaffold and return it so resume flow can continue. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_plan to set the plan.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID to retrieve");
-        ]);
-      ]);
-      ("required", `List [`String "task_id"]);
-    ];
-  };
-
-  (* masc_run_list *)
-  {
-    name = "masc_run_list";
-    description = "List all task runs with their status (active/completed) and plan presence. \\nUse when starting a session to find abandoned work or review completed runs. \\nAfter finding a run, call masc_run_get for full details or masc_run_init to start a new one.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc []);
-    ];
-  };
-
-]
+let schemas : Masc_domain.tool_schema list = Tool_schemas_run.schemas
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -21,7 +21,8 @@ val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.
 (** {1 Dispatcher} *)
 
 (** Dispatch run tool by name. Returns None if not a run tool. *)
-(** Tool schemas for MCP tools/list *)
+(** Tool schemas for MCP tools/list. Aliases {!Tool_schemas_run.schemas};
+    keep the run-tool schema contract in that SSOT. *)
 val schemas : Masc_domain.tool_schema list
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option

--- a/lib/tool_schemas/tool_schemas_run.ml
+++ b/lib/tool_schemas/tool_schemas_run.ml
@@ -11,7 +11,9 @@ let schemas : Masc_domain.tool_schema list =
     {
       name = "masc_run_init";
       description =
-        "Initialize execution memory (.masc/runs/{task_id}/) to track plan, logs, and deliverables. Use after claiming a task to enable structured progress tracking.";
+        "Create an execution memory directory (.masc/runs/{task_id}/) to track the run plan. \
+         Call when starting work on a claimed task to enable structured progress tracking. \
+         After init, use masc_run_plan to set approach and masc_run_get to review.";
       input_schema =
         `Assoc
           [
@@ -19,8 +21,18 @@ let schemas : Masc_domain.tool_schema list =
             ( "properties",
               `Assoc
                 [
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                  ( "task_id",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "Task ID to track");
+                      ] );
+                  ( "agent_name",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "Agent working on the task");
+                      ] );
                 ] );
             ("required", `List [ `String "task_id"; `String "agent_name" ]);
             ("additionalProperties", `Bool false);
@@ -28,7 +40,11 @@ let schemas : Masc_domain.tool_schema list =
     };
     {
       name = "masc_run_plan";
-      description = "Set or update the execution plan for a task run.";
+      description =
+        "Set or update the execution plan (markdown) for a task run; each update \
+         creates a new revision. \\nCall after masc_run_init to document your \
+         approach before starting implementation. \\nOther agents can view plans via \
+         masc_run_get for workspace and handoff context.";
       input_schema =
         `Assoc
           [
@@ -36,8 +52,18 @@ let schemas : Masc_domain.tool_schema list =
             ( "properties",
               `Assoc
                 [
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("plan", `Assoc [ ("type", `String "string") ]);
+                  ( "task_id",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "Task ID");
+                      ] );
+                  ( "plan",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "The plan (markdown supported)");
+                      ] );
                 ] );
             ("required", `List [ `String "task_id"; `String "plan" ]);
             ("additionalProperties", `Bool false);
@@ -46,13 +72,24 @@ let schemas : Masc_domain.tool_schema list =
     {
       name = "masc_run_get";
       description =
-        "Retrieve the full execution history for a task including plan revisions, log notes, and deliverables. If the task has no run record yet, create an empty run scaffold and return it. Use when reviewing progress before handoff or for post-mortem analysis.";
+        "Retrieve the run record and execution plan for a task. \\nIf the task has no \
+         run record yet, create an empty run scaffold and return it so resume flow \
+         can continue. \\nUse when resuming work on a task, reviewing progress, or \
+         preparing a handoff. \\nPair with masc_run_plan to set the plan.";
       input_schema =
         `Assoc
           [
             ("type", `String "object");
             ( "properties",
-              `Assoc [ ("task_id", `Assoc [ ("type", `String "string") ]) ] );
+              `Assoc
+                [
+                  ( "task_id",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "Task ID to retrieve");
+                      ] );
+                ] );
             ("required", `List [ `String "task_id" ]);
             ("additionalProperties", `Bool false);
           ];
@@ -60,7 +97,10 @@ let schemas : Masc_domain.tool_schema list =
     {
       name = "masc_run_list";
       description =
-        "List all task runs with their current status (init, active, completed). Use when surveying execution state across tasks or finding abandoned runs to resume.";
+        "List all task runs with their status (active/completed) and plan presence. \
+         \\nUse when starting a session to find abandoned work or review completed \
+         runs. \\nAfter finding a run, call masc_run_get for full details or \
+         masc_run_init to start a new one.";
       input_schema =
         `Assoc
           [

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -42,6 +42,27 @@ let get_json_assoc key obj =
        | _ -> None)
   | _ -> None
 
+let get_json_bool key obj =
+  match obj with
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`Bool value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let schema_property schema property =
+  match get_json_assoc "properties" schema.input_schema with
+  | Some properties -> List.assoc_opt property properties
+  | None -> None
+
+let property_description schema property =
+  match schema_property schema property with
+  | Some (`Assoc fields) ->
+      (match List.assoc_opt "description" fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | Some _ | None -> None
+
 let contains_substring ~needle value =
   let needle_len = String.length needle in
   let value_len = String.length value in
@@ -220,6 +241,58 @@ let test_masc_transition_schema () =
           Alcotest.(check bool) "task_id required" true (List.mem (`String "task_id") reqs);
           Alcotest.(check bool) "action required" true (List.mem (`String "action") reqs)
       | None -> Alcotest.fail "masc_transition missing required field"
+
+let run_tool_names =
+  [ "masc_run_init"; "masc_run_plan"; "masc_run_get"; "masc_run_list" ]
+
+let test_masc_run_schemas_share_ssot () =
+  Alcotest.(check int)
+    "run schema count"
+    (List.length Tool_schemas_run.schemas)
+    (List.length Masc.Tool_run.schemas);
+  List.iter2
+    (fun (expected : Masc_domain.tool_schema) (actual : Masc_domain.tool_schema) ->
+       Alcotest.(check string) "schema name" expected.name actual.name;
+       Alcotest.(check string)
+         (expected.name ^ " description")
+         expected.description
+         actual.description;
+       Alcotest.(check string)
+         (expected.name ^ " input_schema")
+         (Yojson.Safe.to_string expected.input_schema)
+         (Yojson.Safe.to_string actual.input_schema))
+    Tool_schemas_run.schemas
+    Masc.Tool_run.schemas
+
+let test_masc_run_schemas_are_strict_and_documented () =
+  List.iter
+    (fun name ->
+       match find_registered_tool name with
+       | None -> Alcotest.failf "%s not registered" name
+       | Some schema ->
+           Alcotest.(check (option bool))
+             (name ^ " additionalProperties=false")
+             (Some false)
+             (get_json_bool "additionalProperties" schema.input_schema))
+    run_tool_names;
+  List.iter
+    (fun (name, properties) ->
+       let schema =
+         match find_registered_tool name with
+         | Some schema -> schema
+         | None -> Alcotest.failf "%s not registered" name
+       in
+       List.iter
+         (fun property ->
+            Alcotest.(check bool)
+              (Printf.sprintf "%s.%s has description" name property)
+              true
+              (Option.is_some (property_description schema property)))
+         properties)
+    [ "masc_run_init", [ "task_id"; "agent_name" ]
+    ; "masc_run_plan", [ "task_id"; "plan" ]
+    ; "masc_run_get", [ "task_id" ]
+    ]
 
 let test_masc_add_task_schema () =
   match find_registered_tool "masc_add_task" with
@@ -755,6 +828,10 @@ let () =
       Alcotest.test_case "masc_status" `Quick test_masc_status_schema;
       Alcotest.test_case "masc_broadcast" `Quick test_masc_broadcast_schema;
       Alcotest.test_case "masc_transition" `Quick test_masc_transition_schema;
+      Alcotest.test_case "masc_run schemas share SSOT" `Quick
+        test_masc_run_schemas_share_ssot;
+      Alcotest.test_case "masc_run schemas strict documented" `Quick
+        test_masc_run_schemas_are_strict_and_documented;
       Alcotest.test_case "masc_add_task" `Quick test_masc_add_task_schema;
       Alcotest.test_case "masc_batch_add_tasks" `Quick
         test_masc_batch_add_tasks_schema;


### PR DESCRIPTION
## Summary
- move the richer masc_run_* descriptions and per-property descriptions into Tool_schemas_run
- keep additionalProperties:false on all four run tool schemas in the SSOT
- make Tool_run.schemas alias Tool_schemas_run.schemas so Tool_spec registration and advertised surfaces consume one source
- add regression coverage for run schema SSOT parity, strict schemas, and property descriptions

Fixes #22177.

## Verification
- ocamlformat --check lib/tool_schemas/tool_schemas_run.ml lib/tool_run.ml lib/tool_run.mli test/test_tools_coverage.ml
- git diff --check
- rg -n 'let schemas : Masc_domain\.tool_schema list = \[|Task ID to track|Agent working on the task|The plan \(markdown supported\)|Task ID to retrieve|additionalProperties' lib/tool_run.ml lib/tool_schemas/tool_schemas_run.ml test/test_tools_coverage.ml

## Local build note
- scripts/dune-local.sh build test/test_tools_coverage.exe stopped before this test could run because the worktree expects agent_sdk 0.207.25 while the machine-wide floor is 0.207.26.
- Retrying with MASC_SKIP_PIN_CHECK=1 compiled far enough to show the existing current-main drift in lib/keeper/keeper_vision_ingest.ml against the newer agent_sdk closed source_type variant (Base64 | Url | File_id). I did not downgrade the shared switch below the recorded floor.
