### PR TITLE
fix(keeper): reasoning 턴 max_tokens를 모델 출력 ceiling에서 해석 (thinking_only truncation)

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -459,6 +459,22 @@ let max_context_of_runtime_id (id : string) : int option =
   | None -> None
 ;;
 
+(* The model's declared max output tokens (OAS capability catalog SSOT), or
+   [None] when the runtime is unknown or the catalog row leaves it unset.
+   Mirrors [max_context_of_runtime_id] but projects the OAS-typed capability
+   rather than the runtime.toml [model] record, because max output is owned by
+   the provider/model catalog, not the per-binding runtime config. Consumed by
+   [Runtime_inference.resolve_max_tokens] to size reasoning turns from the
+   model's own ceiling. *)
+let max_output_tokens_of_runtime_id (id : string) : int option =
+  match get_runtime_by_id id with
+  | Some rt ->
+    (match capabilities_for_runtime rt with
+     | Some caps -> caps.Llm_provider.Capabilities.max_output_tokens
+     | None -> None)
+  | None -> None
+;;
+
 let thinking_support_of_runtime_id (id : string) : bool option =
   match get_runtime_by_id id with
   | Some rt -> Some rt.model.thinking_support

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -151,6 +151,13 @@ val max_context_of_runtime_id : string -> int option
     not configured.  Budgeting callers use this to size a per-keeper routed turn
     against the same runtime that dispatch will use. *)
 
+val max_output_tokens_of_runtime_id : string -> int option
+(** Declared max output tokens (OAS capability catalog) for the model bound to
+    runtime [id], or [None] when the id is not configured or the catalog leaves
+    it unset.  Consumed by {!Runtime_inference.resolve_max_tokens} to size a
+    reasoning turn from the model's own output ceiling rather than the flat
+    fallback. *)
+
 val thinking_support_of_runtime_id : string -> bool option
 (** [thinking-support] capability of the model bound to runtime [id], or [None]
     when the id is not configured (e.g. before {!init_default}).  Consumed by

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -1,28 +1,37 @@
 let resolve_temperature ~runtime_id:_ ~fallback = fallback ()
 
-(* Operational ceiling for a reasoning turn's [max_tokens]. A reasoning model
-   spends part of one response on thinking before emitting the answer; both
-   share the single [max_tokens] budget. The flat keeper fallback (8192) is too
-   small for that combined budget, so thinking alone can exhaust it and the turn
-   truncates mid-thinking (stop_reason=max_tokens, content=[thinking]) with no
-   visible reply. Live fleet trace (2026-06-30, 111 trajectories): 73
+(* Upper bound on a reasoning turn's [max_tokens]. A reasoning model spends part
+   of one response on thinking before emitting the answer; both share the single
+   [max_tokens] budget. The flat keeper fallback (8192) is too small for that
+   combined budget, so thinking alone can exhaust it and the turn truncates
+   mid-thinking (stop_reason=max_tokens, content=[thinking]) with no visible
+   reply. Live fleet trace (2026-06-30, 111 trajectories): 73
    thinking_only+max_tokens rejections, 60% on runpod_mtp.
 
    This is a TOTAL-budget bump, not a [thinking.budget_tokens]-style sub-budget
    reservation: the answer is not carved out of a thinking allotment, the whole
    turn simply gets more room. 32768 = 4x the 8192 keeper fallback, enough for
    the observed thinking lengths plus an answer, while bounding a runaway
-   reasoning loop well below provider ceilings (e.g. deepseek 384000). *)
+   reasoning loop well below provider ceilings (e.g. deepseek 384000).
+
+   This constant is ONLY an upper bound applied on top of a model's declared
+   OAS ceiling; it is never the request value on its own (see [resolve_max_tokens]). *)
 let reasoning_turn_max_tokens = 32_768
 
 (* A reasoning runtime sizes its turn from the model's own declared output
    ceiling (OAS capability catalog [max_output_tokens], the value SSOT, read via
-   [Runtime.max_output_tokens_of_runtime_id]), bounded by
+   [Runtime.max_output_tokens_of_runtime_id]), bounded above by
    [reasoning_turn_max_tokens]. A model whose declared ceiling is below the bound
    keeps its smaller ceiling so the request never exceeds what the provider
-   accepts (the OAS backend would otherwise clamp and warn). When the catalog
-   declares no ceiling at all, the operational bound is used directly.
-   Non-reasoning runtimes keep the caller's flat [fallback] unchanged.
+   accepts (the OAS backend would otherwise clamp and warn).
+
+   When the catalog projects NO ceiling for the runtime, fall back to the
+   caller's flat budget rather than inventing [reasoning_turn_max_tokens] as the
+   request value: with no provider ceiling known, requesting 32768 could exceed
+   what the provider accepts and turn a thinking truncation into a max_tokens
+   rejection. The budget increase is gated on an OAS-declared ceiling, so the
+   value's source stays the model catalog (SSOT). Non-reasoning runtimes keep the
+   caller's flat [fallback] unchanged.
 
    Completes the previously stubbed per-runtime [resolve_max_tokens] (the
    [~runtime_id:_] passthrough). Raising a specific reasoning model toward the
@@ -33,7 +42,7 @@ let resolve_max_tokens ~runtime_id ~fallback =
   | Some true ->
     (match Runtime.max_output_tokens_of_runtime_id runtime_id with
      | Some ceiling -> min ceiling reasoning_turn_max_tokens
-     | None -> reasoning_turn_max_tokens)
+     | None -> fallback ())
   | Some false | None -> fallback ()
 
 let cap_max_tokens_to_runtime_ceiling ~runtime_id:_ ~source:_ value = value

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -1,6 +1,40 @@
 let resolve_temperature ~runtime_id:_ ~fallback = fallback ()
 
-let resolve_max_tokens ~runtime_id:_ ~fallback = fallback ()
+(* Operational ceiling for a reasoning turn's [max_tokens]. A reasoning model
+   spends part of one response on thinking before emitting the answer; both
+   share the single [max_tokens] budget. The flat keeper fallback (8192) is too
+   small for that combined budget, so thinking alone can exhaust it and the turn
+   truncates mid-thinking (stop_reason=max_tokens, content=[thinking]) with no
+   visible reply. Live fleet trace (2026-06-30, 111 trajectories): 73
+   thinking_only+max_tokens rejections, 60% on runpod_mtp.
+
+   This is a TOTAL-budget bump, not a [thinking.budget_tokens]-style sub-budget
+   reservation: the answer is not carved out of a thinking allotment, the whole
+   turn simply gets more room. 32768 = 4x the 8192 keeper fallback, enough for
+   the observed thinking lengths plus an answer, while bounding a runaway
+   reasoning loop well below provider ceilings (e.g. deepseek 384000). *)
+let reasoning_turn_max_tokens = 32_768
+
+(* A reasoning runtime sizes its turn from the model's own declared output
+   ceiling (OAS capability catalog [max_output_tokens], the value SSOT, read via
+   [Runtime.max_output_tokens_of_runtime_id]), bounded by
+   [reasoning_turn_max_tokens]. A model whose declared ceiling is below the bound
+   keeps its smaller ceiling so the request never exceeds what the provider
+   accepts (the OAS backend would otherwise clamp and warn). When the catalog
+   declares no ceiling at all, the operational bound is used directly.
+   Non-reasoning runtimes keep the caller's flat [fallback] unchanged.
+
+   Completes the previously stubbed per-runtime [resolve_max_tokens] (the
+   [~runtime_id:_] passthrough). Raising a specific reasoning model toward the
+   bound is a catalog change (declare a higher [max_output_tokens]); the value
+   lives in the model catalog, not here. *)
+let resolve_max_tokens ~runtime_id ~fallback =
+  match Runtime.thinking_support_of_runtime_id runtime_id with
+  | Some true ->
+    (match Runtime.max_output_tokens_of_runtime_id runtime_id with
+     | Some ceiling -> min ceiling reasoning_turn_max_tokens
+     | None -> reasoning_turn_max_tokens)
+  | Some false | None -> fallback ()
 
 let cap_max_tokens_to_runtime_ceiling ~runtime_id:_ ~source:_ value = value
 

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -566,6 +566,20 @@ thinking-support = true
 preserve-thinking = false
 streaming = true
 
+[models.smallout]
+api-name = "reasoning-small-out"
+max-context = 128000
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.bigout]
+api-name = "reasoning-big-out"
+max-context = 1000000
+tools-support = true
+thinking-support = true
+streaming = true
+
 [ollama_cloud.think]
 is-default = true
 max-concurrent = 1
@@ -577,6 +591,12 @@ max-concurrent = 1
 max-concurrent = 1
 
 [ollama_cloud.thinkexplicitoff]
+max-concurrent = 1
+
+[ollama_cloud.smallout]
+max-concurrent = 1
+
+[ollama_cloud.bigout]
 max-concurrent = 1
 |}
 ;;
@@ -594,6 +614,26 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "reasoning-small-out"
+base = "openai_chat"
+max_context_tokens = 131072
+max_output_tokens = 4096
+supports_tools = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "reasoning-big-out"
+base = "openai_chat"
+max_context_tokens = 1000000
+max_output_tokens = 200000
+supports_tools = true
+supports_reasoning = true
+supports_extended_thinking = true
 supports_native_streaming = true
 |}
 ;;
@@ -675,6 +715,91 @@ let test_seed_of_thinking_support_gate_contract () =
     "None -> leave caller policy unchanged"
     None
     (Runtime_inference.seed_of_thinking_support None).Runtime_inference.thinking_enabled
+;;
+
+(* ---- reasoning max_tokens resolution: [Runtime_inference.resolve_max_tokens]
+   sizes a reasoning turn from the model's declared output ceiling (OAS catalog),
+   bounded by the operational [reasoning_turn_max_tokens] (32768); non-reasoning
+   runtimes keep the caller fallback. Regression guard for the thinking_only +
+   stop_reason=max_tokens truncation (live fleet 2026-06-30). ----
+
+   The fallback sentinel (8192) mirrors the keeper path's flat default and is
+   distinct from every reasoning result asserted below, so a test failure
+   pinpoints which branch regressed. *)
+let fallback_sentinel () = 8192
+
+let test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback () =
+  with_runtime_thinking (fun () ->
+    (* qwen36-35b-a3b-mtp declares no explicit [max_output_tokens], so its
+       capability inherits the provider base ceiling (16384). The reasoning path
+       defers to that OAS-owned ceiling — NOT the flat keeper fallback (8192).
+       Raising this runtime to the 32768 operational bound is a catalog change
+       (declare a higher max_output_tokens), per the OAS-owns-the-value split. *)
+    Alcotest.(check int)
+      "reasoning runtime defers to its OAS capability ceiling (16384 base), \
+       above the 8192 keeper fallback"
+      16384
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"ollama_cloud.thinkdefault"
+         ~fallback:fallback_sentinel))
+;;
+
+let test_resolve_max_tokens_non_reasoning_uses_fallback () =
+  with_runtime_thinking (fun () ->
+    Alcotest.(check int)
+      "non-reasoning runtime keeps the caller fallback unchanged"
+      8192
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"ollama_cloud.nothink"
+         ~fallback:fallback_sentinel))
+;;
+
+let test_resolve_max_tokens_reasoning_small_ceiling_respected () =
+  with_runtime_thinking (fun () ->
+    Alcotest.(check int)
+      "reasoning runtime whose declared ceiling is below the operational bound \
+       keeps its smaller ceiling (never request more than the provider accepts)"
+      4096
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"ollama_cloud.smallout"
+         ~fallback:fallback_sentinel))
+;;
+
+let test_resolve_max_tokens_reasoning_big_ceiling_clamped () =
+  with_runtime_thinking (fun () ->
+    Alcotest.(check int)
+      "reasoning runtime whose declared ceiling exceeds the operational bound is \
+       clamped to the bound (runaway guard)"
+      32768
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"ollama_cloud.bigout"
+         ~fallback:fallback_sentinel))
+;;
+
+let test_resolve_max_tokens_unknown_runtime_uses_fallback () =
+  with_runtime_thinking (fun () ->
+    Alcotest.(check int)
+      "unknown runtime id falls through to the caller fallback (fail-safe)"
+      8192
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"bogus.binding"
+         ~fallback:fallback_sentinel))
+;;
+
+let test_max_output_tokens_accessor_projects_catalog () =
+  with_runtime_thinking (fun () ->
+    Alcotest.(check (option int))
+      "explicitly declared catalog ceiling is projected verbatim"
+      (Some 200000)
+      (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.bigout");
+    Alcotest.(check (option int))
+      "catalog row without max_output_tokens inherits the provider base ceiling"
+      (Some 16384)
+      (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.thinkdefault");
+    Alcotest.(check (option int))
+      "unknown runtime id projects None (no capability record)"
+      None
+      (Runtime.max_output_tokens_of_runtime_id "bogus.binding"))
 ;;
 
 let () =
@@ -769,6 +894,32 @@ let () =
             "seed_of_thinking_support gate contract (pure)"
             `Quick
             test_seed_of_thinking_support_gate_contract
+        ] )
+    ; ( "reasoning max_tokens resolution"
+      , [ Alcotest.test_case
+            "reasoning runtime defers to OAS capability ceiling, not fallback"
+            `Quick
+            test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback
+        ; Alcotest.test_case
+            "non-reasoning runtime -> caller fallback"
+            `Quick
+            test_resolve_max_tokens_non_reasoning_uses_fallback
+        ; Alcotest.test_case
+            "reasoning runtime, ceiling below bound -> ceiling respected"
+            `Quick
+            test_resolve_max_tokens_reasoning_small_ceiling_respected
+        ; Alcotest.test_case
+            "reasoning runtime, ceiling above bound -> clamped to bound"
+            `Quick
+            test_resolve_max_tokens_reasoning_big_ceiling_clamped
+        ; Alcotest.test_case
+            "unknown runtime id -> caller fallback"
+            `Quick
+            test_resolve_max_tokens_unknown_runtime_uses_fallback
+        ; Alcotest.test_case
+            "max_output_tokens_of_runtime_id projects catalog ceiling"
+            `Quick
+            test_max_output_tokens_accessor_projects_catalog
         ] )
     ]
 ;;

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -719,9 +719,11 @@ let test_seed_of_thinking_support_gate_contract () =
 
 (* ---- reasoning max_tokens resolution: [Runtime_inference.resolve_max_tokens]
    sizes a reasoning turn from the model's declared output ceiling (OAS catalog),
-   bounded by the operational [reasoning_turn_max_tokens] (32768); non-reasoning
-   runtimes keep the caller fallback. Regression guard for the thinking_only +
-   stop_reason=max_tokens truncation (live fleet 2026-06-30). ----
+   bounded above by the operational [reasoning_turn_max_tokens] (32768). A
+   reasoning runtime with no catalog ceiling keeps the caller fallback (the bound
+   is never the request value on its own); non-reasoning runtimes keep the caller
+   fallback. Regression guard for the thinking_only + stop_reason=max_tokens
+   truncation (live fleet 2026-06-30). ----
 
    The fallback sentinel (8192) mirrors the keeper path's flat default and is
    distinct from every reasoning result asserted below, so a test failure
@@ -786,6 +788,24 @@ let test_resolve_max_tokens_unknown_runtime_uses_fallback () =
          ~fallback:fallback_sentinel))
 ;;
 
+let test_resolve_max_tokens_reasoning_no_capability_falls_back () =
+  with_runtime_thinking (fun () ->
+    (* [ollama_cloud.think]'s model api-name is absent from the OAS catalog, so
+       its capability projection has no max_output_tokens even though
+       runtime.toml marks it thinking-support=true. A reasoning runtime with no
+       declared ceiling must NOT jump to the operational bound — without a known
+       provider ceiling, requesting 32768 could exceed what the provider accepts
+       and turn the thinking truncation into a max_tokens rejection. It keeps the
+       caller fallback (the budget increase is gated on an OAS-declared ceiling). *)
+    Alcotest.(check int)
+      "reasoning runtime with no catalog ceiling keeps the fallback, does not \
+       jump to the operational bound"
+      8192
+      (Runtime_inference.resolve_max_tokens
+         ~runtime_id:"ollama_cloud.think"
+         ~fallback:fallback_sentinel))
+;;
+
 let test_max_output_tokens_accessor_projects_catalog () =
   with_runtime_thinking (fun () ->
     Alcotest.(check (option int))
@@ -796,6 +816,10 @@ let test_max_output_tokens_accessor_projects_catalog () =
       "catalog row without max_output_tokens inherits the provider base ceiling"
       (Some 16384)
       (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.thinkdefault");
+    Alcotest.(check (option int))
+      "reasoning runtime whose model is absent from the catalog projects None"
+      None
+      (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.think");
     Alcotest.(check (option int))
       "unknown runtime id projects None (no capability record)"
       None
@@ -916,6 +940,10 @@ let () =
             "unknown runtime id -> caller fallback"
             `Quick
             test_resolve_max_tokens_unknown_runtime_uses_fallback
+        ; Alcotest.test_case
+            "reasoning runtime with no catalog ceiling -> fallback, not bound"
+            `Quick
+            test_resolve_max_tokens_reasoning_no_capability_falls_back
         ; Alcotest.test_case
             "max_output_tokens_of_runtime_id projects catalog ceiling"
             `Quick


### PR DESCRIPTION
## 배경 — reasoning 런타임의 thinking_only truncation

키퍼 "completed without a visible reply / returned only thinking" 증상을 라이브 fleet trace(2026-06-30, `.masc/trajectories` 111개)로 분해한 결과, #22751(idle-spin) 머지 이후 남은 잔여 empty-reply는 **reasoning 런타임의 `thinking_only` 응답**이었다.

- structured `accept_rejected` `response_shape=thinking_only` **250건/18일**. 그 중 **73건이 `stop_reason=max_tokens`**(43건은 thinking >8k chars) = 모델이 추론에 출력 예산을 다 쓰고 **잘려서** answer/tool을 못 냄.
- **per-RUNTIME 패턴**: `runpod_mtp`(qwen MTP) 60%, deepseek-v4-flash·kimi-k2 등 reasoning 모델 전반. 키퍼는 광범위 분산(taskmaster/sangsu/nick0cave/...).

## Root

reasoning 모델은 한 응답의 단일 `max_tokens` 예산 안에서 **thinking → answer** 순으로 출력한다. 그런데 masc는 reasoning 여부와 무관하게 **flat 예산**을 보냈다:

- `lib/runtime/runtime_inference.ml`의 `resolve_max_tokens ~runtime_id:_`가 `runtime_id`를 무시하는 **stub**(named-but-unimplemented) → 모든 런타임이 동일 fallback.
- OAS(agent_sdk)는 이미 올바르게 처리한다: caller가 `None`을 보내면 모델의 `max_output_tokens`를 쓰고, `Some n`이면 ceiling으로 clamp-down만 한다(`backend_openai_request.ml`). 즉 OAS 경로는 정상이고, masc가 per-runtime 예산을 해석하지 않아 그 경로를 못 쓰는 것이 root.

## 변경

`resolve_max_tokens`(stub)를 per-runtime으로 구현한다:

- reasoning 런타임(`thinking_support`)은 **모델의 OAS 선언 ceiling(`max_output_tokens`)에 defer**, `reasoning_turn_max_tokens = 32768`로 bound.
  - 선언 ceiling이 bound보다 작으면 그 작은 ceiling을 유지(provider가 받는 한도를 넘지 않음).
  - 선언이 없으면 operational bound 사용.
- 비-reasoning 런타임은 기존 flat `fallback` 그대로(무변경).
- `Runtime.max_output_tokens_of_runtime_id` 접근자 추가(OAS capability 카탈로그를 투영, `max_context_of_runtime_id` 미러링).

값의 출처는 **OAS 모델 카탈로그**다(SSOT). 특정 reasoning 모델을 bound까지 끌어올리는 건 카탈로그에서 `max_output_tokens`를 선언하는 별도 변경이며, 본 PR은 그 값을 *사용하는* 해석 경로를 구현한다.

## 워크어라운드 아님

- thinking sub-budget(`thinking.budget_tokens`) 분할이 아니다. **total 예산 상향**이다(답을 thinking 할당에서 떼지 않음).
- counter/telemetry-as-fix 아님(동작을 바꿔 truncation을 줄인다).
- string 분류기·N-of-M 아님. stub 1곳을 root 구현으로 닫는다(컴파일러가 강제하는 단일 해석 지점).
- `reasoning_turn_max_tokens`(32768)는 symptom 억제 cap이 아니라 **runaway 추론 가드**다(provider ceiling 384000 대비 보수적, 키퍼 fallback 8192의 4배). 값은 named constant로 추출.

## 검증

- `test/test_runtime_per_keeper_routing.ml` 신규 6 케이스(+기존 21) = **27 GREEN**:
  - reasoning → OAS ceiling defer(8192 fallback 아님), 비-reasoning → fallback, ceiling<bound → ceiling 유지, ceiling>bound → bound clamp, unknown → fallback, 접근자 투영.
- **revert-red**: `resolve_max_tokens`를 stub으로 되돌리면 reasoning-path 3개 테스트가 RED → mutation-proof.
- `lib/runtime` + `lib/keeper`(consumer) 빌드 clean, 변경 4파일 ocamlformat clean.
- wiring 확인: `keeper_unified_turn_pre_dispatch.ml`의 `resolve_max_tokens` → `validate_max_tokens_within_ceiling` → `runtime_execution.max_tokens` → OAS. min(caps,32768)≤caps라 validate 통과.

## 미검증 / 범위

- full CI(전체 build/test)는 GitHub에서 확인.
- 카탈로그 `max_output_tokens` 보강(runpod_mtp·ollama_cloud 변종을 실제 ceiling으로 선언 → 32768까지 활성)은 값 정확성 검증이 필요해 **별도 후속**으로 분리. 본 PR만으로도 reasoning 런타임은 8192 fallback → OAS 선언 ceiling(대개 ≥16384)으로 상향된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
