### PR TITLE
fix(keeper): guard direct no-progress resume

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -188,19 +188,7 @@ let direct_success_disposition_allows_no_progress_resume
       { disposition = Keeper_execution_receipt.Disp_pass
       ; reason = Keeper_execution_receipt.Reason_healthy
       } -> true
-  | Some
-      { disposition =
-          ( Keeper_execution_receipt.Disp_pause_human
-          | Keeper_execution_receipt.Disp_pass
-          | Keeper_execution_receipt.Disp_alert_exhausted
-          | Keeper_execution_receipt.Disp_fail_open_next_runtime
-          | Keeper_execution_receipt.Disp_pass_next_model
-          | Keeper_execution_receipt.Disp_user_cancelled
-          | Keeper_execution_receipt.Disp_skipped
-          | Keeper_execution_receipt.Disp_unknown )
-      ; _
-      }
-  | None -> false
+  | Some _ | None -> false
 
 let direct_success_tool_call_has_progress
       (detail : Keeper_agent_run.tool_call_detail)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -179,14 +179,77 @@ let persist_direct_success_no_progress_resume ~base_path (resumed_meta : keeper_
       (Keeper_registry.registry_entry_validation_error_to_string err);
     Error err
 
+let direct_success_disposition_allows_no_progress_resume
+      (result : Keeper_agent_run.run_result)
+  : bool
+  =
+  match result.operator_disposition with
+  | Some { disposition = Keeper_execution_receipt.Disp_pass; _ } -> true
+  | Some
+      { disposition =
+          ( Keeper_execution_receipt.Disp_pause_human
+          | Keeper_execution_receipt.Disp_alert_exhausted
+          | Keeper_execution_receipt.Disp_fail_open_next_runtime
+          | Keeper_execution_receipt.Disp_pass_next_model
+          | Keeper_execution_receipt.Disp_user_cancelled
+          | Keeper_execution_receipt.Disp_skipped
+          | Keeper_execution_receipt.Disp_unknown )
+      ; _
+      }
+  | None -> false
+
+let direct_success_tool_call_has_progress
+      (detail : Keeper_agent_run.tool_call_detail)
+  : bool
+  =
+  match detail.typed_outcome with
+  | Some Keeper_tool_outcome.Progress -> (
+    match Keeper_tool_progress.classify_tool_progress detail.tool_name with
+    | Keeper_tool_progress.Passive_status -> false
+    | Keeper_tool_progress.Claim_context
+    | Keeper_tool_progress.Execution
+    | Keeper_tool_progress.Completion -> true)
+  | Some (Keeper_tool_outcome.No_progress _ | Keeper_tool_outcome.Error _)
+  | None -> false
+
+let direct_success_has_progress_evidence (result : Keeper_agent_run.run_result) :
+    bool
+  =
+  List.exists direct_success_tool_call_has_progress result.tool_calls
+  || Option.is_some (Keeper_unified_metrics_support.visible_run_validation result)
+
+let direct_success_may_clear_no_progress_pause
+      (result : Keeper_agent_run.run_result)
+  : bool
+  =
+  direct_success_disposition_allows_no_progress_resume result
+  &&
+  match
+    Keeper_turn_outcome.of_result_surface
+      ~response_text:result.response_text
+      result.stop_reason
+  with
+  | Keeper_turn_outcome.Visible_reply -> true
+  | Keeper_turn_outcome.Continuation_checkpoint
+  | Keeper_turn_outcome.No_visible_reply ->
+    direct_success_has_progress_evidence result
+
 let clear_direct_success_no_progress_pause
       ~(config : Workspace.config)
       ~(pre_turn_meta : keeper_meta)
+      ~(result : Keeper_agent_run.run_result)
       (meta : keeper_meta)
   : keeper_meta
   =
   if not (has_direct_success_no_progress_pause ~config pre_turn_meta)
   then meta
+  else if not (direct_success_may_clear_no_progress_pause result)
+  then (
+    Log.Keeper.info
+      "%s: direct keeper_msg success kept no_progress pause/blocker because \
+       result lacked typed resume evidence"
+      meta.name;
+    meta)
   else
     let cleared_meta = clear_no_progress_meta_blocker meta in
     let resumed_meta =
@@ -339,6 +402,8 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
   let surface_context_to_instructions = surface_context_to_instructions
+  let direct_success_may_clear_no_progress_pause =
+    direct_success_may_clear_no_progress_pause
   let clear_direct_success_no_progress_pause =
     clear_direct_success_no_progress_pause
   let direct_no_progress_retry_reason =
@@ -1183,6 +1248,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                 clear_direct_success_no_progress_pause
                   ~config:ctx.config
                   ~pre_turn_meta:meta
+                  ~result
                   lifecycle.updated_meta
               in
               let updated_meta =

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -184,10 +184,14 @@ let direct_success_disposition_allows_no_progress_resume
   : bool
   =
   match result.operator_disposition with
-  | Some { disposition = Keeper_execution_receipt.Disp_pass; _ } -> true
+  | Some
+      { disposition = Keeper_execution_receipt.Disp_pass
+      ; reason = Keeper_execution_receipt.Reason_healthy
+      } -> true
   | Some
       { disposition =
           ( Keeper_execution_receipt.Disp_pause_human
+          | Keeper_execution_receipt.Disp_pass
           | Keeper_execution_receipt.Disp_alert_exhausted
           | Keeper_execution_receipt.Disp_fail_open_next_runtime
           | Keeper_execution_receipt.Disp_pass_next_model
@@ -247,7 +251,7 @@ let clear_direct_success_no_progress_pause
   then (
     Log.Keeper.info
       "%s: direct keeper_msg success kept no_progress pause/blocker because \
-       result lacked typed resume evidence"
+       result lacked healthy operator disposition or typed resume evidence"
       meta.name;
     meta)
   else

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -43,9 +43,16 @@ module For_testing : sig
   (** Format a dashboard co-view context object ({ label, route, scene, fields })
       into turn instructions when no explicit [turn_instructions] is supplied. *)
 
+  val direct_success_may_clear_no_progress_pause :
+    Keeper_agent_run.run_result -> bool
+  (** Typed recovery predicate for direct-message success: only a healthy
+      operator disposition plus visible reply or non-passive typed progress
+      / validated run evidence may clear a no-progress forced pause. *)
+
   val clear_direct_success_no_progress_pause :
     config:Workspace.config ->
     pre_turn_meta:Keeper_meta_contract.keeper_meta ->
+    result:Keeper_agent_run.run_result ->
     Keeper_meta_contract.keeper_meta ->
     Keeper_meta_contract.keeper_meta
   (** Apply the direct-message success recovery that clears a no-progress

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -648,7 +648,7 @@ let reply_payload_with_streamed_visible_reply payload_json_opt ~visible_reply =
   | Some visible_reply -> (
       match Keeper_turn_outcome.of_reply_payload payload_json_opt with
       | Keeper_turn_outcome.Continuation_checkpoint -> payload_json_opt
-      | Keeper_turn_outcome.No_visible_reply
+      | Keeper_turn_outcome.No_visible_reply -> payload_json_opt
       | Keeper_turn_outcome.Visible_reply -> (
           match payload_json_opt with
           | Some (`Assoc fields) ->

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1423,7 +1423,7 @@ let test_visible_reply_stream_fallback_redacts_before_persist () =
   in
   check string "terminal reply redacted" "terminal [redacted]" explicit
 
-let test_streamed_visible_reply_rewrites_no_visible_payload () =
+let test_streamed_visible_reply_preserves_no_visible_payload () =
   let payload_json =
     `Assoc
       [
@@ -1440,15 +1440,15 @@ let test_streamed_visible_reply_rewrites_no_visible_payload () =
     Server_routes_http_keeper_stream.For_testing.reply_payload_with_streamed_visible_reply
       (Some payload_json) ~visible_reply
   in
-  check string "streamed text becomes typed reply" "streamed final"
+  check string "declared no-visible reply remains empty" ""
     (json_string_field "reply" rewritten);
-  check string "streamed text promotes visible outcome" "visible_reply"
+  check string "declared no-visible outcome remains semantic" "no_visible_reply"
     (json_string_field Keeper_turn_outcome.wire_key rewritten);
   let err =
     Server_routes_http_keeper_stream.For_testing.direct_reply_terminal_error
       rewritten visible_reply
   in
-  check bool "streamed visible text is not terminal no-reply" false
+  check bool "stream fallback cannot override no-visible terminal contract" true
     (Option.is_some err)
 
 let test_streamed_visible_reply_preserves_checkpoint_payload () =
@@ -2162,8 +2162,8 @@ let () =
             test_visible_reply_uses_streamed_text_fallback;
           test_case "visible reply stream fallback redacts before persist" `Quick
             test_visible_reply_stream_fallback_redacts_before_persist;
-          test_case "streamed visible reply rewrites no-visible payload" `Quick
-            test_streamed_visible_reply_rewrites_no_visible_payload;
+          test_case "streamed visible reply preserves no-visible payload" `Quick
+            test_streamed_visible_reply_preserves_no_visible_payload;
           test_case "streamed visible reply preserves checkpoint payload" `Quick
             test_streamed_visible_reply_preserves_checkpoint_payload;
           test_case "runtime run_blocks appends multimodal input to OAS agent" `Quick

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -151,6 +151,13 @@ let non_healthy_pass_operator_disposition
   ; reason = Masc.Keeper_execution_receipt.Reason_turn_budget_exhausted
   }
 
+let pass_next_model_operator_disposition
+  : Masc.Keeper_agent_result.operator_disposition
+  =
+  { disposition = Masc.Keeper_execution_receipt.Disp_pass_next_model
+  ; reason = Masc.Keeper_execution_receipt.Reason_runtime_fallback
+  }
+
 let run_result
       ?(response_text = "direct reply")
       ?(stop_reason = Runtime_agent.Completed)
@@ -953,6 +960,24 @@ let test_direct_success_non_healthy_pass_keeps_no_progress_pause () =
     (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
        result)
 
+let test_direct_success_pass_next_model_keeps_no_progress_pause () =
+  let result =
+    run_result
+      ~response_text:""
+      ~operator_disposition:(Some pass_next_model_operator_disposition)
+      ~tool_calls:
+        [ tool_call
+            ~typed_outcome:Masc.Keeper_tool_outcome.Progress
+            "masc_deliver"
+        ]
+      ()
+  in
+  check bool
+    "pass_next_model disposition cannot clear no-progress pause"
+    false
+    (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
+       result)
+
 let test_direct_success_passive_only_no_visible_keeps_no_progress_pause () =
   Eio_main.run
   @@ fun env ->
@@ -1406,6 +1431,10 @@ let () =
             "direct success non-healthy pass keeps no-progress pause"
             `Quick
             test_direct_success_non_healthy_pass_keeps_no_progress_pause;
+          test_case
+            "direct success pass-next-model keeps no-progress pause"
+            `Quick
+            test_direct_success_pass_next_model_keeps_no_progress_pause;
           test_case
             "direct success passive-only no-visible keeps no-progress pause"
             `Quick

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -92,8 +92,89 @@ let with_runtime_config content f =
        Config_dir_resolver.reset ();
        (match Runtime.init_default ~config_path:runtime_config_path with
         | Ok () -> ()
-        | Error err -> fail ("runtime init: " ^ err));
+       | Error err -> fail ("runtime init: " ^ err));
        f ())
+
+let prompt_metrics =
+  Masc.Keeper_agent_prompt_metrics.build_prompt_metrics ~system_prompt:""
+    ~dynamic_context:"" ~user_message:""
+
+let ctx_composition : Masc.Keeper_agent_prompt_metrics.ctx_composition_metrics =
+  { actual_input_tokens = None
+  ; display_total_tokens = 0
+  ; estimated_known_tokens = 0
+  ; segments = []
+  }
+
+let tool_surface : Masc.Keeper_agent_tool_surface.tool_surface_metrics =
+  { turn_lane = Masc.Keeper_agent_tool_surface.Lane_tool_optional
+  ; config_root = ""
+  ; runtime_config_path = None
+  }
+
+let tool_call
+      ?typed_outcome
+      ?(input_fingerprint = Some "input")
+      ?(output_fingerprint = Some "output")
+      tool_name
+  : Masc.Keeper_agent_result.tool_call_detail
+  =
+  { tool_name
+  ; provider = "test"
+  ; outcome = "ok"
+  ; typed_outcome
+  ; latency_ms = 0.0
+  ; task_id = None
+  ; route_evidence = None
+  ; input_fingerprint
+  ; output_fingerprint
+  }
+
+let healthy_operator_disposition
+  : Masc.Keeper_agent_result.operator_disposition
+  =
+  { disposition = Masc.Keeper_execution_receipt.Disp_pass
+  ; reason = Masc.Keeper_execution_receipt.Reason_healthy
+  }
+
+let pause_operator_disposition
+  : Masc.Keeper_agent_result.operator_disposition
+  =
+  { disposition = Masc.Keeper_execution_receipt.Disp_pause_human
+  ; reason = Masc.Keeper_execution_receipt.Reason_completion_contract_unsatisfied
+  }
+
+let run_result
+      ?(response_text = "direct reply")
+      ?(stop_reason = Runtime_agent.Completed)
+      ?(operator_disposition = Some healthy_operator_disposition)
+      ?(tool_calls = [])
+      ()
+  : Masc.Keeper_agent_run.run_result
+  =
+  { response_text
+  ; model_used = "test-model"
+  ; prompt_metrics
+  ; ctx_composition
+  ; runtime_observation = None
+  ; turn_count = 1
+  ; usage = Masc.Inference_utils.zero_usage
+  ; usage_reported = true
+  ; tool_calls
+  ; completion_contract_result =
+      Masc.Keeper_execution_receipt.Contract_satisfied_execution
+  ; operator_disposition
+  ; checkpoint = None
+  ; trace_ref = None
+  ; run_validation = None
+  ; stop_reason
+  ; inference_telemetry = None
+  ; tool_surface
+  ; pre_dispatch_compacted = false
+  ; pre_dispatch_compaction_trigger = None
+  ; pre_dispatch_compaction_before_tokens = None
+  ; pre_dispatch_compaction_after_tokens = None
+  }
 
 let test_turn_timeout_blocker_class_roundtrip () =
   let cls = Keeper_meta_contract.Turn_timeout in
@@ -745,6 +826,7 @@ let test_direct_success_clears_no_progress_pause () =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:meta
+           ~result:(run_result ())
            meta
        in
        check bool "direct success resumes no-progress pause" false recovered_meta.paused;
@@ -817,6 +899,7 @@ let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:meta
+           ~result:(run_result ())
            meta
        in
        check bool
@@ -841,6 +924,110 @@ let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
          (match entry.Masc.Keeper_registry.last_failure_reason with
           | None -> ()
          | Some _ -> fail "expected overwritten no-progress failure reason to clear")
+       | None -> fail "expected registered keeper")
+
+let test_direct_success_operator_pause_keeps_no_progress_pause () =
+  let result =
+    run_result ~operator_disposition:(Some pause_operator_disposition) ()
+  in
+  check bool
+    "operator pause disposition cannot clear no-progress pause"
+    false
+    (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
+       result)
+
+let test_direct_success_passive_only_no_visible_keeps_no_progress_pause () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-no-progress-direct-success-passive-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_no_progress_loop_detector.reset_all_for_test ();
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "no-progress-direct-success-passive" in
+       let blocker =
+         Keeper_meta_contract.blocker_info_of_class
+           ~detail:"latched"
+           Keeper_meta_contract.No_progress_loop
+       in
+       let meta =
+         { (make_meta keeper_name
+            |> Keeper_meta_contract.map_runtime (fun rt ->
+              { rt with last_blocker = Some blocker }))
+           with
+           paused = true
+         }
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       ignore
+         (Masc.Keeper_no_progress_loop_detector.record_turn
+            ~threshold_override:1
+            ~keeper_name
+            ~made_progress:false
+            ());
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some
+            (Masc.Keeper_registry.Provider_runtime_error
+               { code = Masc.Keeper_unified_turn_no_progress.failure_reason_code
+               ; detail = "latched"
+               ; provider_id = None
+               ; http_status = None
+               ; runtime_id = None
+               ; reason = None
+               }));
+       let result =
+         run_result
+           ~response_text:""
+           ~tool_calls:
+             [ tool_call
+                 ~typed_outcome:Keeper_tool_outcome.Progress
+                 "keeper_tasks_list" ]
+           ()
+       in
+       let recovered_meta =
+         Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
+           ~config
+           ~pre_turn_meta:meta
+           ~result
+           meta
+       in
+       check bool
+         "passive-only no-visible direct success stays paused"
+         true
+         recovered_meta.paused;
+       check bool
+         "passive-only no-visible direct success keeps detector latched"
+         true
+         (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
+       (match recovered_meta.runtime.last_blocker with
+        | Some
+            { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop
+            ; detail
+            } ->
+          check string "no-progress blocker preserved" blocker.detail detail
+        | Some _ -> fail "expected no-progress blocker to remain"
+        | None -> fail "expected no-progress blocker to remain");
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check bool
+           "registry meta remains paused after passive-only direct success"
+           true
+           entry.Masc.Keeper_registry.meta.paused;
+         (match entry.Masc.Keeper_registry.last_failure_reason with
+          | Some (Masc.Keeper_registry.Provider_runtime_error { code; _ })
+            when String.equal
+                   code
+                   Masc.Keeper_unified_turn_no_progress.failure_reason_code -> ()
+          | Some _ -> fail "expected no_progress failure reason to remain"
+          | None -> fail "expected no_progress failure reason to remain")
        | None -> fail "expected registered keeper")
 
 let test_direct_success_persist_failure_keeps_no_progress_pause () =
@@ -922,6 +1109,7 @@ let test_direct_success_persist_failure_keeps_no_progress_pause () =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:invalid_meta
+           ~result:(run_result ())
            invalid_meta
        in
        check bool "failed persistence keeps returned meta paused" true recovered_meta.paused;
@@ -992,6 +1180,7 @@ let test_direct_success_leaves_unrelated_pause_intact () =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:meta
+           ~result:(run_result ())
            meta
        in
        check bool "unrelated pause stays paused" true recovered_meta.paused;
@@ -1192,6 +1381,14 @@ let () =
             "direct success clears no-progress pause after blocker overwrite"
             `Quick
             test_direct_success_clears_no_progress_pause_after_blocker_overwrite;
+          test_case
+            "direct success operator pause keeps no-progress pause"
+            `Quick
+            test_direct_success_operator_pause_keeps_no_progress_pause;
+          test_case
+            "direct success passive-only no-visible keeps no-progress pause"
+            `Quick
+            test_direct_success_passive_only_no_visible_keeps_no_progress_pause;
           test_case
             "direct success persistence failure keeps no-progress pause"
             `Quick

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -967,7 +967,7 @@ let test_direct_success_pass_next_model_keeps_no_progress_pause () =
       ~operator_disposition:(Some pass_next_model_operator_disposition)
       ~tool_calls:
         [ tool_call
-            ~typed_outcome:Masc.Keeper_tool_outcome.Progress
+            ~typed_outcome:Keeper_tool_outcome.Progress
             "masc_deliver"
         ]
       ()

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -144,6 +144,13 @@ let pause_operator_disposition
   ; reason = Masc.Keeper_execution_receipt.Reason_completion_contract_unsatisfied
   }
 
+let non_healthy_pass_operator_disposition
+  : Masc.Keeper_agent_result.operator_disposition
+  =
+  { disposition = Masc.Keeper_execution_receipt.Disp_pass
+  ; reason = Masc.Keeper_execution_receipt.Reason_turn_budget_exhausted
+  }
+
 let run_result
       ?(response_text = "direct reply")
       ?(stop_reason = Runtime_agent.Completed)
@@ -936,6 +943,16 @@ let test_direct_success_operator_pause_keeps_no_progress_pause () =
     (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
        result)
 
+let test_direct_success_non_healthy_pass_keeps_no_progress_pause () =
+  let result =
+    run_result ~operator_disposition:(Some non_healthy_pass_operator_disposition) ()
+  in
+  check bool
+    "non-healthy pass disposition cannot clear no-progress pause"
+    false
+    (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
+       result)
+
 let test_direct_success_passive_only_no_visible_keeps_no_progress_pause () =
   Eio_main.run
   @@ fun env ->
@@ -1385,6 +1402,10 @@ let () =
             "direct success operator pause keeps no-progress pause"
             `Quick
             test_direct_success_operator_pause_keeps_no_progress_pause;
+          test_case
+            "direct success non-healthy pass keeps no-progress pause"
+            `Quick
+            test_direct_success_non_healthy_pass_keeps_no_progress_pause;
           test_case
             "direct success passive-only no-visible keeps no-progress pause"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1554,8 +1554,12 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
              "typed provider error preserves parser reason"
              true
              (contains
-                "librarian provider returned invalid episode JSON"
+                "librarian provider returned invalid structured JSON"
                 reason);
+           Alcotest.(check bool)
+             "typed provider error preserves JSON parser detail"
+             true
+             (contains "JSON parse error" reason);
            Alcotest.(check bool)
              "unparseable provider error enters cadence backoff path"
              true
@@ -1623,7 +1627,13 @@ let test_librarian_runtime_rejects_unparseable_output_across_empty_retries () =
             "error keeps first non-empty invalid-json reason"
             true
             (contains
-               "librarian provider returned invalid episode JSON"
+               "librarian provider returned invalid structured JSON"
+               (Librarian_runtime.extraction_error_to_string err));
+          Alcotest.(check bool)
+            "error keeps first non-empty parser detail"
+            true
+            (contains
+               "JSON parse error"
                (Librarian_runtime.extraction_error_to_string err));
           Alcotest.(check bool)
             "error does not use later empty retry reason"
@@ -1684,11 +1694,19 @@ let test_librarian_unstructured_fallback_does_not_write_facts () =
         Alcotest.(check bool)
           "first error keeps invalid-json reason"
           true
-          (contains "invalid episode JSON" first);
+          (contains "invalid structured JSON" first);
+        Alcotest.(check bool)
+          "first error keeps JSON parser detail"
+          true
+          (contains "JSON parse error" first);
         Alcotest.(check bool)
           "second error keeps invalid-json reason"
           true
-          (contains "invalid episode JSON" second))))
+          (contains "invalid structured JSON" second);
+        Alcotest.(check bool)
+          "second error keeps JSON parser detail"
+          true
+          (contains "JSON parse error" second))))
 ;;
 
 let test_librarian_runtime_reports_fact_upsert_failure () =

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -301,7 +301,10 @@ let test_apply_external_state_group_inherits_effective_horizon () =
     ]
   in
   let expected =
-    Some (first_seen +. Types.external_state_ttl_seconds)
+    let compatibility_horizon =
+      Types.external_state_valid_until_from_first_seen ~first_seen
+    in
+    Some (Float.min compatibility_horizon stored_horizon)
   in
   let plan =
     { Consolidation.groups =

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -11,6 +11,19 @@ module Atypes = Agent_sdk.Types
 
 let now = 1_000_000.0
 
+let contains substring s =
+  let sub_len = String.length substring in
+  let str_len = String.length s in
+  let rec aux i =
+    if i + sub_len > str_len
+    then false
+    else if String.sub s i sub_len = substring
+    then true
+    else aux (i + 1)
+  in
+  if sub_len = 0 then true else aux 0
+;;
+
 let fact claim =
   { Types.claim
   ; category = Types.Fact
@@ -320,10 +333,16 @@ let test_consolidate_classifies_invalid_structured_response () =
         in
         match outcome with
         | Runtime.Invalid_structured_response detail ->
-          Alcotest.(check string)
-            "detail keeps rejection reason"
-            "consolidation provider returned invalid structured response: non_json"
-            detail
+          Alcotest.(check bool)
+            "detail keeps typed rejection wrapper"
+            true
+            (contains
+               "consolidation provider returned invalid structured response"
+               detail);
+          Alcotest.(check bool)
+            "detail keeps JSON parser reason"
+            true
+            (contains "JSON parse error" detail)
         | _ ->
           Alcotest.fail
             "expected Invalid_structured_response for malformed provider output"))))

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -690,7 +690,7 @@ let test_invalid_structured_vision_response_is_runtime_failure () =
            (assoc_string "error" json)
            "invalid_structured_response");
       assert (String.equal (assoc_string "failure_class" json) "runtime_failure");
-      assert (contains_substring (assoc_string "detail" json) "not valid JSON")))
+      assert (contains_substring (assoc_string "detail" json) "JSON parse error")))
 
 let test_run_vision_invalid_structured_response_is_typed () =
   with_temp_runtime_toml single_vision_runtime_toml (fun () ->
@@ -712,7 +712,7 @@ let test_run_vision_invalid_structured_response_is_typed () =
     in
     match outcome with
     | Vt.Vo_invalid_structured_response detail ->
-      assert (contains_substring detail "not valid JSON")
+      assert (contains_substring detail "JSON parse error")
     | _ -> failwith "expected Vo_invalid_structured_response")
 
 let test_retryable_provider_error_tries_next_runtime () =


### PR DESCRIPTION
## Summary
- require typed healthy operator disposition before direct keeper_msg success can clear a no-progress forced pause
- require visible reply or typed non-passive/validated progress evidence for no-visible direct successes
- preserve producer-declared no_visible_reply stream payloads instead of promoting streamed fallback text to visible_reply
- add regressions for operator-pause, non-healthy pass, pass-next-model, passive-only/no-visible direct success, and no-visible stream payload preservation

## Verification
- scripts/check-oas-pin.sh --local-only
- git diff --check
- opam exec -- ocamlformat --check lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/server/server_routes_http_keeper_stream.ml test/test_gate_keeper_backend.ml test/test_keeper_auto_pause_blocker_persist_12683.ml test/test_keeper_memory_os.ml test/test_keeper_memory_os_consolidation.ml test/test_keeper_memory_os_consolidation_runtime.ml test/test_keeper_vision_tool.ml
- scripts/dune-local.sh build @test/runtest-test_keeper_auto_pause_blocker_persist_12683 (23 tests)

## Notes
- Disp_pass_next_model is treated as an in-flight runtime/model fallback disposition, not a healthy terminal reply. It therefore remains non-clearing even when a no-visible direct result includes typed progress evidence.