### PR TITLE
fix(dashboard): use stable_sort for keeper trace line ordering

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -66,8 +66,15 @@ let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)
   : Trajectory.trajectory_line list
   =
   let internal_lines = read_internal_history_lines ~config ~trace_id in
+  (* [stable_sort], not [sort]: the comparator returns 0 for two lines of the
+     same kind at the same timestamp, and [List.sort] does not guarantee those
+     keep their original order (only [stable_sort] does, per the OCaml 5.4
+     manual). Stability preserves the deterministic merge order
+     ([trajectory_lines] then [internal_lines]) so repeated same-timestamp
+     thinking/tool lines render in a fixed sequence rather than an arbitrary
+     one. *)
   dedupe_thinking_lines (trajectory_lines @ internal_lines)
-  |> List.sort (fun left right ->
+  |> List.stable_sort (fun left right ->
     let cmp = Float.compare (line_ts left) (line_ts right) in
     if cmp <> 0
     then cmp


### PR DESCRIPTION
## 무엇을

`merge_keeper_trace_lines`(`server_dashboard_http_keeper_api_trace.ml`)의 trace 라인 정렬을 `List.sort` → `List.stable_sort`로 교체합니다.

## 왜

dashboard keeper trace 표시 순서가 동일 timestamp 라인에 대해 **비결정적**입니다.

comparator는 1차로 timestamp, 2차로 `Thinking` < `Tool_call`만 정의하고 같은 종류·같은 timestamp 쌍에는 `0`을 반환합니다. **OCaml 5.4 공식 매뉴얼**(ocaml.org/manual/5.4/api/List.html):

- `List.sort`: equal 요소의 원래 순서 유지를 **보장하지 않음**.
- `List.stable_sort`: "elements that compare equal are kept in their original order" **보장**.

따라서 동일 timestamp의 두 thinking 라인(또는 두 tool_call 라인)이 `List.sort` 하에서 임의 순서로 렌더될 수 있습니다 — 같은 입력이 표시 순서가 흔들리는 silent 비결정성.

## 변경

`List.stable_sort`로 교체. 안정 정렬은 comparator가 `0`을 반환하는 쌍에 대해 입력 순서(= `dedupe_thinking_lines (trajectory_lines @ internal_lines)`의 병합 순서: trajectory 먼저, 그 다음 internal)를 보존하므로 동일 timestamp 라인이 고정된 순서로 표시됩니다.

- 성능 동일(둘 다 merge sort, stdlib에서 `sort`는 내부적으로 `stable_sort`).
- MASC 관례와 일치(`cognitive_gravity`/`keeper_event_queue`/`keeper_guards` 등이 이미 `List.stable_sort` 사용).
- 최근 #22666(immutable set으로 thinking dedup)을 보완: dedup이 중복을 제거하고, stable_sort가 생존 라인의 순서 결정성을 보장.

## 범위

표시 정렬 1개 호출부. comparator 로직·dedup·데이터 소스는 불변. tool_call dedup 비대칭(thinking만 dedup)은 #22666의 의도적 scope로 판단하여 건드리지 않음.

RFC-WAIVED: `server_dashboard_http_keeper_api_trace.ml`는 dashboard **trace 표시** helper로 RFC-gated subsystem(credential/keeper_sandbox/operator_control/dashboard-credential/hooks/workflow/repo_manager)이 아닙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
