### PR TITLE
refactor(oas-consume): route tool-schema budget gauge through OAS token estimator

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -99,20 +99,28 @@ let () =
      Uses Config.raw_all_tool_schemas, including domain-adapter schemas not
      present in Tools.all_schemas_extended. *)
   Keeper_tool_dispatch_runtime.inject_masc_schemas Config.raw_all_tool_schemas;
-  (* Report tool schema budget to Otel_metric_store (#7483 Step 1). *)
+  (* Report tool schema budget to Otel_metric_store (#7483 Step 1).
+     Token estimate goes through the OAS Context_reducer facade
+     (Keeper_context_core_accessors.estimate_char_tokens), the MASC SSOT for
+     token estimation, instead of a third ad-hoc chars/4 byte heuristic. byte/4
+     weights every UTF-8 byte equally (a 3-byte CJK char counts as ~0.75
+     token), whereas the OAS estimator classifies per character: ~4 ASCII
+     chars/token and ~2/3 token per multi-byte char. ASCII-only schemas land on
+     the same value; CJK-bearing schemas use the empirically-tuned char-based
+     estimate. One estimate per schema preserves the gauge's per-schema budget
+     meaning. *)
   (let schemas = Config.visible_tool_schemas () in
    let count = List.length schemas in
-   let chars =
+   let approx_tokens =
      List.fold_left
        (fun acc (s : Masc_domain.tool_schema) ->
           acc
-          + String.length s.name
-          + String.length s.description
-          + String.length (Yojson.Safe.to_string s.input_schema))
+          + Keeper_context_core_accessors.estimate_char_tokens
+              (s.name ^ s.description ^ Yojson.Safe.to_string s.input_schema))
        0
        schemas
    in
-   Otel_metric_store.set_tool_schema_stats ~count ~approx_tokens:(chars / 4));
+   Otel_metric_store.set_tool_schema_stats ~count ~approx_tokens);
   (* Wire tag-based dispatch for keeper masc_* tools.
      See #4579: keeper_tool_dispatch_runtime uses handler registry (Tool_Board only),
      this callback adds tag-registry dispatch for ~190 more tools. *)

--- a/test/dune
+++ b/test/dune
@@ -1466,6 +1466,7 @@
   test_resilience_coverage
   test_types_coverage
   test_oas_canonical_delegation_contract
+  test_oas_token_estimation_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage
@@ -1512,6 +1513,7 @@
   test_resilience_coverage
   test_types_coverage
   test_oas_canonical_delegation_contract
+  test_oas_token_estimation_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage

--- a/test/test_oas_token_estimation_contract.ml
+++ b/test/test_oas_token_estimation_contract.ml
@@ -1,0 +1,51 @@
+(** OAS canonical token-estimator contract for the tool-schema budget gauge
+    (masc axis-1b — under-wired OAS consumption).
+
+    [lib/mcp_server_eio.ml] reports the tool-schema budget (#7483 Step 1) through
+    the OAS Context_reducer facade
+    ([Keeper_context_core_accessors.estimate_char_tokens], which delegates to
+    [Agent_sdk.Context_reducer.estimate_char_tokens]) instead of a hand-rolled
+    byte-length/4 heuristic — a third ad-hoc copy of token math the MASC facade
+    designates OAS as the SSOT for.
+
+    These tests pin the canonical estimator's char-classified contract that the
+    gauge now consumes, and show it is distinct from byte/4. A silent revert to
+    the ad-hoc heuristic, or an OAS change to the estimator, surfaces here
+    instead of drifting the emitted gauge value silently. They assert the
+    estimator contract, not a direction of "correctness" against byte/4. *)
+
+open Alcotest
+
+let est = Agent_sdk.Context_reducer.estimate_char_tokens
+let byte_over_4 s = String.length s / 4
+
+(* Canonical contract values, mirroring OAS text_estimate inline tests:
+   ASCII ~4 chars/token, multi-byte ~2/3 token/char, min 1 (no zero downstream).
+   CJK/emoji written as UTF-8 escapes for byte-exactness:
+   "\xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94" = 안녕하세요 (5 Hangul)
+   "\xF0\x9F\x98\x80\xF0\x9F\x98\x80" = 😀😀 (two 4-byte emoji) *)
+let test_canonical_contract () =
+  check int "empty -> 1" 1 (est "");
+  check int "ascii 'hello world' -> ceil(11/4) = 3" 3 (est "hello world");
+  check int "100 ascii 'x' -> 25" 25 (est (String.make 100 'x'));
+  check int "5 Hangul -> (5*2+2)/3 = 4" 4
+    (est "\xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94");
+  check int "two 4-byte emoji -> 2" 2 (est "\xF0\x9F\x98\x80\xF0\x9F\x98\x80")
+
+(* Non-vacuous: the char-classified estimator is not byte-length/4 for CJK
+   content, so routing the gauge through it changes the reported value. We pin
+   that they differ, not which one is "more correct". 40 Hangul "한" (EC->ED 95 9C):
+   byte/4 = 120/4 = 30; estimator = (40*2+2)/3 = 27. *)
+let test_differs_from_byte_over_4_on_cjk () =
+  let cjk = String.concat "" (List.init 40 (fun _ -> "\xED\x95\x9C")) in
+  check bool "canonical estimate differs from byte/4 on CJK-heavy text" true
+    (est cjk <> byte_over_4 cjk)
+
+let () =
+  run "oas_token_estimation_contract"
+    [ ( "contract"
+      , [ test_case "canonical estimator contract" `Quick test_canonical_contract
+        ; test_case "distinct from byte/4 on CJK" `Quick
+            test_differs_from_byte_over_4_on_cjk
+        ] )
+    ]


### PR DESCRIPTION
## 목표

`lib/mcp_server_eio.ml`의 tool-schema budget gauge(#7483 Step 1)가 ad-hoc `chars / 4`(byte length / 4) 토큰 추정을 직접 구현하고 있었습니다. MASC facade `keeper_context_core_accessors`는 OAS를 token estimation SSOT로 지정하고 "다른 keeper 모듈은 `Agent_sdk.Context_reducer.estimate_*`를 직접 hand-roll 하지 말 것"을 명시하는데, 이 사이트는 그 facade도 OAS도 우회한 **세 번째 token-math 구현**입니다. axis-1b(under-wired OAS consumption) sweep로 발견·검증했습니다.

## 변경

- `lib/mcp_server_eio.ml`: `chars / 4` fold → `Keeper_context_core_accessors.estimate_char_tokens`(OAS `Context_reducer`로 위임)를 schema당 1회 호출. 누산기 `chars` → `approx_tokens`.

## 동작 (정직한 framing)

이건 **정확성 버그 수정이 아니라 SSOT 일원화**입니다.
- `byte/4`는 모든 UTF-8 byte를 동일 가중(3-byte CJK 문자 = ~0.75 token).
- OAS estimator는 **문자 단위** 분류: ASCII ~4 char/token, multi-byte ~2/3 token/char (경험적 튜닝, ceil 기반, min 1).
- ASCII-only 스키마는 동일 값. CJK 스키마는 두 방식이 텍스트 크기에 따라 **역전**합니다(작은 CJK는 byte/4가 낮고, 큰 CJK는 byte/4가 높음). 단조 under/over-count 아님 — sweep의 "~2x undercount" 주장은 실제 공식 정독 결과 부정확하여 채택하지 않았습니다.

가치: ad-hoc 휴리스틱 제거 + 경험적 튜닝된 canonical estimator 채택 + facade SSOT 계약 준수(드리프트 방지).

## 검증

- 테스트 `test/test_oas_token_estimation_contract.ml`: canonical estimator 계약값 pin(`"hello world"=3`, `안녕하세요=4`, `100 ascii=25`, `2 emoji=2`, empty=1) + CJK-heavy 텍스트에서 `byte/4`와 **다름** 증명(non-vacuous). OAS가 estimator를 바꾸거나 누군가 byte/4로 되돌리면 여기서 드러납니다.
- 로컬 빌드는 머신-wide dune 락(병렬 세션 빌드 중)으로 미실행 → CI 검증.

## 경계

- OAS 무변경(MASC가 OAS 소비). read-only OTel gauge, failover/orchestration/lane-scheduling 무관.
- reachability: `lib/dune (include_subdirs unqualified)`로 keeper 모듈이 masc 라이브러리에 편입 → `Keeper_context_core_accessors.estimate_char_tokens` 직접 호출 가능(이미 동급 in-library 모듈 참조 중).

## 범위

axis-1b sweep confirmed 다수 중 1건만 분리한 surgical PR입니다. 나머지(usage cost cache-token 누락, message 생성자 byte-identical 위임 7건, keeper_failure_policy 라벨 위임)는 테스트 가능성/리스크 기준으로 별도 PR로 분리 예정.

RFC-WAIVED: OAS 소비 일원화 리팩터(credential/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 무관). ad-hoc 휴리스틱 제거이며 workaround 아님.
