### PR TITLE
fix(health): centralize status rank SSOT

### DIFF
--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -108,41 +108,16 @@ let session_recent_events session_json =
 let event_detail_json event_json =
   member_assoc "detail" event_json
 
-(** Health severity level — ordered from worst to best.
+(** Health severity level — ordered by {!Health_status.rank}.
     Parsed from dashboard/operator JSON at the call site via
     [health_level_of_string], then used in typed predicates below. *)
-type health_level =
-  | HL_critical
-  | HL_bad
-  | HL_risk
-  | HL_warn
-  | HL_degraded
-  | HL_ok
-  | HL_unknown  (** Unparseable or missing health string *)
+type health_level = Health_status.t
 
-let health_level_of_string s =
-  match String.lowercase_ascii (String.trim s) with
-  | "critical" -> HL_critical
-  | "bad" -> HL_bad
-  | "risk" -> HL_risk
-  | "warn" | "watch" -> HL_warn
-  | "degraded" | "interrupted" -> HL_degraded
-  | "ok" | "good" | "healthy" -> HL_ok
-  | _ -> HL_unknown
+let health_level_of_string = Health_status.of_string
 
-let string_of_health_level = function
-  | HL_critical -> "critical"
-  | HL_bad -> "bad"
-  | HL_risk -> "risk"
-  | HL_warn -> "warn"
-  | HL_degraded -> "degraded"
-  | HL_ok -> "ok"
-  | HL_unknown -> unknown_status_label
+let string_of_health_level = Health_status.to_string
 
-let severity_rank_of_health_level = function
-  | HL_critical | HL_bad | HL_risk -> 2
-  | HL_warn | HL_degraded -> 1
-  | HL_ok | HL_unknown -> 0
+let severity_rank_of_health_level = Health_status.rank
 
 (** Session lifecycle — parsed from session JSON at call sites.
     The variant makes the different terminal sets visible:
@@ -192,17 +167,14 @@ let string_of_session_lifecycle = function
 let is_keeper_offline status =
   List.mem status [ "offline"; "inactive"; "error" ]
 
-let is_health_critical = function
-  | HL_bad | HL_critical -> true
-  | HL_risk | HL_warn | HL_degraded | HL_ok | HL_unknown -> false
+let is_health_critical = Health_status.requires_operator_action
 
-let is_health_warning = function
-  | HL_warn | HL_degraded -> true
-  | HL_critical | HL_bad | HL_risk | HL_ok | HL_unknown -> false
+let is_health_warning health =
+  match Health_status.rank health with
+  | 1 | 2 -> true
+  | _ -> false
 
-let is_health_at_risk = function
-  | HL_bad | HL_risk | HL_critical -> true
-  | HL_warn | HL_degraded | HL_ok | HL_unknown -> false
+let is_health_at_risk health = Health_status.rank health >= 2
 
 let is_session_terminal = function
   | SL_completed | SL_cancelled | SL_failed | SL_stopped -> true

--- a/lib/dashboard_utils/dashboard_utils.mli
+++ b/lib/dashboard_utils/dashboard_utils.mli
@@ -93,18 +93,11 @@ val take : int -> 'a list -> 'a list
 
 (** {1 Health level} *)
 
-(** Health severity, ordered by intent (worst → best). Parsed from
+(** Health severity, ordered by {!Health_status.rank}. Parsed from
     dashboard/operator JSON via {!health_level_of_string}, then used in
     typed predicates ({!is_health_critical} etc.) instead of string
     matching. *)
-type health_level =
-  | HL_critical
-  | HL_bad
-  | HL_risk
-  | HL_warn
-  | HL_degraded
-  | HL_ok
-  | HL_unknown  (** Unparseable or missing health string. *)
+type health_level = Health_status.t
 
 val health_level_of_string : string -> health_level
 val string_of_health_level : health_level -> string

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -415,14 +415,9 @@ let assoc_bool_opt name json =
   | Some (`Bool value) -> Some value
   | _ -> None
 
-let health_status_rank = function
-  | "blocked" | "error" | "timeout" -> 3
-  | "degraded" | "stale" | "warning" | "unavailable" | "unknown" -> 2
-  | "warming" | "snapshot_not_ready" -> 1
-  | _ -> 0
+let health_status_rank = Health_status.rank_string
 
-let max_health_status left right =
-  if health_status_rank left >= health_status_rank right then left else right
+let max_health_status = Health_status.max_string
 
 let full_health_operator_summary ~keeper_fleet_safety
     ~keeper_identity_drift_json ~reaction_ledger_json ~keeper_config_schema_status
@@ -442,10 +437,11 @@ let full_health_operator_summary ~keeper_fleet_safety
       | Some value -> value
       | None -> false
     in
+    let parsed_component_status = Health_status.of_string component_status in
     if
       action_required
-      || health_status_rank component_status >= 3
-      || String.equal component_status "unknown"
+      || Health_status.requires_operator_action parsed_component_status
+      || Health_status.equal parsed_component_status Health_status.Unknown
     then
       let reason =
         match fallback_reason with

--- a/lib/types/dune
+++ b/lib/types/dune
@@ -12,6 +12,7 @@
   turn_record
   evidence_claim
   deterministic_evidence_evaluator
+  health_status
   types_core
   types_auth
   masc_domain

--- a/lib/types/health_status.ml
+++ b/lib/types/health_status.ml
@@ -1,0 +1,59 @@
+type t =
+  | Ok
+  | Warming
+  | Snapshot_not_ready
+  | Degraded
+  | Stale
+  | Warning
+  | Unavailable
+  | Unknown
+  | Blocked
+  | Error
+  | Timeout
+
+let of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "ok" | "good" | "healthy" -> Ok
+  | "warming" -> Warming
+  | "snapshot_not_ready" -> Snapshot_not_ready
+  | "degraded" | "interrupted" -> Degraded
+  | "stale" -> Stale
+  | "warning" | "warn" | "watch" | "risk" -> Warning
+  | "unavailable" -> Unavailable
+  | "blocked" -> Blocked
+  | "error" | "bad" | "critical" -> Error
+  | "timeout" -> Timeout
+  | "unknown" | _ -> Unknown
+
+let to_string = function
+  | Ok -> "ok"
+  | Warming -> "warming"
+  | Snapshot_not_ready -> "snapshot_not_ready"
+  | Degraded -> "degraded"
+  | Stale -> "stale"
+  | Warning -> "warning"
+  | Unavailable -> "unavailable"
+  | Unknown -> "unknown"
+  | Blocked -> "blocked"
+  | Error -> "error"
+  | Timeout -> "timeout"
+
+let equal left right = left = right
+
+let pp fmt status = Format.pp_print_string fmt (to_string status)
+
+let rank = function
+  | Blocked | Error | Timeout -> 3
+  | Degraded | Stale | Warning | Unavailable | Unknown -> 2
+  | Warming | Snapshot_not_ready -> 1
+  | Ok -> 0
+
+let rank_string raw = raw |> of_string |> rank
+
+let max left right = if rank left >= rank right then left else right
+
+let max_string left right = max (of_string left) (of_string right) |> to_string
+
+let requires_operator_action status = rank status >= 3
+
+let requires_operator_action_string raw = raw |> of_string |> requires_operator_action

--- a/lib/types/health_status.mli
+++ b/lib/types/health_status.mli
@@ -1,0 +1,23 @@
+type t =
+  | Ok
+  | Warming
+  | Snapshot_not_ready
+  | Degraded
+  | Stale
+  | Warning
+  | Unavailable
+  | Unknown
+  | Blocked
+  | Error
+  | Timeout
+
+val of_string : string -> t
+val to_string : t -> string
+val equal : t -> t -> bool
+val pp : Format.formatter -> t -> unit
+val rank : t -> int
+val rank_string : string -> int
+val max : t -> t -> t
+val max_string : string -> string -> string
+val requires_operator_action : t -> bool
+val requires_operator_action_string : string -> bool

--- a/test/dune
+++ b/test/dune
@@ -834,6 +834,11 @@
 
 ; Focused single-module tests
 
+(test
+ (name test_health_status)
+ (modules test_health_status)
+ (libraries alcotest masc.masc_types masc.dashboard_utils))
+
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.
 

--- a/test/test_health_status.ml
+++ b/test/test_health_status.ml
@@ -1,0 +1,54 @@
+open Alcotest
+
+let test_rank_contract () =
+  check int "blocked" 3 (Health_status.rank_string "blocked");
+  check int "error" 3 (Health_status.rank_string "error");
+  check int "timeout" 3 (Health_status.rank_string "timeout");
+  check int "degraded" 2 (Health_status.rank_string "degraded");
+  check int "stale" 2 (Health_status.rank_string "stale");
+  check int "warning" 2 (Health_status.rank_string "warning");
+  check int "unavailable" 2 (Health_status.rank_string "unavailable");
+  check int "unknown" 2 (Health_status.rank_string "unknown");
+  check int "warming" 1 (Health_status.rank_string "warming");
+  check int "snapshot_not_ready" 1 (Health_status.rank_string "snapshot_not_ready");
+  check int "ok" 0 (Health_status.rank_string "ok")
+
+let test_dashboard_compat_uses_health_status_ssot () =
+  let blocked = Dashboard_utils.health_level_of_string "blocked" in
+  check int "blocked rank" 3 (Dashboard_utils.severity_rank_of_health_level blocked);
+  check bool "blocked critical" true (Dashboard_utils.is_health_critical blocked);
+  check bool "blocked at risk" true (Dashboard_utils.is_health_at_risk blocked);
+  check string "blocked label" "blocked" (Dashboard_utils.string_of_health_level blocked);
+  let unknown = Dashboard_utils.health_level_of_string "future_status" in
+  check int "unknown rank" 2 (Dashboard_utils.severity_rank_of_health_level unknown);
+  check bool "unknown warning" true (Dashboard_utils.is_health_warning unknown);
+  check string "unknown label" "unknown" (Dashboard_utils.string_of_health_level unknown)
+
+let test_legacy_dashboard_synonyms_map_to_shared_statuses () =
+  check Health_status.(testable pp equal) "critical" Error (Health_status.of_string "critical");
+  check Health_status.(testable pp equal) "bad" Error (Health_status.of_string "bad");
+  check Health_status.(testable pp equal) "risk" Warning (Health_status.of_string "risk");
+  check Health_status.(testable pp equal) "watch" Warning (Health_status.of_string "watch");
+  check Health_status.(testable pp equal) "interrupted" Degraded
+    (Health_status.of_string "interrupted");
+  check Health_status.(testable pp equal) "healthy" Ok (Health_status.of_string "healthy")
+
+let test_max_string_canonicalizes_through_ssot () =
+  check string "stronger right" "timeout" (Health_status.max_string "warning" "timeout");
+  check string "tie keeps left canonical" "blocked" (Health_status.max_string "blocked" "error");
+  check string "unknown beats ok" "unknown" (Health_status.max_string "ok" "new_status")
+
+let () =
+  run "Health_status"
+    [
+      ( "rank",
+        [
+          test_case "rank contract" `Quick test_rank_contract;
+          test_case "max string" `Quick test_max_string_canonicalizes_through_ssot;
+        ] );
+      ( "dashboard compat",
+        [
+          test_case "dashboard wrappers use SSOT" `Quick test_dashboard_compat_uses_health_status_ssot;
+          test_case "legacy synonyms" `Quick test_legacy_dashboard_synonyms_map_to_shared_statuses;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add `Health_status` in `masc_types` as the closed-sum SSOT for `/health` status parsing, labels, rank, max, and operator-action severity.
- Route `/health` overall aggregation and dashboard health parsing/ranking through that shared module.
- Add focused `test_health_status` coverage for the rank contract, dashboard `blocked`/unknown handling, legacy dashboard synonyms, and max-status canonicalization.

Fixes #22639

## Verification
- `ocamlformat --check lib/types/health_status.ml lib/types/health_status.mli lib/dashboard_utils/dashboard_utils.ml lib/dashboard_utils/dashboard_utils.mli lib/server/server_routes_http_runtime.ml test/test_health_status.ml`
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_health_status.exe @lib/types/all @lib/dashboard_utils/all @lib/server/all`
- `./_build/default/test/test_health_status.exe` (4 tests)

Note: plain `scripts/dune-local.sh build ...` is blocked in this local switch by `agent_sdk` pin drift (`c8c3f7f...`, expected `b6b2ae6...`), so the focused local compile used `MASC_SKIP_PIN_CHECK=1` and CI remains the pinned-switch authority.