### PR TITLE
[codex] Expose redacted keeper stream fallback for tests

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -189,6 +189,8 @@ module For_testing : sig
   val direct_reply_terminal_error : Yojson.Safe.t option -> string -> string option
   val visible_reply_with_stream_fallback :
     streamed_text:string -> string -> string
+  val redacted_visible_reply_with_stream_fallback :
+    redact:(string -> string) -> streamed_text:string -> string -> string
   val reply_payload_with_streamed_visible_reply :
     Yojson.Safe.t option -> visible_reply:string -> Yojson.Safe.t option
   val format_surface_context : Yojson.Safe.t -> string


### PR DESCRIPTION
## Summary
- expose `redacted_visible_reply_with_stream_fallback` through `Server_routes_http_keeper_stream.For_testing`
- keep the implementation unchanged; this fixes the interface/test mismatch from `test_gate_keeper_backend`

## Validation
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_gate_keeper_backend.exe`

## Notes
- Regular `scripts/dune-local.sh build ...` is blocked locally by `agent_sdk` pin drift before Dune runs: current `9fe586c197205815f2e55a43761821e14a29ff83`, expected `785d99977588db04fd4528f61daf26f06e60063c`.
- The earlier direct `dune build .` cache `rmdir(...Directory not empty)` looks like shared Dune artifact-cache contention; this validation used the repo wrapper with `DUNE_CACHE=disabled`.