### PR TITLE
fix(test): #22767 회귀 — ollama vision 런타임 model catalog 설치

### DIFF
--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -495,6 +495,60 @@ let with_temp_runtime_toml content f =
       init_runtime_or_fail path;
       f ())
 
+(* The structured-output capability gate (SDK [validate_output_schema_request])
+   resolves a model's [supports_structured_output] from the global
+   [Model_catalog], not from the runtime.toml [capabilities] block. Production
+   wires this by walking cwd parents for oas-models.toml and exporting
+   OAS_MODEL_CATALOG (server_runtime_bootstrap), which the SDK lazily loads.
+   These pure tests never run that bootstrap, so without an installed catalog
+   the synthetic ollama vision runtimes resolve to [default_capabilities]
+   (supports_structured_output = false); [vision_runtime_candidates] then
+   filters them out and the tool short-circuits to no_capable_runtime before
+   ever reaching the provider sub-call. Install a minimal catalog so the
+   provider-reaching tests below exercise their intended paths.
+   Ref #22767 (consume provider capability contract). *)
+let vision_model_catalog_toml =
+  {|
+[[models]]
+id_prefix = "ollama/vision-a"
+base = "ollama"
+supports_image_input = true
+supports_multimodal_inputs = true
+supports_structured_output = true
+
+[[models]]
+id_prefix = "ollama/vision-b"
+base = "ollama"
+supports_image_input = true
+supports_multimodal_inputs = true
+supports_structured_output = true
+
+[[models]]
+id_prefix = "ollama/vision-c"
+base = "ollama"
+supports_image_input = true
+supports_multimodal_inputs = true
+supports_structured_output = true
+|}
+
+let with_vision_model_catalog f =
+  let path = Filename.temp_file "masc-vision-catalog-" ".toml" in
+  write_file path vision_model_catalog_toml;
+  let previous = Llm_provider.Model_catalog.global () in
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous with
+       | Some catalog -> Llm_provider.Model_catalog.set_global catalog
+       | None -> Llm_provider.Model_catalog.clear_global ());
+      try Sys.remove path with
+      | _ -> ())
+    (fun () ->
+      match Llm_provider.Model_catalog.load_file path with
+      | Error msg -> failwith ("vision test model catalog should load: " ^ msg)
+      | Ok catalog ->
+        Llm_provider.Model_catalog.set_global catalog;
+        f ())
+
 let vision_failover_runtime_toml =
   {|
 [runtime]
@@ -1012,11 +1066,16 @@ let () =
   test_oversize_image_is_runtime_failure_before_provider_call ();
   test_temp_runtime_toml_restores_runtime_cache ();
   test_schema_unsupported_vision_runtime_is_skipped_before_provider_call ();
-  test_invalid_structured_vision_response_is_runtime_failure ();
-  test_retryable_provider_error_tries_next_runtime ();
-  test_deadline_exhaustion_preserves_provider_error ();
-  test_non_retryable_provider_error_stops_without_trying_next_runtime ();
-  test_accept_rejected_is_policy_rejection_without_failover ();
+  (* These tests drive the synthetic ollama vision runtimes past the
+     schema-capability gate to the provider sub-call, so they need an installed
+     model catalog that advertises supports_structured_output (see
+     [with_vision_model_catalog]). *)
+  with_vision_model_catalog (fun () ->
+    test_invalid_structured_vision_response_is_runtime_failure ();
+    test_retryable_provider_error_tries_next_runtime ();
+    test_deadline_exhaustion_preserves_provider_error ();
+    test_non_retryable_provider_error_stops_without_trying_next_runtime ();
+    test_accept_rejected_is_policy_rejection_without_failover ());
   test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();


### PR DESCRIPTION
## 증상
`main`이 #22767(provider capability contract) 머지 이후 RED. required check **Build and Test → Run tests (quick suite)**가 `test/test_keeper_vision_tool.ml:631`에서 `Assertion failed`로 중단. (84b71c29b=green → 3d2a9dad1(#22767)=red 확정.)

## 근본 원인
#22767이 agent_sdk를 범프하면서 `validate_output_schema_request`가 **Ollama kind의 `supports_structured_output`을 글로벌 `Model_catalog`에서 해석**하도록 조였습니다(이전엔 무조건 `Ok`). `test_keeper_vision_tool`은 catalog를 설치하지 않으므로(프로덕션은 `server_runtime_bootstrap`이 `OAS_MODEL_CATALOG`→`oas-models.toml`을 export + `capability-manifest.json`으로 배선) 합성 ollama 런타임이 `default_capabilities`(`supports_structured_output = false`)로 떨어짐 → `vision_runtime_candidates`가 필터아웃 → provider 호출 전에 `no_capable_runtime`으로 단락.

`test_invalid_structured_vision_response_is_runtime_failure`(line 631)가 첫 실패로 노출됐고, fatal-assert abort로 가려졌던 4개(retryable/deadline/non-retryable/accept-rejected)도 동일 원인.

## 변경
- `with_vision_model_catalog` 헬퍼 추가: ollama `vision-a/-b/-c`에 `supports_structured_output=true`를 선언하는 최소 catalog를 `Model_catalog.set_global`로 설치, `Fun.protect`로 직전 global 복원.
- 러너에서 **provider 호출에 도달하는 5개 테스트만** 이 헬퍼로 감쌈. 앞선 테스트와 `schema_unsupported`(openai-compat, `no_capable_runtime` 기대)는 영향 없음.

## correct-vs-stale 판정
새 동작이 **옳고 테스트가 stale**입니다. capability SSOT는 OAS 카탈로그(`oas-models.toml`)이며 프로덕션은 정상(검증: 카탈로그에 `ollama_cloud/minimax-m3`·`kimi-k2.6`이 `supports_structured_output=true`로 등록). 본 변경은 버그 마스킹이 아니라 catalog 계약 도입(#22767) 전에 작성된 테스트 인프라를 계약에 맞춘 것. **소스/프로덕션 변경 없음, 테스트 전용.**

## 검증
- `dune build --root . test/test_keeper_vision_tool.exe` RC:0
- `dune exec test/test_keeper_vision_tool.exe` → 27 테스트 전부 통과(`all assertions passed`).
- `schema_unsupported`(openai-compat)는 여전히 `no_capable_runtime`으로 정상 거부.

RFC-WAIVED: 테스트 전용 변경(테스트 인프라 catalog 설치), credential/operator/sandbox subsystem 미해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)