### PR TITLE
fix(runtime): emit deprecated-capability notice once per process (WARN flood)

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -189,16 +189,30 @@ let parse_credential (tbl : Otoml.t) (path : string)
      | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t)))
 ;;
 
+(* Deprecation notices fire once per process per [path.capabilities.key], not
+   once per parse. runtime.toml is re-parsed on every keeper boot, so a per-parse
+   warning flooded the WARN log — one observed day carried ~315 of these (25% of
+   the live WARN volume) from a handful of deprecated capability keys across
+   providers, drowning genuine warnings. The notice still surfaces once so an
+   operator can remove the ignored field; only the per-parse repetition is
+   dropped, so no signal is lost. Best-effort (no lock): config parsing runs on
+   the main domain, and a racing double-notice would be harmless anyway. *)
+let deprecation_notice_seen : (string, unit) Hashtbl.t = Hashtbl.create 16
+
 let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabilities =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
   let warn_deprecated key =
     match Otoml.find_opt tbl Fun.id [ key ] with
     | None -> ()
     | Some _ ->
-      Log.Runtime.warn
-        "runtime_toml: %s.capabilities.%s is deprecated and ignored; runtime-MCP capability is resolved from OAS provider bindings"
-        path
-        key
+      let notice_key = path ^ ".capabilities." ^ key in
+      if not (Hashtbl.mem deprecation_notice_seen notice_key)
+      then (
+        Hashtbl.replace deprecation_notice_seen notice_key ();
+        Log.Runtime.warn
+          "runtime_toml: %s.capabilities.%s is deprecated and ignored; runtime-MCP capability is resolved from OAS provider bindings"
+          path
+          key)
   in
   let string_list_field key =
     match Otoml.find_opt tbl Fun.id [ key ] with

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -195,9 +195,9 @@ let parse_credential (tbl : Otoml.t) (path : string)
    the live WARN volume) from a handful of deprecated capability keys across
    providers, drowning genuine warnings. The notice still surfaces once so an
    operator can remove the ignored field; only the per-parse repetition is
-   dropped, so no signal is lost. Best-effort (no lock): config parsing runs on
-   the main domain, and a racing double-notice would be harmless anyway. *)
+   dropped, so no signal is lost. *)
 let deprecation_notice_seen : (string, unit) Hashtbl.t = Hashtbl.create 16
+let deprecation_notice_seen_mu = Stdlib.Mutex.create ()
 
 let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabilities =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
@@ -206,13 +206,20 @@ let parse_capabilities ~(path : string) (tbl : Otoml.t) : Runtime_schema.capabil
     | None -> ()
     | Some _ ->
       let notice_key = path ^ ".capabilities." ^ key in
-      if not (Hashtbl.mem deprecation_notice_seen notice_key)
-      then (
-        Hashtbl.replace deprecation_notice_seen notice_key ();
+      let should_warn =
+        Stdlib.Mutex.protect deprecation_notice_seen_mu (fun () ->
+          if Hashtbl.mem deprecation_notice_seen notice_key
+          then false
+          else (
+            Hashtbl.replace deprecation_notice_seen notice_key ();
+            true))
+      in
+      if should_warn
+      then
         Log.Runtime.warn
           "runtime_toml: %s.capabilities.%s is deprecated and ignored; runtime-MCP capability is resolved from OAS provider bindings"
           path
-          key)
+          key
   in
   let string_list_field key =
     match Otoml.find_opt tbl Fun.id [ key ] with

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1264,6 +1264,48 @@ let test_save_config_text_refreshes_cross_verifier_runtime () =
         (Some "local.libr")
         (Runtime.cross_verifier_runtime_id ()))
 
+let test_deprecated_capability_notice_warns_once_per_process () =
+  (* runtime.toml is re-parsed on every keeper boot; a per-parse deprecation
+     warning flooded the WARN log (~315/day, 25% of live WARN volume). The
+     notice must fire once per process per capability key, not once per parse.
+     [dedupcheck] is a unique provider id so the process-level dedup table is
+     not pre-populated by another test. The deprecated key sits under
+     [providers.<id>.capabilities] because that is where parse_capabilities (the
+     emitter) runs. *)
+  let content =
+    "[providers.dedupcheck]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [providers.dedupcheck.capabilities]\n\
+     supports-runtime-mcp-tools = true\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [dedupcheck.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"dedupcheck.sample\"\n"
+  in
+  let warns = ref [] in
+  Console_sink.For_testing.reset ();
+  Console_sink.For_testing.set_writer (Some (fun l -> warns := l :: !warns));
+  Fun.protect ~finally:Console_sink.For_testing.reset (fun () ->
+    (* Parse twice; the deprecated key is present both times. *)
+    ignore (Runtime_toml.parse_string content);
+    ignore (Runtime_toml.parse_string content));
+  let dep_warns =
+    List.filter
+      (fun l ->
+        String_util.contains_substring l "dedupcheck"
+        && String_util.contains_substring l "is deprecated")
+      !warns
+  in
+  check int "deprecation notice fires once per process across two parses" 1
+    (List.length dep_warns)
+
 let () =
   run "runtime_config_validity"
     [ ( "runtime TOML gate",
@@ -1314,5 +1356,8 @@ let () =
           test_case "non-positive max-concurrent is rejected" `Quick
             test_runtime_toml_rejects_non_positive_max_concurrent;
           test_case "max-concurrent flows from binding to runtime candidate" `Quick
-            test_runtime_toml_max_concurrent_flows_to_candidate ] )
+            test_runtime_toml_max_concurrent_flows_to_candidate;
+          test_case
+            "deprecated capability notice warns once per process, not per parse"
+            `Quick test_deprecated_capability_notice_warns_once_per_process ] )
     ]


### PR DESCRIPTION
## 목적

런타임 로그 분석(`system_log_2026-06-30.jsonl`)에서 live WARN의 **~25%(약 315건)가 `runtime_toml: providers.*.capabilities.supports-runtime-mcp-tools is deprecated and ignored`** 한 줄이었습니다 — 실제 경고를 익사시키는 관측성 저하.

## 메커니즘

`parse_capabilities`의 `warn_deprecated`가 provider의 deprecated capability key를 **parse마다** 경고. runtime.toml은 keeper boot마다 재파싱되므로 `deprecated key 수 × provider 수 × 재파싱 수`만큼 누적.

## 변경 (`fix(runtime)`)

- deprecation 통지를 **process당 1회**(`"<path>.capabilities.<key>"` seen-set)로 가드. 통지는 유지(operator가 ignored 필드를 제거할 수 있게) — per-parse 반복만 제거. 파싱 결과 불변, 로깅 볼륨만 감소.
- best-effort(락 없음): config 파싱은 main 도메인, 경쟁적 중복 통지는 무해.

## 검증

신규 테스트 `deprecated capability notice warns once per process, not per parse`: deprecated provider capability key를 가진 config를 2회 파싱 → 통지 **정확히 1회**(`Console_sink.For_testing` 캡처). 빌드 green.

## 비고 (투명성)

이 브랜치의 로컬 `test_runtime_config_validity` 실행에서 무관한 3개 케이스(#3/#5/#15, repo OAS catalog/runtime.toml capability 해소)가 실패하는데, 이는 **로컬 opam 스위치가 agent_sdk 0.208.5인 반면 repo가 0.208.7을 pin**(minimax-m3 supports-structured-output 정렬은 0.208.7 기준)하기 때문입니다. 이 로깅 변경과 무관하며, pin 버전(CI)에선 영향 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
