### PR TITLE
fix(dashboard): summarise undecodable trace rows once per file (WARN flood)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -44,21 +44,34 @@ let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string
   =
   let path = Keeper_types_support.keeper_internal_history_path config trace_id in
   (* Streaming filter: avoid materialising the full JSONL list when only a
-     subset of lines decode to [trajectory_line]. *)
-  Fs_compat.fold_jsonl_lines
-    ~init:[]
-    ~f:(fun acc ~line_no json ->
-       match
-         Server_dashboard_http_keeper_api_types
-         .internal_history_json_to_trajectory_line
-           json
-       with
-       | Some line -> line :: acc
-       | None ->
-         Log.Dashboard.warn "Skipped invalid internal history trace row (trace=%s, line=%d)" trace_id line_no;
-         acc)
-    path
-  |> List.rev
+     subset of lines decode to [trajectory_line].
+
+     Rows that do not decode to a thinking line (older content-block format,
+     non-assistant sources, or empty-text rows) are expected here. They are
+     summarised once per read rather than warned per row: the dashboard re-reads
+     each trace file on every poll, so a single undecodable file emitted one
+     WARN per skipped row per read — a busy trace produced ~16k warnings/day,
+     dominating the WARN log and drowning genuine warnings. The per-file summary
+     keeps the signal (skipped/total counts) without the per-row volume. *)
+  let lines_rev, skipped, total =
+    Fs_compat.fold_jsonl_lines
+      ~init:([], 0, 0)
+      ~f:(fun (acc, skipped, total) ~line_no:_ json ->
+         match
+           Server_dashboard_http_keeper_api_types
+           .internal_history_json_to_trajectory_line
+             json
+         with
+         | Some line -> (line :: acc, skipped, total + 1)
+         | None -> (acc, skipped + 1, total + 1))
+      path
+  in
+  if skipped > 0 then
+    Log.Dashboard.warn
+      "internal history trace %s: %d of %d rows did not decode to a thinking \
+       line (older content-block format or non-assistant rows)"
+      trace_id skipped total;
+  List.rev lines_rev
 ;;
 
 let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -117,6 +117,42 @@ let test_converter_rejects_flat_content () =
     (Option.is_none (Types.internal_history_json_to_trajectory_line json))
 ;;
 
+let test_skip_warns_once_per_file () =
+  (* Per-file summary: a trace file whose rows do not decode to thinking lines
+     must emit ONE summary WARN, not one per row. The dashboard re-reads each
+     trace on every poll, so the previous per-row WARN flooded the log (~16k/day
+     from a single busy trace, 84% of all warnings in one observed day). *)
+  with_temp_dir (fun dir ->
+    let config = Workspace.default_config dir in
+    let trace_file =
+      Keeper_types_support.keeper_internal_history_path config "summary_trace"
+    in
+    let trace_dir = Filename.dirname trace_file in
+    Unix.system (Printf.sprintf "mkdir -p '%s'" trace_dir) |> ignore;
+    let oc = open_out trace_file in
+    (* Four rows that do not decode to a thinking line (no ts field -> ts<=0). *)
+    Printf.fprintf
+      oc
+      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}]}\n\
+       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
+       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}]}\n\
+       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"D\"}]}\n";
+    close_out oc;
+    let warnings = ref [] in
+    Console_sink.For_testing.reset ();
+    Console_sink.For_testing.set_writer (Some (fun l -> warnings := l :: !warnings));
+    Fun.protect ~finally:Console_sink.For_testing.reset (fun () ->
+      let result = Trace.read_internal_history_lines ~config ~trace_id:"summary_trace" in
+      check int "all four undecodable rows skipped" 0 (List.length result));
+    let trace_warns =
+      List.filter
+        (fun l -> Astring.String.is_infix ~affix:"internal history trace" l)
+        !warnings
+    in
+    check int "one summary warn for the file, not one per skipped row" 1
+      (List.length trace_warns))
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -128,7 +164,9 @@ let () =
         ; test_case "preserves sub-microsecond precision" `Quick test_dedupe_precision
         ] )
     ; ( "read_internal_history_lines"
-      , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips ] )
+      , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips
+        ; test_case "summarises skips once per file" `Quick test_skip_warns_once_per_file
+        ] )
     ; ( "internal_history_json_to_trajectory_line"
       , [ test_case
             "decodes content_blocks rows"


### PR DESCRIPTION
## 목적

오늘 런타임 로그(`~/me/.masc/logs/system_log_2026-06-30.jsonl`, 68,139줄) 분석에서 **WARN의 84%(16,373건)가 단일 메시지** `"Skipped invalid internal history trace row"`였습니다 — 실제 경고(ERROR 800, minimax 런타임 실패 등)를 익사시키는 관측성 저하.

## 메커니즘

`server_dashboard_http_keeper_api_trace.ml`의 `read_internal_history_lines`가 keeper internal-history JSONL을 읽어 **row마다** thinking line으로 디코드 실패 시 WARN. 대시보드는 각 trace 파일을 **매 polling마다 재독** → 디코드 안 되는 파일 하나가 `row 수 × 재독 수`만큼 WARN. 관측 사례: 2개 파일 × 모든 row × ~21 read/일 = 16K.

## 변경 (`fix(dashboard)`)

- fold를 `(lines, skipped, total)`로 바꿔 **파일당 요약 WARN 1회**(`N of M rows did not decode to a thinking line`)로 대체. 반환되는 trajectory line은 **불변** — 경고 볼륨만 감소.
- "invalid" 표현 제거: thinking line으로 디코드 안 되는 row는 **정상**(older content-block 포맷 / 비-assistant source)이지 malformed가 아님.
- `content_blocks_of_json`(메시지 round-trip 공유, all-or-nothing) **미변경** — 리스크 회피.

## 범위 / 정직한 framing

- 관측된 16K 버스트는 **00–02 UTC(이전 서버 인스턴스)**에 발생, 이후 9시간+ 0건. 현재 서버는 **current-format decode fix(#22533, 06-28)**를 가져 current row를 정상 디코드 → skip 없음. 즉 **라이브 flood가 아니라 과거 버스트**.
- 이 PR은 그 **per-row·per-read 경고 메커니즘을 하드닝**(재발 시 파일당 1회로 캡) + 오표기 정정. 어떤 row가 디코드되는지는 안 바꿈.
- old-format 파일이 디코드 안 되는 데이터-가시성 이슈는 별도(OAS content-block cross-version 호환 / 포맷 마이그레이션) — lenient fallback은 CLAUDE.md 안티패턴이라 의도적으로 회피.

## 검증

`test_server_dashboard_http_keeper_api_trace` 6 케이스 통과 — 신규 `summarises skips once per file`: undecodable 4 row → 0 thinking line + **WARN 정확히 1회**(`Console_sink.For_testing` 캡처). ocamlformat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
