### PR TITLE
refactor(oas-consume): delegate hand-rolled message records to Agent_sdk smart constructors

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -92,17 +92,10 @@ let summarize_chunk (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.mess
   match lines with
   | [] -> None
   | _ ->
-    Some {
-      Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
-      content = [
-        Agent_sdk.Types.Text
-          (Printf.sprintf "[MEMORY_SUMMARY] Compacted %d older messages\n%s"
-             (List.length msgs) (String.concat "\n" lines))
-      ];
-      name = None;
-      tool_call_id = None;
-      metadata = [];
-    }
+    Some
+      (Agent_sdk.Types.assistant_msg
+         (Printf.sprintf "[MEMORY_SUMMARY] Compacted %d older messages\n%s"
+            (List.length msgs) (String.concat "\n" lines)))
 
 (** Score a list of messages by importance for context compaction.
     Returns [(index, score)] pairs where score is in [0.0, 1.0].

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -178,15 +178,7 @@ let metric_of_block
                 "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"
           | _ -> 0))
   in
-  let msg : Agent_sdk.Types.message =
-    {
-      Agent_sdk.Types.role;
-      content = [block];
-      name = None;
-      tool_call_id = None;
-      metadata = [];
-    }
-  in
+  let msg : Agent_sdk.Types.message = Agent_sdk.Types.make_message ~role [ block ] in
   {
     bytes;
     estimated_tokens = Keeper_context_core.msg_tokens msg;

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -102,16 +102,7 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
     if blocks = []
     then ""
     else
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = blocks;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
+      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_content blocks)
   in
   match content_blocks_of_json json with
   | Some blocks -> text_of_blocks blocks

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -72,11 +72,7 @@ let summary_schema_supported provider_cfg =
     Keeper_structured_output_schema.memory_bank_summary_output_schema
     provider_cfg
 
-let text_block text : Agent_sdk.Types.content_block =
-  Agent_sdk.Types.Text text
-
-let message role text : Agent_sdk.Types.message =
-  { role; content = [ text_block text ]; name = None; tool_call_id = None; metadata = [] }
+let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
 let bounded_notes_text texts =
   texts

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -20,13 +20,7 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 ;;
 
-let user_message text : Agent_sdk.Types.message =
-  { role = Agent_sdk.Types.User
-  ; content = [ Agent_sdk.Types.Text text ]
-  ; name = None
-  ; tool_call_id = None
-  ; metadata = []
-  }
+let user_message text : Agent_sdk.Types.message = Agent_sdk.Types.user_msg text
 ;;
 
 let with_timeout ?clock ~timeout_sec f =

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -199,17 +199,7 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
           let runtime_id =
             Local_runtime_pool.runtime_id_of_base_url provider_config.base_url
           in
-          let messages : Oas_types.message list =
-            [
-              {
-                Oas_types.role = Oas_types.User;
-                content = [ Oas_types.Text prompt ];
-                name = None;
-                tool_call_id = None;
-                metadata = [];
-              };
-            ]
-          in
+          let messages : Oas_types.message list = [ Oas_types.user_msg prompt ] in
           let run_completion () =
             Llm_provider.Complete.complete ~sw:env.sw ~net:env.net
               ~config:provider_config ~messages ()

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -110,17 +110,7 @@ let probe_chat_completion_compatible
           ~request_path:Masc_network_defaults.openai_chat_completions_path
           ~max_tokens:1 ~temperature:Runtime_provider_defaults.deterministic_temperature ()
       in
-      let messages : Oas_types.message list =
-        [
-          {
-            Oas_types.role = Oas_types.User;
-            content = [ Oas_types.Text "hi" ];
-            name = None;
-            tool_call_id = None;
-            metadata = [];
-          };
-        ]
-      in
+      let messages : Oas_types.message list = [ Oas_types.user_msg "hi" ] in
       let run_completion () =
         Llm_provider.Complete.complete ~sw:env.sw ~net:env.net
           ~config:provider_config ~messages ()

--- a/test/dune
+++ b/test/dune
@@ -1469,6 +1469,7 @@
   test_types_coverage
   test_oas_canonical_delegation_contract
   test_oas_token_estimation_contract
+  test_oas_message_constructor_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage
@@ -1516,6 +1517,7 @@
   test_types_coverage
   test_oas_canonical_delegation_contract
   test_oas_token_estimation_contract
+  test_oas_message_constructor_contract
   test_dashboard_coverage
   test_rate_limit_coverage
   test_session_coverage

--- a/test/test_oas_message_constructor_contract.ml
+++ b/test/test_oas_message_constructor_contract.ml
@@ -1,0 +1,69 @@
+(** OAS message smart-constructor contract (masc axis-1b — under-wired OAS
+    consumption).
+
+    Seven MASC sites delegated hand-rolled [Agent_sdk.Types.message] record
+    literals to the OAS smart constructors instead of re-spelling the
+    [{ role; content; name = None; tool_call_id = None; metadata = [] }] shape:
+    [user_msg], [user_msg_blocks], [assistant_msg], [text_message],
+    [make_message], [text_block], and [text_of_content] (the last replacing a
+    synthetic User message built only to call [text_of_message]).
+
+    These tests pin the exact records/strings those constructors produce, so a
+    future OAS change to a default (metadata, a new message field, role mapping)
+    surfaces here instead of silently diverging the messages MASC builds. They
+    document the byte-identical equivalence each delegation relies on. *)
+
+open Alcotest
+module T = Agent_sdk.Types
+
+(* Canonical message shape the delegated sites previously hand-rolled. *)
+let msg ?(role = T.User) ?(name = None) ?(tool_call_id = None) ?(metadata = [])
+    content : T.message =
+  { role; content; name; tool_call_id; metadata }
+
+let test_user_msg () =
+  check bool "user_msg = User single-Text record" true
+    (T.user_msg "hi" = msg [ T.Text "hi" ])
+
+let test_user_msg_blocks () =
+  let blocks = [ T.Text "a"; T.Text "b" ] in
+  check bool "user_msg_blocks = User record with given blocks" true
+    (T.user_msg_blocks blocks = msg blocks)
+
+let test_assistant_msg () =
+  check bool "assistant_msg = Assistant single-Text record" true
+    (T.assistant_msg "yo" = msg ~role:T.Assistant [ T.Text "yo" ])
+
+let test_text_message () =
+  check bool "text_message role = single-Text record with that role" true
+    (T.text_message T.System "s" = msg ~role:T.System [ T.Text "s" ])
+
+let test_make_message () =
+  let block = T.Text "b" in
+  check bool "make_message ~role content = record, defaults None/None/[]" true
+    (T.make_message ~role:T.Tool [ block ] = msg ~role:T.Tool [ block ])
+
+let test_text_block () =
+  check bool "text_block = Text constructor" true (T.text_block "x" = T.Text "x")
+
+let test_text_of_content_matches_text_of_message () =
+  (* keeper_context_core_message_json drops a synthetic User envelope:
+     text_of_message ignores role/name/etc and reads only content. *)
+  let blocks = [ T.Text "alpha"; T.Text "beta" ] in
+  check string "text_of_content = text_of_message of the wrapping User msg"
+    (T.text_of_message (msg blocks))
+    (T.text_of_content blocks)
+
+let () =
+  run "oas_message_constructor_contract"
+    [ ( "contract"
+      , [ test_case "user_msg" `Quick test_user_msg
+        ; test_case "user_msg_blocks" `Quick test_user_msg_blocks
+        ; test_case "assistant_msg" `Quick test_assistant_msg
+        ; test_case "text_message" `Quick test_text_message
+        ; test_case "make_message" `Quick test_make_message
+        ; test_case "text_block" `Quick test_text_block
+        ; test_case "text_of_content matches text_of_message" `Quick
+            test_text_of_content_matches_text_of_message
+        ] )
+    ]


### PR DESCRIPTION
## 목표

7개 MASC 사이트가 `Agent_sdk.Types.message`를 `{ role; content; name = None; tool_call_id = None; metadata = [] }` record literal로 손수 만들고 있었습니다. OAS가 정확히 그 record를 만드는 smart constructor를 공개(`user_msg`/`user_msg_blocks`/`assistant_msg`/`text_message`/`make_message`/`text_block`/`text_of_content`)하는데도 다시 만든 케이스 — axis-1b sweep으로 발견·검증했습니다.

## 변경 (모두 byte-identical 위임)

| 파일 | 기존 | 위임 |
|------|------|------|
| `keeper_memory_os_consolidation_runtime.ml` | `user_message` record literal | `Agent_sdk.Types.user_msg` |
| `keeper_memory_llm_summary.ml` | `text_block`/`message` | `text_block`/`text_message` (unused가 된 local `text_block` 제거) |
| `keeper_context_core_message_json.ml` | `text_of_message` 호출용 synthetic User envelope | `text_of_content blocks` (불필요한 record 할당 제거) |
| `context_compact_oas.ml` | Assistant 요약 record literal | `assistant_msg` |
| `keeper_agent_prompt_metrics.ml` | one-block record literal | `make_message ~role [block]` |
| `tool_local_runtime_verify.ml` / `tool_local_runtime_bench.ml` | probe User msg literal | `Oas_types.user_msg` (`Oas_types = Agent_sdk.Types`) |

## 근거

`make_message ?name ?tool_call_id ?(metadata=[]) ~role content`은 name/tool_call_id를 `None`, metadata를 `[]`로 default → 모든 hand-rolled literal과 필드 단위 동일(OAS `lib/llm_provider/types.ml`). `text_of_message msg = text_of_content msg.content`(role/name 무시)라 synthetic envelope는 죽은 오버헤드. **동작 변화 없음** — 순수 생성/투영.

가치: OAS가 `message` record에 필드를 추가하면 hand-rolled 7곳이 전부 컴파일 깨져 7번 수동 수정(N-of-M 패치)해야 하지만, smart constructor 위임 시 canonical 결정이 OAS 한 곳(SSOT). 컴파일러가 동기화 강제.

## 검증

- 테스트 `test/test_oas_message_constructor_contract.ml`: 각 constructor가 손수 만들던 record/string과 정확히 일치함을 pin(`user_msg`/`user_msg_blocks`/`assistant_msg`/`text_message`/`make_message`/`text_block`/`text_of_content`). OAS가 default를 바꾸면 여기서 드러납니다.
- 로컬 빌드는 머신-wide dune 락(병렬 세션)으로 미실행 → CI 검증.

## 경계

- OAS 무변경(MASC가 OAS 소비). 메시지 생성/투영은 OAS single-provider type scope 내, failover/orchestration 무관.
- reachability 확인: smart constructor 전부 `lib/llm_provider/types.mli` public(383/391/414/415/417/418/448) + `Agent_sdk.Types`로 re-export(base/types `include Llm_provider.Types`).

RFC-WAIVED: OAS 소비 일원화 byte-identical 리팩터(credential/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 무관). hand-rolled 제거이며 workaround 아님.
