### PR TITLE
Clarify gate settings preview controls

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -419,6 +419,48 @@ describe('SettingsSurface', () => {
     expect(gateInput?.value).toBe('https://gate.example.test')
   })
 
+  it('gate connector toggles are browser-session previews, not live connection state', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    const summary = () => container.querySelector('[data-testid="gate-local-summary"]') as HTMLElement
+    expect(summary().textContent).toContain('local connector preview')
+    expect(summary().textContent).toContain('3/4 enabled')
+    expect(container.textContent).toContain('Live connector runtime, availability')
+    expect(container.textContent).not.toContain('Connected')
+    expect(container.textContent).not.toContain('Inactive')
+
+    const toggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
+    expect(toggles.length).toBe(4)
+    expect(toggles[0]!.getAttribute('data-active')).toBe('true')
+
+    await fireEvent.click(toggles[0]!)
+
+    expect(toggles[0]!.getAttribute('data-active')).toBe('false')
+    expect(summary().textContent).toContain('2/4 enabled')
+    expect(JSON.parse(sessionStorage.getItem('masc.settings.local.gateConnectorPreview') ?? '{}')).toMatchObject({
+      Slack: false,
+    })
+
+    const triggers = () => Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-trigger"]'))
+    expect(triggers().length).toBe(4)
+    await fireEvent.click(triggers()[2] as HTMLButtonElement)
+    expect(triggers()[2]?.getAttribute('data-active')).toBe('true')
+    expect(sessionStorage.getItem('masc.settings.local.discordTrigger')).toBe('all')
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-connectors-link"]') as HTMLButtonElement)
+    expect(navigate).toHaveBeenLastCalledWith('connectors')
+
+    render(null, container)
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    expect(summary().textContent).toContain('2/4 enabled')
+    expect((container.querySelector('[data-testid="set-toggle"]') as HTMLButtonElement).getAttribute('data-active')).toBe('false')
+    expect(triggers()[2]?.getAttribute('data-active')).toBe('true')
+  })
+
   it('paths local preview values can be format-checked without claiming live verification', async () => {
     render(html`<${SettingsSurface} />`, container)
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -285,6 +285,12 @@ const DISCORD_TRIGGER: readonly [string, string][] = [
   ['all', '모든 메시지에 응답'],
   ['user_only', '특정 사용자(snowflake)만'],
 ]
+const DEFAULT_GATE_CONNECTOR_PREVIEW: Record<string, boolean> = {
+  Slack: true,
+  Discord: true,
+  Amplitude: true,
+  GitHub: false,
+}
 
 // System-log row: [time, level, identity, message, status]. Derived from live
 // ring entries (`/api/v1/dashboard/logs`) — the same source the Logs surface
@@ -756,7 +762,7 @@ export function SettingsSurface() {
   const [fusionWeb, setFusionWeb] = useState(FUSION.webTools)
 
   // discord trigger policy (gate section) — keeper-v2 settings.jsx:183
-  const [discordTrigger, setDiscordTrigger] = useState('mention_or_thread')
+  const [discordTrigger, setDiscordTrigger] = useLocalPreviewString('discordTrigger', 'mention_or_thread')
 
   // lifecycle
   const [idleDrain, setIdleDrain] = useState(30)
@@ -766,12 +772,7 @@ export function SettingsSurface() {
 
   // gate / paths
   const [gateBase, setGateBase] = useLocalPreviewString('gateBase', 'https://gate.masc.local')
-  const [gateOn, setGateOn] = useState<Record<string, boolean>>({
-    Slack: true,
-    Discord: true,
-    Amplitude: true,
-    GitHub: false,
-  })
+  const [gateOn, setGateOn] = useLocalPreviewBoolRecord('gateConnectorPreview', DEFAULT_GATE_CONNECTOR_PREVIEW)
   const [wtBase, setWtBase] = useLocalPreviewString('wtBase', '~/wt')
   const [storeUrl, setStoreUrl] = useLocalPreviewString('storeUrl', 'postgres://masc.local:5432/masc')
   const [pathChecks, setPathChecks] = useState<Partial<Record<PathCheckTarget, PathCheckResult>>>({})
@@ -844,6 +845,7 @@ export function SettingsSurface() {
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
   const sectionState = settingsSectionState(sec, fusionSettingsWritable)
   const grantedGroupCount = Object.values(grant).filter(Boolean).length
+  const gatePreviewEnabledCount = Object.values(gateOn).filter(Boolean).length
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -1294,14 +1296,20 @@ export function SettingsSurface() {
 
             ${sec === 'gate' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Default settings for external gate connections. Per-channel→keeper bindings are managed in
+                Browser-session preview for connector defaults. Live connector runtime, availability and per-channel→keeper bindings are managed in
                 <button
                   type="button"
                   class="set-link"
+                  data-testid="settings-connectors-link"
                   onClick=${() => navigate('connectors')}
                 >
                   Connectors →
                 </button>.
+              </div>
+              <div class="set-local-summary" data-testid="gate-local-summary">
+                <span>local connector preview</span>
+                <span class="mono">${gatePreviewEnabledCount}/${Object.keys(DEFAULT_GATE_CONNECTOR_PREVIEW).length} enabled</span>
+                <${PreviewBadge} />
               </div>
               <${SetRow} label="Gate base URL" hint="GET /api/v1/gate/connectors">
                 <div class="set-path">
@@ -1315,8 +1323,11 @@ export function SettingsSurface() {
                 </div>
               <//>
               ${['Slack', 'Discord', 'Amplitude', 'GitHub'].map(g => html`
-                <${SetRow} key=${g} label=${g} hint=${gateOn[g] ? 'Connected' : 'Inactive'}>
-                  <${SetToggle} on=${gateOn[g]} onChange=${(v: boolean) => setGateOn(p => ({ ...p, [g]: v }))} />
+                <${SetRow} key=${g} label=${g} hint=${gateOn[g] ? 'local preview enabled' : 'local preview disabled'}>
+                  <div class="set-tg-control">
+                    <${PreviewBadge} />
+                    <${SetToggle} on=${gateOn[g] ?? false} onChange=${(v: boolean) => setGateOn(p => ({ ...p, [g]: v }))} />
+                  </div>
                 <//>
               `)}
               ${gateOn.Discord && html`


### PR DESCRIPTION
## Summary
- clarify Settings > Gate connector toggles as browser-session previews, not live connector connection state
- persist gate connector preview toggles and Discord trigger policy in sessionStorage
- route operators to Connectors for live runtime, availability, and binding truth

## Validation
- git diff --check
- PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules tsc --noEmit --pretty false
- PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules eslint src/components/settings-surface.ts
- PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules vitest run src/components/settings-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- Playwright fallback rendered check: desktop 1440x960 and mobile 390x844, Gate summary 3/4 -> 2/4, Slack preview persisted after reload, Discord trigger persisted after reload

## Render Evidence
- Browser plugin not available in this Codex session; used Python Playwright fallback
- screenshots: /private/tmp/masc-settings-gate-preview-20260630.png, /private/tmp/masc-settings-gate-preview-mobile-20260630.png
