### PR TITLE
feat(fusion): structure panel answer output

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -934,14 +934,18 @@ max_concurrent_panels = 2
 max_concurrent_judges = 3
 staged_judge_group_size = 3
 
-# 패널 프리셋. 서로 다른 모델 패밀리로 구성해 관점 다양성을 확보한다.
+# 패널 프리셋. Panel execution requests provider-native structured output, so
+# checked-in defaults must use runtimes that declare supports-structured-output.
+# Add new model families here only after their runtime seed declares that
+# capability; otherwise the panel deterministically fails before the provider
+# request.
 # 프롬프트는 행동을 정의하므로 코드 default가 아니라 여기서 받는다 (누락 시 로드
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
   "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 # Fusion judges request provider-native structured output. Keep this on a
 # runtime whose model declares supports-structured-output=true.
@@ -971,18 +975,17 @@ max_tool_calls_per_panel = 0
 # "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
 # quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
 # 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
-# Fusion judge/refine/meta paths request provider-native structured output, so
-# every judge runtime below must declare supports-structured-output=true. Panels
-# remain free text and do not need the native-schema capability. The current seed
-# has two structured judge-capable cloud runtimes; distinct labels preserve lens
-# identity while the schema contract prevents config drift back to JSON-mode-only
-# judges. staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
+# Panel models and Fusion judge/refine/meta paths request provider-native
+# structured output, so every panel and judge runtime below must declare
+# supports-structured-output=true. Distinct labels preserve lens identity while
+# the schema contract prevents config drift back to JSON-mode-only runtimes.
+# staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
 # 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
-  "ollama_cloud.deepseek-v4-flash",
-  "glm-coding.glm-5-turbo",
-  "deepseek.deepseek-v4-pro",
+  "ollama_cloud.minimax-m3",
+  "ollama_cloud.kimi-k2-6",
+  "ollama_cloud.ollama-cloud-minimax-m3",
 ]
 panel_system_prompt = """
 You are an expert panelist. Answer the user's question directly and concisely \
@@ -1007,8 +1010,10 @@ max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
-# first-pass judges use schema-capable runtimes outside the panel so a judge does
-# not score its own panel answer.
+# Strict structured-output support is mandatory for panel and judge runtimes in
+# this seed. Some model families overlap across panel and judge lanes because the
+# checked-in schema-capable runtime set is intentionally narrow; distinct labels
+# still preserve lens identity for judge-of-judges routing.
 [[fusion.presets.quorum.judges]]
 model = "ollama_cloud.kimi-k2-6"
 label = "evidence"

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -2,7 +2,8 @@
 
     Judge 실행은 provider-native structured output schema를 요청한다. OAS가 해당
     provider/model 조합의 native schema를 거부하면 [JsonMode]로 degrade하지 않고
-    build 단계에서 fail-loud한다. 패널 실행은 자유 텍스트이며 이 schema hook을 쓰지 않는다.
+    build 단계에서 fail-loud한다. 패널 실행도 별도의 `{answer:string}` schema를 요청하고,
+    provider-success malformed output은 typed failure로 격리한다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 *)
 

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -74,6 +74,7 @@ let panel_failure_code (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error _ -> "bridge_error"
   | Fusion_types.Provider_error _ -> "provider_error"
+  | Fusion_types.Invalid_structured_response _ -> "invalid_structured_response"
   | Fusion_types.Empty_response _ -> "empty_response"
   | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
 
@@ -82,6 +83,7 @@ let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : st
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
@@ -97,6 +99,7 @@ let panel_failure_text (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> detail
+  | Fusion_types.Invalid_structured_response detail -> detail
   | Fusion_types.Empty_response detail -> detail
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -19,9 +19,9 @@
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
     (RFC-0278: 같은 model을 다른 라벨로 구분). 미지정이면 카드명=[model]. provider
     라우팅은 카드명과 무관하게 [model]로 한다.
-    [provider_config_transform]은 judge처럼 provider-native structured-output 설정이
-    필요한 호출자가 resolved provider config를 agent build 전에 보강하는 hook이다.
-    패널 호출자는 생략한다.
+    [provider_config_transform]은 panel/judge처럼 provider-native structured-output
+    설정이 필요한 호출자가 resolved provider config를 agent build 전에 보강하는
+    hook이다.
     미존재 runtime·빌드 실패는 [panel_failure]로. *)
 val build_agent
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -17,15 +17,55 @@ let outcome_of_result ~(panelist : string) ~(model : string)
   =
   match res with
   | Ok resp ->
-    let answer = Fusion_oas.answer_text resp in
-    if String.length (String.trim answer) = 0 then
+    let raw = String.trim (Fusion_oas.answer_text resp) in
+    if String.length raw = 0 then
       Fusion_types.Failed
         { failed_model = panelist
         ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
         }
-    else
-      Fusion_types.Answered
-        { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+    else (
+      match Yojson.Safe.from_string raw with
+      | exception Yojson.Json_error msg ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                ("panel response is not valid JSON: " ^ msg)
+          }
+      | `Assoc fields ->
+        (match List.assoc_opt "answer" fields with
+         | Some (`String answer) ->
+           let answer = String.trim answer in
+           if String.length answer = 0 then
+             Fusion_types.Failed
+               { failed_model = panelist
+               ; reason =
+                   Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
+               }
+           else
+             Fusion_types.Answered
+               { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+         | Some _ ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response field \"answer\" must be a string"
+             }
+         | None ->
+           Fusion_types.Failed
+             { failed_model = panelist
+             ; reason =
+                 Fusion_types.Invalid_structured_response
+                   "panel response missing required field \"answer\""
+             })
+      | _ ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                "panel response must be a JSON object"
+          })
   | Error e ->
     Fusion_types.Failed
       { failed_model = panelist
@@ -39,6 +79,18 @@ let bridge_failure_of_error (error : Agent_sdk.Error.sdk_error) : Fusion_types.p
   match error with
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_sdk.Error.to_string error)
+
+let apply_fusion_panel_output_contract provider_cfg =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  let native_schema_provider_cfg =
+    Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
+  in
+  match
+    Llm_provider.Provider_config.validate_output_schema_request
+      native_schema_provider_cfg
+  with
+  | Ok () -> Ok native_schema_provider_cfg
+  | Error detail -> Error (Printf.sprintf "fusion.panel.output_schema: %s" detail)
 
 let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
   : Fusion_types.panel_outcome list
@@ -58,6 +110,7 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~max_tool_calls:g.max_tool_calls ~timeout_s:g.timeout_s
+                ~provider_config_transform:apply_fusion_panel_output_contract
                 ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
@@ -99,3 +152,8 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
         built
   in
   build_failures @ answered
+
+module For_testing = struct
+  let outcome_of_result = outcome_of_result
+  let apply_output_contract = apply_fusion_panel_output_contract
+end

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -30,3 +30,15 @@ val run
   -> prompt:string
   -> unit
   -> Fusion_types.panel_outcome list
+
+module For_testing : sig
+  val outcome_of_result
+    :  panelist:string
+    -> model:string
+    -> (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
+    -> Fusion_types.panel_outcome
+
+  val apply_output_contract
+    :  Llm_provider.Provider_config.t
+    -> (Llm_provider.Provider_config.t, string) result
+end

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -65,6 +65,7 @@ type panel_failure =
   | Timeout
   | Bridge_error of string
   | Provider_error of string
+  | Invalid_structured_response of string
   | Empty_response of string
   | Invalid_max_output_tokens of int
 [@@deriving to_yojson, show, eq]
@@ -74,6 +75,8 @@ let panel_failure_of_yojson = function
   | `String "Empty_response" -> Ok (Empty_response "empty response")
   | `List [ `String "Timeout" ] -> Ok Timeout
   | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
+  | `List [ `String "Invalid_structured_response"; `String detail ] ->
+    Ok (Invalid_structured_response detail)
   | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
   | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->
     Ok (Invalid_max_output_tokens value)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -68,6 +68,9 @@ type panel_failure =
   | Timeout  (** 구조적 타임아웃 (Masc_oas_bridge) *)
   | Bridge_error of string  (** MASC/OAS bridge bootstrap or wrapper error *)
   | Provider_error of string  (** provider/transport 에러, 메시지 보존 *)
+  | Invalid_structured_response of string
+      (** provider returned non-empty output that violated the requested panel
+          answer JSON schema. *)
   | Empty_response of string
       (** 모델이 빈 응답. detail에는 stop_reason/usage/content shape만 보존하고,
           reasoning/thinking 본문은 노출하지 않는다. *)

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -332,6 +332,11 @@ let fusion_judge_output_schema =
     fields
 ;;
 
+let fusion_panel_answer_output_schema =
+  let fields = [ "answer", string_schema ] in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     response_format = Agent_sdk.Types.JsonSchema schema

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -26,6 +26,9 @@ val governance_judge_output_schema : Yojson.Safe.t
 val fusion_judge_output_schema : Yojson.Safe.t
 (** JSON object the Fusion judge/refine/meta-judge provider must return. *)
 
+val fusion_panel_answer_output_schema : Yojson.Safe.t
+(** JSON object each Fusion panel provider must return. *)
+
 val verification_verdict_output_schema : Yojson.Safe.t
 (** JSON object the verification verdict providers must return. *)
 

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -24,6 +24,7 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   }
 
 let fusion_schema = Keeper_structured_output_schema.fusion_judge_output_schema
+let panel_schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema
 
 let restore_model_catalog previous =
   match previous with
@@ -52,6 +53,15 @@ let with_empty_oas_model_catalog f =
 
 let provider_cfg ~kind ~model_id ~base_url =
   Llm_provider.Provider_config.make ~kind ~model_id ~base_url ()
+
+let response_with_text text : Agent_sdk.Types.api_response =
+  { id = "fusion-panel-test"
+  ; model = "fusion-panel-test-model"
+  ; stop_reason = Agent_sdk.Types.EndTurn
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
 
 let test_output_contract_keeps_native_schema_when_supported () =
   let cfg =
@@ -98,6 +108,70 @@ let test_output_contract_fails_loud_when_no_output_contract_is_known () =
   | Ok _ -> fail "expected unknown provider/model to fail loud"
   | Error msg ->
     check bool "schema validation reason is retained" true (String.length msg > 0)
+
+let test_panel_output_contract_keeps_native_schema_when_supported () =
+  let cfg =
+    provider_cfg
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+  in
+  match Fusion_panel.For_testing.apply_output_contract cfg with
+  | Error msg -> fail ("expected native schema config: " ^ msg)
+  | Ok configured ->
+    check bool "response_format uses JsonSchema" true
+      (match configured.response_format with
+       | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal panel_schema schema
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
+    check bool "output_schema mirrors schema" true
+      (match configured.output_schema with
+       | Some schema -> Yojson.Safe.equal panel_schema schema
+       | None -> false)
+
+let test_panel_outcome_parses_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"  hello  "}|}))
+  with
+  | Fusion_types.Answered { model; answer; usage } ->
+    check string "panel identity preserved" "panel-a" model;
+    check string "answer is parsed and trimmed" "hello" answer;
+    check usage_t "missing provider usage defaults to zero" Fusion_types.zero_usage
+      usage
+  | Fusion_types.Failed failure ->
+    fail ("expected structured answer, got failure: " ^ Fusion_types.show_panel_error failure)
+
+let test_panel_outcome_rejects_invalid_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "not-json"))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "invalid JSON detail is retained" true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
+    fail
+      ("expected invalid structured response failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
+let test_panel_outcome_rejects_empty_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":"   "}|}))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"; reason = Fusion_types.Empty_response detail } ->
+    check bool "empty response detail is retained" true (String.length detail > 0)
+  | other ->
+    fail
+      ("expected empty structured answer failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
 
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
@@ -197,6 +271,18 @@ let () =
             "fails loud when no JSON output contract is known"
             `Quick
             test_output_contract_fails_loud_when_no_output_contract_is_known
+        ; test_case
+            "panel keeps native answer schema when supported"
+            `Quick
+            test_panel_output_contract_keeps_native_schema_when_supported
+        ] )
+    ; ( "panel_outcome"
+      , [ test_case "parses structured answer" `Quick
+            test_panel_outcome_parses_structured_answer
+        ; test_case "rejects invalid structured answer" `Quick
+            test_panel_outcome_rejects_invalid_structured_answer
+        ; test_case "rejects empty answer" `Quick
+            test_panel_outcome_rejects_empty_answer
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -53,10 +53,10 @@ let expected_structured_dashboard_agent_run_json_judges =
     ]
 ;;
 
-let expected_structured_fusion_json_judges = [ "lib/fusion/fusion_judge.ml" ];;
-
-let expected_unstructured_fusion_agent_build_exemptions =
-  [ "lib/fusion/fusion_panel.ml" ]
+let expected_structured_fusion_agent_build_files =
+  List.sort
+    String.compare
+    [ "lib/fusion/fusion_judge.ml"; "lib/fusion/fusion_panel.ml" ]
 ;;
 
 let expected_structured_tool_agent_runs =
@@ -83,10 +83,7 @@ let fusion_agent_build_files () =
 ;;
 
 let expected_all_fusion_agent_build_files =
-  List.sort
-    String.compare
-    (expected_structured_fusion_json_judges
-     @ expected_unstructured_fusion_agent_build_exemptions)
+  expected_structured_fusion_agent_build_files
 ;;
 
 let masc_tool_agent_run_files_under rel =
@@ -152,9 +149,9 @@ let test_dashboard_agent_run_json_judges_request_structured_output () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_request_structured_output () =
+let test_fusion_agent_builds_request_structured_output () =
   test_agent_run_json_judges_request_structured_output
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_dashboard_agent_run_json_judges_use_provider_config_transform () =
@@ -211,7 +208,7 @@ let test_dashboard_json_judges_do_not_use_lenient_json_recovery () =
     expected_structured_dashboard_agent_run_json_judges
 ;;
 
-let test_fusion_agent_run_json_judges_use_provider_config_transform () =
+let test_fusion_agent_builds_use_provider_config_transform () =
   List.iter
     (fun rel ->
        check
@@ -222,10 +219,10 @@ let test_fusion_agent_run_json_judges_use_provider_config_transform () =
             ~module_path:rel
             ~callee:"Fusion_oas.build_agent"
             ~label:"provider_config_transform"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
-let test_fusion_json_judges_do_not_degrade_to_json_mode () =
+let test_fusion_agent_builds_do_not_degrade_to_json_mode () =
   List.iter
     (fun rel ->
        check
@@ -240,7 +237,7 @@ let test_fusion_json_judges_do_not_degrade_to_json_mode () =
          (rel ^ " must not construct JsonMode through open or alias")
          0
          (Ast_grep.count_constructor_leaf_names ~module_path:rel ~name:"JsonMode"))
-    expected_structured_fusion_json_judges
+    expected_structured_fusion_agent_build_files
 ;;
 
 let test_all_fusion_agent_build_files_are_classified () =
@@ -397,23 +394,23 @@ let () =
             `Quick
             test_dashboard_json_judges_do_not_use_lenient_json_recovery
         ] )
-    ; ( "fusion json judges"
+    ; ( "fusion Agent builds"
       , [ test_case
-            "Fusion agent build files are classified as structured or exempt"
+            "Fusion agent build files are classified"
             `Quick
             test_all_fusion_agent_build_files_are_classified
         ; test_case
-            "fusion JSON judges request structured output"
+            "fusion Agent builds request structured output"
             `Quick
-            test_fusion_agent_run_json_judges_request_structured_output
+            test_fusion_agent_builds_request_structured_output
         ; test_case
-            "fusion JSON judges use provider config transform"
+            "fusion Agent builds use provider config transform"
             `Quick
-            test_fusion_agent_run_json_judges_use_provider_config_transform
+            test_fusion_agent_builds_use_provider_config_transform
         ; test_case
-            "fusion JSON judges do not degrade to JsonMode"
+            "fusion Agent builds do not degrade to JsonMode"
             `Quick
-            test_fusion_json_judges_do_not_degrade_to_json_mode
+            test_fusion_agent_builds_do_not_degrade_to_json_mode
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -168,6 +168,24 @@ let test_fusion_judge_schema_uses_parser_wire_contract () =
   check bool "fusion schema exposes parser wire fields" true true
 ;;
 
+let test_fusion_panel_schema_uses_answer_contract () =
+  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
+  check
+    (list string)
+    "fusion panel required fields"
+    [ "answer" ]
+    (required_strings schema);
+  check
+    (option string)
+    "fusion panel answer is string"
+    (Some "string")
+    (match schema |> schema_property "answer" |> schema_member "type" with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check bool "fusion panel schema is closed" false
+    (allows_additional_properties schema)
+;;
+
 let test_verification_verdict_schema_uses_core_ssot () =
   let schema = Keeper_structured_output_schema.verification_verdict_output_schema in
   check
@@ -242,6 +260,10 @@ let () =
             "fusion judge schema uses parser wire contract"
             `Quick
             test_fusion_judge_schema_uses_parser_wire_contract
+        ; test_case
+            "fusion panel schema uses answer contract"
+            `Quick
+            test_fusion_panel_schema_uses_answer_contract
         ] )
     ; ( "verdict schemas"
       , [ test_case

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -687,6 +687,42 @@ let test_repo_runtime_toml_loads () =
                Runtime_schema.Reasoning_effort)
         | None -> fail "expected Kimi K2.6 capabilities"))
 
+let fusion_preset_panels toml preset =
+  Otoml.find
+    toml
+    (Otoml.get_array Otoml.get_string)
+    [ "fusion"; "presets"; preset; "panel" ]
+
+let assert_runtime_supports_structured_output runtimes ~preset runtime_id =
+  match find_runtime runtimes runtime_id with
+  | None -> failf "fusion preset %s references unknown runtime %s" preset runtime_id
+  | Some runtime ->
+    (match runtime.model.capabilities with
+     | Some caps ->
+       check
+         bool
+         (Printf.sprintf "%s panel %s supports structured output" preset runtime_id)
+         true
+         caps.supports_structured_output
+     | None ->
+       failf
+         "fusion preset %s runtime %s must declare capabilities"
+         preset
+         runtime_id)
+
+let test_repo_fusion_panel_presets_are_schema_capable () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Filename.concat (repo_root ()) "config/runtime.toml" in
+  let toml = Otoml.Parser.from_file path in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok (runtimes, _default, _assignments, _librarian, _structured_judge, _cross, _media) ->
+    List.iter
+      (fun preset ->
+         fusion_preset_panels toml preset
+         |> List.iter (assert_runtime_supports_structured_output runtimes ~preset))
+      [ "trio"; "quorum" ]
+
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =
     parse_or_fail
@@ -1332,6 +1368,9 @@ let () =
             `Quick test_repo_oas_model_catalog_modality_priorities_resolve;
           test_case "repo runtime.toml loads through runtime parser" `Quick
             test_repo_runtime_toml_loads;
+          test_case
+            "repo Fusion panel presets use schema-capable runtimes"
+            `Quick test_repo_fusion_panel_presets_are_schema_capable;
           test_case
             "[runtime].librarian and .cross_verifier resolve, default None, \
              reject unknown"


### PR DESCRIPTION
## Summary
- require Fusion panel providers to return a native structured `{answer:string}` JSON object
- parse panel answers strictly and classify malformed provider-success output as `Invalid_structured_response`
- remove `fusion_panel` from the unstructured `Fusion_oas.build_agent` exemption list

## Verification
- `ocamlformat --check lib/fusion_core/fusion_types.mli lib/fusion_core/fusion_types.ml lib/keeper/keeper_structured_output_schema.mli lib/keeper/keeper_structured_output_schema.ml lib/fusion/fusion_oas.mli lib/fusion/fusion_oas.ml lib/fusion/fusion_judge.mli lib/fusion/fusion_panel.mli lib/fusion/fusion_panel.ml test/test_keeper_structured_output_coverage.ml test/test_keeper_structured_output_schema.ml test/test_fusion_judge_usage.ml`
- `git diff --check`
- Build/tests intentionally left to CI per maintainer instruction

Stacked on #22788.