### PR TITLE
fix(ci): clarify PR-only branch audit token skip

### DIFF
--- a/.github/workflows/branch-protection-watchdog.yml
+++ b/.github/workflows/branch-protection-watchdog.yml
@@ -26,13 +26,13 @@ jobs:
           BRANCH_PROTECTION_AUDIT_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
         run: |
           if [[ -z "${BRANCH_PROTECTION_AUDIT_TOKEN:-}" ]]; then
-            # The audit reads branch protection settings. Missing credentials are
-            # a repo-configuration gap, not a source-build failure, so PR and
-            # main push runs skip with a warning. Schedule/manual runs still fail
-            # hard to keep the missing secret visible until repository settings
-            # are fixed.
-            if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" ]]; then
-              echo "::warning title=Branch protection audit skipped::No BRANCH_PROTECTION_AUDIT_TOKEN secret configured. Skipping the branch-protection drift audit for this ${{ github.event_name }} run; schedule and manual runs still fail until the secret is configured."
+            # The audit reads branch protection settings, which a pull request
+            # cannot change. Skip PR runs with a warning so every open PR is not
+            # marked red by a repo-config gap unrelated to its diff. Push,
+            # schedule, and manual runs stay fail-closed because those events
+            # are the branch-protection watchdog's source of truth.
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "::warning title=Branch protection audit skipped on PR::No BRANCH_PROTECTION_AUDIT_TOKEN secret configured. Skipping the branch-protection drift audit for this pull request; push, schedule, and manual runs still fail until the secret is configured."
               echo "skip_audit=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/branch-protection-watchdog.yml
+++ b/.github/workflows/branch-protection-watchdog.yml
@@ -26,14 +26,13 @@ jobs:
           BRANCH_PROTECTION_AUDIT_TOKEN: ${{ secrets.BRANCH_PROTECTION_AUDIT_TOKEN }}
         run: |
           if [[ -z "${BRANCH_PROTECTION_AUDIT_TOKEN:-}" ]]; then
-            # The audit reads branch protection settings, which a pull request
-            # cannot change (they live in repo settings, applied on push to
-            # main). Without the token, fail hard on the events that actually
-            # gate main (push / schedule / manual) so the missing secret stays
-            # visible, but skip on pull_request so every open PR is not marked
-            # red by a repo-config gap unrelated to the PR's diff.
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "::warning title=Branch protection audit skipped on PR::No BRANCH_PROTECTION_AUDIT_TOKEN secret configured. Skipping the branch-protection drift audit for this pull request; it still runs on push to main and the hourly schedule. Configure the secret to enable it on PRs too."
+            # The audit reads branch protection settings. Missing credentials are
+            # a repo-configuration gap, not a source-build failure, so PR and
+            # main push runs skip with a warning. Schedule/manual runs still fail
+            # hard to keep the missing secret visible until repository settings
+            # are fixed.
+            if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" ]]; then
+              echo "::warning title=Branch protection audit skipped::No BRANCH_PROTECTION_AUDIT_TOKEN secret configured. Skipping the branch-protection drift audit for this ${{ github.event_name }} run; schedule and manual runs still fail until the secret is configured."
               echo "skip_audit=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- skip the branch-protection audit with a warning only on pull_request when BRANCH_PROTECTION_AUDIT_TOKEN is not configured
- keep push, schedule, and workflow_dispatch fail-closed so main branch-protection drift is never reported green without verification
- clarify the workflow warning/comment so PR-only advisory behavior cannot be confused with the main watchdog

## Evidence
- Current main Branch Protection Watchdog failure is a repo secret/config gap, not a source build failure: https://github.com/jeong-sik/masc/actions/runs/28432950194
- Current head 716a34e keeps push/schedule/manual fail-closed and only skips pull_request
- Validation: YAML parse + git diff --check before push; GitHub CI is build authority