### PR TITLE
[codex] Surface runtime catalog before assignments

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -653,6 +653,10 @@ describe('SettingsSurface', () => {
         expect.stringContaining('Provider B'),
       ])
       expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')
+      expect(
+        Array.from(container.querySelectorAll('[data-runtime-section]'))
+          .map(section => section.getAttribute('data-runtime-section')),
+      ).toEqual(['catalog', 'routing', 'assignments'])
     })
     expect(container.textContent).not.toContain('oas·seoul-1')
   })

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1001,47 +1001,54 @@ export function SettingsSurface() {
                   <//>
                 </div>
 
-                <div class="set-sub-h">Model routing</div>
-                <div class="set-route-summary" data-testid="runtime-routing-summary">
-                  ${librarianRuntime
-                    ? html`<span><span class="sub-k">librarian</span><span class="mono">${librarianRuntime}</span></span>`
-                    : html`<span><span class="sub-k">librarian</span><span class="mono">default runtime</span></span>`}
-                  ${crossVerifierRuntime
-                    ? html`<span><span class="sub-k">cross verifier</span><span class="mono">${crossVerifierRuntime}</span></span>`
-                    : html`<span><span class="sub-k">cross verifier</span><span class="mono">default runtime</span></span>`}
-                  <span><span class="sub-k">media failover</span><span class="mono">${mediaFailover.length > 0 ? mediaFailover.join(', ') : 'none'}</span></span>
+                <div class="settings-runtime-section" data-runtime-section="catalog" data-testid="runtime-catalog-section">
+                  <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
+                  ${runtimeCatalogStatus === 'loading'
+                    ? html`<div class="set-hint" data-testid="runtime-catalog-loading">runtime catalog 불러오는 중...</div>`
+                    : runtimeCatalogStatus === 'error'
+                      ? html`<div class="set-hint" data-testid="runtime-catalog-error">runtime catalog를 불러오지 못했습니다.</div>`
+                      : runtimeCatalogEntries.length === 0
+                        ? html`<div class="set-hint" data-testid="runtime-catalog-empty">표시할 runtime catalog entry가 없습니다.</div>`
+                        : html`
+                          <div class="settings-runtime-catalog" data-testid="runtime-catalog-summary">
+                            ${runtimeCatalogEntries.map(item => html`
+                              <${RuntimeCatalogCard}
+                                key=${runtimeCatalogKey(item)}
+                                item=${item}
+                                defaultRuntimeId=${defaultRuntimeId}
+                              />
+                            `)}
+                          </div>
+                        `}
                 </div>
-                <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
-                ${keeperAssignments.length === 0
-                  ? html`<div class="set-hint" data-testid="routing-assignments-empty">명시적 keeper 할당이 없습니다 — 모두 기본 런타임을 사용합니다.</div>`
-                  : html`<div class="settings-runtime-routing" data-testid="routing-assignments-list">
-                    ${keeperAssignments.map(a => html`
-                      <div class="set-routing-row" key=${a.keeper}>
-                        <span class="mono">${a.keeper}</span>
-                        <span class="set-routing-arrow">→</span>
-                        <span class="mono" data-testid="routing-assignment">${a.runtime_id}</span>
-                      </div>
-                    `)}
-                  </div>`}
 
-                <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
-                ${runtimeCatalogStatus === 'loading'
-                  ? html`<div class="set-hint" data-testid="runtime-catalog-loading">runtime catalog 불러오는 중...</div>`
-                  : runtimeCatalogStatus === 'error'
-                    ? html`<div class="set-hint" data-testid="runtime-catalog-error">runtime catalog를 불러오지 못했습니다.</div>`
-                    : runtimeCatalogEntries.length === 0
-                      ? html`<div class="set-hint" data-testid="runtime-catalog-empty">표시할 runtime catalog entry가 없습니다.</div>`
-                      : html`
-                        <div class="settings-runtime-catalog" data-testid="runtime-catalog-summary">
-                          ${runtimeCatalogEntries.map(item => html`
-                            <${RuntimeCatalogCard}
-                              key=${runtimeCatalogKey(item)}
-                              item=${item}
-                              defaultRuntimeId=${defaultRuntimeId}
-                            />
-                          `)}
+                <div class="settings-runtime-section" data-runtime-section="routing" data-testid="runtime-routing-section">
+                  <div class="set-sub-h">Model routing</div>
+                  <div class="set-route-summary" data-testid="runtime-routing-summary">
+                    ${librarianRuntime
+                      ? html`<span><span class="sub-k">librarian</span><span class="mono">${librarianRuntime}</span></span>`
+                      : html`<span><span class="sub-k">librarian</span><span class="mono">default runtime</span></span>`}
+                    ${crossVerifierRuntime
+                      ? html`<span><span class="sub-k">cross verifier</span><span class="mono">${crossVerifierRuntime}</span></span>`
+                      : html`<span><span class="sub-k">cross verifier</span><span class="mono">default runtime</span></span>`}
+                    <span><span class="sub-k">media failover</span><span class="mono">${mediaFailover.length > 0 ? mediaFailover.join(', ') : 'none'}</span></span>
+                  </div>
+                </div>
+
+                <div class="settings-runtime-section" data-runtime-section="assignments" data-testid="runtime-assignments-section">
+                  <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
+                  ${keeperAssignments.length === 0
+                    ? html`<div class="set-hint" data-testid="routing-assignments-empty">명시적 keeper 할당이 없습니다 — 모두 기본 런타임을 사용합니다.</div>`
+                    : html`<div class="settings-runtime-routing" data-testid="routing-assignments-list">
+                      ${keeperAssignments.map(a => html`
+                        <div class="set-routing-row" key=${a.keeper}>
+                          <span class="mono">${a.keeper}</span>
+                          <span class="set-routing-arrow">→</span>
+                          <span class="mono" data-testid="routing-assignment">${a.runtime_id}</span>
                         </div>
-                      `}
+                      `)}
+                    </div>`}
+                </div>
               </div>
             `}
 

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -290,6 +290,17 @@
   padding: 6px 8px;
 }
 
+.settings-runtime-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-runtime-section .set-sub-h {
+  margin: 0;
+}
+
 .settings-runtime-catalog {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary

- Move the live Runtime catalog above model routing and keeper assignments in Settings > Runtime.
- Add stable runtime section markers and a regression assertion for the order: catalog -> routing -> assignments.
- Add scoped spacing for the new runtime sections so the reordered layout stays compact.

## Why

`/api/v1/providers` already returns the provider catalog, but the Settings page placed the catalog after model routing and the full keeper-assignment list. On a live config with 13 keeper assignments, the catalog existed in the DOM but started below the first viewport, so it looked like the catalog was missing.

## Validation

- `vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
  - 29 tests passed
- `tsc --noEmit`
- `eslint src/components/settings-surface.ts`
- `git diff --check`
- Browser check: `python3 /private/tmp/masc_settings_catalog_first_view_check.py`
  - title: `MASC · Settings`
  - runtime catalog card count: 9
  - runtime section order: `catalog`, `routing`, `assignments`
  - catalog top: `y=665.203125` in a 1440x1100 viewport
  - page errors: none
  - screenshot: `/private/tmp/masc-settings-runtime-catalog-visible-after.png`

## Notes

- The Vite dev server still reports the pre-existing `bench-kpi.ts` dependency-scan warning from `dashboard/design-system/preview/bench-kpi.html`; this is unrelated to the Settings runtime change and is already tracked in #22769.
