### PR TITLE
refactor(fusion): consume OAS Response_shape.summarize_blocks for empty-response diagnostics

### DIFF
--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -11,45 +11,13 @@ let answer_text (resp : Agent_sdk.Types.api_response) : string =
 
 let stop_reason_label = Keeper_hooks_oas_types.stop_reason_to_label
 
-type empty_response_content_counts =
-  { text_blocks : int
-  ; text_chars : int
-  ; tool_use_count : int
-  ; tool_result_count : int
-  ; image_count : int
-  ; document_count : int
-  ; audio_count : int
-  }
-
-let zero_empty_response_content_counts =
-  { text_blocks = 0
-  ; text_chars = 0
-  ; tool_use_count = 0
-  ; tool_result_count = 0
-  ; image_count = 0
-  ; document_count = 0
-  ; audio_count = 0
-  }
-
-let empty_response_content_counts content =
-  List.fold_left
-    (fun acc -> function
-      | Agent_sdk.Types.Text s ->
-        { acc with
-          text_blocks = acc.text_blocks + 1
-        ; text_chars = acc.text_chars + String.length s
-        }
-      | Thinking _ | RedactedThinking _ -> acc
-      | ToolUse _ -> { acc with tool_use_count = acc.tool_use_count + 1 }
-      | ToolResult _ ->
-        { acc with tool_result_count = acc.tool_result_count + 1 }
-      | Image _ -> { acc with image_count = acc.image_count + 1 }
-      | Document _ -> { acc with document_count = acc.document_count + 1 }
-      | Audio _ -> { acc with audio_count = acc.audio_count + 1 })
-    zero_empty_response_content_counts content
-
+(* 콘텐츠 블록 카운팅은 OAS canonical projection
+   [Agent_sdk.Response_shape.summarize_blocks]에 위임한다. 로컬 fold를 재구현하지 않는다
+   (keeper_hooks_oas_types.ml의 F2 canonical projection 원칙과 동일 — 미이행 사이트였다).
+   thinking_kind 분류만 MASC가 소유한다: OAS는 model-family thinking 의미를 의도적으로
+   노출하지 않으므로 [summarize_thinking_blocks]로 별도 산출한다. *)
 let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
-  let counts = empty_response_content_counts resp.content in
+  let shape = Agent_sdk.Response_shape.summarize_blocks resp.content in
   let thinking = Keeper_hooks_oas_types.summarize_thinking_blocks resp.content in
   let input_tokens, output_tokens =
     match resp.usage with
@@ -64,17 +32,17 @@ let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
      output_tokens=%s)"
     (stop_reason_label resp.stop_reason)
     (List.length resp.content)
-    counts.text_blocks
-    counts.text_chars
+    shape.Agent_sdk.Response_shape.text_blocks
+    shape.Agent_sdk.Response_shape.text_chars
     thinking.Keeper_hooks_oas_types.thinking_kind
     thinking.Keeper_hooks_oas_types.thinking_blocks
     thinking.Keeper_hooks_oas_types.thinking_chars
     thinking.Keeper_hooks_oas_types.redacted_thinking_blocks
-    counts.tool_use_count
-    counts.tool_result_count
-    counts.image_count
-    counts.document_count
-    counts.audio_count
+    shape.Agent_sdk.Response_shape.tool_use_count
+    shape.Agent_sdk.Response_shape.tool_result_count
+    shape.Agent_sdk.Response_shape.image_count
+    shape.Agent_sdk.Response_shape.document_count
+    shape.Agent_sdk.Response_shape.audio_count
     input_tokens
     output_tokens
 

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -139,6 +139,28 @@ let test_empty_response_detail_uses_canonical_unknown_stop_reason () =
     (String_util.string_contains_substring ~needle:"line\nquote" detail)
 ;;
 
+let test_empty_response_detail_counts_via_canonical_projection () =
+  (* 비-thinking 카운트가 OAS canonical projection
+     [Agent_sdk.Response_shape.summarize_blocks]에서 산출됨을 증명한다(로컬 fold 제거 후).
+     text_chars는 OAS 규약대로 trim 후 길이다: "  hi  "(2) + "yo"(2) = 4. *)
+  let response : Agent_sdk.Types.api_response =
+    { id = "r"
+    ; model = "m"
+    ; stop_reason = Agent_sdk.Types.MaxTokens
+    ; content = [ Agent_sdk.Types.Text "  hi  "; Agent_sdk.Types.Text "yo" ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let detail = Fusion_oas.For_testing.empty_response_detail response in
+  Alcotest.(check bool) "content blocks total counted" true
+    (String_util.string_contains_substring ~needle:"content_blocks=2" detail);
+  Alcotest.(check bool) "text blocks from canonical projection" true
+    (String_util.string_contains_substring ~needle:"text_blocks=2" detail);
+  Alcotest.(check bool) "text chars use canonical trimmed length" true
+    (String_util.string_contains_substring ~needle:"text_chars=4" detail)
+;;
+
 let test_panel_failure_yojson_accepts_legacy_empty_response () =
   let decode json =
     match Fusion_types.panel_failure_of_yojson json with
@@ -237,6 +259,10 @@ let () =
             "empty response detail summarizes shape"
             `Quick
             test_empty_response_detail_summarizes_shape
+        ; Alcotest.test_case
+            "empty response detail counts via canonical projection"
+            `Quick
+            test_empty_response_detail_counts_via_canonical_projection
         ; Alcotest.test_case
             "empty response detail uses canonical unknown stop reason"
             `Quick


### PR DESCRIPTION
## 목표
`fusion_oas.ml`의 empty-response 진단에서 content-block 카운팅 **로컬 재구현을 제거**하고 OAS canonical projection `Agent_sdk.Response_shape.summarize_blocks`로 위임한다.

## 근본 원인 (경계 부채)
`empty_response_content_counts`(fusion_oas.ml:14-49)가 `Agent_sdk.Types.content_block` 리스트를 직접 `fold_left`로 다시 세어 7개 카운트(text_blocks/text_chars/tool_use_count/tool_result_count/image_count/document_count/audio_count)를 만들었다. 동일 record를 OAS가 `Response_shape.summarize_blocks : Types.content_block list -> t`(oas `lib/llm_provider/response_shape.mli:34`, `agent_sdk.mli:48`로 재export)로 이미 노출한다.

- MASC는 `keeper_hooks_oas_types.ml:209-216`에 "block 카운팅은 OAS `Response_shape.summarize_blocks`에 위임한다(F2 canonical projection)"를 canonical 원칙으로 문서화·이행했다. `fusion_oas.ml`은 그 마이그레이션의 **미이행 사이트**였다.
- 게다가 같은 리스트를 `empty_response_detail`에서 OAS `summarize_thinking_blocks`로도 한 번 fold하므로(thinking 카운트만 사용) **동일 리스트 2회 fold**였다.

경계 방향은 정방향(MASC→OAS)이라 OAS 변경 불요.

## 변경
- `empty_response_content_counts` type/zero/fold(36줄) 삭제.
- `empty_response_detail`이 `Agent_sdk.Response_shape.summarize_blocks resp.content`로 7개 비-thinking 카운트를 읽음.
- `thinking_kind` 분류는 MASC `summarize_thinking_blocks`로 유지 — OAS는 model-family thinking 의미를 의도적으로 노출하지 않으므로 이 부분은 MASC 소유가 맞다.
- 회귀 테스트 1개 추가(`test_empty_response_detail_counts_via_canonical_projection`): 카운트가 canonical projection에서 산출됨을 단언.

### 동작 델타 1개 (의도된 개선)
`text_chars`가 OAS 규약대로 **trim 후 길이**가 된다(`String.length (String.trim text)`). 빈 응답 진단에서 더 정확하며, 기존 테스트는 raw text_chars를 단언하지 않으므로 회귀 없음(신규 테스트가 trim 동작을 명시 단언).

## 검증
- 변경 범위: `lib/fusion/fusion_oas.ml`, `test/test_fusion_oas_error_detail.ml` 2파일.
- 빌드/테스트는 이 PR의 CI(dune)로 검증한다(로컬 switch는 무관한 OAS pin drift로 막힘).
- 기존 `test_empty_response_detail_summarizes_shape`(thinking/stop_reason/usage 단언)는 그대로 통과해야 하며, 신규 테스트가 비-thinking 카운트 경로를 잠근다.

## 경계 / RFC
- OAS 무변경(이미 canonical projection 제공). 수정은 MASC consumer 측만.
- RFC 해당 없음: credential/operator/sandbox/dashboard-credential/hooks/workflow subsystem 미접촉(`lib/fusion/`만 변경).
- 워크어라운드 아님: 재구현을 **추가**가 아니라 **제거**하여 기존 SSOT projection을 소비(N-of-M을 닫는 방향).

근거: MASC↔OAS 경계 부채 적대적 sweep(9 후보 → 7 refuted, 1 confirmed=A1, 1 uncertain). 본 PR은 confirmed A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
