### PR TITLE
fix(keeper): fail-closed on Execute pipeline with stdin/stdout/stderr redirect

### DIFF
--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -270,8 +270,31 @@ let of_json (json : Yojson.Safe.t) =
     let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
     Ok (Exec { executable; argv; cwd; env; stdin; stdout; stderr })
   | false, Some (path, value) ->
-    let* stages = parse_pipeline ~path value in
-    Ok (Pipeline { stages; cwd; env })
+    (* RFC-0198 Phase B 한계: typed redirect triple(stdin/stdout/stderr)은 [Exec]
+       variant에만 존재하고 [Pipeline]에는 없다. 그런데 이 세 키는
+       reject_unknown_fields 허용 목록(위 reject_unknown_fields ~allowed)에 들어
+       있어 pipeline과 함께 와도 파싱은 통과하고, [Pipeline { stages; cwd; env }]가
+       redirect를 버려 조용히 폐기된다 — silent failure. 명시적으로 거부해 사일런트
+       드롭을 차단한다. 근본 해결(Pipeline endpoint redirect 실제 지원)은 [Pipeline]
+       variant에 redirect_target triple을 추가하는 타입 확장이며 후속 작업이다. *)
+    let redirect_present key =
+      match member fields key with
+      | None | Some `Null -> false
+      | Some _ -> true
+    in
+    if
+      redirect_present "stdin"
+      || redirect_present "stdout"
+      || redirect_present "stderr"
+    then
+      Error
+        "$.stdin / $.stdout / $.stderr are not supported with $.pipeline; typed \
+         redirects apply only to the single-process {executable, argv} form. \
+         Put the redirecting command in its own pipeline stage, or use the \
+         {executable, argv} form with the typed redirect fields."
+    else
+      let* stages = parse_pipeline ~path value in
+      Ok (Pipeline { stages; cwd; env })
   | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -538,6 +538,27 @@ let test_of_json_rejects_exec_and_pipeline_together () =
     (String_util.contains_substring_ci msg "mutually exclusive")
 ;;
 
+(* Pipeline은 redirect_target triple을 갖지 않는다(Exec variant 전용). stdin/stdout/stderr가
+   pipeline과 함께 오면 이전에는 of_json이 조용히 버렸다(silent failure). 명시적 거부를 고정. *)
+let test_of_json_rejects_pipeline_with_redirect () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String "printf"; "argv", `List [ `String "x" ] ]
+                ; `Assoc [ "executable", `String "wc" ]
+                ] )
+          ; "stdout", `Assoc [ "file", `String "/tmp/out.log" ]
+          ])
+  in
+  Alcotest.(check bool)
+    "error states redirects unsupported with pipeline"
+    true
+    (String_util.contains_substring_ci msg "not supported with $.pipeline")
+;;
+
 let test_of_json_rejects_stages_alias () =
   let msg =
     parse_json_error
@@ -1223,6 +1244,10 @@ let suite =
           "of_json_rejects_exec_and_pipeline_together"
           `Quick
           test_of_json_rejects_exec_and_pipeline_together
+      ; Alcotest.test_case
+          "of_json_rejects_pipeline_with_redirect"
+          `Quick
+          test_of_json_rejects_pipeline_with_redirect
       ; Alcotest.test_case
           "of_json_rejects_stages_alias"
           `Quick


### PR DESCRIPTION
## 목표

typed Execute의 `of_json`은 `pipeline` 폼과 함께 `stdin`/`stdout`/`stderr` redirect 필드가 와도 **조용히 폐기**한다(silent failure). 세 필드는 `reject_unknown_fields` 허용 목록에 있어 파싱은 통과하지만, `Pipeline` variant는 redirect_target triple을 갖지 않아(`Exec` variant 전용, RFC-0198 Phase B) 버려진다. 키퍼가 `pipeline=[...] stdout={file:"/abs"}`를 보내면 redirect 없이 실행되며 아무 신호도 받지 못한다.

## 변경

- `lib/keeper/keeper_tool_execute_typed_input.ml` (`of_json` pipeline 분기): `pipeline`과 함께 stdin/stdout/stderr가 present(non-null)면 **명시적 Error로 fail-closed**. 조용한 폐기를 차단하고, 어떻게 표현해야 하는지(별도 pipeline stage 또는 단일 {executable, argv} 폼 + typed redirect) 안내한다. 에러 스타일은 같은 함수의 기존 "$.executable and $.pipeline are mutually exclusive" 문자열 에러와 일치.
- `.mli` 불변(`of_json` 시그니처 `(execute_input, string) result` 그대로).
- 근본 해결(Pipeline endpoint redirect 실제 지원)은 `Pipeline` variant에 redirect_target triple을 추가하는 타입 확장이며, 주석으로 후속임을 명시.

## 테스트

- `test/test_keeper_tool_execute_typed_input.ml`: `of_json_rejects_pipeline_with_redirect` 추가 — `pipeline + stdout:{file}` 입력이 (이전: 조용히 통과 → 수정 후: Error)임을 고정.
- 회귀: 기존 `of_json_pipeline`(pipeline + cwd, redirect 없음)은 그대로 통과.

## 로컬 검증

- 브랜치를 현재 origin/main으로 rebase (이전 base는 oas 0.207.27 핀 #22742 이전이라 로컬 oas 0.207.27과 skew).
- `dune exec --root . test/test_keeper_tool_execute_typed_input.exe` → `Test Successful. 51 tests run` (신규 `of_json_rejects_pipeline_with_redirect` 포함 전부 통과, lib/keeper 전체 빌드 green).
- 회귀: 기존 pipeline+cwd(redirect 없음) 경로 그대로 통과.

## 워크어라운드 아님

string-match/silent-strip/normalize가 아니라, 표현 불가능한 입력 조합을 typed-shape 경계에서 명시적으로 거부하는 fail-closed 수정이다(Parse, don't validate). 기존 of_json의 mutual-exclusion 거부와 동형.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
