### PR TITLE
fix(task): suppress stale missing-task transitions

### DIFF
--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -10,6 +10,7 @@
 open Keeper_tools_oas
 
 let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) : string =
+  let meta = Keeper_current_task_reconcile.sync_current_task_id_from_backlog ~config meta in
   match meta.current_task_id with
   | None -> "No task currently assigned. Use keeper_task_claim or masc_tasks to find one."
   | Some tid ->

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -21,6 +21,36 @@ let task_log_error ~task_id fmt =
     (fun message -> Log.Task.error "task_id=%s %s" task_id message)
     fmt
 
+let missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~action_s =
+  sync_owner_current_task_binding ctx;
+  sync_planning_current_task_with_owned_task ctx;
+  task_log_warn ~task_id
+    "transition rejected stale task_id for action=%s agent=%s; reconciled current task bindings"
+    action_s ctx.agent_name;
+  Tool_result.error
+    ~failure_class:(Some Tool_result.Workflow_rejection)
+    ~tool_name
+    ~start_time
+    (workflow_rejection_payload_json
+       ~rule_id:"stale_task_id_not_found"
+       ~tool_suggestion:"keeper_tasks_list"
+       ~hint:
+         "The requested task_id is absent from the live backlog. Do not retry \
+          this task_id from memory; refresh keeper_tasks_list or masc_tasks and \
+          choose a live task."
+       ~scope_policy:"observe"
+       ~alternatives:[ "keeper_tasks_list"; "masc_tasks"; "keeper_task_claim" ]
+       ~extra_fields:
+         [ "task_id", `String task_id
+         ; "action", `String action_s
+         ; "requested_agent", `String ctx.agent_name
+         ; "stale_context", `Bool true
+         ]
+       (Printf.sprintf
+          "Task %s is absent from the live backlog; cleared stale current-task \
+           bindings and suppressed transition action=%s."
+          task_id action_s))
+
 let rec handle_done ~tool_name ~start_time ctx args =
   let notes = get_string args "notes" "" in
   handle_transition ~tool_name ~start_time ctx
@@ -173,6 +203,10 @@ and handle_transition ~tool_name ~start_time ctx args =
   in
   let tasks = Workspace.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
+  match task_opt with
+  | None ->
+    missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~action_s
+  | Some _ ->
   let release_owner_mismatch_rejection =
     match action, task_opt with
     | Masc_domain.Release, Some task ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1711,6 +1711,30 @@ let () = test "transition_claim_sets_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
+let () = test "transition_missing_task_clears_stale_current_task" (fun () ->
+  let ctx = make_test_ctx () in
+  (match Planning_eio.set_current_task ctx.config ~task_id:"task-1468" with
+   | Ok () -> ()
+   | Error msg -> failwith msg);
+  let result =
+    Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [("task_id", `String "task-1468"); ("action", `String "start")])
+  in
+  assert (not (Tool_result.is_success result));
+  assert (Tool_result.failure_class result = Some Tool_result.Workflow_rejection);
+  assert (Planning_eio.get_current_task ctx.config = None);
+  let data = Tool_result.data result in
+  assert (Json_util.get_bool data "stale_context" = Some true);
+  assert (
+    match Json_util.assoc_member_opt "diagnosis" data with
+    | Some diagnosis ->
+      Json_util.get_string diagnosis "rule_id" = Some "stale_task_id_not_found"
+      && Json_util.get_string diagnosis "tool_suggestion"
+         = Some "keeper_tasks_list"
+    | None -> false);
+  assert (str_contains (Tool_result.message result) "absent from the live backlog")
+)
+
 (* RFC-0109 Phase E (#18822, 2026-05-27) retired the transition-layer
    substring evidence gate. The two tests that previously locked in
    the substring-reject behaviour

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -35,6 +35,15 @@ let file_contains_pattern file_rel pattern =
 let file_not_contains_pattern file_rel pattern =
   not (file_contains_pattern file_rel pattern)
 
+let string_contains text pattern =
+  if String.length pattern = 0 then true
+  else
+    let re = Str.regexp_string pattern in
+    try
+      ignore (Str.search_forward re text 0);
+      true
+    with Not_found -> false
+
 let require_write_ok label = function
   | Ok () -> ()
   | Error msg -> failf "%s: %s" label msg
@@ -206,6 +215,54 @@ let test_fusion_default_descriptor_is_bundle_visible () =
           check bool "masc_fusion is in the executable OAS tool bundle" true
             (List.mem "masc_fusion" names)))
 
+let test_missing_current_task_reconciled_before_transition_hint () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_stale_task_hint_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir dir with _ -> ())
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some "test-stale-task-hint"));
+      let task_id =
+        match Keeper_id.Task_id.of_string "task-1468" with
+        | Ok task_id -> task_id
+        | Error msg -> failf "task id parse failed: %s" msg
+      in
+      let meta =
+        { (make_meta ~name:"test-stale-task-hint" ()) with
+          current_task_id = Some task_id
+        }
+      in
+      let ctx_snapshot =
+        Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+          ~max_tokens:4000
+      in
+      let bundle =
+        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+      in
+      Fun.protect
+        ~finally:bundle.cleanup
+        (fun () ->
+          let description =
+            bundle.tools
+            |> List.find_map (fun (tool : Agent_sdk.Tool.t) ->
+                 if String.equal tool.schema.name "masc_transition"
+                 then Some tool.schema.description
+                 else None)
+          in
+          match description with
+          | None -> fail "masc_transition not found in bundle"
+          | Some description ->
+            check bool "missing task hint removed" false
+              (string_contains description "not found in backlog");
+            check bool "reconciled hint asks for claim/list" true
+              (string_contains description "No task currently assigned")))
+
 (* ── Test 2: Atomic agent JSON writes ─────────────────────────── *)
 
 let test_atomic_write_not_empty () =
@@ -328,6 +385,8 @@ let () =
             test_web_alias_bundle_visible_without_injected_masc_schema;
           test_case "fusion default descriptor reaches OAS bundle" `Quick
             test_fusion_default_descriptor_is_bundle_visible;
+          test_case "missing current task reconciles before transition hint" `Quick
+            test_missing_current_task_reconciled_before_transition_hint;
         ] );
       ( "atomic_agent_json",
         [


### PR DESCRIPTION
## Summary
- reject masc_transition calls for task ids absent from the live backlog before dispatching to the backend
- reconcile keeper/planning current-task bindings when a stale missing task id is observed
- reconcile current_task_id before rendering the masc_transition OAS hint so stale missing tasks do not keep reappearing in prompt context

## Validation
- scripts/check-oas-pin.sh --local-only
- opam exec -- ocamlformat --check lib/task/tool_task.ml lib/keeper/keeper_tools_oas_bundle.ml test/test_tool_task_coverage.ml test/test_warn_root_causes.ml
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build @test/runtest-test_tool_task_coverage (93 tests)
- scripts/dune-local.sh build @test/runtest-test_warn_root_causes (12 tests)

Full local Dune suite was not run; CI remains the broader merge gate.