### PR TITLE
fix(memory): centralize Memory OS size policy

### DIFF
--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -504,37 +504,26 @@ let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
     ~n
 ;;
 
-(* RFC-0239 Q4: the per-keeper fact recall *retention target* — the size the
-   store is trimmed back to when the cap fires. NOT the recall scan window: the
-   store legitimately holds up to [fact_store_max] facts between caps (see the
-   hysteresis note on [fact_store_max]), so a reader that scans only this many
-   tail rows can miss the highest-ranked rows the last cap wrote at the file head.
-   Recall scans [fact_store_max] for that reason. *)
-let fact_recall_window = 256
+(* RFC-0239 Q4: Memory OS size policy lives in [Keeper_memory_os_policy]. These
+   aliases preserve the existing IO public surface for callers/tests while
+   keeping raw policy values in one module. *)
+let fact_recall_window = Keeper_memory_os_policy.fact_recall_window
 
-(* The largest a bounded store can grow before the retention cap rewrites it: the
-   cap triggers when the store exceeds this and trims back to [fact_recall_window]
-   (hysteresis = [fact_recall_window]/2 keeps rewrites off the per-turn hot path).
-   SSOT for two callers that MUST agree: the librarian write path passes it as the
-   cap [trigger], and recall scans this many tail rows so it sees the entire
-   bounded store — including the high-rank durable rows a fresh cap places at the
-   file head, which a [fact_recall_window]-sized tail scan would exclude in the
-   [fact_recall_window]..[fact_store_max] band. *)
-let fact_store_max = fact_recall_window + (fact_recall_window / 2)
+let fact_store_max = Keeper_memory_os_policy.fact_store_max
 
 (* RFC-0272 (defect D): retention bounds for the append-only episode log
    ([events.jsonl] line count and [episodes/] file count). Same shape and
    hysteresis band as the facts cap ([fact_recall_window] / [fact_store_max]): a
    trim/unlink fires only when the count exceeds the high-water [*_store_max] and
    trims back to the low-water [*_recall_window], so it stays off the per-turn
-   hot path. The low-water is 256 = 8x the recall scan window
-   ([Keeper_memory_os_recall.episode_tail_scan] = 32), so a trim can never starve
-   recall of its 32 current episodes; [test_cap_events_preserves_recall_window]
-   asserts that coupling so an edit to either constant cannot silently break it. *)
-let event_recall_window = 256
-let event_store_max = event_recall_window + (event_recall_window / 2)
-let episode_file_window = 256
-let episode_file_store_max = episode_file_window + (episode_file_window / 2)
+   hot path. The low-water values intentionally exceed
+   [Keeper_memory_os_policy.recall_episode_tail_scan], so a trim can never starve
+   recall; [test_cap_events_preserves_recall_window] asserts that coupling so an
+   edit to either constant cannot silently break it. *)
+let event_recall_window = Keeper_memory_os_policy.event_recall_window
+let event_store_max = Keeper_memory_os_policy.event_store_max
+let episode_file_window = Keeper_memory_os_policy.episode_file_window
+let episode_file_store_max = Keeper_memory_os_policy.episode_file_store_max
 
 let take_first n xs =
   let rec aux k = function

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -120,24 +120,17 @@ val read_episodes_tail : keeper_id:string -> n:int -> episode list
 
 (** {1 Retention (RFC-0239 Q4, supersedes RFC-0238 Capped_by_score)} *)
 
-(** Per-keeper fact retention target: the size the cap trims the store back to.
-    NOT the recall scan window — the store holds up to {!fact_store_max} between
-    caps, so recall scans {!fact_store_max} (not this) to see the whole bounded
-    store. *)
+(** Alias for {!Keeper_memory_os_policy.fact_recall_window}; retained on the IO
+    surface for compatibility with existing callers. *)
 val fact_recall_window : int
 
-(** Upper bound on a bounded store between caps: the retention cap [trigger]
-    (= [fact_recall_window] + [fact_recall_window]/2). SSOT shared by the
-    librarian write path (cap trigger) and recall (tail scan window) so the read
-    side scans the entire bounded store — including the high-rank rows a fresh cap
-    writes at the file head, which a [fact_recall_window]-sized scan would miss. *)
+(** Alias for {!Keeper_memory_os_policy.fact_store_max}; retained on the IO
+    surface for compatibility with existing callers. *)
 val fact_store_max : int
 
-(** RFC-0272 (defect D): episode-log retention bounds, same shape and hysteresis
-    band as the facts cap. [event_recall_window] / [episode_file_window] are the
-    low-water trim targets; [event_store_max] / [episode_file_store_max] are the
-    high-water triggers. The low-water (256) exceeds the recall scan window
-    ([Keeper_memory_os_recall.episode_tail_scan] = 32) so a trim cannot starve
+(** RFC-0272 (defect D): aliases for the episode-log retention bounds in
+    {!Keeper_memory_os_policy}. The low-water values exceed
+    {!Keeper_memory_os_policy.recall_episode_tail_scan}, so a trim cannot starve
     recall. *)
 val event_recall_window : int
 

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -14,6 +14,19 @@ open Keeper_memory_os_types
    interleave. *)
 let durable_retention_tier = 1.0e15
 
+(* Memory OS recall and retention size policy. Keep raw numbers here so the
+   read, write, dashboard, and test surfaces do not drift independently. *)
+let fact_recall_window = 256
+let fact_store_max = fact_recall_window + (fact_recall_window / 2)
+let event_recall_window = 256
+let event_store_max = event_recall_window + (event_recall_window / 2)
+let episode_file_window = 256
+let episode_file_store_max = episode_file_window + (episode_file_window / 2)
+let recall_default_max_facts = 8
+let recall_default_max_episodes = 2
+let recall_default_max_shared_facts = 4
+let recall_episode_tail_scan = 32
+
 (* RFC-0247 §-1: structural retention rank for the bounded store cap. This is NOT
    a relevance score — it is a deterministic two-tier lexicographic order used
    ONLY to decide which rows the size cap drops when the store grows past its

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -6,6 +6,40 @@
 
 open Keeper_memory_os_types
 
+(** {1 Recall and retention size policy} *)
+
+(** Per-keeper fact retention target: the low-water size the facts cap trims
+    back to. This is not the recall scan window; recall scans
+    {!fact_store_max} so it can see the whole bounded store between caps. *)
+val fact_recall_window : int
+
+(** High-water fact cap trigger and full bounded-store recall scan window. *)
+val fact_store_max : int
+
+(** Low-water event-log retention target. *)
+val event_recall_window : int
+
+(** High-water event-log retention trigger. *)
+val event_store_max : int
+
+(** Low-water episode-file retention target. *)
+val episode_file_window : int
+
+(** High-water episode-file retention trigger. *)
+val episode_file_store_max : int
+
+(** Default number of keeper-local facts injected into recall context. *)
+val recall_default_max_facts : int
+
+(** Default number of memory episodes injected into recall context. *)
+val recall_default_max_episodes : int
+
+(** Default number of shared-tier facts appended after keeper-local recall. *)
+val recall_default_max_shared_facts : int
+
+(** Episode tail scan used before current/prompt-recallable filtering. *)
+val recall_episode_tail_scan : int
+
 (** Structural retention rank for the bounded store cap (RFC-0247 §-1). NOT a
     relevance score: a deterministic two-tier order — durable categories outrank
     Ephemeral, then most-recently-verified (else first-seen) wins. Used only to

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -2,14 +2,14 @@
 
 open Keeper_memory_os_types
 
-let default_max_facts = 8
-let default_max_episodes = 2
+let default_max_facts = Keeper_memory_os_policy.recall_default_max_facts
+let default_max_episodes = Keeper_memory_os_policy.recall_default_max_episodes
 
 (* RFC-0244 Tier 2: how many shared-semantic facts to append after the keeper's
    own (private-precedence) facts. Kept small so the communal tier informs
    without crowding out keeper-local memory. *)
-let default_max_shared_facts = 4
-let episode_tail_scan = 32
+let default_max_shared_facts = Keeper_memory_os_policy.recall_default_max_shared_facts
+let episode_tail_scan = Keeper_memory_os_policy.recall_episode_tail_scan
 let max_fact_text_len = 260
 let max_episode_text_len = 360
 let max_atom_len = 48

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -5,13 +5,13 @@
     OAS [extra_system_context]. *)
 
 val default_max_facts : int
-(** Default number of keeper-local facts injected into the recall prompt block. *)
+(** Alias for {!Keeper_memory_os_policy.recall_default_max_facts}. *)
 
 val default_max_shared_facts : int
-(** Default number of shared-tier facts appended after keeper-local recall facts. *)
+(** Alias for {!Keeper_memory_os_policy.recall_default_max_shared_facts}. *)
 
 val default_max_episodes : int
-(** Default number of memory episodes injected into the recall prompt block. *)
+(** Alias for {!Keeper_memory_os_policy.recall_default_max_episodes}. *)
 
 val render_context
   :  keeper_id:string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -179,10 +179,10 @@ let memory_os_selection_policy ~keeper_id ~fact_tail_limit ~recent_episode_limit
   ; episodes_source = "Keeper_memory_os_io.read_episodes_tail"
   ; dashboard_fact_tail_limit = fact_tail_limit
   ; dashboard_episode_tail_limit = recent_episode_limit
-  ; recall_private_fact_limit = Keeper_memory_os_recall.default_max_facts
+  ; recall_private_fact_limit = Keeper_memory_os_policy.recall_default_max_facts
   ; recall_shared_fact_limit =
-      (if has_shared_tier then Keeper_memory_os_recall.default_max_shared_facts else 0)
-  ; recall_episode_limit = Keeper_memory_os_recall.default_max_episodes
+      (if has_shared_tier then Keeper_memory_os_policy.recall_default_max_shared_facts else 0)
+  ; recall_episode_limit = Keeper_memory_os_policy.recall_default_max_episodes
   ; category_source = "Keeper_memory_os_types.category_to_string"
   ; claim_kind_source = "Keeper_memory_os_types.claim_kind_to_string"
   ; recall_block = "Keeper_memory_os_recall.render_if_enabled"
@@ -193,7 +193,7 @@ let memory_os_selection_policy ~keeper_id ~fact_tail_limit ~recent_episode_limit
 let memory_os_dashboard_json ~keeper_id =
   let now = Time_compat.now () in
   let recent_episode_limit = 12 in
-  let fact_tail_limit = Keeper_memory_os_io.fact_store_max in
+  let fact_tail_limit = Keeper_memory_os_policy.fact_store_max in
   let episodes, episode_error =
     memory_os_read_episodes ~keeper_id ~n:recent_episode_limit
   in

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2186,7 +2186,7 @@ let test_gc_waits_for_fact_writer_lock () =
     let allow_writer, resolve_allow_writer = Eio.Promise.create () in
     let writer_done, resolve_writer_done = Eio.Promise.create () in
     let gc_result = ref None in
-    let fact_store_trigger = Memory_io.fact_recall_window + (Memory_io.fact_recall_window / 2) in
+    let fact_store_trigger = Policy.fact_store_max in
     Eio.Fiber.fork ~sw (fun () ->
       File_lock_eio.with_lock (Memory_io.facts_path ~keeper_id) (fun () ->
         Eio.Promise.resolve resolve_writer_entered ();
@@ -2197,7 +2197,7 @@ let test_gc_waits_for_fact_writer_lock () =
             ~keeper_id
             ~merge:(Policy.reobserve_fact ~now)
             ~incoming:[ fresh ]
-            ~keep:Memory_io.fact_recall_window
+            ~keep:Policy.fact_recall_window
             ~trigger:fact_store_trigger
             ~rank:(Policy.retention_rank ~now)
         in
@@ -2503,7 +2503,7 @@ let test_recall_scans_whole_bounded_store () =
           }
         in
         let cap_fillers =
-          List.init Memory_io.fact_store_max (fun i ->
+          List.init Policy.fact_store_max (fun i ->
             { (fact_fixture ~now ()) with
               Types.claim = Printf.sprintf "pre-cap filler durable fact %d" (i + 1)
             ; Types.last_verified_at = Some (now -. days 30 -. float_of_int i)
@@ -2515,15 +2515,15 @@ let test_recall_scans_whole_bounded_store () =
             ~keeper_id
             ~merge:(Policy.reobserve_fact ~now)
             ~incoming:(head :: cap_fillers)
-            ~keep:Memory_io.fact_recall_window
-            ~trigger:Memory_io.fact_store_max
+            ~keep:Policy.fact_recall_window
+            ~trigger:Policy.fact_store_max
             ~rank:(Policy.retention_rank ~now)
         in
         Alcotest.(check bool) "cap rewrite dropped low-ranked rows" true (cap_stats.dropped > 0);
         let capped = Memory_io.read_facts_all ~keeper_id in
         Alcotest.(check int)
           "cap rewrites to the recall window size"
-          Memory_io.fact_recall_window
+          Policy.fact_recall_window
           (List.length capped);
         for i = 1 to 20 do
           let tail =
@@ -2538,7 +2538,7 @@ let test_recall_scans_whole_bounded_store () =
         Alcotest.(check bool)
           "store sits in the (fact_recall_window, fact_store_max] band"
           true
-          (total > Memory_io.fact_recall_window && total <= Memory_io.fact_store_max);
+          (total > Policy.fact_recall_window && total <= Policy.fact_store_max);
         match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> Alcotest.fail "expected Some recall block for a seeded store"
         | Some block ->
@@ -2932,8 +2932,8 @@ let test_cap_drops_expired_below_trigger () =
       Memory_io.cap_facts
         ~now
         ~keeper_id
-        ~keep:Memory_io.fact_recall_window
-        ~trigger:Memory_io.fact_store_max
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "one expired row dropped below trigger" 1 dropped;
@@ -2947,8 +2947,8 @@ let test_cap_drops_expired_below_trigger () =
       Memory_io.cap_facts
         ~now
         ~keeper_id
-        ~keep:Memory_io.fact_recall_window
-        ~trigger:Memory_io.fact_store_max
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "idempotent: no-op once clean" 0 dropped2)
@@ -2974,8 +2974,8 @@ let test_merge_and_cap_drops_expired_no_incoming () =
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[]
-        ~keep:Memory_io.fact_recall_window
-        ~trigger:Memory_io.fact_store_max
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "expired counted in dropped" 1 stats.Memory_io.dropped;
@@ -3005,13 +3005,13 @@ let test_trim_target_hysteresis () =
     "episode-file band non-empty"
     true
     (Memory_io.episode_file_window < Memory_io.episode_file_store_max);
-  (* coupling guard: Keeper_memory_os_recall.episode_tail_scan = 32. If a future
-     edit drops the low-water below the recall window, recall starves — fail here
-     instead. *)
+  (* Coupling guard: if a future edit drops the low-water below the policy recall
+     window, recall starves — fail here instead. *)
   Alcotest.(check bool)
-    "low-water clears the recall scan window (32)"
+    "low-water clears the recall scan window"
     true
-    (Memory_io.event_recall_window > 32 && Memory_io.episode_file_window > 32)
+    (Memory_io.event_recall_window > Policy.recall_episode_tail_scan
+     && Memory_io.episode_file_window > Policy.recall_episode_tail_scan)
 ;;
 
 (* RFC-0272 (defect D): cap_events keeps the newest [keep] raw lines once the log
@@ -3263,8 +3263,8 @@ let test_merge_and_cap_upserts_reobserved_claim () =
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ reobserved ]
-        ~keep:256
-        ~trigger:384
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "one claim merged" 1 stats.Memory_io.merged;
@@ -3692,7 +3692,7 @@ let test_recall_scans_whole_shared_store () =
           }
         in
         Memory_io.append_fact ~keeper_id:Types.shared_store_id shared_head;
-        for i = 1 to Memory_io.fact_recall_window + 10 do
+        for i = 1 to Policy.fact_recall_window + 10 do
           let filler =
             { (mk_shared_fixture ~now (Printf.sprintf "old shared filler fact %d" i)) with
               Types.observed_by = [ "alpha"; "beta" ]
@@ -3705,7 +3705,7 @@ let test_recall_scans_whole_shared_store () =
         Alcotest.(check bool)
           "shared store exceeds the private recall tail window"
           true
-          (total > Memory_io.fact_recall_window);
+          (total > Policy.fact_recall_window);
         let observer_block = Recall.render_context ~keeper_id:"observer" ~now () in
         Alcotest.(check bool)
           "shared recall surfaces a head fact beyond the tail window"
@@ -4414,8 +4414,8 @@ let test_merge_and_cap_upserts_same_claim_id () =
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ reworded ]
-        ~keep:256
-        ~trigger:384
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "same-claim_id reworded merged, not appended" 1 stats.Memory_io.merged;
@@ -4464,8 +4464,8 @@ let test_merge_and_cap_no_over_merge_distinct_conclusions () =
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ merged ]
-        ~keep:256
-        ~trigger:384
+        ~keep:Policy.fact_recall_window
+        ~trigger:Policy.fact_store_max
         ~rank:(Policy.retention_rank ~now)
     in
     Alcotest.(check int) "distinct conclusion appended, not merged" 1 stats.Memory_io.appended;
@@ -4756,7 +4756,7 @@ let test_dashboard_json_selection_policy_contract () =
       (string_field "policy" policy "episodes_source");
     Alcotest.(check int)
       "dashboard fact bound"
-      Memory_io.fact_store_max
+      Policy.fact_store_max
       (int_field "policy" policy "dashboard_fact_tail_limit");
     Alcotest.(check int)
       "dashboard episode bound"
@@ -4764,15 +4764,15 @@ let test_dashboard_json_selection_policy_contract () =
       (int_field "policy" policy "dashboard_episode_tail_limit");
     Alcotest.(check int)
       "prompt private fact bound"
-      Recall.default_max_facts
+      Policy.recall_default_max_facts
       (int_field "policy" policy "recall_private_fact_limit");
     Alcotest.(check int)
       "prompt shared fact bound"
-      Recall.default_max_shared_facts
+      Policy.recall_default_max_shared_facts
       (int_field "policy" policy "recall_shared_fact_limit");
     Alcotest.(check int)
       "prompt episode bound"
-      Recall.default_max_episodes
+      Policy.recall_default_max_episodes
       (int_field "policy" policy "recall_episode_limit");
     Alcotest.(check string)
       "category source"


### PR DESCRIPTION
## Summary
- centralize Memory OS recall/retention size policy in `Keeper_memory_os_policy`
- keep existing `Keeper_memory_os_io` and `Keeper_memory_os_recall` constants as compatibility aliases
- route dashboard selection-policy limits and Memory OS tests to the policy SSOT

Closes #22294

## Verification
- `ocamlformat --check lib/keeper/keeper_memory_os_policy.ml lib/keeper/keeper_memory_os_policy.mli lib/keeper/keeper_memory_os_io.ml lib/keeper/keeper_memory_os_io.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_memory_os_recall.mli lib/server/server_dashboard_http_keeper_api.ml test/test_keeper_memory_os.ml`
- `git diff --check`
- `rg -n "~keep:256|~trigger:384|fact_recall_window \\+ \\(Memory_io.fact_recall_window / 2\\)|Memory_io\\.fact_store_max|Memory_io\\.fact_recall_window|Recall\\.default_max" test/test_keeper_memory_os.ml` returned no matches

Local Dune build/test intentionally not run; CI is the build authority for this change per maintainer instruction.