### PR TITLE
docs(readme): Quick Start (5-min) + masc start subcommand + .env.local source

### DIFF
--- a/Formula/masc.rb
+++ b/Formula/masc.rb
@@ -1,0 +1,44 @@
+# Homebrew formula for masc.
+#
+# Two install paths both work:
+#   brew tap jeong-sik/masc && brew install masc            # this repo as the tap
+#   brew install jeong-sik/masc/masc                        # one-liner
+#
+# On each release, bump `version` and the per-arch url/sha256 below. masc does
+# not publish a SHA256SUMS file, so compute each (download first, then hash):
+#   curl -fsSL -o /tmp/masc-macos-arm64 <url> && shasum -a 256 /tmp/masc-macos-arm64
+class Masc < Formula
+  desc "MASC MCP Server: multi-agent streaming coordination"
+  homepage "https://github.com/jeong-sik/masc"
+  license "MIT"
+  version "v0.19.51"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/jeong-sik/masc/releases/download/v0.19.51/masc-macos-arm64"
+      sha256 "fb2e6cf37917b1fd3a54ff25b40c0801f4689e393a938d1a124dc61d8509c05b"
+    end
+    on_intel do
+      odie "masc macOS x86_64 release asset is not built. Build from source per README."
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/jeong-sik/masc/releases/download/v0.19.51/masc-linux-x64"
+      sha256 "731afe9657a11a8b500135bda2f6213499128b53751b8d2a0e435b3c182f57e8"
+    end
+    on_arm do
+      odie "masc Linux arm64 release asset is not built yet."
+    end
+  end
+
+  # The downloaded resource is the bare platform binary (no archive to uncompress).
+  def install
+    bin.install File.basename(stable.url) => "masc"
+  end
+
+  test do
+    assert_match "MASC", shell_output("#{bin}/masc --version 2>&1", 1)
+  end
+end

--- a/README.ko.md
+++ b/README.ko.md
@@ -76,6 +76,41 @@
 
 ---
 
+## 빠른 시작 (5분) / Quick Start
+
+```bash
+# 1. 바이너리 설치 (macOS arm64 / Linux x86_64)
+curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
+#   소스 빌드: git clone https://github.com/jeong-sik/masc.git && cd masc &&
+#     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
+#     scripts/dune-local.sh build @default
+
+# 2. 설정 시드 + provider 키 입력
+masc init
+#   .masc/config/.env.local 편집:
+#     export OLLAMA_CLOUD_API_KEY=...     # 아래 표에서 하나 선택
+
+# 3. 키 적용 + 시작
+source .masc/config/.env.local && masc start
+curl http://127.0.0.1:8935/health        # → 200 OK
+
+# 4. (선택) 대시보드
+cd dashboard && pnpm install && pnpm dev
+```
+
+Provider 키 (사용할 것을 `.masc/config/.env.local`에):
+
+| `runtime.toml` provider | 환경 변수 |
+|---|---|
+| `ollama_cloud` | `OLLAMA_CLOUD_API_KEY` |
+| `deepseek` | `DEEPSEEK_API_KEY` |
+| `glm-coding` | `ZAI_API_KEY_SB` |
+| `ollama` (로컬) | — (키 불필요) |
+
+> `masc init`이 `.masc/config/runtime.toml`을 시드합니다(`[runtime].default` 포함). 서버가 `refusing to boot`를 로그하면 워크스페이스에서 먼저 `masc init`을 실행하세요. `masc start`는 subcommand 없이 `masc`를 실행한 것과 동일(가이드용 명시적 이름).
+
+---
+
 ## 설치 / Install
 
 ### 바이너리 (prebuilt)

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,7 +80,8 @@
 
 ```bash
 # 1. 바이너리 설치 (macOS arm64 / Linux x86_64)
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
+brew install jeong-sik/masc/masc            # Homebrew (이 repo의 Formula/masc.rb)
+#   또는:  curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
 #   소스 빌드: git clone https://github.com/jeong-sik/masc.git && cd masc &&
 #     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
 #     scripts/dune-local.sh build @default

--- a/README.md
+++ b/README.md
@@ -83,6 +83,41 @@ Legend — ✅ working now · 🟡 partially working · ❌ not working. Status 
 
 ---
 
+## Quick Start (5 minutes)
+
+```bash
+# 1. Install the binary (macOS arm64 / Linux x86_64)
+curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
+#   from source: git clone https://github.com/jeong-sik/masc.git && cd masc &&
+#     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
+#     scripts/dune-local.sh build @default
+
+# 2. Seed config, then set your provider key
+masc init
+#   edit .masc/config/.env.local:
+#     export OLLAMA_CLOUD_API_KEY=...     # one provider, see table below
+
+# 3. Load your key + start
+source .masc/config/.env.local && masc start
+curl http://127.0.0.1:8935/health        # → 200 OK
+
+# 4. (optional) Dashboard
+cd dashboard && pnpm install && pnpm dev
+```
+
+Provider keys (put the one you use in `.masc/config/.env.local`):
+
+| Provider in `runtime.toml` | Environment variable |
+|---|---|
+| `ollama_cloud` | `OLLAMA_CLOUD_API_KEY` |
+| `deepseek` | `DEEPSEEK_API_KEY` |
+| `glm-coding` | `ZAI_API_KEY_SB` |
+| `ollama` (local) | — (no key) |
+
+> `masc init` seeds `.masc/config/runtime.toml`, which already sets `[runtime].default`. If the server logs `refusing to boot`, run `masc init` in your workspace first. `masc start` is the same as running `masc` with no subcommand (kept as an explicit name for tutorials).
+
+---
+
 ## Install
 
 ### Prebuilt binary

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Legend — ✅ working now · 🟡 partially working · ❌ not working. Status 
 
 ```bash
 # 1. Install the binary (macOS arm64 / Linux x86_64)
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
+brew install jeong-sik/masc/masc            # Homebrew (Formula/masc.rb in this repo)
+#   or:  curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
 #   from source: git clone https://github.com/jeong-sik/masc.git && cd masc &&
 #     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
 #     scripts/dune-local.sh build @default

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -854,6 +854,14 @@ let login_cmd =
       $ login_role $ login_client_env $ login_no_expiry $ login_json
       $ login_shell)
 
+let start_cmd =
+  let doc =
+    "Start the MASC MCP server (HTTP/SSE). Same as running `masc` with no \
+     subcommand; exposed as an explicit name for quick-start guides."
+  in
+  let info = Cmd.info "start" ~doc in
+  Cmd.v info Term.(const run_cmd_exit $ host $ port $ run_base_path)
+
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in
   Arg.(value & flag & info ["force"] ~doc)
@@ -977,7 +985,7 @@ let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc" ~version:Masc.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ run_base_path)
-    info [ init_cmd; login_cmd; memory_os_gc_dry_run_cmd ]
+    info [ init_cmd; start_cmd; login_cmd; memory_os_gc_dry_run_cmd ]
 
 let () =
   setup_gc ();

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -24,6 +24,16 @@ if command -v opam >/dev/null 2>&1; then
     eval "$(opam env 2>/dev/null)" >/dev/null 2>/dev/null || true
 fi
 
+# Load provider credentials from .masc/config/.env.local if present, so the
+# one-shot `masc init` setup flows into start without manual exports. $PWD here
+# is the caller's workspace before we cd into SCRIPT_DIR below; --base-path is
+# honored by the binary's own bootstrap for non-default base paths.
+if [ -f "$PWD/.masc/config/.env.local" ]; then
+    set -a
+    . "$PWD/.masc/config/.env.local"
+    set +a
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -24,16 +24,6 @@ if command -v opam >/dev/null 2>&1; then
     eval "$(opam env 2>/dev/null)" >/dev/null 2>/dev/null || true
 fi
 
-# Load provider credentials from .masc/config/.env.local if present, so the
-# one-shot `masc init` setup flows into start without manual exports. $PWD here
-# is the caller's workspace before we cd into SCRIPT_DIR below; --base-path is
-# honored by the binary's own bootstrap for non-default base paths.
-if [ -f "$PWD/.masc/config/.env.local" ]; then
-    set -a
-    . "$PWD/.masc/config/.env.local"
-    set +a
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -474,6 +464,44 @@ restore_env_override() {
     fi
 }
 
+load_base_path_env_local() {
+    local base_path="$1"
+    local env_file="$base_path/.masc/config/.env.local"
+    if [ ! -f "$env_file" ]; then
+        return 0
+    fi
+
+    for env_name in \
+        MASC_KEEPER_BOOTSTRAP_ENABLED \
+        MASC_PORT \
+        MASC_HOST \
+        MASC_BASE_PATH \
+        MASC_SIDECAR_ROOT \
+        MASC_CONFIG_DIR \
+        MASC_PERSONAS_DIR \
+        MASC_WS_ENABLED \
+        MASC_WEBRTC_ENABLED
+    do
+        preserve_env_override "$env_name"
+    done
+
+    load_env_file "$env_file"
+
+    for env_name in \
+        MASC_KEEPER_BOOTSTRAP_ENABLED \
+        MASC_PORT \
+        MASC_HOST \
+        MASC_BASE_PATH \
+        MASC_SIDECAR_ROOT \
+        MASC_CONFIG_DIR \
+        MASC_PERSONAS_DIR \
+        MASC_WS_ENABLED \
+        MASC_WEBRTC_ENABLED
+    do
+        restore_env_override "$env_name"
+    done
+}
+
 REPO_ENV_ROOT="$(resolve_repo_env_root)"
 
 repo_local_config_dir_match() {
@@ -900,6 +928,11 @@ if [ -z "${MASC_CONFIG_DIR:-}" ]; then
 fi
 # Leave MASC_PERSONAS_DIR unset unless the caller explicitly overrides it.
 # The server-side config resolver will then use "$MASC_CONFIG_DIR/personas".
+
+# Load provider credentials from the active workspace after base-path resolution
+# and config bootstrap. This keeps --base-path/--path starts from importing
+# another workspace's .masc/config/.env.local via the caller's current directory.
+load_base_path_env_local "$RESOLVED_BASE_PATH"
 
 # Wait for port to become available.
 # Default behavior is fail-fast on conflict to prevent duplicate server startup.


### PR DESCRIPTION
## 목적
사용자 피드백: "masc README만 읽고도 바로 시작할 수 있을 정도로 친절한 Install/시작 메뉴얼. 지금은 너무 어렵고 따라하기 어렵다. Configuration 한 방에."

## 변경
- **`bin/main_eio.ml`**: `masc start` subcommand 추가 (기존 default run과 동일, 가이드용 명시적 이름). `Cmd.group`에 등록. flag-only 호출(`masc --base-path ...`)은 기존대로 동작(호환성 보존).
- **`README.md` + `README.ko.md`**: Quick Start (5분) 섹션을 Features 직후/Install 전에 삽입 — install → `masc init` → `source .env.local && masc start` → health check. provider/env key 표(ollama_cloud/deepseek/glm-coding/ollama) 추가.
- **`start-masc.sh`**: opam env 후 `.masc/config/.env.local`을 source — `masc init`으로 만든 credential이 수동 export 없이 적용.

## 배경 진단
- Quick Start 단일 경로 부재 (README이 참조형).
- provider credential(`[providers.*.credentials] key=...`)을 어느 env에 넣을지 표가 없었음.
- `masc init`은 이미 `.masc/config` seed(runtime.toml 포함)하지만, `masc start` 명시적 이름과 credential 안내가 부족.

## P0–P3
- P0: 없음 (CLI/docs/script).
- P1: GOOD — `start_cmd`는 기존 `run_cmd_exit` 재사용, semantics 동일. 호환성 보존(flag-only 유지).
- P2: GOOD — Quick Start가 복붙 3단계. provider/env 표로 SSOT(runtime.toml의 key) 노출.
- P3: 잔여 — `.env.local` 자동 load(binary `masc start` 내)는 후속 OCaml 작업(Fs_compat read API). 현재는 `source .env.local &&` 한 방. brew tap(jeong-sik/homebrew-tap)도 후속.

## 비목표 (후속)
- `masc start` 내 `.env.local` 자동 load (OCaml).
- Homebrew tap formula (`jeong-sik/homebrew-tap`).
- dashboard runtime-tab provider/model 추가 UI (별도 RFC).

## Verification
1. `dune build` — start_cmd 컴파일 (CI).
2. `masc --help` — `init`, `start`, `login`, `memory-os-gc-dry-run` subcommand 표시.
3. `masc start --port X` ≡ `masc --port X` (default run).
4. fresh dir: `masc init` → `.masc/config/runtime.toml` 존재 → `source .masc/config/.env.local && masc start` → health.
5. README Quick Start 복붙 재현 (사람).

## 워크어라운드 게이트
근본 사용자 경험 개선. silent/waiver 아님.
