### PR TITLE
feat(dashboard): require strict JSON for judges

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -531,25 +531,14 @@ let parse_recommended_action json =
   | _ -> None
 
 type governance_response_parse_failure =
-  | Lenient_fallback of string
   | Structural_error of string
 
-let parse_lenient_governance_json raw_text =
-  let parsed = Llm_provider.Lenient_json.parse raw_text in
-  match parsed with
-  | `Assoc [("raw", `String raw)] -> (
-      match Judge_json_recovery.extract_balanced_object raw with
-      | Some block -> (
-          try
-            match Llm_provider.Lenient_json.parse block with
-            | `Assoc [ ("raw", `String recovered_raw) ] ->
-                Error (Lenient_fallback recovered_raw)
-            | parsed -> Ok parsed
-          with
-          | Yojson.Json_error _ -> Error (Lenient_fallback raw)
-          | Failure _ -> Error (Lenient_fallback raw))
-      | None -> Error (Lenient_fallback raw))
-  | _ -> Ok parsed
+let parse_strict_governance_json raw_text =
+  match Yojson.Safe.from_string (String.trim raw_text) with
+  | json -> Ok json
+  | exception Yojson.Json_error msg ->
+      Error
+        (Structural_error (Printf.sprintf "invalid strict JSON: %s" msg))
 
 let parse_required_guardrail_state json =
   match Json_util.assoc_member_opt "guardrail_state" json with
@@ -632,7 +621,7 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
                  ]))
 
 let parse_governance_response ~raw_text ~generated_at ~expires_at ~model_used =
-  match parse_lenient_governance_json raw_text with
+  match parse_strict_governance_json raw_text with
   | Error _ as error -> error
   | Ok parsed -> (
       match parsed with
@@ -747,13 +736,6 @@ let compute_judgments
             ~model_used:resolved_model
         with
         | Ok judgments -> Ok (resolved_model, generated_at, expires_at, judgments)
-        | Error (Lenient_fallback raw) ->
-            let msg =
-              Judge_diagnostics.record_lenient_fallback
-                ~judge_label:"Governance" raw
-            in
-            Log.Governance.warn "%s" msg;
-            Error msg
         | Error (Structural_error reason) ->
             let msg =
               Judge_diagnostics.record_unparseable_response

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -240,12 +240,10 @@ val resolve_governance_model_used :
     not expose concrete provider/model identity. *)
 
 type governance_response_parse_failure =
-  | Lenient_fallback of string
   | Structural_error of string
 (** Failure class for governance judge response parsing.
-    [Lenient_fallback raw] means all deterministic JSON recovery
-    failed. [Structural_error reason] means JSON parsed but
-    violated the judge output contract. *)
+    [Structural_error reason] means the response was not strict JSON
+    or violated the judge output contract. *)
 
 val parse_governance_response_for_testing :
   raw_text:string ->

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -63,12 +63,10 @@ let key_preview = "preview"
 let key_provenance = "provenance"
 let key_authoritative = "authoritative"
 let key_confirm_required = "confirm_required"
-let key_raw = "raw"
 let keeper_name_operator_judge = "operator-judge"
 let backoff_status_slots_saturated = "Backoff: local slots saturated"
 let severity_warn = "warn"
 let provenance_judgment = "judgment"
-let judge_label_operator = "Operator"
 let model_used_runtime = "runtime"
 let prompt_dashboard_operator_judge = "dashboard.operator_judge"
 let field_facts_json = "facts_json"
@@ -269,25 +267,15 @@ let compute_judgments
   | Ok result -> (
       let response = result.Runtime_agent.response in
       try
-        (* See dashboard_governance_judge.ml for rationale: LLMs frequently
-           wrap JSON in ```json … ``` markdown fences. Lenient_json strips
-           fences and applies other deterministic recovery transforms. *)
         let raw_text = Agent_sdk_response.text_of_response response in
-        match Llm_provider.Lenient_json.parse raw_text with
-        | `Assoc [(key_raw, `String raw)] ->
-            (* #9774: include a preview so the failure diagnostic doesn't
-               require enabling raw provider logging. *)
-            let msg =
-              Judge_diagnostics.record_lenient_fallback ~judge_label:judge_label_operator raw
-            in
-            Log.Governance.warn "%s" msg;
-            Error msg
-        | parsed ->
+        match Yojson.Safe.from_string (String.trim raw_text) with
+        | `Assoc _ as parsed ->
             let _ = response.model in
             Ok (model_used_runtime, parsed)
+        | _ -> Error "Operator judge returned non-object strict JSON"
       with
       | Yojson.Json_error msg ->
-          Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
+          Error (Printf.sprintf "Operator judge returned invalid strict JSON: %s" msg)
       | exn ->
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -39,6 +39,8 @@ let string_contains s sub =
 let iso8601_of_unix ts =
   Masc_domain.iso8601_of_unix_seconds ts
 
+let approval_resume_test_timeout_s = 1.0
+
 let write_legacy_judgment ~base_path json =
   let masc = Filename.concat base_path Common.masc_dirname in
   let governance = Filename.concat masc "governance" in
@@ -449,8 +451,6 @@ let test_parse_governance_response_requires_guardrail_state () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names guardrail_state" true
         (string_contains reason "missing guardrail_state")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "missing guardrail_state must fail closed"
 
 let test_parse_governance_response_preserves_guardrail_state () =
@@ -529,8 +529,6 @@ let test_parse_governance_response_requires_guardrail_fields () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names missing field" true
         (string_contains reason "missing guardrail_state.pending_confirm_token")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "incomplete guardrail_state must fail closed"
 
 let test_parse_governance_response_requires_items_array () =
@@ -543,23 +541,19 @@ let test_parse_governance_response_requires_items_array () =
   | Error (Dashboard_governance_judge.Structural_error reason) ->
       check bool "reason names items array" true
         (string_contains reason "items array")
-  | Error (Dashboard_governance_judge.Lenient_fallback _) ->
-      fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "missing items array must fail closed"
 
-let test_parse_governance_response_rejects_unparseable_recovered_block () =
+let test_parse_governance_response_rejects_embedded_json_block () =
   let raw = "prefix {\"items\": [} suffix" in
   match
     Dashboard_governance_judge.parse_governance_response_for_testing
       ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
       ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
   with
-  | Error (Dashboard_governance_judge.Lenient_fallback recovered) ->
-      check bool "fallback keeps recovered fragment" true
-        (string_contains recovered "items")
   | Error (Dashboard_governance_judge.Structural_error reason) ->
-      fail ("expected lenient fallback, got structural error: " ^ reason)
-  | Ok _ -> fail "unparseable recovered JSON must stay lenient fallback"
+      check bool "reason names strict JSON" true
+        (string_contains reason "invalid strict JSON")
+  | Ok _ -> fail "embedded malformed JSON must fail closed"
 
 let test_refresh_failure_keeps_fresh_cache_online () =
   let dir = test_dir () in
@@ -962,6 +956,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
       ignore (Lib.Workspace.init config ~agent_name:(Some "dashboard"));
       Eio.Switch.run @@ fun sw ->
       let decision_result = ref None in
+      let resumed, resume_resolver = Eio.Promise.create () in
       Eio.Fiber.fork ~sw (fun () ->
         let decision =
           Lib.Keeper_approval_queue.submit_and_await
@@ -973,7 +968,8 @@ let test_dashboard_exposes_keeper_approval_queue () =
             ~selected_model:"openai:gpt-5.4"
             ()
         in
-        decision_result := Some decision);
+        decision_result := Some decision;
+        Eio.Promise.resolve resume_resolver ());
       Eio.Fiber.yield ();
       let json =
         Dashboard_governance.dashboard_json ~base_path:dir ~limit:20 ~offset:0
@@ -1002,8 +998,23 @@ let test_dashboard_exposes_keeper_approval_queue () =
        | Ok () -> ()
        | Error err ->
          fail ("resolve failed: " ^ Lib.Keeper_approval_queue.resolve_error_to_string err));
-      Eio.Fiber.yield ();
-      match !decision_result with
+      let decision_result =
+        match
+          Eio.Time.with_timeout
+            (Eio.Stdenv.clock env)
+            approval_resume_test_timeout_s
+            (fun () ->
+               Eio.Promise.await resumed;
+               Ok !decision_result)
+        with
+        | Ok decision_result -> decision_result
+        | Error `Timeout ->
+          fail
+            (Printf.sprintf
+               "approval fiber did not resume within %.1fs"
+               approval_resume_test_timeout_s)
+      in
+      match decision_result with
       | Some Agent_sdk.Hooks.Approve -> ()
       | Some (Agent_sdk.Hooks.Reject reason) ->
         fail ("expected approval resume, got reject: " ^ reason)
@@ -1125,8 +1136,8 @@ let () =
             test_parse_governance_response_requires_guardrail_fields;
           test_case "parser requires items array" `Quick
             test_parse_governance_response_requires_items_array;
-          test_case "parser rejects unparseable recovered block" `Quick
-            test_parse_governance_response_rejects_unparseable_recovered_block;
+          test_case "parser rejects embedded JSON block" `Quick
+            test_parse_governance_response_rejects_embedded_json_block;
           test_case "refresh failure keeps fresh cache online" `Quick
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -191,6 +191,26 @@ let test_dashboard_agent_run_json_judges_use_structured_judge_runtime () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
+let test_dashboard_json_judges_do_not_use_lenient_json_recovery () =
+  List.iter
+    (fun rel ->
+       check
+         int
+         (rel ^ " must not call Llm_provider.Lenient_json.parse")
+         0
+         (Ast_grep.count_calls
+            ~module_path:rel
+            ~callee:"Llm_provider.Lenient_json.parse");
+       check
+         int
+         (rel ^ " must not call Judge_json_recovery.extract_balanced_object")
+         0
+         (Ast_grep.count_calls
+            ~module_path:rel
+            ~callee:"Judge_json_recovery.extract_balanced_object"))
+    expected_structured_dashboard_agent_run_json_judges
+;;
+
 let test_fusion_agent_run_json_judges_use_provider_config_transform () =
   List.iter
     (fun rel ->
@@ -362,6 +382,10 @@ let () =
             "dashboard Agent.run JSON judges use structured runtime lane"
             `Quick
             test_dashboard_agent_run_json_judges_use_structured_judge_runtime
+        ; test_case
+            "dashboard JSON judges do not use lenient JSON recovery"
+            `Quick
+            test_dashboard_json_judges_do_not_use_lenient_json_recovery
         ] )
     ; ( "fusion json judges"
       , [ test_case


### PR DESCRIPTION
Stacked on #22768.\n\n## What changed\n- Remove lenient JSON recovery from governance judge response parsing.\n- Parse dashboard governance/operator judge responses as strict JSON after provider-native schema requests.\n- Update parser tests to fail closed on embedded/prose JSON.\n- Add a structured-output coverage ratchet preventing dashboard judges from reintroducing Lenient_json or balanced-object recovery.\n\n## Local checks\n- git diff --check\n- ocamlformat --check lib/dashboard/dashboard_governance_judge.ml lib/dashboard/dashboard_governance_judge.mli lib/dashboard/dashboard_operator_judge.ml test/test_dashboard_governance.ml test/test_keeper_structured_output_coverage.ml\n- targeted rg checks for removed lenient fallback paths\n\nFull build/tests left to GitHub CI per operator preference.