### PR TITLE
fix(keeper-stream): reset OAS block state at message boundary

### DIFF
--- a/lib/keeper/keeper_chat_oas_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_oas_stream_bridge.ml
@@ -105,7 +105,27 @@ let translate ~redact_text ~on_text_delta bridge_state
         chat_events = [ Oas_stream_message_delta { stop_reason; usage } ]
       }
   | MessageStop ->
-      { bridge_state; chat_events = [ Oas_stream_message_stop ] }
+      (* Block indices are scoped to one provider message. A keeper dispatch is a
+         multi-turn tool loop: each OAS call is a separate stream whose block
+         indices restart at 0. Clear the per-message block table at message end
+         so the next call's reused index cannot collide with a stale [Active_tool]
+         (the cross-message [tool_args_without_start] seen with deepseek-v4-flash
+         via ollama_cloud, an OpenAI-compat stream carrying no wire
+         content_block_stop). Close any tool block still open here with a
+         [Tool_call_end] rather than dropping it silently — with OAS now emitting
+         balanced ContentBlockStop the open set is normally already empty. *)
+      let tool_ends =
+        List.filter_map
+          (fun (_index, block) ->
+            match block with
+            | Active_tool tool ->
+                Some (Tool_call_end { tool_call_id = tool.tool_call_id })
+            | Invalid_tool_block _ -> None)
+          bridge_state.blocks_by_index
+      in
+      { bridge_state = empty_state;
+        chat_events = tool_ends @ [ Oas_stream_message_stop ]
+      }
   | Ping ->
       { bridge_state; chat_events = [ Oas_stream_ping ] }
   | Timeout reason ->

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -897,6 +897,66 @@ let test_keeper_stream_bridge_rejects_conflicting_tool_index_reuse () =
       fail
         "expected conflicting reused-index tool start to fail closed without forged tool events"
 
+let test_keeper_stream_bridge_isolates_tool_blocks_across_messages () =
+  let open Agent_sdk.Types in
+  (* A keeper dispatch is a multi-turn tool loop: each OAS call is a SEPARATE
+     provider message whose block indices restart at 0, and the OpenAI-compat
+     path carries no wire content_block_stop. The MessageStop ending message 1
+     must clear the per-message block table so message 2's tool start at the SAME
+     reused index opens a fresh Active_tool instead of colliding with message 1's
+     still-open block — otherwise the args delta surfaces a spurious
+     tool_args_without_start. Live regression: deepseek-v4-flash via ollama_cloud.
+     Contrast with the within-message reuse test above, which MUST still fail
+     closed (no MessageStop separates the two starts there). *)
+  let events =
+    translate_oas_stream_events
+      [
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "call_first";
+            tool_name = Some "keeper_tasks_audit" };
+        ContentBlockDelta { index = 2; delta = InputJsonDelta "{\"a\":1}" };
+        MessageStop;
+        ContentBlockStart
+          { index = 2;
+            content_type = "tool_use";
+            tool_id = Some "call_second";
+            tool_name = Some "keeper_tasks_audit" };
+        ContentBlockDelta { index = 2; delta = InputJsonDelta "{\"b\":2}" };
+      ]
+  in
+  check bool "no protocol error across message boundary" false
+    (has_stream_protocol_error events);
+  let tool_starts =
+    List.filter_map
+      (function
+        | Keeper_chat_events.Tool_call_start { tool_call_id; _ } -> Some tool_call_id
+        | _ -> None)
+      events
+  in
+  check (list string) "both messages start their tool cleanly"
+    [ "call_first"; "call_second" ] tool_starts;
+  let tool_ends =
+    List.filter_map
+      (function
+        | Keeper_chat_events.Tool_call_end { tool_call_id } -> Some tool_call_id
+        | _ -> None)
+      events
+  in
+  check bool "message-1 tool closed at MessageStop" true
+    (List.mem "call_first" tool_ends);
+  let second_args =
+    List.filter_map
+      (function
+        | Keeper_chat_events.Tool_call_args { tool_call_id = "call_second"; delta } ->
+            Some delta
+        | _ -> None)
+      events
+  in
+  check (list string) "message-2 args routed to its own fresh block"
+    [ "{\"b\":2}" ] second_args
+
 let test_keeper_stream_bridge_surfaces_oas_message_metadata () =
   let open Agent_sdk.Types in
   let usage_start =
@@ -2034,6 +2094,8 @@ let () =
             test_keeper_stream_bridge_rejects_replayed_tool_name_drift;
           test_case "stream bridge rejects conflicting tool index reuse" `Quick
             test_keeper_stream_bridge_rejects_conflicting_tool_index_reuse;
+          test_case "stream bridge isolates tool blocks across messages" `Quick
+            test_keeper_stream_bridge_isolates_tool_blocks_across_messages;
           test_case "stream bridge surfaces OAS message metadata" `Quick
             test_keeper_stream_bridge_surfaces_oas_message_metadata;
           test_case "stream bridge preserves typed media source" `Quick


### PR DESCRIPTION
## 문제

대시보드 keeper 채팅(`ollama_cloud.deepseek-v4-flash`)에서 스트리밍 중 빨간 글씨가 쏟아지는 현상:
```
tool_args_without_start | index=N | tool_call_id=call_xxxx | tool argument event arrived after invalid tool block start
```

## 근본 원인

keeper dispatch 한 건(`masc_keeper_msg`)은 multi-turn tool loop이며 **여러 번의 OAS provider 호출**을 포함합니다. 각 OAS 호출은 별도 SSE 스트림이라 content-block index가 **0부터 재시작**합니다. 그런데 `consume_worker_events`는 dispatch 전체에 걸쳐 `bridge_state` 하나를 threading하고, OpenAI 호환 스트림은 wire에 `content_block_stop`이 없습니다.

결과: turn 1의 `Active_tool` 블록이 제거되지 않은 채 남아, turn 2가 같은 재사용 index에 다른 tool로 `ContentBlockStart` → duplicate index → `Invalid_tool_block` → 이후 args delta가 `tool_args_without_start`(직전 turn의 tool_call_id 포함)로 표면화. 최종 메시지는 별도 파싱이라 "전체가 다 오면 올바르게 표시"되는 것과 일치.

raw wire 재현으로 단일 응답 내 결함이 아님을 확인했습니다(id+name+args가 한 청크에 정상 도착).

## 변경

block index는 **하나의 provider message 범위**입니다. `MessageStop`(각 OAS 호출 종료, `[DONE]`에서 확실히 방출)에서 per-message block table을 비우고, 그 시점에 아직 열린 tool 블록은 silent drop 대신 `Tool_call_end`로 닫습니다. within-message duplicate 감지는 변경 없음(그 starts 사이엔 MessageStop이 없음).

생산자 측 짝(OAS가 `ContentBlockStop`을 합성)은 별도 PR: jeong-sik/oas#2356. 그쪽이 머지되면 정상 경로에선 MessageStop 시점에 이미 블록이 닫혀 이 reset은 안전망으로 동작합니다. 두 수정은 독립적으로 증상을 해소합니다.

## 검증

`test/test_gate_keeper_backend.ml`: 87개 통과.
- 신규 `stream bridge isolates tool blocks across messages` — cross-message 재사용 index가 충돌 없이 각자 fresh 블록으로 시작, message-1 tool은 MessageStop에서 닫힘.
- 기존 `stream bridge rejects conflicting tool index reuse`(within-message duplicate) 여전히 fail-closed — 정상 가드 유지.

dashboard `keeper-stream.ts`는 `KEEPER_STREAM_PROTOCOL_ERROR`를 표시만 하는 순수 소비자라 변경 불필요(OCaml에서 에러가 더 이상 생성되지 않으면 자동 해소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
