### PR TITLE
fix(runtime): re-export OAS thinking control format

### DIFF
--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -37,7 +37,7 @@ Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) tri
 | `api_format` | `Messages_api \| Chat_completions_api \| Ollama_api` | `runtime_api_format` |
 | `transport` | `Http of string \| Cli of string` | `runtime_transport` |
 | `credential` | `Env of string \| File of string \| Inline of string` | `runtime_credential` |
-| `thinking_control_format` | `No_thinking_control \| Thinking_object \| Chat_template_kwargs` | `runtime_thinking_control_format` |
+| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
 | `capabilities` | 10-field provider 행동 record + `capabilities_default` | `runtime_capabilities` |
 | `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `runtime_model_capabilities` |
 | `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `runtime_provider` |

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -75,13 +75,20 @@ type provider =
 
 (** How an OpenAI-compat backend's request body encodes "enable thinking".
     Pinned on the model because the same physical model can be served by
-    backends with different thinking-control wire shapes. *)
+    backends with different thinking-control wire shapes.
+
+    This re-exports the OAS capability enum so OAS variant changes break MASC
+    compile instead of leaving a stale local mirror. *)
 type thinking_control_format =
+  Llm_provider.Capabilities.thinking_control_format =
   | No_thinking_control
   | Thinking_object
+  | Thinking_object_only
   | Chat_template_kwargs
   | Chat_template_token
+  | Ollama_think
   | Reasoning_effort
+  | Enable_thinking
 [@@deriving show, eq]
 
 (** Per-model capabilities, mirroring OAS [Llm_provider.Capabilities] for the

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -64,12 +64,18 @@ type provider =
 
 (** {1 Layer 2: Model} *)
 
+(** Re-exported from OAS so thinking-control capability drift is
+    compiler-checked. *)
 type thinking_control_format =
+  Llm_provider.Capabilities.thinking_control_format =
   | No_thinking_control
   | Thinking_object
+  | Thinking_object_only
   | Chat_template_kwargs
   | Chat_template_token
+  | Ollama_think
   | Reasoning_effort
+  | Enable_thinking
 [@@deriving show, eq]
 
 type model_capabilities =

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -361,9 +361,13 @@ let parse_thinking_control_format ~(path : string) (raw : string)
   | "" | "none" | "no-thinking-control" | "no_thinking_control" ->
     Ok Runtime_schema.No_thinking_control
   | "thinking-object" | "thinking_object" -> Ok Runtime_schema.Thinking_object
+  | "thinking-object-only" | "thinking_object_only" ->
+    Ok Runtime_schema.Thinking_object_only
   | "chat-template-kwargs" | "chat_template_kwargs" -> Ok Runtime_schema.Chat_template_kwargs
   | "chat-template-token" | "chat_template_token" -> Ok Runtime_schema.Chat_template_token
+  | "ollama-think" | "ollama_think" -> Ok Runtime_schema.Ollama_think
   | "reasoning-effort" | "reasoning_effort" -> Ok Runtime_schema.Reasoning_effort
+  | "enable-thinking" | "enable_thinking" -> Ok Runtime_schema.Enable_thinking
   | other ->
     (* Unknown enum members fail the load, mirroring how this parser already
        rejects unknown protocols / credential types. A silent downgrade to
@@ -374,7 +378,7 @@ let parse_thinking_control_format ~(path : string) (raw : string)
          (path ^ ".thinking-control-format")
          (Printf.sprintf
             "unknown thinking-control-format %S — expected one of \
-             none|thinking-object|chat-template-kwargs|chat-template-token|reasoning-effort"
+             none|thinking-object|thinking-object-only|chat-template-kwargs|chat-template-token|ollama-think|reasoning-effort|enable-thinking"
             other))
 ;;
 

--- a/test/test_thinking_control_format_unknown_error.ml
+++ b/test/test_thinking_control_format_unknown_error.ml
@@ -27,9 +27,51 @@ max-context = 1000
 let is_error = function Ok _ -> false | Error _ -> true
 let is_ok = function Ok _ -> true | Error _ -> false
 
-let test_valid_value_loads () =
-  check bool "valid thinking-control-format loads" true
-    (is_ok (Runtime_toml.parse_string (toml_with_tcf "reasoning-effort")))
+let render_errors errs =
+  errs
+  |> List.map (fun (err : Runtime_toml.parse_error) ->
+    Printf.sprintf "%s: %s" err.path err.message)
+  |> String.concat "\n"
+
+let parsed_thinking_control_format raw =
+  match Runtime_toml.parse_string (toml_with_tcf raw) with
+  | Error errs -> failf "expected %S to parse:\n%s" raw (render_errors errs)
+  | Ok cfg ->
+    (match cfg.Runtime_schema.models with
+     | [ model ] ->
+       (match model.Runtime_schema.capabilities with
+        | Some caps -> caps.Runtime_schema.thinking_control_format
+        | None -> failf "expected capabilities for %S" raw)
+     | models -> failf "expected one model for %S, got %d" raw (List.length models))
+
+let test_valid_values_load_and_map_to_oas_variants () =
+  let cases =
+    Runtime_schema.
+      [ "none", No_thinking_control
+      ; "no-thinking-control", No_thinking_control
+      ; "thinking_object", Thinking_object
+      ; "thinking-object", Thinking_object
+      ; "thinking_object_only", Thinking_object_only
+      ; "thinking-object-only", Thinking_object_only
+      ; "chat_template_kwargs", Chat_template_kwargs
+      ; "chat-template-kwargs", Chat_template_kwargs
+      ; "chat_template_token", Chat_template_token
+      ; "chat-template-token", Chat_template_token
+      ; "ollama_think", Ollama_think
+      ; "ollama-think", Ollama_think
+      ; "reasoning_effort", Reasoning_effort
+      ; "reasoning-effort", Reasoning_effort
+      ; "enable_thinking", Enable_thinking
+      ; "enable-thinking", Enable_thinking
+      ]
+  in
+  List.iter
+    (fun (raw, expected) ->
+       check bool ("thinking-control-format " ^ raw) true
+         (Runtime_schema.equal_thinking_control_format
+            (parsed_thinking_control_format raw)
+            expected))
+    cases
 
 let test_unknown_value_fails_load () =
   check bool "unknown thinking-control-format fails the load (Error)" true
@@ -45,7 +87,8 @@ let () =
     [
       ( "parse_string",
         [
-          test_case "valid value loads" `Quick test_valid_value_loads;
+          test_case "valid values map to OAS variants" `Quick
+            test_valid_values_load_and_map_to_oas_variants;
           test_case "unknown value fails load" `Quick test_unknown_value_fails_load;
           test_case "absent capabilities loads" `Quick
             test_absent_capabilities_loads;


### PR DESCRIPTION
## Summary
- Re-export OAS `Llm_provider.Capabilities.thinking_control_format` from `Runtime_schema` so capability drift is compiler-checked.
- Extend `runtime.toml` parsing for the full OAS thinking-control vocabulary, including snake_case and kebab-case spellings.
- Expand focused parser coverage and refresh RFC-0206’s stale enum row.

## Validation
- `git diff --check`
- `ocamlformat --check lib/runtime/runtime_schema.ml lib/runtime/runtime_schema.mli lib/runtime/runtime_toml.ml test/test_thinking_control_format_unknown_error.ml`
- `rg -n "Llm_provider\\.Capabilities\\.thinking_control_format|thinking_object_only|ollama_think|enable_thinking|Thinking_object_only|Ollama_think|Enable_thinking" lib/runtime test docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md`
- Blocked locally: `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_thinking_control_format_unknown_error.exe @lib/runtime/all --force` refused because an existing bare `dune build @check` was active outside the wrapper.

Closes #22654