### PR TITLE
fix(sse): route agent_failed through typed event

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -224,15 +224,21 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     in
     Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
-    let payload =
-      `Assoc
-        ([ "agent_name", `String agent_name
-         ; "task_id", `String task_id
-         ; "elapsed_s", `Float elapsed
-         ]
-         @ agent_failed_error_fields error)
-    in
-    Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
+    let projection = agent_failed_error_projection error in
+    Some
+      (Sse_event.agent_failed
+         ?caused_by
+         ~ts_unix:ts
+         ~correlation_id
+         ~run_id
+         ~agent_name
+         ~task_id
+         ~elapsed_s:elapsed
+         ~error:projection.error
+         ~error_domain:projection.error_domain
+         ~error_code:projection.error_code
+         ~error_retryable:projection.error_retryable
+         ~error_detail:projection.error_detail)
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; tool_use_id; _ } ->
     (* tool_called publishes before execution, so the keeper hook has not
        minted an execution_id yet — this row carries the provider call id

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -238,7 +238,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          ~error_domain:projection.error_domain
          ~error_code:projection.error_code
          ~error_retryable:projection.error_retryable
-         ~error_detail:projection.error_detail)
+         ~error_detail:projection.error_detail
+         ())
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; tool_use_id; _ } ->
     (* tool_called publishes before execution, so the keeper hook has not
        minted an execution_id yet — this row carries the provider call id

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -340,14 +340,31 @@ let sdk_error_json error =
      @ sdk_error_detail_fields error)
 ;;
 
+type agent_failed_error_projection =
+  { error : string
+  ; error_domain : string
+  ; error_code : string
+  ; error_retryable : bool
+  ; error_detail : Yojson.Safe.t
+  }
+
+let agent_failed_error_projection error =
+  { error = Agent_sdk.Error.to_string error
+  ; error_domain = Keeper_agent_error.sdk_error_kind error
+  ; error_code =
+      (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed error
+       |> Keeper_turn_terminal_code.to_wire)
+  ; error_retryable = Agent_sdk.Error.is_retryable error
+  ; error_detail = sdk_error_json error
+  }
+;;
+
 let agent_failed_error_fields error =
-  [ "error", `String (Agent_sdk.Error.to_string error)
-  ; "error_domain", `String (Keeper_agent_error.sdk_error_kind error)
-  ; ( "error_code"
-    , `String
-        (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed error
-         |> Keeper_turn_terminal_code.to_wire) )
-  ; "error_retryable", `Bool (Agent_sdk.Error.is_retryable error)
-  ; "error_detail", sdk_error_json error
+  let projection = agent_failed_error_projection error in
+  [ "error", `String projection.error
+  ; "error_domain", `String projection.error_domain
+  ; "error_code", `String projection.error_code
+  ; "error_retryable", `Bool projection.error_retryable
+  ; "error_detail", projection.error_detail
   ]
 ;;

--- a/lib/keeper/keeper_event_bridge_error_json.mli
+++ b/lib/keeper/keeper_event_bridge_error_json.mli
@@ -4,6 +4,18 @@ val agent_completed_result_fields
   :  (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
   -> (string * Yojson.Safe.t) list
 
+type agent_failed_error_projection =
+  { error : string
+  ; error_domain : string
+  ; error_code : string
+  ; error_retryable : bool
+  ; error_detail : Yojson.Safe.t
+  }
+
+val agent_failed_error_projection
+  :  Agent_sdk.Error.sdk_error
+  -> agent_failed_error_projection
+
 val agent_failed_error_fields
   :  Agent_sdk.Error.sdk_error
   -> (string * Yojson.Safe.t) list

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -573,6 +573,7 @@ let agent_failed
       ~(error_code : string)
       ~(error_retryable : bool)
       ~(error_detail : Yojson.Safe.t)
+      ()
   : Yojson.Safe.t
   =
   let payload_json =

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -21,6 +21,7 @@ type envelope_meta =
   ; ts_unix : float
   ; correlation_id : string
   ; run_id : string
+  ; caused_by : string option
   ; agent_name : string option
   ; task_id : string option
   ; turn : int option
@@ -47,6 +48,7 @@ let wrap_envelope (meta : envelope_meta) (payload : Yojson.Safe.t) : Yojson.Safe
     ; "ts_unix", `Float meta.ts_unix
     ; "correlation_id", `String meta.correlation_id
     ; "run_id", `String meta.run_id
+    ; "caused_by", json_string_opt meta.caused_by
     ; "agent_name", json_string_opt meta.agent_name
     ; "task_id", json_string_opt meta.task_id
     ; ( "turn"
@@ -80,6 +82,7 @@ let agent_started
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = Some task_id
     ; turn = None
@@ -109,6 +112,7 @@ let tool_called
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = None
@@ -135,6 +139,7 @@ let tool_completed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = None
@@ -161,6 +166,7 @@ let turn_started
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = Some turn
@@ -187,6 +193,7 @@ let turn_completed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = Some turn
@@ -227,6 +234,7 @@ let turn_ready
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = Some turn
@@ -257,6 +265,7 @@ let handoff_requested
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some from_agent
     ; task_id = None
     ; turn = None
@@ -286,6 +295,7 @@ let handoff_completed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some from_agent
     ; task_id = None
     ; turn = None
@@ -318,6 +328,7 @@ let context_compacted
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = None
@@ -350,6 +361,7 @@ let context_overflow_imminent
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = None
@@ -379,6 +391,7 @@ let context_compact_started
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = None
     ; turn = None
@@ -411,6 +424,7 @@ let content_replacement_replaced
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = None
     ; task_id = None
     ; turn = None
@@ -440,6 +454,7 @@ let content_replacement_kept
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = None
     ; task_id = None
     ; turn = None
@@ -474,6 +489,7 @@ let slot_scheduler_observed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = None
     ; task_id = None
     ; turn = None
@@ -532,6 +548,7 @@ let agent_completed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by = None
     ; agent_name = Some agent_name
     ; task_id = Some task_id
     ; turn = None
@@ -544,6 +561,7 @@ let agent_completed
     encoded in the atd schema; the caller passes the simple
     projections directly. *)
 let agent_failed
+      ?caused_by
       ~(ts_unix : float)
       ~(correlation_id : string)
       ~(run_id : string)
@@ -576,6 +594,7 @@ let agent_failed
     ; ts_unix
     ; correlation_id
     ; run_id
+    ; caused_by
     ; agent_name = Some agent_name
     ; task_id = Some task_id
     ; turn = None

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -5,6 +5,7 @@ type envelope_meta =
   ; ts_unix : float
   ; correlation_id : string
   ; run_id : string
+  ; caused_by : string option
   ; agent_name : string option
   ; task_id : string option
   ; turn : int option
@@ -164,7 +165,8 @@ val agent_completed
   -> Yojson.Safe.t
 
 val agent_failed
-  :  ts_unix:float
+  :  ?caused_by:string
+  -> ts_unix:float
   -> correlation_id:string
   -> run_id:string
   -> agent_name:string

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -177,4 +177,5 @@ val agent_failed
   -> error_code:string
   -> error_retryable:bool
   -> error_detail:Yojson.Safe.t
+  -> unit
   -> Yojson.Safe.t

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -789,7 +789,8 @@ let test_agent_failed_byte_equal () =
          ~error_domain:agent_failed_error_domain
          ~error_code:agent_failed_error_code
          ~error_retryable:agent_failed_error_retryable
-         ~error_detail:agent_failed_error_detail)
+         ~error_detail:agent_failed_error_detail
+         ())
   in
   Alcotest.(check string) "agent_failed typed == baseline" baseline typed
 ;;

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -25,6 +25,7 @@ let baseline_wrap_event
       ~run_id
       ~event_type
       ~payload
+      ?caused_by
       ?agent_name
       ?task_id
       ?turn
@@ -37,6 +38,7 @@ let baseline_wrap_event
     ; "ts_unix", `Float ts
     ; "correlation_id", `String correlation_id
     ; "run_id", `String run_id
+    ; "caused_by", baseline_json_string_opt caused_by
     ; "agent_name", baseline_json_string_opt agent_name
     ; "task_id", baseline_json_string_opt task_id
     ; ( "turn"

--- a/test/stanzas/test_keeper_execution_join.inc
+++ b/test/stanzas/test_keeper_execution_join.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_execution_join)
  (modules test_keeper_execution_join)
- (libraries masc_test_deps))
+ (libraries masc_test_deps sse_event))

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -6,7 +6,6 @@ open Alcotest
 module Join = Masc.Keeper_execution_join
 module Bridge = Masc.Keeper_event_bridge
 module Error_json = Masc.Keeper_event_bridge_error_json
-module Sse_event = Masc.Sse_event
 
 let member key json =
   match json with
@@ -157,6 +156,7 @@ let test_agent_failed_matches_typed_sse_event () =
       ~error_code:projection.error_code
       ~error_retryable:projection.error_retryable
       ~error_detail:projection.error_detail
+      ()
     |> Yojson.Safe.to_string
   in
   check string "agent_failed bridge matches typed constructor" expected actual

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -5,6 +5,8 @@
 open Alcotest
 module Join = Masc.Keeper_execution_join
 module Bridge = Masc.Keeper_event_bridge
+module Error_json = Masc.Keeper_event_bridge_error_json
+module Sse_event = Masc.Sse_event
 
 let member key json =
   match json with
@@ -125,6 +127,40 @@ let test_empty_tool_use_id_omitted_from_payload () =
   check bool "empty provider id is omitted" true
     (payload_member "tool_use_id" json = None)
 
+let test_agent_failed_matches_typed_sse_event () =
+  let agent_name = "oas-r1" in
+  let task_id = "task-failed-1" in
+  let elapsed_s = 4.25 in
+  let caused_by = "run-agent-started-1" in
+  let error = Agent_sdk.Error.Internal "bridge failure" in
+  let projection = Error_json.agent_failed_error_projection error in
+  let actual =
+    Bridge.native_event_to_json
+      (mk_event
+         ~caused_by
+         (Agent_sdk.Event_bus.AgentFailed
+            { agent_name; task_id; error; elapsed = elapsed_s }))
+    |> Option.get
+    |> Yojson.Safe.to_string
+  in
+  let expected =
+    Sse_event.agent_failed
+      ~caused_by
+      ~ts_unix:1781200000.0
+      ~correlation_id:"corr-1"
+      ~run_id:"run-1"
+      ~agent_name
+      ~task_id
+      ~elapsed_s
+      ~error:projection.error
+      ~error_domain:projection.error_domain
+      ~error_code:projection.error_code
+      ~error_retryable:projection.error_retryable
+      ~error_detail:projection.error_detail
+    |> Yojson.Safe.to_string
+  in
+  check string "agent_failed bridge matches typed constructor" expected actual
+
 let () =
   run "keeper_execution_join"
     [ ( "join_table"
@@ -142,5 +178,7 @@ let () =
             test_tool_completed_without_entry_omits_execution_id
         ; test_case "empty tool_use_id omitted" `Quick
             test_empty_tool_use_id_omitted_from_payload
+        ; test_case "agent_failed matches typed constructor" `Quick
+            test_agent_failed_matches_typed_sse_event
         ] )
     ]


### PR DESCRIPTION
## Summary

- Route the production `AgentFailed` SSE bridge arm through `Sse_event.agent_failed`.
- Expose a typed `agent_failed_error_projection` so the bridge passes the five error fields as constructor arguments instead of splicing raw JSON.
- Align the typed SSE envelope with the existing `caused_by` slot and add bridge coverage that compares production output to the typed constructor output.

Fixes #22188.

## Validation

- `ocamlformat --check lib/keeper/keeper_event_bridge.ml lib/keeper/keeper_event_bridge_error_json.ml lib/keeper/keeper_event_bridge_error_json.mli lib/sse_event/sse_event.ml lib/sse_event/sse_event.mli test/sse_event/test_sse_event.ml test/test_keeper_execution_join.ml`
- `git diff --check origin/main...HEAD`
- `rg -n "Sse_event\\.agent_failed|AgentFailed|agent_failed_error_projection|agent_failed_error_fields" lib/keeper lib/sse_event test --glob '!_build'`
- Local Dune build/test not run; CI owns build/test validation for this change.
