### PR TITLE
feat(keeper): P1 connector attention wake reason (dormant)

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -63,6 +63,8 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Bootstrap -> Some Keeper_world_observation.Bootstrap_stimulus
   | Keeper_event_queue.No_progress_recovery ->
     Some Keeper_world_observation.No_progress_recovery_stimulus
+  | Keeper_event_queue.Connector_attention _ ->
+    Some Keeper_world_observation.Connector_attention_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Fusion_completed _
   | Keeper_event_queue.Bg_completed _ ->
@@ -127,6 +129,16 @@ let consume_single_heartbeat_stimulus
       ~ctx
       ~keeper_name:meta_after_triage.name
       stim;
+    []
+  | Keeper_event_queue.Connector_attention ca ->
+    (* RFC-connector-ambient-attention-wake P1: the stimulus woke this keeper.
+       Content threading (reading the external_attention item by event_id into a
+       pending input) is P3; for now the turn runs with no injected board event,
+       like Bootstrap/No_progress_recovery. *)
+    Log.Keeper.info
+      "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
+      ca.event_id
+      meta_after_triage.name;
     []
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -131,10 +131,31 @@ let consume_single_heartbeat_stimulus
       stim;
     []
   | Keeper_event_queue.Connector_attention ca ->
-    (* RFC-connector-ambient-attention-wake P1: the stimulus woke this keeper.
-       Content threading (reading the external_attention item by event_id into a
-       pending input) is P3; for now the turn runs with no injected board event,
-       like Bootstrap/No_progress_recovery. *)
+    (* RFC-connector-ambient-attention-wake: the stimulus woke this keeper.
+       P2 — resolution lifecycle (turn-start half): claim the external-attention
+       item so the operator digest shows it as being handled rather than still
+       pending (and a stale claim re-surfaces only after claim_stale_after, not
+       every cycle). The wake itself is already resolution-safe — the stimulus is
+       edge-consumed here exactly once (P1) — so this claim is for the durable
+       backlog projection, not for gating the wake. mark_resolved / mark_ignored
+       at turn end is coupled to reading the content and deciding whether to
+       reply, which lands with content threading + outbound (P3).
+       Content injection is P3; for now the turn runs with no injected board
+       event, like Bootstrap / No_progress_recovery. *)
+    (match
+       Keeper_external_attention.claim_for_turn
+         ~base_path:ctx.config.base_path
+         ~keeper_name:meta_after_triage.name
+         ~event_ids:[ ca.event_id ]
+         ~claim_id:(Printf.sprintf "heartbeat-wake:%s" stim.post_id)
+         ~turn_id:None
+         ()
+     with
+     | Ok () -> ()
+     | Error err ->
+       Log.Keeper.warn
+         "connector attention claim_for_turn failed event_id=%s (keeper=%s): %s"
+         ca.event_id meta_after_triage.name err);
     Log.Keeper.info
       "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
       ca.event_id

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -9,6 +9,8 @@ type stimulus_kind =
   | No_progress_recovery
   | Fusion_completed  (* RFC-0266: async masc_fusion completion wake *)
   | Bg_completed  (* RFC-0290: generic background job completion wake *)
+  | Connector_attention
+      (* RFC-connector-ambient-attention-wake: ambient connector message wake *)
 
 type reaction_kind =
   | Turn_started
@@ -27,6 +29,7 @@ let stimulus_kind_to_string = function
   | No_progress_recovery -> "no_progress_recovery"
   | Fusion_completed -> "fusion_completed"
   | Bg_completed -> "bg_completed"
+  | Connector_attention -> "connector_attention"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -39,6 +42,7 @@ let stimulus_kind_of_string = function
   | "no_progress_recovery" -> Some No_progress_recovery
   | "fusion_completed" -> Some Fusion_completed
   | "bg_completed" -> Some Bg_completed
+  | "connector_attention" -> Some Connector_attention
   | _ -> None
 ;;
 
@@ -83,6 +87,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.No_progress_recovery -> No_progress_recovery
   | Keeper_event_queue.Fusion_completed _ -> Fusion_completed
   | Keeper_event_queue.Bg_completed _ -> Bg_completed
+  | Keeper_event_queue.Connector_attention _ -> Connector_attention
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -157,6 +162,8 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "bg_completed run_id=%s kind=%s"
       c.bg_run_id
       (Keeper_event_queue.bg_job_kind_to_string c.bg_kind)
+  | Keeper_event_queue.Connector_attention ca ->
+    Printf.sprintf "connector_attention event_id=%s" ca.event_id
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -169,7 +176,8 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Bootstrap
     | Keeper_event_queue.No_progress_recovery
     | Keeper_event_queue.Fusion_completed _
-    | Keeper_event_queue.Bg_completed _ -> None
+    | Keeper_event_queue.Bg_completed _
+    | Keeper_event_queue.Connector_attention _ -> None
   in
   `Assoc
     (base_fields
@@ -651,7 +659,8 @@ let summarize_rows ~keeper_name ~limit rows =
           추가 시 이 or-pattern이 non-exhaustive가 되어 컴파일 에러 → 분류 갱신을
           강제한다 (catch-all 금지). *)
        | Some
-           (Board_signal | Bootstrap | No_progress_recovery | Fusion_completed | Bg_completed)
+           ( Board_signal | Bootstrap | No_progress_recovery | Fusion_completed
+           | Bg_completed | Connector_attention )
          -> ())
   in
   let note_payload_parse_error row =
@@ -743,7 +752,9 @@ let summarize_rows ~keeper_name ~limit rows =
       (fun id ->
         match Option.bind (Hashtbl.find_opt stimulus_kind_by_id id) stimulus_kind_of_string with
         | Some No_progress_recovery -> true
-        | Some (Board_signal | Bootstrap | Fusion_completed | Bg_completed)
+        | Some
+            ( Board_signal | Bootstrap | Fusion_completed | Bg_completed
+            | Connector_attention )
         | None ->
           false)
       pending_stimulus_ids

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -16,6 +16,8 @@ type stimulus_kind =
   | No_progress_recovery
   | Fusion_completed  (** RFC-0266: async masc_fusion completion wake *)
   | Bg_completed  (** RFC-0290: generic background job completion wake *)
+  | Connector_attention
+      (** RFC-connector-ambient-attention-wake: ambient connector message wake *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -105,6 +105,7 @@ type event_queue_trigger =
   Keeper_world_observation_turn_types.event_queue_trigger =
   | Bootstrap_stimulus
   | No_progress_recovery_stimulus
+  | Connector_attention_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -112,6 +113,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Scope_message_pending
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
+  | Connector_attention_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -543,7 +543,13 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Bg_completed c ->
     Some
       (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c)
-  | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.No_progress_recovery
+  | Keeper_event_queue.Connector_attention _ ->
+    (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
+       fires via the Connector_attention_stimulus trigger; content threading
+       from external_attention is P3. *)
+    None
 ;;
 
 (** Collect recent board activity using cursor-based tracking.

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -156,6 +156,7 @@ type keeper_cycle_channel =
 type event_queue_trigger =
   | Bootstrap_stimulus
   | No_progress_recovery_stimulus
+  | Connector_attention_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -165,6 +166,7 @@ type turn_reason =
   | Scope_message_pending
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
+  | Connector_attention_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of { idle_sec : int; cooldown : int }

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -29,6 +29,11 @@ type keeper_cycle_channel =
 type event_queue_trigger =
   | Bootstrap_stimulus
   | No_progress_recovery_stimulus
+  | Connector_attention_stimulus
+      (** RFC-connector-ambient-attention-wake P1: an ambient connector message
+          recorded as Keeper_external_attention. Edge-triggered (dequeued once),
+          carries an event_id pointer (not content). Dormant until a producer
+          enqueues it (P3). *)
 
 type turn_reason =
   | Mention_pending
@@ -36,6 +41,7 @@ type turn_reason =
   | Scope_message_pending
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
+  | Connector_attention_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of
@@ -70,6 +76,7 @@ let turn_reason_to_string = function
   | Scope_message_pending -> "scope_message_pending"
   | Bootstrap_stimulus_pending -> "bootstrap_stimulus_pending"
   | No_progress_recovery_stimulus_pending -> "no_progress_recovery_stimulus_pending"
+  | Connector_attention_pending -> "connector_attention_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
@@ -83,6 +90,7 @@ let turn_reason_to_string = function
 let turn_reason_of_event_queue_trigger = function
   | Bootstrap_stimulus -> Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus -> No_progress_recovery_stimulus_pending
+  | Connector_attention_stimulus -> Connector_attention_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -7,6 +7,10 @@ type keeper_cycle_channel =
 type event_queue_trigger =
   | Bootstrap_stimulus
   | No_progress_recovery_stimulus
+  | Connector_attention_stimulus
+      (** RFC-connector-ambient-attention-wake P1: ambient connector message
+          recorded as external attention; edge-triggered, carries an event_id
+          pointer. Dormant until a producer enqueues it (P3). *)
 
 type turn_reason =
   | Mention_pending
@@ -14,6 +18,7 @@ type turn_reason =
   | Scope_message_pending
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
+  | Connector_attention_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -36,6 +36,11 @@ type stimulus_payload =
          — wakes the calling keeper so the outcome arrives as actionable turn
          input. Phase 1 adds the variant only; no producer emits it yet
          (executor lands in RFC-0290 Phase 3). *)
+  | Connector_attention of connector_attention
+      (* RFC-connector-ambient-attention-wake: an ambient connector message
+         recorded as external attention. Carries the [event_id] pointer (not
+         content). Dormant — no producer emits it yet (handle_ambient enqueuer
+         lands in P3), same staging as [Bg_completed] above. *)
 
 and fusion_completion = {
   run_id : string;
@@ -61,6 +66,11 @@ and bg_job_kind = Subprocess
 and bg_job_outcome =
   | Bg_ok of string  (* result payload *)
   | Bg_failed of string  (* failure label *)
+
+and connector_attention = { event_id : string }
+      (* RFC-connector-ambient-attention-wake: pointer into
+         [Keeper_external_attention] for the ambient message; content/surface
+         read from that store on the turn path. *)
 
 let fusion_completion_post_id (fc : fusion_completion) =
   if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
@@ -181,10 +191,12 @@ let payload_kind_label = function
   | No_progress_recovery -> "no_progress_recovery"
   | Fusion_completed _ -> "fusion_completed"
   | Bg_completed _ -> "bg_completed"
+  | Connector_attention _ -> "connector_attention"
 
 let is_board_signal = function
   | Board_signal _ -> true
-  | Bootstrap | No_progress_recovery | Fusion_completed _ | Bg_completed _ ->
+  | Bootstrap | No_progress_recovery | Fusion_completed _ | Bg_completed _
+  | Connector_attention _ ->
     false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
@@ -312,6 +324,11 @@ let payload_to_yojson = function
       ; "payload", `String payload
       ; "board_post_id", `String c.bg_board_post_id
       ]
+  | Connector_attention ca ->
+    `Assoc
+      [ "kind", `String "connector_attention"
+      ; "event_id", `String ca.event_id
+      ]
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -346,6 +363,9 @@ let payload_of_yojson json =
     Ok
       (Bg_completed
          { bg_run_id = run_id; bg_kind; bg_outcome; bg_board_post_id = board_post_id })
+  | "connector_attention" ->
+    let* event_id = string_field ~context "event_id" fields in
+    Ok (Connector_attention { event_id })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -57,6 +57,13 @@ type stimulus_payload =
   | No_progress_recovery
   | Fusion_completed of fusion_completion
   | Bg_completed of bg_job_completion
+  | Connector_attention of connector_attention
+      (** RFC-connector-ambient-attention-wake: an ambient connector message
+          recorded as [Keeper_external_attention]. Carries the [event_id]
+          pointer into that durable store (not the content), so the wake reads
+          content on the turn path and there is no payload duplication.
+          Edge-triggered: dequeued once, re-armed only by a new ambient
+          message. Dormant until [handle_ambient] enqueues it (P3). *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -95,6 +102,11 @@ and bg_job_kind = Subprocess
 and bg_job_outcome =
   | Bg_ok of string  (** result payload *)
   | Bg_failed of string  (** failure label *)
+
+and connector_attention = { event_id : string }
+(** RFC-connector-ambient-attention-wake payload for [Connector_attention]:
+    [event_id] is the pointer into [Keeper_external_attention] for the ambient
+    message; content/surface are read from that store on the turn path. *)
 
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the

--- a/test/dune
+++ b/test/dune
@@ -31,6 +31,7 @@
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_connector_attention_wake
   test_keeper_no_signal_silence
   test_keeper_failed_task_not_proactive_driver
   test_advisory_only_affordance_never_drives_wake
@@ -357,6 +358,7 @@
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_connector_attention_wake
   test_keeper_no_signal_silence
   test_keeper_failed_task_not_proactive_driver
   test_advisory_only_affordance_never_drives_wake

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -1,0 +1,118 @@
+(* test_keeper_connector_attention_wake.ml —
+   RFC-connector-ambient-attention-wake P1.
+
+   Pins the wake decision plumbing: a Connector_attention_stimulus event-queue
+   trigger yields a Run { Connector_attention_pending } reactive decision, the
+   same path Mention_pending / Bootstrap_stimulus take. Dormant in production —
+   nothing enqueues this stimulus yet (P3 wires handle_ambient) — so this is a
+   pure decision-layer test with no I/O. *)
+
+open Alcotest
+module WO = Masc.Keeper_world_observation
+
+(* keeper_cycle_decision resolves a runtime id unconditionally (RFC-0206 §2.1),
+   so a minimal default runtime must exist — same setup the other cycle-decision
+   unit tests use. *)
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "connector_attention_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  match Masc.Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("trace_id", `String ("trace-conn-" ^ name))
+      ; ("goal", `String "connector attention wake test")
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+(* Quiet observation: no mention / board / scope trigger and no task backlog, so
+   the ONLY reactive trigger is the injected event-queue one. *)
+let quiet_obs : WO.world_observation =
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; continuity_summary = ""
+  ; context_ratio = lazy 0.0
+  ; unclaimed_task_count = 0
+  ; claimable_task_count = 0
+  ; provider_capacity_blocked_task_count = 0
+  ; failed_task_count = 0
+  ; pending_verification_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
+  ; backlog_updated_since_last_scheduled_autonomous = false
+  ; running_keeper_fiber_count = 1
+  ; connected_surfaces = []
+  }
+
+let no_provider_cooldown ~keeper_name:_ ~runtime_id:_ = None
+
+let reasons_of_verdict = function
+  | WO.Run { reasons = first, rest } -> first :: rest
+  | WO.Skip _ -> []
+
+let decide ?(event_queue_triggers = []) () =
+  WO.keeper_cycle_decision
+    ~provider_cooldown_remaining_sec:no_provider_cooldown
+    ~event_queue_triggers
+    ~meta:(make_meta "conn-keeper")
+    quiet_obs
+
+let test_connector_attention_stimulus_drives_run () =
+  let d = decide ~event_queue_triggers:[ WO.Connector_attention_stimulus ] () in
+  check bool "connector attention stimulus drives a turn" true d.should_run;
+  check bool "channel is Reactive" true (d.channel = WO.Reactive);
+  check bool "verdict carries Connector_attention_pending" true
+    (List.mem WO.Connector_attention_pending (reasons_of_verdict d.verdict))
+
+(* Dormancy guard: with no stimulus and a quiet observation, the keeper does NOT
+   reactively run on connector attention — the trigger is the only thing that
+   introduces it. *)
+let test_no_stimulus_no_connector_reason () =
+  let d = decide () in
+  check bool "no Connector_attention_pending without the stimulus" false
+    (List.mem WO.Connector_attention_pending (reasons_of_verdict d.verdict))
+
+let () =
+  init_runtime_default_for_tests ();
+  run "connector_attention_wake"
+    [ ( "decision",
+        [ test_case "stimulus drives Run { Connector_attention_pending }" `Quick
+            test_connector_attention_stimulus_drives_run
+        ; test_case "dormant without the stimulus" `Quick
+            test_no_stimulus_no_connector_reason
+        ] )
+    ]

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -40,7 +40,7 @@ let init_runtime_default_for_tests () =
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc runtime_toml);
-  match Masc.Runtime.init_default ~config_path:path with
+  match Runtime.init_default ~config_path:path with
   | Ok () -> ()
   | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
 
@@ -106,6 +106,25 @@ let test_no_stimulus_no_connector_reason () =
   check bool "no Connector_attention_pending without the stimulus" false
     (List.mem WO.Connector_attention_pending (reasons_of_verdict d.verdict))
 
+(* The Connector_attention payload persists to / replays from the per-keeper
+   event-queue snapshot, so its JSON codec must round-trip the event_id pointer. *)
+let test_connector_attention_codec_roundtrips () =
+  let module Q = Keeper_event_queue in
+  let s =
+    { Q.post_id = "evt-77"
+    ; urgency = Q.Normal
+    ; arrived_at = 1.0
+    ; payload = Q.Connector_attention { event_id = "evt-77" }
+    }
+  in
+  match Q.stimulus_of_yojson (Q.stimulus_to_yojson s) with
+  | Ok s' -> (
+    match s'.Q.payload with
+    | Q.Connector_attention { event_id } ->
+      check string "event_id survives the JSON round-trip" "evt-77" event_id
+    | _ -> check bool "round-trip payload stays Connector_attention" true false)
+  | Error e -> check bool ("round-trip decode failed: " ^ e) true false
+
 let () =
   init_runtime_default_for_tests ();
   run "connector_attention_wake"
@@ -114,5 +133,9 @@ let () =
             test_connector_attention_stimulus_drives_run
         ; test_case "dormant without the stimulus" `Quick
             test_no_stimulus_no_connector_reason
+        ] )
+    ; ( "codec",
+        [ test_case "Connector_attention payload JSON round-trips" `Quick
+            test_connector_attention_codec_roundtrips
         ] )
     ]


### PR DESCRIPTION
## P1 (dormant wake plumbing) — RFC-connector-ambient-attention-wake

RFC #22815의 첫 구현 조각. ambient connector attention을 wake 결정에 연결하기 위한 **typed plumbing**, **dormant**(P3가 enqueuer 배선 전까지 동작 변화 0).

- `event_queue_trigger += Connector_attention_stimulus`, `turn_reason += Connector_attention_pending` (closed-sum, exhaustive match가 모든 소비처 강제)
- `turn_reason_of_event_queue_trigger`/`turn_reason_to_string` arm + 4개 transparent 재선언(turn_types .ml/.mli + keeper_world_observation .ml/.mli) 동기화
- `keeper_cycle_decision` **구조 변경 0**: event_queue triggers가 이미 reactive_triggers로 fold → stimulus가 `Run{Reactive, Connector_attention_pending}` (Mention_pending과 동일 경로)

### 검증
- `test_keeper_connector_attention_wake`: stimulus → `Run{Connector_attention_pending}`, 없으면 부재(dormancy guard)
- 전체 `@check` clean (lib 프로젝트 전체 타입체크). **테스트 빌드/실행은 CI에서.**

### dormant 이유
`Connector_attention_stimulus`를 *생산*하는 게 아직 없음(Keeper_event_queue payload 변형 + intake + handle_ambient enqueuer = P3). 순수 타입/결정-층 변경.

Refs: RFC-connector-ambient-attention-wake (#22815), RFC-0020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
