### PR TITLE
fix(keeper): fail contract-attention turns

### DIFF
--- a/docs/observability/keeper-turn-fsm-metrics.md
+++ b/docs/observability/keeper-turn-fsm-metrics.md
@@ -143,13 +143,13 @@ Source-of-truth cross-reference (after Step 4 caller adoption):
 | `Streaming → Completing` | `keeper_unified_turn_success.ml` | #11308 |
 | `Streaming → Cancelled supervisor_stop` (HonorStopSignal, Eio.Cancel) | `keeper_unified_turn.ml:884` | Cycle 1b-iv |
 | `Completing → Done` (success exit) | `keeper_unified_turn_success.ml` | #11288 |
+| `Completing → Failed completion_contract_violation` (typed completion-contract attention) | `keeper_unified_turn_success.ml` | current |
 
 Pending edges (require `keeper_agent_run.ml run_turn` adoption — volume risk):
 - `Streaming ⇄ Awaiting_tool_result` per tool call
 
 Pending RISKY edges (require feature-flag / dual-emit infrastructure):
 - `Completing → Failed receipt_lost` (Step 3 — receipt authoritative)
-- `Streaming → Failed completion_contract_violation` (Step 6b-2 — typed classifier replacing string match)
 
 ## See also
 

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -70,6 +70,7 @@ type run_result =
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
+  ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -15,6 +15,11 @@ type tool_call_detail =
   ; output_fingerprint : string option
   }
 
+type operator_disposition =
+  { disposition : Keeper_execution_receipt.operator_disposition_kind
+  ; reason : Keeper_execution_receipt.operator_disposition_reason
+  }
+
 let tool_call_detail_to_json (detail : tool_call_detail) =
   let route_evidence_field =
     match detail.route_evidence with
@@ -71,6 +76,7 @@ type run_result =
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
   ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
+  ; operator_disposition : operator_disposition option
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -12,6 +12,11 @@ type tool_call_detail =
   ; output_fingerprint : string option
   }
 
+type operator_disposition =
+  { disposition : Keeper_execution_receipt.operator_disposition_kind
+  ; reason : Keeper_execution_receipt.operator_disposition_reason
+  }
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -24,6 +29,7 @@ type run_result =
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
   ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
+  ; operator_disposition : operator_disposition option
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -23,6 +23,7 @@ type run_result =
   ; usage : Agent_sdk.Types.api_usage
   ; usage_reported : bool
   ; tool_calls : tool_call_detail list
+  ; completion_contract_result : Keeper_execution_receipt.completion_contract_result
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -624,6 +624,7 @@ let run_turn
                    Contract_helpers.observed_completion_contract_status
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
+                     ~response_text_present:(String.trim text <> "")
                  in
                  let contract_status = completion_contract_status () in
                  acc.receipt_completion_contract_result <- contract_status;

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -41,11 +41,15 @@ let progress_keeper_tool_names_for_contract
 
 let observed_completion_contract_status
       ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
+      ~response_text_present
   : Keeper_execution_receipt.completion_contract_result
   =
-  Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-    ~had_owned_active_task_at_turn_start
-    ~actual_keeper_tool_names
+  if (not response_text_present) && actual_keeper_tool_names = []
+  then Contract_violated
+  else
+    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+      ~had_owned_active_task_at_turn_start
+      ~actual_keeper_tool_names
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -16,4 +16,5 @@ val progress_keeper_tool_names_for_contract :
 val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
+  response_text_present:bool ->
   Keeper_execution_receipt.completion_contract_result

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -472,6 +472,7 @@ let finalize
       ; usage_reported = Option.is_some result.response.usage
       ; tool_calls = List.rev acc.tool_calls
       ; completion_contract_result
+      ; operator_disposition = None
       ; checkpoint = saved_checkpoint
       ; trace_ref = result.trace_ref
       ; run_validation = result.run_validation

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -471,6 +471,7 @@ let finalize
       ; usage
       ; usage_reported = Option.is_some result.response.usage
       ; tool_calls = List.rev acc.tool_calls
+      ; completion_contract_result
       ; checkpoint = saved_checkpoint
       ; trace_ref = result.trace_ref
       ; run_validation = result.run_validation

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -197,6 +197,15 @@ let finalize
     ; pre_dispatch_compaction_after_tokens
     }
   in
+  let disposition, reason = Keeper_execution_receipt.operator_disposition receipt in
+  let operator_disposition =
+    Some ({ disposition; reason } : Keeper_agent_result.operator_disposition)
+  in
+  let turn_result_with_operator_disposition =
+    match turn_result with
+    | Ok result -> Ok { result with operator_disposition }
+    | Error _ -> turn_result
+  in
   let receipt_path =
     Keeper_runtime_manifest.execution_receipt_path_for_today config
       ~keeper_name:meta.name
@@ -269,9 +278,9 @@ let finalize
   in
   Keeper_agent_run_phase5_task_link.run ~config ~meta ~acc ();
   let final_result =
-    match turn_result, receipt_append_outcome with
-    | Error _, _ -> turn_result
-    | Ok _, Ok () -> turn_result
+    match turn_result_with_operator_disposition, receipt_append_outcome with
+    | Error _, _ -> turn_result_with_operator_disposition
+    | Ok _, Ok () -> turn_result_with_operator_disposition
     | Ok _, Error err_msg ->
       Error
         (Agent_sdk.Error.Internal

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -170,6 +170,7 @@ val append_metrics_snapshot :
   compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   ?provider_timeout_plan_json:Yojson.Safe.t ->
+  ?count_completed_turn:bool ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -22,7 +22,8 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(message_count : int)
     ~(compaction : Keeper_context_runtime.compaction_event)
     ~(handoff_json : Yojson.Safe.t option)
-    ?provider_timeout_plan_json ?deliberation_execution () : unit =
+    ?provider_timeout_plan_json ?(count_completed_turn = true)
+    ?deliberation_execution () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
@@ -91,10 +92,12 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~channel:(Keeper_world_observation.channel_to_string channel)
     ~runtime_profile
     ~latency_ms;
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string TurnCompleted)
-    ~labels:[("keeper", meta.name)]
-    ();
+  if count_completed_turn
+  then
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string TurnCompleted)
+      ~labels:[("keeper", meta.name)]
+      ();
   let snapshot =
     `Assoc
       [

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -17,6 +17,7 @@ val append_metrics_snapshot :
   compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   ?provider_timeout_plan_json:Yojson.Safe.t ->
+  ?count_completed_turn:bool ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -337,6 +337,11 @@ let terminal_outcome_to_activity_kind = function
   | Terminal_failed_completion_contract _ -> "keeper.turn_failed"
   | Terminal_done | Terminal_checkpoint -> "keeper.turn_completed"
 
+let terminal_outcome_to_label = function
+  | Terminal_done -> "done"
+  | Terminal_checkpoint -> "checkpoint"
+  | Terminal_failed_completion_contract _ -> "failed"
+
 let terminal_outcome_to_log_label = function
   | Terminal_done -> "OK"
   | Terminal_checkpoint -> "checkpoint"
@@ -471,7 +476,7 @@ let emit_activity_graph
         ~payload:
           (`Assoc
               ([ "keeper_name", `String updated_meta.name
-               ; "terminal_outcome", `String (terminal_outcome_to_log_label terminal_outcome)
+               ; "terminal_outcome", `String (terminal_outcome_to_label terminal_outcome)
                ; ( "input_tokens"
                  , if usage_trusted then `Int result.Keeper_agent_run.usage.input_tokens else `Null )
                ; ( "output_tokens"

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -296,19 +296,51 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
       ~was_latched
 ;;
 
-let completion_contract_attention_reason_code result =
-  let completion_contract_result =
-    result.Keeper_agent_run.completion_contract_result
-  in
-  if
-    Keeper_execution_receipt.completion_contract_result_requires_attention
-      completion_contract_result
-  then
+type terminal_outcome =
+  | Terminal_done
+  | Terminal_checkpoint
+  | Terminal_failed_completion_contract of { reason_code : string }
+
+let completion_contract_terminal_failure_reason_code result =
+  match result.Keeper_agent_run.operator_disposition with
+  | Some
+      { disposition = Keeper_execution_receipt.Disp_pause_human
+      ; reason = Keeper_execution_receipt.Reason_completion_contract_unsatisfied
+      } ->
     Some
       (Keeper_execution_receipt.completion_contract_result_to_string
-         completion_contract_result)
-  else None
+         result.Keeper_agent_run.completion_contract_result)
+  | Some _ -> None
+  | None ->
+    Some
+      (Keeper_execution_receipt.operator_disposition_reason_to_string
+         Keeper_execution_receipt.Reason_unmapped_runtime_state)
 ;;
+
+let terminal_outcome_of_result result =
+  match completion_contract_terminal_failure_reason_code result with
+  | Some reason_code -> Terminal_failed_completion_contract { reason_code }
+  | None ->
+    (match result.Keeper_agent_run.stop_reason with
+     | Runtime_agent.Completed -> Terminal_done
+     | Runtime_agent.TurnBudgetExhausted _
+     | Runtime_agent.MutationBoundaryReached _ ->
+       Terminal_checkpoint)
+;;
+
+let terminal_outcome_is_completed_turn = function
+  | Terminal_done | Terminal_checkpoint -> true
+  | Terminal_failed_completion_contract _ -> false
+;;
+
+let terminal_outcome_to_activity_kind = function
+  | Terminal_failed_completion_contract _ -> "keeper.turn_failed"
+  | Terminal_done | Terminal_checkpoint -> "keeper.turn_completed"
+
+let terminal_outcome_to_log_label = function
+  | Terminal_done -> "OK"
+  | Terminal_checkpoint -> "checkpoint"
+  | Terminal_failed_completion_contract _ -> "failed"
 
 module For_testing = struct
   let budget_exhausted_no_progress_threshold_override =
@@ -329,8 +361,16 @@ module For_testing = struct
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
 
-  let completion_contract_attention_reason_code =
-    completion_contract_attention_reason_code
+  let completion_contract_terminal_failure_reason_code =
+    completion_contract_terminal_failure_reason_code
+
+  type nonrec terminal_outcome = terminal_outcome =
+    | Terminal_done
+    | Terminal_checkpoint
+    | Terminal_failed_completion_contract of { reason_code : string }
+
+  let terminal_outcome_of_result = terminal_outcome_of_result
+  let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
 
   let apply_loop_detectors = apply_loop_detectors
 end
@@ -345,6 +385,7 @@ let append_metrics_snapshot
       ~turn_cost
       ~(lifecycle : KEC.post_turn_lifecycle)
       ~last_provider_timeout_budget
+      ~terminal_outcome
   =
   let any_pending =
     observation.Keeper_world_observation.pending_mentions <> []
@@ -382,6 +423,7 @@ let append_metrics_snapshot
       ~handoff_json:lifecycle.handoff_json
       ?provider_timeout_plan_json:
         (Option.map KCB.provider_timeout_budget_to_yojson last_provider_timeout_budget)
+      ~count_completed_turn:(terminal_outcome_is_completed_turn terminal_outcome)
       ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -417,16 +459,19 @@ let emit_activity_graph
       ~turn_mode_label
       ~(lifecycle : KEC.post_turn_lifecycle)
       ~wall_tokens_per_second
+      ~terminal_outcome
   =
   try
+    let activity_kind = terminal_outcome_to_activity_kind terminal_outcome in
     let event =
       Activity_graph.emit
         config
         ~actor:{ kind = "agent"; id = updated_meta.Keeper_meta_contract.agent_name }
-        ~kind:"keeper.turn_completed"
+        ~kind:activity_kind
         ~payload:
           (`Assoc
               ([ "keeper_name", `String updated_meta.name
+               ; "terminal_outcome", `String (terminal_outcome_to_log_label terminal_outcome)
                ; ( "input_tokens"
                  , if usage_trusted then `Int result.Keeper_agent_run.usage.input_tokens else `Null )
                ; ( "output_tokens"
@@ -475,8 +520,9 @@ let emit_activity_graph
         ()
     in
     Log.Keeper.debug
-      "%s: activity graph turn_completed emitted seq=%d"
+      "%s: activity graph %s emitted seq=%d"
       updated_meta.name
+      activity_kind
       event.seq
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -484,7 +530,7 @@ let emit_activity_graph
     Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
       ~config
       ~keeper_name:updated_meta.name
-      ~side_effect:"activity graph turn_completed emit"
+      ~side_effect:"activity graph turn terminal emit"
       (Printexc.to_string exn)
 ;;
 
@@ -496,6 +542,7 @@ let emit_usage_metrics_and_log
       ~usage_trusted
       ~turn_mode_label
       ~(lifecycle : KEC.post_turn_lifecycle)
+      ~terminal_outcome
   =
   let outcome_str =
     match result.Keeper_agent_run.stop_reason with
@@ -508,10 +555,14 @@ let emit_usage_metrics_and_log
        | None -> Printf.sprintf "mutation_boundary(%d)" turns_used)
   in
   let outcome_label =
-    match result.stop_reason with
-    | Runtime_agent.Completed -> "success"
-    | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
-    | Runtime_agent.MutationBoundaryReached _ -> "mutation_boundary"
+    match terminal_outcome with
+    | Terminal_failed_completion_contract _ -> "failure"
+    | Terminal_done -> "success"
+    | Terminal_checkpoint ->
+      (match result.stop_reason with
+       | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
+       | Runtime_agent.MutationBoundaryReached _ -> "mutation_boundary"
+       | Runtime_agent.Completed -> "success")
   in
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string Turns)
@@ -580,29 +631,60 @@ let emit_usage_metrics_and_log
   let logged_total_tokens =
     if usage_trusted then result.usage.input_tokens + result.usage.output_tokens else 0
   in
-  Log.Keeper.info
-    "%s: keeper cycle OK runtime_lane=%s tokens=%d latency=%dms mode=%s stop=%s"
-    updated_meta.name
-    runtime_lane_label
-    logged_total_tokens
-    latency_ms
-    turn_mode_label
-    outcome_str
+  match terminal_outcome with
+  | Terminal_failed_completion_contract { reason_code } ->
+    Log.Keeper.warn
+      "%s: keeper cycle failed runtime_lane=%s tokens=%d latency=%dms mode=%s \
+       stop=%s terminal=completion_contract_violation reason=%s"
+      updated_meta.name
+      runtime_lane_label
+      logged_total_tokens
+      latency_ms
+      turn_mode_label
+      outcome_str
+      reason_code
+  | Terminal_done | Terminal_checkpoint ->
+    Log.Keeper.info
+      "%s: keeper cycle %s runtime_lane=%s tokens=%d latency=%dms mode=%s stop=%s"
+      updated_meta.name
+      (terminal_outcome_to_log_label terminal_outcome)
+      runtime_lane_label
+      logged_total_tokens
+      latency_ms
+      turn_mode_label
+      outcome_str
 ;;
 
 type decision_outcome =
   | Decision_success
   | Decision_checkpoint
+  | Decision_failure
 
-let decision_outcome_of_stop_reason = function
-  | Runtime_agent.Completed -> Decision_success
-  | Runtime_agent.TurnBudgetExhausted _
-  | Runtime_agent.MutationBoundaryReached _ ->
-    Decision_checkpoint
+let decision_outcome_of_terminal_outcome = function
+  | Terminal_done -> Decision_success
+  | Terminal_checkpoint -> Decision_checkpoint
+  | Terminal_failed_completion_contract _ -> Decision_failure
 
 let decision_outcome_to_label = function
   | Decision_success -> "success"
   | Decision_checkpoint -> "checkpoint"
+  | Decision_failure -> "failure"
+
+let terminal_reason_of_outcome result = function
+  | Terminal_done -> Keeper_turn_terminal.success ()
+  | Terminal_checkpoint ->
+    (match result.Keeper_agent_run.stop_reason with
+     | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
+       Keeper_turn_terminal.of_disposition
+         ~source:"runtime_stop_reason"
+         (Keeper_turn_disposition.Turn_budget_exhausted
+            { detail = None; used = turns_used; limit })
+     | Runtime_agent.MutationBoundaryReached _ | Runtime_agent.Completed ->
+       Keeper_turn_terminal.success ())
+  | Terminal_failed_completion_contract _ ->
+    Keeper_turn_terminal.of_disposition
+      ~source:"completion_contract"
+      Keeper_turn_disposition.Completion_contract_unsatisfied
 
 let persist_success_meta ~config ~original_meta ~updated_meta =
   let updated_meta =
@@ -737,14 +819,21 @@ let record_completion_contract_attention_failure
   else updated_meta
 ;;
 
-let emit_terminal_fsm_for_result ~config ~meta ~keeper_turn_id ~updated_meta result =
+let emit_terminal_fsm
+      ~config
+      ~meta
+      ~keeper_turn_id
+      ~updated_meta
+      ~terminal_outcome
+      result
+  =
   Keeper_turn_fsm.emit_transition
     ~keeper_name:meta.Keeper_meta_contract.name
     ~turn_id:keeper_turn_id
     ~prev:Keeper_turn_fsm.Streaming
     Keeper_turn_fsm.Completing;
-  match completion_contract_attention_reason_code result with
-  | Some reason_code ->
+  match terminal_outcome with
+  | Terminal_failed_completion_contract { reason_code } ->
     let updated_meta =
       record_completion_contract_attention_failure
         ~config
@@ -758,7 +847,7 @@ let emit_terminal_fsm_for_result ~config ~meta ~keeper_turn_id ~updated_meta res
       (Keeper_turn_fsm.Failed
          (Keeper_turn_fsm.Failure_completion_contract_violation { reason_code }));
     updated_meta
-  | None ->
+  | Terminal_done | Terminal_checkpoint ->
     reset_turn_failures_for_stop_reason ~config ~updated_meta result;
     Keeper_turn_fsm.emit_transition
       ~keeper_name:meta.name
@@ -806,6 +895,7 @@ let handle
   let updated_meta =
     apply_loop_detectors ~config ~observation ~meta updated_meta result
   in
+  let terminal_outcome = terminal_outcome_of_result result in
   append_metrics_snapshot
     ~config
     ~meta
@@ -815,7 +905,8 @@ let handle
     ~latency_ms
     ~turn_cost
     ~lifecycle
-    ~last_provider_timeout_budget;
+    ~last_provider_timeout_budget
+    ~terminal_outcome;
   let turn_mode = KUM.turn_mode_of_result result in
   let turn_mode_label = KUM.turn_mode_to_string turn_mode in
   let usage_trust =
@@ -840,7 +931,8 @@ let handle
     ~usage_trusted
     ~turn_mode_label
     ~lifecycle
-    ~wall_tokens_per_second;
+    ~wall_tokens_per_second
+    ~terminal_outcome;
   KUM.broadcast_lifecycle_events
     ~name:updated_meta.name
     ~turn_generation:lifecycle.turn_generation
@@ -854,11 +946,12 @@ let handle
     ~latency_ms
     ~outcome:
       (decision_outcome_to_label
-         (decision_outcome_of_stop_reason result.Keeper_agent_run.stop_reason))
+         (decision_outcome_of_terminal_outcome terminal_outcome))
     ~degraded_retry_applied
     ?degraded_retry_runtime
     ?fallback_reason:(Option.map Keeper_error_classify.degraded_retry_reason_to_string fallback_reason)
     ~turn_mode
+    ~terminal_reason:(terminal_reason_of_outcome result terminal_outcome)
     ~result:(Some result)
     ();
   emit_usage_metrics_and_log
@@ -868,8 +961,14 @@ let handle
     ~usage_trust
     ~usage_trusted
     ~turn_mode_label
-    ~lifecycle;
-  let updated_meta = persist_success_meta ~config ~original_meta:meta ~updated_meta in
+    ~lifecycle
+    ~terminal_outcome;
+  let updated_meta =
+    match terminal_outcome with
+    | Terminal_failed_completion_contract _ -> updated_meta
+    | Terminal_done | Terminal_checkpoint ->
+      persist_success_meta ~config ~original_meta:meta ~updated_meta
+  in
   let tool_call_summaries =
     let max_tool_calls = 10 in
     result.Keeper_agent_run.tool_calls
@@ -886,8 +985,15 @@ let handle
     }
   in
   (* Single source of truth for success-path terminal FSM transitions.
-     [Keeper_unified_turn.handle] is the only caller. Runtime-level success
-     still ends as [Done], but a typed completion-contract attention result is
-     terminal [Failed] so the failure streak is not reset as a healthy turn. *)
-  emit_terminal_fsm_for_result ~config ~meta ~keeper_turn_id ~updated_meta result
+     [Keeper_unified_turn.handle] is the only caller. The terminal outcome is
+     computed before side effects, so metrics, decision records, activity graph,
+     meta writes, health/failure accounting, and FSM emission cannot disagree
+     on whether this turn completed or failed its completion contract. *)
+  emit_terminal_fsm
+    ~config
+    ~meta
+    ~keeper_turn_id
+    ~updated_meta
+    ~terminal_outcome
+    result
 ;;

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -296,6 +296,20 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
       ~was_latched
 ;;
 
+let completion_contract_attention_reason_code result =
+  let completion_contract_result =
+    result.Keeper_agent_run.completion_contract_result
+  in
+  if
+    Keeper_execution_receipt.completion_contract_result_requires_attention
+      completion_contract_result
+  then
+    Some
+      (Keeper_execution_receipt.completion_contract_result_to_string
+         completion_contract_result)
+  else None
+;;
+
 module For_testing = struct
   let budget_exhausted_no_progress_threshold_override =
     budget_exhausted_no_progress_threshold_override
@@ -314,6 +328,9 @@ module For_testing = struct
   let delivery_requires_evidence = delivery_requires_evidence
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
+
+  let completion_contract_attention_reason_code =
+    completion_contract_attention_reason_code
 
   let apply_loop_detectors = apply_loop_detectors
 end
@@ -648,6 +665,109 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
   | Runtime_agent.Completed -> reset_failure_state ()
 ;;
 
+let completion_contract_attention_detail ~reason_code =
+  Printf.sprintf
+    "completion contract requires attention after runtime success: result=%s"
+    reason_code
+;;
+
+let record_completion_contract_attention_failure
+      ~(config : Workspace.config)
+      ~(updated_meta : Keeper_meta_contract.keeper_meta)
+      ~reason_code
+  =
+  let base_path = config.Workspace.base_path in
+  let detail = completion_contract_attention_detail ~reason_code in
+  Keeper_registry.increment_turn_failures ~base_path updated_meta.name;
+  Keeper_registry.set_failure_reason
+    ~base_path
+    updated_meta.name
+    (Some (Keeper_registry.Completion_contract_violation { detail }));
+  Health.record_failure
+    ~agent_name:updated_meta.name
+    ~reason:(Keeper_types_profile.short_preview detail);
+  let count = Keeper_registry.get_turn_failures ~base_path updated_meta.name in
+  let pause_threshold = Runtime.pause_threshold () in
+  let turn_fail_streak_threshold =
+    pause_threshold.Runtime_schema.turn_fail_streak_threshold
+  in
+  if count >= turn_fail_streak_threshold && not updated_meta.paused
+  then (
+    let blocker =
+      Keeper_meta_contract.blocker_info_of_class
+        ~detail:(Keeper_types_profile.short_preview detail)
+        Keeper_meta_contract.Completion_contract_violation
+    in
+    let pause_meta =
+      { updated_meta with
+        runtime = { updated_meta.runtime with last_blocker = Some blocker }
+      }
+    in
+    match
+      KCB.sync_keeper_paused_state_with_resume_policy
+        ~config
+        ~meta:pause_meta
+        ~paused:true
+        ~resume_policy:Keeper_supervisor_pause_policy.Manual_resume_required
+    with
+    | Ok paused_meta ->
+      Log.Keeper.warn
+        "%s: auto-paused after %d completion contract attention failures \
+         (pause_threshold=%d, reason=%s); operator must inspect provider/model \
+         reasoning/tool interleave before resuming"
+        updated_meta.name
+        count
+        turn_fail_streak_threshold
+        reason_code;
+      paused_meta
+    | Error sync_err ->
+      Log.Keeper.error
+        "%s: completion contract attention auto-pause sync failed: %s \
+         (persistent failure remains counted)"
+        updated_meta.name
+        sync_err;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string RuntimeSyncFailures)
+        ~labels:
+          [ "keeper", updated_meta.name
+          ; "site", "completion_contract_attention_auto_pause"
+          ]
+        ();
+      pause_meta)
+  else updated_meta
+;;
+
+let emit_terminal_fsm_for_result ~config ~meta ~keeper_turn_id ~updated_meta result =
+  Keeper_turn_fsm.emit_transition
+    ~keeper_name:meta.Keeper_meta_contract.name
+    ~turn_id:keeper_turn_id
+    ~prev:Keeper_turn_fsm.Streaming
+    Keeper_turn_fsm.Completing;
+  match completion_contract_attention_reason_code result with
+  | Some reason_code ->
+    let updated_meta =
+      record_completion_contract_attention_failure
+        ~config
+        ~updated_meta
+        ~reason_code
+    in
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
+      ~prev:Keeper_turn_fsm.Completing
+      (Keeper_turn_fsm.Failed
+         (Keeper_turn_fsm.Failure_completion_contract_violation { reason_code }));
+    updated_meta
+  | None ->
+    reset_turn_failures_for_stop_reason ~config ~updated_meta result;
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
+      ~prev:Keeper_turn_fsm.Completing
+      Keeper_turn_fsm.Done;
+    updated_meta
+;;
+
 let handle
       ~config
       ~base_dir
@@ -766,18 +886,8 @@ let handle
     }
   in
   (* Single source of truth for success-path terminal FSM transitions.
-     [Keeper_unified_turn.handle] is the only caller; do not add another
-     Streaming -> Completing -> Done emitter on the success path. *)
-  Keeper_turn_fsm.emit_transition
-    ~keeper_name:meta.name
-    ~turn_id:keeper_turn_id
-    ~prev:Keeper_turn_fsm.Streaming
-    Keeper_turn_fsm.Completing;
-  reset_turn_failures_for_stop_reason ~config ~updated_meta result;
-  Keeper_turn_fsm.emit_transition
-    ~keeper_name:meta.name
-    ~turn_id:keeper_turn_id
-    ~prev:Keeper_turn_fsm.Completing
-    Keeper_turn_fsm.Done;
-  updated_meta
+     [Keeper_unified_turn.handle] is the only caller. Runtime-level success
+     still ends as [Done], but a typed completion-contract attention result is
+     terminal [Failed] so the failure streak is not reset as a healthy turn. *)
+  emit_terminal_fsm_for_result ~config ~meta ~keeper_turn_id ~updated_meta result
 ;;

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -1,9 +1,10 @@
 (** Success-path post-processing for [Keeper_unified_turn].
 
     Emits terminal FSM transitions for runtime-success turns. Runtime-success
-    turns with a satisfied completion contract emit
+    turns whose authoritative receipt/operator disposition is healthy emit
     [Streaming -> Completing -> Done]. Runtime-success turns whose typed
-    completion-contract result requires attention emit
+    receipt/operator disposition requires human pause for an unsatisfied
+    completion contract emit
     [Streaming -> Completing -> Failed completion_contract_violation] instead.
     This function is the single source of truth for those transitions on the
     success path and must be called at most once per turn.
@@ -52,8 +53,16 @@ module For_testing : sig
   val claim_bound_work
     : (string * Keeper_tool_outcome.t option) list -> bool
 
-  val completion_contract_attention_reason_code
+  val completion_contract_terminal_failure_reason_code
     : Keeper_agent_run.run_result -> string option
+
+  type terminal_outcome =
+    | Terminal_done
+    | Terminal_checkpoint
+    | Terminal_failed_completion_contract of { reason_code : string }
+
+  val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
+  val terminal_outcome_is_completed_turn : terminal_outcome -> bool
 
   val apply_loop_detectors
     :  config:Workspace.config

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -1,7 +1,11 @@
 (** Success-path post-processing for [Keeper_unified_turn].
 
-    Emits the terminal FSM transitions [Streaming -> Completing -> Done];
-    this function is the single source of truth for those transitions on the
+    Emits terminal FSM transitions for runtime-success turns. Runtime-success
+    turns with a satisfied completion contract emit
+    [Streaming -> Completing -> Done]. Runtime-success turns whose typed
+    completion-contract result requires attention emit
+    [Streaming -> Completing -> Failed completion_contract_violation] instead.
+    This function is the single source of truth for those transitions on the
     success path and must be called at most once per turn.
     [Keeper_unified_turn.run_keeper_cycle] is the expected caller. *)
 
@@ -47,6 +51,9 @@ module For_testing : sig
       turn is no longer exempt from the no-progress streak. *)
   val claim_bound_work
     : (string * Keeper_tool_outcome.t option) list -> bool
+
+  val completion_contract_attention_reason_code
+    : Keeper_agent_run.run_result -> string option
 
   val apply_loop_detectors
     :  config:Workspace.config

--- a/test/test_keeper_turn_fsm_wired_sites.ml
+++ b/test/test_keeper_turn_fsm_wired_sites.ml
@@ -54,8 +54,10 @@ let count_substring haystack needle =
 
     - [keeper_unified_turn.ml] owns entry, routing, pre-dispatch, streaming
       failure/cancellation, and pre-provider transitions.
-    - [keeper_unified_turn_success.ml] owns the successful
-      [Streaming -> Completing -> Done] pair.
+    - [keeper_unified_turn_success.ml] owns runtime-success terminal
+      transitions: [Streaming -> Completing -> Done] for satisfied completion
+      contracts, and [Streaming -> Completing -> Failed] for typed
+      completion-contract attention results.
 
     Other extracted handlers may emit their own terminal transitions; this test
     intentionally does not count those modules. *)
@@ -96,11 +98,14 @@ let test_success_completion_transitions_owned_once () =
     "success completion transitions not emitted by caller" 0
     (count_substring unified "Keeper_turn_fsm.Completing");
   Alcotest.(check int)
-    "success handler owns two completion-state references" 2
+    "success handler owns three completion-state references" 3
     (count_substring success "Keeper_turn_fsm.Completing");
   Alcotest.(check int)
     "success handler owns one done transition" 1
-    (count_substring success "Keeper_turn_fsm.Done")
+    (count_substring success "Keeper_turn_fsm.Done");
+  Alcotest.(check int)
+    "success handler owns one typed failed transition" 1
+    (count_substring success "Keeper_turn_fsm.Failed")
 
 let () =
   Alcotest.run "keeper_turn_fsm_wired_sites"

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -150,6 +150,26 @@ let test_execution_tools_satisfy_contract_progress () =
   ()
 ;;
 
+let test_empty_no_tool_response_violates_contract () =
+  let result ~response_text_present =
+    KAR.Contract_helpers.observed_completion_contract_status
+      ~had_owned_active_task_at_turn_start:false
+      ~actual_keeper_tool_names:[]
+      ~response_text_present
+    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
+  in
+  check
+    string
+    "empty no-tool response is not satisfied completion"
+    "violated"
+    (result ~response_text_present:false);
+  check
+    string
+    "visible no-tool response remains completion"
+    "satisfied_completion"
+    (result ~response_text_present:true)
+;;
+
 let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
@@ -243,6 +263,10 @@ let () =
             "execution tools satisfy contract progress"
             `Quick
             test_execution_tools_satisfy_contract_progress
+        ; test_case
+            "empty no-tool response violates completion contract"
+            `Quick
+            test_empty_no_tool_response_violates_contract
         ; test_case
             "contract progress filters no-progress tool results"
             `Quick

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -560,6 +560,12 @@ let tool_call
 let run_result
       ?(completion_contract_result =
         Masc.Keeper_execution_receipt.Contract_satisfied_execution)
+      ?(operator_disposition =
+        Some
+          ({ disposition = Masc.Keeper_execution_receipt.Disp_pass
+           ; reason = Masc.Keeper_execution_receipt.Reason_healthy
+           }
+             : Masc.Keeper_agent_result.operator_disposition))
       tool_calls
     : Masc.Keeper_agent_run.run_result
   =
@@ -573,6 +579,7 @@ let run_result
   ; usage_reported = true
   ; tool_calls
   ; completion_contract_result
+  ; operator_disposition
   ; checkpoint = None
   ; trace_ref = None
   ; run_validation = None
@@ -682,24 +689,51 @@ let test_progress_identity_normalizes_duplicate_keys_stably () =
     "{\"dup\":\"first\",\"dup\":\"second\",\"z\":0}"
     normalized
 
-let test_completion_contract_attention_reason_code () =
+let test_completion_contract_terminal_failure_reason_code () =
   let satisfied = run_result [] in
   Alcotest.(check bool)
-    "satisfied execution does not require attention"
+    "satisfied execution is not a completion-contract terminal failure"
     true
-    (Option.is_none (Success.completion_contract_attention_reason_code satisfied));
-  let passive_only =
+    (Option.is_none
+       (Success.completion_contract_terminal_failure_reason_code satisfied));
+  let healthy_passive_only =
     run_result
       ~completion_contract_result:
         Masc.Keeper_execution_receipt.Contract_passive_only
       []
   in
+  Alcotest.(check bool)
+    "healthy passive-only idle is not a terminal failure"
+    true
+    (Option.is_none
+       (Success.completion_contract_terminal_failure_reason_code
+          healthy_passive_only));
+  let failed_passive_only =
+    run_result
+      ~completion_contract_result:
+        Masc.Keeper_execution_receipt.Contract_passive_only
+      ~operator_disposition:
+        (Some
+           ({ disposition = Masc.Keeper_execution_receipt.Disp_pause_human
+            ; reason =
+                Masc.Keeper_execution_receipt.Reason_completion_contract_unsatisfied
+            }
+              : Masc.Keeper_agent_result.operator_disposition))
+      []
+  in
   Alcotest.(check string)
-    "passive-only attention reason is the typed contract label"
+    "failed passive-only reason is the typed contract label"
     "passive_only"
     (Option.value
        ~default:""
-       (Success.completion_contract_attention_reason_code passive_only))
+       (Success.completion_contract_terminal_failure_reason_code
+          failed_passive_only))
+  ;
+  Alcotest.(check bool)
+    "failed passive-only is not counted as completed turn"
+    false
+    (Success.terminal_outcome_is_completed_turn
+       (Success.terminal_outcome_of_result failed_passive_only))
 
 let output_fingerprint_of output_text =
   match
@@ -922,7 +956,7 @@ let () =
             `Quick test_progress_identity_normalizes_duplicate_keys_stably;
           Alcotest.test_case
             "completion contract attention keeps typed reason"
-            `Quick test_completion_contract_attention_reason_code;
+            `Quick test_completion_contract_terminal_failure_reason_code;
           Alcotest.test_case
             "stored output fingerprint uses blob identity"
             `Quick test_stored_output_fingerprint_uses_blob_identity;

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -557,7 +557,12 @@ let tool_call
   ; output_fingerprint
   }
 
-let run_result tool_calls : Masc.Keeper_agent_run.run_result =
+let run_result
+      ?(completion_contract_result =
+        Masc.Keeper_execution_receipt.Contract_satisfied_execution)
+      tool_calls
+    : Masc.Keeper_agent_run.run_result
+  =
   { response_text = ""
   ; model_used = "test-model"
   ; prompt_metrics
@@ -567,6 +572,7 @@ let run_result tool_calls : Masc.Keeper_agent_run.run_result =
   ; usage = Masc.Inference_utils.zero_usage
   ; usage_reported = true
   ; tool_calls
+  ; completion_contract_result
   ; checkpoint = None
   ; trace_ref = None
   ; run_validation = None
@@ -675,6 +681,25 @@ let test_progress_identity_normalizes_duplicate_keys_stably () =
     "duplicate-key relative order is stable after key sort"
     "{\"dup\":\"first\",\"dup\":\"second\",\"z\":0}"
     normalized
+
+let test_completion_contract_attention_reason_code () =
+  let satisfied = run_result [] in
+  Alcotest.(check bool)
+    "satisfied execution does not require attention"
+    true
+    (Option.is_none (Success.completion_contract_attention_reason_code satisfied));
+  let passive_only =
+    run_result
+      ~completion_contract_result:
+        Masc.Keeper_execution_receipt.Contract_passive_only
+      []
+  in
+  Alcotest.(check string)
+    "passive-only attention reason is the typed contract label"
+    "passive_only"
+    (Option.value
+       ~default:""
+       (Success.completion_contract_attention_reason_code passive_only))
 
 let output_fingerprint_of output_text =
   match
@@ -895,6 +920,9 @@ let () =
           Alcotest.test_case
             "progress identity normalizes duplicate JSON keys stably"
             `Quick test_progress_identity_normalizes_duplicate_keys_stably;
+          Alcotest.test_case
+            "completion contract attention keeps typed reason"
+            `Quick test_completion_contract_attention_reason_code;
           Alcotest.test_case
             "stored output fingerprint uses blob identity"
             `Quick test_stored_output_fingerprint_uses_blob_identity;

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -733,7 +733,26 @@ let test_completion_contract_terminal_failure_reason_code () =
     "failed passive-only is not counted as completed turn"
     false
     (Success.terminal_outcome_is_completed_turn
-       (Success.terminal_outcome_of_result failed_passive_only))
+       (Success.terminal_outcome_of_result failed_passive_only));
+  let no_capable_provider =
+    run_result
+      ~completion_contract_result:
+        Masc.Keeper_execution_receipt.Contract_no_capable_provider
+      ~operator_disposition:
+        (Some
+           ({ disposition = Masc.Keeper_execution_receipt.Disp_pause_human
+            ; reason =
+                Masc.Keeper_execution_receipt.Reason_tool_route_recoverable_failure
+            }
+              : Masc.Keeper_agent_result.operator_disposition))
+      []
+  in
+  Alcotest.(check bool)
+    "no-capable-provider tool-route pause is not completion-contract auto-pause"
+    true
+    (Option.is_none
+       (Success.completion_contract_terminal_failure_reason_code
+          no_capable_provider))
 
 let output_fingerprint_of output_text =
   match


### PR DESCRIPTION
## Summary
- Carry the typed completion_contract_result from finalization into Keeper_agent_run.run_result.
- Treat runtime-success turns whose completion contract requires attention as terminal Failed completion_contract_violation instead of Done.
- Count those turns toward the existing completion-contract failure streak and manual-resume auto-pause path.
- Classify no-tool + empty-response runtime success as Contract_violated instead of satisfied_completion, so thinking-only/empty final turns do not end as healthy Done.
- Update FSM wiring tests and observability docs for the new Completing -> Failed edge.

## Verification
- PASS: ocamlformat --check on changed OCaml files.
- PASS: git diff --check.
- BLOCKED locally: focused scripts/dune-local.sh build first timed out waiting for /tmp/me-dune-local.lock, then refused because a bare `dune build @install --root .` process was running outside the wrapper. Per workflow, CI is the build authority.

## Runtime Evidence
- Live runtime is still version 0.19.54 at commit 4d28401ae29 from the root checkout, so #22810 is not deployed there yet.
- Current logs show albini turn 491 had completion_contract_result=passive_only but still emitted Completing -> Done. This PR changes that terminal path to Failed completion_contract_violation.
- Current logs also show albini turn 529 synthesized state from 0 tools with stop=completed and emitted Completing -> Done. This PR changes no-tool + empty response contract classification to violated.

## Notes
- The branch uses the existing Keeper_execution_receipt completion_contract_result closed union. It does not infer from tool names or model prose.
- The patch keeps the existing completion-contract pause semantics: it pauses with Manual_resume_required at the configured turn-failure threshold and does not introduce a new global keeper constraint.