### PR TITLE
fix(dashboard): decode history content_blocks across keeper trace + conversation views

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -304,7 +304,13 @@ let keeper_history_summary_json
         let j = Yojson.Safe.from_string line in
         let role = Safe_ops.json_string ~default:"" "role" j |> String.trim in
         let role_lc = String.lowercase_ascii role in
-        let content = Safe_ops.json_string ~default:"" "content" j |> String.trim in
+        (* Message text lives in typed [content_blocks], not a flat [content]
+           string. Reading flat [content] decoded "" for every row, so the
+           keeper conversation / k2k summary was empty. Same SSOT extractor as
+           the trace view. *)
+        let content =
+          Keeper_context_core.text_of_history_jsonl_json j |> String.trim
+        in
         let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
         let ts_unix =
           let ts0 = Safe_ops.json_float ~default:0.0 "ts_unix" j in

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -327,7 +327,14 @@ let claim_scope_summary_absent =
 let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
     : Trajectory.trajectory_line option =
   let source = Safe_ops.json_string ~default:"" "source" json in
-  let content = Safe_ops.json_string ~default:"" "content" json in
+  (* History rows persist message text as typed [content_blocks], not a flat
+     [content] string (Keeper_context_core_message_json: "Structured
+     content_blocks is the only supported message-content shape"). Reading a
+     flat [content] field decoded to "" for every persisted internal_assistant
+     row, so the whole keeper reasoning history was skipped and invisible in the
+     dashboard trace. Use the SSOT extractor (shared with history routing /
+     memory recall) so content_blocks rows decode to their text. *)
+  let content = Keeper_context_core.text_of_history_jsonl_json json in
   if source <> "internal_assistant" || String.trim content = "" then None
   else
     let ts =

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -233,6 +233,50 @@ let test_metrics_window_redacts_model_and_handoff_labels () =
         (handoff |> member "to_model" = `Null)
   | None -> fail "expected last handoff summary")
 
+let with_temp_history content f =
+  let path = Filename.temp_file "khist" ".jsonl" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ()) (fun () -> f path)
+
+(* Regression: keeper history rows persist message text as typed
+   [content_blocks], not a flat [content] string. Reading flat [content]
+   decoded "" for every row, so the dashboard keeper conversation feed and the
+   k2k mention graph were entirely empty. *)
+let test_history_summary_decodes_content_blocks () =
+  let rows =
+    String.concat
+      "\n"
+      [ {|{"role":"assistant","content_blocks":[{"type":"text","text":"hello from albini"}],"ts_unix":1.0}|}
+      ; {|{"role":"user","content_blocks":[{"type":"text","text":"ping @taskmaster please"}],"ts_unix":2.0}|}
+      ]
+    ^ "\n"
+  in
+  with_temp_history rows (fun path ->
+      let conversation, _k2k_recent, _k2k_mentions, raw_count, _frag, _filtered =
+        Metrics.keeper_history_summary_json
+          ~all_keeper_names:[ "albini"; "taskmaster" ]
+          ~keeper_name:"albini"
+          ~history_path:path
+          ~filter_fragments:false
+      in
+      check int "raw_count counts content_blocks rows" 2 raw_count;
+      match conversation with
+      | `List (first :: _ as items) ->
+          check int "conversation length" 2 (List.length items);
+          let content =
+            first
+            |> Yojson.Safe.Util.member "content"
+            |> Yojson.Safe.Util.to_string
+          in
+          check
+            string
+            "first row content extracted from blocks"
+            "hello from albini"
+            content
+      | _ -> fail "expected non-empty conversation list")
+
 let () =
   run "dashboard_keeper_metrics_10286"
     [
@@ -260,5 +304,10 @@ let () =
             test_metrics_series_ignores_sparse_tool_events;
           test_case "redacts model and handoff labels" `Quick
             test_metrics_window_redacts_model_and_handoff_labels;
+        ] );
+      ( "history_summary",
+        [
+          test_case "decodes content_blocks rows" `Quick
+            test_history_summary_decodes_content_blocks;
         ] );
     ]

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -1,6 +1,7 @@
 open Alcotest
 open Masc
 module Trace = Server_dashboard_http_keeper_api_trace
+module Types = Server_dashboard_http_keeper_api_types
 module T = Trajectory
 
 let mk_thinking ~ts ~redacted ~content =
@@ -61,12 +62,14 @@ let test_read_invalid_json_skips () =
     let trace_dir = Filename.dirname trace_file in
     Unix.system (Printf.sprintf "mkdir -p '%s'" trace_dir) |> ignore;
     let oc = open_out trace_file in
-    (* 1 valid line, 1 invalid line (missing ts/timestamp), 1 valid line *)
+    (* Rows persist message text as typed [content_blocks] (the only supported
+       message-content shape), not a flat [content] string. 1 valid line, 1
+       invalid line (missing ts/timestamp), 1 valid line. *)
     Printf.fprintf
       oc
-      "{\"source\":\"internal_assistant\",\"content\":\"A\",\"ts_unix\":1.0}\n\
-       {\"source\":\"internal_assistant\",\"content\":\"B\"}\n\
-       {\"source\":\"internal_assistant\",\"content\":\"C\",\"ts_unix\":3.0}\n";
+      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}],\"ts_unix\":1.0}\n\
+       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
+       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}],\"ts_unix\":3.0}\n";
     close_out oc;
     let result = Trace.read_internal_history_lines ~config ~trace_id:"test_trace" in
     (* Should skip the invalid line ("B") without failing *)
@@ -78,6 +81,40 @@ let test_read_invalid_json_skips () =
       check string "second" "C" c.content;
       check (float 0.0) "second_ts" 3.0 c.ts
     | _ -> fail "expected two valid thinking lines")
+;;
+
+let test_converter_decodes_content_blocks () =
+  (* Regression: persisted internal_assistant rows store text under typed
+     [content_blocks]. Before the fix, the converter read a flat [content]
+     field, decoded "" for every row, and returned None — the whole keeper
+     reasoning history was skipped (3339+ "Skipped invalid internal history
+     trace row" WARNs/day) and invisible in the dashboard trace. *)
+  let json =
+    Yojson.Safe.from_string
+      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"hello world\"}],\"ts_unix\":2.0}"
+  in
+  match Types.internal_history_json_to_trajectory_line json with
+  | Some (T.Thinking entry) ->
+    check string "content" "hello world" entry.content;
+    check int "content_length" (String.length "hello world") entry.content_length;
+    check (float 0.0) "ts" 2.0 entry.ts
+  | Some (T.Tool_call _) -> fail "expected Thinking, got Tool_call"
+  | None -> fail "content_blocks row must decode to a Thinking line"
+;;
+
+let test_converter_rejects_flat_content () =
+  (* Contract: [content_blocks] is the only supported message-content shape
+     (Keeper_context_core_message_json). A legacy flat [content] string is not
+     the supported shape and must not silently masquerade as message text. *)
+  let json =
+    Yojson.Safe.from_string
+      "{\"source\":\"internal_assistant\",\"content\":\"legacy flat\",\"ts_unix\":2.0}"
+  in
+  check
+    bool
+    "flat content (no content_blocks) does not decode"
+    true
+    (Option.is_none (Types.internal_history_json_to_trajectory_line json))
 ;;
 
 let () =
@@ -92,5 +129,15 @@ let () =
         ] )
     ; ( "read_internal_history_lines"
       , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips ] )
+    ; ( "internal_history_json_to_trajectory_line"
+      , [ test_case
+            "decodes content_blocks rows"
+            `Quick
+            test_converter_decodes_content_blocks
+        ; test_case
+            "rejects flat content rows"
+            `Quick
+            test_converter_rejects_flat_content
+        ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

대시보드 keeper 뷰에서 **키퍼의 히스토리(추론 + 대화)가 전혀 노출되지 않던** 버그를 고친다. 동일 root cause(flat `content` vs typed `content_blocks`)가 **두 개의 operator-visible 뷰**를 각각 100% 비우고 있었다. "대시보드에 안 보이는 게 많다"의 정량적 실체.

| 사이트 | 함수 | 비어있던 뷰 |
|---|---|---|
| `lib/server/server_dashboard_http_keeper_api_types.ml` | `internal_history_json_to_trajectory_line` | keeper trace의 **Thinking(추론) 라인** |
| `lib/dashboard/dashboard_http_keeper_metrics.ml` | `keeper_history_summary_json` | keeper **대화 피드 + k2k mention 그래프** |

> N-of-M 회피: 동일 root cause이므로 두 사이트를 한 PR에서 함께 수정. `dashboard_operator_nudges.ml`의 `body/message/content` 읽기는 operator nudge 스키마(다른 형식)라 무관 — 확인 후 제외.

## 근본 원인

`server_dashboard_http_keeper_api_types.internal_history_json_to_trajectory_line`이 메시지 텍스트를 flat `content` 문자열로 읽는다:

```ocaml
let content = Safe_ops.json_string ~default:"" "content" json in
if source <> "internal_assistant" || String.trim content = "" then None
```

그러나 history 행은 텍스트를 typed `content_blocks`로만 저장한다 — `Keeper_context_core_message_json`의 주석이 명시: *"Structured content_blocks is the only supported message-content shape."* 따라서 모든 `internal_assistant` 행이 `content=""`로 디코드되어 `None`(skip)이 되고, `read_internal_history_lines`는 행마다 `Log.Dashboard.warn "Skipped invalid internal history trace row"`를 찍는다.

### 실측 (결정론적 근거)

- internal history(`history.internal.jsonl`) **22173행 전수**: 전부 `content_blocks`-only. flat `content`-only **0건**.
- main history(`history.jsonl`) **2989행 전수**(user 1673 / assistant 1316): 전부 `content_blocks`-only. flat `content`-only **0건**.
- `~/me/.masc/logs/system_log_2026-06-30.jsonl`: `Skipped invalid internal history trace row` WARN **3339건**(단일 일자, 전체 WARN의 최다). 전량 이 버그로 인한 false skip.
- 즉 대시보드는 키퍼 추론 히스토리 + 대화 피드의 **0%**를 보여주고 있었다.

## 변경

두 사이트 모두 content 추출을 SSOT 함수 `Keeper_context_core.text_of_history_jsonl_json`로 교체. 이 함수는 `content_blocks_of_json`(typed Agent_sdk 블록) → `Agent_sdk.Types.text_of_message`로 텍스트를 뽑으며 history routing(`classify_history_jsonl_line`)·memory recall과 **동일 경로**를 공유한다.

- `lib/server/server_dashboard_http_keeper_api_types.ml`: trace Thinking 라인 추출 교체.
- `lib/dashboard/dashboard_http_keeper_metrics.ml`: 대화 요약/k2k 추출 교체.
- flat-content fallback은 **추가하지 않는다**: persisted 0건이고 SSOT가 content_blocks-only를 선언하므로, fallback은 죽은 두 번째 추출 경로(SSOT 위반)가 된다.
- 부수 효과: internal_assistant 행이 정상 디코드되어 `Skipped invalid internal history trace row` WARN 스팸도 소멸.

## 테스트

- `test/test_server_dashboard_http_keeper_api_trace.ml`:
  - `internal_history_json_to_trajectory_line / decodes content_blocks rows` (신규): content_blocks 행이 텍스트를 가진 Thinking 라인으로 디코드됨을 고정 (수정 전: None).
  - `internal_history_json_to_trajectory_line / rejects flat content rows` (신규): flat `content`(content_blocks 부재)는 디코드되지 않음 — SSOT 계약 명시.
  - `read_internal_history_lines / skips invalid jsonl rows` (갱신): fixture를 stale flat-content 형식에서 실제 persisted 형식(content_blocks)으로 교체. invalid(ts 누락) 행 skip 의미는 유지.
- `test/test_dashboard_keeper_metrics_10286.ml`:
  - `history_summary / decodes content_blocks rows` (신규): content_blocks 행이 `raw_count>0` + 추출된 content를 가진 conversation으로 디코드됨을 고정 (수정 전: 빈 conversation).

## 로컬 검증

- `dune exec --root . test/test_server_dashboard_http_keeper_api_trace.exe` → `Test Successful. 5 tests run`.
- `dune exec --root . test/test_dashboard_keeper_metrics_10286.exe` → `Test Successful. 9 tests run`.
- 둘 다 전부 통과, lib/server + lib/dashboard 빌드 green. 브랜치는 origin/main(`b010e1f2ed5`, oas 0.207.27 핀 포함) 기준.

## 알려진 별개 이슈 (이 PR 범위 외)

- `keeper_history_summary_json`의 `.mli` doc 주석(`turns_json, models_json, tools_json...`)은 실제 반환(`conversation, k2k_recent, k2k_mentions...`)과 불일치하는 stale doc. 별도 문서 수정 대상.

## 워크어라운드 아님

string-match/silent-strip이 아니라, 잘못된 필드(flat `content`)에서 읽던 추출을 **SSOT typed 추출기**로 교체해 데이터 손실(전량 silent skip)을 제거하는 수정이다. 두 번째 추출 경로를 새로 만들지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
