### PR TITLE
fix(keeper): resolve system-internal tools so prompts do not strip them

### DIFF
--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -21,6 +21,12 @@ type tried_source =
   | Tool_schema                 (** S7: policy tool-schema inventory name extraction *)
   | Descriptor_registry         (** S7.5: Keeper_tool_descriptor.all_descriptors public_name —
                                     flat SSOT incl. internal_descriptors (masc_keeper_* live here) *)
+  | System_internal             (** S8: Tool_catalog_surfaces.is_system_internal_hidden —
+                                    system-internal tools (masc_gc, masc_reset,
+                                    masc_cleanup_zombies, …) dispatched via tool_misc and
+                                    hidden from keeper surfaces. Real tools, not
+                                    stale/hallucinated tokens, so the prompt-token integrity
+                                    scanner must not flag or strip them. *)
 
 type resolution =
   | Resolved of { canonical : string ; via : tried_source }
@@ -43,6 +49,7 @@ let string_of_tried_source = function
   | Registry_core_tools -> "registry_core_tools"
   | Tool_schema -> "tool_schema"
   | Descriptor_registry -> "descriptor_registry"
+  | System_internal -> "system_internal"
 
 let string_of_tried sources =
   String.concat ", " (List.map string_of_tried_source sources)
@@ -87,6 +94,17 @@ let resolve name =
            without touching dispatch — resolve is a validity gate; [via] is only
            used for the error string. *)
         Resolved { canonical = normalized; via = Descriptor_registry }
+      else if Tool_catalog_surfaces.is_system_internal_hidden normalized then
+        (* System-internal tools (masc_gc, masc_reset, masc_cleanup_zombies, …)
+           are dispatched directly via tool_misc and hidden from keeper surfaces,
+           so they appear in no keeper-facing registry above. They are real
+           tools, not stale/hallucinated names, so the prompt-token integrity
+           scanner must treat them as valid (otherwise it strips them from
+           continuity prose and emits a per-render WARN — observed as ~33/day of
+           false "stripped masc token masc_gc" for keeper taskmaster). resolve is
+           a validity gate whose only callers are that scanner/sanitizer, so this
+           does not widen keeper tool admission. *)
+        Resolved { canonical = normalized; via = System_internal }
       else
         (* The per-actor surface coverage gate (RFC-0084 §1.3) was removed in
            the surface-cut refactor: the [surface] type and its lists are
@@ -103,6 +121,7 @@ let resolve name =
               ; Registry_core_tools
               ; Tool_schema
               ; Descriptor_registry
+              ; System_internal
               ]
           }
 
@@ -132,6 +151,8 @@ let all_admitting_sources name =
         String.equal d.Keeper_tool_descriptor.public_name normalized)
       (Keeper_tool_descriptor.all_descriptors ())
   then sources := Descriptor_registry :: !sources;
+  if Tool_catalog_surfaces.is_system_internal_hidden normalized then
+    sources := System_internal :: !sources;
   (* The per-actor surface admit sources (RFC-0084 §1.3) were removed in the
      surface-cut refactor — the [surface] type is deleted. *)
   List.rev !sources

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -14,6 +14,8 @@ type tried_source =
   | Registry_core_tools         (** effective_core_tools *)
   | Tool_schema                 (** Tool_shard.all_keeper_tool_schemas + inline schemas *)
   | Descriptor_registry         (** Keeper_tool_descriptor.all_descriptors public_name (flat SSOT) *)
+  | System_internal             (** Tool_catalog_surfaces.is_system_internal_hidden — system-internal
+                                    tools hidden from keeper surfaces but still real/dispatchable *)
 
 (** Resolution outcome for a tool name. *)
 type resolution =

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -92,6 +92,23 @@ let test_masc_board_post_resolves () =
       fail (Printf.sprintf "masc_board_post should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
+let test_system_internal_hidden_tool_resolves () =
+  (* masc_gc is a system-internal tool (tool_misc dispatch, hidden from keeper
+     surfaces). Before the System_internal source it resolved to Unknown, so the
+     prompt-token integrity scanner stripped it from continuity prose and emitted
+     ~33 false "stripped masc token masc_gc" WARNs/day for keeper taskmaster. It
+     is a real tool and must now resolve via System_internal. *)
+  match TR.resolve "masc_gc" with
+  | TR.Resolved { via = TR.System_internal; canonical } ->
+      check string "canonical preserved" "masc_gc" canonical
+  | TR.Resolved { via; _ } | TR.Alias_to { via; _ } ->
+      fail (Printf.sprintf "masc_gc resolved via %s; expected System_internal"
+              (TR.string_of_tried_source via))
+  | TR.Unknown { tried; _ } ->
+      fail (Printf.sprintf
+              "masc_gc must resolve (system-internal tool), got Unknown (tried: %s)"
+              (TR.string_of_tried tried))
+
 (* ── Policy validation surface ── *)
 
 let resolves name =
@@ -318,6 +335,7 @@ let () =
         test_case "tool_execute resolves" `Quick test_tool_execute_resolves;
         test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
         test_case "masc_board_post resolves" `Quick test_masc_board_post_resolves;
+        test_case "system-internal hidden tool (masc_gc) resolves via System_internal" `Quick test_system_internal_hidden_tool_resolves;
       ]
     ; "policy_validation", [
         test_case "known tools resolve" `Quick test_policy_validation_known_tools_resolve;


### PR DESCRIPTION
## 목적

런타임 로그 live 윈도우에서 `keeper_prompt_token_integrity: stripped masc token "masc_gc" from prompt for keeper taskmaster`가 **~33회/일** 발생 — false positive 관측성 노이즈.

## 원인

`masc_gc`는 **실제 system-internal tool**(`tool_misc` 디스패치 + `tool_catalog_surfaces.system_internal_hidden`, keeper surface서 숨김). 그런데 `Keeper_tool_resolution.resolve`의 7개 소스(Dispatch_table / Public_descriptor / Alias / Registry / Tool_schema / Descriptor_registry) 어디에도 system-internal 리스트가 없어 **Unknown**으로 떨어짐. 그러면 prompt-token integrity 스캐너가 이를 stale/hallucinated 이름으로 오분류해 continuity 산문에서 **strip + 매 렌더 WARN**.

## 변경 (`fix(keeper)`)

- `resolve`에 **S8 `System_internal` 소스** 추가 — `Tool_catalog_surfaces.is_system_internal_hidden`(이 tool들의 SSOT, masc lib가 이미 의존하는 clean leaf) 기반. `all_admitting_sources`·타입·.mli도 동기.
- `resolve`는 **validity gate**(유일 호출자 = integrity 스캐너/새니타이저, tool admission 게이트 아님)이므로 keeper가 호출 가능한 tool 범위는 **안 바뀜** — 실재 tool을 stale로 오분류하던 것만 교정.
- #19797 orphan 복원(S7.5 Descriptor_registry)과 동형 패턴.

## 검증

- 신규 테스트: `resolve "masc_gc"` → `Resolved { via = System_internal }`.
- 기존 `keeper_tool_resolution`(16) + `keeper_prompt_token_integrity`(15) 통과 — 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
