### PR TITLE
refactor(dashboard): centralize chat HTML escaping

### DIFF
--- a/dashboard/src/components/chat/chat-linkify.ts
+++ b/dashboard/src/components/chat/chat-linkify.ts
@@ -1,16 +1,9 @@
+import { escapeHtml } from '../../lib/html-escape'
+
 const URL_RE = /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g
 const BOARD_POST_ID_RE = /(^|[\s([{"'`>])(p-[a-f0-9]{32})(?=$|[\s)\].,!?:;}"'`<])/gi
 const ANCHOR_RE = /(<a\b[\s\S]*?<\/a>)/gi
 const HTML_TAG_RE = /(<[^>]+>)/g
-
-function escapeHtml(raw: string): string {
-  return raw
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
 
 function boardPostHref(postId: string): string {
   return `#board?post=${encodeURIComponent(postId)}`

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -232,8 +232,8 @@ describe('parseMarkdownToBlocks', () => {
     // ...and the trailing prose survives (not swallowed into a code box).
     expect(p.html).toContain('This prose should not be trapped.')
     expect(p.html).toContain('More prose.')
-    // The fenced JSON body is rendered literally (escapeHtml escapes &<> only).
-    expect(p.html).toContain('{"x":1}')
+    // The fenced JSON body is rendered literally after HTML escaping.
+    expect(p.html).toContain('{&quot;x&quot;:1}')
     // Newlines are preserved as <br> for the multi-line body.
     expect(p.html).toContain('<br>')
   })

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -1,12 +1,9 @@
 import { marked, type Token, type Tokens } from 'marked'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
+import { escapeHtml } from '../../lib/html-escape'
 import type { ChatBlock, ChatCalloutSeverity, ChatTableCellValue } from '../../types'
 import { linkifyHtmlReferences } from './chat-linkify'
 import { FENCE_OPEN_RE, STANDALONE_URL_RE, isSvgDocument } from './markdown-cue'
-
-function escapeHtml(raw: string): string {
-  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
 
 // A standalone URL occupying the whole paragraph renders as a link/image card,
 // matching the line-based parser in lib/chat-blocks.ts so this rich parser is a

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import type { ComponentChildren, VNode } from 'preact'
 import { JsonViewerCard } from '../common/json-viewer'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
+import { escapeHtml } from '../../lib/html-escape'
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
@@ -3076,10 +3077,6 @@ export const STREAM_STALL_THRESHOLD_S = 15
 export const CHAT_COMPOSER_DEFAULT_KEEPER_LABEL = 'keeper'
 export const CHAT_COMPOSER_COMMAND_HEADER_SUFFIX = '명령'
 export const CHAT_COMPOSER_DROP_PLACEHOLDER = '여기에 놓아 첨부…'
-
-function escapeHtml(raw: string): string {
-  return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
 
 export function AttachDraftChip({
   attachment,

--- a/dashboard/src/lib/chat-blocks.ts
+++ b/dashboard/src/lib/chat-blocks.ts
@@ -1,14 +1,5 @@
 import type { ChatBlock, ChatImageBlock, ChatLinkBlock } from '../types'
-
-/** Escape plain text so it can be safely injected as HTML. */
-function escapeHtml(raw: string): string {
-  return raw
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
+import { escapeHtml } from './html-escape'
 
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
 

--- a/dashboard/src/lib/html-escape.test.ts
+++ b/dashboard/src/lib/html-escape.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { escapeHtml } from './html-escape'
+
+describe('escapeHtml', () => {
+  it('escapes text and attribute delimiters', () => {
+    expect(escapeHtml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&#39;')
+  })
+
+  it('leaves ordinary text unchanged', () => {
+    expect(escapeHtml('plain text 123')).toBe('plain text 123')
+  })
+})

--- a/dashboard/src/lib/html-escape.ts
+++ b/dashboard/src/lib/html-escape.ts
@@ -1,0 +1,9 @@
+/** Escape plain text for safe HTML text or attribute interpolation. */
+export function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}


### PR DESCRIPTION
## Summary
- Add `dashboard/src/lib/html-escape.ts` as the canonical 5-character HTML escaper for dashboard chat text/attribute interpolation.
- Route `chat-linkify.ts`, `markdown-blocks.ts`, `primitives.ts`, and `lib/chat-blocks.ts` through the shared helper instead of local copies.
- Add focused unit coverage for the canonical escaper and update the markdown-blocks expectation for quote escaping.
- Leave `shiki-highlighter.ts` DOM text-node escaping untouched; it is a distinct renderer-local variant called out by #21953 for separate review.

## Validation
- `tsc -p dashboard/tsconfig.json --noEmit --pretty false` using the existing dashboard toolchain
- `vitest run --config vitest.config.ts src/lib/html-escape.test.ts src/lib/chat-blocks.test.ts src/components/chat/markdown-blocks.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1`
- `eslint src/components/chat/chat-linkify.ts src/components/chat/markdown-blocks.ts src/components/chat/primitives.ts`
- `git diff --check`
- Local dashboard build intentionally not run; CI per operator instruction.

Refs #21953