### PR TITLE
[codex] Clean up dashboard settings surface

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -6,47 +6,39 @@ import { fireEvent, waitFor } from '@testing-library/preact'
 import {
   SettingsSurface,
   checkSettingsMcpEndpoint,
-  checkSettingsStoreUrl,
-  checkSettingsWorktreeBase,
   mcpExposedToolNames,
   logEntryToSysRow,
   logRowStatus,
   normalizeSettingsSection,
 } from './settings-surface'
 import type {
+  ConfigEntry,
+  DashboardConfigResponse,
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
   LogEntry,
   RuntimeDefaultsResponse,
 } from '../api/dashboard'
-import type { GateConnectorsData, GateConnectorInfo } from '../api/gate'
-import type { Keeper, KeeperConfig } from '../types'
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 
 const MOCK_RUNTIME_PATH = 'fixture/config/runtime.toml'
-import { dashboardLoading } from '../store'
-import { keepers } from '../store'
+import { dashboardLoading, shellConfigResolution, shellRuntimeResolution } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { resetDevTokenBootstrap } from '../api/dev-token'
 
 const apiMock = vi.hoisted(() => ({
+  fetchDashboardConfig: vi.fn(),
   fetchLogs: vi.fn(),
   fetchDashboardTools: vi.fn(),
   fetchRuntimeDefaults: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
-  fetchKeeperConfig: vi.fn(),
-  patchKeeperConfig: vi.fn(),
 }))
 
-const gateApiMock = vi.hoisted(() => ({
-  fetchGateConnectors: vi.fn(),
-}))
-
-const keeperApiMock = vi.hoisted(() => ({
-  fetchKeepersComposite: vi.fn(),
+const mcpMock = vi.hoisted(() => ({
+  callMcpTool: vi.fn(async () => 'namespace ok'),
 }))
 
 const promptApiMock = vi.hoisted(() => ({
@@ -79,30 +71,17 @@ vi.mock('../api/dashboard.js', async () => {
   const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
   return {
     ...actual,
+    fetchDashboardConfig: apiMock.fetchDashboardConfig,
     fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
     fetchRuntimeProviders: apiMock.fetchRuntimeProviders,
-    fetchKeeperConfig: apiMock.fetchKeeperConfig,
-    patchKeeperConfig: apiMock.patchKeeperConfig,
   }
 })
 
-vi.mock('../api/gate', async () => {
-  const actual = await vi.importActual<typeof import('../api/gate')>('../api/gate')
-  return {
-    ...actual,
-    fetchGateConnectors: gateApiMock.fetchGateConnectors,
-  }
-})
-
-vi.mock('../api/keeper', async () => {
-  const actual = await vi.importActual<typeof import('../api/keeper')>('../api/keeper')
-  return {
-    ...actual,
-    fetchKeepersComposite: keeperApiMock.fetchKeepersComposite,
-  }
-})
+vi.mock('../api/mcp', () => ({
+  callMcpTool: mcpMock.callMcpTool,
+}))
 
 vi.mock('../api', async () => {
   const actual = await vi.importActual<typeof import('../api')>('../api')
@@ -237,216 +216,53 @@ function makeRuntimeProviders(
   }
 }
 
-function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
+function makeConfigEntry(overrides: Partial<ConfigEntry> = {}): ConfigEntry {
   return {
-    name: 'sangsu',
-    status: 'idle',
-    sandbox_profile: 'local',
+    env: 'MASC_BASE_PATH',
+    description: 'Base storage directory',
+    value: null,
+    default: '(cwd)',
+    source: 'runtime',
+    source_detail: 'resolved from runtime',
+    provenance: {
+      kind: 'runtime',
+      detail: 'resolved from runtime',
+    },
+    sensitive: false,
     ...overrides,
   }
 }
 
-function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
+function makeDashboardConfig(overrides: Partial<DashboardConfigResponse> = {}): DashboardConfigResponse {
   return {
-    name: 'sangsu',
-    active_goal_ids: [],
-    autoboot_enabled: true,
-    max_context_override: null,
-    limits: {
-      min_context_override_tokens: null,
-      max_context_override_tokens: null,
-    },
-    sandbox_profile: 'local',
-    network_mode: 'inherit',
-    sandbox_last_error: null,
-    allowed_paths: ['workspace/masc'],
-    effective_allowed_paths: ['/fixture/workspace/masc'],
-    prompt: {
-      goal: '',
-      instructions: '',
-      system_prompt_blocks: {
-        constitution: { key: 'keeper.constitution', source: 'file', text: '' },
-        world: { key: 'keeper.world', source: 'file', text: '' },
-        capabilities: { key: 'keeper.capabilities', source: 'file', text: '' },
-      },
-      effective_system_prompt: '',
-      unified_system_prompt: '',
-      unified_user_message_preview: '',
-    },
-    execution: {
-      models: [],
-      active_model: '',
-      active_model_label: null,
-      last_model_used_label: null,
-      per_provider_timeout_sec: null,
-      per_provider_timeout_mode: 'turn_budget_default',
-      verify: false,
-      selected_runtime_id: 'rt-a',
-      selected_runtime_canonical: 'rt-a',
-      runtime_options: ['rt-a', 'rt-b'],
-    },
-    compaction: {
-      profile: 'off',
-      ratio_gate: 0.85,
-      message_gate: 0,
-      token_gate: 0,
-      cooldown_sec: 0,
-    },
-    proactive: {
-      enabled: false,
-      idle_sec: 0,
-      cooldown_sec: 0,
-    },
-    drift: {
-      status: 'unwired',
-      enabled: null,
-      min_turn_gap: null,
-      count_total: null,
-      last_reason: null,
-    },
-    handoff: {
-      auto: false,
-      threshold: 0.85,
-      cooldown_sec: 0,
-    },
-    runtime: {
-      paused: false,
-      registered: true,
-      keepalive_running: true,
-      registry_state: 'registered',
-      fiber_health: 'idle',
-      runtime_blocker_class: null,
-      active_model_label: null,
-      last_model_used_label: null,
-      runtime_blocker_summary: null,
-      runtime_blocker_continue_gate: null,
-    },
-    runtime_trust: null,
-    workspace: {
-      mention_targets: [],
-      bound_workspace_ids: [],
-      active_goal_ids: [],
-      active_goals: [],
-      active_goal_count: 0,
-      missing_active_goal_ids: [],
-    },
-    tools: {
-      tool_access: [],
-      resolved_allowlist: [],
-      tool_denylist: [],
-      active_masc_tool_count: 0,
-      active_keeper_tool_count: 0,
-      total_active: 0,
-    },
-    sources: {
-      live_meta_path: '/fixture/.masc/config/keepers/sangsu.toml',
-      default_manifest_path: null,
-      default_source_kind: 'toml',
-      precedence: [],
-      has_live_override: true,
-      override_fields: [],
-    },
-    metrics: {
-      generation: 1,
-      total_turns: 0,
-      total_input_tokens: 0,
-      total_output_tokens: 0,
-      total_tokens: 0,
-      total_cost_usd: 0,
-      last_model_used: '',
-      last_input_tokens: 0,
-      last_output_tokens: 0,
-      last_total_tokens: 0,
-      last_latency_ms: null,
-      last_total_tokens_per_sec: null,
-      last_output_tokens_per_sec: null,
-      compaction_count: 0,
-    },
-    ...overrides,
-  }
-}
-
-function makeGateConnector(overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo {
-  return {
-    connector_id: 'discord',
-    display_name: 'Discord',
-    channel: 'discord',
-    capabilities: ['bindings'],
-    status: 'connected',
-    available: true,
-    connected: true,
-    stale: false,
-    stale_after_sec: 60,
-    gateway_state: 'connected',
-    status_source: 'in_process_gateway',
-    error: '',
-    status_path: '/state/discord.json',
-    binding_store_path: '/bindings/discord.json',
-    audit_path: '/audit/discord.jsonl',
-    updated_at: '2026-06-30T00:00:00Z',
-    reply_mode: 'mention_or_thread',
-    self_chat_guid: '',
-    last_ready_at: '2026-06-30T00:00:00Z',
-    bot_user_name: 'masc-bot',
-    bot_user_id: 'bot-1',
-    guild_count: 1,
-    gate_base_url: 'https://gate.masc.local',
-    gate_healthy: true,
-    gate_health_checked_at: '2026-06-30T00:00:00Z',
-    binding_source: '/bindings/discord.json',
-    runtime_bindings_count: 1,
-    pid: 123,
-    configured_bindings: [{ channel_id: 'C1', keeper_name: 'sangsu' }],
-    recent_audit: [],
-    storage_paths: {
-      status_path: '/state/discord.json',
-      binding_store_path: '/bindings/discord.json',
-      audit_path: '/audit/discord.jsonl',
-      names_path: '/names/discord.json',
-    },
-    runtime_summary: {
-      available: true,
-      connected: true,
-      stale: false,
-      stale_after_sec: 60,
-      status: 'connected',
-      error: '',
-      updated_at: '2026-06-30T00:00:00Z',
-      reply_mode: 'mention_or_thread',
-      self_chat_guid: '',
-      last_ready_at: '2026-06-30T00:00:00Z',
-      bot_user_name: 'masc-bot',
-      bot_user_id: 'bot-1',
-      guild_count: 1,
-      gate_base_url: 'https://gate.masc.local',
-      gate_healthy: true,
-      gate_health_checked_at: '2026-06-30T00:00:00Z',
+    generated_at: '2026-06-21T00:00:00Z',
+    server: {
+      version: 'test',
+      git_commit: null,
+      ocaml_version: '5.4.0',
+      uptime_seconds: 12,
       pid: 123,
     },
-    binding_summary: {
-      binding_source: '/bindings/discord.json',
-      runtime_bindings_count: 1,
-      configured_bindings_count: 1,
+    categories: {
+      server: [
+        makeConfigEntry({ env: 'MASC_URL', description: 'MCP URL', value: 'http://127.0.0.1:8935/mcp', default: '(derived)', source: 'env', source_detail: 'environment variable MASC_URL' }),
+        makeConfigEntry({ env: 'MASC_HTTP_BASE_URL', description: 'HTTP base URL', value: 'http://127.0.0.1:8935', default: '(derived)', source: 'env', source_detail: 'environment variable MASC_HTTP_BASE_URL' }),
+        makeConfigEntry({ env: 'MASC_BASE_PATH', description: 'Base storage directory', value: '/workspace', default: '(cwd)', source: 'env', source_detail: 'environment variable MASC_BASE_PATH' }),
+      ],
+      path: [
+        makeConfigEntry({ env: 'MASC_CONFIG_DIR', description: 'Config directory override', value: null, default: '(none)', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DATA_DIR', description: 'Data directory override', value: null, default: '(none)', source: 'default', source_detail: 'compiled default value' }),
+      ],
+      dashboard: [
+        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_PREPARING', description: 'Context preparing', value: '0.70', default: '0.70', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_CTX_HANDOFF_IMMINENT', description: 'Context imminent', value: '0.85', default: '0.85', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO', description: 'Runtime warning', value: '0.95', default: '0.95', source: 'default', source_detail: 'compiled default value' }),
+        makeConfigEntry({ env: 'MASC_DASHBOARD_SIGNAL_STALE_SEC', description: 'Signal stale', value: '1200.0', default: '1200.0', source: 'default', source_detail: 'compiled default value' }),
+      ],
+      alerting: [
+        makeConfigEntry({ env: 'MASC_ALERT_DEDUP_WINDOW_SEC', description: 'Alert dedup', value: '60.0', default: '60.0', source: 'default', source_detail: 'compiled default value' }),
+      ],
     },
-    observed_channel: null,
-    names_path: '/names/discord.json',
-    names: {
-      guild_names: {},
-      channel_names: {},
-      channel_to_guild: {},
-      updated_at: '',
-    },
-    ...overrides,
-  }
-}
-
-function makeGateConnectors(overrides: Partial<GateConnectorsData> = {}): GateConnectorsData {
-  return {
-    connectors: [makeGateConnector()],
-    total: 1,
-    active_count: 1,
-    discord_trigger_policy: 'mention_or_thread',
-    generated_at: '2026-06-30T00:00:00Z',
     ...overrides,
   }
 }
@@ -455,93 +271,12 @@ function stubRuntimeDefaults(value: RuntimeDefaultsResponse = makeRuntimeDefault
   apiMock.fetchRuntimeDefaults.mockResolvedValue(value)
 }
 
-function stubRuntimeRawFetch(sourceText = '[runtime]\ndefault = "rt-a"\n') {
-  vi.stubGlobal('fetch', vi.fn(async (input: unknown) => {
-    const requestUrl =
-      typeof input === 'string'
-        ? input
-        : input instanceof URL
-          ? input.href
-          : typeof (input as { url?: unknown }).url === 'string'
-            ? (input as { url: string }).url
-            : ''
-    const path = requestUrl.startsWith('http')
-      ? new URL(requestUrl).pathname
-      : requestUrl.split('?')[0] ?? requestUrl
-    if (path === '/api/v1/dashboard/dev-token') {
-      return new Response(JSON.stringify({ token: 'dev-token', actor: 'dashboard' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-    if (path === '/api/v1/runtime/config/raw') {
-      return new Response(JSON.stringify({
-        ok: true,
-        path: MOCK_RUNTIME_PATH,
-        file_name: 'runtime.toml',
-        source_text: sourceText,
-        reloaded: false,
-      }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-    return new Response(JSON.stringify({ message: `unexpected ${path}` }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }))
-}
-
-function sourceTextForRouting(): string {
-  return `[runtime]
-default = "p.m1"
-librarian = "p.m2"
-cross_verifier = "p.m2"
-
-[providers.p]
-display-name = "Provider"
-protocol = "openai-http"
-endpoint = "https://runtime.example/v1"
-
-[models.m1]
-api-name = "m1"
-max-context = 128000
-tools-support = true
-thinking-support = false
-json-support = true
-streaming = true
-
-[models.m2]
-api-name = "m2"
-max-context = 128000
-tools-support = true
-thinking-support = true
-json-support = true
-streaming = true
-
-[p.m1]
-is-default = true
-
-[p.m2]
-`
-}
-
 function stubEmptyApi() {
+  apiMock.fetchDashboardConfig.mockResolvedValue(makeDashboardConfig())
   apiMock.fetchLogs.mockResolvedValue({ total: 0, entries: [] })
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
   stubRuntimeDefaults()
   apiMock.fetchRuntimeProviders.mockResolvedValue(makeRuntimeProviders())
-  apiMock.fetchKeeperConfig.mockResolvedValue(makeKeeperConfig())
-  apiMock.patchKeeperConfig.mockImplementation(async (_name: string, payload: Partial<KeeperConfig>) =>
-    makeKeeperConfig(payload),
-  )
-  gateApiMock.fetchGateConnectors.mockResolvedValue(makeGateConnectors())
-  keeperApiMock.fetchKeepersComposite.mockResolvedValue({
-    generated_at: '2026-06-30T00:00:00Z',
-    count: 1,
-    snapshots: [{ keeper: 'sangsu' }],
-  })
 }
 
 const navigate = vi.fn()
@@ -562,19 +297,53 @@ describe('SettingsSurface', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    apiMock.fetchDashboardConfig.mockReset()
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
-    apiMock.fetchKeeperConfig.mockReset()
-    apiMock.patchKeeperConfig.mockReset()
-    gateApiMock.fetchGateConnectors.mockReset()
-    keeperApiMock.fetchKeepersComposite.mockReset()
+    mcpMock.callMcpTool.mockClear()
     promptApiMock.clearPromptOverride.mockClear()
     promptApiMock.fetchDashboardPrompts.mockClear()
     promptApiMock.savePromptOverride.mockClear()
     stubEmptyApi()
-    keepers.value = [makeKeeper()]
+    shellRuntimeResolution.value = {
+      generated_at: '2026-06-21T00:00:00Z',
+      status: 'ready',
+      warnings: [],
+      base_path: { path: '/workspace', exists: true, source: 'MASC_BASE_PATH' },
+      workspace_path: { path: '/workspace', exists: true, source: 'workspace' },
+      resolved_base_path: { path: '/workspace/.masc', exists: true, source: 'runtime' },
+      data_root: { path: '/workspace/.masc/data', exists: true, source: 'derived' },
+      prompt_markdown_dir: { path: '/workspace/.masc/prompts', exists: true, source: 'derived' },
+      server_repo_path: null,
+      server_repo_git_commit: null,
+      workspace_git_commit: null,
+      resolved_base_git_commit: null,
+      source_mismatch: false,
+      server_workspace_mismatch: false,
+      diagnostics: [],
+      build: {
+        release_version: 'test',
+        commit: null,
+        started_at: '2026-06-21T00:00:00Z',
+        uptime_seconds: 12,
+      },
+      keeper_runtime: null,
+      fleet_safety: null,
+      fd_accountant: null,
+      cdal: null,
+    }
+    shellConfigResolution.value = {
+      status: 'ready',
+      warnings: [],
+      config_root: { path: '/workspace/.masc/config', exists: true, source: 'derived' },
+      runtime_authoring: { path: '/workspace/.masc/config/runtime.toml', exists: true, source: 'derived' },
+      runtime: { path: MOCK_RUNTIME_PATH, exists: true, source: 'runtime.toml' },
+      prompts: { path: '/workspace/.masc/config/prompts', exists: true, source: 'derived' },
+      keepers: { path: '/workspace/.masc/keepers', exists: true, source: 'derived' },
+      personas: { path: '/workspace/.masc/personas', exists: true, source: 'derived' },
+    }
     window.location.hash = '#settings'
     route.value = { tab: 'settings', params: {}, postId: null }
   })
@@ -583,9 +352,10 @@ describe('SettingsSurface', () => {
     render(null, container)
     container.remove()
     navigate.mockClear()
+    shellConfigResolution.value = null
+    shellRuntimeResolution.value = null
     resetDevTokenBootstrap()
     sessionStorage.clear()
-    keepers.value = []
     vi.unstubAllGlobals()
     vi.unstubAllEnvs()
   })
@@ -595,35 +365,41 @@ describe('SettingsSurface', () => {
 
     expect(container.querySelector('.v2-shell-surface')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-surface"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="settings-nav-account"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-nav-runtime"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-runtimes"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-paths"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-mcp"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-notify"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="settings-nav-logs"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-account"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-policy"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-gate"]')).toBeNull()
   })
 
   it('applies StyleSeed surface and card classes', () => {
     render(html`<${SettingsSurface} />`, container)
 
     expect(container.querySelector('.v2-shell-surface.ss-surface.bg-surface-page.text-text-primary')).not.toBeNull()
-    expect(container.querySelector('.set-card-b.ss-card')).not.toBeNull()
+    expect(container.querySelector('.set-card-b.set-card-b-wide')).not.toBeNull()
   })
 
   it('switches sections when category navigation is clicked', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     const title = () => container.querySelector('[data-testid="settings-section-title"]') as HTMLElement
-    expect(title().textContent).toBe('계정')
+    expect(title().textContent).toBe('런타임')
+
+    const pathsNav = container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement
+    await fireEvent.click(pathsNav)
+
+    expect(title().textContent).toBe('경로 · Path')
+    expect(pathsNav.getAttribute('data-active')).toBe('true')
+    expect(navigate).toHaveBeenLastCalledWith('settings', { section: 'paths' })
 
     const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
     await fireEvent.click(runtimeNav)
 
-    expect(title().textContent).toBe('런타임 기본값')
-    expect(runtimeNav.getAttribute('data-active')).toBe('true')
-    expect(navigate).toHaveBeenLastCalledWith('settings', { section: 'runtime' })
-
-    const accountNav = container.querySelector('[data-testid="settings-nav-account"]') as HTMLElement
-    await fireEvent.click(accountNav)
-
-    expect(title().textContent).toBe('계정')
+    expect(title().textContent).toBe('런타임')
     expect(navigate).toHaveBeenLastCalledWith('settings', {})
   })
 
@@ -648,20 +424,20 @@ describe('SettingsSurface', () => {
     expect(themeButton).toBeTruthy()
   })
 
-  it('falls invalid settings sections back to account without a fake subsection', () => {
-    expect(normalizeSettingsSection('not-real')).toBe('account')
+  it('falls invalid settings sections back to runtime without a fake subsection', () => {
+    expect(normalizeSettingsSection('not-real')).toBe('runtime')
     route.value = { tab: 'settings', params: { section: 'not-real' }, postId: null }
 
     render(html`<${SettingsSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('계정')
-    expect(container.querySelector('[data-testid="settings-nav-account"]')?.getAttribute('data-active')).toBe('true')
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임')
+    expect(container.querySelector('[data-testid="settings-nav-runtime"]')?.getAttribute('data-active')).toBe('true')
   })
 
   it('syncs when the dashboard route section changes while mounted', async () => {
     render(html`<${SettingsSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('계정')
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임')
 
     route.value = { tab: 'settings', params: { section: 'logs' }, postId: null }
 
@@ -670,213 +446,85 @@ describe('SettingsSurface', () => {
     })
   })
 
-  it('marks unbacked settings sections as local preview controls instead of fake saved actions', async () => {
+  it('does not render removed fake-only settings sections', async () => {
     render(html`<${SettingsSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
-    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml + provider catalog')
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('live')
     expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.textContent).not.toContain('Save changes')
     expect(container.textContent).not.toContain('Reissue')
     expect(container.textContent).not.toContain('Log out')
-    expect(container.querySelector('[data-testid="token-toggle"]')).toBeNull()
-    expect(container.querySelector<HTMLInputElement>('.set-path .set-input')?.readOnly).toBe(true)
-
-    const policyNav = container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement
-    await fireEvent.click(policyNav)
-
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('local preview only')
-    expect(container.querySelector('[data-testid="settings-preview-badge"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="set-verify"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-account"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-policy"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-sandbox"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-gate"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-nav-ide"]')).toBeNull()
   })
 
-  it('local preview segmented controls update visible state when clicked', async () => {
-    render(html`<${SettingsSurface} />`, container)
+  it('MCP server page shows resolved endpoint, inventory, and runs a real status check', async () => {
+    apiMock.fetchDashboardTools.mockResolvedValue({
+      tool_inventory: {
+        count: 2,
+        tools: [
+          makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp'] }),
+          makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
+          makeToolItem({ name: 'internal_only', surfaces: ['internal'] }),
+        ],
+      },
+    })
+    mcpMock.callMcpTool.mockResolvedValueOnce('status ok from mcp')
 
-    const never = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
-      .find(button => button.textContent === '안 함')
-    expect(never).toBeTruthy()
-    expect(never?.disabled).toBe(false)
-
-    await fireEvent.click(never as HTMLButtonElement)
-
-    expect(never?.getAttribute('data-active')).toBe('true')
-  })
-
-  it('local preview text inputs are editable and reflected in dependent text', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
 
-    const input = container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')
-    expect(input).toBeTruthy()
-    expect(input?.readOnly).toBe(false)
-
-    await fireEvent.input(input as HTMLInputElement, {
-      target: { value: 'http://127.0.0.1:7777/mcp' },
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-mcp-endpoint"]')?.textContent).toBe('http://127.0.0.1:8935/mcp')
+      expect(container.querySelector('[data-testid="mcp-tools-list"]')?.textContent).toContain('masc_handoff')
+      expect(container.querySelector('[data-testid="mcp-tools-list"]')?.textContent).not.toContain('internal_only')
     })
 
-    expect(input?.value).toBe('http://127.0.0.1:7777/mcp')
-    expect(container.querySelector('.set-mcp-detail')?.textContent).toContain('POST http://127.0.0.1:7777/mcp')
-    expect(container.querySelector('[data-testid="settings-preview-badge"]')?.textContent).toBe('local only')
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
-
-    expect(container.querySelector<HTMLInputElement>('[data-testid="settings-mcp-endpoint-input"]')?.value).toBe('http://127.0.0.1:7777/mcp')
-  })
-
-  it('does not render a fabricated stdio process pid in the MCP preview', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
-
-    const stdio = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
-      .find(button => button.textContent === 'stdio')
-    expect(stdio).toBeTruthy()
-    await fireEvent.click(stdio as HTMLButtonElement)
-
-    const detail = container.querySelector('.set-mcp-detail')?.textContent ?? ''
-    expect(detail).toContain('masc-mcp serve --stdio')
-    expect(detail).not.toContain('pid 8421')
-  })
-
-  it('does not render pid-shaped runtime state in any MCP transport preview', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
-
-    const segByLabel = (label: string) =>
-      Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
-        .find(button => button.textContent === label)
-    const fabricatedPid = /\bpid\b[:=\s·]*\d+/i
-
-    for (const transport of ['http', 'stdio', 'sse']) {
-      const seg = segByLabel(transport)
-      expect(seg).toBeTruthy()
-      await fireEvent.click(seg as HTMLButtonElement)
-      const detail = container.querySelector('.set-mcp-detail')?.textContent ?? ''
-      expect(detail).not.toMatch(fabricatedPid)
-    }
-  })
-
-  it('edits sandbox from live keeper config instead of fake global controls', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-sandbox"]') as HTMLElement)
+    await fireEvent.click(container.querySelector('[data-testid="settings-mcp-check"]') as HTMLElement)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('keeper config live-backed')
-      expect(container.querySelector('[data-testid="settings-sandbox-profile"]')).not.toBeNull()
+      expect(mcpMock.callMcpTool).toHaveBeenCalledWith('masc_status', {})
+      expect(container.querySelector('[data-testid="settings-mcp-check-result"]')?.textContent).toContain('status ok from mcp')
     })
-
-    expect(container.querySelector('[data-testid="settings-allowed-domains-input"]')).toBeNull()
-    expect(container.textContent).not.toContain('Allowed domains')
-    expect(container.textContent).not.toContain('Resource limits')
-
-    const profile = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-profile"]')
-    const network = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-network"]')
-    const allowedPaths = container.querySelector<HTMLTextAreaElement>('[data-testid="settings-sandbox-allowed-paths"]')
-    expect(profile).toBeTruthy()
-    expect(network).toBeTruthy()
-    expect(allowedPaths).toBeTruthy()
-
-    ;(profile as HTMLSelectElement).value = 'docker'
-    await fireEvent.input(profile as HTMLSelectElement)
-    await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-sandbox-network"]')?.textContent).toContain('none')
-    })
-    const updatedNetwork = container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-network"]')
-    ;(updatedNetwork as HTMLSelectElement).value = 'none'
-    await fireEvent.input(updatedNetwork as HTMLSelectElement)
-    await fireEvent.input(allowedPaths as HTMLTextAreaElement, {
-      target: { value: 'workspace/oas\nworkspace/oas\n  ' },
-    })
-
-    const save = container.querySelector<HTMLButtonElement>('[data-testid="settings-sandbox-save"]')
-    expect(save).toBeTruthy()
-    expect(save?.disabled).toBe(false)
-    await fireEvent.click(save as HTMLButtonElement)
-
-    await waitFor(() => {
-      expect(apiMock.patchKeeperConfig).toHaveBeenCalledWith('sangsu', {
-        sandbox_profile: 'docker',
-        network_mode: 'none',
-        allowed_paths: ['workspace/oas'],
-      })
-    })
-    expect(container.querySelector('[data-testid="settings-sandbox-source"]')?.textContent).toContain('/fixture/.masc/config/keepers/sangsu.toml')
   })
 
-  it('falls back to fleet composite keeper names when sandbox opens before the keeper store is hydrated', async () => {
-    keepers.value = []
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-sandbox"]') as HTMLElement)
-
-    await waitFor(() => {
-      expect(keeperApiMock.fetchKeepersComposite).toHaveBeenCalledTimes(1)
-      expect(apiMock.fetchKeeperConfig).toHaveBeenCalledWith('sangsu')
-      expect(container.querySelector('[data-testid="settings-sandbox-profile"]')).not.toBeNull()
-    })
-    expect(container.querySelector<HTMLSelectElement>('[data-testid="settings-sandbox-keeper-select"]')?.value).toBe('sangsu')
-    expect(container.querySelector('[data-testid="settings-sandbox-empty"]')).toBeNull()
-  })
-
-  it('renders gate connectors from the live connector payload without local toggles', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
-
-    await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('gate connector live-backed')
-      expect(container.querySelector('[data-testid="settings-gate-connectors"]')).not.toBeNull()
-    })
-
-    expect(container.querySelector('[data-testid="gate-live-summary"]')?.textContent).toContain('1/1 active')
-    expect(container.querySelector('[data-testid="settings-gate-discord-trigger"]')?.textContent).toBe('mention_or_thread')
-    expect(container.querySelector('[data-testid="settings-gate-base-live"]')?.textContent).toContain('https://gate.masc.local')
-
-    const connectorCards = Array.from(container.querySelectorAll('[data-testid="settings-gate-connector"]'))
-    expect(connectorCards.length).toBe(1)
-    expect(connectorCards[0]?.textContent).toContain('discord')
-    expect(connectorCards[0]?.textContent).toContain('Discord')
-    expect(connectorCards[0]?.textContent).toContain('bindings 1')
-    expect(container.textContent).not.toContain('Amplitude')
-    expect(container.querySelector('[data-testid="settings-preview-badge"]')).toBeNull()
-    expect(container.querySelector('[data-testid="set-toggle"]')).toBeNull()
-    expect(container.querySelector('[data-testid="set-trigger"]')).toBeNull()
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-connectors-link"]') as HTMLButtonElement)
-    expect(navigate).toHaveBeenLastCalledWith('connectors')
-  })
-
-  it('paths local preview values can be format-checked without claiming live verification', async () => {
+  it('paths page shows resolved server paths instead of editable local previews', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
 
-    expect(container.textContent).toContain('format-checked only')
-    expect(container.textContent).not.toContain('Each item can be verified')
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-mcp"]') as HTMLElement)
-    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-store"]') as HTMLElement)
-    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-worktree"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="settings-path-check-result-mcp"]')?.textContent).toBe('valid MCP URL')
-    expect(container.querySelector('[data-testid="settings-path-check-result-mcp"]')?.getAttribute('data-ok')).toBe('true')
-    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.textContent).toBe('valid store URL')
-    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.getAttribute('data-ok')).toBe('true')
-    expect(container.querySelector('[data-testid="settings-path-check-result-worktree"]')?.textContent).toBe('valid local path')
-    expect(container.querySelector('[data-testid="settings-path-check-result-worktree"]')?.getAttribute('data-ok')).toBe('true')
-
-    const storeInput = container.querySelector<HTMLInputElement>('[data-testid="settings-store-url-input"]')
-    await fireEvent.input(storeInput as HTMLInputElement, {
-      target: { value: 'not-a-url' },
+    await waitFor(() => {
+      expect(container.textContent).toContain('/workspace/.masc')
+      expect(container.textContent).toContain(MOCK_RUNTIME_PATH)
+      expect(container.textContent).toContain('MASC_BASE_PATH')
     })
-    await fireEvent.click(container.querySelector('[data-testid="settings-path-check-store"]') as HTMLElement)
+    expect(container.textContent).not.toContain('format-checked only')
+    expect(container.querySelector('[data-testid="settings-store-url-input"]')).toBeNull()
+    expect(container.querySelector('[data-testid="settings-worktree-base-input"]')).toBeNull()
+  })
 
-    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.textContent).toBe('invalid URL')
-    expect(container.querySelector('[data-testid="settings-path-check-result-store"]')?.getAttribute('data-ok')).toBe('false')
+  it('notify page shows live thresholds plus local routing preview controls', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('MASC_DASHBOARD_CTX_PREPARING')
+      expect(container.textContent).toContain('70%')
+      expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('local routing preview')
+    })
+
+    const discord = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
+      .find(button => button.textContent === 'Discord')
+    expect(discord).toBeTruthy()
+    await fireEvent.click(discord as HTMLButtonElement)
+    expect(discord?.getAttribute('data-active')).toBe('true')
+    expect(sessionStorage.getItem('masc.settings.local.notifyChannel')).toBe('Discord')
   })
 
   it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
@@ -886,7 +534,7 @@ describe('SettingsSurface', () => {
     await fireEvent.click(runtimeNav)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml + provider catalog')
       expect(container.querySelector('[data-testid="runtime-settings-live"]')).not.toBeNull()
       expect(container.querySelector('[data-testid="runtime-settings-edit"]')).not.toBeNull()
     })
@@ -964,47 +612,40 @@ describe('SettingsSurface', () => {
       ])
       expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')
     })
-    expect(container.querySelector('[data-testid="runtime-default-context"]')).toBeNull()
     expect(container.textContent).not.toContain('oas·seoul-1')
   })
 
-  it('routing section opens the live runtime.toml routing editor', async () => {
-    keepers.value = [makeKeeper(), makeKeeper({ name: 'mad-improver', status: 'running' })]
-    stubRuntimeRawFetch(`${sourceTextForRouting()}
-
-[runtime.assignments]
-sangsu = "p.m2"
-mad-improver = "p.m1"
-`)
+  it('runtime section shows resolved keeper assignments read-only', async () => {
     render(html`<${SettingsSurface} />`, container)
 
-    const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
-    await fireEvent.click(routingNav)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
-      expect(container.querySelector('[data-testid="runtime-toml-editor"]')).not.toBeNull()
-      expect(container.querySelector('[data-testid="runtime-section-routing"]')).not.toBeNull()
-      expect(container.querySelector('[data-testid="runtime-environment-save"]')).toBeNull()
-      expect(container.textContent).toContain('backend typed writer')
+      expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('librarian')
+      const assignments = Array.from(
+        container.querySelectorAll('[data-testid="routing-assignment"]'),
+      ).map(n => n.textContent)
+      expect(assignments).toEqual(['rt-b'])
     })
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('모델 라우팅')
-    expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('라우팅')
-    expect(container.textContent).toContain('memory-os 라이브러리안')
-    expect(container.textContent).toContain('cross-verifier')
-    expect(container.textContent).not.toContain('Read-only')
-    expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
 
-  it('routing section reports empty runtime.toml bindings without fabricating rows', async () => {
-    stubRuntimeRawFetch('[runtime]\ndefault = "rt-a"\n')
+  it('routing section reports no assignments without fabricating rows', async () => {
+    stubRuntimeDefaults(
+      makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [],
+          librarian_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: [],
+        },
+      }),
+    )
     render(html`<${SettingsSurface} />`, container)
 
-    const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
-    await fireEvent.click(routingNav)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="runtime-environment-empty"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="routing-assignments-empty"]')).not.toBeNull()
     })
     expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
@@ -1068,122 +709,6 @@ mad-improver = "p.m1"
     expect(allRows().length).toBe(6)
   })
 
-  it('shows the live MCP exposed-tools list from the capability registry', async () => {
-    apiMock.fetchDashboardTools.mockResolvedValue({
-      tool_inventory: {
-        count: 2,
-        tools: [
-          makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp'] }),
-          makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
-          makeToolItem({ name: 'internal_only', surfaces: ['internal'] }),
-        ],
-      },
-    })
-
-    render(html`<${SettingsSurface} />`, container)
-
-    const mcpNav = container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement
-    await fireEvent.click(mcpNav)
-
-    await waitFor(() => {
-      const labels = Array.from(container.querySelectorAll('.set-row .mono')).map(n => n.textContent)
-      expect(labels).toContain('masc_handoff')
-      expect(labels).toContain('masc_start')
-      // internal-only tools are not exposed over public MCP.
-      expect(labels).not.toContain('internal_only')
-    })
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('live inventory + local controls')
-    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
-  })
-
-  it('MCP exposed-tool toggles are browser-session exposure previews', async () => {
-    apiMock.fetchDashboardTools.mockResolvedValue({
-      tool_inventory: {
-        count: 2,
-        tools: [
-          makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp'] }),
-          makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
-        ],
-      },
-    })
-
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
-    await waitFor(() => {
-      expect(container.textContent).toContain('Local tool exposure preview (2/2)')
-    })
-    expect(container.querySelector('[data-testid="mcp-local-summary"]')?.textContent).toContain('2/2 listed tools selected')
-    expect(container.textContent).toContain('browser-session exposure previews only')
-
-    const toggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
-    expect(toggles.length).toBe(2)
-    expect(toggles[0]!.disabled).toBe(false)
-    expect(toggles[0]!.getAttribute('aria-checked')).toBe('true')
-
-    await fireEvent.click(toggles[0]!)
-
-    expect(toggles[0]!.getAttribute('aria-checked')).toBe('false')
-    expect(container.textContent).toContain('Local tool exposure preview (1/2)')
-    expect(sessionStorage.getItem('masc.settings.local.mcpToolPreview')).toContain('"masc_handoff":false')
-
-    render(null, container)
-    route.value = { tab: 'settings', params: {}, postId: null }
-    render(html`<${SettingsSurface} />`, container)
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
-
-    await waitFor(() => {
-      expect(container.querySelector('[data-testid="mcp-local-summary"]')?.textContent).toContain('1/2 listed tools selected')
-    })
-    const restoredToggles = Array.from(container.querySelectorAll<HTMLButtonElement>('[data-testid="set-toggle"]'))
-    expect(restoredToggles[0]!.getAttribute('aria-checked')).toBe('false')
-  })
-
-  it('notify controls are browser-session previews with persisted thresholds and events', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Slack channel')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('4/5 events enabled')
-
-    const range = container.querySelector<HTMLInputElement>('input[type="range"]')
-    expect(range).toBeTruthy()
-    await fireEvent.input(range as HTMLInputElement, { target: { value: '92' } })
-
-    const plus = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
-      .find(button => button.textContent === '+')
-    expect(plus).toBeTruthy()
-    await fireEvent.click(plus as HTMLButtonElement)
-
-    const discord = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
-      .find(button => button.textContent === 'Discord')
-    expect(discord).toBeTruthy()
-    await fireEvent.click(discord as HTMLButtonElement)
-
-    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="set-toggle"]')
-    expect(toggle).toBeTruthy()
-    await fireEvent.click(toggle as HTMLButtonElement)
-
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Discord channel')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('context 92%')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('failures 4')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('3/5 events enabled')
-    expect(sessionStorage.getItem('masc.settings.local.notifyContextThreshold')).toBe('92')
-    expect(sessionStorage.getItem('masc.settings.local.notifyFailureThreshold')).toBe('4')
-    expect(sessionStorage.getItem('masc.settings.local.notifyChannel')).toBe('Discord')
-    expect(sessionStorage.getItem('masc.settings.local.notifyEventPreview')).toContain('"컨텍스트 임계치 초과":false')
-
-    render(null, container)
-    route.value = { tab: 'settings', params: {}, postId: null }
-    render(html`<${SettingsSurface} />`, container)
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('Discord channel')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('context 92%')
-    expect(container.querySelector('[data-testid="notify-local-summary"]')?.textContent).toContain('failures 4')
-  })
-
   it('renders the fusion preset section (panel families + judge) read-only', async () => {
     render(html`<${SettingsSurface} />`, container)
 
@@ -1236,67 +761,6 @@ mad-improver = "p.m1"
     expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
     expect(container.textContent).not.toContain('ollama_cloud.deepseek-v4-flash')
-  })
-
-  it('renders the tool-group policy with exec-guard and last_turn_safe', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('도구 정책')
-    // 11 named groups in the prototype snapshot.
-    expect(container.querySelectorAll('[data-testid="set-tg-row"]').length).toBe(11)
-    expect(container.textContent).toContain('browser-session grant preview')
-    expect(container.textContent).toContain('현재는 live tool-policy writer가 없어 prototype group catalog 스냅샷으로 표시합니다.')
-    expect(container.textContent).not.toContain('기본 부여 그룹과 안전장치를 관리합니다')
-    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('10/11 enabled')
-    expect(container.querySelectorAll('[data-testid="settings-preview-badge"]').length).toBeGreaterThanOrEqual(12)
-    // execute group carries the 3-layer guard badge; voice is opt-in.
-    const kinds = Array.from(container.querySelectorAll('.set-tg-kind')).map(n => n.textContent?.trim())
-    expect(kinds).toContain('3-layer guard')
-    expect(kinds).toContain('opt-in')
-    const firstToggle = container.querySelector('[data-testid="set-tg-row"] [data-testid="set-toggle"]') as HTMLButtonElement
-    expect(firstToggle.getAttribute('data-active')).toBe('true')
-    await fireEvent.click(firstToggle)
-    expect(firstToggle.getAttribute('data-active')).toBe('false')
-    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('9/11 enabled')
-    expect(sessionStorage.getItem('masc.settings.local.policyGrant')).toContain('"base":false')
-
-    render(null, container)
-    route.value = { tab: 'settings', params: {}, postId: null }
-    render(html`<${SettingsSurface} />`, container)
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="policy-local-summary"]')?.textContent).toContain('9/11 enabled')
-    expect(
-      container.querySelector('[data-testid="set-tg-row"] [data-testid="set-toggle"]')?.getAttribute('data-active'),
-    ).toBe('false')
-    // exec-guard pipeline: validate_command → destructive_guard → write_gate.
-    const guardSteps = Array.from(
-      container.querySelectorAll('[data-testid="set-guard"] .set-guard-step'),
-    ).map(n => n.textContent)
-    expect(guardSteps).toEqual(['validate_command', 'destructive_guard', 'write_gate'])
-    expect(container.querySelectorAll('[data-testid="set-guard"] .set-guard-arrow').length).toBe(2)
-    // last_turn_safe chips carry the .safe modifier.
-    expect(container.querySelectorAll('.set-tg-chip.safe').length).toBeGreaterThan(0)
-  })
-
-  it('shows the Discord trigger policy as live connector data without preview radios', async () => {
-    gateApiMock.fetchGateConnectors.mockResolvedValue(makeGateConnectors({
-      connectors: [],
-      total: 0,
-      active_count: 0,
-      discord_trigger_policy: 'mention_only',
-    }))
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
-
-    await waitFor(() => {
-      expect(container.querySelector('[data-testid="settings-gate-discord-trigger"]')?.textContent).toBe('mention_only')
-      expect(container.querySelector('[data-testid="settings-gate-empty"]')).not.toBeNull()
-    })
-    expect(container.querySelector('[data-testid="set-trigger"]')).toBeNull()
   })
 
   it('opens the live runtime.toml editor from runtime management', async () => {
@@ -1364,16 +828,12 @@ describe('SettingsSurface shell route', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    apiMock.fetchDashboardConfig.mockReset()
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
-    apiMock.fetchKeeperConfig.mockReset()
-    apiMock.patchKeeperConfig.mockReset()
-    gateApiMock.fetchGateConnectors.mockReset()
-    keeperApiMock.fetchKeepersComposite.mockReset()
     stubEmptyApi()
-    keepers.value = [makeKeeper()]
     dashboardLoading.value = false
     connected.value = true
     namespaceTruthInitializing.value = false
@@ -1383,7 +843,6 @@ describe('SettingsSurface shell route', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
-    keepers.value = []
   })
 
   it('renders from the dashboard shell route', async () => {
@@ -1401,7 +860,7 @@ describe('SettingsSurface shell route', () => {
 })
 
 describe('settings read-surface helpers', () => {
-  it('checks Settings path preview values by format only', () => {
+  it('checks Settings MCP endpoint preview values by format only', () => {
     expect(checkSettingsMcpEndpoint('https://masc.local/mcp')).toEqual({
       ok: true,
       message: 'valid MCP URL',
@@ -1413,24 +872,6 @@ describe('settings read-surface helpers', () => {
     expect(checkSettingsMcpEndpoint('https://masc.local/api')).toEqual({
       ok: false,
       message: 'path should include /mcp',
-    })
-
-    expect(checkSettingsStoreUrl('postgres://masc.local:5432/masc')).toEqual({
-      ok: true,
-      message: 'valid store URL',
-    })
-    expect(checkSettingsStoreUrl('https://masc.local/db')).toEqual({
-      ok: false,
-      message: 'expected postgres URL',
-    })
-
-    expect(checkSettingsWorktreeBase('~/wt')).toEqual({
-      ok: true,
-      message: 'valid local path',
-    })
-    expect(checkSettingsWorktreeBase('http://masc.local/wt')).toEqual({
-      ok: false,
-      message: 'expected filesystem path',
     })
   })
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1,7 +1,6 @@
-// MASC Dashboard — Settings surface (keeper-v2 port)
-// Read surfaces (MCP exposed-tools list, system-log tail, runtime defaults /
-// model routing) are wired to live backend data. Most write surfaces remain
-// read-only previews; runtime.toml management is live-backed.
+// MASC Dashboard — Settings surface
+// Operator-facing settings only: runtime management, resolved paths, MCP server
+// health/inventory, notification thresholds, prompt/fusion/log/display controls.
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
@@ -10,40 +9,29 @@ import {
   type SettingsRouteSectionId,
 } from '../config/navigation'
 import { navigate, route } from '../router'
-import {
-  fetchDashboardTools,
-  fetchKeeperConfig,
-  fetchLogs,
-  fetchRuntimeDefaults,
-  fetchRuntimeProviders,
-  patchKeeperConfig,
-} from '../api/dashboard.js'
+import { fetchDashboardConfig, fetchDashboardTools, fetchLogs, fetchRuntimeDefaults, fetchRuntimeProviders } from '../api/dashboard.js'
 import type {
+  ConfigEntry,
+  DashboardConfigResponse,
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
-  KeeperConfigUpdatePayload,
   LogEntry,
   RuntimeDefaultsResponse,
-  SandboxNetworkMode,
-  SandboxProfile,
 } from '../api/dashboard.js'
-import { fetchGateConnectors, type GateConnectorInfo, type GateConnectorsData } from '../api/gate'
-import { fetchKeepersComposite } from '../api/keeper'
+import { callMcpTool } from '../api/mcp'
 import { envBool } from '../config/env'
-import { keepers } from '../store'
-import type { KeeperConfig } from '../types'
+import { shellConfigResolution, shellRuntimeResolution } from '../store'
+import type { DashboardConfigResolutionItem } from '../types'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
 import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
 import type { ComponentChildren } from 'preact'
-import { errorToString } from '../lib/format-string'
 
 type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
-type PathCheckTarget = 'mcp' | 'store' | 'worktree'
 type PathCheckResult = {
   readonly ok: boolean
   readonly message: string
@@ -51,37 +39,25 @@ type PathCheckResult = {
 type BoolRecordUpdater = Record<string, boolean> | ((prev: Record<string, boolean>) => Record<string, boolean>)
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const SETTINGS_LOCAL_STORAGE_PREFIX = 'masc.settings.local.'
+const DEFAULT_SETTINGS_SECTION: SectionId = 'runtime'
 
 const SET_SECTIONS: [SectionId, string, string][] = [
-  ['account', 'Account', '계정'],
-  ['mcp', 'MCP', 'MCP 서버'],
-  ['runtime', 'Runtime', '런타임 기본값'],
+  ['runtime', 'Runtime', '런타임'],
   ['runtimes', 'Runtimes', '런타임 관리'],
-  ['routing', 'Routing', '모델 라우팅'],
-  ['prompts', 'Prompts', '기본 프롬프트'],
-  // keeper-v2 settings.jsx:35-36 — Fusion '패널·심판 심의', Policy '도구 정책'.
-  ['fusion', 'Fusion', '패널·심판 심의'],
-  ['policy', 'Policy', '도구 정책'],
-  ['lifecycle', 'Lifecycle', 'keeper 수명'],
-  ['sandbox', 'Sandbox', '샌드박스'],
-  ['ide', 'IDE', 'IDE · 편집기'],
-  ['gate', 'Gate', '커넥터 게이트'],
-  ['paths', 'Paths', '경로 · Basepath'],
-  ['logs', 'Logs', '관측 · 시스템 로그'],
+  ['paths', 'Paths', '경로 · Path'],
+  ['mcp', 'MCP', 'MCP 서버'],
   ['notify', 'Notify', '알림'],
+  ['prompts', 'Prompts', '기본 프롬프트'],
+  ['fusion', 'Fusion', '패널·심판 심의'],
+  ['logs', 'Logs', '관측 · 시스템 로그'],
   ['display', 'Display', '표시'],
 ]
 
 const SET_GROUPS: [string, SectionId[]][] = [
-  // KO group labels per keeper-v2 settings.jsx SET_GROUPS — matches the
-  // Korean section names below (avoids EN-header / KO-item bilingual mismatch).
-  ['계정', ['account']],
-  // keeper-v2 settings.jsx:49 — 'Keeper 운영' group order: runtime · routing ·
-  // prompts · fusion · lifecycle · policy.
-  ['Keeper 운영', ['runtime', 'routing', 'prompts', 'fusion', 'lifecycle', 'policy']],
-  ['인프라 · 실행', ['runtimes', 'sandbox', 'paths']],
-  ['연결 · 통합', ['mcp', 'gate', 'ide']],
-  ['관측 · 표시', ['logs', 'notify', 'display']],
+  ['런타임', ['runtime', 'runtimes']],
+  ['경로 · 연결', ['paths', 'mcp']],
+  ['운영 알림', ['notify', 'logs']],
+  ['고급 설정', ['prompts', 'fusion', 'display']],
 ]
 
 // Tools exposed over the public MCP server, derived from the live capability
@@ -90,19 +66,11 @@ const SET_GROUPS: [string, SectionId[]][] = [
 // (Tool_catalog.is_public_mcp). Unknown/empty inventory yields an empty list
 // (no fabricated tool names).
 const MCP_PUBLIC_SURFACE = 'public_mcp'
-const MCP_TRANSPORT_OPTIONS = ['http', 'stdio', 'sse']
 const SETTINGS_LOG_LIMIT = 50
 const SETTINGS_LOG_POLL_MS = 3000
-const DEFAULT_NOTIFY_EVENT_PREVIEW: Record<string, boolean> = {
-  '컨텍스트 임계치 초과': true,
-  '연속 실패': true,
-  'keeper crash/dead': true,
-  '핸드오프 완료': false,
-  '승인 요청': true,
-}
 
 export function normalizeSettingsSection(value: string | null | undefined): SectionId {
-  return SETTINGS_ROUTE_SECTION_SET.has(value ?? '') ? (value as SectionId) : 'account'
+  return SETTINGS_ROUTE_SECTION_SET.has(value ?? '') ? (value as SectionId) : DEFAULT_SETTINGS_SECTION
 }
 
 export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]): string[] {
@@ -130,39 +98,6 @@ export function checkSettingsMcpEndpoint(value: string): PathCheckResult {
   }
 }
 
-export function checkSettingsStoreUrl(value: string): PathCheckResult {
-  const trimmed = value.trim()
-  if (trimmed === '') return { ok: false, message: 'URL required' }
-  try {
-    const url = new URL(trimmed)
-    if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
-      return { ok: false, message: 'expected postgres URL' }
-    }
-    if (url.hostname.trim() === '') return { ok: false, message: 'host required' }
-    return { ok: true, message: 'valid store URL' }
-  } catch {
-    return { ok: false, message: 'invalid URL' }
-  }
-}
-
-export function checkSettingsWorktreeBase(value: string): PathCheckResult {
-  const trimmed = value.trim()
-  if (trimmed === '') return { ok: false, message: 'path required' }
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
-    return { ok: false, message: 'expected filesystem path' }
-  }
-  if (
-    trimmed.startsWith('~/') ||
-    trimmed === '~' ||
-    trimmed.startsWith('/') ||
-    trimmed.startsWith('./') ||
-    trimmed.startsWith('../')
-  ) {
-    return { ok: true, message: 'valid local path' }
-  }
-  return { ok: false, message: 'use absolute, ./, ../, or ~/' }
-}
-
 function readLocalPreviewString(key: string, fallback: string): string {
   try {
     if (typeof sessionStorage === 'undefined') return fallback
@@ -179,11 +114,6 @@ function writeLocalPreviewString(key: string, value: string) {
   } catch {
     // Local preview settings are best-effort; blocked storage should not break Settings.
   }
-}
-
-function readLocalPreviewNumber(key: string, fallback: number): number {
-  const parsed = Number(readLocalPreviewString(key, String(fallback)))
-  return Number.isFinite(parsed) ? parsed : fallback
 }
 
 function readLocalPreviewBoolRecord(key: string, fallback: Record<string, boolean>): Record<string, boolean> {
@@ -218,15 +148,6 @@ function useLocalPreviewString(key: string, initialValue: string): [string, (nex
   const setStoredValue = (next: string) => {
     setValue(next)
     writeLocalPreviewString(key, next)
-  }
-  return [value, setStoredValue]
-}
-
-function useLocalPreviewNumber(key: string, initialValue: number): [number, (next: number) => void] {
-  const [value, setValue] = useState(() => readLocalPreviewNumber(key, initialValue))
-  const setStoredValue = (next: number) => {
-    setValue(next)
-    writeLocalPreviewString(key, String(next))
   }
   return [value, setStoredValue]
 }
@@ -278,42 +199,6 @@ const FUSION: FusionConfig = {
   maxToolCallsPerPanel: 0,
 }
 
-// Tool-group catalog for the prototype settings surface snapshot.
-// keeper-v2 settings.jsx:85-97 (TOOL_GROUPS). kind 'local' = [groups.*]
-// (keeper-local), 'masc' = [masc.*] (server). guard/optin map to the
-// [groups.execute] 3-layer guard and opt-in voice group.
-// NOTE: read-only snapshot only; live tool_policy/tier policy data is not yet
-// projected from backend policy SSOT.
-type ToolGroup = {
-  readonly id: string
-  readonly kind: 'local' | 'masc'
-  readonly tools: readonly string[]
-  readonly guard?: boolean
-  readonly optin?: boolean
-}
-const TOOL_GROUPS: readonly ToolGroup[] = [
-  { id: 'base', kind: 'local', tools: ['keeper_time_now', 'keeper_context_status', 'keeper_memory_search', 'keeper_memory_write', 'keeper_tool_search', 'keeper_tools_list'] },
-  { id: 'board_core', kind: 'local', tools: ['keeper_board_get', 'keeper_board_post', 'keeper_board_comment', 'keeper_board_vote', 'keeper_board_list', 'keeper_board_curation_read', 'keeper_board_curation_submit'] },
-  { id: 'workspace_core', kind: 'local', tools: ['keeper_tasks_list', 'keeper_task_claim', 'keeper_task_create', 'keeper_task_done', 'keeper_broadcast'] },
-  { id: 'filesystem', kind: 'local', tools: ['tool_read_file'] },
-  { id: 'workspace_write', kind: 'local', tools: ['tool_edit_file', 'tool_write_file'] },
-  { id: 'execute', kind: 'local', guard: true, tools: ['tool_execute'] },
-  { id: 'library', kind: 'local', tools: ['keeper_library_search', 'keeper_library_read'] },
-  { id: 'voice', kind: 'local', optin: true, tools: ['keeper_voice_speak', 'keeper_voice_listen', 'keeper_voice_agent', 'keeper_voice_sessions'] },
-  { id: 'masc.essential', kind: 'masc', tools: ['masc_status', 'masc_web_search', 'masc_web_fetch'] },
-  { id: 'masc.workspace', kind: 'masc', tools: ['masc_tasks', 'masc_claim_next', 'masc_transition', 'masc_add_task', 'masc_agents', 'masc_broadcast', 'masc_messages', 'masc_heartbeat'] },
-  { id: 'masc.goal', kind: 'masc', tools: ['masc_goal_list', 'masc_goal_upsert', 'masc_goal_transition', 'masc_goal_verify'] },
-]
-const DEFAULT_TOOL_GROUP_GRANTS: Record<string, boolean> = Object.fromEntries(
-  TOOL_GROUPS.map(g => [g.id, !g.optin]),
-)
-// [groups.last_turn_safe] — keeper-v2 settings.jsx:99. On a keeper's final
-// turn, allowed tools are intersected with this set. Snapshot from the
-// prototype settings view; backend parity is deferred.
-const LAST_TURN_SAFE: readonly string[] = ['keeper_board_post', 'keeper_board_comment', 'keeper_board_curation_submit', 'keeper_context_status', 'extend_turns', 'keeper_time_now', 'keeper_tool_search', 'keeper_broadcast', 'keeper_tasks_list', 'keeper_task_done', 'masc_tasks', 'masc_transition', 'tool_read_file', 'tool_search_files', 'tool_execute', 'masc_web_search', 'masc_web_fetch']
-// tool_execute 3-layer deterministic guard — keeper-v2 settings.jsx:101
-// ([groups.execute]).
-const EXEC_GUARD: readonly string[] = ['validate_command', 'destructive_guard', 'write_gate']
 // System-log row: [time, level, identity, message, status]. Derived from live
 // ring entries (`/api/v1/dashboard/logs`) — the same source the Logs surface
 // polls. Status is derived from the entry level only (error→fail, warn→warn,
@@ -468,29 +353,6 @@ function PreviewBadge({ label = 'local only' }: { label?: string }) {
   `
 }
 
-function PathCheckBadge({
-  result,
-  target,
-}: {
-  result: PathCheckResult | undefined
-  target: PathCheckTarget
-}) {
-  if (!result) return null
-  return html`
-    <span
-      class=${`set-path-check-result ${result.ok ? 'ok' : 'fail'}`}
-      data-testid=${`settings-path-check-result-${target}`}
-      data-ok=${result.ok ? 'true' : 'false'}
-    >
-      ${result.message}
-    </span>
-  `
-}
-
-function RolePill({ children }: { children: ComponentChildren }) {
-  return html`<span class="set-rolepill">${children}</span>`
-}
-
 function formatRuntimeContext(value: number | null | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'ctx 미수집'
   if (value >= 1_000_000) return `${Number.parseFloat((value / 1_000_000).toFixed(1))}M ctx`
@@ -563,109 +425,139 @@ function RuntimeCatalogCard({
   `
 }
 
-type SandboxDraft = {
-  sandbox_profile: SandboxProfile
-  network_mode: SandboxNetworkMode
-  allowed_paths_text: string
-}
-
-function coerceSandboxProfile(raw: string | null | undefined): SandboxProfile {
-  return raw === 'docker' ? 'docker' : 'local'
-}
-
-function coerceNetworkMode(raw: string | null | undefined): SandboxNetworkMode {
-  return raw === 'none' ? 'none' : 'inherit'
-}
-
-function dedupeListText(text: string): string[] {
-  const seen = new Set<string>()
-  const values: string[] = []
-  for (const raw of text.split('\n')) {
-    const item = raw.trim()
-    if (!item || seen.has(item)) continue
-    seen.add(item)
-    values.push(item)
+function configEntry(data: DashboardConfigResponse | null, env: string): ConfigEntry | null {
+  if (!data) return null
+  for (const entries of Object.values(data.categories)) {
+    const found = entries.find(entry => entry.env === env)
+    if (found) return found
   }
-  return values
+  return null
 }
 
-function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index])
+function configEntryDisplayValue(entry: ConfigEntry | null): string | null {
+  if (!entry) return null
+  return entry.value ?? entry.default
 }
 
-function sandboxDraftFromConfig(config: KeeperConfig): SandboxDraft {
-  return {
-    sandbox_profile: coerceSandboxProfile(config.sandbox_profile),
-    network_mode: coerceNetworkMode(config.network_mode),
-    allowed_paths_text: (config.allowed_paths ?? []).join('\n'),
+function concreteConfigValue(entry: ConfigEntry | null): string | null {
+  const value = configEntryDisplayValue(entry)?.trim()
+  if (!value || /^\(.+\)$/.test(value)) return null
+  return value
+}
+
+function formatConfigSource(entry: ConfigEntry | null): string {
+  if (!entry) return 'missing'
+  return entry.source_detail ?? entry.source
+}
+
+function endpointFromWindow(): string {
+  if (typeof window === 'undefined') return '/mcp'
+  const origin = window.location.origin
+  if (!origin || origin === 'null') return '/mcp'
+  return `${origin.replace(/\/$/, '')}/mcp`
+}
+
+function mcpEndpointFromConfig(config: DashboardConfigResponse | null): string {
+  const mcpUrl = concreteConfigValue(configEntry(config, 'MASC_URL'))
+  if (mcpUrl) return mcpUrl
+  const httpBaseUrl = concreteConfigValue(configEntry(config, 'MASC_HTTP_BASE_URL'))
+  if (httpBaseUrl) {
+    try {
+      return new URL('/mcp', httpBaseUrl).toString()
+    } catch {
+      return `${httpBaseUrl.replace(/\/$/, '')}/mcp`
+    }
   }
+  return endpointFromWindow()
 }
 
-function buildSandboxPayload(draft: SandboxDraft, config: KeeperConfig): KeeperConfigUpdatePayload {
-  const payload: KeeperConfigUpdatePayload = {}
-  const allowedPaths = dedupeListText(draft.allowed_paths_text)
-  if (draft.sandbox_profile !== coerceSandboxProfile(config.sandbox_profile)) {
-    payload.sandbox_profile = draft.sandbox_profile
-  }
-  if (draft.network_mode !== coerceNetworkMode(config.network_mode)) {
-    payload.network_mode = draft.network_mode
-  }
-  if (!sameStringArray(allowedPaths, config.allowed_paths ?? [])) {
-    payload.allowed_paths = allowedPaths
-  }
-  return payload
+function formatThresholdPercent(value: string | null): string {
+  const parsed = value == null ? NaN : Number.parseFloat(value)
+  if (!Number.isFinite(parsed)) return value ?? '미수집'
+  return `${Math.round(parsed * 100)}%`
 }
 
-function connectorState(connector: GateConnectorInfo): 'connected' | 'stale' | 'offline' {
-  if (!connector.available) return 'offline'
-  if (connector.stale) return 'stale'
-  return connector.connected ? 'connected' : 'offline'
+function ConfigTruthRow({
+  label,
+  entry,
+  fallback,
+}: {
+  label: string
+  entry: ConfigEntry | null
+  fallback?: string | null
+}) {
+  const value = configEntryDisplayValue(entry) ?? fallback ?? '미수집'
+  return html`
+    <${SetRow} label=${label} hint=${entry?.description ?? 'dashboard config projection'}>
+      <div class="set-truth-value">
+        <span class="mono" data-testid=${`settings-config-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}>${value}</span>
+        <span class="set-truth-source">${formatConfigSource(entry)}</span>
+      </div>
+    <//>
+  `
 }
 
-function connectorStateText(connector: GateConnectorInfo): string {
-  const state = connectorState(connector)
-  if (state === 'connected') return 'connected'
-  if (state === 'stale') return 'stale'
-  return connector.status || 'offline'
+function ThresholdTruthRow({
+  label,
+  entry,
+  value,
+}: {
+  label: string
+  entry: ConfigEntry | null
+  value: string
+}) {
+  return html`
+    <${SetRow} label=${label} hint=${entry?.env ?? 'dashboard alert threshold'}>
+      <div class="set-truth-value">
+        <span class="mono">${value}</span>
+        <span class="set-truth-source">${formatConfigSource(entry)}</span>
+      </div>
+    <//>
+  `
 }
 
-function uniqueConnectorGateBaseUrls(connectors: readonly GateConnectorInfo[]): string[] {
-  return Array.from(new Set(
-    connectors
-      .map(connector => connector.gate_base_url.trim())
-      .filter(Boolean),
-  )).sort((a, b) => a.localeCompare(b))
+function PathTruthRow({
+  label,
+  item,
+  fallback,
+}: {
+  label: string
+  item?: DashboardConfigResolutionItem | null
+  fallback?: string | null
+}) {
+  const path = item?.path ?? fallback ?? '미수집'
+  const exists = item ? item.exists : null
+  const status =
+    exists === null ? 'unknown'
+    : exists ? 'exists'
+    : 'missing'
+  return html`
+    <${SetRow} label=${label} hint=${item?.source ?? 'runtime resolution'}>
+      <div class="set-path-truth">
+        <span class="mono set-path-truth-path" title=${path}>${path}</span>
+        <span class=${`set-path-truth-state ${status}`} data-testid=${`settings-path-${status}`}>${status}</span>
+      </div>
+    <//>
+  `
 }
 
-function uniqueNonEmptyStrings(values: readonly (string | null | undefined)[]): string[] {
-  const seen = new Set<string>()
-  const names: string[] = []
-  for (const value of values) {
-    const name = value?.trim()
-    if (!name || seen.has(name)) continue
-    seen.add(name)
-    names.push(name)
-  }
-  return names
-}
-
-type SettingsSectionMode = 'live' | 'local'
+type SettingsSectionMode = 'live' | 'mixed' | 'local'
 
 function settingsSectionState(
   section: SectionId,
   fusionSettingsWritable: boolean,
 ): { mode: SettingsSectionMode; label: string } {
-  if (section === 'runtime') return { mode: 'live', label: 'runtime.toml live-backed' }
+  if (section === 'runtime') return { mode: 'live', label: 'runtime.toml + provider catalog' }
   if (section === 'runtimes') return { mode: 'live', label: 'runtime.toml live-backed' }
-  if (section === 'routing') return { mode: 'live', label: 'runtime.toml live-backed' }
   if (section === 'prompts') return { mode: 'live', label: 'prompt registry live-backed' }
-  if (section === 'sandbox') return { mode: 'live', label: 'keeper config live-backed' }
-  if (section === 'gate') return { mode: 'live', label: 'gate connector live-backed' }
   if (section === 'fusion' && fusionSettingsWritable) {
     return { mode: 'live', label: 'runtime.toml live-backed' }
   }
-  if (section === 'mcp') return { mode: 'local', label: 'live inventory + local controls' }
-  if (section === 'logs') return { mode: 'local', label: 'live logs + local controls' }
+  if (section === 'paths') return { mode: 'live', label: 'resolved by server' }
+  if (section === 'mcp') return { mode: 'mixed', label: 'live MCP check + inventory' }
+  if (section === 'logs') return { mode: 'mixed', label: 'live logs + local filters' }
+  if (section === 'notify') return { mode: 'mixed', label: 'live thresholds + local preview' }
+  if (section === 'display') return { mode: 'local', label: 'browser preference' }
   return { mode: 'local', label: 'local preview only' }
 }
 
@@ -788,17 +680,37 @@ export function SettingsSurface() {
 
   function openSection(id: SectionId) {
     setSec(id)
-    navigate('settings', id === 'account' ? {} : { section: id })
+    navigate('settings', id === DEFAULT_SETTINGS_SECTION ? {} : { section: id })
   }
 
-  // account
-  const [sessionExpiry, setSessionExpiry] = useState('8시간')
+  // Server config projection — used by Paths, MCP and Notifications.
+  const [dashboardConfig, setDashboardConfig] = useState<DashboardConfigResponse | null>(null)
+  const [dashboardConfigStatus, setDashboardConfigStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+
+  useEffect(() => {
+    let active = true
+    setDashboardConfigStatus('loading')
+    void (async () => {
+      try {
+        const resp = await fetchDashboardConfig()
+        if (!active) return
+        setDashboardConfig(resp)
+        setDashboardConfigStatus('ready')
+      } catch {
+        if (!active) return
+        setDashboardConfig(null)
+        setDashboardConfigStatus('error')
+      }
+    })()
+    return () => { active = false }
+  }, [])
 
   // mcp — exposed tools come from the live capability registry (public_mcp surface)
-  const [mcpUrl, setMcpUrl] = useLocalPreviewString('mcpUrl', 'https://masc.local/mcp')
-  const [transport, setTransport] = useLocalPreviewString('mcpTransport', 'http')
   const [mcpTools, setMcpTools] = useState<string[]>([])
-  const [tools, setTools] = useState<Record<string, boolean>>({})
+  const [mcpCheck, setMcpCheck] = useState<{ status: 'idle' | 'checking' | 'ok' | 'error'; message: string }>({
+    status: 'idle',
+    message: '아직 확인하지 않음',
+  })
 
   useEffect(() => {
     let active = true
@@ -808,23 +720,27 @@ export function SettingsSurface() {
         if (!active) return
         const names = mcpExposedToolNames(resp.tool_inventory?.tools ?? [])
         setMcpTools(names)
-        setTools(readLocalPreviewBoolRecord('mcpToolPreview', Object.fromEntries(names.map(n => [n, true]))))
       } catch {
         if (!active) return
         // No fabricated tool names on failure.
         setMcpTools([])
-        setTools({})
       }
     })()
     return () => { active = false }
   }, [])
 
-  function updateMcpToolPreview(tool: string, enabled: boolean) {
-    setTools(prev => {
-      const next = { ...prev, [tool]: enabled }
-      writeLocalPreviewBoolRecord('mcpToolPreview', next)
-      return next
-    })
+  async function runMcpServerCheck() {
+    setMcpCheck({ status: 'checking', message: 'masc_status 호출 중...' })
+    try {
+      const text = await callMcpTool('masc_status', {})
+      const summary = text.trim().replace(/\s+/g, ' ').slice(0, 140)
+      setMcpCheck({ status: 'ok', message: summary || 'masc_status 응답 확인' })
+    } catch (err) {
+      setMcpCheck({
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   // runtime defaults / model routing — resolved from runtime.toml (SSOT)
@@ -865,10 +781,6 @@ export function SettingsSurface() {
     return () => { active = false }
   }, [])
 
-  // policy — tool-group grants (namespace default-grant per [groups.*]); opt-in groups
-  // start off. keeper-v2 settings.jsx:177.
-  const [grant, setGrant] = useLocalPreviewBoolRecord('policyGrant', DEFAULT_TOOL_GROUP_GRANTS)
-
   // fusion (config/runtime.toml [fusion]) — keeper-v2 settings.jsx:178-182
   const fusionSettingsWritable = envBool('VITE_FUSION_SETTINGS_WRITABLE', false)
   const [fusionOn, setFusionOn] = useState(FUSION.enabled)
@@ -876,187 +788,17 @@ export function SettingsSurface() {
   const [fusionPanels, setFusionPanels] = useState(FUSION.maxConcurrentPanels)
   const [fusionWeb, setFusionWeb] = useState(FUSION.webTools)
 
-  // lifecycle
-  const [idleDrain, setIdleDrain] = useState(30)
-  const [autoRestart, setAutoRestart] = useState(true)
-  const [restartMax, setRestartMax] = useState(3)
-  const [onOverflow, setOnOverflow] = useState('자동 compact')
-
-  // gate / paths
-  const [gateConnectorsData, setGateConnectorsData] = useState<GateConnectorsData | null>(null)
-  const [gateConnectorsStatus, setGateConnectorsStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
-  const [gateConnectorsError, setGateConnectorsError] = useState<string | null>(null)
-  const [wtBase, setWtBase] = useLocalPreviewString('wtBase', '~/wt')
-  const [storeUrl, setStoreUrl] = useLocalPreviewString('storeUrl', 'postgres://masc.local:5432/masc')
-  const [pathChecks, setPathChecks] = useState<Partial<Record<PathCheckTarget, PathCheckResult>>>({})
-
-  function runPathCheck(target: PathCheckTarget) {
-    let result: PathCheckResult
-    switch (target) {
-      case 'mcp':
-        result = checkSettingsMcpEndpoint(mcpUrl)
-        break
-      case 'store':
-        result = checkSettingsStoreUrl(storeUrl)
-        break
-      case 'worktree':
-        result = checkSettingsWorktreeBase(wtBase)
-        break
-    }
-    setPathChecks(current => ({ ...current, [target]: result }))
-  }
-
-  // sandbox — per-keeper live config, not a global sandbox policy.
-  const [sandboxFallbackKeeperNames, setSandboxFallbackKeeperNames] = useState<string[]>([])
-  const [sandboxKeeperListStatus, setSandboxKeeperListStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle')
-  const [sandboxKeeperListError, setSandboxKeeperListError] = useState<string | null>(null)
-  const liveKeeperCount = keepers.value.length
-  const keeperList = liveKeeperCount > 0
-    ? keepers.value
-    : sandboxFallbackKeeperNames.map(name => ({ name, status: 'unknown' }))
-  const keeperNamesKey = keeperList.map(keeper => keeper.name).join('\u0000')
-  const [sandboxKeeperName, setSandboxKeeperName] = useState('')
-  const [sandboxConfig, setSandboxConfig] = useState<KeeperConfig | null>(null)
-  const [sandboxDraft, setSandboxDraft] = useState<SandboxDraft | null>(null)
-  const [sandboxStatus, setSandboxStatus] = useState<'idle' | 'loading' | 'ready' | 'saving' | 'error'>('idle')
-  const [sandboxError, setSandboxError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (sec !== 'sandbox') return
-    setSandboxKeeperName(current => {
-      if (current && keeperList.some(keeper => keeper.name === current)) return current
-      return keeperList[0]?.name ?? ''
-    })
-  }, [keeperNamesKey, sec])
-
-  useEffect(() => {
-    if (sec !== 'sandbox' || liveKeeperCount > 0) return undefined
-    const controller = new AbortController()
-    setSandboxKeeperListStatus('loading')
-    setSandboxKeeperListError(null)
-    void (async () => {
-      try {
-        const fleet = await fetchKeepersComposite({ signal: controller.signal })
-        if (controller.signal.aborted) return
-        const names = uniqueNonEmptyStrings(fleet.snapshots.map(snapshot => snapshot.keeper))
-        setSandboxFallbackKeeperNames(names)
-        setSandboxKeeperListStatus('ready')
-      } catch (err: unknown) {
-        if (controller.signal.aborted) return
-        setSandboxFallbackKeeperNames([])
-        setSandboxKeeperListStatus('error')
-        setSandboxKeeperListError(errorToString(err))
-      }
-    })()
-    return () => controller.abort()
-  }, [liveKeeperCount, sec])
-
-  useEffect(() => {
-    if (sec !== 'gate') return undefined
-    const controller = new AbortController()
-    setGateConnectorsStatus('loading')
-    setGateConnectorsError(null)
-    void (async () => {
-      try {
-        const resp = await fetchGateConnectors(controller.signal)
-        setGateConnectorsData(resp)
-        setGateConnectorsStatus('ready')
-      } catch (err: unknown) {
-        if (controller.signal.aborted) return
-        setGateConnectorsData(null)
-        setGateConnectorsStatus('error')
-        setGateConnectorsError(errorToString(err))
-      }
-    })()
-    return () => controller.abort()
-  }, [sec])
-
-  useEffect(() => {
-    if (sec !== 'sandbox' || !sandboxKeeperName) return undefined
-    let active = true
-    setSandboxStatus('loading')
-    setSandboxError(null)
-    setSandboxConfig(null)
-    setSandboxDraft(null)
-    void (async () => {
-      try {
-        const config = await fetchKeeperConfig(sandboxKeeperName)
-        if (!active) return
-        setSandboxConfig(config)
-        setSandboxDraft(sandboxDraftFromConfig(config))
-        setSandboxStatus('ready')
-      } catch (err: unknown) {
-        if (!active) return
-        setSandboxStatus('error')
-        setSandboxError(errorToString(err))
-      }
-    })()
-    return () => { active = false }
-  }, [sandboxKeeperName, sec])
-
-  function updateSandboxDraft(field: keyof SandboxDraft, value: string) {
-    setSandboxDraft(current => {
-      if (!current) return current
-      const next = { ...current, [field]: value } as SandboxDraft
-      if (field === 'sandbox_profile' && next.sandbox_profile !== 'docker' && next.network_mode === 'none') {
-        next.network_mode = 'inherit'
-      }
-      if (field === 'network_mode' && next.sandbox_profile !== 'docker' && next.network_mode === 'none') {
-        next.network_mode = 'inherit'
-      }
-      return next
-    })
-  }
-
-  async function saveSandboxConfig() {
-    if (!sandboxConfig || !sandboxDraft || sandboxStatus === 'saving') return
-    const payload = buildSandboxPayload(sandboxDraft, sandboxConfig)
-    if (Object.keys(payload).length === 0) return
-    setSandboxStatus('saving')
-    setSandboxError(null)
-    try {
-      const updated = await patchKeeperConfig(sandboxConfig.name, payload)
-      setSandboxConfig(updated)
-      setSandboxDraft(sandboxDraftFromConfig(updated))
-      setSandboxStatus('ready')
-      keepers.value = keepers.value.map(keeper =>
-        keeper.name === updated.name
-          ? { ...keeper, sandbox_profile: coerceSandboxProfile(updated.sandbox_profile) }
-          : keeper,
-      )
-    } catch (err: unknown) {
-      setSandboxStatus('error')
-      setSandboxError(errorToString(err))
-    }
-  }
-
-  // ide
-  const [ideView, setIdeView] = useState('split-diff')
-  const [diffStyle, setDiffStyle] = useState('side-by-side')
-  const [tabWidth, setTabWidth] = useState(2)
-  const [formatOnSave, setFormatOnSave] = useState(true)
-  const [wrapLines, setWrapLines] = useState(false)
-  const [liveCursors, setLiveCursors] = useState(true)
-  const [ideOwnership, setIdeOwnership] = useState(true)
-  const [convRail, setConvRail] = useState(true)
-  const [contextLens, setContextLens] = useState(true)
-  const [blameGutter, setBlameGutter] = useState(true)
-  const [ideAnnos, setIdeAnnos] = useState(true)
-  const [annoAutoLink, setAnnoAutoLink] = useState(true)
-  const [embedTerminal, setEmbedTerminal] = useState(true)
-  const [searchIndex, setSearchIndex] = useState(true)
-  const [ideRepo, setIdeRepo] = useLocalPreviewString('ideRepo', 'masc/masc-mcp')
-
-  // logs
-  const [traceKeep, setTraceKeep] = useState('30일')
-  const [logLevel, setLogLevel] = useState('info')
-  const [sampling, setSampling] = useState(100)
-
   // notify / display
-  const [notifyCtx, setNotifyCtx] = useLocalPreviewNumber('notifyContextThreshold', 85)
-  const [notifyFails, setNotifyFails] = useLocalPreviewNumber('notifyFailureThreshold', 3)
+  const [notifyCtx, setNotifyCtx] = useState(95)
+  const [notifyFails, setNotifyFails] = useState(3)
   const [notifyCh, setNotifyCh] = useLocalPreviewString('notifyChannel', 'Slack')
-  const [notifyOn, setNotifyOn] = useLocalPreviewBoolRecord('notifyEventPreview', DEFAULT_NOTIFY_EVENT_PREVIEW)
+  const [notifyOn, setNotifyOn] = useLocalPreviewBoolRecord('notifyEvents', {
+    '컨텍스트 임계치 초과': true,
+    '연속 실패': true,
+    'keeper crash/dead': true,
+    '핸드오프 완료': false,
+    '승인 요청': true,
+  })
   const [density, setDensity] = useState('regular')
   const [tz, setTz] = useState('Asia/Seoul')
   const [locale, setLocale] = useState('KO')
@@ -1064,11 +806,6 @@ export function SettingsSurface() {
 
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
   const sectionState = settingsSectionState(sec, fusionSettingsWritable)
-  const grantedGroupCount = Object.values(grant).filter(Boolean).length
-  const liveGateConnectors = gateConnectorsData?.connectors ?? []
-  const liveGateBaseUrls = uniqueConnectorGateBaseUrls(liveGateConnectors)
-  const sandboxDirty = sandboxConfig !== null && sandboxDraft !== null
-    && Object.keys(buildSandboxPayload(sandboxDraft, sandboxConfig)).length > 0
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -1083,8 +820,22 @@ export function SettingsSurface() {
   const keeperAssignmentCount = keeperAssignments.length > 0
     ? keeperAssignments.length
     : runtimeProviders?.assignment_governance?.assignment_count ?? 0
-  const mcpPreviewEnabledCount = Object.values(tools).filter(Boolean).length
-  const notifyPreviewEnabledCount = Object.values(notifyOn).filter(Boolean).length
+  const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
+  const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
+  const mediaFailover = runtimeDefaults?.model_routing.media_failover ?? []
+  const runtimeResolution = shellRuntimeResolution.value
+  const configResolution = shellConfigResolution.value
+  const mcpEndpoint = mcpEndpointFromConfig(dashboardConfig)
+  const mcpUrlEntry = configEntry(dashboardConfig, 'MASC_URL')
+  const httpBaseUrlEntry = configEntry(dashboardConfig, 'MASC_HTTP_BASE_URL')
+  const basePathEntry = configEntry(dashboardConfig, 'MASC_BASE_PATH')
+  const dataDirEntry = configEntry(dashboardConfig, 'MASC_DATA_DIR')
+  const configDirEntry = configEntry(dashboardConfig, 'MASC_CONFIG_DIR')
+  const ctxPreparingEntry = configEntry(dashboardConfig, 'MASC_DASHBOARD_CTX_PREPARING')
+  const ctxHandoffEntry = configEntry(dashboardConfig, 'MASC_DASHBOARD_CTX_HANDOFF_IMMINENT')
+  const runtimeWarningEntry = configEntry(dashboardConfig, 'MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO')
+  const signalStaleEntry = configEntry(dashboardConfig, 'MASC_DASHBOARD_SIGNAL_STALE_SEC')
+  const alertDedupEntry = configEntry(dashboardConfig, 'MASC_ALERT_DEDUP_WINDOW_SEC')
 
   return html`
     <main class="v2-shell-surface settings-surf ss-surface bg-surface-page text-text-primary" data-screen-label="설정" data-testid="settings-surface">
@@ -1134,75 +885,46 @@ export function SettingsSurface() {
           </header>
 
           <div
-            class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'routing' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
+            class=${`set-card-b mx-6 my-6 ${sec === 'runtime' || sec === 'runtimes' || sec === 'paths' || sec === 'mcp' || sec === 'notify' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
             data-preview-locked="false"
             data-settings-mode=${sectionState.mode}
           >
-            ${sec === 'account' && html`
-              <${SetRow} label="Operator" hint="Currently logged-in operator">
-                <span class="mono" style=${{ color: 'var(--text-bright)' }}>@operator</span>
-              <//>
-              <${SetRow} label="Role" hint="MASC role — DM / player / keeper / operator">
-                <${RolePill}>operator<//>
-              <//>
-              <${SetRow} label="API token" hint="Used for MCP·gate authentication">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    readOnly
-                    value="••••••••••••••"
-                  />
-                  <${PreviewBadge} label="redacted" />
-                </div>
-              <//>
-              <${SetRow} label="Session expiry" hint="Auto-logout timeout">
-                <${SetSeg} value=${sessionExpiry} options=${['1시간', '8시간', '안 함']} onChange=${setSessionExpiry} />
-              <//>
-            `}
-
             ${sec === 'mcp' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Live <span class="mono">public_mcp</span> inventory is read from the backend. Endpoint, transport and per-tool switches below are browser-session exposure previews only; they do not rewrite MCP server policy.
+                현재 대시보드가 사용하는 HTTP MCP 서버 상태와 public MCP 도구 노출 목록입니다. 도구 노출은 서버 capability registry가 SSOT입니다.
               </div>
-              <div class="set-local-summary" data-testid="mcp-local-summary">
-                Previewing ${transport} against ${mcpUrl}; ${mcpPreviewEnabledCount}/${mcpTools.length} listed tools selected in this browser session.
-              </div>
-              <${SetRow} label="MCP endpoint" hint="GET/POST /mcp">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-mcp-endpoint-input"
-                    value=${mcpUrl}
-                    onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
+              <${SetRow} label="MCP endpoint" hint="Resolved from MASC_URL / MASC_HTTP_BASE_URL / current origin">
+                <div class="set-truth-value">
+                  <span class="mono" data-testid="settings-mcp-endpoint">${mcpEndpoint}</span>
+                  <span class="set-truth-source">${formatConfigSource(mcpUrlEntry ?? httpBaseUrlEntry)}</span>
                 </div>
               <//>
-              <${SetRow} label="Transport" hint="browser-session preview">
-                <div class="set-tg-control">
-                  <${PreviewBadge} />
-                  <${SetSeg} value=${transport} options=${MCP_TRANSPORT_OPTIONS} onChange=${setTransport} />
+              <${SetRow} label="Transport" hint="Dashboard client transport">
+                <div class="set-truth-value">
+                  <span class="mono">streamable HTTP</span>
+                  <span class="set-truth-source">POST /mcp · Accept: application/json, text/event-stream</span>
                 </div>
               <//>
-              <div class="set-mcp-detail mono">
-                ${transport === 'http' && html`<span>POST ${mcpUrl} · Content-Type: application/json · Authorization: Bearer ••••</span>`}
-                ${transport === 'stdio' && html`<span>spawn: masc-mcp serve --stdio · framing: ndjson</span>`}
-                ${transport === 'sse' && html`<span>GET ${mcpUrl}/sse · keep-alive 15s · event: message</span>`}
-              </div>
-              <div class="set-sub-h">Local tool exposure preview (${mcpPreviewEnabledCount}/${mcpTools.length})</div>
+              <${SetRow} label="Server check" hint="Calls masc_status through the same MCP client used by dashboard actions">
+                <div class="set-mcp-check">
+                  <button
+                    type="button"
+                    class=${`set-verify ${mcpCheck.status}`}
+                    data-testid="settings-mcp-check"
+                    disabled=${mcpCheck.status === 'checking'}
+                    onClick=${() => void runMcpServerCheck()}
+                  >
+                    ${mcpCheck.status === 'checking' ? 'Checking...' : 'Check MCP'}
+                  </button>
+                  <span class=${`set-mcp-check-result ${mcpCheck.status}`} data-testid="settings-mcp-check-result">${mcpCheck.message}</span>
+                </div>
+              <//>
+              <div class="set-sub-h">Exposed public MCP tools (${mcpTools.length})</div>
               ${mcpTools.length === 0
                 ? html`<div class="set-hint" data-testid="mcp-tools-empty">노출된 MCP 도구가 없습니다.</div>`
-                : mcpTools.map(t => html`
-                <${SetRow} key=${t} label=${html`<span class="mono" style=${{ fontSize: '12.5px' }}>${t}</span>`}>
-                  <div class="set-tg-control">
-                    <${PreviewBadge} />
-                    <${SetToggle}
-                      on=${tools[t] ?? false}
-                      onChange=${(v: boolean) => updateMcpToolPreview(t, v)}
-                    />
-                  </div>
-                <//>
-              `)}
+                : html`<div class="set-tg-tools" data-testid="mcp-tools-list">
+                  ${mcpTools.map(t => html`<span key=${t} class="set-tg-chip mono">${t}</span>`)}
+                </div>`}
             `}
 
             ${sec === 'runtime' && html`
@@ -1248,7 +970,35 @@ export function SettingsSurface() {
                   <${SetRow} label="Default model" hint="Resolved model API name">
                     <span class="mono" data-testid="runtime-default-model">${runtimeDefaults?.default_model ?? defaultCatalogEntry?.model_api_name ?? '—'}</span>
                   <//>
+                  <${SetRow} label="Default context" hint="Resolved context window">
+                    <span class="mono" data-testid="runtime-default-context">
+                      ${formatRuntimeContext(runtimeDefaults?.default_max_context ?? defaultCatalogEntry?.max_context ?? null)}
+                    </span>
+                  <//>
                 </div>
+
+                <div class="set-sub-h">Model routing</div>
+                <div class="set-route-summary" data-testid="runtime-routing-summary">
+                  ${librarianRuntime
+                    ? html`<span><span class="sub-k">librarian</span><span class="mono">${librarianRuntime}</span></span>`
+                    : html`<span><span class="sub-k">librarian</span><span class="mono">default runtime</span></span>`}
+                  ${crossVerifierRuntime
+                    ? html`<span><span class="sub-k">cross verifier</span><span class="mono">${crossVerifierRuntime}</span></span>`
+                    : html`<span><span class="sub-k">cross verifier</span><span class="mono">default runtime</span></span>`}
+                  <span><span class="sub-k">media failover</span><span class="mono">${mediaFailover.length > 0 ? mediaFailover.join(', ') : 'none'}</span></span>
+                </div>
+                <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
+                ${keeperAssignments.length === 0
+                  ? html`<div class="set-hint" data-testid="routing-assignments-empty">명시적 keeper 할당이 없습니다 — 모두 기본 런타임을 사용합니다.</div>`
+                  : html`<div class="settings-runtime-routing" data-testid="routing-assignments-list">
+                    ${keeperAssignments.map(a => html`
+                      <div class="set-routing-row" key=${a.keeper}>
+                        <span class="mono">${a.keeper}</span>
+                        <span class="set-routing-arrow">→</span>
+                        <span class="mono" data-testid="routing-assignment">${a.runtime_id}</span>
+                      </div>
+                    `)}
+                  </div>`}
 
                 <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
                 ${runtimeCatalogStatus === 'loading'
@@ -1272,13 +1022,6 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtimes' && html`
-              <${RuntimeTomlEditor} />
-            `}
-
-            ${sec === 'routing' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                runtime.toml 의 라우팅 레인과 keeper 배정을 직접 수정합니다. 기본 런타임, memory-os 라이브러리안, cross-verifier, keeper별 배정은 모두 같은 SSOT에 저장됩니다.
-              </div>
               <${RuntimeTomlEditor} />
             `}
 
@@ -1324,400 +1067,83 @@ export function SettingsSurface() {
               `}
             `}
 
-            ${sec === 'policy' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                keeper 의 <span class="mono">tool_access</span> 는 named 그룹(<span class="mono">tool_policy.toml</span>)의 도구를 참조합니다. 이 섹션은 runtime 정책을 저장하지 않고 browser-session grant preview만 조정합니다.
-              </div>
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                현재는 live tool-policy writer가 없어 prototype group catalog 스냅샷으로 표시합니다. 런타임 도구 정책이 SSOT로 연동되면 값이 교체됩니다.
-              </div>
-              <div class="set-local-summary" data-testid="policy-local-summary">
-                <span>local grant preview</span>
-                <span class="mono">${grantedGroupCount}/${TOOL_GROUPS.length} enabled</span>
-                <${PreviewBadge} />
-              </div>
-              <div class="set-sub-h">도구 그룹 부여</div>
-              ${TOOL_GROUPS.map(g => html`
-                <div key=${g.id} class="set-tg-row" data-testid="set-tg-row">
-                  <div class="set-tg-l">
-                    <div class="set-tg-head">
-                      <span class="set-tg-id mono">${g.id}</span>
-                      <span class=${`set-tg-kind ${g.kind}`}>${g.kind}</span>
-                      ${g.guard ? html`<span class="set-tg-kind guard">3-layer guard</span>` : null}
-                      ${g.optin ? html`<span class="set-tg-kind optin">opt-in</span>` : null}
-                    </div>
-                    <div class="set-tg-tools">${g.tools.map(t => html`<span key=${t} class="set-tg-chip mono">${t}</span>`)}</div>
-                  </div>
-                  <div class="set-tg-control">
-                    <${PreviewBadge} />
-                    <${SetToggle}
-                      on=${grant[g.id] ?? false}
-                      onChange=${(v: boolean) => setGrant(p => ({ ...p, [g.id]: v }))}
-                    />
-                  </div>
-                </div>
-              `)}
-
-              <div class="set-sub-h">tool_execute 가드 — 3계층 결정적</div>
-              <div class="set-hint" style=${{ marginBottom: '8px' }}>
-                셸 타입된 argv 명령은 세 계층을 순차 통과해야 실행됩니다. redirection/tee 또는 직접 file write 우회는 여기서 막힙니다.
-              </div>
-              <div class="set-guard" data-testid="set-guard">
-                ${EXEC_GUARD.map((step, i) => html`
-                  ${i > 0 ? html`<span key=${`a${i}`} class="set-guard-arrow">→</span>` : null}
-                  <span key=${step} class="set-guard-step mono">${step}</span>
-                `)}
-              </div>
-
-              <div class="set-sub-h">마지막 턴 안전 도구 — last_turn_safe</div>
-              <div class="set-hint" style=${{ marginBottom: '8px' }}>
-                keeper 의 마지막 턴에서는 허용 도구가 이 집합과 교집합됩니다 (${LAST_TURN_SAFE.length}개).
-              </div>
-              <div class="set-tg-tools">${LAST_TURN_SAFE.map(t => html`<span key=${t} class="set-tg-chip mono safe">${t}</span>`)}</div>
-            `}
-
-            ${sec === 'lifecycle' && html`
-              <${SetRow} label="Idle auto-drain" hint="Minutes until graceful shutdown">
-                <${SetSlider} value=${idleDrain} min=${0} max=${120} step=${5} suffix=${idleDrain ? '분' : '안 함'} onChange=${setIdleDrain} />
-              <//>
-              <${SetRow} label="Crash auto-restart" hint="Crashed → Restarting attempts">
-                <${SetToggle} on=${autoRestart} onChange=${setAutoRestart} />
-              <//>
-              ${autoRestart && html`
-                <${SetRow} label="Max restart attempts" hint="Transition to Dead when exceeded">
-                  <${SetStepper} v=${restartMax} set=${setRestartMax} min=${1} max=${10} />
-                <//>
-              `}
-              <${SetRow} label="Overflowed action" hint="When context window overflows">
-                <${SetSeg} value=${onOverflow} options=${['자동 compact', '자동 종료', 'operator 대기']} onChange=${setOnOverflow} />
-              <//>
-            `}
-
-            ${sec === 'sandbox' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Keeper별 <span class="mono">sandbox_profile</span>, <span class="mono">network_mode</span>, <span class="mono">allowed_paths</span>를 live keeper config에 저장합니다. 선택한 keeper의 source path와 effective_paths를 함께 표시합니다.
-              </div>
-              ${keeperList.length === 0
-                ? sandboxKeeperListStatus === 'loading'
-                  ? html`<div class="set-hint" data-testid="settings-sandbox-keepers-loading">keeper 목록을 불러오는 중...</div>`
-                  : sandboxKeeperListStatus === 'error'
-                    ? html`<div class="set-hint" data-testid="settings-sandbox-keepers-error">${sandboxKeeperListError ?? 'keeper 목록을 불러오지 못했습니다.'}</div>`
-                    : html`<div class="set-hint" data-testid="settings-sandbox-empty">표시할 keeper가 없습니다.</div>`
-                : html`
-                  <${SetRow} label="Keeper" hint="config/keepers/<name>.toml + live override">
-                    <select
-                      class="set-select mono"
-                      data-testid="settings-sandbox-keeper-select"
-                      value=${sandboxKeeperName}
-                      onInput=${(event: Event) => setSandboxKeeperName((event.currentTarget as HTMLSelectElement).value)}
-                      onChange=${(event: Event) => setSandboxKeeperName((event.currentTarget as HTMLSelectElement).value)}
-                    >
-                      ${keeperList.map(keeper => html`<option key=${keeper.name} value=${keeper.name}>${keeper.name}</option>`)}
-                    </select>
-                  <//>
-                  ${sandboxStatus === 'loading'
-                    ? html`<div class="set-hint" data-testid="settings-sandbox-loading">keeper sandbox 설정을 불러오는 중...</div>`
-                    : sandboxStatus === 'error'
-                      ? html`<div class="set-hint" data-testid="settings-sandbox-error">${sandboxError ?? 'keeper sandbox 설정을 불러오지 못했습니다.'}</div>`
-                      : sandboxConfig && sandboxDraft
-                        ? html`
-                          <${SetRow} label="sandbox_profile" hint="local 또는 docker">
-                            <select
-                              class="set-select mono"
-                              data-testid="settings-sandbox-profile"
-                              value=${sandboxDraft.sandbox_profile}
-                              disabled=${sandboxStatus === 'saving'}
-                              onInput=${(event: Event) => updateSandboxDraft('sandbox_profile', (event.currentTarget as HTMLSelectElement).value)}
-                              onChange=${(event: Event) => updateSandboxDraft('sandbox_profile', (event.currentTarget as HTMLSelectElement).value)}
-                            >
-                              <option value="local">local</option>
-                              <option value="docker">docker</option>
-                            </select>
-                          <//>
-                          <${SetRow} label="network_mode" hint="docker일 때 none 선택 가능">
-                            <select
-                              class="set-select mono"
-                              data-testid="settings-sandbox-network"
-                              value=${sandboxDraft.network_mode}
-                              disabled=${sandboxStatus === 'saving'}
-                              onInput=${(event: Event) => updateSandboxDraft('network_mode', (event.currentTarget as HTMLSelectElement).value)}
-                              onChange=${(event: Event) => updateSandboxDraft('network_mode', (event.currentTarget as HTMLSelectElement).value)}
-                            >
-                              <option value="inherit">inherit</option>
-                              ${sandboxDraft.sandbox_profile === 'docker' ? html`<option value="none">none</option>` : null}
-                            </select>
-                          <//>
-                          <${SetRow} label="allowed_paths" hint="한 줄에 하나, 비우면 computed default">
-                            <textarea
-                              class="set-input mono"
-                              data-testid="settings-sandbox-allowed-paths"
-                              rows=${4}
-                              disabled=${sandboxStatus === 'saving'}
-                              value=${sandboxDraft.allowed_paths_text}
-                              onInput=${(event: Event) => updateSandboxDraft('allowed_paths_text', (event.currentTarget as HTMLTextAreaElement).value)}
-                            ></textarea>
-                          <//>
-                          <div class="set-mcp-detail mono" data-testid="settings-sandbox-effective-paths">
-                            effective_paths ${(sandboxConfig.effective_allowed_paths ?? []).join(', ') || '(computed default)'}
-                          </div>
-                          <div class="set-actions">
-                            <button
-                              type="button"
-                              class="set-verify"
-                              data-testid="settings-sandbox-save"
-                              disabled=${!sandboxDirty || sandboxStatus === 'saving'}
-                              onClick=${() => { void saveSandboxConfig() }}
-                            >
-                              ${sandboxStatus === 'saving' ? 'Saving' : 'Save'}
-                            </button>
-                            <span class="set-hint" data-testid="settings-sandbox-source">
-                              ${sandboxConfig.sources.live_meta_path || sandboxConfig.sources.default_manifest_path || sandboxConfig.name}
-                            </span>
-                          </div>
-                        `
-                        : null}
-                `}
-            `}
-
-            ${sec === 'ide' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Shared IDE behaviour for every keeper: editor, collaboration, code insight and version-control defaults.
-              </div>
-              <div class="set-sub-h">Editor</div>
-              <${SetRow} label="Default view" hint="View when opening a file">
-                <${SetSeg} value=${ideView} options=${['source', 'unified', 'split-diff']} onChange=${setIdeView} />
-              <//>
-              <${SetRow} label="Diff style" hint="Change comparison mode">
-                <${SetSeg} value=${diffStyle} options=${['inline', 'side-by-side']} onChange=${setDiffStyle} />
-              <//>
-              <${SetRow} label="Tab width" hint="Indent columns">
-                <${SetStepper} v=${tabWidth} set=${setTabWidth} min=${2} max=${8} />
-              <//>
-              <${SetRow} label="Format on save" hint="format-on-save">
-                <${SetToggle} on=${formatOnSave} onChange=${setFormatOnSave} />
-              <//>
-              <${SetRow} label="Wrap long lines" hint="word wrap">
-                <${SetToggle} on=${wrapLines} onChange=${setWrapLines} />
-              <//>
-
-              <div class="set-sub-h">Collaboration (presence)</div>
-              <${SetRow} label="Other keeper cursors" hint="Live cursor·selection·focus_mode">
-                <${SetToggle} on=${liveCursors} onChange=${setLiveCursors} />
-              <//>
-              <${SetRow} label="Ownership tint" hint="Keeper color per file/region">
-                <${SetToggle} on=${ideOwnership} onChange=${setIdeOwnership} />
-              <//>
-              <${SetRow} label="Conversation rail" hint="Context panel beside editor">
-                <${SetToggle} on=${convRail} onChange=${setConvRail} />
-              <//>
-              <${SetRow} label="Context lens" hint="Turn·tool event overlay">
-                <${SetToggle} on=${contextLens} onChange=${setContextLens} />
-              <//>
-
-              <div class="set-sub-h">Code insight</div>
-              <${SetRow} label="Blame gutter" hint="Last-change keeper·turn per line">
-                <${SetToggle} on=${blameGutter} onChange=${setBlameGutter} />
-              <//>
-              <${SetRow} label="Inline annotations" hint="goal·task·PR-linked annotations">
-                <${SetToggle} on=${ideAnnos} onChange=${setIdeAnnos} />
-              <//>
-              ${ideAnnos && html`
-                <${SetRow} label="Auto-link annotations" hint="Link new annotations to active goal/task/PR">
-                  <${SetToggle} on=${annoAutoLink} onChange=${setAnnoAutoLink} />
-                <//>
-              `}
-
-              <div class="set-sub-h">Execution · Version control</div>
-              <${SetRow} label="Embedded terminal" hint="Shell inside IDE — sandbox policy applies">
-                <${SetToggle} on=${embedTerminal} onChange=${setEmbedTerminal} />
-              <//>
-              <${SetRow} label="Search index" hint="Maintain symbol·full-text search index">
-                <${SetToggle} on=${searchIndex} onChange=${setSearchIndex} />
-              <//>
-              <${SetRow} label="Linked repo" hint="diff·PR·blame source — e.g. #7732">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-ide-repo-input"
-                    value=${ideRepo}
-                    onInput=${(e: Event) => setIdeRepo((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
-                </div>
-              <//>
-            `}
-
-            ${sec === 'gate' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Live connector runtime, availability, trigger policy and channel→keeper bindings are read from <span class="mono">GET /api/v1/gate/connectors</span>. Add, remove, bind and sidecar lifecycle actions live in
-                <button
-                  type="button"
-                  class="set-link"
-                  data-testid="settings-connectors-link"
-                  onClick=${() => navigate('connectors')}
-                >
-                  Connectors →
-                </button>.
-              </div>
-              <div class="set-local-summary" data-testid="gate-live-summary">
-                <span>live connector status</span>
-                <span class="mono">
-                  ${gateConnectorsStatus === 'ready'
-                    ? `${gateConnectorsData?.active_count ?? 0}/${gateConnectorsData?.total ?? liveGateConnectors.length} active`
-                    : gateConnectorsStatus}
-                </span>
-              </div>
-              ${gateConnectorsStatus === 'loading'
-                ? html`<div class="set-hint" data-testid="settings-gate-loading">connector 상태를 불러오는 중...</div>`
-                : gateConnectorsStatus === 'error'
-                  ? html`<div class="set-hint" data-testid="settings-gate-error">${gateConnectorsError ?? 'connector 상태를 불러오지 못했습니다.'}</div>`
-                  : html`
-                    <${SetRow} label="Discord trigger policy" hint="live connector payload">
-                      <span class="mono" data-testid="settings-gate-discord-trigger">${gateConnectorsData?.discord_trigger_policy ?? 'unknown'}</span>
-                    <//>
-                    <${SetRow} label="Gate base URL" hint="connector-advertised URLs">
-                      <span class="mono" data-testid="settings-gate-base-live">
-                        ${liveGateBaseUrls.length > 0 ? liveGateBaseUrls.join(', ') : '미수집'}
-                      </span>
-                    <//>
-                    <div class="set-sub-h">Configured connectors (${liveGateConnectors.length})</div>
-                    ${liveGateConnectors.length === 0
-                      ? html`<div class="set-hint" data-testid="settings-gate-empty">설정된 connector가 없습니다.</div>`
-                      : html`
-                        <div class="settings-gate-connectors" data-testid="settings-gate-connectors">
-                          ${liveGateConnectors.map(connector => html`
-                            <div key=${connector.connector_id} class="settings-gate-connector" data-testid="settings-gate-connector">
-                              <div class="settings-gate-connector-head">
-                                <span class="mono">${connector.connector_id}</span>
-                                <span class=${`settings-gate-state ${connectorState(connector)}`}>${connectorStateText(connector)}</span>
-                              </div>
-                              <div class="settings-gate-connector-name">${connector.display_name || connector.channel}</div>
-                              <div class="settings-gate-connector-meta mono">
-                                bindings ${connector.configured_bindings.length} · reply ${connector.reply_mode || 'manual'} · pid ${connector.pid || '-'}
-                              </div>
-                              ${connector.error
-                                ? html`<div class="settings-gate-connector-error">${connector.error}</div>`
-                                : null}
-                            </div>
-                          `)}
-                        </div>
-                      `}
-                  `}
-            `}
-
             ${sec === 'paths' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Server·store basepaths and keeper worktree root. Local preview values can be format-checked only.
+                서버가 실제로 해석한 base path, data/config root, runtime.toml 경로입니다. 값은 dashboard shell/config projection에서 읽고, 입력 필드로 덮어쓰지 않습니다.
               </div>
-              <${SetRow} label="MCP endpoint" hint="/mcp HTTP entrypoint">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-mcp-endpoint-input"
-                    value=${mcpUrl}
-                    onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
-                  <button
-                    type="button"
-                    class="set-verify"
-                    data-testid="settings-path-check-mcp"
-                    onClick=${() => runPathCheck('mcp')}
-                  >
-                    Check
-                  </button>
-                  <${PathCheckBadge} target="mcp" result=${pathChecks.mcp} />
-                </div>
-              <//>
-              <${SetRow} label="Store (DB)" hint="trace·audit persistence">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-store-url-input"
-                    value=${storeUrl}
-                    onInput=${(e: Event) => setStoreUrl((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
-                  <button
-                    type="button"
-                    class="set-verify"
-                    data-testid="settings-path-check-store"
-                    onClick=${() => runPathCheck('store')}
-                  >
-                    Check
-                  </button>
-                  <${PathCheckBadge} target="store" result=${pathChecks.store} />
-                </div>
-              <//>
-              <${SetRow} label="Default worktree basepath" hint="keeper worktree root — e.g. ~/wt/<keeper>">
-                <div class="set-path">
-                  <input
-                    class="set-input mono"
-                    data-testid="settings-worktree-base-input"
-                    value=${wtBase}
-                    onInput=${(e: Event) => setWtBase((e.target as HTMLInputElement).value)}
-                  />
-                  <${PreviewBadge} />
-                  <button
-                    type="button"
-                    class="set-verify"
-                    data-testid="settings-path-check-worktree"
-                    onClick=${() => runPathCheck('worktree')}
-                  >
-                    Check
-                  </button>
-                  <${PathCheckBadge} target="worktree" result=${pathChecks.worktree} />
-                </div>
-              <//>
+              ${dashboardConfigStatus === 'error'
+                ? html`<div class="set-hint" data-testid="settings-config-error">dashboard config projection을 불러오지 못했습니다.</div>`
+                : null}
+              <div class="set-sub-h">Runtime path resolution</div>
+              <${PathTruthRow} label="Base path" item=${runtimeResolution?.base_path ?? null} fallback=${concreteConfigValue(basePathEntry)} />
+              <${PathTruthRow} label="Resolved base path" item=${runtimeResolution?.resolved_base_path ?? null} />
+              <${PathTruthRow} label="Workspace path" item=${runtimeResolution?.workspace_path ?? null} />
+              <${PathTruthRow} label="Data root" item=${runtimeResolution?.data_root ?? null} fallback=${concreteConfigValue(dataDirEntry)} />
+              <${PathTruthRow} label="Prompt markdown dir" item=${runtimeResolution?.prompt_markdown_dir ?? null} />
+              <${PathTruthRow} label="Runtime TOML" item=${configResolution?.runtime ?? null} fallback=${runtimeConfigPath} />
+              <${PathTruthRow} label="Config root" item=${configResolution?.config_root ?? null} fallback=${concreteConfigValue(configDirEntry)} />
+
+              <div class="set-sub-h">Config env inputs</div>
+              <${ConfigTruthRow} label="MASC_BASE_PATH" entry=${basePathEntry} />
+              <${ConfigTruthRow} label="MASC_CONFIG_DIR" entry=${configDirEntry} />
+              <${ConfigTruthRow} label="MASC_DATA_DIR" entry=${dataDirEntry} />
+              <${ConfigTruthRow} label="MCP endpoint" entry=${mcpUrlEntry} fallback=${mcpEndpoint} />
             `}
 
             ${sec === 'logs' && html`
-              <${SetRow} label="Trace retention" hint="Auto-archive after">
-                <${SetSeg} value=${traceKeep} options=${['7일', '30일', '90일']} onChange=${setTraceKeep} />
-              <//>
-              <${SetRow} label="Log level" hint="Keeper runtime log level">
-                <${SetSeg} value=${logLevel} options=${['error', 'warn', 'info', 'debug']} onChange=${setLogLevel} />
-              <//>
-              <${SetRow} label="Telemetry sampling" hint="Trace collection ratio">
-                <${SetSlider} value=${sampling} min=${1} max=${100} suffix="%" onChange=${setSampling} />
-              <//>
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                시스템 로그는 <span class="mono">/api/v1/dashboard/logs</span> ring에서 직접 읽습니다. 필터는 화면 표시만 바꾸며 서버 설정을 쓰지 않습니다.
+              </div>
               <div class="set-sub-h">System log (all keepers · live)</div>
               <${LogViewer} />
             `}
 
             ${sec === 'notify' && html`
-              <div class="set-local-summary" data-testid="notify-local-summary">
-                Browser-session preview: ${notifyCh} channel, context ${notifyCtx}%, failures ${notifyFails}, ${notifyPreviewEnabledCount}/${Object.keys(notifyOn).length} events enabled.
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                알림 임계값은 현재 서버 config projection에서 읽습니다. 아래 라우팅/이벤트 토글은 알림 writer가 생기기 전까지 브라우저 세션 preview입니다.
               </div>
-              <div class="set-notify-section">
-              <${SetRow} label="Context threshold alert" hint="Notify when context exceeds this %">
-                <div class="set-tg-control">
-                  <${PreviewBadge} />
-                  <${SetSlider} value=${notifyCtx} min=${70} max=${98} suffix="%" onChange=${setNotifyCtx} />
-                </div>
+              <div class="set-sub-h">Live alert thresholds</div>
+              <${ThresholdTruthRow}
+                label="Preparing context"
+                entry=${ctxPreparingEntry}
+                value=${formatThresholdPercent(configEntryDisplayValue(ctxPreparingEntry))}
+              />
+              <${ThresholdTruthRow}
+                label="Handoff imminent"
+                entry=${ctxHandoffEntry}
+                value=${formatThresholdPercent(configEntryDisplayValue(ctxHandoffEntry))}
+              />
+              <${ThresholdTruthRow}
+                label="Runtime warning"
+                entry=${runtimeWarningEntry}
+                value=${formatThresholdPercent(configEntryDisplayValue(runtimeWarningEntry))}
+              />
+              <${ConfigTruthRow} label="Signal stale seconds" entry=${signalStaleEntry} />
+              <${ConfigTruthRow} label="Alert dedup window" entry=${alertDedupEntry} />
+
+              <div class="set-local-summary" data-testid="notify-local-summary">
+                <span>local routing preview</span>
+                <span class="mono">${Object.values(notifyOn).filter(Boolean).length}/${Object.keys(notifyOn).length} events enabled</span>
+                <${PreviewBadge} />
+              </div>
+              <${SetRow} label="Preview context alert" hint="Local what-if threshold; server truth is shown above">
+                <${SetSlider} value=${notifyCtx} min=${70} max=${98} suffix="%" onChange=${setNotifyCtx} />
               <//>
-              <${SetRow} label="Consecutive failure alert" hint="Notify after this many consecutive failures">
-                <div class="set-tg-control">
-                  <${PreviewBadge} />
-                  <${SetStepper} v=${notifyFails} set=${setNotifyFails} min=${1} max=${10} />
-                </div>
+              <${SetRow} label="Preview failure count" hint="Local what-if count; no backend writer exists yet">
+                <${SetStepper} v=${notifyFails} set=${setNotifyFails} min=${1} max=${10} />
               <//>
-              <${SetRow} label="Notify channel" hint="Where to send">
-                <div class="set-tg-control">
-                  <${PreviewBadge} />
-                  <${SetSeg} value=${notifyCh} options=${['Slack', 'Discord', '없음']} onChange=${setNotifyCh} />
-                </div>
+              <${SetRow} label="Preview channel" hint="Local routing preview">
+                <${SetSeg} value=${notifyCh} options=${['Slack', 'Discord', '없음']} onChange=${setNotifyCh} />
               <//>
               <div class="set-sub-h">Notify events</div>
               ${Object.keys(notifyOn).map(k => html`
                 <${SetRow} key=${k} label=${k}>
                   <div class="set-tg-control">
                     <${PreviewBadge} />
-                    <${SetToggle} on=${notifyOn[k]} onChange=${(v: boolean) => setNotifyOn(p => ({ ...p, [k]: v }))} />
+                    <${SetToggle} on=${notifyOn[k] ?? false} onChange=${(v: boolean) => setNotifyOn(p => ({ ...p, [k]: v }))} />
                   </div>
                 <//>
               `)}
-              </div>
             `}
 
             ${sec === 'display' && html`

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -2,21 +2,14 @@ import type { RouteState, TabId } from '../types'
 
 type SurfaceId = TabId
 export const SETTINGS_ROUTE_SECTION_IDS = [
-  'account',
-  'mcp',
   'runtime',
   'runtimes',
-  'routing',
+  'paths',
+  'mcp',
+  'notify',
   'prompts',
   'fusion',
-  'policy',
-  'lifecycle',
-  'sandbox',
-  'ide',
-  'gate',
-  'paths',
   'logs',
-  'notify',
   'display',
 ] as const
 export type SettingsRouteSectionId = typeof SETTINGS_ROUTE_SECTION_IDS[number]
@@ -564,7 +557,7 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
   const legacyObservatoryRanges = new Set(['1h', '6h', '24h', '7d'])
 
   if (tabId === 'settings') {
-    if (!isSettingsRouteSection(next.section) || next.section === 'account') {
+    if (!isSettingsRouteSection(next.section)) {
       delete next.section
     }
     delete next.surface

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -133,6 +133,7 @@
   }
   .set-nav {
     width: auto;
+    align-items: center;
     flex-direction: row;
     overflow-x: auto;
     border-right: 0;
@@ -149,10 +150,19 @@
     display: none;
   }
   .set-nav-item {
+    align-items: center;
     flex: none;
+    min-height: 40px;
     margin: 6px 2px;
+    padding: 8px 12px;
+  }
+  .settings-surf .set-nav-item .ko {
+    white-space: nowrap;
   }
   .set-nav-item .en {
+    display: none;
+  }
+  .settings-surf .set-nav-note {
     display: none;
   }
   .settings-surf .set-card-b {
@@ -222,6 +232,11 @@
   border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
 }
 
+.set-section-state.mixed {
+  color: var(--volt);
+  border-color: var(--volt-dim);
+}
+
 .set-section-state.local {
   color: var(--status-warn);
   border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
@@ -284,6 +299,37 @@
 .settings-runtime-catalog .set-rt {
   margin-top: 0;
   min-width: 0;
+}
+
+.settings-runtime-routing,
+.set-route-summary {
+  display: grid;
+  gap: 8px;
+}
+
+.set-route-summary {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.set-route-summary > span,
+.set-routing-row {
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.set-routing-row {
+  justify-content: space-between;
+}
+
+.set-routing-arrow {
+  color: var(--text-dim);
+  flex: none;
 }
 
 .set-runtime-transport {
@@ -412,82 +458,61 @@
   max-width: 100%;
 }
 
-.set-select {
-  width: 260px;
-  max-width: 100%;
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-sm);
-  background: var(--bg-well);
-  color: var(--text-mid);
-  padding: 7px 10px;
-  outline: none;
-}
-
-.set-row textarea.set-input {
-  width: min(420px, 100%);
-  min-height: 92px;
-  resize: vertical;
-  white-space: pre;
-}
-
-@media (max-width: 640px) {
-  .set-row {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .set-row-c {
-    width: 100%;
-  }
-
-  .set-select,
-  .set-path .set-input,
-  .set-row textarea.set-input {
-    width: 100%;
-  }
-
-  .set-mcp-detail {
-    white-space: normal;
-    overflow-wrap: anywhere;
-  }
-}
-
-.set-actions {
-  display: flex;
+.set-truth-value,
+.set-path-truth,
+.set-mcp-check {
   align-items: center;
+  display: flex;
   flex-wrap: wrap;
-  gap: 10px;
-  padding-top: 10px;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
-.set-verify:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
+.set-truth-value .mono,
+.set-path-truth-path {
+  color: var(--text-bright);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.set-path-check-result {
-  font-size: var(--fs-11);
-  font-family: var(--font-mono);
+.set-truth-source,
+.set-path-truth-state {
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  color: var(--text-dim);
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
   line-height: 1;
+  padding: 4px 8px;
 }
 
-.set-path-check-result.ok {
+.set-path-truth-state.exists {
+  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
   color: var(--status-ok);
 }
 
-.set-path-check-result.fail {
+.set-path-truth-state.missing {
+  border-color: color-mix(in oklab, var(--status-fail) 45%, transparent);
   color: var(--status-fail);
 }
 
-.set-rolepill {
+.set-mcp-check-result {
+  color: var(--text-dim);
   font-family: var(--font-mono);
   font-size: var(--fs-11);
-  color: var(--volt-strong);
-  border: 1px solid var(--volt-dim);
-  background: var(--volt-wash);
-  padding: 3px 10px;
-  border-radius: var(--radius-pill);
+  max-width: 520px;
+  overflow-wrap: anywhere;
+}
+
+.set-mcp-check-result.ok {
+  color: var(--status-ok);
+}
+
+.set-mcp-check-result.error {
+  color: var(--status-fail);
 }
 
 .set-rt {
@@ -591,73 +616,6 @@
 .set-rt-open:hover {
   background: var(--volt);
   color: var(--volt-ink);
-}
-
-.settings-gate-connectors {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 10px;
-  margin-top: 10px;
-}
-
-.settings-gate-connector {
-  min-width: 0;
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-sm);
-  background: var(--bg-card);
-  padding: 11px 12px;
-}
-
-.settings-gate-connector-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
-
-.settings-gate-state {
-  flex: none;
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-pill);
-  padding: 2px 8px;
-  font-family: var(--font-ui);
-  font-size: var(--fs-10);
-  color: var(--text-dim);
-}
-
-.settings-gate-state.connected {
-  color: var(--status-ok);
-  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
-}
-
-.settings-gate-state.stale {
-  color: var(--status-warn);
-  border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
-}
-
-.settings-gate-state.offline {
-  color: var(--status-fail);
-  border-color: color-mix(in oklab, var(--status-fail) 45%, transparent);
-}
-
-.settings-gate-connector-name {
-  margin-top: 7px;
-  color: var(--text-mid);
-  font-size: var(--fs-13);
-}
-
-.settings-gate-connector-meta,
-.settings-gate-connector-error {
-  margin-top: 5px;
-  font-size: var(--fs-11);
-}
-
-.settings-gate-connector-meta {
-  color: var(--text-dim);
-}
-
-.settings-gate-connector-error {
-  color: var(--status-fail);
 }
 
 /* system log viewer */
@@ -993,26 +951,6 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-}
-
-.settings-surf .set-notify-section .set-row {
-  align-items: flex-start;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.settings-surf .set-notify-section .set-row-l,
-.settings-surf .set-notify-section .set-row-c {
-  width: 100%;
-}
-
-.settings-surf .set-notify-section .set-row-c {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.settings-surf .set-notify-section .set-row-c > .set-tg-control {
-  flex-wrap: wrap;
 }
 
 .set-tg-l {

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -50,20 +50,14 @@ let valid_sections =
     )
   ; "code", [ "ide-shell" ]
   ; ( "settings"
-    , [ "mcp"
-      ; "runtime"
+    , [ "runtime"
       ; "runtimes"
-      ; "routing"
+      ; "paths"
+      ; "mcp"
+      ; "notify"
       ; "prompts"
       ; "fusion"
-      ; "policy"
-      ; "lifecycle"
-      ; "sandbox"
-      ; "ide"
-      ; "gate"
-      ; "paths"
       ; "logs"
-      ; "notify"
       ; "display"
       ] )
   ]

--- a/test/test_dashboard_nav_event.ml
+++ b/test/test_dashboard_nav_event.ml
@@ -53,6 +53,15 @@ let test_reject_settings_account_section () =
     (Astring.String.is_infix ~affix:"unknown section" msg)
 ;;
 
+let test_reject_retired_settings_routing_section () =
+  let msg = parse_err {|{"surface":"settings","section":"routing"}|} in
+  check
+    bool
+    "mentions section"
+    true
+    (Astring.String.is_infix ~affix:"unknown section" msg)
+;;
+
 let test_parse_full_event () =
   let event =
     parse_ok {|{"surface":"monitoring","section":"agents","redirected_from":"none"}|}
@@ -206,6 +215,10 @@ let () =
             "rejects settings account section"
             `Quick
             test_reject_settings_account_section
+        ; test_case
+            "rejects retired settings routing section"
+            `Quick
+            test_reject_retired_settings_routing_section
         ; test_case "full event" `Quick test_parse_full_event
         ; test_case "redirected_from accepted" `Quick test_parse_redirected
         ; test_case "rejects unknown surface" `Quick test_reject_unknown_surface


### PR DESCRIPTION
## Summary

- Remove fake-only Settings sections from dashboard navigation and route normalization.
- Rework Settings around operator-backed sections: Runtime, Runtimes, Paths, MCP, Notify, Prompts, Fusion, Logs, and Display.
- Make Runtime show model routing/keeper assignments, Paths read resolved server path/config truth, MCP show live endpoint/tool inventory plus a `masc_status` check, and Notify show live alert thresholds with clearly local preview controls.
- Keep backend dashboard nav-event telemetry allowlist in parity with the new Settings route sections.
- Fix mobile Settings section navigation so active tabs stay compact.

## Validation

- `scripts/check-dashboard-nav-event-parity.sh --check`
- `scripts/dune-local.sh build test/test_dashboard_nav_event.exe`
- `./_build/default/test/test_dashboard_nav_event.exe`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run build`
- `python3 /private/tmp/masc-settings-render-check.py` against live `127.0.0.1:8935` dashboard backend

## Notes

- Existing non-blocking Vite build warnings remain: unresolved runtime font asset and large chunk warnings.
- Unrelated dev-server dependency-scan warning for missing `dashboard/design-system/preview/bench-kpi.ts` is tracked separately in #22769.
