### PR TITLE
feat(fusion): require native schema for judge output

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -51,6 +51,8 @@ let string_of_failure (f : Fusion_types.panel_failure) : string =
   | Fusion_types.Bridge_error msg -> "bridge_error: " ^ msg
   | Fusion_types.Provider_error msg -> "provider_error: " ^ msg
   | Fusion_types.Empty_response detail -> "empty_response: " ^ detail
+  | Fusion_types.Invalid_structured_response detail ->
+    "invalid_structured_response: " ^ detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid_max_output_tokens: %d" n
 

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -12,18 +12,17 @@
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
 # memory-os librarian (post-turn episode extraction) requests provider-native
-# structured output, so it is routed independently of keeper chat to a
-# schema-capable runtime. minimax-m3 declares supports-structured-output;
-# deepseek-v4-flash does not in this runtime seed and measured ~74%
-# empty/invalid-JSON on the librarian (2026-06-18). Override per process with
-# MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each keeper's
-# runtime (legacy).
-librarian = "ollama_cloud.minimax-m3"
+# structured output, so it is routed independently of keeper chat to a runtime
+# whose OAS catalog row advertises native structured output. Keep MiniMax out of
+# this lane until OAS capability truth proves native schema support. Override per
+# process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
+# keeper's runtime (legacy).
+librarian = "ollama_cloud.ollama-cloud-devstral-2-123b"
 # Provider-native structured-output judges must not inherit the fleet chat
 # default when that default lacks schema support. Keep this lane explicit so
 # dashboard operator/governance judges fail at config load on typo/unsupported
 # routing instead of discovering the mismatch in the daemon loop.
-structured_judge = "ollama_cloud.minimax-m3"
+structured_judge = "ollama_cloud.ollama-cloud-devstral-2-123b"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
@@ -173,15 +172,10 @@ supports-structured-output = false
 
 [glm-coding.glm-5-turbo]
 
-# MiniMax M3 (Ollama Cloud) — schema-capable runtime for Memory OS
-# librarian/summary/consolidation and dashboard structured judges. These lanes
-# request provider-native JsonSchema/output_schema; a runtime whose model omits
-# structured-output support can fail closed or produce unconstrained output. The
-# fleet default (deepseek-v4-flash, no structured-output capability declared in
-# this seed) measured ~74% empty / invalid-JSON on the librarian. Activate for
-# the librarian only via
-# MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID=ollama_cloud.minimax-m3 (keeper chat
-# stays on [runtime].default). api-name originally verified 2026-06-18 against
+# MiniMax M3 (Ollama Cloud) — chat/runtime binding retained for explicit
+# operator use. Do not route provider-native structured-output lanes here unless
+# the OAS catalog proves a native schema guarantee for this runtime.
+# api-name originally verified 2026-06-18 against
 # https://ollama.com/v1/chat/completions.
 [models.minimax-m3]
 api-name = "minimax-m3"
@@ -223,8 +217,10 @@ supports-extended-thinking = true
 supports-reasoning-budget = true
 thinking-control-format = "reasoning-effort"
 supports-native-streaming = true
-supports-response-format-json = true
-supports-structured-output = true
+# SSOT = OAS models.toml; Ollama Cloud Kimi rows do not currently advertise a
+# native schema/response_format guarantee.
+supports-response-format-json = false
+supports-structured-output = false
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -319,6 +315,8 @@ supports-extended-thinking = false
 supports-reasoning-budget = false
 thinking-control-format = "none"
 supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -337,6 +335,8 @@ supports-extended-thinking = false
 supports-reasoning-budget = false
 thinking-control-format = "none"
 supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -718,6 +718,8 @@ supports-extended-thinking = false
 supports-reasoning-budget = false
 thinking-control-format = "none"
 supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -946,13 +948,13 @@ staged_judge_group_size = 3
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]
 panel = [
-  "ollama_cloud.minimax-m3",
-  "ollama_cloud.kimi-k2-6",
-  "ollama_cloud.ollama-cloud-minimax-m3",
+  "ollama_cloud.ollama-cloud-devstral-2-123b",
+  "ollama_cloud.ollama-cloud-devstral-small-2-24b",
+  "ollama_cloud.ollama-cloud-ministral-3-14b",
 ]
 # Fusion judges request provider-native structured output. Keep this on a
-# runtime whose model declares supports-structured-output=true.
-judge = "ollama_cloud.kimi-k2-6"
+# runtime whose model resolves through the OAS catalog with native schema support.
+judge = "ollama_cloud.ollama-cloud-devstral-2-123b"
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
 with your best independent analysis. Do not defer to other models; give your \
@@ -986,9 +988,9 @@ max_tool_calls_per_panel = 0
 # 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
-  "ollama_cloud.minimax-m3",
-  "ollama_cloud.kimi-k2-6",
-  "ollama_cloud.ollama-cloud-minimax-m3",
+  "ollama_cloud.ollama-cloud-devstral-2-123b",
+  "ollama_cloud.ollama-cloud-devstral-small-2-24b",
+  "ollama_cloud.ollama-cloud-ministral-3-14b",
 ]
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
@@ -996,7 +998,7 @@ with your best independent analysis. Do not defer to other models; give your \
 own view.
 """
 # meta judge: 1차 심판들의 종합을 재조정하는 최종 reducer (RFC-0283).
-judge = "ollama_cloud.minimax-m3"
+judge = "ollama_cloud.ollama-cloud-ministral-3-14b"
 judge_system_prompt = """
 You are the meta-judge. You are given several independent judge syntheses of the \
 same panel of model answers, each produced through a different evaluative lens. \
@@ -1018,7 +1020,7 @@ max_tool_calls_per_panel = 0
 # checked-in schema-capable runtime set is intentionally narrow; distinct labels
 # still preserve lens identity for judge-of-judges routing.
 [[fusion.presets.quorum.judges]]
-model = "ollama_cloud.kimi-k2-6"
+model = "ollama_cloud.ollama-cloud-devstral-2-123b"
 label = "evidence"
 system_prompt = """
 You are an impartial first-pass judge. Synthesize the panel of model answers \
@@ -1029,7 +1031,7 @@ Respond with ONLY the requested JSON object, no prose and no code fences.
 timeout_s = 300.0
 
 [[fusion.presets.quorum.judges]]
-model = "ollama_cloud.minimax-m3"
+model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
 label = "coverage"
 system_prompt = """
 You are an impartial first-pass judge. Synthesize the panel of model answers \

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -937,14 +937,18 @@ max_concurrent_panels = 2
 max_concurrent_judges = 3
 staged_judge_group_size = 3
 
-# 패널 프리셋. 서로 다른 모델 패밀리로 구성해 관점 다양성을 확보한다.
+# 패널 프리셋. Panel execution requests provider-native structured output, so
+# checked-in defaults must use runtimes that declare supports-structured-output.
+# Add new model families here only after their runtime seed declares that
+# capability; otherwise the panel deterministically fails before the provider
+# request.
 # 프롬프트는 행동을 정의하므로 코드 default가 아니라 여기서 받는다 (누락 시 로드
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
   "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 # Fusion judges request provider-native structured output. Keep this on a
 # runtime whose model declares supports-structured-output=true.
@@ -974,18 +978,17 @@ max_tool_calls_per_panel = 0
 # "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
 # quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
 # 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
-# Fusion judge/refine/meta paths request provider-native structured output, so
-# every judge runtime below must declare supports-structured-output=true. Panels
-# remain free text and do not need the native-schema capability. The current seed
-# has two structured judge-capable cloud runtimes; distinct labels preserve lens
-# identity while the schema contract prevents config drift back to JSON-mode-only
-# judges. staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
+# Panel models and Fusion judge/refine/meta paths request provider-native
+# structured output, so every panel and judge runtime below must declare
+# supports-structured-output=true. Distinct labels preserve lens identity while
+# the schema contract prevents config drift back to JSON-mode-only runtimes.
+# staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
 # 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
-  "deepseek.deepseek-v4-pro",
+  "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
@@ -1010,8 +1013,10 @@ max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
-# first-pass judges use schema-capable runtimes outside the panel so a judge does
-# not score its own panel answer.
+# Strict structured-output support is mandatory for panel and judge runtimes in
+# this seed. Some model families overlap across panel and judge lanes because the
+# checked-in schema-capable runtime set is intentionally narrow; distinct labels
+# still preserve lens identity for judge-of-judges routing.
 [[fusion.presets.quorum.judges]]
 model = "ollama_cloud.kimi-k2-6"
 label = "evidence"

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -946,7 +946,9 @@ panel = [
   "glm-coding.glm-5-turbo",
   "ollama_cloud.minimax-m3",
 ]
-judge = "deepseek.deepseek-v4-pro"
+# Fusion judges request provider-native structured output. Keep this on a
+# runtime whose model declares supports-structured-output=true.
+judge = "ollama_cloud.kimi-k2-6"
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
 with your best independent analysis. Do not defer to other models; give your \
@@ -972,15 +974,18 @@ max_tool_calls_per_panel = 0
 # "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
 # quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
 # 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
-# 모델은 모두 supports-response-format-json=true (fusion judge는 응답 텍스트에서 JSON을
-# 파싱하므로 native structured-output host allowlist와 무관하나, JSON 신뢰성을 위해
-# JSON-선언 모델만 사용한다). staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)
-# 의 정확한 배수 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
+# Fusion judge/refine/meta paths request provider-native structured output, so
+# every judge runtime below must declare supports-structured-output=true. Panels
+# remain free text and do not need the native-schema capability. The current seed
+# has two structured judge-capable cloud runtimes; distinct labels preserve lens
+# identity while the schema contract prevents config drift back to JSON-mode-only
+# judges. staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
+# 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
   "ollama_cloud.deepseek-v4-flash",
   "glm-coding.glm-5-turbo",
-  "ollama_cloud.minimax-m3",
+  "deepseek.deepseek-v4-pro",
 ]
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
@@ -988,7 +993,7 @@ with your best independent analysis. Do not defer to other models; give your \
 own view.
 """
 # meta judge: 1차 심판들의 종합을 재조정하는 최종 reducer (RFC-0283).
-judge = "deepseek.deepseek-v4-pro"
+judge = "ollama_cloud.minimax-m3"
 judge_system_prompt = """
 You are the meta-judge. You are given several independent judge syntheses of the \
 same panel of model answers, each produced through a different evaluative lens. \
@@ -1005,11 +1010,10 @@ max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
-# evidence judge는 panel에 없는 모델을 쓴다 — 자기 답변이 포함된 panel을 심판하는
-# self-preference bias를 구조적으로 배제(panel = deepseek-v4-flash/glm-5-turbo/minimax-m3,
-# coverage judge=kimi-k2-6, meta judge=deepseek-v4-pro 모두 panel 외부).
+# first-pass judges use schema-capable runtimes outside the panel so a judge does
+# not score its own panel answer.
 [[fusion.presets.quorum.judges]]
-model = "glm-coding.glm-4-7-coding"
+model = "ollama_cloud.kimi-k2-6"
 label = "evidence"
 system_prompt = """
 You are an impartial first-pass judge. Synthesize the panel of model answers \
@@ -1020,7 +1024,7 @@ Respond with ONLY the requested JSON object, no prose and no code fences.
 timeout_s = 300.0
 
 [[fusion.presets.quorum.judges]]
-model = "ollama_cloud.kimi-k2-6"
+model = "ollama_cloud.minimax-m3"
 label = "coverage"
 system_prompt = """
 You are an impartial first-pass judge. Synthesize the panel of model answers \

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -372,6 +372,11 @@ Legacy flat preset-level keys:
 | `judge_max_output_tokens` | int > 0 | runtime default | simple/refine/meta judge output token budget override |
 | `min_answered` | int 1..panel count | `1` | judge 실행에 필요한 answered panel quorum |
 
+Fusion judge/refine/meta calls request provider-native structured output; every
+configured judge runtime must therefore resolve to a model that declares
+`supports-structured-output=true`. Panel runtimes remain free-text producers and
+do not need that capability.
+
 Heterogeneous presets move model lists into group tables:
 
 - `[[fusion.presets.<name>.panels]]`: each group owns `models`,

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -372,10 +372,12 @@ Legacy flat preset-level keys:
 | `judge_max_output_tokens` | int > 0 | runtime default | simple/refine/meta judge output token budget override |
 | `min_answered` | int 1..panel count | `1` | judge 실행에 필요한 answered panel quorum |
 
-Fusion judge/refine/meta calls request provider-native structured output; every
-configured judge runtime must therefore resolve to a model that declares
-`supports-structured-output=true`. Panel runtimes remain free-text producers and
-do not need that capability.
+Fusion panel/judge/refine/meta calls request provider-native structured output;
+every configured panel runtime (`panel` and `[[...panels]].models`) and judge
+runtime (`judge` and `[[...judges]].model`) must therefore resolve to a model
+that declares `supports-structured-output=true`. Panel responses must be JSON
+objects with a string `answer` field; malformed or non-schema responses are
+isolated as panel failures rather than treated as free text.
 
 Heterogeneous presets move model lists into group tables:
 

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -531,25 +531,14 @@ let parse_recommended_action json =
   | _ -> None
 
 type governance_response_parse_failure =
-  | Lenient_fallback of string
   | Structural_error of string
 
-let parse_lenient_governance_json raw_text =
-  let parsed = Llm_provider.Lenient_json.parse raw_text in
-  match parsed with
-  | `Assoc [("raw", `String raw)] -> (
-      match Judge_json_recovery.extract_balanced_object raw with
-      | Some block -> (
-          try
-            match Llm_provider.Lenient_json.parse block with
-            | `Assoc [ ("raw", `String recovered_raw) ] ->
-                Error (Lenient_fallback recovered_raw)
-            | parsed -> Ok parsed
-          with
-          | Yojson.Json_error _ -> Error (Lenient_fallback raw)
-          | Failure _ -> Error (Lenient_fallback raw))
-      | None -> Error (Lenient_fallback raw))
-  | _ -> Ok parsed
+let parse_strict_governance_json raw_text =
+  match Yojson.Safe.from_string (String.trim raw_text) with
+  | json -> Ok json
+  | exception Yojson.Json_error msg ->
+      Error
+        (Structural_error (Printf.sprintf "invalid strict JSON: %s" msg))
 
 let parse_required_guardrail_state json =
   match Json_util.assoc_member_opt "guardrail_state" json with
@@ -632,7 +621,7 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
                  ]))
 
 let parse_governance_response ~raw_text ~generated_at ~expires_at ~model_used =
-  match parse_lenient_governance_json raw_text with
+  match parse_strict_governance_json raw_text with
   | Error _ as error -> error
   | Ok parsed -> (
       match parsed with
@@ -747,13 +736,6 @@ let compute_judgments
             ~model_used:resolved_model
         with
         | Ok judgments -> Ok (resolved_model, generated_at, expires_at, judgments)
-        | Error (Lenient_fallback raw) ->
-            let msg =
-              Judge_diagnostics.record_lenient_fallback
-                ~judge_label:"Governance" raw
-            in
-            Log.Governance.warn "%s" msg;
-            Error msg
         | Error (Structural_error reason) ->
             let msg =
               Judge_diagnostics.record_unparseable_response

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -240,12 +240,10 @@ val resolve_governance_model_used :
     not expose concrete provider/model identity. *)
 
 type governance_response_parse_failure =
-  | Lenient_fallback of string
   | Structural_error of string
 (** Failure class for governance judge response parsing.
-    [Lenient_fallback raw] means all deterministic JSON recovery
-    failed. [Structural_error reason] means JSON parsed but
-    violated the judge output contract. *)
+    [Structural_error reason] means the response was not strict JSON
+    or violated the judge output contract. *)
 
 val parse_governance_response_for_testing :
   raw_text:string ->

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -63,12 +63,10 @@ let key_preview = "preview"
 let key_provenance = "provenance"
 let key_authoritative = "authoritative"
 let key_confirm_required = "confirm_required"
-let key_raw = "raw"
 let keeper_name_operator_judge = "operator-judge"
 let backoff_status_slots_saturated = "Backoff: local slots saturated"
 let severity_warn = "warn"
 let provenance_judgment = "judgment"
-let judge_label_operator = "Operator"
 let model_used_runtime = "runtime"
 let prompt_dashboard_operator_judge = "dashboard.operator_judge"
 let field_facts_json = "facts_json"
@@ -269,25 +267,15 @@ let compute_judgments
   | Ok result -> (
       let response = result.Runtime_agent.response in
       try
-        (* See dashboard_governance_judge.ml for rationale: LLMs frequently
-           wrap JSON in ```json … ``` markdown fences. Lenient_json strips
-           fences and applies other deterministic recovery transforms. *)
         let raw_text = Agent_sdk_response.text_of_response response in
-        match Llm_provider.Lenient_json.parse raw_text with
-        | `Assoc [(key_raw, `String raw)] ->
-            (* #9774: include a preview so the failure diagnostic doesn't
-               require enabling raw provider logging. *)
-            let msg =
-              Judge_diagnostics.record_lenient_fallback ~judge_label:judge_label_operator raw
-            in
-            Log.Governance.warn "%s" msg;
-            Error msg
-        | parsed ->
+        match Yojson.Safe.from_string (String.trim raw_text) with
+        | `Assoc _ as parsed ->
             let _ = response.model in
             Ok (model_used_runtime, parsed)
+        | _ -> Error "Operator judge returned non-object strict JSON"
       with
       | Yojson.Json_error msg ->
-          Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
+          Error (Printf.sprintf "Operator judge returned invalid strict JSON: %s" msg)
       | exn ->
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -141,30 +141,18 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
     Provider_error
       (prefix ^ Fusion_oas.provider_error_detail ~runtime_id (sdk_error_detail e))
 
-let provider_config_supports_json_mode provider_cfg =
-  match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
-  | Some caps -> caps.Llm_provider.Capabilities.supports_response_format_json
-  | None -> false
-
 let apply_fusion_judge_output_contract provider_cfg =
   let schema = Keeper_structured_output_schema.fusion_judge_output_schema in
   let native_schema_provider_cfg =
     Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
   in
   (* The tier is decided by OAS capability facts, never by provider-name
-     special cases: native schema first, JSON mode only when declared, otherwise
-     fail before an HTTP request. *)
+     special cases: native schema or fail before an HTTP request. *)
   match
     Llm_provider.Provider_config.validate_output_schema_request
       native_schema_provider_cfg
   with
   | Ok () -> Ok native_schema_provider_cfg
-  | Error detail when provider_config_supports_json_mode provider_cfg ->
-    Ok
-      { provider_cfg with
-        response_format = Agent_sdk.Types.JsonMode
-      ; output_schema = None
-      }
   | Error detail -> Error (Printf.sprintf "fusion.judge.output_schema: %s" detail)
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -2,7 +2,8 @@
 
     Judge 실행은 provider-native structured output schema를 요청한다. OAS가 해당
     provider/model 조합의 native schema를 거부하면 [JsonMode]로 degrade하지 않고
-    build 단계에서 fail-loud한다. 패널 실행은 자유 텍스트이며 이 schema hook을 쓰지 않는다.
+    build 단계에서 fail-loud한다. 패널 실행도 별도의 `{answer:string}` schema를 요청하고,
+    provider-success malformed output은 typed failure로 격리한다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 *)
 

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -1,8 +1,7 @@
 (** Fusion — 심판. 패널 답들을 judge 모델에 넘겨 구조화 종합({!Fusion_types.judge_synthesis})을 받는다.
 
-    Judge 실행은 provider-native structured output schema를 우선 요청한다. OAS가 해당
-    provider/model 조합의 native schema를 거부하되 JSON mode capability를 선언한 경우에는
-    [JsonMode] + {!Fusion_judge_parse}(LLM-facing JSON 파서)로 degrade한다. 둘 다 없으면
+    Judge 실행은 provider-native structured output schema를 요청한다. OAS가 해당
+    provider/model 조합의 native schema를 거부하면 [JsonMode]로 degrade하지 않고
     build 단계에서 fail-loud한다. 패널 실행은 자유 텍스트이며 이 schema hook을 쓰지 않는다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 *)

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -74,6 +74,7 @@ let panel_failure_code (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error _ -> "bridge_error"
   | Fusion_types.Provider_error _ -> "provider_error"
+  | Fusion_types.Invalid_structured_response _ -> "invalid_structured_response"
   | Fusion_types.Empty_response _ -> "empty_response"
   | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
 
@@ -82,6 +83,7 @@ let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : st
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
@@ -97,6 +99,7 @@ let panel_failure_text (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -19,9 +19,9 @@
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
     (RFC-0278: 같은 model을 다른 라벨로 구분). 미지정이면 카드명=[model]. provider
     라우팅은 카드명과 무관하게 [model]로 한다.
-    [provider_config_transform]은 judge처럼 provider-native structured-output 설정이
-    필요한 호출자가 resolved provider config를 agent build 전에 보강하는 hook이다.
-    패널 호출자는 생략한다.
+    [provider_config_transform]은 panel/judge처럼 provider-native structured-output
+    설정이 필요한 호출자가 resolved provider config를 agent build 전에 보강하는
+    hook이다.
     미존재 runtime·빌드 실패는 [panel_failure]로. *)
 val build_agent
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -17,15 +17,55 @@ let outcome_of_result ~(panelist : string) ~(model : string)
   =
   match res with
   | Ok resp ->
-    let answer = Fusion_oas.answer_text resp in
-    if String.length (String.trim answer) = 0 then
+    let raw = String.trim (Fusion_oas.answer_text resp) in
+    if String.length raw = 0 then
       Fusion_types.Failed
         { failed_model = panelist
         ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
         }
-    else
-      Fusion_types.Answered
-        { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+    else (
+      match Yojson.Safe.from_string raw with
+      | exception Yojson.Json_error msg ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                ("panel response is not valid JSON: " ^ msg)
+          }
+      | `Assoc fields ->
+        (match List.assoc_opt "answer" fields with
+         | Some (`String answer) ->
+           let answer = String.trim answer in
+           if String.length answer = 0 then
+             Fusion_types.Failed
+               { failed_model = panelist
+               ; reason =
+                   Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
+               }
+           else
+             Fusion_types.Answered
+               { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+         | Some _ ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response field \"answer\" must be a string"
+             }
+         | None ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response missing required field \"answer\""
+             })
+      | _ ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                "panel response must be a JSON object"
+          })
   | Error e ->
     Fusion_types.Failed
       { failed_model = panelist
@@ -39,6 +79,18 @@ let bridge_failure_of_error (error : Agent_sdk.Error.sdk_error) : Fusion_types.p
   match error with
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_sdk.Error.to_string error)
+
+let apply_fusion_panel_output_contract provider_cfg =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  let native_schema_provider_cfg =
+    Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
+  in
+  match
+    Llm_provider.Provider_config.validate_output_schema_request
+      native_schema_provider_cfg
+  with
+  | Ok () -> Ok native_schema_provider_cfg
+  | Error detail -> Error (Printf.sprintf "fusion.panel.output_schema: %s" detail)
 
 let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
   : Fusion_types.panel_outcome list
@@ -58,6 +110,7 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~max_tool_calls:g.max_tool_calls ~timeout_s:g.timeout_s
+                ~provider_config_transform:apply_fusion_panel_output_contract
                 ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
@@ -99,3 +152,8 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
         built
   in
   build_failures @ answered
+
+module For_testing = struct
+  let outcome_of_result = outcome_of_result
+  let apply_output_contract = apply_fusion_panel_output_contract
+end

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -30,3 +30,15 @@ val run
   -> prompt:string
   -> unit
   -> Fusion_types.panel_outcome list
+
+module For_testing : sig
+  val outcome_of_result
+    :  panelist:string
+    -> model:string
+    -> (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
+    -> Fusion_types.panel_outcome
+
+  val apply_output_contract
+    :  Llm_provider.Provider_config.t
+    -> (Llm_provider.Provider_config.t, string) result
+end

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -16,6 +16,9 @@
       모델들을 에이전트로 빌드한다 (그룹마다 다를 수 있음 = 이종). 모든 그룹의
       에이전트를 하나의 [Async_agent.all]에 union으로 던진다.
     - [web_tools]가 true인 그룹은 web_search/web_fetch 도구를 주입한다.
+    - 패널 에이전트는 [fusion.panel.output_schema] provider-native structured output
+      contract를 요청한다. 응답은 string [answer] 필드를 가진 JSON object여야 하며,
+      free-text/invalid JSON/missing answer는 [Failed]로 격리된다.
     - [max_tool_calls]: 0이면 무제한, 양수면 에이전트 [max_turns]로 근approximate.
     - [outer_timeout_s]: 전체 fan-out을 감싸는 [Masc_oas_bridge.run_safe] 구조적
       타임아웃(보통 그룹 timeout 중 max). 타임아웃 시 빌드된 모델은 [Failed Timeout].

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -65,6 +65,7 @@ type panel_failure =
   | Timeout
   | Bridge_error of string
   | Provider_error of string
+  | Invalid_structured_response of string
   | Empty_response of string
   | Invalid_max_output_tokens of int
 [@@deriving to_yojson, show, eq]
@@ -74,6 +75,8 @@ let panel_failure_of_yojson = function
   | `String "Empty_response" -> Ok (Empty_response "empty response")
   | `List [ `String "Timeout" ] -> Ok Timeout
   | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
+  | `List [ `String "Invalid_structured_response"; `String detail ] ->
+    Ok (Invalid_structured_response detail)
   | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
   | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->
     Ok (Invalid_max_output_tokens value)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -68,6 +68,9 @@ type panel_failure =
   | Timeout  (** 구조적 타임아웃 (Masc_oas_bridge) *)
   | Bridge_error of string  (** MASC/OAS bridge bootstrap or wrapper error *)
   | Provider_error of string  (** provider/transport 에러, 메시지 보존 *)
+  | Invalid_structured_response of string
+      (** provider returned non-empty output that violated the requested panel
+          answer JSON schema. *)
   | Empty_response of string
       (** 모델이 빈 응답. detail에는 stop_reason/usage/content shape만 보존하고,
           reasoning/thinking 본문은 노출하지 않는다. *)

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -29,54 +29,22 @@ let apply_report_verdict_output_schema provider_cfg =
          (Agent_sdk.Error.InvalidConfig
             { field = "verification.adversarial_review.output_schema"; detail }))
 
-let parse_json_payload text =
-  let trimmed = String.trim text in
-  let attempt s =
-    try Some (Yojson.Safe.from_string s) with
-    | Yojson.Json_error _ -> None
-  in
-  match attempt trimmed with
-  | Some json -> Some json
-  | None ->
-    let len = String.length trimmed in
-    if len = 0 then None
-    else
-      let start_opt =
-        let brace = try Some (String.index trimmed '{') with Not_found -> None in
-        let bracket = try Some (String.index trimmed '[') with Not_found -> None in
-        match brace, bracket with
-        | Some i, Some j -> Some (min i j)
-        | Some i, None -> Some i
-        | None, Some j -> Some j
-        | None, None -> None
-      in
-      match start_opt with
-      | None -> None
-      | Some start ->
-        let closing = if trimmed.[start] = '{' then '}' else ']' in
-        let rec find_last idx =
-          if idx < 0 then None
-          else if trimmed.[idx] = closing then Some idx
-          else find_last (idx - 1)
-        in
-        match find_last (len - 1) with
-        | None -> None
-        | Some fin -> attempt (String.sub trimmed start (fin - start + 1))
+let parse_grounded_verdict_from_response_text text =
+  match Yojson.Safe.from_string (String.trim text) with
+  | json -> Verifier_core.parse_grounded_verdict_from_json json
+  | exception Yojson.Json_error msg ->
+    Error
+      (Printf.sprintf
+         "adversarial review response must be strict JSON: %s"
+         msg)
 
-let parse_verdict_from_text text =
-  match parse_json_payload text with
-  | None ->
-    Error "model did not return a structured verdict (no JSON payload found)"
-  | Some json -> Verifier_core.parse_verdict_from_json json
-
-let parse_grounded_verdict_from_text text =
-  match parse_json_payload text with
-  | None ->
-    Error "model did not return a structured verdict (no JSON payload found)"
-  | Some json -> Verifier_core.parse_grounded_verdict_from_json json
+module For_testing = struct
+  let parse_grounded_verdict_from_response_text =
+    parse_grounded_verdict_from_response_text
+end
 
 (* Mirrors [Verifier_oas.verify]: structured verdict via the [report_verdict]
-   tool, with a structured JSON fallback if the model answers in free text.
+   tool, with a strict JSON fallback if the model answers without the tool.
    The judgment itself is the model's; this only routes its structured output
    back as a typed [Verifier_core.verdict]. *)
 let run_grounded_review ~base_path ~runtime_id (input : review_input) :
@@ -125,9 +93,10 @@ let run_grounded_review ~base_path ~runtime_id (input : review_input) :
       match !verdict_ref with
       | Some v -> Ok v
       | None ->
-        (* Model answered in text instead of calling report_verdict. *)
+        (* Model answered without calling report_verdict. Provider-native
+           schema still requires a strict JSON grounded verdict object. *)
         let text = Agent_sdk_response.text_of_response result.response in
-        parse_grounded_verdict_from_text text)
+        parse_grounded_verdict_from_response_text text)
     | Error err -> Error (Agent_sdk.Error.to_string err)
 
 let run_review ~base_path ~runtime_id (input : review_input) :

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -10,11 +10,12 @@
 
     The verdict is the LLM's judgment. On the structured [report_verdict] path
     there is no rule, heuristic, or string match deciding pass/fail. The
-    free-text fallback parses a JSON payload with [Verifier_core]; it does not
-    use string matching to decide pass/fail. The grounded entry point requires
-    evidence for WARN/FAIL before wake-on-fail routing. The only deterministic
-    parts are identity (which keeper authored the work, hence who to wake) and
-    event-id dedup (a given task-level FAIL wakes the author at most once).
+    response fallback accepts only a strict JSON grounded verdict object; it
+    does not extract JSON from prose or fences. The grounded entry point
+    requires evidence for WARN/FAIL before wake-on-fail routing. The only
+    deterministic parts are identity (which keeper authored the work, hence who
+    to wake) and event-id dedup (a given task-level FAIL wakes the author at
+    most once).
 
     This module is a proof-of-concept. It is not yet wired to a keeper
     lifecycle trigger; integration with the tool registration in #21357 is the
@@ -48,10 +49,9 @@ val run_grounded_review :
   review_input ->
   (Verifier_core.grounded_verdict, string) result
 (** Run the adversarial reviewer agent and read its structured grounded verdict
-    via the [report_verdict] tool. If the model answers in free text, the
-    fallback attempts to parse a JSON payload and decode it with
-    [Verifier_core.parse_grounded_verdict_from_json]; it never uses string
-    matching to decide pass/fail. *)
+    via the [report_verdict] tool. If the model answers without calling the
+    tool, the fallback accepts only a strict JSON response object decoded with
+    [Verifier_core.parse_grounded_verdict_from_json]. *)
 
 val act_on_verdict :
   base_path:string -> input:review_input -> Verifier_core.verdict -> (unit, string) result
@@ -78,3 +78,8 @@ val review_and_wake_on_fail :
   (Verifier_core.verdict, string) result
 (** [run_grounded_review] followed by [act_on_grounded_verdict] on the resulting
     verdict, returning the compatibility [Verifier_core.verdict]. *)
+
+module For_testing : sig
+  val parse_grounded_verdict_from_response_text :
+    string -> (Verifier_core.grounded_verdict, string) result
+end

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -4,10 +4,9 @@
    [min provider_cfg.max_tokens librarian_max_tokens] at the complete call
    (see [extract] below). The previous fixed cap of 1024 truncated episode
    JSON mid-object whenever the summary plus facts exceeded ~1024 output
-   tokens, surfacing as "invalid_json: Unexpected end of input" and an
-   unstructured fallback every turn. 4096 covers realistic episode payloads
-   while staying well under the JSON-capable model context budget; tunable
-   via Env_config.KeeperMemoryOs. *)
+   tokens, surfacing as "invalid_json: Unexpected end of input" every turn.
+   4096 covers realistic episode payloads while staying well under the
+   JSON-capable model context budget; tunable via Env_config.KeeperMemoryOs. *)
 let librarian_max_tokens = Env_config.KeeperMemoryOs.librarian_max_tokens_default
 
 (* Memory extraction runs against a JSON-capable model with a long context
@@ -383,6 +382,7 @@ type extraction_error =
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response
+  | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
 let librarian_provider_clock_unavailable_error =
@@ -396,6 +396,8 @@ let extraction_error_to_string = function
   | Provider_timeout -> "librarian provider timed out"
   | Provider_transport_failed msg -> msg
   | Provider_empty_response -> "librarian provider returned empty response"
+  | Provider_unparseable_response msg ->
+    "librarian provider returned unparseable structured response: " ^ msg
   | Memory_fact_upsert_failed msg -> "memory os fact upsert failed: " ^ msg
 ;;
 
@@ -416,27 +418,12 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
 
-type extraction_kind =
-  | Structured_episode
-  | Unstructured_fallback
-
-type extraction_result =
-  { episode : Keeper_memory_os_types.episode
-  ; kind : extraction_kind
-  }
-
-let should_record_cadence_success = function
-  | Structured_episode -> true
-  | Unstructured_fallback -> false
-;;
-
-let should_record_cadence_backoff = function
-  | Structured_episode -> false
-  | Unstructured_fallback -> true
-;;
-
 let should_record_cadence_backoff_after_error = function
-  | Provider_timeout | Provider_transport_failed _ | Provider_empty_response -> true
+  | Provider_timeout
+  | Provider_transport_failed _
+  | Provider_empty_response
+  | Provider_unparseable_response _ ->
+    true
   | Provider_clock_unavailable
   | Provider_config_rejected _
   | Prompt_render_failed _
@@ -444,13 +431,9 @@ let should_record_cadence_backoff_after_error = function
     false
 ;;
 
-let should_preserve_unstructured_fallback raw =
-  not (String.equal (String.trim raw) "")
-;;
-
 let prefer_unparseable_response prior current =
   match current.raw_evidence with
-  | Some raw when should_preserve_unstructured_fallback raw -> current
+  | Some raw when not (String.equal (String.trim raw) "") -> current
   | Some _ | None ->
     (match prior with
      | Some best -> best
@@ -514,83 +497,6 @@ let with_timeout ~clock ~timeout_sec f =
   | Eio.Time.Timeout -> None
 ;;
 
-let unstructured_note_max_chars = 900
-
-let collapse_for_unstructured_note raw =
-  let buf = Buffer.create (String.length raw) in
-  let previous_space = ref true in
-  String.iter
-    (fun c ->
-       match c with
-       | '\n' | '\r' | '\t' | ' ' ->
-         if not !previous_space then Buffer.add_char buf ' ';
-         previous_space := true
-       | c ->
-         Buffer.add_char buf c;
-         previous_space := false)
-    raw;
-  Buffer.contents buf |> String.trim
-
-let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
-  let raw_excerpt, _ =
-    Keeper_text_processing.truncate_utf8_prefix
-      ~max_bytes:unstructured_note_max_chars
-      (collapse_for_unstructured_note raw)
-  in
-  let note =
-    let prefix = Keeper_memory_os_types.librarian_unstructured_fallback_claim_prefix in
-    if String.equal raw_excerpt ""
-    then Printf.sprintf "%s (%s): <empty response>" prefix reason
-    else Printf.sprintf "%s (%s): %s" prefix reason raw_excerpt
-  in
-  let source_turn_range =
-    match List.length inp.messages with
-    | 0 -> None
-    | n -> Some (0, n - 1)
-  in
-  let fact : Keeper_memory_os_types.fact =
-    { claim = note
-    ; category = Keeper_memory_os_types.Ephemeral
-    ; external_ref = None
-    ; (* A parse-retry fallback note is system-authored diagnostic evidence, not a
-         librarian-classified memory claim. Tag it at the producer boundary so recall
-         can exclude it without string-matching the raw claim text. *)
-      claim_kind = Some Keeper_memory_os_types.Diagnostic
-    ; source = { trace_id = inp.trace_id; turn = 0; tool_call_id = None }
-    ; observed_by = []
-    ; first_seen = now
-    ; valid_until =
-        Keeper_memory_os_types.fact_valid_until
-          ~now
-          ~external_ref:None
-          ~claim_kind:(Some Keeper_memory_os_types.Diagnostic)
-          Keeper_memory_os_types.Ephemeral
-    ; last_verified_at = Some now
-    ; schema_version = Keeper_memory_os_types.schema_version
-    ; (* MASC authors this diagnostic fallback, not the LLM librarian. Do not
-         overload the librarian [claim_id] producer-identity field; diagnostic
-         fallback rows degrade to exact-text identity via [claim_id = None]. *)
-      claim_id = None
-    }
-  in
-  { Keeper_memory_os_types.trace_id = inp.trace_id
-  ; generation
-  ; episode_summary = "Unstructured librarian note preserved after parse failure"
-  ; claims = [ fact ]
-  ; open_items = []
-  ; constraints = []
-  ; preserved_tool_refs = []
-  ; source_turn_range
-  ; created_at = now
-  ; valid_until =
-      Keeper_memory_os_types.category_valid_until
-        ~now
-        Keeper_memory_os_types.Ephemeral
-  ; terminal_marker =
-      Some Keeper_memory_os_types.librarian_unstructured_fallback_terminal_marker
-  ; schema_version = Keeper_memory_os_types.schema_version
-  }
-
 let extract_with_provider_classified
     ?(complete = default_complete)
     ?clock
@@ -603,67 +509,52 @@ let extract_with_provider_classified
   =
   match clock with
   | None -> Error Provider_clock_unavailable
-  | Some clock -> (
-  match messages_for_librarian inp with
-  | Error msg -> Error (Prompt_render_failed msg)
-  | Ok messages ->
-    let provider_cfg = provider_for_librarian provider_cfg in
-    (match
-       Llm_provider.Provider_config.validate_output_schema_request provider_cfg
-     with
-     | Error msg -> Error (Provider_config_rejected msg)
-     | Ok () ->
-    let attempt messages =
-      match
-        with_timeout ~clock ~timeout_sec (fun () ->
-          complete ~sw ~net ~clock ~config:provider_cfg ~messages ())
-      with
-      | None -> Transport_failed Provider_timeout
-      | Some (Error err) ->
-        Transport_failed (Provider_transport_failed (Provider_http_error.to_message err))
-      | Some (Ok response) ->
-        let raw = Agent_sdk_response.text_of_response response |> String.trim in
-        if String.equal raw ""
-        then Unparseable (unparseable_response "librarian provider returned empty response")
-        else (
-          match Keeper_librarian.episode_of_output_result ~generation inp raw with
-          | Ok episode -> Parsed episode
-          | Error error ->
-            Unparseable
-              (unparseable_response
-                 ~raw_evidence:raw
-                 (Printf.sprintf
-                    "librarian provider returned invalid episode JSON (%s)"
-                    (Keeper_librarian.parse_error_to_string error))))
-    in
-    (match
-       run_with_parse_retries
-         ~max_retries:librarian_max_parse_retries
-         ~attempt
-         messages
-     with
-     | Ok episode -> Ok { episode; kind = Structured_episode }
-     | Error (Retry_transport_failed err) -> Error err
-     | Error (Retry_exhausted_unparseable diagnostic) ->
-       let raw =
-         match diagnostic.raw_evidence with
-         | Some raw -> raw
-         | None -> ""
-       in
-       if not (should_preserve_unstructured_fallback raw)
-       then Error Provider_empty_response
-       else (
-         let now = Eio.Time.now clock in
-         Log.Keeper.warn
-           "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
-           inp.trace_id
-           generation
-           diagnostic.reason;
-         Ok
-          { episode = unstructured_episode ~now ~generation inp ~reason:diagnostic.reason ~raw
-          ; kind = Unstructured_fallback
-          })))
-    )
+  | Some clock ->
+    (match messages_for_librarian inp with
+     | Error msg -> Error (Prompt_render_failed msg)
+     | Ok messages ->
+       let provider_cfg = provider_for_librarian provider_cfg in
+       (match
+          Llm_provider.Provider_config.validate_output_schema_request provider_cfg
+        with
+        | Error msg -> Error (Provider_config_rejected msg)
+        | Ok () ->
+          let attempt messages =
+            match
+              with_timeout ~clock ~timeout_sec (fun () ->
+                complete ~sw ~net ~clock ~config:provider_cfg ~messages ())
+            with
+            | None -> Transport_failed Provider_timeout
+            | Some (Error err) ->
+              Transport_failed
+                (Provider_transport_failed (Provider_http_error.to_message err))
+            | Some (Ok response) ->
+              let raw = Agent_sdk_response.text_of_response response |> String.trim in
+              if String.equal raw ""
+              then
+                Unparseable
+                  (unparseable_response "librarian provider returned empty response")
+              else (
+                match Keeper_librarian.episode_of_output_result ~generation inp raw with
+                | Ok episode -> Parsed episode
+                | Error error ->
+                  Unparseable
+                    (unparseable_response
+                       ~raw_evidence:raw
+                       (Printf.sprintf
+                          "librarian provider returned invalid episode JSON (%s)"
+                          (Keeper_librarian.parse_error_to_string error))))
+          in
+          (match
+             run_with_parse_retries
+               ~max_retries:librarian_max_parse_retries
+               ~attempt
+               messages
+           with
+           | Ok episode -> Ok episode
+           | Error (Retry_transport_failed err) -> Error err
+           | Error (Retry_exhausted_unparseable diagnostic) ->
+             Error (Provider_unparseable_response diagnostic.reason))))
 ;;
 
 let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =
@@ -679,7 +570,7 @@ let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~
       inp
   with
   | Error err -> Error (extraction_error_to_string err)
-  | Ok { episode; kind = _ } -> Ok episode
+  | Ok episode -> Ok episode
 ;;
 
 let extract_and_append_with_provider_classified
@@ -713,7 +604,7 @@ let extract_and_append_with_provider_classified
          inp
      with
   | Error _ as e -> e
-  | Ok ({ episode; kind = _ } as extraction) ->
+  | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in
     (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
        re-extracted across turns is folded into the existing row
@@ -768,7 +659,7 @@ let extract_and_append_with_provider_classified
         (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
            (dark-by-default, no recall consumer), so the fact upsert above is the only
            post-merge work. *)
-        Ok extraction
+        Ok episode
       | Error message -> Error (Memory_fact_upsert_failed message)))
 ;;
 
@@ -794,7 +685,7 @@ let extract_and_append_with_provider
       inp
   with
   | Error err -> Error (extraction_error_to_string err)
-  | Ok { episode; kind = _ } -> Ok episode
+  | Ok episode -> Ok episode
 ;;
 
 let provider_for_runtime ~runtime_id =
@@ -864,24 +755,13 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
                  runtime_id
                  (per_keeper_slot_capacity ())
-             | Some (Ok { episode; kind }) ->
-               if should_record_cadence_success kind
-               then (
-                 (* Only structured extraction records semantic success. *)
-                 cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
-                 Log.Keeper.info ~keeper_name:keeper_id
-                   "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-                   episode.Keeper_memory_os_types.trace_id
-                   episode.generation
-                   (List.length episode.claims))
-               else (
-                 if should_record_cadence_backoff kind
-                 then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
-                 Log.Keeper.warn ~keeper_name:keeper_id
-                   "memory os librarian wrote unstructured fallback trace_id=%s generation=%d claims=%d; cadence deferred"
-                   episode.Keeper_memory_os_types.trace_id
-                   episode.generation
-                   (List.length episode.claims))
+             | Some (Ok episode) ->
+               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
+               Log.Keeper.info ~keeper_name:keeper_id
+                 "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+                 episode.Keeper_memory_os_types.trace_id
+                 episode.generation
+                 (List.length episode.claims)
              | Some (Error err) ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -59,17 +59,17 @@ val cadence_record_success : keeper_id:string -> trace_id:string -> unit
 (** Record a successful structured extraction for [keeper_id] on [trace_id] so
     the cadence counter resets and the next cycle can begin. Must only be called
     after a due turn actually produced a structured episode; skipped, failed, or
-    unstructured-fallback attempts must not call this.
+    unparseable provider attempts must not call this.
 
     Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
     focused pre-Eio tests keep a direct single-threaded path. *)
 
 val cadence_record_attempt : keeper_id:string -> trace_id:string -> unit
 (** Record a completed non-success extraction attempt for [keeper_id] on
-    [trace_id] so transient provider failures and diagnostic fallbacks do not
-    immediately retry every keeper turn. This intentionally does not mark the
-    extraction as semantically successful. Skipped work such as a busy provider
-    slot must not call this, because no provider attempt happened.
+    [trace_id] so transient provider failures and unparseable structured-output
+    failures do not immediately retry every keeper turn. This intentionally does
+    not mark the extraction as semantically successful. Skipped work such as a
+    busy provider slot must not call this, because no provider attempt happened.
 
     Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
     focused pre-Eio tests keep a direct single-threaded path. *)
@@ -135,6 +135,7 @@ type extraction_error =
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response
+  | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
 val extraction_error_to_string : extraction_error -> string
@@ -146,8 +147,8 @@ type unparseable_response =
 
 val unparseable_response : ?raw_evidence:string -> string -> unparseable_response
 (** Typed retry diagnostic. [raw_evidence] is present only when the provider
-    returned non-empty output that can be preserved as an unstructured fallback;
-    [reason] describes that same response. *)
+    returned non-empty output; [reason] describes that same response so the
+    final typed provider error is not replaced by a later empty retry. *)
 
 type attempt_outcome =
   | Parsed of Keeper_memory_os_types.episode
@@ -158,34 +159,10 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
 
-type extraction_kind =
-  | Structured_episode
-  | Unstructured_fallback
-
-type extraction_result =
-  { episode : Keeper_memory_os_types.episode
-  ; kind : extraction_kind
-  }
-
-val should_record_cadence_success : extraction_kind -> bool
-(** Whether this extraction kind is allowed to reset the librarian cadence.
-    Unstructured fallback episodes are durable diagnostics, but they mean the
-    provider still failed to produce structured memory. *)
-
-val should_record_cadence_backoff : extraction_kind -> bool
-(** Whether this non-success extraction kind should defer the next attempt until
-    the next cadence window. Structured episodes use [cadence_record_success]
-    instead. *)
-
 val should_record_cadence_backoff_after_error : extraction_error -> bool
 (** Whether an extraction error represents enough completed work to defer the
     next attempt until the next cadence window. Only completed provider-attempt
     failures should defer cadence; local deterministic failures stay due. *)
-
-val should_preserve_unstructured_fallback : string -> bool
-(** Whether raw unparseable provider output is worth preserving as a diagnostic
-    fallback fact. Empty output carries no evidence and should remain a provider
-    failure instead of polluting memory. *)
 
 val run_with_parse_retries
   :  max_retries:int
@@ -244,7 +221,7 @@ val extract_with_provider_classified
   -> provider_cfg:Llm_provider.Provider_config.t
   -> generation:int
   -> Keeper_librarian.input
-  -> (extraction_result, extraction_error) result
+  -> (Keeper_memory_os_types.episode, extraction_error) result
 (** Provider-backed librarian extraction. [clock] stays optional at the API
     boundary because [run_best_effort] may be called from contexts that cannot
     supply an Eio clock; [None] returns
@@ -271,7 +248,7 @@ val extract_and_append_with_provider_classified
   -> keeper_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
-  -> (extraction_result, extraction_error) result
+  -> (Keeper_memory_os_types.episode, extraction_error) result
 
 val run_best_effort
   :  ?complete:complete_fn

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -22,7 +22,8 @@ let () =
     ~name:Keeper_metrics.(to_string MemoryLlmSummaryOutcomes)
     ~help:
       "Total [summarize_with_provider] attempts classified by label \
-       [outcome] (ok_summary | timed_out | http_error | empty_response). \
+       [outcome] (ok_summary | timed_out | http_error | empty_response | \
+       invalid_structured_response). \
        Labels: [outcome], [provider] (model_id), [runtime_id]."
     ();
   Otel_metric_store.register_counter
@@ -112,28 +113,43 @@ let raw_response_text (response : Agent_sdk.Types.api_response) : string option 
   in
   if text = "" then None else Some text
 
-let summary_text_of_raw_text raw =
-  try
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
+let summary_text_result_of_raw_text raw =
+  let raw = String.trim raw in
+  if raw = "" then Error Empty_summary_response
+  else
     match Yojson.Safe.from_string raw with
+    | exception Yojson.Json_error msg ->
+        Error (Invalid_structured_response ("invalid JSON: " ^ msg))
     | `Assoc fields ->
-      (match List.assoc_opt "summary" fields with
-       | Some (`String summary) ->
-         let summary = String.trim summary in
-         if summary = "" then None else Some summary
-       | Some _
-       | None -> None)
-    | _ -> None
-  with Yojson.Json_error _ -> None
+        (match List.assoc_opt "summary" fields with
+         | Some (`String summary) ->
+             let summary = String.trim summary in
+             if summary = "" then Error Empty_summary_response else Ok summary
+         | Some _ ->
+             Error (Invalid_structured_response "summary field must be a string")
+         | None ->
+             Error (Invalid_structured_response "missing summary field"))
+    | _ -> Error (Invalid_structured_response "summary response must be an object")
 ;;
 
-let summary_text_of_response response =
+let summary_text_result_of_response response =
   match raw_response_text response with
-  | None -> None
-  | Some raw -> summary_text_of_raw_text raw
+  | None -> Error Empty_summary_response
+  | Some raw -> summary_text_result_of_raw_text raw
+
+let summary_text_of_response response =
+  match summary_text_result_of_response response with
+  | Ok summary -> Some summary
+  | Error _ -> None
 ;;
 
 module For_testing = struct
   let summary_text_of_response = summary_text_of_response
+  let summary_text_result_of_response = summary_text_result_of_response
 end
 
 let with_timeout ?clock ~timeout_sec f =
@@ -180,14 +196,20 @@ let summarize_with_provider
           trace_id provider_cfg.model_id timeout_sec;
         None, Keeper_memory_llm_summary_outcome.Timed_out
     | Some (Ok response) ->
-        (match summary_text_of_response response with
-         | Some _ as summary ->
-             summary, Keeper_memory_llm_summary_outcome.Ok_summary
-         | None ->
+        (match summary_text_result_of_response response with
+         | Ok summary ->
+             Some summary, Keeper_memory_llm_summary_outcome.Ok_summary
+         | Error Empty_summary_response ->
              Log.Keeper.warn
                "memory LLM summary empty trace_id=%s provider=%s"
                trace_id provider_cfg.model_id;
-             None, Keeper_memory_llm_summary_outcome.Empty_response)
+             None, Keeper_memory_llm_summary_outcome.Empty_response
+         | Error (Invalid_structured_response detail) ->
+             Log.Keeper.warn
+               "memory LLM summary invalid structured response trace_id=%s \
+                provider=%s detail=%s"
+               trace_id provider_cfg.model_id detail;
+             None, Keeper_memory_llm_summary_outcome.Invalid_structured_response)
     | Some (Error err) ->
         Log.Keeper.warn
           "memory LLM summary failed trace_id=%s provider=%s: %s"

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -22,8 +22,15 @@ val summary_schema_supported : Llm_provider.Provider_config.t -> bool
 val messages_for_summary :
   trace_id:string -> texts:string list -> Agent_sdk.Types.message list
 
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
 module For_testing : sig
   val summary_text_of_response : Agent_sdk.Types.api_response -> string option
+
+  val summary_text_result_of_response :
+    Agent_sdk.Types.api_response -> (string, summary_parse_error) result
 end
 
 val make :

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -211,12 +211,18 @@ let log_rejected_output ~reason ~raw =
     (String.length raw)
 ;;
 
-let plan_of_string raw =
+let plan_result_of_string raw =
   match json_of_output_result raw with
-  | Ok json -> Some (plan_of_json json)
+  | Ok json -> Ok (plan_of_json json)
   | Error reason ->
     log_rejected_output ~reason ~raw;
-    None
+    Error reason
+;;
+
+let plan_of_string raw =
+  match plan_result_of_string raw with
+  | Ok plan -> Some plan
+  | Error _ -> None
 ;;
 
 (* ---------- Apply (pure, deterministic) ---------- *)

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -30,6 +30,12 @@ type consolidation_plan =
 
 val empty_plan : consolidation_plan
 
+type output_rejection_reason =
+  | Non_json
+  | Non_object_json
+
+val output_rejection_reason_to_string : output_rejection_reason -> string
+
 (** The numbered fact list the consolidation prompt sees: one 0-based line per
     fact, ["i: [category] claim"]. The index is the LLM's only handle on an
     existing fact, matching [apply_plan]'s reading. *)
@@ -39,6 +45,11 @@ val render_numbered_facts : fact list -> string
     (dropped with warning counts, not fatal); a wholly invalid object yields
     [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
+
+(** Parse the provider output as an exact JSON object, preserving the structured
+    rejection reason for runtime outcome classification. *)
+val plan_result_of_string :
+  string -> (consolidation_plan, output_rejection_reason) result
 
 (** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.
     Rejections emit a warning with a bounded reason label and byte count so

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -54,6 +54,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int
@@ -125,6 +127,12 @@ let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~aft
         Consolidated { before; after }))
 ;;
 
+let invalid_structured_response reason =
+  Invalid_structured_response
+    ("consolidation provider returned invalid structured response: "
+     ^ Consolidation.output_rejection_reason_to_string reason)
+;;
+
 (* Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it, and
    (unless [dry_run]) rewrite the store atomically. Returns what happened without
    raising for the expected failure modes (too few facts, transport error,
@@ -163,11 +171,11 @@ let consolidate_keeper
          | Some (Error _) -> Transport_failed "consolidation provider transport error"
          | Some (Ok response) ->
            (match response_text response with
-            | None -> Unparseable "consolidation provider returned empty response"
+            | None -> Empty_response
             | Some raw ->
-              (match Consolidation.plan_of_string raw with
-               | None -> Unparseable "consolidation provider returned invalid plan JSON"
-               | Some plan ->
+              (match Consolidation.plan_result_of_string raw with
+               | Error reason -> invalid_structured_response reason
+               | Ok plan ->
                  let survivors = Consolidation.apply_plan ~now ~facts plan in
                  let after = List.length survivors in
                  if dry_run

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -14,6 +14,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -353,12 +353,12 @@ let librarian_unstructured_fallback_terminal_marker =
 ;;
 
 let fact_prompt_recallable (fact : fact) =
-  (* [claim_kind] is the sole recall-eligibility signal: the producer
-     ([Keeper_librarian_runtime.unstructured_episode]) tags fallback notes as
-     [Diagnostic] at the write boundary, so recall excludes them by type without
-     string-matching [claim]. Rows lacking [claim_kind] are ordinary recallable
-     facts; their [valid_until] horizon ([fact_is_current]) bounds any stale
-     pre-[Diagnostic] rows still on disk. *)
+  (* [claim_kind] is the sole recall-eligibility signal: current librarian
+     extraction rejects unparseable structured output before persistence, while
+     historical fallback diagnostics were tagged [Diagnostic]. Recall excludes
+     diagnostics by type without string-matching [claim]. Rows lacking
+     [claim_kind] are ordinary recallable facts; their [valid_until] horizon
+     ([fact_is_current]) bounds any stale pre-[Diagnostic] rows still on disk. *)
   match fact.claim_kind with
   | Some Diagnostic -> false
   | Some Self_observation | Some External_state | Some Durable_knowledge -> true

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -229,14 +229,15 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
-(** Claim prefix used by the producer for librarian parse-failure fallback
-    facts. The producer tags these [Diagnostic] at the write boundary, so this
-    prefix is a display label only — recall eligibility is decided by
-    [claim_kind], not by string-matching [claim]. *)
+(** Legacy claim prefix for historical librarian parse-failure fallback facts.
+    Current provider-backed extraction rejects unparseable structured output
+    before persistence. Recall eligibility for any older rows is still decided
+    by [claim_kind], not by string-matching [claim]. *)
 val librarian_unstructured_fallback_claim_prefix : string
 
-(** Terminal marker used on episodes that preserve unstructured librarian output
-    after strict JSON parsing fails. *)
+(** Legacy terminal marker for historical episodes that preserved unstructured
+    librarian output after strict JSON parsing failed. Current extraction no
+    longer writes this marker. *)
 val librarian_unstructured_fallback_terminal_marker : string
 
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -332,6 +332,11 @@ let fusion_judge_output_schema =
     fields
 ;;
 
+let fusion_panel_answer_output_schema =
+  let fields = [ "answer", string_schema ] in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     response_format = Agent_sdk.Types.JsonSchema schema

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -26,6 +26,9 @@ val governance_judge_output_schema : Yojson.Safe.t
 val fusion_judge_output_schema : Yojson.Safe.t
 (** JSON object the Fusion judge/refine/meta-judge provider must return. *)
 
+val fusion_panel_answer_output_schema : Yojson.Safe.t
+(** JSON object each Fusion panel provider must return. *)
+
 val verification_verdict_output_schema : Yojson.Safe.t
 (** JSON object the verification verdict providers must return. *)
 

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -49,6 +49,18 @@ let record_eviction ~mode ~result ~reason =
     ()
 ;;
 
+let eager_read_eviction_reason_of_outcome = function
+  | Keeper_vision_tool.Vo_ok _ -> None
+  | Keeper_vision_tool.Vo_empty -> Some "eager_empty"
+  | Keeper_vision_tool.Vo_truncated -> Some "eager_truncated"
+  | Keeper_vision_tool.Vo_timeout -> Some "eager_timeout"
+  | Keeper_vision_tool.Vo_no_runtime _ -> Some "eager_no_runtime"
+  | Keeper_vision_tool.Vo_invalid_request _ -> Some "eager_invalid_request"
+  | Keeper_vision_tool.Vo_invalid_structured_response _ ->
+    Some "eager_invalid_structured_response"
+  | Keeper_vision_tool.Vo_provider _ -> Some "eager_provider_error"
+;;
+
 let truncate_read_text text =
   let length = String.length text in
   if length <= max_read_text_chars
@@ -95,14 +107,10 @@ let eager_read ~media_type ~bytes : (string, string) result option =
          ()
      with
      | Keeper_vision_tool.Vo_ok text -> Some (Ok (truncate_read_text text))
-     | Keeper_vision_tool.Vo_empty -> Some (Error "vision returned no text")
-     | Keeper_vision_tool.Vo_truncated -> Some (Error "vision reply truncated")
-     | Keeper_vision_tool.Vo_timeout -> Some (Error "vision sub-call timed out")
-     | Keeper_vision_tool.Vo_no_runtime msg -> Some (Error ("no vision runtime: " ^ msg))
-     | Keeper_vision_tool.Vo_invalid_request msg ->
-       Some (Error ("invalid vision request: " ^ msg))
-     | Keeper_vision_tool.Vo_provider { detail; _ } ->
-       Some (Error ("vision provider error: " ^ detail)))
+     | outcome ->
+       (match eager_read_eviction_reason_of_outcome outcome with
+        | Some reason -> Some (Error reason)
+        | None -> Some (Error "eager_read_failed")))
   | _ -> None
 ;;
 
@@ -157,8 +165,8 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                        record_eviction ~mode ~result:"ok" ~reason:"eager_read";
                        Agent_sdk.Types.Text
                          (image_read_placeholder ~handle ~media_type ~read_text)
-                     | Some (Error _reason) ->
-                       record_eviction ~mode ~result:"error" ~reason:"eager_read_failed";
+                     | Some (Error reason) ->
+                       record_eviction ~mode ~result:"error" ~reason;
                        Agent_sdk.Types.Text
                          (image_unread_placeholder
                             ~handle

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -24,6 +24,14 @@ type mode =
 val extraction_query : string
 (** The fixed exhaustive extraction query used by [Eager] (RFC §2.3-eager). *)
 
+val eager_read_eviction_reason_of_outcome
+  :  Keeper_vision_tool.vision_outcome
+  -> string option
+(** Metric reason projection for failed [Eager] vision sub-calls. [Vo_ok] has
+    no error reason; every non-ok outcome maps to a finite eviction reason so
+    provider failures, timeouts, invalid requests, and invalid structured
+    responses do not collapse into one counter bucket. *)
+
 val evict_blocks
   :  mode:mode
   -> policy:Keeper_types_profile.multimodal_policy

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -261,6 +261,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of
       { failure_class : Tool_result.tool_failure_class
       ; detail : string
@@ -300,8 +301,7 @@ let ok_or_classified_json (response : Agent_sdk.Types.api_response) =
 
 let outcome_of_response (response : Agent_sdk.Types.api_response) =
   match vision_text_of_response response with
-  | Error detail ->
-    Vo_provider { failure_class = Tool_result.Runtime_failure; detail }
+  | Error detail -> Vo_invalid_structured_response detail
   | Ok text ->
     let truncated = truncated_of_stop_reason response.stop_reason in
     (match Va.classify ~truncated ~content:text with

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -102,6 +102,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of { failure_class : Tool_result.tool_failure_class; detail : string }
   | Vo_empty
   | Vo_truncated
@@ -121,8 +122,9 @@ val run_vision
     call under [with_timeout] + §2.2 classification). Used by {!handle} and by
     eager ingestion. Requires the turn clock, so eager ingestion cannot run an
     unbounded provider call. Non-cancellation exceptions are converted to
-    [Vo_provider] so eager ingestion can keep the turn alive with a typed unread
-    placeholder. *)
+    [Vo_provider]; provider success with malformed structured output is
+    [Vo_invalid_structured_response], so eager ingestion can keep the turn alive
+    with a typed unread placeholder. *)
 
 val handle
   :  ?complete:complete_fn

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
@@ -3,10 +3,12 @@ type t =
   | Timed_out
   | Http_error
   | Empty_response
+  | Invalid_structured_response
 
 let to_label = function
   | Ok_summary -> "ok_summary"
   | Timed_out -> "timed_out"
   | Http_error -> "http_error"
   | Empty_response -> "empty_response"
+  | Invalid_structured_response -> "invalid_structured_response"
 ;;

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
@@ -1,11 +1,11 @@
 (** Keeper_memory_llm_summary_outcome — closed sum naming each path
     out of {!Keeper_memory_llm_summary.summarize_with_provider}.
 
-    Until this module existed, the three failure modes (timeout, HTTP
-    error, empty/whitespace-only response) each logged at warn but
-    were not aggregated as a counter, so operators could not see
-    "what fraction of summary attempts succeed" or
-    "which provider is regressing".  Successful summaries left no
+    Until this module existed, the failure modes (timeout, HTTP
+    error, empty/whitespace-only response, invalid structured response)
+    each logged at warn but were not aggregated as a counter, so
+    operators could not see "what fraction of summary attempts succeed"
+    or "which provider is regressing".  Successful summaries left no
     record at all.  Additionally, {!summarize_with_providers}
     returning [None] after exhausting every provider in the runtime
     was *silent* — no log, no metric, just a missing summary on the
@@ -27,5 +27,8 @@ type t =
       (** Provider returned 2xx but [response_text] collapsed to
           empty after trim — usually a model that produced only
           whitespace or refused the task. *)
+  | Invalid_structured_response
+      (** Provider returned 2xx with non-empty text that could not be
+          parsed as the requested summary JSON object. *)
 
 val to_label : t -> string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -100,6 +100,15 @@ let run_memory_os_consolidation_tick
           "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
           keeper_id
           msg
+      | Empty_response ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s empty_response"
+          keeper_id
+      | Invalid_structured_response msg ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s invalid_structured_response: %s"
+          keeper_id
+          msg
       | Snapshot_changed { before; current } ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -567,19 +567,26 @@ let parse_verdict_typed (text : string) : (verdict, verdict_parse_error) result 
                |> String_util.to_string)))
 ;;
 
-let parse_verdict (text : string) : (verdict, string) result =
-  match parse_verdict_typed text with
+let parse_verdict (raw_text : string) : (verdict, string) result =
+  match parse_verdict_typed raw_text with
   | Ok v -> Ok v
   | Error err -> Error (verdict_parse_error_to_string err)
 ;;
 
-let parse_review_verdict_from_text text =
-  match Yojson.Safe.from_string (String.trim text) with
-  | json -> (
-    match parse_review_verdict_from_json json with
-    | Ok verdict -> Ok verdict
-    | Error msg -> Error (Unrecognized_review_format msg))
-  | exception Yojson.Json_error _ -> parse_verdict_typed text
+let parse_review_verdict_from_response_text text =
+  let trimmed = String.trim text in
+  if String.length trimmed = 0
+  then Error Empty_review_output
+  else
+    match Yojson.Safe.from_string trimmed with
+    | json -> (
+      match parse_review_verdict_from_json json with
+      | Ok verdict -> Ok verdict
+      | Error msg -> Error (Unrecognized_review_format msg))
+    | exception Yojson.Json_error msg ->
+      Error
+        (Unrecognized_review_format
+           (sprintf "response text is not strict verdict JSON: %s" msg))
 ;;
 
 (* ================================================================ *)
@@ -812,10 +819,11 @@ let review
                 task_info "[anti-rationalization] verdict via structured tool call";
                 v, Structured_tool, None
               | None ->
-                (* LLM responded without a tool call — parse native JSON first,
-                   then the legacy text fallback. *)
-                task_info "[anti-rationalization] verdict via text fallback";
-                (match parse_review_verdict_from_text text with
+                (* LLM responded without a tool call. The provider-native
+                   schema response must be the strict verdict JSON object; do
+                   not accept legacy prose verdicts on this path. *)
+                task_info "[anti-rationalization] verdict via native JSON response";
+                (match parse_review_verdict_from_response_text text with
                  | Ok v -> v, Llm_text_fallback, None
                  | Error parse_error ->
                    let parse_err = verdict_parse_error_to_string parse_error in

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -77,8 +77,13 @@ let apply_report_verdict_output_schema provider_cfg =
 let parse_verdict_from_response_text text =
   match Yojson.Safe.from_string (String.trim text) with
   | json -> Core.parse_verdict_from_json json
-  | exception Yojson.Json_error _ -> Core.parse_verdict text
+  | exception Yojson.Json_error msg ->
+      Error (sprintf "verifier response must be strict JSON: %s" msg)
 ;;
+
+module For_testing = struct
+  let parse_verdict_from_response_text = parse_verdict_from_response_text
+end
 
 (* ================================================================ *)
 (* Core: verify                                                     *)
@@ -87,12 +92,11 @@ let parse_verdict_from_response_text text =
 (** Verify an action using structured tool output (ADR D3 compliant).
 
     Primary path: LLM calls [report_verdict] tool with typed verdict.
-    Fallback path: if LLM responds with text, parse provider-native JSON when
-    available, otherwise extract the verdict from free text.
+    Fallback path: if LLM responds with text, parse provider-native JSON only.
 
     The structured path is deterministic (JSON schema constrains output).
-    The fallback path is nondeterministic but returns Error on failure
-    instead of silently degrading. *)
+    The fallback path is strict JSON and returns Error on failure instead of
+    extracting a verdict from prose. *)
 let verify (req : Core.verification_request) : (Core.verdict, string) result =
   if Core.should_skip ~action_description:req.action_description
   then Ok Core.Pass
@@ -137,9 +141,11 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
          Log.Verifier.debug "verdict via structured tool call";
          Ok v
        | None ->
-         (* LLM responded with text instead of tool call — lenient fallback *)
+         (* LLM responded with text instead of tool call. The provider-native
+            schema contract still requires a strict JSON verdict object here. *)
          let text = Agent_sdk_response.text_of_response result.response in
-         Log.Verifier.info "verdict via text fallback (model did not call report_verdict)";
+         Log.Verifier.info
+           "verdict via strict JSON response fallback (model did not call report_verdict)";
         (match parse_verdict_from_response_text text with
          | Ok verdict -> Ok verdict
           | Error parse_err ->

--- a/lib/verifier_oas.mli
+++ b/lib/verifier_oas.mli
@@ -48,3 +48,8 @@ val read_only_predicate : Agent_sdk.Types.tool_schema -> bool
 
 val eval_gate_to_oas_guardrails :
   Eval_gate.gate_config -> Agent_sdk.Guardrails.t
+
+module For_testing : sig
+  val parse_verdict_from_response_text :
+    string -> (Verifier_core.verdict, string) result
+end

--- a/oas-models.toml
+++ b/oas-models.toml
@@ -241,6 +241,8 @@ thinking_control_format = "none"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
+supports_response_format_json = true
+supports_structured_output = true
 
 [[models]]
 id_prefix = "ollama_cloud/devstral-small-2:24b"
@@ -256,6 +258,8 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+supports_response_format_json = true
+supports_structured_output = true
 
 [[models]]
 id_prefix = "ollama_cloud/gemini-3-flash-preview"
@@ -567,6 +571,8 @@ supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
 supports_native_streaming = true
+supports_response_format_json = true
+supports_structured_output = true
 
 [[models]]
 id_prefix = "ollama_cloud/mistral-large-3:675b"

--- a/test/dune
+++ b/test/dune
@@ -701,7 +701,7 @@
 (test
  (name test_runtime_config_validity)
  (modules test_runtime_config_validity)
- (libraries masc_test_deps masc.fusion_core))
+ (libraries masc_test_deps))
 
 (test
  (name test_keeper_structured_output_coverage)

--- a/test/dune
+++ b/test/dune
@@ -701,7 +701,7 @@
 (test
  (name test_runtime_config_validity)
  (modules test_runtime_config_validity)
- (libraries masc_test_deps))
+ (libraries masc_test_deps masc.fusion_core))
 
 (test
  (name test_keeper_structured_output_coverage)

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -27,6 +27,20 @@ let with_reviewer reviewer f =
       Atomic.set AR.run_llm_reviewer_fn reviewer;
       f ())
 
+let contains_substring haystack needle =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 let test_empty_verdict_emits_typed_error () =
   match AR.parse_verdict_typed "" with
   | Error AR.Empty_review_output -> ()
@@ -79,6 +93,56 @@ let test_review_rejects_empty_evaluator_output () =
         Alcotest.fail
           "empty evaluator output must not approve by liveness")
 
+let test_review_accepts_strict_json_evaluator_response () =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, {|{"verdict":"APPROVE"}|}))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:"test-json-evaluator" (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "llm_text_fallback" (AR.gate_to_string result.AR.gate);
+      match result.AR.verdict with
+      | AR.Approve -> ()
+      | AR.Reject reason ->
+        Alcotest.failf "strict JSON APPROVE should pass, rejected: %s" reason)
+
+let check_review_rejects_evaluator_text ~label ~text ~reason_substring =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, text))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:("test-" ^ label) (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "format_reject" (AR.gate_to_string result.AR.gate);
+      (match result.AR.fallback_reason with
+       | Some reason ->
+         Alcotest.(check bool)
+           "fallback reason names strict JSON requirement"
+           true
+           (contains_substring reason reason_substring)
+       | None -> Alcotest.fail "format reject should include a fallback reason");
+      match result.AR.verdict with
+      | AR.Reject _ -> ()
+      | AR.Approve -> Alcotest.failf "%s evaluator output must not approve" label)
+
+let test_review_rejects_prose_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"prose-evaluator" ~text:"APPROVE"
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_malformed_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"malformed-json-evaluator"
+    ~text:{|{"verdict":"APPROVE"|}
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_non_object_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"array-json-evaluator"
+    ~text:{|[{"verdict":"APPROVE"}]|}
+    ~reason_substring:"review verdict"
+
 let () =
   Alcotest.run
     "anti_rationalization_empty_reject"
@@ -104,5 +168,21 @@ let () =
             "empty evaluator output rejects"
             `Quick
             test_review_rejects_empty_evaluator_output;
+          Alcotest.test_case
+            "strict JSON evaluator response passes"
+            `Quick
+            test_review_accepts_strict_json_evaluator_response;
+          Alcotest.test_case
+            "prose evaluator response rejects"
+            `Quick
+            test_review_rejects_prose_evaluator_response;
+          Alcotest.test_case
+            "malformed JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_malformed_json_evaluator_response;
+          Alcotest.test_case
+            "non-object JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_non_object_json_evaluator_response;
         ] );
     ]

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -39,6 +39,8 @@ let string_contains s sub =
 let iso8601_of_unix ts =
   Masc_domain.iso8601_of_unix_seconds ts
 
+let approval_resume_test_timeout_s = 1.0
+
 let write_legacy_judgment ~base_path json =
   let masc = Filename.concat base_path Common.masc_dirname in
   let governance = Filename.concat masc "governance" in
@@ -449,8 +451,6 @@ let test_parse_governance_response_requires_guardrail_state () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names guardrail_state" true
         (string_contains reason "missing guardrail_state")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "missing guardrail_state must fail closed"
 
 let test_parse_governance_response_preserves_guardrail_state () =
@@ -529,8 +529,6 @@ let test_parse_governance_response_requires_guardrail_fields () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names missing field" true
         (string_contains reason "missing guardrail_state.pending_confirm_token")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "incomplete guardrail_state must fail closed"
 
 let test_parse_governance_response_requires_items_array () =
@@ -543,23 +541,19 @@ let test_parse_governance_response_requires_items_array () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names items array" true
         (string_contains reason "items array")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "missing items array must fail closed"
 
-let test_parse_governance_response_rejects_unparseable_recovered_block () =
+let test_parse_governance_response_rejects_embedded_json_block () =
   let raw = "prefix {\"items\": [} suffix" in
   match
     Dashboard_governance_judge.parse_governance_response_for_testing
       ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
       ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
   with
-  | Error (Dashboard_governance_judge.Lenient_fallback recovered) ->
-      check bool "fallback keeps recovered fragment" true
-        (string_contains recovered "items")
   | Error (Dashboard_governance_judge.Structural_error reason) ->
-      fail ("expected lenient fallback, got structural error: " ^ reason)
-  | Ok _ -> fail "unparseable recovered JSON must stay lenient fallback"
+      check bool "reason names strict JSON" true
+        (string_contains reason "invalid strict JSON")
+  | Ok _ -> fail "embedded malformed JSON must fail closed"
 
 let test_refresh_failure_keeps_fresh_cache_online () =
   let dir = test_dir () in
@@ -962,6 +956,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
       ignore (Lib.Workspace.init config ~agent_name:(Some "dashboard"));
       Eio.Switch.run @@ fun sw ->
       let decision_result = ref None in
+      let resumed, resume_resolver = Eio.Promise.create () in
       Eio.Fiber.fork ~sw (fun () ->
         let decision =
           Lib.Keeper_approval_queue.submit_and_await
@@ -973,7 +968,8 @@ let test_dashboard_exposes_keeper_approval_queue () =
             ~selected_model:"openai:gpt-5.4"
             ()
         in
-        decision_result := Some decision);
+        decision_result := Some decision;
+        Eio.Promise.resolve resume_resolver ());
       Eio.Fiber.yield ();
       let json =
         Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
@@ -1002,8 +998,23 @@ let test_dashboard_exposes_keeper_approval_queue () =
        | Ok () -> ()
        | Error err ->
          fail ("resolve failed: " ^ Lib.Keeper_approval_queue.resolve_error_to_string err));
-      Eio.Fiber.yield ();
-      match !decision_result with
+      let decision_result =
+        match
+          Eio.Time.with_timeout
+            (Eio.Stdenv.clock env)
+            approval_resume_test_timeout_s
+            (fun () ->
+               Eio.Promise.await resumed;
+               Ok !decision_result)
+        with
+        | Ok decision_result -> decision_result
+        | Error `Timeout ->
+          fail
+            (Printf.sprintf
+               "approval fiber did not resume within %.1fs"
+               approval_resume_test_timeout_s)
+      in
+      match decision_result with
       | Some Agent_sdk.Hooks.Approve -> ()
       | Some (Agent_sdk.Hooks.Reject reason) ->
         fail ("expected approval resume, got reject: " ^ reason)
@@ -1125,8 +1136,8 @@ let () =
             test_parse_governance_response_requires_guardrail_fields;
           test_case "parser requires items array" `Quick
             test_parse_governance_response_requires_items_array;
-          test_case "parser rejects unparseable recovered block" `Quick
-            test_parse_governance_response_rejects_unparseable_recovered_block;
+          test_case "parser rejects embedded JSON block" `Quick
+            test_parse_governance_response_rejects_embedded_json_block;
           test_case "refresh failure keeps fresh cache online" `Quick
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -72,7 +72,7 @@ let test_output_contract_keeps_native_schema_when_supported () =
        | Some schema -> Yojson.Safe.equal fusion_schema schema
        | None -> false)
 
-let test_output_contract_degrades_to_json_mode_when_schema_is_not_native () =
+let test_output_contract_fails_loud_when_schema_is_not_native () =
   with_repo_oas_model_catalog @@ fun () ->
   let cfg =
     provider_cfg
@@ -81,14 +81,10 @@ let test_output_contract_degrades_to_json_mode_when_schema_is_not_native () =
       ~base_url:"https://api.deepseek.com"
   in
   match Fusion_judge.For_testing.apply_output_contract cfg with
-  | Error msg -> fail ("expected JSON-mode fallback: " ^ msg)
-  | Ok configured ->
-    check bool "response_format uses JsonMode" true
-      (match configured.response_format with
-       | Agent_sdk.Types.JsonMode -> true
-       | Agent_sdk.Types.JsonSchema _ | Agent_sdk.Types.Off -> false);
-    check (option string) "native output_schema is cleared" None
-      (Option.map Yojson.Safe.to_string configured.output_schema)
+  | Ok _ -> fail "expected schema-native fusion judge to fail loud"
+  | Error msg ->
+    check bool "schema validation reason is retained" true
+      (String.length msg > 0)
 
 let test_output_contract_fails_loud_when_no_output_contract_is_known () =
   with_empty_oas_model_catalog @@ fun () ->
@@ -194,9 +190,9 @@ let () =
             `Quick
             test_output_contract_keeps_native_schema_when_supported
         ; test_case
-            "uses JSON mode when native schema is not available"
+            "fails loud when native schema is not available"
             `Quick
-            test_output_contract_degrades_to_json_mode_when_schema_is_not_native
+            test_output_contract_fails_loud_when_schema_is_not_native
         ; test_case
             "fails loud when no JSON output contract is known"
             `Quick

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -24,6 +24,7 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   }
 
 let fusion_schema = Keeper_structured_output_schema.fusion_judge_output_schema
+let panel_schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema
 
 let restore_model_catalog previous =
   match previous with
@@ -52,6 +53,15 @@ let with_empty_oas_model_catalog f =
 
 let provider_cfg ~kind ~model_id ~base_url =
   Llm_provider.Provider_config.make ~kind ~model_id ~base_url ()
+
+let response_with_text text : Agent_sdk.Types.api_response =
+  { id = "fusion-panel-test"
+  ; model = "fusion-panel-test-model"
+  ; stop_reason = Agent_sdk.Types.EndTurn
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
 
 let test_output_contract_keeps_native_schema_when_supported () =
   let cfg =
@@ -98,6 +108,70 @@ let test_output_contract_fails_loud_when_no_output_contract_is_known () =
   | Ok _ -> fail "expected unknown provider/model to fail loud"
   | Error msg ->
     check bool "schema validation reason is retained" true (String.length msg > 0)
+
+let test_panel_output_contract_keeps_native_schema_when_supported () =
+  let cfg =
+    provider_cfg
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+  in
+  match Fusion_panel.For_testing.apply_output_contract cfg with
+  | Error msg -> fail ("expected native schema config: " ^ msg)
+  | Ok configured ->
+    check bool "response_format uses JsonSchema" true
+      (match configured.response_format with
+       | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal panel_schema schema
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
+    check bool "output_schema mirrors schema" true
+      (match configured.output_schema with
+       | Some schema -> Yojson.Safe.equal panel_schema schema
+       | None -> false)
+
+let test_panel_outcome_parses_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"  hello  "}|}))
+  with
+  | Fusion_types.Answered { model; answer; usage } ->
+    check string "panel identity preserved" "panel-a" model;
+    check string "answer is parsed and trimmed" "hello" answer;
+    check usage_t "missing provider usage defaults to zero" Fusion_types.zero_usage
+      usage
+  | Fusion_types.Failed failure ->
+    fail ("expected structured answer, got failure: " ^ Fusion_types.show_panel_error failure)
+
+let test_panel_outcome_rejects_invalid_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "not-json"))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "invalid JSON detail is retained" true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
+    fail
+      ("expected invalid structured response failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
+let test_panel_outcome_rejects_empty_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"   "}|}))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"; reason = Fusion_types.Empty_response detail } ->
+    check bool "empty response detail is retained" true (String.length detail > 0)
+  | other ->
+    fail
+      ("expected empty structured answer failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
 
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
@@ -197,6 +271,18 @@ let () =
             "fails loud when no JSON output contract is known"
             `Quick
             test_output_contract_fails_loud_when_no_output_contract_is_known
+        ; test_case
+            "panel keeps native answer schema when supported"
+            `Quick
+            test_panel_output_contract_keeps_native_schema_when_supported
+        ] )
+    ; ( "panel_outcome"
+      , [ test_case "parses structured answer" `Quick
+            test_panel_outcome_parses_structured_answer
+        ; test_case "rejects invalid structured answer" `Quick
+            test_panel_outcome_rejects_invalid_structured_answer
+        ; test_case "rejects empty answer" `Quick
+            test_panel_outcome_rejects_empty_answer
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -101,6 +101,53 @@ let check_ok = function
   | Ok () -> ()
   | Error msg -> Alcotest.fail msg
 
+let test_response_text_accepts_strict_json () =
+  let raw =
+    {|{"verdict":"FAIL","reason":"bad branch","evidence":[{"path":"lib/foo.ml","line":12,"quote":"let bad = true"}]}|}
+  in
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Ok grounded ->
+    check string
+      "verdict"
+      "FAIL"
+      (VC.verdict_constructor_name grounded.VC.verdict);
+    check int "evidence count" 1 (List.length grounded.VC.evidence)
+  | Error msg -> fail ("strict JSON response rejected: " ^ msg)
+
+let test_response_text_rejects_embedded_json () =
+  let raw =
+    {|Here is the verdict: {"verdict":"PASS","reason":null,"evidence":[]}|}
+  in
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Error _ -> ()
+  | Ok grounded ->
+    failf
+      "embedded JSON should be rejected, got %s"
+      (VC.verdict_to_string grounded.VC.verdict)
+
+let check_response_text_rejected label raw =
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Error _ -> ()
+  | Ok grounded ->
+    failf
+      "%s should be rejected, got %s"
+      label
+      (VC.verdict_to_string grounded.VC.verdict)
+
+let test_response_text_rejects_empty_text () =
+  check_response_text_rejected "empty response" "";
+  check_response_text_rejected "whitespace response" "  \n\t  "
+
+let test_response_text_rejects_malformed_json () =
+  check_response_text_rejected
+    "malformed JSON response"
+    {|{"verdict":"PASS","reason":null,"evidence":[]|}
+
+let test_response_text_rejects_non_object_json () =
+  check_response_text_rejected
+    "array JSON response"
+    {|[{"verdict":"PASS","reason":null,"evidence":[]}]|}
+
 let test_fail_wakes_author () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
@@ -294,6 +341,19 @@ let test_build_prompt_preserves_literal_braces_in_values () =
 let () =
   Alcotest.run "keeper-adversarial-review"
     [
+      ( "response-parser",
+        [
+          test_case "accepts strict JSON response" `Quick
+            test_response_text_accepts_strict_json;
+          test_case "rejects embedded JSON response" `Quick
+            test_response_text_rejects_embedded_json;
+          test_case "rejects empty response text" `Quick
+            test_response_text_rejects_empty_text;
+          test_case "rejects malformed JSON response" `Quick
+            test_response_text_rejects_malformed_json;
+          test_case "rejects non-object JSON response" `Quick
+            test_response_text_rejects_non_object_json;
+        ] );
       ( "wake-on-fail",
         [
           test_case "fail wakes author" `Quick test_fail_wakes_author;

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -253,16 +253,6 @@ let test_cadence_record_attempt_defers () =
   check bool "after a completed non-success attempt the next turn is not due" false
     (R.cadence_due ~keeper_id:kid ~trace_id:tid)
 
-let test_cadence_success_policy () =
-  check bool "structured extraction resets cadence" true
-    (R.should_record_cadence_success R.Structured_episode);
-  check bool "unstructured fallback is not semantic success" false
-    (R.should_record_cadence_success R.Unstructured_fallback);
-  check bool "structured extraction uses success path, not backoff" false
-    (R.should_record_cadence_backoff R.Structured_episode);
-  check bool "unstructured fallback defers cadence" true
-    (R.should_record_cadence_backoff R.Unstructured_fallback)
-
 let test_cadence_error_backoff_policy () =
   check bool "empty provider response defers cadence" true
     (R.should_record_cadence_backoff_after_error R.Provider_empty_response);
@@ -271,6 +261,9 @@ let test_cadence_error_backoff_policy () =
   check bool "provider transport failure defers cadence" true
     (R.should_record_cadence_backoff_after_error
        (R.Provider_transport_failed "http timeout"));
+  check bool "unparseable provider response defers cadence" true
+    (R.should_record_cadence_backoff_after_error
+       (R.Provider_unparseable_response "invalid_json"));
   check bool "prompt render failure stays due" false
     (R.should_record_cadence_backoff_after_error
        (R.Prompt_render_failed "missing template"));
@@ -279,14 +272,6 @@ let test_cadence_error_backoff_policy () =
        (R.Memory_fact_upsert_failed "permission denied"));
   check bool "missing provider clock does not claim a completed attempt" false
     (R.should_record_cadence_backoff_after_error R.Provider_clock_unavailable)
-
-let test_unstructured_fallback_preservation_policy () =
-  check bool "empty response is not preserved" false
-    (R.should_preserve_unstructured_fallback "");
-  check bool "whitespace response is not preserved" false
-    (R.should_preserve_unstructured_fallback " \n\t ");
-  check bool "invalid text response is preserved" true
-    (R.should_preserve_unstructured_fallback "not json, but evidence")
 
 (* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
    [run_best_effort] uses). A fresh pair is due immediately, and successful
@@ -569,10 +554,7 @@ let () =
           test_case "step transitions" `Quick test_cadence_step_transitions;
           test_case "record success resets" `Quick test_cadence_record_success_resets;
           test_case "record attempt defers" `Quick test_cadence_record_attempt_defers;
-          test_case "success policy excludes fallback" `Quick test_cadence_success_policy;
           test_case "error backoff policy" `Quick test_cadence_error_backoff_policy;
-          test_case "fallback preservation policy" `Quick
-            test_unstructured_fallback_preservation_policy;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
           test_case "cadence_due resets on trace rollover" `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1246,22 +1246,49 @@ let test_memory_llm_summary_response_parser_accepts_only_summary_json () =
   let parse raw =
     Memory_summary.For_testing.summary_text_of_response (fake_response raw)
   in
+  let parse_result raw =
+    Memory_summary.For_testing.summary_text_result_of_response (fake_response raw)
+  in
+  let check_invalid_structured label = function
+    | Error (Memory_summary.Invalid_structured_response _) -> ()
+    | Ok summary -> Alcotest.failf "%s: expected invalid structured response, got %S" label summary
+    | Error Memory_summary.Empty_summary_response ->
+        Alcotest.failf "%s: expected invalid structured response, got empty response" label
+  in
   Alcotest.(check (option string))
     "valid summary json"
     (Some "Remember exact command.")
     (parse {|{"summary":" Remember exact command.  "}|});
+  (match parse_result {|{"summary":" Remember exact command.  "}|} with
+   | Ok summary ->
+       Alcotest.(check string)
+         "valid summary json result"
+         "Remember exact command."
+         summary
+   | Error _ -> Alcotest.fail "valid summary json result rejected");
   Alcotest.(check (option string))
     "plain text rejected"
     None
     (parse "Remember exact command.");
+  check_invalid_structured "plain text result" (parse_result "Remember exact command.");
   Alcotest.(check (option string))
     "empty summary rejected"
     None
     (parse {|{"summary":"   "}|});
+  Alcotest.(check bool)
+    "empty summary result"
+    true
+    (match parse_result {|{"summary":"   "}|} with
+     | Error Memory_summary.Empty_summary_response -> true
+     | Ok _
+     | Error (Memory_summary.Invalid_structured_response _) -> false);
   Alcotest.(check (option string))
     "wrong field rejected"
     None
-    (parse {|{"text":"Remember exact command."}|})
+    (parse {|{"text":"Remember exact command."}|});
+  check_invalid_structured
+    "wrong field result"
+    (parse_result {|{"text":"Remember exact command."}|})
 ;;
 
 let json_episode_file_count ~keeper_id =
@@ -1485,7 +1512,7 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
           (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_runtime_preserves_unstructured_fallback () =
+let test_librarian_runtime_rejects_unstructured_fallback () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1501,7 +1528,10 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
           ; messages = [ text_message "Please remember the fallback path." ]
           }
         in
-        let fallback_started_at = Eio.Time.now clock in
+        Alcotest.(check bool)
+          "production cadence gate is due before provider attempt"
+          true
+          (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id);
         let fallback_result =
           Librarian_runtime.extract_and_append_with_provider_classified
             ~complete
@@ -1513,113 +1543,47 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
             ~provider_cfg:(test_provider_cfg ())
             inp
         in
-        let fallback_finished_at = Eio.Time.now clock in
-        let fallback_created_at = ref None in
-        let check_in_clock_window label value =
-          Alcotest.(check bool)
-            label
-            true
-            (value >= fallback_started_at && value <= fallback_finished_at +. 0.001)
-        in
         (match fallback_result with
-         | Error err ->
-           Alcotest.fail (Librarian_runtime.extraction_error_to_string err)
-         | Ok extraction ->
-           let episode = extraction.Librarian_runtime.episode in
-           let kind = extraction.Librarian_runtime.kind in
-           (match kind with
-            | Librarian_runtime.Unstructured_fallback -> ()
-            | Librarian_runtime.Structured_episode ->
-              Alcotest.fail "expected unstructured fallback extraction");
-           Alcotest.(check bool)
-             "fallback does not count as cadence success"
-             false
-             (Librarian_runtime.should_record_cadence_success kind);
-           Alcotest.(check bool)
-             "fallback defers the next cadence attempt"
-             true
-             (Librarian_runtime.should_record_cadence_backoff kind);
-           fallback_created_at := Some episode.Types.created_at;
-           check_in_clock_window
-             "fallback created_at derives from injected clock"
-             episode.Types.created_at;
+         | Ok _ -> Alcotest.fail "unstructured provider output must not persist"
+         | Error (Librarian_runtime.Provider_unparseable_response reason as err) ->
            Alcotest.(check int)
              "initial attempt + parse retries"
              (1 + Librarian_runtime.librarian_max_parse_retries)
              !calls;
-           Alcotest.(check string)
-             "fallback summary"
-             "Unstructured librarian note preserved after parse failure"
-             episode.Types.episode_summary;
-           Alcotest.(check (option string))
-             "fallback marker"
-             (Some Types.librarian_unstructured_fallback_terminal_marker)
-             episode.Types.terminal_marker;
-           (match episode.Types.claims with
-            | [ fact ] ->
-              Alcotest.(check bool)
-                "fallback claim keeps raw provider text"
-                true
-                (contains "not json, but keep this observation" fact.Types.claim);
-              Alcotest.(check bool)
-                "fallback is ephemeral"
-                true
-                (fact.Types.category = Types.Ephemeral);
-              Alcotest.(check (option string))
-                "fallback is diagnostic"
-                (Some "diagnostic")
-                (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
-              Alcotest.(check (option string))
-                "fallback diagnostic does not author claim_id"
-                None
-                fact.Types.claim_id;
-              Alcotest.(check (float 0.001))
-                "fallback fact first_seen uses episode timestamp"
-                episode.Types.created_at
-                fact.Types.first_seen;
-              Alcotest.(check (option (float 0.001)))
-                "fallback fact last_verified_at uses episode timestamp"
-                (Some episode.Types.created_at)
-                fact.Types.last_verified_at
-            | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)));
-        let fallback_created_at =
-          match !fallback_created_at with
-          | Some ts -> ts
-          | None -> Alcotest.fail "fallback result timestamp was not captured"
-        in
+           Alcotest.(check bool)
+             "typed provider error preserves parser reason"
+             true
+             (contains
+                "librarian provider returned invalid episode JSON"
+                reason);
+           Alcotest.(check bool)
+             "unparseable provider error enters cadence backoff path"
+             true
+             (Librarian_runtime.should_record_cadence_backoff_after_error err);
+           Librarian_runtime.cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
+           Alcotest.(check bool)
+             "cadence attempt defers the next provider retry"
+             false
+             (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id)
+         | Error err ->
+           Alcotest.failf
+             "expected Provider_unparseable_response, got %s"
+             (Librarian_runtime.extraction_error_to_string err));
         Alcotest.(check int)
-          "episode file persisted"
-          1
+          "episode file not persisted"
+          0
           (json_episode_file_count ~keeper_id);
-        (match Memory_io.read_events_tail ~keeper_id ~n:1 with
-         | [ episode ] ->
-           Alcotest.(check (option string))
-             "event persisted with fallback marker"
-             (Some Types.librarian_unstructured_fallback_terminal_marker)
-             episode.Types.terminal_marker;
-           Alcotest.(check (float 0.001))
-             "event persisted with injected-clock timestamp"
-             fallback_created_at
-             episode.Types.created_at
-         | events -> Alcotest.failf "expected one event, got %d" (List.length events));
-        match Memory_io.read_facts_tail ~keeper_id ~n:1 with
-        | [ fact ] ->
-          Alcotest.(check bool)
-            "fact persisted as unstructured note"
-            true
-            (contains "unstructured_note" fact.Types.claim);
-          Alcotest.(check (option string))
-            "persisted fact is diagnostic"
-            (Some "diagnostic")
-            (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
-          Alcotest.(check (float 0.001))
-            "persisted fact first_seen uses injected clock"
-            fallback_created_at
-            fact.Types.first_seen
-        | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+        Alcotest.(check int)
+          "event not persisted"
+          0
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
+        Alcotest.(check int)
+          "fact not persisted"
+          0
+          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries () =
+let test_librarian_runtime_rejects_unparseable_output_across_empty_retries () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1649,42 +1613,35 @@ let test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries () =
             ~provider_cfg:(test_provider_cfg ())
             inp
         with
+        | Ok _ -> Alcotest.fail "unparseable provider output must not persist"
         | Error err ->
-          Alcotest.fail
-            (Printf.sprintf
-               "expected non-empty first response to be preserved, got %s"
-               (Librarian_runtime.extraction_error_to_string err))
-        | Ok extraction ->
           Alcotest.(check int)
             "initial invalid response + empty retries"
             (1 + Librarian_runtime.librarian_max_parse_retries)
             !calls;
-          (match extraction.Librarian_runtime.kind with
-           | Librarian_runtime.Unstructured_fallback -> ()
-           | Librarian_runtime.Structured_episode ->
-             Alcotest.fail "expected unstructured fallback extraction");
-          (match extraction.Librarian_runtime.episode.Types.claims with
-           | [ fact ] ->
-             Alcotest.(check bool)
-               "fallback claim keeps first non-empty provider text"
-               true
-               (contains "first invalid librarian payload" fact.Types.claim);
-             Alcotest.(check bool)
-               "fallback claim keeps invalid-json reason"
-               true
-               (contains
-                  "librarian provider returned invalid episode JSON"
-                  fact.Types.claim);
-             Alcotest.(check bool)
-               "fallback claim does not use later empty retry reason"
-               false
-               (contains
-                  "librarian provider returned empty response"
-                  fact.Types.claim)
-           | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)))))
+          Alcotest.(check bool)
+            "error keeps first non-empty invalid-json reason"
+            true
+            (contains
+               "librarian provider returned invalid episode JSON"
+               (Librarian_runtime.extraction_error_to_string err));
+          Alcotest.(check bool)
+            "error does not use later empty retry reason"
+            false
+            (contains
+               "librarian provider returned empty response"
+               (Librarian_runtime.extraction_error_to_string err));
+          Alcotest.(check int)
+            "event not persisted"
+            0
+            (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
+          Alcotest.(check int)
+            "fact not persisted"
+            0
+            (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_unstructured_fallback_uses_exact_text_identity () =
+let test_librarian_unstructured_fallback_does_not_write_facts () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1713,57 +1670,25 @@ let test_librarian_unstructured_fallback_uses_exact_text_identity () =
               ~provider_cfg:(test_provider_cfg ())
               inp
           with
-          | Error msg -> Alcotest.fail msg
-          | Ok episode -> episode
+          | Ok _ -> Alcotest.fail "unparseable provider output must not persist"
+          | Error msg -> msg
         in
         let first = run_once first_complete in
         let second = run_once second_complete in
         Alcotest.(check int)
-          "both fallback episodes are still evented"
-          2
+          "fallback events are not written"
+          0
           (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
         let facts = Memory_io.read_facts_all ~keeper_id in
-        Alcotest.(check int) "distinct diagnostics remain distinct facts" 2 (List.length facts);
+        Alcotest.(check int) "diagnostic facts are not written" 0 (List.length facts);
         Alcotest.(check bool)
-          "fallback diagnostics do not author claim_id"
+          "first error keeps invalid-json reason"
           true
-          (List.for_all (fun fact -> Option.is_none fact.Types.claim_id) facts);
+          (contains "invalid episode JSON" first);
         Alcotest.(check bool)
-          "fallback diagnostics are typed diagnostic"
+          "second error keeps invalid-json reason"
           true
-          (List.for_all (fun fact -> fact.Types.claim_kind = Some Types.Diagnostic) facts);
-        Alcotest.(check bool)
-          "first raw note is preserved"
-          true
-          (List.exists
-             (fun fact -> contains "first invalid librarian payload" fact.Types.claim)
-             facts);
-        Alcotest.(check bool)
-          "second raw note is preserved"
-          true
-          (List.exists
-             (fun fact -> contains "second invalid librarian payload" fact.Types.claim)
-             facts);
-        (match first.Types.claims, second.Types.claims with
-         | [ first_fact ], [ second_fact ] ->
-           Alcotest.(check bool)
-             "first result has no claim_id"
-             true
-             (Option.is_none first_fact.Types.claim_id);
-           Alcotest.(check bool)
-             "second result has no claim_id"
-             true
-             (Option.is_none second_fact.Types.claim_id);
-           Alcotest.(check bool)
-             "result fallback facts are diagnostic"
-             true
-             (first_fact.Types.claim_kind = Some Types.Diagnostic
-              && second_fact.Types.claim_kind = Some Types.Diagnostic)
-         | first_claims, second_claims ->
-           Alcotest.failf
-             "expected one fallback fact in each result, got %d/%d"
-             (List.length first_claims)
-             (List.length second_claims)))))
+          (contains "invalid episode JSON" second))))
 ;;
 
 let test_librarian_runtime_reports_fact_upsert_failure () =
@@ -5711,17 +5636,17 @@ let () =
         ] )
     ; ( "librarian runtime"
       , [ Alcotest.test_case
-            "unparseable output is preserved as unstructured fallback"
+            "unparseable output is rejected instead of persisted"
             `Quick
-            test_librarian_runtime_preserves_unstructured_fallback
+            test_librarian_runtime_rejects_unstructured_fallback
         ; Alcotest.test_case
-            "non-empty fallback evidence survives empty retries"
+            "non-empty fallback evidence remains an error across empty retries"
             `Quick
-            test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries
+            test_librarian_runtime_rejects_unparseable_output_across_empty_retries
         ; Alcotest.test_case
-            "unstructured fallback uses exact-text identity"
+            "unstructured fallback does not write facts"
             `Quick
-            test_librarian_unstructured_fallback_uses_exact_text_identity
+            test_librarian_unstructured_fallback_does_not_write_facts
         ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -447,6 +447,23 @@ let test_parse_non_json_is_none () =
   Alcotest.(check bool) "JSON array yields None" true (Consolidation.plan_of_string "[]" = None)
 ;;
 
+let test_parse_result_reports_rejection_reason () =
+  Alcotest.(check bool)
+    "non-JSON result"
+    true
+    (match Consolidation.plan_result_of_string "not json {{{" with
+     | Error Consolidation.Non_json -> true
+     | Ok _
+     | Error Consolidation.Non_object_json -> false);
+  Alcotest.(check bool)
+    "non-object result"
+    true
+    (match Consolidation.plan_result_of_string {|"not an object"|} with
+     | Error Consolidation.Non_object_json -> true
+     | Ok _
+     | Error Consolidation.Non_json -> false)
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os_consolidation"
@@ -480,10 +497,14 @@ let () =
 	    ; ( "parse"
 	      , [ Alcotest.test_case "parses a plan" `Quick test_parse_plan_json
 	        ; Alcotest.test_case "rejects fractional indices" `Quick test_parse_rejects_fractional_indices
-	        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
-	        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
-	        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
-	        ] )
+        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
+        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
+        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
+        ; Alcotest.test_case
+            "result reports rejection reason"
+            `Quick
+            test_parse_result_reports_rejection_reason
+        ] )
     ; ( "render"
       , [ Alcotest.test_case
             "keeps one fact per prompt line"

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -275,6 +275,60 @@ let test_consolidate_rejects_malformed_fact_store () =
         | _ -> Alcotest.fail "expected Unparseable for malformed fact store"))))
 ;;
 
+let test_consolidate_classifies_empty_provider_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "   ")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Empty_response -> ()
+        | _ -> Alcotest.fail "expected Empty_response for blank provider output"))))
+;;
+
+let test_consolidate_classifies_invalid_structured_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "not json {{{")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Invalid_structured_response detail ->
+          Alcotest.(check string)
+            "detail keeps rejection reason"
+            "consolidation provider returned invalid structured response: non_json"
+            detail
+        | _ ->
+          Alcotest.fail
+            "expected Invalid_structured_response for malformed provider output"))))
+;;
+
 let test_consolidate_respects_provider_config_and_prompt_template () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -357,8 +411,16 @@ let () =
       , [ Alcotest.test_case "applies the model's plan" `Quick test_consolidate_applies_plan
         ; Alcotest.test_case "skips when too few facts" `Quick test_consolidate_skips_too_few
 	        ; Alcotest.test_case "dry-run preserves the store" `Quick test_consolidate_dry_run_preserves_store
-	        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
-	        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
+        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case
+            "classifies empty provider response"
+            `Quick
+            test_consolidate_classifies_empty_provider_response
+        ; Alcotest.test_case
+            "classifies invalid structured provider response"
+            `Quick
+            test_consolidate_classifies_invalid_structured_response
         ; Alcotest.test_case
             "respects provider config and prompt template"
             `Quick

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -53,10 +53,10 @@ let expected_structured_dashboard_agent_run_json_judges =
     ]
 ;;
 
-let expected_structured_fusion_json_judges = [ "lib/fusion/fusion_judge.ml" ];;
-
-let expected_unstructured_fusion_agent_build_exemptions =
-  [ "lib/fusion/fusion_panel.ml" ]
+let expected_structured_fusion_agent_build_files =
+  List.sort
+    String.compare
+    [ "lib/fusion/fusion_judge.ml"; "lib/fusion/fusion_panel.ml" ]
 ;;
 
 let expected_structured_tool_agent_runs =
@@ -83,10 +83,7 @@ let fusion_agent_build_files () =
 ;;
 
 let expected_all_fusion_agent_build_files =
-  List.sort
-    String.compare
-    (expected_structured_fusion_json_judges
-     @ expected_unstructured_fusion_agent_build_exemptions)
+  expected_structured_fusion_agent_build_files
 ;;
 
 let masc_tool_agent_run_files_under rel =
@@ -152,9 +149,9 @@ let test_dashboard_agent_run_json_judges_request_structured_output () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_request_structured_output () =
+let test_fusion_agent_builds_request_structured_output () =
   test_agent_run_json_judges_request_structured_output
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_dashboard_agent_run_json_judges_use_provider_config_transform () =
@@ -211,7 +208,7 @@ let test_dashboard_json_judges_do_not_use_lenient_json_recovery () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_use_provider_config_transform () =
+let test_fusion_agent_builds_use_provider_config_transform () =
   List.iter
     (fun rel ->
        check
@@ -222,10 +219,10 @@ let test_fusion_agent_run_json_judges_use_provider_config_transform () =
             ~module_path:rel
             ~callee:"Fusion_oas.build_agent"
             ~label:"provider_config_transform"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
-let test_fusion_json_judges_do_not_degrade_to_json_mode () =
+let test_fusion_agent_builds_do_not_degrade_to_json_mode () =
   List.iter
     (fun rel ->
        check
@@ -240,7 +237,7 @@ let test_fusion_json_judges_do_not_degrade_to_json_mode () =
          (rel ^ " must not construct JsonMode through open or alias")
          0
          (Ast_grep.count_constructor_leaf_names ~module_path:rel ~name:"JsonMode"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_all_fusion_agent_build_files_are_classified () =
@@ -397,23 +394,23 @@ let () =
             `Quick
             test_dashboard_json_judges_do_not_use_lenient_json_recovery
         ] )
-    ; ( "fusion json judges"
+    ; ( "fusion Agent builds"
       , [ test_case
-            "Fusion agent build files are classified as structured or exempt"
+            "Fusion agent build files are classified"
             `Quick
             test_all_fusion_agent_build_files_are_classified
         ; test_case
-            "fusion JSON judges request structured output"
+            "fusion Agent builds request structured output"
             `Quick
-            test_fusion_agent_run_json_judges_request_structured_output
+            test_fusion_agent_builds_request_structured_output
         ; test_case
-            "fusion JSON judges use provider config transform"
+            "fusion Agent builds use provider config transform"
             `Quick
-            test_fusion_agent_run_json_judges_use_provider_config_transform
+            test_fusion_agent_builds_use_provider_config_transform
         ; test_case
-            "fusion JSON judges do not degrade to JsonMode"
+            "fusion Agent builds do not degrade to JsonMode"
             `Quick
-            test_fusion_json_judges_do_not_degrade_to_json_mode
+            test_fusion_agent_builds_do_not_degrade_to_json_mode
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -333,6 +333,16 @@ let test_verifier_oas_uses_structured_judge_runtime () =
        ~callee:"Runtime.get_default_runtime_id")
 ;;
 
+let test_verifier_oas_response_text_fallback_is_strict_json () =
+  check
+    int
+    "verifier_oas must not call prose verdict parser for provider-native response text"
+    0
+    (Ast_grep.count_calls
+       ~module_path:"lib/verifier_oas.ml"
+       ~callee:"Core.parse_verdict")
+;;
+
 let test_model_label_wrappers_can_receive_provider_config_transform () =
   let rel = "lib/keeper/keeper_turn_driver_wrappers.ml" in
   check
@@ -422,6 +432,10 @@ let () =
             "verifier_oas uses structured_judge runtime"
             `Quick
             test_verifier_oas_uses_structured_judge_runtime
+        ; test_case
+            "verifier_oas response fallback is strict JSON"
+            `Quick
+            test_verifier_oas_response_text_fallback_is_strict_json
         ] )
     ; ( "model-label wrappers"
       , [ test_case

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -191,6 +191,26 @@ let test_dashboard_agent_run_json_judges_use_structured_judge_runtime () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
+let test_dashboard_json_judges_do_not_use_lenient_json_recovery () =
+  List.iter
+    (fun rel ->
+       check
+         int
+         (rel ^ " must not call Llm_provider.Lenient_json.parse")
+         0
+         (Ast_grep.count_calls
+            ~module_path:rel
+            ~callee:"Llm_provider.Lenient_json.parse");
+       check
+         int
+         (rel ^ " must not call Judge_json_recovery.extract_balanced_object")
+         0
+         (Ast_grep.count_calls
+            ~module_path:rel
+            ~callee:"Judge_json_recovery.extract_balanced_object"))
+    expected_structured_dashboard_agent_run_json_judges
+;;
+
 let test_fusion_agent_run_json_judges_use_provider_config_transform () =
   List.iter
     (fun rel ->
@@ -362,6 +382,10 @@ let () =
             "dashboard Agent.run JSON judges use structured runtime lane"
             `Quick
             test_dashboard_agent_run_json_judges_use_structured_judge_runtime
+        ; test_case
+            "dashboard JSON judges do not use lenient JSON recovery"
+            `Quick
+            test_dashboard_json_judges_do_not_use_lenient_json_recovery
         ] )
     ; ( "fusion json judges"
       , [ test_case

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -205,6 +205,24 @@ let test_fusion_agent_run_json_judges_use_provider_config_transform () =
     expected_structured_fusion_json_judges
 ;;
 
+let test_fusion_json_judges_do_not_degrade_to_json_mode () =
+  List.iter
+    (fun rel ->
+       check
+         int
+         (rel ^ " must not fully qualify a JsonMode downgrade")
+         0
+         (Ast_grep.count_constructors
+            ~module_path:rel
+            ~constructor:"Agent_sdk.Types.JsonMode");
+       check
+         int
+         (rel ^ " must not construct JsonMode through open or alias")
+         0
+         (Ast_grep.count_constructor_leaf_names ~module_path:rel ~name:"JsonMode"))
+    expected_structured_fusion_json_judges
+;;
+
 let test_all_fusion_agent_build_files_are_classified () =
   check
     (list string)
@@ -358,6 +376,10 @@ let () =
             "fusion JSON judges use provider config transform"
             `Quick
             test_fusion_agent_run_json_judges_use_provider_config_transform
+        ; test_case
+            "fusion JSON judges do not degrade to JsonMode"
+            `Quick
+            test_fusion_json_judges_do_not_degrade_to_json_mode
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -86,6 +86,31 @@ let expected_all_fusion_agent_build_files =
   expected_structured_fusion_agent_build_files
 ;;
 
+let with_repo_oas_model_catalog f =
+  let path = Ast_grep.resolve_path "oas-models.toml" in
+  check bool "repo oas-models.toml present" true (Sys.file_exists path);
+  match Llm_provider.Model_catalog.load_file path with
+  | Error msg -> failf "repo oas-models.toml should load: %s" msg
+  | Ok catalog ->
+    Fun.protect
+      ~finally:Llm_provider.Model_catalog.clear_global
+      (fun () ->
+         Llm_provider.Model_catalog.set_global catalog;
+         f catalog)
+;;
+
+let fusion_toml_or_fail path =
+  match Otoml.Parser.from_file_result path with
+  | Ok toml -> toml
+  | Error msg -> failf "fusion TOML parse failed: %s" msg
+;;
+
+let runtime_by_id_or_fail runtimes id =
+  match List.find_opt (fun (runtime : Runtime.t) -> String.equal runtime.id id) runtimes with
+  | Some runtime -> runtime
+  | None -> failf "runtime id %s should resolve in repo runtime.toml" id
+;;
+
 let masc_tool_agent_run_files_under rel =
   ml_files_under rel
   |> List.filter (fun rel ->
@@ -238,6 +263,100 @@ let test_fusion_agent_builds_do_not_degrade_to_json_mode () =
          0
          (Ast_grep.count_constructor_leaf_names ~module_path:rel ~name:"JsonMode"))
     expected_structured_fusion_agent_build_files
+;;
+
+let test_repo_fusion_seed_judges_accept_native_schema () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Ast_grep.resolve_path "config/runtime.toml" in
+  check bool "repo runtime.toml present" true (Sys.file_exists path);
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok
+      ( runtimes
+      , _default
+      , _assignments
+      , _librarian
+      , _structured_judge
+      , _cross_verifier
+      , _media_failover ) ->
+    let runtime_cfg = fusion_toml_or_fail path in
+    (match Fusion_config.of_toml runtime_cfg with
+     | Error errs ->
+       failf
+         "repo fusion config should load: %s"
+         (String.concat ", " (List.map Fusion_config.show_config_error errs))
+     | Ok policy ->
+       List.iter
+         (fun validated_preset ->
+            let preset = Fusion_policy.Validated_preset.preset validated_preset in
+            let judge_runtime_ids =
+              preset.Fusion_policy.judge
+              :: List.map
+                   (fun (judge : Fusion_policy.judge_spec) -> judge.jmodel)
+                   preset.Fusion_policy.judges
+            in
+            List.iter
+              (fun runtime_id ->
+                 let runtime = runtime_by_id_or_fail runtimes runtime_id in
+                 match
+                   Fusion_judge.For_testing.apply_output_contract
+                     runtime.provider_config
+                 with
+                 | Ok _ -> ()
+                 | Error msg ->
+                   failf
+                     "fusion preset %s judge runtime %s must accept native schema: %s"
+                     preset.Fusion_policy.name
+                     runtime_id
+                     msg)
+              judge_runtime_ids)
+         policy.Fusion_policy.presets)
+;;
+
+let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
+  let runtime = runtime_by_id_or_fail runtimes runtime_id in
+  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
+  | Ok _ -> ()
+  | Error msg ->
+    failf
+      "fusion preset %s panel runtime %s must accept native schema: %s"
+      preset
+      runtime_id
+      msg
+;;
+
+let test_repo_fusion_panel_presets_are_schema_capable () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Ast_grep.resolve_path "config/runtime.toml" in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok
+      ( runtimes
+      , _default
+      , _assignments
+      , _librarian
+      , _structured_judge
+      , _cross
+      , _media ) ->
+    let runtime_cfg = fusion_toml_or_fail path in
+    (match Fusion_config.of_toml runtime_cfg with
+     | Error errs ->
+       failf
+         "repo fusion config should load: %s"
+         (String.concat ", " (List.map Fusion_config.show_config_error errs))
+     | Ok policy ->
+       List.iter
+         (fun validated_preset ->
+            let preset = Fusion_policy.Validated_preset.preset validated_preset in
+            List.iter
+              (fun (group : Fusion_policy.panel_group) ->
+                 List.iter
+                   (assert_panel_runtime_accepts_native_schema
+                      runtimes
+                      ~preset:preset.Fusion_policy.name)
+                   group.Fusion_policy.models)
+              preset.Fusion_policy.panels)
+         policy.Fusion_policy.presets)
 ;;
 
 let test_all_fusion_agent_build_files_are_classified () =
@@ -411,6 +530,14 @@ let () =
             "fusion Agent builds do not degrade to JsonMode"
             `Quick
             test_fusion_agent_builds_do_not_degrade_to_json_mode
+        ; test_case
+            "repo Fusion seed judge runtimes accept native schema"
+            `Quick
+            test_repo_fusion_seed_judges_accept_native_schema
+        ; test_case
+            "repo Fusion panel presets use schema-capable runtimes"
+            `Quick
+            test_repo_fusion_panel_presets_are_schema_capable
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -168,6 +168,24 @@ let test_fusion_judge_schema_uses_parser_wire_contract () =
   check bool "fusion schema exposes parser wire fields" true true
 ;;
 
+let test_fusion_panel_schema_uses_answer_contract () =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  check
+    (list string)
+    "fusion panel required fields"
+    [ "answer" ]
+    (required_strings schema);
+  check
+    (option string)
+    "fusion panel answer is string"
+    (Some "string")
+    (match schema |> schema_property "answer" |> schema_member "type" with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check bool "fusion panel schema is closed" false
+    (allows_additional_properties schema)
+;;
+
 let test_verification_verdict_schema_uses_core_ssot () =
   let schema = Keeper_structured_output_schema.verification_verdict_output_schema in
   check
@@ -242,6 +260,10 @@ let () =
             "fusion judge schema uses parser wire contract"
             `Quick
             test_fusion_judge_schema_uses_parser_wire_contract
+        ; test_case
+            "fusion panel schema uses answer contract"
+            `Quick
+            test_fusion_panel_schema_uses_answer_contract
         ] )
     ; ( "verdict schemas"
       , [ test_case

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -692,6 +692,29 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
       assert (contains_substring (assoc_string "detail" json) "not valid JSON")))
 
+let test_run_vision_invalid_structured_response_is_typed () =
+  with_temp_runtime_toml single_vision_runtime_toml (fun () ->
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      Ok (text_response "not-json")
+    in
+    let outcome =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.run_vision
+            ~complete
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~query:"describe"
+            ~media_type:"image/png"
+            ~bytes:"\x89PNG\r\n\x1a\nraw"
+            ()))
+    in
+    match outcome with
+    | Vt.Vo_invalid_structured_response detail ->
+      assert (contains_substring detail "not valid JSON")
+    | _ -> failwith "expected Vo_invalid_structured_response")
+
 let test_retryable_provider_error_tries_next_runtime () =
   with_temp_runtime_toml vision_failover_runtime_toml (fun () ->
     with_temp_base (fun _ ->
@@ -845,6 +868,22 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       assert (List.rev !models = [ "vision-a" ]);
       assert (String.equal (assoc_string "error" json) "provider_error");
       assert (String.equal (assoc_string "failure_class" json) "policy_rejection")))
+
+let test_eager_eviction_reason_preserves_typed_outcome () =
+  let reason = Vi.eager_read_eviction_reason_of_outcome in
+  assert (reason (Vt.Vo_ok "text") = None);
+  assert (reason Vt.Vo_empty = Some "eager_empty");
+  assert (reason Vt.Vo_truncated = Some "eager_truncated");
+  assert (reason Vt.Vo_timeout = Some "eager_timeout");
+  assert (reason (Vt.Vo_no_runtime "missing") = Some "eager_no_runtime");
+  assert (reason (Vt.Vo_invalid_request "bad") = Some "eager_invalid_request");
+  assert
+    (reason (Vt.Vo_invalid_structured_response "bad json")
+     = Some "eager_invalid_structured_response");
+  assert
+    (reason
+       (Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail = "boom" })
+     = Some "eager_provider_error")
 
 let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
   with_temp_base (fun _ ->
@@ -1075,10 +1114,12 @@ let () =
      [with_vision_model_catalog]). *)
   with_vision_model_catalog (fun () ->
     test_invalid_structured_vision_response_is_runtime_failure ();
+    test_run_vision_invalid_structured_response_is_typed ();
     test_retryable_provider_error_tries_next_runtime ();
     test_deadline_exhaustion_preserves_provider_error ();
     test_non_retryable_provider_error_stops_without_trying_next_runtime ();
-    test_accept_rejected_is_policy_rejection_without_failover ());
+    test_accept_rejected_is_policy_rejection_without_failover ();
+    test_eager_eviction_reason_preserves_typed_outcome ());
   test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -347,6 +347,7 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
          (function
            | Agent_sdk.Types.Text text -> Some text
            | Agent_sdk.Types.Thinking _
+           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.RedactedThinking _
            | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.ToolUse _
@@ -369,6 +370,7 @@ let count_tool_blocks messages =
            | Agent_sdk.Types.ToolResult _ -> tool_uses, tool_results + 1
            | Agent_sdk.Types.Text _
            | Agent_sdk.Types.Thinking _
+           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.RedactedThinking _
            | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.Image _

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -346,7 +346,14 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
        List.filter_map
          (function
            | Agent_sdk.Types.Text text -> Some text
-           | _ -> None)
+           | Agent_sdk.Types.Thinking _
+           | Agent_sdk.Types.RedactedThinking _
+           | Agent_sdk.Types.ReasoningDetails _
+           | Agent_sdk.Types.ToolUse _
+           | Agent_sdk.Types.ToolResult _
+           | Agent_sdk.Types.Image _
+           | Agent_sdk.Types.Document _
+           | Agent_sdk.Types.Audio _ -> None)
          msg.content)
     messages
 
@@ -360,7 +367,13 @@ let count_tool_blocks messages =
          (fun (tool_uses, tool_results) -> function
            | Agent_sdk.Types.ToolUse _ -> tool_uses + 1, tool_results
            | Agent_sdk.Types.ToolResult _ -> tool_uses, tool_results + 1
-           | _ -> tool_uses, tool_results)
+           | Agent_sdk.Types.Text _
+           | Agent_sdk.Types.Thinking _
+           | Agent_sdk.Types.RedactedThinking _
+           | Agent_sdk.Types.ReasoningDetails _
+           | Agent_sdk.Types.Image _
+           | Agent_sdk.Types.Document _
+           | Agent_sdk.Types.Audio _ -> tool_uses, tool_results)
          counts
          msg.content)
     (0, 0)

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -349,7 +349,6 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
            | Agent_sdk.Types.Thinking _
            | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.RedactedThinking _
-           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.ToolUse _
            | Agent_sdk.Types.ToolResult _
            | Agent_sdk.Types.Image _
@@ -372,7 +371,6 @@ let count_tool_blocks messages =
            | Agent_sdk.Types.Thinking _
            | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.RedactedThinking _
-           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.Image _
            | Agent_sdk.Types.Document _
            | Agent_sdk.Types.Audio _ -> tool_uses, tool_results)

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -346,14 +346,7 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
        List.filter_map
          (function
            | Agent_sdk.Types.Text text -> Some text
-           | Agent_sdk.Types.Thinking _
-           | Agent_sdk.Types.ReasoningDetails _
-           | Agent_sdk.Types.RedactedThinking _
-           | Agent_sdk.Types.ToolUse _
-           | Agent_sdk.Types.ToolResult _
-           | Agent_sdk.Types.Image _
-           | Agent_sdk.Types.Document _
-           | Agent_sdk.Types.Audio _ -> None)
+           | _ -> None)
          msg.content)
     messages
 
@@ -367,13 +360,7 @@ let count_tool_blocks messages =
          (fun (tool_uses, tool_results) -> function
            | Agent_sdk.Types.ToolUse _ -> tool_uses + 1, tool_results
            | Agent_sdk.Types.ToolResult _ -> tool_uses, tool_results + 1
-           | Agent_sdk.Types.Text _
-           | Agent_sdk.Types.Thinking _
-           | Agent_sdk.Types.ReasoningDetails _
-           | Agent_sdk.Types.RedactedThinking _
-           | Agent_sdk.Types.Image _
-           | Agent_sdk.Types.Document _
-           | Agent_sdk.Types.Audio _ -> tool_uses, tool_results)
+           | _ -> tool_uses, tool_results)
          counts
          msg.content)
     (0, 0)

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -8,11 +8,6 @@ let parse_or_fail content =
   | Ok doc -> doc
   | Error msg -> failf "TOML parse failed: %s" msg
 
-let fusion_toml_or_fail path =
-  match Otoml.Parser.from_file_result path with
-  | Ok toml -> toml
-  | Error msg -> failf "fusion TOML parse failed: %s" msg
-
 let rec repo_root_from dir =
   let dune_project = Filename.concat dir "dune-project" in
   if Sys.file_exists dune_project then dir
@@ -467,48 +462,6 @@ let test_repo_runtime_bindings_resolve_through_oas_catalog () =
          | Some _ -> ())
       runtimes
 
-let runtime_by_id_or_fail runtimes id =
-  match List.find_opt (fun (runtime : Runtime.t) -> String.equal runtime.id id) runtimes with
-  | Some runtime -> runtime
-  | None -> failf "runtime id %s should resolve in repo runtime.toml" id
-
-let test_repo_fusion_seed_judges_accept_native_schema () =
-  with_repo_oas_model_catalog @@ fun _catalog ->
-  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
-  check bool "repo runtime.toml present" true (Sys.file_exists path);
-  match Runtime.load_list ~config_path:path with
-  | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross_verifier, _media_failover) ->
-    let runtime_cfg = fusion_toml_or_fail path in
-    (match Fusion_config.of_toml runtime_cfg with
-     | Error errs ->
-       failf
-         "repo fusion config should load: %s"
-         (String.concat ", " (List.map Fusion_config.show_config_error errs))
-     | Ok policy ->
-       List.iter
-         (fun validated_preset ->
-            let preset = Fusion_policy.Validated_preset.preset validated_preset in
-            let judge_runtime_ids =
-              preset.Fusion_policy.judge
-              :: List.map
-                   (fun (judge : Fusion_policy.judge_spec) -> judge.jmodel)
-                   preset.Fusion_policy.judges
-            in
-            List.iter
-              (fun runtime_id ->
-                 let runtime = runtime_by_id_or_fail runtimes runtime_id in
-                 match Fusion_judge.For_testing.apply_output_contract runtime.provider_config with
-                 | Ok _ -> ()
-                 | Error msg ->
-                   failf
-                     "fusion preset %s judge runtime %s must accept native schema: %s"
-                     preset.Fusion_policy.name
-                     runtime_id
-                     msg)
-              judge_runtime_ids)
-         policy.Fusion_policy.presets)
-
 let test_repo_oas_model_catalog_modality_priorities_resolve () =
   with_repo_oas_model_catalog @@ fun catalog ->
   let rows =
@@ -690,49 +643,6 @@ let test_repo_runtime_toml_loads () =
                caps.thinking_control_format
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.6 capabilities"))
-
-let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
-  let runtime = runtime_by_id_or_fail runtimes runtime_id in
-  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
-  | Ok _ -> ()
-  | Error msg ->
-    failf
-      "fusion preset %s panel runtime %s must accept native schema: %s"
-      preset
-      runtime_id
-      msg
-
-let test_repo_fusion_panel_presets_are_schema_capable () =
-  with_repo_oas_model_catalog @@ fun _catalog ->
-  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
-  match Runtime.load_list ~config_path:path with
-  | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok
-      ( runtimes
-      , _default
-      , _assignments
-      , _librarian
-      , _structured_judge
-      , _cross
-      , _media ) ->
-    let runtime_cfg = fusion_toml_or_fail path in
-    (match Fusion_config.of_toml runtime_cfg with
-     | Error errs ->
-       failf
-         "repo fusion config should load: %s"
-         (String.concat ", " (List.map Fusion_config.show_config_error errs))
-     | Ok policy ->
-       List.iter
-         (fun validated_preset ->
-            let preset = Fusion_policy.Validated_preset.preset validated_preset in
-            List.iter
-              (fun (group : Fusion_policy.panel_group) ->
-                 List.iter
-                   (assert_panel_runtime_accepts_native_schema runtimes
-                      ~preset:preset.Fusion_policy.name)
-                   group.Fusion_policy.models)
-              preset.Fusion_policy.panels)
-         policy.Fusion_policy.presets)
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
@@ -1372,16 +1282,10 @@ let () =
             "repo runtime bindings resolve through the OAS catalog"
             `Quick test_repo_runtime_bindings_resolve_through_oas_catalog;
           test_case
-            "repo Fusion seed judge runtimes accept native schema"
-            `Quick test_repo_fusion_seed_judges_accept_native_schema;
-          test_case
             "repo OAS catalog modality priority strings resolve"
             `Quick test_repo_oas_model_catalog_modality_priorities_resolve;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
-          test_case
-            "repo Fusion panel presets use schema-capable runtimes"
-            `Quick test_repo_fusion_panel_presets_are_schema_capable;
           test_case
             "[runtime].librarian and .cross_verifier resolve, default None, \
              reject unknown"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -687,6 +687,42 @@ let test_repo_runtime_toml_loads () =
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.6 capabilities"))
 
+let fusion_preset_panels toml preset =
+  Otoml.find
+    toml
+    (Otoml.get_array Otoml.get_string)
+    [ "fusion"; "presets"; preset; "panel" ]
+
+let assert_runtime_supports_structured_output runtimes ~preset runtime_id =
+  match find_runtime runtimes runtime_id with
+  | None -> failf "fusion preset %s references unknown runtime %s" preset runtime_id
+  | Some runtime ->
+    (match runtime.model.capabilities with
+     | Some caps ->
+       check
+         bool
+         (Printf.sprintf "%s panel %s supports structured output" preset runtime_id)
+         true
+         caps.supports_structured_output
+     | None ->
+       failf
+         "fusion preset %s runtime %s must declare capabilities"
+         preset
+         runtime_id)
+
+let test_repo_fusion_panel_presets_are_schema_capable () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  let toml = Otoml.Parser.from_file path in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross, _media) ->
+    List.iter
+      (fun preset ->
+         fusion_preset_panels toml preset
+         |> List.iter (assert_runtime_supports_structured_output runtimes ~preset))
+      [ "trio"; "quorum" ]
+
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
     parse_or_fail
@@ -1332,6 +1368,9 @@ let () =
             `Quick test_repo_oas_model_catalog_modality_priorities_resolve;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
+          test_case
+            "repo Fusion panel presets use schema-capable runtimes"
+            `Quick test_repo_fusion_panel_presets_are_schema_capable;
           test_case
             "[runtime].librarian and .cross_verifier resolve, default None, \
              reject unknown"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -691,41 +691,48 @@ let test_repo_runtime_toml_loads () =
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.6 capabilities"))
 
-let fusion_preset_panels toml preset =
-  Otoml.find
-    toml
-    (Otoml.get_array Otoml.get_string)
-    [ "fusion"; "presets"; preset; "panel" ]
-
-let assert_runtime_supports_structured_output runtimes ~preset runtime_id =
-  match find_runtime runtimes runtime_id with
-  | None -> failf "fusion preset %s references unknown runtime %s" preset runtime_id
-  | Some runtime ->
-    (match runtime.model.capabilities with
-     | Some caps ->
-       check
-         bool
-         (Printf.sprintf "%s panel %s supports structured output" preset runtime_id)
-         true
-         caps.supports_structured_output
-     | None ->
-       failf
-         "fusion preset %s runtime %s must declare capabilities"
-         preset
-         runtime_id)
+let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
+  let runtime = runtime_by_id_or_fail runtimes runtime_id in
+  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
+  | Ok _ -> ()
+  | Error msg ->
+    failf
+      "fusion preset %s panel runtime %s must accept native schema: %s"
+      preset
+      runtime_id
+      msg
 
 let test_repo_fusion_panel_presets_are_schema_capable () =
   with_repo_oas_model_catalog @@ fun _catalog ->
   let path = Filename.concat (repo_root ()) "config/runtime.toml" in
-  let toml = Otoml.Parser.from_file path in
   match Runtime.load_list ~config_path:path with
   | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross, _media) ->
-    List.iter
-      (fun preset ->
-         fusion_preset_panels toml preset
-         |> List.iter (assert_runtime_supports_structured_output runtimes ~preset))
-      [ "trio"; "quorum" ]
+  | Ok
+      ( runtimes
+      , _default
+      , _assignments
+      , _librarian
+      , _structured_judge
+      , _cross
+      , _media ) ->
+    let runtime_cfg = fusion_toml_or_fail path in
+    (match Fusion_config.of_toml runtime_cfg with
+     | Error errs ->
+       failf
+         "repo fusion config should load: %s"
+         (String.concat ", " (List.map Fusion_config.show_config_error errs))
+     | Ok policy ->
+       List.iter
+         (fun validated_preset ->
+            let preset = Fusion_policy.Validated_preset.preset validated_preset in
+            List.iter
+              (fun (group : Fusion_policy.panel_group) ->
+                 List.iter
+                   (assert_panel_runtime_accepts_native_schema runtimes
+                      ~preset:preset.Fusion_policy.name)
+                   group.Fusion_policy.models)
+              preset.Fusion_policy.panels)
+         policy.Fusion_policy.presets)
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -8,6 +8,11 @@ let parse_or_fail content =
   | Ok doc -> doc
   | Error msg -> failf "TOML parse failed: %s" msg
 
+let fusion_toml_or_fail path =
+  match Otoml.Parser.from_file_result path with
+  | Ok toml -> toml
+  | Error msg -> failf "fusion TOML parse failed: %s" msg
+
 let rec repo_root_from dir =
   let dune_project = Filename.concat dir "dune-project" in
   if Sys.file_exists dune_project then dir
@@ -461,6 +466,48 @@ let test_repo_runtime_bindings_resolve_through_oas_catalog () =
              runtime.provider_config.model_id
          | Some _ -> ())
       runtimes
+
+let runtime_by_id_or_fail runtimes id =
+  match List.find_opt (fun (runtime : Runtime.t) -> String.equal runtime.id id) runtimes with
+  | Some runtime -> runtime
+  | None -> failf "runtime id %s should resolve in repo runtime.toml" id
+
+let test_repo_fusion_seed_judges_accept_native_schema () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  check bool "repo runtime.toml present" true (Sys.file_exists path);
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross_verifier, _media_failover) ->
+    let runtime_cfg = fusion_toml_or_fail path in
+    (match Fusion_config.of_toml runtime_cfg with
+     | Error errs ->
+       failf
+         "repo fusion config should load: %s"
+         (String.concat ", " (List.map Fusion_config.show_config_error errs))
+     | Ok policy ->
+       List.iter
+         (fun validated_preset ->
+            let preset = Fusion_policy.Validated_preset.preset validated_preset in
+            let judge_runtime_ids =
+              preset.Fusion_policy.judge
+              :: List.map
+                   (fun (judge : Fusion_policy.judge_spec) -> judge.jmodel)
+                   preset.Fusion_policy.judges
+            in
+            List.iter
+              (fun runtime_id ->
+                 let runtime = runtime_by_id_or_fail runtimes runtime_id in
+                 match Fusion_judge.For_testing.apply_output_contract runtime.provider_config with
+                 | Ok _ -> ()
+                 | Error msg ->
+                   failf
+                     "fusion preset %s judge runtime %s must accept native schema: %s"
+                     preset.Fusion_policy.name
+                     runtime_id
+                     msg)
+              judge_runtime_ids)
+         policy.Fusion_policy.presets)
 
 let test_repo_oas_model_catalog_modality_priorities_resolve () =
   with_repo_oas_model_catalog @@ fun catalog ->
@@ -1277,6 +1324,9 @@ let () =
           test_case
             "repo runtime bindings resolve through the OAS catalog"
             `Quick test_repo_runtime_bindings_resolve_through_oas_catalog;
+          test_case
+            "repo Fusion seed judge runtimes accept native schema"
+            `Quick test_repo_fusion_seed_judges_accept_native_schema;
           test_case
             "repo OAS catalog modality priority strings resolve"
             `Quick test_repo_oas_model_catalog_modality_priorities_resolve;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -570,7 +570,7 @@ let test_repo_runtime_toml_loads () =
     check
       (option string)
       "structured judge runtime"
-      (Some "ollama_cloud.minimax-m3")
+      (Some "ollama_cloud.ollama-cloud-devstral-2-123b")
       structured_judge;
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
@@ -659,7 +659,11 @@ let test_repo_runtime_toml_loads () =
        check string "MiniMax M3 api name" "minimax-m3" runtime.model.api_name;
        check int "MiniMax M3 context" 524288 runtime.model.max_context;
        (match runtime.model.capabilities with
-        | Some caps ->
+       | Some caps ->
+          check bool "MiniMax M3 response_format json disabled" false
+            caps.supports_response_format_json;
+          check bool "MiniMax M3 structured output disabled" false
+            caps.supports_structured_output;
           check bool "MiniMax M3 image input" true caps.supports_image_input;
           check bool "MiniMax M3 multimodal input" true
             caps.supports_multimodal_inputs;

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -230,6 +230,27 @@ let test_parse_verdict_rejects_warning_prefix () =
       (String.length msg > 0)
   | Ok _ -> Alcotest.fail "WARNING should be rejected as invalid verdict"
 
+let test_parse_response_text_accepts_strict_json () =
+  let raw =
+    {|{"verdict":"WARN","reason":"minor issue","evidence":[]}|}
+  in
+  match Verifier_oas.For_testing.parse_verdict_from_response_text raw with
+  | Ok (Core.Warn reason) ->
+    Alcotest.(check string) "reason" "minor issue" reason
+  | Ok other ->
+    Alcotest.failf
+      "expected WARN, got %s"
+      (Core.verdict_to_string other)
+  | Error msg -> Alcotest.fail ("strict JSON response rejected: " ^ msg)
+
+let test_parse_response_text_rejects_plain_verdict () =
+  match Verifier_oas.For_testing.parse_verdict_from_response_text "PASS" with
+  | Error _ -> ()
+  | Ok verdict ->
+    Alcotest.failf
+      "plain verdict should be rejected, got %s"
+      (Core.verdict_to_string verdict)
+
 (* ================================================================ *)
 (* should_skip (verify fast path)                                    *)
 (* ================================================================ *)
@@ -369,6 +390,10 @@ let () =
         test_parse_verdict_rejects_passing_prefix;
       Alcotest.test_case "WARNING prefix rejected" `Quick
         test_parse_verdict_rejects_warning_prefix;
+      Alcotest.test_case "response text accepts strict JSON" `Quick
+        test_parse_response_text_accepts_strict_json;
+      Alcotest.test_case "response text rejects plain verdict" `Quick
+        test_parse_response_text_rejects_plain_verdict;
     ]);
     ("verify_skip", [
       Alcotest.test_case "read-only skips" `Quick test_verify_skips_readonly;

--- a/test_lib/ast_grep.ml
+++ b/test_lib/ast_grep.ml
@@ -54,6 +54,12 @@ let rec longident_to_string : Longident.t -> string = function
     ^ ")"
 ;;
 
+let rec longident_leaf : Longident.t -> string = function
+  | Lident s -> s
+  | Ldot (_, name) -> name.Location.txt
+  | Lapply (_, r) -> longident_leaf r.Location.txt
+;;
+
 (* Count function-application sites where the callee identifier matches
    [callee] exactly (string form "Module.fn" or just "fn" for unqualified).
    Skips comments / docstrings (AST has no nodes for them). *)
@@ -134,6 +140,42 @@ let count_calls_with_label ~module_path ~callee ~label =
            | Pexp_apply ({ pexp_desc = Pexp_ident { txt; _ }; _ }, args)
              when String.equal (longident_to_string txt) callee
                   && has_label args -> incr count
+           | _ -> ());
+          Ast_iterator.default_iterator.expr self e)
+    }
+  in
+  iter.structure iter structure;
+  !count
+;;
+
+let count_constructors ~module_path ~constructor =
+  let structure = parse_implementation_or_fail module_path in
+  let count = ref 0 in
+  let iter =
+    { Ast_iterator.default_iterator with
+      expr =
+        (fun self e ->
+          (match e.pexp_desc with
+           | Pexp_construct ({ txt; _ }, _) ->
+             if longident_to_string txt = constructor then incr count
+           | _ -> ());
+          Ast_iterator.default_iterator.expr self e)
+    }
+  in
+  iter.structure iter structure;
+  !count
+;;
+
+let count_constructor_leaf_names ~module_path ~name =
+  let structure = parse_implementation_or_fail module_path in
+  let count = ref 0 in
+  let iter =
+    { Ast_iterator.default_iterator with
+      expr =
+        (fun self e ->
+          (match e.pexp_desc with
+           | Pexp_construct ({ txt; _ }, _) ->
+             if String.equal (longident_leaf txt) name then incr count
            | _ -> ());
           Ast_iterator.default_iterator.expr self e)
     }


### PR DESCRIPTION
## Summary
- make Fusion judge output contract fail loud when provider-native JsonSchema is unsupported
- remove the JsonMode downgrade path for Fusion judge synthesis
- add coverage so structured Fusion judges cannot reintroduce Agent_sdk.Types.JsonMode

## Validation
- git diff --check
- ocamlformat --check lib/fusion/fusion_judge.ml lib/fusion/fusion_judge.mli test/test_fusion_judge_usage.ml test/test_keeper_structured_output_coverage.ml

Stacked on #22765. Local Dune build/test intentionally left to CI per operator instruction.