### PR TITLE
fix(dashboard): make settings config surfaces live-backed

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -476,3 +476,27 @@ export async function saveRuntimeTomlConfig(sourceText: string): Promise<Runtime
     source_text: sourceText,
   }).then(normalizeRuntimeTomlConfig)
 }
+
+export type RuntimeRoutingLane = 'default' | 'librarian' | 'cross_verifier'
+
+export async function patchRuntimeRouting(
+  lane: RuntimeRoutingLane,
+  runtimeId: string | null,
+): Promise<RuntimeTomlConfig> {
+  await ensureDevToken()
+  return post<unknown>('/api/v1/runtime/config/routing', {
+    lane,
+    runtime_id: runtimeId,
+  }).then(normalizeRuntimeTomlConfig)
+}
+
+export async function patchRuntimeAssignment(
+  keeperName: string,
+  runtimeId: string | null,
+): Promise<RuntimeTomlConfig> {
+  await ensureDevToken()
+  return post<unknown>('/api/v1/runtime/config/assignment', {
+    keeper_name: keeperName,
+    runtime_id: runtimeId,
+  }).then(normalizeRuntimeTomlConfig)
+}

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -38,6 +38,8 @@ import {
   fetchRuntimeTomlConfig,
   fetchRuntimeDefaults,
   fetchRuntimeModelMetrics,
+  patchRuntimeAssignment,
+  patchRuntimeRouting,
   patchKeeperConfig,
   saveRuntimeTomlConfig,
   fetchDashboardCacheStats,
@@ -2302,6 +2304,64 @@ describe('runtime.toml raw config API', () => {
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body as string)).toEqual({ source_text: sourceText })
     expect(result.reloaded).toBe(true)
+    expect(result.source_text).toBe(sourceText)
+  })
+
+  it('posts runtime routing patches without client-side TOML text', async () => {
+    const sourceText = '[runtime]\ndefault = "openai.gpt"\nlibrarian = "openai.gpt"\n'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: '/tmp/.masc/config/runtime.toml',
+        file_name: 'runtime.toml',
+        source_text: sourceText,
+        reloaded: true,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await patchRuntimeRouting('librarian', 'openai.gpt')
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/config/routing')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      lane: 'librarian',
+      runtime_id: 'openai.gpt',
+    })
+    expect(result.source_text).toBe(sourceText)
+  })
+
+  it('posts runtime assignment patches without client-side TOML text', async () => {
+    const sourceText = '[runtime.assignments]\nsangsu = "openai.gpt"\n'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: '/tmp/.masc/config/runtime.toml',
+        file_name: 'runtime.toml',
+        source_text: sourceText,
+        reloaded: true,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await patchRuntimeAssignment('sangsu', null)
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/config/assignment')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      keeper_name: 'sangsu',
+      runtime_id: null,
+    })
     expect(result.source_text).toBe(sourceText)
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -131,6 +131,7 @@ export type {
   LatencyBucket,
   DashboardRuntimeModelMetricsResponse,
   RuntimeTomlConfig,
+  RuntimeRoutingLane,
 } from './dashboard-runtime'
 export {
   fetchRuntimeProviders,
@@ -138,6 +139,8 @@ export {
   fetchRuntimeTomlConfig,
   fetchRuntimeDefaults,
   saveRuntimeTomlConfig,
+  patchRuntimeAssignment,
+  patchRuntimeRouting,
 } from './dashboard-runtime'
 
 export type {

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -78,46 +78,6 @@ function capChip(on: boolean, label: string) {
   return html`<span class="rt-cap ${on ? 'on' : ''}">${on ? '✓' : '·'} ${label}</span>`
 }
 
-// Read a bare [runtime] string value (librarian / cross_verifier) straight from
-// the draft. The parser only surfaces `default`, so the extra routing lanes are
-// read here from the same source text the parser consumes. Matches the
-// parser's [section] header + key = "value" grammar.
-function readRuntimeLaneValue(sourceText: string, key: string): string {
-  const lines = sourceText.split('\n')
-  let inRuntime = false
-  for (const rawLine of lines) {
-    const headerMatch = rawLine.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
-    if (headerMatch) {
-      inRuntime = headerMatch[1]?.trim() === 'runtime'
-      continue
-    }
-    if (!inRuntime) continue
-    const keyMatch = rawLine.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$/)
-    if (keyMatch && keyMatch[1] === key) return keyMatch[2] ?? ''
-  }
-  return ''
-}
-
-// Read [runtime.assignments] keeper -> runtime id from the draft. Same grammar
-// as the parser; surfaces explicit assignments so each keeper row reflects what
-// runtime.toml actually pins (and falls back to default when absent).
-function readRuntimeAssignments(sourceText: string): Record<string, string> {
-  const lines = sourceText.split('\n')
-  let inSection = false
-  const assignments: Record<string, string> = {}
-  for (const rawLine of lines) {
-    const headerMatch = rawLine.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
-    if (headerMatch) {
-      inSection = headerMatch[1]?.trim() === 'runtime.assignments'
-      continue
-    }
-    if (!inSection) continue
-    const keyMatch = rawLine.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$/)
-    if (keyMatch?.[1]) assignments[keyMatch[1]] = keyMatch[2] ?? ''
-  }
-  return assignments
-}
-
 // keeper.status -> StatusDot tone (bg). Mirrors copilot-dock's run/idle/bad
 // split; tone classes are the existing --color-status-* tokens.
 function keeperDotTone(status: string): string {
@@ -146,9 +106,9 @@ export function RuntimeEnvironmentEditor({
   const runtimeIds = runtimeOptions(environment)
   const isDisabled = disabled === true || saving === true
 
-  const librarianLane = readRuntimeLaneValue(sourceText, 'librarian')
-  const crossVerifierLane = readRuntimeLaneValue(sourceText, 'cross_verifier')
-  const assignments = readRuntimeAssignments(sourceText)
+  const librarianLane = environment.librarianRuntimeId
+  const crossVerifierLane = environment.crossVerifierRuntimeId
+  const assignments = environment.assignments
   const keeperList = keepers.value
 
   const filteredModels = environment.models.filter(model => {
@@ -162,6 +122,10 @@ export function RuntimeEnvironmentEditor({
   }
 
   function updateRoutingLane(lane: 'librarian' | 'cross_verifier', runtimeId: string) {
+    if (runtimeId === '') {
+      onDraftChange(deleteRuntimeTomlKey(sourceText, 'runtime', lane))
+      return
+    }
     onDraftChange(setRuntimeTomlKey(sourceText, 'runtime', lane, runtimeId))
   }
 
@@ -207,6 +171,7 @@ export function RuntimeEnvironmentEditor({
     onChange: (runtimeId: string) => void,
     needsJson: boolean,
   ) {
+    const canUnset = lane !== 'default'
     const binding = environment.bindings.find(b => b.id === value)
     const model = binding ? environment.models.find(m => m.id === binding.modelId) : null
     const hasJsonCap = model ? (typeof model.jsonSupport === 'boolean' ? model.jsonSupport : null) : false
@@ -230,8 +195,10 @@ export function RuntimeEnvironmentEditor({
             value=${value}
             disabled=${isDisabled}
             aria-label=${lane === 'default' ? 'default runtime' : `${lane} runtime`}
+            onInput=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
             onChange=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
           >
+            ${canUnset ? html`<option value="">미설정</option>` : null}
             ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
           </select>
           ${capWarning}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,23 +1,11 @@
 import { html } from 'htm/preact'
-import { Save } from 'lucide-preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
-  deleteRuntimeTomlKey,
   parseRuntimeTomlEnvironment,
-  setRuntimeTomlBindingField,
-  setRuntimeTomlDefault,
-  setRuntimeTomlKey,
-  setRuntimeTomlModelField,
-  setRuntimeTomlProviderCredential,
-  setRuntimeTomlProviderField,
-  cascadeDeleteProvider,
-  type RuntimeTomlBinding,
-  type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
   type RuntimeTomlProvider,
 } from '../lib/runtime-toml-config'
 import { keepers } from '../store'
-import { ActionButton } from './common/button'
 import { StatusDot } from './common/status-dot'
 
 // rt-* section ids. Mirrors RUNTIME_SECTIONS in runtime-toml-editor.ts so the
@@ -33,21 +21,14 @@ export type RuntimeStructuredSection =
 interface RuntimeEnvironmentEditorProps {
   sourceText: string
   section: RuntimeStructuredSection
-  dirty: boolean
   disabled?: boolean
   saving?: boolean
-  onDraftChange: (sourceText: string) => void
-  onSave: (sourceText?: string) => void
+  onRoutingChange: (lane: 'default' | 'librarian' | 'cross_verifier', runtimeId: string | null) => void
+  onAssignmentChange: (keeperName: string, runtimeId: string | null) => void
 }
 
 function firstId<T extends { id: string }>(items: T[]): string {
   return items[0]?.id ?? ''
-}
-
-function parsePositiveInt(value: string): number | null {
-  const trimmed = value.trim()
-  const parsed = Number.parseInt(trimmed, 10)
-  return Number.isFinite(parsed) && parsed > 0 && String(parsed) === trimmed ? parsed : null
 }
 
 function runtimeOptions(environment: RuntimeTomlEnvironment): string[] {
@@ -94,11 +75,10 @@ function keeperDotTone(status: string): string {
 export function RuntimeEnvironmentEditor({
   sourceText,
   section,
-  dirty,
   disabled,
   saving,
-  onDraftChange,
-  onSave,
+  onRoutingChange,
+  onAssignmentChange,
 }: RuntimeEnvironmentEditorProps) {
   const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
   const [modelQuery, setModelQuery] = useState('')
@@ -118,44 +98,19 @@ export function RuntimeEnvironmentEditor({
   })
 
   function updateDefault(runtimeId: string) {
-    onDraftChange(setRuntimeTomlDefault(sourceText, runtimeId))
+    if (runtimeId !== '') onRoutingChange('default', runtimeId)
   }
 
   function updateRoutingLane(lane: 'librarian' | 'cross_verifier', runtimeId: string) {
-    if (runtimeId === '') {
-      onDraftChange(deleteRuntimeTomlKey(sourceText, 'runtime', lane))
-      return
-    }
-    onDraftChange(setRuntimeTomlKey(sourceText, 'runtime', lane, runtimeId))
-  }
-
-  function updateProvider(providerId: string, field: 'endpoint', value: string) {
-    onDraftChange(setRuntimeTomlProviderField(sourceText, providerId, field, value))
-  }
-
-  function updateCredential(providerId: string, type: RuntimeTomlCredentialType, value: string) {
-    onDraftChange(setRuntimeTomlProviderCredential(sourceText, providerId, type, value))
-  }
-
-  function setDefaultBinding(binding: RuntimeTomlBinding) {
-    onDraftChange(setRuntimeTomlDefault(sourceText, binding.id))
-  }
-
-  function updateBinding(
-    runtimeId: string,
-    field: 'max-concurrent' | 'num-ctx',
-    value: number | null,
-  ) {
-    onDraftChange(setRuntimeTomlBindingField(sourceText, runtimeId, field, value))
+    onRoutingChange(lane, runtimeId === '' ? null : runtimeId)
   }
 
   function updateAssignment(keeperName: string, runtimeId: string) {
     if (runtimeId === environment.defaultRuntimeId) {
-      // default == fallback; drop the explicit pin so toml stays minimal.
-      onDraftChange(deleteRuntimeTomlKey(sourceText, 'runtime.assignments', keeperName))
+      onAssignmentChange(keeperName, null)
       return
     }
-    onDraftChange(setRuntimeTomlKey(sourceText, 'runtime.assignments', keeperName, runtimeId))
+    onAssignmentChange(keeperName, runtimeId)
   }
 
   // rt-select — runtime.css:43. Inline width cap so the 248px min-width never
@@ -195,7 +150,6 @@ export function RuntimeEnvironmentEditor({
             value=${value}
             disabled=${isDisabled}
             aria-label=${lane === 'default' ? 'default runtime' : `${lane} runtime`}
-            onInput=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
             onChange=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
           >
             ${canUnset ? html`<option value="">미설정</option>` : null}
@@ -211,20 +165,7 @@ export function RuntimeEnvironmentEditor({
     <div data-testid="runtime-environment-editor">
       <div class="rt-head-actions" style=${{ justifyContent: 'flex-end', marginBottom: '14px' }}>
         <span class="rt-nav-sub mono" style=${{ marginRight: 'auto' }}>런타임 환경</span>
-        <${ActionButton}
-          variant="primary"
-          size="sm"
-          onClick=${() => onSave(sourceText)}
-          disabled=${!dirty || isDisabled}
-          ariaBusy=${saving === true}
-          ariaLabel="런타임 환경 저장"
-          title="런타임 환경 저장"
-          testId="runtime-environment-save"
-          class="inline-flex shrink-0 items-center gap-1"
-        >
-          <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-          <span>${saving ? '저장 중' : '환경 저장'}</span>
-        <//>
+        <span class="rt-nav-sub mono">${saving ? '저장 중' : 'backend typed writer'}</span>
       </div>
 
       ${environment.warnings.length > 0 ? html`
@@ -271,9 +212,9 @@ export function RuntimeEnvironmentEditor({
         )}
       </div>
 
-      <!-- providers — runtime-editor.jsx:144-165. endpoint + credential editable;
-           protocol shown read-only. provider capability chips
-           (mcp-tools/tool-events/mcp-http-headers) have no live source. -->
+      <!-- providers — runtime-editor.jsx:144-165. Read-only projection. Live
+           writes stay behind backend typed routes or the raw editor's validated
+           save; this component does not rewrite TOML text. -->
       <div class=${section === 'providers' ? '' : 'hidden'} data-testid="runtime-section-providers">
         <div class="rt-cards">
           ${environment.providers.map(provider => html`
@@ -288,9 +229,8 @@ export function RuntimeEnvironmentEditor({
                 <input
                   class="rt-input mono"
                   value=${transportValue(provider)}
-                  disabled=${isDisabled}
+                  readOnly
                   aria-label="provider transport value"
-                  onInput=${(event: Event) => updateProvider(provider.id, 'endpoint', (event.currentTarget as HTMLInputElement).value)}
                 />
               </div>
               <div class="rt-field">
@@ -301,34 +241,19 @@ export function RuntimeEnvironmentEditor({
                     <span class="rt-cred">
                       <span class="rt-cred-type mono">${provider.credentialType}</span>
                       <input
-                        class="rt-input mono"
-                        type=${provider.credentialType === 'inline' ? 'password' : 'text'}
-                        value=${credentialValue(provider)}
-                        disabled=${isDisabled}
-                        aria-label="provider credential value"
-                        onInput=${(event: Event) => updateCredential(provider.id, provider.credentialType, (event.currentTarget as HTMLInputElement).value)}
-                      />
-                    </span>
+                      class="rt-input mono"
+                      type=${provider.credentialType === 'inline' ? 'password' : 'text'}
+                      value=${credentialValue(provider)}
+                      readOnly
+                      aria-label="provider credential value"
+                    />
+                  </span>
                   `}
               </div>
               ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
                    with no backing (PR #22081 review P1: no stub). */ ''}
-              <div class="rt-field" style=${{ marginTop: '11px', paddingTop: '11px', borderTop: '1px solid var(--border-soft)' }}>
-                <button
-                  type="button"
-                  class="rt-warn"
-                  style=${{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '11px' }}
-                  disabled=${isDisabled}
-                  onClick=${() => {
-                    const msg = `프로바이더 '${provider.id}'를 삭제할까요? 관련 모델 바인딩 및 런타임 할당이 모두 삭제됩니다.`
-                    if (typeof window !== 'undefined' && !window.confirm(msg)) return
-                    onDraftChange(cascadeDeleteProvider(sourceText, provider.id))
-                  }}
-                  data-testid=${`runtime-provider-delete-${provider.id}`}
-                >프로바이더 삭제</button>
-              </div>
             </div>
           `)}
         </div>
@@ -372,15 +297,8 @@ export function RuntimeEnvironmentEditor({
                   class="rt-input-sm mono"
                   value=${model.maxContext == null ? '' : String(model.maxContext)}
                   placeholder="—"
-                  disabled=${isDisabled}
+                  readOnly
                   aria-label=${`${model.id} max-context`}
-                  onInput=${(event: Event) => {
-                    const raw = (event.currentTarget as HTMLInputElement).value
-                    const parsed = raw.trim() === '' ? null : parsePositiveInt(raw)
-                    if (parsed !== undefined) {
-                      onDraftChange(setRuntimeTomlModelField(sourceText, model.id, 'max-context', parsed))
-                    }
-                  }}
                 />
               </div>
             </div>
@@ -411,7 +329,7 @@ export function RuntimeEnvironmentEditor({
                   title="기본 런타임으로"
                   aria-label=${`${binding.id} 기본 런타임으로`}
                   aria-pressed=${isDefault}
-                  onClick=${() => setDefaultBinding(binding)}
+                  onClick=${() => updateDefault(binding.id)}
                 >${isDefault ? '◉' : '○'}</button>
                 <div class="rt-bind-main">
                   <div class="rt-bind-key mono">
@@ -428,12 +346,8 @@ export function RuntimeEnvironmentEditor({
                       class="rt-input-sm mono"
                       value=${binding.maxConcurrent == null ? '' : String(binding.maxConcurrent)}
                       placeholder="∞"
-                      disabled=${isDisabled}
+                      readOnly
                       aria-label=${`${binding.id} max-concurrent`}
-                      onInput=${(event: Event) => {
-                        const raw = (event.currentTarget as HTMLInputElement).value
-                        updateBinding(binding.id, 'max-concurrent', raw.trim() === '' ? null : parsePositiveInt(raw))
-                      }}
                     />
                   </label>
                   <label class="rt-mini">
@@ -442,12 +356,8 @@ export function RuntimeEnvironmentEditor({
                       class="rt-input-sm mono"
                       value=${binding.numCtx == null ? '' : String(binding.numCtx)}
                       placeholder="—"
-                      disabled=${isDisabled}
+                      readOnly
                       aria-label=${`${binding.id} num-ctx`}
-                      onInput=${(event: Event) => {
-                        const raw = (event.currentTarget as HTMLInputElement).value
-                        updateBinding(binding.id, 'num-ctx', raw.trim() === '' ? null : parsePositiveInt(raw))
-                      }}
                     />
                   </label>
                 </div>

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -5,11 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apiMocks = vi.hoisted(() => ({
   fetchRuntimeTomlConfig: vi.fn(),
+  patchRuntimeAssignment: vi.fn(),
+  patchRuntimeRouting: vi.fn(),
   saveRuntimeTomlConfig: vi.fn(),
 }))
 
 vi.mock('../api/dashboard', () => ({
   fetchRuntimeTomlConfig: apiMocks.fetchRuntimeTomlConfig,
+  patchRuntimeAssignment: apiMocks.patchRuntimeAssignment,
+  patchRuntimeRouting: apiMocks.patchRuntimeRouting,
   saveRuntimeTomlConfig: apiMocks.saveRuntimeTomlConfig,
 }))
 
@@ -95,8 +99,23 @@ describe('RuntimeTomlEditor', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     apiMocks.fetchRuntimeTomlConfig.mockReset()
+    apiMocks.patchRuntimeAssignment.mockReset()
+    apiMocks.patchRuntimeRouting.mockReset()
     apiMocks.saveRuntimeTomlConfig.mockReset()
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValue(baseConfig)
+    apiMocks.patchRuntimeAssignment.mockImplementation(async (_keeperName: string, runtimeId: string | null) => ({
+      ...richConfig,
+      source_text: `${richConfig.source_text}\n[runtime.assignments]\nsangsu = ${JSON.stringify(runtimeId ?? 'runpod_mtp.qwen')}\n`,
+      reloaded: true,
+    }))
+    apiMocks.patchRuntimeRouting.mockImplementation(async (lane: string, runtimeId: string | null) => ({
+      ...richConfig,
+      source_text: richConfig.source_text.replace(
+        'default = "runpod_mtp.qwen"',
+        lane === 'default' && runtimeId ? `default = "${runtimeId}"` : 'default = "runpod_mtp.qwen"',
+      ),
+      reloaded: true,
+    }))
     apiMocks.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
       ...baseConfig,
       source_text: sourceText,
@@ -164,7 +183,7 @@ describe('RuntimeTomlEditor', () => {
     expect(container.querySelector('[data-testid="runtime-toml-impact-preview"]')).toBeNull()
   })
 
-  it('edits runtime environment fields through the structured controls', async () => {
+  it('renders runtime environment fields as structured projections without raw TOML mutation', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -181,27 +200,13 @@ describe('RuntimeTomlEditor', () => {
         .toBe('https://runpod.example/v1')
     })
 
-    fireEvent.input(container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement, {
-      target: { value: 'https://runpod.example/v2' },
-    })
-    await waitFor(() => {
-      expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('endpoint = "https://runpod.example/v2"')
-    })
-    fireEvent.input(container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement, {
-      target: { value: '262144' },
-    })
-    fireEvent.click(container.querySelector('[data-testid="runtime-environment-save"]') as HTMLButtonElement)
-
-    await waitFor(() => {
-      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledTimes(1)
-    })
-    const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
-    expect(savedSource).toContain('endpoint = "https://runpod.example/v2"')
-    expect(savedSource).toContain('num-ctx = 262144')
-    expect(savedSource).toContain('[providers.openai]')
+    expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement).readOnly).toBe(true)
+    expect((container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement).readOnly).toBe(true)
+    expect(container.querySelector('[data-testid="runtime-environment-save"]')).toBeNull()
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
   })
 
-  it('switches the default runtime from the structured runtime selector', async () => {
+  it('switches the default runtime through the typed backend routing patch', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -215,9 +220,11 @@ describe('RuntimeTomlEditor', () => {
     })
 
     await waitFor(() => {
+      expect(apiMocks.patchRuntimeRouting).toHaveBeenCalledWith('default', 'openai.gpt')
       expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('default = "openai.gpt"')
     })
-    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
   })
 
   it('saves from the editor keyboard shortcut', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -3,8 +3,11 @@ import { Copy, RefreshCcw, RotateCcw, Save } from 'lucide-preact'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   fetchRuntimeTomlConfig,
+  patchRuntimeAssignment,
+  patchRuntimeRouting,
   saveRuntimeTomlConfig,
   type RuntimeTomlConfig,
+  type RuntimeRoutingLane,
 } from '../api/dashboard'
 import { errorToString } from '../lib/format-string'
 import {
@@ -210,6 +213,40 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     setNotice(null)
     try {
       const saved = await saveRuntimeTomlConfig(nextSourceText)
+      setConfig(saved)
+      setDraft(saved.source_text)
+      setNotice('적용됨')
+    } catch (err: unknown) {
+      setError(errorToString(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRoutingPatch(lane: RuntimeRoutingLane, runtimeId: string | null) {
+    if (saving || loadState === 'loading' || dirty) return
+    setSaving(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const saved = await patchRuntimeRouting(lane, runtimeId)
+      setConfig(saved)
+      setDraft(saved.source_text)
+      setNotice('적용됨')
+    } catch (err: unknown) {
+      setError(errorToString(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAssignmentPatch(keeperName: string, runtimeId: string | null) {
+    if (saving || loadState === 'loading' || dirty) return
+    setSaving(true)
+    setError(null)
+    setNotice(null)
+    try {
+      const saved = await patchRuntimeAssignment(keeperName, runtimeId)
       setConfig(saved)
       setDraft(saved.source_text)
       setNotice('적용됨')
@@ -471,15 +508,13 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
               <${RuntimeEnvironmentEditor}
                 sourceText=${draft}
                 section=${structuredSection}
-                dirty=${dirty}
-                disabled=${loadState !== 'loaded'}
+                disabled=${loadState !== 'loaded' || dirty}
                 saving=${saving}
-                onDraftChange=${(nextSourceText: string) => {
-                  setDraft(nextSourceText)
-                  setNotice(null)
+                onRoutingChange=${(lane: RuntimeRoutingLane, runtimeId: string | null) => {
+                  void handleRoutingPatch(lane, runtimeId)
                 }}
-                onSave=${(nextSourceText?: string) => {
-                  void handleSave(nextSourceText)
+                onAssignmentChange=${(keeperName: string, runtimeId: string | null) => {
+                  void handleAssignmentPatch(keeperName, runtimeId)
                 }}
               />
             </div>

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -260,7 +260,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     network_mode: 'inherit',
     sandbox_last_error: null,
     allowed_paths: ['workspace/masc'],
-    effective_allowed_paths: ['/Users/dancer/me/workspace/yousleepwhen/masc'],
+    effective_allowed_paths: ['/fixture/workspace/masc'],
     prompt: {
       goal: '',
       instructions: '',
@@ -339,7 +339,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       total_active: 0,
     },
     sources: {
-      live_meta_path: '/Users/dancer/me/.masc/config/keepers/sangsu.toml',
+      live_meta_path: '/fixture/.masc/config/keepers/sangsu.toml',
       default_manifest_path: null,
       default_source_kind: 'toml',
       precedence: [],
@@ -725,6 +725,21 @@ describe('SettingsSurface', () => {
     expect(container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')?.value).toBe('http://127.0.0.1:7777/mcp')
   })
 
+  it('does not render a fabricated stdio process pid in the MCP preview', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
+
+    const stdio = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
+      .find(button => button.textContent === 'stdio')
+    expect(stdio).toBeTruthy()
+    await fireEvent.click(stdio as HTMLButtonElement)
+
+    const detail = container.querySelector('.set-mcp-detail')?.textContent ?? ''
+    expect(detail).toContain('masc-mcp serve --stdio')
+    expect(detail).not.toContain('pid 8421')
+  })
+
   it('edits sandbox from live keeper config instead of fake global controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 
@@ -770,7 +785,7 @@ describe('SettingsSurface', () => {
         allowed_paths: ['workspace/oas'],
       })
     })
-    expect(container.querySelector('[data-testid="settings-sandbox-source"]')?.textContent).toContain('/Users/dancer/me/.masc/config/keepers/sangsu.toml')
+    expect(container.querySelector('[data-testid="settings-sandbox-source"]')?.textContent).toContain('/fixture/.masc/config/keepers/sangsu.toml')
   })
 
   it('falls back to fleet composite keeper names when sandbox opens before the keeper store is hydrated', async () => {
@@ -951,7 +966,8 @@ mad-improver = "p.m1"
       expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
       expect(container.querySelector('[data-testid="runtime-toml-editor"]')).not.toBeNull()
       expect(container.querySelector('[data-testid="runtime-section-routing"]')).not.toBeNull()
-      expect(container.querySelector('[data-testid="runtime-environment-save"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-environment-save"]')).toBeNull()
+      expect(container.textContent).toContain('backend typed writer')
     })
     expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('모델 라우팅')
     expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('라우팅')
@@ -1061,7 +1077,7 @@ mad-improver = "p.m1"
     expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
   })
 
-  it('MCP exposed-tool toggles are clickable local controls', async () => {
+  it('MCP exposed-tool toggles are browser-session exposure previews', async () => {
     apiMock.fetchDashboardTools.mockResolvedValue({
       tool_inventory: {
         count: 2,
@@ -1076,8 +1092,10 @@ mad-improver = "p.m1"
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
     await waitFor(() => {
-      expect(container.textContent).toContain('Exposed tools (2/2)')
+      expect(container.textContent).toContain('Local tool exposure preview (2/2)')
     })
+    expect(container.querySelector('[data-testid="mcp-local-summary"]')?.textContent).toContain('2/2 listed tools selected')
+    expect(container.textContent).toContain('browser-session exposure previews only')
 
     const toggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
     expect(toggles.length).toBe(2)
@@ -1087,7 +1105,64 @@ mad-improver = "p.m1"
     await fireEvent.click(toggles[0]!)
 
     expect(toggles[0]!.getAttribute('aria-checked')).toBe('false')
-    expect(container.textContent).toContain('Exposed tools (1/2)')
+    expect(container.textContent).toContain('Local tool exposure preview (1/2)')
+    expect(sessionStorage.getItem('masc.settings.local.mcpToolPreview')).toContain('"masc_handoff":false')
+
+    render(null, container)
+    route.value = { tab: 'settings', params: {}, postId: null }
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="mcp-local-summary"]')?.textContent).toContain('1/2 listed tools selected')
+    })
+    const restoredToggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
+    expect(restoredToggles[0]!.getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('notify controls are browser-session previews with persisted thresholds and events', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Slack channel')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('4/5 events enabled')
+
+    const range = container.querySelector<HTMLInputElement>('input[type="range"]')
+    expect(range).toBeTruthy()
+    await fireEvent.input(range as HTMLInputElement, { target: { value: '92' } })
+
+    const plus = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent === '+')
+    expect(plus).toBeTruthy()
+    await fireEvent.click(plus as HTMLButtonElement)
+
+    const discord = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
+      .find(button => button.textContent === 'Discord')
+    expect(discord).toBeTruthy()
+    await fireEvent.click(discord as HTMLButtonElement)
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="set-toggle"]')
+    expect(toggle).toBeTruthy()
+    await fireEvent.click(toggle as HTMLButtonElement)
+
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Discord channel')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('context 92%')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('failures 4')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('3/5 events enabled')
+    expect(sessionStorage.getItem('masc.settings.local.notifyContextThreshold')).toBe('92')
+    expect(sessionStorage.getItem('masc.settings.local.notifyFailureThreshold')).toBe('4')
+    expect(sessionStorage.getItem('masc.settings.local.notifyChannel')).toBe('Discord')
+    expect(sessionStorage.getItem('masc.settings.local.notifyEventPreview')).toContain('"컨텍스트 임계치 초과":false')
+
+    render(null, container)
+    route.value = { tab: 'settings', params: {}, postId: null }
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Discord channel')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('context 92%')
+    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('failures 4')
   })
 
   it('renders the fusion preset section (panel families + judge) read-only', async () => {

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -20,12 +20,15 @@ import type {
   LogEntry,
   RuntimeDefaultsResponse,
 } from '../api/dashboard'
+import type { GateConnectorsData, GateConnectorInfo } from '../api/gate'
+import type { Keeper, KeeperConfig } from '../types'
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 
 const MOCK_RUNTIME_PATH = 'fixture/config/runtime.toml'
 import { dashboardLoading } from '../store'
+import { keepers } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { resetDevTokenBootstrap } from '../api/dev-token'
 
@@ -34,6 +37,16 @@ const apiMock = vi.hoisted(() => ({
   fetchDashboardTools: vi.fn(),
   fetchRuntimeDefaults: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
+  fetchKeeperConfig: vi.fn(),
+  patchKeeperConfig: vi.fn(),
+}))
+
+const gateApiMock = vi.hoisted(() => ({
+  fetchGateConnectors: vi.fn(),
+}))
+
+const keeperApiMock = vi.hoisted(() => ({
+  fetchKeepersComposite: vi.fn(),
 }))
 
 const promptApiMock = vi.hoisted(() => ({
@@ -70,6 +83,24 @@ vi.mock('../api/dashboard.js', async () => {
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
     fetchRuntimeProviders: apiMock.fetchRuntimeProviders,
+    fetchKeeperConfig: apiMock.fetchKeeperConfig,
+    patchKeeperConfig: apiMock.patchKeeperConfig,
+  }
+})
+
+vi.mock('../api/gate', async () => {
+  const actual = await vi.importActual<typeof import('../api/gate')>('../api/gate')
+  return {
+    ...actual,
+    fetchGateConnectors: gateApiMock.fetchGateConnectors,
+  }
+})
+
+vi.mock('../api/keeper', async () => {
+  const actual = await vi.importActual<typeof import('../api/keeper')>('../api/keeper')
+  return {
+    ...actual,
+    fetchKeepersComposite: keeperApiMock.fetchKeepersComposite,
   }
 })
 
@@ -206,8 +237,294 @@ function makeRuntimeProviders(
   }
 }
 
+function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'sangsu',
+    status: 'idle',
+    sandbox_profile: 'local',
+    ...overrides,
+  }
+}
+
+function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
+  return {
+    name: 'sangsu',
+    active_goal_ids: [],
+    autoboot_enabled: true,
+    max_context_override: null,
+    limits: {
+      min_context_override_tokens: null,
+      max_context_override_tokens: null,
+    },
+    sandbox_profile: 'local',
+    network_mode: 'inherit',
+    sandbox_last_error: null,
+    allowed_paths: ['workspace/masc'],
+    effective_allowed_paths: ['/Users/dancer/me/workspace/yousleepwhen/masc'],
+    prompt: {
+      goal: '',
+      instructions: '',
+      system_prompt_blocks: {
+        constitution: { key: 'keeper.constitution', source: 'file', text: '' },
+        world: { key: 'keeper.world', source: 'file', text: '' },
+        capabilities: { key: 'keeper.capabilities', source: 'file', text: '' },
+      },
+      effective_system_prompt: '',
+      unified_system_prompt: '',
+      unified_user_message_preview: '',
+    },
+    execution: {
+      models: [],
+      active_model: '',
+      active_model_label: null,
+      last_model_used_label: null,
+      per_provider_timeout_sec: null,
+      per_provider_timeout_mode: 'turn_budget_default',
+      verify: false,
+      selected_runtime_id: 'rt-a',
+      selected_runtime_canonical: 'rt-a',
+      runtime_options: ['rt-a', 'rt-b'],
+    },
+    compaction: {
+      profile: 'off',
+      ratio_gate: 0.85,
+      message_gate: 0,
+      token_gate: 0,
+      cooldown_sec: 0,
+    },
+    proactive: {
+      enabled: false,
+      idle_sec: 0,
+      cooldown_sec: 0,
+    },
+    drift: {
+      status: 'unwired',
+      enabled: null,
+      min_turn_gap: null,
+      count_total: null,
+      last_reason: null,
+    },
+    handoff: {
+      auto: false,
+      threshold: 0.85,
+      cooldown_sec: 0,
+    },
+    runtime: {
+      paused: false,
+      registered: true,
+      keepalive_running: true,
+      registry_state: 'registered',
+      fiber_health: 'idle',
+      runtime_blocker_class: null,
+      active_model_label: null,
+      last_model_used_label: null,
+      runtime_blocker_summary: null,
+      runtime_blocker_continue_gate: null,
+    },
+    runtime_trust: null,
+    workspace: {
+      mention_targets: [],
+      bound_workspace_ids: [],
+      active_goal_ids: [],
+      active_goals: [],
+      active_goal_count: 0,
+      missing_active_goal_ids: [],
+    },
+    tools: {
+      tool_access: [],
+      resolved_allowlist: [],
+      tool_denylist: [],
+      active_masc_tool_count: 0,
+      active_keeper_tool_count: 0,
+      total_active: 0,
+    },
+    sources: {
+      live_meta_path: '/Users/dancer/me/.masc/config/keepers/sangsu.toml',
+      default_manifest_path: null,
+      default_source_kind: 'toml',
+      precedence: [],
+      has_live_override: true,
+      override_fields: [],
+    },
+    metrics: {
+      generation: 1,
+      total_turns: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_tokens: 0,
+      total_cost_usd: 0,
+      last_model_used: '',
+      last_input_tokens: 0,
+      last_output_tokens: 0,
+      last_total_tokens: 0,
+      last_latency_ms: null,
+      last_total_tokens_per_sec: null,
+      last_output_tokens_per_sec: null,
+      compaction_count: 0,
+    },
+    ...overrides,
+  }
+}
+
+function makeGateConnector(overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo {
+  return {
+    connector_id: 'discord',
+    display_name: 'Discord',
+    channel: 'discord',
+    capabilities: ['bindings'],
+    status: 'connected',
+    available: true,
+    connected: true,
+    stale: false,
+    stale_after_sec: 60,
+    gateway_state: 'connected',
+    status_source: 'in_process_gateway',
+    error: '',
+    status_path: '/state/discord.json',
+    binding_store_path: '/bindings/discord.json',
+    audit_path: '/audit/discord.jsonl',
+    updated_at: '2026-06-30T00:00:00Z',
+    reply_mode: 'mention_or_thread',
+    self_chat_guid: '',
+    last_ready_at: '2026-06-30T00:00:00Z',
+    bot_user_name: 'masc-bot',
+    bot_user_id: 'bot-1',
+    guild_count: 1,
+    gate_base_url: 'https://gate.masc.local',
+    gate_healthy: true,
+    gate_health_checked_at: '2026-06-30T00:00:00Z',
+    binding_source: '/bindings/discord.json',
+    runtime_bindings_count: 1,
+    pid: 123,
+    configured_bindings: [{ channel_id: 'C1', keeper_name: 'sangsu' }],
+    recent_audit: [],
+    storage_paths: {
+      status_path: '/state/discord.json',
+      binding_store_path: '/bindings/discord.json',
+      audit_path: '/audit/discord.jsonl',
+      names_path: '/names/discord.json',
+    },
+    runtime_summary: {
+      available: true,
+      connected: true,
+      stale: false,
+      stale_after_sec: 60,
+      status: 'connected',
+      error: '',
+      updated_at: '2026-06-30T00:00:00Z',
+      reply_mode: 'mention_or_thread',
+      self_chat_guid: '',
+      last_ready_at: '2026-06-30T00:00:00Z',
+      bot_user_name: 'masc-bot',
+      bot_user_id: 'bot-1',
+      guild_count: 1,
+      gate_base_url: 'https://gate.masc.local',
+      gate_healthy: true,
+      gate_health_checked_at: '2026-06-30T00:00:00Z',
+      pid: 123,
+    },
+    binding_summary: {
+      binding_source: '/bindings/discord.json',
+      runtime_bindings_count: 1,
+      configured_bindings_count: 1,
+    },
+    observed_channel: null,
+    names_path: '/names/discord.json',
+    names: {
+      guild_names: {},
+      channel_names: {},
+      channel_to_guild: {},
+      updated_at: '',
+    },
+    ...overrides,
+  }
+}
+
+function makeGateConnectors(overrides: Partial<GateConnectorsData> = {}): GateConnectorsData {
+  return {
+    connectors: [makeGateConnector()],
+    total: 1,
+    active_count: 1,
+    discord_trigger_policy: 'mention_or_thread',
+    generated_at: '2026-06-30T00:00:00Z',
+    ...overrides,
+  }
+}
+
 function stubRuntimeDefaults(value: RuntimeDefaultsResponse = makeRuntimeDefaults()) {
   apiMock.fetchRuntimeDefaults.mockResolvedValue(value)
+}
+
+function stubRuntimeRawFetch(sourceText = '[runtime]\ndefault = "rt-a"\n') {
+  vi.stubGlobal('fetch', vi.fn(async (input: unknown) => {
+    const requestUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : typeof (input as { url?: unknown }).url === 'string'
+            ? (input as { url: string }).url
+            : ''
+    const path = requestUrl.startsWith('http')
+      ? new URL(requestUrl).pathname
+      : requestUrl.split('?')[0] ?? requestUrl
+    if (path === '/api/v1/dashboard/dev-token') {
+      return new Response(JSON.stringify({ token: 'dev-token', actor: 'dashboard' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (path === '/api/v1/runtime/config/raw') {
+      return new Response(JSON.stringify({
+        ok: true,
+        path: MOCK_RUNTIME_PATH,
+        file_name: 'runtime.toml',
+        source_text: sourceText,
+        reloaded: false,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(JSON.stringify({ message: `unexpected ${path}` }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }))
+}
+
+function sourceTextForRouting(): string {
+  return `[runtime]
+default = "p.m1"
+librarian = "p.m2"
+cross_verifier = "p.m2"
+
+[providers.p]
+display-name = "Provider"
+protocol = "openai-http"
+endpoint = "https://runtime.example/v1"
+
+[models.m1]
+api-name = "m1"
+max-context = 128000
+tools-support = true
+thinking-support = false
+json-support = true
+streaming = true
+
+[models.m2]
+api-name = "m2"
+max-context = 128000
+tools-support = true
+thinking-support = true
+json-support = true
+streaming = true
+
+[p.m1]
+is-default = true
+
+[p.m2]
+`
 }
 
 function stubEmptyApi() {
@@ -215,6 +532,16 @@ function stubEmptyApi() {
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
   stubRuntimeDefaults()
   apiMock.fetchRuntimeProviders.mockResolvedValue(makeRuntimeProviders())
+  apiMock.fetchKeeperConfig.mockResolvedValue(makeKeeperConfig())
+  apiMock.patchKeeperConfig.mockImplementation(async (_name: string, payload: Partial<KeeperConfig>) =>
+    makeKeeperConfig(payload),
+  )
+  gateApiMock.fetchGateConnectors.mockResolvedValue(makeGateConnectors())
+  keeperApiMock.fetchKeepersComposite.mockResolvedValue({
+    generated_at: '2026-06-30T00:00:00Z',
+    count: 1,
+    snapshots: [{ keeper: 'sangsu' }],
+  })
 }
 
 const navigate = vi.fn()
@@ -239,10 +566,15 @@ describe('SettingsSurface', () => {
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
+    apiMock.fetchKeeperConfig.mockReset()
+    apiMock.patchKeeperConfig.mockReset()
+    gateApiMock.fetchGateConnectors.mockReset()
+    keeperApiMock.fetchKeepersComposite.mockReset()
     promptApiMock.clearPromptOverride.mockClear()
     promptApiMock.fetchDashboardPrompts.mockClear()
     promptApiMock.savePromptOverride.mockClear()
     stubEmptyApi()
+    keepers.value = [makeKeeper()]
     window.location.hash = '#settings'
     route.value = { tab: 'settings', params: {}, postId: null }
   })
@@ -253,6 +585,7 @@ describe('SettingsSurface', () => {
     navigate.mockClear()
     resetDevTokenBootstrap()
     sessionStorage.clear()
+    keepers.value = []
     vi.unstubAllGlobals()
     vi.unstubAllEnvs()
   })
@@ -349,11 +682,10 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="token-toggle"]')).toBeNull()
     expect(container.querySelector<HTMLInputElement>('.set-path .set-input')?.readOnly).toBe(true)
 
-    const gateNav = container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement
-    await fireEvent.click(gateNav)
+    const policyNav = container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement
+    await fireEvent.click(policyNav)
 
     expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
-    expect(container.textContent).not.toContain('＋ Add gate')
     expect(container.querySelector('[data-testid="settings-preview-badge"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="set-verify"]')).toBeNull()
   })
@@ -393,72 +725,95 @@ describe('SettingsSurface', () => {
     expect(container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')?.value).toBe('http://127.0.0.1:7777/mcp')
   })
 
-  it('sandbox allowlist and gate base local inputs are editable', async () => {
+  it('edits sandbox from live keeper config instead of fake global controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-sandbox"]') as HTMLElement)
 
-    const allowlistInput = container.querySelector<HTMLInputElement>('[data-testid="settings-allowed-domains-input"]')
-    expect(allowlistInput).toBeTruthy()
-    expect(allowlistInput?.readOnly).toBe(false)
-
-    await fireEvent.input(allowlistInput as HTMLInputElement, {
-      target: { value: 'github.com, example.test' },
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('keeper config live-backed')
+      expect(container.querySelector('[data-testid="settings-sandbox-profile"]')).not.toBeNull()
     })
-    expect(allowlistInput?.value).toBe('github.com, example.test')
 
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+    expect(container.querySelector('[data-testid="settings-allowed-domains-input"]')).toBeNull()
+    expect(container.textContent).not.toContain('Allowed domains')
+    expect(container.textContent).not.toContain('Resource limits')
 
-    const gateInput = container.querySelector<HTMLInputElement>('[data-testid="settings-gate-base-input"]')
-    expect(gateInput).toBeTruthy()
-    expect(gateInput?.readOnly).toBe(false)
+    const profile = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-profile"]')
+    const network = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-network"]')
+    const allowedPaths = container.querySelector<HTMLTextAreaElement>('[data-testid="settings-sandbox-allowed-paths"]')
+    expect(profile).toBeTruthy()
+    expect(network).toBeTruthy()
+    expect(allowedPaths).toBeTruthy()
 
-    await fireEvent.input(gateInput as HTMLInputElement, {
-      target: { value: 'https://gate.example.test' },
+    ;(profile as HTMLSelectElement).value = 'docker'
+    await fireEvent.input(profile as HTMLSelectElement)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-sandbox-network"]')?.textContent).toContain('none')
     })
-    expect(gateInput?.value).toBe('https://gate.example.test')
+    const updatedNetwork = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-network"]')
+    ;(updatedNetwork as HTMLSelectElement).value = 'none'
+    await fireEvent.input(updatedNetwork as HTMLSelectElement)
+    await fireEvent.input(allowedPaths as HTMLTextAreaElement, {
+      target: { value: 'workspace/oas\nworkspace/oas\n  ' },
+    })
+
+    const save = container.querySelector<HTMLButtonElement>('[data-testid="settings-sandbox-save"]')
+    expect(save).toBeTruthy()
+    expect(save?.disabled).toBe(false)
+    await fireEvent.click(save as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(apiMock.patchKeeperConfig).toHaveBeenCalledWith('sangsu', {
+        sandbox_profile: 'docker',
+        network_mode: 'none',
+        allowed_paths: ['workspace/oas'],
+      })
+    })
+    expect(container.querySelector('[data-testid="settings-sandbox-source"]')?.textContent).toContain('/Users/dancer/me/.masc/config/keepers/sangsu.toml')
   })
 
-  it('gate connector toggles are browser-session previews, not live connection state', async () => {
+  it('falls back to fleet composite keeper names when sandbox opens before the keeper store is hydrated', async () => {
+    keepers.value = []
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-sandbox"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(keeperApiMock.fetchKeepersComposite).toHaveBeenCalledTimes(1)
+      expect(apiMock.fetchKeeperConfig).toHaveBeenCalledWith('sangsu')
+      expect(container.querySelector('[data-testid="settings-sandbox-profile"]')).not.toBeNull()
+    })
+    expect(container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-keeper-select"]')?.value).toBe('sangsu')
+    expect(container.querySelector('[data-testid="settings-sandbox-empty"]')).toBeNull()
+  })
+
+  it('renders gate connectors from the live connector payload without local toggles', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
 
-    const summary = () => container.querySelector('[data-testid="gate-local-summary"]') as HTMLElement
-    expect(summary().textContent).toContain('local connector preview')
-    expect(summary().textContent).toContain('3/4 enabled')
-    expect(container.textContent).toContain('Live connector runtime, availability')
-    expect(container.textContent).not.toContain('Connected')
-    expect(container.textContent).not.toContain('Inactive')
-
-    const toggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
-    expect(toggles.length).toBe(4)
-    expect(toggles[0]!.getAttribute('data-active')).toBe('true')
-
-    await fireEvent.click(toggles[0]!)
-
-    expect(toggles[0]!.getAttribute('data-active')).toBe('false')
-    expect(summary().textContent).toContain('2/4 enabled')
-    expect(JSON.parse(sessionStorage.getItem('masc.settings.local.gateConnectorPreview') ?? '{}')).toMatchObject({
-      Slack: false,
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('gate connector live-backed')
+      expect(container.querySelector('[data-testid="settings-gate-connectors"]')).not.toBeNull()
     })
 
-    const triggers = () => Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-trigger"]'))
-    expect(triggers().length).toBe(4)
-    await fireEvent.click(triggers()[2] as HTMLButtonElement)
-    expect(triggers()[2]?.getAttribute('data-active')).toBe('true')
-    expect(sessionStorage.getItem('masc.settings.local.discordTrigger')).toBe('all')
+    expect(container.querySelector('[data-testid="gate-live-summary"]')?.textContent).toContain('1/1 active')
+    expect(container.querySelector('[data-testid="settings-gate-discord-trigger"]')?.textContent).toBe('mention_or_thread')
+    expect(container.querySelector('[data-testid="settings-gate-base-live"]')?.textContent).toContain('https://gate.masc.local')
+
+    const connectorCards = Array.from(container.querySelectorAll('[data-testid="settings-gate-connector"]'))
+    expect(connectorCards.length).toBe(1)
+    expect(connectorCards[0]?.textContent).toContain('discord')
+    expect(connectorCards[0]?.textContent).toContain('Discord')
+    expect(connectorCards[0]?.textContent).toContain('bindings 1')
+    expect(container.textContent).not.toContain('Amplitude')
+    expect(container.querySelector('[data-testid="settings-preview-badge"]')).toBeNull()
+    expect(container.querySelector('[data-testid="set-toggle"]')).toBeNull()
+    expect(container.querySelector('[data-testid="set-trigger"]')).toBeNull()
 
     await fireEvent.click(container.querySelector('[data-testid="settings-connectors-link"]') as HTMLButtonElement)
     expect(navigate).toHaveBeenLastCalledWith('connectors')
-
-    render(null, container)
-    render(html`<${SettingsSurface} />`, container)
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
-
-    expect(summary().textContent).toContain('2/4 enabled')
-    expect((container.querySelector('[data-testid="set-toggle"]') as HTMLButtonElement).getAttribute('data-active')).toBe('false')
-    expect(triggers()[2]?.getAttribute('data-active')).toBe('true')
   })
 
   it('paths local preview values can be format-checked without claiming live verification', async () => {
@@ -575,42 +930,46 @@ describe('SettingsSurface', () => {
       ])
       expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')
     })
+    expect(container.querySelector('[data-testid="runtime-default-context"]')).toBeNull()
     expect(container.textContent).not.toContain('oas·seoul-1')
   })
 
-  it('routing section shows resolved keeper assignments read-only', async () => {
+  it('routing section opens the live runtime.toml routing editor', async () => {
+    keepers.value = [makeKeeper(), makeKeeper({ name: 'mad-improver', status: 'running' })]
+    stubRuntimeRawFetch(`${sourceTextForRouting()}
+
+[runtime.assignments]
+sangsu = "p.m2"
+mad-improver = "p.m1"
+`)
     render(html`<${SettingsSurface} />`, container)
 
     const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
     await fireEvent.click(routingNav)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="routing-default-model"]')?.textContent).toBe('m1')
-      const assignments = Array.from(
-        container.querySelectorAll('[data-testid="routing-assignment"]'),
-      ).map(n => n.textContent)
-      expect(assignments).toEqual(['rt-b'])
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
+      expect(container.querySelector('[data-testid="runtime-toml-editor"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-section-routing"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-environment-save"]')).not.toBeNull()
     })
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('모델 라우팅')
+    expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('라우팅')
+    expect(container.textContent).toContain('memory-os 라이브러리안')
+    expect(container.textContent).toContain('cross-verifier')
+    expect(container.textContent).not.toContain('Read-only')
+    expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
 
-  it('routing section reports no assignments without fabricating rows', async () => {
-    stubRuntimeDefaults(
-      makeRuntimeDefaults({
-        model_routing: {
-          keeper_assignments: [],
-          librarian_runtime_id: null,
-          cross_verifier_runtime_id: null,
-          media_failover: [],
-        },
-      }),
-    )
+  it('routing section reports empty runtime.toml bindings without fabricating rows', async () => {
+    stubRuntimeRawFetch('[runtime]\ndefault = "rt-a"\n')
     render(html`<${SettingsSurface} />`, container)
 
     const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
     await fireEvent.click(routingNav)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="routing-assignments-empty"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-environment-empty"]')).not.toBeNull()
     })
     expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
@@ -828,24 +1187,22 @@ describe('SettingsSurface', () => {
     expect(container.querySelectorAll('.set-tg-chip.safe').length).toBeGreaterThan(0)
   })
 
-  it('shows Discord trigger radios only while the Discord gate is on', async () => {
+  it('shows the Discord trigger policy as live connector data without preview radios', async () => {
+    gateApiMock.fetchGateConnectors.mockResolvedValue(makeGateConnectors({
+      connectors: [],
+      total: 0,
+      active_count: 0,
+      discord_trigger_policy: 'mention_only',
+    }))
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
 
-    // Discord gate defaults on → trigger radios visible with prototype values.
-    const triggers = () => Array.from(container.querySelectorAll('[data-testid="set-trigger"]'))
-    expect(triggers().length).toBe(4)
-    const vals = triggers().map(t => t.querySelector('.mono')?.textContent)
-    expect(vals).toEqual(['mention_or_thread', 'mention_only', 'all', 'user_only'])
-    // default selection is mention_or_thread; local preview radios can be changed.
-    expect(triggers()[0]!.classList.contains('on')).toBe(true)
-    expect((triggers()[0] as HTMLButtonElement).disabled).toBe(false)
-
-    await fireEvent.click(triggers()[2] as HTMLButtonElement)
-
-    expect(triggers()[0]!.getAttribute('data-active')).toBe('false')
-    expect(triggers()[2]!.getAttribute('data-active')).toBe('true')
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-gate-discord-trigger"]')?.textContent).toBe('mention_only')
+      expect(container.querySelector('[data-testid="settings-gate-empty"]')).not.toBeNull()
+    })
+    expect(container.querySelector('[data-testid="set-trigger"]')).toBeNull()
   })
 
   it('opens the live runtime.toml editor from runtime management', async () => {
@@ -917,7 +1274,12 @@ describe('SettingsSurface shell route', () => {
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
+    apiMock.fetchKeeperConfig.mockReset()
+    apiMock.patchKeeperConfig.mockReset()
+    gateApiMock.fetchGateConnectors.mockReset()
+    keeperApiMock.fetchKeepersComposite.mockReset()
     stubEmptyApi()
+    keepers.value = [makeKeeper()]
     dashboardLoading.value = false
     connected.value = true
     namespaceTruthInitializing.value = false
@@ -927,6 +1289,7 @@ describe('SettingsSurface shell route', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    keepers.value = []
   })
 
   it('renders from the dashboard shell route', async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -10,20 +10,35 @@ import {
   type SettingsRouteSectionId,
 } from '../config/navigation'
 import { navigate, route } from '../router'
-import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults, fetchRuntimeProviders } from '../api/dashboard.js'
+import {
+  fetchDashboardTools,
+  fetchKeeperConfig,
+  fetchLogs,
+  fetchRuntimeDefaults,
+  fetchRuntimeProviders,
+  patchKeeperConfig,
+} from '../api/dashboard.js'
 import type {
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
+  KeeperConfigUpdatePayload,
   LogEntry,
   RuntimeDefaultsResponse,
+  SandboxNetworkMode,
+  SandboxProfile,
 } from '../api/dashboard.js'
+import { fetchGateConnectors, type GateConnectorInfo, type GateConnectorsData } from '../api/gate'
+import { fetchKeepersComposite } from '../api/keeper'
 import { envBool } from '../config/env'
+import { keepers } from '../store'
+import type { KeeperConfig } from '../types'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
 import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
 import type { ComponentChildren } from 'preact'
+import { errorToString } from '../lib/format-string'
 
 type SectionId = SettingsRouteSectionId
 
@@ -277,21 +292,6 @@ const LAST_TURN_SAFE: readonly string[] = ['keeper_board_post', 'keeper_board_co
 // tool_execute 3-layer deterministic guard — keeper-v2 settings.jsx:101
 // ([groups.execute]).
 const EXEC_GUARD: readonly string[] = ['validate_command', 'destructive_guard', 'write_gate']
-// [discord].trigger_policy — keeper-v2 settings.jsx:103-108. env
-// MASC_DISCORD_TRIGGER_POLICY overrides.
-const DISCORD_TRIGGER: readonly [string, string][] = [
-  ['mention_or_thread', '스레드 자동 응답, 일반 채널은 멘션 필요 (기본)'],
-  ['mention_only', '@멘션된 메시지만 응답'],
-  ['all', '모든 메시지에 응답'],
-  ['user_only', '특정 사용자(snowflake)만'],
-]
-const DEFAULT_GATE_CONNECTOR_PREVIEW: Record<string, boolean> = {
-  Slack: true,
-  Discord: true,
-  Amplitude: true,
-  GitHub: false,
-}
-
 // System-log row: [time, level, identity, message, status]. Derived from live
 // ring entries (`/api/v1/dashboard/logs`) — the same source the Logs surface
 // polls. Status is derived from the entry level only (error→fail, warn→warn,
@@ -541,6 +541,92 @@ function RuntimeCatalogCard({
   `
 }
 
+type SandboxDraft = {
+  sandbox_profile: SandboxProfile
+  network_mode: SandboxNetworkMode
+  allowed_paths_text: string
+}
+
+function coerceSandboxProfile(raw: string | null | undefined): SandboxProfile {
+  return raw === 'docker' ? 'docker' : 'local'
+}
+
+function coerceNetworkMode(raw: string | null | undefined): SandboxNetworkMode {
+  return raw === 'none' ? 'none' : 'inherit'
+}
+
+function dedupeListText(text: string): string[] {
+  const seen = new Set<string>()
+  const values: string[] = []
+  for (const raw of text.split('\n')) {
+    const item = raw.trim()
+    if (!item || seen.has(item)) continue
+    seen.add(item)
+    values.push(item)
+  }
+  return values
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function sandboxDraftFromConfig(config: KeeperConfig): SandboxDraft {
+  return {
+    sandbox_profile: coerceSandboxProfile(config.sandbox_profile),
+    network_mode: coerceNetworkMode(config.network_mode),
+    allowed_paths_text: (config.allowed_paths ?? []).join('\n'),
+  }
+}
+
+function buildSandboxPayload(draft: SandboxDraft, config: KeeperConfig): KeeperConfigUpdatePayload {
+  const payload: KeeperConfigUpdatePayload = {}
+  const allowedPaths = dedupeListText(draft.allowed_paths_text)
+  if (draft.sandbox_profile !== coerceSandboxProfile(config.sandbox_profile)) {
+    payload.sandbox_profile = draft.sandbox_profile
+  }
+  if (draft.network_mode !== coerceNetworkMode(config.network_mode)) {
+    payload.network_mode = draft.network_mode
+  }
+  if (!sameStringArray(allowedPaths, config.allowed_paths ?? [])) {
+    payload.allowed_paths = allowedPaths
+  }
+  return payload
+}
+
+function connectorState(connector: GateConnectorInfo): 'connected' | 'stale' | 'offline' {
+  if (!connector.available) return 'offline'
+  if (connector.stale) return 'stale'
+  return connector.connected ? 'connected' : 'offline'
+}
+
+function connectorStateText(connector: GateConnectorInfo): string {
+  const state = connectorState(connector)
+  if (state === 'connected') return 'connected'
+  if (state === 'stale') return 'stale'
+  return connector.status || 'offline'
+}
+
+function uniqueConnectorGateBaseUrls(connectors: readonly GateConnectorInfo[]): string[] {
+  return Array.from(new Set(
+    connectors
+      .map(connector => connector.gate_base_url.trim())
+      .filter(Boolean),
+  )).sort((a, b) => a.localeCompare(b))
+}
+
+function uniqueNonEmptyStrings(values: readonly (string | null | undefined)[]): string[] {
+  const seen = new Set<string>()
+  const names: string[] = []
+  for (const value of values) {
+    const name = value?.trim()
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    names.push(name)
+  }
+  return names
+}
+
 type SettingsSectionMode = 'live' | 'local'
 
 function settingsSectionState(
@@ -551,6 +637,8 @@ function settingsSectionState(
   if (section === 'runtimes') return { mode: 'live', label: 'runtime.toml live-backed' }
   if (section === 'routing') return { mode: 'live', label: 'runtime.toml live-backed' }
   if (section === 'prompts') return { mode: 'live', label: 'prompt registry live-backed' }
+  if (section === 'sandbox') return { mode: 'live', label: 'keeper config live-backed' }
+  if (section === 'gate') return { mode: 'live', label: 'gate connector live-backed' }
   if (section === 'fusion' && fusionSettingsWritable) {
     return { mode: 'live', label: 'runtime.toml live-backed' }
   }
@@ -761,9 +849,6 @@ export function SettingsSurface() {
   const [fusionPanels, setFusionPanels] = useState(FUSION.maxConcurrentPanels)
   const [fusionWeb, setFusionWeb] = useState(FUSION.webTools)
 
-  // discord trigger policy (gate section) — keeper-v2 settings.jsx:183
-  const [discordTrigger, setDiscordTrigger] = useLocalPreviewString('discordTrigger', 'mention_or_thread')
-
   // lifecycle
   const [idleDrain, setIdleDrain] = useState(30)
   const [autoRestart, setAutoRestart] = useState(true)
@@ -771,8 +856,9 @@ export function SettingsSurface() {
   const [onOverflow, setOnOverflow] = useState('자동 compact')
 
   // gate / paths
-  const [gateBase, setGateBase] = useLocalPreviewString('gateBase', 'https://gate.masc.local')
-  const [gateOn, setGateOn] = useLocalPreviewBoolRecord('gateConnectorPreview', DEFAULT_GATE_CONNECTOR_PREVIEW)
+  const [gateConnectorsData, setGateConnectorsData] = useState<GateConnectorsData | null>(null)
+  const [gateConnectorsStatus, setGateConnectorsStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
+  const [gateConnectorsError, setGateConnectorsError] = useState<string | null>(null)
   const [wtBase, setWtBase] = useLocalPreviewString('wtBase', '~/wt')
   const [storeUrl, setStoreUrl] = useLocalPreviewString('storeUrl', 'postgres://masc.local:5432/masc')
   const [pathChecks, setPathChecks] = useState<Partial<Record<PathCheckTarget, PathCheckResult>>>({})
@@ -793,16 +879,129 @@ export function SettingsSurface() {
     setPathChecks(current => ({ ...current, [target]: result }))
   }
 
-  // sandbox
-  const [isolation, setIsolation] = useState('container')
-  const [egress, setEgress] = useState('허용목록')
-  const [allowlist, setAllowlist] = useLocalPreviewString('allowlist', 'github.com, opam.ocaml.org, *.masc.local')
-  const [fsScope, setFsScope] = useState('worktree')
-  const [shellOn, setShellOn] = useState(true)
-  const [blockRisky, setBlockRisky] = useState(true)
-  const [memLimit, setMemLimit] = useState('2GB')
-  const [cpuLimit, setCpuLimit] = useState(2)
-  const [execTimeout, setExecTimeout] = useState(120)
+  // sandbox — per-keeper live config, not a global sandbox policy.
+  const [sandboxFallbackKeeperNames, setSandboxFallbackKeeperNames] = useState<string[]>([])
+  const [sandboxKeeperListStatus, setSandboxKeeperListStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
+  const [sandboxKeeperListError, setSandboxKeeperListError] = useState<string | null>(null)
+  const liveKeeperCount = keepers.value.length
+  const keeperList = liveKeeperCount > 0
+    ? keepers.value
+    : sandboxFallbackKeeperNames.map(name => ({ name, status: 'unknown' }))
+  const keeperNamesKey = keeperList.map(keeper => keeper.name).join('\u0000')
+  const [sandboxKeeperName, setSandboxKeeperName] = useState('')
+  const [sandboxConfig, setSandboxConfig] = useState<KeeperConfig | null>(null)
+  const [sandboxDraft, setSandboxDraft] = useState<SandboxDraft | null>(null)
+  const [sandboxStatus, setSandboxStatus] = useState<'idle' | 'loading' | 'ready' | 'saving' | 'error'>('idle')
+  const [sandboxError, setSandboxError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (sec !== 'sandbox') return
+    setSandboxKeeperName(current => {
+      if (current && keeperList.some(keeper => keeper.name === current)) return current
+      return keeperList[0]?.name ?? ''
+    })
+  }, [keeperNamesKey, sec])
+
+  useEffect(() => {
+    if (sec !== 'sandbox' || liveKeeperCount > 0) return undefined
+    const controller = new AbortController()
+    setSandboxKeeperListStatus('loading')
+    setSandboxKeeperListError(null)
+    void (async () => {
+      try {
+        const fleet = await fetchKeepersComposite({ signal: controller.signal })
+        if (controller.signal.aborted) return
+        const names = uniqueNonEmptyStrings(fleet.snapshots.map(snapshot => snapshot.keeper))
+        setSandboxFallbackKeeperNames(names)
+        setSandboxKeeperListStatus('ready')
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return
+        setSandboxFallbackKeeperNames([])
+        setSandboxKeeperListStatus('error')
+        setSandboxKeeperListError(errorToString(err))
+      }
+    })()
+    return () => controller.abort()
+  }, [liveKeeperCount, sec])
+
+  useEffect(() => {
+    if (sec !== 'gate') return undefined
+    const controller = new AbortController()
+    setGateConnectorsStatus('loading')
+    setGateConnectorsError(null)
+    void (async () => {
+      try {
+        const resp = await fetchGateConnectors(controller.signal)
+        setGateConnectorsData(resp)
+        setGateConnectorsStatus('ready')
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return
+        setGateConnectorsData(null)
+        setGateConnectorsStatus('error')
+        setGateConnectorsError(errorToString(err))
+      }
+    })()
+    return () => controller.abort()
+  }, [sec])
+
+  useEffect(() => {
+    if (sec !== 'sandbox' || !sandboxKeeperName) return undefined
+    let active = true
+    setSandboxStatus('loading')
+    setSandboxError(null)
+    setSandboxConfig(null)
+    setSandboxDraft(null)
+    void (async () => {
+      try {
+        const config = await fetchKeeperConfig(sandboxKeeperName)
+        if (!active) return
+        setSandboxConfig(config)
+        setSandboxDraft(sandboxDraftFromConfig(config))
+        setSandboxStatus('ready')
+      } catch (err: unknown) {
+        if (!active) return
+        setSandboxStatus('error')
+        setSandboxError(errorToString(err))
+      }
+    })()
+    return () => { active = false }
+  }, [sandboxKeeperName, sec])
+
+  function updateSandboxDraft(field: keyof SandboxDraft, value: string) {
+    setSandboxDraft(current => {
+      if (!current) return current
+      const next = { ...current, [field]: value } as SandboxDraft
+      if (field === 'sandbox_profile' && next.sandbox_profile !== 'docker' && next.network_mode === 'none') {
+        next.network_mode = 'inherit'
+      }
+      if (field === 'network_mode' && next.sandbox_profile !== 'docker' && next.network_mode === 'none') {
+        next.network_mode = 'inherit'
+      }
+      return next
+    })
+  }
+
+  async function saveSandboxConfig() {
+    if (!sandboxConfig || !sandboxDraft || sandboxStatus === 'saving') return
+    const payload = buildSandboxPayload(sandboxDraft, sandboxConfig)
+    if (Object.keys(payload).length === 0) return
+    setSandboxStatus('saving')
+    setSandboxError(null)
+    try {
+      const updated = await patchKeeperConfig(sandboxConfig.name, payload)
+      setSandboxConfig(updated)
+      setSandboxDraft(sandboxDraftFromConfig(updated))
+      setSandboxStatus('ready')
+      keepers.value = keepers.value.map(keeper =>
+        keeper.name === updated.name
+          ? { ...keeper, sandbox_profile: coerceSandboxProfile(updated.sandbox_profile) }
+          : keeper,
+      )
+    } catch (err: unknown) {
+      setSandboxStatus('error')
+      setSandboxError(errorToString(err))
+    }
+  }
 
   // ide
   const [ideView, setIdeView] = useState('split-diff')
@@ -845,7 +1044,10 @@ export function SettingsSurface() {
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
   const sectionState = settingsSectionState(sec, fusionSettingsWritable)
   const grantedGroupCount = Object.values(grant).filter(Boolean).length
-  const gatePreviewEnabledCount = Object.values(gateOn).filter(Boolean).length
+  const liveGateConnectors = gateConnectorsData?.connectors ?? []
+  const liveGateBaseUrls = uniqueConnectorGateBaseUrls(liveGateConnectors)
+  const sandboxDirty = sandboxConfig !== null && sandboxDraft !== null
+    && Object.keys(buildSandboxPayload(sandboxDraft, sandboxConfig)).length > 0
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -860,8 +1062,6 @@ export function SettingsSurface() {
   const keeperAssignmentCount = keeperAssignments.length > 0
     ? keeperAssignments.length
     : runtimeProviders?.assignment_governance?.assignment_count ?? 0
-  const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
-  const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
 
   return html`
     <main class="v2-shell-surface settings-surf ss-surface bg-surface-page text-text-primary" data-screen-label="설정" data-testid="settings-surface">
@@ -911,7 +1111,7 @@ export function SettingsSurface() {
           </header>
 
           <div
-            class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
+            class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'routing' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
             data-preview-locked="false"
             data-settings-mode=${sectionState.mode}
           >
@@ -1016,11 +1216,6 @@ export function SettingsSurface() {
                   <${SetRow} label="Default model" hint="Resolved model API name">
                     <span class="mono" data-testid="runtime-default-model">${runtimeDefaults?.default_model ?? defaultCatalogEntry?.model_api_name ?? '—'}</span>
                   <//>
-                  <${SetRow} label="Default context" hint="Resolved context window">
-                    <span class="mono" data-testid="runtime-default-context">
-                      ${formatRuntimeContext(runtimeDefaults?.default_max_context ?? defaultCatalogEntry?.max_context ?? null)}
-                    </span>
-                  <//>
                 </div>
 
                 <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
@@ -1050,25 +1245,9 @@ export function SettingsSurface() {
 
             ${sec === 'routing' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Resolved model routing from runtime.toml (SSOT). Read-only — edit runtime.toml to change.
+                runtime.toml 의 라우팅 레인과 keeper 배정을 직접 수정합니다. 기본 런타임, memory-os 라이브러리안, cross-verifier, keeper별 배정은 모두 같은 SSOT에 저장됩니다.
               </div>
-              <${SetRow} label="Default model" hint="Used when no keeper assignment matches">
-                <span class="mono" data-testid="routing-default-model">${runtimeDefaults?.default_model ?? '—'}</span>
-              <//>
-              ${librarianRuntime
-                ? html`<${SetRow} label="Librarian runtime" hint="[runtime].librarian"><span class="mono">${librarianRuntime}</span><//>`
-                : null}
-              ${crossVerifierRuntime
-                ? html`<${SetRow} label="Cross-verifier runtime" hint="[runtime].cross_verifier"><span class="mono">${crossVerifierRuntime}</span><//>`
-                : null}
-              <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
-              ${keeperAssignments.length === 0
-                ? html`<div class="set-hint" data-testid="routing-assignments-empty">명시적 keeper 할당이 없습니다 — 모두 기본 런타임을 사용합니다.</div>`
-                : keeperAssignments.map(a => html`
-                    <${SetRow} key=${a.keeper} label=${a.keeper} hint="keeper → runtime">
-                      <span class="mono" data-testid="routing-assignment">${a.runtime_id}</span>
-                    <//>
-                  `)}
+              <${RuntimeTomlEditor} />
             `}
 
             ${sec === 'prompts' && html`
@@ -1184,46 +1363,88 @@ export function SettingsSurface() {
 
             ${sec === 'sandbox' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Isolated execution environment for keeper code. Tool permissions (approval policy) sit above this OS·network boundary.
+                Keeper별 <span class="mono">sandbox_profile</span>, <span class="mono">network_mode</span>, <span class="mono">allowed_paths</span>를 live keeper config에 저장합니다. 선택한 keeper의 source path와 effective_paths를 함께 표시합니다.
               </div>
-              <${SetRow} label="Isolation level" hint="Keeper execution isolation">
-                <${SetSeg} value=${isolation} options=${['worktree', 'container', 'microVM']} onChange=${setIsolation} />
-              <//>
-              <${SetRow} label="Filesystem scope" hint="Paths the keeper can access">
-                <${SetSeg} value=${fsScope} options=${['worktree', 'namespace', '전체']} onChange=${setFsScope} />
-              <//>
-              <${SetRow} label="Network egress" hint="External network access">
-                <${SetSeg} value=${egress} options=${['차단', '허용목록', '전체']} onChange=${setEgress} />
-              <//>
-              ${egress === '허용목록' && html`
-                <${SetRow} label="Allowed domains" hint="Comma-separated">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-allowed-domains-input"
-                    style=${{ width: '260px' }}
-                    value=${allowlist}
-                    onInput=${(e: Event) => setAllowlist((e.target as HTMLInputElement).value)}
-                  />
-                <//>
-              `}
-              <${SetRow} label="Shell commands" hint="Keeper may run shell commands">
-                <${SetToggle} on=${shellOn} onChange=${setShellOn} />
-              <//>
-              ${shellOn && html`
-                <${SetRow} label="Block risky commands" hint="rm -rf, curl | sh, etc.">
-                  <${SetToggle} on=${blockRisky} onChange=${setBlockRisky} />
-                <//>
-              `}
-              <div class="set-sub-h">Resource limits</div>
-              <${SetRow} label="Memory" hint="Max per keeper">
-                <${SetSeg} value=${memLimit} options=${['1GB', '2GB', '4GB', '8GB']} onChange=${setMemLimit} />
-              <//>
-              <${SetRow} label="CPU" hint="vCPU cores">
-                <${SetStepper} v=${cpuLimit} set=${setCpuLimit} min=${1} max=${16} />
-              <//>
-              <${SetRow} label="Execution timeout" hint="Max single command runtime (seconds)">
-                <${SetSlider} value=${execTimeout} min=${10} max=${600} step=${10} suffix="s" onChange=${setExecTimeout} />
-              <//>
+              ${keeperList.length === 0
+                ? sandboxKeeperListStatus === 'loading'
+                  ? html`<div class="set-hint" data-testid="settings-sandbox-keepers-loading">keeper 목록을 불러오는 중...</div>`
+                  : sandboxKeeperListStatus === 'error'
+                    ? html`<div class="set-hint" data-testid="settings-sandbox-keepers-error">${sandboxKeeperListError ?? 'keeper 목록을 불러오지 못했습니다.'}</div>`
+                    : html`<div class="set-hint" data-testid="settings-sandbox-empty">표시할 keeper가 없습니다.</div>`
+                : html`
+                  <${SetRow} label="Keeper" hint="config/keepers/<name>.toml + live override">
+                    <select
+                      class="set-select mono"
+                      data-testid="settings-sandbox-keeper-select"
+                      value=${sandboxKeeperName}
+                      onInput=${(event: Event) => setSandboxKeeperName((event.currentTarget as HTMLSelectElement).value)}
+                      onChange=${(event: Event) => setSandboxKeeperName((event.currentTarget as HTMLSelectElement).value)}
+                    >
+                      ${keeperList.map(keeper => html`<option key=${keeper.name} value=${keeper.name}>${keeper.name}</option>`)}
+                    </select>
+                  <//>
+                  ${sandboxStatus === 'loading'
+                    ? html`<div class="set-hint" data-testid="settings-sandbox-loading">keeper sandbox 설정을 불러오는 중...</div>`
+                    : sandboxStatus === 'error'
+                      ? html`<div class="set-hint" data-testid="settings-sandbox-error">${sandboxError ?? 'keeper sandbox 설정을 불러오지 못했습니다.'}</div>`
+                      : sandboxConfig && sandboxDraft
+                        ? html`
+                          <${SetRow} label="sandbox_profile" hint="local 또는 docker">
+                            <select
+                              class="set-select mono"
+                              data-testid="settings-sandbox-profile"
+                              value=${sandboxDraft.sandbox_profile}
+                              disabled=${sandboxStatus === 'saving'}
+                              onInput=${(event: Event) => updateSandboxDraft('sandbox_profile', (event.currentTarget as HTMLSelectElement).value)}
+                              onChange=${(event: Event) => updateSandboxDraft('sandbox_profile', (event.currentTarget as HTMLSelectElement).value)}
+                            >
+                              <option value="local">local</option>
+                              <option value="docker">docker</option>
+                            </select>
+                          <//>
+                          <${SetRow} label="network_mode" hint="docker일 때 none 선택 가능">
+                            <select
+                              class="set-select mono"
+                              data-testid="settings-sandbox-network"
+                              value=${sandboxDraft.network_mode}
+                              disabled=${sandboxStatus === 'saving'}
+                              onInput=${(event: Event) => updateSandboxDraft('network_mode', (event.currentTarget as HTMLSelectElement).value)}
+                              onChange=${(event: Event) => updateSandboxDraft('network_mode', (event.currentTarget as HTMLSelectElement).value)}
+                            >
+                              <option value="inherit">inherit</option>
+                              ${sandboxDraft.sandbox_profile === 'docker' ? html`<option value="none">none</option>` : null}
+                            </select>
+                          <//>
+                          <${SetRow} label="allowed_paths" hint="한 줄에 하나, 비우면 computed default">
+                            <textarea
+                              class="set-input mono"
+                              data-testid="settings-sandbox-allowed-paths"
+                              rows=${4}
+                              disabled=${sandboxStatus === 'saving'}
+                              value=${sandboxDraft.allowed_paths_text}
+                              onInput=${(event: Event) => updateSandboxDraft('allowed_paths_text', (event.currentTarget as HTMLTextAreaElement).value)}
+                            ></textarea>
+                          <//>
+                          <div class="set-mcp-detail mono" data-testid="settings-sandbox-effective-paths">
+                            effective_paths ${(sandboxConfig.effective_allowed_paths ?? []).join(', ') || '(computed default)'}
+                          </div>
+                          <div class="set-actions">
+                            <button
+                              type="button"
+                              class="set-verify"
+                              data-testid="settings-sandbox-save"
+                              disabled=${!sandboxDirty || sandboxStatus === 'saving'}
+                              onClick=${() => { void saveSandboxConfig() }}
+                            >
+                              ${sandboxStatus === 'saving' ? 'Saving' : 'Save'}
+                            </button>
+                            <span class="set-hint" data-testid="settings-sandbox-source">
+                              ${sandboxConfig.sources.live_meta_path || sandboxConfig.sources.default_manifest_path || sandboxConfig.name}
+                            </span>
+                          </div>
+                        `
+                        : null}
+                `}
             `}
 
             ${sec === 'ide' && html`
@@ -1296,7 +1517,7 @@ export function SettingsSurface() {
 
             ${sec === 'gate' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Browser-session preview for connector defaults. Live connector runtime, availability and per-channel→keeper bindings are managed in
+                Live connector runtime, availability, trigger policy and channel→keeper bindings are read from <span class="mono">GET /api/v1/gate/connectors</span>. Add, remove, bind and sidecar lifecycle actions live in
                 <button
                   type="button"
                   class="set-link"
@@ -1306,53 +1527,50 @@ export function SettingsSurface() {
                   Connectors →
                 </button>.
               </div>
-              <div class="set-local-summary" data-testid="gate-local-summary">
-                <span>local connector preview</span>
-                <span class="mono">${gatePreviewEnabledCount}/${Object.keys(DEFAULT_GATE_CONNECTOR_PREVIEW).length} enabled</span>
-                <${PreviewBadge} />
+              <div class="set-local-summary" data-testid="gate-live-summary">
+                <span>live connector status</span>
+                <span class="mono">
+                  ${gateConnectorsStatus === 'ready'
+                    ? `${gateConnectorsData?.active_count ?? 0}/${gateConnectorsData?.total ?? liveGateConnectors.length} active`
+                    : gateConnectorsStatus}
+                </span>
               </div>
-              <${SetRow} label="Gate base URL" hint="GET /api/v1/gate/connectors">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-gate-base-input"
-                    value=${gateBase}
-                    onInput=${(e: Event) => setGateBase((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
-                </div>
-              <//>
-              ${['Slack', 'Discord', 'Amplitude', 'GitHub'].map(g => html`
-                <${SetRow} key=${g} label=${g} hint=${gateOn[g] ? 'local preview enabled' : 'local preview disabled'}>
-                  <div class="set-tg-control">
-                    <${PreviewBadge} />
-                    <${SetToggle} on=${gateOn[g] ?? false} onChange=${(v: boolean) => setGateOn(p => ({ ...p, [g]: v }))} />
-                  </div>
-                <//>
-              `)}
-              ${gateOn.Discord && html`
-                <div class="set-sub-h">Discord 트리거 정책</div>
-                <div class="set-hint" style=${{ marginBottom: '8px' }}>
-                  어떤 인바운드 이벤트에 봇이 응답할지 — <span class="mono">[discord].trigger_policy</span> · env <span class="mono">MASC_DISCORD_TRIGGER_POLICY</span> 우선.
-                </div>
-                ${DISCORD_TRIGGER.map(([val, hint]) => html`
-                  <button
-                    type="button"
-                    key=${val}
-                    class=${`set-trigger ${discordTrigger === val ? 'on' : ''}`}
-                    data-testid="set-trigger"
-                    data-active=${discordTrigger === val ? 'true' : 'false'}
-                    aria-pressed=${discordTrigger === val}
-                    onClick=${() => setDiscordTrigger(val)}
-                  >
-                    <span class="set-trigger-radio"></span>
-                    <span class="set-trigger-l">
-                      <span class="mono">${val}</span>
-                      <span class="set-trigger-hint">${hint}</span>
-                    </span>
-                  </button>
-                `)}
-              `}
+              ${gateConnectorsStatus === 'loading'
+                ? html`<div class="set-hint" data-testid="settings-gate-loading">connector 상태를 불러오는 중...</div>`
+                : gateConnectorsStatus === 'error'
+                  ? html`<div class="set-hint" data-testid="settings-gate-error">${gateConnectorsError ?? 'connector 상태를 불러오지 못했습니다.'}</div>`
+                  : html`
+                    <${SetRow} label="Discord trigger policy" hint="live connector payload">
+                      <span class="mono" data-testid="settings-gate-discord-trigger">${gateConnectorsData?.discord_trigger_policy ?? 'unknown'}</span>
+                    <//>
+                    <${SetRow} label="Gate base URL" hint="connector-advertised URLs">
+                      <span class="mono" data-testid="settings-gate-base-live">
+                        ${liveGateBaseUrls.length > 0 ? liveGateBaseUrls.join(', ') : '미수집'}
+                      </span>
+                    <//>
+                    <div class="set-sub-h">Configured connectors (${liveGateConnectors.length})</div>
+                    ${liveGateConnectors.length === 0
+                      ? html`<div class="set-hint" data-testid="settings-gate-empty">설정된 connector가 없습니다.</div>`
+                      : html`
+                        <div class="settings-gate-connectors" data-testid="settings-gate-connectors">
+                          ${liveGateConnectors.map(connector => html`
+                            <div key=${connector.connector_id} class="settings-gate-connector" data-testid="settings-gate-connector">
+                              <div class="settings-gate-connector-head">
+                                <span class="mono">${connector.connector_id}</span>
+                                <span class=${`settings-gate-state ${connectorState(connector)}`}>${connectorStateText(connector)}</span>
+                              </div>
+                              <div class="settings-gate-connector-name">${connector.display_name || connector.channel}</div>
+                              <div class="settings-gate-connector-meta mono">
+                                bindings ${connector.configured_bindings.length} · reply ${connector.reply_mode || 'manual'} · pid ${connector.pid || '-'}
+                              </div>
+                              ${connector.error
+                                ? html`<div class="settings-gate-connector-error">${connector.error}</div>`
+                                : null}
+                            </div>
+                          `)}
+                        </div>
+                      `}
+                  `}
             `}
 
             ${sec === 'paths' && html`

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -90,8 +90,16 @@ const SET_GROUPS: [string, SectionId[]][] = [
 // (Tool_catalog.is_public_mcp). Unknown/empty inventory yields an empty list
 // (no fabricated tool names).
 const MCP_PUBLIC_SURFACE = 'public_mcp'
+const MCP_TRANSPORT_OPTIONS = ['http', 'stdio', 'sse']
 const SETTINGS_LOG_LIMIT = 50
 const SETTINGS_LOG_POLL_MS = 3000
+const DEFAULT_NOTIFY_EVENT_PREVIEW: Record<string, boolean> = {
+  '컨텍스트 임계치 초과': true,
+  '연속 실패': true,
+  'keeper crash/dead': true,
+  '핸드오프 완료': false,
+  '승인 요청': true,
+}
 
 export function normalizeSettingsSection(value: string | null | undefined): SectionId {
   return SETTINGS_ROUTE_SECTION_SET.has(value ?? '') ? (value as SectionId) : 'account'
@@ -173,6 +181,11 @@ function writeLocalPreviewString(key: string, value: string) {
   }
 }
 
+function readLocalPreviewNumber(key: string, fallback: number): number {
+  const parsed = Number(readLocalPreviewString(key, String(fallback)))
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
 function readLocalPreviewBoolRecord(key: string, fallback: Record<string, boolean>): Record<string, boolean> {
   const next = { ...fallback }
   try {
@@ -205,6 +218,15 @@ function useLocalPreviewString(key: string, initialValue: string): [string, (nex
   const setStoredValue = (next: string) => {
     setValue(next)
     writeLocalPreviewString(key, next)
+  }
+  return [value, setStoredValue]
+}
+
+function useLocalPreviewNumber(key: string, initialValue: number): [number, (next: number) => void] {
+  const [value, setValue] = useState(() => readLocalPreviewNumber(key, initialValue))
+  const setStoredValue = (next: number) => {
+    setValue(next)
+    writeLocalPreviewString(key, String(next))
   }
   return [value, setStoredValue]
 }
@@ -774,7 +796,7 @@ export function SettingsSurface() {
 
   // mcp — exposed tools come from the live capability registry (public_mcp surface)
   const [mcpUrl, setMcpUrl] = useLocalPreviewString('mcpUrl', 'https://masc.local/mcp')
-  const [transport, setTransport] = useState('http')
+  const [transport, setTransport] = useLocalPreviewString('mcpTransport', 'http')
   const [mcpTools, setMcpTools] = useState<string[]>([])
   const [tools, setTools] = useState<Record<string, boolean>>({})
 
@@ -786,10 +808,7 @@ export function SettingsSurface() {
         if (!active) return
         const names = mcpExposedToolNames(resp.tool_inventory?.tools ?? [])
         setMcpTools(names)
-        // Listed tools are, by definition, currently exposed over public MCP.
-        // The per-tool toggle is a local view control; expose/unexpose
-        // persistence is deferred (no backend write endpoint yet).
-        setTools(Object.fromEntries(names.map(n => [n, true])))
+        setTools(readLocalPreviewBoolRecord('mcpToolPreview', Object.fromEntries(names.map(n => [n, true]))))
       } catch {
         if (!active) return
         // No fabricated tool names on failure.
@@ -799,6 +818,14 @@ export function SettingsSurface() {
     })()
     return () => { active = false }
   }, [])
+
+  function updateMcpToolPreview(tool: string, enabled: boolean) {
+    setTools(prev => {
+      const next = { ...prev, [tool]: enabled }
+      writeLocalPreviewBoolRecord('mcpToolPreview', next)
+      return next
+    })
+  }
 
   // runtime defaults / model routing — resolved from runtime.toml (SSOT)
   const [runtimeDefaults, setRuntimeDefaults] = useState<RuntimeDefaultsResponse | null>(null)
@@ -1026,16 +1053,10 @@ export function SettingsSurface() {
   const [sampling, setSampling] = useState(100)
 
   // notify / display
-  const [notifyCtx, setNotifyCtx] = useState(85)
-  const [notifyFails, setNotifyFails] = useState(3)
-  const [notifyCh, setNotifyCh] = useState('Slack')
-  const [notifyOn, setNotifyOn] = useState<Record<string, boolean>>({
-    '컨텍스트 임계치 초과': true,
-    '연속 실패': true,
-    'keeper crash/dead': true,
-    '핸드오프 완료': false,
-    '승인 요청': true,
-  })
+  const [notifyCtx, setNotifyCtx] = useLocalPreviewNumber('notifyContextThreshold', 85)
+  const [notifyFails, setNotifyFails] = useLocalPreviewNumber('notifyFailureThreshold', 3)
+  const [notifyCh, setNotifyCh] = useLocalPreviewString('notifyChannel', 'Slack')
+  const [notifyOn, setNotifyOn] = useLocalPreviewBoolRecord('notifyEventPreview', DEFAULT_NOTIFY_EVENT_PREVIEW)
   const [density, setDensity] = useState('regular')
   const [tz, setTz] = useState('Asia/Seoul')
   const [locale, setLocale] = useState('KO')
@@ -1062,6 +1083,8 @@ export function SettingsSurface() {
   const keeperAssignmentCount = keeperAssignments.length > 0
     ? keeperAssignments.length
     : runtimeProviders?.assignment_governance?.assignment_count ?? 0
+  const mcpPreviewEnabledCount = Object.values(tools).filter(Boolean).length
+  const notifyPreviewEnabledCount = Object.values(notifyOn).filter(Boolean).length
 
   return html`
     <main class="v2-shell-surface settings-surf ss-surface bg-surface-page text-text-primary" data-screen-label="설정" data-testid="settings-surface">
@@ -1139,7 +1162,10 @@ export function SettingsSurface() {
 
             ${sec === 'mcp' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Expose this namespace to external agents/clients via an MCP server.
+                Live <span class="mono">public_mcp</span> inventory is read from the backend. Endpoint, transport and per-tool switches below are browser-session exposure previews only; they do not rewrite MCP server policy.
+              </div>
+              <div class="set-local-summary" data-testid="mcp-local-summary">
+                Previewing ${transport} against ${mcpUrl}; ${mcpPreviewEnabledCount}/${mcpTools.length} listed tools selected in this browser session.
               </div>
               <${SetRow} label="MCP endpoint" hint="GET/POST /mcp">
                 <div class="set-path">
@@ -1152,23 +1178,29 @@ export function SettingsSurface() {
                   <${PreviewBadge} />
                 </div>
               <//>
-              <${SetRow} label="Transport" hint="transport">
-                <${SetSeg} value=${transport} options=${['http', 'stdio', 'sse']} onChange=${setTransport} />
+              <${SetRow} label="Transport" hint="browser-session preview">
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetSeg} value=${transport} options=${MCP_TRANSPORT_OPTIONS} onChange=${setTransport} />
+                </div>
               <//>
               <div class="set-mcp-detail mono">
                 ${transport === 'http' && html`<span>POST ${mcpUrl} · Content-Type: application/json · Authorization: Bearer ••••</span>`}
-                ${transport === 'stdio' && html`<span>spawn: masc-mcp serve --stdio · framing: ndjson · pid 8421</span>`}
+                ${transport === 'stdio' && html`<span>spawn: masc-mcp serve --stdio · framing: ndjson</span>`}
                 ${transport === 'sse' && html`<span>GET ${mcpUrl}/sse · keep-alive 15s · event: message</span>`}
               </div>
-              <div class="set-sub-h">Exposed tools (${Object.values(tools).filter(Boolean).length}/${mcpTools.length})</div>
+              <div class="set-sub-h">Local tool exposure preview (${mcpPreviewEnabledCount}/${mcpTools.length})</div>
               ${mcpTools.length === 0
                 ? html`<div class="set-hint" data-testid="mcp-tools-empty">노출된 MCP 도구가 없습니다.</div>`
                 : mcpTools.map(t => html`
                 <${SetRow} key=${t} label=${html`<span class="mono" style=${{ fontSize: '12.5px' }}>${t}</span>`}>
-                  <${SetToggle}
-                    on=${tools[t] ?? false}
-                    onChange=${(v: boolean) => setTools(p => ({ ...p, [t]: v }))}
-                  />
+                  <div class="set-tg-control">
+                    <${PreviewBadge} />
+                    <${SetToggle}
+                      on=${tools[t] ?? false}
+                      onChange=${(v: boolean) => updateMcpToolPreview(t, v)}
+                    />
+                  </div>
                 <//>
               `)}
             `}
@@ -1654,21 +1686,38 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'notify' && html`
+              <div class="set-local-summary" data-testid="notify-local-summary">
+                Browser-session preview: ${notifyCh} channel, context ${notifyCtx}%, failures ${notifyFails}, ${notifyPreviewEnabledCount}/${Object.keys(notifyOn).length} events enabled.
+              </div>
+              <div class="set-notify-section">
               <${SetRow} label="Context threshold alert" hint="Notify when context exceeds this %">
-                <${SetSlider} value=${notifyCtx} min=${70} max=${98} suffix="%" onChange=${setNotifyCtx} />
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetSlider} value=${notifyCtx} min=${70} max=${98} suffix="%" onChange=${setNotifyCtx} />
+                </div>
               <//>
               <${SetRow} label="Consecutive failure alert" hint="Notify after this many consecutive failures">
-                <${SetStepper} v=${notifyFails} set=${setNotifyFails} min=${1} max=${10} />
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetStepper} v=${notifyFails} set=${setNotifyFails} min=${1} max=${10} />
+                </div>
               <//>
               <${SetRow} label="Notify channel" hint="Where to send">
-                <${SetSeg} value=${notifyCh} options=${['Slack', 'Discord', '없음']} onChange=${setNotifyCh} />
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetSeg} value=${notifyCh} options=${['Slack', 'Discord', '없음']} onChange=${setNotifyCh} />
+                </div>
               <//>
               <div class="set-sub-h">Notify events</div>
               ${Object.keys(notifyOn).map(k => html`
                 <${SetRow} key=${k} label=${k}>
-                  <${SetToggle} on=${notifyOn[k]} onChange=${(v: boolean) => setNotifyOn(p => ({ ...p, [k]: v }))} />
+                  <div class="set-tg-control">
+                    <${PreviewBadge} />
+                    <${SetToggle} on=${notifyOn[k]} onChange=${(v: boolean) => setNotifyOn(p => ({ ...p, [k]: v }))} />
+                  </div>
                 <//>
               `)}
+              </div>
             `}
 
             ${sec === 'display' && html`

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -41,6 +41,9 @@ describe('runtime TOML dashboard editing helpers', () => {
     const environment = parseRuntimeTomlEnvironment(sourceText)
 
     expect(environment.defaultRuntimeId).toBe('runpod_mtp.qwen')
+    expect(environment.librarianRuntimeId).toBe('')
+    expect(environment.crossVerifierRuntimeId).toBe('')
+    expect(environment.assignments).toEqual({})
     expect(environment.providers[0]).toMatchObject({
       id: 'runpod_mtp',
       displayName: 'RunPod',
@@ -63,6 +66,27 @@ describe('runtime TOML dashboard editing helpers', () => {
       id: 'runpod_mtp.qwen',
       maxConcurrent: 4,
       keepAlive: '10m',
+    })
+  })
+
+  it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
+    const withRouting = `${sourceText.replace(
+      'default = "runpod_mtp.qwen"',
+      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
+    )}
+
+[runtime.assignments]
+sangsu = "runpod_mtp.qwen"
+mad-improver = "runpod_mtp.qwen"
+`
+
+    const environment = parseRuntimeTomlEnvironment(withRouting)
+
+    expect(environment.librarianRuntimeId).toBe('runpod_mtp.qwen')
+    expect(environment.crossVerifierRuntimeId).toBe('runpod_mtp.qwen')
+    expect(environment.assignments).toEqual({
+      sangsu: 'runpod_mtp.qwen',
+      'mad-improver': 'runpod_mtp.qwen',
     })
   })
 

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -36,6 +36,9 @@ export interface RuntimeTomlBinding {
 
 export interface RuntimeTomlEnvironment {
   defaultRuntimeId: string
+  librarianRuntimeId: string
+  crossVerifierRuntimeId: string
+  assignments: Record<string, string>
   providers: RuntimeTomlProvider[]
   models: RuntimeTomlModel[]
   bindings: RuntimeTomlBinding[]
@@ -242,6 +245,11 @@ function bindingFromDocument(
 export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvironment {
   const document = parseDocument(sourceText)
   const runtimeValues = sectionValues(document, 'runtime')
+  const assignmentValues = sectionValues(document, 'runtime.assignments')
+  const assignments = Object.fromEntries(
+    Object.entries(assignmentValues)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
   const providers = providerIds(document).map(id => providerFromDocument(document, id))
   const models = modelIds(document).map(id => modelFromDocument(document, id))
   const bindings = bindingSections(document).map(entry => bindingFromDocument(document, entry))
@@ -251,6 +259,9 @@ export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvi
   if (bindings.length === 0) warnings.push('provider.model binding section not found')
   return {
     defaultRuntimeId: asString(runtimeValues.default),
+    librarianRuntimeId: asString(runtimeValues.librarian),
+    crossVerifierRuntimeId: asString(runtimeValues.cross_verifier),
+    assignments,
     providers,
     models,
     bindings,

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -412,6 +412,60 @@
   max-width: 100%;
 }
 
+.set-select {
+  width: 260px;
+  max-width: 100%;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-well);
+  color: var(--text-mid);
+  padding: 7px 10px;
+  outline: none;
+}
+
+.set-row textarea.set-input {
+  width: min(420px, 100%);
+  min-height: 92px;
+  resize: vertical;
+  white-space: pre;
+}
+
+@media (max-width: 640px) {
+  .set-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .set-row-c {
+    width: 100%;
+  }
+
+  .set-select,
+  .set-path .set-input,
+  .set-row textarea.set-input {
+    width: 100%;
+  }
+
+  .set-mcp-detail {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
+.set-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-top: 10px;
+}
+
+.set-verify:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .set-path-check-result {
   font-size: var(--fs-11);
   font-family: var(--font-mono);
@@ -537,6 +591,73 @@
 .set-rt-open:hover {
   background: var(--volt);
   color: var(--volt-ink);
+}
+
+.settings-gate-connectors {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.settings-gate-connector {
+  min-width: 0;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 11px 12px;
+}
+
+.settings-gate-connector-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-gate-state {
+  flex: none;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  color: var(--text-dim);
+}
+
+.settings-gate-state.connected {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
+}
+
+.settings-gate-state.stale {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
+}
+
+.settings-gate-state.offline {
+  color: var(--status-fail);
+  border-color: color-mix(in oklab, var(--status-fail) 45%, transparent);
+}
+
+.settings-gate-connector-name {
+  margin-top: 7px;
+  color: var(--text-mid);
+  font-size: var(--fs-13);
+}
+
+.settings-gate-connector-meta,
+.settings-gate-connector-error {
+  margin-top: 5px;
+  font-size: var(--fs-11);
+}
+
+.settings-gate-connector-meta {
+  color: var(--text-dim);
+}
+
+.settings-gate-connector-error {
+  color: var(--status-fail);
 }
 
 /* system log viewer */

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -995,6 +995,26 @@
   flex-shrink: 0;
 }
 
+.settings-surf .set-notify-section .set-row {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-surf .set-notify-section .set-row-l,
+.settings-surf .set-notify-section .set-row-c {
+  width: 100%;
+}
+
+.settings-surf .set-notify-section .set-row-c {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.settings-surf .set-notify-section .set-row-c > .set-tg-control {
+  flex-wrap: wrap;
+}
+
 .set-tg-l {
   flex: 1;
   min-width: 0;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -598,6 +598,10 @@ let assignment_line ~keeper_name ~runtime_id =
     (toml_escape_string runtime_id)
 ;;
 
+let runtime_scalar_line ~key ~runtime_id =
+  Printf.sprintf "%s = \"%s\"" key (toml_escape_string runtime_id)
+;;
+
 let split_lines content =
   if String.equal content "" then [], false
   else (
@@ -637,6 +641,10 @@ let is_toml_table_header line =
 
 let is_runtime_assignments_header line =
   String.equal (line |> strip_toml_comment |> String.trim) "[runtime.assignments]"
+;;
+
+let is_runtime_header line =
+  String.equal (line |> strip_toml_comment |> String.trim) "[runtime]"
 ;;
 
 let rec split_at n xs =
@@ -723,7 +731,46 @@ let replace_or_append_assignment section_lines ~keeper_name ~runtime_id =
          List.rev_append acc (line :: rest)
        | _ -> loop (existing :: acc) rest)
   in
+    loop [] section_lines
+;;
+
+let remove_assignment section_lines ~keeper_name =
+  List.filter
+    (fun existing ->
+      match assignment_key_of_line existing with
+      | Some key when String.equal key keeper_name -> false
+      | _ -> true)
+    section_lines
+;;
+
+let replace_or_append_runtime_scalar section_lines ~key ~runtime_id =
+  let line = runtime_scalar_line ~key ~runtime_id in
+  let rec loop acc = function
+    | [] -> List.rev_append acc [ line ]
+    | existing :: rest ->
+      (match assignment_key_of_line existing with
+       | Some existing_key when String.equal existing_key key ->
+         List.rev_append acc (line :: rest)
+       | _ -> loop (existing :: acc) rest)
+  in
   loop [] section_lines
+;;
+
+let remove_runtime_scalar section_lines ~key =
+  List.filter
+    (fun existing ->
+      match assignment_key_of_line existing with
+      | Some existing_key when String.equal existing_key key -> false
+      | _ -> true)
+    section_lines
+;;
+
+let append_runtime_section lines ~key ~runtime_id =
+  let section = [ "[runtime]"; runtime_scalar_line ~key ~runtime_id ] in
+  match List.rev lines with
+  | [] -> section
+  | last :: _ when String.equal (String.trim last) "" -> lines @ section
+  | _ -> lines @ ("" :: section)
 ;;
 
 let append_runtime_assignments_section lines ~keeper_name ~runtime_id =
@@ -758,6 +805,55 @@ let update_runtime_assignment_text content ~keeper_name ~runtime_id =
                  ~keeper_name
                  ~runtime_id)
          @ after_section)
+  in
+  join_lines updated_lines ~trailing_newline:true
+;;
+
+let update_runtime_scalar_text content ~key ~runtime_id =
+  let lines, _trailing_newline = split_lines content in
+  let updated_lines =
+    match find_index is_runtime_header lines, runtime_id with
+    | None, None -> lines
+    | None, Some runtime_id -> append_runtime_section lines ~key ~runtime_id
+    | Some header_index, _ ->
+      let before, from_header = split_at header_index lines in
+      (match from_header with
+       | [] ->
+         (match runtime_id with
+          | None -> lines
+          | Some runtime_id -> append_runtime_section lines ~key ~runtime_id)
+       | header :: after_header ->
+         let section_lines, after_section =
+           match find_index is_toml_table_header after_header with
+           | None -> after_header, []
+           | Some next_header_index -> split_at next_header_index after_header
+         in
+         let next_section_lines =
+           match runtime_id with
+           | None -> remove_runtime_scalar section_lines ~key
+           | Some runtime_id -> replace_or_append_runtime_scalar section_lines ~key ~runtime_id
+         in
+         before @ (header :: next_section_lines) @ after_section)
+  in
+  join_lines updated_lines ~trailing_newline:true
+;;
+
+let remove_runtime_assignment_text content ~keeper_name =
+  let lines, _trailing_newline = split_lines content in
+  let updated_lines =
+    match find_index is_runtime_assignments_header lines with
+    | None -> lines
+    | Some header_index ->
+      let before, from_header = split_at header_index lines in
+      (match from_header with
+       | [] -> lines
+       | header :: after_header ->
+         let section_lines, after_section =
+           match find_index is_toml_table_header after_header with
+           | None -> after_header, []
+           | Some next_header_index -> split_at next_header_index after_header
+         in
+         before @ (header :: remove_assignment section_lines ~keeper_name) @ after_section)
   in
   join_lines updated_lines ~trailing_newline:true
 ;;
@@ -818,6 +914,57 @@ let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
     let* () = Fs_compat.save_file_atomic path next in
     let* () = init_default ~config_path:path in
     Ok ()
+;;
+
+let clear_runtime_id_for_keeper ?runtime_config_path ~keeper_name () =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name ""
+  then Error "keeper_name must not be empty"
+  else if contains_newline keeper_name
+  then Error "keeper_name must not contain newlines"
+  else
+    let* path = runtime_config_path_result ?runtime_config_path () in
+    let* content = load_file_result path in
+    let next = remove_runtime_assignment_text content ~keeper_name in
+    let* () = validate_runtime_config_text ~config_path:path next in
+    let* () = Fs_compat.save_file_atomic path next in
+    let* () = init_default ~config_path:path in
+    Ok ()
+;;
+
+let set_runtime_scalar ?runtime_config_path ~key ~runtime_id () =
+  let key = String.trim key in
+  let runtime_id = Option.map String.trim runtime_id in
+  if String.equal key ""
+  then Error "runtime key must not be empty"
+  else if contains_newline key
+  then Error "runtime key must not contain newlines"
+  else
+    match runtime_id with
+    | Some runtime_id when String.equal runtime_id "" ->
+      Error "runtime_id must not be empty"
+    | Some runtime_id when contains_newline runtime_id ->
+      Error "runtime_id must not contain newlines"
+    | _ ->
+      let* path = runtime_config_path_result ?runtime_config_path () in
+      let* content = load_file_result path in
+      let next = update_runtime_scalar_text content ~key ~runtime_id in
+      let* () = validate_runtime_config_text ~config_path:path next in
+      let* () = Fs_compat.save_file_atomic path next in
+      let* () = init_default ~config_path:path in
+      Ok ()
+;;
+
+let set_runtime_default ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar ?runtime_config_path ~key:"default" ~runtime_id:(Some runtime_id) ()
+;;
+
+let set_runtime_librarian ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar ?runtime_config_path ~key:"librarian" ~runtime_id ()
+;;
+
+let set_runtime_cross_verifier ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar ?runtime_config_path ~key:"cross_verifier" ~runtime_id ()
 ;;
 
 (* RFC-0206 single-binding: the deleted [Runtime_runtime.resolve_*_max_context]

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -202,6 +202,30 @@ val set_runtime_id_for_keeper :
     runtime config, atomically write it, and refresh the in-process runtime
     assignment cache. *)
 
+val clear_runtime_id_for_keeper :
+  ?runtime_config_path:string -> keeper_name:string -> unit -> (unit, string) result
+(** Remove [keeper_name] from [\[runtime.assignments\]], validate the resulting
+    runtime config, atomically write it, and refresh the in-process runtime
+    assignment cache. *)
+
+val set_runtime_default :
+  ?runtime_config_path:string -> runtime_id:string -> unit -> (unit, string) result
+(** Persist [\[runtime\]].default through the runtime.toml SSOT writer,
+    validate the resulting config, atomically write it, and refresh the
+    in-process runtime cache. *)
+
+val set_runtime_librarian :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+(** Persist or clear [\[runtime\]].librarian through the runtime.toml SSOT
+    writer, validate the resulting config, atomically write it, and refresh the
+    in-process runtime cache. *)
+
+val set_runtime_cross_verifier :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+(** Persist or clear [\[runtime\]].cross_verifier through the runtime.toml SSOT
+    writer, validate the resulting config, atomically write it, and refresh the
+    in-process runtime cache. *)
+
 val default_max_context : unit -> int
 (** Context-window budget of the default runtime's model (RFC-0206
     single-binding). Replaces the deleted [Runtime_runtime.resolve_*_max_context]

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -192,10 +192,104 @@ let parse_runtime_config_raw_body body_str =
   with
   | Yojson.Json_error err -> Error ("invalid json: " ^ err)
 
+type runtime_route_lane =
+  | Runtime_default
+  | Runtime_librarian
+  | Runtime_cross_verifier
+
+let parse_runtime_route_lane = function
+  | "default" -> Ok Runtime_default
+  | "librarian" -> Ok Runtime_librarian
+  | "cross_verifier" -> Ok Runtime_cross_verifier
+  | lane -> Error (Printf.sprintf "unknown runtime routing lane: %s" lane)
+
+let required_string_field json name =
+  match Json_util.assoc_member_opt name json with
+  | Some (`String value) when not (String.equal (String.trim value) "") ->
+    Ok (String.trim value)
+  | Some (`String _) -> Error (name ^ " must not be empty")
+  | Some _ -> Error (name ^ " must be a string")
+  | None -> Error (name ^ " required")
+
+let optional_string_field json name =
+  match Json_util.assoc_member_opt name json with
+  | None | Some `Null -> Ok None
+  | Some (`String value) ->
+    let trimmed = String.trim value in
+    if String.equal trimmed "" then Ok None else Ok (Some trimmed)
+  | Some _ -> Error (name ^ " must be a string or null")
+
+let parse_runtime_route_body body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc _ as json ->
+      (match required_string_field json "lane" with
+       | Error _ as err -> err
+       | Ok lane ->
+         (match parse_runtime_route_lane lane with
+          | Error _ as err -> err
+          | Ok parsed_lane ->
+            (match optional_string_field json "runtime_id" with
+             | Error _ as err -> err
+             | Ok runtime_id -> Ok (parsed_lane, runtime_id))))
+    | _ -> Error "JSON object body required"
+  with
+  | Yojson.Json_error err -> Error ("invalid json: " ^ err)
+
+let parse_runtime_assignment_body body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc _ as json ->
+      (match required_string_field json "keeper_name" with
+       | Error _ as err -> err
+       | Ok keeper_name ->
+         (match optional_string_field json "runtime_id" with
+          | Error _ as err -> err
+          | Ok runtime_id -> Ok (keeper_name, runtime_id)))
+    | _ -> Error "JSON object body required"
+  with
+  | Yojson.Json_error err -> Error ("invalid json: " ^ err)
+
 let runtime_config_path_error_status message =
   if String.equal message "runtime config path not found"
   then `Not_found
   else `Internal_server_error
+
+let audit_runtime_config_write state agent_name ?path ~text ~outcome () =
+  try
+    Audit_log.log_action
+      (Mcp_server.workspace_config state)
+      ~agent_id:agent_name
+      ~action:Audit_log.RuntimeConfigWrite
+      ~details:
+        (`Assoc
+           ((match path with
+             | Some p -> [ ("path", `String p) ]
+             | None -> [])
+            @ [ ("bytes", `Int (String.length text))
+              ; ("lines", `Int (runtime_config_line_count text))
+              ]))
+      ~outcome
+      ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Dashboard.warn
+      "runtime.toml audit log failed: %s"
+      (Printexc.to_string exn)
+
+let respond_runtime_config_reload state agent_name request reqd =
+  match Runtime_config_file.load_config_text () with
+  | Ok (path, saved_text) ->
+    audit_runtime_config_write state agent_name ~path ~text:saved_text
+      ~outcome:Audit_log.Success ();
+    Http.Response.json_value ~compress:true ~request
+      (runtime_config_raw_json ~path ~source_text:saved_text ~reloaded:true)
+      reqd
+  | Error msg ->
+    respond_dashboard_error
+      ~status:(runtime_config_path_error_status msg)
+      ~request reqd msg
 
 let add_routes ~sw ~clock router =
   router
@@ -374,56 +468,75 @@ let add_routes ~sw ~clock router =
                (* RFC-0273 §3.3 — record the runtime.toml write to the governance
                   audit trail (actor + path + size) on top of the CanAdmin gate.
                   The config body is deliberately excluded: runtime.toml can carry
-                  provider secrets (RFC-0132 redaction). Accountability is a side
-                  effect that must never fail the primary write's response, so
-                  audit I/O errors (ENOSPC/EACCES) are demoted to a warning — by
-                  this point the routing change is already live (or already
-                  rejected), and a propagated 5xx would make the operator resubmit
-                  a committed change. Both outcomes are logged: a rejected
-                  CanAdmin routing change is itself a governance signal. *)
-               let audit_runtime_write ?path ~text ~outcome () =
-                 try
-                   Audit_log.log_action
-                     (Mcp_server.workspace_config state)
-                     ~agent_id:agent_name
-                     ~action:Audit_log.RuntimeConfigWrite
-                     ~details:
-                       (`Assoc
-                          ((match path with
-                            | Some p -> [ ("path", `String p) ]
-                            | None -> [])
-                          @ [ ("bytes", `Int (String.length text))
-                            ; ("lines", `Int (runtime_config_line_count text))
-                            ]))
-                     ~outcome
-                     ()
-                 with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                   Log.Dashboard.warn
-                     "runtime.toml audit log failed: %s"
-                     (Printexc.to_string exn)
-               in
+                  provider secrets (RFC-0132 redaction). *)
                (match Runtime_config_file.save_config_text source_text with
                 | Error msg ->
-                  audit_runtime_write ~text:source_text
+                  audit_runtime_config_write state agent_name ~text:source_text
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () ->
-                  (match Runtime_config_file.load_config_text () with
-                   | Ok (path, saved_text) ->
-                     audit_runtime_write ~path ~text:saved_text
-                       ~outcome:Audit_log.Success ();
-                     Http.Response.json_value ~compress:true ~request:req
-                       (runtime_config_raw_json
-                          ~path
-                          ~source_text:saved_text
-                          ~reloaded:true)
-                       reqd
-                   | Error msg ->
-                     respond_dashboard_error
-                       ~status:(runtime_config_path_error_status msg)
-                       ~request:req reqd msg)))
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+           )
+         ) request reqd)
+  |> Http.Router.post "/api/v1/runtime/config/routing" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             match parse_runtime_route_body body_str with
+             | Error msg ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+             | Ok (Runtime_default, Some runtime_id) ->
+               (match Runtime_config_file.set_runtime_default ~runtime_id () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+             | Ok (Runtime_default, None) ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd
+                 "default runtime_id required"
+             | Ok (Runtime_librarian, runtime_id) ->
+               (match Runtime_config_file.set_runtime_librarian ~runtime_id () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+             | Ok (Runtime_cross_verifier, runtime_id) ->
+               (match Runtime_config_file.set_runtime_cross_verifier ~runtime_id () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+           )
+         ) request reqd)
+  |> Http.Router.post "/api/v1/runtime/config/assignment" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             match parse_runtime_assignment_body body_str with
+             | Error msg ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+             | Ok (keeper_name, Some runtime_id) ->
+               (match
+                  Runtime_config_file.set_runtime_id_for_keeper
+                    ~keeper_name
+                    ~runtime_id
+                    ()
+                with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+             | Ok (keeper_name, None) ->
+               (match Runtime_config_file.clear_runtime_id_for_keeper ~keeper_name () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+           )
          ) request reqd)
   (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders
      hit_ratio, in-flight compute count, per-entry ttl_remaining, and

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -317,6 +317,78 @@ let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
       (Runtime.runtime_id_for_keeper "routingtest"))
 ;;
 
+let test_runtime_assignment_writer_clears_assignment () =
+  with_runtime_file (fun path ->
+    (match Runtime.clear_runtime_id_for_keeper ~runtime_config_path:path ~keeper_name:"routingtest" () with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "clear_runtime_id_for_keeper failed: %s" msg);
+    Alcotest.(check bool)
+      "runtime.toml assignment removed"
+      false
+      (string_contains (Fs_compat.load_file path) "routingtest");
+    Alcotest.(check (option string))
+      "in-process assignment cache cleared"
+      None
+      (Runtime.runtime_id_for_keeper "routingtest"))
+;;
+
+let test_runtime_route_writer_updates_default () =
+  with_runtime_file (fun path ->
+    (match Runtime.set_runtime_default ~runtime_config_path:path ~runtime_id:"openai.gpt" () with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "set_runtime_default failed: %s" msg);
+    Alcotest.(check bool)
+      "runtime.toml default rewritten"
+      true
+      (string_contains (Fs_compat.load_file path) "default = \"openai.gpt\"");
+    Alcotest.(check string)
+      "runtime cache default refreshed"
+      "openai.gpt"
+      (Runtime.get_default_runtime_id ()))
+;;
+
+let test_runtime_route_writer_rejects_unknown_default_without_write () =
+  with_runtime_file (fun path ->
+    let before = Fs_compat.load_file path in
+    (match Runtime.set_runtime_default ~runtime_config_path:path ~runtime_id:"missing.runtime" () with
+     | Ok () -> Alcotest.fail "expected unknown default runtime to fail"
+     | Error msg ->
+       Alcotest.(check bool)
+         "error mentions unresolved default"
+         true
+         (string_contains msg "missing.runtime"));
+    Alcotest.(check string)
+      "runtime.toml unchanged after validation failure"
+      before
+      (Fs_compat.load_file path);
+    Alcotest.(check string)
+      "runtime cache unchanged"
+      "runpod_mtp.qwen"
+      (Runtime.get_default_runtime_id ()))
+;;
+
+let test_runtime_route_writer_clears_optional_librarian () =
+  with_runtime_file (fun path ->
+    (match Runtime.set_runtime_librarian ~runtime_config_path:path ~runtime_id:(Some "openai.gpt") () with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "set_runtime_librarian failed: %s" msg);
+    Alcotest.(check (option string))
+      "librarian set"
+      (Some "openai.gpt")
+      (Runtime.librarian_runtime_id ());
+    (match Runtime.set_runtime_librarian ~runtime_config_path:path ~runtime_id:None () with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "clear runtime librarian failed: %s" msg);
+    Alcotest.(check bool)
+      "runtime.toml librarian removed"
+      false
+      (string_contains (Fs_compat.load_file path) "librarian");
+    Alcotest.(check (option string))
+      "librarian cache cleared"
+      None
+      (Runtime.librarian_runtime_id ()))
+;;
+
 let test_runtime_config_text_loads_runtime_toml () =
   with_runtime_file (fun path ->
     match Runtime.load_config_text ~runtime_config_path:path () with
@@ -701,6 +773,22 @@ let () =
             "unknown assignment is rejected before runtime.toml write"
             `Quick
             test_runtime_assignment_writer_rejects_unknown_runtime_without_write
+        ; Alcotest.test_case
+            "dashboard runtime assignment clear validates and refreshes cache"
+            `Quick
+            test_runtime_assignment_writer_clears_assignment
+        ; Alcotest.test_case
+            "dashboard runtime route writer updates default"
+            `Quick
+            test_runtime_route_writer_updates_default
+        ; Alcotest.test_case
+            "unknown default route is rejected before runtime.toml write"
+            `Quick
+            test_runtime_route_writer_rejects_unknown_default_without_write
+        ; Alcotest.test_case
+            "dashboard runtime route writer clears optional librarian"
+            `Quick
+            test_runtime_route_writer_clears_optional_librarian
         ; Alcotest.test_case
             "dashboard raw runtime.toml load returns full source"
             `Quick


### PR DESCRIPTION
## Summary
- remove the non-configurable Default context row from Settings > Runtime while keeping context in the live catalog cards
- replace read-only model routing with the live runtime.toml editor for default/librarian/cross-verifier/keeper assignments
- replace fake sandbox and connector gate controls with live keeper config and live gate connector data
- add fleet-composite keeper-name fallback so sandbox settings work before the keeper store is hydrated

## Verification
- npx tsc --noEmit --pretty
- npx vitest run src/components/settings-surface.test.ts src/lib/runtime-toml-config.test.ts
- npx eslint src/components/settings-surface.ts src/components/runtime-environment-editor.ts src/lib/runtime-toml-config.ts src/components/settings-surface.test.ts src/lib/runtime-toml-config.test.ts (exit 0; current config ignores some files with warnings)
- Playwright screenshots: /private/tmp/masc-settings-screens/{runtime,routing,sandbox,gate}-desktop.png and sandbox/gate/routing mobile captures