### PR TITLE
feat(task): require strict anti-rationalization responses

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -567,19 +567,26 @@ let parse_verdict_typed (text : string) : (verdict, verdict_parse_error) result 
                |> String_util.to_string)))
 ;;
 
-let parse_verdict (text : string) : (verdict, string) result =
-  match parse_verdict_typed text with
+let parse_verdict (raw_text : string) : (verdict, string) result =
+  match parse_verdict_typed raw_text with
   | Ok v -> Ok v
   | Error err -> Error (verdict_parse_error_to_string err)
 ;;
 
-let parse_review_verdict_from_text text =
-  match Yojson.Safe.from_string (String.trim text) with
-  | json -> (
-    match parse_review_verdict_from_json json with
-    | Ok verdict -> Ok verdict
-    | Error msg -> Error (Unrecognized_review_format msg))
-  | exception Yojson.Json_error _ -> parse_verdict_typed text
+let parse_review_verdict_from_response_text text =
+  let trimmed = String.trim text in
+  if String.length trimmed = 0
+  then Error Empty_review_output
+  else
+    match Yojson.Safe.from_string trimmed with
+    | json -> (
+      match parse_review_verdict_from_json json with
+      | Ok verdict -> Ok verdict
+      | Error msg -> Error (Unrecognized_review_format msg))
+    | exception Yojson.Json_error msg ->
+      Error
+        (Unrecognized_review_format
+           (sprintf "response text is not strict verdict JSON: %s" msg))
 ;;
 
 (* ================================================================ *)
@@ -812,10 +819,11 @@ let review
                 task_info "[anti-rationalization] verdict via structured tool call";
                 v, Structured_tool, None
               | None ->
-                (* LLM responded without a tool call — parse native JSON first,
-                   then the legacy text fallback. *)
-                task_info "[anti-rationalization] verdict via text fallback";
-                (match parse_review_verdict_from_text text with
+                (* LLM responded without a tool call. The provider-native
+                   schema response must be the strict verdict JSON object; do
+                   not accept legacy prose verdicts on this path. *)
+                task_info "[anti-rationalization] verdict via native JSON response";
+                (match parse_review_verdict_from_response_text text with
                  | Ok v -> v, Llm_text_fallback, None
                  | Error parse_error ->
                    let parse_err = verdict_parse_error_to_string parse_error in

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -27,6 +27,20 @@ let with_reviewer reviewer f =
       Atomic.set AR.run_llm_reviewer_fn reviewer;
       f ())
 
+let contains_substring haystack needle =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0
+    then true
+    else if idx + needle_len > haystack_len
+    then false
+    else if String.sub haystack idx needle_len = needle
+    then true
+    else loop (idx + 1)
+  in
+  loop 0
+
 let test_empty_verdict_emits_typed_error () =
   match AR.parse_verdict_typed "" with
   | Error AR.Empty_review_output -> ()
@@ -79,6 +93,56 @@ let test_review_rejects_empty_evaluator_output () =
         Alcotest.fail
           "empty evaluator output must not approve by liveness")
 
+let test_review_accepts_strict_json_evaluator_response () =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, {|{"verdict":"APPROVE"}|}))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:"test-json-evaluator" (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "llm_text_fallback" (AR.gate_to_string result.AR.gate);
+      match result.AR.verdict with
+      | AR.Approve -> ()
+      | AR.Reject reason ->
+        Alcotest.failf "strict JSON APPROVE should pass, rejected: %s" reason)
+
+let check_review_rejects_evaluator_text ~label ~text ~reason_substring =
+  with_reviewer
+    (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+      Ok (None, text))
+    (fun () ->
+      let result =
+        AR.review ~evaluator_runtime:("test-" ^ label) (make_request ())
+      in
+      Alcotest.(check string)
+        "gate" "format_reject" (AR.gate_to_string result.AR.gate);
+      (match result.AR.fallback_reason with
+       | Some reason ->
+         Alcotest.(check bool)
+           "fallback reason names strict JSON requirement"
+           true
+           (contains_substring reason reason_substring)
+       | None -> Alcotest.fail "format reject should include a fallback reason");
+      match result.AR.verdict with
+      | AR.Reject _ -> ()
+      | AR.Approve -> Alcotest.failf "%s evaluator output must not approve" label)
+
+let test_review_rejects_prose_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"prose-evaluator" ~text:"APPROVE"
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_malformed_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"malformed-json-evaluator"
+    ~text:{|{"verdict":"APPROVE"|}
+    ~reason_substring:"strict verdict JSON"
+
+let test_review_rejects_non_object_json_evaluator_response () =
+  check_review_rejects_evaluator_text ~label:"array-json-evaluator"
+    ~text:{|[{"verdict":"APPROVE"}]|}
+    ~reason_substring:"review verdict"
+
 let () =
   Alcotest.run
     "anti_rationalization_empty_reject"
@@ -104,5 +168,21 @@ let () =
             "empty evaluator output rejects"
             `Quick
             test_review_rejects_empty_evaluator_output;
+          Alcotest.test_case
+            "strict JSON evaluator response passes"
+            `Quick
+            test_review_accepts_strict_json_evaluator_response;
+          Alcotest.test_case
+            "prose evaluator response rejects"
+            `Quick
+            test_review_rejects_prose_evaluator_response;
+          Alcotest.test_case
+            "malformed JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_malformed_json_evaluator_response;
+          Alcotest.test_case
+            "non-object JSON evaluator response rejects"
+            `Quick
+            test_review_rejects_non_object_json_evaluator_response;
         ] );
     ]


### PR DESCRIPTION
Summary: Require anti-rationalization provider-native response fallback to parse strict verdict JSON only; reject prose-only APPROVE/REJECT responses; add runtime and structured-output coverage ratchets. Checks: ocamlformat --check lib/task/anti_rationalization.ml test/test_anti_rationalization_empty_reject.ml test/test_keeper_structured_output_coverage.ml; git diff --check. Full build/test is left to GitHub CI per operator instruction.