### PR TITLE
refactor(sidecar): consume Attempt_state for lifecycle attempts

### DIFF
--- a/lib/attempt_state.mli
+++ b/lib/attempt_state.mli
@@ -1,9 +1,8 @@
 (** Shared retry/attempt state for reconcile-style surfaces.
 
-    Purpose: a single record + backoff predicate reused by surfaces that
-    today reimplement their own [attempt_record] / [last_attempt_*] fields
-    (sidecar lifecycle routes, voice bridge, dashboard cache). See #8930
-    for the consolidation trail.
+    Purpose: a single record + backoff predicate reused by sidecar lifecycle
+    routes and other surfaces that need [attempt_record] /
+    [last_attempt_*] state. See #8930 for the consolidation trail.
 
     Boundary rules:
     - Internal state is [float] (seconds-since-epoch). ISO serialization is

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -73,6 +73,30 @@ type attempt_record =
   ; operator_next_action : string
   }
 
+type attempt_record_decode_error =
+  | Attempt_record_not_object of string
+  | Attempt_record_invalid_field of
+      { field : string
+      ; expected : string
+      ; actual : string
+      }
+  | Attempt_record_unknown_result of string
+  | Attempt_record_invalid_timestamp of
+      { field : string
+      ; value : string
+      }
+
+let attempt_record_decode_error_to_string = function
+  | Attempt_record_not_object actual ->
+    Printf.sprintf "attempt record must be an object, got %s" actual
+  | Attempt_record_invalid_field { field; expected; actual } ->
+    Printf.sprintf "field %S must be %s, got %s" field expected actual
+  | Attempt_record_unknown_result value ->
+    Printf.sprintf "field %S has unknown result %S" "last_attempt_result" value
+  | Attempt_record_invalid_timestamp { field; value } ->
+    Printf.sprintf "field %S has invalid ISO-8601 timestamp %S" field value
+;;
+
 let sidecar_operator_next_action =
   "wait for observed status, or open logs if the sidecar remains offline after \
    backoff"
@@ -105,50 +129,83 @@ let attempt_record_json (record : attempt_record) =
     ]
 ;;
 
-let attempt_record_of_json = function
+let invalid_attempt_field ~field ~expected actual =
+  Error
+    (Attempt_record_invalid_field
+       { field; expected; actual = Json_util.kind_name actual })
+;;
+
+let required_string_field fields field =
+  match List.assoc_opt field fields with
+  | Some (`String value) -> Ok value
+  | Some actual -> invalid_attempt_field ~field ~expected:"string" actual
+  | None ->
+    Error
+      (Attempt_record_invalid_field { field; expected = "string"; actual = "missing" })
+;;
+
+let required_int_field fields field =
+  match List.assoc_opt field fields with
+  | Some (`Int value) -> Ok value
+  | Some actual -> invalid_attempt_field ~field ~expected:"integer" actual
+  | None ->
+    Error
+      (Attempt_record_invalid_field
+         { field; expected = "integer"; actual = "missing" })
+;;
+
+let parse_timestamp_field ~field value =
+  match Types_core.parse_iso8601_opt value with
+  | Some unix -> Ok unix
+  | None -> Error (Attempt_record_invalid_timestamp { field; value })
+;;
+
+let optional_next_retry_unix fields =
+  match List.assoc_opt "next_retry_at" fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) ->
+    (match parse_timestamp_field ~field:"next_retry_at" value with
+     | Ok unix -> Ok (Some unix)
+     | Error _ as error -> error)
+  | Some actual -> invalid_attempt_field ~field:"next_retry_at" ~expected:"string or null" actual
+;;
+
+let attempt_record_of_json_result = function
   | `Assoc fields ->
-    let ( let* ) = Option.bind in
-    (match
-       ( List.assoc_opt "connector_id" fields
-       , List.assoc_opt "generation" fields
-       , List.assoc_opt "attempt_id" fields
-       , List.assoc_opt "attempt_number" fields
-       , List.assoc_opt "last_attempt_result" fields
-       , List.assoc_opt "next_retry_at" fields
-       , List.assoc_opt "operator_next_action" fields
-       , List.assoc_opt "updated_at" fields )
-     with
-     | ( Some (`String connector_id)
-       , Some (`Int generation)
-       , Some (`String attempt_id)
-       , Some (`Int attempt_number)
-       , Some (`String last_attempt_result)
-       , next_retry_at
-       , Some (`String operator_next_action)
-       , Some (`String updated_at) ) ->
-       let* last_result = Attempt.result_of_string_opt last_attempt_result in
-       let* next_retry_unix =
-         match next_retry_at with
-         | Some (`String value) ->
-           Types_core.parse_iso8601_opt value |> Option.map (fun value -> Some value)
-         | Some `Null | None -> Some None
-         | _ -> None
-       in
-       let* updated_unix = Types_core.parse_iso8601_opt updated_at in
-       Some
-         { connector_id
-         ; attempt =
-             { generation
-             ; attempt_id
-             ; attempt_number
-             ; last_result
-             ; next_retry_unix
-             ; updated_unix
-             }
-         ; operator_next_action
-         }
-     | _ -> None)
-  | _ -> None
+    let ( let* ) = Result.bind in
+    let* connector_id = required_string_field fields "connector_id" in
+    let* generation = required_int_field fields "generation" in
+    let* attempt_id = required_string_field fields "attempt_id" in
+    let* attempt_number = required_int_field fields "attempt_number" in
+    let* last_attempt_result = required_string_field fields "last_attempt_result" in
+    let* last_result =
+      match Attempt.result_of_string_opt last_attempt_result with
+      | Some result -> Ok result
+      | None -> Error (Attempt_record_unknown_result last_attempt_result)
+    in
+    let* next_retry_unix = optional_next_retry_unix fields in
+    let* operator_next_action = required_string_field fields "operator_next_action" in
+    let* updated_at = required_string_field fields "updated_at" in
+    let* updated_unix = parse_timestamp_field ~field:"updated_at" updated_at in
+    Ok
+      { connector_id
+      ; attempt =
+          { generation
+          ; attempt_id
+          ; attempt_number
+          ; last_result
+          ; next_retry_unix
+          ; updated_unix
+          }
+      ; operator_next_action
+      }
+  | other -> Error (Attempt_record_not_object (Json_util.kind_name other))
+;;
+
+let attempt_record_of_json json =
+  match attempt_record_of_json_result json with
+  | Ok record -> Some record
+  | Error _ -> None
 ;;
 
 let desired_record_json (record : desired_record) =
@@ -194,14 +251,15 @@ let sidecar_attempt_path ~base_path id =
     (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_attempt.json" id)
 ;;
 
-(* Silent [Sys_error _ | Yojson.Json_error _ -> None] previously
-   collapsed two distinct failure modes into "no record":
+(* Silent [Sys_error _ | Yojson.Json_error _ -> None] previously collapsed
+   distinct failure modes into "no record":
    (1) file existed at [Sys.file_exists] check but read failed (TOCTOU
        race, permission change, partial write mid-rename),
-   (2) file read OK but JSON was malformed.
-   Operators tracing why [/api/v1/sidecar/status] reports stale state
-   need to tell these apart from a genuinely absent record. Log-only —
-   [None] return preserved so caller contracts are unchanged. *)
+   (2) file read OK but JSON was malformed,
+   (3) JSON was syntactically valid but semantically invalid.
+   Desired-state reads remain log-only for compatibility. Attempt-state reads
+   use [read_attempt_record_result] so reconcile/status callers can fail closed
+   or surface corruption instead of treating it as absence. *)
 let read_desired_record ~base_path id =
   let path = sidecar_desired_path ~base_path id in
   if not (Sys.file_exists path)
@@ -219,21 +277,35 @@ let read_desired_record ~base_path id =
       None)
 ;;
 
-let read_attempt_record ~base_path id =
+let read_attempt_record_result ~base_path id =
   let path = sidecar_attempt_path ~base_path id in
   if not (Sys.file_exists path)
-  then None
+  then Ok None
   else (
-    try read_file path |> Yojson.Safe.from_string |> attempt_record_of_json with
+    try
+      let json = read_file path |> Yojson.Safe.from_string in
+      match attempt_record_of_json_result json with
+      | Ok record -> Ok (Some record)
+      | Error error ->
+        let detail = attempt_record_decode_error_to_string error in
+        Log.Server.warn "[sidecar/attempt] invalid persisted state at %s: %s" path detail;
+        Error (Printf.sprintf "invalid persisted attempt state at %s: %s" path detail)
+    with
     | Sys_error msg ->
       Log.Server.warn
         "[sidecar/attempt] file_exists OK but read failed at %s: %s"
         path
         msg;
-      None
+      Error (Printf.sprintf "attempt state read failed at %s: %s" path msg)
     | Yojson.Json_error msg ->
       Log.Server.warn "[sidecar/attempt] malformed JSON at %s: %s" path msg;
-      None)
+      Error (Printf.sprintf "malformed attempt state JSON at %s: %s" path msg))
+;;
+
+let read_attempt_record ~base_path id =
+  match read_attempt_record_result ~base_path id with
+  | Ok record -> record
+  | Error _ -> None
 ;;
 
 (** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
@@ -319,33 +391,44 @@ let retry_backoff_seconds () = Env_config_runtime.Sidecar.reconcile_backoff_sec
     [now] via [Types_core.parse_iso8601_opt], then delegates the deadline
     comparison to [Attempt_state.is_backoff_active].  Persisted
     [next_retry_at] strings are parsed once at the JSON boundary into
-    [Attempt_state.t], so runtime backoff no longer compares wire strings. *)
+    [Attempt_state.t], so runtime backoff no longer compares wire strings.
+    Malformed [now] keeps backoff inactive so reconcile retries instead of
+    stalling (#8930 phase 3); malformed persisted deadlines fail at the
+    attempt-record read boundary. *)
 let retry_backoff_active ~now attempt =
   match Types_core.parse_iso8601_opt now with
   | Some now_unix -> Attempt.is_backoff_active ~now:now_unix attempt.attempt
   | None -> false
 ;;
 
-let unix_of_iso_exn ~field value =
+let unix_of_iso_result ~field value =
   match Types_core.parse_iso8601_opt value with
-  | Some unix -> unix
-  | None -> invalid_arg (Printf.sprintf "invalid %s: %s" field value)
+  | Some unix -> Ok unix
+  | None -> Error (Printf.sprintf "invalid %s: %s" field value)
 ;;
 
-let next_attempt_record ~now ~next_retry_at previous (record : desired_record) =
-  let now_unix = unix_of_iso_exn ~field:"now" now in
-  let next_retry_unix = unix_of_iso_exn ~field:"next_retry_at" next_retry_at in
+let next_attempt_record_result ~now ~next_retry_at previous (record : desired_record) =
+  let ( let* ) = Result.bind in
+  let* now_unix = unix_of_iso_result ~field:"now" now in
+  let* next_retry_unix = unix_of_iso_result ~field:"next_retry_at" next_retry_at in
   let previous = Option.map (fun record -> record.attempt) previous in
-  { connector_id = record.connector_id
-  ; attempt =
-      Attempt.make_next
-        ~now:now_unix
-        ~backoff_seconds:(next_retry_unix -. now_unix)
-        ~generation:record.generation
-        ~last_result:Attempt.Start_dispatched
-        ~previous
-  ; operator_next_action = sidecar_operator_next_action
-  }
+  Ok
+    { connector_id = record.connector_id
+    ; attempt =
+        Attempt.make_next
+          ~now:now_unix
+          ~backoff_seconds:(next_retry_unix -. now_unix)
+          ~generation:record.generation
+          ~last_result:Attempt.Start_dispatched
+          ~previous
+    ; operator_next_action = sidecar_operator_next_action
+    }
+;;
+
+let next_attempt_record ~now ~next_retry_at previous record =
+  match next_attempt_record_result ~now ~next_retry_at previous record with
+  | Ok record -> record
+  | Error msg -> invalid_arg msg
 ;;
 
 let reconcile_desired_once
@@ -369,12 +452,20 @@ let reconcile_desired_once
               && retry_backoff_active ~now attempt ->
          Reconcile_noop "backoff_active"
        | _ ->
-         let attempt = next_attempt_record ~now ~next_retry_at previous_attempt record in
-         (match write_attempt attempt with
-          | Ok () ->
-            start_process ();
-            Reconcile_started
-          | Error _ -> Reconcile_noop "attempt_write_failed"))
+         (match next_attempt_record_result ~now ~next_retry_at previous_attempt record with
+          | Error msg ->
+            Log.Server.warn
+              "[sidecar/reconcile] invalid attempt timestamp for %s generation %d: %s"
+              record.connector_id
+              record.generation
+              msg;
+            Reconcile_noop "attempt_time_invalid"
+          | Ok attempt ->
+            (match write_attempt attempt with
+             | Ok () ->
+               start_process ();
+               Reconcile_started
+             | Error _ -> Reconcile_noop "attempt_write_failed")))
     | Desired_running, Observed_available -> Reconcile_noop "already_available"
     | Desired_stopped, _ -> Reconcile_noop "desired_stopped")
 ;;
@@ -410,7 +501,11 @@ let attempt_fields = function
 
 let lifecycle_json ~base_path id status_json =
   let observed_state = observed_state_of_status_json status_json in
-  let previous_attempt = read_attempt_record ~base_path id in
+  let previous_attempt, attempt_error_fields =
+    match read_attempt_record_result ~base_path id with
+    | Ok previous_attempt -> previous_attempt, []
+    | Error msg -> None, [ "attempt_read_error", `String msg ]
+  in
   match read_desired_record ~base_path id with
   | None ->
     `Assoc
@@ -419,7 +514,8 @@ let lifecycle_json ~base_path id status_json =
        ; "observed_state", `String (observed_state_to_string observed_state)
        ; "reconcile_result", `String "none"
        ]
-       @ attempt_fields previous_attempt)
+       @ attempt_fields previous_attempt
+       @ attempt_error_fields)
   | Some record ->
     `Assoc
       ([ "desired_state", `String (desired_state_to_string record.desired_state)
@@ -430,7 +526,8 @@ let lifecycle_json ~base_path id status_json =
        ; ( "reconcile_result"
          , `String (reconcile_preview ?previous_attempt record observed_state) )
        ]
-       @ attempt_fields previous_attempt)
+       @ attempt_fields previous_attempt
+       @ attempt_error_fields)
 ;;
 
 let append_assoc key value = function
@@ -839,52 +936,65 @@ let handle_start state request reqd =
          ~status:`Service_unavailable
          (`Assoc [ "ok", `Bool false; "error", `String msg ])
      | Ok script ->
-       (match
-          write_desired_record ~base_path ~id ~updated_by:"http:start" Desired_running
-        with
+       (match read_attempt_record_result ~base_path id with
         | Error msg ->
           respond_json
             request
             reqd
             ~status:`Internal_server_error
-            (`Assoc [ "ok", `Bool false; "error", `String msg ])
-        | Ok desired ->
+            (`Assoc
+                [ "ok", `Bool false
+                ; "id", `String id
+                ; "error", `String "sidecar attempt state invalid"
+                ; "detail", `String msg
+                ])
+        | Ok previous_attempt ->
+          (match
+             write_desired_record ~base_path ~id ~updated_by:"http:start" Desired_running
+           with
+           | Error msg ->
+             respond_json
+               request
+               reqd
+               ~status:`Internal_server_error
+               (`Assoc [ "ok", `Bool false; "error", `String msg ])
+           | Ok desired ->
           (* Detach without a shell: [Process_eio] gives the child its own
              session and redirects stdio to [/dev/null], so the sidecar
              survives backend restart without retaining server FDs. *)
-          let status_json = read_status_json ~base_path id in
-          let observed_state = observed_state_of_status_json status_json in
-          let previous_attempt = read_attempt_record ~base_path id in
-          let reconcile_result =
-            reconcile_desired_once
-              ~current_generation:desired.generation
-              ?previous_attempt
-              ~observed_state
-              ~write_attempt:(write_attempt_record ~base_path ~id)
-              ~start_process:(fun () ->
-                match start_sidecar_process ~base_path ~script with
-                | Ok () -> ()
-                | Error msg ->
-                  Log.Misc.warn "[Sidecar] detached start failed: %s" msg)
-              desired
-          in
-          respond_json
-            request
-            reqd
-            ~status:`Accepted
-            (`Assoc
-                [ "ok", `Bool true
-                ; "id", `String id
-                ; "desired_state", `String (desired_state_to_string desired.desired_state)
-                ; "desired_generation", `Int desired.generation
-                ; "observed_state", `String (observed_state_to_string observed_state)
-                ; ( "reconcile_result"
-                  , `String (reconcile_result_to_string reconcile_result) )
-                ; ( "note"
-                  , `String
-                      "sidecar desired state updated; poll \
-                       /api/v1/sidecar/status?name=..." )
-                ])))
+             let status_json = read_status_json ~base_path id in
+             let observed_state = observed_state_of_status_json status_json in
+             let reconcile_result =
+               reconcile_desired_once
+                 ~current_generation:desired.generation
+                 ?previous_attempt
+                 ~observed_state
+                 ~write_attempt:(write_attempt_record ~base_path ~id)
+                 ~start_process:(fun () ->
+                   match start_sidecar_process ~base_path ~script with
+                   | Ok () -> ()
+                   | Error msg ->
+                     Log.Misc.warn "[Sidecar] detached start failed: %s" msg)
+                 desired
+             in
+             respond_json
+               request
+               reqd
+               ~status:`Accepted
+               (`Assoc
+                   [ "ok", `Bool true
+                   ; "id", `String id
+                   ; ( "desired_state"
+                     , `String (desired_state_to_string desired.desired_state) )
+                   ; "desired_generation", `Int desired.generation
+                   ; "observed_state", `String (observed_state_to_string observed_state)
+                   ; ( "reconcile_result"
+                     , `String (reconcile_result_to_string reconcile_result) )
+                   ; ( "note"
+                     , `String
+                         "sidecar desired state updated; poll \
+                          /api/v1/sidecar/status?name=..." )
+                   ]))))
 ;;
 
 (** Register sidecar lifecycle routes on the router. *)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -65,16 +65,22 @@ type reconcile_result = Server_routes_http_routes_sidecar_state.reconcile_result
   | Reconcile_started
   | Reconcile_noop of string
 
+module Attempt = Attempt_state
+
 type attempt_record =
   { connector_id : string
-  ; generation : int
-  ; attempt_id : string
-  ; attempt_number : int
-  ; last_attempt_result : string
-  ; next_retry_at : string option
+  ; attempt : Attempt.t
   ; operator_next_action : string
-  ; updated_at : string
   }
+
+let sidecar_operator_next_action =
+  "wait for observed status, or open logs if the sidecar remains offline after \
+   backoff"
+;;
+
+let iso_of_unix_opt = Option.map Masc_domain.iso8601_of_unix_seconds
+let next_retry_at record = iso_of_unix_opt record.attempt.next_retry_unix
+let updated_at record = Masc_domain.iso8601_of_unix_seconds record.attempt.updated_unix
 
 let desired_state_to_string =
   Server_routes_http_routes_sidecar_state.desired_state_to_string
@@ -86,20 +92,22 @@ let reconcile_result_to_string =
   Server_routes_http_routes_sidecar_state.reconcile_result_to_string
 
 let attempt_record_json (record : attempt_record) =
+  let attempt = record.attempt in
   `Assoc
     [ "connector_id", `String record.connector_id
-    ; "generation", `Int record.generation
-    ; "attempt_id", `String record.attempt_id
-    ; "attempt_number", `Int record.attempt_number
-    ; "last_attempt_result", `String record.last_attempt_result
-    ; ( "next_retry_at", Json_util.string_opt_to_json record.next_retry_at )
+    ; "generation", `Int attempt.generation
+    ; "attempt_id", `String attempt.attempt_id
+    ; "attempt_number", `Int attempt.attempt_number
+    ; "last_attempt_result", `String (Attempt.result_to_string attempt.last_result)
+    ; ( "next_retry_at", Json_util.string_opt_to_json (next_retry_at record) )
     ; "operator_next_action", `String record.operator_next_action
-    ; "updated_at", `String record.updated_at
+    ; "updated_at", `String (updated_at record)
     ]
 ;;
 
 let attempt_record_of_json = function
   | `Assoc fields ->
+    let ( let* ) = Option.bind in
     (match
        ( List.assoc_opt "connector_id" fields
        , List.assoc_opt "generation" fields
@@ -118,21 +126,26 @@ let attempt_record_of_json = function
        , next_retry_at
        , Some (`String operator_next_action)
        , Some (`String updated_at) ) ->
-       let next_retry_at =
+       let* last_result = Attempt.result_of_string_opt last_attempt_result in
+       let* next_retry_unix =
          match next_retry_at with
-         | Some (`String value) -> Some value
-         | Some `Null | None -> None
+         | Some (`String value) ->
+           Types_core.parse_iso8601_opt value |> Option.map (fun value -> Some value)
+         | Some `Null | None -> Some None
          | _ -> None
        in
+       let* updated_unix = Types_core.parse_iso8601_opt updated_at in
        Some
          { connector_id
-         ; generation
-         ; attempt_id
-         ; attempt_number
-         ; last_attempt_result
-         ; next_retry_at
+         ; attempt =
+             { generation
+             ; attempt_id
+             ; attempt_number
+             ; last_result
+             ; next_retry_unix
+             ; updated_unix
+             }
          ; operator_next_action
-         ; updated_at
          }
      | _ -> None)
   | _ -> None
@@ -303,40 +316,35 @@ let observed_state_of_status_json = function
 let retry_backoff_seconds () = Env_config_runtime.Sidecar.reconcile_backoff_sec
 
 (** Compare backoff deadline against [now] in unix-epoch seconds. Parses both
-    sides via [Types_core.parse_iso8601_opt] so that an ISO string that
-    serialises before-but-sorts-after (e.g. drift between timezones or a
-    clock skew) still resolves to the correct ordering. Fail-closed: if
-    either side fails to parse (malformed sidecar or boundary layer drift),
-    treat the backoff as inactive so reconcile retries instead of stalling.
-    See #8930 phase 3. *)
+    [now] via [Types_core.parse_iso8601_opt], then delegates the deadline
+    comparison to [Attempt_state.is_backoff_active].  Persisted
+    [next_retry_at] strings are parsed once at the JSON boundary into
+    [Attempt_state.t], so runtime backoff no longer compares wire strings. *)
 let retry_backoff_active ~now attempt =
-  match attempt.next_retry_at with
+  match Types_core.parse_iso8601_opt now with
+  | Some now_unix -> Attempt.is_backoff_active ~now:now_unix attempt.attempt
   | None -> false
-  | Some next_retry_at ->
-    (match
-       Types_core.parse_iso8601_opt next_retry_at, Types_core.parse_iso8601_opt now
-     with
-     | Some next_unix, Some now_unix -> next_unix > now_unix
-     | _ -> false)
+;;
+
+let unix_of_iso_exn ~field value =
+  match Types_core.parse_iso8601_opt value with
+  | Some unix -> unix
+  | None -> invalid_arg (Printf.sprintf "invalid %s: %s" field value)
 ;;
 
 let next_attempt_record ~now ~next_retry_at previous (record : desired_record) =
-  let attempt_number =
-    match previous with
-    | Some attempt when attempt.generation = record.generation ->
-      attempt.attempt_number + 1
-    | _ -> 1
-  in
+  let now_unix = unix_of_iso_exn ~field:"now" now in
+  let next_retry_unix = unix_of_iso_exn ~field:"next_retry_at" next_retry_at in
+  let previous = Option.map (fun record -> record.attempt) previous in
   { connector_id = record.connector_id
-  ; generation = record.generation
-  ; attempt_id = Printf.sprintf "%d:%d" record.generation attempt_number
-  ; attempt_number
-  ; last_attempt_result = "start_dispatched"
-  ; next_retry_at = Some next_retry_at
-  ; operator_next_action =
-      "wait for observed status, or open logs if the sidecar remains offline after \
-       backoff"
-  ; updated_at = now
+  ; attempt =
+      Attempt.make_next
+        ~now:now_unix
+        ~backoff_seconds:(next_retry_unix -. now_unix)
+        ~generation:record.generation
+        ~last_result:Attempt.Start_dispatched
+        ~previous
+  ; operator_next_action = sidecar_operator_next_action
   }
 ;;
 
@@ -357,8 +365,9 @@ let reconcile_desired_once
     | Desired_running, Observed_unavailable ->
       (match previous_attempt with
        | Some attempt
-         when attempt.generation = record.generation && retry_backoff_active ~now attempt
-         -> Reconcile_noop "backoff_active"
+         when attempt.attempt.generation = record.generation
+              && retry_backoff_active ~now attempt ->
+         Reconcile_noop "backoff_active"
        | _ ->
          let attempt = next_attempt_record ~now ~next_retry_at previous_attempt record in
          (match write_attempt attempt with
@@ -376,7 +385,8 @@ let reconcile_preview ?now ?previous_attempt (record : desired_record) observed_
     let now = Option.value now ~default:(Masc_domain.now_iso ()) in
     (match previous_attempt with
      | Some attempt
-       when attempt.generation = record.generation && retry_backoff_active ~now attempt ->
+       when attempt.attempt.generation = record.generation
+            && retry_backoff_active ~now attempt ->
        "noop:backoff_active"
      | _ -> "would_start")
   | Desired_running, Observed_available -> "noop:already_available"
@@ -390,10 +400,11 @@ let attempt_fields = function
     ; "operator_next_action", `Null
     ]
   | Some attempt ->
-    [ "last_attempt_result", `String attempt.last_attempt_result
-    ; ( "next_retry_at", Json_util.string_opt_to_json attempt.next_retry_at )
+    [ ( "last_attempt_result"
+      , `String (Attempt.result_to_string attempt.attempt.last_result) )
+    ; ( "next_retry_at", Json_util.string_opt_to_json (next_retry_at attempt) )
     ; "operator_next_action", `String attempt.operator_next_action
-    ; "attempt_id", `String attempt.attempt_id
+    ; "attempt_id", `String attempt.attempt.attempt_id
     ]
 ;;
 

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -180,12 +180,29 @@ type attempt_record = {
     [attempt] is the shared {!Attempt_state.t} SSOT; ISO timestamps and
     string result tokens are only used at the JSON wire boundary. *)
 
+type attempt_record_decode_error =
+  | Attempt_record_not_object of string
+  | Attempt_record_invalid_field of {
+      field : string;
+      expected : string;
+      actual : string;
+    }
+  | Attempt_record_unknown_result of string
+  | Attempt_record_invalid_timestamp of {
+      field : string;
+      value : string;
+    }
+
+val attempt_record_decode_error_to_string : attempt_record_decode_error -> string
+
 val desired_state_to_string : desired_state -> string
 val desired_state_of_string : string -> desired_state option
 val observed_state_to_string : observed_state -> string
 val reconcile_result_to_string : reconcile_result -> string
 
 val attempt_record_json : attempt_record -> Yojson.Safe.t
+val attempt_record_of_json_result :
+  Yojson.Safe.t -> (attempt_record, attempt_record_decode_error) result
 val attempt_record_of_json : Yojson.Safe.t -> attempt_record option
 val desired_record_json : desired_record -> Yojson.Safe.t
 val desired_record_of_json : Yojson.Safe.t -> desired_record option
@@ -193,6 +210,8 @@ val desired_record_of_json : Yojson.Safe.t -> desired_record option
 val sidecar_desired_path : base_path:string -> string -> string
 val sidecar_attempt_path : base_path:string -> string -> string
 val read_desired_record : base_path:string -> string -> desired_record option
+val read_attempt_record_result :
+  base_path:string -> string -> (attempt_record option, string) result
 val read_attempt_record : base_path:string -> string -> attempt_record option
 
 val ensure_parent_dir : string -> unit

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -173,15 +173,12 @@ type reconcile_result = Reconcile_started | Reconcile_noop of string
 
 type attempt_record = {
   connector_id : string;
-  generation : int;
-  attempt_id : string;
-  attempt_number : int;
-  last_attempt_result : string;
-  next_retry_at : string option;
+  attempt : Attempt_state.t;
   operator_next_action : string;
-  updated_at : string;
 }
-(** Persisted reconciliation attempt record (one per generation). *)
+(** Persisted reconciliation attempt record (one per generation).
+    [attempt] is the shared {!Attempt_state.t} SSOT; ISO timestamps and
+    string result tokens are only used at the JSON wire boundary. *)
 
 val desired_state_to_string : desired_state -> string
 val desired_state_of_string : string -> desired_state option
@@ -220,7 +217,8 @@ val retry_backoff_seconds : unit -> float
 
 val retry_backoff_active : now:string -> attempt_record -> bool
 (** [true] when [now] is still inside the backoff window for the
-    last attempt. *)
+    last attempt. [now] is parsed at the boundary; the deadline comparison
+    uses {!Attempt_state.is_backoff_active}. *)
 
 val next_attempt_record :
   now:string ->

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -42,8 +42,8 @@ lib/playground_repo_readiness.ml:400  # argv_subsystem
 lib/repo_manager/repo_git.ml:41  # argv_workspace
 lib/server/server_dashboard_http_runtime_info.ml:270  # argv_dispatch
 lib/server/server_dashboard_http_runtime_info.ml:368  # argv_dispatch
-lib/server/server_routes_http_routes_sidecar.ml:564  # argv_dispatch
-lib/server/server_routes_http_routes_sidecar.ml:628  # argv_dispatch
+lib/server/server_routes_http_routes_sidecar.ml:575  # argv_dispatch
+lib/server/server_routes_http_routes_sidecar.ml:639  # argv_dispatch
 lib/server/server_routes_http_routes_workspace.ml:372  # argv_dispatch
 lib/server/server_routes_sidecar_config_schema.ml:40  # argv_dispatch
 lib/server/server_startup_takeover.ml:81  # argv_dispatch

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -977,11 +977,48 @@ let test_attempt_record_of_json_rejects_malformed_next_retry_at () =
       ; "updated_at", `String "2026-01-01T00:00:00Z"
       ]
   in
-  check
-    bool
-    "malformed next_retry_at → rejected at boundary"
-    true
-    (Routes.attempt_record_of_json json = None)
+  (match Routes.attempt_record_of_json_result json with
+   | Error (Routes.Attempt_record_invalid_timestamp { field; value }) ->
+     check string "field" "next_retry_at" field;
+     check string "value" "not-an-iso-stamp" value
+   | Error error ->
+     failf
+       "unexpected decode error: %s"
+       (Routes.attempt_record_decode_error_to_string error)
+   | Ok _ -> failf "malformed next_retry_at should be rejected at boundary");
+  check bool "compat option wrapper still rejects" true (Routes.attempt_record_of_json json = None)
+;;
+
+let test_read_attempt_record_result_reports_semantic_corruption () =
+  with_temp_dir "sidecar-attempt-corrupt-read" (fun base_path ->
+    let path = Routes.sidecar_attempt_path ~base_path "discord" in
+    write_file
+      path
+      {|{"connector_id":"discord","generation":1,"attempt_id":"1:1","attempt_number":1,"last_attempt_result":"start_dispatched","next_retry_at":"not-an-iso-stamp","operator_next_action":"none","updated_at":"2026-01-01T00:00:00Z"}|};
+    match Routes.read_attempt_record_result ~base_path "discord" with
+    | Error msg ->
+      check bool "mentions field" true (contains_substring msg "next_retry_at");
+      check bool "mentions bad value" true (contains_substring msg "not-an-iso-stamp")
+    | Ok None -> failf "corrupt persisted attempt state must not look absent"
+    | Ok (Some _) -> failf "corrupt persisted attempt state should not decode")
+;;
+
+let test_status_json_surfaces_invalid_attempt_state () =
+  with_temp_dir "sidecar-attempt-corrupt-status" (fun base_path ->
+    let path = Routes.sidecar_attempt_path ~base_path "discord" in
+    write_file
+      path
+      {|{"connector_id":"discord","generation":1,"attempt_id":"1:1","attempt_number":1,"last_attempt_result":"start_dispatched","next_retry_at":"not-an-iso-stamp","operator_next_action":"none","updated_at":"2026-01-01T00:00:00Z"}|};
+    let json = Routes.read_status_json ~base_path "discord" in
+    let open Yojson.Safe.Util in
+    let lifecycle = json |> member "sidecar_lifecycle" in
+    let error =
+      match lifecycle |> member "attempt_read_error" with
+      | `String msg -> msg
+      | other -> failf "expected attempt_read_error string, got %s" (Yojson.Safe.to_string other)
+    in
+    check bool "mentions field" true (contains_substring error "next_retry_at");
+    check bool "mentions bad value" true (contains_substring error "not-an-iso-stamp"))
 ;;
 
 let test_retry_backoff_fail_closed_on_malformed_now () =
@@ -991,6 +1028,33 @@ let test_retry_backoff_fail_closed_on_malformed_now () =
     "malformed now → fail-closed"
     false
     (Routes.retry_backoff_active ~now:"not-an-iso-stamp" attempt)
+;;
+
+let test_reconcile_invalid_attempt_time_noops_without_exception () =
+  let process_calls = ref 0 in
+  let desired : Routes.desired_record =
+    { Routes.connector_id = "discord"
+    ; desired_state = Routes.Desired_running
+    ; generation = 3
+    ; updated_by = "test"
+    ; updated_at = "2026-04-20T00:00:00Z"
+    }
+  in
+  let result =
+    Routes.reconcile_desired_once
+      ~now:"not-an-iso-stamp"
+      ~next_retry_at:"2099-04-20T00:00:30Z"
+      ~current_generation:3
+      ~observed_state:Routes.Observed_unavailable
+      ~start_process:(fun () -> incr process_calls)
+      desired
+  in
+  check int "invalid attempt time suppresses process start" 0 !process_calls;
+  check
+    string
+    "invalid time result"
+    "noop:attempt_time_invalid"
+    (Routes.reconcile_result_to_string result)
 ;;
 
 (* ---- Fault-recovery gaps (untested subprocess failure paths) ----
@@ -1216,9 +1280,21 @@ let () =
             `Quick
             test_attempt_record_of_json_rejects_malformed_next_retry_at
         ; test_case
+            "malformed persisted attempt → read error"
+            `Quick
+            test_read_attempt_record_result_reports_semantic_corruption
+        ; test_case
+            "malformed persisted attempt → status error"
+            `Quick
+            test_status_json_surfaces_invalid_attempt_state
+        ; test_case
             "malformed now → fail-closed"
             `Quick
             test_retry_backoff_fail_closed_on_malformed_now
+        ; test_case
+            "malformed reconcile time → noop"
+            `Quick
+            test_reconcile_invalid_attempt_time_noops_without_exception
         ] )
     ; ( "fault_recovery_gaps"
       , [ test_case

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -10,6 +10,7 @@
 
 open Alcotest
 module Routes = Server_routes_http_routes_sidecar
+module Attempt_state = Masc.Attempt_state
 
 let result_of = function
   | Ok s -> "Ok " ^ s
@@ -18,6 +19,48 @@ let result_of = function
 
 let result_t = testable (Fmt.of_to_string result_of) ( = )
 let validate name = Routes.validate_name name
+
+let unix_of_iso_exn value =
+  match Types_core.parse_iso8601_opt value with
+  | Some unix -> unix
+  | None -> invalid_arg ("invalid test timestamp: " ^ value)
+;;
+
+let make_attempt_record
+      ?(connector_id = "discord")
+      ?(generation = 1)
+      ?(attempt_number = 1)
+      ?attempt_id
+      ?(last_result = Attempt_state.Start_dispatched)
+      ?next_retry_at
+      ?(operator_next_action = "none")
+      ?(updated_at = "2026-01-01T00:00:00Z")
+      ()
+  =
+  let attempt_id =
+    Option.value attempt_id ~default:(Printf.sprintf "%d:%d" generation attempt_number)
+  in
+  let next_retry_unix = Option.map unix_of_iso_exn next_retry_at in
+  let updated_unix = unix_of_iso_exn updated_at in
+  let attempt : Attempt_state.t =
+    { generation
+    ; attempt_number
+    ; attempt_id
+    ; last_result
+    ; next_retry_unix
+    ; updated_unix
+    }
+  in
+  { Routes.connector_id; attempt; operator_next_action }
+;;
+
+let attempt_result_token (record : Routes.attempt_record) =
+  Attempt_state.result_to_string record.Routes.attempt.last_result
+;;
+
+let attempt_next_retry_at (record : Routes.attempt_record) =
+  Option.map Masc_domain.iso8601_of_unix_seconds record.Routes.attempt.next_retry_unix
+;;
 
 let contains_substring haystack needle =
   let hlen = String.length haystack in
@@ -481,12 +524,12 @@ let test_reconcile_running_unavailable_starts_once () =
       string
       "attempt result is operator-visible"
       "start_dispatched"
-      attempt.Routes.last_attempt_result;
+      (attempt_result_token attempt);
     check
       string
       "next retry recorded"
       "2099-04-20T00:00:30Z"
-      (Option.value attempt.next_retry_at ~default:"");
+      (Option.value (attempt_next_retry_at attempt) ~default:"");
     check
       string
       "next action recorded"
@@ -535,17 +578,14 @@ let test_reconcile_running_unavailable_backoff_noops () =
     }
   in
   let previous_attempt : Routes.attempt_record =
-    { connector_id = "discord"
-    ; generation = 3
-    ; attempt_id = "3:1"
-    ; attempt_number = 1
-    ; last_attempt_result = "start_dispatched"
-    ; next_retry_at = Some "2099-04-20T00:00:30Z"
-    ; operator_next_action =
+    make_attempt_record
+      ~generation:3
+      ~next_retry_at:"2099-04-20T00:00:30Z"
+      ~operator_next_action:
         "wait for observed status, or open logs if the sidecar remains offline after \
          backoff"
-    ; updated_at = "2026-04-20T00:00:00Z"
-    }
+      ~updated_at:"2026-04-20T00:00:00Z"
+      ()
   in
   let result =
     Routes.reconcile_desired_once
@@ -602,17 +642,13 @@ let test_status_json_includes_lifecycle_shape () =
      | Ok _ -> ()
      | Error msg -> failf "desired write failed: %s" msg);
     let attempt : Routes.attempt_record =
-      { connector_id = "discord"
-      ; generation = 1
-      ; attempt_id = "1:1"
-      ; attempt_number = 1
-      ; last_attempt_result = "start_dispatched"
-      ; next_retry_at = Some "2099-04-20T00:00:30Z"
-      ; operator_next_action =
+      make_attempt_record
+        ~next_retry_at:"2099-04-20T00:00:30Z"
+        ~operator_next_action:
           "wait for observed status, or open logs if the sidecar remains offline after \
            backoff"
-      ; updated_at = "2026-04-20T00:00:00Z"
-      }
+        ~updated_at:"2026-04-20T00:00:00Z"
+        ()
     in
     check
       (result unit string)
@@ -853,13 +889,10 @@ let test_atomic_write_file_replaces_content () =
 ;;
 
 (* ── ISO format invariants ────────────────────────────────────────────
-   [retry_backoff_active] compares [next_retry_at : string] against
-   [now : string] with [String.compare]. That is safe only while both
-   sides emit the exact 20-character "YYYY-MM-DDTHH:MM:SSZ" shape, which
-   makes lexical order coincide with chronological order. These tests
-   pin the shape so a future refactor (offset, millisecond, timezone)
-   cannot silently land without also revisiting the backoff comparison.
-   See #8930 for the attempt_state SSOT consolidation. *)
+   Sidecar lifecycle JSON keeps the existing [next_retry_at]/[updated_at]
+   wire strings, while the in-memory retry state uses [Attempt_state.t]
+   floats. These tests pin the boundary format so dashboard consumers see
+   the same contract. *)
 
 let test_isoish_now_fixed_shape () =
   let s = Masc_domain.now_iso () in
@@ -883,8 +916,6 @@ let test_isoish_at_epoch_round_trip () =
 ;;
 
 let test_isoish_lexical_matches_chronological () =
-  (* If these two lose correspondence, [retry_backoff_active]'s
-     [String.compare next_retry_at now > 0] would silently drift.  *)
   let earlier = Masc_domain.iso8601_of_unix_seconds 1_000_000.0 in
   let later = Masc_domain.iso8601_of_unix_seconds 2_000_000.0 in
   check bool "earlier < later lexically" true (String.compare earlier later < 0);
@@ -896,23 +927,14 @@ let test_isoish_lexical_matches_chronological () =
     (String.compare earlier (Masc_domain.iso8601_of_unix_seconds 1_000_000.0))
 ;;
 
-(* ── retry_backoff_active (#8930 phase 3) ──────────────────────────────
-   After phase 3, [retry_backoff_active] parses both [next_retry_at] and
-   [now] via [Types_core.parse_iso8601_opt] and compares float unix-epoch
-   values. If either side is malformed the function returns false
-   (fail-closed) so a broken sidecar record retries instead of stalling. *)
+(* ── retry_backoff_active (#8930 / #22246) ─────────────────────────────
+   [retry_backoff_active] parses [now] at the boundary and delegates the
+   deadline check to [Attempt_state.is_backoff_active]. Malformed persisted
+   [next_retry_at] values are rejected by [attempt_record_of_json] instead
+   of entering the in-memory state. *)
 
 let make_attempt ~next_retry_at =
-  Routes.
-    { connector_id = "discord"
-    ; generation = 1
-    ; attempt_id = "1:1"
-    ; attempt_number = 1
-    ; last_attempt_result = "start_dispatched"
-    ; next_retry_at
-    ; operator_next_action = "none"
-    ; updated_at = "2026-01-01T00:00:00Z"
-    }
+  make_attempt_record ?next_retry_at ()
 ;;
 
 let test_retry_backoff_active_before_deadline () =
@@ -942,13 +964,24 @@ let test_retry_backoff_inactive_when_no_deadline () =
     (Routes.retry_backoff_active ~now:"2026-01-01T00:00:00Z" attempt)
 ;;
 
-let test_retry_backoff_fail_closed_on_malformed_next () =
-  let attempt = make_attempt ~next_retry_at:(Some "not-an-iso-stamp") in
+let test_attempt_record_of_json_rejects_malformed_next_retry_at () =
+  let json =
+    `Assoc
+      [ "connector_id", `String "discord"
+      ; "generation", `Int 1
+      ; "attempt_id", `String "1:1"
+      ; "attempt_number", `Int 1
+      ; "last_attempt_result", `String "start_dispatched"
+      ; "next_retry_at", `String "not-an-iso-stamp"
+      ; "operator_next_action", `String "none"
+      ; "updated_at", `String "2026-01-01T00:00:00Z"
+      ]
+  in
   check
     bool
-    "malformed next_retry_at → fail-closed"
-    false
-    (Routes.retry_backoff_active ~now:"2026-01-01T00:00:00Z" attempt)
+    "malformed next_retry_at → rejected at boundary"
+    true
+    (Routes.attempt_record_of_json json = None)
 ;;
 
 let test_retry_backoff_fail_closed_on_malformed_now () =
@@ -1179,9 +1212,9 @@ let () =
             `Quick
             test_retry_backoff_inactive_when_no_deadline
         ; test_case
-            "malformed next_retry_at → fail-closed"
+            "malformed next_retry_at → rejected at boundary"
             `Quick
-            test_retry_backoff_fail_closed_on_malformed_next
+            test_attempt_record_of_json_rejects_malformed_next_retry_at
         ; test_case
             "malformed now → fail-closed"
             `Quick


### PR DESCRIPTION
## Summary
- migrate sidecar lifecycle attempt_record to embed Attempt_state.t instead of duplicating generation/attempt/result/deadline fields
- keep the existing dashboard/wire JSON fields: last_attempt_result, next_retry_at, updated_at, attempt_id
- route backoff checks through Attempt_state.is_backoff_active and reject malformed persisted next_retry_at at the JSON boundary

Fixes #22246

## Validation
- ocamlformat --check lib/server/server_routes_http_routes_sidecar.ml lib/server/server_routes_http_routes_sidecar.mli lib/attempt_state.mli test/test_sidecar_lifecycle_routes.ml
- git diff --check
- rg -l "Attempt_state" lib/ bin/ --glob '!**/.worktrees/**'
- rg confirmed no sidecar public attempt_record fields remain for last_attempt_result : string / next_retry_at : string option

Local Dune build/test intentionally not run per operator instruction; CI is the build authority for this PR.