### PR TITLE
feat(fusion): ship JoJ-capable `quorum` preset so judge_of_judges is reachable

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1012,8 +1012,11 @@ max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
+# evidence judge는 panel에 없는 모델을 쓴다 — 자기 답변이 포함된 panel을 심판하는
+# self-preference bias를 구조적으로 배제(panel = deepseek-v4-flash/glm-5-turbo/minimax-m3,
+# coverage judge=kimi-k2-6, meta judge=deepseek-v4-pro 모두 panel 외부).
 [[fusion.presets.quorum.judges]]
-model = "ollama_cloud.minimax-m3"
+model = "glm-coding.glm-4-7-coding"
 label = "evidence"
 system_prompt = """
 You are an impartial first-pass judge. Synthesize the panel of model answers \

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -972,3 +972,64 @@ judge_timeout_s = 300.0
 web_tools = false
 # 패널 모델당 최대 tool 호출 수 (0 = 무제한, OpenRouter Fusion 허용 범위 0..16).
 max_tool_calls_per_panel = 0
+
+# ── JoJ-capable preset (RFC-0283 judge-of-judges) ───────────────────────────
+# masc_fusion topology="judge_of_judges"는 preset에 1차 심판 >= 2명을 요구한다
+# (fusion_orchestrator.run_judge_of_judges). trio는 단일 judge라 JoJ 호출이 항상
+# "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
+# quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
+# 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
+# 모델은 모두 supports-response-format-json=true (fusion judge는 응답 텍스트에서 JSON을
+# 파싱하므로 native structured-output host allowlist와 무관하나, JSON 신뢰성을 위해
+# JSON-선언 모델만 사용한다). staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)
+# 의 정확한 배수 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
+[fusion.presets.quorum]
+panel = [
+  "ollama_cloud.deepseek-v4-flash",
+  "glm-coding.glm-5-turbo",
+  "ollama_cloud.minimax-m3",
+]
+panel_system_prompt = """
+You are an expert panelist. Answer the user's question directly and concisely \
+with your best independent analysis. Do not defer to other models; give your \
+own view.
+"""
+# meta judge: 1차 심판들의 종합을 재조정하는 최종 reducer (RFC-0283).
+judge = "deepseek.deepseek-v4-pro"
+judge_system_prompt = """
+You are the meta-judge. You are given several independent judge syntheses of the \
+same panel of model answers, each produced through a different evaluative lens. \
+Reconcile them: where the judges agree, state the consensus; where they diverge, \
+adjudicate with reasons; surface any blind spot that a single lens missed. Produce \
+one resolved answer. Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
+# meta/stage-meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
+meta_timeout_s = 300.0
+web_tools = false
+max_tool_calls_per_panel = 0
+
+# 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
+# label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
+[[fusion.presets.quorum.judges]]
+model = "ollama_cloud.minimax-m3"
+label = "evidence"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through an EVIDENCE lens: weigh each claim by how well it is supported, flag \
+unsupported assertions, and prefer conclusions grounded in verifiable reasoning. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.quorum.judges]]
+model = "ollama_cloud.kimi-k2-6"
+label = "coverage"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through a COVERAGE lens: map what each answer addresses and omits, surface blind \
+spots and unique insights, and prefer the most complete resolution. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -146,6 +146,59 @@ let test_config_valid () =
     Alcotest.failf "expected Ok, got errors: %s"
       (String.concat ", " (List.map Fusion_config.show_config_error es))
 
+(* JoJ-capable preset: [[fusion.presets.X.judges]] array-of-tables 파싱 경로 (RFC-0283).
+   config/runtime.toml [fusion.presets.quorum] 의 구조를 미러한다(모델 id는 placeholder).
+   topology=judge_of_judges는 orchestrator 런타임에서 judges >= 2 를 요구하므로
+   (fusion_orchestrator.run_judge_of_judges), JoJ를 키퍼가 실제로 쓰려면 judges>=2 preset이
+   shipped config에 있어야 한다. 이 테스트는 그 preset이 의존하는 TOML array-of-tables 파싱
+   (Fusion_config.parse_judge_spec)을 end-to-end로 고정한다 — 기존 Validated_preset 테스트는
+   OCaml-구성 judges만 다뤄 이 파싱 경로를 덮지 않는다. *)
+let joj_preset_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "quorum"
+[fusion.presets.quorum]
+panel = ["pa", "pb", "pc"]
+judge = "meta-reducer"
+panel_system_prompt = "answer independently"
+judge_system_prompt = "reconcile the first-judge syntheses"
+meta_timeout_s = 120.0
+
+[[fusion.presets.quorum.judges]]
+model = "judge-evidence"
+label = "evidence"
+system_prompt = "judge through an evidence lens"
+
+[[fusion.presets.quorum.judges]]
+model = "judge-coverage"
+label = "coverage"
+system_prompt = "judge through a coverage lens"
+|}
+
+let test_config_joj_preset_parses () =
+  match Fusion_config.of_toml (parse joj_preset_toml) with
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = raw vp in
+       let judges = preset.Fusion_policy.judges in
+       Alcotest.(check int) "two first judges (JoJ requires >= 2)" 2
+         (List.length judges);
+       Alcotest.(check bool) "meta judge set" true
+         (String.trim preset.Fusion_policy.judge <> "");
+       Alcotest.(check (list string))
+         "judge models parsed from [[...judges]] array-of-tables"
+         [ "judge-evidence"; "judge-coverage" ]
+         (List.map (fun (j : Fusion_policy.judge_spec) -> j.Fusion_policy.jmodel) judges);
+       Alcotest.(check (list string)) "distinct judge lenses parsed"
+         [ "evidence"; "coverage" ]
+         (List.map (fun (j : Fusion_policy.judge_spec) -> j.Fusion_policy.jlabel) judges)
+     | _ -> Alcotest.fail "expected exactly one preset")
+  | Error es ->
+    Alcotest.failf "JoJ preset must parse+validate, got errors: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+
 (* --- byte-identity: legacy flat preset == single explicit panel group --- *)
 
 let golden_flat_toml =
@@ -1549,6 +1602,7 @@ let () =
     ; ( "config"
       , [ Alcotest.test_case "absent" `Quick test_config_absent
         ; Alcotest.test_case "valid" `Quick test_config_valid
+        ; Alcotest.test_case "joj_preset_parses" `Quick test_config_joj_preset_parses
         ; Alcotest.test_case "panels_golden" `Quick test_config_panels_golden
         ; Alcotest.test_case "heterogeneous" `Quick test_config_heterogeneous
         ; Alcotest.test_case "empty_panels" `Quick test_config_empty_panels


### PR DESCRIPTION
## 목표

`masc_fusion` 도구는 `topology=judge_of_judges` / `staged_judge_of_judges`(JoJ)를 입력 스키마와 `keeper_tool_descriptor`에서 노출·문서화하지만, **shipped preset이 `trio` 하나뿐이고 단일 `judge`만 구성**한다. `fusion_orchestrator.run_judge_of_judges`는 `preset.judges >= 2`를 요구하며 미충족 시 `"requires >= 2 judges configured in the preset"`로 fail-closed한다. 따라서 키퍼가 JoJ topology를 고르면 **항상 실패** — JoJ는 문서화됐으나 out-of-the-box로 도달 불가였다.

이 PR은 그 provisioning 갭을 닫는다. 코드 경로(JoJ orchestrator, 검증, 파서)는 이미 완비돼 있고 데이터만 없었다.

## 변경

- `config/runtime.toml`: JoJ-capable preset **`quorum`** 추가 (additive, `trio` 불변).
  - panel: 3 모델 (trio 패널 재사용 — 검증된 구성): `deepseek-v4-flash`, `glm-5-turbo`, `minimax-m3`
  - 1차 심판 2명(서로 다른 lens·model·identity): `glm-coding.glm-4-7-coding`(evidence), `ollama_cloud.kimi-k2-6`(coverage)
  - meta judge(reducer): `deepseek.deepseek-v4-pro`
  - **모든 judge(evidence/coverage/meta)가 panel 외부** — 자기 답변 포함 panel을 심판하는 self-preference bias를 구조적으로 배제 (적대적 리뷰 P2 반영, commit d2b15798062).
  - 세 judge 모델 모두 `supports-response-format-json = true` (runtime.toml `[models.*.capabilities]` 기준)
  - 사용: `masc_fusion preset="quorum" topology="judge_of_judges"`
- `test/fusion_core/test_fusion.ml`: `config/joj_preset_parses` 테스트 추가 — `[[fusion.presets.X.judges]]` array-of-tables 파싱 경로(`Fusion_config.parse_judge_spec`)를 end-to-end로 고정. 기존 `Validated_preset` 테스트는 OCaml-구성 judges만 다뤄 이 TOML 파싱 경로를 덮지 않았다.

## 경계 / no-silent-failure 메모

- fusion judge는 **응답 텍스트에서 JSON을 파싱**(`fusion_oas.answer_text` + `fusion_judge_parse`)하지 OAS native structured-output API를 쓰지 않는다. 따라서 structured-output host allowlist 게이트는 이 judge들에 적용되지 않는다(현 `trio` judge `deepseek-v4-pro`가 비-allowlist host인데도 작동하는 이유와 동일). JSON 신뢰성을 위해 JSON-선언 모델만 선택했다.
- `staged_judge_of_judges`는 `[fusion].staged_judge_group_size`(=3)의 정확한 배수 그룹을 요구하므로 `quorum`(2 judges)은 비대상이다. staged용 preset(≥6 judges)은 별도 후속.

## 로컬 검증

- `dune exec --root . test/fusion_core/test_fusion.exe` → `Test Successful in 0.030s. 85 tests run` (신규 `joj_preset_parses` 포함 전부 통과).
- `config/runtime.toml` 전체를 `tomllib`로 파싱 → `presets=[trio, quorum]`, quorum judges=2(distinct identity evidence/coverage), meta judge=`deepseek.deepseek-v4-pro`, meta_timeout_s=300 확인.
- 모든 `Validated_preset` 검증 gate(panel size 3, 프롬프트 비-공백, panel/judge identity distinct, min_answered 기본 1) 충족.

## 남은 미검증 (Draft)

- 라이브 키퍼가 `preset="quorum" topology="judge_of_judges"`로 실제 JoJ run을 완료하는 end-to-end는 로컬에서 미실행(실 모델 호출 필요). 서버 부팅 시 config 검증 통과 + orchestrator 경로는 코드상 확인.

RFC-0283 (fusion judge-of-judges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
