### PR TITLE
[codex] Clarify settings policy preview

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -751,11 +751,31 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('도구 정책')
     // 11 named groups in the prototype snapshot.
     expect(container.querySelectorAll('[data-testid="set-tg-row"]').length).toBe(11)
-    expect(container.textContent).toContain('현재는 live tool-policy 연동이 없어 prototype 표기 스냅샷으로 표시합니다.')
+    expect(container.textContent).toContain('browser-session grant preview')
+    expect(container.textContent).toContain('현재는 live tool-policy writer가 없어 prototype group catalog 스냅샷으로 표시합니다.')
+    expect(container.textContent).not.toContain('기본 부여 그룹과 안전장치를 관리합니다')
+    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('10/11 enabled')
+    expect(container.querySelectorAll('[data-testid="settings-preview-badge"]').length).toBeGreaterThanOrEqual(12)
     // execute group carries the 3-layer guard badge; voice is opt-in.
     const kinds = Array.from(container.querySelectorAll('.set-tg-kind')).map(n => n.textContent?.trim())
     expect(kinds).toContain('3-layer guard')
     expect(kinds).toContain('opt-in')
+    const firstToggle = container.querySelector('[data-testid="set-tg-row"] [data-testid="set-toggle"]') as HTMLButtonElement
+    expect(firstToggle.getAttribute('data-active')).toBe('true')
+    await fireEvent.click(firstToggle)
+    expect(firstToggle.getAttribute('data-active')).toBe('false')
+    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('9/11 enabled')
+    expect(sessionStorage.getItem('masc.settings.local.policyGrant')).toContain('"base":false')
+
+    render(null, container)
+    route.value = { tab: 'settings', params: {}, postId: null }
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('9/11 enabled')
+    expect(
+      container.querySelector('[data-testid="set-tg-row"] [data-testid="set-toggle"]')?.getAttribute('data-active'),
+    ).toBe('false')
     // exec-guard pipeline: validate_command → destructive_guard → write_gate.
     const guardSteps = Array.from(
       container.querySelectorAll('[data-testid="set-guard"] .set-guard-step'),

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -33,6 +33,7 @@ type PathCheckResult = {
   readonly ok: boolean
   readonly message: string
 }
+type BoolRecordUpdater = Record<string, boolean> | ((prev: Record<string, boolean>) => Record<string, boolean>)
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const SETTINGS_LOCAL_STORAGE_PREFIX = 'masc.settings.local.'
 
@@ -157,11 +158,53 @@ function writeLocalPreviewString(key: string, value: string) {
   }
 }
 
+function readLocalPreviewBoolRecord(key: string, fallback: Record<string, boolean>): Record<string, boolean> {
+  const next = { ...fallback }
+  try {
+    if (typeof sessionStorage === 'undefined') return next
+    const raw = sessionStorage.getItem(`${SETTINGS_LOCAL_STORAGE_PREFIX}${key}`)
+    if (raw === null) return next
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return next
+    const values = parsed as Record<string, unknown>
+    for (const id of Object.keys(next)) {
+      if (typeof values[id] === 'boolean') next[id] = values[id]
+    }
+  } catch {
+    return next
+  }
+  return next
+}
+
+function writeLocalPreviewBoolRecord(key: string, value: Record<string, boolean>) {
+  try {
+    if (typeof sessionStorage === 'undefined') return
+    sessionStorage.setItem(`${SETTINGS_LOCAL_STORAGE_PREFIX}${key}`, JSON.stringify(value))
+  } catch {
+    // Local preview settings are best-effort; blocked storage should not break Settings.
+  }
+}
+
 function useLocalPreviewString(key: string, initialValue: string): [string, (next: string) => void] {
   const [value, setValue] = useState(() => readLocalPreviewString(key, initialValue))
   const setStoredValue = (next: string) => {
     setValue(next)
     writeLocalPreviewString(key, next)
+  }
+  return [value, setStoredValue]
+}
+
+function useLocalPreviewBoolRecord(
+  key: string,
+  initialValue: Record<string, boolean>,
+): [Record<string, boolean>, (next: BoolRecordUpdater) => void] {
+  const [value, setValue] = useState(() => readLocalPreviewBoolRecord(key, initialValue))
+  const setStoredValue = (nextOrUpdate: BoolRecordUpdater) => {
+    setValue(prev => {
+      const next = typeof nextOrUpdate === 'function' ? nextOrUpdate(prev) : nextOrUpdate
+      writeLocalPreviewBoolRecord(key, next)
+      return next
+    })
   }
   return [value, setStoredValue]
 }
@@ -224,6 +267,9 @@ const TOOL_GROUPS: readonly ToolGroup[] = [
   { id: 'masc.workspace', kind: 'masc', tools: ['masc_tasks', 'masc_claim_next', 'masc_transition', 'masc_add_task', 'masc_agents', 'masc_broadcast', 'masc_messages', 'masc_heartbeat'] },
   { id: 'masc.goal', kind: 'masc', tools: ['masc_goal_list', 'masc_goal_upsert', 'masc_goal_transition', 'masc_goal_verify'] },
 ]
+const DEFAULT_TOOL_GROUP_GRANTS: Record<string, boolean> = Object.fromEntries(
+  TOOL_GROUPS.map(g => [g.id, !g.optin]),
+)
 // [groups.last_turn_safe] — keeper-v2 settings.jsx:99. On a keeper's final
 // turn, allowed tools are intersected with this set. Snapshot from the
 // prototype settings view; backend parity is deferred.
@@ -286,6 +332,7 @@ function SetToggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => vo
       role="switch"
       aria-checked=${on}
       data-testid="set-toggle"
+      data-active=${on ? 'true' : 'false'}
       onClick=${() => onChange(!on)}
     >
       <span class="knob"></span>
@@ -699,9 +746,7 @@ export function SettingsSurface() {
 
   // policy — tool-group grants (namespace default-grant per [groups.*]); opt-in groups
   // start off. keeper-v2 settings.jsx:177.
-  const [grant, setGrant] = useState<Record<string, boolean>>(
-    Object.fromEntries(TOOL_GROUPS.map(g => [g.id, !g.optin])),
-  )
+  const [grant, setGrant] = useLocalPreviewBoolRecord('policyGrant', DEFAULT_TOOL_GROUP_GRANTS)
 
   // fusion (config/runtime.toml [fusion]) — keeper-v2 settings.jsx:178-182
   const fusionSettingsWritable = envBool('VITE_FUSION_SETTINGS_WRITABLE', false)
@@ -798,6 +843,7 @@ export function SettingsSurface() {
 
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
   const sectionState = settingsSectionState(sec, fusionSettingsWritable)
+  const grantedGroupCount = Object.values(grant).filter(Boolean).length
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -1067,10 +1113,15 @@ export function SettingsSurface() {
 
             ${sec === 'policy' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                keeper 의 <span class="mono">tool_access</span> 는 named 그룹(<span class="mono">tool_policy.toml</span>)의 도구를 참조합니다. 여기서 namespace 기본 부여 그룹과 안전장치를 관리합니다.
+                keeper 의 <span class="mono">tool_access</span> 는 named 그룹(<span class="mono">tool_policy.toml</span>)의 도구를 참조합니다. 이 섹션은 runtime 정책을 저장하지 않고 browser-session grant preview만 조정합니다.
               </div>
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                현재는 live tool-policy 연동이 없어 prototype 표기 스냅샷으로 표시합니다. 런타임 도구 정책이 SSOT로 연동되면 값이 교체됩니다.
+                현재는 live tool-policy writer가 없어 prototype group catalog 스냅샷으로 표시합니다. 런타임 도구 정책이 SSOT로 연동되면 값이 교체됩니다.
+              </div>
+              <div class="set-local-summary" data-testid="policy-local-summary">
+                <span>local grant preview</span>
+                <span class="mono">${grantedGroupCount}/${TOOL_GROUPS.length} enabled</span>
+                <${PreviewBadge} />
               </div>
               <div class="set-sub-h">도구 그룹 부여</div>
               ${TOOL_GROUPS.map(g => html`
@@ -1084,10 +1135,13 @@ export function SettingsSurface() {
                     </div>
                     <div class="set-tg-tools">${g.tools.map(t => html`<span key=${t} class="set-tg-chip mono">${t}</span>`)}</div>
                   </div>
-                  <${SetToggle}
-                    on=${grant[g.id] ?? false}
-                    onChange=${(v: boolean) => setGrant(p => ({ ...p, [g.id]: v }))}
-                  />
+                  <div class="set-tg-control">
+                    <${PreviewBadge} />
+                    <${SetToggle}
+                      on=${grant[g.id] ?? false}
+                      onChange=${(v: boolean) => setGrant(p => ({ ...p, [g.id]: v }))}
+                    />
+                  </div>
                 </div>
               `)}
 

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -848,6 +848,16 @@
   color: var(--volt);
 }
 
+.set-local-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--text-mid);
+  font-size: 12px;
+}
+
 /* tool-group policy — keeper-v2 styles/surfaces.css:555-565 (.set-tg-*) */
 .set-tg-row {
   display: flex;
@@ -855,6 +865,13 @@
   gap: 14px;
   padding: 12px 0;
   border-bottom: 1px solid var(--border-soft);
+}
+
+.set-tg-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .set-tg-l {


### PR DESCRIPTION
## What

- Clarifies the Settings > Policy surface as a browser-session grant preview instead of implying live runtime policy management.
- Persists policy grant preview toggles in `sessionStorage` so local edits survive Settings remount/reload during the browser session.
- Adds visible `local only` badges and an enabled-group summary to the policy grant controls.

## Why

The Policy section mixed a prototype snapshot warning with copy that said the operator could manage namespace grants and guards. The toggles changed local UI state only, which made the section look more authoritative than it was. This keeps the boundary honest while making the visible controls behave like local preview controls.

## Validation

- `git diff --check`
- `npx tsc --noEmit --pretty false`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/settings-surface.ts`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run src/components/settings-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run src/components/settings-surface.test.ts src/components/runtime-toml-editor.test.ts src/components/keeper-runtime-model-editor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- Rendered smoke via Python Playwright on `http://127.0.0.1:5176/dashboard/#settings`:
  - desktop: Policy `base` grant toggle changed `data-active=true` to `false`, summary changed `10/11 enabled` to `9/11 enabled`, and the value persisted after reload
  - mobile: same Policy local-preview toggle/reload flow passed
  - console/page errors: no page errors; only existing PerformanceMonitor slow-frame warnings were observed
  - screenshots: `/private/tmp/masc-settings-policy-preview-20260630.png`, `/private/tmp/masc-settings-policy-preview-mobile-20260630.png`

## Notes

Continuation after #22734 merged. Build remains for CI.
