### PR TITLE
fix(test): correct keeper_tool_matrix actor/principal identity and board_post_update body fixture

### DIFF
--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -226,7 +226,18 @@ let temp_dir prefix =
   Unix.mkdir dir 0o755;
   dir
 
-let tool_matrix_agent_name = "matrix"
+(* Must equal the keeper registry's normalized identity for the keeper
+   fixture registered in test_keeper_tool_matrix_cases.ml's [make_fixture]
+   ("tool-matrix" — Keeper_registry strips the "keeper-" prefix from
+   meta.name when resolving the keeper's own agent_name for dispatch
+   context). Confirmed empirically: ctx.agent_name inside
+   Workspace_goals.principal_matches_authenticated_caller is "tool-matrix",
+   not meta.name/meta.agent_name ("keeper-tool-matrix"). Self-attested
+   actor/principal fields built here (via [goal_principal]) must match, or
+   masc_goal_transition/masc_goal_verify's identity-binding guard rejects
+   every matrix call ("<field> id must match authenticated caller") instead
+   of exercising the real transition/verification path. *)
+let tool_matrix_agent_name = "tool-matrix"
 
 let rec waitpid_nointr pid =
   try Unix.waitpid [] pid with
@@ -758,6 +769,11 @@ let tool_arguments fixture (schema : Masc_domain.tool_schema) =
           (* Schema no longer requires content|author (both are validated at
              the handler layer so body/content aliases both work). Matrix
              test still needs to supply body so board_core accepts it. *)
+          [ "body" ]
+      | "masc_board_post_update" ->
+          (* Same as masc_board_post: body is optional in the schema
+             (validated at the handler layer), but the matrix fixture must
+             supply a non-empty body or the handler rejects the edit. *)
           [ "body" ]
       | "masc_goal_transition" ->
           [ "override_note"; "note" ]


### PR DESCRIPTION
## Summary
- `masc_goal_transition`/`masc_goal_verify` always failed the keeper matrix (`055_masc_board_post_update`/`076_masc_goal_transition`/`078_masc_goal_verify`) because `test_mcp_tool_matrix_cases.ml`'s `tool_matrix_agent_name` ("matrix") never matched the keeper registry's normalized dispatch identity ("tool-matrix" — `Keeper_registry` strips the `keeper-` prefix from `meta.name` when resolving `ctx.agent_name`). Confirmed empirically via a temporary debug print in `Workspace_goals.principal_matches_authenticated_caller` (removed before commit).
- `masc_board_post_update` failed for an unrelated reason: like `masc_board_post`, `body`/`content` are optional in the schema (validated at the handler layer), so the fixture must explicitly supply a non-empty body.
- No production code changed — this is a test-fixture-only fix.

## Test plan
- [x] `keeper_tool_matrix_case_runner.exe masc_goal_transition` → `ok:true`
- [x] `keeper_tool_matrix_case_runner.exe masc_goal_verify` → `ok:true` (hits recognized "no active verification request" guard)
- [x] `keeper_tool_matrix_case_runner.exe masc_board_post_update` → `ok:true`
- [x] Full `dune build @runtest` (via `scripts/dune-local.sh`): `keeper_tool_matrix` binary now `Test Successful in 80.834s. 140 tests run.` (was `3 failures! ... 140 tests run.` before this fix)
- [x] `ocamlformat --check` on the changed file
- [ ] Remaining pre-existing/unrelated failures in the same full-suite run (env-boundary anchoring, provider-error parsing, repository policy, mcp_tool_matrix "registry inconsistency" aggregate, and a `DUNE_CACHE`-pollution-sensitive flaky test in `test_ci_run_tests_script.ml`) are untouched by this PR — out of scope, not introduced or fixed here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>