### PR TITLE
chore(config): purge 15 dead environment knobs

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -159,18 +159,6 @@ module Model_defaults = struct
   (** Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). *)
   let default_runtime_opt () =
     Sys.getenv_opt "MASC_DEFAULT_RUNTIME" |> trim_opt
-
-  (** Default provider name. *)
-  let default_provider_opt () =
-    Sys.getenv_opt "MASC_DEFAULT_PROVIDER" |> trim_opt
-
-  (** Default model id. *)
-  let default_model_opt () =
-    Sys.getenv_opt "MASC_DEFAULT_MODEL" |> trim_opt
-
-  (** Goal models (comma-separated). *)
-  let goal_models_opt () =
-    Sys.getenv_opt "MASC_GOAL_MODELS" |> trim_opt
 end
 
 (** {1 Anti-Rationalization Configuration}

--- a/lib/config/env_config_governance.mli
+++ b/lib/config/env_config_governance.mli
@@ -147,9 +147,6 @@ end
 
 module Model_defaults : sig
   val default_runtime_opt : unit -> string option
-  val default_provider_opt : unit -> string option
-  val default_model_opt : unit -> string option
-  val goal_models_opt : unit -> string option
 end
 
 (** {1 Anti-rationalization} *)

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -117,20 +117,6 @@ module Orchestrator = struct
     Feature_flag_registry.get_bool Env_config_core.orchestrator_enabled_env_key
 end
 
-(** {1 Spawn Configuration} *)
-
-module Spawn = struct
-  (** Default spawn timeout for agent processes (seconds).
-      Used by spawn.ml, spawn_eio.ml, and tool_relay.ml.
-      Higher value (600s) allows for slow network/API conditions while preventing indefinite hangs. *)
-  let timeout_seconds =
-    int_of_float (get_float ~default:600.0 "MASC_SPAWN_TIMEOUT_SEC")
-
-  (** Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). *)
-  let grace_period_seconds =
-    int_of_float (get_float ~default:60.0 "MASC_SPAWN_GRACE_PERIOD_SEC")
-end
-
 (** {1 Local MODEL Server Configuration} *)
 
 (** Local MODEL runtime config (llama-server / any OpenAI-compatible backend).
@@ -139,18 +125,6 @@ module Local_runtime = struct
   (** OpenAI-compatible local MODEL server URL *)
   let server_url =
     get_string ~default:Masc_network_defaults.local_llm_default_url "LLAMA_SERVER_URL"
-
-  (** Default local runtime model id for llama.cpp/OpenAI-compatible servers. *)
-  let default_model =
-    get_string ~default:"explicit-model-required" "LLAMA_DEFAULT_MODEL"
-
-  (** Upper bound for local runtime requests.
-      Callers may request less, but never more than this cap.
-      Falls back to MASC_LLAMA_MAX_TOKENS for backward compatibility. *)
-  let max_tokens =
-    let primary = get_int ~default:0 "MASC_LOCAL_MAX_TOKENS" in
-    if primary > 0 then primary
-    else get_int ~default:32768 "MASC_LLAMA_MAX_TOKENS"
 
   (** Default worker model override for the local runtime. *)
   let worker_model_opt () =
@@ -320,23 +294,6 @@ module Transport = struct
   let startup_watchdog_sec () =
     let v = get_float ~default:240.0 "MASC_STARTUP_WATCHDOG_SEC" in
     Float.max 30.0 (Float.min 600.0 v)
-end
-
-module Cdal = struct
-  (** Enable contract-driven proof capture. Default: true. *)
-  let enabled () =
-    Feature_flag_registry.get_bool "MASC_CDAL_ENABLED"
-
-  (** Block task completion when contract verdict is Violated/Inconclusive. Default: false. *)
-  let gate_enabled () =
-    Feature_flag_registry.get_bool "MASC_CDAL_GATE_ENABLED"
-
-  (** Max verdicts to scan when looking up the latest verdict by task_id.
-      Beyond this limit, older entries are silently skipped — WARN is logged
-      by the gate when the task_id is not found. Default: 500.
-      Issue #7546. *)
-  let verdict_lookup_limit () =
-    get_int ~default:500 "MASC_CDAL_VERDICT_LOOKUP_LIMIT"
 end
 
 module Verification = struct
@@ -513,32 +470,6 @@ module Tools = struct
   let list_page_size () =
     let v = get_int ~default:512 "MASC_LIST_PAGE_SIZE" in
     max 10 (min 1024 v)
-
-  (** Default outer MCP tool-call timeout, clamped to [5, 300] seconds.
-      Board writes have a separate timeout below so operators can tune
-      persistence stalls without raising every tool.
-      @category Timeouts
-      @ops_class operator *)
-  let timeout_default_sec () =
-    let v = get_int ~default:60 "MASC_TOOL_TIMEOUT_DEFAULT_SEC" in
-    float_of_int (max 5 (min 300 v))
-
-  (** Board write outer MCP tool-call timeout, clamped to [5, 300] seconds.
-      Default: 90 seconds (#10569).
-      @category Timeouts
-      @ops_class operator *)
-  let board_write_timeout_sec () =
-    let v = get_int ~default:90 "MASC_TOOL_TIMEOUT_BOARD_SEC" in
-    float_of_int (max 5 (min 300 v))
-
-  (** Tool description budget (max chars). None = unlimited. *)
-  let description_budget_opt () =
-    match Sys.getenv_opt "MASC_TOOL_DESCRIPTION_BUDGET" |> trim_opt with
-    | Some raw -> (
-        match int_of_string_opt raw with
-        | Some v when v > 0 -> Some v
-        | _ -> None)
-    | None -> None
 
   (** Read-only tool retry limit. Default: 2. *)
   let readonly_retry_limit = get_int ~default:2 "MASC_TOOL_READONLY_RETRY_LIMIT"
@@ -803,10 +734,6 @@ module InternalTimers = struct
   let metrics_flush_sec =
     get_float ~default:300.0 "MASC_METRICS_FLUSH_SEC"
 
-  (** Team session live turn window (seconds). Default: 300 (5 min). *)
-  let session_live_turn_window_sec =
-    get_float ~default:300.0 "MASC_SESSION_LIVE_TURN_WINDOW_SEC"
-
   (** Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). *)
   let label_quiet_threshold_sec =
     get_float ~default:300.0 "MASC_LABEL_QUIET_THRESHOLD_SEC"
@@ -826,14 +753,6 @@ module InternalTimers = struct
   (** SSE buffer TTL (seconds). Default: 300 (5 min). *)
   let sse_buffer_ttl_sec =
     get_float ~default:300.0 "MASC_SSE_BUFFER_TTL_SEC"
-
-  (** Cancellation token cleanup interval (seconds). Default: 300 (5 min). *)
-  let cancellation_cleanup_sec =
-    get_float ~default:300.0 "MASC_CANCELLATION_CLEANUP_SEC"
-
-  (** Provider run finished TTL (seconds). Default: 3600 (1 hour). *)
-  let provider_run_ttl_sec =
-    get_float ~default:3600.0 "MASC_PROVIDER_RUN_TTL_SEC"
 
   (** Operator digest stalled session threshold (seconds). Default: 300 (5 min). *)
   let stalled_session_threshold_sec =

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -75,19 +75,10 @@ module Orchestrator : sig
   val enabled : bool
 end
 
-(** {1 Spawn} *)
-
-module Spawn : sig
-  val timeout_seconds : int
-  val grace_period_seconds : int
-end
-
 (** {1 Local runtime / llama.cpp} *)
 
 module Local_runtime : sig
   val server_url : string
-  val default_model : string
-  val max_tokens : int
   val worker_model_opt : unit -> string option
   val mcp_url : unit -> string
 end
@@ -152,14 +143,6 @@ module Transport : sig
   val agent_transport_opt : unit -> agent_transport option
   val http_auth_strict_env_enabled : unit -> bool
   val startup_watchdog_sec : unit -> float
-end
-
-(** {1 Contract-verdict gate} *)
-
-module Cdal : sig
-  val enabled : unit -> bool
-  val gate_enabled : unit -> bool
-  val verdict_lookup_limit : unit -> int
 end
 
 (** {1 Verification FSM} *)
@@ -249,9 +232,6 @@ module Tools : sig
      removed alongside the [MASC_DISPATCH_V2] feature flag. *)
   val full_surface_enabled : unit -> bool
   val list_page_size : unit -> int
-  val timeout_default_sec : unit -> float
-  val board_write_timeout_sec : unit -> float
-  val description_budget_opt : unit -> int option
   val readonly_retry_limit : int
   val public_tools_extra_opt : unit -> string option
   val web_search_provider_opt : unit -> string option
@@ -323,14 +303,11 @@ end
 
 module InternalTimers : sig
   val metrics_flush_sec : float
-  val session_live_turn_window_sec : float
   val label_quiet_threshold_sec : float
   val label_stuck_threshold_sec : float
   val briefing_cache_ttl_sec : float
   val bootstrap_window_sec : float
   val sse_buffer_ttl_sec : float
-  val cancellation_cleanup_sec : float
-  val provider_run_ttl_sec : float
   val stalled_session_threshold_sec : float
   val janitor_interval_sec : float
   val repo_sync_interval_sec : float

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -36,8 +36,6 @@ let auth_entries =
 
 let runtime_entries =
   [
-    entry ~default:"(none)" "MASC_CDAL_ENABLED"
-      "Contract-driven agent loop proof capture (feature flag)";
     (* RFC-0084 host-config-cleanup-J — MASC_DISPATCH_V2 removed. *)
     entry ~default:"(auto)" Env_config_core.log_level_env_key "Log level override";
     entry ~default:"debug" Env_config_core.log_routine_level_env_key
@@ -406,8 +404,6 @@ let internal_timer_entries =
   [
     entry ~default:"300.0" "MASC_BRIEFING_CACHE_TTL_SEC"
       "Mission briefing cache TTL (seconds, 5 min)";
-    entry ~default:"300.0" "MASC_CANCELLATION_CLEANUP_SEC"
-      "Cancellation token cleanup interval (seconds)";
     entry ~default:"300.0" "MASC_KEEPER_BOOTSTRAP_WINDOW_SEC"
       "Keeper world observation bootstrap window (seconds, 5 min)";
     entry ~default:"300.0" "MASC_LABEL_QUIET_THRESHOLD_SEC"
@@ -416,10 +412,6 @@ let internal_timer_entries =
       "Dashboard label stuck threshold (seconds, 15 min)";
     entry ~default:"300.0" "MASC_METRICS_FLUSH_SEC"
       "Tool metrics flush interval (seconds, 5 min)";
-    entry ~default:"3600.0" "MASC_PROVIDER_RUN_TTL_SEC"
-      "Provider run finished TTL (seconds, 1 hour)";
-    entry ~default:"300.0" "MASC_SESSION_LIVE_TURN_WINDOW_SEC"
-      "Team session live turn window (seconds, 5 min)";
     entry ~default:"300.0" "MASC_SSE_BUFFER_TTL_SEC"
       "SSE buffer TTL (seconds, 5 min)";
     entry ~default:"300.0" "MASC_STALLED_SESSION_THRESHOLD_SEC"
@@ -569,10 +561,6 @@ let keeper_tool_entries =
 
 let local_runtime_entries =
   [
-    entry ~default:"32768" "MASC_LLAMA_MAX_TOKENS"
-      "Upper bound for local runtime requests (fallback)";
-    entry ~default:"0" "MASC_LOCAL_MAX_TOKENS"
-      "Upper bound for local runtime requests (primary; falls back to MASC_LLAMA_MAX_TOKENS)";
     entry ~default:"(none)" "MASC_URL"
       "MASC MCP endpoint URL";
   ]
@@ -660,8 +648,6 @@ let model_routing_entries =
       "Default provider name; None when unset";
     entry ~default:"task" "MASC_GOAL_DISPATCH_RUNTIME"
       "Goal dispatch runtime type";
-    entry ~default:"(none)" "MASC_GOAL_MODELS"
-      "Goal models comma-separated; None when unset";
     entry ~default:"(none)" "MASC_ROUTING_RUNTIME"
       "Routing runtime for team session routing";
   ]
@@ -764,14 +750,6 @@ let smart_heartbeat_entries =
       "Idle threshold before multiplier kicks in (seconds, clamped 60-3600)";
   ]
 
-let spawn_entries =
-  [
-    entry ~default:"60.0" "MASC_SPAWN_GRACE_PERIOD_SEC"
-      "Grace period before timeout for SIGTERM checkpoint (seconds)";
-    entry ~default:"600.0" "MASC_SPAWN_TIMEOUT_SEC"
-      "Default spawn timeout for agent processes (seconds)";
-  ]
-
 let sse_entries =
   [
     entry ~default:"(none)" "MASC_SSE_STREAM_CAPACITY"
@@ -834,8 +812,6 @@ let tool_entries =
       "Enable placeholder tool exposure";
     entry ~default:"(none)" "MASC_PUBLIC_TOOLS_EXTRA"
       "Extra public tools (comma-separated names); None when unset";
-    entry ~default:"(none)" "MASC_TOOL_DESCRIPTION_BUDGET"
-      "Tool description budget max chars; None=unlimited";
     entry ~default:"2" "MASC_TOOL_READONLY_RETRY_LIMIT"
       "Read-only tool retry limit";
   ]
@@ -927,7 +903,7 @@ let all_categories () =
       (operator_entries @ orchestrator_entries @ smart_heartbeat_entries);
     category "channel" channel_gate_entries;
     category "process"
-      (shutdown_entries @ spawn_entries
+      (shutdown_entries
        @ cancellation_entries @ zombie_cleanup_entries @ lock_entries
        @ procedural_memory_entries);
     category "worker" (worker_entries @ worker_runtime_entries);

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -193,16 +193,6 @@ let all_flags : flag list = [
     lifecycle = Active; since = "2.208.0" };
 
   (* ── Contract verification ───────────────────────────────── *)
-  { env_name = "MASC_CDAL_ENABLED";
-    description = "Contract verification: proof capture and verdict evaluation";
-    default = true; category = "runtime";
-    lifecycle = Active; since = "2.162.0" };
-
-  { env_name = "MASC_CDAL_GATE_ENABLED";
-    description = "Contract-verdict gate: block task completion when verdict is Violated/Inconclusive";
-    default = true; category = "runtime";
-    lifecycle = Active; since = "0.9.3" };
-
   { env_name = "MASC_VERIFICATION_FSM_ENABLED";
     description = "Task verification FSM: AwaitingVerification state and cross-agent approval";
     default = true; category = "runtime";


### PR DESCRIPTION
## 죽은 환경변수 15개 숙청

`env_config`에 정의됐지만 **코드 어디서도 읽히지 않는** env knob 15개와 그 getter/문서/registry entry 제거.

### 검증 방법 (중요)
dead 판정을 **getter 이름이 아니라 env-var 문자열**로 했습니다. getter 호출이 0이어도 그 env 변수는 다른 곳에서 `get_int "MASC_X"`로 직접 읽힐 수 있기 때문입니다(아래 ALIVE 사례). 각 변수를 repo 전체에서 정확한 문자열로 grep해 진짜 dead만 골랐습니다.

### 제거된 15개 (read site 0)
`MASC_SPAWN_TIMEOUT_SEC`, `MASC_SPAWN_GRACE_PERIOD_SEC`, `LLAMA_DEFAULT_MODEL`, `MASC_LOCAL_MAX_TOKENS`, `MASC_LLAMA_MAX_TOKENS`, `MASC_CDAL_ENABLED`, `MASC_CDAL_GATE_ENABLED`, `MASC_CDAL_VERDICT_LOOKUP_LIMIT`, `MASC_TOOL_TIMEOUT_DEFAULT_SEC`, `MASC_TOOL_TIMEOUT_BOARD_SEC`, `MASC_TOOL_DESCRIPTION_BUDGET`, `MASC_SESSION_LIVE_TURN_WINDOW_SEC`, `MASC_CANCELLATION_CLEANUP_SEC`, `MASC_PROVIDER_RUN_TTL_SEC`, `MASC_GOAL_MODELS`

- `module Spawn`, `module Cdal`는 전 멤버가 dead라 통째 제거.
- 빈 `spawn_entries` snapshot 리스트 + `all_categories` 참조도 제거(dead `[]` stub 방지).

### 보존한 것 (false-positive 차단)
- **`MASC_ORCHESTRATOR_*` (INTERVAL/MIN_PRIORITY/TIMEOUT/ENABLED)**: `orchestrator.ml`이 env를 직접 읽음 → 살아있음. env_config의 wrapper getter는 dead 중복이지만 env 숙청 범위 밖이라 미터치.
- **`MASC_DEFAULT_PROVIDER` / `MASC_DEFAULT_MODEL`**: `runtime_model/provider_runtime_projection.ml`이 직접 읽음 → 살아있음. dead wrapper getter(`Model_defaults.default_provider_opt`/`default_model_opt`)만 제거, env·snapshot 문서는 보존.
- `Local_runtime.{server_url,worker_model_opt,mcp_url}`, `Ollama.default_model`, `Tools`/`InternalTimers`의 나머지 멤버, `MASC_SPAWN_CACHE_POLICY` 등은 미터치.

### RFC note
`MASC_CDAL_*`는 RFC-0109(cdal-goal-integration) 관련. cdal 런타임(`lib/cdal_runtime/`)은 실재하지만 이 knob들을 어떤 read path에도 연결한 적이 없어, dead config 제거가 cdal 동작을 바꾸지 않습니다. wire-up이 나중에 들어오면 해당 RFC로 재추가하면 됩니다.

### 검증
- `dune build --root . @check`의 red는 base의 `agent_sdk` reasoning_details pin-drift(keeper lib, 이 변경과 무관)였고, 최신 origin/main(#22832 adapt)으로 rebase. `masc_config` 라이브러리는 standalone 빌드 통과.
- 제거 후 15개 env 문자열 + 제거 getter의 잔여 참조 0 (substring 오탐 `OLLAMA_DEFAULT_MODEL`/`token_gate_enabled` 제외).
- `ocamlformat --check` clean.
- CI가 핀된 agent_sdk로 최종 green 게이트.

### Follow-up (out of scope)
`test/test_tool_task_coverage.ml`이 `MASC_CDAL_GATE_ENABLED`를 `with_env`로 2곳 설정 — reader가 없어 no-op. nested-scope churn 회피 위해 미터치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
