### PR TITLE
fix(keeper): expose redacted stream fallback helper

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -189,6 +189,8 @@ module For_testing : sig
   val direct_reply_terminal_error : Yojson.Safe.t option -> string -> string option
   val visible_reply_with_stream_fallback :
     streamed_text:string -> string -> string
+  val redacted_visible_reply_with_stream_fallback :
+    redact:(string -> string) -> streamed_text:string -> string -> string
   val reply_payload_with_streamed_visible_reply :
     Yojson.Safe.t option -> visible_reply:string -> Yojson.Safe.t option
   val format_surface_context : Yojson.Safe.t -> string


### PR DESCRIPTION
## Summary
- Expose For_testing.redacted_visible_reply_with_stream_fallback in server_routes_http_keeper_stream.mli.
- Keep the post-22763 fix scoped to the interface drift that broke CI Health compile.

## Evidence
- PR 22763 merged at 8962113ce4e before its CI Health failure was resolved.
- Failing job: 84237854809 in run 28428612103.
- Observed compile failure: Unbound value Server_routes_http_keeper_stream.For_testing.redacted_visible_reply_with_stream_fallback.

## Local checks
- ocamlformat --check lib/server/server_routes_http_keeper_stream.mli passed.
- git diff --check passed.
- scripts/dune-local.sh build test/test_gate_keeper_backend.exe was attempted, but stopped while waiting on /tmp/me-dune-local.lock; CI is the build authority for this follow-up.
