### PR TITLE
feat(keeper): expose no-progress reason facts

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -302,12 +302,86 @@ let runtime_exhaustion_reason_of_json json =
    [blocker_class] the only authoritative class eliminates that recovery path;
    [detail] carries free-form context for UI / Otel_metric_store labels (no
    classification semantics). *)
+type no_progress_blocker_facts =
+  { no_progress_reason : string
+  ; no_progress_streak : int
+  ; no_progress_threshold : int
+  ; no_progress_latched : bool
+  }
+
+type blocker_facts =
+  | No_progress_loop_facts of no_progress_blocker_facts
+
 type blocker_info = {
   klass : blocker_class;
   detail : string;
+  facts : blocker_facts option;
 }
 
-let blocker_info_of_class ?(detail = "") klass = { klass; detail }
+let blocker_info_of_class ?(detail = "") ?facts klass = { klass; detail; facts }
+
+let blocker_info_of_no_progress_loop
+      ?(detail = "")
+      ~reason
+      ~streak
+      ~threshold
+      ~latched
+      ()
+  =
+  blocker_info_of_class
+    ~detail
+    ~facts:
+      (No_progress_loop_facts
+         { no_progress_reason = reason
+         ; no_progress_streak = streak
+         ; no_progress_threshold = threshold
+         ; no_progress_latched = latched
+         })
+    No_progress_loop
+;;
+
+let no_progress_blocker_facts_to_json facts : Yojson.Safe.t =
+  `Assoc
+    [ "kind", `String "no_progress_loop"
+    ; "reason", `String facts.no_progress_reason
+    ; "streak", `Int facts.no_progress_streak
+    ; "threshold", `Int facts.no_progress_threshold
+    ; "latched", `Bool facts.no_progress_latched
+    ]
+;;
+
+let blocker_facts_to_json = function
+  | No_progress_loop_facts facts -> no_progress_blocker_facts_to_json facts
+;;
+
+let no_progress_blocker_facts_of_fields fields =
+  match
+    ( List.assoc_opt "reason" fields
+    , List.assoc_opt "streak" fields
+    , List.assoc_opt "threshold" fields
+    , List.assoc_opt "latched" fields )
+  with
+  | Some (`String reason), Some (`Int streak), Some (`Int threshold), Some (`Bool latched)
+    when String.trim reason <> "" ->
+    Some
+      { no_progress_reason = reason
+      ; no_progress_streak = streak
+      ; no_progress_threshold = threshold
+      ; no_progress_latched = latched
+      }
+  | _ -> None
+;;
+
+let blocker_facts_of_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "no_progress_loop") ->
+       Option.map
+         (fun facts -> No_progress_loop_facts facts)
+         (no_progress_blocker_facts_of_fields fields)
+     | _ -> None)
+  | _ -> None
+;;
 
 let blocker_info_to_json (info : blocker_info) : Yojson.Safe.t =
   let klass_payload = match info.klass with
@@ -317,10 +391,17 @@ let blocker_info_to_json (info : blocker_info) : Yojson.Safe.t =
              ]
     | _ -> `String (blocker_class_to_string info.klass)
   in
-  `Assoc
+  let fields =
     [ "klass", klass_payload
     ; "detail", `String info.detail
     ]
+  in
+  let fields =
+    match info.facts with
+    | Some facts -> fields @ [ "facts", blocker_facts_to_json facts ]
+    | None -> fields
+  in
+  `Assoc fields
 ;;
 
 let blocker_info_of_json (json : Yojson.Safe.t) : blocker_info option =
@@ -353,7 +434,12 @@ let blocker_info_of_json (json : Yojson.Safe.t) : blocker_info option =
          | Some (`String s) -> s
          | _ -> ""
        in
-       Some { klass; detail })
+       let facts =
+         match List.assoc_opt "facts" fields with
+         | Some raw -> blocker_facts_of_json raw
+         | None -> None
+       in
+       Some { klass; detail; facts })
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -210,9 +210,23 @@ val blocker_class_of_serialized_string :
 
 (** {1 Unified blocker_info} *)
 
+type no_progress_blocker_facts = {
+  no_progress_reason : string;
+  no_progress_streak : int;
+  no_progress_threshold : int;
+  no_progress_latched : bool;
+}
+(** Structured facts for a persisted [No_progress_loop] blocker.  These fields
+    are machine-readable state; [blocker_info.detail] remains presentation
+    text only. *)
+
+type blocker_facts =
+  | No_progress_loop_facts of no_progress_blocker_facts
+
 type blocker_info = {
   klass : blocker_class;
   detail : string;
+  facts : blocker_facts option;
 }
 (** Authoritative blocker representation: a typed [blocker_class]
     paired with optional free-form [detail] (UI / Otel_metric_store label).
@@ -222,9 +236,22 @@ type blocker_info = {
     blocker, the runtime state holds [None]; when there is a blocker,
     [klass] is always populated and [detail] may be ["" ]. *)
 
-val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
+val blocker_info_of_class :
+  ?detail:string -> ?facts:blocker_facts -> blocker_class -> blocker_info
 (** [blocker_info_of_class ?detail klass] constructs a [blocker_info]
     for [klass].  [detail] defaults to [""]. *)
+
+val blocker_info_of_no_progress_loop :
+  ?detail:string ->
+  reason:string ->
+  streak:int ->
+  threshold:int ->
+  latched:bool ->
+  unit ->
+  blocker_info
+(** [blocker_info_of_no_progress_loop] stamps [No_progress_loop] with
+    structured telemetry facts so downstream status surfaces do not parse
+    the human-readable [detail]. *)
 
 val blocker_info_to_json : blocker_info -> Yojson.Safe.t
 (** Round-trippable JSON encoding.  [Runtime_exhausted reason] uses

--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -11,6 +11,34 @@ type record_outcome =
 
 type progress_identity = Keeper_tool_progress_identity.t
 
+type no_progress_reason =
+  | Empty
+  | Thinking_only
+  | Read_only
+  | Repeated_identity
+  | Surface_mismatch
+  | Stale_task
+
+let no_progress_reason_to_string = function
+  | Empty -> "empty"
+  | Thinking_only -> "thinking_only"
+  | Read_only -> "read_only"
+  | Repeated_identity -> "repeated_identity"
+  | Surface_mismatch -> "surface_mismatch"
+  | Stale_task -> "stale_task"
+;;
+
+let no_progress_reason_of_string value =
+  match String.trim value |> String.lowercase_ascii with
+  | "empty" -> Some Empty
+  | "thinking_only" -> Some Thinking_only
+  | "read_only" -> Some Read_only
+  | "repeated_identity" -> Some Repeated_identity
+  | "surface_mismatch" -> Some Surface_mismatch
+  | "stale_task" -> Some Stale_task
+  | _ -> None
+;;
+
 (* Per-keeper state: current streak + latched flag so the
    detected-counter only bumps once per loop episode, not on every
    turn while the keeper is stuck. *)
@@ -18,6 +46,7 @@ type keeper_state = {
   mutable streak : int;
   mutable detected_latched : bool;
   mutable last_progress_identity : progress_identity option;
+  mutable last_no_progress_reason : no_progress_reason option;
 }
 
 let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
@@ -35,7 +64,11 @@ let get_or_create keeper_name =
   | Some s -> s
   | None ->
       let s =
-        { streak = 0; detected_latched = false; last_progress_identity = None }
+        { streak = 0
+        ; detected_latched = false
+        ; last_progress_identity = None
+        ; last_no_progress_reason = None
+        }
       in
       Hashtbl.replace state keeper_name s;
       s
@@ -76,12 +109,21 @@ let repeated_progress_identity s progress_identity =
     repeated
 ;;
 
-let record_turn ?threshold_override ?progress_identity ~keeper_name ~made_progress () =
+let record_turn
+      ?threshold_override
+      ?progress_identity
+      ?no_progress_reason
+      ~keeper_name
+      ~made_progress
+      ()
+  =
   with_lock (fun () ->
     let s = get_or_create keeper_name in
     let repeated_identity = repeated_progress_identity s progress_identity in
     let made_progress = made_progress && not repeated_identity in
     if not made_progress then begin
+      s.last_no_progress_reason <-
+        (if repeated_identity then Some Repeated_identity else no_progress_reason);
       s.streak <- s.streak + 1;
       update_streak_gauge keeper_name s.streak;
       let t =
@@ -111,6 +153,7 @@ let record_turn ?threshold_override ?progress_identity ~keeper_name ~made_progre
         update_streak_gauge keeper_name 0;
       s.streak <- 0;
       s.detected_latched <- false;
+      s.last_no_progress_reason <- None;
       if previous_streak = 0 then Normal else Loop_reset { previous_streak; was_latched }
     end)
 
@@ -119,6 +162,12 @@ let current_streak ~keeper_name =
     match Hashtbl.find_opt state keeper_name with
     | Some s -> s.streak
     | None -> 0)
+
+let current_reason ~keeper_name =
+  with_lock (fun () ->
+    match Hashtbl.find_opt state keeper_name with
+    | Some s -> s.last_no_progress_reason
+    | None -> None)
 
 (* RFC-0246: expose latched state so the wake-tombstone gate can suppress
    automatic wake for a keeper stuck in a no-progress loop. The detector owns

--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -18,6 +18,13 @@ type no_progress_reason =
   | Repeated_identity
   | Surface_mismatch
   | Stale_task
+  (* A loop was detected (streak crossed threshold) but the turn's delivery
+     shape didn't match any of the specific classifiers above — e.g. a
+     [User_facing] delivery that still failed to produce durable evidence.
+     Distinct from [None]/absent: this records that classification ran and
+     genuinely found no specific match, so downstream readers (status bridge)
+     don't silently drop the fact that a reason segment exists. *)
+  | Unclassified
 
 let no_progress_reason_to_string = function
   | Empty -> "empty"
@@ -26,6 +33,7 @@ let no_progress_reason_to_string = function
   | Repeated_identity -> "repeated_identity"
   | Surface_mismatch -> "surface_mismatch"
   | Stale_task -> "stale_task"
+  | Unclassified -> "unclassified"
 ;;
 
 let no_progress_reason_of_string value =
@@ -36,6 +44,7 @@ let no_progress_reason_of_string value =
   | "repeated_identity" -> Some Repeated_identity
   | "surface_mismatch" -> Some Surface_mismatch
   | "stale_task" -> Some Stale_task
+  | "unclassified" -> Some Unclassified
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_no_progress_loop_detector.mli
+++ b/lib/keeper/keeper_no_progress_loop_detector.mli
@@ -42,6 +42,7 @@ type no_progress_reason =
   | Repeated_identity
   | Surface_mismatch
   | Stale_task
+  | Unclassified
 
 val no_progress_reason_to_string : no_progress_reason -> string
 val no_progress_reason_of_string : string -> no_progress_reason option

--- a/lib/keeper/keeper_no_progress_loop_detector.mli
+++ b/lib/keeper/keeper_no_progress_loop_detector.mli
@@ -35,6 +35,17 @@ type record_outcome =
 
 type progress_identity = Keeper_tool_progress_identity.t
 
+type no_progress_reason =
+  | Empty
+  | Thinking_only
+  | Read_only
+  | Repeated_identity
+  | Surface_mismatch
+  | Stale_task
+
+val no_progress_reason_to_string : no_progress_reason -> string
+val no_progress_reason_of_string : string -> no_progress_reason option
+
 (** [turn_made_progress ~strong_evidence ~surface_requires_evidence] is the
     no-progress predicate (RFC-0239 §3 R3). A turn makes progress when it
     produced durable evidence ([strong_evidence]), or when its delivery surface
@@ -64,6 +75,7 @@ val turn_made_progress :
 val record_turn :
   ?threshold_override:int ->
   ?progress_identity:progress_identity ->
+  ?no_progress_reason:no_progress_reason ->
   keeper_name:string ->
   made_progress:bool ->
   unit ->
@@ -71,6 +83,11 @@ val record_turn :
 
 (** Current consecutive no-progress count for [keeper_name]. *)
 val current_streak : keeper_name:string -> int
+
+(** Current no-progress reason for [keeper_name], if the current streak was
+    classified by the caller. Repeated progress identities are classified in
+    this module and override the caller-supplied reason. *)
+val current_reason : keeper_name:string -> no_progress_reason option
 
 (** RFC-0246: true iff this keeper is latched in a no-progress loop — the
     streak crossed the threshold and has not been reset by a progress turn.

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -166,12 +166,69 @@ let last_runtime_attempt_json (meta : keeper_meta) =
   | Some attempt -> runtime_attempt_record_json attempt
 ;;
 
+let no_progress_detail_value ~key detail =
+  let prefix = key ^ "=" in
+  detail
+  |> String.split_on_char ';'
+  |> List.concat_map (fun token -> String.split_on_char ' ' token)
+  |> List.find_map (fun token ->
+    let token = String.trim token in
+    if String.starts_with ~prefix token
+    then
+      Some
+        (String.sub token
+           (String.length prefix)
+           (String.length token - String.length prefix)
+         |> String.trim)
+    else None)
+;;
+
+let no_progress_int_from_detail ~key detail =
+  match no_progress_detail_value ~key detail with
+  | Some value -> int_of_string_opt value
+  | None -> None
+;;
+
+let no_progress_reason_from_detail detail =
+  match no_progress_detail_value ~key:"reason" detail with
+  | Some value -> Keeper_no_progress_loop_detector.no_progress_reason_of_string value
+  | None -> None
+;;
+
+let no_progress_blocker_detail meta =
+  match meta.runtime.last_blocker with
+  | Some { klass = No_progress_loop; detail } -> Some detail
+  | Some _ | None -> None
+;;
+
+let no_progress_runtime_blocker_fact_fields meta =
+  match no_progress_blocker_detail meta with
+  | None -> []
+  | Some detail ->
+    let reason =
+      no_progress_reason_from_detail detail
+      |> Option.map Keeper_no_progress_loop_detector.no_progress_reason_to_string
+    in
+    let reason_source = Option.map (fun _ -> "blocker_detail") reason in
+    [ "no_progress_reason", Json_util.string_opt_to_json reason
+    ; "no_progress_reason_source", Json_util.string_opt_to_json reason_source
+    ; ( "no_progress_threshold"
+      , Json_util.int_opt_to_json (no_progress_int_from_detail ~key:"threshold" detail)
+      )
+    ; ( "no_progress_streak"
+      , Json_util.int_opt_to_json (no_progress_int_from_detail ~key:"streak" detail)
+      )
+    ; "no_progress_latched", `Bool true
+    ]
+;;
+
 let runtime_blocker_facts_json (meta : keeper_meta) =
   `Assoc
-    [ "source", `String "keeper_runtime.last_runtime_attempt"
-    ; "runtime_id", `String (runtime_id_of_meta meta)
-    ; "last_runtime_attempt", last_runtime_attempt_json meta
-    ]
+    ([ "source", `String "keeper_runtime.last_runtime_attempt"
+     ; "runtime_id", `String (runtime_id_of_meta meta)
+     ; "last_runtime_attempt", last_runtime_attempt_json meta
+     ]
+     @ no_progress_runtime_blocker_fact_fields meta)
 ;;
 
 let runtime_blocker_fields_json (config : Workspace_utils.config) (meta : keeper_meta) =

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -166,59 +166,27 @@ let last_runtime_attempt_json (meta : keeper_meta) =
   | Some attempt -> runtime_attempt_record_json attempt
 ;;
 
-let no_progress_detail_value ~key detail =
-  let prefix = key ^ "=" in
-  detail
-  |> String.split_on_char ';'
-  |> List.concat_map (fun token -> String.split_on_char ' ' token)
-  |> List.find_map (fun token ->
-    let token = String.trim token in
-    if String.starts_with ~prefix token
-    then
-      Some
-        (String.sub token
-           (String.length prefix)
-           (String.length token - String.length prefix)
-         |> String.trim)
-    else None)
-;;
-
-let no_progress_int_from_detail ~key detail =
-  match no_progress_detail_value ~key detail with
-  | Some value -> int_of_string_opt value
-  | None -> None
-;;
-
-let no_progress_reason_from_detail detail =
-  match no_progress_detail_value ~key:"reason" detail with
-  | Some value -> Keeper_no_progress_loop_detector.no_progress_reason_of_string value
-  | None -> None
-;;
-
-let no_progress_blocker_detail meta =
+let no_progress_blocker_facts meta =
   match meta.runtime.last_blocker with
-  | Some { klass = No_progress_loop; detail } -> Some detail
+  | Some
+      { klass = No_progress_loop
+      ; facts = Some (No_progress_loop_facts facts)
+      ; _
+      } -> Some facts
   | Some _ | None -> None
 ;;
 
 let no_progress_runtime_blocker_fact_fields meta =
-  match no_progress_blocker_detail meta with
+  match no_progress_blocker_facts meta with
   | None -> []
-  | Some detail ->
-    let reason =
-      no_progress_reason_from_detail detail
-      |> Option.map Keeper_no_progress_loop_detector.no_progress_reason_to_string
-    in
-    let reason_source = Option.map (fun _ -> "blocker_detail") reason in
-    [ "no_progress_reason", Json_util.string_opt_to_json reason
-    ; "no_progress_reason_source", Json_util.string_opt_to_json reason_source
+  | Some facts ->
+    [ "no_progress_reason", `String facts.no_progress_reason
+    ; "no_progress_reason_source", `String "blocker_facts"
     ; ( "no_progress_threshold"
-      , Json_util.int_opt_to_json (no_progress_int_from_detail ~key:"threshold" detail)
-      )
+      , `Int facts.no_progress_threshold )
     ; ( "no_progress_streak"
-      , Json_util.int_opt_to_json (no_progress_int_from_detail ~key:"streak" detail)
-      )
-    ; "no_progress_latched", `Bool true
+      , `Int facts.no_progress_streak )
+    ; "no_progress_latched", `Bool facts.no_progress_latched
     ]
 ;;
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -641,13 +641,12 @@ let run (ctx : ctx)
             { turn_state with
               current_turn_blocker_info =
                 Some
-                  { klass = Sdk_token_budget_exceeded
-                  ; detail =
-                      Keeper_state_machine.event_to_string
-                        overflow_event
-                      ^ ": "
-                      ^ Agent_sdk.Error.to_string err
-                  }
+                  (Keeper_meta_contract.blocker_info_of_class
+                     ~detail:
+                       (Keeper_state_machine.event_to_string overflow_event
+                        ^ ": "
+                        ^ Agent_sdk.Error.to_string err)
+                     Sdk_token_budget_exceeded)
             }
           in
           Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -12,9 +12,10 @@ let mark_loop_detected
       ~threshold
   =
   let reason =
-    match no_progress_reason with
-    | Some reason -> Keeper_no_progress_loop_detector.no_progress_reason_to_string reason
-    | None -> "unclassified"
+    (match no_progress_reason with
+     | Some reason -> reason
+     | None -> Keeper_no_progress_loop_detector.Unclassified)
+    |> Keeper_no_progress_loop_detector.no_progress_reason_to_string
   in
   let detail =
     Printf.sprintf

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -4,12 +4,24 @@ let failure_reason_code = "no_progress_loop"
 
 let recovery_post_id ~keeper_name = "no-progress-loop:" ^ keeper_name
 
-let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
+let mark_loop_detected
+      ?no_progress_reason
+      ~(config : Workspace.config)
+      meta
+      ~streak
+      ~threshold
+  =
+  let reason =
+    match no_progress_reason with
+    | Some reason -> Keeper_no_progress_loop_detector.no_progress_reason_to_string reason
+    | None -> "unclassified"
+  in
   let detail =
     Printf.sprintf
-      "no_progress loop detected: streak=%d threshold=%d; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
+      "no_progress loop detected: streak=%d threshold=%d; reason=%s; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
       streak
       threshold
+      reason
   in
   let failure_reason =
     Keeper_registry.Provider_runtime_error

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -44,9 +44,13 @@ let mark_loop_detected
        { rt with
          last_blocker =
            Some
-             (Keeper_meta_contract.blocker_info_of_class
+             (Keeper_meta_contract.blocker_info_of_no_progress_loop
                 ~detail
-                Keeper_meta_contract.No_progress_loop)
+                ~reason
+                ~streak
+                ~threshold
+                ~latched:true
+                ())
        })
     meta
   in

--- a/lib/keeper/keeper_unified_turn_no_progress.mli
+++ b/lib/keeper/keeper_unified_turn_no_progress.mli
@@ -3,7 +3,9 @@
 val failure_reason_code : string
 
 val mark_loop_detected
-  :  config:Workspace.config
+  :  ?no_progress_reason:
+       Keeper_no_progress_loop_detector.no_progress_reason
+  -> config:Workspace.config
   -> Keeper_meta_contract.keeper_meta
   -> streak:int
   -> threshold:int

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -190,6 +190,27 @@ let claim_bound_work (calls : (string * Keeper_tool_outcome.t option) list) =
     calls
 ;;
 
+let no_progress_reason_of_turn
+      ~delivery
+      ~(calls_with_outcomes : (string * Keeper_tool_outcome.t option) list)
+      ~made_progress
+  =
+  if made_progress
+  then None
+  else
+    match delivery with
+    | User_facing -> None
+    | Internal_prose -> Some Keeper_no_progress_loop_detector.Thinking_only
+    | Task_claim -> Some Keeper_no_progress_loop_detector.Empty
+    | Peer_only ->
+      let calls = List.map fst calls_with_outcomes in
+      if calls = []
+      then Some Keeper_no_progress_loop_detector.Empty
+      else if List.for_all Keeper_tool_progress.is_passive_status_tool_name calls
+      then Some Keeper_no_progress_loop_detector.Read_only
+      else Some Keeper_no_progress_loop_detector.Surface_mismatch
+;;
+
 let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
      no-progress verdict derived from observed turn facts, not the LLM
@@ -223,8 +244,9 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
     Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
       observation
   in
+  let delivery = classify_turn_delivery ~is_autonomous ~reply_delivery:Internal_only result in
   let surface_requires_evidence =
-    match classify_turn_delivery ~is_autonomous ~reply_delivery:Internal_only result with
+    match delivery with
     | Task_claim -> not (claim_bound_work calls_with_outcomes)
     | (Peer_only | User_facing | Internal_prose) as delivery ->
       delivery_requires_evidence delivery
@@ -252,6 +274,9 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
       ~strong_evidence
       ~surface_requires_evidence
   in
+  let no_progress_reason =
+    no_progress_reason_of_turn ~delivery ~calls_with_outcomes ~made_progress
+  in
   let progress_identity =
     if strong_evidence && surface_requires_evidence
     then
@@ -277,6 +302,7 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
     Keeper_no_progress_loop_detector.record_turn
       ?threshold_override
       ?progress_identity
+      ?no_progress_reason
       ~keeper_name:updated_meta.Keeper_meta_contract.name
       ~made_progress
       ()
@@ -284,6 +310,7 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   | Keeper_no_progress_loop_detector.Normal -> updated_meta
   | Keeper_no_progress_loop_detector.Loop_detected { streak; threshold } ->
     Keeper_unified_turn_no_progress.mark_loop_detected
+      ?no_progress_reason
       ~config
       updated_meta
       ~streak
@@ -365,6 +392,7 @@ module For_testing = struct
   let delivery_requires_evidence = delivery_requires_evidence
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
+  let no_progress_reason_of_turn = no_progress_reason_of_turn
 
   let completion_contract_terminal_failure_reason_code =
     completion_contract_terminal_failure_reason_code

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -309,6 +309,10 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   with
   | Keeper_no_progress_loop_detector.Normal -> updated_meta
   | Keeper_no_progress_loop_detector.Loop_detected { streak; threshold } ->
+    let no_progress_reason =
+      Keeper_no_progress_loop_detector.current_reason
+        ~keeper_name:updated_meta.Keeper_meta_contract.name
+    in
     Keeper_unified_turn_no_progress.mark_loop_detected
       ?no_progress_reason
       ~config

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -380,7 +380,7 @@ let test_no_progress_loop_detection_pauses_keeper () =
          None
          paused_meta.auto_resume_after_sec;
        (match paused_meta.runtime.last_blocker with
-        | Some { Keeper_meta_contract.klass = No_progress_loop; detail } ->
+        | Some { Keeper_meta_contract.klass = No_progress_loop; detail; _ } ->
           check
             string
             "blocker detail"
@@ -989,7 +989,7 @@ let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
          false
          (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
        (match recovered_meta.runtime.last_blocker with
-        | Some { Keeper_meta_contract.klass = Turn_timeout; detail } ->
+        | Some { Keeper_meta_contract.klass = Turn_timeout; detail; _ } ->
           check string "non-no-progress blocker preserved" blocker.detail detail
         | Some _ -> fail "expected overwritten Turn_timeout blocker to remain"
         | None -> fail "expected non-no-progress blocker to remain");
@@ -1117,6 +1117,7 @@ let test_direct_success_passive_only_no_visible_keeps_no_progress_pause () =
         | Some
             { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop
             ; detail
+            ; _
             } ->
           check string "no-progress blocker preserved" blocker.detail detail
         | Some _ -> fail "expected no-progress blocker to remain"
@@ -1300,7 +1301,7 @@ let test_direct_success_leaves_unrelated_pause_intact () =
          false
          (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
        (match recovered_meta.runtime.last_blocker with
-        | Some { Keeper_meta_contract.klass = Turn_timeout; detail } ->
+        | Some { Keeper_meta_contract.klass = Turn_timeout; detail; _ } ->
           check string "unrelated blocker preserved" blocker.detail detail
         | Some _ -> fail "expected unrelated Turn_timeout blocker to remain"
         | None -> fail "expected unrelated blocker to remain");
@@ -1352,7 +1353,7 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
            None
            paused_meta.auto_resume_after_sec;
          (match paused_meta.runtime.last_blocker with
-          | Some { Keeper_meta_contract.klass = Sdk_idle_detected; detail } ->
+          | Some { Keeper_meta_contract.klass = Sdk_idle_detected; detail; _ } ->
             check
               string
               "blocker detail"

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -384,7 +384,7 @@ let test_no_progress_loop_detection_pauses_keeper () =
           check
             string
             "blocker detail"
-            "no_progress loop detected: streak=10 threshold=10; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
+            "no_progress loop detected: streak=10 threshold=10; reason=unclassified; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
             detail
         | Some _ -> fail "expected No_progress_loop blocker"
         | None -> fail "expected no_progress loop blocker");

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -74,10 +74,14 @@ let non_overflow_classes_are_not_matched () =
    intentionally redacted to placeholder text — the gate semantics depend
    only on [klass]. *)
 let overflow_info : Keeper_meta_contract.blocker_info =
-  { klass = Keeper_meta_contract.Sdk_token_budget_exceeded; detail = "<opaque-detail>" }
+  Keeper_meta_contract.blocker_info_of_class
+    ~detail:"<opaque-detail>"
+    Keeper_meta_contract.Sdk_token_budget_exceeded
 
 let non_overflow_info : Keeper_meta_contract.blocker_info =
-  { klass = Keeper_meta_contract.Sdk_max_turns_exceeded; detail = "<opaque-detail>" }
+  Keeper_meta_contract.blocker_info_of_class
+    ~detail:"<opaque-detail>"
+    Keeper_meta_contract.Sdk_max_turns_exceeded
 
 let gate_skips_when_auto_handoff_disabled () =
   let decision =

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -56,6 +56,34 @@ let runtime_blocker_facts_of_typed_last_blocker klass ~detail =
   | None -> Alcotest.fail "missing runtime_blocker_facts"
 ;;
 
+let runtime_blocker_facts_of_no_progress_blocker ~detail ~reason ~streak ~threshold =
+  let config = Workspace.default_config "/tmp/masc-test-status-bridge" in
+  let meta = meta_with_summary "" in
+  let meta =
+    { meta with
+      runtime =
+        { meta.runtime with
+          last_blocker =
+            Some
+              (Keeper_meta_contract.blocker_info_of_no_progress_loop
+                 ~detail
+                 ~reason
+                 ~streak
+                 ~threshold
+                 ~latched:true
+                 ())
+        }
+    }
+  in
+  match
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+    |> List.assoc_opt "runtime_blocker_facts"
+  with
+  | Some (`Assoc facts) -> facts
+  | Some _ -> Alcotest.fail "expected runtime_blocker_facts object"
+  | None -> Alcotest.fail "missing runtime_blocker_facts"
+;;
+
 let write_file path content =
   let oc = open_out path in
   Fun.protect
@@ -139,33 +167,35 @@ let test_no_progress_loop_summary_normalizes_legacy_detail () =
 let test_no_progress_runtime_blocker_facts_include_reason () =
   init_runtime_default_for_tests ();
   let detail =
-    "no_progress loop detected: streak=10 threshold=10; reason=read_only; auto-paused after repeated no-evidence turns"
+    "operator-facing no-progress blocker text changed; no parseable tokens here"
   in
   let facts =
-    runtime_blocker_facts_of_typed_last_blocker
-      Keeper_meta_contract.No_progress_loop
+    runtime_blocker_facts_of_no_progress_blocker
       ~detail
+      ~reason:"read_only"
+      ~streak:10
+      ~threshold:10
   in
   Alcotest.(check (option string))
-    "reason comes from persisted blocker detail"
+    "reason comes from persisted blocker facts"
     (Some "read_only")
     (match List.assoc_opt "no_progress_reason" facts with
      | Some (`String value) -> Some value
      | _ -> None);
   Alcotest.(check (option string))
-    "reason source names blocker detail"
-    (Some "blocker_detail")
+    "reason source names structured blocker facts"
+    (Some "blocker_facts")
     (match List.assoc_opt "no_progress_reason_source" facts with
      | Some (`String value) -> Some value
      | _ -> None);
   Alcotest.(check (option int))
-    "streak comes from persisted blocker detail"
+    "streak comes from persisted blocker facts"
     (Some 10)
     (match List.assoc_opt "no_progress_streak" facts with
      | Some (`Int value) -> Some value
      | _ -> None);
   Alcotest.(check (option int))
-    "threshold comes from persisted blocker detail"
+    "threshold comes from persisted blocker facts"
     (Some 10)
     (match List.assoc_opt "no_progress_threshold" facts with
      | Some (`Int value) -> Some value
@@ -187,18 +217,73 @@ let test_no_progress_runtime_blocker_facts_include_reason () =
 let test_no_progress_runtime_blocker_facts_include_unclassified_reason () =
   init_runtime_default_for_tests ();
   let detail =
-    "no_progress loop detected: streak=10 threshold=10; reason=unclassified; auto-paused after repeated no-evidence turns"
+    "operator-facing no-progress blocker text changed; no parseable tokens here"
   in
   let facts =
-    runtime_blocker_facts_of_typed_last_blocker
-      Keeper_meta_contract.No_progress_loop
+    runtime_blocker_facts_of_no_progress_blocker
       ~detail
+      ~reason:"unclassified"
+      ~streak:10
+      ~threshold:10
   in
   Alcotest.(check (option string))
-    "unclassified reason still round-trips from persisted blocker detail"
+    "unclassified reason round-trips from persisted blocker facts"
     (Some "unclassified")
     (match List.assoc_opt "no_progress_reason" facts with
      | Some (`String value) -> Some value
+     | _ -> None)
+;;
+
+let test_no_progress_blocker_facts_round_trip_independent_of_detail () =
+  init_runtime_default_for_tests ();
+  let detail = "localized presentation sentence without key-value tokens" in
+  let blocker =
+    Keeper_meta_contract.blocker_info_of_no_progress_loop
+      ~detail
+      ~reason:"surface_mismatch"
+      ~streak:12
+      ~threshold:10
+      ~latched:true
+      ()
+  in
+  let meta =
+    { (meta_with_summary "") with
+      runtime =
+        { (meta_with_summary "").runtime with
+          last_blocker =
+            Keeper_meta_contract.blocker_info_to_json blocker
+            |> Keeper_meta_contract.blocker_info_of_json
+        }
+    }
+  in
+  let facts =
+    match
+      Keeper_status_bridge.runtime_blocker_fields_json
+        (Workspace.default_config "/tmp/masc-test-status-bridge")
+        meta
+      |> List.assoc_opt "runtime_blocker_facts"
+    with
+    | Some (`Assoc facts) -> facts
+    | Some _ -> Alcotest.fail "expected runtime_blocker_facts object"
+    | None -> Alcotest.fail "missing runtime_blocker_facts"
+  in
+  Alcotest.(check (option string))
+    "detail wording does not affect reason"
+    (Some "surface_mismatch")
+    (match List.assoc_opt "no_progress_reason" facts with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option int))
+    "detail wording does not affect streak"
+    (Some 12)
+    (match List.assoc_opt "no_progress_streak" facts with
+     | Some (`Int value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option int))
+    "detail wording does not affect threshold"
+    (Some 10)
+    (match List.assoc_opt "no_progress_threshold" facts with
+     | Some (`Int value) -> Some value
      | _ -> None)
 ;;
 
@@ -268,6 +353,10 @@ let () =
             "no-progress blocker facts include unclassified reason"
             `Quick
             test_no_progress_runtime_blocker_facts_include_unclassified_reason;
+          Alcotest.test_case
+            "no-progress blocker facts survive detail wording changes"
+            `Quick
+            test_no_progress_blocker_facts_round_trip_independent_of_detail;
         ] );
       ( "profile default override provenance",
         [

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -178,6 +178,30 @@ let test_no_progress_runtime_blocker_facts_include_reason () =
      | _ -> None)
 ;;
 
+(* Regression for the round-trip gap Copilot flagged on PR #22865:
+   [Keeper_unified_turn_no_progress.mark_loop_detected] persists the literal
+   string "unclassified" when no specific reason was classified, but
+   [no_progress_reason_of_string] previously had no matching case for it, so
+   the fact silently came back [None] even though the detail string carried a
+   real (if unclassified) reason token. *)
+let test_no_progress_runtime_blocker_facts_include_unclassified_reason () =
+  init_runtime_default_for_tests ();
+  let detail =
+    "no_progress loop detected: streak=10 threshold=10; reason=unclassified; auto-paused after repeated no-evidence turns"
+  in
+  let facts =
+    runtime_blocker_facts_of_typed_last_blocker
+      Keeper_meta_contract.No_progress_loop
+      ~detail
+  in
+  Alcotest.(check (option string))
+    "unclassified reason still round-trips from persisted blocker detail"
+    (Some "unclassified")
+    (match List.assoc_opt "no_progress_reason" facts with
+     | Some (`String value) -> Some value
+     | _ -> None)
+;;
+
 let defaults_with_prompt_fields =
   { Keeper_types_profile.empty_keeper_profile_defaults with
     manifest_path = Some "/tmp/keeper.toml";
@@ -240,6 +264,10 @@ let () =
             "no-progress blocker facts include typed reason"
             `Quick
             test_no_progress_runtime_blocker_facts_include_reason;
+          Alcotest.test_case
+            "no-progress blocker facts include unclassified reason"
+            `Quick
+            test_no_progress_runtime_blocker_facts_include_unclassified_reason;
         ] );
       ( "profile default override provenance",
         [

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -35,6 +35,27 @@ let blocker_of_typed_last_blocker klass ~detail =
   Keeper_status_bridge.runtime_blocker_surface_opt config meta
 ;;
 
+let runtime_blocker_facts_of_typed_last_blocker klass ~detail =
+  let config = Workspace.default_config "/tmp/masc-test-status-bridge" in
+  let meta = meta_with_summary "" in
+  let meta =
+    { meta with
+      runtime =
+        { meta.runtime with
+          last_blocker =
+            Some (Keeper_meta_contract.blocker_info_of_class ~detail klass)
+        }
+    }
+  in
+  match
+    Keeper_status_bridge.runtime_blocker_fields_json config meta
+    |> List.assoc_opt "runtime_blocker_facts"
+  with
+  | Some (`Assoc facts) -> facts
+  | Some _ -> Alcotest.fail "expected runtime_blocker_facts object"
+  | None -> Alcotest.fail "missing runtime_blocker_facts"
+;;
+
 let write_file path content =
   let oc = open_out path in
   Fun.protect
@@ -115,6 +136,48 @@ let test_no_progress_loop_summary_normalizes_legacy_detail () =
   | None -> Alcotest.fail "expected no_progress_loop blocker"
 ;;
 
+let test_no_progress_runtime_blocker_facts_include_reason () =
+  init_runtime_default_for_tests ();
+  let detail =
+    "no_progress loop detected: streak=10 threshold=10; reason=read_only; auto-paused after repeated no-evidence turns"
+  in
+  let facts =
+    runtime_blocker_facts_of_typed_last_blocker
+      Keeper_meta_contract.No_progress_loop
+      ~detail
+  in
+  Alcotest.(check (option string))
+    "reason comes from persisted blocker detail"
+    (Some "read_only")
+    (match List.assoc_opt "no_progress_reason" facts with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option string))
+    "reason source names blocker detail"
+    (Some "blocker_detail")
+    (match List.assoc_opt "no_progress_reason_source" facts with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option int))
+    "streak comes from persisted blocker detail"
+    (Some 10)
+    (match List.assoc_opt "no_progress_streak" facts with
+     | Some (`Int value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option int))
+    "threshold comes from persisted blocker detail"
+    (Some 10)
+    (match List.assoc_opt "no_progress_threshold" facts with
+     | Some (`Int value) -> Some value
+     | _ -> None);
+  Alcotest.(check (option bool))
+    "typed no-progress blocker is latched"
+    (Some true)
+    (match List.assoc_opt "no_progress_latched" facts with
+     | Some (`Bool value) -> Some value
+     | _ -> None)
+;;
+
 let defaults_with_prompt_fields =
   { Keeper_types_profile.empty_keeper_profile_defaults with
     manifest_path = Some "/tmp/keeper.toml";
@@ -173,6 +236,10 @@ let () =
             "no-progress loop summary normalizes legacy detail"
             `Quick
             test_no_progress_loop_summary_normalizes_legacy_detail;
+          Alcotest.test_case
+            "no-progress blocker facts include typed reason"
+            `Quick
+            test_no_progress_runtime_blocker_facts_include_reason;
         ] );
       ( "profile default override provenance",
         [

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -946,6 +946,47 @@ let test_apply_loop_detectors_claim_no_eligible_accrues () =
     (Some "empty")
     (reason_label (D.current_reason ~keeper_name:keeper))
 
+let test_apply_loop_detectors_repeated_identity_blocker_uses_detector_reason () =
+  D.reset_all_for_test ();
+  with_temp_config @@ fun config ->
+  ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+  Masc.Keeper_registry.clear ();
+  let keeper = "apply-repeated-identity-loop" in
+  let meta = make_meta keeper in
+  ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper meta);
+  let result = run_result [ tool_call "tool_execute" ] in
+  let rec apply count current_meta =
+    if count = 0
+    then current_meta
+    else
+      let next_meta =
+        Success.apply_loop_detectors
+          ~config
+          ~observation:scheduled_observation
+          ~meta:current_meta
+          current_meta
+          result
+      in
+      apply (count - 1) next_meta
+  in
+  let final_meta = apply (D.threshold () + 1) meta in
+  Alcotest.(check bool) "repeated identity loop pauses keeper" true final_meta.paused;
+  Alcotest.(check (option string))
+    "detector reason is repeated_identity"
+    (Some "repeated_identity")
+    (reason_label (D.current_reason ~keeper_name:keeper));
+  match final_meta.runtime.last_blocker with
+  | Some
+      { Masc.Keeper_meta_contract.klass = Masc.Keeper_meta_contract.No_progress_loop
+      ; detail
+      } ->
+    Alcotest.(check bool)
+      "blocker detail uses detector-final reason"
+      true
+      (String_util.contains_substring detail "reason=repeated_identity")
+  | Some _ -> Alcotest.fail "expected No_progress_loop blocker"
+  | None -> Alcotest.fail "expected no-progress blocker"
+
 (* RFC-0289 / SSOT: [Keeper_tool_outcome.is_nonprogress] is the single owner of
    the outcome gate (previously inlined in [typed_outcome_is_nonprogress], now a
    thin delegate). Pin its mapping directly against the variant so the
@@ -1030,6 +1071,11 @@ let () =
           Alcotest.test_case
             "apply_loop_detectors typed no-eligible claim accrues"
             `Quick (with_eio test_apply_loop_detectors_claim_no_eligible_accrues);
+          Alcotest.test_case
+            "apply_loop_detectors repeated identity blocker uses detector reason"
+            `Quick
+            (with_eio
+               test_apply_loop_detectors_repeated_identity_blocker_uses_detector_reason);
           Alcotest.test_case "is_nonprogress 4-arm mapping (RFC-0289 SSOT)"
             `Quick test_is_nonprogress_branches;
           Alcotest.test_case

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -133,6 +133,7 @@ let test_no_progress_reason_string_mapping () =
     ; D.Repeated_identity, "repeated_identity"
     ; D.Surface_mismatch, "surface_mismatch"
     ; D.Stale_task, "stale_task"
+    ; D.Unclassified, "unclassified"
     ]
   in
   List.iter

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -979,6 +979,7 @@ let test_apply_loop_detectors_repeated_identity_blocker_uses_detector_reason () 
   | Some
       { Masc.Keeper_meta_contract.klass = Masc.Keeper_meta_contract.No_progress_loop
       ; detail
+      ; _
       } ->
     Alcotest.(check bool)
       "blocker detail uses detector-final reason"

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -47,6 +47,8 @@ let record_turn ~keeper_name ~made_progress =
 let ignore_outcome = function
   | D.Normal | D.Loop_detected _ | D.Loop_reset _ -> ()
 
+let reason_label = Option.map D.no_progress_reason_to_string
+
 let scheduled_observation : WO.world_observation =
   { pending_mentions = []
   ; pending_board_events = []
@@ -103,6 +105,51 @@ let test_any_other_act_resets () =
   record_turn ~keeper_name:k ~made_progress:false |> ignore_outcome;
   Alcotest.(check int) "after new no-progress turn" 1
     (D.current_streak ~keeper_name:k)
+
+let test_no_progress_reason_tracks_and_resets () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-reason-tracks" in
+  D.record_turn
+    ~keeper_name:k
+    ~made_progress:false
+    ~no_progress_reason:D.Read_only
+    ()
+  |> ignore_outcome;
+  Alcotest.(check (option string))
+    "reason tracks current no-progress turn"
+    (Some "read_only")
+    (reason_label (D.current_reason ~keeper_name:k));
+  D.record_turn ~keeper_name:k ~made_progress:true () |> ignore_outcome;
+  Alcotest.(check (option string))
+    "progress clears reason"
+    None
+    (reason_label (D.current_reason ~keeper_name:k))
+
+let test_no_progress_reason_string_mapping () =
+  let cases =
+    [ D.Empty, "empty"
+    ; D.Thinking_only, "thinking_only"
+    ; D.Read_only, "read_only"
+    ; D.Repeated_identity, "repeated_identity"
+    ; D.Surface_mismatch, "surface_mismatch"
+    ; D.Stale_task, "stale_task"
+    ]
+  in
+  List.iter
+    (fun (reason, label) ->
+       Alcotest.(check string)
+         ("to_string " ^ label)
+         label
+         (D.no_progress_reason_to_string reason);
+       Alcotest.(check (option string))
+         ("of_string " ^ label)
+         (Some label)
+         (reason_label (D.no_progress_reason_of_string label)))
+    cases;
+  Alcotest.(check (option string))
+    "unknown reason is rejected"
+    None
+    (reason_label (D.no_progress_reason_of_string "unknown"))
 
 let test_threshold_crossing_fires_counter () =
   D.reset_all_for_test ();
@@ -617,10 +664,18 @@ let test_repeated_progress_identity_accrues_streak () =
   |> ignore_outcome;
   Alcotest.(check int) "first evidence identity is progress" 0
     (D.current_streak ~keeper_name:k);
+  Alcotest.(check (option string))
+    "first evidence identity has no no-progress reason"
+    None
+    (reason_label (D.current_reason ~keeper_name:k));
   D.record_turn ~keeper_name:k ~made_progress:true ~progress_identity ()
   |> ignore_outcome;
   Alcotest.(check int) "same evidence identity repeats => no-progress" 1
     (D.current_streak ~keeper_name:k);
+  Alcotest.(check (option string))
+    "same identity reason is typed"
+    (Some "repeated_identity")
+    (reason_label (D.current_reason ~keeper_name:k));
   D.record_turn ~keeper_name:k ~made_progress:true ~progress_identity ()
   |> ignore_outcome;
   Alcotest.(check int) "same evidence identity keeps accruing" 2
@@ -867,7 +922,11 @@ let test_apply_loop_detectors_passive_only_no_work_now_accrues () =
     (Success.apply_loop_detectors ~config ~observation:scheduled_observation
        ~meta meta result);
   Alcotest.(check int) "production detector path accrues passive no-work (#22747)" 1
-    (D.current_streak ~keeper_name:keeper)
+    (D.current_streak ~keeper_name:keeper);
+  Alcotest.(check (option string))
+    "passive-only no-work reason is read_only"
+    (Some "read_only")
+    (reason_label (D.current_reason ~keeper_name:keeper))
 
 let test_apply_loop_detectors_claim_no_eligible_accrues () =
   D.reset_all_for_test ();
@@ -880,7 +939,11 @@ let test_apply_loop_detectors_claim_no_eligible_accrues () =
     (Success.apply_loop_detectors ~config ~observation:scheduled_observation ~meta
        meta result);
   Alcotest.(check int) "production detector path accrues typed no-eligible claim" 1
-    (D.current_streak ~keeper_name:keeper)
+    (D.current_streak ~keeper_name:keeper);
+  Alcotest.(check (option string))
+    "typed no-eligible claim reason is empty"
+    (Some "empty")
+    (reason_label (D.current_reason ~keeper_name:keeper))
 
 (* RFC-0289 / SSOT: [Keeper_tool_outcome.is_nonprogress] is the single owner of
    the outcome gate (previously inlined in [typed_outcome_is_nonprogress], now a
@@ -909,6 +972,10 @@ let () =
             `Quick (with_eio test_any_other_act_resets);
           Alcotest.test_case "explicit reset"
             `Quick (with_eio test_explicit_reset);
+          Alcotest.test_case "no-progress reason tracks and resets"
+            `Quick (with_eio test_no_progress_reason_tracks_and_resets);
+          Alcotest.test_case "no-progress reason string mapping"
+            `Quick test_no_progress_reason_string_mapping;
           Alcotest.test_case "no-progress predicate (RFC-0239 R3)"
             `Quick (with_eio test_made_progress_predicate);
           Alcotest.test_case "no-progress board post accrues streak (RFC-0239 R3)"


### PR DESCRIPTION
## Summary

- Add typed no-progress reason dimensions to the keeper no-progress loop detector.
- Stamp the reason into the no-progress pause blocker detail so it survives restart.
- Expose `runtime_blocker_facts.no_progress_reason`, `no_progress_streak`, `no_progress_threshold`, and `no_progress_latched` for typed no-progress blockers.

## Notes

- This branch is based on `origin/main` after #22857 merged.
- `mark_loop_detected` accepts the typed reason from the success path instead of reading detector mutex state, so existing non-Eio test/call paths stay valid.
- Status facts parse the durable blocker detail rather than depending on in-memory detector state.

## Verification

- `scripts/check-oas-pin.sh --local-only`
- `git diff --check HEAD~1..HEAD`
- `opam exec -- ocamlformat --check lib/keeper/keeper_no_progress_loop_detector.mli lib/keeper/keeper_no_progress_loop_detector.ml lib/keeper/keeper_unified_turn_success.ml lib/keeper/keeper_unified_turn_no_progress.mli lib/keeper/keeper_unified_turn_no_progress.ml lib/keeper/keeper_status_bridge.ml test/test_no_progress_loop_detector.ml test/test_keeper_status_bridge.ml test/test_keeper_auto_pause_blocker_persist_12683.ml`
- `scripts/dune-local.sh build @test/runtest-test_no_progress_loop_detector`
- `scripts/dune-local.sh build @test/runtest-test_keeper_status_bridge`
- `scripts/dune-local.sh build @test/runtest-test_keeper_auto_pause_blocker_persist_12683`
- `bash scripts/ci/check-determinism-contract.sh`
