### PR TITLE
[codex] Wire runtime binding draft edits

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -18,13 +18,21 @@ export type RuntimeStructuredSection =
   | 'bindings'
   | 'assignments'
 
+export type RuntimeBindingEditableField = 'max-concurrent' | 'keep-alive' | 'num-ctx'
+
 interface RuntimeEnvironmentEditorProps {
   sourceText: string
   section: RuntimeStructuredSection
   disabled?: boolean
+  draftDirty?: boolean
   saving?: boolean
   onRoutingChange: (lane: 'default' | 'librarian' | 'cross_verifier', runtimeId: string | null) => void
   onAssignmentChange: (keeperName: string, runtimeId: string | null) => void
+  onBindingFieldChange: (
+    runtimeId: string,
+    field: RuntimeBindingEditableField,
+    value: string | number | null,
+  ) => void
 }
 
 function firstId<T extends { id: string }>(items: T[]): string {
@@ -53,6 +61,14 @@ function protoContext(value: number | null | undefined): string {
   return `${(value / 1000).toFixed(0)}k ctx`
 }
 
+function parseOptionalPositiveInteger(raw: string): number | null | undefined {
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  if (!/^\d+$/.test(trimmed)) return undefined
+  const parsed = Number.parseInt(trimmed, 10)
+  return parsed > 0 ? parsed : undefined
+}
+
 // rt-cap chip — runtime-editor.jsx:17 rtCapChip. `on` toggles the ✓/· glyph
 // and the .on tone (runtime.css:64). Read-only capability readout.
 function capChip(on: boolean, label: string) {
@@ -76,9 +92,11 @@ export function RuntimeEnvironmentEditor({
   sourceText,
   section,
   disabled,
+  draftDirty,
   saving,
   onRoutingChange,
   onAssignmentChange,
+  onBindingFieldChange,
 }: RuntimeEnvironmentEditorProps) {
   const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
   const [modelQuery, setModelQuery] = useState('')
@@ -90,6 +108,7 @@ export function RuntimeEnvironmentEditor({
   const crossVerifierLane = environment.crossVerifierRuntimeId
   const assignments = environment.assignments
   const keeperList = keepers.value
+  const typedPatchDisabled = isDisabled || draftDirty === true
 
   const filteredModels = environment.models.filter(model => {
     if (modelQuery.trim() === '') return true
@@ -111,6 +130,21 @@ export function RuntimeEnvironmentEditor({
       return
     }
     onAssignmentChange(keeperName, runtimeId)
+  }
+
+  function updateBindingNumber(
+    runtimeId: string,
+    field: 'max-concurrent' | 'num-ctx',
+    raw: string,
+  ) {
+    const next = parseOptionalPositiveInteger(raw)
+    if (next === undefined) return
+    onBindingFieldChange(runtimeId, field, next)
+  }
+
+  function updateBindingKeepAlive(runtimeId: string, raw: string) {
+    const next = raw.trim()
+    onBindingFieldChange(runtimeId, 'keep-alive', next === '' ? null : next)
   }
 
   // rt-select — runtime.css:43. Inline width cap so the 248px min-width never
@@ -148,7 +182,7 @@ export function RuntimeEnvironmentEditor({
           <select
             class="rt-select mono"
             value=${value}
-            disabled=${isDisabled}
+            disabled=${typedPatchDisabled}
             aria-label=${lane === 'default' ? 'default runtime' : `${lane} runtime`}
             onChange=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
           >
@@ -165,7 +199,7 @@ export function RuntimeEnvironmentEditor({
     <div data-testid="runtime-environment-editor">
       <div class="rt-head-actions" style=${{ justifyContent: 'flex-end', marginBottom: '14px' }}>
         <span class="rt-nav-sub mono" style=${{ marginRight: 'auto' }}>런타임 환경</span>
-        <span class="rt-nav-sub mono">${saving ? '저장 중' : 'backend typed writer'}</span>
+        <span class="rt-nav-sub mono">${saving ? '저장 중' : 'routing live · bindings draft'}</span>
       </div>
 
       ${environment.warnings.length > 0 ? html`
@@ -310,12 +344,13 @@ export function RuntimeEnvironmentEditor({
       </div>
 
       <!-- bindings — runtime-editor.jsx:193-214. radio sets the default runtime;
-           max-conc / num-ctx editable. price / effort sub-line has no live
-           source. -->
+           max-conc / keep-alive / num-ctx edit the draft runtime.toml and are
+           applied through the existing validated Save path. price / effort
+           sub-line has no live source. -->
       <div class=${section === 'bindings' ? '' : 'hidden'} data-testid="runtime-section-bindings">
         <div class="rt-binds">
           <div class="rt-note">
-            바인딩 = 런타임 id <span class="mono">provider.model</span>. 라디오로 기본 런타임 지정.
+            바인딩 = 런타임 id <span class="mono">provider.model</span>. 라디오는 기본 런타임을 즉시 적용하고, 숫자/keep-alive 변경은 draft를 만든 뒤 라이브 적용 버튼으로 저장합니다.
           </div>
           ${environment.bindings.map(binding => {
             const isDefault = binding.id === environment.defaultRuntimeId || binding.isDefault
@@ -325,7 +360,7 @@ export function RuntimeEnvironmentEditor({
                 <button
                   type="button"
                   class="rt-radio ${isDefault ? 'on' : ''}"
-                  disabled=${isDisabled}
+                  disabled=${typedPatchDisabled}
                   title="기본 런타임으로"
                   aria-label=${`${binding.id} 기본 런타임으로`}
                   aria-pressed=${isDefault}
@@ -344,20 +379,42 @@ export function RuntimeEnvironmentEditor({
                     <span>max-conc</span>
                     <input
                       class="rt-input-sm mono"
+                      type="number"
+                      min="1"
+                      step="1"
                       value=${binding.maxConcurrent == null ? '' : String(binding.maxConcurrent)}
                       placeholder="∞"
-                      readOnly
+                      disabled=${isDisabled}
                       aria-label=${`${binding.id} max-concurrent`}
+                      onInput=${(event: Event) => updateBindingNumber(binding.id, 'max-concurrent', (event.currentTarget as HTMLInputElement).value)}
+                      data-testid=${`runtime-binding-${binding.id}-max-concurrent`}
+                    />
+                  </label>
+                  <label class="rt-mini">
+                    <span>keep-alive</span>
+                    <input
+                      class="rt-input-sm mono"
+                      value=${binding.keepAlive}
+                      placeholder="—"
+                      disabled=${isDisabled}
+                      aria-label=${`${binding.id} keep-alive`}
+                      onInput=${(event: Event) => updateBindingKeepAlive(binding.id, (event.currentTarget as HTMLInputElement).value)}
+                      data-testid=${`runtime-binding-${binding.id}-keep-alive`}
                     />
                   </label>
                   <label class="rt-mini">
                     <span>num-ctx</span>
                     <input
                       class="rt-input-sm mono"
+                      type="number"
+                      min="1"
+                      step="1"
                       value=${binding.numCtx == null ? '' : String(binding.numCtx)}
                       placeholder="—"
-                      readOnly
+                      disabled=${isDisabled}
                       aria-label=${`${binding.id} num-ctx`}
+                      onInput=${(event: Event) => updateBindingNumber(binding.id, 'num-ctx', (event.currentTarget as HTMLInputElement).value)}
+                      data-testid=${`runtime-binding-${binding.id}-num-ctx`}
                     />
                   </label>
                 </div>
@@ -388,7 +445,7 @@ export function RuntimeEnvironmentEditor({
                 <select
                   class="rt-select mono"
                   value=${current}
-                  disabled=${isDisabled}
+                  disabled=${typedPatchDisabled}
                   aria-label=${`${keeper.name} 런타임 배정`}
                   onChange=${(event: Event) => updateAssignment(keeper.name, (event.currentTarget as HTMLSelectElement).value)}
                 >

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -190,9 +190,8 @@ describe('RuntimeTomlEditor', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('런타임 환경')
       // The prototype models section renders each model read-only: id + context
-      // (protoContext → "128k ctx") + capability chips. It replaced the legacy
-      // editable catalog grid; context length is now edited per-runtime via the
-      // binding num-ctx control (asserted below), not by mutating the model fact.
+      // (protoContext → "128k ctx") + capability chips. Model facts stay
+      // read-only; runtime execution knobs are edited per binding instead.
       const modelsSection = container.querySelector('[data-testid="runtime-section-models"]')
       expect(modelsSection?.textContent).toContain('qwen')
       expect(modelsSection?.textContent).toContain('128k ctx')
@@ -201,9 +200,82 @@ describe('RuntimeTomlEditor', () => {
     })
 
     expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement).readOnly).toBe(true)
-    expect((container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement).readOnly).toBe(true)
     expect(container.querySelector('[data-testid="runtime-environment-save"]')).toBeNull()
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+  })
+
+  it('edits binding runtime knobs as a draft and applies them through the existing save path', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-bindings"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+
+    const maxConcurrent = container.querySelector('[aria-label="runpod_mtp.qwen max-concurrent"]') as HTMLInputElement
+    const keepAlive = container.querySelector('[aria-label="runpod_mtp.qwen keep-alive"]') as HTMLInputElement
+    const numCtx = container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement
+
+    expect(maxConcurrent.readOnly).toBe(false)
+    expect(maxConcurrent.disabled).toBe(false)
+    expect(maxConcurrent.value).toBe('4')
+    expect(keepAlive.value).toBe('10m')
+
+    fireEvent.input(maxConcurrent, { target: { value: '6' } })
+    fireEvent.input(keepAlive, { target: { value: '20m' } })
+    fireEvent.input(numCtx, { target: { value: '262144' } })
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('max-concurrent = 6')
+      expect(source).toContain('keep-alive = "20m"')
+      expect(source).toContain('num-ctx = 262144')
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
+      expect(savedSource).toContain('max-concurrent = 6')
+      expect(savedSource).toContain('keep-alive = "20m"')
+      expect(savedSource).toContain('num-ctx = 262144')
+      expect(container.textContent).toContain('적용됨')
+    })
+    expect(apiMocks.patchRuntimeRouting).not.toHaveBeenCalled()
+    expect(apiMocks.patchRuntimeAssignment).not.toHaveBeenCalled()
+  })
+
+  it('ignores invalid binding number edits without dirtying the draft', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-bindings"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+
+    const textarea = container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement
+    const maxConcurrent = container.querySelector('[aria-label="runpod_mtp.qwen max-concurrent"]') as HTMLInputElement
+    const numCtx = container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement
+
+    expect(textarea.value).toBe(richSourceText)
+    fireEvent.input(maxConcurrent, { target: { value: '0' } })
+    fireEvent.input(numCtx, { target: { value: '-1' } })
+
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value)
+        .toBe(richSourceText)
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(true)
+    })
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+    expect(apiMocks.patchRuntimeRouting).not.toHaveBeenCalled()
+    expect(apiMocks.patchRuntimeAssignment).not.toHaveBeenCalled()
   })
 
   it('switches the default runtime through the typed backend routing patch', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -13,6 +13,7 @@ import { errorToString } from '../lib/format-string'
 import {
   parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
+  setRuntimeTomlBindingField,
   type RuntimeTomlImpactSummary,
 } from '../lib/runtime-toml-config'
 import { ActionButton } from './common/button'
@@ -20,7 +21,11 @@ import { SectionCard } from './common/card'
 import { copyToClipboard } from './common/copyable-code'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { ringFocusClasses } from './common/ring'
-import { RuntimeEnvironmentEditor, type RuntimeStructuredSection } from './runtime-environment-editor'
+import {
+  RuntimeEnvironmentEditor,
+  type RuntimeBindingEditableField,
+  type RuntimeStructuredSection,
+} from './runtime-environment-editor'
 
 type LoadState = 'idle' | 'loading' | 'loaded'
 
@@ -255,6 +260,17 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     } finally {
       setSaving(false)
     }
+  }
+
+  function handleBindingFieldChange(
+    runtimeId: string,
+    field: RuntimeBindingEditableField,
+    value: string | number | null,
+  ) {
+    if (saving || loadState !== 'loaded') return
+    setDraft(current => setRuntimeTomlBindingField(current, runtimeId, field, value))
+    setNotice(null)
+    setError(null)
   }
 
   async function handleRefresh() {
@@ -493,6 +509,7 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
           </header>
 
           <div class="rt-body">
+            ${toolbar}
             ${error ? html`<${ErrorState} message=${error} />` : null}
             ${notice ? html`
               <div
@@ -508,7 +525,8 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
               <${RuntimeEnvironmentEditor}
                 sourceText=${draft}
                 section=${structuredSection}
-                disabled=${loadState !== 'loaded' || dirty}
+                disabled=${loadState !== 'loaded'}
+                draftDirty=${dirty}
                 saving=${saving}
                 onRoutingChange=${(lane: RuntimeRoutingLane, runtimeId: string | null) => {
                   void handleRoutingPatch(lane, runtimeId)
@@ -516,11 +534,11 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
                 onAssignmentChange=${(keeperName: string, runtimeId: string | null) => {
                   void handleAssignmentPatch(keeperName, runtimeId)
                 }}
+                onBindingFieldChange=${handleBindingFieldChange}
               />
             </div>
 
             <div class=${tomlActive ? 'flex flex-col gap-3' : 'hidden'} data-testid="runtime-toml-section">
-              ${toolbar}
               <div class="rt-toml-wrap">
                 <div class="rt-toml-bar">
                   <span class="mono">${path}</span>


### PR DESCRIPTION
## Summary

- Make Settings > Runtimes > Bindings runtime knobs editable instead of read-only.
- Wire `max-concurrent`, `keep-alive`, and `num-ctx` edits into the runtime.toml draft through the existing TOML utility layer.
- Keep routing/assignment typed backend patches disabled while a draft is dirty, so immediate backend patches do not mix with unsaved TOML edits.
- Show the existing runtime.toml toolbar in structured sections so bindings can be edited and applied without jumping into the raw TOML tab.

## Validation

- `git diff --check`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm run typecheck`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm exec eslint src/components/runtime-environment-editor.ts src/components/runtime-toml-editor.ts`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm exec vitest run --config vitest.config.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules pnpm exec vitest run --config vitest.config.ts src/lib/runtime-toml-config.test.ts --no-file-parallelism --maxWorkers=1`
- Rendered Playwright fallback at `http://127.0.0.1:5179/dashboard/#settings?section=runtimes`: edited binding `max-concurrent`, `keep-alive`, and `num-ctx`; verified draft TOML changed; clicked `라이브 적용`; verified the mocked save payload contains all edited fields.

Browser plugin is not available in this session, so rendered validation used Python Playwright fallback. The rendered save route was mocked to avoid writing the live runtime.toml while still proving the UI submit payload.
