### PR TITLE
[codex] Wire display density settings preview

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -23,6 +23,7 @@ import type {
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
+import { tweaksDensity } from './tweaks-panel'
 
 const MOCK_RUNTIME_PATH = 'fixture/config/runtime.toml'
 import { dashboardLoading, shellConfigResolution, shellRuntimeResolution } from '../store'
@@ -344,6 +345,8 @@ describe('SettingsSurface', () => {
       keepers: { path: '/workspace/.masc/keepers', exists: true, source: 'derived' },
       personas: { path: '/workspace/.masc/personas', exists: true, source: 'derived' },
     }
+    localStorage.clear()
+    tweaksDensity.value = 'spacious'
     window.location.hash = '#settings'
     route.value = { tab: 'settings', params: {}, postId: null }
   })
@@ -356,6 +359,8 @@ describe('SettingsSurface', () => {
     shellRuntimeResolution.value = null
     resetDevTokenBootstrap()
     sessionStorage.clear()
+    localStorage.clear()
+    tweaksDensity.value = 'spacious'
     vi.unstubAllGlobals()
     vi.unstubAllEnvs()
   })
@@ -422,6 +427,43 @@ describe('SettingsSurface', () => {
     const themeButton = [...container.querySelectorAll('button')]
       .find(b => /DARK|STYLESEED|PAPER/.test(b.textContent ?? ''))
     expect(themeButton).toBeTruthy()
+  })
+
+  it('wires display density to the dashboard density signal and keeps local-only display previews honest', async () => {
+    route.value = { tab: 'settings', params: { section: 'display' }, postId: null }
+
+    render(html`<${SettingsSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent)
+      .toContain('theme/density live + local preview')
+    expect(container.querySelector('[data-testid="display-local-summary"]')?.textContent)
+      .toContain('spacious')
+
+    const clickSeg = async (label: string) => {
+      const button = Array.from(container.querySelectorAll<HTMLButtonElement>('.set-seg-b'))
+        .find(candidate => candidate.textContent === label)
+      expect(button).toBeTruthy()
+      await fireEvent.click(button as HTMLButtonElement)
+    }
+
+    await clickSeg('compact')
+    await clickSeg('EN')
+    await clickSeg('UTC')
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('[data-testid="set-toggle"]') as HTMLButtonElement)
+
+    expect(tweaksDensity.value).toBe('compact')
+    expect(sessionStorage.getItem('masc.settings.local.displayLocale')).toBe('EN')
+    expect(sessionStorage.getItem('masc.settings.local.displayTimezone')).toBe('UTC')
+    expect(sessionStorage.getItem('masc.settings.local.displayClock24')).toBe('false')
+    expect(container.querySelector('[data-testid="display-local-summary"]')?.textContent)
+      .toContain('compact · EN · UTC · 12-hour clock')
+
+    render(null, container)
+    render(html`<${SettingsSurface} />`, container)
+
+    expect(tweaksDensity.value).toBe('compact')
+    expect(container.querySelector('[data-testid="display-local-summary"]')?.textContent)
+      .toContain('compact · EN · UTC · 12-hour clock')
   })
 
   it('falls invalid settings sections back to runtime without a fake subsection', () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -27,6 +27,7 @@ import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
 import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
+import { tweaksDensity, type Density } from './tweaks-panel'
 import type { ComponentChildren } from 'preact'
 
 type SectionId = SettingsRouteSectionId
@@ -68,6 +69,7 @@ const SET_GROUPS: [string, SectionId[]][] = [
 const MCP_PUBLIC_SURFACE = 'public_mcp'
 const SETTINGS_LOG_LIMIT = 50
 const SETTINGS_LOG_POLL_MS = 3000
+const DISPLAY_DENSITY_OPTIONS: Density[] = ['compact', 'regular', 'spacious']
 
 export function normalizeSettingsSection(value: string | null | undefined): SectionId {
   return SETTINGS_ROUTE_SECTION_SET.has(value ?? '') ? (value as SectionId) : DEFAULT_SETTINGS_SECTION
@@ -116,6 +118,13 @@ function writeLocalPreviewString(key: string, value: string) {
   }
 }
 
+function readLocalPreviewBool(key: string, fallback: boolean): boolean {
+  const raw = readLocalPreviewString(key, fallback ? 'true' : 'false')
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  return fallback
+}
+
 function readLocalPreviewBoolRecord(key: string, fallback: Record<string, boolean>): Record<string, boolean> {
   const next = { ...fallback }
   try {
@@ -148,6 +157,15 @@ function useLocalPreviewString(key: string, initialValue: string): [string, (nex
   const setStoredValue = (next: string) => {
     setValue(next)
     writeLocalPreviewString(key, next)
+  }
+  return [value, setStoredValue]
+}
+
+function useLocalPreviewBool(key: string, initialValue: boolean): [boolean, (next: boolean) => void] {
+  const [value, setValue] = useState(() => readLocalPreviewBool(key, initialValue))
+  const setStoredValue = (next: boolean) => {
+    setValue(next)
+    writeLocalPreviewString(key, next ? 'true' : 'false')
   }
   return [value, setStoredValue]
 }
@@ -557,7 +575,7 @@ function settingsSectionState(
   if (section === 'mcp') return { mode: 'mixed', label: 'live MCP check + inventory' }
   if (section === 'logs') return { mode: 'mixed', label: 'live logs + local filters' }
   if (section === 'notify') return { mode: 'mixed', label: 'live thresholds + local preview' }
-  if (section === 'display') return { mode: 'local', label: 'browser preference' }
+  if (section === 'display') return { mode: 'mixed', label: 'theme/density live + local preview' }
   return { mode: 'local', label: 'local preview only' }
 }
 
@@ -799,10 +817,16 @@ export function SettingsSurface() {
     '핸드오프 완료': false,
     '승인 요청': true,
   })
-  const [density, setDensity] = useState('regular')
-  const [tz, setTz] = useState('Asia/Seoul')
-  const [locale, setLocale] = useState('KO')
-  const [clock24, setClock24] = useState(true)
+  const density = tweaksDensity.value
+  const setDensity = (next: string) => {
+    if ((DISPLAY_DENSITY_OPTIONS as string[]).includes(next)) {
+      tweaksDensity.value = next as Density
+    }
+  }
+  const [tz, setTz] = useLocalPreviewString('displayTimezone', 'Asia/Seoul')
+  const [locale, setLocale] = useLocalPreviewString('displayLocale', 'KO')
+  const [clock24, setClock24] = useLocalPreviewBool('displayClock24', true)
+  const clockLabel = clock24 ? '24-hour clock' : '12-hour clock'
 
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
   const sectionState = settingsSectionState(sec, fusionSettingsWritable)
@@ -1147,20 +1171,39 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'display' && html`
-              <${SetRow} label="Theme" hint="Color palette — Dark / StyleSeed / Paper">
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                Theme and density apply to this browser immediately. Language, timezone and clock format are browser-session previews only until the dashboard has a renderer-wide locale/time setting.
+              </div>
+              <div class="set-local-summary" data-testid="display-local-summary">
+                <span>display session</span>
+                <span class="mono">${density} · ${locale} · ${tz} · ${clockLabel}</span>
+              </div>
+              <${SetRow} label="Theme" hint="Live color palette — Dark / StyleSeed / Paper">
                 <${ThemeSwitch} />
               <//>
-              <${SetRow} label="Density" hint="List/card spacing">
-                <${SetSeg} value=${density} options=${['compact', 'regular']} onChange=${setDensity} />
+              <${SetRow} label="Density" hint="Live list/card spacing on the dashboard shell">
+                <div class="set-tg-control">
+                  <${PreviewBadge} label="live shell" />
+                  <${SetSeg} value=${density} options=${DISPLAY_DENSITY_OPTIONS} onChange=${setDensity} />
+                </div>
               <//>
-              <${SetRow} label="Language" hint="UI labels">
-                <${SetSeg} value=${locale} options=${['KO', 'EN']} onChange=${setLocale} />
+              <${SetRow} label="Language" hint="Session preview for UI labels">
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetSeg} value=${locale} options=${['KO', 'EN']} onChange=${setLocale} />
+                </div>
               <//>
-              <${SetRow} label="Timezone" hint="Timestamp basis">
-                <${SetSeg} value=${tz} options=${['Asia/Seoul', 'Asia/Tokyo', 'UTC']} onChange=${setTz} />
+              <${SetRow} label="Timezone" hint="Session preview for timestamp basis">
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetSeg} value=${tz} options=${['Asia/Seoul', 'Asia/Tokyo', 'UTC']} onChange=${setTz} />
+                </div>
               <//>
-              <${SetRow} label="24-hour clock" hint="Time format">
-                <${SetToggle} on=${clock24} onChange=${setClock24} />
+              <${SetRow} label="24-hour clock" hint="Session preview for time format">
+                <div class="set-tg-control">
+                  <${PreviewBadge} />
+                  <${SetToggle} on=${clock24} onChange=${setClock24} />
+                </div>
               <//>
             `}
           </div>


### PR DESCRIPTION
## Summary

- Wire Settings > Display density to the existing `tweaksDensity` persistent signal that drives `.v2-app[data-density]`.
- Add the missing `spacious` density option and label density as a live shell control.
- Keep language, timezone, and 24-hour clock as honest browser-session previews with persisted summary text instead of implying backend saves.
- Add focused coverage for the density signal and local display preview storage.

## Validation

- `git diff --check`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm run typecheck`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm exec eslint src/components/settings-surface.ts`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- Rendered Playwright fallback at `http://127.0.0.1:5178/dashboard/#settings?section=display`: verified `.v2-app[data-density]` changes from `spacious` to `compact`, Display summary persists after reload, and no page/console errors were reported.
- GitHub CI on head `e7f72c69897cc4652d3c69cf69bb1e931061f22d`: `Dashboard`, `Lint`, `Meta Guards`, and `CI Gate` passed.

Browser plugin is not available in this session, so rendered validation used Python Playwright fallback.

## CI Note

`PR Axis Cross-Check` is currently failing outside this PR because open PRs #22749 and #22798 both claim `RFC-0301`. Tracked separately in #22803.
