### PR TITLE
fix(keeper): passive-only no-work 턴이 no-progress streak를 accrue하도록 (#22747)

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -190,37 +190,6 @@ let claim_bound_work (calls : (string * Keeper_tool_outcome.t option) list) =
     calls
 ;;
 
-let legitimate_no_work_passive_only
-      ~observation
-      ~(tool_calls : (string * Keeper_tool_outcome.t option) list)
-      ~had_owned_active_task
-  =
-  let actionable_signal =
-    Keeper_contract_classifier.classify_actionable_signal
-      (Keeper_contract_classifier.of_keeper_world_observation observation)
-  in
-  let passive_status_tool name =
-    match Keeper_tool_progress.classify_tool_progress name with
-    | Keeper_tool_progress.Passive_status -> true
-    | Keeper_tool_progress.Claim_context
-    | Keeper_tool_progress.Execution
-    | Keeper_tool_progress.Completion -> false
-  in
-  let non_material_outcome_effect name outcome =
-    match Keeper_tool_progress.classify_tool_progress_with_outcome name outcome with
-    | Keeper_tool_progress.Streak_increment
-    | Keeper_tool_progress.Streak_reset_and_empty_queue_sleep _ -> true
-    | Keeper_tool_progress.Streak_reset -> false
-  in
-  (not had_owned_active_task)
-  && tool_calls <> []
-  && List.for_all
-       (fun (name, outcome) ->
-          passive_status_tool name && non_material_outcome_effect name outcome)
-       tool_calls
-  && actionable_signal = Keeper_contract_classifier.No_actionable_signal
-;;
-
 let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
      no-progress verdict derived from observed turn facts, not the LLM
@@ -260,18 +229,28 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
     | (Peer_only | User_facing | Internal_prose) as delivery ->
       delivery_requires_evidence delivery
   in
-  let had_owned_active_task_at_turn_start =
-    Option.is_some meta.Keeper_meta_contract.current_task_id
-  in
-  let legitimate_no_work_passive_only =
-    legitimate_no_work_passive_only ~observation ~tool_calls:calls_with_outcomes
-      ~had_owned_active_task:had_owned_active_task_at_turn_start
-  in
+  (* #22747 / RFC-keeper-proactive-wake-actionability-invariant: a passive-only
+     no-work turn (only [Passive_status] tools, no owned task, no actionable
+     signal) is NOT treated as progress. The retired [legitimate_no_work_passive_only]
+     carve-out marked such turns as progress, which RESET the no-progress streak
+     every cycle, so the detector never latched — and the RFC-0246/0294 R2b
+     wake-tombstone (which suppresses self-cadence re-wakes only while latched)
+     could never engage. A keeper with nothing to do therefore re-woke on its
+     min-interval cadence forever, ran keeper_context_status, found no work, and
+     produced no visible reply: the idle spin.
+
+     Letting these turns accrue the streak makes passive-no-work consistent with
+     the already-shipped claim-no-eligible loop (PR #21065, test
+     test_sangsu_claim_idle_loop_accrues): both are "repeatedly found nothing to
+     do" and both now latch at the threshold. The threshold (default 10) already
+     tolerates a single legitimate idle check, so a healthy keeper that gets work
+     before the threshold resets cleanly; only a persistent idle loop latches and
+     is paused for operator resume (Keeper_unified_turn_no_progress.mark_loop_detected),
+     which also arms the self-cadence wake-tombstone. *)
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
       ~strong_evidence
       ~surface_requires_evidence
-    || legitimate_no_work_passive_only
   in
   let threshold_override =
     budget_exhausted_no_progress_threshold_override
@@ -320,8 +299,6 @@ module For_testing = struct
   let delivery_requires_evidence = delivery_requires_evidence
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
-
-  let legitimate_no_work_passive_only = legitimate_no_work_passive_only
 
   let apply_loop_detectors = apply_loop_detectors
 end

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -48,16 +48,6 @@ module For_testing : sig
   val claim_bound_work
     : (string * Keeper_tool_outcome.t option) list -> bool
 
-  (** task-5: a passive-only no-work exemption. A turn that only called tools
-      classified as [Passive_status] and whose typed outcomes do not prove
-      material progress, while observing no actionable work at turn start, is
-      legitimately idle and must not accrue the no-progress streak. *)
-  val legitimate_no_work_passive_only
-    :  observation:Keeper_world_observation.world_observation
-    -> tool_calls:(string * Keeper_tool_outcome.t option) list
-    -> had_owned_active_task:bool
-    -> bool
-
   val apply_loop_detectors
     :  config:Workspace.config
     -> observation:Keeper_world_observation.world_observation

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -493,52 +493,6 @@ let test_scope_message_internal_textonly_accrues_streak () =
     "internal scope-message prose without evidence accrues streak" 4
     (D.current_streak ~keeper_name:k)
 
-(* task-5 keeper-stability: a passive-only turn that observed no actionable
-   work and did not own an active task is legitimately idle. It must not accrue
-   the no-progress streak even when the surface otherwise requires evidence.
-   The exemption applies to any tool classified as [Passive_status] by
-   [Keeper_tool_progress.classify_tool_progress], including peer-surface tools
-   when no work/owned task exists. *)
-let test_passive_only_no_work_does_not_accrue () =
-  D.reset_all_for_test ();
-  let k = "passive-no-work" in
-  (* The classifier uses [claimable_task_count] to decide whether there is an
-     actionable signal, so [unclaimed_task_count] is omitted here. *)
-  let observation =
-    { scheduled_observation with
-      claimable_task_count = 0
-    }
-  in
-  let is_legitimate tool_calls had_owned_active_task =
-    Success.legitimate_no_work_passive_only
-      ~observation
-      ~tool_calls
-      ~had_owned_active_task
-  in
-  Alcotest.(check bool) "passive-only no-work is legitimate" true
-    (is_legitimate [ ("keeper_surface_read", None) ] false);
-  Alcotest.(check bool) "owned active task breaks legitimacy" false
-    (is_legitimate [ ("keeper_surface_read", None) ] true);
-  Alcotest.(check bool) "actionable signal breaks legitimacy" false
-    (Success.legitimate_no_work_passive_only
-       ~observation:{ observation with claimable_task_count = 1 }
-       ~tool_calls:[ ("keeper_surface_read", None) ]
-       ~had_owned_active_task:false);
-  (* [classify_tool_progress] currently treats [tool_execute] as [Passive_status],
-     so the negative case for a non-passive tool uses a claim tool instead. *)
-  Alcotest.(check bool) "non-passive tool breaks legitimacy" false
-    (is_legitimate [ (List.hd Cap.claim_task_tool_names, None) ] false);
-  for _ = 1 to D.threshold () do
-    let surface_requires_evidence = true in
-    record_turn ~keeper_name:k
-      ~made_progress:
-        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence
-         || is_legitimate [ ("keeper_surface_read", None) ] false)
-    |> ignore_outcome
-  done;
-  Alcotest.(check int) "streak stays 0" 0 (D.current_streak ~keeper_name:k)
-;;
-
 (* RFC-0239 / audit D1·D3: the no-progress detector reads the typed outcome
    recorded on each tool call, not just the tool name. *)
 module Outcome = Keeper_tool_outcome
@@ -665,18 +619,24 @@ let test_sangsu_claim_idle_loop_accrues () =
     (D.turn_made_progress ~strong_evidence:false
        ~surface_requires_evidence:(not (Success.claim_bound_work bound)))
 
-let test_apply_loop_detectors_passive_only_no_work_does_not_accrue () =
+(* #22747: a passive-only no-work turn now ACCRUES the no-progress streak. The
+   retired [legitimate_no_work_passive_only] carve-out marked such turns as
+   progress and reset the streak every cycle, so the detector never latched and
+   the RFC-0246/0294 R2b wake-tombstone (which suppresses self-cadence re-wakes
+   only while latched) could not engage — the keeper re-woke on its min-interval
+   cadence forever, the idle spin. This mirrors the claim-no-eligible accrual
+   below: both are "repeatedly found nothing to do". Re-adding the carve-out
+   flips this assertion back to 0 (revert-red). *)
+let test_apply_loop_detectors_passive_only_no_work_now_accrues () =
   D.reset_all_for_test ();
   with_temp_config @@ fun config ->
   let keeper = "apply-passive-no-work" in
   let meta = make_meta keeper in
   let result = run_result [ tool_call "keeper_surface_read" ] in
-  for _ = 1 to D.threshold () do
-    ignore
-      (Success.apply_loop_detectors ~config ~observation:scheduled_observation
-         ~meta meta result)
-  done;
-  Alcotest.(check int) "production detector path keeps passive no-work at zero" 0
+  ignore
+    (Success.apply_loop_detectors ~config ~observation:scheduled_observation
+       ~meta meta result);
+  Alcotest.(check int) "production detector path accrues passive no-work (#22747)" 1
     (D.current_streak ~keeper_name:keeper)
 
 let test_apply_loop_detectors_claim_no_eligible_accrues () =
@@ -754,9 +714,6 @@ let () =
           Alcotest.test_case
             "R3 scope-message internal prose accrues streak"
             `Quick (with_eio test_scope_message_internal_textonly_accrues_streak);
-          Alcotest.test_case
-            "passive-only no-work does not accrue streak (task-5)"
-            `Quick (with_eio test_passive_only_no_work_does_not_accrue);
           Alcotest.test_case "claim exemption is outcome-aware (D3)"
             `Quick test_claim_outcome_aware_exemption;
           Alcotest.test_case "strong evidence drops typed-failure completions (D1)"
@@ -764,8 +721,8 @@ let () =
           Alcotest.test_case "sangsu claim-idle loop accrues streak"
             `Quick test_sangsu_claim_idle_loop_accrues;
           Alcotest.test_case
-            "apply_loop_detectors passive-only no-work stays reset"
-            `Quick (with_eio test_apply_loop_detectors_passive_only_no_work_does_not_accrue);
+            "apply_loop_detectors passive-only no-work now accrues (#22747)"
+            `Quick (with_eio test_apply_loop_detectors_passive_only_no_work_now_accrues);
           Alcotest.test_case
             "apply_loop_detectors typed no-eligible claim accrues"
             `Quick (with_eio test_apply_loop_detectors_claim_no_eligible_accrues);


### PR DESCRIPTION
## 목표

`Keeper completed without a visible reply; the runtime returned only thinking or internal state.` 로 표면화되는 idle spin을 근본 수정한다. 증상: actionable signal도 owned task도 없는 keeper가 `keeper_context_status` 같은 passive-status 도구만 반복 호출하며 thinking을 누적하다 visible reply 없이 종료. interactive에선 위 에러, autonomous에선 토큰 소진.

## 근본 원인

시스템은 idle spin을 멈출 2단 기계를 이미 갖고 있다:

1. `keeper_world_observation.keeper_cycle_decision`의 `min_interval`가 liveness turn을 **요청** (RFC-keeper-proactive-wake-actionability-invariant T3).
2. `keeper_heartbeat_loop_scheduling.decide_keepalive_scheduling`이 no-progress loop가 latch되면 그 self-cadence turn을 **억제** (RFC-0246 / RFC-0294 R2b wake-tombstone).

`apply_loop_detectors`의 `legitimate_no_work_passive_only` carve-out이 이 기계를 무력화했다: passive-only no-work turn을 `made_progress = true`로 표시 → no-progress streak를 매 cycle **리셋** → detector가 영원히 latch 안 됨 → wake-tombstone이 self-cadence 재기동을 억제하지 못함 → keeper가 min-interval cadence로 무한 재기동 = spin. **면제 clause가 자신을 멈출 latch를 스스로 막는 순환.**

`#22710`/`#22714`가 이 carve-out에 `actionable_signal` 게이트를 추가했으나, 라이브 keeper는 genuinely `No_actionable_signal`이라 면제가 그대로 적용돼 미해결.

## 변경

- `lib/keeper/keeper_unified_turn_success.ml`: `legitimate_no_work_passive_only` 함수 및 `made_progress` disjunct 제거. 이제 passive-only no-work turn이 streak를 accrue한다.
- `lib/keeper/keeper_unified_turn_success.mli` + `For_testing`: 해당 함수 노출 제거 (dead code).
- `test/test_no_progress_loop_detector.ml`: carve-out 전용 테스트 2건을 "이제 accrue" 정책으로 갱신.

이미 출시된 claim-no-eligible loop 처리(`PR #21065`, `test_sangsu_claim_idle_loop_accrues`)와 **일관**된다 — 둘 다 "반복적으로 할 일 못 찾음"이며 둘 다 threshold에서 latch한다. 워크어라운드(cap/cooldown/dedup/telemetry-as-fix)가 아니라, loop 감지를 무력화하던 **면제 자체를 제거**하는 de-complecting 근본 수정이다.

## 동작 변화

- threshold(기본 10) 미만 연속 idle 점검: streak < threshold → latch 안 됨 → 정상 liveness 유지. 중간에 실제 작업이 오면 `made_progress`로 streak 리셋.
- threshold 이상 연속 idle 점검(진짜 spin): latch → `mark_loop_detected`가 keeper를 `Manual_resume_required`로 **pause** + self-cadence wake-tombstone 무장. **이는 claim-no-eligible loop의 기존 동작과 동일**하며, 새로운 공격적 동작이 아니다.
- RFC T3 liveness 보존: `keeper_world_observation`을 건드리지 않으므로 min-interval turn 요청은 그대로다. `test_keeper_failed_task_orphan_does_not_livelock` GREEN 유지.

## 검증

- `test_no_progress_loop_detector` 25건 GREEN (passive-no-work accrues 신규 assertion 포함).
- revert-red: carve-out을 faithful하게 재현하면 신규 테스트만 RED로 flip(streak 0), claim 테스트는 green 유지 → 테스트가 회귀를 정확히 잡음을 확인.
- 인접 keeper 테스트 GREEN: `test_keeper_wake_tombstone`(7), `test_keeper_latched_reason`(8), `test_keeper_auto_pause_blocker_persist_12683`(18), `test_keeper_pause_silent_failure_source`(15), `test_keeper_unified_turn_completion_contract`(7), `test_keeper_unified_claim_progress`(11), `test_advisory_only_affordance_never_drives_wake`(3), `test_keeper_no_signal_silence`(5), `test_keeper_failed_task_orphan_does_not_livelock`(2), `test_keeper_failed_task_not_proactive_driver`(3), `test_heartbeat_integration`(31).
- 전체 `dune build` 성공.

## 미검증 / residual risk

- threshold(10)는 기존 상수 그대로 사용. passive-no-work spin의 적정 threshold 별도 튜닝은 범위 밖.
- latch된 idle keeper는 `@mention`/operator로만 재기동(Board_reactive/Heartbeat 억제) — RFC-0246 의도된 동작이나, claimable task 도착 시 reactive 경로 재기동 여부는 기존 wake-tombstone 정책에 의존.

## RFC

- RFC-keeper-proactive-wake-actionability-invariant (T3 liveness, R1g/R2b)
- RFC-0246 (wake-cascade recovery tombstone), RFC-0294 R2b (self-cadence tombstone wiring)
- 관련 이슈: #22747, #20528(max_turns safety net). 선행: #22710/#22714.

이 변경은 `lib/keeper/credential_*`/`operator_control*`/`keeper_sandbox*`/hooks/workflow 등 RFC-gate subsystem에 해당하지 않는다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
