### PR TITLE
feat(memory): reject unstructured librarian fallbacks

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -934,14 +934,18 @@ max_concurrent_panels = 2
 max_concurrent_judges = 3
 staged_judge_group_size = 3
 
-# 패널 프리셋. 서로 다른 모델 패밀리로 구성해 관점 다양성을 확보한다.
+# 패널 프리셋. Panel execution requests provider-native structured output, so
+# checked-in defaults must use runtimes that declare supports-structured-output.
+# Add new model families here only after their runtime seed declares that
+# capability; otherwise the panel deterministically fails before the provider
+# request.
 # 프롬프트는 행동을 정의하므로 코드 default가 아니라 여기서 받는다 (누락 시 로드
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
   "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 # Fusion judges request provider-native structured output. Keep this on a
 # runtime whose model declares supports-structured-output=true.
@@ -971,18 +975,17 @@ max_tool_calls_per_panel = 0
 # "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
 # quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
 # 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
-# Fusion judge/refine/meta paths request provider-native structured output, so
-# every judge runtime below must declare supports-structured-output=true. Panels
-# remain free text and do not need the native-schema capability. The current seed
-# has two structured judge-capable cloud runtimes; distinct labels preserve lens
-# identity while the schema contract prevents config drift back to JSON-mode-only
-# judges. staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
+# Panel models and Fusion judge/refine/meta paths request provider-native
+# structured output, so every panel and judge runtime below must declare
+# supports-structured-output=true. Distinct labels preserve lens identity while
+# the schema contract prevents config drift back to JSON-mode-only runtimes.
+# staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
 # 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
-  "deepseek.deepseek-v4-pro",
+  "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
@@ -1007,8 +1010,10 @@ max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
-# first-pass judges use schema-capable runtimes outside the panel so a judge does
-# not score its own panel answer.
+# Strict structured-output support is mandatory for panel and judge runtimes in
+# this seed. Some model families overlap across panel and judge lanes because the
+# checked-in schema-capable runtime set is intentionally narrow; distinct labels
+# still preserve lens identity for judge-of-judges routing.
 [[fusion.presets.quorum.judges]]
 model = "ollama_cloud.kimi-k2-6"
 label = "evidence"

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -2,7 +2,8 @@
 
     Judge 실행은 provider-native structured output schema를 요청한다. OAS가 해당
     provider/model 조합의 native schema를 거부하면 [JsonMode]로 degrade하지 않고
-    build 단계에서 fail-loud한다. 패널 실행은 자유 텍스트이며 이 schema hook을 쓰지 않는다.
+    build 단계에서 fail-loud한다. 패널 실행도 별도의 `{answer:string}` schema를 요청하고,
+    provider-success malformed output은 typed failure로 격리한다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 *)
 

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -74,6 +74,7 @@ let panel_failure_code (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error _ -> "bridge_error"
   | Fusion_types.Provider_error _ -> "provider_error"
+  | Fusion_types.Invalid_structured_response _ -> "invalid_structured_response"
   | Fusion_types.Empty_response _ -> "empty_response"
   | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
 
@@ -82,6 +83,7 @@ let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : st
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
@@ -97,6 +99,7 @@ let panel_failure_text (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -19,9 +19,9 @@
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
     (RFC-0278: 같은 model을 다른 라벨로 구분). 미지정이면 카드명=[model]. provider
     라우팅은 카드명과 무관하게 [model]로 한다.
-    [provider_config_transform]은 judge처럼 provider-native structured-output 설정이
-    필요한 호출자가 resolved provider config를 agent build 전에 보강하는 hook이다.
-    패널 호출자는 생략한다.
+    [provider_config_transform]은 panel/judge처럼 provider-native structured-output
+    설정이 필요한 호출자가 resolved provider config를 agent build 전에 보강하는
+    hook이다.
     미존재 runtime·빌드 실패는 [panel_failure]로. *)
 val build_agent
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -17,15 +17,55 @@ let outcome_of_result ~(panelist : string) ~(model : string)
   =
   match res with
   | Ok resp ->
-    let answer = Fusion_oas.answer_text resp in
-    if String.length (String.trim answer) = 0 then
+    let raw = String.trim (Fusion_oas.answer_text resp) in
+    if String.length raw = 0 then
       Fusion_types.Failed
         { failed_model = panelist
         ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
         }
-    else
-      Fusion_types.Answered
-        { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+    else (
+      match Yojson.Safe.from_string raw with
+      | exception Yojson.Json_error msg ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                ("panel response is not valid JSON: " ^ msg)
+          }
+      | `Assoc fields ->
+        (match List.assoc_opt "answer" fields with
+         | Some (`String answer) ->
+           let answer = String.trim answer in
+           if String.length answer = 0 then
+             Fusion_types.Failed
+               { failed_model = panelist
+               ; reason =
+                   Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
+               }
+           else
+             Fusion_types.Answered
+               { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+         | Some _ ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response field \"answer\" must be a string"
+             }
+         | None ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response missing required field \"answer\""
+             })
+      | _ ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                "panel response must be a JSON object"
+          })
   | Error e ->
     Fusion_types.Failed
       { failed_model = panelist
@@ -39,6 +79,18 @@ let bridge_failure_of_error (error : Agent_sdk.Error.sdk_error) : Fusion_types.p
   match error with
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_sdk.Error.to_string error)
+
+let apply_fusion_panel_output_contract provider_cfg =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  let native_schema_provider_cfg =
+    Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
+  in
+  match
+    Llm_provider.Provider_config.validate_output_schema_request
+      native_schema_provider_cfg
+  with
+  | Ok () -> Ok native_schema_provider_cfg
+  | Error detail -> Error (Printf.sprintf "fusion.panel.output_schema: %s" detail)
 
 let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
   : Fusion_types.panel_outcome list
@@ -58,6 +110,7 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~max_tool_calls:g.max_tool_calls ~timeout_s:g.timeout_s
+                ~provider_config_transform:apply_fusion_panel_output_contract
                 ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
@@ -99,3 +152,8 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
         built
   in
   build_failures @ answered
+
+module For_testing = struct
+  let outcome_of_result = outcome_of_result
+  let apply_output_contract = apply_fusion_panel_output_contract
+end

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -30,3 +30,15 @@ val run
   -> prompt:string
   -> unit
   -> Fusion_types.panel_outcome list
+
+module For_testing : sig
+  val outcome_of_result
+    :  panelist:string
+    -> model:string
+    -> (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
+    -> Fusion_types.panel_outcome
+
+  val apply_output_contract
+    :  Llm_provider.Provider_config.t
+    -> (Llm_provider.Provider_config.t, string) result
+end

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -65,6 +65,7 @@ type panel_failure =
   | Timeout
   | Bridge_error of string
   | Provider_error of string
+  | Invalid_structured_response of string
   | Empty_response of string
   | Invalid_max_output_tokens of int
 [@@deriving to_yojson, show, eq]
@@ -74,6 +75,8 @@ let panel_failure_of_yojson = function
   | `String "Empty_response" -> Ok (Empty_response "empty response")
   | `List [ `String "Timeout" ] -> Ok Timeout
   | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
+  | `List [ `String "Invalid_structured_response"; `String detail ] ->
+    Ok (Invalid_structured_response detail)
   | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
   | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->
     Ok (Invalid_max_output_tokens value)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -68,6 +68,9 @@ type panel_failure =
   | Timeout  (** 구조적 타임아웃 (Masc_oas_bridge) *)
   | Bridge_error of string  (** MASC/OAS bridge bootstrap or wrapper error *)
   | Provider_error of string  (** provider/transport 에러, 메시지 보존 *)
+  | Invalid_structured_response of string
+      (** provider returned non-empty output that violated the requested panel
+          answer JSON schema. *)
   | Empty_response of string
       (** 모델이 빈 응답. detail에는 stop_reason/usage/content shape만 보존하고,
           reasoning/thinking 본문은 노출하지 않는다. *)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -418,25 +418,6 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
 
-type extraction_kind =
-  | Structured_episode
-  | Unstructured_fallback
-
-type extraction_result =
-  { episode : Keeper_memory_os_types.episode
-  ; kind : extraction_kind
-  }
-
-let should_record_cadence_success = function
-  | Structured_episode -> true
-  | Unstructured_fallback -> false
-;;
-
-let should_record_cadence_backoff = function
-  | Structured_episode -> false
-  | Unstructured_fallback -> true
-;;
-
 let should_record_cadence_backoff_after_error = function
   | Provider_timeout
   | Provider_transport_failed _
@@ -570,7 +551,7 @@ let extract_with_provider_classified
                ~attempt
                messages
            with
-           | Ok episode -> Ok { episode; kind = Structured_episode }
+           | Ok episode -> Ok episode
            | Error (Retry_transport_failed err) -> Error err
            | Error (Retry_exhausted_unparseable diagnostic) ->
              Error (Provider_unparseable_response diagnostic.reason))))
@@ -589,7 +570,7 @@ let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~
       inp
   with
   | Error err -> Error (extraction_error_to_string err)
-  | Ok { episode; kind = _ } -> Ok episode
+  | Ok episode -> Ok episode
 ;;
 
 let extract_and_append_with_provider_classified
@@ -623,7 +604,7 @@ let extract_and_append_with_provider_classified
          inp
      with
   | Error _ as e -> e
-  | Ok ({ episode; kind = _ } as extraction) ->
+  | Ok episode ->
     let now = episode.Keeper_memory_os_types.created_at in
     (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
        re-extracted across turns is folded into the existing row
@@ -678,7 +659,7 @@ let extract_and_append_with_provider_classified
         (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
            (dark-by-default, no recall consumer), so the fact upsert above is the only
            post-merge work. *)
-        Ok extraction
+        Ok episode
       | Error message -> Error (Memory_fact_upsert_failed message)))
 ;;
 
@@ -704,7 +685,7 @@ let extract_and_append_with_provider
       inp
   with
   | Error err -> Error (extraction_error_to_string err)
-  | Ok { episode; kind = _ } -> Ok episode
+  | Ok episode -> Ok episode
 ;;
 
 let provider_for_runtime ~runtime_id =
@@ -774,24 +755,13 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
                  runtime_id
                  (per_keeper_slot_capacity ())
-             | Some (Ok { episode; kind }) ->
-               if should_record_cadence_success kind
-               then (
-                 (* Only structured extraction records semantic success. *)
-                 cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
-                 Log.Keeper.info ~keeper_name:keeper_id
-                   "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-                   episode.Keeper_memory_os_types.trace_id
-                   episode.generation
-                   (List.length episode.claims))
-               else (
-                 if should_record_cadence_backoff kind
-                 then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
-                 Log.Keeper.warn ~keeper_name:keeper_id
-                   "memory os librarian produced non-structured extraction trace_id=%s generation=%d claims=%d; cadence deferred"
-                   episode.Keeper_memory_os_types.trace_id
-                   episode.generation
-                   (List.length episode.claims))
+             | Some (Ok episode) ->
+               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
+               Log.Keeper.info ~keeper_name:keeper_id
+                 "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+                 episode.Keeper_memory_os_types.trace_id
+                 episode.generation
+                 (List.length episode.claims)
              | Some (Error err) ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -4,10 +4,9 @@
    [min provider_cfg.max_tokens librarian_max_tokens] at the complete call
    (see [extract] below). The previous fixed cap of 1024 truncated episode
    JSON mid-object whenever the summary plus facts exceeded ~1024 output
-   tokens, surfacing as "invalid_json: Unexpected end of input" and an
-   unstructured fallback every turn. 4096 covers realistic episode payloads
-   while staying well under the JSON-capable model context budget; tunable
-   via Env_config.KeeperMemoryOs. *)
+   tokens, surfacing as "invalid_json: Unexpected end of input" every turn.
+   4096 covers realistic episode payloads while staying well under the
+   JSON-capable model context budget; tunable via Env_config.KeeperMemoryOs. *)
 let librarian_max_tokens = Env_config.KeeperMemoryOs.librarian_max_tokens_default
 
 (* Memory extraction runs against a JSON-capable model with a long context
@@ -383,6 +382,7 @@ type extraction_error =
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response
+  | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
 let librarian_provider_clock_unavailable_error =
@@ -396,6 +396,8 @@ let extraction_error_to_string = function
   | Provider_timeout -> "librarian provider timed out"
   | Provider_transport_failed msg -> msg
   | Provider_empty_response -> "librarian provider returned empty response"
+  | Provider_unparseable_response msg ->
+    "librarian provider returned unparseable structured response: " ^ msg
   | Memory_fact_upsert_failed msg -> "memory os fact upsert failed: " ^ msg
 ;;
 
@@ -436,7 +438,11 @@ let should_record_cadence_backoff = function
 ;;
 
 let should_record_cadence_backoff_after_error = function
-  | Provider_timeout | Provider_transport_failed _ | Provider_empty_response -> true
+  | Provider_timeout
+  | Provider_transport_failed _
+  | Provider_empty_response
+  | Provider_unparseable_response _ ->
+    true
   | Provider_clock_unavailable
   | Provider_config_rejected _
   | Prompt_render_failed _
@@ -444,13 +450,9 @@ let should_record_cadence_backoff_after_error = function
     false
 ;;
 
-let should_preserve_unstructured_fallback raw =
-  not (String.equal (String.trim raw) "")
-;;
-
 let prefer_unparseable_response prior current =
   match current.raw_evidence with
-  | Some raw when should_preserve_unstructured_fallback raw -> current
+  | Some raw when not (String.equal (String.trim raw) "") -> current
   | Some _ | None ->
     (match prior with
      | Some best -> best
@@ -514,83 +516,6 @@ let with_timeout ~clock ~timeout_sec f =
   | Eio.Time.Timeout -> None
 ;;
 
-let unstructured_note_max_chars = 900
-
-let collapse_for_unstructured_note raw =
-  let buf = Buffer.create (String.length raw) in
-  let previous_space = ref true in
-  String.iter
-    (fun c ->
-       match c with
-       | '\n' | '\r' | '\t' | ' ' ->
-         if not !previous_space then Buffer.add_char buf ' ';
-         previous_space := true
-       | c ->
-         Buffer.add_char buf c;
-         previous_space := false)
-    raw;
-  Buffer.contents buf |> String.trim
-
-let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
-  let raw_excerpt, _ =
-    Keeper_text_processing.truncate_utf8_prefix
-      ~max_bytes:unstructured_note_max_chars
-      (collapse_for_unstructured_note raw)
-  in
-  let note =
-    let prefix = Keeper_memory_os_types.librarian_unstructured_fallback_claim_prefix in
-    if String.equal raw_excerpt ""
-    then Printf.sprintf "%s (%s): <empty response>" prefix reason
-    else Printf.sprintf "%s (%s): %s" prefix reason raw_excerpt
-  in
-  let source_turn_range =
-    match List.length inp.messages with
-    | 0 -> None
-    | n -> Some (0, n - 1)
-  in
-  let fact : Keeper_memory_os_types.fact =
-    { claim = note
-    ; category = Keeper_memory_os_types.Ephemeral
-    ; external_ref = None
-    ; (* A parse-retry fallback note is system-authored diagnostic evidence, not a
-         librarian-classified memory claim. Tag it at the producer boundary so recall
-         can exclude it without string-matching the raw claim text. *)
-      claim_kind = Some Keeper_memory_os_types.Diagnostic
-    ; source = { trace_id = inp.trace_id; turn = 0; tool_call_id = None }
-    ; observed_by = []
-    ; first_seen = now
-    ; valid_until =
-        Keeper_memory_os_types.fact_valid_until
-          ~now
-          ~external_ref:None
-          ~claim_kind:(Some Keeper_memory_os_types.Diagnostic)
-          Keeper_memory_os_types.Ephemeral
-    ; last_verified_at = Some now
-    ; schema_version = Keeper_memory_os_types.schema_version
-    ; (* MASC authors this diagnostic fallback, not the LLM librarian. Do not
-         overload the librarian [claim_id] producer-identity field; diagnostic
-         fallback rows degrade to exact-text identity via [claim_id = None]. *)
-      claim_id = None
-    }
-  in
-  { Keeper_memory_os_types.trace_id = inp.trace_id
-  ; generation
-  ; episode_summary = "Unstructured librarian note preserved after parse failure"
-  ; claims = [ fact ]
-  ; open_items = []
-  ; constraints = []
-  ; preserved_tool_refs = []
-  ; source_turn_range
-  ; created_at = now
-  ; valid_until =
-      Keeper_memory_os_types.category_valid_until
-        ~now
-        Keeper_memory_os_types.Ephemeral
-  ; terminal_marker =
-      Some Keeper_memory_os_types.librarian_unstructured_fallback_terminal_marker
-  ; schema_version = Keeper_memory_os_types.schema_version
-  }
-
 let extract_with_provider_classified
     ?(complete = default_complete)
     ?clock
@@ -645,24 +570,7 @@ let extract_with_provider_classified
      | Ok episode -> Ok { episode; kind = Structured_episode }
      | Error (Retry_transport_failed err) -> Error err
      | Error (Retry_exhausted_unparseable diagnostic) ->
-       let raw =
-         match diagnostic.raw_evidence with
-         | Some raw -> raw
-         | None -> ""
-       in
-       if not (should_preserve_unstructured_fallback raw)
-       then Error Provider_empty_response
-       else (
-         let now = Eio.Time.now clock in
-         Log.Keeper.warn
-           "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
-           inp.trace_id
-           generation
-           diagnostic.reason;
-         Ok
-          { episode = unstructured_episode ~now ~generation inp ~reason:diagnostic.reason ~raw
-          ; kind = Unstructured_fallback
-          })))
+       Error (Provider_unparseable_response diagnostic.reason))
     )
 ;;
 
@@ -878,7 +786,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  if should_record_cadence_backoff kind
                  then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
                  Log.Keeper.warn ~keeper_name:keeper_id
-                   "memory os librarian wrote unstructured fallback trace_id=%s generation=%d claims=%d; cadence deferred"
+                   "memory os librarian produced non-structured extraction trace_id=%s generation=%d claims=%d; cadence deferred"
                    episode.Keeper_memory_os_types.trace_id
                    episode.generation
                    (List.length episode.claims))

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -528,50 +528,52 @@ let extract_with_provider_classified
   =
   match clock with
   | None -> Error Provider_clock_unavailable
-  | Some clock -> (
-  match messages_for_librarian inp with
-  | Error msg -> Error (Prompt_render_failed msg)
-  | Ok messages ->
-    let provider_cfg = provider_for_librarian provider_cfg in
-    (match
-       Llm_provider.Provider_config.validate_output_schema_request provider_cfg
-     with
-     | Error msg -> Error (Provider_config_rejected msg)
-     | Ok () ->
-    let attempt messages =
-      match
-        with_timeout ~clock ~timeout_sec (fun () ->
-          complete ~sw ~net ~clock ~config:provider_cfg ~messages ())
-      with
-      | None -> Transport_failed Provider_timeout
-      | Some (Error err) ->
-        Transport_failed (Provider_transport_failed (Provider_http_error.to_message err))
-      | Some (Ok response) ->
-        let raw = Agent_sdk_response.text_of_response response |> String.trim in
-        if String.equal raw ""
-        then Unparseable (unparseable_response "librarian provider returned empty response")
-        else (
-          match Keeper_librarian.episode_of_output_result ~generation inp raw with
-          | Ok episode -> Parsed episode
-          | Error error ->
-            Unparseable
-              (unparseable_response
-                 ~raw_evidence:raw
-                 (Printf.sprintf
-                    "librarian provider returned invalid episode JSON (%s)"
-                    (Keeper_librarian.parse_error_to_string error))))
-    in
-    (match
-       run_with_parse_retries
-         ~max_retries:librarian_max_parse_retries
-         ~attempt
-         messages
-     with
-     | Ok episode -> Ok { episode; kind = Structured_episode }
-     | Error (Retry_transport_failed err) -> Error err
-     | Error (Retry_exhausted_unparseable diagnostic) ->
-       Error (Provider_unparseable_response diagnostic.reason))
-    )
+  | Some clock ->
+    (match messages_for_librarian inp with
+     | Error msg -> Error (Prompt_render_failed msg)
+     | Ok messages ->
+       let provider_cfg = provider_for_librarian provider_cfg in
+       (match
+          Llm_provider.Provider_config.validate_output_schema_request provider_cfg
+        with
+        | Error msg -> Error (Provider_config_rejected msg)
+        | Ok () ->
+          let attempt messages =
+            match
+              with_timeout ~clock ~timeout_sec (fun () ->
+                complete ~sw ~net ~clock ~config:provider_cfg ~messages ())
+            with
+            | None -> Transport_failed Provider_timeout
+            | Some (Error err) ->
+              Transport_failed
+                (Provider_transport_failed (Provider_http_error.to_message err))
+            | Some (Ok response) ->
+              let raw = Agent_sdk_response.text_of_response response |> String.trim in
+              if String.equal raw ""
+              then
+                Unparseable
+                  (unparseable_response "librarian provider returned empty response")
+              else (
+                match Keeper_librarian.episode_of_output_result ~generation inp raw with
+                | Ok episode -> Parsed episode
+                | Error error ->
+                  Unparseable
+                    (unparseable_response
+                       ~raw_evidence:raw
+                       (Printf.sprintf
+                          "librarian provider returned invalid episode JSON (%s)"
+                          (Keeper_librarian.parse_error_to_string error))))
+          in
+          (match
+             run_with_parse_retries
+               ~max_retries:librarian_max_parse_retries
+               ~attempt
+               messages
+           with
+           | Ok episode -> Ok { episode; kind = Structured_episode }
+           | Error (Retry_transport_failed err) -> Error err
+           | Error (Retry_exhausted_unparseable diagnostic) ->
+             Error (Provider_unparseable_response diagnostic.reason))))
 ;;
 
 let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -135,6 +135,7 @@ type extraction_error =
   | Provider_timeout
   | Provider_transport_failed of string
   | Provider_empty_response
+  | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
 
 val extraction_error_to_string : extraction_error -> string
@@ -146,8 +147,8 @@ type unparseable_response =
 
 val unparseable_response : ?raw_evidence:string -> string -> unparseable_response
 (** Typed retry diagnostic. [raw_evidence] is present only when the provider
-    returned non-empty output that can be preserved as an unstructured fallback;
-    [reason] describes that same response. *)
+    returned non-empty output; [reason] describes that same response so the
+    final typed provider error is not replaced by a later empty retry. *)
 
 type attempt_outcome =
   | Parsed of Keeper_memory_os_types.episode
@@ -160,6 +161,9 @@ type parse_retry_error =
 
 type extraction_kind =
   | Structured_episode
+  (* Compatibility constructor for older callers/tests that classify historical
+     diagnostic episodes. Current provider extraction no longer constructs this
+     variant from unparseable model output. *)
   | Unstructured_fallback
 
 type extraction_result =
@@ -169,8 +173,7 @@ type extraction_result =
 
 val should_record_cadence_success : extraction_kind -> bool
 (** Whether this extraction kind is allowed to reset the librarian cadence.
-    Unstructured fallback episodes are durable diagnostics, but they mean the
-    provider still failed to produce structured memory. *)
+    Structured episodes are semantic success. *)
 
 val should_record_cadence_backoff : extraction_kind -> bool
 (** Whether this non-success extraction kind should defer the next attempt until
@@ -181,11 +184,6 @@ val should_record_cadence_backoff_after_error : extraction_error -> bool
 (** Whether an extraction error represents enough completed work to defer the
     next attempt until the next cadence window. Only completed provider-attempt
     failures should defer cadence; local deterministic failures stay due. *)
-
-val should_preserve_unstructured_fallback : string -> bool
-(** Whether raw unparseable provider output is worth preserving as a diagnostic
-    fallback fact. Empty output carries no evidence and should remain a provider
-    failure instead of polluting memory. *)
 
 val run_with_parse_retries
   :  max_retries:int

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -59,17 +59,17 @@ val cadence_record_success : keeper_id:string -> trace_id:string -> unit
 (** Record a successful structured extraction for [keeper_id] on [trace_id] so
     the cadence counter resets and the next cycle can begin. Must only be called
     after a due turn actually produced a structured episode; skipped, failed, or
-    unstructured-fallback attempts must not call this.
+    unparseable provider attempts must not call this.
 
     Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
     focused pre-Eio tests keep a direct single-threaded path. *)
 
 val cadence_record_attempt : keeper_id:string -> trace_id:string -> unit
 (** Record a completed non-success extraction attempt for [keeper_id] on
-    [trace_id] so transient provider failures and diagnostic fallbacks do not
-    immediately retry every keeper turn. This intentionally does not mark the
-    extraction as semantically successful. Skipped work such as a busy provider
-    slot must not call this, because no provider attempt happened.
+    [trace_id] so transient provider failures and unparseable structured-output
+    failures do not immediately retry every keeper turn. This intentionally does
+    not mark the extraction as semantically successful. Skipped work such as a
+    busy provider slot must not call this, because no provider attempt happened.
 
     Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
     focused pre-Eio tests keep a direct single-threaded path. *)
@@ -159,27 +159,6 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
 
-type extraction_kind =
-  | Structured_episode
-  (* Compatibility constructor for older callers/tests that classify historical
-     diagnostic episodes. Current provider extraction no longer constructs this
-     variant from unparseable model output. *)
-  | Unstructured_fallback
-
-type extraction_result =
-  { episode : Keeper_memory_os_types.episode
-  ; kind : extraction_kind
-  }
-
-val should_record_cadence_success : extraction_kind -> bool
-(** Whether this extraction kind is allowed to reset the librarian cadence.
-    Structured episodes are semantic success. *)
-
-val should_record_cadence_backoff : extraction_kind -> bool
-(** Whether this non-success extraction kind should defer the next attempt until
-    the next cadence window. Structured episodes use [cadence_record_success]
-    instead. *)
-
 val should_record_cadence_backoff_after_error : extraction_error -> bool
 (** Whether an extraction error represents enough completed work to defer the
     next attempt until the next cadence window. Only completed provider-attempt
@@ -242,7 +221,7 @@ val extract_with_provider_classified
   -> provider_cfg:Llm_provider.Provider_config.t
   -> generation:int
   -> Keeper_librarian.input
-  -> (extraction_result, extraction_error) result
+  -> (Keeper_memory_os_types.episode, extraction_error) result
 (** Provider-backed librarian extraction. [clock] stays optional at the API
     boundary because [run_best_effort] may be called from contexts that cannot
     supply an Eio clock; [None] returns
@@ -269,7 +248,7 @@ val extract_and_append_with_provider_classified
   -> keeper_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
-  -> (extraction_result, extraction_error) result
+  -> (Keeper_memory_os_types.episode, extraction_error) result
 
 val run_best_effort
   :  ?complete:complete_fn

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -22,7 +22,8 @@ let () =
     ~name:Keeper_metrics.(to_string MemoryLlmSummaryOutcomes)
     ~help:
       "Total [summarize_with_provider] attempts classified by label \
-       [outcome] (ok_summary | timed_out | http_error | empty_response). \
+       [outcome] (ok_summary | timed_out | http_error | empty_response | \
+       invalid_structured_response). \
        Labels: [outcome], [provider] (model_id), [runtime_id]."
     ();
   Otel_metric_store.register_counter
@@ -116,28 +117,43 @@ let raw_response_text (response : Agent_sdk.Types.api_response) : string option 
   in
   if text = "" then None else Some text
 
-let summary_text_of_raw_text raw =
-  try
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
+let summary_text_result_of_raw_text raw =
+  let raw = String.trim raw in
+  if raw = "" then Error Empty_summary_response
+  else
     match Yojson.Safe.from_string raw with
+    | exception Yojson.Json_error msg ->
+        Error (Invalid_structured_response ("invalid JSON: " ^ msg))
     | `Assoc fields ->
-      (match List.assoc_opt "summary" fields with
-       | Some (`String summary) ->
-         let summary = String.trim summary in
-         if summary = "" then None else Some summary
-       | Some _
-       | None -> None)
-    | _ -> None
-  with Yojson.Json_error _ -> None
+        (match List.assoc_opt "summary" fields with
+         | Some (`String summary) ->
+             let summary = String.trim summary in
+             if summary = "" then Error Empty_summary_response else Ok summary
+         | Some _ ->
+             Error (Invalid_structured_response "summary field must be a string")
+         | None ->
+             Error (Invalid_structured_response "missing summary field"))
+    | _ -> Error (Invalid_structured_response "summary response must be an object")
 ;;
 
-let summary_text_of_response response =
+let summary_text_result_of_response response =
   match raw_response_text response with
-  | None -> None
-  | Some raw -> summary_text_of_raw_text raw
+  | None -> Error Empty_summary_response
+  | Some raw -> summary_text_result_of_raw_text raw
+
+let summary_text_of_response response =
+  match summary_text_result_of_response response with
+  | Ok summary -> Some summary
+  | Error _ -> None
 ;;
 
 module For_testing = struct
   let summary_text_of_response = summary_text_of_response
+  let summary_text_result_of_response = summary_text_result_of_response
 end
 
 let with_timeout ?clock ~timeout_sec f =
@@ -184,14 +200,20 @@ let summarize_with_provider
           trace_id provider_cfg.model_id timeout_sec;
         None, Keeper_memory_llm_summary_outcome.Timed_out
     | Some (Ok response) ->
-        (match summary_text_of_response response with
-         | Some _ as summary ->
-             summary, Keeper_memory_llm_summary_outcome.Ok_summary
-         | None ->
+        (match summary_text_result_of_response response with
+         | Ok summary ->
+             Some summary, Keeper_memory_llm_summary_outcome.Ok_summary
+         | Error Empty_summary_response ->
              Log.Keeper.warn
                "memory LLM summary empty trace_id=%s provider=%s"
                trace_id provider_cfg.model_id;
-             None, Keeper_memory_llm_summary_outcome.Empty_response)
+             None, Keeper_memory_llm_summary_outcome.Empty_response
+         | Error (Invalid_structured_response detail) ->
+             Log.Keeper.warn
+               "memory LLM summary invalid structured response trace_id=%s \
+                provider=%s detail=%s"
+               trace_id provider_cfg.model_id detail;
+             None, Keeper_memory_llm_summary_outcome.Invalid_structured_response)
     | Some (Error err) ->
         Log.Keeper.warn
           "memory LLM summary failed trace_id=%s provider=%s: %s"

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -22,8 +22,15 @@ val summary_schema_supported : Llm_provider.Provider_config.t -> bool
 val messages_for_summary :
   trace_id:string -> texts:string list -> Agent_sdk.Types.message list
 
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
 module For_testing : sig
   val summary_text_of_response : Agent_sdk.Types.api_response -> string option
+
+  val summary_text_result_of_response :
+    Agent_sdk.Types.api_response -> (string, summary_parse_error) result
 end
 
 val make :

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -211,12 +211,18 @@ let log_rejected_output ~reason ~raw =
     (String.length raw)
 ;;
 
-let plan_of_string raw =
+let plan_result_of_string raw =
   match json_of_output_result raw with
-  | Ok json -> Some (plan_of_json json)
+  | Ok json -> Ok (plan_of_json json)
   | Error reason ->
     log_rejected_output ~reason ~raw;
-    None
+    Error reason
+;;
+
+let plan_of_string raw =
+  match plan_result_of_string raw with
+  | Ok plan -> Some plan
+  | Error _ -> None
 ;;
 
 (* ---------- Apply (pure, deterministic) ---------- *)

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -30,6 +30,12 @@ type consolidation_plan =
 
 val empty_plan : consolidation_plan
 
+type output_rejection_reason =
+  | Non_json
+  | Non_object_json
+
+val output_rejection_reason_to_string : output_rejection_reason -> string
+
 (** The numbered fact list the consolidation prompt sees: one 0-based line per
     fact, ["i: [category] claim"]. The index is the LLM's only handle on an
     existing fact, matching [apply_plan]'s reading. *)
@@ -39,6 +45,11 @@ val render_numbered_facts : fact list -> string
     (dropped with warning counts, not fatal); a wholly invalid object yields
     [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
+
+(** Parse the provider output as an exact JSON object, preserving the structured
+    rejection reason for runtime outcome classification. *)
+val plan_result_of_string :
+  string -> (consolidation_plan, output_rejection_reason) result
 
 (** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.
     Rejections emit a warning with a bounded reason label and byte count so

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -60,6 +60,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int
@@ -131,6 +133,12 @@ let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~aft
         Consolidated { before; after }))
 ;;
 
+let invalid_structured_response reason =
+  Invalid_structured_response
+    ("consolidation provider returned invalid structured response: "
+     ^ Consolidation.output_rejection_reason_to_string reason)
+;;
+
 (* Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it, and
    (unless [dry_run]) rewrite the store atomically. Returns what happened without
    raising for the expected failure modes (too few facts, transport error,
@@ -169,11 +177,11 @@ let consolidate_keeper
          | Some (Error _) -> Transport_failed "consolidation provider transport error"
          | Some (Ok response) ->
            (match response_text response with
-            | None -> Unparseable "consolidation provider returned empty response"
+            | None -> Empty_response
             | Some raw ->
-              (match Consolidation.plan_of_string raw with
-               | None -> Unparseable "consolidation provider returned invalid plan JSON"
-               | Some plan ->
+              (match Consolidation.plan_result_of_string raw with
+               | Error reason -> invalid_structured_response reason
+               | Ok plan ->
                  let survivors = Consolidation.apply_plan ~now ~facts plan in
                  let after = List.length survivors in
                  if dry_run

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -14,6 +14,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -354,11 +354,11 @@ let librarian_unstructured_fallback_terminal_marker =
 
 let fact_prompt_recallable (fact : fact) =
   (* [claim_kind] is the sole recall-eligibility signal: the producer
-     ([Keeper_librarian_runtime.unstructured_episode]) tags fallback notes as
-     [Diagnostic] at the write boundary, so recall excludes them by type without
-     string-matching [claim]. Rows lacking [claim_kind] are ordinary recallable
-     facts; their [valid_until] horizon ([fact_is_current]) bounds any stale
-     pre-[Diagnostic] rows still on disk. *)
+     historically tagged fallback notes as [Diagnostic] at the write boundary,
+     so recall excludes them by type without string-matching [claim]. Rows
+     lacking [claim_kind] are ordinary recallable facts; their [valid_until]
+     horizon ([fact_is_current]) bounds any stale pre-[Diagnostic] rows still on
+     disk. *)
   match fact.claim_kind with
   | Some Diagnostic -> false
   | Some Self_observation | Some External_state | Some Durable_knowledge -> true

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -353,12 +353,12 @@ let librarian_unstructured_fallback_terminal_marker =
 ;;
 
 let fact_prompt_recallable (fact : fact) =
-  (* [claim_kind] is the sole recall-eligibility signal: the producer
-     historically tagged fallback notes as [Diagnostic] at the write boundary,
-     so recall excludes them by type without string-matching [claim]. Rows
-     lacking [claim_kind] are ordinary recallable facts; their [valid_until]
-     horizon ([fact_is_current]) bounds any stale pre-[Diagnostic] rows still on
-     disk. *)
+  (* [claim_kind] is the sole recall-eligibility signal: current librarian
+     extraction rejects unparseable structured output before persistence, while
+     historical fallback diagnostics were tagged [Diagnostic]. Recall excludes
+     diagnostics by type without string-matching [claim]. Rows lacking
+     [claim_kind] are ordinary recallable facts; their [valid_until] horizon
+     ([fact_is_current]) bounds any stale pre-[Diagnostic] rows still on disk. *)
   match fact.claim_kind with
   | Some Diagnostic -> false
   | Some Self_observation | Some External_state | Some Durable_knowledge -> true

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -229,14 +229,15 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
-(** Claim prefix used by the producer for librarian parse-failure fallback
-    facts. The producer tags these [Diagnostic] at the write boundary, so this
-    prefix is a display label only — recall eligibility is decided by
-    [claim_kind], not by string-matching [claim]. *)
+(** Legacy claim prefix for historical librarian parse-failure fallback facts.
+    Current provider-backed extraction rejects unparseable structured output
+    before persistence. Recall eligibility for any older rows is still decided
+    by [claim_kind], not by string-matching [claim]. *)
 val librarian_unstructured_fallback_claim_prefix : string
 
-(** Terminal marker used on episodes that preserve unstructured librarian output
-    after strict JSON parsing fails. *)
+(** Legacy terminal marker for historical episodes that preserved unstructured
+    librarian output after strict JSON parsing failed. Current extraction no
+    longer writes this marker. *)
 val librarian_unstructured_fallback_terminal_marker : string
 
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -332,6 +332,11 @@ let fusion_judge_output_schema =
     fields
 ;;
 
+let fusion_panel_answer_output_schema =
+  let fields = [ "answer", string_schema ] in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     response_format = Agent_sdk.Types.JsonSchema schema

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -26,6 +26,9 @@ val governance_judge_output_schema : Yojson.Safe.t
 val fusion_judge_output_schema : Yojson.Safe.t
 (** JSON object the Fusion judge/refine/meta-judge provider must return. *)
 
+val fusion_panel_answer_output_schema : Yojson.Safe.t
+(** JSON object each Fusion panel provider must return. *)
+
 val verification_verdict_output_schema : Yojson.Safe.t
 (** JSON object the verification verdict providers must return. *)
 

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -49,6 +49,18 @@ let record_eviction ~mode ~result ~reason =
     ()
 ;;
 
+let eager_read_eviction_reason_of_outcome = function
+  | Keeper_vision_tool.Vo_ok _ -> None
+  | Keeper_vision_tool.Vo_empty -> Some "eager_empty"
+  | Keeper_vision_tool.Vo_truncated -> Some "eager_truncated"
+  | Keeper_vision_tool.Vo_timeout -> Some "eager_timeout"
+  | Keeper_vision_tool.Vo_no_runtime _ -> Some "eager_no_runtime"
+  | Keeper_vision_tool.Vo_invalid_request _ -> Some "eager_invalid_request"
+  | Keeper_vision_tool.Vo_invalid_structured_response _ ->
+    Some "eager_invalid_structured_response"
+  | Keeper_vision_tool.Vo_provider _ -> Some "eager_provider_error"
+;;
+
 let truncate_read_text text =
   let length = String.length text in
   if length <= max_read_text_chars
@@ -95,14 +107,10 @@ let eager_read ~media_type ~bytes : (string, string) result option =
          ()
      with
      | Keeper_vision_tool.Vo_ok text -> Some (Ok (truncate_read_text text))
-     | Keeper_vision_tool.Vo_empty -> Some (Error "vision returned no text")
-     | Keeper_vision_tool.Vo_truncated -> Some (Error "vision reply truncated")
-     | Keeper_vision_tool.Vo_timeout -> Some (Error "vision sub-call timed out")
-     | Keeper_vision_tool.Vo_no_runtime msg -> Some (Error ("no vision runtime: " ^ msg))
-     | Keeper_vision_tool.Vo_invalid_request msg ->
-       Some (Error ("invalid vision request: " ^ msg))
-     | Keeper_vision_tool.Vo_provider { detail; _ } ->
-       Some (Error ("vision provider error: " ^ detail)))
+     | outcome ->
+       (match eager_read_eviction_reason_of_outcome outcome with
+        | Some reason -> Some (Error reason)
+        | None -> Some (Error "eager_read_failed")))
   | _ -> None
 ;;
 
@@ -157,8 +165,8 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                        record_eviction ~mode ~result:"ok" ~reason:"eager_read";
                        Agent_sdk.Types.Text
                          (image_read_placeholder ~handle ~media_type ~read_text)
-                     | Some (Error _reason) ->
-                       record_eviction ~mode ~result:"error" ~reason:"eager_read_failed";
+                     | Some (Error reason) ->
+                       record_eviction ~mode ~result:"error" ~reason;
                        Agent_sdk.Types.Text
                          (image_unread_placeholder
                             ~handle

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -24,6 +24,14 @@ type mode =
 val extraction_query : string
 (** The fixed exhaustive extraction query used by [Eager] (RFC §2.3-eager). *)
 
+val eager_read_eviction_reason_of_outcome
+  :  Keeper_vision_tool.vision_outcome
+  -> string option
+(** Metric reason projection for failed [Eager] vision sub-calls. [Vo_ok] has
+    no error reason; every non-ok outcome maps to a finite eviction reason so
+    provider failures, timeouts, invalid requests, and invalid structured
+    responses do not collapse into one counter bucket. *)
+
 val evict_blocks
   :  mode:mode
   -> policy:Keeper_types_profile.multimodal_policy

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -261,6 +261,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of
       { failure_class : Tool_result.tool_failure_class
       ; detail : string
@@ -300,8 +301,7 @@ let ok_or_classified_json (response : Agent_sdk.Types.api_response) =
 
 let outcome_of_response (response : Agent_sdk.Types.api_response) =
   match vision_text_of_response response with
-  | Error detail ->
-    Vo_provider { failure_class = Tool_result.Runtime_failure; detail }
+  | Error detail -> Vo_invalid_structured_response detail
   | Ok text ->
     let truncated = truncated_of_stop_reason response.stop_reason in
     (match Va.classify ~truncated ~content:text with

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -102,6 +102,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of { failure_class : Tool_result.tool_failure_class; detail : string }
   | Vo_empty
   | Vo_truncated
@@ -121,8 +122,9 @@ val run_vision
     call under [with_timeout] + §2.2 classification). Used by {!handle} and by
     eager ingestion. Requires the turn clock, so eager ingestion cannot run an
     unbounded provider call. Non-cancellation exceptions are converted to
-    [Vo_provider] so eager ingestion can keep the turn alive with a typed unread
-    placeholder. *)
+    [Vo_provider]; provider success with malformed structured output is
+    [Vo_invalid_structured_response], so eager ingestion can keep the turn alive
+    with a typed unread placeholder. *)
 
 val handle
   :  ?complete:complete_fn

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
@@ -3,10 +3,12 @@ type t =
   | Timed_out
   | Http_error
   | Empty_response
+  | Invalid_structured_response
 
 let to_label = function
   | Ok_summary -> "ok_summary"
   | Timed_out -> "timed_out"
   | Http_error -> "http_error"
   | Empty_response -> "empty_response"
+  | Invalid_structured_response -> "invalid_structured_response"
 ;;

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
@@ -1,11 +1,11 @@
 (** Keeper_memory_llm_summary_outcome — closed sum naming each path
     out of {!Keeper_memory_llm_summary.summarize_with_provider}.
 
-    Until this module existed, the three failure modes (timeout, HTTP
-    error, empty/whitespace-only response) each logged at warn but
-    were not aggregated as a counter, so operators could not see
-    "what fraction of summary attempts succeed" or
-    "which provider is regressing".  Successful summaries left no
+    Until this module existed, the failure modes (timeout, HTTP
+    error, empty/whitespace-only response, invalid structured response)
+    each logged at warn but were not aggregated as a counter, so
+    operators could not see "what fraction of summary attempts succeed"
+    or "which provider is regressing".  Successful summaries left no
     record at all.  Additionally, {!summarize_with_providers}
     returning [None] after exhausting every provider in the runtime
     was *silent* — no log, no metric, just a missing summary on the
@@ -27,5 +27,8 @@ type t =
       (** Provider returned 2xx but [response_text] collapsed to
           empty after trim — usually a model that produced only
           whitespace or refused the task. *)
+  | Invalid_structured_response
+      (** Provider returned 2xx with non-empty text that could not be
+          parsed as the requested summary JSON object. *)
 
 val to_label : t -> string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -100,6 +100,15 @@ let run_memory_os_consolidation_tick
           "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
           keeper_id
           msg
+      | Empty_response ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s empty_response"
+          keeper_id
+      | Invalid_structured_response msg ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s invalid_structured_response: %s"
+          keeper_id
+          msg
       | Snapshot_changed { before; current } ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -24,6 +24,7 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   }
 
 let fusion_schema = Keeper_structured_output_schema.fusion_judge_output_schema
+let panel_schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema
 
 let restore_model_catalog previous =
   match previous with
@@ -52,6 +53,15 @@ let with_empty_oas_model_catalog f =
 
 let provider_cfg ~kind ~model_id ~base_url =
   Llm_provider.Provider_config.make ~kind ~model_id ~base_url ()
+
+let response_with_text text : Agent_sdk.Types.api_response =
+  { id = "fusion-panel-test"
+  ; model = "fusion-panel-test-model"
+  ; stop_reason = Agent_sdk.Types.EndTurn
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
 
 let test_output_contract_keeps_native_schema_when_supported () =
   let cfg =
@@ -98,6 +108,70 @@ let test_output_contract_fails_loud_when_no_output_contract_is_known () =
   | Ok _ -> fail "expected unknown provider/model to fail loud"
   | Error msg ->
     check bool "schema validation reason is retained" true (String.length msg > 0)
+
+let test_panel_output_contract_keeps_native_schema_when_supported () =
+  let cfg =
+    provider_cfg
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+  in
+  match Fusion_panel.For_testing.apply_output_contract cfg with
+  | Error msg -> fail ("expected native schema config: " ^ msg)
+  | Ok configured ->
+    check bool "response_format uses JsonSchema" true
+      (match configured.response_format with
+       | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal panel_schema schema
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
+    check bool "output_schema mirrors schema" true
+      (match configured.output_schema with
+       | Some schema -> Yojson.Safe.equal panel_schema schema
+       | None -> false)
+
+let test_panel_outcome_parses_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"  hello  "}|}))
+  with
+  | Fusion_types.Answered { model; answer; usage } ->
+    check string "panel identity preserved" "panel-a" model;
+    check string "answer is parsed and trimmed" "hello" answer;
+    check usage_t "missing provider usage defaults to zero" Fusion_types.zero_usage
+      usage
+  | Fusion_types.Failed failure ->
+    fail ("expected structured answer, got failure: " ^ Fusion_types.show_panel_error failure)
+
+let test_panel_outcome_rejects_invalid_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "not-json"))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "invalid JSON detail is retained" true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
+    fail
+      ("expected invalid structured response failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
+let test_panel_outcome_rejects_empty_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"   "}|}))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"; reason = Fusion_types.Empty_response detail } ->
+    check bool "empty response detail is retained" true (String.length detail > 0)
+  | other ->
+    fail
+      ("expected empty structured answer failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
 
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
@@ -197,6 +271,18 @@ let () =
             "fails loud when no JSON output contract is known"
             `Quick
             test_output_contract_fails_loud_when_no_output_contract_is_known
+        ; test_case
+            "panel keeps native answer schema when supported"
+            `Quick
+            test_panel_output_contract_keeps_native_schema_when_supported
+        ] )
+    ; ( "panel_outcome"
+      , [ test_case "parses structured answer" `Quick
+            test_panel_outcome_parses_structured_answer
+        ; test_case "rejects invalid structured answer" `Quick
+            test_panel_outcome_rejects_invalid_structured_answer
+        ; test_case "rejects empty answer" `Quick
+            test_panel_outcome_rejects_empty_answer
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -271,6 +271,9 @@ let test_cadence_error_backoff_policy () =
   check bool "provider transport failure defers cadence" true
     (R.should_record_cadence_backoff_after_error
        (R.Provider_transport_failed "http timeout"));
+  check bool "unparseable provider response defers cadence" true
+    (R.should_record_cadence_backoff_after_error
+       (R.Provider_unparseable_response "invalid_json"));
   check bool "prompt render failure stays due" false
     (R.should_record_cadence_backoff_after_error
        (R.Prompt_render_failed "missing template"));
@@ -279,14 +282,6 @@ let test_cadence_error_backoff_policy () =
        (R.Memory_fact_upsert_failed "permission denied"));
   check bool "missing provider clock does not claim a completed attempt" false
     (R.should_record_cadence_backoff_after_error R.Provider_clock_unavailable)
-
-let test_unstructured_fallback_preservation_policy () =
-  check bool "empty response is not preserved" false
-    (R.should_preserve_unstructured_fallback "");
-  check bool "whitespace response is not preserved" false
-    (R.should_preserve_unstructured_fallback " \n\t ");
-  check bool "invalid text response is preserved" true
-    (R.should_preserve_unstructured_fallback "not json, but evidence")
 
 (* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
    [run_best_effort] uses). A fresh pair is due immediately, and successful
@@ -571,8 +566,6 @@ let () =
           test_case "record attempt defers" `Quick test_cadence_record_attempt_defers;
           test_case "success policy excludes fallback" `Quick test_cadence_success_policy;
           test_case "error backoff policy" `Quick test_cadence_error_backoff_policy;
-          test_case "fallback preservation policy" `Quick
-            test_unstructured_fallback_preservation_policy;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
           test_case "cadence_due resets on trace rollover" `Quick

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -253,16 +253,6 @@ let test_cadence_record_attempt_defers () =
   check bool "after a completed non-success attempt the next turn is not due" false
     (R.cadence_due ~keeper_id:kid ~trace_id:tid)
 
-let test_cadence_success_policy () =
-  check bool "structured extraction resets cadence" true
-    (R.should_record_cadence_success R.Structured_episode);
-  check bool "unstructured fallback is not semantic success" false
-    (R.should_record_cadence_success R.Unstructured_fallback);
-  check bool "structured extraction uses success path, not backoff" false
-    (R.should_record_cadence_backoff R.Structured_episode);
-  check bool "unstructured fallback defers cadence" true
-    (R.should_record_cadence_backoff R.Unstructured_fallback)
-
 let test_cadence_error_backoff_policy () =
   check bool "empty provider response defers cadence" true
     (R.should_record_cadence_backoff_after_error R.Provider_empty_response);
@@ -564,7 +554,6 @@ let () =
           test_case "step transitions" `Quick test_cadence_step_transitions;
           test_case "record success resets" `Quick test_cadence_record_success_resets;
           test_case "record attempt defers" `Quick test_cadence_record_attempt_defers;
-          test_case "success policy excludes fallback" `Quick test_cadence_success_policy;
           test_case "error backoff policy" `Quick test_cadence_error_backoff_policy;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1481,7 +1481,7 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
           (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_runtime_preserves_unstructured_fallback () =
+let test_librarian_runtime_rejects_unstructured_fallback () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1497,7 +1497,6 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
           ; messages = [ text_message "Please remember the fallback path." ]
           }
         in
-        let fallback_started_at = Eio.Time.now clock in
         let fallback_result =
           Librarian_runtime.extract_and_append_with_provider_classified
             ~complete
@@ -1509,113 +1508,34 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
             ~provider_cfg:(test_provider_cfg ())
             inp
         in
-        let fallback_finished_at = Eio.Time.now clock in
-        let fallback_created_at = ref None in
-        let check_in_clock_window label value =
-          Alcotest.(check bool)
-            label
-            true
-            (value >= fallback_started_at && value <= fallback_finished_at +. 0.001)
-        in
         (match fallback_result with
+         | Ok _ -> Alcotest.fail "unstructured provider output must not persist"
          | Error err ->
-           Alcotest.fail (Librarian_runtime.extraction_error_to_string err)
-         | Ok extraction ->
-           let episode = extraction.Librarian_runtime.episode in
-           let kind = extraction.Librarian_runtime.kind in
-           (match kind with
-            | Librarian_runtime.Unstructured_fallback -> ()
-            | Librarian_runtime.Structured_episode ->
-              Alcotest.fail "expected unstructured fallback extraction");
-           Alcotest.(check bool)
-             "fallback does not count as cadence success"
-             false
-             (Librarian_runtime.should_record_cadence_success kind);
-           Alcotest.(check bool)
-             "fallback defers the next cadence attempt"
-             true
-             (Librarian_runtime.should_record_cadence_backoff kind);
-           fallback_created_at := Some episode.Types.created_at;
-           check_in_clock_window
-             "fallback created_at derives from injected clock"
-             episode.Types.created_at;
            Alcotest.(check int)
              "initial attempt + parse retries"
              (1 + Librarian_runtime.librarian_max_parse_retries)
              !calls;
-           Alcotest.(check string)
-             "fallback summary"
-             "Unstructured librarian note preserved after parse failure"
-             episode.Types.episode_summary;
-           Alcotest.(check (option string))
-             "fallback marker"
-             (Some Types.librarian_unstructured_fallback_terminal_marker)
-             episode.Types.terminal_marker;
-           (match episode.Types.claims with
-            | [ fact ] ->
-              Alcotest.(check bool)
-                "fallback claim keeps raw provider text"
-                true
-                (contains "not json, but keep this observation" fact.Types.claim);
-              Alcotest.(check bool)
-                "fallback is ephemeral"
-                true
-                (fact.Types.category = Types.Ephemeral);
-              Alcotest.(check (option string))
-                "fallback is diagnostic"
-                (Some "diagnostic")
-                (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
-              Alcotest.(check (option string))
-                "fallback diagnostic does not author claim_id"
-                None
-                fact.Types.claim_id;
-              Alcotest.(check (float 0.001))
-                "fallback fact first_seen uses episode timestamp"
-                episode.Types.created_at
-                fact.Types.first_seen;
-              Alcotest.(check (option (float 0.001)))
-                "fallback fact last_verified_at uses episode timestamp"
-                (Some episode.Types.created_at)
-                fact.Types.last_verified_at
-            | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)));
-        let fallback_created_at =
-          match !fallback_created_at with
-          | Some ts -> ts
-          | None -> Alcotest.fail "fallback result timestamp was not captured"
-        in
+           Alcotest.(check bool)
+             "error kind"
+             true
+             (contains
+                "librarian provider returned unparseable structured response"
+                (Librarian_runtime.extraction_error_to_string err)));
         Alcotest.(check int)
-          "episode file persisted"
-          1
+          "episode file not persisted"
+          0
           (json_episode_file_count ~keeper_id);
-        (match Memory_io.read_events_tail ~keeper_id ~n:1 with
-         | [ episode ] ->
-           Alcotest.(check (option string))
-             "event persisted with fallback marker"
-             (Some Types.librarian_unstructured_fallback_terminal_marker)
-             episode.Types.terminal_marker;
-           Alcotest.(check (float 0.001))
-             "event persisted with injected-clock timestamp"
-             fallback_created_at
-             episode.Types.created_at
-         | events -> Alcotest.failf "expected one event, got %d" (List.length events));
-        match Memory_io.read_facts_tail ~keeper_id ~n:1 with
-        | [ fact ] ->
-          Alcotest.(check bool)
-            "fact persisted as unstructured note"
-            true
-            (contains "unstructured_note" fact.Types.claim);
-          Alcotest.(check (option string))
-            "persisted fact is diagnostic"
-            (Some "diagnostic")
-            (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
-          Alcotest.(check (float 0.001))
-            "persisted fact first_seen uses injected clock"
-            fallback_created_at
-            fact.Types.first_seen
-        | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+        Alcotest.(check int)
+          "event not persisted"
+          0
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
+        Alcotest.(check int)
+          "fact not persisted"
+          0
+          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries () =
+let test_librarian_runtime_rejects_unparseable_output_across_empty_retries () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1645,42 +1565,35 @@ let test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries () =
             ~provider_cfg:(test_provider_cfg ())
             inp
         with
+        | Ok _ -> Alcotest.fail "unparseable provider output must not persist"
         | Error err ->
-          Alcotest.fail
-            (Printf.sprintf
-               "expected non-empty first response to be preserved, got %s"
-               (Librarian_runtime.extraction_error_to_string err))
-        | Ok extraction ->
           Alcotest.(check int)
             "initial invalid response + empty retries"
             (1 + Librarian_runtime.librarian_max_parse_retries)
             !calls;
-          (match extraction.Librarian_runtime.kind with
-           | Librarian_runtime.Unstructured_fallback -> ()
-           | Librarian_runtime.Structured_episode ->
-             Alcotest.fail "expected unstructured fallback extraction");
-          (match extraction.Librarian_runtime.episode.Types.claims with
-           | [ fact ] ->
-             Alcotest.(check bool)
-               "fallback claim keeps first non-empty provider text"
-               true
-               (contains "first invalid librarian payload" fact.Types.claim);
-             Alcotest.(check bool)
-               "fallback claim keeps invalid-json reason"
-               true
-               (contains
-                  "librarian provider returned invalid episode JSON"
-                  fact.Types.claim);
-             Alcotest.(check bool)
-               "fallback claim does not use later empty retry reason"
-               false
-               (contains
-                  "librarian provider returned empty response"
-                  fact.Types.claim)
-           | facts -> Alcotest.failf "expected one fallback fact, got %d" (List.length facts)))))
+          Alcotest.(check bool)
+            "error keeps first non-empty invalid-json reason"
+            true
+            (contains
+               "librarian provider returned invalid episode JSON"
+               (Librarian_runtime.extraction_error_to_string err));
+          Alcotest.(check bool)
+            "error does not use later empty retry reason"
+            false
+            (contains
+               "librarian provider returned empty response"
+               (Librarian_runtime.extraction_error_to_string err));
+          Alcotest.(check int)
+            "event not persisted"
+            0
+            (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
+          Alcotest.(check int)
+            "fact not persisted"
+            0
+            (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
 ;;
 
-let test_librarian_unstructured_fallback_uses_exact_text_identity () =
+let test_librarian_unstructured_fallback_does_not_write_facts () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1709,57 +1622,25 @@ let test_librarian_unstructured_fallback_uses_exact_text_identity () =
               ~provider_cfg:(test_provider_cfg ())
               inp
           with
-          | Error msg -> Alcotest.fail msg
-          | Ok episode -> episode
+          | Ok _ -> Alcotest.fail "unparseable provider output must not persist"
+          | Error msg -> msg
         in
         let first = run_once first_complete in
         let second = run_once second_complete in
         Alcotest.(check int)
-          "both fallback episodes are still evented"
-          2
+          "fallback events are not written"
+          0
           (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
         let facts = Memory_io.read_facts_all ~keeper_id in
-        Alcotest.(check int) "distinct diagnostics remain distinct facts" 2 (List.length facts);
+        Alcotest.(check int) "diagnostic facts are not written" 0 (List.length facts);
         Alcotest.(check bool)
-          "fallback diagnostics do not author claim_id"
+          "first error keeps invalid-json reason"
           true
-          (List.for_all (fun fact -> Option.is_none fact.Types.claim_id) facts);
+          (contains "invalid episode JSON" first);
         Alcotest.(check bool)
-          "fallback diagnostics are typed diagnostic"
+          "second error keeps invalid-json reason"
           true
-          (List.for_all (fun fact -> fact.Types.claim_kind = Some Types.Diagnostic) facts);
-        Alcotest.(check bool)
-          "first raw note is preserved"
-          true
-          (List.exists
-             (fun fact -> contains "first invalid librarian payload" fact.Types.claim)
-             facts);
-        Alcotest.(check bool)
-          "second raw note is preserved"
-          true
-          (List.exists
-             (fun fact -> contains "second invalid librarian payload" fact.Types.claim)
-             facts);
-        (match first.Types.claims, second.Types.claims with
-         | [ first_fact ], [ second_fact ] ->
-           Alcotest.(check bool)
-             "first result has no claim_id"
-             true
-             (Option.is_none first_fact.Types.claim_id);
-           Alcotest.(check bool)
-             "second result has no claim_id"
-             true
-             (Option.is_none second_fact.Types.claim_id);
-           Alcotest.(check bool)
-             "result fallback facts are diagnostic"
-             true
-             (first_fact.Types.claim_kind = Some Types.Diagnostic
-              && second_fact.Types.claim_kind = Some Types.Diagnostic)
-         | first_claims, second_claims ->
-           Alcotest.failf
-             "expected one fallback fact in each result, got %d/%d"
-             (List.length first_claims)
-             (List.length second_claims)))))
+          (contains "invalid episode JSON" second))))
 ;;
 
 let test_librarian_runtime_reports_fact_upsert_failure () =
@@ -5658,17 +5539,17 @@ let () =
         ] )
     ; ( "librarian runtime"
       , [ Alcotest.test_case
-            "unparseable output is preserved as unstructured fallback"
+            "unparseable output is rejected instead of persisted"
             `Quick
-            test_librarian_runtime_preserves_unstructured_fallback
+            test_librarian_runtime_rejects_unstructured_fallback
         ; Alcotest.test_case
-            "non-empty fallback evidence survives empty retries"
+            "non-empty fallback evidence remains an error across empty retries"
             `Quick
-            test_librarian_runtime_keeps_nonempty_fallback_across_empty_retries
+            test_librarian_runtime_rejects_unparseable_output_across_empty_retries
         ; Alcotest.test_case
-            "unstructured fallback uses exact-text identity"
+            "unstructured fallback does not write facts"
             `Quick
-            test_librarian_unstructured_fallback_uses_exact_text_identity
+            test_librarian_unstructured_fallback_does_not_write_facts
         ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1242,22 +1242,49 @@ let test_memory_llm_summary_response_parser_accepts_only_summary_json () =
   let parse raw =
     Memory_summary.For_testing.summary_text_of_response (fake_response raw)
   in
+  let parse_result raw =
+    Memory_summary.For_testing.summary_text_result_of_response (fake_response raw)
+  in
+  let check_invalid_structured label = function
+    | Error (Memory_summary.Invalid_structured_response _) -> ()
+    | Ok summary -> Alcotest.failf "%s: expected invalid structured response, got %S" label summary
+    | Error Memory_summary.Empty_summary_response ->
+        Alcotest.failf "%s: expected invalid structured response, got empty response" label
+  in
   Alcotest.(check (option string))
     "valid summary json"
     (Some "Remember exact command.")
     (parse {|{"summary":" Remember exact command.  "}|});
+  (match parse_result {|{"summary":" Remember exact command.  "}|} with
+   | Ok summary ->
+       Alcotest.(check string)
+         "valid summary json result"
+         "Remember exact command."
+         summary
+   | Error _ -> Alcotest.fail "valid summary json result rejected");
   Alcotest.(check (option string))
     "plain text rejected"
     None
     (parse "Remember exact command.");
+  check_invalid_structured "plain text result" (parse_result "Remember exact command.");
   Alcotest.(check (option string))
     "empty summary rejected"
     None
     (parse {|{"summary":"   "}|});
+  Alcotest.(check bool)
+    "empty summary result"
+    true
+    (match parse_result {|{"summary":"   "}|} with
+     | Error Memory_summary.Empty_summary_response -> true
+     | Ok _
+     | Error (Memory_summary.Invalid_structured_response _) -> false);
   Alcotest.(check (option string))
     "wrong field rejected"
     None
-    (parse {|{"text":"Remember exact command."}|})
+    (parse {|{"text":"Remember exact command."}|});
+  check_invalid_structured
+    "wrong field result"
+    (parse_result {|{"text":"Remember exact command."}|})
 ;;
 
 let json_episode_file_count ~keeper_id =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1524,6 +1524,10 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
           ; messages = [ text_message "Please remember the fallback path." ]
           }
         in
+        Alcotest.(check bool)
+          "production cadence gate is due before provider attempt"
+          true
+          (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id);
         let fallback_result =
           Librarian_runtime.extract_and_append_with_provider_classified
             ~complete
@@ -1537,17 +1541,30 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
         in
         (match fallback_result with
          | Ok _ -> Alcotest.fail "unstructured provider output must not persist"
-         | Error err ->
+         | Error (Librarian_runtime.Provider_unparseable_response reason as err) ->
            Alcotest.(check int)
              "initial attempt + parse retries"
              (1 + Librarian_runtime.librarian_max_parse_retries)
              !calls;
            Alcotest.(check bool)
-             "error kind"
+             "typed provider error preserves parser reason"
              true
              (contains
-                "librarian provider returned unparseable structured response"
-                (Librarian_runtime.extraction_error_to_string err)));
+                "librarian provider returned invalid episode JSON"
+                reason);
+           Alcotest.(check bool)
+             "unparseable provider error enters cadence backoff path"
+             true
+             (Librarian_runtime.should_record_cadence_backoff_after_error err);
+           Librarian_runtime.cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
+           Alcotest.(check bool)
+             "cadence attempt defers the next provider retry"
+             false
+             (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id)
+         | Error err ->
+           Alcotest.failf
+             "expected Provider_unparseable_response, got %s"
+             (Librarian_runtime.extraction_error_to_string err));
         Alcotest.(check int)
           "episode file not persisted"
           0

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -447,6 +447,23 @@ let test_parse_non_json_is_none () =
   Alcotest.(check bool) "JSON array yields None" true (Consolidation.plan_of_string "[]" = None)
 ;;
 
+let test_parse_result_reports_rejection_reason () =
+  Alcotest.(check bool)
+    "non-JSON result"
+    true
+    (match Consolidation.plan_result_of_string "not json {{{" with
+     | Error Consolidation.Non_json -> true
+     | Ok _
+     | Error Consolidation.Non_object_json -> false);
+  Alcotest.(check bool)
+    "non-object result"
+    true
+    (match Consolidation.plan_result_of_string {|"not an object"|} with
+     | Error Consolidation.Non_object_json -> true
+     | Ok _
+     | Error Consolidation.Non_json -> false)
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os_consolidation"
@@ -480,10 +497,14 @@ let () =
 	    ; ( "parse"
 	      , [ Alcotest.test_case "parses a plan" `Quick test_parse_plan_json
 	        ; Alcotest.test_case "rejects fractional indices" `Quick test_parse_rejects_fractional_indices
-	        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
-	        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
-	        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
-	        ] )
+        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
+        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
+        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
+        ; Alcotest.test_case
+            "result reports rejection reason"
+            `Quick
+            test_parse_result_reports_rejection_reason
+        ] )
     ; ( "render"
       , [ Alcotest.test_case
             "keeps one fact per prompt line"

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -275,6 +275,60 @@ let test_consolidate_rejects_malformed_fact_store () =
         | _ -> Alcotest.fail "expected Unparseable for malformed fact store"))))
 ;;
 
+let test_consolidate_classifies_empty_provider_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "   ")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Empty_response -> ()
+        | _ -> Alcotest.fail "expected Empty_response for blank provider output"))))
+;;
+
+let test_consolidate_classifies_invalid_structured_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "not json {{{")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Invalid_structured_response detail ->
+          Alcotest.(check string)
+            "detail keeps rejection reason"
+            "consolidation provider returned invalid structured response: non_json"
+            detail
+        | _ ->
+          Alcotest.fail
+            "expected Invalid_structured_response for malformed provider output"))))
+;;
+
 let test_consolidate_respects_provider_config_and_prompt_template () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -357,8 +411,16 @@ let () =
       , [ Alcotest.test_case "applies the model's plan" `Quick test_consolidate_applies_plan
         ; Alcotest.test_case "skips when too few facts" `Quick test_consolidate_skips_too_few
 	        ; Alcotest.test_case "dry-run preserves the store" `Quick test_consolidate_dry_run_preserves_store
-	        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
-	        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
+        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case
+            "classifies empty provider response"
+            `Quick
+            test_consolidate_classifies_empty_provider_response
+        ; Alcotest.test_case
+            "classifies invalid structured provider response"
+            `Quick
+            test_consolidate_classifies_invalid_structured_response
         ; Alcotest.test_case
             "respects provider config and prompt template"
             `Quick

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -53,10 +53,10 @@ let expected_structured_dashboard_agent_run_json_judges =
     ]
 ;;
 
-let expected_structured_fusion_json_judges = [ "lib/fusion/fusion_judge.ml" ];;
-
-let expected_unstructured_fusion_agent_build_exemptions =
-  [ "lib/fusion/fusion_panel.ml" ]
+let expected_structured_fusion_agent_build_files =
+  List.sort
+    String.compare
+    [ "lib/fusion/fusion_judge.ml"; "lib/fusion/fusion_panel.ml" ]
 ;;
 
 let expected_structured_tool_agent_runs =
@@ -83,10 +83,7 @@ let fusion_agent_build_files () =
 ;;
 
 let expected_all_fusion_agent_build_files =
-  List.sort
-    String.compare
-    (expected_structured_fusion_json_judges
-     @ expected_unstructured_fusion_agent_build_exemptions)
+  expected_structured_fusion_agent_build_files
 ;;
 
 let masc_tool_agent_run_files_under rel =
@@ -152,9 +149,9 @@ let test_dashboard_agent_run_json_judges_request_structured_output () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_request_structured_output () =
+let test_fusion_agent_builds_request_structured_output () =
   test_agent_run_json_judges_request_structured_output
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_dashboard_agent_run_json_judges_use_provider_config_transform () =
@@ -211,7 +208,7 @@ let test_dashboard_json_judges_do_not_use_lenient_json_recovery () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_use_provider_config_transform () =
+let test_fusion_agent_builds_use_provider_config_transform () =
   List.iter
     (fun rel ->
        check
@@ -222,10 +219,10 @@ let test_fusion_agent_run_json_judges_use_provider_config_transform () =
             ~module_path:rel
             ~callee:"Fusion_oas.build_agent"
             ~label:"provider_config_transform"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
-let test_fusion_json_judges_do_not_degrade_to_json_mode () =
+let test_fusion_agent_builds_do_not_degrade_to_json_mode () =
   List.iter
     (fun rel ->
        check
@@ -240,7 +237,7 @@ let test_fusion_json_judges_do_not_degrade_to_json_mode () =
          (rel ^ " must not construct JsonMode through open or alias")
          0
          (Ast_grep.count_constructor_leaf_names ~module_path:rel ~name:"JsonMode"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_all_fusion_agent_build_files_are_classified () =
@@ -397,23 +394,23 @@ let () =
             `Quick
             test_dashboard_json_judges_do_not_use_lenient_json_recovery
         ] )
-    ; ( "fusion json judges"
+    ; ( "fusion Agent builds"
       , [ test_case
-            "Fusion agent build files are classified as structured or exempt"
+            "Fusion agent build files are classified"
             `Quick
             test_all_fusion_agent_build_files_are_classified
         ; test_case
-            "fusion JSON judges request structured output"
+            "fusion Agent builds request structured output"
             `Quick
-            test_fusion_agent_run_json_judges_request_structured_output
+            test_fusion_agent_builds_request_structured_output
         ; test_case
-            "fusion JSON judges use provider config transform"
+            "fusion Agent builds use provider config transform"
             `Quick
-            test_fusion_agent_run_json_judges_use_provider_config_transform
+            test_fusion_agent_builds_use_provider_config_transform
         ; test_case
-            "fusion JSON judges do not degrade to JsonMode"
+            "fusion Agent builds do not degrade to JsonMode"
             `Quick
-            test_fusion_json_judges_do_not_degrade_to_json_mode
+            test_fusion_agent_builds_do_not_degrade_to_json_mode
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -168,6 +168,24 @@ let test_fusion_judge_schema_uses_parser_wire_contract () =
   check bool "fusion schema exposes parser wire fields" true true
 ;;
 
+let test_fusion_panel_schema_uses_answer_contract () =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  check
+    (list string)
+    "fusion panel required fields"
+    [ "answer" ]
+    (required_strings schema);
+  check
+    (option string)
+    "fusion panel answer is string"
+    (Some "string")
+    (match schema |> schema_property "answer" |> schema_member "type" with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check bool "fusion panel schema is closed" false
+    (allows_additional_properties schema)
+;;
+
 let test_verification_verdict_schema_uses_core_ssot () =
   let schema = Keeper_structured_output_schema.verification_verdict_output_schema in
   check
@@ -242,6 +260,10 @@ let () =
             "fusion judge schema uses parser wire contract"
             `Quick
             test_fusion_judge_schema_uses_parser_wire_contract
+        ; test_case
+            "fusion panel schema uses answer contract"
+            `Quick
+            test_fusion_panel_schema_uses_answer_contract
         ] )
     ; ( "verdict schemas"
       , [ test_case

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -692,6 +692,29 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
       assert (contains_substring (assoc_string "detail" json) "not valid JSON")))
 
+let test_run_vision_invalid_structured_response_is_typed () =
+  with_temp_runtime_toml single_vision_runtime_toml (fun () ->
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      Ok (text_response "not-json")
+    in
+    let outcome =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.run_vision
+            ~complete
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~query:"describe"
+            ~media_type:"image/png"
+            ~bytes:"\x89PNG\r\n\x1a\nraw"
+            ()))
+    in
+    match outcome with
+    | Vt.Vo_invalid_structured_response detail ->
+      assert (contains_substring detail "not valid JSON")
+    | _ -> failwith "expected Vo_invalid_structured_response")
+
 let test_retryable_provider_error_tries_next_runtime () =
   with_temp_runtime_toml vision_failover_runtime_toml (fun () ->
     with_temp_base (fun _ ->
@@ -845,6 +868,22 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       assert (List.rev !models = [ "vision-a" ]);
       assert (String.equal (assoc_string "error" json) "provider_error");
       assert (String.equal (assoc_string "failure_class" json) "policy_rejection")))
+
+let test_eager_eviction_reason_preserves_typed_outcome () =
+  let reason = Vi.eager_read_eviction_reason_of_outcome in
+  assert (reason (Vt.Vo_ok "text") = None);
+  assert (reason Vt.Vo_empty = Some "eager_empty");
+  assert (reason Vt.Vo_truncated = Some "eager_truncated");
+  assert (reason Vt.Vo_timeout = Some "eager_timeout");
+  assert (reason (Vt.Vo_no_runtime "missing") = Some "eager_no_runtime");
+  assert (reason (Vt.Vo_invalid_request "bad") = Some "eager_invalid_request");
+  assert
+    (reason (Vt.Vo_invalid_structured_response "bad json")
+     = Some "eager_invalid_structured_response");
+  assert
+    (reason
+       (Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail = "boom" })
+     = Some "eager_provider_error")
 
 let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
   with_temp_base (fun _ ->
@@ -1075,10 +1114,12 @@ let () =
      [with_vision_model_catalog]). *)
   with_vision_model_catalog (fun () ->
     test_invalid_structured_vision_response_is_runtime_failure ();
+    test_run_vision_invalid_structured_response_is_typed ();
     test_retryable_provider_error_tries_next_runtime ();
     test_deadline_exhaustion_preserves_provider_error ();
     test_non_retryable_provider_error_stops_without_trying_next_runtime ();
-    test_accept_rejected_is_policy_rejection_without_failover ());
+    test_accept_rejected_is_policy_rejection_without_failover ();
+    test_eager_eviction_reason_preserves_typed_outcome ());
   test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -687,6 +687,42 @@ let test_repo_runtime_toml_loads () =
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.6 capabilities"))
 
+let fusion_preset_panels toml preset =
+  Otoml.find
+    toml
+    (Otoml.get_array Otoml.get_string)
+    [ "fusion"; "presets"; preset; "panel" ]
+
+let assert_runtime_supports_structured_output runtimes ~preset runtime_id =
+  match find_runtime runtimes runtime_id with
+  | None -> failf "fusion preset %s references unknown runtime %s" preset runtime_id
+  | Some runtime ->
+    (match runtime.model.capabilities with
+     | Some caps ->
+       check
+         bool
+         (Printf.sprintf "%s panel %s supports structured output" preset runtime_id)
+         true
+         caps.supports_structured_output
+     | None ->
+       failf
+         "fusion preset %s runtime %s must declare capabilities"
+         preset
+         runtime_id)
+
+let test_repo_fusion_panel_presets_are_schema_capable () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  let toml = Otoml.Parser.from_file path in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross, _media) ->
+    List.iter
+      (fun preset ->
+         fusion_preset_panels toml preset
+         |> List.iter (assert_runtime_supports_structured_output runtimes ~preset))
+      [ "trio"; "quorum" ]
+
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
     parse_or_fail
@@ -1332,6 +1368,9 @@ let () =
             `Quick test_repo_oas_model_catalog_modality_priorities_resolve;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
+          test_case
+            "repo Fusion panel presets use schema-capable runtimes"
+            `Quick test_repo_fusion_panel_presets_are_schema_capable;
           test_case
             "[runtime].librarian and .cross_verifier resolve, default None, \
              reject unknown"


### PR DESCRIPTION
Summary: Stop preserving unparseable librarian provider output as diagnostic fallback episodes; return a typed Provider_unparseable_response instead; keep parse-retry diagnostics so the first non-empty invalid response is still surfaced; add coverage ratchet preventing the unstructured fallback builder from returning. Checks: ocamlformat --check lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_librarian_retry.ml test/test_keeper_memory_os.ml test/test_keeper_structured_output_coverage.ml; git diff --check. Full build/test is left to GitHub CI per operator instruction.