### PR TITLE
test(keeper): cover deferred-reply back half (consumer drain + delivery routing)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -859,6 +859,7 @@
 (tests
  (names
   test_keeper_busy_connector_deferred
+  test_keeper_chat_consumer_delivery
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage
@@ -1051,6 +1052,7 @@
   test_board_moderation)
  (modules
   test_keeper_busy_connector_deferred
+  test_keeper_chat_consumer_delivery
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -1,0 +1,178 @@
+(* test_keeper_chat_consumer_delivery.ml — the back half of the connector
+   deferred-reply pipeline (RFC-connector-deferred-reply-via-chat-queue).
+
+   The merged fix enqueues a busy connector message onto Keeper_chat_queue; the
+   front half (enqueue + queued ACK) is covered by
+   test_keeper_busy_connector_deferred. This pins the back half:
+   Keeper_chat_consumer drains the queue once the keeper's turn slot frees, routes
+   each same-source run as ONE coalesced turn, and hands handle_turn the typed
+   Discord source carrying the channel_id — the routing key the Discord delivery
+   adapter (Keeper_chat_discord.adapter_loop -> Discord_rest_client) posts to.
+
+   handle_turn is the consumer's injection seam, so this is deterministic with no
+   provider and no Discord REST call: a capturing handle_turn records what the
+   consumer would have delivered. The literal HTTP POST is Discord_rest_client's
+   transport responsibility and is out of scope for this unit (no DI seam). *)
+
+open Masc
+
+let failures = ref 0
+
+let check name cond =
+  if cond then Printf.printf "  \xe2\x9c\x93 %s\n%!" name
+  else (
+    incr failures;
+    Printf.printf "  \xe2\x9c\x97 %s\n%!" name)
+
+let keeper_name = "consumer-delivery-keeper"
+
+let discord_msg ~content ~channel_id ~user_id ~ts =
+  { Keeper_chat_queue.content
+  ; user_blocks = []
+  ; attachments = []
+  ; timestamp = ts
+  ; source = Keeper_chat_queue.Discord { channel_id; user_id }
+  }
+
+(* Run [body] with a fresh temp base path, an Eio env, and a clean queue +
+   admission slot. *)
+let with_env body =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-consumer-deliv-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      Keeper_chat_queue.clear ~keeper_name;
+      body ~base ~clock)
+
+(* Capture handle_turn calls; resolve [first] on the first call so the test can
+   wait without polling. The queue is emptied by the first drain, so the consumer
+   does not call handle_turn again. *)
+let capturing () =
+  let captured = ref [] in
+  let resolved = ref false in
+  let first, set_first = Eio.Promise.create () in
+  let handle_turn ~sw:_ ~keeper_name:kn ~queued_message =
+    captured := (kn, queued_message) :: !captured;
+    if not !resolved then (
+      resolved := true;
+      Eio.Promise.resolve set_first ())
+  in
+  (captured, first, handle_turn)
+
+(* Await [p] but never hang the suite: lose to a timeout and report it. *)
+let await_or_timeout ~clock ~secs p =
+  Eio.Fiber.first
+    (fun () ->
+      Eio.Promise.await p;
+      `Got)
+    (fun () ->
+      Eio.Time.sleep clock secs;
+      `Timeout)
+
+(* [Keeper_chat_consumer.start] forks a non-daemon poll fiber that never returns,
+   so a normal [Switch.run] would wait on it forever (in production the
+   server-wide switch lives for the process lifetime). Force teardown by raising
+   inside the switch body, which cancels the poll fiber. *)
+exception Stop
+
+let with_consumer_switch f =
+  try Eio.Switch.run (fun sw -> f sw; raise Stop) with Stop -> ()
+
+let test_drains_discord_to_handle_turn () =
+  Printf.printf "Test: consumer drains a Discord queue entry to handle_turn\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_chat_queue.enqueue ~keeper_name
+      (discord_msg ~content:"are you free now?" ~channel_id:"chan-1"
+         ~user_id:"u-1" ~ts:1.0);
+    let captured, first, handle_turn = capturing () in
+    with_consumer_switch (fun sw ->
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+      (match await_or_timeout ~clock ~secs:5.0 first with
+       | `Got -> ()
+       | `Timeout -> check "consumer drained within timeout" false));
+    match !captured with
+    | [ (kn, qm) ] ->
+        check "delivered to the bound keeper" (kn = keeper_name);
+        (match qm.Keeper_chat_queue.source with
+         | Keeper_chat_queue.Discord { channel_id; user_id } ->
+             check "routing key is the Discord channel_id" (channel_id = "chan-1");
+             check "routing key carries the user_id" (user_id = "u-1")
+         | _ -> check "delivered source is Discord" false);
+        check "delivered the user's content" (qm.content = "are you free now?")
+    | _ -> check "exactly one handle_turn call" false)
+
+let test_coalesces_same_source_run () =
+  Printf.printf
+    "Test: same-source messages coalesce into one delivered turn\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_chat_queue.enqueue ~keeper_name
+      (discord_msg ~content:"first" ~channel_id:"chan-9" ~user_id:"u-9" ~ts:1.0);
+    Keeper_chat_queue.enqueue ~keeper_name
+      (discord_msg ~content:"second" ~channel_id:"chan-9" ~user_id:"u-9" ~ts:2.0);
+    let captured, first, handle_turn = capturing () in
+    with_consumer_switch (fun sw ->
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+      ignore (await_or_timeout ~clock ~secs:5.0 first));
+    match !captured with
+    | [ (_, qm) ] ->
+        check "two same-source messages became one turn"
+          (Keeper_chat_queue.length ~keeper_name = 0);
+        check "coalesced content keeps the first message"
+          (String_util.string_contains_substring ~needle:"first" qm.content);
+        check "coalesced content keeps the second message"
+          (String_util.string_contains_substring ~needle:"second" qm.content)
+    | _ -> check "exactly one coalesced handle_turn call" false)
+
+let test_gates_while_turn_in_flight () =
+  Printf.printf "Test: queue is not drained while a turn is in flight\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_chat_queue.enqueue ~keeper_name
+      (discord_msg ~content:"during busy" ~channel_id:"chan-5" ~user_id:"u-5"
+         ~ts:1.0);
+    let captured, first, handle_turn = capturing () in
+    with_consumer_switch (fun sw ->
+      (* Hold the admission slot busy in a sibling fiber. *)
+      let started, set_started = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        ignore
+          (Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
+             (fun () ->
+               Eio.Promise.resolve set_started ();
+               Eio.Promise.await release)));
+      Eio.Promise.await started;
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+      (* The first poll runs immediately; if the consumer ignored the in-flight
+         gate it would drain within this window. *)
+      (match await_or_timeout ~clock ~secs:0.3 first with
+       | `Got -> check "consumer must not drain while a turn is in flight" false
+       | `Timeout ->
+           check "queue stayed put while the turn was in flight"
+             (Keeper_chat_queue.length ~keeper_name = 1));
+      (* Release the slot; the next poll drains. *)
+      Eio.Promise.resolve set_release ();
+      (match await_or_timeout ~clock ~secs:5.0 first with
+       | `Got -> ()
+       | `Timeout -> check "consumer drains once the slot frees" false));
+    check "delivered exactly once after release" (List.length !captured = 1))
+
+let () =
+  test_drains_discord_to_handle_turn ();
+  test_coalesces_same_source_run ();
+  test_gates_while_turn_in_flight ();
+  if !failures > 0 then (
+    Printf.printf "FAILED: %d check(s)\n%!" !failures;
+    exit 1)
+  else Printf.printf "All keeper_chat_consumer_delivery checks passed\n%!"


### PR DESCRIPTION
## 무엇을 / 왜

#22798(connector deferred reply)은 파이프라인 **앞절반**(busy connector 메시지 → `Keeper_chat_queue` enqueue)을 증명했습니다. **뒷절반** — `Keeper_chat_consumer`가 슬롯 free 시 큐를 drain하고 각 메시지를 Discord 전달 어댑터로 라우팅 — 은 테스트가 **0건**이었습니다(`keeper_chat_consumer`/`adapter_loop`를 참조하는 테스트 없음).

## 변경

`test/test_keeper_chat_consumer_delivery.ml` 추가(9 checks). consumer의 `handle_turn` 콜백을 주입 seam으로 사용해 **provider·Discord REST 없이 결정론적**:
- **drain**: 큐의 `Keeper_chat_queue.Discord` 엔트리가 typed source(channel_id/user_id = Discord 전달 라우팅 키) + 원본 content로 handle_turn에 전달됨
- **coalescing**: same-source 2건 → merged content의 1 turn
- **single-flight gate**: turn in_flight 중엔 미drain, 슬롯 free 후 정확히 1회 전달

실제 Discord HTTP POST는 `Discord_rest_client`(transport, DI seam 없음) 책임이라 이 단위 범위 밖.

### 구현 노트
`Keeper_chat_consumer.start`는 영구 실행 non-daemon poll fiber를 fork하므로, 테스트는 `Switch.run` body에서 raise해 취소(`with_consumer_switch`) — 정상 반환은 poll fiber를 영원히 기다림.

## 검증
`test_keeper_chat_consumer_delivery` 9 checks green, ocamlformat clean. test-only(동작 변경 없음).

Refs: RFC-connector-deferred-reply-via-chat-queue §4, RFC-0225 §3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
