### PR TITLE
fix(runtime): route structured judges through Ollama native schema

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -12,17 +12,18 @@
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
 # memory-os librarian (post-turn episode extraction) requests provider-native
-# structured output, so it is routed independently of keeper chat to a runtime
-# whose OAS catalog row advertises native structured output. Keep MiniMax out of
-# this lane until OAS capability truth proves native schema support. Override per
+# structured output, so it is routed independently of keeper chat to the native
+# Ollama /api/chat binding whose `format` schema path was live-verified. The
+# OpenAI-compatible /v1 path accepts response_format but can still return fenced
+# prose, so do not point this lane at [providers.ollama_cloud]. Override per
 # process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
 # keeper's runtime (legacy).
-librarian = "ollama_cloud.ollama-cloud-devstral-2-123b"
+librarian = "ollama_cloud_native.minimax-m3-native-structured"
 # Provider-native structured-output judges must not inherit the fleet chat
 # default when that default lacks schema support. Keep this lane explicit so
 # dashboard operator/governance judges fail at config load on typo/unsupported
 # routing instead of discovering the mismatch in the daemon loop.
-structured_judge = "ollama_cloud.ollama-cloud-devstral-2-123b"
+structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
@@ -44,6 +45,18 @@ endpoint = "https://ollama.com/v1"
 connect-timeout-s = 600.0
 
 [providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[providers.ollama_cloud_native]
+display-name = "Ollama Cloud Native"
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+# Mirrors [providers.ollama_cloud]. This lane uses native /api/chat for schema
+# output, not OpenAI-compatible /v1/chat/completions.
+connect-timeout-s = 600.0
+
+[providers.ollama_cloud_native.credentials]
 type = "env"
 key = "OLLAMA_CLOUD_API_KEY"
 
@@ -199,6 +212,31 @@ supports-image-input = true
 supports-multimodal-inputs = true
 
 [ollama_cloud.minimax-m3]
+
+# MiniMax M3 native Ollama Cloud structured-output lane. This uses the same
+# provider-owned model id as [models.minimax-m3], but a distinct runtime model key
+# because the OpenAI-compatible /v1 transport does not strictly enforce
+# response_format/json_schema while native /api/chat `format` does.
+[models.minimax-m3-native-structured]
+api-name = "minimax-m3"
+max-context = 524288
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.minimax-m3-native-structured.capabilities]
+max-output-tokens = 131072
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "ollama_think"
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud_native.minimax-m3-native-structured]
 
 # Kimi K2.6 (Ollama Cloud) — vision-capable Cloud runtime. The model name is
 # kept separate from Kimi's direct API route; OAS owns provider/model wire

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -523,7 +523,7 @@ let test_repo_runtime_toml_loads () =
     check
       (option string)
       "structured judge runtime"
-      (Some "ollama_cloud.ollama-cloud-devstral-2-123b")
+      (Some "ollama_cloud_native.minimax-m3-native-structured")
       structured_judge;
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
@@ -623,6 +623,31 @@ let test_repo_runtime_toml_loads () =
           check bool "MiniMax M3 forced tool_choice disabled" false
             caps.supports_tool_choice
         | None -> fail "expected MiniMax M3 capabilities"));
+    (match
+       List.find_opt
+         (fun (runtime : Runtime.t) ->
+            String.equal runtime.id
+              "ollama_cloud_native.minimax-m3-native-structured")
+         runtimes
+     with
+     | None -> fail "expected native MiniMax M3 structured-output runtime in seed"
+     | Some runtime ->
+       check string "native MiniMax M3 api name" "minimax-m3"
+         runtime.model.api_name;
+       check (option (float 0.0)) "native MiniMax M3 connect timeout"
+         (Some 600.0)
+         runtime.provider_config.connect_timeout_s;
+       (match runtime.model.capabilities with
+       | Some caps ->
+         check bool "native MiniMax M3 response_format json" true
+           caps.supports_response_format_json;
+         check bool "native MiniMax M3 structured output" true
+           caps.supports_structured_output;
+         check bool "native MiniMax M3 Ollama think control" true
+           (Runtime_schema.equal_thinking_control_format
+              caps.thinking_control_format
+              Runtime_schema.Ollama_think)
+       | None -> fail "expected native MiniMax M3 capabilities"));
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->


### PR DESCRIPTION
## Problem

`[runtime].librarian` and `[runtime].structured_judge` currently point at `ollama_cloud.ollama-cloud-devstral-2-123b`. That binding uses `protocol = "openai-compatible-http"` against `https://ollama.com/v1`.

Live probes show this is not a strict structured-output lane: Ollama Cloud `/v1/chat/completions` accepts `response_format.json_schema`, but `devstral-2:123b` and `minimax-m3` can still return prose/fenced JSON. The native Ollama Cloud `/api/chat` path with `format` returned strict JSON content for `minimax-m3`.

So the issue is a transport/capability mismatch: the model can be schema-capable through native Ollama, while the current MASC runtime lane is OpenAI-compatible.

## Changes

- Add `[providers.ollama_cloud_native]` using `protocol = "ollama-http"` and `endpoint = "https://ollama.com"`.
- Add a distinct `minimax-m3-native-structured` runtime model key for the native schema lane.
- Route `[runtime].librarian` and `[runtime].structured_judge` to `ollama_cloud_native.minimax-m3-native-structured`.
- Extend `test_runtime_config_validity` so the seed asserts the native structured-output runtime, JSON/schema capability, and `ollama_think` control dialect.

## Verification

- `git diff --check`
- `python3 -c 'import tomllib; tomllib.load(open("config/runtime.toml", "rb")); print("runtime.toml ok")'`
- `ocamlformat --check test/test_runtime_config_validity.ml`
- `scripts/masc-sync-ollama-caps.py --check`

Local Dune was intentionally not run; PR CI is the build authority for this change.

## Live evidence

- `/v1/chat/completions` + `response_format.json_schema` for `devstral-2:123b` returned explanatory text plus fenced JSON.
- `/v1/chat/completions` + `response_format.json_schema` for `minimax-m3` returned fenced JSON and reasoning.
- `/api/chat` + native `format` schema for `minimax-m3` returned content exactly `{"ok": true}`.
