### PR TITLE
chore(oas): refresh API surface fingerprint

### DIFF
--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "cbaafd683ae3416a1d3d8ec1c808301d2c7829e3",
-  "pinned_version": "v0.208.3",
+  "pinned_sha": "8d9a62020b2e745f9983796290650265be28785d",
+  "pinned_version": "v0.208.5",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## Summary

Follow-up from the #22662/current-main recheck. #22662 itself is already merged and has no remaining PR-specific thread or stale p1 label, but current main later drifted after the OAS 0.208.5 pin bump.

- Refresh `scripts/oas-api-surface.json` metadata from `scripts/oas-agent-sdk-pin.sh`.
- Align fingerprint metadata with `agent_sdk 0.208.5` / `8d9a62020b2e745f9983796290650265be28785d`.
- Leave surface arrays unchanged; this is metadata drift only, with no MASC consumer code change.

## Boundary

This does not reopen #22662 source blockers. It closes the later current-main OAS fingerprint drift introduced after the pin advanced beyond the `v0.208.3` fingerprint metadata.

## Verification

- PASS: `bash scripts/oas-drift-check.sh`
- PASS: `bash scripts/sync-oas-pin-manifests.sh --check`
- PASS: `git diff --check`
- NOTE: `bash scripts/check-oas-pin.sh --local-only` reports a local opam switch pin-source mismatch on this machine (`#v0.208.5` vs expected SHA). Repository manifests pass; I did not mutate the shared local opam switch.

[근거] `gh pr view 22662 --repo jeong-sik/masc --json state,mergedAt,mergeCommit,labels`, GraphQL `reviewThreads(first:100)`, `bash scripts/oas-drift-check.sh`, `bash scripts/oas-drift-check.sh --regenerate`, `bash scripts/sync-oas-pin-manifests.sh --check`, `git diff --check`; checked 2026-06-30 21:14-21:25 KST, confidence High.