### PR TITLE
feat(board): expose owner-gated post edit as masc_board_post_update tool

### DIFF
--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -23,6 +23,13 @@ let handle_tool name args : Tool_result.result =
     in
     Board_tool_cache.invalidate_board_list_cache ();
     result
+  | "masc_board_post_update" ->
+    let result =
+      Board_tool_format.with_yojson_boundary ~tool_name:name ~start_time (fun () ->
+        Board_tool_post.handle_post_edit ~tool_name:name ~start_time args)
+    in
+    Board_tool_cache.invalidate_board_list_cache ();
+    result
   | "masc_board_list" ->
     Board_tool_post.handle_post_list ~tool_name:name ~start_time args
   | "masc_board_post_get" ->

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -169,6 +169,86 @@ let handle_post_create ~tool_name ~start_time args : Tool_result.result =
            Board_tool_format.error_of_board_error ~tool_name ~start_time e))
 ;;
 
+let handle_post_edit ~tool_name ~start_time args : Tool_result.result =
+  let post_id = get_string args "post_id" "" in
+  (* Mirror create's body/content handling: strip [STATE] blocks at the tool
+     boundary (an LLM output artifact) and let [body] win over [content]. The
+     core then re-normalizes against the existing meta; via this tool path the
+     body carries no state block, so meta is preserved. *)
+  let body_arg =
+    get_string_opt args "body" |> Option.map Board_tool_format.strip_state_blocks_text
+  in
+  let raw_content =
+    match body_arg with
+    | Some value -> value
+    | None -> get_string args "content" ""
+  in
+  let content = Board_tool_format.strip_state_blocks_text raw_content in
+  let body = Option.map (fun _ -> content) body_arg in
+  (* A blank/absent title means "re-derive from the new body"; only a non-empty
+     title overrides. *)
+  let title =
+    match get_string_opt args "title" with
+    | Some t when not (String.equal (String.trim t) "") -> Some t
+    | _ -> None
+  in
+  (* Parse [author] into a validated editor string at the boundary instead of
+     carrying a [string option] and defaulting at the call site. Owner-gate
+     enforcement downstream needs a concrete editor identity, so an absent,
+     blank, or "anonymous" author is rejected here; the dispatch then only ever
+     receives a non-empty editor (no unreachable default to guess). *)
+  let valid_editor =
+    match get_string_opt args "author" |> Option.map String.trim with
+    | Some editor
+      when (not (String.equal editor "")) && not (String.equal editor "anonymous") ->
+      Some editor
+    | _ -> None
+  in
+  if String.equal (String.trim post_id) ""
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "post_id is required"
+  else if String.equal (String.trim content) ""
+  then
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      "New body content must not be empty (resend the full post body to edit)"
+  else (
+    match valid_editor with
+    | None ->
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time
+        "author is required"
+    | Some editor ->
+      if String.length content > Board.Limits.max_content_length
+      then
+        Tool_result.make_err
+          ~tool_name
+          ~class_:Tool_result.Workflow_rejection
+          ~start_time
+          (Printf.sprintf
+             "Content exceeds max length (%d > %d chars)"
+             (String.length content)
+             Board.Limits.max_content_length)
+      else (
+        match Board_dispatch.update_post ~post_id ~editor ~content ?title ?body () with
+        | Ok post ->
+          let json = Board.post_to_yojson post in
+          (* Structured result via [Tool_result.ok]; see "Post created" note above. *)
+          Tool_result.ok
+            ~tool_name
+            ~start_time
+            (Printf.sprintf "Post updated:\n%s" (Yojson.Safe.pretty_to_string json))
+        | Error e -> Board_tool_format.error_of_board_error ~tool_name ~start_time e))
+;;
+
 let handle_post_list_uncached ~tool_name ~start_time args : Tool_result.result =
   let limit = get_int args "limit" 20 |> max 1 |> min 100 in
   let compact = get_bool args "compact" true in

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -187,6 +187,7 @@ let board_tool_curation_submit : Masc_domain.tool_schema =
     Order preserved from pre-split board_tool.ml. *)
 let tools =
   [ Board_tool_schemas.tool_post_create
+  ; Board_tool_schemas.tool_post_edit
   ; Board_tool_schemas.tool_post_list
   ; Board_tool_schemas.tool_post_get
   ; Board_tool_schemas.tool_comment_add
@@ -217,6 +218,7 @@ let schema_for_board_name board_name =
 
 let identity_fields_for_board_name = function
   | Tool_name.Board_name.Board_post
+  | Tool_name.Board_name.Board_post_update
   | Tool_name.Board_name.Board_comment -> [ "author" ]
   | Tool_name.Board_name.Board_vote
   | Tool_name.Board_name.Board_comment_vote -> [ "voter" ]
@@ -240,6 +242,7 @@ let identity_fields_for_board_name = function
 
 let identity_input_fields =
   [ Tool_name.Board_name.Board_post
+  ; Tool_name.Board_name.Board_post_update
   ; Tool_name.Board_name.Board_comment
   ; Tool_name.Board_name.Board_vote
   ; Tool_name.Board_name.Board_comment_vote

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -133,6 +133,64 @@ let tool_post_create : Masc_domain.tool_schema =
   }
 ;;
 
+let tool_post_edit : Masc_domain.tool_schema =
+  { name = "masc_board_post_update"
+  ; description =
+      "Edit an existing board post you authored, by exact post_id. Only the post's \
+       author can edit it; an edit by anyone else is rejected. Pass the full new \
+       `body` (or `content`) — the post body is replaced, not appended. `title` is \
+       optional (omit to keep deriving it from the body). `author` is auto-filled \
+       from the caller's agent identity when omitted. Get the post_id from \
+       masc_board_list, masc_board_post_get, or visible board context."
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; ( "properties"
+          , `Assoc
+              [ ( "post_id"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Required exact board post ID (format: p-xxxx) of the post to \
+                           edit." )
+                    ] )
+              ; ( "body"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String "New post body text (preferred alias for `content`)" )
+                    ] )
+              ; ( "content"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; "maxLength", `Int 4000
+                    ; ( "description"
+                      , `String
+                          "New post body text (alternative to `body`, max 4000 chars)" )
+                    ] )
+              ; ( "title"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Optional new title. When omitted, the title is re-derived \
+                           from the new body." )
+                    ] )
+              ; ( "author"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Editor identity; must match the post's author. Auto-filled \
+                           from caller's agent_name when omitted." )
+                    ] )
+              ] )
+        ; "required", `List [ `String "post_id" ]
+        ]
+  }
+;;
+
 let tool_post_list : Masc_domain.tool_schema =
   { name = "masc_board_list"
   ; description =

--- a/lib/board_tool_adapter/board_tool_schemas.mli
+++ b/lib/board_tool_adapter/board_tool_schemas.mli
@@ -6,6 +6,7 @@
 open Masc_board_handlers
 
 val tool_post_create : Masc_domain.tool_schema
+val tool_post_edit : Masc_domain.tool_schema
 val tool_post_list : Masc_domain.tool_schema
 val tool_post_get : Masc_domain.tool_schema
 val tool_comment_add : Masc_domain.tool_schema

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -334,6 +334,7 @@ let is_board_write_name = function
   | Tool_name.Board_name.Board_comment
   | Tool_name.Board_name.Board_curation_submit
   | Tool_name.Board_name.Board_post
+  | Tool_name.Board_name.Board_post_update
   | Tool_name.Board_name.Board_vote -> true
   | Tool_name.Board_name.Board_cleanup
   | Tool_name.Board_name.Board_comment_vote

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -73,6 +73,7 @@ module Board_name = struct
     | Board_hearths
     | Board_list
     | Board_post
+    | Board_post_update
     | Board_profile
     | Board_reaction
     | Board_search
@@ -95,6 +96,7 @@ module Board_name = struct
     | Board_hearths -> "masc_board_hearths"
     | Board_list -> "masc_board_list"
     | Board_post -> "masc_board_post"
+    | Board_post_update -> "masc_board_post_update"
     | Board_profile -> "masc_board_profile"
     | Board_reaction -> "masc_board_reaction"
     | Board_search -> "masc_board_search"
@@ -118,6 +120,7 @@ module Board_name = struct
     | "masc_board_hearths" -> Some Board_hearths
     | "masc_board_list" -> Some Board_list
     | "masc_board_post" -> Some Board_post
+    | "masc_board_post_update" -> Some Board_post_update
     | "masc_board_profile" -> Some Board_profile
     | "masc_board_reaction" -> Some Board_reaction
     | "masc_board_search" -> Some Board_search

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -134,6 +134,30 @@ module Board_name = struct
     | _ -> None
   ;;
 
+  let is_resource_write = function
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_curation_submit
+    | Board_delete
+    | Board_post
+    | Board_post_update
+    | Board_reaction
+    | Board_sub_board_create
+    | Board_sub_board_delete
+    | Board_sub_board_update
+    | Board_vote -> true
+    | Board_curation_read
+    | Board_post_get
+    | Board_hearths
+    | Board_list
+    | Board_profile
+    | Board_search
+    | Board_stats
+    | Board_sub_board_get
+    | Board_sub_board_list -> false
+  ;;
+
   let pp fmt t = Format.pp_print_string fmt (to_string t)
 end
 

--- a/lib/tool/tool_name.mli
+++ b/lib/tool/tool_name.mli
@@ -33,6 +33,7 @@ module Board_name : sig
     | Board_hearths
     | Board_list
     | Board_post
+    | Board_post_update
     | Board_profile
     | Board_reaction
     | Board_search

--- a/lib/tool/tool_name.mli
+++ b/lib/tool/tool_name.mli
@@ -47,6 +47,7 @@ module Board_name : sig
 
   val to_string : t -> string
   val of_string : string -> t option
+  val is_resource_write : t -> bool
   val pp : Stdlib.Format.formatter -> t -> unit
 end
 

--- a/lib/tool_surface/tool_resource_axis.ml
+++ b/lib/tool_surface/tool_resource_axis.ml
@@ -183,70 +183,60 @@ let classify_catalog_metadata_tool ~tool_name =
   | _ -> None
 ;;
 
+let classify_board_tool_name ~tool_name =
+  match Tool_name.Board_name.of_string tool_name with
+  | Some board_name ->
+    Some
+      (if Tool_name.Board_name.is_resource_write board_name then Board_write else Ungated)
+  | None -> None
+;;
+
 let classify_catalog_tool ~tool_name =
-  match tool_name with
-  | "masc_web_fetch" | "masc_web_search" -> Some Web
-  | "masc_board_cleanup"
-  | "masc_board_comment"
-  | "masc_board_comment_vote"
-  | "masc_board_curation_submit"
-  | "masc_board_delete"
-  | "masc_board_post"
-  | "masc_board_post_update"
-  | "masc_board_reaction"
-  | "masc_board_sub_board_create"
-  | "masc_board_sub_board_delete"
-  | "masc_board_sub_board_update"
-  | "masc_board_vote" -> Some Board_write
-  | "masc_add_task"
-  | "masc_batch_add_tasks"
-  | "masc_deliver"
-  | "masc_goal_transition"
-  | "masc_goal_upsert"
-  | "masc_goal_verify"
-  | "masc_heartbeat"
-  | "masc_note_add"
-  | "masc_plan_clear_task"
-  | "masc_plan_init"
-  | "masc_plan_set_task"
-  | "masc_plan_update"
-  | "masc_reset"
-  | "masc_tool_grant"
-  | "masc_tool_revoke"
-  | "masc_transition"
-  | "masc_update_priority" -> Some Workspace_write
-  | "masc_broadcast"
-  | "masc_cleanup_zombies"
-  | "masc_gc" -> Some Generic_write
-  | "masc_board_curation_read"
-  | "masc_board_post_get"
-  | "masc_board_hearths"
-  | "masc_board_list"
-  | "masc_board_profile"
-  | "masc_board_search"
-  | "masc_board_stats"
-  | "masc_board_sub_board_get"
-  | "masc_board_sub_board_list"
-  | "masc_check"
-  | "masc_config"
-  | "masc_dashboard"
-  | "masc_get_metrics"
-  | "masc_goal_list"
-  | "masc_messages"
-  | "masc_operator_digest"
-  | "masc_operator_snapshot"
-  | "masc_pause"
-  | "masc_plan_get"
-  | "masc_plan_get_task"
-  | "masc_resume"
-  | "masc_session"
-  | "masc_start"
-  | "masc_status"
-  | "masc_task_history"
-  | "masc_tasks"
-  | "masc_tool_list"
-  | "masc_tool_stats" -> Some Ungated
-  | _ -> None
+  match classify_board_tool_name ~tool_name with
+  | Some resource_class -> Some resource_class
+  | None ->
+    (match tool_name with
+     | "masc_web_fetch" | "masc_web_search" -> Some Web
+     | "masc_add_task"
+     | "masc_batch_add_tasks"
+     | "masc_deliver"
+     | "masc_goal_transition"
+     | "masc_goal_upsert"
+     | "masc_goal_verify"
+     | "masc_heartbeat"
+     | "masc_note_add"
+     | "masc_plan_clear_task"
+     | "masc_plan_init"
+     | "masc_plan_set_task"
+     | "masc_plan_update"
+     | "masc_reset"
+     | "masc_tool_grant"
+     | "masc_tool_revoke"
+     | "masc_transition"
+     | "masc_update_priority" -> Some Workspace_write
+     | "masc_broadcast"
+     | "masc_cleanup_zombies"
+     | "masc_gc" -> Some Generic_write
+     | "masc_check"
+     | "masc_config"
+     | "masc_dashboard"
+     | "masc_get_metrics"
+     | "masc_goal_list"
+     | "masc_messages"
+     | "masc_operator_digest"
+     | "masc_operator_snapshot"
+     | "masc_pause"
+     | "masc_plan_get"
+     | "masc_plan_get_task"
+     | "masc_resume"
+     | "masc_session"
+     | "masc_start"
+     | "masc_status"
+     | "masc_task_history"
+     | "masc_tasks"
+     | "masc_tool_list"
+     | "masc_tool_stats" -> Some Ungated
+     | _ -> None)
 ;;
 
 let classify_descriptor_tool ~tool_name ~arguments =

--- a/lib/tool_surface/tool_resource_axis.ml
+++ b/lib/tool_surface/tool_resource_axis.ml
@@ -192,6 +192,7 @@ let classify_catalog_tool ~tool_name =
   | "masc_board_curation_submit"
   | "masc_board_delete"
   | "masc_board_post"
+  | "masc_board_post_update"
   | "masc_board_reaction"
   | "masc_board_sub_board_create"
   | "masc_board_sub_board_delete"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1466,6 +1466,78 @@ let test_dispatch_delete_empty_id () =
   Alcotest.(check bool) "error mentions required" true
     (contains_substring body "required")
 
+let test_dispatch_post_update_success () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let _ok, body =
+    dispatch "masc_board_post"
+      (make_args
+         [ ("content", `String "original tool body")
+         ; ("author", `String "edit-tool-author")
+         ])
+  in
+  let post_id =
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
+  in
+  let ok_edit, msg_edit =
+    dispatch "masc_board_post_update"
+      (make_args
+         [ ("post_id", `String post_id)
+         ; ("author", `String "edit-tool-author")
+         ; ("content", `String "edited tool body")
+         ])
+  in
+  Alcotest.(check bool) "edit ok" true ok_edit;
+  Alcotest.(check bool) "edit msg contains new body" true
+    (contains_substring msg_edit "edited tool body");
+  (match Board_dispatch.get_post ~post_id with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok post -> Alcotest.(check string) "edit persisted" "edited tool body" post.content)
+
+let test_dispatch_post_update_rejects_non_owner () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let _ok, body =
+    dispatch "masc_board_post"
+      (make_args
+         [ ("content", `String "owned tool body"); ("author", `String "tool-owner") ])
+  in
+  let post_id =
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
+  in
+  let ok_edit, _msg =
+    dispatch "masc_board_post_update"
+      (make_args
+         [ ("post_id", `String post_id)
+         ; ("author", `String "tool-intruder")
+         ; ("content", `String "hijacked tool body")
+         ])
+  in
+  Alcotest.(check bool) "non-owner edit rejected" false ok_edit;
+  (* the rejected edit must not touch the stored content *)
+  (match Board_dispatch.get_post ~post_id with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok post ->
+     Alcotest.(check string) "original preserved on rejected edit" "owned tool body"
+       post.content)
+
+let test_dispatch_post_update_missing_id () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body =
+    dispatch "masc_board_post_update"
+      (make_args [ ("author", `String "x"); ("content", `String "y") ])
+  in
+  Alcotest.(check bool) "missing post_id rejected" false ok;
+  Alcotest.(check bool) "error mentions required" true (contains_substring body "required")
+
 let test_post_get_success () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1706,7 +1778,7 @@ let test_tools_count () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "19 tool schemas" 19 (List.length Board_tool.tools)
+  Alcotest.(check int) "20 tool schemas" 20 (List.length Board_tool.tools)
 
 let test_tools_names_unique () =
   with_eio @@ fun env ->
@@ -2045,6 +2117,12 @@ let () =
           Alcotest.test_case "delete success" `Quick test_dispatch_delete_success;
           Alcotest.test_case "delete not found" `Quick test_dispatch_delete_not_found;
           Alcotest.test_case "delete empty id" `Quick test_dispatch_delete_empty_id;
+          Alcotest.test_case "post update by owner" `Quick
+            test_dispatch_post_update_success;
+          Alcotest.test_case "post update rejects non-owner" `Quick
+            test_dispatch_post_update_rejects_non_owner;
+          Alcotest.test_case "post update missing id" `Quick
+            test_dispatch_post_update_missing_id;
         ] );
       ( "schemas",
         [

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -127,6 +127,7 @@ let test_classifies_host_local_bottlenecks () =
        ~is_read_only:true
        ~args:(`Assoc [ "op", `String "bash" ]));
   check string "board write" "board_write" (classify "masc_board_post");
+  check string "board edit write" "board_write" (classify "masc_board_post_update");
   check string "transition" "workspace_write" (classify "masc_transition");
   check string "worker shell_exec" "shell" (classify "shell_exec");
   check

--- a/test/test_tool_resource_gate.ml
+++ b/test/test_tool_resource_gate.ml
@@ -128,6 +128,16 @@ let test_classifies_host_local_bottlenecks () =
        ~args:(`Assoc [ "op", `String "bash" ]));
   check string "board write" "board_write" (classify "masc_board_post");
   check string "board edit write" "board_write" (classify "masc_board_post_update");
+  check
+    string
+    "board sub-board update write"
+    "board_write"
+    (classify "masc_board_sub_board_update");
+  check
+    string
+    "board sub-board list read"
+    "ungated"
+    (classify ~is_read_only:true "masc_board_sub_board_list");
   check string "transition" "workspace_write" (classify "masc_transition");
   check string "worker shell_exec" "shell" (classify "shell_exec");
   check


### PR DESCRIPTION
## 목표

Board post edit을 **LLM/operator가 호출 가능한 MCP tool로 노출**합니다. 코어(`update_post_with_outcome` + `Board_dispatch.update_post`)는 #22761에서 머지됐으나 호출 표면이 없었습니다. 본 PR은 내부 `masc_board_post_update` tool을 추가합니다 (operator/dashboard 표면; keeper `ln_` alias 없음 → RFC-0064 public-surface 변경 없음).

스코프 선택: 사용자 결정 "Operator surface, 별도 PR".

## 변경

- **tool_name**: `Board_name.Board_post_update` variant 추가 (+ `to_string`/`of_string` = `masc_board_post_update`). exhaustive match라 컴파일러가 누락 사이트 강제.
- **board_tool_schemas**: `tool_post_edit` schema (`post_id` 필수; `body`/`content`/`title`/`author`; body는 교체이지 append 아님).
- **board_tool_post**: `handle_post_edit` — tool 경계에서 `[STATE]` block strip(create와 동일), `post_id`/`content`/`author` 검증, `Board_dispatch.update_post` 호출, "Post updated:" 포맷.
- **board_tool_dispatch**: `masc_board_post_update` 라우팅(mutation → board_list 캐시 invalidate).
- **board_tool_registry**: schema 등록 + `["author"]` identity field 선언 → editor 식별자 자동 주입. **owner-gate가 self-asserted author가 아니라 인증된 agent 기준으로 enforce됩니다.**
- **board-write 분류**: `keeper_tool_name.is_board_write_name` + `tool_resource_axis.classify_catalog_tool` 양쪽에 등록 → edit이 create/comment와 동일 concurrency lane(Board_write)에 들어감.

## 발견 (follow-up 후보)

board-write 분류기가 **두 개의 수동 목록**(`is_board_write_name` typed match + `classify_catalog_tool` string match)으로 중복돼 있습니다. 새 board mutation 도구는 양쪽에 등록해야 일관됩니다(본 PR에서 양쪽 처리). 단일 typed SSOT로 통합하는 것이 근본 해결입니다 — 별도 트랙.

## 검증 (로컬)

- `dune build @lib/tool/check @lib/keeper_tooling/check @lib/board_tool_adapter/check` RC:0.
- `test_tool_board_coverage` dispatch 그룹: owner edit persist / 비소유자 거부+원본 보존 / 없는 post_id 거부; tools count 19→20.
- `test_tool_resource_gate`: `masc_board_post_update` → `board_write` 분류.
- 전체: board coverage 92 tests + gate 6 tests green.

참고: 로컬 전체 빌드는 무관한 `runtime_wire_overlay.ml`의 agent_sdk 0.208.1 pin drift(#22764 CLOSED)로 막혀, 테스트 실행 시 해당 파일을 임시 patch 후 되돌렸습니다(본 PR 미포함). CI는 0.208.0이라 영향 없음.

RFC-WAIVED: board subsystem은 RFC 게이트 대상(credential/operator/keeper sandbox/dashboard credential/hooks/workflow) 아님. keeper `ln_` alias 미추가 → RFC-0064 public-surface 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
