### PR TITLE
test(keeper): expect OAS tool arg snapshots in interleaved stream

### DIFF
--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -413,7 +413,7 @@
 }
 
 .set-path-check-result {
-  font-size: 11px;
+  font-size: var(--fs-11);
   font-family: var(--font-mono);
   line-height: 1;
 }
@@ -523,7 +523,7 @@
 
 .set-rt-open {
   font-family: var(--font-ui);
-  font-size: 13px;
+  font-size: var(--fs-13);
   padding: 9px 18px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--volt-dim);
@@ -855,7 +855,7 @@
   gap: 8px;
   margin-bottom: 12px;
   color: var(--text-mid);
-  font-size: 12px;
+  font-size: var(--fs-12);
 }
 
 /* tool-group policy — keeper-v2 styles/surfaces.css:555-565 (.set-tg-*) */

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -510,7 +510,8 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
           tool_call_name = Some block_tool_name };
       Keeper_chat_events.Tool_call_start { tool_call_id; tool_call_name };
       Keeper_chat_events.Tool_call_args { tool_call_id = args_id_a; delta = args_a };
-      Keeper_chat_events.Tool_call_args { tool_call_id = args_id_b; delta = args_b };
+      Keeper_chat_events.Tool_call_args_snapshot
+        { tool_call_id = snapshot_id; snapshot };
       Keeper_chat_events.Oas_content_block_stop { index = stop_index };
       Keeper_chat_events.Tool_call_end { tool_call_id = end_id };
       Keeper_chat_events.Oas_thinking_delta { index = last_index; delta = last } ] ->
@@ -523,9 +524,9 @@ let test_keeper_stream_bridge_preserves_interleaved_thinking_and_tool () =
       check string "tool id" "tc-1" tool_call_id;
       check string "tool name" "keeper_board_list" tool_call_name;
       check string "args id a" "tc-1" args_id_a;
-      check string "args id b" "tc-1" args_id_b;
+      check string "snapshot id" "tc-1" snapshot_id;
       check string "args a" "{\"limit\":" args_a;
-      check string "args b" "{\"limit\":1}" args_b;
+      check string "snapshot" "{\"limit\":1}" snapshot;
       check int "tool stop index" 1 stop_index;
       check string "end id" "tc-1" end_id;
       check int "last thinking index" 2 last_index;


### PR DESCRIPTION
## Summary
- Align the interleaved keeper stream bridge test with OAS `InputJsonSnapshot` semantics.
- The bridge emits `Tool_call_args_snapshot` for complete argument snapshots, so the mixed delta+snapshot fixture should expect append then replace instead of two appends.
- Replace three existing settings-surface raw font-size literals with `--fs-*` tokens so the PR CI raw-font ratchet stays aligned with the design-token SSOT.

## Verification
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_gate_keeper_backend.exe`
- `scripts/lint/no-raw-font-size-px.sh`
- `git diff --check`