### PR TITLE
fix(ide): use atomic write helper for annotations compaction

### DIFF
--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -97,7 +97,7 @@ let write_all_partition ~base_dir partition annotations =
   let content = String.concat "" (List.map (fun line -> line ^ "\n") lines) in
   match Fs_compat.save_file_atomic path content with
   | Ok () -> ()
-  | Error msg -> failwith msg
+  | Error msg -> raise (Sys_error msg)
 ;;
 
 let create

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -94,24 +94,10 @@ let write_all_partition ~base_dir partition annotations =
   let path = annotations_file_for ~base_dir partition in
   let jsons = List.map annotation_to_json annotations in
   let lines = List.map Yojson.Safe.to_string jsons in
-  let tmp_path = path ^ ".tmp" in
-  let oc = open_out_bin tmp_path in
-  (* [Fun.protect] guarantees the fd is closed even if [output_string] /
-     [output_char] / [flush] raises mid-write (e.g. ENOSPC). Without it the
-     fd leaked on exception, since [close_out] below was unreachable -- the
-     other writers in this codebase (fs_compat, masc_log) already guard this
-     way. [flush] inside the body surfaces write errors so a failed write
-     re-raises before [Sys.rename] promotes a partial file over the good one. *)
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-       List.iter
-         (fun line ->
-            output_string oc line;
-            output_char oc '\n')
-         lines;
-       flush oc);
-  Sys.rename tmp_path path
+  let content = String.concat "" (List.map (fun line -> line ^ "\n") lines) in
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> failwith msg
 ;;
 
 let create

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -720,9 +720,9 @@ let test_document_highlights_related () =
 ;;
 
 (* Round-trip through [compact], which calls the internal
-   [write_all_partition].  Guards the [Fun.protect] fd-safe rewrite: the
-   happy path must still write every annotation back so a later [list]
-   sees them all. *)
+   [write_all_partition].  Guards the [Fs_compat.save_file_atomic] rewrite:
+   the happy path must still write every annotation back so a later [list] sees
+   them all. *)
 let test_compact_preserves_annotations () =
   with_temp_dir (fun base_dir ->
     let mk content =
@@ -774,7 +774,7 @@ let () =
     "ide_annotations"
     [ ( "compact"
       , [ test_case
-            "compact preserves annotations (fd-safe write)"
+            "compact preserves annotations (atomic write)"
             `Quick
             test_compact_preserves_annotations
         ] )


### PR DESCRIPTION
## Summary

- replace `Ide_annotations.write_all_partition` hand-rolled tmp-write/rename with `Fs_compat.save_file_atomic`
- keep the existing exception-style failure behavior by raising on `Error msg`
- update the compact round-trip test label/comment to describe the atomic helper path

Closes #22034

## Validation

- `ocamlformat --check lib/ide/ide_annotations.ml test/test_ide_annotations.ml`
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build @install test/test_ide_annotations.exe`
- `./_build/default/test/test_ide_annotations.exe`

Note: the first Dune wrapper run stopped before compilation because the shared local opam switch recorded `agent_sdk` floor `0.208.2` while this branch's pinned floor is `0.208.1`; `scripts/opam-pin-external-deps.sh --install` correctly refused to downgrade the shared switch. The focused build was then run with the current higher local pin and `MASC_SKIP_PIN_CHECK=1`.
