### PR TITLE
fix(keeper): handle non-base64 vision source kinds

### DIFF
--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -75,6 +75,15 @@ let raw_bytes_of_image_data data =
   | Error (`Msg m) -> Error m
 ;;
 
+let image_source_is_base64 source_type =
+  (* Use the SDK's serializer instead of matching future constructors by name:
+     the pinned SDK exposes [Base64], while newer local switches may add more
+     source kinds. This stays exhaustive across both shapes. *)
+  String.equal
+    (Agent_sdk.Types.media_source_kind_to_string source_type)
+    (Agent_sdk.Types.media_source_kind_to_string Agent_sdk.Types.Base64)
+;;
+
 (* Eager extraction through the shared vision core, only when an Eio context is
    present (prod turn). Absent (tests / pre-bootstrap) -> [None]; the caller then
    emits an unread placeholder. Bounded by [run_vision]'s [with_timeout]. *)
@@ -113,7 +122,7 @@ let eager_read ~media_type ~bytes : (string, string) result option =
 let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.content_block) =
   match block with
   | Agent_sdk.Types.Image { media_type; data; source_type } ->
-    if not (match source_type with Agent_sdk.Types.Base64 -> true) then (
+    if not (image_source_is_base64 source_type) then (
       record_eviction ~mode ~result:"error" ~reason:"invalid_source_type";
       Agent_sdk.Types.Text
         (image_store_failed_placeholder ~reason:"unsupported image source"))


### PR DESCRIPTION
## Summary
- make keeper vision ingestion avoid non-exhaustive matching on `media_source_kind`
- preserve existing unsupported-source placeholder behavior using the SDK serializer instead of future constructor names
- keep compatibility with the current pinned `agent_sdk` and newer local SDKs that may add source-kind constructors

Closes #22719

## Validation
- `ocamlformat --check lib/keeper/keeper_vision_ingest.ml test/test_keeper_vision_tool.ml`
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_board_dispatch.exe test/test_keeper_vision_tool.exe @install --force`
- `./_build/default/test/test_keeper_vision_tool.exe`

## Local caveat
- Local focused builds used `MASC_SKIP_PIN_CHECK=1` while validating against the workspace switch. CI uses the repository pin and caught the first version of this PR referencing future-only constructors; this revision avoids those constructor names.