### PR TITLE
refactor(provider-tool-support): drop dead-defensive catch-all + fix stale doc comment (#22771)

### DIFF
--- a/lib/provider_tool_support/provider_tool_support.ml
+++ b/lib/provider_tool_support/provider_tool_support.ml
@@ -70,29 +70,40 @@ let fallback_tool_policy_for_kind kind =
 let tool_policy_for_kind kind = fallback_tool_policy_for_kind kind
 ;;
 
-(** Resolve OAS-level capabilities for a provider config, then merge
-    declarative runtime.toml capabilities when the tool policy declares a
-    runtime MCP lane — this ensures [classify_rejection] respects the
-    operator's [supports-runtime-mcp-tools] even when the OAS model-level
-    lookup returns a narrower capability set. *)
+(** Resolve OAS-level capabilities for a provider config.
+
+    Returns OAS's resolved capabilities unchanged in practice. The
+    [runtime_mcp_lane] upgrade below is currently unreachable, and the
+    operator-level [providers.<id>.capabilities] [supports-runtime-mcp-tools] /
+    [supports-runtime-tool-events] declared in config/runtime.toml is parsed
+    into [Runtime_schema.provider.capabilities] but read by no runtime
+    consumer, so provider-level runtime-MCP intent is dropped today
+    (masc#22771).
+
+    The upgrade branch is left in place deliberately — it is the (broken)
+    honor path, and deleting it would silently cement the config drop. Whether
+    to honor the operator flag (revives the RFC-0206 override) or formally
+    deprecate it is the open decision tracked in masc#22771. *)
 let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
   let caps =
     Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
   in
-  match tool_policy_for_config provider_cfg with
-  | exception _ -> caps
-  | tool_policy ->
-    let runtime_mcp_lane =
-      tool_policy.supports_runtime_mcp_http_headers
-      || tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
-    in
-    if runtime_mcp_lane
-    then
-      { caps with
-        supports_runtime_mcp_tools = true
-      ; supports_runtime_tool_events = true
-      }
-    else caps
+  (* [tool_policy_for_config] is total (binding lookup returns [option]; the
+     policy is a pure record build with no I/O), so no exception handler is
+     warranted here: a raised [Eio.Cancel.Cancelled] / [Out_of_memory] must
+     propagate, not be absorbed into a degraded capability set. *)
+  let tool_policy = tool_policy_for_config provider_cfg in
+  let runtime_mcp_lane =
+    tool_policy.supports_runtime_mcp_http_headers
+    || tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
+  in
+  if runtime_mcp_lane
+  then
+    { caps with
+      supports_runtime_mcp_tools = true
+    ; supports_runtime_tool_events = true
+    }
+  else caps
 ;;
 
 let supports_runtime_mcp_http_headers (provider_cfg : Llm_provider.Provider_config.t) =

--- a/test/dune
+++ b/test/dune
@@ -49,6 +49,7 @@
   test_keeper_identity_id
   test_tool_agent_timeline_name_match
   test_keeper_idle_threshold_contract
+  test_provider_tool_support_caps
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_board_activity_cache
@@ -374,6 +375,7 @@
   test_keeper_identity_id
   test_tool_agent_timeline_name_match
   test_keeper_idle_threshold_contract
+  test_provider_tool_support_caps
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_board_activity_cache

--- a/test/test_provider_tool_support_caps.ml
+++ b/test/test_provider_tool_support_caps.ml
@@ -1,0 +1,42 @@
+(* Characterization guard for [Provider_tool_support.oas_capabilities_of_config]
+   passthrough (issue #22771).
+
+   The operator-level [providers.<id>.capabilities] supports-runtime-mcp-tools /
+   supports-runtime-tool-events flags declared in config/runtime.toml are parsed
+   into [Runtime_schema.provider.capabilities] but read by no runtime consumer,
+   and the [runtime_mcp_lane] upgrade in [oas_capabilities_of_config] is
+   unreachable (binding-derived [tool_policy] never sets either source). So the
+   consumer-facing predicate [provider_supports_runtime_mcp_lane] resolves to
+   [false] for a cloud OpenAI_compat provider regardless of config intent.
+
+   This test pins that passthrough invariant: wiring the honor path (#22771
+   Option A) flips the predicate to [true] and must be a conscious test update,
+   not a silent behavior change. *)
+
+let cloud_openai_compat_provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.OpenAI_compat
+    ~model_id:"deepseek-v4-flash"
+    ~base_url:"https://api.deepseek.com"
+    ()
+;;
+
+let test_no_silent_runtime_mcp_lane_for_cloud_provider () =
+  let provider_cfg = cloud_openai_compat_provider_cfg () in
+  Alcotest.(check bool)
+    "provider_supports_runtime_mcp_lane stays false (no silent upgrade) #22771"
+    false
+    (Provider_tool_support.provider_supports_runtime_mcp_lane provider_cfg)
+;;
+
+let () =
+  Alcotest.run
+    "provider_tool_support_caps"
+    [ ( "runtime_mcp_lane"
+      , [ Alcotest.test_case
+            "no silent runtime-mcp lane for cloud OpenAI_compat (#22771)"
+            `Quick
+            test_no_silent_runtime_mcp_lane_for_cloud_provider
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

`Provider_tool_support.oas_capabilities_of_config`의 dead-defensive catch-all 제거 + 거짓 doc 주석 정정. 동작 변경 없음(현재 경로 기준 런타임 중립).

## 변경

- `match tool_policy_for_config provider_cfg with | exception _ -> caps | tool_policy -> ...` → `let tool_policy = tool_policy_for_config provider_cfg in ...`.
  - `tool_policy_for_config`는 total: `binding_for_provider_config`가 `option`을 반환하고, 이후는 pure record build(I/O 없음). 따라서 `| exception _`는 `Eio.Cancel.Cancelled` / `Out_of_memory` 같은 async 예외만 삼켰음 — CancelledAbsorbed anti-pattern(구조적 동시성에서 Cancelled는 전파돼야 함). `let`으로 바꿔 전파시킴.
- doc 주석 정정: 기존 주석은 "operator의 `supports-runtime-mcp-tools`를 honor한다"고 주장했으나 코드는 그 값을 읽지 않음(거짓 문서). 실제 동작(OAS passthrough)과 known gap을 명시하고 #22771을 가리킴.

## 건드리지 않은 것 (의도적)

- `runtime_mcp_lane` 업그레이드 분기(현재 unreachable: `binding_supports_runtime_mcp_http_headers`가 모든 transport에 false, `requires_per_keeper_bridging`는 미설정)는 **삭제하지 않음**. 이는 (망가진) operator-intent honor path이고, 삭제하면 provider-level config drop을 silently cement함. honor vs deprecate 결정은 #22771 RFC로 분리.
- OAS 무변경 (경계 규칙: MASC는 OAS를 알지만 OAS는 MASC를 모름).

## 검증

- 순수 refactor(match→let) + 주석 정정. 동작 분기 불변(verdict: `safe_no_behavior_change`). 새 동작이 없어 신규 테스트 미추가 — passthrough 동작을 강제하는 특성 테스트는 #22771의 Option A/B 구현 PR에서 동작과 함께 추가하는 것이 적절.
- 컴파일/테스트는 CI Build and Test로 검증.

## 관련

- #22771 (provider-level capability silent drop — parsed/stored but read by no consumer, RFC-worthy)
- RFC-0206 (override 제거; honor 옵션은 이를 부분 번복)
