### PR TITLE
refactor(oas-consume): delegate to OAS canonical projections instead of hand-rolling

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -82,12 +82,7 @@ let summarize_chunk (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.mess
   let lines =
     msgs
     |> List.mapi (fun i (m : Agent_sdk.Types.message) ->
-      let role_str = match m.role with
-        | Agent_sdk.Types.User -> "user"
-        | Agent_sdk.Types.Assistant -> "assistant"
-        | Agent_sdk.Types.System -> "system"
-        | Agent_sdk.Types.Tool -> "tool"
-      in
+      let role_str = Agent_sdk.Types.role_to_string m.role in
       let text = String.trim (Agent_sdk.Types.text_of_message m) in
       if text = "" then None
       else Some (Printf.sprintf "[%d] %s: %s" (i + 1) role_str (first_sentence text))

--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -34,11 +34,8 @@ let tool_start_is_replay existing tool =
   String.equal existing.tool_call_id tool.tool_call_id
   && String.equal existing.tool_call_name tool.tool_call_name
 
-let sdk_stream_event_is_deliverable =
-  Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal
-
 let stream_start_is_tool ~index ~content_type ~tool_id ~tool_name =
-  sdk_stream_event_is_deliverable
+  Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal
     (Agent_sdk.Types.ContentBlockStart
        { index; content_type; tool_id; tool_name })
 

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -9,7 +9,7 @@ let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
     ; "output_tokens", `Int usage.output_tokens
     ; "cache_creation_input_tokens", `Int usage.cache_creation_input_tokens
     ; "cache_read_input_tokens", `Int usage.cache_read_input_tokens
-    ; "total_tokens", `Int (usage.input_tokens + usage.output_tokens)
+    ; "total_tokens", `Int (Agent_sdk.Types.total_tokens usage)
     ; ( "cost_usd"
       , match usage.cost_usd with
         | Some cost -> `Float cost

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -165,38 +165,8 @@ let prepare_agent_setup
     let tbl = Hashtbl.create (List.length keeper_tools) in
     List.iter
       (fun (t : Agent_sdk.Tool.t) ->
-         let param_type_str (pt : Agent_sdk.Types.param_type) =
-           match pt with
-           | String -> "string"
-           | Integer -> "integer"
-           | Number -> "number"
-           | Boolean -> "boolean"
-           | Array -> "array"
-           | Object -> "object"
-         in
-         let props =
-           List.map
-             (fun (p : Agent_sdk.Types.tool_param) ->
-                ( p.name
-                , `Assoc
-                    [ "type", `String (param_type_str p.param_type)
-                    ; "description", `String p.description
-                    ] ))
-             t.schema.parameters
-         in
-         let required =
-           t.schema.parameters
-           |> List.filter (fun (p : Agent_sdk.Types.tool_param) -> p.required)
-           |> List.map (fun (p : Agent_sdk.Types.tool_param) -> `String p.name)
-         in
-         let schema =
-           `Assoc
-             [ "type", `String "object"
-             ; "properties", `Assoc props
-             ; "required", `List required
-             ]
-         in
-         Hashtbl.replace tbl t.schema.name schema)
+         Hashtbl.replace tbl t.schema.name
+           (Agent_sdk.Types.params_to_input_schema t.schema.parameters))
       keeper_tools;
     tbl
   in

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -248,17 +248,14 @@ let validate_input_json schema json =
   validate_json_value ~label:"input" schema json
 
 (* Strict classifier: returns [None] for unknown JSON Schema types so
-   callers can distinguish "rule fired" from "fall-through default".
-   See #8832. *)
+   callers can distinguish "rule fired" from "fall-through default"
+   (see #8832). Delegates to the OAS SSOT
+   [Agent_sdk.Types.param_type_of_string] ([Error _ -> None]) so a
+   param_type added upstream stays in sync without editing this table.
+   NB: not [Tool_bridge.param_type_of_string] / [Mcp.json_schema_type_to_param_type],
+   whose permissive [_ -> String] default would erase the strict [None]. *)
 let param_type_of_schema_opt schema : Agent_sdk.Types.param_type option =
-  match schema_type schema with
-  | "string" -> Some Agent_sdk.Types.String
-  | "integer" -> Some Agent_sdk.Types.Integer
-  | "number" -> Some Agent_sdk.Types.Number
-  | "boolean" -> Some Agent_sdk.Types.Boolean
-  | "array" -> Some Agent_sdk.Types.Array
-  | "object" -> Some Agent_sdk.Types.Object
-  | _ -> None
+  Agent_sdk.Types.param_type_of_string (schema_type schema) |> Result.to_option
 
 let tool_params_of_input_schema schema =
   let required = required_names schema in

--- a/test/dune
+++ b/test/dune
@@ -705,6 +705,11 @@
  (libraries alcotest ast_grep masc_test_deps masc.fusion_core))
 
 (test
+ (name test_oas_canonical_delegation)
+ (modules test_oas_canonical_delegation)
+ (libraries alcotest ast_grep masc_test_deps))
+
+(test
  (name test_keeper_structured_output_schema)
  (modules test_keeper_structured_output_schema)
  (libraries alcotest masc_test_deps masc.fusion_core))

--- a/test/dune
+++ b/test/dune
@@ -1465,6 +1465,7 @@
   test_mention_coverage
   test_resilience_coverage
   test_types_coverage
+  test_oas_canonical_delegation_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage
@@ -1510,6 +1511,7 @@
   test_mention_coverage
   test_resilience_coverage
   test_types_coverage
+  test_oas_canonical_delegation_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage

--- a/test/test_oas_canonical_delegation.ml
+++ b/test/test_oas_canonical_delegation.ml
@@ -33,6 +33,14 @@ let test_masc_delegates_canonical_oas_projections () =
     ~expected:1
 ;;
 
+let test_masc_delegates_oas_stream_progress_predicates () =
+  check_calls
+    ~file:"lib/keeper/keeper_chat_oas_stream_bridge.ml"
+    ~callee:
+      "Agent_sdk.Llm_provider.Streaming.sse_event_is_deliverable_progress_signal"
+    ~expected:1
+;;
+
 let test_hand_rolled_tool_schema_projection_is_not_reintroduced () =
   check_no_binding ~file:"lib/keeper/keeper_run_tools_setup.ml" ~name:"param_type_str";
   check_calls
@@ -49,6 +57,10 @@ let () =
             "MASC delegates canonical projections to OAS"
             `Quick
             test_masc_delegates_canonical_oas_projections
+        ; test_case
+            "MASC delegates stream progress classification to OAS"
+            `Quick
+            test_masc_delegates_oas_stream_progress_predicates
         ; test_case
             "tool schema projection helper is not hand-rolled locally"
             `Quick

--- a/test/test_oas_canonical_delegation.ml
+++ b/test/test_oas_canonical_delegation.ml
@@ -1,0 +1,58 @@
+open Alcotest
+
+let check_calls ~file ~callee ~expected =
+  check int
+    (Printf.sprintf "%s calls %s" file callee)
+    expected
+    (Ast_grep.count_calls ~module_path:file ~callee)
+;;
+
+let check_no_binding ~file ~name =
+  check int
+    (Printf.sprintf "%s does not define %s" file name)
+    0
+    (Ast_grep.count_value_bindings ~module_path:file ~name)
+;;
+
+let test_masc_delegates_canonical_oas_projections () =
+  check_calls
+    ~file:"lib/context_compact_oas.ml"
+    ~callee:"Agent_sdk.Types.role_to_string"
+    ~expected:1;
+  check_calls
+    ~file:"lib/keeper/keeper_event_bridge_error_json.ml"
+    ~callee:"Agent_sdk.Types.total_tokens"
+    ~expected:1;
+  check_calls
+    ~file:"lib/keeper/keeper_run_tools_setup.ml"
+    ~callee:"Agent_sdk.Types.params_to_input_schema"
+    ~expected:1;
+  check_calls
+    ~file:"lib/sdk_tool_contract.ml"
+    ~callee:"Agent_sdk.Types.param_type_of_string"
+    ~expected:1
+;;
+
+let test_hand_rolled_tool_schema_projection_is_not_reintroduced () =
+  check_no_binding ~file:"lib/keeper/keeper_run_tools_setup.ml" ~name:"param_type_str";
+  check_calls
+    ~file:"lib/keeper/keeper_run_tools_setup.ml"
+    ~callee:"Agent_sdk.Types.param_type_to_string"
+    ~expected:0
+;;
+
+let () =
+  Alcotest.run
+    "oas-canonical-delegation"
+    [ ( "delegation"
+      , [ test_case
+            "MASC delegates canonical projections to OAS"
+            `Quick
+            test_masc_delegates_canonical_oas_projections
+        ; test_case
+            "tool schema projection helper is not hand-rolled locally"
+            `Quick
+            test_hand_rolled_tool_schema_projection_is_not_reintroduced
+        ] )
+    ]
+;;

--- a/test/test_oas_canonical_delegation_contract.ml
+++ b/test/test_oas_canonical_delegation_contract.ml
@@ -1,0 +1,80 @@
+(** OAS canonical-delegation boundary contract (masc#22809).
+
+    Four MASC sites delegate to OAS [Agent_sdk.Types] canonical projections
+    instead of hand-rolling them:
+    - [keeper_event_bridge_error_json]: [total_tokens]
+    - [context_compact_oas]: [role_to_string]
+    - [sdk_tool_contract]: [param_type_of_string] (strict [None] on unknown)
+    - [keeper_run_tools_setup]: [params_to_input_schema]
+
+    These tests pin the exact OAS outputs MASC now emits on the wire (provider
+    request tool schema, dashboard role labels, usage JSON). They are a boundary
+    regression guard: if an OAS release changes any of these canonical outputs,
+    the change surfaces here loudly instead of drifting MASC's emitted wire
+    silently. They also document the byte-identical equivalence the delegations
+    rely on. *)
+
+open Alcotest
+
+(* keeper_event_bridge_error_json.ml:12 — billable total excludes cache tokens. *)
+let test_total_tokens () =
+  let usage : Agent_sdk.Types.api_usage =
+    { input_tokens = 30
+    ; output_tokens = 12
+    ; cache_creation_input_tokens = 7
+    ; cache_read_input_tokens = 5
+    ; cost_usd = None
+    }
+  in
+  check int "billable = input + output (cache excluded)" 42
+    (Agent_sdk.Types.total_tokens usage)
+
+(* context_compact_oas.ml:85 — every role variant maps to its canonical wire string. *)
+let test_role_to_string () =
+  check string "system" "system" (Agent_sdk.Types.role_to_string Agent_sdk.Types.System);
+  check string "user" "user" (Agent_sdk.Types.role_to_string Agent_sdk.Types.User);
+  check string "assistant" "assistant"
+    (Agent_sdk.Types.role_to_string Agent_sdk.Types.Assistant);
+  check string "tool" "tool" (Agent_sdk.Types.role_to_string Agent_sdk.Types.Tool)
+
+(* sdk_tool_contract.ml:253 — strict [None] on unknown (#8832 drift WARN driver). *)
+let test_param_type_of_string_strict_option () =
+  let opt s = Agent_sdk.Types.param_type_of_string s |> Result.to_option in
+  check bool "string" true (opt "string" = Some Agent_sdk.Types.String);
+  check bool "integer" true (opt "integer" = Some Agent_sdk.Types.Integer);
+  check bool "number" true (opt "number" = Some Agent_sdk.Types.Number);
+  check bool "boolean" true (opt "boolean" = Some Agent_sdk.Types.Boolean);
+  check bool "array" true (opt "array" = Some Agent_sdk.Types.Array);
+  check bool "object" true (opt "object" = Some Agent_sdk.Types.Object);
+  check bool "unknown -> None (strict, #8832)" true (opt "definitely-not-a-type" = None)
+
+(* keeper_run_tools_setup.ml:168 — input schema shape equals the prior hand-built JSON:
+   ordered properties, {type; description} per param, required = required names. *)
+let test_params_to_input_schema_shape () =
+  let params : Agent_sdk.Types.tool_param list =
+    [ { name = "path"; description = "file path"; param_type = Agent_sdk.Types.String; required = true }
+    ; { name = "limit"; description = "max rows"; param_type = Agent_sdk.Types.Integer; required = false }
+    ]
+  in
+  let expected =
+    `Assoc
+      [ "type", `String "object"
+      ; ( "properties"
+        , `Assoc
+            [ "path", `Assoc [ "type", `String "string"; "description", `String "file path" ]
+            ; "limit", `Assoc [ "type", `String "integer"; "description", `String "max rows" ]
+            ] )
+      ; "required", `List [ `String "path" ]
+      ]
+  in
+  check bool "params_to_input_schema matches hand-rolled shape" true
+    (Agent_sdk.Types.params_to_input_schema params = expected)
+
+let suite =
+  [ test_case "total_tokens billable" `Quick test_total_tokens
+  ; test_case "role_to_string variants" `Quick test_role_to_string
+  ; test_case "param_type_of_string strict option" `Quick test_param_type_of_string_strict_option
+  ; test_case "params_to_input_schema shape" `Quick test_params_to_input_schema_shape
+  ]
+
+let () = run "oas_canonical_delegation_contract" [ "contract", suite ]


### PR DESCRIPTION
## Summary
Delegate four MASC re-implementations of public `Agent_sdk` total functions to the OAS SSOT. MASC consumes OAS; no OAS change. Surfaced by an adversarial axis-1 sweep (typed-sum / canonical-projection reimplementation), each confirmed byte-identical on the reachable input domain and corroborated by sibling sites in this repo that already delegate.

- `lib/keeper/keeper_event_bridge_error_json.ml`: `usage.input_tokens + usage.output_tokens` -> `Agent_sdk.Types.total_tokens usage` (sibling already delegates: `keeper_chat_events.ml`).
- `lib/sdk_tool_contract.ml`: a 6-arm JSON-Schema-type string match -> `Agent_sdk.Types.param_type_of_string (...) |> Result.to_option`. Strict `None`-on-unknown is preserved (`Error _ -> None`) and the caller's `#8832` drift WARN still fires; the drift-prone `_ -> None` catch-all is removed.
- `lib/keeper/keeper_run_tools_setup.ml`: a hand-built `{type:object, properties, required}` tool input schema -> `Agent_sdk.Types.params_to_input_schema t.schema.parameters` (sibling already delegates: `typed_tool_masc.ml:68`).
- `lib/context_compact_oas.ml`: an inline 4-arm role match -> `Agent_sdk.Types.role_to_string` (siblings already delegate: `keeper_context_core_message_json.ml`, `keeper_librarian.ml`, `keeper_wake_telemetry.ml`).

Net -38 lines. Each delegate is byte-identical to the replaced code on every reachable input (verified against agent_sdk 785d999 = 0.208.2 `.mli`/`.ml`). The compiler now keeps MASC's emitted wire labels in sync when OAS extends these closed sums, closing the silent-drift gap each hand-rolled copy carried.

## Validation
- `bash scripts/dune-local.sh` (full build) — green.
- Behavior-preserving refactor: no new types, no control-flow change; the replaced expressions and the OAS delegates produce identical output for the full reachable input domain.

## Not a workaround
This is reimplementation removal, the inverse of a workaround: it deletes hand-rolled classifiers/serializers in favor of the OAS SSOT. The `sdk_tool_contract.ml` change *removes* a string-literal classifier (it does not add one) and preserves the strict `None`-on-unknown contract.

## Out of scope (refuted by the same sweep)
11 sibling candidates were refuted as legitimately MASC-specific and left unchanged — e.g. `keeper_failure_policy` (a deliberately dependency-free typed boundary with its own closed sums + anti-corruption adapter), `keeper_chat_store` (a deliberately narrower 3-variant chat role; widening to OAS's 4-variant would admit an illegal `System` chat row), and `ag_ui` role (an AG-UI protocol-boundary type with independent ownership).

RFC-WAIVED: no credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow surface touched; behavior-preserving delegation to existing public OAS functions.
