### PR TITLE
fix(keeper-wip): exempt repoless tasks from per-repo cap (fleet collapse)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -243,9 +243,6 @@ let no_eligible_blocker_summary
     blocked_count
 ;;
 
-let wip_admission_default_repo config =
-  Keeper_alerting_path.project_root_of_config config |> Filename.basename
-;;
 
 let wip_admission_kind = "claim_wip_admission"
 
@@ -503,7 +500,6 @@ let handle_keeper_task_tool
     let claim_goal_scope =
       Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
     in
-    let wip_default_repo = wip_admission_default_repo config in
     let wip_rejections = ref [] in
     let task_goal_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let remember_wip_rejection task_id rejection =
@@ -512,13 +508,10 @@ let handle_keeper_task_tool
     in
     let wip_admission_filter ~active_tasks task =
       let active_items =
-        Keeper_wip_admission.active_items_of_tasks
-          ~task_goal_index
-          ~default_repo:wip_default_repo
-          active_tasks
+        Keeper_wip_admission.active_items_of_tasks ~task_goal_index active_tasks
       in
       let scope =
-        Keeper_wip_admission.scope_of_task ~task_goal_index ~default_repo:wip_default_repo task
+        Keeper_wip_admission.scope_of_task ~task_goal_index task
       in
       match Keeper_wip_admission.decide active_items ~scope with
       | Keeper_wip_admission.Admit _ -> true

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -50,20 +50,28 @@ let title_category title =
   if stop <= 0 then Other "other" else String.sub normalized 0 stop |> category_of_string
 
 type scope = {
-  repo : string;
+  repo : string option;
   goal_id : string option;
   category : category;
 }
 
-let task_repo ~default_repo (task : Masc_domain.task) =
-  ignore task;
-  default_repo
+(* The task model carries no repo attribution (see [Masc_domain.task]); its only
+   repo-ish field is [files], a heuristic path list we deliberately do not parse.
+   A repoless task resolves to [None] and — exactly like a goalless task under the
+   per-goal cap (RFC-0245, see [decide]) — is exempt from the per-repo cap,
+   bounded only by the global/category caps. The per-repo cap stays live for any
+   task that DOES resolve to a repo ([Some]), so the mechanism is preserved for
+   when the task model carries one. Returning a single fallback repo here instead
+   collapsed every fleet task into one [repo:<basename>] bucket, turning
+   [max_per_repo] into a fleet-wide cap tighter than [max_global] — every keeper
+   blocked once 6 tasks were active anywhere in the fleet. *)
+let task_repo (_task : Masc_domain.task) : string option = None
 
-let scope_of_task ?(task_goal_index = Hashtbl.create 0) ~default_repo (task : Masc_domain.task) =
+let scope_of_task ?(task_goal_index = Hashtbl.create 0) (task : Masc_domain.task) =
   let goal_id =
     try Some (List.hd (Hashtbl.find task_goal_index task.id)) with Not_found -> None
   in
-  { repo = task_repo ~default_repo task
+  { repo = task_repo task
   ; goal_id
   ; category = title_category task.title
   }
@@ -96,13 +104,13 @@ let task_is_active_wip (task : Masc_domain.task) =
   | Masc_domain.Done _
   | Masc_domain.Cancelled _ -> false
 
-let active_item_of_task ?task_goal_index ~default_repo (task : Masc_domain.task) =
-  { id = task.id; scope = scope_of_task ?task_goal_index ~default_repo task }
+let active_item_of_task ?task_goal_index (task : Masc_domain.task) =
+  { id = task.id; scope = scope_of_task ?task_goal_index task }
 
-let active_items_of_tasks ?task_goal_index ~default_repo tasks =
+let active_items_of_tasks ?task_goal_index tasks =
   tasks
   |> List.filter task_is_active_wip
-  |> List.map (active_item_of_task ?task_goal_index ~default_repo)
+  |> List.map (active_item_of_task ?task_goal_index)
 
 type reject_reason =
   | Global_cap
@@ -142,6 +150,12 @@ let same_goal a b =
   | None, None -> true
   | _ -> false
 
+let same_repo a b =
+  match a, b with
+  | Some a, Some b -> same_string a b
+  | None, None -> true
+  | _ -> false
+
 let same_category a b =
   String.equal (category_to_string a) (category_to_string b)
 
@@ -150,8 +164,9 @@ let count_matching predicate active =
 
 let global_key = "global"
 
-let repo_key repo =
-  Printf.sprintf "repo:%s" (normalize repo)
+let repo_key = function
+  | Some repo -> Printf.sprintf "repo:%s" (normalize repo)
+  | None -> "repo:<none>"
 
 let goal_key = function
   | Some goal_id -> Printf.sprintf "goal:%s" (normalize goal_id)
@@ -163,7 +178,7 @@ let category_key category =
 let active_counts ~scope active =
   [ global_key, List.length active
   ; ( repo_key scope.repo,
-      count_matching (fun item -> same_string item.scope.repo scope.repo) active )
+      count_matching (fun item -> same_repo item.scope.repo scope.repo) active )
   ; ( goal_key scope.goal_id,
       count_matching
         (fun item -> same_goal item.scope.goal_id scope.goal_id)
@@ -185,7 +200,7 @@ let first_rejection checks =
 let decide ?(caps = default_caps) active ~scope =
   let global_count = List.length active in
   let repo_count =
-    count_matching (fun item -> same_string item.scope.repo scope.repo) active
+    count_matching (fun item -> same_repo item.scope.repo scope.repo) active
   in
   let goal_count =
     count_matching
@@ -211,10 +226,21 @@ let decide ?(caps = default_caps) active ~scope =
         caps.max_per_goal
     | None -> None
   in
+  (* Mirror the per-goal exemption above: a task with no resolved repo
+     ([repo:<none>]) shares no repo scope with any other, so it cannot collide.
+     Applying [max_per_repo] to the [None] bucket lumps every repoless task into
+     one fleet-wide cap — the collapse this module previously suffered. Exempt
+     [None]; the global/category caps still bound repoless WIP. *)
+  let repo_cap_check =
+    match scope.repo with
+    | Some _ ->
+      reject_if_at_cap Repo_cap (repo_key scope.repo) repo_count caps.max_per_repo
+    | None -> None
+  in
   match
     first_rejection
       [ reject_if_at_cap Global_cap global_key global_count caps.max_global
-      ; reject_if_at_cap Repo_cap (repo_key scope.repo) repo_count caps.max_per_repo
+      ; repo_cap_check
       ; goal_cap_check
       ; reject_if_at_cap Category_cap
           (category_key scope.category)

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -15,13 +15,13 @@ val category_of_string : string -> category
 val title_category : string -> category
 
 type scope = {
-  repo : string;
+  repo : string option;
   goal_id : string option;
   category : category;
 }
 
 val scope_of_task :
-  ?task_goal_index:(string, string list) Hashtbl.t -> default_repo:string -> Masc_domain.task -> scope
+  ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> scope
 
 type caps = {
   max_global : int option;
@@ -39,9 +39,9 @@ type active_item = {
 
 val task_is_active_wip : Masc_domain.task -> bool
 val active_item_of_task :
-  ?task_goal_index:(string, string list) Hashtbl.t -> default_repo:string -> Masc_domain.task -> active_item
+  ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> active_item
 val active_items_of_tasks :
-  ?task_goal_index:(string, string list) Hashtbl.t -> default_repo:string -> Masc_domain.task list -> active_item list
+  ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task list -> active_item list
 
 type reject_reason =
   | Global_cap

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -4,8 +4,11 @@ module Admission = Masc.Keeper_wip_admission
 module Task_runtime = Masc.Keeper_tool_task_runtime
 module U = Yojson.Safe.Util
 
+(* Cap-mechanism tests pass a concrete repo string; wrap it as [Some] so the
+   per-repo cap is exercised. [task_repo] resolves real tasks to [None] (no repo
+   attribution in the task model), covered separately below. *)
 let scope ?goal_id ?(category = Admission.Fix) repo =
-  { Admission.repo; goal_id; category }
+  { Admission.repo = Some repo; goal_id; category }
 
 let item ?goal_id ?(category = Admission.Fix) repo id =
   { Admission.id; scope = scope ?goal_id ~category repo }
@@ -111,20 +114,42 @@ let test_decision_json_rejects_with_scope_key () =
   check string "scope key" "global"
     Yojson.Safe.Util.(json |> member "scope_key" |> to_string)
 
-let test_scope_of_task_uses_repo_goal_and_title_category () =
+let test_scope_of_task_has_no_repo_uses_goal_and_title_category () =
   let task_goal_index = Hashtbl.create 1 in
   Hashtbl.replace task_goal_index "task-001" ["goal-a"];
   let scope =
     Admission.scope_of_task
       ~task_goal_index
-      ~default_repo:"fallback"
       (task
          ~title:"refactor(keeper): split claim gate"
          "task-001")
   in
-  check string "repo" "fallback" scope.repo;
+  (* The task model carries no repo, so the scope resolves to [None] — exempt
+     from the per-repo cap rather than collapsed into a fleet-wide bucket. *)
+  check (option string) "repo" None scope.repo;
   check (option string) "goal" (Some "goal-a") scope.goal_id;
   check string "category" "refactor" (Admission.category_to_string scope.category)
+
+let test_repoless_tasks_exempt_from_repo_cap () =
+  (* Regression guard for the WIP-cap collapse: many repoless ([None]) tasks must
+     NOT share a single fleet-wide repo bucket. With [max_per_repo = Some 2] and
+     three already-active repoless items, a fourth repoless task still admits
+     (only the global cap bounds it). Before the fix, [task_repo] returned a
+     shared fallback string, so this rejected with repo_cap once 2 were active. *)
+  let active =
+    [ { Admission.id = "one"; scope = { Admission.repo = None; goal_id = None; category = Admission.Fix } }
+    ; { Admission.id = "two"; scope = { Admission.repo = None; goal_id = None; category = Admission.Docs } }
+    ; { Admission.id = "three"; scope = { Admission.repo = None; goal_id = None; category = Admission.Chore } }
+    ]
+  in
+  let repoless_scope = { Admission.repo = None; goal_id = None; category = Admission.Ci } in
+  match Admission.decide ~caps active ~scope:repoless_scope with
+  | Admission.Admit { active_count_after_admit } ->
+    check int "active after admit" 4 active_count_after_admit
+  | Reject rejection ->
+    fail
+      (Printf.sprintf "repoless task should be exempt from repo cap, got %s"
+         (Admission.reject_reason_to_string rejection.reason))
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_wip_admission_" "" in
@@ -269,7 +294,7 @@ let test_active_items_only_include_claimed_or_in_progress () =
     ; task ~title:"fix: still todo" "task-003"
     ]
   in
-  let active = Admission.active_items_of_tasks ~default_repo:"fallback" tasks in
+  let active = Admission.active_items_of_tasks tasks in
   check (list string) "active ids" [ "task-001"; "task-002" ]
     (List.map (fun item -> item.Admission.id) active);
   check (list string) "categories" [ "fix"; "docs" ]
@@ -295,7 +320,7 @@ let test_active_items_include_all_active_assignees () =
         "task-progress-b"
     ]
   in
-  let active = Admission.active_items_of_tasks ~default_repo:"fallback" tasks in
+  let active = Admission.active_items_of_tasks tasks in
   check (list string) "all active ids"
     [ "task-claimed-a"; "task-progress-a"; "task-claimed-b"; "task-progress-b" ]
     (List.map (fun item -> item.Admission.id) active)
@@ -362,8 +387,10 @@ let () =
             test_active_counts_surface_all_axes
         ; test_case "decision JSON rejects with scope key" `Quick
             test_decision_json_rejects_with_scope_key
-        ; test_case "task scope uses repo goal and title category" `Quick
-            test_scope_of_task_uses_repo_goal_and_title_category
+        ; test_case "task scope has no repo, uses goal and title category" `Quick
+            test_scope_of_task_has_no_repo_uses_goal_and_title_category
+        ; test_case "repoless tasks exempt from repo cap" `Quick
+            test_repoless_tasks_exempt_from_repo_cap
         ; test_case "keeper_task_claim reports other keepers WIP cap" `Quick
             test_keeper_task_claim_reports_other_keepers_wip_cap
         ; test_case "keeper_task_claim no-unclaimed emits no-work outcome" `Quick


### PR DESCRIPTION
## 문제

BASE keeper가 14시간+ idle에 빠진 근본 원인 중 claim 차단 축. `keeper_wip_admission.ml`의 `task_repo`가 task를 무시하고 `default_repo`(= 프로젝트 루트 basename)를 반환합니다. 모든 keeper가 하나의 `.masc` 워크스페이스를 공유하므로 `default_repo`는 fleet 전체에서 동일 문자열입니다.

결과: **모든 task가 단일 `repo:<basename>` 버킷으로 붕괴** → `max_per_repo=6`이 `max_global=16`보다 빡빡한 fleet 전체 cap=6이 됨. fleet 어디서든 6개가 active면 모든 keeper의 claim이 `repo_cap 6/6`으로 하드 리젝. (라이브 증상: BASE의 task-1581 = "scheduler hint says claimable but repo_cap=6/6 blocks all claims".)

## 변경

per-goal cap의 선례(RFC-0245, 이미 이 파일에 존재)를 그대로 미러링:
- `scope.repo`를 `string option`으로
- `task_repo`는 repoless task를 `None`으로 resolve (task 모델은 repo를 운반하지 않음 — `Masc_domain.task`엔 휴리스틱 `files` 리스트뿐이라 파싱하지 않음)
- `decide`에서 `None`은 per-repo cap에서 **면제** (충돌할 repo scope가 없음). global/category cap은 그대로 적용.
- per-repo cap 메커니즘은 `Some` repo에 대해 그대로 살아있음 → task 모델이 repo를 운반하게 되면 즉시 동작
- vestigial해진 `default_repo` plumbing 제거

## 왜 워크어라운드가 아닌가

증상 억제(cap/cooldown/dedup)가 아니라 **붕괴를 일으킨 추상화 결함**을 고칩니다. `task_repo` stub(`ignore task; default_repo`)이 모든 task를 한 string으로 압축한 것이 root이고, 이를 typed `option` + 선례 일관 면제로 교정합니다.

## 검증

`test/test_keeper_wip_admission.ml`: 15개 통과.
- `rejects repo cap before goal cap` (Some repo) — cap 메커니즘 보존 확인
- `repoless tasks exempt from repo cap` (신규) — 붕괴 회귀 가드
- `task scope has no repo` — `scope_of_task`가 repo=None resolve

## 남은 축 (이 PR 범위 밖)

셀프루프는 다축입니다. 이 PR은 claim 차단 축만 해소합니다. 나머지(Memory OS staleness = 검증 없이 낡은 사실 재인용, scheduler-hint cap-blindness = wip_rejection 피드백 부재)는 별도 추적/PR 대상입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
