### PR TITLE
feat(memory): classify invalid summary structured output

### DIFF
--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -22,7 +22,8 @@ let () =
     ~name:Keeper_metrics.(to_string MemoryLlmSummaryOutcomes)
     ~help:
       "Total [summarize_with_provider] attempts classified by label \
-       [outcome] (ok_summary | timed_out | http_error | empty_response). \
+       [outcome] (ok_summary | timed_out | http_error | empty_response | \
+       invalid_structured_response). \
        Labels: [outcome], [provider] (model_id), [runtime_id]."
     ();
   Otel_metric_store.register_counter
@@ -116,28 +117,43 @@ let raw_response_text (response : Agent_sdk.Types.api_response) : string option 
   in
   if text = "" then None else Some text
 
-let summary_text_of_raw_text raw =
-  try
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
+let summary_text_result_of_raw_text raw =
+  let raw = String.trim raw in
+  if raw = "" then Error Empty_summary_response
+  else
     match Yojson.Safe.from_string raw with
+    | exception Yojson.Json_error msg ->
+        Error (Invalid_structured_response ("invalid JSON: " ^ msg))
     | `Assoc fields ->
-      (match List.assoc_opt "summary" fields with
-       | Some (`String summary) ->
-         let summary = String.trim summary in
-         if summary = "" then None else Some summary
-       | Some _
-       | None -> None)
-    | _ -> None
-  with Yojson.Json_error _ -> None
+        (match List.assoc_opt "summary" fields with
+         | Some (`String summary) ->
+             let summary = String.trim summary in
+             if summary = "" then Error Empty_summary_response else Ok summary
+         | Some _ ->
+             Error (Invalid_structured_response "summary field must be a string")
+         | None ->
+             Error (Invalid_structured_response "missing summary field"))
+    | _ -> Error (Invalid_structured_response "summary response must be an object")
 ;;
 
-let summary_text_of_response response =
+let summary_text_result_of_response response =
   match raw_response_text response with
-  | None -> None
-  | Some raw -> summary_text_of_raw_text raw
+  | None -> Error Empty_summary_response
+  | Some raw -> summary_text_result_of_raw_text raw
+
+let summary_text_of_response response =
+  match summary_text_result_of_response response with
+  | Ok summary -> Some summary
+  | Error _ -> None
 ;;
 
 module For_testing = struct
   let summary_text_of_response = summary_text_of_response
+  let summary_text_result_of_response = summary_text_result_of_response
 end
 
 let with_timeout ?clock ~timeout_sec f =
@@ -184,14 +200,20 @@ let summarize_with_provider
           trace_id provider_cfg.model_id timeout_sec;
         None, Keeper_memory_llm_summary_outcome.Timed_out
     | Some (Ok response) ->
-        (match summary_text_of_response response with
-         | Some _ as summary ->
-             summary, Keeper_memory_llm_summary_outcome.Ok_summary
-         | None ->
+        (match summary_text_result_of_response response with
+         | Ok summary ->
+             Some summary, Keeper_memory_llm_summary_outcome.Ok_summary
+         | Error Empty_summary_response ->
              Log.Keeper.warn
                "memory LLM summary empty trace_id=%s provider=%s"
                trace_id provider_cfg.model_id;
-             None, Keeper_memory_llm_summary_outcome.Empty_response)
+             None, Keeper_memory_llm_summary_outcome.Empty_response
+         | Error (Invalid_structured_response detail) ->
+             Log.Keeper.warn
+               "memory LLM summary invalid structured response trace_id=%s \
+                provider=%s detail=%s"
+               trace_id provider_cfg.model_id detail;
+             None, Keeper_memory_llm_summary_outcome.Invalid_structured_response)
     | Some (Error err) ->
         Log.Keeper.warn
           "memory LLM summary failed trace_id=%s provider=%s: %s"

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -22,8 +22,15 @@ val summary_schema_supported : Llm_provider.Provider_config.t -> bool
 val messages_for_summary :
   trace_id:string -> texts:string list -> Agent_sdk.Types.message list
 
+type summary_parse_error =
+  | Empty_summary_response
+  | Invalid_structured_response of string
+
 module For_testing : sig
   val summary_text_of_response : Agent_sdk.Types.api_response -> string option
+
+  val summary_text_result_of_response :
+    Agent_sdk.Types.api_response -> (string, summary_parse_error) result
 end
 
 val make :

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -211,12 +211,18 @@ let log_rejected_output ~reason ~raw =
     (String.length raw)
 ;;
 
-let plan_of_string raw =
+let plan_result_of_string raw =
   match json_of_output_result raw with
-  | Ok json -> Some (plan_of_json json)
+  | Ok json -> Ok (plan_of_json json)
   | Error reason ->
     log_rejected_output ~reason ~raw;
-    None
+    Error reason
+;;
+
+let plan_of_string raw =
+  match plan_result_of_string raw with
+  | Ok plan -> Some plan
+  | Error _ -> None
 ;;
 
 (* ---------- Apply (pure, deterministic) ---------- *)

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -30,6 +30,12 @@ type consolidation_plan =
 
 val empty_plan : consolidation_plan
 
+type output_rejection_reason =
+  | Non_json
+  | Non_object_json
+
+val output_rejection_reason_to_string : output_rejection_reason -> string
+
 (** The numbered fact list the consolidation prompt sees: one 0-based line per
     fact, ["i: [category] claim"]. The index is the LLM's only handle on an
     existing fact, matching [apply_plan]'s reading. *)
@@ -39,6 +45,11 @@ val render_numbered_facts : fact list -> string
     (dropped with warning counts, not fatal); a wholly invalid object yields
     [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
+
+(** Parse the provider output as an exact JSON object, preserving the structured
+    rejection reason for runtime outcome classification. *)
+val plan_result_of_string :
+  string -> (consolidation_plan, output_rejection_reason) result
 
 (** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.
     Rejections emit a warning with a bounded reason label and byte count so

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -60,6 +60,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int
@@ -131,6 +133,12 @@ let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~aft
         Consolidated { before; after }))
 ;;
 
+let invalid_structured_response reason =
+  Invalid_structured_response
+    ("consolidation provider returned invalid structured response: "
+     ^ Consolidation.output_rejection_reason_to_string reason)
+;;
+
 (* Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it, and
    (unless [dry_run]) rewrite the store atomically. Returns what happened without
    raising for the expected failure modes (too few facts, transport error,
@@ -169,11 +177,11 @@ let consolidate_keeper
          | Some (Error _) -> Transport_failed "consolidation provider transport error"
          | Some (Ok response) ->
            (match response_text response with
-            | None -> Unparseable "consolidation provider returned empty response"
+            | None -> Empty_response
             | Some raw ->
-              (match Consolidation.plan_of_string raw with
-               | None -> Unparseable "consolidation provider returned invalid plan JSON"
-               | Some plan ->
+              (match Consolidation.plan_result_of_string raw with
+               | Error reason -> invalid_structured_response reason
+               | Ok plan ->
                  let survivors = Consolidation.apply_plan ~now ~facts plan in
                  let after = List.length survivors in
                  if dry_run

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -14,6 +14,8 @@ type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
   | Unparseable of string
+  | Empty_response
+  | Invalid_structured_response of string
   | Snapshot_changed of
       { before : int
       ; current : int

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -49,6 +49,18 @@ let record_eviction ~mode ~result ~reason =
     ()
 ;;
 
+let eager_read_eviction_reason_of_outcome = function
+  | Keeper_vision_tool.Vo_ok _ -> None
+  | Keeper_vision_tool.Vo_empty -> Some "eager_empty"
+  | Keeper_vision_tool.Vo_truncated -> Some "eager_truncated"
+  | Keeper_vision_tool.Vo_timeout -> Some "eager_timeout"
+  | Keeper_vision_tool.Vo_no_runtime _ -> Some "eager_no_runtime"
+  | Keeper_vision_tool.Vo_invalid_request _ -> Some "eager_invalid_request"
+  | Keeper_vision_tool.Vo_invalid_structured_response _ ->
+    Some "eager_invalid_structured_response"
+  | Keeper_vision_tool.Vo_provider _ -> Some "eager_provider_error"
+;;
+
 let truncate_read_text text =
   let length = String.length text in
   if length <= max_read_text_chars
@@ -95,14 +107,10 @@ let eager_read ~media_type ~bytes : (string, string) result option =
          ()
      with
      | Keeper_vision_tool.Vo_ok text -> Some (Ok (truncate_read_text text))
-     | Keeper_vision_tool.Vo_empty -> Some (Error "vision returned no text")
-     | Keeper_vision_tool.Vo_truncated -> Some (Error "vision reply truncated")
-     | Keeper_vision_tool.Vo_timeout -> Some (Error "vision sub-call timed out")
-     | Keeper_vision_tool.Vo_no_runtime msg -> Some (Error ("no vision runtime: " ^ msg))
-     | Keeper_vision_tool.Vo_invalid_request msg ->
-       Some (Error ("invalid vision request: " ^ msg))
-     | Keeper_vision_tool.Vo_provider { detail; _ } ->
-       Some (Error ("vision provider error: " ^ detail)))
+     | outcome ->
+       (match eager_read_eviction_reason_of_outcome outcome with
+        | Some reason -> Some (Error reason)
+        | None -> Some (Error "eager_read_failed")))
   | _ -> None
 ;;
 
@@ -157,8 +165,8 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                        record_eviction ~mode ~result:"ok" ~reason:"eager_read";
                        Agent_sdk.Types.Text
                          (image_read_placeholder ~handle ~media_type ~read_text)
-                     | Some (Error _reason) ->
-                       record_eviction ~mode ~result:"error" ~reason:"eager_read_failed";
+                     | Some (Error reason) ->
+                       record_eviction ~mode ~result:"error" ~reason;
                        Agent_sdk.Types.Text
                          (image_unread_placeholder
                             ~handle

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -24,6 +24,14 @@ type mode =
 val extraction_query : string
 (** The fixed exhaustive extraction query used by [Eager] (RFC §2.3-eager). *)
 
+val eager_read_eviction_reason_of_outcome
+  :  Keeper_vision_tool.vision_outcome
+  -> string option
+(** Metric reason projection for failed [Eager] vision sub-calls. [Vo_ok] has
+    no error reason; every non-ok outcome maps to a finite eviction reason so
+    provider failures, timeouts, invalid requests, and invalid structured
+    responses do not collapse into one counter bucket. *)
+
 val evict_blocks
   :  mode:mode
   -> policy:Keeper_types_profile.multimodal_policy

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -261,6 +261,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of
       { failure_class : Tool_result.tool_failure_class
       ; detail : string
@@ -300,8 +301,7 @@ let ok_or_classified_json (response : Agent_sdk.Types.api_response) =
 
 let outcome_of_response (response : Agent_sdk.Types.api_response) =
   match vision_text_of_response response with
-  | Error detail ->
-    Vo_provider { failure_class = Tool_result.Runtime_failure; detail }
+  | Error detail -> Vo_invalid_structured_response detail
   | Ok text ->
     let truncated = truncated_of_stop_reason response.stop_reason in
     (match Va.classify ~truncated ~content:text with

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -102,6 +102,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of { failure_class : Tool_result.tool_failure_class; detail : string }
   | Vo_empty
   | Vo_truncated
@@ -121,8 +122,9 @@ val run_vision
     call under [with_timeout] + §2.2 classification). Used by {!handle} and by
     eager ingestion. Requires the turn clock, so eager ingestion cannot run an
     unbounded provider call. Non-cancellation exceptions are converted to
-    [Vo_provider] so eager ingestion can keep the turn alive with a typed unread
-    placeholder. *)
+    [Vo_provider]; provider success with malformed structured output is
+    [Vo_invalid_structured_response], so eager ingestion can keep the turn alive
+    with a typed unread placeholder. *)
 
 val handle
   :  ?complete:complete_fn

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml
@@ -3,10 +3,12 @@ type t =
   | Timed_out
   | Http_error
   | Empty_response
+  | Invalid_structured_response
 
 let to_label = function
   | Ok_summary -> "ok_summary"
   | Timed_out -> "timed_out"
   | Http_error -> "http_error"
   | Empty_response -> "empty_response"
+  | Invalid_structured_response -> "invalid_structured_response"
 ;;

--- a/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
+++ b/lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli
@@ -1,11 +1,11 @@
 (** Keeper_memory_llm_summary_outcome — closed sum naming each path
     out of {!Keeper_memory_llm_summary.summarize_with_provider}.
 
-    Until this module existed, the three failure modes (timeout, HTTP
-    error, empty/whitespace-only response) each logged at warn but
-    were not aggregated as a counter, so operators could not see
-    "what fraction of summary attempts succeed" or
-    "which provider is regressing".  Successful summaries left no
+    Until this module existed, the failure modes (timeout, HTTP
+    error, empty/whitespace-only response, invalid structured response)
+    each logged at warn but were not aggregated as a counter, so
+    operators could not see "what fraction of summary attempts succeed"
+    or "which provider is regressing".  Successful summaries left no
     record at all.  Additionally, {!summarize_with_providers}
     returning [None] after exhausting every provider in the runtime
     was *silent* — no log, no metric, just a missing summary on the
@@ -27,5 +27,8 @@ type t =
       (** Provider returned 2xx but [response_text] collapsed to
           empty after trim — usually a model that produced only
           whitespace or refused the task. *)
+  | Invalid_structured_response
+      (** Provider returned 2xx with non-empty text that could not be
+          parsed as the requested summary JSON object. *)
 
 val to_label : t -> string

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -100,6 +100,15 @@ let run_memory_os_consolidation_tick
           "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
           keeper_id
           msg
+      | Empty_response ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s empty_response"
+          keeper_id
+      | Invalid_structured_response msg ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s invalid_structured_response: %s"
+          keeper_id
+          msg
       | Snapshot_changed { before; current } ->
         Log.Server.info
           "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1242,22 +1242,49 @@ let test_memory_llm_summary_response_parser_accepts_only_summary_json () =
   let parse raw =
     Memory_summary.For_testing.summary_text_of_response (fake_response raw)
   in
+  let parse_result raw =
+    Memory_summary.For_testing.summary_text_result_of_response (fake_response raw)
+  in
+  let check_invalid_structured label = function
+    | Error (Memory_summary.Invalid_structured_response _) -> ()
+    | Ok summary -> Alcotest.failf "%s: expected invalid structured response, got %S" label summary
+    | Error Memory_summary.Empty_summary_response ->
+        Alcotest.failf "%s: expected invalid structured response, got empty response" label
+  in
   Alcotest.(check (option string))
     "valid summary json"
     (Some "Remember exact command.")
     (parse {|{"summary":" Remember exact command.  "}|});
+  (match parse_result {|{"summary":" Remember exact command.  "}|} with
+   | Ok summary ->
+       Alcotest.(check string)
+         "valid summary json result"
+         "Remember exact command."
+         summary
+   | Error _ -> Alcotest.fail "valid summary json result rejected");
   Alcotest.(check (option string))
     "plain text rejected"
     None
     (parse "Remember exact command.");
+  check_invalid_structured "plain text result" (parse_result "Remember exact command.");
   Alcotest.(check (option string))
     "empty summary rejected"
     None
     (parse {|{"summary":"   "}|});
+  Alcotest.(check bool)
+    "empty summary result"
+    true
+    (match parse_result {|{"summary":"   "}|} with
+     | Error Memory_summary.Empty_summary_response -> true
+     | Ok _
+     | Error (Memory_summary.Invalid_structured_response _) -> false);
   Alcotest.(check (option string))
     "wrong field rejected"
     None
-    (parse {|{"text":"Remember exact command."}|})
+    (parse {|{"text":"Remember exact command."}|});
+  check_invalid_structured
+    "wrong field result"
+    (parse_result {|{"text":"Remember exact command."}|)
 ;;
 
 let json_episode_file_count ~keeper_id =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1284,7 +1284,7 @@ let test_memory_llm_summary_response_parser_accepts_only_summary_json () =
     (parse {|{"text":"Remember exact command."}|});
   check_invalid_structured
     "wrong field result"
-    (parse_result {|{"text":"Remember exact command."}|)
+    (parse_result {|{"text":"Remember exact command."}|})
 ;;
 
 let json_episode_file_count ~keeper_id =

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -447,6 +447,23 @@ let test_parse_non_json_is_none () =
   Alcotest.(check bool) "JSON array yields None" true (Consolidation.plan_of_string "[]" = None)
 ;;
 
+let test_parse_result_reports_rejection_reason () =
+  Alcotest.(check bool)
+    "non-JSON result"
+    true
+    (match Consolidation.plan_result_of_string "not json {{{" with
+     | Error Consolidation.Non_json -> true
+     | Ok _
+     | Error Consolidation.Non_object_json -> false);
+  Alcotest.(check bool)
+    "non-object result"
+    true
+    (match Consolidation.plan_result_of_string {|"not an object"|} with
+     | Error Consolidation.Non_object_json -> true
+     | Ok _
+     | Error Consolidation.Non_json -> false)
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os_consolidation"
@@ -480,10 +497,14 @@ let () =
 	    ; ( "parse"
 	      , [ Alcotest.test_case "parses a plan" `Quick test_parse_plan_json
 	        ; Alcotest.test_case "rejects fractional indices" `Quick test_parse_rejects_fractional_indices
-	        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
-	        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
-	        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
-	        ] )
+        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
+        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
+        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
+        ; Alcotest.test_case
+            "result reports rejection reason"
+            `Quick
+            test_parse_result_reports_rejection_reason
+        ] )
     ; ( "render"
       , [ Alcotest.test_case
             "keeps one fact per prompt line"

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -275,6 +275,60 @@ let test_consolidate_rejects_malformed_fact_store () =
         | _ -> Alcotest.fail "expected Unparseable for malformed fact store"))))
 ;;
 
+let test_consolidate_classifies_empty_provider_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "   ")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Empty_response -> ()
+        | _ -> Alcotest.fail "expected Empty_response for blank provider output"))))
+;;
+
+let test_consolidate_classifies_invalid_structured_response () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter
+          (Io.append_fact ~keeper_id)
+          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let outcome =
+          Runtime.consolidate_keeper
+            ~complete:(fake_complete "not json {{{")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        match outcome with
+        | Runtime.Invalid_structured_response detail ->
+          Alcotest.(check string)
+            "detail keeps rejection reason"
+            "consolidation provider returned invalid structured response: non_json"
+            detail
+        | _ ->
+          Alcotest.fail
+            "expected Invalid_structured_response for malformed provider output"))))
+;;
+
 let test_consolidate_respects_provider_config_and_prompt_template () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -357,8 +411,16 @@ let () =
       , [ Alcotest.test_case "applies the model's plan" `Quick test_consolidate_applies_plan
         ; Alcotest.test_case "skips when too few facts" `Quick test_consolidate_skips_too_few
 	        ; Alcotest.test_case "dry-run preserves the store" `Quick test_consolidate_dry_run_preserves_store
-	        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
-	        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
+        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
+        ; Alcotest.test_case
+            "classifies empty provider response"
+            `Quick
+            test_consolidate_classifies_empty_provider_response
+        ; Alcotest.test_case
+            "classifies invalid structured provider response"
+            `Quick
+            test_consolidate_classifies_invalid_structured_response
         ; Alcotest.test_case
             "respects provider config and prompt template"
             `Quick

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -635,6 +635,29 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
       assert (contains_substring (assoc_string "detail" json) "not valid JSON")))
 
+let test_run_vision_invalid_structured_response_is_typed () =
+  with_temp_runtime_toml single_vision_runtime_toml (fun () ->
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      Ok (text_response "not-json")
+    in
+    let outcome =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.run_vision
+            ~complete
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~query:"describe"
+            ~media_type:"image/png"
+            ~bytes:"\x89PNG\r\n\x1a\nraw"
+            ()))
+    in
+    match outcome with
+    | Vt.Vo_invalid_structured_response detail ->
+      assert (contains_substring detail "not valid JSON")
+    | _ -> failwith "expected Vo_invalid_structured_response")
+
 let test_retryable_provider_error_tries_next_runtime () =
   with_temp_runtime_toml vision_failover_runtime_toml (fun () ->
     with_temp_base (fun _ ->
@@ -788,6 +811,22 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       assert (List.rev !models = [ "vision-a" ]);
       assert (String.equal (assoc_string "error" json) "provider_error");
       assert (String.equal (assoc_string "failure_class" json) "policy_rejection")))
+
+let test_eager_eviction_reason_preserves_typed_outcome () =
+  let reason = Vi.eager_read_eviction_reason_of_outcome in
+  assert (reason (Vt.Vo_ok "text") = None);
+  assert (reason Vt.Vo_empty = Some "eager_empty");
+  assert (reason Vt.Vo_truncated = Some "eager_truncated");
+  assert (reason Vt.Vo_timeout = Some "eager_timeout");
+  assert (reason (Vt.Vo_no_runtime "missing") = Some "eager_no_runtime");
+  assert (reason (Vt.Vo_invalid_request "bad") = Some "eager_invalid_request");
+  assert
+    (reason (Vt.Vo_invalid_structured_response "bad json")
+     = Some "eager_invalid_structured_response");
+  assert
+    (reason
+       (Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail = "boom" })
+     = Some "eager_provider_error")
 
 let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
   with_temp_base (fun _ ->
@@ -1013,10 +1052,12 @@ let () =
   test_temp_runtime_toml_restores_runtime_cache ();
   test_schema_unsupported_vision_runtime_is_skipped_before_provider_call ();
   test_invalid_structured_vision_response_is_runtime_failure ();
+  test_run_vision_invalid_structured_response_is_typed ();
   test_retryable_provider_error_tries_next_runtime ();
   test_deadline_exhaustion_preserves_provider_error ();
   test_non_retryable_provider_error_stops_without_trying_next_runtime ();
   test_accept_rejected_is_policy_rejection_without_failover ();
+  test_eager_eviction_reason_preserves_typed_outcome ();
   test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();


### PR DESCRIPTION
## Summary
- split memory LLM summary parse failures into a typed invalid_structured_response outcome
- preserve the existing option parser while exposing a result parser for tests
- keep empty/whitespace summary output as empty_response and classify malformed JSON / wrong schema separately

## Verification
- ocamlformat --check lib/keeper_metrics/keeper_memory_llm_summary_outcome.mli lib/keeper_metrics/keeper_memory_llm_summary_outcome.ml lib/keeper/keeper_memory_llm_summary.mli lib/keeper/keeper_memory_llm_summary.ml test/test_keeper_memory_os.ml
- git diff --check
- CI will run the build/tests

Stacked on #22783.