### PR TITLE
fix(stream): fail closed on conflicting OAS tool blocks

### DIFF
--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1049,6 +1049,32 @@ export function markAssistantToolTraceEnded(
   if (!found) warnMissingToolTrace('end patch', name, entryId, id)
 }
 
+export function markAssistantToolTraceErrored(
+  name: string,
+  entryId: string,
+  toolCallId: string,
+): void {
+  const id = toolCallId.trim()
+  if (!id) return
+  let found = false
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const traceSteps = existing.map((trace) => {
+      if (trace.kind !== 'tool' || trace.toolCallId !== id) return trace
+      found = true
+      return {
+        ...trace,
+        status: 'err' as const,
+      }
+    })
+    return {
+      ...entry,
+      traceSteps,
+    }
+  })
+  if (!found) warnMissingToolTrace('error patch', name, entryId, id)
+}
+
 export function finalizeAssistantEntry(
   name: string,
   entryId: string,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -522,6 +522,9 @@ describe('applyKeeperStreamEvent tool calls', () => {
         tool_call_name: 'keeper_board_list',
       },
     })
+    let reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toBeUndefined()
+
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TOOL_CALL_START',
       toolCallId: 'tc-oas',
@@ -542,7 +545,7 @@ describe('applyKeeperStreamEvent tool calls', () => {
       value: { index: 7 },
     })
 
-    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
     expect(reply?.traceSteps).toEqual([
       {
         kind: 'tool',
@@ -554,6 +557,66 @@ describe('applyKeeperStreamEvent tool calls', () => {
         oasBlockIndex: 7,
       },
     ])
+  })
+
+  it('marks the active tool errored when a server protocol error carries tool_call_id', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTENT_BLOCK_START',
+      value: {
+        index: 2,
+        content_type: 'tool_use',
+        tool_call_id: 'tc-first',
+        tool_call_name: 'keeper_memory_search',
+      },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-first',
+      toolCallName: 'keeper_memory_search',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTENT_BLOCK_START',
+      value: {
+        index: 2,
+        content_type: 'tool_use',
+        tool_call_id: 'tc-second',
+        tool_call_name: 'keeper_board_list',
+      },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_PROTOCOL_ERROR',
+      value: {
+        kind: 'tool_start_duplicate_index',
+        index: 2,
+        tool_call_id: 'tc-first',
+        reason: 'tool-use block index already active',
+      },
+    })
+
+    const thread = keeperThreads.value.sangsu ?? []
+    expect(thread.find(entry => entry.id === 'tool-tc-second')).toBeUndefined()
+    const tool = thread.find(entry => entry.id === 'tool-tc-first')
+    expect(tool?.delivery).toBe('error')
+    expect(tool?.streamState).toBeNull()
+    expect(tool?.error).toBe(
+      'tool_start_duplicate_index | index=2 | tool_call_id=tc-first | tool-use block index already active',
+    )
+    const reply = thread.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'keeper_memory_search',
+        toolCallId: 'tc-first',
+        status: 'err',
+        ts: expect.any(String),
+        oasBlockIndex: 2,
+      },
+    ])
+    expect(reply?.rawText).toContain('[stream protocol] tool_start_duplicate_index')
   })
 
   it('records a protocol error instead of guessing the tool when toolCallId is missing', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -17,6 +17,7 @@ import {
   insertThreadEntryBefore,
   finalizeAssistantEntry,
   markAssistantToolTraceEnded,
+  markAssistantToolTraceErrored,
   clearActiveStream,
   clearActiveStreamRequestId,
   releaseActiveStreamRequestId,
@@ -33,6 +34,8 @@ import { toolEntryIdFromCallId } from './tool-call-output-store'
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
 
+const pendingOasToolBlockIndexes = new Map<string, number>()
+
 export interface KeeperThreadAbortResult {
   readonly keeperName: string
   readonly entryId: string | null
@@ -45,8 +48,15 @@ function streamProtocolMessage(value: unknown, fallback: string): string {
   const kind = asString(value.kind, '').trim()
   const reason = asString(value.reason, '').trim()
   const eventType = asString(value.event_type, '').trim()
+  const toolCallId = asString(value.tool_call_id, '').trim()
   const index = typeof value.index === 'number' ? `index=${value.index}` : ''
-  return [kind || fallback, eventType ? `event=${eventType}` : '', index, reason]
+  return [
+    kind || fallback,
+    eventType ? `event=${eventType}` : '',
+    index,
+    toolCallId ? `tool_call_id=${toolCallId}` : '',
+    reason,
+  ]
     .filter(part => part.trim() !== '')
     .join(' | ')
 }
@@ -55,6 +65,7 @@ function recordStreamProtocolError(
   keeperName: string,
   assistantEntryId: string,
   message: string,
+  toolCallId?: string,
 ): void {
   updateThreadEntry(keeperName, assistantEntryId, entry => {
     const line = `[stream protocol] ${message}`
@@ -64,6 +75,61 @@ function recordStreamProtocolError(
       error: message,
     }
   })
+  const id = toolCallId?.trim()
+  if (id) {
+    markAssistantToolTraceErrored(keeperName, assistantEntryId, id)
+    updateThreadEntry(keeperName, toolEntryIdFromCallId(id), entry => ({
+      ...entry,
+      delivery: 'error',
+      streamState: null,
+      error: message,
+    }))
+  }
+}
+
+function oasToolBlockKey(keeperName: string, assistantEntryId: string, toolCallId: string): string {
+  return `${keeperName}\u0000${assistantEntryId}\u0000${toolCallId}`
+}
+
+function rememberOasToolBlockIndex(
+  keeperName: string,
+  assistantEntryId: string,
+  toolCallId: string,
+  index: number | undefined,
+): void {
+  const id = toolCallId.trim()
+  if (!id || index === undefined) return
+  pendingOasToolBlockIndexes.set(oasToolBlockKey(keeperName, assistantEntryId, id), index)
+}
+
+function takeOasToolBlockIndex(
+  keeperName: string,
+  assistantEntryId: string,
+  toolCallId: string,
+): number | undefined {
+  const key = oasToolBlockKey(keeperName, assistantEntryId, toolCallId)
+  const index = pendingOasToolBlockIndexes.get(key)
+  pendingOasToolBlockIndexes.delete(key)
+  return index
+}
+
+function forgetOasToolBlockIndexByIndex(
+  keeperName: string,
+  assistantEntryId: string,
+  index: number | undefined,
+): void {
+  if (index === undefined) return
+  const prefix = `${keeperName}\u0000${assistantEntryId}\u0000`
+  for (const [key, value] of pendingOasToolBlockIndexes.entries()) {
+    if (key.startsWith(prefix) && value === index) pendingOasToolBlockIndexes.delete(key)
+  }
+}
+
+function clearPendingOasToolBlockIndexesForEntry(keeperName: string, assistantEntryId: string): void {
+  const prefix = `${keeperName}\u0000${assistantEntryId}\u0000`
+  for (const key of pendingOasToolBlockIndexes.keys()) {
+    if (key.startsWith(prefix)) pendingOasToolBlockIndexes.delete(key)
+  }
 }
 
 function normalizeStreamUsage(raw: unknown): NonNullable<KeeperConversationDetails['usage']> | null {
@@ -119,6 +185,7 @@ export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult 
       error: null,
       timestamp: new Date().toISOString(),
     })
+    clearPendingOasToolBlockIndexesForEntry(keeperName, entryId)
   }
   clearActiveStream(keeperName)
   setRecordValue(keeperSending, keeperName, false)
@@ -153,6 +220,7 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TEXT_MESSAGE_END':
+      clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
       setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
       return null
     case 'TOOL_CALL_START': {
@@ -169,6 +237,7 @@ export function applyKeeperStreamEvent(
       appendAssistantToolTraceStep(keeperName, assistantEntryId, {
         toolCallId,
         name: toolName,
+        oasBlockIndex: takeOasToolBlockIndex(keeperName, assistantEntryId, toolCallId),
       })
       // Insert above the live assistant bubble so the final reply text
       // stays the last entry in the transcript.
@@ -262,6 +331,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
+        clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
         setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
         return null
       }
@@ -275,16 +345,18 @@ export function applyKeeperStreamEvent(
         const toolCallId = asString(value?.tool_call_id)
         const toolName = asString(value?.tool_call_name)
         if (toolCallId && toolName) {
-          appendAssistantToolTraceStep(keeperName, assistantEntryId, {
-            toolCallId,
-            name: toolName,
-            oasBlockIndex,
-          })
+          rememberOasToolBlockIndex(keeperName, assistantEntryId, toolCallId, oasBlockIndex)
         }
         setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_STOP') {
+        const value = isRecord(event.value) ? event.value : null
+        forgetOasToolBlockIndexByIndex(
+          keeperName,
+          assistantEntryId,
+          asNumber(value?.index) ?? asNumber(value?.block_index),
+        )
         setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
         return null
       }
@@ -307,10 +379,17 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_STREAM_PROTOCOL_ERROR') {
+        const value = isRecord(event.value) ? event.value : null
+        forgetOasToolBlockIndexByIndex(
+          keeperName,
+          assistantEntryId,
+          asNumber(value?.index) ?? asNumber(value?.block_index),
+        )
         recordStreamProtocolError(
           keeperName,
           assistantEntryId,
           streamProtocolMessage(event.value, 'stream protocol error'),
+          asString(value?.tool_call_id),
         )
         return null
       }
@@ -350,6 +429,7 @@ export function applyKeeperStreamEvent(
         if (!TERMINAL_REQUEST_STATUSES.has(status)) {
           return null
         }
+        clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
         if (terminalRequestId) releaseActiveStreamRequestId(terminalRequestId)
         else clearActiveStreamRequestId(keeperName)
         const ok = terminal?.ok === true

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -13,6 +13,7 @@ type stream_protocol_error_kind =
 type stream_protocol_error = {
   kind : stream_protocol_error_kind;
   index : int option;
+  tool_call_id : string option;
   event_type : string option;
   reason : string option;
   raw_bytes : int option;
@@ -116,6 +117,7 @@ let stream_protocol_error_summary error =
     [
       Some (stream_protocol_error_kind_to_string error.kind);
       Option.map (Printf.sprintf "index=%d") error.index;
+      Option.map (Printf.sprintf "tool_call_id=%s") error.tool_call_id;
       Option.map (Printf.sprintf "event_type=%s") error.event_type;
       error.reason;
       Option.map (Printf.sprintf "raw_bytes=%d") error.raw_bytes;
@@ -131,6 +133,8 @@ let stream_protocol_error_to_json error =
         `String (stream_protocol_error_kind_to_string error.kind) );
     ]
     @ json_opt "index" (Option.map (fun value -> `Int value) error.index)
+    @ json_opt "tool_call_id"
+        (Option.map (fun value -> `String value) error.tool_call_id)
     @ json_opt "event_type"
         (Option.map (fun value -> `String value) error.event_type)
     @ json_opt "reason" (Option.map (fun value -> `String value) error.reason)

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -23,6 +23,7 @@ type stream_protocol_error_kind =
 type stream_protocol_error = {
   kind : stream_protocol_error_kind;
   index : int option;
+  tool_call_id : string option;
   event_type : string option;
   reason : string option;
   raw_bytes : int option;

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -3,28 +3,36 @@ type tool_ref = {
   tool_call_name : string;
 }
 
-type state = { tools_by_index : (int * tool_ref) list }
+type block_state =
+  | Active_tool of tool_ref
+  | Invalid_tool_block of { failed_tool_call_id : string option }
+
+type state = { blocks_by_index : (int * block_state) list }
 
 type translated_event = {
   bridge_state : state;
   chat_events : Keeper_chat_events.keeper_chat_event list;
 }
 
-let empty_state = { tools_by_index = [] }
+let empty_state = { blocks_by_index = [] }
 
-let stream_tool_for_index bridge_state index =
-  List.assoc_opt index bridge_state.tools_by_index
+let stream_block_for_index bridge_state index =
+  List.assoc_opt index bridge_state.blocks_by_index
 
-let replace_tool bridge_state index tool =
-  { tools_by_index =
-      (index, tool) :: List.remove_assoc index bridge_state.tools_by_index
+let replace_block bridge_state index block =
+  { blocks_by_index =
+      (index, block) :: List.remove_assoc index bridge_state.blocks_by_index
   }
 
-let remove_tool bridge_state index =
-  { tools_by_index = List.remove_assoc index bridge_state.tools_by_index }
+let invalidate_block bridge_state index ~failed_tool_call_id =
+  replace_block bridge_state index (Invalid_tool_block { failed_tool_call_id })
+
+let remove_block bridge_state index =
+  { blocks_by_index = List.remove_assoc index bridge_state.blocks_by_index }
 
 let tool_start_is_replay existing tool =
   String.equal existing.tool_call_id tool.tool_call_id
+  && String.equal existing.tool_call_name tool.tool_call_name
 
 let sdk_stream_event_is_deliverable =
   Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal
@@ -39,9 +47,9 @@ let has_any_tool_identity ~tool_id ~tool_name =
   | None, None -> false
   | _ -> true
 
-let protocol_error ?index ?event_type ?reason ?raw_bytes kind =
+let protocol_error ?index ?tool_call_id ?event_type ?reason ?raw_bytes kind =
   Keeper_chat_events.Oas_stream_protocol_error
-    { kind; index; event_type; reason; raw_bytes }
+    { kind; index; tool_call_id; event_type; reason; raw_bytes }
 
 let content_block_start_event ~index ~content_type ~tool_id ~tool_name =
   Keeper_chat_events.Oas_content_block_start
@@ -56,8 +64,8 @@ let content_block_stop_event ~index =
 
 let tool_args_event ~redact_text ~snapshot bridge_state index args =
   let open Keeper_chat_events in
-  match stream_tool_for_index bridge_state index with
-  | Some tool ->
+  match stream_block_for_index bridge_state index with
+  | Some (Active_tool tool) ->
       let args = redact_text args in
       let chat_event =
         if snapshot then
@@ -65,6 +73,13 @@ let tool_args_event ~redact_text ~snapshot bridge_state index args =
         else Tool_call_args { tool_call_id = tool.tool_call_id; delta = args }
       in
       { bridge_state; chat_events = [ chat_event ] }
+  | Some (Invalid_tool_block { failed_tool_call_id }) ->
+      { bridge_state;
+        chat_events =
+          [ protocol_error ?tool_call_id:failed_tool_call_id ~index
+              ~reason:"tool argument event arrived after invalid tool block start"
+              Tool_args_without_start ]
+      }
   | None ->
       { bridge_state;
         chat_events =
@@ -127,27 +142,47 @@ let translate ~redact_text ~on_text_delta bridge_state
       | Some tid, Some tname
         when String.trim tid <> "" && String.trim tname <> "" ->
       let tool = { tool_call_id = tid; tool_call_name = tname } in
-      let existing_tool = stream_tool_for_index bridge_state index in
+      let existing_block = stream_block_for_index bridge_state index in
       let block_start =
         content_block_start_event ~index ~content_type ~tool_id:(Some tid)
           ~tool_name:(Some tname)
       in
-      { bridge_state = replace_tool bridge_state index tool;
-        chat_events =
-          block_start
-          :: (match existing_tool with
-           | Some existing when tool_start_is_replay existing tool -> []
-           | Some existing ->
-               [ Tool_call_end { tool_call_id = existing.tool_call_id };
+      (match existing_block with
+       | Some (Active_tool existing) when tool_start_is_replay existing tool ->
+           { bridge_state; chat_events = [ block_start ] }
+       | Some (Active_tool existing) ->
+           { bridge_state =
+               invalidate_block bridge_state index
+                 ~failed_tool_call_id:(Some existing.tool_call_id);
+             chat_events =
+               [ block_start;
+                 protocol_error ~index ~tool_call_id:existing.tool_call_id
+                   ~reason:
+                     (Printf.sprintf
+                        "tool-use block index already active: existing tool %s/%s, incoming tool %s/%s"
+                        existing.tool_call_id existing.tool_call_name tid tname)
+                   Tool_start_duplicate_index ]
+           }
+       | Some (Invalid_tool_block { failed_tool_call_id }) ->
+           { bridge_state;
+             chat_events =
+               [ block_start;
+                 protocol_error ?tool_call_id:failed_tool_call_id ~index
+                   ~reason:"tool-use block index already invalid"
+                   Tool_start_duplicate_index ]
+           }
+       | None ->
+           { bridge_state = replace_block bridge_state index (Active_tool tool);
+             chat_events =
+               [ block_start;
                  Tool_call_start { tool_call_id = tid; tool_call_name = tname } ]
-           | None ->
-               [ Tool_call_start { tool_call_id = tid; tool_call_name = tname } ])
-      }
+           })
       | _ ->
           let block_start =
             content_block_start_event ~index ~content_type ~tool_id ~tool_name
           in
-          { bridge_state;
+          { bridge_state =
+              invalidate_block bridge_state index ~failed_tool_call_id:None;
             chat_events =
               [ block_start;
                 protocol_error ~index
@@ -159,7 +194,10 @@ let translate ~redact_text ~on_text_delta bridge_state
         content_block_start_event ~index ~content_type ~tool_id ~tool_name
       in
       if has_any_tool_identity ~tool_id ~tool_name then
-        { bridge_state;
+        { bridge_state =
+            invalidate_block bridge_state index
+              ~failed_tool_call_id:(Option.bind tool_id (fun id ->
+                   if String.trim id = "" then None else Some id));
           chat_events =
             [ block_start;
               protocol_error ~index
@@ -173,11 +211,19 @@ let translate ~redact_text ~on_text_delta bridge_state
       tool_args_event ~redact_text ~snapshot:true bridge_state index args
   | ContentBlockStop { index } -> (
       let block_stop = content_block_stop_event ~index in
-      match stream_tool_for_index bridge_state index with
-      | Some tool ->
-          { bridge_state = remove_tool bridge_state index;
+      match stream_block_for_index bridge_state index with
+      | Some (Active_tool tool) ->
+          { bridge_state = remove_block bridge_state index;
             chat_events =
               [ block_stop; Tool_call_end { tool_call_id = tool.tool_call_id } ]
+          }
+      | Some (Invalid_tool_block { failed_tool_call_id }) ->
+          { bridge_state = remove_block bridge_state index;
+            chat_events =
+              [ block_stop;
+                protocol_error ?tool_call_id:failed_tool_call_id ~index
+                  ~reason:"content block stop arrived for invalid tool block"
+                  Tool_stop_without_start ]
           }
       | None ->
           { bridge_state; chat_events = [ block_stop ] })

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -667,7 +667,59 @@ let test_keeper_stream_bridge_ignores_replayed_tool_start () =
       fail
         "expected replayed block start, one tool start, one args delta, and one end"
 
-let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
+let test_keeper_stream_bridge_rejects_replayed_tool_name_drift () =
+  let open Agent_sdk.Types in
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-repeat";
+            tool_name = Some "keeper_memory_search" };
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "tc-repeat";
+            tool_name = Some "keeper_board_list" };
+      ]
+  in
+  match events with
+  | [ Keeper_chat_events.Oas_content_block_start
+        { tool_call_id = Some first_block_id;
+          tool_call_name = Some first_block_name;
+          _ };
+      Keeper_chat_events.Tool_call_start
+        { tool_call_id = first_start_id; tool_call_name = first_start_name };
+      Keeper_chat_events.Oas_content_block_start
+        { tool_call_id = Some replay_block_id;
+          tool_call_name = Some replay_block_name;
+          _ };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind;
+          index = Some index;
+          tool_call_id = Some error_tool_id;
+          reason = Some reason;
+          _ } ] ->
+      check string "first block id" "tc-repeat" first_block_id;
+      check string "first block name" "keeper_memory_search" first_block_name;
+      check string "first start id" "tc-repeat" first_start_id;
+      check string "first start name" "keeper_memory_search" first_start_name;
+      check string "replay block id" "tc-repeat" replay_block_id;
+      check string "replay block name" "keeper_board_list" replay_block_name;
+      check string "kind" "tool_start_duplicate_index"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string kind);
+      check int "index" 2 index;
+      check string "error tool id" "tc-repeat" error_tool_id;
+      check bool "reason names original tool" true
+        (string_contains reason "existing tool tc-repeat/keeper_memory_search");
+      check bool "reason names incoming tool" true
+        (string_contains reason "incoming tool tc-repeat/keeper_board_list")
+  | _ ->
+      fail
+        "expected same-id different-name tool start replay to fail closed"
+
+let test_keeper_stream_bridge_rejects_conflicting_tool_index_reuse () =
   let open Agent_sdk.Types in
   let events =
     translate_oas_stream_events
@@ -687,7 +739,7 @@ let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
         ContentBlockStop { index = 2 };
       ]
   in
-  check bool "no protocol error for recoverable reused index" false
+  check bool "protocol error for conflicting reused index" true
     (has_stream_protocol_error events);
   match events with
   | [ Keeper_chat_events.Oas_content_block_start
@@ -696,11 +748,25 @@ let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
       Keeper_chat_events.Tool_call_args { tool_call_id = first_args; delta = args_a };
       Keeper_chat_events.Oas_content_block_start
         { index = second_block_index; tool_call_id = Some second_block_id; _ };
-      Keeper_chat_events.Tool_call_end { tool_call_id = first_end };
-      Keeper_chat_events.Tool_call_start { tool_call_id = second_start; _ };
-      Keeper_chat_events.Tool_call_args { tool_call_id = second_args; delta = args_b };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind = duplicate_kind;
+          index = Some duplicate_index;
+          tool_call_id = Some duplicate_tool_id;
+          reason = Some duplicate_reason;
+          _ };
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind = args_kind;
+          index = Some args_index;
+          tool_call_id = Some args_tool_id;
+          reason = Some args_reason;
+          _ };
       Keeper_chat_events.Oas_content_block_stop { index = stop_index };
-      Keeper_chat_events.Tool_call_end { tool_call_id = second_end } ] ->
+      Keeper_chat_events.Oas_stream_protocol_error
+        { kind = stop_kind;
+          index = Some stop_error_index;
+          tool_call_id = Some stop_tool_id;
+          reason = Some stop_reason;
+          _ } ] ->
       check int "first block index" 2 first_block_index;
       check string "first block id" "tc-first" first_block_id;
       check string "first start" "tc-first" first_start;
@@ -708,13 +774,29 @@ let test_keeper_stream_bridge_closes_tool_when_index_is_reused () =
       check string "first args" "{\"q\":\"first\"}" args_a;
       check int "second block index" 2 second_block_index;
       check string "second block id" "tc-second" second_block_id;
-      check string "first implicit end" "tc-first" first_end;
-      check string "second start" "tc-second" second_start;
-      check string "second args id" "tc-second" second_args;
-      check string "second args" "{\"q\":\"second\"}" args_b;
+      check string "duplicate kind" "tool_start_duplicate_index"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string
+           duplicate_kind);
+      check int "duplicate index" 2 duplicate_index;
+      check string "duplicate tool id" "tc-first" duplicate_tool_id;
+      check bool "duplicate reason names incoming tool" true
+        (string_contains duplicate_reason "incoming tool tc-second");
+      check string "args kind" "tool_args_without_start"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string args_kind);
+      check int "args index" 2 args_index;
+      check string "args error tool id" "tc-first" args_tool_id;
+      check string "args reason"
+        "tool argument event arrived after invalid tool block start" args_reason;
       check int "stop index" 2 stop_index;
-      check string "second end" "tc-second" second_end
-  | _ -> fail "expected previous tool to close before reused-index tool starts"
+      check string "stop kind" "tool_stop_without_start"
+        (Keeper_chat_events.stream_protocol_error_kind_to_string stop_kind);
+      check int "stop error index" 2 stop_error_index;
+      check string "stop error tool id" "tc-first" stop_tool_id;
+      check string "stop reason"
+        "content block stop arrived for invalid tool block" stop_reason
+  | _ ->
+      fail
+        "expected conflicting reused-index tool start to fail closed without forged tool events"
 
 let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
   let open Agent_sdk.Types in
@@ -911,6 +993,7 @@ let test_stream_protocol_error_summary_includes_diagnostics () =
       {
         kind = Keeper_chat_events.Tool_args_without_start;
         index = Some 2;
+        tool_call_id = Some "tc-1";
         event_type = Some "response.future";
         reason = Some "tool argument delta arrived before tool start";
         raw_bytes = Some 7;
@@ -918,6 +1001,7 @@ let test_stream_protocol_error_summary_includes_diagnostics () =
   in
   check bool "kind" true (string_contains summary "tool_args_without_start");
   check bool "index" true (string_contains summary "index=2");
+  check bool "tool id" true (string_contains summary "tool_call_id=tc-1");
   check bool "event type" true
     (string_contains summary "event_type=response.future");
   check bool "reason" true
@@ -1730,8 +1814,10 @@ let () =
             test_keeper_stream_bridge_preserves_tool_args_snapshot;
           test_case "stream bridge ignores replayed tool starts" `Quick
             test_keeper_stream_bridge_ignores_replayed_tool_start;
-          test_case "stream bridge closes tool when index is reused" `Quick
-            test_keeper_stream_bridge_closes_tool_when_index_is_reused;
+          test_case "stream bridge rejects replayed tool name drift" `Quick
+            test_keeper_stream_bridge_rejects_replayed_tool_name_drift;
+          test_case "stream bridge rejects conflicting tool index reuse" `Quick
+            test_keeper_stream_bridge_rejects_conflicting_tool_index_reuse;
           test_case "stream bridge surfaces OAS message metadata" `Quick
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge preserves typed media source" `Quick


### PR DESCRIPTION
## Summary
- fail closed when OAS reuses an active content block index for a different tool identity instead of implicitly ending/replacing the tool
- carry optional tool_call_id on stream protocol errors so dashboard traces can mark the affected tool as err
- separate OAS content-block index mapping from AG-UI TOOL_CALL_START so invalid block-start events do not create fake tool traces

## Verification
- pre-rebase: env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe
- pre-rebase: ./_build/default/test/test_gate_keeper_backend.exe (79 tests)
- post-rebase: /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit -p dashboard/tsconfig.json
- post-rebase: /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-stream.test.ts
- post-rebase: ocamlformat --check lib/keeper/keeper_chat_events.mli lib/keeper/keeper_chat_events.ml lib/keeper/keeper_chat_oas_stream_bridge.ml test/test_gate_keeper_backend.ml
- post-rebase: git diff --check

Note: a post-rebase rerun of the local Dune target was queued behind other shared Dune/opam lock holders and was interrupted; the same target and executable passed before the conflict-free rebase, and PR CI should be the final build authority.