### PR TITLE
refactor(runtime): deprecate provider runtime-mcp flags

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -48,11 +48,6 @@ connect-timeout-s = 600.0
 type = "env"
 key = "OLLAMA_CLOUD_API_KEY"
 
-[providers.ollama_cloud.capabilities]
-supports-runtime-mcp-tools = true
-supports-runtime-tool-events = true
-supports-runtime-mcp-http-headers = true
-
 [providers.deepseek]
 display-name = "DeepSeek API"
 protocol = "openai-compatible-http"
@@ -62,11 +57,6 @@ endpoint = "https://api.deepseek.com"
 type = "env"
 key = "DEEPSEEK_API_KEY"
 
-[providers.deepseek.capabilities]
-supports-runtime-mcp-tools = true
-supports-runtime-tool-events = true
-supports-runtime-mcp-http-headers = true
-
 [providers.glm-coding]
 display-name = "GLM Coding Plan"
 protocol = "openai-compatible-http"
@@ -75,11 +65,6 @@ endpoint = "https://api.z.ai/api/coding/paas/v4"
 [providers.glm-coding.credentials]
 type = "env"
 key = "ZAI_API_KEY_SB"
-
-[providers.glm-coding.capabilities]
-supports-runtime-mcp-tools = true
-supports-runtime-tool-events = true
-supports-runtime-mcp-http-headers = true
 
 [providers.ollama]
 display-name = "Local Ollama"

--- a/lib/provider_tool_support/provider_tool_support.ml
+++ b/lib/provider_tool_support/provider_tool_support.ml
@@ -72,38 +72,12 @@ let tool_policy_for_kind kind = fallback_tool_policy_for_kind kind
 
 (** Resolve OAS-level capabilities for a provider config.
 
-    Returns OAS's resolved capabilities unchanged in practice. The
-    [runtime_mcp_lane] upgrade below is currently unreachable, and the
-    operator-level [providers.<id>.capabilities] [supports-runtime-mcp-tools] /
-    [supports-runtime-tool-events] declared in config/runtime.toml is parsed
-    into [Runtime_schema.provider.capabilities] but read by no runtime
-    consumer, so provider-level runtime-MCP intent is dropped today
-    (masc#22771).
-
-    The upgrade branch is left in place deliberately — it is the (broken)
-    honor path, and deleting it would silently cement the config drop. Whether
-    to honor the operator flag (revives the RFC-0206 override) or formally
-    deprecate it is the open decision tracked in masc#22771. *)
+    Runtime-MCP capability truth is owned by OAS provider bindings. The
+    deprecated runtime.toml [supports-runtime-mcp-*] provider flags are parsed
+    only for an explicit deprecation warning and do not override this result
+    (masc#22771). *)
 let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
-  let caps =
-    Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
-  in
-  (* [tool_policy_for_config] is total (binding lookup returns [option]; the
-     policy is a pure record build with no I/O), so no exception handler is
-     warranted here: a raised [Eio.Cancel.Cancelled] / [Out_of_memory] must
-     propagate, not be absorbed into a degraded capability set. *)
-  let tool_policy = tool_policy_for_config provider_cfg in
-  let runtime_mcp_lane =
-    tool_policy.supports_runtime_mcp_http_headers
-    || tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
-  in
-  if runtime_mcp_lane
-  then
-    { caps with
-      supports_runtime_mcp_tools = true
-    ; supports_runtime_tool_events = true
-    }
-  else caps
+  Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
 ;;
 
 let supports_runtime_mcp_http_headers (provider_cfg : Llm_provider.Provider_config.t) =
@@ -260,5 +234,4 @@ let provider_debug_label (cfg : Llm_provider.Provider_config.t) =
 let provider_kind_label (cfg : Llm_provider.Provider_config.t) =
   Llm_provider.Provider_config.string_of_provider_kind cfg.kind
 ;;
-
 

--- a/lib/provider_tool_support/provider_tool_support.mli
+++ b/lib/provider_tool_support/provider_tool_support.mli
@@ -38,11 +38,9 @@ type runtime_capabilities_override =
 (** {1 Capability resolution} *)
 
 (** [oas_capabilities_of_config cfg] returns OAS-resolved
-    {!Llm_provider.Capabilities.capabilities} plus MASC's local
-    tool-delivery projection.  Provider/model/catalog capability truth
-    comes from OAS [Provider_runtime_binding]; if the declarative
-    runtime.toml tool policy declares a runtime-MCP lane, the two
-    runtime-MCP capability flags are merged to [true]. *)
+    {!Llm_provider.Capabilities.capabilities}. Provider/model/catalog
+    capability truth comes from OAS [Provider_runtime_binding]; deprecated
+    runtime.toml [supports-runtime-mcp-*] provider flags are not honored. *)
 val oas_capabilities_of_config
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Capabilities.capabilities
@@ -54,9 +52,9 @@ val oas_capabilities_of_config
     - [supports_inline_tool_choice =
        caps.supports_tools && caps.supports_tool_choice]
     - [supports_runtime_mcp_tools] / [supports_runtime_tool_events]:
-      passthrough.
+      OAS passthrough.
     - [supports_runtime_mcp_http_headers]: queried via the local
-      runtime.toml provider-tool policy projection. *)
+      binding-derived provider-tool policy projection. *)
 val capabilities_of_config
   :  ?override:runtime_capabilities_override
   -> Llm_provider.Provider_config.t
@@ -145,5 +143,4 @@ val provider_debug_label : Llm_provider.Provider_config.t -> string
 val provider_kind_label : Llm_provider.Provider_config.t -> string
 
 (** {1 Otel_metric_store filter-rejection counter (#10474)} *)
-
 

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -32,9 +32,6 @@ type credential =
     transport/tool lane must be driven for a provider, independent of model. *)
 type capabilities =
   { supports_inline_tools : bool
-  ; supports_runtime_mcp_tools : bool
-  ; supports_runtime_tool_events : bool
-  ; supports_runtime_mcp_http_headers : bool
   ; requires_per_keeper_bridging_for_bound_actor_tools : bool
   ; identity_runtime_mcp_header_keys : string list
   ; argv_prompt_preflight : bool

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -28,9 +28,6 @@ type credential =
 
 type capabilities =
   { supports_inline_tools : bool
-  ; supports_runtime_mcp_tools : bool
-  ; supports_runtime_tool_events : bool
-  ; supports_runtime_mcp_http_headers : bool
   ; requires_per_keeper_bridging_for_bound_actor_tools : bool
   ; identity_runtime_mcp_header_keys : string list
   ; argv_prompt_preflight : bool

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -191,6 +191,15 @@ let parse_credential (tbl : Otoml.t) (path : string)
 
 let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabilities =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let warn_deprecated key =
+    match Otoml.find_opt tbl Fun.id [ key ] with
+    | None -> ()
+    | Some _ ->
+      Log.Runtime.warn
+        "runtime_toml: %s.capabilities.%s is deprecated and ignored; runtime-MCP capability is resolved from OAS provider bindings"
+        path
+        key
+  in
   let string_list_field key =
     match Otoml.find_opt tbl Fun.id [ key ] with
     | None -> []
@@ -218,10 +227,13 @@ let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabil
           n;
       None
   in
+  List.iter
+    warn_deprecated
+    [ "supports-runtime-mcp-tools"
+    ; "supports-runtime-tool-events"
+    ; "supports-runtime-mcp-http-headers"
+    ];
   { Runtime_schema.supports_inline_tools = b "supports-inline-tools"
-  ; supports_runtime_mcp_tools = b "supports-runtime-mcp-tools"
-  ; supports_runtime_tool_events = b "supports-runtime-tool-events"
-  ; supports_runtime_mcp_http_headers = b "supports-runtime-mcp-http-headers"
   ; requires_per_keeper_bridging_for_bound_actor_tools =
       b "requires-per-keeper-bridging-for-bound-actor-tools"
   ; identity_runtime_mcp_header_keys =

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -516,6 +516,7 @@ max-context = 4096
 [models.vision-a.capabilities]
 supports-image-input = true
 supports-multimodal-inputs = true
+supports-structured-output = true
 
 [models.vision-b]
 api-name = "vision-b"
@@ -524,6 +525,7 @@ max-context = 4096
 [models.vision-b.capabilities]
 supports-image-input = true
 supports-multimodal-inputs = true
+supports-structured-output = true
 
 [p1.vision-a]
 
@@ -547,6 +549,7 @@ max-context = 4096
 [models.vision-c.capabilities]
 supports-image-input = true
 supports-multimodal-inputs = true
+supports-structured-output = true
 
 [p3.vision-c]
 |}

--- a/test/test_provider_tool_support_caps.ml
+++ b/test/test_provider_tool_support_caps.ml
@@ -1,13 +1,11 @@
 (* Characterization guard for [Provider_tool_support.oas_capabilities_of_config]
    passthrough (issue #22771).
 
-   The operator-level [providers.<id>.capabilities] supports-runtime-mcp-tools /
-   supports-runtime-tool-events flags declared in config/runtime.toml are parsed
-   into [Runtime_schema.provider.capabilities] but read by no runtime consumer,
-   and the [runtime_mcp_lane] upgrade in [oas_capabilities_of_config] is
-   unreachable (binding-derived [tool_policy] never sets either source). So the
-   consumer-facing predicate [provider_supports_runtime_mcp_lane] resolves to
-   [false] for a cloud OpenAI_compat provider regardless of config intent.
+   The deprecated operator-level [providers.<id>.capabilities]
+   supports-runtime-mcp-* flags are ignored: runtime-MCP capability truth comes
+   from OAS provider bindings. So the consumer-facing predicate
+   [provider_supports_runtime_mcp_lane] resolves to [false] for a cloud
+   OpenAI_compat provider regardless of stale config intent.
 
    This test pins that passthrough invariant: wiring the honor path (#22771
    Option A) flips the predicate to [true] and must be a conscious test update,


### PR DESCRIPTION
## Summary
- remove deprecated provider-level `supports-runtime-mcp-*` flags from the runtime seed and `Runtime_schema.capabilities`
- keep legacy live configs fail-soft by warning and ignoring those deprecated keys at parse time
- simplify `Provider_tool_support.oas_capabilities_of_config` to the OAS provider-binding passthrough, making OAS the runtime-MCP capability SSOT

Closes #22771

## Validation
- `ocamlformat --check lib/runtime/runtime_schema.ml lib/runtime/runtime_schema.mli lib/runtime/runtime_toml.ml lib/provider_tool_support/provider_tool_support.ml lib/provider_tool_support/provider_tool_support.mli test/test_provider_tool_support_caps.ml`
- `git diff --check`
- `scripts/dune-local.sh build @install test/test_provider_tool_support_caps.exe test/test_runtime_provider_auth_headers.exe test/test_runtime_config_validity.exe`
- `./_build/default/test/test_provider_tool_support_caps.exe`
- `./_build/default/test/test_runtime_provider_auth_headers.exe`
- `./_build/default/test/test_runtime_config_validity.exe`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/oas-boundary-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
