### PR TITLE
fix(runtime): align minimax-m3 structured-output capability with OAS SSOT (#2339)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -197,8 +197,10 @@ supports-extended-thinking = true
 supports-reasoning-budget = true
 thinking-control-format = "reasoning-effort"
 supports-native-streaming = true
-supports-response-format-json = true
-supports-structured-output = true
+# SSOT = OAS models.toml per official MiniMax Chat docs: Chat tool_choice /
+# response_format / structured output are not documented (jeong-sik/oas#2339).
+supports-response-format-json = false
+supports-structured-output = false
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -659,8 +661,9 @@ supports-extended-thinking = true
 supports-reasoning-budget = true
 thinking-control-format = "reasoning-effort"
 supports-native-streaming = true
-supports-response-format-json = true
-supports-structured-output = true
+# SSOT = OAS models.toml per official MiniMax Chat docs (jeong-sik/oas#2339).
+supports-response-format-json = false
+supports-structured-output = false
 supports-image-input = true
 supports-multimodal-inputs = true
 


### PR DESCRIPTION
## 목적

masc `runtime.toml`의 minimax-m3 structured-output capability를 OAS SSOT에 맞춰 정정.

## 근거

OAS `models.toml` (#2339)이 공식 MiniMax Chat docs 기반으로 minimax-m3를 정정:
```
supports_response_format_json = false
supports_structured_output = false
supports_tool_choice = false
```
이유: MiniMax Chat의 `tool_choice` / `response_format` / structured output이 공식 문서에 문서화되어 있지 않음. fail-closed capability truth.

masc `runtime.toml`은 여전히 `[models.minimax-m3.capabilities]`와 `[models.ollama-cloud-minimax-m3.capabilities]`에서 둘 다 `true`로 선언 — OAS 진실과 모순되는 local belief.

## 변경

두 block의 `supports-response-format-json` / `supports-structured-output`을 `true` → `false`로 정정 (주석에 SSOT 근거 `#2339` 명시).

## 영향

- **#22768 P1 cross-PR blocker 해소의 전제**: minimax-m3가 native structured output을 지원하지 않으므로, Fusion judge/refine/meta slot에 seed하면 안 됩니다. 이 정정 후 #22768은 judge seed를 schema-capable runtime으로 재설계 (rebase 시 consume).
- **test 영향 없음**: `test_runtime_config_validity`는 minimax-m3의 image/multimodal/tool_choice만 check (structured-output 아님).
- **librarian runtime**: minimax-m3가 memory-os librarian runtime인 점은 unchanged (librarian은 본 PR 범위 밖; structured-output을 요구하는 경로가 있으면 별도 후속).

## P0–P3

- **P0 (보안/데이터 손실)**: 해당 없음.
- **P1 (정확성)**: GOOD — OAS SSOT(#2339, 공식 docs)에 정합. fail-closed capability truth.
- **P2 (구조)**: GOOD — local belief → OAS catalog SSOT로 일원화. 노 스트링매치, 노 silent.
- **P3 (잔여)**: capable Fusion judge runtime 추가(devstral/gemma4/qwen3 등)는 별도 PR — provider endpoint 검증 동반. #22768은 본 PR 머지 후 judge seed 재설계.

## 워크어라운드 게이트

SSOT 정정 (근본). silent recovery 아님. telemetry-as-fix / string classifier / N-of-M 아님.

병합 가능성: OAS #2339와 정합, test 영향 없음. CI green 후 머지.
