### PR TITLE
refactor(oas): consume structured response extraction

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -12,17 +12,18 @@
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
 # memory-os librarian (post-turn episode extraction) requests provider-native
-# structured output, so it is routed independently of keeper chat to a runtime
-# whose OAS catalog row advertises native structured output. Keep MiniMax out of
-# this lane until OAS capability truth proves native schema support. Override per
+# structured output, so it is routed independently of keeper chat to the native
+# Ollama /api/chat binding whose `format` schema path was live-verified. The
+# OpenAI-compatible /v1 path accepts response_format but can still return fenced
+# prose, so do not point this lane at [providers.ollama_cloud]. Override per
 # process with MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID. Unset = inherit each
 # keeper's runtime (legacy).
-librarian = "ollama_cloud.ollama-cloud-devstral-2-123b"
+librarian = "ollama_cloud_native.minimax-m3-native-structured"
 # Provider-native structured-output judges must not inherit the fleet chat
 # default when that default lacks schema support. Keep this lane explicit so
 # dashboard operator/governance judges fail at config load on typo/unsupported
 # routing instead of discovering the mismatch in the daemon loop.
-structured_judge = "ollama_cloud.ollama-cloud-devstral-2-123b"
+structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.
@@ -44,6 +45,18 @@ endpoint = "https://ollama.com/v1"
 connect-timeout-s = 600.0
 
 [providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[providers.ollama_cloud_native]
+display-name = "Ollama Cloud Native"
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+# Mirrors [providers.ollama_cloud]. This lane uses native /api/chat for schema
+# output, not OpenAI-compatible /v1/chat/completions.
+connect-timeout-s = 600.0
+
+[providers.ollama_cloud_native.credentials]
 type = "env"
 key = "OLLAMA_CLOUD_API_KEY"
 
@@ -199,6 +212,31 @@ supports-image-input = true
 supports-multimodal-inputs = true
 
 [ollama_cloud.minimax-m3]
+
+# MiniMax M3 native Ollama Cloud structured-output lane. This uses the same
+# provider-owned model id as [models.minimax-m3], but a distinct runtime model key
+# because the OpenAI-compatible /v1 transport does not strictly enforce
+# response_format/json_schema while native /api/chat `format` does.
+[models.minimax-m3-native-structured]
+api-name = "minimax-m3"
+max-context = 524288
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.minimax-m3-native-structured.capabilities]
+max-output-tokens = 131072
+supports-tool-choice = false
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "ollama_think"
+supports-native-streaming = true
+supports-response-format-json = true
+supports-structured-output = true
+supports-image-input = true
+supports-multimodal-inputs = true
+
+[ollama_cloud_native.minimax-m3-native-structured]
 
 # Kimi K2.6 (Ollama Cloud) — vision-capable Cloud runtime. The model name is
 # kept separate from Kimi's direct API route; OAS owns provider/model wire

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 372 unique knobs across 9 modules.
+**Total**: 358 unique knobs across 9 modules.
 
-**Typed getter classification**: 44/223 tagged (`operator`: 44, `algorithm`: 0, `unclassified`: 179).
+**Typed getter classification**: 42/213 tagged (`operator`: 42, `algorithm`: 0, `unclassified`: 171).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -50,12 +50,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 426 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 290 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_governance (33 knobs; typed classification 2/23)
+## Env_config_governance (30 knobs; typed classification 2/23)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 200 |  |
-| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 222 |  |
+| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 188 |  |
+| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 210 |  |
 | `MASC_AUTONOMY_MAX_STARVATION_TICKS` | typed:int | unclassified | unclassified | 79 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
 | `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 71 | Quiet hours end (0-23). |
 | `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 67 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
@@ -66,10 +66,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 142 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | feature_flag | n/a | n/a | 153 | Whether governance judge is enabled. Default: true. |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 150 | Governance judge interval, clamped to >= 15s. Default: 60. |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 169 | Default model id. |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 165 | Default provider name. |
 | `MASC_DEFAULT_RUNTIME` | string_literal | n/a | n/a | 161 | Default runtime label (e.g. "glm:pro,openai:gpt-4.1"). |
-| `MASC_GOAL_MODELS` | string_literal | n/a | n/a | 173 | Goal models (comma-separated). |
 | `MASC_INFERENCE_CACHE_ENABLED` | feature_flag | n/a | n/a | 20 | Enable inference response cache (L1+L2). |
 | `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | typed:int | unclassified | unclassified | 38 | L1 in-memory entry cap. BUG-015: Reduced from 2048 to 512 — unbounded growth with 2048 default caused excessive mem... |
 | `MASC_INFERENCE_CACHE_MAX_PROMPT_CHARS` | typed:int | unclassified | unclassified | 28 | Skip caching for oversized prompts (character count). |
@@ -207,121 +204,108 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 69 |  |
 
-## Env_config_runtime (113 knobs; typed classification 6/90)
+## Env_config_runtime (100 knobs; typed classification 4/80)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 589 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 586 | Per-agent requests per second. Default: 20. |
-| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 305 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 378 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
-| `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 386 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
-| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 476 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
-| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 472 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 463 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 820 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 520 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 517 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 279 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
+| `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 335 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
+| `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 343 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
+| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 433 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
+| `MASC_BOARD_FLUSHER_INBOX_CAPACITY` | typed:int | Concurrency | operator | 429 | Capacity of the board flusher inbox (scheduled sweep/flush messages enqueued by the sweeper). Single source of truth ... |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 420 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 747 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 73 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 69 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 832 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
-| `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 180 | Token cleanup max age (seconds) |
-| `MASC_CDAL_ENABLED` | feature_flag | n/a | n/a | 328 | Enable contract-driven proof capture. Default: true. |
-| `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 332 | Block task completion when contract verdict is Violated/Inconclusive. Default: false. |
-| `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 339 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
+| `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 154 | Token cleanup max age (seconds) |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | unclassified | unclassified | 96 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 667 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 663 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 665 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 706 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 720 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 658 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 730 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 763 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 750 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 695 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 690 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 739 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 654 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 650 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 646 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 598 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 594 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 596 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 637 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 651 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 589 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 661 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 694 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 681 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 626 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 621 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 670 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 585 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 581 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 577 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 85 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 793 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 781 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 509 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
-| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 280 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 276 | gRPC server port. Default: 8936. |
-| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 284 | gRPC client target address. Derived from grpc_port when unset. |
-| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 310 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 848 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 824 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
-| `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC` | typed:float | Timeouts | operator | 428 | In-turn progress-silence threshold in seconds; produces [Mid_turn_no_progress] when a running turn records no progres... |
-| `MASC_KEEPER_STALE_RUN_SEC` | typed:float | unclassified | unclassified | 401 | {1 Keeper Stale-Run Window (RFC-0250)} Default-on wall-clock window for the no-turn-produced case. It keys on [last_t... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 724 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 712 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 466 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
+| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 254 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 250 | gRPC server port. Default: 8936. |
+| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 258 | gRPC client target address. Derived from grpc_port when unset. |
+| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 284 |  |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 767 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 751 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
+| `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC` | typed:float | Timeouts | operator | 385 | In-turn progress-silence threshold in seconds; produces [Mid_turn_no_progress] when a running turn records no progres... |
+| `MASC_KEEPER_STALE_RUN_SEC` | typed:float | unclassified | unclassified | 358 | {1 Keeper Stale-Run Window (RFC-0250)} Default-on wall-clock window for the no-turn-produced case. It keys on [last_t... |
 | `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 10 | Threshold for keeper agents (longer grace period, default 1 hour) |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 812 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 816 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 514 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
-| `MASC_LLAMA_MAX_TOKENS` | typed:int | unclassified | unclassified | 153 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_MAX_TOKENS` | typed:int | unclassified | unclassified | 151 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 601 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 597 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 607 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 604 | Local worker max tokens per request. Default: 1024. |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 739 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 743 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 471 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 532 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 528 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 538 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 535 | Local worker max tokens per request. Default: 1024. |
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | unclassified | unclassified | 28 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 24 | Default lock timeout (seconds). Reduced from 1800s (30 min) to 120s (2 min) — file locks should fail fast; a 30-min... |
-| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 222 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 804 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 615 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 196 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 735 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 546 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 108 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 104 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 111 |  |
 | `MASC_ORCHESTRATOR_TIMEOUT` | typed:int | unclassified | unclassified | 114 |  |
-| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 489 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
-| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 485 | Minimum evidence count for crystallization. Default: 3. |
-| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 836 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 548 | Extra public tools (comma-separated names). |
-| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 496 | Max consecutive consumer failures before recovery. Default: 3. |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 583 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 580 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 862 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 854 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
-| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 808 | Team session live turn window (seconds). Default: 300 (5 min). |
+| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 446 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
+| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 442 | Minimum evidence count for crystallization. Default: 3. |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 479 | Extra public tools (comma-separated names). |
+| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 453 | Max consecutive consumer failures before recovery. Default: 3. |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 514 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 511 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 781 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 773 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 36 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 955 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 888 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 876 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 904 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 439 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
-| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 624 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
-| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 629 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
-| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 634 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
-| `MASC_SPAWN_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 131 | Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). |
-| `MASC_SPAWN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 127 | Default spawn timeout for agent processes (seconds). Used by spawn.ml, spawn_eio.ml, and tool_relay.ml. Higher value ... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 828 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 840 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
-| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 321 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
+| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 874 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 807 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 795 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 823 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 396 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
+| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 555 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
+| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 560 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
+| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 565 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 755 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 759 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 295 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 61 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 57 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 536 | Tool description budget (max chars). None = unlimited. |
-| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 544 | Read-only tool retry limit. Default: 2. |
-| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 531 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
-| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 523 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
-| `MASC_USE_H2` | string_literal | n/a | n/a | 299 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 345 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
-| `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 355 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
-| `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 350 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
-| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 295 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 564 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 557 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 551 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 554 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 572 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 568 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 560 |  |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 939 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
-| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 291 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
-| `MASC_WS_PORT` | string_literal | n/a | n/a | 287 | WebSocket server port. Default: 8937. |
+| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 475 | Read-only tool retry limit. Default: 2. |
+| `MASC_USE_H2` | string_literal | n/a | n/a | 273 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
+| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 302 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
+| `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 312 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
+| `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 307 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
+| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 269 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 495 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 488 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 482 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 485 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 503 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 499 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 491 |  |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 858 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 265 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
+| `MASC_WS_PORT` | string_literal | n/a | n/a | 261 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |
 | `MASC_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 6 | Threshold for considering a resource as zombie (seconds) |
 
@@ -348,89 +332,91 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_SANDBOX_TMPFS_SIZE` | typed:string | unclassified | unclassified | 30 |  |
 | `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 190 |  |
 
-## Env_config_snapshot (82 knobs; typed classification 0/0)
+## Env_config_snapshot (84 knobs; typed classification 0/0)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 705 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 709 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 711 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 230 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 320 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 322 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 232 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 240 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 284 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 338 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 340 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 324 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 221 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 220 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 219 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 385 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 387 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 389 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 391 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 393 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 395 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 397 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 399 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 401 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 821 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 661 |  |
-| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 84 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 213 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 223 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 222 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 691 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 695 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 697 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 228 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 318 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 320 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 230 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 238 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 282 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 336 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 338 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 645 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 647 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 322 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 219 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 218 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 217 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 383 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 385 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 387 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 389 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 391 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 393 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 395 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 397 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 399 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 799 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 649 |  |
+| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 211 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 221 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 220 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 326 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 179 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 170 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 172 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 168 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 558 |  |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | string_literal | n/a | n/a | 620 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 197 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 193 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 191 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 195 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 187 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 189 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 185 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 562 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 564 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 174 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 566 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 514 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 516 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 177 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 176 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 224 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 797 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 833 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 665 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 481 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 845 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 747 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 749 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 751 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 753 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 823 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 777 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 160 |  |
-| `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 56 |  |
-| `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 53 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 813 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 815 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 162 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 877 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 879 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 881 |  |
-| `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 94 |  |
-| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 91 |  |
-| `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 118 |  |
-| `MASC_WS_MAX_INBOUND_FRAME_BYTES` | string_literal | n/a | n/a | 98 |  |
-| `MASC_WS_MAX_INBOUND_MESSAGE_BYTES` | string_literal | n/a | n/a | 102 |  |
-| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 106 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 324 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 177 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 168 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 170 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 166 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 550 |  |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | string_literal | n/a | n/a | 608 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 195 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 191 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 189 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 193 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 185 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 187 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 183 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 554 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 172 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 558 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 506 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 508 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 175 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 174 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 222 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 775 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 811 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 651 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 473 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 821 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 733 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 735 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 737 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 739 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 801 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 755 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 158 |  |
+| `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 54 |  |
+| `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 51 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 791 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 793 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 160 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 853 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 855 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 857 |  |
+| `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 92 |  |
+| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
+| `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 116 |  |
+| `MASC_WS_MAX_INBOUND_FRAME_BYTES` | string_literal | n/a | n/a | 96 |  |
+| `MASC_WS_MAX_INBOUND_MESSAGE_BYTES` | string_literal | n/a | n/a | 100 |  |
+| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 104 |  |

--- a/lib/agent_sdk_response.ml
+++ b/lib/agent_sdk_response.ml
@@ -8,4 +8,22 @@ type api_response = Agent_sdk.Types.api_response
 let text_of_response (response : api_response) =
   Agent_sdk.Types.visible_text_of_response response
 
+let visible_text_response (response : api_response) : api_response =
+  let text = text_of_response response in
+  { response with
+    content = if String.trim text = "" then [] else [ Agent_sdk.Types.Text text ]
+  }
+;;
+
+let structured_json_of_response ?(schema_name = "masc_structured_response") response =
+  let schema : Yojson.Safe.t Agent_sdk.Structured.schema =
+    { name = schema_name
+    ; description = "MASC structured JSON response"
+    ; params = []
+    ; parse = (fun json -> Ok json)
+    }
+  in
+  Agent_sdk.Structured.schema_extractor schema (visible_text_response response)
+;;
+
 let usage (response : api_response) = response.usage

--- a/lib/agent_sdk_response.mli
+++ b/lib/agent_sdk_response.mli
@@ -9,6 +9,14 @@ val text_of_response : api_response -> string
 (** Extract end-user-visible answer text from an API response. Thinking,
     ToolUse, ToolResult, and media blocks are intentionally excluded. *)
 
+val structured_json_of_response
+  :  ?schema_name:string
+  -> api_response
+  -> (Yojson.Safe.t, string) result
+(** Extract provider-native structured JSON from an API response through the
+    OAS structured-output extractor. Callers remain responsible for domain
+    validation of the returned JSON value. *)
+
 val usage : api_response -> Agent_sdk.Types.api_usage option
 (** Return provider-reported usage stats, if present. [None] means the
     provider did not report usage; callers must not treat it as zero. *)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -620,33 +620,34 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used:_ json =
                    ("guardrail_state", guardrail_state);
                  ]))
 
+let parse_governance_response_json ~json ~generated_at ~expires_at ~model_used =
+  match json with
+  | `Assoc _ ->
+    (match Json_util.assoc_member_opt "items" json with
+     | Some (`List rows) ->
+       let rec loop acc = function
+         | [] -> Ok (List.rev acc)
+         | row :: rest ->
+           (match parse_item_judgment ~generated_at ~expires_at ~model_used row with
+            | Error reason -> Error (Structural_error reason)
+            | Ok None -> loop acc rest
+            | Ok (Some judgment) -> loop (judgment :: acc) rest)
+       in
+       loop [] rows
+     | _ ->
+       Error
+         (Structural_error
+            "expected top-level items array in judge response"))
+  | _ ->
+    Error
+      (Structural_error
+         "expected top-level JSON object in judge response")
+;;
+
 let parse_governance_response ~raw_text ~generated_at ~expires_at ~model_used =
   match parse_strict_governance_json raw_text with
   | Error _ as error -> error
-  | Ok parsed -> (
-      match parsed with
-      | `Assoc _ -> (
-          match Json_util.assoc_member_opt "items" parsed with
-          | Some (`List rows) ->
-              let rec loop acc = function
-                | [] -> Ok (List.rev acc)
-                | row :: rest -> (
-                    match
-                      parse_item_judgment ~generated_at ~expires_at ~model_used row
-                    with
-                    | Error reason -> Error (Structural_error reason)
-                    | Ok None -> loop acc rest
-                    | Ok (Some judgment) -> loop (judgment :: acc) rest)
-              in
-              loop [] rows
-          | _ ->
-              Error
-                (Structural_error
-                   "expected top-level items array in judge response"))
-      | _ ->
-          Error
-            (Structural_error
-               "expected top-level JSON object in judge response"))
+  | Ok json -> parse_governance_response_json ~json ~generated_at ~expires_at ~model_used
 
 let parse_governance_response_for_testing =
   parse_governance_response
@@ -731,10 +732,24 @@ let compute_judgments
                 "compute_judgments: response.model empty -> fallback=%s (#9880)"
                 source;
         end;
-        match
-          parse_governance_response ~raw_text ~generated_at ~expires_at
-            ~model_used:resolved_model
-        with
+        let parsed_response =
+          match
+            Agent_sdk_response.structured_json_of_response
+              ~schema_name:"dashboard_governance_judge"
+              response
+          with
+          | Ok json ->
+            parse_governance_response_json
+              ~json
+              ~generated_at
+              ~expires_at
+              ~model_used:resolved_model
+          | Error detail ->
+            Error
+              (Structural_error
+                 (Printf.sprintf "invalid structured JSON: %s" detail))
+        in
+        match parsed_response with
         | Ok judgments -> Ok (resolved_model, generated_at, expires_at, judgments)
         | Error (Structural_error reason) ->
             let msg =
@@ -744,8 +759,6 @@ let compute_judgments
             Log.Governance.warn "%s" msg;
             Error msg
       with
-      | Yojson.Json_error msg ->
-          Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)
       | exn ->
           Error (Printf.sprintf "Governance judge parse error: %s" (Printexc.to_string exn)))
 

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -267,15 +267,21 @@ let compute_judgments
   | Ok result -> (
       let response = result.Runtime_agent.response in
       try
-        let raw_text = Agent_sdk_response.text_of_response response in
-        match Yojson.Safe.from_string (String.trim raw_text) with
-        | `Assoc _ as parsed ->
+        match
+          Agent_sdk_response.structured_json_of_response
+            ~schema_name:"dashboard_operator_judge"
+            response
+        with
+        | Ok (`Assoc _ as parsed) ->
             let _ = response.model in
             Ok (model_used_runtime, parsed)
-        | _ -> Error "Operator judge returned non-object strict JSON"
+        | Ok _ -> Error "Operator judge returned non-object structured JSON"
+        | Error msg ->
+          Error
+            (Printf.sprintf
+               "Operator judge returned invalid structured JSON: %s"
+               msg)
       with
-      | Yojson.Json_error msg ->
-          Error (Printf.sprintf "Operator judge returned invalid strict JSON: %s" msg)
       | exn ->
           Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -38,6 +38,19 @@ let parse_grounded_verdict_from_response_text text =
          "adversarial review response must be strict JSON: %s"
          msg)
 
+let parse_grounded_verdict_from_response response =
+  match
+    Agent_sdk_response.structured_json_of_response
+      ~schema_name:"verification_adversarial_review"
+      response
+  with
+  | Ok json -> Verifier_core.parse_grounded_verdict_from_json json
+  | Error msg ->
+    Error
+      (Printf.sprintf
+         "adversarial review response must be structured JSON: %s"
+         msg)
+
 module For_testing = struct
   let parse_grounded_verdict_from_response_text =
     parse_grounded_verdict_from_response_text
@@ -95,8 +108,7 @@ let run_grounded_review ~base_path ~runtime_id (input : review_input) :
       | None ->
         (* Model answered without calling report_verdict. Provider-native
            schema still requires a strict JSON grounded verdict object. *)
-        let text = Agent_sdk_response.text_of_response result.response in
-        parse_grounded_verdict_from_response_text text)
+        parse_grounded_verdict_from_response result.response)
     | Error err -> Error (Agent_sdk.Error.to_string err)
 
 let run_review ~base_path ~runtime_id (input : review_input) :

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -269,7 +269,7 @@ let unexpected_claim_field = function
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
 ;;
 
-let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
+let episode_of_json_result ?now ~generation (inp : input) (json : Yojson.Safe.t) :
   (episode, parse_error) result
   =
   let now =
@@ -279,49 +279,54 @@ let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
       (* NDT-OK: extraction timestamps are provenance/retention metadata only. *)
       Unix.gettimeofday ()
   in
+  match json with
+  | `Assoc fields ->
+    (match first_unexpected_field ~allowed:accepted_episode_fields fields with
+     | Some field -> Error (Unexpected_field field)
+     | None ->
+       (match
+          string_field wire_field_episode_summary fields
+          , List.assoc_opt wire_field_claims fields
+          , string_list_field_or_empty wire_field_open_items fields
+          , string_list_field_or_empty wire_field_constraints fields
+          , string_list_field_or_empty wire_field_preserved_tool_refs fields
+        with
+        | ( Some episode_summary
+          , Some (`List claim_items)
+          , Some open_items
+          , Some constraints
+          , Some preserved_tool_refs ) ->
+          (match List.find_map unexpected_claim_field claim_items with
+           | Some field -> Error (Unexpected_field field)
+           | None ->
+             (match traverse (fact_of_json ~trace_id:inp.trace_id ~now) claim_items with
+              | Some claims ->
+                Ok
+                  { trace_id = inp.trace_id
+                  ; generation
+                  ; episode_summary
+                  ; claims
+                  ; open_items
+                  ; constraints
+                  ; preserved_tool_refs
+                  ; source_turn_range = source_turn_range claims
+                  ; created_at = now
+                  ; valid_until = None
+                  ; terminal_marker = None
+                  ; schema_version
+                  }
+              | None -> Error Claim_schema_mismatch))
+        | _ -> Error Missing_required_fields))
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error Top_level_not_object
+;;
+
+let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
+  (episode, parse_error) result
+  =
   match json_of_output raw with
   | Error _ as error -> error
-  | Ok json ->
-    (match json with
-    | `Assoc fields ->
-      (match first_unexpected_field ~allowed:accepted_episode_fields fields with
-       | Some field -> Error (Unexpected_field field)
-       | None ->
-         (match
-            string_field wire_field_episode_summary fields
-            , List.assoc_opt wire_field_claims fields
-            , string_list_field_or_empty wire_field_open_items fields
-            , string_list_field_or_empty wire_field_constraints fields
-            , string_list_field_or_empty wire_field_preserved_tool_refs fields
-          with
-          | ( Some episode_summary
-            , Some (`List claim_items)
-            , Some open_items
-            , Some constraints
-            , Some preserved_tool_refs ) ->
-            (match List.find_map unexpected_claim_field claim_items with
-             | Some field -> Error (Unexpected_field field)
-             | None ->
-               (match traverse (fact_of_json ~trace_id:inp.trace_id ~now) claim_items with
-                | Some claims ->
-                  Ok
-                    { trace_id = inp.trace_id
-                    ; generation
-                    ; episode_summary
-                    ; claims
-                    ; open_items
-                    ; constraints
-                    ; preserved_tool_refs
-                    ; source_turn_range = source_turn_range claims
-                    ; created_at = now
-                    ; valid_until = None
-                    ; terminal_marker = None
-                    ; schema_version
-                    }
-                | None -> Error Claim_schema_mismatch))
-          | _ -> Error Missing_required_fields))
-    | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
-      Error Top_level_not_object)
+  | Ok json -> episode_of_json_result ?now ~generation inp json
 ;;
 
 let episode_of_output ?now ~generation inp raw : episode option =

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -65,6 +65,15 @@ val episode_of_output_result
   -> string
   -> (Keeper_memory_os_types.episode, parse_error) result
 
+val episode_of_json_result
+  :  ?now:float
+  -> generation:int
+  -> input
+  -> Yojson.Safe.t
+  -> (Keeper_memory_os_types.episode, parse_error) result
+(** Parse an already extracted provider-native JSON response into an episode.
+    This is the runtime path used after OAS structured response extraction. *)
+
 (** Parse a raw strict-JSON LLM response into an episode.
 
     Compatibility wrapper over {!episode_of_output_result}; [None] means the

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -529,21 +529,35 @@ let extract_with_provider_classified
               Transport_failed
                 (Provider_transport_failed (Provider_http_error.to_message err))
             | Some (Ok response) ->
-              let raw = Agent_sdk_response.text_of_response response |> String.trim in
-              if String.equal raw ""
-              then
-                Unparseable
-                  (unparseable_response "librarian provider returned empty response")
-              else (
-                match Keeper_librarian.episode_of_output_result ~generation inp raw with
-                | Ok episode -> Parsed episode
-                | Error error ->
-                  Unparseable
-                    (unparseable_response
-                       ~raw_evidence:raw
-                       (Printf.sprintf
-                          "librarian provider returned invalid episode JSON (%s)"
-                          (Keeper_librarian.parse_error_to_string error))))
+              let raw_evidence = Agent_sdk_response.text_of_response response |> String.trim in
+              (match
+                 Agent_sdk_response.structured_json_of_response
+                   ~schema_name:"keeper_librarian_episode"
+                   response
+               with
+               | Error detail ->
+                 let raw_evidence =
+                   if String.equal raw_evidence "" then None else Some raw_evidence
+                 in
+                 Unparseable
+                   (unparseable_response
+                      ?raw_evidence
+                      (Printf.sprintf
+                         "librarian provider returned invalid structured JSON (%s)"
+                         detail))
+               | Ok json ->
+                 (match Keeper_librarian.episode_of_json_result ~generation inp json with
+                  | Ok episode -> Parsed episode
+                  | Error error ->
+                    let raw_evidence =
+                      if String.equal raw_evidence "" then None else Some raw_evidence
+                    in
+                    Unparseable
+                      (unparseable_response
+                         ?raw_evidence
+                         (Printf.sprintf
+                            "librarian provider returned invalid episode JSON (%s)"
+                            (Keeper_librarian.parse_error_to_string error)))))
           in
           (match
              run_with_parse_retries

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -104,7 +104,7 @@ let messages_for_summary ~trace_id ~texts =
 
 let raw_response_text (response : Agent_sdk.Types.api_response) : string option =
   let text =
-    Agent_sdk.Types.visible_text_of_response response
+    Agent_sdk_response.text_of_response response
     |> String.split_on_char '\n'
     |> List.map String.trim
     |> List.filter (fun s -> s <> "")
@@ -117,6 +117,17 @@ type summary_parse_error =
   | Empty_summary_response
   | Invalid_structured_response of string
 
+let summary_text_result_of_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "summary" fields with
+     | Some (`String summary) ->
+       let summary = String.trim summary in
+       if summary = "" then Error Empty_summary_response else Ok summary
+     | Some _ -> Error (Invalid_structured_response "summary field must be a string")
+     | None -> Error (Invalid_structured_response "missing summary field"))
+  | _ -> Error (Invalid_structured_response "summary response must be an object")
+;;
+
 let summary_text_result_of_raw_text raw =
   let raw = String.trim raw in
   if raw = "" then Error Empty_summary_response
@@ -124,22 +135,20 @@ let summary_text_result_of_raw_text raw =
     match Yojson.Safe.from_string raw with
     | exception Yojson.Json_error msg ->
         Error (Invalid_structured_response ("invalid JSON: " ^ msg))
-    | `Assoc fields ->
-        (match List.assoc_opt "summary" fields with
-         | Some (`String summary) ->
-             let summary = String.trim summary in
-             if summary = "" then Error Empty_summary_response else Ok summary
-         | Some _ ->
-             Error (Invalid_structured_response "summary field must be a string")
-         | None ->
-             Error (Invalid_structured_response "missing summary field"))
-    | _ -> Error (Invalid_structured_response "summary response must be an object")
+    | json -> summary_text_result_of_json json
 ;;
 
 let summary_text_result_of_response response =
   match raw_response_text response with
   | None -> Error Empty_summary_response
-  | Some raw -> summary_text_result_of_raw_text raw
+  | Some _ ->
+    (match
+       Agent_sdk_response.structured_json_of_response
+         ~schema_name:"keeper_memory_bank_summary"
+         response
+     with
+     | Ok json -> summary_text_result_of_json json
+     | Error detail -> Error (Invalid_structured_response detail))
 
 let summary_text_of_response response =
   match summary_text_result_of_response response with

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -31,18 +31,6 @@ let with_timeout ?clock ~timeout_sec f =
      | Eio.Time.Timeout -> None)
 ;;
 
-let response_text (response : Agent_sdk.Types.api_response) : string option =
-  let text =
-    Agent_sdk.Types.visible_text_of_response response
-    |> String.split_on_char '\n'
-    |> List.map String.trim
-    |> List.filter (fun s -> s <> "")
-    |> String.concat "\n"
-    |> String.trim
-  in
-  if String.equal text "" then None else Some text
-;;
-
 (* Below this many facts there is nothing to consolidate; skip the LLM call. *)
 let min_facts_to_consolidate = 4
 
@@ -133,6 +121,11 @@ let invalid_structured_response reason =
      ^ Consolidation.output_rejection_reason_to_string reason)
 ;;
 
+let invalid_structured_response_detail detail =
+  Invalid_structured_response
+    ("consolidation provider returned invalid structured response: " ^ detail)
+;;
+
 (* Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it, and
    (unless [dry_run]) rewrite the store atomically. Returns what happened without
    raising for the expected failure modes (too few facts, transport error,
@@ -170,24 +163,31 @@ let consolidate_keeper
          | None -> Transport_failed "consolidation provider timed out"
          | Some (Error _) -> Transport_failed "consolidation provider transport error"
          | Some (Ok response) ->
-           (match response_text response with
-            | None -> Empty_response
-            | Some raw ->
-              (match Consolidation.plan_result_of_string raw with
-               | Error reason -> invalid_structured_response reason
-               | Ok plan ->
-                 let survivors = Consolidation.apply_plan ~now ~facts plan in
-                 let after = List.length survivors in
-                 if dry_run
-                 then Consolidated { before; after }
-                 else
-                   rewrite_if_snapshot_current
-                     ?clock
-                     ~keeper_id
-                     ~facts
-                     ~survivors
-                     ~before
-                     ~after
-                     ())))
+           if String.trim (Agent_sdk_response.text_of_response response) = ""
+           then Empty_response
+           else
+             (match
+                Agent_sdk_response.structured_json_of_response
+                  ~schema_name:"keeper_memory_consolidation_plan"
+                  response
+              with
+              | Error detail -> invalid_structured_response_detail detail
+              | Ok (`Assoc _ as json) ->
+                let plan = Consolidation.plan_of_json json in
+                let survivors = Consolidation.apply_plan ~now ~facts plan in
+                let after = List.length survivors in
+                if dry_run
+                then Consolidated { before; after }
+                else
+                  rewrite_if_snapshot_current
+                    ?clock
+                    ~keeper_id
+                    ~facts
+                    ~survivors
+                    ~before
+                    ~after
+                    ()
+              | Ok _ -> invalid_structured_response Consolidation.Non_object_json)
+        )
         )
 ;;

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -269,18 +269,23 @@ type vision_outcome =
   | Vo_empty
   | Vo_truncated
 
+let vision_text_of_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "text" fields with
+     | Some (`String text) -> Ok (String.trim text)
+     | Some _ -> Error "vision response field \"text\" must be a string"
+     | None -> Error "vision response missing required field \"text\"")
+  | _ -> Error "vision response must be a JSON object"
+;;
+
 let vision_text_of_response (response : Agent_sdk.Types.api_response) =
-  let raw = String.trim (Agent_sdk_response.text_of_response response) in
-  try
-    match Yojson.Safe.from_string raw with
-    | `Assoc fields ->
-      (match List.assoc_opt "text" fields with
-       | Some (`String text) -> Ok (String.trim text)
-       | Some _ -> Error "vision response field \"text\" must be a string"
-       | None -> Error "vision response missing required field \"text\"")
-    | _ -> Error "vision response must be a JSON object"
+  match
+    Agent_sdk_response.structured_json_of_response
+      ~schema_name:"keeper_vision_analyze"
+      response
   with
-  | Yojson.Json_error msg -> Error ("vision response is not valid JSON: " ^ msg)
+  | Ok json -> vision_text_of_json json
+  | Error msg -> Error ("vision response is not valid structured JSON: " ^ msg)
 ;;
 
 let ok_or_classified_json (response : Agent_sdk.Types.api_response) =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -81,6 +81,17 @@ let parse_verdict_from_response_text text =
       Error (sprintf "verifier response must be strict JSON: %s" msg)
 ;;
 
+let parse_verdict_from_response response =
+  match
+    Agent_sdk_response.structured_json_of_response
+      ~schema_name:"verification_report_verdict"
+      response
+  with
+  | Ok json -> Core.parse_verdict_from_json json
+  | Error msg ->
+    Error (sprintf "verifier response must be structured JSON: %s" msg)
+;;
+
 module For_testing = struct
   let parse_verdict_from_response_text = parse_verdict_from_response_text
 end
@@ -143,16 +154,14 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
        | None ->
          (* LLM responded with text instead of tool call. The provider-native
             schema contract still requires a strict JSON verdict object here. *)
-         let text = Agent_sdk_response.text_of_response result.response in
          Log.Verifier.info
            "verdict via strict JSON response fallback (model did not call report_verdict)";
-        (match parse_verdict_from_response_text text with
+        (match parse_verdict_from_response result.response with
          | Ok verdict -> Ok verdict
           | Error parse_err ->
             Log.Verifier.warn
-              "Verdict parse failed (%s); raw=%s"
-              parse_err
-              (String.sub text 0 (min 80 (String.length text)));
+              "Verdict parse failed (%s)"
+              parse_err;
             Error (sprintf "verdict parse: %s" parse_err)))
     | Error err -> Error (Agent_sdk.Error.to_string err))
 ;;

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -227,6 +227,34 @@ let test_agent_sdk_response_visible_text_excludes_non_answer_blocks () =
     "visible\ntail"
     (Agent_sdk_response.text_of_response response)
 
+let test_agent_sdk_response_structured_json_uses_oas_visible_projection () =
+  let response : Agent_sdk.Types.api_response =
+    { id = "resp"
+    ; model = "model"
+    ; stop_reason = Agent_sdk.Types.EndTurn
+    ; content =
+        [ Agent_sdk.Types.ToolResult
+            { tool_use_id = "tool-1"
+            ; content = {|{"text":"tool payload must not be parsed"}|}
+            ; is_error = false
+            ; json = None
+            ; content_blocks = None
+            }
+        ; Agent_sdk.Types.Thinking { signature = None; content = "private reasoning" }
+        ; Agent_sdk.Types.Text "```json\n{\"text\":\"visible answer\"}\n```"
+        ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match Agent_sdk_response.structured_json_of_response response with
+  | Error msg -> Alcotest.fail ("structured JSON rejected: " ^ msg)
+  | Ok json ->
+    Alcotest.(check string)
+      "parsed visible JSON"
+      "visible answer"
+      Yojson.Safe.Util.(json |> member "text" |> to_string)
+
 (* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
@@ -260,5 +288,7 @@ let () =
     "response_projection", [
       Alcotest.test_case "visible text excludes non-answer blocks" `Quick
         test_agent_sdk_response_visible_text_excludes_non_answer_blocks;
+      Alcotest.test_case "structured JSON uses OAS visible projection" `Quick
+        test_agent_sdk_response_structured_json_uses_oas_visible_projection;
     ];
   ]

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -523,7 +523,7 @@ let test_repo_runtime_toml_loads () =
     check
       (option string)
       "structured judge runtime"
-      (Some "ollama_cloud.ollama-cloud-devstral-2-123b")
+      (Some "ollama_cloud_native.minimax-m3-native-structured")
       structured_judge;
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
@@ -623,6 +623,31 @@ let test_repo_runtime_toml_loads () =
           check bool "MiniMax M3 forced tool_choice disabled" false
             caps.supports_tool_choice
         | None -> fail "expected MiniMax M3 capabilities"));
+    (match
+       List.find_opt
+         (fun (runtime : Runtime.t) ->
+            String.equal runtime.id
+              "ollama_cloud_native.minimax-m3-native-structured")
+         runtimes
+     with
+     | None -> fail "expected native MiniMax M3 structured-output runtime in seed"
+     | Some runtime ->
+       check string "native MiniMax M3 api name" "minimax-m3"
+         runtime.model.api_name;
+       check (option (float 0.0)) "native MiniMax M3 connect timeout"
+         (Some 600.0)
+         runtime.provider_config.connect_timeout_s;
+       (match runtime.model.capabilities with
+       | Some caps ->
+         check bool "native MiniMax M3 response_format json" true
+           caps.supports_response_format_json;
+         check bool "native MiniMax M3 structured output" true
+           caps.supports_structured_output;
+         check bool "native MiniMax M3 Ollama think control" true
+           (Runtime_schema.equal_thinking_control_format
+              caps.thinking_control_format
+              Runtime_schema.Ollama_think)
+       | None -> fail "expected native MiniMax M3 capabilities"));
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->


### PR DESCRIPTION
## Summary
- add Agent_sdk_response.structured_json_of_response as the MASC-side SSOT for extracting provider-native structured JSON through OAS Agent_sdk.Structured.schema_extractor
- route dashboard governance/operator judges, verifier/adversarial review fallbacks, librarian, memory summary, memory consolidation, and vision analyzer through that helper before domain validation
- keep raw-text parsers as test/compatibility surfaces and raw response text only for diagnostics or empty-response classification
- add adapter coverage that proves structured JSON extraction ignores ToolResult/Thinking and uses the visible assistant projection

## Stack
- Base: #22850 (fix/runtime-tunables-doc-drift-20260630), so this PR does not duplicate the generated runtime-tunables docs drift fix.

## Validation
- PASS: git diff --check fix/runtime-tunables-doc-drift-20260630..HEAD
- PASS: opam exec -- ocamlformat --check <changed OCaml files>
- BLOCKED local focused build: scripts/dune-local.sh build <focused test exes> aborts because the local opam switch has agent_sdk 0.208.5 while MASC requires >= 0.208.7. Re-running with MASC_SKIP_PIN_CHECK reaches pre-existing unbound Agent_sdk.Types.reasoning_details_text errors from the stale local SDK. CI should be the build authority for this stack.