### PR TITLE
feat(keeper): require strict adversarial review responses

### DIFF
--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -29,54 +29,22 @@ let apply_report_verdict_output_schema provider_cfg =
          (Agent_sdk.Error.InvalidConfig
             { field = "verification.adversarial_review.output_schema"; detail }))
 
-let parse_json_payload text =
-  let trimmed = String.trim text in
-  let attempt s =
-    try Some (Yojson.Safe.from_string s) with
-    | Yojson.Json_error _ -> None
-  in
-  match attempt trimmed with
-  | Some json -> Some json
-  | None ->
-    let len = String.length trimmed in
-    if len = 0 then None
-    else
-      let start_opt =
-        let brace = try Some (String.index trimmed '{') with Not_found -> None in
-        let bracket = try Some (String.index trimmed '[') with Not_found -> None in
-        match brace, bracket with
-        | Some i, Some j -> Some (min i j)
-        | Some i, None -> Some i
-        | None, Some j -> Some j
-        | None, None -> None
-      in
-      match start_opt with
-      | None -> None
-      | Some start ->
-        let closing = if trimmed.[start] = '{' then '}' else ']' in
-        let rec find_last idx =
-          if idx < 0 then None
-          else if trimmed.[idx] = closing then Some idx
-          else find_last (idx - 1)
-        in
-        match find_last (len - 1) with
-        | None -> None
-        | Some fin -> attempt (String.sub trimmed start (fin - start + 1))
+let parse_grounded_verdict_from_response_text text =
+  match Yojson.Safe.from_string (String.trim text) with
+  | json -> Verifier_core.parse_grounded_verdict_from_json json
+  | exception Yojson.Json_error msg ->
+    Error
+      (Printf.sprintf
+         "adversarial review response must be strict JSON: %s"
+         msg)
 
-let parse_verdict_from_text text =
-  match parse_json_payload text with
-  | None ->
-    Error "model did not return a structured verdict (no JSON payload found)"
-  | Some json -> Verifier_core.parse_verdict_from_json json
-
-let parse_grounded_verdict_from_text text =
-  match parse_json_payload text with
-  | None ->
-    Error "model did not return a structured verdict (no JSON payload found)"
-  | Some json -> Verifier_core.parse_grounded_verdict_from_json json
+module For_testing = struct
+  let parse_grounded_verdict_from_response_text =
+    parse_grounded_verdict_from_response_text
+end
 
 (* Mirrors [Verifier_oas.verify]: structured verdict via the [report_verdict]
-   tool, with a structured JSON fallback if the model answers in free text.
+   tool, with a strict JSON fallback if the model answers without the tool.
    The judgment itself is the model's; this only routes its structured output
    back as a typed [Verifier_core.verdict]. *)
 let run_grounded_review ~base_path ~runtime_id (input : review_input) :
@@ -125,9 +93,10 @@ let run_grounded_review ~base_path ~runtime_id (input : review_input) :
       match !verdict_ref with
       | Some v -> Ok v
       | None ->
-        (* Model answered in text instead of calling report_verdict. *)
+        (* Model answered without calling report_verdict. Provider-native
+           schema still requires a strict JSON grounded verdict object. *)
         let text = Agent_sdk_response.text_of_response result.response in
-        parse_grounded_verdict_from_text text)
+        parse_grounded_verdict_from_response_text text)
     | Error err -> Error (Agent_sdk.Error.to_string err)
 
 let run_review ~base_path ~runtime_id (input : review_input) :

--- a/lib/keeper/keeper_adversarial_review.mli
+++ b/lib/keeper/keeper_adversarial_review.mli
@@ -10,11 +10,12 @@
 
     The verdict is the LLM's judgment. On the structured [report_verdict] path
     there is no rule, heuristic, or string match deciding pass/fail. The
-    free-text fallback parses a JSON payload with [Verifier_core]; it does not
-    use string matching to decide pass/fail. The grounded entry point requires
-    evidence for WARN/FAIL before wake-on-fail routing. The only deterministic
-    parts are identity (which keeper authored the work, hence who to wake) and
-    event-id dedup (a given task-level FAIL wakes the author at most once).
+    response fallback accepts only a strict JSON grounded verdict object; it
+    does not extract JSON from prose or fences. The grounded entry point
+    requires evidence for WARN/FAIL before wake-on-fail routing. The only
+    deterministic parts are identity (which keeper authored the work, hence who
+    to wake) and event-id dedup (a given task-level FAIL wakes the author at
+    most once).
 
     This module is a proof-of-concept. It is not yet wired to a keeper
     lifecycle trigger; integration with the tool registration in #21357 is the
@@ -48,10 +49,9 @@ val run_grounded_review :
   review_input ->
   (Verifier_core.grounded_verdict, string) result
 (** Run the adversarial reviewer agent and read its structured grounded verdict
-    via the [report_verdict] tool. If the model answers in free text, the
-    fallback attempts to parse a JSON payload and decode it with
-    [Verifier_core.parse_grounded_verdict_from_json]; it never uses string
-    matching to decide pass/fail. *)
+    via the [report_verdict] tool. If the model answers without calling the
+    tool, the fallback accepts only a strict JSON response object decoded with
+    [Verifier_core.parse_grounded_verdict_from_json]. *)
 
 val act_on_verdict :
   base_path:string -> input:review_input -> Verifier_core.verdict -> (unit, string) result
@@ -78,3 +78,8 @@ val review_and_wake_on_fail :
   (Verifier_core.verdict, string) result
 (** [run_grounded_review] followed by [act_on_grounded_verdict] on the resulting
     verdict, returning the compatibility [Verifier_core.verdict]. *)
+
+module For_testing : sig
+  val parse_grounded_verdict_from_response_text :
+    string -> (Verifier_core.grounded_verdict, string) result
+end

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -567,19 +567,26 @@ let parse_verdict_typed (text : string) : (verdict, verdict_parse_error) result 
                |> String_util.to_string)))
 ;;
 
-let parse_verdict (text : string) : (verdict, string) result =
-  match parse_verdict_typed text with
+let parse_verdict (raw_text : string) : (verdict, string) result =
+  match parse_verdict_typed raw_text with
   | Ok v -> Ok v
   | Error err -> Error (verdict_parse_error_to_string err)
 ;;
 
-let parse_review_verdict_from_text text =
-  match Yojson.Safe.from_string (String.trim text) with
-  | json -> (
-    match parse_review_verdict_from_json json with
-    | Ok verdict -> Ok verdict
-    | Error msg -> Error (Unrecognized_review_format msg))
-  | exception Yojson.Json_error _ -> parse_verdict_typed text
+let parse_review_verdict_from_response_text text =
+  let trimmed = String.trim text in
+  if String.length trimmed = 0
+  then Error Empty_review_output
+  else
+    match Yojson.Safe.from_string trimmed with
+    | json -> (
+      match parse_review_verdict_from_json json with
+      | Ok verdict -> Ok verdict
+      | Error msg -> Error (Unrecognized_review_format msg))
+    | exception Yojson.Json_error msg ->
+      Error
+        (Unrecognized_review_format
+           (sprintf "response text is not strict verdict JSON: %s" msg))
 ;;
 
 (* ================================================================ *)
@@ -812,10 +819,11 @@ let review
                 task_info "[anti-rationalization] verdict via structured tool call";
                 v, Structured_tool, None
               | None ->
-                (* LLM responded without a tool call — parse native JSON first,
-                   then the legacy text fallback. *)
-                task_info "[anti-rationalization] verdict via text fallback";
-                (match parse_review_verdict_from_text text with
+                (* LLM responded without a tool call. The provider-native
+                   schema response must be the strict verdict JSON object; do
+                   not accept legacy prose verdicts on this path. *)
+                task_info "[anti-rationalization] verdict via native JSON response";
+                (match parse_review_verdict_from_response_text text with
                  | Ok v -> v, Llm_text_fallback, None
                  | Error parse_error ->
                    let parse_err = verdict_parse_error_to_string parse_error in

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -27,6 +27,20 @@ let with_reviewer reviewer f =
       Atomic.set AR.run_llm_reviewer_fn reviewer;
       f ())
 
+let contains_substring haystack needle =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 let test_empty_verdict_emits_typed_error () =
   match AR.parse_verdict_typed "" with
   | Error AR.Empty_review_output -> ()
@@ -79,6 +93,56 @@ let test_review_rejects_empty_evaluator_output () =
         Alcotest.fail
           "empty evaluator output must not approve by liveness")
 
+let test_review_accepts_strict_json_evaluator_response () =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, {|{"verdict":"APPROVE"}|}))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:"test-json-evaluator" (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "llm_text_fallback" (AR.gate_to_string result.AR.gate);
+      match result.AR.verdict with
+      | AR.Approve -> ()
+      | AR.Reject reason ->
+        Alcotest.failf "strict JSON APPROVE should pass, rejected: %s" reason)
+
+let check_review_rejects_evaluator_text ~label ~text ~reason_substring =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, text))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:("test-" ^ label) (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "format_reject" (AR.gate_to_string result.AR.gate);
+      (match result.AR.fallback_reason with
+       | Some reason ->
+         Alcotest.(check bool)
+           "fallback reason names strict JSON requirement"
+           true
+           (contains_substring reason reason_substring)
+       | None -> Alcotest.fail "format reject should include a fallback reason");
+      match result.AR.verdict with
+      | AR.Reject _ -> ()
+      | AR.Approve -> Alcotest.failf "%s evaluator output must not approve" label)
+
+let test_review_rejects_prose_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"prose-evaluator" ~text:"APPROVE"
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_malformed_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"malformed-json-evaluator"
+    ~text:{|{"verdict":"APPROVE"|}
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_non_object_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"array-json-evaluator"
+    ~text:{|[{"verdict":"APPROVE"}]|}
+    ~reason_substring:"review verdict"
+
 let () =
   Alcotest.run
     "anti_rationalization_empty_reject"
@@ -104,5 +168,21 @@ let () =
             "empty evaluator output rejects"
             `Quick
             test_review_rejects_empty_evaluator_output;
+          Alcotest.test_case
+            "strict JSON evaluator response passes"
+            `Quick
+            test_review_accepts_strict_json_evaluator_response;
+          Alcotest.test_case
+            "prose evaluator response rejects"
+            `Quick
+            test_review_rejects_prose_evaluator_response;
+          Alcotest.test_case
+            "malformed JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_malformed_json_evaluator_response;
+          Alcotest.test_case
+            "non-object JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_non_object_json_evaluator_response;
         ] );
     ]

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -101,6 +101,30 @@ let check_ok = function
   | Ok () -> ()
   | Error msg -> Alcotest.fail msg
 
+let test_response_text_accepts_strict_json () =
+  let raw =
+    {|{"verdict":"FAIL","reason":"bad branch","evidence":[{"path":"lib/foo.ml","line":12,"quote":"let bad = true"}]}|}
+  in
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Ok grounded ->
+    check string
+      "verdict"
+      "FAIL"
+      (VC.verdict_constructor_name grounded.VC.verdict);
+    check int "evidence count" 1 (List.length grounded.VC.evidence)
+  | Error msg -> fail ("strict JSON response rejected: " ^ msg)
+
+let test_response_text_rejects_embedded_json () =
+  let raw =
+    {|Here is the verdict: {"verdict":"PASS","reason":null,"evidence":[]}|}
+  in
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Error _ -> ()
+  | Ok grounded ->
+    failf
+      "embedded JSON should be rejected, got %s"
+      (VC.verdict_to_string grounded.VC.verdict)
+
 let test_fail_wakes_author () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
@@ -294,6 +318,13 @@ let test_build_prompt_preserves_literal_braces_in_values () =
 let () =
   Alcotest.run "keeper-adversarial-review"
     [
+      ( "response-parser",
+        [
+          test_case "accepts strict JSON response" `Quick
+            test_response_text_accepts_strict_json;
+          test_case "rejects embedded JSON response" `Quick
+            test_response_text_rejects_embedded_json;
+        ] );
       ( "wake-on-fail",
         [
           test_case "fail wakes author" `Quick test_fail_wakes_author;

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -125,6 +125,29 @@ let test_response_text_rejects_embedded_json () =
       "embedded JSON should be rejected, got %s"
       (VC.verdict_to_string grounded.VC.verdict)
 
+let check_response_text_rejected label raw =
+  match AR.For_testing.parse_grounded_verdict_from_response_text raw with
+  | Error _ -> ()
+  | Ok grounded ->
+    failf
+      "%s should be rejected, got %s"
+      label
+      (VC.verdict_to_string grounded.VC.verdict)
+
+let test_response_text_rejects_empty_text () =
+  check_response_text_rejected "empty response" "";
+  check_response_text_rejected "whitespace response" "  \n\t  "
+
+let test_response_text_rejects_malformed_json () =
+  check_response_text_rejected
+    "malformed JSON response"
+    {|{"verdict":"PASS","reason":null,"evidence":[]|}
+
+let test_response_text_rejects_non_object_json () =
+  check_response_text_rejected
+    "array JSON response"
+    {|[{"verdict":"PASS","reason":null,"evidence":[]}]|}
+
 let test_fail_wakes_author () =
   with_temp_base (fun base ->
       let author = "builder-keeper" in
@@ -324,6 +347,12 @@ let () =
             test_response_text_accepts_strict_json;
           test_case "rejects embedded JSON response" `Quick
             test_response_text_rejects_embedded_json;
+          test_case "rejects empty response text" `Quick
+            test_response_text_rejects_empty_text;
+          test_case "rejects malformed JSON response" `Quick
+            test_response_text_rejects_malformed_json;
+          test_case "rejects non-object JSON response" `Quick
+            test_response_text_rejects_non_object_json;
         ] );
       ( "wake-on-fail",
         [

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -338,6 +338,25 @@ let test_verifier_oas_response_text_fallback_is_strict_json () =
        ~callee:"Core.parse_verdict")
 ;;
 
+let test_adversarial_review_response_text_fallback_is_strict_json () =
+  let rel = "lib/keeper/keeper_adversarial_review.ml" in
+  check
+    int
+    "adversarial review must not keep prose JSON payload extractor"
+    0
+    (Ast_grep.count_value_bindings ~module_path:rel ~name:"parse_json_payload");
+  check
+    int
+    "adversarial review must not scan response text for an embedded JSON start"
+    0
+    (Ast_grep.count_calls ~module_path:rel ~callee:"String.index");
+  check
+    int
+    "adversarial review must not slice response text into recovered JSON"
+    0
+    (Ast_grep.count_calls ~module_path:rel ~callee:"String.sub")
+;;
+
 let test_model_label_wrappers_can_receive_provider_config_transform () =
   let rel = "lib/keeper/keeper_turn_driver_wrappers.ml" in
   check
@@ -431,6 +450,10 @@ let () =
             "verifier_oas response fallback is strict JSON"
             `Quick
             test_verifier_oas_response_text_fallback_is_strict_json
+        ; test_case
+            "adversarial review response fallback is strict JSON"
+            `Quick
+            test_adversarial_review_response_text_fallback_is_strict_json
         ] )
     ; ( "model-label wrappers"
       , [ test_case

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -338,25 +338,6 @@ let test_verifier_oas_response_text_fallback_is_strict_json () =
        ~callee:"Core.parse_verdict")
 ;;
 
-let test_adversarial_review_response_text_fallback_is_strict_json () =
-  let rel = "lib/keeper/keeper_adversarial_review.ml" in
-  check
-    int
-    "adversarial review must not keep prose JSON payload extractor"
-    0
-    (Ast_grep.count_value_bindings ~module_path:rel ~name:"parse_json_payload");
-  check
-    int
-    "adversarial review must not scan response text for an embedded JSON start"
-    0
-    (Ast_grep.count_calls ~module_path:rel ~callee:"String.index");
-  check
-    int
-    "adversarial review must not slice response text into recovered JSON"
-    0
-    (Ast_grep.count_calls ~module_path:rel ~callee:"String.sub")
-;;
-
 let test_model_label_wrappers_can_receive_provider_config_transform () =
   let rel = "lib/keeper/keeper_turn_driver_wrappers.ml" in
   check
@@ -450,10 +431,6 @@ let () =
             "verifier_oas response fallback is strict JSON"
             `Quick
             test_verifier_oas_response_text_fallback_is_strict_json
-        ; test_case
-            "adversarial review response fallback is strict JSON"
-            `Quick
-            test_adversarial_review_response_text_fallback_is_strict_json
         ] )
     ; ( "model-label wrappers"
       , [ test_case


### PR DESCRIPTION
Stacked on #22775.\n\n## What changed\n- Remove JSON substring recovery from keeper adversarial review response fallback.\n- Keep the primary report_verdict tool path unchanged.\n- If the reviewer responds without calling report_verdict, accept only a strict JSON grounded verdict object.\n- Update docs and add parser/coverage tests to prevent prose/fenced JSON recovery from returning.\n\n## Local checks\n- git diff --check\n- ocamlformat --check lib/keeper/keeper_adversarial_review.ml lib/keeper/keeper_adversarial_review.mli test/test_keeper_adversarial_review.ml test/test_keeper_structured_output_coverage.ml\n- targeted rg checks for removed JSON substring recovery\n\nFocused build/tests left to GitHub CI per operator preference.