### PR TITLE
refactor(oas): centralize response text projection

### DIFF
--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -5,7 +5,7 @@
    fusion 개념은 OAS에 노출하지 않는다. *)
 
 let answer_text (resp : Agent_sdk.Types.api_response) : string =
-  Agent_sdk.Types.visible_text_of_response resp
+  Agent_sdk_response.text_of_response resp
 
 let stop_reason_label = Keeper_hooks_oas_types.stop_reason_to_label
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -751,9 +751,7 @@ and run_existing_worker_agent
          ~raw_trace;
        match result with
        | Ok response ->
-         let output =
-           Agent_sdk.Types.visible_text_of_response response
-         in
+         let output = Agent_sdk_response.text_of_response response in
          let* () =
            Worker_container.append_worker_completion_log
              ~base_path

--- a/test/test_oas_canonical_delegation.ml
+++ b/test/test_oas_canonical_delegation.ml
@@ -57,6 +57,21 @@ let test_masc_delegates_oas_response_shape_metrics () =
   check_calls ~file ~callee:"Response_shape.content_shape_to_string" ~expected:1
 ;;
 
+let test_masc_routes_response_text_projection_through_adapter () =
+  check_calls
+    ~file:"lib/agent_sdk_response.ml"
+    ~callee:"Agent_sdk.Types.visible_text_of_response"
+    ~expected:1;
+  check_calls
+    ~file:"lib/fusion/fusion_oas.ml"
+    ~callee:"Agent_sdk.Types.visible_text_of_response"
+    ~expected:0;
+  check_calls
+    ~file:"lib/worker_oas.ml"
+    ~callee:"Agent_sdk.Types.visible_text_of_response"
+    ~expected:0
+;;
+
 let test_masc_delegates_oas_tool_call_projection () =
   check_calls
     ~file:"lib/keeper/keeper_context_tool_message_pairs.ml"
@@ -123,6 +138,10 @@ let () =
             "MASC delegates response shape metrics to OAS"
             `Quick
             test_masc_delegates_oas_response_shape_metrics
+        ; test_case
+            "MASC routes response text projection through adapter"
+            `Quick
+            test_masc_routes_response_text_projection_through_adapter
         ; test_case
             "MASC delegates tool-call block projection to OAS"
             `Quick


### PR DESCRIPTION
## Summary
- route Fusion answer text extraction through Agent_sdk_response.text_of_response
- route Worker completion output extraction through Agent_sdk_response.text_of_response
- add an AST ratchet proving direct Agent_sdk.Types.visible_text_of_response use remains isolated to the adapter

## Why
MASC should consume OAS response projections through one local boundary. This keeps Fusion/Worker from reaching into OAS primitives directly and prepares the next pin bump to OAS 0.208.9, where response_json_extractor can replace the temporary schema_extractor-backed JSON adapter in one place.

## Validation
- opam exec -- ocamlformat --check lib/fusion/fusion_oas.ml lib/worker_oas.ml test/test_oas_canonical_delegation.ml
- git diff --check
- rg -n 'Agent_sdk\.Types\.visible_text_of_response' lib -g '*.ml' -g '*.mli' -> only lib/agent_sdk_response.ml

## Local build note
- scripts/dune-local.sh build test/test_oas_canonical_delegation.exe is blocked by local shared switch drift: installed agent_sdk 0.208.5, repo requires >=0.208.7
- MASC_SKIP_PIN_CHECK=1 confirms the same stale-SDK class: Agent_sdk.Types.reasoning_details_text is unavailable in the local switch
