### PR TITLE
fix(dashboard): persist keeper turn trace blocks

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -358,6 +358,52 @@ describe('thread history merge & persistence', () => {
     ])
   })
 
+  it('preserves persisted thinking/tool interleaving trace blocks on reload', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'done',
+        ts: 1_780_000_000,
+        turn_ref: 'trace-ui#12',
+        blocks: [
+          { t: 'p', html: 'done' },
+          {
+            t: 'trace',
+            trace: [
+              { kind: 'think', text: 'checking tasks', ts: '2026-07-01T00:00:00Z' },
+              {
+                kind: 'tool',
+                name: 'keeper_tasks_list',
+                tool_call_id: 'exec-1',
+                status: 'ok',
+                args: {},
+                result: { ok: true },
+                ts: '2026-07-01T00:00:01Z',
+              },
+              { kind: 'think', text: 'summarizing', ts: '2026-07-01T00:00:02Z' },
+            ],
+          },
+        ] as unknown as ChatBlock[],
+      },
+    ])
+
+    const traceBlock = entries[0]?.blocks?.find((block): block is Extract<ChatBlock, { t: 'trace' }> => block.t === 'trace')
+    expect(traceBlock?.trace).toEqual([
+      { kind: 'think', text: 'checking tasks', ts: '2026-07-01T00:00:00Z' },
+      {
+        kind: 'tool',
+        name: 'keeper_tasks_list',
+        toolCallId: 'exec-1',
+        status: 'ok',
+        args: '{}',
+        result: '{\n  "ok": true\n}',
+        ts: '2026-07-01T00:00:01Z',
+      },
+      { kind: 'think', text: 'summarizing', ts: '2026-07-01T00:00:02Z' },
+    ])
+    expect(entries[0]?.turnRef).toBe('trace-ui#12')
+  })
+
   it('maps persisted tool rows to the live tool-entry convention', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: 'run checks', ts: 1_780_000_000 },

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -574,14 +574,17 @@ let block_of_yojson json : chat_block option =
           | _ -> None
         in
         (match get_step_string "kind" with
-         | Some "think" ->
-           Option.bind (get_step_string "text") (fun text ->
-             Some
-               (Trace_think
-                  { text
-                  ; ts = get_step_string "ts"
-                  ; oas_block_index = get_step_int "oas_block_index"
-                  }))
+          | Some "think" ->
+            Option.bind (get_step_string "text") (fun text ->
+              Some
+                (Trace_think
+                   { text
+                   ; ts = get_step_string "ts"
+                   ; oas_block_index =
+                       (match get_step_int "oas_block_index" with
+                        | Some _ as v -> v
+                        | None -> get_step_int "oasBlockIndex")
+                   }))
          | Some "reason" ->
            Option.bind (get_step_string "text") (fun text ->
              Some
@@ -590,32 +593,30 @@ let block_of_yojson json : chat_block option =
                   ; detail = get_step_string "detail"
                   ; ts = get_step_string "ts"
                   }))
-         | Some "tool" ->
-           Option.bind (get_step_string "name") (fun name ->
-             let status_result =
-               match get_step_string "status" with
-               | None -> Some None
-               | Some status -> Option.map Option.some (trace_tool_status_of_label status)
-             in
-             Option.map
-               (fun status ->
-                 Trace_tool
-                   { name
-                   ; tool_call_id =
-                       (match get_step_string "tool_call_id" with
-                        | Some _ as v -> v
-                        | None -> get_step_string "toolCallId")
-                   ; status
-                   ; dur = get_step_string "dur"
-                   ; args = List.assoc_opt "args" step_fields
-                   ; result = List.assoc_opt "result" step_fields
-                   ; ts = get_step_string "ts"
-                   ; oas_block_index =
-                       (match get_step_int "oas_block_index" with
-                        | Some _ as v -> v
-                        | None -> get_step_int "oasBlockIndex")
-                   })
-               status_result)
+          | Some "tool" ->
+            Option.bind (get_step_string "name") (fun name ->
+             let status =
+                match get_step_string "status" with
+                | None -> None
+                | Some status -> trace_tool_status_of_label status
+              in
+             Some
+               (Trace_tool
+                  { name
+                  ; tool_call_id =
+                      (match get_step_string "tool_call_id" with
+                       | Some _ as v -> v
+                       | None -> get_step_string "toolCallId")
+                  ; status
+                  ; dur = get_step_string "dur"
+                  ; args = List.assoc_opt "args" step_fields
+                  ; result = List.assoc_opt "result" step_fields
+                  ; ts = get_step_string "ts"
+                  ; oas_block_index =
+                      (match get_step_int "oas_block_index" with
+                       | Some _ as v -> v
+                       | None -> get_step_int "oasBlockIndex")
+                  }))
          | _ -> None)
       | _ -> None
     in

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -81,6 +81,35 @@ type fusion_block = {
   run_id : string;
 }
 
+type trace_tool_status =
+  | Trace_tool_pending
+  | Trace_tool_ok
+  | Trace_tool_err
+
+type trace_step =
+  | Trace_think of {
+      text : string;
+      ts : string option;
+      oas_block_index : int option;
+    }
+  | Trace_reason of {
+      text : string;
+      detail : string option;
+      ts : string option;
+    }
+  | Trace_tool of {
+      name : string;
+      tool_call_id : string option;
+      status : trace_tool_status option;
+      dur : string option;
+      args : Yojson.Safe.t option;
+      result : Yojson.Safe.t option;
+      ts : string option;
+      oas_block_index : int option;
+    }
+
+type trace_block = { trace : trace_step list }
+
 type chat_block =
   | Text of text_block
   | Heading of text_block
@@ -95,6 +124,7 @@ type chat_block =
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
+  | Trace of trace_block
 
 let escape_html raw =
   raw
@@ -208,11 +238,58 @@ let opt_int_field key = function
   | Some value -> [ (key, `Int value) ]
 ;;
 
+let opt_json_field key = function
+  | None -> []
+  | Some value -> [ (key, value) ]
+;;
+
 let table_cell_to_yojson = function
   | Cell_text value -> `String value
   | Cell_value { v; num; muted } ->
     `Assoc
       ([ ("v", `String v) ] @ opt_bool_field "num" num @ opt_bool_field "muted" muted)
+;;
+
+let trace_tool_status_to_label = function
+  | Trace_tool_pending -> "pending"
+  | Trace_tool_ok -> "ok"
+  | Trace_tool_err -> "err"
+;;
+
+let trace_tool_status_of_label = function
+  | "pending" -> Some Trace_tool_pending
+  | "ok" -> Some Trace_tool_ok
+  | "err" -> Some Trace_tool_err
+  | _ -> None
+;;
+
+let trace_status_to_yojson = function
+  | None -> []
+  | Some status -> [ ("status", `String (trace_tool_status_to_label status)) ]
+;;
+
+let trace_step_to_yojson = function
+  | Trace_think { text; ts; oas_block_index } ->
+    `Assoc
+      ([ ("kind", `String "think"); ("text", `String text) ]
+       @ opt_string_field "ts" ts
+       @ opt_int_field "oas_block_index" oas_block_index)
+  | Trace_reason { text; detail; ts } ->
+    `Assoc
+      ([ ("kind", `String "reason"); ("text", `String text) ]
+       @ opt_string_field "detail" detail
+       @ opt_string_field "ts" ts)
+  | Trace_tool
+      { name; tool_call_id; status; dur; args; result; ts; oas_block_index } ->
+    `Assoc
+      ([ ("kind", `String "tool"); ("name", `String name) ]
+       @ opt_string_field "tool_call_id" tool_call_id
+       @ trace_status_to_yojson status
+       @ opt_string_field "dur" dur
+       @ opt_json_field "args" args
+       @ opt_json_field "result" result
+       @ opt_string_field "ts" ts
+       @ opt_int_field "oas_block_index" oas_block_index)
 ;;
 
 let table_cell_of_yojson = function
@@ -456,6 +533,11 @@ let block_to_yojson = function
       ; ("board_post_id", `String board_post_id)
       ; ("run_id", `String run_id)
       ]
+  | Trace { trace } ->
+    `Assoc
+      [ ("t", `String "trace")
+      ; ("trace", `List (List.map trace_step_to_yojson trace))
+      ]
 ;;
 
 let blocks_to_yojson blocks = `List (List.map block_to_yojson blocks)
@@ -477,6 +559,68 @@ let block_of_yojson json : chat_block option =
     let get_int key =
       match List.assoc_opt key fields with
       | Some (`Int i) -> Some i
+      | _ -> None
+    in
+    let trace_step_of_yojson = function
+      | `Assoc step_fields ->
+        let get_step_string key =
+          match List.assoc_opt key step_fields with
+          | Some (`String s) -> Some s
+          | _ -> None
+        in
+        let get_step_int key =
+          match List.assoc_opt key step_fields with
+          | Some (`Int i) -> Some i
+          | _ -> None
+        in
+        (match get_step_string "kind" with
+         | Some "think" ->
+           Option.bind (get_step_string "text") (fun text ->
+             Some
+               (Trace_think
+                  { text
+                  ; ts = get_step_string "ts"
+                  ; oas_block_index = get_step_int "oas_block_index"
+                  }))
+         | Some "reason" ->
+           Option.bind (get_step_string "text") (fun text ->
+             Some
+               (Trace_reason
+                  { text
+                  ; detail = get_step_string "detail"
+                  ; ts = get_step_string "ts"
+                  }))
+         | Some "tool" ->
+           Option.bind (get_step_string "name") (fun name ->
+             let status_result =
+               match get_step_string "status" with
+               | None -> Some None
+               | Some status -> Option.map Option.some (trace_tool_status_of_label status)
+             in
+             Option.map
+               (fun status ->
+                 Trace_tool
+                   { name
+                   ; tool_call_id =
+                       (match get_step_string "tool_call_id" with
+                        | Some _ as v -> v
+                        | None -> get_step_string "toolCallId")
+                   ; status
+                   ; dur = get_step_string "dur"
+                   ; args = List.assoc_opt "args" step_fields
+                   ; result = List.assoc_opt "result" step_fields
+                   ; ts = get_step_string "ts"
+                   ; oas_block_index =
+                       (match get_step_int "oas_block_index" with
+                        | Some _ as v -> v
+                        | None -> get_step_int "oasBlockIndex")
+                   })
+               status_result)
+         | _ -> None)
+      | _ -> None
+    in
+    let trace_steps_of_yojson = function
+      | `List items -> list_all_map trace_step_of_yojson items
       | _ -> None
     in
     (match get_string "t" with
@@ -561,6 +705,10 @@ let block_of_yojson json : chat_block option =
        Option.bind (get_string "board_post_id") (fun board_post_id ->
          let run_id = Option.value (get_string "run_id") ~default:"" in
          Some (Fusion { board_post_id; run_id }))
+     | Some "trace" ->
+       Option.bind (List.assoc_opt "trace" fields) (fun trace_json ->
+         Option.bind (trace_steps_of_yojson trace_json) (fun trace ->
+           if trace = [] then None else Some (Trace { trace })))
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -97,6 +97,35 @@ type fusion_block = {
   run_id : string;
 }
 
+type trace_tool_status =
+  | Trace_tool_pending
+  | Trace_tool_ok
+  | Trace_tool_err
+
+type trace_step =
+  | Trace_think of {
+      text : string;
+      ts : string option;
+      oas_block_index : int option;
+    }
+  | Trace_reason of {
+      text : string;
+      detail : string option;
+      ts : string option;
+    }
+  | Trace_tool of {
+      name : string;
+      tool_call_id : string option;
+      status : trace_tool_status option;
+      dur : string option;
+      args : Yojson.Safe.t option;
+      result : Yojson.Safe.t option;
+      ts : string option;
+      oas_block_index : int option;
+    }
+
+type trace_block = { trace : trace_step list }
+
 type chat_block =
   | Text of text_block
   | Heading of text_block
@@ -111,6 +140,7 @@ type chat_block =
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
+  | Trace of trace_block
 
 type dropped_http_url_reason =
   | Missing_scheme

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -282,7 +282,8 @@ let rich_embed_of_chat_block = function
   | Keeper_chat_blocks.Svg _
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
-  | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Fusion _
+  | Keeper_chat_blocks.Trace _ -> None
 
 let rich_embeds_of_text text =
   text

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -151,7 +151,8 @@ let slack_block_of_chat_block = function
   | Keeper_chat_blocks.Svg _
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
-  | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Fusion _
+  | Keeper_chat_blocks.Trace _ -> None
 
 let content_blocks_of_text text =
   text

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -967,7 +967,26 @@ let audio_fields_with_expired ~base_dir audio =
       in
       [ ("audio", `Assoc (audio_to_json { a with expired })) ]
 
-let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
+let blocks_with_trace ~trace_block_by_turn_ref (m : chat_message) =
+  let base =
+    match m.blocks with
+    | Some blocks -> blocks
+    | None -> []
+  in
+  match m.role, m.turn_ref, trace_block_by_turn_ref with
+  | Role.Assistant, Some turn_ref, Some trace_block_by_turn_ref -> (
+      match trace_block_by_turn_ref turn_ref with
+      | Some trace_block -> base @ [ trace_block ]
+      | None -> base)
+  | _ -> base
+
+let blocks_fields_of_list = function
+  | [] -> []
+  | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
+;;
+
+let to_json_array ?base_dir ?trace_block_by_turn_ref
+    (messages : chat_message list) : Yojson.Safe.t =
   `List
     (List.map
        (fun m ->
@@ -1015,7 +1034,7 @@ let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
                      ) atts in
                      [("attachments", `List att_json)])
               @ audio_fields_with_expired ~base_dir m.audio
-              @ blocks_fields m.blocks
+              @ blocks_fields_of_list (blocks_with_trace ~trace_block_by_turn_ref m)
               @ opt_string_field "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -289,7 +289,11 @@ val load_page :
     [speaker_id] / [speaker_name] / [speaker_authority] appear only
     when present. When [base_dir] is supplied, the history endpoint marks
     audio clips as [expired] when the underlying MP3 file is gone. *)
-val to_json_array : ?base_dir:string -> chat_message list -> Yojson.Safe.t
+val to_json_array :
+  ?base_dir:string ->
+  ?trace_block_by_turn_ref:(Ids.Turn_ref.t -> chat_block option) ->
+  chat_message list ->
+  Yojson.Safe.t
 
 (** {1 Turn transcript (RFC-0233 §7)} *)
 

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -72,6 +72,68 @@ let memory_os_count pred xs =
   List.fold_left (fun count value -> if pred value then count + 1 else count) 0 xs
 ;;
 
+let trajectory_line_to_chat_trace_step = function
+  | Trajectory.Thinking entry ->
+    Some
+      (Keeper_chat_blocks.Trace_think
+         { text = entry.content
+         ; ts = Some entry.ts_iso
+         ; oas_block_index = None
+         })
+  | Trajectory.Tool_call entry ->
+    let result =
+      Option.map
+        (fun text ->
+          try Yojson.Safe.from_string text with
+          | Yojson.Json_error _ -> `String text)
+        entry.result
+    in
+    Some
+      (Keeper_chat_blocks.Trace_tool
+         { name = entry.tool_name
+         ; tool_call_id = entry.execution_id
+         ; status =
+             (match entry.error with
+              | Some _ -> Some Keeper_chat_blocks.Trace_tool_err
+              | None -> Some Keeper_chat_blocks.Trace_tool_ok)
+         ; dur = Some (Printf.sprintf "%dms" entry.duration_ms)
+         ; args =
+             Some
+               (try Yojson.Safe.from_string entry.args_json with
+                | Yojson.Json_error _ -> `String entry.args_json)
+         ; result
+         ; ts = Some entry.ts_iso
+         ; oas_block_index = None
+         })
+;;
+
+let keeper_chat_trace_block_by_turn_ref ~config ~keeper_name ~trace_id =
+  let masc_root = Workspace.masc_root_dir config in
+  let trajectory_lines =
+    Trajectory.read_recent_lines ~masc_root ~keeper_name ~trace_id
+      ~max_lines:trajectory_max_limit
+  in
+  let all_lines =
+    Server_dashboard_http_keeper_api_trace.merge_keeper_trace_lines_bounded
+      ~config ~trace_id ~max_internal_lines:trajectory_max_limit
+      trajectory_lines
+  in
+  fun turn_ref ->
+    if not (String.equal (Ids.Turn_ref.trace_id turn_ref) trace_id) then None
+    else
+      let absolute_turn = Ids.Turn_ref.absolute_turn turn_ref in
+      let trace =
+        all_lines
+        |> List.filter (function
+             | Trajectory.Thinking entry -> entry.turn = absolute_turn
+             | Trajectory.Tool_call entry -> entry.turn = absolute_turn)
+        |> List.filter_map trajectory_line_to_chat_trace_step
+      in
+      match trace with
+      | [] -> None
+      | trace -> Some (Keeper_chat_blocks.Trace { trace })
+;;
+
 let memory_os_read_episodes ~keeper_id ~n =
   try Keeper_memory_os_io.read_episodes_tail ~keeper_id ~n, None with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1023,12 +1085,29 @@ let handle_keeper_get_subroutes state req request reqd =
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
     else
-      let base_dir = (Mcp_server.workspace_config state).base_path in
+      let config = Mcp_server.workspace_config state in
+      let base_dir = config.base_path in
       let messages =
         Keeper_chat_store.load ~base_dir ~keeper_name:name
       in
+      let trace_block_by_turn_ref =
+        match Keeper_meta_store.read_meta config name with
+        | Ok (Some m) ->
+          let trace_id = Keeper_id.Trace_id.to_string m.runtime.trace_id in
+          Some
+            (keeper_chat_trace_block_by_turn_ref ~config ~keeper_name:name
+               ~trace_id)
+        | Ok None -> None
+        | Error err ->
+          Log.Keeper.warn
+            "dashboard keeper chat history: read_meta failed for %s; trace enrichment skipped: %s"
+            name
+            err;
+          None
+      in
       Server_auth.respond_json_value_with_cors ~status:`OK request reqd
-        (Keeper_chat_store.to_json_array ~base_dir messages)
+        (Keeper_chat_store.to_json_array ~base_dir ?trace_block_by_turn_ref
+           messages)
   else if ends_with "/person-notes" then
     (* RFC-0229 P2: keeper-authored person notes for the roster pane.
        Read-only fold over the notes store; same shape as the tool

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -72,66 +72,9 @@ let memory_os_count pred xs =
   List.fold_left (fun count value -> if pred value then count + 1 else count) 0 xs
 ;;
 
-let trajectory_line_to_chat_trace_step = function
-  | Trajectory.Thinking entry ->
-    Some
-      (Keeper_chat_blocks.Trace_think
-         { text = entry.content
-         ; ts = Some entry.ts_iso
-         ; oas_block_index = None
-         })
-  | Trajectory.Tool_call entry ->
-    let result =
-      Option.map
-        (fun text ->
-          try Yojson.Safe.from_string text with
-          | Yojson.Json_error _ -> `String text)
-        entry.result
-    in
-    Some
-      (Keeper_chat_blocks.Trace_tool
-         { name = entry.tool_name
-         ; tool_call_id = entry.execution_id
-         ; status =
-             (match entry.error with
-              | Some _ -> Some Keeper_chat_blocks.Trace_tool_err
-              | None -> Some Keeper_chat_blocks.Trace_tool_ok)
-         ; dur = Some (Printf.sprintf "%dms" entry.duration_ms)
-         ; args =
-             Some
-               (try Yojson.Safe.from_string entry.args_json with
-                | Yojson.Json_error _ -> `String entry.args_json)
-         ; result
-         ; ts = Some entry.ts_iso
-         ; oas_block_index = None
-         })
-;;
-
-let keeper_chat_trace_block_by_turn_ref ~config ~keeper_name ~trace_id =
-  let masc_root = Workspace.masc_root_dir config in
-  let trajectory_lines =
-    Trajectory.read_recent_lines ~masc_root ~keeper_name ~trace_id
-      ~max_lines:trajectory_max_limit
-  in
-  let all_lines =
-    Server_dashboard_http_keeper_api_trace.merge_keeper_trace_lines_bounded
-      ~config ~trace_id ~max_internal_lines:trajectory_max_limit
-      trajectory_lines
-  in
-  fun turn_ref ->
-    if not (String.equal (Ids.Turn_ref.trace_id turn_ref) trace_id) then None
-    else
-      let absolute_turn = Ids.Turn_ref.absolute_turn turn_ref in
-      let trace =
-        all_lines
-        |> List.filter (function
-             | Trajectory.Thinking entry -> entry.turn = absolute_turn
-             | Trajectory.Tool_call entry -> entry.turn = absolute_turn)
-        |> List.filter_map trajectory_line_to_chat_trace_step
-      in
-      match trace with
-      | [] -> None
-      | trace -> Some (Keeper_chat_blocks.Trace { trace })
+let keeper_chat_allowed_trace_ids (m : Keeper_meta_contract.keeper_meta) =
+  Keeper_id.Trace_id.to_string m.runtime.trace_id :: m.runtime.trace_history
+  |> Json_util.dedupe_keep_order
 ;;
 
 let memory_os_read_episodes ~keeper_id ~n =
@@ -1093,10 +1036,13 @@ let handle_keeper_get_subroutes state req request reqd =
       let trace_block_by_turn_ref =
         match Keeper_meta_store.read_meta config name with
         | Ok (Some m) ->
-          let trace_id = Keeper_id.Trace_id.to_string m.runtime.trace_id in
           Some
-            (keeper_chat_trace_block_by_turn_ref ~config ~keeper_name:name
-               ~trace_id)
+            (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
+               ~max_lines:trajectory_max_limit
+               ~max_internal_lines:trajectory_max_limit
+               ~config
+               ~keeper_name:name
+               ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
         | Ok None -> None
         | Error err ->
           Log.Keeper.warn

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -39,6 +39,44 @@ let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
   List.rev rev_deduped
 ;;
 
+let log_internal_history_skips ~trace_id ~skipped ~total =
+  if skipped > 0 then
+    Log.Dashboard.warn
+      "internal history trace %s: %d of %d rows did not decode to a thinking \
+       line (older content-block format or non-assistant rows)"
+      trace_id skipped total
+;;
+
+let internal_history_lines_of_jsons ~trace_id jsons =
+  let lines_rev, skipped, total =
+    List.fold_left
+      (fun (acc, skipped, total) json ->
+        match
+          Server_dashboard_http_keeper_api_types
+          .internal_history_json_to_trajectory_line
+            json
+        with
+        | Some line -> line :: acc, skipped, total + 1
+        | None -> acc, skipped + 1, total + 1)
+      ([], 0, 0)
+      jsons
+  in
+  log_internal_history_skips ~trace_id ~skipped ~total;
+  List.rev lines_rev
+;;
+
+let read_internal_history_tail_lines ~max_lines ~(config : Workspace.config)
+    ~(trace_id : string)
+  : Trajectory.trajectory_line list
+  =
+  let path = Keeper_types_support.keeper_internal_history_path config trace_id in
+  let jsons, _malformed =
+    Dated_jsonl.load_tail_lines path ~max_lines
+    |> Fs_compat.parse_jsonl_lines ~source:path
+  in
+  internal_history_lines_of_jsons ~trace_id jsons
+;;
+
 let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string)
   : Trajectory.trajectory_line list
   =
@@ -62,23 +100,17 @@ let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string
            .internal_history_json_to_trajectory_line
              json
          with
-         | Some line -> (line :: acc, skipped, total + 1)
-         | None -> (acc, skipped + 1, total + 1))
+       | Some line -> (line :: acc, skipped, total + 1)
+       | None -> (acc, skipped + 1, total + 1))
       path
   in
-  if skipped > 0 then
-    Log.Dashboard.warn
-      "internal history trace %s: %d of %d rows did not decode to a thinking \
-       line (older content-block format or non-assistant rows)"
-      trace_id skipped total;
+  log_internal_history_skips ~trace_id ~skipped ~total;
   List.rev lines_rev
 ;;
 
-let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)
-      (trajectory_lines : Trajectory.trajectory_line list)
+let merge_lines ~internal_lines (trajectory_lines : Trajectory.trajectory_line list)
   : Trajectory.trajectory_line list
   =
-  let internal_lines = read_internal_history_lines ~config ~trace_id in
   (* [stable_sort], not [sort]: the comparator returns 0 for two lines of the
      same kind at the same timestamp, and [List.sort] does not guarantee those
      keep their original order (only [stable_sort] does, per the OCaml 5.4
@@ -96,4 +128,25 @@ let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)
       | Trajectory.Thinking _, Trajectory.Tool_call _ -> -1
       | Trajectory.Tool_call _, Trajectory.Thinking _ -> 1
       | _ -> 0)
+;;
+
+let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)
+      (trajectory_lines : Trajectory.trajectory_line list)
+  : Trajectory.trajectory_line list
+  =
+  let internal_lines = read_internal_history_lines ~config ~trace_id in
+  merge_lines ~internal_lines trajectory_lines
+;;
+
+let merge_keeper_trace_lines_bounded ~max_internal_lines
+    ~(config : Workspace.config)
+    ~(trace_id : string)
+    (trajectory_lines : Trajectory.trajectory_line list)
+  : Trajectory.trajectory_line list
+  =
+  let internal_lines =
+    read_internal_history_tail_lines ~max_lines:max_internal_lines ~config
+      ~trace_id
+  in
+  merge_lines ~internal_lines trajectory_lines
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -150,3 +150,90 @@ let merge_keeper_trace_lines_bounded ~max_internal_lines
   in
   merge_lines ~internal_lines trajectory_lines
 ;;
+
+let trajectory_line_to_chat_trace_step = function
+  | Trajectory.Thinking entry ->
+    Some
+      (Keeper_chat_blocks.Trace_think
+         { text = entry.content
+         ; ts = Some entry.ts_iso
+         ; oas_block_index = None
+         })
+  | Trajectory.Tool_call entry ->
+    let result =
+      Option.map
+        (fun text ->
+          try Yojson.Safe.from_string text with
+          | Yojson.Json_error _ -> `String text)
+        entry.result
+    in
+    Some
+      (Keeper_chat_blocks.Trace_tool
+         { name = entry.tool_name
+         ; tool_call_id = entry.execution_id
+         ; status =
+             (match entry.error with
+              | Some _ -> Some Keeper_chat_blocks.Trace_tool_err
+              | None -> Some Keeper_chat_blocks.Trace_tool_ok)
+         ; dur = Some (Printf.sprintf "%dms" entry.duration_ms)
+         ; args =
+             Some
+               (try Yojson.Safe.from_string entry.args_json with
+                | Yojson.Json_error _ -> `String entry.args_json)
+         ; result
+         ; ts = Some entry.ts_iso
+         ; oas_block_index = None
+         })
+;;
+
+let allowed_trace_id_set trace_ids =
+  List.fold_left
+    (fun acc trace_id -> Set_util.StringSet.add trace_id acc)
+    Set_util.StringSet.empty
+    trace_ids
+;;
+
+let chat_trace_block_by_turn_ref ~max_lines ~max_internal_lines
+    ~(config : Workspace.config)
+    ~(keeper_name : string)
+    ~(allowed_trace_ids : string list)
+  =
+  let allowed_trace_ids = Json_util.dedupe_keep_order allowed_trace_ids in
+  let allowed = allowed_trace_id_set allowed_trace_ids in
+  let cache = Hashtbl.create (max 1 (List.length allowed_trace_ids)) in
+  let masc_root = Workspace.masc_root_dir config in
+  let lines_for_trace_id trace_id =
+    if not (Set_util.StringSet.mem trace_id allowed)
+    then None
+    else (
+      match Hashtbl.find_opt cache trace_id with
+      | Some lines -> Some lines
+      | None ->
+        let trajectory_lines =
+          Trajectory.read_recent_lines ~masc_root ~keeper_name ~trace_id
+            ~max_lines
+        in
+        let all_lines =
+          merge_keeper_trace_lines_bounded ~config ~trace_id ~max_internal_lines
+            trajectory_lines
+        in
+        Hashtbl.replace cache trace_id all_lines;
+        Some all_lines)
+  in
+  fun turn_ref ->
+    let trace_id = Ids.Turn_ref.trace_id turn_ref in
+    match lines_for_trace_id trace_id with
+    | None -> None
+    | Some all_lines ->
+      let absolute_turn = Ids.Turn_ref.absolute_turn turn_ref in
+      let trace =
+        all_lines
+        |> List.filter (function
+             | Trajectory.Thinking entry -> entry.turn = absolute_turn
+             | Trajectory.Tool_call entry -> entry.turn = absolute_turn)
+        |> List.filter_map trajectory_line_to_chat_trace_step
+      in
+      (match trace with
+       | [] -> None
+       | trace -> Some (Keeper_chat_blocks.Trace { trace }))
+;;

--- a/lib/server/server_dashboard_http_keeper_api_trace.mli
+++ b/lib/server/server_dashboard_http_keeper_api_trace.mli
@@ -29,3 +29,12 @@ val merge_keeper_trace_lines_bounded
   -> trace_id:string
   -> Trajectory.trajectory_line list
   -> Trajectory.trajectory_line list
+
+val chat_trace_block_by_turn_ref
+  :  max_lines:int
+  -> max_internal_lines:int
+  -> config:Workspace.config
+  -> keeper_name:string
+  -> allowed_trace_ids:string list
+  -> Ids.Turn_ref.t
+  -> Keeper_chat_blocks.chat_block option

--- a/lib/server/server_dashboard_http_keeper_api_trace.mli
+++ b/lib/server/server_dashboard_http_keeper_api_trace.mli
@@ -11,8 +11,21 @@ val read_internal_history_lines
   -> trace_id:string
   -> Trajectory.trajectory_line list
 
+val read_internal_history_tail_lines
+  :  max_lines:int
+  -> config:Workspace.config
+  -> trace_id:string
+  -> Trajectory.trajectory_line list
+
 val merge_keeper_trace_lines
   :  config:Workspace.config
+  -> trace_id:string
+  -> Trajectory.trajectory_line list
+  -> Trajectory.trajectory_line list
+
+val merge_keeper_trace_lines_bounded
+  :  max_internal_lines:int
+  -> config:Workspace.config
   -> trace_id:string
   -> Trajectory.trajectory_line list
   -> Trajectory.trajectory_line list

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -260,6 +260,40 @@ let test_dashboard_rich_blocks_roundtrip () =
       (blocks_to_json_list parsed)
   | None -> Alcotest.fail "blocks_of_yojson rejected valid dashboard rich blocks"
 
+let test_trace_decoder_accepts_dashboard_fallbacks () =
+  let json =
+    `List
+      [ `Assoc
+          [ ("t", `String "trace")
+          ; ( "trace"
+            , `List
+                [ `Assoc
+                    [ ("kind", `String "think")
+                    ; ("text", `String "thinking")
+                    ; ("oasBlockIndex", `Int 7)
+                    ]
+                ; `Assoc
+                    [ ("kind", `String "tool")
+                    ; ("name", `String "keeper_tasks_list")
+                    ; ("status", `String "paused")
+                    ; ("oasBlockIndex", `Int 8)
+                    ]
+                ] )
+          ]
+      ]
+  in
+  match B.blocks_of_yojson json with
+  | Some
+      [ B.Trace
+          { trace =
+              [ B.Trace_think { oas_block_index = Some 7; _ }
+              ; B.Trace_tool { status = None; oas_block_index = Some 8; _ }
+              ]
+          }
+      ] -> ()
+  | Some _ -> Alcotest.fail "unexpected trace block shape"
+  | None -> Alcotest.fail "trace decoder rejected dashboard-compatible fields"
+
 let test_non_http_markdown_image_becomes_text () =
   let blocks = B.parse_text_to_blocks "before ![alt](ftp://example.com/a.png) after" in
   Alcotest.(check (list yojson_testable))
@@ -404,10 +438,12 @@ let () =
             test_blocks_of_yojson_roundtrip;
           Alcotest.test_case "code block roundtrip" `Quick
             test_code_block_roundtrip;
-          Alcotest.test_case "dashboard rich blocks roundtrip" `Quick
-            test_dashboard_rich_blocks_roundtrip;
-          Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
-            test_blocks_of_yojson_rejects_malformed;
+           Alcotest.test_case "dashboard rich blocks roundtrip" `Quick
+             test_dashboard_rich_blocks_roundtrip;
+           Alcotest.test_case "trace decoder accepts dashboard fallbacks" `Quick
+             test_trace_decoder_accepts_dashboard_fallbacks;
+           Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
+             test_blocks_of_yojson_rejects_malformed;
           Alcotest.test_case "fusion block roundtrip" `Quick
             test_fusion_block_roundtrip;
           Alcotest.test_case "fusion block requires board_post_id" `Quick

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -221,6 +221,35 @@ let test_dashboard_rich_blocks_roundtrip () =
           size_bytes = Some 42;
           kind = Some "video";
         };
+      B.Trace
+        {
+          trace =
+            [
+              B.Trace_think
+                {
+                  text = "checking";
+                  ts = Some "2026-07-01T00:00:00Z";
+                  oas_block_index = Some 0;
+                };
+              B.Trace_tool
+                {
+                  name = "keeper_tasks_list";
+                  tool_call_id = Some "exec-1";
+                  status = Some B.Trace_tool_ok;
+                  dur = Some "2ms";
+                  args = Some (`Assoc [ ("limit", `Int 5) ]);
+                  result = Some (`Assoc [ ("ok", `Bool true) ]);
+                  ts = Some "2026-07-01T00:00:01Z";
+                  oas_block_index = Some 1;
+                };
+              B.Trace_reason
+                {
+                  text = "done";
+                  detail = Some "visible";
+                  ts = Some "2026-07-01T00:00:02Z";
+                };
+            ];
+        };
     ]
   in
   match B.blocks_of_yojson (B.blocks_to_yojson original) with

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1,4 +1,5 @@
 module K = Masc.Keeper_chat_store
+module B = Masc.Keeper_chat_blocks
 module MS = Masc.Keeper_world_observation_message_scope
 module P = Masc.Otel_metric_store
 module KT = Masc.Keeper_turn
@@ -1150,6 +1151,71 @@ let test_turn_ref_persisted_on_turn_rows () =
       Alcotest.(check bool) "turn_ref present in to_json_array" true
         (contains_substring s "trace-abc#7"))
 
+let test_to_json_array_appends_trace_block_to_assistant_turn () =
+  let base_dir = temp_base_path "keeper-chat-store-turn-trace" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-turn-trace" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-ui" ~absolute_turn:12 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"status"
+        ~user_attachments:[]
+        ~tool_calls:[ { K.call_id = "exec-1"; call_name = "keeper_tasks_list"; args = "{}" } ]
+        ~turn_ref:tref ~assistant_content:"done" ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref
+        then
+          Some
+            (B.Trace
+               {
+                 trace =
+                   [
+                     B.Trace_think
+                       {
+                         text = "checking tasks";
+                         ts = Some "2026-07-01T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                     B.Trace_tool
+                         {
+                           name = "keeper_tasks_list";
+                           tool_call_id = Some "exec-1";
+                           status = Some B.Trace_tool_ok;
+                           dur = Some "1ms";
+                         args = Some (`Assoc []);
+                         result = Some (`Assoc [ ("ok", `Bool true) ]);
+                         ts = Some "2026-07-01T00:00:01Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref messages)
+      in
+      let assistant =
+        List.find
+          (function
+            | `Assoc fields -> (
+                match List.assoc_opt "role" fields with
+                | Some (`String "assistant") -> true
+                | _ -> false)
+            | _ -> false)
+          rows
+      in
+      match json_blocks assistant with
+      | Some blocks ->
+        let last = List.nth blocks (List.length blocks - 1) in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "trace block appended" "trace"
+          (last |> member "t" |> to_string);
+        Alcotest.(check int) "trace keeps thinking and tool" 2
+          (last |> member "trace" |> to_list |> List.length)
+      | None -> Alcotest.fail "assistant json missing blocks")
+
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
 let test_turn_ref_malformed_reads_none () =
@@ -1277,6 +1343,8 @@ let () =
             test_user_and_tool_rows_have_no_blocks;
           Alcotest.test_case "blocks roundtrip and malformed dropped" `Quick
             test_blocks_roundtrip_and_drop_malformed;
+          Alcotest.test_case "assistant history appends trace block" `Quick
+            test_to_json_array_appends_trace_block_to_assistant_turn;
         ] );
       ( "row_kind",
         [

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -4,15 +4,19 @@ module Trace = Server_dashboard_http_keeper_api_trace
 module Types = Server_dashboard_http_keeper_api_types
 module T = Trajectory
 
-let mk_thinking ~ts ~redacted ~content =
+let mk_thinking_with_turn ~turn ~ts ~redacted ~content =
   T.Thinking
     { ts
     ; ts_iso = "2026-06-29T00:00:00Z"
-    ; turn = 1
+    ; turn
     ; content
     ; content_length = String.length content
     ; redacted
     }
+;;
+
+let mk_thinking ~ts ~redacted ~content =
+  mk_thinking_with_turn ~turn:1 ~ts ~redacted ~content
 ;;
 
 let test_dedupe_preserves_first_order () =
@@ -153,6 +157,59 @@ let test_skip_warns_once_per_file () =
       (List.length trace_warns))
 ;;
 
+let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
+  with_temp_dir (fun dir ->
+    let config = Workspace.default_config dir in
+    let masc_root = Workspace.masc_root_dir config in
+    let keeper_name = "keeper-chat-trace" in
+    T.append_thinking
+      ~masc_root
+      ~keeper_name
+      ~trace_id:"trace-current"
+      { ts = 1.0
+      ; ts_iso = "2026-07-01T00:00:01Z"
+      ; turn = 1
+      ; content = "current turn"
+      ; content_length = String.length "current turn"
+      ; redacted = false
+      };
+    T.append_thinking
+      ~masc_root
+      ~keeper_name
+      ~trace_id:"trace-old"
+      { ts = 2.0
+      ; ts_iso = "2026-07-01T00:00:02Z"
+      ; turn = 42
+      ; content = "old turn"
+      ; content_length = String.length "old turn"
+      ; redacted = false
+      };
+    let trace_block_by_turn_ref =
+      Trace.chat_trace_block_by_turn_ref
+        ~max_lines:10
+        ~max_internal_lines:10
+        ~config
+        ~keeper_name
+        ~allowed_trace_ids:[ "trace-current"; "trace-old" ]
+    in
+    let old_ref = Ids.Turn_ref.make ~trace_id:"trace-old" ~absolute_turn:42 in
+    (match trace_block_by_turn_ref old_ref with
+     | Some
+         (Keeper_chat_blocks.Trace
+           { trace = [ Keeper_chat_blocks.Trace_think { text = "old turn"; _ } ] })
+       -> ()
+     | Some _ -> fail "old trace_id returned unexpected trace block"
+     | None -> fail "old trace_id from trace_history should enrich");
+    let disallowed_ref =
+      Ids.Turn_ref.make ~trace_id:"trace-unlisted" ~absolute_turn:42
+    in
+    check
+      bool
+      "unlisted trace_id is not used as a filesystem read key"
+      true
+      (Option.is_none (trace_block_by_turn_ref disallowed_ref)))
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -167,15 +224,21 @@ let () =
       , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips
         ; test_case "summarises skips once per file" `Quick test_skip_warns_once_per_file
         ] )
-    ; ( "internal_history_json_to_trajectory_line"
-      , [ test_case
-            "decodes content_blocks rows"
-            `Quick
-            test_converter_decodes_content_blocks
-        ; test_case
-            "rejects flat content rows"
-            `Quick
-            test_converter_rejects_flat_content
-        ] )
-    ]
+     ; ( "internal_history_json_to_trajectory_line"
+       , [ test_case
+             "decodes content_blocks rows"
+             `Quick
+             test_converter_decodes_content_blocks
+         ; test_case
+             "rejects flat content rows"
+             `Quick
+             test_converter_rejects_flat_content
+         ] )
+     ; ( "chat_trace_block_by_turn_ref"
+       , [ test_case
+             "reads allowed trace_history trace ids"
+             `Quick
+             test_chat_trace_block_by_turn_ref_reads_allowed_trace_history
+         ] )
+     ]
 ;;


### PR DESCRIPTION
## Summary
- add typed keeper chat trace blocks for thinking/reason/tool interleaving
- enrich dashboard chat history from persisted trajectory/internal trace lines by exact turn_ref
- keep chat-history trace enrichment bounded and observable on meta read failures

## Boundary
- MASC-only dashboard/runtime persistence fix
- no OAS provider normalization changes in this PR
- exact trace_id + absolute_turn join only; no timestamp/text heuristic attribution

## Verification
- scripts/dune-local.sh build test/test_keeper_chat_blocks.exe test/test_keeper_chat_store.exe
- ./_build/default/test/test_keeper_chat_blocks.exe
- ./_build/default/test/test_keeper_chat_store.exe
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/keeper-state.test.ts --no-file-parallelism --maxWorkers=1