### PR TITLE
fix(keeper): add staleness detection to WIP admission (task-1570)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -294,7 +294,23 @@ let wip_admission_result_fields rejections =
           ; "action", `String wip_admission_action
           ; "rejected_count", `Int (List.length rejections)
           ; "rejections", `List (List.map wip_admission_rejection_json rejections)
-          ] )
+            ] )
+      ]
+;;
+
+let stale_claim_release_fields releases =
+  match releases with
+  | [] -> []
+  | releases ->
+    [ ( "stale_claim_releases"
+      , `List
+          (List.map
+             (fun (task_id, assignee) ->
+                `Assoc
+                  [ "task_id", `String task_id
+                  ; "assignee", `String assignee
+                  ])
+             releases) )
     ]
 ;;
 
@@ -500,19 +516,24 @@ let handle_keeper_task_tool
     let claim_goal_scope =
       Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
     in
+    let stale_claim_releases =
+      match
+        Workspace.release_stale_claims config
+          ~ttl_seconds:Env_config_runtime.Claim.ttl_seconds
+      with
+      | releases -> Ok releases
+      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+      | exception exn -> Error (Printexc.to_string exn)
+    in
     let wip_rejections = ref [] in
     let task_goal_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let remember_wip_rejection task_id rejection =
       if not (List.exists (fun (existing_id, _) -> String.equal existing_id task_id) !wip_rejections)
       then wip_rejections := (task_id, rejection) :: !wip_rejections
     in
-    (* DET-OK: boundary read, reused for every admission_filter call below so
-       one claim decision judges all candidates against the same instant. *)
-    let wip_admission_now = Unix.gettimeofday () in
     let wip_admission_filter ~active_tasks task =
       let active_items =
-        Keeper_wip_admission.active_items_of_tasks
-          ~task_goal_index ~now:wip_admission_now active_tasks
+        Keeper_wip_admission.active_items_of_tasks ~task_goal_index active_tasks
       in
       let scope =
         Keeper_wip_admission.scope_of_task ~task_goal_index task
@@ -573,18 +594,32 @@ let handle_keeper_task_tool
         Workspace.Claim_next_error
           (Printf.sprintf "unknown task_id: %s" requested_task_id)
       | Some task -> claim_specific task
+      in
+      let claim_after_stale_release () =
+        if requested_task_id <> "" then
+          explicit_claim_result ()
+        else
+          Workspace.claim_next_r config ~agent_name:meta.agent_name
+            ~task_filter:claim_goal_scope.task_filter
+            ~admission_filter:wip_admission_filter
+            ~allow_scope_fallback:true
+            ()
+      in
+      let result =
+        match stale_claim_releases with
+        | Error err ->
+          Workspace.Claim_next_error
+            (Printf.sprintf
+               "stale-claim release failed before WIP admission: %s"
+               err)
+        | Ok _ -> claim_after_stale_release ()
+      in
+    let stale_claim_releases =
+      match stale_claim_releases with
+      | Ok releases -> releases
+      | Error _ -> []
     in
-    let result =
-      if requested_task_id <> "" then
-        explicit_claim_result ()
-      else
-        Workspace.claim_next_r config ~agent_name:meta.agent_name
-          ~task_filter:claim_goal_scope.task_filter
-          ~admission_filter:wip_admission_filter
-          ~allow_scope_fallback:true
-          ()
-    in
-    let wip_rejections = List.rev !wip_rejections in
+      let wip_rejections = List.rev !wip_rejections in
     let auto_started_ok = ref false in
     let harness_completed = ref false in
     (match result with
@@ -807,12 +842,13 @@ let handle_keeper_task_tool
             ("claim_scope", claim_scope);
             ("auto_started", `Bool !auto_started_ok);
           ]
-         @ (match typed_outcome_field with
-            | Some field -> [ field ]
-            | None -> [])
-         @ claimed_task_fields
-         @ wip_admission_result_fields wip_rejections
-         @
+           @ (match typed_outcome_field with
+              | Some field -> [ field ]
+              | None -> [])
+           @ claimed_task_fields
+         @ stale_claim_release_fields stale_claim_releases
+           @ wip_admission_result_fields wip_rejections
+           @
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]
          | None -> []))

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -506,9 +506,8 @@ let handle_keeper_task_tool
       if not (List.exists (fun (existing_id, _) -> String.equal existing_id task_id) !wip_rejections)
       then wip_rejections := (task_id, rejection) :: !wip_rejections
     in
-    (* DET-OK: sole wall-clock read for this claim turn's WIP-staleness check,
-       reused across every admission_filter invocation below so all candidates
-       in one claim decision are judged against the same instant. *)
+    (* DET-OK: boundary read, reused for every admission_filter call below so
+       one claim decision judges all candidates against the same instant. *)
     let wip_admission_now = Unix.gettimeofday () in
     let wip_admission_filter ~active_tasks task =
       let active_items =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -506,9 +506,14 @@ let handle_keeper_task_tool
       if not (List.exists (fun (existing_id, _) -> String.equal existing_id task_id) !wip_rejections)
       then wip_rejections := (task_id, rejection) :: !wip_rejections
     in
+    (* DET-OK: sole wall-clock read for this claim turn's WIP-staleness check,
+       reused across every admission_filter invocation below so all candidates
+       in one claim decision are judged against the same instant. *)
+    let wip_admission_now = Unix.gettimeofday () in
     let wip_admission_filter ~active_tasks task =
       let active_items =
-        Keeper_wip_admission.active_items_of_tasks ~task_goal_index active_tasks
+        Keeper_wip_admission.active_items_of_tasks
+          ~task_goal_index ~now:wip_admission_now active_tasks
       in
       let scope =
         Keeper_wip_admission.scope_of_task ~task_goal_index task

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -95,10 +95,29 @@ type active_item = {
   scope : scope;
 }
 
-let task_is_active_wip (task : Masc_domain.task) =
+(* WIP admission's own default: a claim/in-progress task with no observed
+   progress for one hour is stale enough to stop counting against the
+   admission caps. *)
+let default_wip_stale_threshold_s = Masc_time_constants.hour
+
+let task_is_active_wip ?(stale_threshold_s = default_wip_stale_threshold_s)
+    (task : Masc_domain.task)
+  =
+  let now = Unix.gettimeofday () in
+  let is_stale ts =
+    (* Fail-closed: an unparseable timestamp is treated as stale rather than
+       silently defaulting to "60 seconds ago" (parse_iso8601's own default),
+       which would admit a task with a malformed claimed_at/started_at as
+       fresh WIP. Matches workspace_resilience.ml's existing is_stale
+       convention for unparseable timestamps. *)
+    match Masc_domain.parse_iso8601_opt ts with
+    | None -> true
+    | Some t -> now -. t > stale_threshold_s
+  in
   match task.task_status with
-  | Masc_domain.Claimed _
-  | Masc_domain.InProgress _ -> true
+  | Masc_domain.Claimed { claimed_at; _ } when is_stale claimed_at -> false
+  | Masc_domain.InProgress { started_at; _ } when is_stale started_at -> false
+  | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> true
   | Masc_domain.Todo
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
@@ -107,9 +126,9 @@ let task_is_active_wip (task : Masc_domain.task) =
 let active_item_of_task ?task_goal_index (task : Masc_domain.task) =
   { id = task.id; scope = scope_of_task ?task_goal_index task }
 
-let active_items_of_tasks ?task_goal_index tasks =
+let active_items_of_tasks ?task_goal_index ?stale_threshold_s tasks =
   tasks
-  |> List.filter task_is_active_wip
+  |> List.filter (task_is_active_wip ?stale_threshold_s)
   |> List.map (active_item_of_task ?task_goal_index)
 
 type reject_reason =

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -100,10 +100,9 @@ type active_item = {
    admission caps. *)
 let default_wip_stale_threshold_s = Masc_time_constants.hour
 
-let task_is_active_wip ?(stale_threshold_s = default_wip_stale_threshold_s)
+let task_is_active_wip ~now ?(stale_threshold_s = default_wip_stale_threshold_s)
     (task : Masc_domain.task)
   =
-  let now = Unix.gettimeofday () in
   let is_stale ts =
     (* Fail-closed: an unparseable timestamp is treated as stale rather than
        silently defaulting to "60 seconds ago" (parse_iso8601's own default),
@@ -126,9 +125,9 @@ let task_is_active_wip ?(stale_threshold_s = default_wip_stale_threshold_s)
 let active_item_of_task ?task_goal_index (task : Masc_domain.task) =
   { id = task.id; scope = scope_of_task ?task_goal_index task }
 
-let active_items_of_tasks ?task_goal_index ?stale_threshold_s tasks =
+let active_items_of_tasks ?task_goal_index ?stale_threshold_s ~now tasks =
   tasks
-  |> List.filter (task_is_active_wip ?stale_threshold_s)
+  |> List.filter (task_is_active_wip ~now ?stale_threshold_s)
   |> List.map (active_item_of_task ?task_goal_index)
 
 type reject_reason =

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -95,27 +95,8 @@ type active_item = {
   scope : scope;
 }
 
-(* WIP admission's own default: a claim/in-progress task with no observed
-   progress for one hour is stale enough to stop counting against the
-   admission caps. *)
-let default_wip_stale_threshold_s = Masc_time_constants.hour
-
-let task_is_active_wip ~now ?(stale_threshold_s = default_wip_stale_threshold_s)
-    (task : Masc_domain.task)
-  =
-  let is_stale ts =
-    (* Fail-closed: an unparseable timestamp is treated as stale rather than
-       silently defaulting to "60 seconds ago" (parse_iso8601's own default),
-       which would admit a task with a malformed claimed_at/started_at as
-       fresh WIP. Matches workspace_resilience.ml's existing is_stale
-       convention for unparseable timestamps. *)
-    match Masc_domain.parse_iso8601_opt ts with
-    | None -> true
-    | Some t -> now -. t > stale_threshold_s
-  in
+let task_is_active_wip (task : Masc_domain.task) =
   match task.task_status with
-  | Masc_domain.Claimed { claimed_at; _ } when is_stale claimed_at -> false
-  | Masc_domain.InProgress { started_at; _ } when is_stale started_at -> false
   | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> true
   | Masc_domain.Todo
   | Masc_domain.AwaitingVerification _
@@ -125,9 +106,9 @@ let task_is_active_wip ~now ?(stale_threshold_s = default_wip_stale_threshold_s)
 let active_item_of_task ?task_goal_index (task : Masc_domain.task) =
   { id = task.id; scope = scope_of_task ?task_goal_index task }
 
-let active_items_of_tasks ?task_goal_index ?stale_threshold_s ~now tasks =
+let active_items_of_tasks ?task_goal_index tasks =
   tasks
-  |> List.filter (task_is_active_wip ~now ?stale_threshold_s)
+  |> List.filter task_is_active_wip
   |> List.map (active_item_of_task ?task_goal_index)
 
 type reject_reason =

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -37,10 +37,10 @@ type active_item = {
   scope : scope;
 }
 
-val task_is_active_wip : Masc_domain.task -> bool
+val task_is_active_wip : ?stale_threshold_s:float -> Masc_domain.task -> bool
 val active_item_of_task :
   ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> active_item
-val active_items_of_tasks :
+val active_items_of_tasks : ?stale_threshold_s:float ->
   ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task list -> active_item list
 
 type reject_reason =

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -38,12 +38,12 @@ type active_item = {
 }
 
 val task_is_active_wip :
-  now:float -> ?stale_threshold_s:float -> Masc_domain.task -> bool
+  Masc_domain.task -> bool
 val active_item_of_task :
   ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> active_item
 val active_items_of_tasks :
-  ?task_goal_index:(string, string list) Hashtbl.t -> ?stale_threshold_s:float ->
-  now:float -> Masc_domain.task list -> active_item list
+  ?task_goal_index:(string, string list) Hashtbl.t ->
+  Masc_domain.task list -> active_item list
 
 type reject_reason =
   | Global_cap

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -40,8 +40,9 @@ type active_item = {
 val task_is_active_wip : ?stale_threshold_s:float -> Masc_domain.task -> bool
 val active_item_of_task :
   ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> active_item
-val active_items_of_tasks : ?stale_threshold_s:float ->
-  ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task list -> active_item list
+val active_items_of_tasks :
+  ?task_goal_index:(string, string list) Hashtbl.t -> ?stale_threshold_s:float ->
+  Masc_domain.task list -> active_item list
 
 type reject_reason =
   | Global_cap

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -37,12 +37,13 @@ type active_item = {
   scope : scope;
 }
 
-val task_is_active_wip : ?stale_threshold_s:float -> Masc_domain.task -> bool
+val task_is_active_wip :
+  now:float -> ?stale_threshold_s:float -> Masc_domain.task -> bool
 val active_item_of_task :
   ?task_goal_index:(string, string list) Hashtbl.t -> Masc_domain.task -> active_item
 val active_items_of_tasks :
   ?task_goal_index:(string, string list) Hashtbl.t -> ?stale_threshold_s:float ->
-  Masc_domain.task list -> active_item list
+  now:float -> Masc_domain.task list -> active_item list
 
 type reject_reason =
   | Global_cap

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -283,12 +283,13 @@ let test_keeper_task_claim_no_unclaimed_emits_no_work_outcome () =
          (typed |> U.member "reason" |> U.member "kind" |> U.to_string))
 
 let test_active_items_only_include_claimed_or_in_progress () =
+  let now = Masc_domain.now_iso () in
   let tasks =
     [ task
-        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = "now" })
+        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = now })
         "task-001"
     ; task
-        ~status:(Masc_domain.InProgress { assignee = "b"; started_at = "now" })
+        ~status:(Masc_domain.InProgress { assignee = "b"; started_at = now })
         ~title:"docs: update runbook"
         "task-002"
     ; task ~title:"fix: still todo" "task-003"
@@ -303,20 +304,21 @@ let test_active_items_only_include_claimed_or_in_progress () =
        active)
 
 let test_active_items_include_all_active_assignees () =
+  let now = Masc_domain.now_iso () in
   let tasks =
     [ task
-        ~status:(Masc_domain.Claimed { assignee = "keeper-a"; claimed_at = "now" })
+        ~status:(Masc_domain.Claimed { assignee = "keeper-a"; claimed_at = now })
         "task-claimed-a"
     ; task
         ~status:
-          (Masc_domain.InProgress { assignee = "keeper-a"; started_at = "now" })
+          (Masc_domain.InProgress { assignee = "keeper-a"; started_at = now })
         "task-progress-a"
     ; task
-        ~status:(Masc_domain.Claimed { assignee = "keeper-b"; claimed_at = "now" })
+        ~status:(Masc_domain.Claimed { assignee = "keeper-b"; claimed_at = now })
         "task-claimed-b"
     ; task
         ~status:
-          (Masc_domain.InProgress { assignee = "keeper-b"; started_at = "now" })
+          (Masc_domain.InProgress { assignee = "keeper-b"; started_at = now })
         "task-progress-b"
     ]
   in
@@ -324,6 +326,53 @@ let test_active_items_include_all_active_assignees () =
   check (list string) "all active ids"
     [ "task-claimed-a"; "task-progress-a"; "task-claimed-b"; "task-progress-b" ]
     (List.map (fun item -> item.Admission.id) active)
+
+let iso8601_of_unix_time t =
+  let tm = Unix.gmtime t in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let test_stale_claimed_task_not_active () =
+  (* claimed 2 hours ago, default threshold is 1 hour -> stale, not active *)
+  let two_hours_ago = iso8601_of_unix_time (Unix.gettimeofday () -. 7200.) in
+  let tasks =
+    [ task
+        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = two_hours_ago })
+        "task-stale"
+    ]
+  in
+  check (list string) "no active ids" []
+    (List.map (fun item -> item.Admission.id) (Admission.active_items_of_tasks tasks))
+
+let test_fresh_claimed_task_stays_active_under_custom_threshold () =
+  (* claimed 30 minutes ago, custom threshold 10 minutes -> stale under that
+     threshold, but active under the (higher) default. Exercises the
+     ?stale_threshold_s override on both task_is_active_wip and
+     active_items_of_tasks. *)
+  let thirty_min_ago = iso8601_of_unix_time (Unix.gettimeofday () -. 1800.) in
+  let claimed_task =
+    task
+      ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = thirty_min_ago })
+      "task-recent"
+  in
+  check bool "active under default (1h) threshold" true
+    (Admission.task_is_active_wip claimed_task);
+  check bool "stale under a 10-minute threshold" false
+    (Admission.task_is_active_wip ~stale_threshold_s:600. claimed_task)
+
+let test_unparseable_claimed_at_treated_as_stale () =
+  (* Fail-closed: a malformed/unparseable claimed_at must not silently be
+     treated as fresh WIP (parse_iso8601's own default is "60 seconds ago",
+     which would otherwise always admit it). *)
+  let tasks =
+    [ task
+        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = "not-a-timestamp" })
+        "task-malformed"
+    ]
+  in
+  check (list string) "no active ids for malformed timestamp" []
+    (List.map (fun item -> item.Admission.id) (Admission.active_items_of_tasks tasks))
 
 let test_goalless_task_exempt_from_goal_cap () =
   (* RFC-0245: a goalless claim must not be rejected by the per-goal cap even
@@ -405,5 +454,11 @@ let () =
             test_goalless_tasks_never_goal_capped
         ; test_case "goalless still bounded by global cap" `Quick
             test_goalless_still_bounded_by_global_cap
+        ; test_case "stale claimed task not active" `Quick
+            test_stale_claimed_task_not_active
+        ; test_case "fresh claimed task stays active under custom threshold" `Quick
+            test_fresh_claimed_task_stays_active_under_custom_threshold
+        ; test_case "unparseable claimed_at treated as stale" `Quick
+            test_unparseable_claimed_at_treated_as_stale
         ] )
     ]

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -295,7 +295,7 @@ let test_active_items_only_include_claimed_or_in_progress () =
     ; task ~title:"fix: still todo" "task-003"
     ]
   in
-  let active = Admission.active_items_of_tasks tasks in
+  let active = Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks in
   check (list string) "active ids" [ "task-001"; "task-002" ]
     (List.map (fun item -> item.Admission.id) active);
   check (list string) "categories" [ "fix"; "docs" ]
@@ -322,7 +322,7 @@ let test_active_items_include_all_active_assignees () =
         "task-progress-b"
     ]
   in
-  let active = Admission.active_items_of_tasks tasks in
+  let active = Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks in
   check (list string) "all active ids"
     [ "task-claimed-a"; "task-progress-a"; "task-claimed-b"; "task-progress-b" ]
     (List.map (fun item -> item.Admission.id) active)
@@ -335,7 +335,8 @@ let iso8601_of_unix_time t =
 
 let test_stale_claimed_task_not_active () =
   (* claimed 2 hours ago, default threshold is 1 hour -> stale, not active *)
-  let two_hours_ago = iso8601_of_unix_time (Unix.gettimeofday () -. 7200.) in
+  let now = Unix.gettimeofday () in
+  let two_hours_ago = iso8601_of_unix_time (now -. 7200.) in
   let tasks =
     [ task
         ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = two_hours_ago })
@@ -343,23 +344,25 @@ let test_stale_claimed_task_not_active () =
     ]
   in
   check (list string) "no active ids" []
-    (List.map (fun item -> item.Admission.id) (Admission.active_items_of_tasks tasks))
+    (List.map (fun item -> item.Admission.id)
+       (Admission.active_items_of_tasks ~now tasks))
 
 let test_fresh_claimed_task_stays_active_under_custom_threshold () =
   (* claimed 30 minutes ago, custom threshold 10 minutes -> stale under that
      threshold, but active under the (higher) default. Exercises the
      ?stale_threshold_s override on both task_is_active_wip and
      active_items_of_tasks. *)
-  let thirty_min_ago = iso8601_of_unix_time (Unix.gettimeofday () -. 1800.) in
+  let now = Unix.gettimeofday () in
+  let thirty_min_ago = iso8601_of_unix_time (now -. 1800.) in
   let claimed_task =
     task
       ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = thirty_min_ago })
       "task-recent"
   in
   check bool "active under default (1h) threshold" true
-    (Admission.task_is_active_wip claimed_task);
+    (Admission.task_is_active_wip ~now claimed_task);
   check bool "stale under a 10-minute threshold" false
-    (Admission.task_is_active_wip ~stale_threshold_s:600. claimed_task)
+    (Admission.task_is_active_wip ~now ~stale_threshold_s:600. claimed_task)
 
 let test_unparseable_claimed_at_treated_as_stale () =
   (* Fail-closed: a malformed/unparseable claimed_at must not silently be
@@ -372,7 +375,8 @@ let test_unparseable_claimed_at_treated_as_stale () =
     ]
   in
   check (list string) "no active ids for malformed timestamp" []
-    (List.map (fun item -> item.Admission.id) (Admission.active_items_of_tasks tasks))
+    (List.map (fun item -> item.Admission.id)
+       (Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks))
 
 let test_goalless_task_exempt_from_goal_cap () =
   (* RFC-0245: a goalless claim must not be rejected by the per-goal cap even

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -181,6 +181,30 @@ let claim_task_exn config ~agent_name ~task_id =
   | Ok _ -> ()
   | Error err -> fail ("claim_task_r failed: " ^ Masc_domain.masc_error_to_string err)
 
+let old_release_timestamp = "2020-01-01T00:00:00Z"
+
+let mark_agent_stale_for_release config ~agent_name =
+  Masc.Workspace.update_local_agent_state config ~agent_name (fun agent ->
+    { agent with status = Masc_domain.Active; last_seen = old_release_timestamp })
+
+let rewrite_task_status config ~task_id ~f =
+  let backlog = Masc.Workspace.read_backlog config in
+  let updated_tasks =
+    List.map
+      (fun (task : Masc_domain.task) ->
+         if String.equal task.id task_id
+         then { task with task_status = f task.task_status }
+         else task)
+      backlog.tasks
+  in
+  Masc.Workspace.write_backlog config { backlog with tasks = updated_tasks }
+
+let age_claimed_task_for_release config ~task_id =
+  rewrite_task_status config ~task_id ~f:(function
+    | Masc_domain.Claimed { assignee; _ } ->
+      Masc_domain.Claimed { assignee; claimed_at = old_release_timestamp }
+    | other -> other)
+
 let meta_with_active_goal goal_id =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -245,9 +269,60 @@ let test_keeper_task_claim_reports_other_keepers_wip_cap () =
        check bool "scope note distinguishes claim cap" true
          (Astring.String.is_infix ~affix:"not a request to create a new repo"
             (rejection |> U.member "scope_note" |> U.to_string));
-       check bool "message tells keeper not to bypass with new work" true
-         (Astring.String.is_infix ~affix:"do not create unrelated repos"
-            (json |> U.member "result" |> U.to_string)))
+         check bool "message tells keeper not to bypass with new work" true
+           (Astring.String.is_infix ~affix:"do not create unrelated repos"
+              (json |> U.member "result" |> U.to_string)))
+
+let test_keeper_task_claim_releases_stale_owner_before_wip_admission () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let goal, _ =
+         match Goal_store.upsert_goal config ~title:"WIP stale release goal" () with
+         | Ok payload -> payload
+         | Error msg -> fail msg
+       in
+       for i = 1 to 4 do
+         add_goal_task config ~goal_id:goal.id
+           ~title:(Printf.sprintf "fix: stale release fixture %d" i)
+       done;
+       let stale_agents =
+         [ "keeper-a-agent"; "keeper-b-agent"; "keeper-c-agent" ]
+       in
+       List.iteri
+         (fun i agent_name ->
+            let task_id = Printf.sprintf "task-%03d" (i + 1) in
+            claim_task_exn config ~agent_name ~task_id;
+            mark_agent_stale_for_release config ~agent_name;
+            age_claimed_task_for_release config ~task_id)
+         stale_agents;
+       let payload =
+         Task_runtime.handle_keeper_task_tool ~config
+           ~meta:(meta_with_active_goal goal.id)
+           ~name:"keeper_task_claim" ~args:(`Assoc [])
+       in
+       let json = Yojson.Safe.from_string payload in
+       check bool "claimed task present" true
+         (json |> U.member "claimed_task" <> `Null);
+       check int "stale release count" 3
+         (json |> U.member "stale_claim_releases" |> U.to_list |> List.length);
+       check string "new claimant took released task" "task-001"
+         (json |> U.member "claimed_task" |> U.member "task_id" |> U.to_string);
+       let backlog = Masc.Workspace.read_backlog config in
+       match
+         List.find_opt
+           (fun (task : Masc_domain.task) -> String.equal task.id "task-002")
+           backlog.tasks
+       with
+       | Some { task_status = Masc_domain.Todo; _ } -> ()
+       | Some task ->
+         fail
+           (Printf.sprintf "expected task-002 to be released, got %s"
+              (Masc_domain.task_status_to_string task.task_status))
+       | None -> fail "task-002 missing from backlog")
 
 let test_keeper_task_claim_no_unclaimed_emits_no_work_outcome () =
   Eio_main.run @@ fun env ->
@@ -295,7 +370,7 @@ let test_active_items_only_include_claimed_or_in_progress () =
     ; task ~title:"fix: still todo" "task-003"
     ]
   in
-  let active = Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks in
+  let active = Admission.active_items_of_tasks tasks in
   check (list string) "active ids" [ "task-001"; "task-002" ]
     (List.map (fun item -> item.Admission.id) active);
   check (list string) "categories" [ "fix"; "docs" ]
@@ -322,61 +397,34 @@ let test_active_items_include_all_active_assignees () =
         "task-progress-b"
     ]
   in
-  let active = Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks in
+  let active = Admission.active_items_of_tasks tasks in
   check (list string) "all active ids"
     [ "task-claimed-a"; "task-progress-a"; "task-claimed-b"; "task-progress-b" ]
     (List.map (fun item -> item.Admission.id) active)
 
-let iso8601_of_unix_time t =
-  let tm = Unix.gmtime t in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
-
-let test_stale_claimed_task_not_active () =
-  (* claimed 2 hours ago, default threshold is 1 hour -> stale, not active *)
-  let now = Unix.gettimeofday () in
-  let two_hours_ago = iso8601_of_unix_time (now -. 7200.) in
+let test_old_claimed_task_stays_active_until_owner_release () =
   let tasks =
     [ task
-        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = two_hours_ago })
-        "task-stale"
+        ~status:
+          (Masc_domain.Claimed
+             { assignee = "a"; claimed_at = old_release_timestamp })
+        "task-old-but-owned"
     ]
   in
-  check (list string) "no active ids" []
+  check (list string) "old claimed task remains active" [ "task-old-but-owned" ]
     (List.map (fun item -> item.Admission.id)
-       (Admission.active_items_of_tasks ~now tasks))
+       (Admission.active_items_of_tasks tasks))
 
-let test_fresh_claimed_task_stays_active_under_custom_threshold () =
-  (* claimed 30 minutes ago, custom threshold 10 minutes -> stale under that
-     threshold, but active under the (higher) default. Exercises the
-     ?stale_threshold_s override on both task_is_active_wip and
-     active_items_of_tasks. *)
-  let now = Unix.gettimeofday () in
-  let thirty_min_ago = iso8601_of_unix_time (now -. 1800.) in
-  let claimed_task =
-    task
-      ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = thirty_min_ago })
-      "task-recent"
-  in
-  check bool "active under default (1h) threshold" true
-    (Admission.task_is_active_wip ~now claimed_task);
-  check bool "stale under a 10-minute threshold" false
-    (Admission.task_is_active_wip ~now ~stale_threshold_s:600. claimed_task)
-
-let test_unparseable_claimed_at_treated_as_stale () =
-  (* Fail-closed: a malformed/unparseable claimed_at must not silently be
-     treated as fresh WIP (parse_iso8601's own default is "60 seconds ago",
-     which would otherwise always admit it). *)
+let test_unparseable_claimed_at_keeps_counting_until_owner_release () =
   let tasks =
     [ task
         ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = "not-a-timestamp" })
         "task-malformed"
     ]
   in
-  check (list string) "no active ids for malformed timestamp" []
+  check (list string) "malformed timestamp stays active" [ "task-malformed" ]
     (List.map (fun item -> item.Admission.id)
-       (Admission.active_items_of_tasks ~now:(Unix.gettimeofday ()) tasks))
+       (Admission.active_items_of_tasks tasks))
 
 let test_goalless_task_exempt_from_goal_cap () =
   (* RFC-0245: a goalless claim must not be rejected by the per-goal cap even
@@ -444,10 +492,13 @@ let () =
             test_scope_of_task_has_no_repo_uses_goal_and_title_category
         ; test_case "repoless tasks exempt from repo cap" `Quick
             test_repoless_tasks_exempt_from_repo_cap
-        ; test_case "keeper_task_claim reports other keepers WIP cap" `Quick
-            test_keeper_task_claim_reports_other_keepers_wip_cap
-        ; test_case "keeper_task_claim no-unclaimed emits no-work outcome" `Quick
-            test_keeper_task_claim_no_unclaimed_emits_no_work_outcome
+          ; test_case "keeper_task_claim reports other keepers WIP cap" `Quick
+              test_keeper_task_claim_reports_other_keepers_wip_cap
+        ; test_case "keeper_task_claim releases stale owners before WIP admission"
+            `Quick
+            test_keeper_task_claim_releases_stale_owner_before_wip_admission
+          ; test_case "keeper_task_claim no-unclaimed emits no-work outcome" `Quick
+              test_keeper_task_claim_no_unclaimed_emits_no_work_outcome
         ; test_case "active items include active WIP only" `Quick
             test_active_items_only_include_claimed_or_in_progress
         ; test_case "active items include all active assignees" `Quick
@@ -458,11 +509,11 @@ let () =
             test_goalless_tasks_never_goal_capped
         ; test_case "goalless still bounded by global cap" `Quick
             test_goalless_still_bounded_by_global_cap
-        ; test_case "stale claimed task not active" `Quick
-            test_stale_claimed_task_not_active
-        ; test_case "fresh claimed task stays active under custom threshold" `Quick
-            test_fresh_claimed_task_stays_active_under_custom_threshold
-        ; test_case "unparseable claimed_at treated as stale" `Quick
-            test_unparseable_claimed_at_treated_as_stale
-        ] )
+        ; test_case "old claimed task stays active until owner release" `Quick
+            test_old_claimed_task_stays_active_until_owner_release
+        ; test_case
+            "unparseable claimed_at keeps counting until owner release"
+            `Quick
+            test_unparseable_claimed_at_keeps_counting_until_owner_release
+          ] )
     ]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -204,6 +204,17 @@ max-concurrent = 4
 [openai.gpt]
 is-default = true
 max-concurrent = 1
+  |}
+;;
+
+let runtime_structured_judge_model_catalog =
+  {|
+[[models]]
+id_prefix = "gpt"
+base = "openai_chat"
+max_context_tokens = 64000
+supports_tools = true
+supports_structured_output = true
 |}
 ;;
 
@@ -432,6 +443,7 @@ let test_runtime_route_writer_updates_media_failover () =
 ;;
 
 let test_runtime_route_writer_clears_optional_structured_judge () =
+  with_model_catalog_content runtime_structured_judge_model_catalog @@ fun () ->
   with_runtime_file (fun path ->
     (match
        Runtime.set_runtime_structured_judge


### PR DESCRIPTION
## What

Run durable stale-claim recovery before WIP admission. Claimed and InProgress tasks continue to count as active WIP until ownership is actually released through the existing workspace/task transition path.

## Why

A stuck owned task should not block admission forever, but claim/start age is not keeper liveness. The safe boundary is to release stale owner claims first, using the existing claim TTL SSOT and release machinery, then run normal WIP admission over the remaining active tasks.

## Changes

- keeper_task_claim runs Workspace.release_stale_claims with Env_config_runtime.Claim.ttl_seconds before WIP admission.
- Successful pre-admission releases are surfaced in the response as stale_claim_releases.
- Keeper_wip_admission.task_is_active_wip is back to a pure status predicate: Claimed and InProgress count until the durable release path transitions them.
- Old or malformed claimed_at values keep counting conservatively instead of silently reducing admission caps.
- docs/runtime-tunables.md was regenerated after the rebase.
- Tests cover old Claimed rows staying active, malformed Claimed rows staying active, and stale owner release before keeper_task_claim admission.

## Verification

- [x] ocamlformat --check on touched OCaml files
- [x] git diff --check
- [x] runtime tunables generator leaves no diff after regeneration
- [x] CI Build and Test green on current head
