### PR TITLE
fix(test): repair main-red test build after OAS 0.208.5 adoption

### DIFF
--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -9,7 +9,9 @@ module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Runtime_resolution = Masc.Keeper_memory_runtime_resolution
 module Memory_summary = Masc.Keeper_memory_llm_summary
 module Structured_schema = Masc.Keeper_structured_output_schema
-module Domain_pool_ref = Masc.Domain_pool_ref
+(* Domain_pool_ref lives in the unwrapped masc_core sublibrary (re_export'd by
+   masc_test_deps), so it is referenced bare — there is no Masc.Domain_pool_ref. *)
+module Domain_pool_ref = Domain_pool_ref
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
@@ -196,6 +198,7 @@ let message_text (message : Agent_sdk.Types.message) =
     | Agent_sdk.Types.Text text -> Some text
     | Agent_sdk.Types.Thinking _
     | Agent_sdk.Types.RedactedThinking _
+    | Agent_sdk.Types.ReasoningDetails _
     | Agent_sdk.Types.ToolUse _
     | Agent_sdk.Types.ToolResult _
     | Agent_sdk.Types.Image _

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -348,6 +348,7 @@ let text_blocks (messages : Agent_sdk.Types.message list) =
            | Agent_sdk.Types.Text text -> Some text
            | Agent_sdk.Types.Thinking _
            | Agent_sdk.Types.RedactedThinking _
+           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.ToolUse _
            | Agent_sdk.Types.ToolResult _
            | Agent_sdk.Types.Image _
@@ -369,6 +370,7 @@ let count_tool_blocks messages =
            | Agent_sdk.Types.Text _
            | Agent_sdk.Types.Thinking _
            | Agent_sdk.Types.RedactedThinking _
+           | Agent_sdk.Types.ReasoningDetails _
            | Agent_sdk.Types.Image _
            | Agent_sdk.Types.Document _
            | Agent_sdk.Types.Audio _ -> tool_uses, tool_results)


### PR DESCRIPTION
## 목적

main이 OAS 0.208.5 채택 직후 **테스트 2개 exe가 컴파일 실패(RED)**입니다. lib는 green이지만 `dune build`가 test에서 깨집니다.

## 원인

- `test_keeper_memory_os.ml`: **#22824**가 `Masc.Domain_pool_ref`를 참조 — `Domain_pool_ref`는 unwrapped `masc_core` 서브라이브러리(`masc_test_deps`가 `re_export`)에 있어 `Masc.*` 경로가 없음 → `Unbound module Masc.Domain_pool_ref`. + `message_text`의 콘텐츠블록 match가 0.208.5 신규 `ReasoningDetails`를 누락.
- `test_pbt_context_overflow.ml`: **#22827**이 lib surface는 채택했으나 테스트의 콘텐츠블록 fold 2곳에서 `ReasoningDetails` 누락 → warning 8 → `-warn-error`.

## 변경 (test-only)

- `test_keeper_memory_os.ml`: `Domain_pool_ref`를 bare 참조 + `message_text`에 `ReasoningDetails` 케이스(텍스트 아님 → None).
- `test_pbt_context_overflow.ml`: 두 fold에 `ReasoningDetails` 케이스(텍스트/툴 아님 → None / count 불변).

## 검증

agent_sdk 0.208.5에서 `test_keeper_memory_os` (125) + `test_pbt_context_overflow` (16) 통과. ocamlformat clean.

## 근본 (경계)

lib는 green인데 test는 red인 채 #22824/#22827이 머지됨 = pin/bump 경계 게이트(`check-oas-pin.sh`)가 **test 컴파일까지 검증하지 않는** 결함. 후속으로 게이트를 test build까지 fail-closed하게 강화하면 동류 회귀를 차단합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
