### PR TITLE
test(oas): ratchet message role delegation

### DIFF
--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -1,6 +1,6 @@
 module Canonical_tool = Agent_sdk.Canonical_tool
 
-let role_to_string = Agent_sdk.Types.role_to_string
+let role_to_string role = Agent_sdk.Types.role_to_string role
 
 (* Issue #8623: returns [Some] only for the 4 wire-format names.
    Callers must handle [None] explicitly — the previous Variant
@@ -9,7 +9,7 @@ let role_to_string = Agent_sdk.Types.role_to_string
    "user" causes the LLM to treat tool output as user instructions,
    echo prior assistant replies as user input, or downgrade system
    prompt privileges. Same anti-pattern class as #8605/#8615. *)
-let role_of_string_opt = Agent_sdk.Types.role_of_string
+let role_of_string_opt role = Agent_sdk.Types.role_of_string role
 
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =

--- a/test/test_oas_canonical_delegation.ml
+++ b/test/test_oas_canonical_delegation.ml
@@ -20,6 +20,14 @@ let test_masc_delegates_canonical_oas_projections () =
     ~callee:"Agent_sdk.Types.role_to_string"
     ~expected:1;
   check_calls
+    ~file:"lib/keeper/keeper_context_core_message_json.ml"
+    ~callee:"Agent_sdk.Types.role_to_string"
+    ~expected:1;
+  check_calls
+    ~file:"lib/keeper/keeper_context_core_message_json.ml"
+    ~callee:"Agent_sdk.Types.role_of_string"
+    ~expected:1;
+  check_calls
     ~file:"lib/keeper/keeper_event_bridge_error_json.ml"
     ~callee:"Agent_sdk.Types.total_tokens"
     ~expected:1;


### PR DESCRIPTION
## Summary
- Follow up merged #22809 by pinning keeper message JSON role encoding/decoding to direct OAS canonical role helpers.
- Keep `Keeper_context_core_message_json.role_to_string` / `role_of_string_opt` as the public MASC facade while delegating implementation to `Agent_sdk.Types`.
- Extend the OAS canonical-delegation AST ratchet so local hand-rolled role projection cannot be reintroduced on the keeper checkpoint/message boundary.

## Validation
- `ocamlformat --check lib/keeper/keeper_context_core_message_json.ml test/test_oas_canonical_delegation.ml`
- `git diff --check origin/main...HEAD`

Dune build/test intentionally not run here per operator instruction; CI is the build authority for this follow-up.