### PR TITLE
[codex] Make runtime provider fields draft-editable

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
   parseRuntimeTomlEnvironment,
+  type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
   type RuntimeTomlProvider,
 } from '../lib/runtime-toml-config'
@@ -19,6 +20,7 @@ export type RuntimeStructuredSection =
   | 'assignments'
 
 export type RuntimeBindingEditableField = 'max-concurrent' | 'keep-alive' | 'num-ctx'
+export type RuntimeProviderTransportEditableField = 'endpoint' | 'command'
 
 interface RuntimeEnvironmentEditorProps {
   sourceText: string
@@ -32,6 +34,16 @@ interface RuntimeEnvironmentEditorProps {
     runtimeId: string,
     field: RuntimeBindingEditableField,
     value: string | number | null,
+  ) => void
+  onProviderTransportChange: (
+    providerId: string,
+    field: RuntimeProviderTransportEditableField,
+    value: string,
+  ) => void
+  onProviderCredentialChange: (
+    providerId: string,
+    credentialType: RuntimeTomlCredentialType,
+    value: string,
   ) => void
 }
 
@@ -53,6 +65,10 @@ function credentialValue(provider: RuntimeTomlProvider): string {
 function transportValue(provider: RuntimeTomlProvider): string {
   if (provider.transportKind === 'command') return provider.command
   return provider.endpoint
+}
+
+function transportField(provider: RuntimeTomlProvider): RuntimeProviderTransportEditableField {
+  return provider.transportKind === 'command' ? 'command' : 'endpoint'
 }
 
 // Prototype rt-model-ctx label — runtime-editor.jsx:176 `(max/1000).toFixed(0)}k ctx`.
@@ -97,6 +113,8 @@ export function RuntimeEnvironmentEditor({
   onRoutingChange,
   onAssignmentChange,
   onBindingFieldChange,
+  onProviderTransportChange,
+  onProviderCredentialChange,
 }: RuntimeEnvironmentEditorProps) {
   const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
   const [modelQuery, setModelQuery] = useState('')
@@ -199,7 +217,7 @@ export function RuntimeEnvironmentEditor({
     <div data-testid="runtime-environment-editor">
       <div class="rt-head-actions" style=${{ justifyContent: 'flex-end', marginBottom: '14px' }}>
         <span class="rt-nav-sub mono" style=${{ marginRight: 'auto' }}>런타임 환경</span>
-        <span class="rt-nav-sub mono">${saving ? '저장 중' : 'routing live · bindings draft'}</span>
+        <span class="rt-nav-sub mono">${saving ? '저장 중' : 'routing live · providers/bindings draft'}</span>
       </div>
 
       ${environment.warnings.length > 0 ? html`
@@ -246,25 +264,35 @@ export function RuntimeEnvironmentEditor({
         )}
       </div>
 
-      <!-- providers — runtime-editor.jsx:144-165. Read-only projection. Live
-           writes stay behind backend typed routes or the raw editor's validated
-           save; this component does not rewrite TOML text. -->
+      <!-- providers — runtime-editor.jsx:144-165. Endpoint/credential edits update
+           the draft runtime.toml and are applied through the validated Save path. -->
       <div class=${section === 'providers' ? '' : 'hidden'} data-testid="runtime-section-providers">
         <div class="rt-cards">
-          ${environment.providers.map(provider => html`
-            <div key=${provider.id} class="rt-card">
+          ${environment.providers.map(provider => {
+            const providerTransportField = transportField(provider)
+            return html`
+            <div key=${provider.id} class="rt-card" data-testid=${`runtime-provider-${provider.id}`}>
               <div class="rt-card-h">
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
               </div>
               <div class="rt-field">
-                <span class="sub-k">endpoint</span>
+                <span class="sub-k">${providerTransportField}</span>
                 <input
                   class="rt-input mono"
                   value=${transportValue(provider)}
-                  readOnly
-                  aria-label="provider transport value"
+                  disabled=${isDisabled}
+                  aria-label=${`${provider.id} provider transport value`}
+                  onInput=${(event: Event) => {
+                    onProviderTransportChange(
+                      provider.id,
+                      providerTransportField,
+                      (event.currentTarget as HTMLInputElement).value,
+                    )
+                  }}
+                  data-testid=${`runtime-provider-${provider.id}-transport`}
+                  data-runtime-provider-transport=${provider.id}
                 />
               </div>
               <div class="rt-field">
@@ -278,8 +306,17 @@ export function RuntimeEnvironmentEditor({
                       class="rt-input mono"
                       type=${provider.credentialType === 'inline' ? 'password' : 'text'}
                       value=${credentialValue(provider)}
-                      readOnly
-                      aria-label="provider credential value"
+                      disabled=${isDisabled}
+                      aria-label=${`${provider.id} provider credential value`}
+                      onInput=${(event: Event) => {
+                        onProviderCredentialChange(
+                          provider.id,
+                          provider.credentialType,
+                          (event.currentTarget as HTMLInputElement).value,
+                        )
+                      }}
+                      data-testid=${`runtime-provider-${provider.id}-credential`}
+                      data-runtime-provider-credential=${provider.id}
                     />
                   </span>
                   `}
@@ -289,7 +326,8 @@ export function RuntimeEnvironmentEditor({
                    provider-capability source exists, rather than implying support
                    with no backing (PR #22081 review P1: no stub). */ ''}
             </div>
-          `)}
+          `
+          })}
         </div>
       </div>
 

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -183,7 +183,7 @@ describe('RuntimeTomlEditor', () => {
     expect(container.querySelector('[data-testid="runtime-toml-impact-preview"]')).toBeNull()
   })
 
-  it('renders runtime environment fields as structured projections without raw TOML mutation', async () => {
+  it('renders runtime environment fields as structured projections', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -195,13 +195,55 @@ describe('RuntimeTomlEditor', () => {
       const modelsSection = container.querySelector('[data-testid="runtime-section-models"]')
       expect(modelsSection?.textContent).toContain('qwen')
       expect(modelsSection?.textContent).toContain('128k ctx')
-      expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement | null)?.value)
+      expect((container.querySelector('[data-testid="runtime-provider-runpod_mtp-transport"]') as HTMLInputElement | null)?.value)
         .toBe('https://runpod.example/v1')
     })
 
-    expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement).readOnly).toBe(true)
     expect(container.querySelector('[data-testid="runtime-environment-save"]')).toBeNull()
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+  })
+
+  it('edits provider transport and credentials as a draft and applies them through the existing save path', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+
+    const transport = container.querySelector('[data-testid="runtime-provider-runpod_mtp-transport"]') as HTMLInputElement
+    const credential = container.querySelector('[data-testid="runtime-provider-runpod_mtp-credential"]') as HTMLInputElement
+
+    expect(transport.readOnly).toBe(false)
+    expect(transport.disabled).toBe(false)
+    expect(transport.value).toBe('https://runpod.example/v1')
+    expect(credential.value).toBe('RUNPOD_API_KEY')
+
+    fireEvent.input(transport, { target: { value: 'https://runpod.example/v2' } })
+    fireEvent.input(credential, { target: { value: 'RUNPOD_API_KEY_NEXT' } })
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('endpoint = "https://runpod.example/v2"')
+      expect(source).toContain('key = "RUNPOD_API_KEY_NEXT"')
+      expect(source).not.toContain('endpoint = "https://runpod.example/v1"')
+      expect(source).not.toContain('key = "RUNPOD_API_KEY"')
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
+      expect(savedSource).toContain('endpoint = "https://runpod.example/v2"')
+      expect(savedSource).toContain('key = "RUNPOD_API_KEY_NEXT"')
+      expect(container.textContent).toContain('적용됨')
+    })
+    expect(apiMocks.patchRuntimeRouting).not.toHaveBeenCalled()
+    expect(apiMocks.patchRuntimeAssignment).not.toHaveBeenCalled()
   })
 
   it('edits binding runtime knobs as a draft and applies them through the existing save path', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -14,6 +14,9 @@ import {
   parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
   setRuntimeTomlBindingField,
+  setRuntimeTomlProviderCredential,
+  setRuntimeTomlProviderField,
+  type RuntimeTomlCredentialType,
   type RuntimeTomlImpactSummary,
 } from '../lib/runtime-toml-config'
 import { ActionButton } from './common/button'
@@ -24,6 +27,7 @@ import { ringFocusClasses } from './common/ring'
 import {
   RuntimeEnvironmentEditor,
   type RuntimeBindingEditableField,
+  type RuntimeProviderTransportEditableField,
   type RuntimeStructuredSection,
 } from './runtime-environment-editor'
 
@@ -269,6 +273,28 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
   ) {
     if (saving || loadState !== 'loaded') return
     setDraft(current => setRuntimeTomlBindingField(current, runtimeId, field, value))
+    setNotice(null)
+    setError(null)
+  }
+
+  function handleProviderTransportChange(
+    providerId: string,
+    field: RuntimeProviderTransportEditableField,
+    value: string,
+  ) {
+    if (saving || loadState !== 'loaded') return
+    setDraft(current => setRuntimeTomlProviderField(current, providerId, field, value))
+    setNotice(null)
+    setError(null)
+  }
+
+  function handleProviderCredentialChange(
+    providerId: string,
+    credentialType: RuntimeTomlCredentialType,
+    value: string,
+  ) {
+    if (saving || loadState !== 'loaded') return
+    setDraft(current => setRuntimeTomlProviderCredential(current, providerId, credentialType, value))
     setNotice(null)
     setError(null)
   }
@@ -535,6 +561,8 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
                   void handleAssignmentPatch(keeperName, runtimeId)
                 }}
                 onBindingFieldChange=${handleBindingFieldChange}
+                onProviderTransportChange=${handleProviderTransportChange}
+                onProviderCredentialChange=${handleProviderCredentialChange}
               />
             </div>
 


### PR DESCRIPTION
## Summary

- Makes runtime provider transport fields editable in Settings > Runtime management.
- Wires provider endpoint/command and credential edits into the existing runtime.toml draft path.
- Keeps live apply behind the existing validated `saveRuntimeTomlConfig` button instead of adding a new backend write route.

## Why

The provider section rendered endpoint and credential values inside inputs, but those inputs were `readOnly`. They looked editable while doing nothing. This turns that fake interaction into the same draft-edit + live-apply workflow already used for binding runtime knobs.

## Validation

- `env PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules vitest run --config vitest.config.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1`
- `env PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules tsc --noEmit`
- `env PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules eslint src/components/runtime-toml-editor.ts src/components/runtime-environment-editor.ts`
- `git diff --check`
- Rendered smoke with Python Playwright: `/dashboard/#settings?section=runtimes` -> provider tab -> edit first provider endpoint -> status becomes `modified` -> save button enables -> reset returns to `saved`.

Rendered smoke screenshot: `/private/tmp/masc-settings-provider-editor-draft.png`

Notes:
- Rendered smoke did not click live apply; it only verified draft mutation and reset to avoid changing live runtime config.
- Browser plugin was not available in this session, so rendered validation used Python Playwright.
