### PR TITLE
fix(dashboard): parse quoted runtime.toml assignment keys

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -1,0 +1,82 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
+import { keepers } from '../store'
+import type { Keeper } from '../types/core'
+
+// Regression for the live ~/.masc/config/runtime.toml shape: keeper names
+// under [runtime.assignments] are quoted TOML keys. The parser fix lives in
+// runtime-toml-config.test.ts; this covers the component actually renders
+// the resulting assignments as pinned (not silently defaulted) and grouped.
+const sourceTextWithQuotedAssignments = `[runtime]
+default = "ollama_cloud.minimax-m3"
+
+[providers.ollama_cloud]
+display-name = "Ollama Cloud"
+protocol = "openai-compatible-http"
+endpoint = "https://ollama.example/v1"
+
+[models.minimax-m3]
+api-name = "minimax-m3"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.deepseek-v4-flash]
+api-name = "deepseek-v4-flash"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[ollama_cloud.minimax-m3]
+
+[ollama_cloud.deepseek-v4-flash]
+
+[runtime.assignments]
+"nick0cave" = "ollama_cloud.deepseek-v4-flash"
+`
+
+function mountEditor(container: HTMLElement) {
+  render(
+    html`<${RuntimeEnvironmentEditor}
+      sourceText=${sourceTextWithQuotedAssignments}
+      section="assignments"
+      onRoutingChange=${() => {}}
+      onAssignmentChange=${() => {}}
+      onBindingFieldChange=${() => {}}
+    />`,
+    container,
+  )
+}
+
+describe('RuntimeEnvironmentEditor assignments section', () => {
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('groups a keeper with an explicit quoted-key assignment as pinned, not default 폴백', () => {
+    const fixtureKeepers: Keeper[] = [
+      { name: 'nick0cave', status: 'idle' },
+      { name: 'issue_king', status: 'idle' },
+    ]
+    keepers.value = fixtureKeepers
+
+    const container = document.createElement('div')
+    mountEditor(container)
+
+    const summary = container.querySelector('[data-testid="runtime-assignments-summary"]')
+    expect(summary?.textContent).toContain('고정 1개')
+    expect(summary?.textContent).toContain('default 폴백 1개')
+
+    const pinnedGroup = container.querySelector('[data-testid="runtime-assignments-group-pinned"]')
+    expect(pinnedGroup?.textContent).toContain('nick0cave')
+    expect(pinnedGroup?.textContent).toContain('고정')
+
+    const fallbackGroup = container.querySelector('[data-testid="runtime-assignments-group-fallback"]')
+    expect(fallbackGroup?.textContent).toContain('issue_king')
+    expect(fallbackGroup?.textContent).toContain('default 폴백')
+
+    render(null, container)
+  })
+})

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -195,6 +195,40 @@ export function RuntimeEnvironmentEditor({
     `
   }
 
+  // Explicit ([runtime.assignments]) entries surfaced first, [runtime].default
+  // fallbacks grouped below — the flat alphabetical list made it hard to tell
+  // at a glance which keepers actually have a pinned runtime vs. which are
+  // just inheriting whatever [runtime].default happens to be.
+  const assignmentRows = keeperList.map(keeper => {
+    const current = assignments[keeper.name] ?? environment.defaultRuntimeId
+    return { keeper, current, isDefault: current === environment.defaultRuntimeId }
+  })
+  const pinnedAssignments = assignmentRows.filter(row => !row.isDefault)
+  const fallbackAssignments = assignmentRows.filter(row => row.isDefault)
+
+  function assignRow(row: (typeof assignmentRows)[number]) {
+    return html`
+      <div key=${row.keeper.name} class="rt-assign">
+        <span class="rt-assign-k">
+          <${StatusDot} size="sm" class=${keeperDotTone(row.keeper.status)} />
+          <span class="mono">${row.keeper.name}</span>
+        </span>
+        <select
+          class="rt-select mono"
+          value=${row.current}
+          disabled=${typedPatchDisabled}
+          aria-label=${`${row.keeper.name} 런타임 배정`}
+          onChange=${(event: Event) => updateAssignment(row.keeper.name, (event.currentTarget as HTMLSelectElement).value)}
+        >
+          ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
+        </select>
+        ${row.isDefault
+          ? html`<span class="rt-assign-tag mono">↳ default 폴백</span>`
+          : html`<span class="rt-assign-tag pin mono">고정</span>`}
+      </div>
+    `
+  }
+
   return html`
     <div data-testid="runtime-environment-editor">
       <div class="rt-head-actions" style=${{ justifyContent: 'flex-end', marginBottom: '14px' }}>
@@ -425,7 +459,9 @@ export function RuntimeEnvironmentEditor({
       </div>
 
       <!-- assignments — runtime-editor.jsx:216-231. keeper -> runtime id from
-           the live keepers signal + [runtime.assignments]. -->
+           the live keepers signal + [runtime.assignments]. Pinned entries are
+           grouped ahead of default-fallback entries so a long keeper list
+           doesn't force scanning every row to see who is actually pinned. -->
       <div class=${section === 'assignments' ? '' : 'hidden'} data-testid="runtime-section-assignments">
         <div class="rt-assigns">
           <div class="rt-note">
@@ -433,30 +469,23 @@ export function RuntimeEnvironmentEditor({
           </div>
           ${keeperList.length === 0 ? html`
             <div class="rt-note" data-testid="runtime-assignments-empty">표시할 keeper가 없습니다.</div>
-          ` : keeperList.map(keeper => {
-            const current = assignments[keeper.name] ?? environment.defaultRuntimeId
-            const isDefault = current === environment.defaultRuntimeId
-            return html`
-              <div key=${keeper.name} class="rt-assign">
-                <span class="rt-assign-k">
-                  <${StatusDot} size="sm" class=${keeperDotTone(keeper.status)} />
-                  <span class="mono">${keeper.name}</span>
-                </span>
-                <select
-                  class="rt-select mono"
-                  value=${current}
-                  disabled=${typedPatchDisabled}
-                  aria-label=${`${keeper.name} 런타임 배정`}
-                  onChange=${(event: Event) => updateAssignment(keeper.name, (event.currentTarget as HTMLSelectElement).value)}
-                >
-                  ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
-                </select>
-                ${isDefault
-                  ? html`<span class="rt-assign-tag mono">↳ default 폴백</span>`
-                  : html`<span class="rt-assign-tag pin mono">고정</span>`}
+          ` : html`
+            <div class="rt-assign-summary mono" data-testid="runtime-assignments-summary">
+              고정 ${pinnedAssignments.length}개 · default 폴백 ${fallbackAssignments.length}개
+            </div>
+            ${pinnedAssignments.length > 0 ? html`
+              <div class="rt-assign-group" data-testid="runtime-assignments-group-pinned">
+                <div class="rt-assign-group-h mono">고정 배정</div>
+                ${pinnedAssignments.map(row => assignRow(row))}
               </div>
-            `
-          })}
+            ` : null}
+            ${fallbackAssignments.length > 0 ? html`
+              <div class="rt-assign-group" data-testid="runtime-assignments-group-fallback">
+                <div class="rt-assign-group-h mono">default 폴백</div>
+                ${fallbackAssignments.map(row => assignRow(row))}
+              </div>
+            ` : null}
+          `}
         </div>
       </div>
     </div>

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -133,6 +133,22 @@ mad-improver = "runpod_mtp.qwen"
     expect(next.match(/nick0cave/g)).toHaveLength(1)
   })
 
+  it('warns instead of silently dropping a line keyLineMatch still cannot parse', () => {
+    const withMalformedLine = `${sourceText}
+
+[runtime.assignments]
+"nick0cave" = "ollama_cloud.deepseek-v4-flash"
+this line has no equals sign
+`
+
+    const environment = parseRuntimeTomlEnvironment(withMalformedLine)
+
+    expect(environment.assignments).toEqual({
+      nick0cave: 'ollama_cloud.deepseek-v4-flash',
+    })
+    expect(environment.warnings.some(w => w.includes('[runtime.assignments]'))).toBe(true)
+  })
+
   it('patches the runtime default without touching other sections', () => {
     const next = setRuntimeTomlDefault(sourceText, 'openai.gpt')
 

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -131,6 +131,30 @@ mad-improver = "runpod_mtp.qwen"
       '"ollama_cloud.kimi-k2-6"',
     )
     expect(next.match(/nick0cave/g)).toHaveLength(1)
+    // The original quoted key spelling must survive an in-place value update --
+    // only the value should change, not the key syntax the TOML author chose.
+    expect(next).toContain('"nick0cave" = "ollama_cloud.kimi-k2-6"')
+    expect(next).not.toContain('\nnick0cave = ')
+  })
+
+  it('does not write a keeper name requiring quotes as an invalid bare key', () => {
+    const withAssignmentsSection = `${sourceText}
+
+[runtime.assignments]
+sangsu = "runpod_mtp.qwen"
+`
+
+    const next = setRuntimeTomlKey(
+      withAssignmentsSection,
+      'runtime.assignments',
+      'qa king',
+      'runpod_mtp.qwen',
+    )
+
+    expect(next).toContain('"qa king" = "runpod_mtp.qwen"')
+    expect(getRuntimeTomlKey(next, 'runtime.assignments', 'qa king')).toBe(
+      '"runpod_mtp.qwen"',
+    )
   })
 
   it('warns instead of silently dropping a line keyLineMatch still cannot parse', () => {

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   deleteRuntimeTomlKey,
+  getRuntimeTomlKey,
   parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,
+  setRuntimeTomlKey,
   setRuntimeTomlModelField,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
@@ -88,6 +90,47 @@ mad-improver = "runpod_mtp.qwen"
       sangsu: 'runpod_mtp.qwen',
       'mad-improver': 'runpod_mtp.qwen',
     })
+  })
+
+  // Regression for the live ~/.masc/config/runtime.toml shape: keeper names
+  // under [runtime.assignments] are written as quoted TOML keys
+  // (`"nick0cave" = "..."`), not the bare keys used above. The dashboard
+  // rendered every keeper as "default 폴백" because the parser silently
+  // dropped every quoted-key line instead of erroring or reading it.
+  it('projects keeper assignments written with quoted TOML keys', () => {
+    const withQuotedAssignments = `${sourceText}
+
+[runtime.assignments]
+"nick0cave" = "ollama_cloud.deepseek-v4-flash"
+"mad-improver" = "glm-coding.glm-5-turbo"
+`
+
+    const environment = parseRuntimeTomlEnvironment(withQuotedAssignments)
+
+    expect(environment.assignments).toEqual({
+      nick0cave: 'ollama_cloud.deepseek-v4-flash',
+      'mad-improver': 'glm-coding.glm-5-turbo',
+    })
+  })
+
+  it('updates an existing quoted-key assignment line in place instead of appending a duplicate', () => {
+    const withQuotedAssignments = `${sourceText}
+
+[runtime.assignments]
+"nick0cave" = "ollama_cloud.deepseek-v4-flash"
+`
+
+    const next = setRuntimeTomlKey(
+      withQuotedAssignments,
+      'runtime.assignments',
+      'nick0cave',
+      'ollama_cloud.kimi-k2-6',
+    )
+
+    expect(getRuntimeTomlKey(next, 'runtime.assignments', 'nick0cave')).toBe(
+      '"ollama_cloud.kimi-k2-6"',
+    )
+    expect(next.match(/nick0cave/g)).toHaveLength(1)
   })
 
   it('patches the runtime default without touching other sections', () => {

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -115,6 +115,19 @@ function dequoteTomlKey(rawKey: string | undefined): string {
   return trimmed
 }
 
+// TOML bare keys may only contain ASCII letters, digits, underscores, and
+// hyphens (https://toml.io/en/v1.0.0#keys) -- the same charset keyLineMatch
+// accepts unquoted. Anything else must be written as a quoted basic string.
+const BARE_TOML_KEY = /^[A-Za-z0-9_-]+$/
+
+// Serialize a key for a brand-new `key = value` line. JSON.stringify produces
+// a valid TOML basic string for the ASCII range keeper/field names use
+// (matching backslash/double-quote escaping), so a name requiring quoting is
+// never written out as an invalid bare key.
+function serializeTomlKey(key: string): string {
+  return BARE_TOML_KEY.test(key) ? key : JSON.stringify(key)
+}
+
 function stripInlineComment(raw: string): string {
   let quote: '"' | "'" | null = null
   let escaped = false
@@ -395,11 +408,16 @@ export function setRuntimeTomlKey(
   for (let index = section.start + 1; index < section.end; index += 1) {
     const match = keyLineMatch(lines[index] ?? '')
     if (match && dequoteTomlKey(match[2]) === key) {
-      lines[index] = `${match[1] ?? ''}${key}${match[3] ?? ' = '}${serialized}`
+      // Reuse the existing key token verbatim -- do not re-serialize it from
+      // the plain `key` argument. A quoted TOML key is not just cosmetic (it
+      // may carry characters illegal in a bare key, or have been emitted
+      // deliberately by the backend/SSOT writer), so updating only the value
+      // must not silently normalize `"nick0cave"` down to `nick0cave`.
+      lines[index] = `${match[1] ?? ''}${match[2]}${match[3] ?? ' = '}${serialized}`
       return joinLines(lines)
     }
   }
-  lines.splice(section.end, 0, `${key} = ${serialized}`)
+  lines.splice(section.end, 0, `${serializeTomlKey(key)} = ${serialized}`)
   return joinLines(lines)
 }
 

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -91,8 +91,28 @@ function sectionOf(document: TomlDocument, name: string): TomlSection | null {
   return document.sections.find(section => section.name === name) ?? null
 }
 
+// Bare key (letters/digits/underscore/hyphen) OR a quoted key ("..."/'...').
+// [runtime.assignments] keeper entries are written as quoted keys (e.g.
+// `"nick0cave" = "..."`); the earlier bare-key-only pattern silently failed
+// to match those lines, so sectionValues() returned {} for every quoted
+// entry and every keeper appeared to fall back to [runtime].default.
 function keyLineMatch(line: string): RegExpMatchArray | null {
-  return line.match(/^(\s*)([A-Za-z0-9_-]+)(\s*=\s*)(.*)$/)
+  return line.match(/^(\s*)("[^"]*"|'[^']*'|[A-Za-z0-9_-]+)(\s*=\s*)(.*)$/)
+}
+
+// Strip the surrounding quotes from a matched key token so callers compare
+// against the plain keeper/field name regardless of how the TOML author
+// quoted it.
+function dequoteTomlKey(rawKey: string | undefined): string {
+  const trimmed = (rawKey ?? '').trim()
+  if (trimmed.length >= 2) {
+    const first = trimmed[0]
+    const last = trimmed[trimmed.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1)
+    }
+  }
+  return trimmed
 }
 
 function stripInlineComment(raw: string): string {
@@ -150,7 +170,7 @@ function sectionValues(document: TomlDocument, name: string): Record<string, Tom
     const line = document.lines[index] ?? ''
     const match = keyLineMatch(line)
     if (!match?.[2] || match[0].trimStart().startsWith('#')) continue
-    values[match[2]] = parseTomlScalar(match[4] ?? '')
+    values[dequoteTomlKey(match[2])] = parseTomlScalar(match[4] ?? '')
   }
   return values
 }
@@ -346,7 +366,7 @@ export function setRuntimeTomlKey(
   const serialized = serializeValue(value)
   for (let index = section.start + 1; index < section.end; index += 1) {
     const match = keyLineMatch(lines[index] ?? '')
-    if (match?.[2] === key) {
+    if (match && dequoteTomlKey(match[2]) === key) {
       lines[index] = `${match[1] ?? ''}${key}${match[3] ?? ' = '}${serialized}`
       return joinLines(lines)
     }
@@ -369,7 +389,7 @@ export function getRuntimeTomlKey(
   if (!section) return undefined
   for (let index = section.start + 1; index < section.end; index += 1) {
     const match = keyLineMatch(document.lines[index] ?? '')
-    if (match?.[2] === key) return stripInlineComment(match[4] ?? '').trim()
+    if (match && dequoteTomlKey(match[2]) === key) return stripInlineComment(match[4] ?? '').trim()
   }
   return undefined
 }
@@ -381,7 +401,7 @@ export function deleteRuntimeTomlKey(sourceText: string, sectionName: string, ke
   const lines = [...document.lines]
   for (let index = section.end - 1; index > section.start; index -= 1) {
     const match = keyLineMatch(lines[index] ?? '')
-    if (match?.[2] === key) lines.splice(index, 1)
+    if (match && dequoteTomlKey(match[2]) === key) lines.splice(index, 1)
   }
   return joinLines(lines)
 }

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -175,6 +175,27 @@ function sectionValues(document: TomlDocument, name: string): Record<string, Tom
   return values
 }
 
+// Line numbers (1-indexed) inside a section that are neither blank, a
+// comment, a nested `[...]` header, nor a key = value pair keyLineMatch can
+// read. A non-empty result means the UI is silently under-reporting that
+// section's contents (exactly how the quoted-key keeper assignments went
+// missing) rather than a real absence of data — surface it instead of
+// hiding it behind a default fallback.
+function sectionUnparsedLineNumbers(document: TomlDocument, name: string): number[] {
+  const section = sectionOf(document, name)
+  if (!section) return []
+  const lineNumbers: number[] = []
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const line = document.lines[index] ?? ''
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) continue
+    if (/^\[.+\]\s*(#.*)?$/.test(trimmed)) continue
+    if (keyLineMatch(line)) continue
+    lineNumbers.push(index + 1)
+  }
+  return lineNumbers
+}
+
 function asString(value: TomlScalar | undefined, fallback = ''): string {
   return typeof value === 'string' ? value : fallback
 }
@@ -277,6 +298,13 @@ export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvi
   if (providers.length === 0) warnings.push('providers.* section not found')
   if (models.length === 0) warnings.push('models.* section not found')
   if (bindings.length === 0) warnings.push('provider.model binding section not found')
+  const unparsedAssignmentLines = sectionUnparsedLineNumbers(document, 'runtime.assignments')
+  if (unparsedAssignmentLines.length > 0) {
+    warnings.push(
+      `[runtime.assignments] ${unparsedAssignmentLines.length}줄을 keeper = runtime-id 형식으로 읽지 못했습니다 ` +
+        `(줄 ${unparsedAssignmentLines.join(', ')}) — 아래 배정 목록이 실제 runtime.toml과 다를 수 있습니다.`,
+    )
+  }
   return {
     defaultRuntimeId: asString(runtimeValues.default),
     librarianRuntimeId: asString(runtimeValues.librarian),

--- a/dashboard/src/styles/keeper-v2/runtime-assign-group-border.test.ts
+++ b/dashboard/src/styles/keeper-v2/runtime-assign-group-border.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+// Regression: grouping assignments under `.rt-assign-group-h` header divs broke
+// `.rt-assign:first-of-type` -- both the header and each row render as <div>, so the
+// header occupies the "first div sibling" slot and no `.rt-assign` row ever matches
+// :first-of-type. The first row of every group kept its top border. Fixed by keying
+// the border off the adjacent-sibling combinator, which does not care what (if
+// anything) precedes the first `.rt-assign` in a group.
+const runtimeCss = readFileSync(resolve(__dirname, 'runtime.css'), 'utf-8')
+
+describe('runtime.assignments row border (grouped layout)', () => {
+  it('does not gate the row border on :first-of-type', () => {
+    const offenders: string[] = []
+    parse(runtimeCss).walkRules((rule) => {
+      if (rule.selectors.some(s => s.includes('.rt-assign') && s.includes(':first-of-type'))) {
+        offenders.push(rule.selector)
+      }
+    })
+    expect(offenders).toEqual([])
+  })
+
+  it('applies border-top only to a .rt-assign preceded by another .rt-assign', () => {
+    let sawAdjacentBorder = false
+    let baseHasBorder = false
+    parse(runtimeCss).walkRules((rule) => {
+      if (rule.selectors.includes('.rt-assign + .rt-assign')) {
+        rule.walkDecls('border-top', () => { sawAdjacentBorder = true })
+      }
+      if (rule.selectors.includes('.rt-assign')) {
+        rule.walkDecls('border-top', () => { baseHasBorder = true })
+      }
+    })
+    expect(sawAdjacentBorder).toBe(true)
+    expect(baseHasBorder).toBe(false)
+  })
+})

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -91,11 +91,15 @@
 
 /* assignments */
 .rt-assigns { display: flex; flex-direction: column; }
+.rt-assign-summary { font-size: var(--fs-11); color: var(--text-dim); margin-bottom: 10px; }
+.rt-assign-group { margin-bottom: 18px; }
+.rt-assign-group:last-child { margin-bottom: 0; }
+.rt-assign-group-h { font-family: var(--font-ui); font-size: var(--fs-9); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); padding-bottom: 4px; }
 .rt-assign { display: flex; align-items: center; gap: 14px; padding: 9px 0; border-top: 1px solid var(--border-soft); }
 .rt-assign:first-of-type { border-top: 0; }
 .rt-assign-k { display: inline-flex; align-items: center; gap: 8px; width: 150px; flex: none; font-size: 12.5px; color: var(--text-bright); }
-.rt-assign-tag { font-size: 10.5px; color: var(--text-dim); }
-.rt-assign-tag.pin { color: var(--volt-strong); }
+.rt-assign-tag { font-family: var(--font-mono); font-size: var(--fs-10); padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+.rt-assign-tag.pin { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt-strong) 34%, transparent); background: color-mix(in oklab, var(--volt-strong) 12%, transparent); }
 
 /* toml */
 .rt-toml-wrap { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -95,8 +95,8 @@
 .rt-assign-group { margin-bottom: 18px; }
 .rt-assign-group:last-child { margin-bottom: 0; }
 .rt-assign-group-h { font-family: var(--font-ui); font-size: var(--fs-9); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); padding-bottom: 4px; }
-.rt-assign { display: flex; align-items: center; gap: 14px; padding: 9px 0; border-top: 1px solid var(--border-soft); }
-.rt-assign:first-of-type { border-top: 0; }
+.rt-assign { display: flex; align-items: center; gap: 14px; padding: 9px 0; }
+.rt-assign + .rt-assign { border-top: 1px solid var(--border-soft); }
 .rt-assign-k { display: inline-flex; align-items: center; gap: 8px; width: 150px; flex: none; font-size: 12.5px; color: var(--text-bright); }
 .rt-assign-tag { font-family: var(--font-mono); font-size: var(--fs-10); padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
 .rt-assign-tag.pin { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt-strong) 34%, transparent); background: color-mix(in oklab, var(--volt-strong) 12%, transparent); }


### PR DESCRIPTION
## 문제

Settings → 런타임 관리 → keeper 배정 화면에서 모든 keeper가 `ollama_cloud.minimax-m3` + `↳ default 폴백`으로 표시됨. 실제 `~/.masc/config/runtime.toml`의 `[runtime.assignments]`에는 대부분 keeper에 명시적 배정이 있는데도 전부 default로 보임.

## 원인

- 실제 runtime.toml의 `[runtime.assignments]` 항목은 keeper 이름을 quoted TOML key로 씀: `"nick0cave" = "ollama_cloud.deepseek-v4-flash"`
- 대시보드의 자체 정규식 TOML 파서(`dashboard/src/lib/runtime-toml-config.ts`)의 `keyLineMatch`가 `/^(\s*)([A-Za-z0-9_-]+)(\s*=\s*)(.*)$/`로 bare key만 매치 → quoted key 줄은 전부 스킵되어 `assignments`가 항상 `{}`
- `runtime-environment-editor.ts`가 `assignments[keeper.name] ?? environment.defaultRuntimeId`로 폴백하면서 모든 keeper가 default처럼 보임
- 부수적으로 `setRuntimeTomlKey`도 같은 정규식을 써서 기존 quoted-key 줄을 못 찾음 → 화면에서 배정을 바꾸면 기존 줄은 그대로 두고 unquoted 중복 키를 append했을 것 (실제 파일 손상 가능성)
- 백엔드 keeper 라우팅(`lib/runtime/runtime_toml.ml`)은 정식 TOML 라이브러리(`Otoml`)를 쓰기 때문에 이 버그의 영향을 받지 않음 — **실제 keeper 라우팅은 정상**이었고 대시보드 표시/편집 UI만 깨져 있었음

## 수정

- `keyLineMatch` 정규식이 quoted key(`"..."`, `'...'`)도 매치하도록 확장
- `dequoteTomlKey()` 헬퍼 추가 → `sectionValues` / `setRuntimeTomlKey` / `getRuntimeTomlKey` / `deleteRuntimeTomlKey` 4곳 모두 quote 유무와 무관하게 정확히 읽고 기존 줄을 in-place로 갱신하도록 수정
- 운영 파일과 동일한 quoted-key 형태로 파싱/편집 회귀 테스트 2개 추가

## 검증

- `vitest run runtime-toml-config.test.ts runtime-toml-editor.test.ts` — 35/35 pass
- `tsc --noEmit -p dashboard` — clean
- `npm run lint` (dashboard) — clean

RFC-WAIVED: dashboard 순수 파서 버그 수정, credential/identity/operator/keeper-sandbox/hooks 등 workflow-pr.md §11 RFC 게이트 대상 subsystem 미해당

---

## 후속 개선 (UI, 사용자 요청)

같은 화면의 부가 개선 3가지:

1. **파싱 실패를 경고로 노출**: `[runtime.assignments]` 안에서 여전히 `keyLineMatch`가 못 읽는 줄이 있으면 (`sectionUnparsedLineNumbers`) `environment.warnings`에 라인 번호와 함께 표시. 앞으로 또 다른 TOML 형태가 등장해도 이번처럼 조용히 사라지지 않고 화면에 경고로 뜸.
2. **keeper 배정 목록 그룹핑**: 「고정 배정」/「default 폴백」으로 섹션을 나누고 상단에 개수 요약(`고정 N개 · default 폴백 M개`) 추가. 알파벳 순 평평한 목록보다 실제로 누가 고정됐는지 한눈에 파악 가능.
3. **고정/default 폴백 태그 시각 구분 강화**: 기존엔 텍스트 색상만 달랐던 태그를 pill 배경+테두리로 구분(`.rt-assign-tag.pin` = volt 계열 배경/테두리).

컴포넌트 렌더링 테스트(`runtime-environment-editor.test.ts`) 신규 추가 — quoted-key 배정이 실제로 "고정" 그룹에 들어가는지 직접 검증.

검증: `vitest run` (parser + editor + environment-editor) 37/37 pass, `tsc --noEmit` clean, `npm run lint` clean.
