### PR TITLE
fix(governance): gate forbidden tools outside hitl threshold

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -334,15 +334,21 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
       | Some threshold -> risk_level_to_int risk >= risk_level_to_int threshold
       | None -> false
     in
+    let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
+    let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
+    let auto_approval_forbidden = hard_forbidden || soft_forbidden in
+    let requires_operator_approval = needs_approval || auto_approval_forbidden in
     if trifecta_active
     then
       Log.Governance.debug
-        "[%s] trifecta_active tool=%s base=%s effective=%s needs_approval=%b"
+        "[%s] trifecta_active tool=%s base=%s effective=%s needs_approval=%b \
+         requires_operator_approval=%b"
         keeper_name
         tool_name
         (risk_level_to_string base_risk)
         (risk_level_to_string risk)
-        needs_approval;
+        needs_approval
+        requires_operator_approval;
     if trifecta_active && risk_level_to_int risk > risk_level_to_int base_risk
     then
       Log.Governance.warn
@@ -351,7 +357,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         tool_name
         (risk_level_to_string base_risk)
         (risk_level_to_string risk);
-    if needs_approval
+    if requires_operator_approval
     then (
       let turn_id =
         Option.map
@@ -389,20 +395,12 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
       let selected_model = selected_model_of_meta meta in
       let risk_level = queue_risk_level risk in
       let base_path = (config : Workspace.config).base_path in
-      let hard_forbidden =
-        runtime_auto_approval_blocked meta
-        || risk = Critical
-      in
-      let soft_forbidden =
-        auto_approval_soft_forbidden ~tool_name ~input
-      in
-      let forbidden = hard_forbidden || soft_forbidden in
       let always_approve =
         Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
         |> Option.value ~default:false
       in
       let rule_match =
-        if forbidden
+        if auto_approval_forbidden
         then None
         else
           Keeper_approval_queue.find_matching_rule
@@ -416,7 +414,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
             ?runtime_contract
             ()
       in
-      if (not forbidden) && always_approve
+      if (not auto_approval_forbidden) && always_approve
       then (
         Keeper_approval_queue.audit_approval_event
           ~base_path

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -121,6 +121,9 @@ val to_oas_approval_callback :
     resolves the approval via the dashboard approval HTTP handler
     ([server_dashboard_http.ml]), resuming the fiber.
 
-    Tools below the threshold are auto-approved.
+    Tools below the threshold are auto-approved unless auto-approval is
+    explicitly forbidden by critical risk, destructive payload semantics, or
+    runtime safety blockers. Those calls still enter the operator approval
+    queue even when HITL thresholds are otherwise disabled.
 
     @since 2.262.0 (#5902, #5907) *)

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -83,6 +83,16 @@ let pending_id_for_keeper ~keeper_name =
       entries
   | _ -> None
 
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    f
+
 let audit_event_names ~base_path ~keeper_name =
   AQ.read_recent_audit ~base_path ~keeper_name ~n:10 ()
   |> List.map (fun json ->
@@ -1336,6 +1346,57 @@ let test_callback_always_approve_respects_forbidden () =
       | Some _ -> Alcotest.fail "expected Approve after operator resolution"
       | None -> Alcotest.fail "destructive tool callback did not suspend for approval")
 
+let test_callback_hitl_disabled_forbidden_requires_approval () =
+  with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "hitl-disabled-forbidden-keeper" in
+  let initial_pending = AQ.pending_count () in
+  let result = ref None in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = Mcp_server.workspace_config state in
+      Eio.Fiber.fork ~sw (fun () ->
+        let cb =
+          GP.to_oas_approval_callback
+            ~config ~governance_level:"production" ~keeper_name ()
+        in
+        let decision =
+          cb
+            ~tool_name:"tool_edit_file"
+            ~input:(`Assoc [ ("path", `String "/dangerous") ])
+        in
+        result := Some decision);
+      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
+      Alcotest.(check int)
+        "forbidden tool still requires approval when HITL threshold is disabled"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      let id =
+        match pending_id_for_keeper ~keeper_name with
+        | Some id -> id
+        | None -> Alcotest.fail "expected pending approval for HITL-disabled forbidden tool"
+      in
+      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+       | Ok () -> ()
+       | Error err ->
+         Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+      yield_until (fun () -> Option.is_some !result);
+      match !result with
+      | Some Agent_sdk.Hooks.Approve -> ()
+      | Some Agent_sdk.Hooks.Reject reason ->
+        Alcotest.fail ("expected Approve after operator resolution, got reject: " ^ reason)
+      | Some Agent_sdk.Hooks.Edit _ ->
+        Alcotest.fail "expected Approve after operator resolution, got edit"
+      | None ->
+        Alcotest.fail "HITL-disabled forbidden callback did not suspend for approval")
+
 let test_read_recent_audit_filters_after_wide_scan () =
   with_temp_masc_base @@ fun base_path ->
   let keeper_name = "audit-target-keeper" in
@@ -1539,5 +1600,7 @@ let () =
         test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick
         test_callback_always_approve_respects_forbidden;
+      Alcotest.test_case "HITL disabled still gates forbidden tools" `Quick
+        test_callback_hitl_disabled_forbidden_requires_approval;
     ]);
   ]


### PR DESCRIPTION
## Summary
- Gate auto-approval-forbidden tool calls independently from the HITL threshold.
- Keep existing operator approval semantics: forbidden destructive/critical calls enter the approval queue instead of auto-approving.
- Add regression coverage for MASC_DISABLE_HITL=true so tool_edit_file still suspends for approval.

## Validation
- scripts/check-oas-pin.sh --local-only
- opam exec -- ocamlformat --check lib/governance_pipeline.ml lib/governance_pipeline.mli test/test_hitl_approval.ml
- git diff --check HEAD~1..HEAD

## Not run locally
- scripts/dune-local.sh build @test/runtest-test_hitl_approval: blocked by live bare Dune process outside scripts/dune-local.sh in another worktree (guard refusal), so CI should be treated as the Dune authority for this draft.
