### PR TITLE
feat(connector): P3+P4 ambient attention wake (gated + throttled)

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -100,6 +100,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.250.0" };
 
+  { env_name = "MASC_CONNECTOR_AMBIENT_WAKE_ENABLED";
+    description = "Wake an idle keeper on an ambient connector message via an external-attention edge stimulus (RFC-connector-ambient-attention-wake). Off until the spurious-wake throttle (P4) lands; enabling without it would run a turn on every ambient line.";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.252.0" };
+
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -136,6 +136,41 @@ type keepalive_turn_outcome = {
   cycle_crashed : bool;
 }
 
+let connector_attention_event_ids_of_stimuli stimuli =
+  List.filter_map
+    (fun (stimulus : Keeper_event_queue.stimulus) ->
+      match stimulus.payload with
+      | Keeper_event_queue.Connector_attention { event_id } -> Some event_id
+      | Keeper_event_queue.Board_signal _
+      | Keeper_event_queue.Fusion_completed _
+      | Keeper_event_queue.Bg_completed _
+      | Keeper_event_queue.Bootstrap
+      | Keeper_event_queue.No_progress_recovery ->
+        None)
+    stimuli
+;;
+
+let mark_connector_attention_ignored_after_turn ~base_path ~keeper_name event_ids =
+  match event_ids with
+  | [] -> ()
+  | _ :: _ ->
+    (match
+       Keeper_external_attention.mark_ignored
+         ~base_path
+         ~keeper_name
+         ~event_ids
+         ~reason:"connector_attention_turn_completed_without_direct_reply"
+         ()
+     with
+     | Ok () -> ()
+     | Error err ->
+       Log.Keeper.warn
+         "connector attention mark_ignored after turn failed keeper=%s events=[%s]: %s"
+         keeper_name
+         (String.concat "," event_ids)
+         err)
+;;
+
 (* T6 audit: record a swallowed cycle exception as a turn failure.
 
    Catch-and-survive is intentional (the fiber must outlive the
@@ -390,11 +425,15 @@ let run_keepalive_unified_turn
       if !consumed_stimuli <> []
       then
         if !consumed_stimuli_turn_completed
-        then
+        then (
           Keeper_registry_event_queue.ack_consumed
             ~base_path:ctx.config.base_path
             meta_after_triage.name
-            !consumed_stimuli
+            !consumed_stimuli;
+          mark_connector_attention_ignored_after_turn
+            ~base_path:ctx.config.base_path
+            ~keeper_name:meta_after_triage.name
+            (connector_attention_event_ids_of_stimuli !consumed_stimuli))
         else
           Keeper_registry_event_queue.requeue_front
             ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -58,6 +58,19 @@ type heartbeat_event_intake = {
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
+let recorded_attention_item_by_event_id ~base_path ~keeper_name ~event_id =
+  Keeper_external_attention.load_events ~base_path ~keeper_name
+  |> List.find_map (function
+       | Keeper_external_attention.Recorded item
+         when String.equal item.Keeper_external_attention.event_id event_id ->
+         Some item
+       | Keeper_external_attention.Recorded _
+       | Keeper_external_attention.Claimed_for_turn _
+       | Keeper_external_attention.Resolved _
+       | Keeper_external_attention.Ignored _ ->
+         None)
+;;
+
 let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
   match stim.payload with
   | Keeper_event_queue.Bootstrap -> Some Keeper_world_observation.Bootstrap_stimulus
@@ -132,16 +145,29 @@ let consume_single_heartbeat_stimulus
     []
   | Keeper_event_queue.Connector_attention ca ->
     (* RFC-connector-ambient-attention-wake: the stimulus woke this keeper.
-       P2 — resolution lifecycle (turn-start half): claim the external-attention
-       item so the operator digest shows it as being handled rather than still
-       pending (and a stale claim re-surfaces only after claim_stale_after, not
-       every cycle). The wake itself is already resolution-safe — the stimulus is
-       edge-consumed here exactly once (P1) — so this claim is for the durable
-       backlog projection, not for gating the wake. mark_resolved / mark_ignored
-       at turn end is coupled to reading the content and deciding whether to
-       reply, which lands with content threading + outbound (P3).
-       Content injection is P3; for now the turn runs with no injected board
-       event, like Bootstrap / No_progress_recovery. *)
+       The event_id is a pointer only; the message/surface content stays in
+       Keeper_external_attention. Load it here and promote it to a pending
+       observation so the turn has real connector context instead of a
+       contentless wake reason. *)
+    let pending_events =
+      match
+        recorded_attention_item_by_event_id
+          ~base_path:ctx.config.base_path
+          ~keeper_name:meta_after_triage.name
+          ~event_id:ca.event_id
+      with
+      | Some item ->
+        [ Keeper_world_observation.pending_board_event_of_external_attention
+            ~meta:meta_after_triage
+            item
+        ]
+      | None ->
+        Log.Keeper.warn
+          "connector attention stimulus missing recorded item event_id=%s (keeper=%s)"
+          ca.event_id
+          meta_after_triage.name;
+        []
+    in
     (match
        Keeper_external_attention.claim_for_turn
          ~base_path:ctx.config.base_path
@@ -160,7 +186,7 @@ let consume_single_heartbeat_stimulus
       "turn entry: connector attention stimulus consumed event_id=%s (keeper=%s)"
       ca.event_id
       meta_after_triage.name;
-    []
+    pending_events
 ;;
 
 let consume_board_stimulus_batch ~meta_after_triage batch =

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -353,6 +353,28 @@ let board_reactive_wakeup_allowed
     ~debounce_sec:board_reactive_debounce_sec
 ;;
 
+(* ── Connector-reactive policy (RFC-connector-ambient-attention-wake P4) ── *)
+
+let connector_reactive_debounce_sec = 60.0
+
+(* Throttle ambient connector wakes with the SAME proven primitive as
+   board-reactive: the RFC-0246 tombstone gate (a latched no-progress keeper is
+   not re-woken) plus a per-key debounce. Keyed per channel, so a chatty channel
+   wakes the keeper at most once per window; the keeper then sees every
+   accumulated message in its chat history (RFC-0226) and decides whether to
+   reply. The dedup_key is namespaced ("connector-ambient:") so it never collides
+   with board dedup keys in the shared per-keeper wakeup map. A dedicated
+   [Connector_reactive] tombstone origin is a follow-up — [Board_reactive]'s
+   suppression is already correct here: a latched keeper must not wake on
+   connector chatter either. *)
+let connector_reactive_wakeup_allowed ~base_path ~keeper_name ~channel_id =
+  Keeper_registry.board_wakeup_allowed
+    ~base_path
+    keeper_name
+    ~dedup_key:("connector-ambient:" ^ channel_id)
+    ~debounce_sec:connector_reactive_debounce_sec
+;;
+
 let take = List.take
 
 (* RFC-0020: select which keepers wake for a board signal from typed

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -139,6 +139,20 @@ val wakeup_all_keepers : ?base_path:string -> unit -> unit
 (** Board-reactive debounce interval (seconds), from runtime config. *)
 val board_reactive_debounce_sec : float
 
+(** Connector-reactive (ambient connector message) debounce interval, seconds.
+    RFC-connector-ambient-attention-wake P4. *)
+val connector_reactive_debounce_sec : float
+
+val connector_reactive_wakeup_allowed :
+  base_path:string -> keeper_name:string -> channel_id:string -> bool
+(** Whether an ambient connector message on [channel_id] may wake [keeper_name]
+    now. Reuses the board-reactive primitive: the RFC-0246 tombstone gate (a
+    latched no-progress keeper is not re-woken) plus a per-channel debounce
+    ({!connector_reactive_debounce_sec}). Returns [false] within the debounce
+    window so a chatty channel wakes the keeper at most once per window; the
+    keeper then sees every accumulated message in its chat history. Records the
+    wakeup timestamp as a side effect when it returns [true]. *)
+
 val board_reactive_wakeup_max : int
 
 (** [board_wakeup_dedup_key] is the content fingerprint a board wakeup is

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -524,6 +524,54 @@ let pending_board_event_of_bg_job_completion
   }
 ;;
 
+let external_attention_actor_label (item : Keeper_external_attention.item) =
+  match item.actor.display_name with
+  | Some name when String.trim name <> "" -> name
+  | Some _ | None ->
+    (match item.actor.actor_id with
+     | Some id when String.trim id <> "" -> id
+     | Some _ | None -> item.source_label)
+;;
+
+let pending_board_event_of_external_attention
+      ~(meta : keeper_meta)
+      (item : Keeper_external_attention.item)
+  : pending_board_event
+  =
+  let surface_label = Surface_ref.lane_label item.conversation.surface in
+  let urgency_label = Keeper_external_attention.urgency_to_string item.urgency in
+  let actor = external_attention_actor_label item in
+  let explicit_mention, matched_targets =
+    match item.urgency with
+    | Keeper_external_attention.Mention
+    | Keeper_external_attention.Direct_message ->
+      true, [ meta.name ]
+    | Keeper_external_attention.Ambient
+    | Keeper_external_attention.System ->
+      false, []
+  in
+  { post_id = "connector-attention:" ^ item.event_id
+  ; author = actor
+  ; title =
+      Printf.sprintf
+        "External %s attention (%s, conversation %s)"
+        surface_label
+        urgency_label
+        item.conversation.conversation_id
+  ; preview = short_preview ~max_len:fusion_result_preview_max_len item.content_preview
+  ; hearth = None
+  ; post_kind = Board.Human_post
+  ; updated_at = item.received_at
+  ; explicit_mention
+  ; matched_targets
+  ; self_commented = false
+  ; new_external_since = 1
+  ; latest_external_author = Some actor
+  ; latest_external_preview = Some (short_preview ~max_len:80 item.content_preview)
+  ; provenance = Unknown
+  }
+;;
+
 let pending_board_event_of_stimulus
       ~continuity_summary
       ~(meta : keeper_meta)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -288,6 +288,15 @@ val pending_board_event_of_bg_job_completion :
   Keeper_event_queue.bg_job_completion ->
   pending_board_event
 
+(** Build the actionable observation for a connector-recorded external
+    attention item. Ambient connector chatter remains observational by default:
+    it is not trusted operator instruction unless another typed path makes it
+    an explicit mention. *)
+val pending_board_event_of_external_attention :
+  meta:Keeper_meta_contract.keeper_meta ->
+  Keeper_external_attention.item ->
+  pending_board_event
+
 (** Convert a queued Event Layer stimulus back into structured board activity
     for the next keeper prompt. [Board_signal], [Fusion_completed] (RFC-0266),
     and [Bg_completed] (RFC-0290) produce [Some];

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -624,6 +624,12 @@ let handle_ambient ~base_dir
       (match attention_event_id with
        | Some event_id
          when Feature_flag_registry.get_bool "MASC_CONNECTOR_AMBIENT_WAKE_ENABLED"
+              (* P4 throttle: the flag short-circuits first (cheap, no side
+                 effect); the debounce records a timestamp only when reached, so
+                 a chatty channel wakes the keeper at most once per window and a
+                 no-progress-latched keeper is not re-woken (RFC-0246). *)
+              && Keeper_keepalive_signal.connector_reactive_wakeup_allowed
+                   ~base_path:base_dir ~keeper_name ~channel_id
          ->
          let stimulus =
            { Keeper_event_queue.post_id = event_id

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -589,7 +589,7 @@ let handle_ambient ~base_dir
       Discord_observability.record_ambient
         Discord_observability.Ambient_dropped_too_long
     else begin
-      let (_ : string option) =
+      let attention_event_id =
         record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
           ~message_id ~author_id ~author_name ~content:trimmed
           ~mentions_bot:false ~route:"ambient"
@@ -614,6 +614,28 @@ let handle_ambient ~base_dir
           }
         ();
       Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
+      (* RFC-connector-ambient-attention-wake P3: wake the (possibly idle) keeper
+         on this ambient message via an edge stimulus carrying the external-
+         attention event_id (not content — content stays in the durable store),
+         plus a wakeup hint for sub-second propagation. Gated off by default:
+         until the spurious-wake throttle (P4) lands, running a turn on every
+         ambient line in a chatty channel is the anti-pattern the trigger policy
+         deliberately filtered. *)
+      (match attention_event_id with
+       | Some event_id
+         when Feature_flag_registry.get_bool "MASC_CONNECTOR_AMBIENT_WAKE_ENABLED"
+         ->
+         let stimulus =
+           { Keeper_event_queue.post_id = event_id
+           ; urgency = Keeper_event_queue.Low
+           ; arrived_at = Unix.gettimeofday ()
+             (* NDT-OK: stimulus receipt time, used only for ordering/age *)
+           ; payload = Keeper_event_queue.Connector_attention { event_id }
+           }
+         in
+         Keeper_registry_event_queue.enqueue ~base_path:base_dir keeper_name stimulus;
+         Keeper_registry.wakeup ~base_path:base_dir keeper_name
+       | Some _ | None -> ());
       Discord_observability.record_ambient
         Discord_observability.Ambient_recorded
     end

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,7 @@
 (tests
  (names
   test_keeper_memory_os_io_fd
+  test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
@@ -354,6 +355,7 @@
   test_keeper_behavior_trace)
  (modules
   test_keeper_memory_os_io_fd
+  test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane
   test_env_keeper_scrub

--- a/test/test_connector_reactive_wake_throttle.ml
+++ b/test/test_connector_reactive_wake_throttle.ml
@@ -1,0 +1,60 @@
+(* test_connector_reactive_wake_throttle.ml —
+   RFC-connector-ambient-attention-wake P4.
+
+   The ambient-connector wake is gated by
+   Keeper_keepalive_signal.connector_reactive_wakeup_allowed, which reuses the
+   board-reactive primitive (RFC-0246 tombstone gate + per-key debounce) with a
+   per-channel dedup key. This pins the throttle: a chatty channel wakes the
+   keeper at most once per debounce window, while a different channel debounces
+   independently (so distinct conversations are not collapsed). *)
+
+open Alcotest
+open Masc
+
+let rm_rf path =
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path)))
+
+let make_meta ~name ~agent_name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String agent_name)
+      ; ("trace_id", `String ("trace-" ^ name))
+      ; ("goal", `String "connector reactive wake throttle test")
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta failed: " ^ err)
+
+let test_per_channel_debounce () =
+  let base_path = Filename.temp_dir "connector-throttle" "" in
+  let config = Workspace.default_config base_path in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      ignore (Workspace.init config ~agent_name:None : string);
+      let keeper_name = "throttle-keeper" in
+      let meta = make_meta ~name:keeper_name ~agent_name:"throttle-keeper-agent" in
+      ignore (Keeper_registry.register ~base_path keeper_name meta);
+      Fun.protect
+        ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+        (fun () ->
+          let allowed channel_id =
+            Keeper_keepalive_signal.connector_reactive_wakeup_allowed ~base_path
+              ~keeper_name ~channel_id
+          in
+          check bool "first ambient wake on a channel is allowed" true
+            (allowed "chan-1");
+          check bool "immediate second wake on the same channel is debounced"
+            false (allowed "chan-1");
+          check bool "a different channel debounces independently" true
+            (allowed "chan-2");
+          check bool "the second channel then debounces too" false
+            (allowed "chan-2")))
+
+let () =
+  run "connector_reactive_wake_throttle"
+    [ ( "throttle",
+        [ test_case "per-channel debounce" `Quick test_per_channel_debounce ] )
+    ]

--- a/test/test_connector_reactive_wake_throttle.ml
+++ b/test/test_connector_reactive_wake_throttle.ml
@@ -11,6 +11,13 @@
 open Alcotest
 open Masc
 
+(* [connector_reactive_wakeup_allowed] reaches [Keeper_no_progress_loop_detector.
+   is_latched], which guards its state with [Eio.Mutex]. In production the call
+   runs inside the Discord gateway's forked fiber ([Eio.Fiber.fork ~sw] around
+   [Gw.run] in [server_discord_in_process_gateway.start]), so the effect handler
+   is always present. The test reproduces that context with [Eio_main.run]. *)
+let with_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let rm_rf path =
   ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path)))
 
@@ -56,5 +63,7 @@ let test_per_channel_debounce () =
 let () =
   run "connector_reactive_wake_throttle"
     [ ( "throttle",
-        [ test_case "per-channel debounce" `Quick test_per_channel_debounce ] )
+        [ test_case "per-channel debounce" `Quick
+            (with_eio test_per_channel_debounce)
+        ] )
     ]

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -9,6 +9,16 @@
 
 open Alcotest
 module WO = Masc.Keeper_world_observation
+module A = Masc.Keeper_external_attention
+
+let contains ~needle haystack =
+  let nl = String.length needle in
+  let hl = String.length haystack in
+  let rec loop i =
+    i + nl <= hl
+    && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
+  in
+  nl = 0 || loop 0
 
 (* keeper_cycle_decision resolves a runtime id unconditionally (RFC-0206 §2.1),
    so a minimal default runtime must exist — same setup the other cycle-decision
@@ -56,6 +66,48 @@ let make_meta name =
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+let discord_surface =
+  A.Discord
+    {
+      guild_id = Some "guild-1";
+      channel_id = "chan-1";
+      parent_channel_id = None;
+      thread_id = None;
+    }
+
+let external_attention_item ?(urgency = A.Ambient) ?(preview = "ambient TOKEN-123")
+    () : A.item =
+  let dedupe_key = "discord:discord:guild-1:channel:chan-1:msg-1" in
+  {
+    A.event_id = A.event_id_of_dedupe_key dedupe_key;
+    dedupe_key;
+    keeper_name = "conn-keeper";
+    conversation =
+      {
+        conversation_id = "discord:guild-1:channel:chan-1";
+        surface = discord_surface;
+      };
+    external_message =
+      Some
+        {
+          surface = discord_surface;
+          message_id = "msg-1";
+          reply_to_message_id = None;
+        };
+    source_label = "discord";
+    actor =
+      {
+        actor_id = Some "user-1";
+        display_name = Some "Alex";
+        authority = Masc.Keeper_chat_store.External;
+      };
+    urgency;
+    content_preview = preview;
+    content_ref = None;
+    received_at = 123.0;
+    metadata = [ ("route", "ambient") ];
+  }
 
 (* Quiet observation: no mention / board / scope trigger and no task backlog, so
    the ONLY reactive trigger is the injected event-queue one. *)
@@ -125,6 +177,23 @@ let test_connector_attention_codec_roundtrips () =
     | _ -> check bool "round-trip payload stays Connector_attention" true false)
   | Error e -> check bool ("round-trip decode failed: " ^ e) true false
 
+let test_external_attention_projects_to_prompt_event () =
+  let meta = make_meta "conn-keeper" in
+  let item = external_attention_item () in
+  let ev = WO.pending_board_event_of_external_attention ~meta item in
+  check string "post id carries event id"
+    ("connector-attention:" ^ item.A.event_id)
+    ev.WO.post_id;
+  check bool "title carries typed surface" true
+    (contains ~needle:"External discord attention" ev.WO.title);
+  check bool "preview carries connector message" true
+    (contains ~needle:"TOKEN-123" ev.WO.preview);
+  check bool "ambient is not an explicit mention" false ev.WO.explicit_mention;
+  check bool "ambient stays observational" true
+    (match ev.WO.provenance with
+     | WO.Unknown -> true
+     | _ -> false)
+
 let () =
   init_runtime_default_for_tests ();
   run "connector_attention_wake"
@@ -137,5 +206,9 @@ let () =
     ; ( "codec",
         [ test_case "Connector_attention payload JSON round-trips" `Quick
             test_connector_attention_codec_roundtrips
+        ] )
+    ; ( "projection",
+        [ test_case "external attention becomes prompt event" `Quick
+            test_external_attention_projects_to_prompt_event
         ] )
     ]


### PR DESCRIPTION
## P3+P4 — connector ambient attention wake: live but gated, throttled, safe to enable

RFC #22815 후속(P1+P2는 #22818로 main 머지됨). ambient connector 메시지가 idle keeper를 깨우는 producer + **안전 throttle** + content threading.

### P3 (producer, gated)
`handle_ambient`(이미 external_attention 기록 + chat line)이 `Connector_attention` edge stimulus(event_id 포인터) enqueue + wakeup. flag `MASC_CONNECTOR_AMBIENT_WAKE_ENABLED`(Experimental, default off) 뒤 → off=no-op.

### P4 (spurious-wake throttle — 안전 게이트)
enqueue를 `Keeper_keepalive_signal.connector_reactive_wakeup_allowed` 뒤로. **검증된 board-reactive primitive 재사용**(`Keeper_registry.board_wakeup_allowed`): RFC-0246 tombstone gate(no-progress latched 키퍼 재wake 차단) + per-channel debounce(`connector-ambient:<channel_id>`, board key와 무충돌). chatty 채널 → window(60s)당 최대 1회 wake. flag short-circuit 먼저라 disabled 시 throttle 부작용 0.

### content threading
intake turn-entry arm이 `[]` 대신 `recorded_attention_item_by_event_id`로 external-attention item을 로드해 `pending_board_event_of_external_attention`로 promote. **boundary**: `explicit_mention`을 urgency로 결정 — Ambient/System → `false`(관찰 맥락, operator 지시 아님), Mention/DM → `true`. content_preview를 prompt에 surface하되 신뢰 경계 유지(actionability 불변식). missing item은 warn + `[]`(fail-soft).

### enable-safe 근거
edge-trigger(P1) + tombstone + per-channel debounce = wake storm 없음, latched 키퍼 재wake 없음. flag flip 안전.

### enable 시 흐름
ambient → stimulus + wakeup → 키퍼 wake(Connector_attention_pending) → claim(P2) → content가 prompt에 surface(content threading) → `keeper_surface_post` 도구로 응답.

### 검증
- base를 최신 origin/main(#22833 포함)으로 rebase — 이전 CI red는 #22827 이전 stale base 상속이었고(내 코드 무관), rebase로 해소.
- `dune build @check` green(전체 타입체크).
- `test_connector_reactive_wake_throttle`: per-channel debounce green.
- `test_keeper_connector_attention_wake`: decision / codec round-trip / projection(content threading) green.
- P4 테스트는 `Eio_main.run`으로 wrap — `connector_reactive_wakeup_allowed`가 `Eio.Mutex`(no-progress detector)에 도달하므로. production은 Discord gateway의 forked fiber(`Eio.Fiber.fork ~sw`) 안이라 컨텍스트 보장.

### correctness refinement (safety 아님, 별도 추적)
mark_resolved/ignored(turn-end), 전용 Connector_reactive tombstone origin.

Refs: RFC-connector-ambient-attention-wake (#22815), RFC-0246, RFC-0226, RFC-0020

Co-Authored-By: MASC Agent <agent@masc.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
