### PR TITLE
refactor(runtime): drop capability mirror, consume OAS Provider.capabilities directly

### DIFF
--- a/lib/runtime/runtime_wire_overlay.ml
+++ b/lib/runtime/runtime_wire_overlay.ml
@@ -29,59 +29,19 @@ let request_kind_of_provider_cfg (provider_cfg : Llm_provider.Provider_config.t)
   | DashScope -> Agent_sdk.Provider.Openai_chat_completions
 ;;
 
-let agent_capabilities_of_llm_capabilities
-      (caps : Llm_provider.Capabilities.capabilities)
-  : Agent_sdk.Provider.capabilities
-  =
-  { max_context_tokens = caps.max_context_tokens
-  ; max_output_tokens = caps.max_output_tokens
-  ; supports_tools = caps.supports_tools
-  ; supports_tool_choice = caps.supports_tool_choice
-  ; supports_required_tool_choice = caps.supports_required_tool_choice
-  ; supports_named_tool_choice = caps.supports_named_tool_choice
-  ; supports_parallel_tool_calls = caps.supports_parallel_tool_calls
-  ; supports_runtime_mcp_tools = caps.supports_runtime_mcp_tools
-  ; supports_runtime_tool_events = caps.supports_runtime_tool_events
-  ; assistant_tool_content_format = caps.assistant_tool_content_format
-  ; supports_reasoning = caps.supports_reasoning
-  ; supports_extended_thinking = caps.supports_extended_thinking
-  ; supports_reasoning_budget = caps.supports_reasoning_budget
-  ; accepted_reasoning_efforts = caps.accepted_reasoning_efforts
-  ; thinking_control_format = caps.thinking_control_format
-  ; preserve_thinking_control_format = caps.preserve_thinking_control_format
-  ; reasoning_replay_override = caps.reasoning_replay_override
-  ; supports_response_format_json = caps.supports_response_format_json
-  ; supports_structured_output = caps.supports_structured_output
-  ; supports_multimodal_inputs = caps.supports_multimodal_inputs
-  ; supports_image_input = caps.supports_image_input
-  ; supports_audio_input = caps.supports_audio_input
-  ; supports_video_input = caps.supports_video_input
-  ; modality_priority = caps.modality_priority
-  ; supports_native_streaming = caps.supports_native_streaming
-  ; supports_system_prompt = caps.supports_system_prompt
-  ; supports_caching = caps.supports_caching
-  ; supports_prompt_caching = caps.supports_prompt_caching
-  ; prompt_cache_alignment = caps.prompt_cache_alignment
-  ; supports_top_k = caps.supports_top_k
-  ; supports_min_p = caps.supports_min_p
-  ; supports_seed = caps.supports_seed
-  ; supports_seed_with_images = caps.supports_seed_with_images
-  ; supports_computer_use = caps.supports_computer_use
-  ; supports_code_execution = caps.supports_code_execution
-  ; emits_usage_tokens = caps.emits_usage_tokens
-  ; supported_models = caps.supported_models
-  ; reasoning_output_format = caps.reasoning_output_format
-  ; reasoning_streaming_format = caps.reasoning_streaming_format
-  }
-;;
-
 let register_capability_overlay_provider
       ~(name : string)
       ~(provider_cfg : Llm_provider.Provider_config.t)
   =
+  (* OAS 0.208.7 (#2355) exposes
+     [Provider.capabilities = Llm_provider.Capabilities.capabilities], so
+     [capabilities_for_provider_config] already returns the registration type.
+     The former 41-field hand-copy (agent_capabilities_of_llm_capabilities) was
+     the identity and is removed — this ends the recurring capability-mirror
+     drift where adding an OAS field (e.g. reasoning_output_format /
+     reasoning_streaming_format) broke the copy until each field was mirrored. *)
   let capabilities =
     Agent_sdk.Provider_runtime_binding.capabilities_for_provider_config provider_cfg
-    |> agent_capabilities_of_llm_capabilities
   in
   Agent_sdk.Provider.register_provider
     { name


### PR DESCRIPTION
## 목표

`runtime_wire_overlay.ml`의 `agent_capabilities_of_llm_capabilities`(41-field `Llm_provider.Capabilities.capabilities` → `Agent_sdk.Provider.capabilities` 1:1 수동복사)를 삭제하고, OAS를 직접 소비합니다.

## 근거

OAS 0.208.7(**#2355**, masc는 #22836으로 이미 pin)이 `Provider.capabilities = Llm_provider.Capabilities.capabilities` 등식을 노출하므로, `Provider_runtime_binding.capabilities_for_provider_config`가 반환하는 값이 곧 `register_provider`가 받는 타입입니다. 41-field 복사는 **identity**가 되어 불필요.

이 수동복사는 **반복 drift의 근원**이었습니다: OAS가 capability 필드를 추가할 때마다(최근 `reasoning_output_format`/`reasoning_streaming_format`, #22827에서 band-aid로 수동 추가) 복사가 컴파일 실패 → 필드를 손으로 미러링해야 main이 복구됐습니다. 이제 컴파일러가 record를 자동 추적 → drift 영구 차단.

## 변경

- `lib/runtime/runtime_wire_overlay.ml`: `agent_capabilities_of_llm_capabilities`(41 field, caller 1곳·.mli 미노출) 삭제. `register_capability_overlay_provider`이 `capabilities_for_provider_config provider_cfg` 결과를 직접 사용(`|> agent_capabilities_of_llm_capabilities` 제거). WHY 주석 추가.

## 동작

**behavior-preserving**: 삭제한 함수는 모든 필드를 `caps.field`로 순수 복사(변환 0). #2355로 두 타입이 동일해져 identity. 등록되는 capabilities 값 불변.

## 경계 / 검증

- OAS 무변경(MASC가 OAS 소비). 이건 band-aid(#22827) + 수동 mirror **제거** = workaround 아님(레거시 숙청).
- 로컬 빌드는 machine-wide dune 락(stuck Codex 빌드)으로 미실행 → CI(Lint=컴파일 검증). 단 masc Build and Test는 ~21분으로 timeout 빈발(infra, 이 PR 무관).
- 후속(별개 PR, OAS #2398 release 후): `runtime_schema` thinking_control_format 9-variant 재선언 → 1줄 축약(#2398 enable).

RFC-WAIVED: runtime wire-overlay 정리(credential/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 무관). band-aid+수동 mirror 제거이며 신규 workaround 아님.
