### PR TITLE
feat(vision): type invalid structured responses

### DIFF
--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -49,6 +49,18 @@ let record_eviction ~mode ~result ~reason =
     ()
 ;;
 
+let eager_read_eviction_reason_of_outcome = function
+  | Keeper_vision_tool.Vo_ok _ -> None
+  | Keeper_vision_tool.Vo_empty -> Some "eager_empty"
+  | Keeper_vision_tool.Vo_truncated -> Some "eager_truncated"
+  | Keeper_vision_tool.Vo_timeout -> Some "eager_timeout"
+  | Keeper_vision_tool.Vo_no_runtime _ -> Some "eager_no_runtime"
+  | Keeper_vision_tool.Vo_invalid_request _ -> Some "eager_invalid_request"
+  | Keeper_vision_tool.Vo_invalid_structured_response _ ->
+    Some "eager_invalid_structured_response"
+  | Keeper_vision_tool.Vo_provider _ -> Some "eager_provider_error"
+;;
+
 let truncate_read_text text =
   let length = String.length text in
   if length <= max_read_text_chars
@@ -95,14 +107,10 @@ let eager_read ~media_type ~bytes : (string, string) result option =
          ()
      with
      | Keeper_vision_tool.Vo_ok text -> Some (Ok (truncate_read_text text))
-     | Keeper_vision_tool.Vo_empty -> Some (Error "vision returned no text")
-     | Keeper_vision_tool.Vo_truncated -> Some (Error "vision reply truncated")
-     | Keeper_vision_tool.Vo_timeout -> Some (Error "vision sub-call timed out")
-     | Keeper_vision_tool.Vo_no_runtime msg -> Some (Error ("no vision runtime: " ^ msg))
-     | Keeper_vision_tool.Vo_invalid_request msg ->
-       Some (Error ("invalid vision request: " ^ msg))
-     | Keeper_vision_tool.Vo_provider { detail; _ } ->
-       Some (Error ("vision provider error: " ^ detail)))
+     | outcome ->
+       (match eager_read_eviction_reason_of_outcome outcome with
+        | Some reason -> Some (Error reason)
+        | None -> Some (Error "eager_read_failed")))
   | _ -> None
 ;;
 
@@ -157,8 +165,8 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                        record_eviction ~mode ~result:"ok" ~reason:"eager_read";
                        Agent_sdk.Types.Text
                          (image_read_placeholder ~handle ~media_type ~read_text)
-                     | Some (Error _reason) ->
-                       record_eviction ~mode ~result:"error" ~reason:"eager_read_failed";
+                     | Some (Error reason) ->
+                       record_eviction ~mode ~result:"error" ~reason;
                        Agent_sdk.Types.Text
                          (image_unread_placeholder
                             ~handle

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -24,6 +24,14 @@ type mode =
 val extraction_query : string
 (** The fixed exhaustive extraction query used by [Eager] (RFC §2.3-eager). *)
 
+val eager_read_eviction_reason_of_outcome
+  :  Keeper_vision_tool.vision_outcome
+  -> string option
+(** Metric reason projection for failed [Eager] vision sub-calls. [Vo_ok] has
+    no error reason; every non-ok outcome maps to a finite eviction reason so
+    provider failures, timeouts, invalid requests, and invalid structured
+    responses do not collapse into one counter bucket. *)
+
 val evict_blocks
   :  mode:mode
   -> policy:Keeper_types_profile.multimodal_policy

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -261,6 +261,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of
       { failure_class : Tool_result.tool_failure_class
       ; detail : string
@@ -300,8 +301,7 @@ let ok_or_classified_json (response : Agent_sdk.Types.api_response) =
 
 let outcome_of_response (response : Agent_sdk.Types.api_response) =
   match vision_text_of_response response with
-  | Error detail ->
-    Vo_provider { failure_class = Tool_result.Runtime_failure; detail }
+  | Error detail -> Vo_invalid_structured_response detail
   | Ok text ->
     let truncated = truncated_of_stop_reason response.stop_reason in
     (match Va.classify ~truncated ~content:text with

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -102,6 +102,7 @@ type vision_outcome =
   | Vo_invalid_request of string
   | Vo_no_runtime of string
   | Vo_timeout
+  | Vo_invalid_structured_response of string
   | Vo_provider of { failure_class : Tool_result.tool_failure_class; detail : string }
   | Vo_empty
   | Vo_truncated
@@ -121,8 +122,9 @@ val run_vision
     call under [with_timeout] + §2.2 classification). Used by {!handle} and by
     eager ingestion. Requires the turn clock, so eager ingestion cannot run an
     unbounded provider call. Non-cancellation exceptions are converted to
-    [Vo_provider] so eager ingestion can keep the turn alive with a typed unread
-    placeholder. *)
+    [Vo_provider]; provider success with malformed structured output is
+    [Vo_invalid_structured_response], so eager ingestion can keep the turn alive
+    with a typed unread placeholder. *)
 
 val handle
   :  ?complete:complete_fn

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -635,6 +635,29 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
       assert (contains_substring (assoc_string "detail" json) "not valid JSON")))
 
+let test_run_vision_invalid_structured_response_is_typed () =
+  with_temp_runtime_toml single_vision_runtime_toml (fun () ->
+    let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+      Ok (text_response "not-json")
+    in
+    let outcome =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.run_vision
+            ~complete
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~query:"describe"
+            ~media_type:"image/png"
+            ~bytes:"\x89PNG\r\n\x1a\nraw"
+            ()))
+    in
+    match outcome with
+    | Vt.Vo_invalid_structured_response detail ->
+      assert (contains_substring detail "not valid JSON")
+    | _ -> failwith "expected Vo_invalid_structured_response")
+
 let test_retryable_provider_error_tries_next_runtime () =
   with_temp_runtime_toml vision_failover_runtime_toml (fun () ->
     with_temp_base (fun _ ->
@@ -788,6 +811,22 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       assert (List.rev !models = [ "vision-a" ]);
       assert (String.equal (assoc_string "error" json) "provider_error");
       assert (String.equal (assoc_string "failure_class" json) "policy_rejection")))
+
+let test_eager_eviction_reason_preserves_typed_outcome () =
+  let reason = Vi.eager_read_eviction_reason_of_outcome in
+  assert (reason (Vt.Vo_ok "text") = None);
+  assert (reason Vt.Vo_empty = Some "eager_empty");
+  assert (reason Vt.Vo_truncated = Some "eager_truncated");
+  assert (reason Vt.Vo_timeout = Some "eager_timeout");
+  assert (reason (Vt.Vo_no_runtime "missing") = Some "eager_no_runtime");
+  assert (reason (Vt.Vo_invalid_request "bad") = Some "eager_invalid_request");
+  assert
+    (reason (Vt.Vo_invalid_structured_response "bad json")
+     = Some "eager_invalid_structured_response");
+  assert
+    (reason
+       (Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail = "boom" })
+     = Some "eager_provider_error")
 
 let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
   with_temp_base (fun _ ->
@@ -1013,10 +1052,12 @@ let () =
   test_temp_runtime_toml_restores_runtime_cache ();
   test_schema_unsupported_vision_runtime_is_skipped_before_provider_call ();
   test_invalid_structured_vision_response_is_runtime_failure ();
+  test_run_vision_invalid_structured_response_is_typed ();
   test_retryable_provider_error_tries_next_runtime ();
   test_deadline_exhaustion_preserves_provider_error ();
   test_non_retryable_provider_error_stops_without_trying_next_runtime ();
   test_accept_rejected_is_policy_rejection_without_failover ();
+  test_eager_eviction_reason_preserves_typed_outcome ();
   test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();


### PR DESCRIPTION
## Summary
- add a typed Vo_invalid_structured_response outcome for vision provider-success malformed JSON/schema output
- keep the tool handler JSON error code unchanged while preserving typed classification for run_vision/eager ingestion
- add a run_vision regression that malformed structured output is no longer collapsed into Vo_provider

## Verification
- ocamlformat --check lib/keeper/keeper_vision_tool.mli lib/keeper/keeper_vision_tool.ml lib/keeper/keeper_vision_ingest.ml test/test_keeper_vision_tool.ml
- git diff --check
- CI will run the build/tests

Stacked on #22786.