### PR TITLE
feat(oas): delegate stop reason projections

### DIFF
--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -1,14 +1,4 @@
-let stop_reason_to_wire = function
-  | Agent_sdk.Types.EndTurn -> "end_turn"
-  | Agent_sdk.Types.StopToolUse -> "tool_use"
-  | Agent_sdk.Types.MaxTokens -> "max_tokens"
-  | Agent_sdk.Types.StopSequence -> "stop_sequence"
-  | Agent_sdk.Types.Refusal -> "refusal"
-  | Agent_sdk.Types.PauseTurn -> "pause_turn"
-  | Agent_sdk.Types.Compaction -> "compaction"
-  | Agent_sdk.Types.ContextWindowExceeded -> "model_context_window_exceeded"
-  | Agent_sdk.Types.Unknown value -> value
-;;
+let stop_reason_to_wire = Agent_sdk.Types.stop_reason_to_string
 
 let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
   match response.usage with

--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml
@@ -262,22 +262,15 @@ let is_keeper_board_write_tool_name tool_name =
 let current_keeper_model _meta =
   runtime_lane_label
 
-let stop_reason_label_end_turn = "end_turn"
-let stop_reason_label_tool_use = "tool_use"
-let stop_reason_label_max_tokens = "max_tokens"
-let stop_reason_label_stop_sequence = "stop_sequence"
-let stop_reason_label_unknown = "unknown"
+let stop_reason_to_label = Agent_sdk.Types.stop_reason_to_metric_label
+let stop_reason_label_end_turn = stop_reason_to_label Agent_sdk.Types.EndTurn
+let stop_reason_label_tool_use = stop_reason_to_label Agent_sdk.Types.StopToolUse
+let stop_reason_label_max_tokens = stop_reason_to_label Agent_sdk.Types.MaxTokens
+let stop_reason_label_stop_sequence =
+  stop_reason_to_label Agent_sdk.Types.StopSequence
 
-let stop_reason_to_label : Agent_sdk.Types.stop_reason -> string = function
-  | Agent_sdk.Types.EndTurn -> stop_reason_label_end_turn
-  | Agent_sdk.Types.StopToolUse -> stop_reason_label_tool_use
-  | Agent_sdk.Types.MaxTokens -> stop_reason_label_max_tokens
-  | Agent_sdk.Types.StopSequence -> stop_reason_label_stop_sequence
-  | Agent_sdk.Types.Refusal -> "refusal"
-  | Agent_sdk.Types.PauseTurn -> "pause_turn"
-  | Agent_sdk.Types.Compaction -> "compaction"
-  | Agent_sdk.Types.ContextWindowExceeded -> "model_context_window_exceeded"
-  | Agent_sdk.Types.Unknown _ -> stop_reason_label_unknown
+let stop_reason_label_unknown =
+  stop_reason_to_label (Agent_sdk.Types.Unknown "")
 
 (* F4 canonical projection consumption: delegate to OAS instead of re-spelling
    the api_usage record literal (SSOT — OAS owns the zero marker). *)

--- a/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli
+++ b/lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli
@@ -186,11 +186,9 @@ val stop_reason_label_stop_sequence : string
 val stop_reason_label_unknown : string
 
 val stop_reason_to_label : Agent_sdk.Types.stop_reason -> string
-(** Canonical telemetry/metric label for a turn stop reason.  Shared by
-    [keeper_hooks_oas] (finish-reason hook field) and
-    [keeper_hooks_oas_response_metrics] (metric label) so the two cannot
-    drift; the four named [stop_reason_label_*] constants back the arms
-    that recur across call sites. *)
+(** Canonical telemetry/metric label for an OAS stop reason.  Delegates to
+    OAS so [keeper_hooks_oas] finish-reason fields and response metrics share
+    the provider/model stop-reason SSOT. *)
 
 val zero_usage : Agent_sdk.Types.api_usage
 (** Internal: zero-token api_usage marker used by classify_usage_trust

--- a/test/test_stop_reason_label.ml
+++ b/test/test_stop_reason_label.ml
@@ -1,12 +1,18 @@
-(** Drift-guard for [Keeper_hooks_oas_types.stop_reason_to_label] — pins
-    the label for all nine [Agent_sdk.Types.stop_reason] variants. The
-    function unifies what were two byte-for-output-identical matches in
-    [keeper_hooks_oas] (finish-reason hook field) and
-    [keeper_hooks_oas_response_metrics] (metric label); this test fails if
-    a label drifts from the shared SSOT. *)
+(** Drift-guard for OAS stop-reason projections consumed by MASC. The metric
+    label path must collapse [Unknown _] to ["unknown"]; the wire path must
+    preserve provider raw values for round-trip/event payloads. *)
 
 let label = Alcotest.(check string)
 let to_label = Keeper_hooks_oas_types.stop_reason_to_label
+
+let response stop_reason : Agent_sdk.Types.api_response =
+  { id = "resp-stop-reason"
+  ; model = "model-stop-reason"
+  ; content = []
+  ; usage = None
+  ; stop_reason
+  ; telemetry = None
+  }
 
 let test_all_variants () =
   label "EndTurn" "end_turn" (to_label Agent_sdk.Types.EndTurn);
@@ -21,8 +27,24 @@ let test_all_variants () =
     (to_label Agent_sdk.Types.ContextWindowExceeded);
   label "Unknown" "unknown" (to_label (Agent_sdk.Types.Unknown "anything"))
 
+let test_agent_completed_stop_reason_wire_uses_oas_string () =
+  let fields =
+    Masc.Keeper_event_bridge_error_json.agent_completed_result_fields
+      (Ok (response (Agent_sdk.Types.Unknown "provider_raw_stop")))
+  in
+  match List.assoc_opt "stop_reason" fields with
+  | Some (`String value) ->
+      label "raw unknown wire value" "provider_raw_stop" value
+  | Some other ->
+      Alcotest.failf "stop_reason field was not a string: %s"
+        (Yojson.Safe.to_string other)
+  | None -> Alcotest.fail "missing stop_reason field"
+
 let () =
   Alcotest.run "stop_reason_label"
     [ ( "stop_reason_to_label"
-      , [ Alcotest.test_case "all nine variants" `Quick test_all_variants ] )
+      , [ Alcotest.test_case "all nine variants" `Quick test_all_variants
+        ; Alcotest.test_case "agent_completed uses OAS wire string" `Quick
+            test_agent_completed_stop_reason_wire_uses_oas_string
+        ] )
     ]


### PR DESCRIPTION
## Summary
- delegate MASC OAS stop-reason metric labels to Agent_sdk.Types.stop_reason_to_metric_label
- delegate agent_completed stop-reason wire serialization to Agent_sdk.Types.stop_reason_to_string
- extend the stop-reason drift guard to pin metric Unknown collapse separately from wire Unknown preservation

## Verification
- scripts/check-oas-pin.sh --local-only
- git diff --check HEAD~1..HEAD
- ocamlformat --check lib/keeper/keeper_event_bridge_error_json.ml lib/keeper_hooks_oas_types/keeper_hooks_oas_types.ml lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli test/test_stop_reason_label.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_stop_reason_label.exe test/test_gate_keeper_backend.exe
- ./_build/default/test/test_stop_reason_label.exe
- ./_build/default/test/test_gate_keeper_backend.exe

## Notes
- Scope is limited to OAS provider/model stop_reason projections. MASC runtime receipt stop reasons remain MASC-owned.
- Used MASC_DUNE_ALLOW_BARE_DUNE=1 because another bare Dune process had been present during local verification; the repo wrapper still verified the agent_sdk pin.
