### PR TITLE
fix(keeper): release owned task on completion-contract pause

### DIFF
--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -139,14 +139,16 @@ let clear_current_task_id_after_successful_pause_release ~config ~meta ~reason_t
 ;;
 
 let blocker_class_releases_owned_tasks_on_pause = function
-  | Turn_timeout | Turn_livelock_blocked | No_progress_loop -> true
+  | Turn_timeout
+  | Turn_livelock_blocked
+  | No_progress_loop
+  | Completion_contract_violation -> true
   | Runtime_exhausted _
   | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Completion_contract_violation
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch
@@ -162,7 +164,7 @@ let blocker_class_releases_owned_tasks_on_pause = function
   | Sdk_input_required -> false
 ;;
 
-let reconcile_persisted_auto_pause_task_release ~config ~meta =
+let release_owned_active_tasks_after_typed_pause ~config ~meta ~reason_tag =
   let release_required =
     meta.paused
     &&
@@ -173,14 +175,14 @@ let reconcile_persisted_auto_pause_task_release ~config ~meta =
   if not release_required
   then Ok meta
   else (
-    let reason_tag = "persisted_auto_pause_reconcile" in
     let release_ok = release_owned_active_tasks_after_pause ~config ~meta ~reason_tag in
     if not release_ok
     then
       Error
         (Printf.sprintf
-           "%s: persisted auto-pause task release failed"
-           meta.name)
+           "%s: %s task release failed"
+           meta.name
+           reason_tag)
     else if
       clear_current_task_id_after_successful_pause_release
         ~config
@@ -190,8 +192,16 @@ let reconcile_persisted_auto_pause_task_release ~config ~meta =
     else
       Error
         (Printf.sprintf
-           "%s: persisted auto-pause current_task_id clear failed"
-           meta.name))
+           "%s: %s current_task_id clear failed"
+           meta.name
+           reason_tag))
+;;
+
+let reconcile_persisted_auto_pause_task_release ~config ~meta =
+  release_owned_active_tasks_after_typed_pause
+    ~config
+    ~meta
+    ~reason_tag:"persisted_auto_pause_reconcile"
 ;;
 
 let handle_crash_auto_pause

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -93,10 +93,22 @@ val handle_auto_pause_from_meta
   -> unit
   -> (Keeper_meta_contract.keeper_meta, string) result
 
+(** [release_owned_active_tasks_after_typed_pause ~config ~meta
+      ~reason_tag] releases keeper-owned active tasks for persisted
+    [paused=true] metas whose typed [last_blocker] is an execution-stopping
+    pause class. Human/non-keeper ownership is not affected because owned-task
+    discovery is constrained by [meta.agent_name] and its resolved keeper
+    aliases. *)
+val release_owned_active_tasks_after_typed_pause
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> reason_tag:string
+  -> (Keeper_meta_contract.keeper_meta, string) result
+
 (** [reconcile_persisted_auto_pause_task_release ~config ~meta] repairs
     durable paused meta left behind by an earlier runtime before the pause
     policy could clear task ownership. It only acts on typed blocker classes
-    whose pause path already owns task release semantics; operator/manual
+    whose pause class owns task release semantics; operator/manual
     pauses without such a blocker are left untouched. *)
 val reconcile_persisted_auto_pause_task_release
   :  config:Workspace.config

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -716,6 +716,30 @@ let sync_keeper_paused_state_impl
         (if paused
          then Keeper_state_machine.Operator_pause
          else Keeper_state_machine.Operator_resume);
+      let synced_meta =
+        if paused
+        then
+          match
+            Keeper_supervisor_pause_policy.release_owned_active_tasks_after_typed_pause
+              ~config
+              ~meta:synced_meta
+              ~reason_tag:"pause_sync"
+          with
+          | Ok released_meta -> released_meta
+          | Error err ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RuntimeSyncFailures)
+              ~labels:[("keeper", meta.name); ("site", "pause_sync_task_release")]
+              ();
+            Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+              ~config
+              ~keeper_name:meta.name
+              ~side_effect:"pause sync task release"
+              ~severity:`Error
+              err;
+            synced_meta
+        else synced_meta
+      in
       (if not paused then
          match Keeper_registry.get ~base_path:config.base_path meta.name with
          (* tla-lint: allow-mutation: fiber signal — wake on resume from runtime budget gate *)

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -146,13 +146,12 @@ let record_failure_and_maybe_escalate
           then
             Log.Keeper.warn
               "%s: auto-paused after %d completion contract no-progress failures \
-               (pause_threshold=%d, crash_threshold=%d, released_task=%s); operator \
-               must inspect provider/model reasoning output before resuming"
+               (pause_threshold=%d, crash_threshold=%d, task_release=policy_checked); \
+               operator must inspect provider/model reasoning output before resuming"
               meta.name
               count
               turn_fail_streak_threshold
               threshold
-              "none"
           else
             Log.Keeper.warn
               "%s: auto-paused after %d idle-detected loop failures \

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -358,6 +358,70 @@ let test_no_progress_loop_detection_releases_owned_active_task () =
        | Ok None -> fail "expected persisted keeper meta"
        | Error err -> fail err)
 
+let test_completion_contract_pause_sync_releases_owned_active_task () =
+  let base_path = temp_dir "masc-completion-contract-release-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       let _init_msg = Masc.Workspace.init config ~agent_name:(Some "operator") in
+       let keeper_name = "completion-contract-owner" in
+       let meta = make_meta keeper_name in
+       let created = create_owned_active_task config meta in
+       let current_task_id = task_id_of_created_task created in
+       let blocker =
+         Keeper_meta_contract.blocker_info_of_class
+           ~detail:"completion contract violated"
+           Keeper_meta_contract.Completion_contract_violation
+       in
+       let meta =
+         { meta with
+           current_task_id = Some current_task_id
+         ; runtime = { meta.runtime with last_blocker = Some blocker }
+         }
+       in
+       Masc.Keeper_registry.clear ();
+       (match Keeper_meta_store.write_meta config meta with
+        | Ok () -> ()
+        | Error err -> fail err);
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       match
+         Masc.Keeper_turn_runtime_budget.sync_keeper_paused_state_with_resume_policy
+           ~config
+           ~meta
+           ~paused:true
+           ~resume_policy:Masc.Keeper_supervisor_pause_policy.Manual_resume_required
+       with
+       | Error err -> fail err
+       | Ok paused_meta ->
+         check bool "returned meta paused" true paused_meta.paused;
+         check (option string) "returned meta current_task_id cleared" None
+           (Option.map Keeper_id.Task_id.to_string paused_meta.current_task_id);
+         (match task_status_by_id config created.task_id with
+          | Masc_domain.Todo -> ()
+          | status ->
+            fail
+              (Printf.sprintf
+                 "expected completion-contract pause to release task to todo, got %s"
+                 (Masc_domain.task_status_to_string status)));
+         (match Keeper_meta_store.read_meta config keeper_name with
+          | Ok (Some persisted) ->
+            check bool "persisted meta paused" true persisted.paused;
+            check (option string) "persisted current_task_id cleared" None
+              (Option.map Keeper_id.Task_id.to_string persisted.current_task_id);
+            (match persisted.runtime.last_blocker with
+             | Some
+                 { Keeper_meta_contract.klass =
+                     Keeper_meta_contract.Completion_contract_violation
+                 ; _
+                 } -> ()
+             | Some _ -> fail "expected completion-contract blocker to remain"
+             | None -> fail "expected completion-contract blocker to remain")
+          | Ok None -> fail "expected persisted keeper meta"
+          | Error err -> fail err))
+
 let test_operator_resume_clears_no_progress_loop_latch () =
   Eio_main.run
   @@ fun env ->
@@ -1198,6 +1262,11 @@ let () =
             test_direct_success_persist_failure_keeps_no_progress_pause;
           test_case "direct success leaves unrelated pause intact" `Quick
             test_direct_success_leaves_unrelated_pause_intact;
+        ] );
+      ( "completion_contract pause",
+        [
+          test_case "pause sync releases owned active task" `Quick
+            test_completion_contract_pause_sync_releases_owned_active_task;
         ] );
       ( "idle-detected loop",
         [


### PR DESCRIPTION
## Summary
- route pause-sync task ownership recovery through the typed pause policy helper
- classify completion-contract pauses as task-release eligible while leaving non-keeper/human ownership outside the release query
- add regression coverage for completion-contract pause sync releasing an owned active task and clearing persisted current_task_id
- replace the stale completion-contract log claim `released_task=none` with `task_release=policy_checked`

## Validation
- `opam exec -- ocamlformat --inplace lib/keeper/keeper_supervisor_pause_policy.ml lib/keeper/keeper_supervisor_pause_policy.mli lib/keeper/keeper_turn_runtime_budget.ml lib/keeper/keeper_unified_turn_failure.ml test/test_keeper_auto_pause_blocker_persist_12683.ml`
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_supervisor_pause_policy.ml lib/keeper/keeper_supervisor_pause_policy.mli lib/keeper/keeper_turn_runtime_budget.ml lib/keeper/keeper_unified_turn_failure.ml test/test_keeper_auto_pause_blocker_persist_12683.ml`
- `scripts/dune-local.sh build @test/runtest-test_keeper_auto_pause_blocker_persist_12683` (20 tests)