### PR TITLE
fix(dashboard): bind interaction judge fusion lifecycle

### DIFF
--- a/docs/design/dashboard-interaction-judge-fusion-lifecycle.md
+++ b/docs/design/dashboard-interaction-judge-fusion-lifecycle.md
@@ -1,0 +1,135 @@
+# Dashboard Interaction Judge Fusion Lifecycle
+
+Owner issue: <https://github.com/jeong-sik/masc/issues/22656>
+
+## Purpose
+
+`/api/v1/dashboard/interaction-judge` is intentionally disabled until the
+dashboard Interaction Judge is migrated onto the Fusion lifecycle. The disabled
+response uses `next_action = "migrate_to_fusion_job_lifecycle"` and exposes this
+document through `lifecycle_contract.doc_path`.
+
+This contract prevents that next action from becoming a free-floating string.
+The disabled route remains observable, but production execution must not resume
+through the old dashboard polling loop.
+
+## Target Lifecycle
+
+The Interaction Judge migration target is a Fusion-backed job with these
+boundaries:
+
+- Entrypoint: the dashboard Interaction Judge route requests or observes a
+  Fusion job owned by the `interaction-judge` lane. It must not run a bespoke
+  dashboard LLM loop.
+- Registry: in-progress and recent completed jobs use `Fusion_run_registry`.
+  Dashboard read projection is `GET /api/v1/dashboard/fusion-runs`.
+- Status event: lifecycle deltas use the existing `fusion_run_status` SSE event
+  emitted by `Fusion_sink.broadcast_run_status`.
+- Owner lane: records use `owner_lane_id = "interaction-judge"` so dashboard
+  projection can distinguish Interaction Judge jobs from ordinary keeper Fusion
+  calls.
+- Prompt template: `config/prompts/dashboard_interaction_judge.md` remains
+  intentionally registered while the route is disabled. It should be reused by
+  the Fusion job unless a replacement prompt is introduced in the same PR that
+  removes it.
+
+## Request Contract
+
+A future live Interaction Judge request must be represented as Fusion input,
+not as dashboard-local loop state. The minimum request shape is:
+
+```json
+{
+  "caller": "dashboard_interaction_judge",
+  "owner_lane_id": "interaction-judge",
+  "prompt_template_id": "dashboard_interaction_judge",
+  "facts_json": {},
+  "requested_at": 0.0
+}
+```
+
+`facts_json` is the same keeper-interaction evidence the disabled prototype used
+to build the prompt. The Fusion job may add preset/model fields, but those fields
+must come from Fusion configuration, not from a dashboard-only hardcoded model.
+
+## Response Contract
+
+While disabled, the route returns:
+
+```json
+{
+  "enabled": false,
+  "judge_online": false,
+  "refreshing": false,
+  "status": "disabled",
+  "next_action": "migrate_to_fusion_job_lifecycle",
+  "lifecycle_contract": {
+    "id": "dashboard_interaction_judge_fusion_lifecycle",
+    "issue_url": "https://github.com/jeong-sik/masc/issues/22656",
+    "doc_path": "docs/design/dashboard-interaction-judge-fusion-lifecycle.md",
+    "fusion_runs_route": "/api/v1/dashboard/fusion-runs",
+    "fusion_run_status_event": "fusion_run_status"
+  },
+  "data": {
+    "stigmergy": {},
+    "interactions": []
+  }
+}
+```
+
+The eventual live route must preserve the existing `data.stigmergy` and
+`data.interactions` projection for `dashboard/src/components/world-visualizer.ts`.
+It may add fields, but it must not remove those fields without changing the
+consumer in the same PR.
+
+## Status Labels
+
+The disabled route currently publishes:
+
+- `disabled`: no production Interaction Judge execution path is active.
+
+The Fusion lifecycle target reuses the `Fusion_run_registry.status_label`
+vocabulary:
+
+- `running`: a Fusion job is executing.
+- `completed`: the Fusion judge/sink completed successfully.
+- `failed`: the Fusion job was denied, aborted, or completed with a failed sink
+  outcome.
+
+No `queued` label is defined until a real admission queue exists. Do not add a
+dashboard-only queued state.
+
+## Timeout And Budget Policy
+
+Interaction Judge execution inherits Fusion budget and timeout policy. It must
+not add a dashboard-only infinite retry loop or a dashboard-only model timeout.
+
+- Budget denial maps to a failed Fusion run with an operator-visible reason.
+- Timeout behavior belongs to Fusion/OAS bridge policy and must be surfaced in
+  the Fusion run record or completion evidence.
+- The dashboard route may poll or subscribe to registry state, but it must not
+  own cancellation semantics.
+
+## Dashboard Projection
+
+The dashboard projection is split:
+
+- World Visualizer keeps using `/api/v1/dashboard/interaction-judge` for the
+  current interaction matrix and disabled state.
+- Fusion surface and registry panels use `/api/v1/dashboard/fusion-runs` plus
+  `fusion_run_status` SSE events for job lifecycle visibility.
+- When the Interaction Judge becomes live, the route should derive its current
+  state from the Fusion registry and the latest completed Interaction Judge job,
+  not from an independent loop-local cache.
+
+## Implementation Tasks
+
+Before flipping `enabled` to true:
+
+1. Add the Fusion job entrypoint for `caller = "dashboard_interaction_judge"`.
+2. Register the job in `Fusion_run_registry` with owner lane
+   `interaction-judge`.
+3. Emit `fusion_run_status` for start and completion.
+4. Project the latest completed job into the current `data.stigmergy` and
+   `data.interactions` response shape.
+5. Add tests for disabled, running, completed, failed, and budget-denied states.

--- a/lib/dashboard/dashboard_interaction_judge.ml
+++ b/lib/dashboard/dashboard_interaction_judge.ml
@@ -2,6 +2,10 @@ let keeper_name = "interaction-judge"
 let production_enabled = false
 let disabled_reason = "interaction judge requires Fusion job lifecycle before production"
 let disabled_next_action = "migrate_to_fusion_job_lifecycle"
+let lifecycle_contract_id = "dashboard_interaction_judge_fusion_lifecycle"
+let lifecycle_contract_doc_path =
+  "docs/design/dashboard-interaction-judge-fusion-lifecycle.md"
+let lifecycle_contract_issue_url = "https://github.com/jeong-sik/masc/issues/22656"
 
 type interaction = {
   source : string;
@@ -21,6 +25,18 @@ type lifecycle_status =
 type lifecycle_next_action =
   | Migrate_to_fusion_job_lifecycle
 
+type lifecycle_contract = {
+  id : string;
+  next_action : string;
+  issue_url : string;
+  doc_path : string;
+  owner_lane_id : string;
+  prompt_template_id : string;
+  fusion_runs_route : string;
+  fusion_run_status_event : string;
+  status_labels : string list;
+}
+
 type lifecycle_event = {
   task_id : string option;
   keeper_id : string;
@@ -39,9 +55,38 @@ let lifecycle_status_to_string = function
 let lifecycle_next_action_to_string = function
   | Migrate_to_fusion_job_lifecycle -> disabled_next_action
 
+let lifecycle_contract =
+  {
+    id = lifecycle_contract_id;
+    next_action = disabled_next_action;
+    issue_url = lifecycle_contract_issue_url;
+    doc_path = lifecycle_contract_doc_path;
+    owner_lane_id = keeper_name;
+    prompt_template_id = "dashboard_interaction_judge";
+    fusion_runs_route = "/api/v1/dashboard/fusion-runs";
+    fusion_run_status_event = "fusion_run_status";
+    status_labels = [ "disabled"; "running"; "completed"; "failed" ];
+  }
+
 let option_to_yojson f = function
   | Some value -> f value
   | None -> `Null
+
+let string_list_to_yojson values =
+  `List (List.map (fun value -> `String value) values)
+
+let lifecycle_contract_to_yojson contract =
+  `Assoc [
+    ("id", `String contract.id);
+    ("next_action", `String contract.next_action);
+    ("issue_url", `String contract.issue_url);
+    ("doc_path", `String contract.doc_path);
+    ("owner_lane_id", `String contract.owner_lane_id);
+    ("prompt_template_id", `String contract.prompt_template_id);
+    ("fusion_runs_route", `String contract.fusion_runs_route);
+    ("fusion_run_status_event", `String contract.fusion_run_status_event);
+    ("status_labels", string_list_to_yojson contract.status_labels);
+  ]
 
 let lifecycle_event_to_yojson event =
   `Assoc [
@@ -53,6 +98,9 @@ let lifecycle_event_to_yojson event =
     ("deadline_s", option_to_yojson (fun f -> `Float f) event.deadline_s);
     ("last_checkpoint", option_to_yojson (fun s -> `String s) event.last_checkpoint);
     ("next_action", `String (lifecycle_next_action_to_string event.next_action));
+    ("contract_id", `String lifecycle_contract.id);
+    ("contract_doc_path", `String lifecycle_contract.doc_path);
+    ("contract_issue_url", `String lifecycle_contract.issue_url);
     ("reason", option_to_yojson (fun s -> `String s) event.reason);
   ]
 
@@ -197,6 +245,7 @@ let fresh_interactions_json ~base_path =
        | Some action -> `String (lifecycle_next_action_to_string action)
        | None -> `Null);
       ("last_error", match st.snapshot.last_error with Some e -> `String e | None -> `Null);
+      ("lifecycle_contract", lifecycle_contract_to_yojson lifecycle_contract);
       ("lifecycle_event",
        match st.snapshot.last_event with
        | Some event -> lifecycle_event_to_yojson event

--- a/lib/dashboard/dashboard_interaction_judge.mli
+++ b/lib/dashboard/dashboard_interaction_judge.mli
@@ -1,6 +1,18 @@
 type judge_response
 type lifecycle_status
 type lifecycle_next_action
+type lifecycle_contract = {
+  id : string;
+  next_action : string;
+  issue_url : string;
+  doc_path : string;
+  owner_lane_id : string;
+  prompt_template_id : string;
+  fusion_runs_route : string;
+  fusion_run_status_event : string;
+  status_labels : string list;
+}
+
 type lifecycle_event
 
 type runtime_snapshot = {
@@ -18,6 +30,10 @@ type runtime_snapshot = {
 }
 
 val parse_judge_response : Yojson.Safe.t -> (judge_response, string) result
+
+val lifecycle_contract : lifecycle_contract
+
+val lifecycle_contract_to_yojson : lifecycle_contract -> Yojson.Safe.t
 
 val start :
   sw:Eio.Switch.t ->

--- a/test/test_dashboard_interaction_judge_contract.ml
+++ b/test/test_dashboard_interaction_judge_contract.ml
@@ -12,26 +12,77 @@ let check_json_bool label expected json =
   | Some (`Bool actual) -> Alcotest.(check bool) label expected actual
   | _ -> Alcotest.fail (label ^ ": expected bool field")
 
+let check_json_string_list_contains label expected json =
+  match json with
+  | Some (`List values) ->
+    let strings =
+      values
+      |> List.filter_map (function
+           | `String value -> Some value
+           | _ -> None)
+    in
+    Alcotest.(check bool) label true (List.exists (String.equal expected) strings)
+  | _ -> Alcotest.fail (label ^ ": expected string list field")
+
 let test_default_surface_is_disabled_and_observable () =
+  let next_action = "migrate_to_fusion_job_lifecycle" in
   let json =
     Dashboard_interaction_judge.fresh_interactions_json
       ~base_path:"/tmp/masc-test-dashboard-interaction-judge"
   in
+  Alcotest.(check string)
+    "typed contract next_action"
+    next_action
+    Dashboard_interaction_judge.lifecycle_contract.next_action;
   check_json_bool "enabled" false (json_member "enabled" json);
   check_json_bool "judge_online" false (json_member "judge_online" json);
   check_json_bool "refreshing" false (json_member "refreshing" json);
   check_json_string "status" "disabled" (json_member "status" json);
-  check_json_string
-    "next_action"
-    "migrate_to_fusion_job_lifecycle"
-    (json_member "next_action" json);
+  check_json_string "next_action" next_action (json_member "next_action" json);
+  (match json_member "lifecycle_contract" json with
+   | Some (`Assoc _ as contract) ->
+     check_json_string
+       "contract id"
+       "dashboard_interaction_judge_fusion_lifecycle"
+       (json_member "id" contract);
+     check_json_string "contract next_action" next_action (json_member "next_action" contract);
+     check_json_string
+       "contract issue"
+       "https://github.com/jeong-sik/masc/issues/22656"
+       (json_member "issue_url" contract);
+     check_json_string
+       "contract doc"
+       "docs/design/dashboard-interaction-judge-fusion-lifecycle.md"
+       (json_member "doc_path" contract);
+     check_json_string
+       "contract route"
+       "/api/v1/dashboard/fusion-runs"
+       (json_member "fusion_runs_route" contract);
+     check_json_string
+       "contract sse event"
+       "fusion_run_status"
+       (json_member "fusion_run_status_event" contract);
+     check_json_string_list_contains
+       "contract running status"
+       "running"
+       (json_member "status_labels" contract);
+     check_json_string_list_contains
+       "contract failed status"
+       "failed"
+       (json_member "status_labels" contract)
+   | _ -> Alcotest.fail "lifecycle_contract: expected object");
   match json_member "lifecycle_event" json with
   | Some (`Assoc _ as event) ->
     check_json_string "event caller" "interaction_judge" (json_member "caller" event);
+    check_json_string "event next_action" next_action (json_member "next_action" event);
     check_json_string
-      "event next_action"
-      "migrate_to_fusion_job_lifecycle"
-      (json_member "next_action" event)
+      "event contract"
+      "dashboard_interaction_judge_fusion_lifecycle"
+      (json_member "contract_id" event);
+    check_json_string
+      "event contract issue"
+      "https://github.com/jeong-sik/masc/issues/22656"
+      (json_member "contract_issue_url" event)
   | _ -> Alcotest.fail "lifecycle_event: expected object"
 
 let test_parser_reports_schema_errors_without_exception () =


### PR DESCRIPTION
## Summary

- add a concrete `lifecycle_contract` to the disabled dashboard Interaction Judge response
- point `migrate_to_fusion_job_lifecycle` at issue #22656 and `docs/design/dashboard-interaction-judge-fusion-lifecycle.md`
- document the Fusion-backed lifecycle target: entrypoint, owner lane, request/response schema, status events, timeout/budget policy, dashboard projection, and prompt-template retention
- extend the OCaml regression so the next action, contract issue/doc, Fusion registry route, SSE event, and status labels stay linked

## Validation

- `git diff --check`
- `ocamlformat --check lib/dashboard/dashboard_interaction_judge.ml lib/dashboard/dashboard_interaction_judge.mli test/test_dashboard_interaction_judge_contract.ml`
- `bash scripts/lint/no-raw-font-size-px.sh`
- attempted: `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_interaction_judge_contract.exe @lib/dashboard/all --force`
  - blocked by ambient local SDK drift in unrelated keeper modules:
    - `lib/keeper/keeper_context_core_message_json.ml`: `Thinking { thinking_type; content }` field mismatch
    - `lib/keeper/keeper_chat_oas_stream_bridge.ml`: missing `InputJsonSnapshot` match arm
- attempted after rebasing onto current `origin/main`: `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_interaction_judge_contract.exe --force`
  - blocked by repo guard because a bare `dune build @check` process was already running outside `scripts/dune-local.sh`; PR CI is the build authority for this branch

Closes #22656
