### PR TITLE
feat(board): add owner-gated post edit (update_post_with_outcome)

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -249,12 +249,12 @@ val create_post_with_outcome
 
 (** Owner-gated in-place edit of an existing post's title/body.  Validates
     [editor] via {!Agent_id.of_string}, folds the canonical [title / body] via
-    {!normalize_post_payload}, then replaces the stored post under {!with_lock}
-    and persists a full JSONL snapshot.  Returns [Unauthorized] when [editor]
-    does not own the post, [Post_not_found] for a missing id, and
-    [Validation_error] for empty/oversized content.  Only the textual content
-    and [updated_at] change; [post_kind]/[meta]/[visibility]/[hearth] are
-    preserved. *)
+    {!normalize_post_payload} (seeded with the existing [meta_json] so a [STATE]
+    block in the edited body lifts into meta instead of being dropped), then
+    replaces the stored post under {!with_lock} and persists a full JSONL
+    snapshot.  Returns [Unauthorized] when [editor] does not own the post,
+    [Post_not_found] for a missing id, and [Validation_error] for
+    empty/oversized content.  [post_kind]/[visibility]/[hearth] are preserved. *)
 val update_post_with_outcome
   :  store
   -> post_id:string

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -247,6 +247,24 @@ val create_post_with_outcome
   -> unit
   -> (create_post_outcome, board_error) Result.t
 
+(** Owner-gated in-place edit of an existing post's title/body.  Validates
+    [editor] via {!Agent_id.of_string}, folds the canonical [title / body] via
+    {!normalize_post_payload}, then replaces the stored post under {!with_lock}
+    and persists a full JSONL snapshot.  Returns [Unauthorized] when [editor]
+    does not own the post, [Post_not_found] for a missing id, and
+    [Validation_error] for empty/oversized content.  Only the textual content
+    and [updated_at] change; [post_kind]/[meta]/[visibility]/[hearth] are
+    preserved. *)
+val update_post_with_outcome
+  :  store
+  -> post_id:string
+  -> editor:string
+  -> content:string
+  -> ?title:string
+  -> ?body:string
+  -> unit
+  -> (post, board_error) Result.t
+
 (** Creates a new post.  Validates [author] via
     {!Agent_id.of_string}, normalises [hearth] (lowercased +
     trimmed), folds the canonical [title / body / kind /

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -695,6 +695,91 @@ let create_post_with_outcome
       | Ok (`Dedup_hit existing) -> Ok (Dedup_hit existing)
       | Error _ as e -> e)
 ;;
+
+(* Owner-gated in-place edit of an existing post's title/body. Mirrors the
+   status-rollup update path (find -> [{ existing with ... }] -> [Hashtbl.replace]
+   -> [mark_dirty_post] -> snapshot save) but is initiated by an explicit edit
+   request rather than a same-key automation re-post. [post_kind]/[meta_json]/
+   [visibility]/[hearth]/[thread_id]/[origin] are intentionally immutable here;
+   edit only touches the textual content + [updated_at]. Author mismatch returns
+   [Unauthorized] (no silent ignore). *)
+let update_post_with_outcome
+      store
+      ~post_id
+      ~editor
+      ~content
+      ?title
+      ?body
+      ()
+  : (post, board_error) Result.t
+  =
+  match Post_id.of_string post_id with
+  | Error e -> Error e
+  | Ok pid ->
+  match Agent_id.of_string editor with
+  | Error e -> Error e
+  | Ok editor_id ->
+  (* [post_kind] is required by [normalize_post_payload] but the result kind is
+     discarded — the existing post's kind is preserved via [{ existing with }]. *)
+  match
+    normalize_post_payload ~content ?title ?body ~post_kind:Human_post ()
+  with
+  | Error (Board_core_payload.Meta_not_assoc payload) ->
+      Error
+        (Validation_error
+           (Printf.sprintf
+              "Malformed meta_json: expected JSON object, got %s"
+              (Yojson.Safe.to_string payload)))
+  | Ok (normalized_title, normalized_body, _kind, _meta) ->
+    if String.length normalized_body > Limits.max_content_length
+    then
+      Error
+        (Validation_error
+           (Printf.sprintf
+              "Content too long: %d > %d"
+              (String.length normalized_body)
+              Limits.max_content_length))
+    else if String.length normalized_body = 0
+    then Error (Validation_error "Content cannot be empty")
+    else (
+      let snapshot_result =
+        with_lock store (fun () ->
+          let key = Post_id.to_string pid in
+          match Hashtbl.find_opt store.posts key with
+          | None -> Error (Post_not_found post_id)
+          | Some existing ->
+            let owner = Agent_id.to_string existing.author in
+            let editor_str = Agent_id.to_string editor_id in
+            if not (String.equal owner editor_str)
+            then
+              Error
+                (Unauthorized
+                   (Printf.sprintf
+                      "agent %s cannot edit post %s owned by %s"
+                      editor_str
+                      key
+                      owner))
+            else (
+              let now = Time_compat.now () in
+              let updated =
+                { existing with
+                  title = normalized_title
+                ; body = normalized_body
+                ; content = normalized_body
+                ; updated_at = now
+                }
+              in
+              Hashtbl.replace store.posts key updated;
+              mark_dirty_post store key;
+              invalidate_post_caches store;
+              Ok (updated, posts_jsonl_unlocked store)))
+      in
+      match snapshot_result with
+      | Error _ as e -> e
+      | Ok (updated, posts_jsonl) ->
+        with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
+        Ok updated)
+;;
 let create_post
       store
       ~author

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -699,10 +699,16 @@ let create_post_with_outcome
 (* Owner-gated in-place edit of an existing post's title/body. Mirrors the
    status-rollup update path (find -> [{ existing with ... }] -> [Hashtbl.replace]
    -> [mark_dirty_post] -> snapshot save) but is initiated by an explicit edit
-   request rather than a same-key automation re-post. [post_kind]/[meta_json]/
-   [visibility]/[hearth]/[thread_id]/[origin] are intentionally immutable here;
-   edit only touches the textual content + [updated_at]. Author mismatch returns
-   [Unauthorized] (no silent ignore). *)
+   request rather than a same-key automation re-post. The edited content is
+   normalized exactly like [create_post_with_outcome]: a [STATE] block in the
+   new body is lifted into [meta_json] (merged onto the existing meta via
+   [merge_meta_json]) rather than being stripped-and-dropped, so an edit cannot
+   silently lose state. [post_kind]/[visibility]/[hearth]/[thread_id]/[origin]
+   are preserved. Author mismatch returns [Unauthorized] (no silent ignore).
+   Normalization runs inside the store lock because the meta merge needs the
+   existing post's [meta_json]; the added work is pure string/JSON manipulation,
+   dominated by the [posts_jsonl_unlocked] snapshot already taken under the
+   lock. *)
 let update_post_with_outcome
       store
       ~post_id
@@ -719,66 +725,76 @@ let update_post_with_outcome
   match Agent_id.of_string editor with
   | Error e -> Error e
   | Ok editor_id ->
-  (* [post_kind] is required by [normalize_post_payload] but the result kind is
-     discarded — the existing post's kind is preserved via [{ existing with }]. *)
-  match
-    normalize_post_payload ~content ?title ?body ~post_kind:Human_post ()
-  with
-  | Error (Board_core_payload.Meta_not_assoc payload) ->
-      Error
-        (Validation_error
-           (Printf.sprintf
-              "Malformed meta_json: expected JSON object, got %s"
-              (Yojson.Safe.to_string payload)))
-  | Ok (normalized_title, normalized_body, _kind, _meta) ->
-    if String.length normalized_body > Limits.max_content_length
-    then
-      Error
-        (Validation_error
-           (Printf.sprintf
-              "Content too long: %d > %d"
-              (String.length normalized_body)
-              Limits.max_content_length))
-    else if String.length normalized_body = 0
-    then Error (Validation_error "Content cannot be empty")
-    else (
-      let snapshot_result =
-        with_lock store (fun () ->
-          let key = Post_id.to_string pid in
-          match Hashtbl.find_opt store.posts key with
-          | None -> Error (Post_not_found post_id)
-          | Some existing ->
-            let owner = Agent_id.to_string existing.author in
-            let editor_str = Agent_id.to_string editor_id in
-            if not (String.equal owner editor_str)
-            then
-              Error
-                (Unauthorized
-                   (Printf.sprintf
-                      "agent %s cannot edit post %s owned by %s"
-                      editor_str
-                      key
-                      owner))
-            else (
-              let now = Time_compat.now () in
-              let updated =
-                { existing with
-                  title = normalized_title
-                ; body = normalized_body
-                ; content = normalized_body
-                ; updated_at = now
-                }
-              in
-              Hashtbl.replace store.posts key updated;
-              mark_dirty_post store key;
-              invalidate_post_caches store;
-              Ok (updated, posts_jsonl_unlocked store)))
-      in
-      match snapshot_result with
-      | Error _ as e -> e
-      | Ok (updated, posts_jsonl) ->
-        with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
-        Ok updated)
+    let snapshot_result =
+      with_lock store (fun () ->
+        let key = Post_id.to_string pid in
+        match Hashtbl.find_opt store.posts key with
+        | None -> Error (Post_not_found post_id)
+        | Some existing ->
+          let owner = Agent_id.to_string existing.author in
+          let editor_str = Agent_id.to_string editor_id in
+          if not (String.equal owner editor_str)
+          then
+            Error
+              (Unauthorized
+                 (Printf.sprintf
+                    "agent %s cannot edit post %s owned by %s"
+                    editor_str
+                    key
+                    owner))
+          else (
+            (* Normalize identically to create, seeded with the existing post's
+               meta so a [STATE] block in the edited body merges into [meta_json]
+               instead of being dropped. [post_kind] is passed through and the
+               result kind ([_kind]) discarded — the existing post's kind is
+               preserved via [{ existing with }]. *)
+            match
+              normalize_post_payload
+                ~content
+                ?title
+                ?body
+                ~post_kind:existing.post_kind
+                ?meta_json:existing.meta_json
+                ()
+            with
+            | Error (Board_core_payload.Meta_not_assoc payload) ->
+                Error
+                  (Validation_error
+                     (Printf.sprintf
+                        "Malformed meta_json: expected JSON object, got %s"
+                        (Yojson.Safe.to_string payload)))
+            | Ok (normalized_title, normalized_body, _kind, normalized_meta) ->
+              if String.length normalized_body > Limits.max_content_length
+              then
+                Error
+                  (Validation_error
+                     (Printf.sprintf
+                        "Content too long: %d > %d"
+                        (String.length normalized_body)
+                        Limits.max_content_length))
+              else if String.length normalized_body = 0
+              then Error (Validation_error "Content cannot be empty")
+              else (
+                let now = Time_compat.now () in
+                let updated =
+                  { existing with
+                    title = normalized_title
+                  ; body = normalized_body
+                  ; content = normalized_body
+                  ; meta_json = normalized_meta
+                  ; updated_at = now
+                  }
+                in
+                Hashtbl.replace store.posts key updated;
+                mark_dirty_post store key;
+                invalidate_post_caches store;
+                Ok (updated, posts_jsonl_unlocked store))))
+    in
+    match snapshot_result with
+    | Error _ as e -> e
+    | Ok (updated, posts_jsonl) ->
+      with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
+      Ok updated
 ;;
 let create_post
       store

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -117,6 +117,21 @@ val create_post_with_outcome :
   unit ->
   (create_post_outcome, board_error) result
 
+(** Owner-gated in-place edit of an existing post's title/body.  Returns
+    [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
+    missing id, and [Validation_error] for empty/oversized content.  Only the
+    textual content and [updated_at] change; kind/meta/visibility are
+    preserved. *)
+val update_post_with_outcome :
+  store ->
+  post_id:string ->
+  editor:string ->
+  content:string ->
+  ?title:string ->
+  ?body:string ->
+  unit ->
+  (post, board_error) result
+
 val create_post :
   store ->
   author:string ->

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -119,9 +119,10 @@ val create_post_with_outcome :
 
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
-    missing id, and [Validation_error] for empty/oversized content.  Only the
-    textual content and [updated_at] change; kind/meta/visibility are
-    preserved. *)
+    missing id, and [Validation_error] for empty/oversized content.  The body is
+    normalized exactly as on create: a [STATE] block in the edited content is
+    lifted into [meta_json] (merged onto the existing meta), so editing cannot
+    silently drop state.  [post_kind]/[visibility]/[hearth] are preserved. *)
 val update_post_with_outcome :
   store ->
   post_id:string ->

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -384,6 +384,12 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
       | Ok (Board.Dedup_hit post) | Ok (Board.Rolled_up_post post) -> Ok post
       | Error _ as err -> err)
 
+let update_post ~post_id ~editor ~content ?title ?body () =
+  match backend () with
+  | Jsonl store ->
+      Board.update_post_with_outcome store ~post_id ~editor ~content ?title
+        ?body ()
+
 let get_post ~post_id =
   match backend () with
   | Jsonl store -> Board.get_post store ~post_id

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -143,6 +143,19 @@ val create_post :
   unit ->
   (Board.post, Board.board_error) Result.t
 
+(** Owner-gated in-place edit of an existing post's title/body.  Returns
+    [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
+    missing id, and [Validation_error] for empty/oversized content.  Only the
+    textual content and [updated_at] change. *)
+val update_post :
+  post_id:string ->
+  editor:string ->
+  content:string ->
+  ?title:string ->
+  ?body:string ->
+  unit ->
+  (Board.post, Board.board_error) Result.t
+
 val get_post : post_id:string -> (Board.post, Board.board_error) Result.t
 
 val list_posts :

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -95,10 +95,14 @@ let board_error_to_string = function
   | Board.Validation_error s -> Printf.sprintf "Validation error: %s" s
   | Board.Already_voted s -> Printf.sprintf "Already voted: %s" s
   | Board.Already_exists s -> Printf.sprintf "Already exists: %s" s
+  | Board.Unauthorized s -> Printf.sprintf "Unauthorized: %s" s
 ;;
 
 let board_error_failure_class = function
-  | Board.Post_not_found _ | Board.Comment_not_found _ ->
+  | Board.Post_not_found _ | Board.Comment_not_found _
+  (* Owner-gated rejection: retrying with the same actor cannot succeed,
+     so it is a workflow rejection rather than a transient runtime failure. *)
+  | Board.Unauthorized _ ->
     Tool_result.Workflow_rejection
   | _ -> Tool_result.Runtime_failure
 ;;

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -27,6 +27,10 @@ type board_error =
   | Validation_error of string
   | Already_voted of string
   | Already_exists of string
+  | Unauthorized of string
+    (** Actor attempted an owner-gated mutation (e.g. editing a post they
+        do not own). Distinct from [Validation_error] so callers can map it
+        to a 403-class rejection rather than a generic input error. *)
   [@@deriving show]
 
 (** {1 Safe ID Module - Parse Don't Validate} *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -26,6 +26,10 @@ type board_error =
   | Validation_error of string
   | Already_voted of string
   | Already_exists of string
+  | Unauthorized of string
+    (** Actor attempted an owner-gated mutation (e.g. editing a post they
+        do not own). Distinct from [Validation_error] so callers can map it
+        to a 403-class rejection rather than a generic input error. *)
 [@@deriving show]
 
 (** {1 Safe ID Modules — Parse, Don't Validate} *)

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -81,6 +81,84 @@ let test_create_and_get_post () =
           Alcotest.(check string) "content matches"
             "dispatch test post" fetched.content
 
+let test_update_post_by_owner () =
+  match
+    Board_dispatch.create_post ~author:"editor-agent"
+      ~content:"original body before edit" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"editor-agent"
+          ~content:"edited body after change" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok updated -> (
+          Alcotest.(check string) "content updated" "edited body after change"
+            updated.content;
+          Alcotest.(check string) "body updated" "edited body after change"
+            updated.body;
+          Alcotest.(check bool) "updated_at not regressed" true
+            (updated.updated_at >= post.updated_at);
+          (* edit persists: a fresh get returns the edited content *)
+          match Board_dispatch.get_post ~post_id:pid with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok fetched ->
+              Alcotest.(check string) "edit persisted via get"
+                "edited body after change" fetched.content))
+
+let test_update_post_rejects_non_owner () =
+  match
+    Board_dispatch.create_post ~author:"owner-agent"
+      ~content:"body owned by owner-agent" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"intruder-agent"
+          ~content:"hijacked content" ()
+      with
+      | Ok _ -> Alcotest.fail "non-owner edit must be rejected"
+      | Error (Board.Unauthorized _) -> (
+          (* the original content must survive a rejected edit *)
+          match Board_dispatch.get_post ~post_id:pid with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok fetched ->
+              Alcotest.(check string) "original preserved on rejected edit"
+                "body owned by owner-agent" fetched.content)
+      | Error e ->
+          Alcotest.fail ("expected Unauthorized, got " ^ Board.show_board_error e))
+
+let test_update_post_missing_id () =
+  match
+    Board_dispatch.update_post ~post_id:"missing-post-id-zzz" ~editor:"any-agent"
+      ~content:"replacement" ()
+  with
+  | Ok _ -> Alcotest.fail "edit of missing post must fail"
+  | Error (Board.Post_not_found _) -> ()
+  | Error e ->
+      Alcotest.fail ("expected Post_not_found, got " ^ Board.show_board_error e)
+
+let test_update_post_rejects_empty_content () =
+  match
+    Board_dispatch.create_post ~author:"empty-edit-agent"
+      ~content:"non-empty original" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"empty-edit-agent"
+          ~content:"   " ()
+      with
+      | Ok _ -> Alcotest.fail "empty content edit must fail"
+      | Error (Board.Validation_error _) -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected Validation_error, got " ^ Board.show_board_error e))
+
 let test_keeper_signal_hook_failure_does_not_abort_create_post () =
   Board_dispatch.set_board_signal_hook (fun _ ->
       failwith "keeper signal hook failed");
@@ -1305,6 +1383,14 @@ let () =
     ];
     "posts", [
       Alcotest.test_case "create and get" `Quick (with_eio test_create_and_get_post);
+      Alcotest.test_case "update by owner persists" `Quick
+        (with_eio test_update_post_by_owner);
+      Alcotest.test_case "update rejects non-owner" `Quick
+        (with_eio test_update_post_rejects_non_owner);
+      Alcotest.test_case "update missing id" `Quick
+        (with_eio test_update_post_missing_id);
+      Alcotest.test_case "update rejects empty content" `Quick
+        (with_eio test_update_post_rejects_empty_content);
       Alcotest.test_case "keeper hook failure does not abort create" `Quick
         (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
       Alcotest.test_case "keeper hook cancellation propagates" `Quick

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -159,6 +159,75 @@ let test_update_post_rejects_empty_content () =
           Alcotest.fail
             ("expected Validation_error, got " ^ Board.show_board_error e))
 
+(* Exercises the explicit [?title]/[?body] params (the default-only path is
+   covered by [test_update_post_by_owner]) and asserts the fields documented as
+   immutable on edit — [post_kind] and [visibility] — are preserved. *)
+let test_update_post_with_explicit_title_and_body () =
+  match
+    Board_dispatch.create_post ~author:"titler-agent"
+      ~content:"original" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"titler-agent"
+          ~content:"content fallback" ~title:"Explicit Title"
+          ~body:"Explicit body text" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok updated ->
+          Alcotest.(check string) "title from ?title" "Explicit Title"
+            updated.title;
+          Alcotest.(check string) "body from ?body" "Explicit body text"
+            updated.body;
+          Alcotest.(check string) "content tracks body" "Explicit body text"
+            updated.content;
+          Alcotest.(check bool) "post_kind preserved" true
+            (updated.post_kind = post.post_kind);
+          Alcotest.(check bool) "visibility preserved" true
+            (updated.visibility = post.visibility))
+
+(* Regression for the meta-drop bug: a [STATE] block in the edited body must be
+   lifted into [meta_json] (same as create), not stripped from the body and
+   silently discarded. *)
+let meta_has_state_block (meta : Yojson.Safe.t option) : bool =
+  match meta with
+  | Some (`Assoc fields) -> List.mem_assoc "state_block" fields
+  | _ -> false
+
+(* stdlib-only substring containment; avoids a [re] dep for this test exe. *)
+let contains_substring ~(needle : string) (haystack : string) : bool =
+  let nlen = String.length needle and hlen = String.length haystack in
+  let rec scan i =
+    if i + nlen > hlen then false
+    else if String.equal (String.sub haystack i nlen) needle then true
+    else scan (i + 1)
+  in
+  nlen = 0 || scan 0
+
+let test_update_post_lifts_state_block_into_meta () =
+  match
+    Board_dispatch.create_post ~author:"stateful-agent"
+      ~content:"plain original body" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      Alcotest.(check bool) "original has no state_block" false
+        (meta_has_state_block post.meta_json);
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"stateful-agent"
+          ~content:"visible text [STATE]progress=halfway[/STATE] trailing" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok updated ->
+          Alcotest.(check bool) "state_block lifted into meta" true
+            (meta_has_state_block updated.meta_json);
+          (* the marker is stripped from the stored body, not left inline *)
+          Alcotest.(check bool) "STATE marker stripped from body" false
+            (contains_substring ~needle:"[STATE]" updated.body))
+
 let test_keeper_signal_hook_failure_does_not_abort_create_post () =
   Board_dispatch.set_board_signal_hook (fun _ ->
       failwith "keeper signal hook failed");
@@ -1391,6 +1460,10 @@ let () =
         (with_eio test_update_post_missing_id);
       Alcotest.test_case "update rejects empty content" `Quick
         (with_eio test_update_post_rejects_empty_content);
+      Alcotest.test_case "update with explicit title and body" `Quick
+        (with_eio test_update_post_with_explicit_title_and_body);
+      Alcotest.test_case "update lifts STATE block into meta" `Quick
+        (with_eio test_update_post_lifts_state_block_into_meta);
       Alcotest.test_case "keeper hook failure does not abort create" `Quick
         (with_eio test_keeper_signal_hook_failure_does_not_abort_create_post);
       Alcotest.test_case "keeper hook cancellation propagates" `Quick


### PR DESCRIPTION
## 목표

Board의 `write/edit/comment/like/emoji` 사양 중 누락된 **post edit**의 core(persistence/dispatch/validation + 테스트)를 구현합니다. post record의 `updated_at` 주석("Last activity: vote, comment, **edit**")이 보여주듯 edit은 원래 설계 의도였고, 본 PR은 그 누락분을 완성합니다.

출처: feature-coverage 감사 w4uacs6wy (Board=partial), task-1593.

## 변경 (core)

- **board_types**: `board_error`에 `Unauthorized of string` 추가. author 불일치를 `Validation_error`로 뭉개지 않고 별도 variant로 분리(403-class workflow rejection).
- **board_core_persist**: `update_post_with_outcome` — status-rollup의 in-place 갱신 경로 재사용(`find → { existing with ... } → Hashtbl.replace → mark_dirty_post → invalidate_post_caches → save_posts_jsonl`) + owner authorization + content 검증.
- **board_core_payload 정합(adversarial review HIGH fix)**: edit content는 `create_post_with_outcome`과 **동일하게** 정규화됩니다. body의 `[STATE]...[/STATE]` block은 `meta_json`(기존 meta에 `merge_meta_json`으로 병합)으로 lift되어 — body에서만 stripped되고 meta엔 누락되던 **silent state loss**를 제거합니다. 이를 위해 normalize를 store lock 안에서 `?meta_json:existing.meta_json`로 seed해 호출합니다. `post_kind`/`visibility`/`hearth`/`thread_id`/`origin`은 보존.
- **board_dispatch**: `update_post` wrapper (`get_post`와 동일한 backend dispatch).
- **board_tool_format**: `Unauthorized` 포맷 + `board_error_failure_class`의 `Workflow_rejection` arm.
- **test_board_dispatch**: 단위 테스트 6건 — owner edit persist / 비소유자 `Unauthorized` 거부+원본 보존 / 없는 id `Post_not_found` / 빈 content `Validation_error` / explicit `?title`·`?body`(post_kind·visibility 보존 검증) / **STATE-block→meta lift regression**.

## 스코프 / 후속

- 본 PR은 **post edit core + 단위 테스트**. tool 노출(`masc_board_post_update` + `Tool_name.Board_name` variant + 식별자 자동 주입)은 **별도 PR**로 진행합니다(95-site variant 전파 + 식별자 주입은 owner-gate enforce를 위해 분리). task-1593.
- comment edit도 후속.

## 검증

- 로컬: `dune build --root . @lib/board/check @lib/board_tool_adapter/check` (RC:0).
- CI: 빌드 + 전체 테스트 green (47 checks pass), 6 board 테스트 포함.
- adversarial review(5 lens × verify): HIGH state-loss 1건 + MEDIUM 2건 해소, 나머지 dismiss.

RFC-WAIVED: board subsystem은 RFC 게이트 대상(credential/operator/keeper sandbox/dashboard credential/hooks/workflow) 아님. tool 노출 변경 없음(별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
