### PR TITLE
fix(keeper): run memory render I/O off the main Eio domain (HOL P0)

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -354,11 +354,20 @@ let assemble_hooks
                   else ctx
                 in
                 let ctx =
+                  (* Off-main: [render_if_enabled] performs synchronous file I/O
+                     (stat/readdir/open over the persisted memory store). Running
+                     it directly on the main Eio domain blocks the cooperative
+                     scheduler, head-of-line-blocking every sibling keeper fiber
+                     until the syscalls return. Push the I/O onto the shared
+                     domain pool ([submit_io_or_inline] runs inline when no pool
+                     is configured, e.g. tests). The render is read-side only and
+                     keeps no module-level mutable state, so it is domain-safe. *)
                   match
-                    Keeper_user_model.render_if_enabled
-                      ~keeper_id:meta.name
-                      ~now:(Time_compat.now ())
-                      ()
+                    Domain_pool_ref.submit_io_or_inline (fun () ->
+                      Keeper_user_model.render_if_enabled
+                        ~keeper_id:meta.name
+                        ~now:(Time_compat.now ())
+                        ())
                   with
                   | None -> ctx
                   | Some block ->
@@ -372,14 +381,20 @@ let assemble_hooks
                      MASC_KEEPER_MEMORY_OS_RECALL. RFC-0247 removed the lexical
                      seed: recall now orders by structural recency, so the
                      current-turn text no longer reranks the recalled facts. *)
+                  (* Off-main: same rationale as the user-model render above —
+                     the recall reads persisted facts/episodes via synchronous
+                     file I/O, which would starve the main Eio domain and HOL
+                     sibling keepers. Read-side only, no module-level mutable
+                     state, so it is domain-safe on the shared pool. *)
                   match
-                    Keeper_memory_os_recall.render_if_enabled
-                      ~keeper_id:meta.name
-                      ~now:(Time_compat.now ())
-                      ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                      ~turn
-                      ~masc_root:(Workspace.masc_root_dir config)
-                      ()
+                    Domain_pool_ref.submit_io_or_inline (fun () ->
+                      Keeper_memory_os_recall.render_if_enabled
+                        ~keeper_id:meta.name
+                        ~now:(Time_compat.now ())
+                        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                        ~turn
+                        ~masc_root:(Workspace.masc_root_dir config)
+                        ())
                   with
                   | None -> ctx
                   | Some block ->

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -9,6 +9,7 @@ module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Runtime_resolution = Masc.Keeper_memory_runtime_resolution
 module Memory_summary = Masc.Keeper_memory_llm_summary
 module Structured_schema = Masc.Keeper_structured_output_schema
+module Domain_pool_ref = Masc.Domain_pool_ref
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
@@ -2422,6 +2423,51 @@ let test_render_if_enabled_renders_persisted_memory () =
             true
             (contains "Gated recall should surface saved facts" block))))
   ;;
+
+(* The keeper turn wraps [render_if_enabled] in
+   [Domain_pool_ref.submit_io_or_inline] so its synchronous memory file I/O runs
+   off the main Eio domain (avoids head-of-line-blocking sibling keepers). Pin
+   that the wrap is transparent: the same block is produced whether the render
+   runs directly or through the pool. Tests configure no pool, so
+   [submit_io_or_inline] takes the inline path here. *)
+let test_render_if_enabled_offmain_wrap_is_transparent () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "offmain-wrap-keeper" in
+        let now = 1_000_000.0 in
+        let episode =
+          { Types.trace_id = "trace-offmain-wrap"
+          ; Types.generation = 1
+          ; Types.episode_summary = "off-main wrap episode"
+          ; Types.claims = [ fact_fixture ~now () ]
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.valid_until = None
+          ; Types.terminal_marker = None
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        let direct =
+          render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir ()
+        in
+        let wrapped =
+          Domain_pool_ref.submit_io_or_inline (fun () ->
+            render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir ())
+        in
+        Alcotest.(check bool)
+          "seeded render produces a block"
+          true
+          (Option.is_some direct);
+        Alcotest.(check (option string))
+          "off-main wrap preserves the render result"
+          direct
+          wrapped)))
+;;
 
 let test_render_if_enabled_omits_diagnostic_memory () =
   with_recall_env "true" (fun () ->
@@ -5495,6 +5541,10 @@ let () =
             "render_if_enabled omits diagnostic memory"
             `Quick
             test_render_if_enabled_omits_diagnostic_memory
+        ; Alcotest.test_case
+            "render_if_enabled off-main wrap is transparent (HOL fix)"
+            `Quick
+            test_render_if_enabled_offmain_wrap_is_transparent
         ; Alcotest.test_case
             "render_if_enabled omits empty episode memory"
             `Quick


### PR DESCRIPTION
## 문제 (profiled, P0)

라이브 `sample`(116.7% CPU)에서 `keeper_memory_os_io`의 **동기 file I/O**(`Sys.file_exists` 1388, `Sys.readdir`, `open_in_bin`, Yojson)가 **단일 main Eio 도메인**을 점유 → 협력적 스케줄러 스타베이션 → 형제 keeper fiber **head-of-line blocking** + MCP dispatch 60s timeout. 사용자 P0 "Keeper 하나가 멈추면 모두가 멈춤"의 측정된 라이브 메커니즘.

핵심: 이 HOL은 **fiber 격리(`Eio_guard.protect`)로 막을 수 없음** — 예외/취소가 아니라 *스케줄러 스타베이션*이기 때문. 두 메커니즘은 별개다.

## 변경

per-turn default-ON 핫패스 2곳(`keeper_run_tools_hooks.ml`)을 `Domain_pool_ref.submit_io_or_inline`로 wrap:
- `Keeper_user_model.render_if_enabled`
- `Keeper_memory_os_recall.render_if_enabled`

`server_dashboard_http`가 이미 main HTTP 도메인을 responsive하게 유지하려고 쓰는 **동일 메커니즘**(`Eio.Executor_pool` weight_io). 재구현 아님 — 기존 라이브러리 사용("Eio 우선").

## 정당성

- **근본 fix**: main 도메인 blocking 제거(off-main worker로). 워크어라운드(cap/cooldown/dedup) 아님.
- **domain-safe**: 두 render는 read-side only, module-level mutable state 없음(`seen` Hashtbl은 함수 내 로컬). 공유 state race 없음.
- **graceful**: `submit_io_or_inline`은 풀 미설정 시 inline 실행(테스트/no-pool).
- **Keeper 제약지옥 아님**: 동작 동일, 단지 I/O가 off-main. signature 무변경.

## 범위 / 후속

이 PR은 **per-turn 핫패스**(default-ON memory recall + user model)를 다룬다. `keeper_memory_os_io`의 다른 동기 I/O 사이트(consolidation/GC sweep)도 같은 패턴으로 off-main 가능하나, 그건 별도 호출 빈도/경로라 follow-up. 더 근본적으로는 `keeper_memory_os_io`를 `Eio.Path`(non-blocking yield)로 마이그레이션하는 것이 정석이나 capability threading 대공사라 별도 RFC 대상.

빌드는 CI에서 확인(로컬 worktree 미빌드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
