### PR TITLE
fix(auth): require workspace-secret proof for bootstrap-grace admin

### DIFF
--- a/docs/rfc/RFC-0302-auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/RFC-0302-auth-bootstrap-grace-token-proof.md
@@ -1,0 +1,115 @@
+# RFC-0302: Auth bootstrap-grace requires proof of token possession
+
+- Status: Implemented
+- Author: Claude (Sonnet 5), on behalf of jeong-sik (vincent)
+- Date: 2026-07-01
+- Related: RFC-0292 (Complete lib/auth de-duplication — out of scope: auth behavior; this RFC is exactly that behavior)
+- Tracking: masc-oas keeper-fleet audit 2026-07-01, item 12 (auth/dashboard token)
+
+## 1. Problem
+
+`Auth.check_permission` and `Auth.resolve_role_with_auth_config`
+(`lib/auth/auth.ml`) both had a "bootstrap grace" branch intended to let the
+agent who ran `enable_auth` always regain access (comment: "the agent who
+enabled auth always has full access", added to prevent BUG-025's circular
+permission deadlock — an admin who can't produce a valid token could
+otherwise never mint themselves a new one).
+
+The branch matched only on `agent_name`:
+
+```ocaml
+else if
+  match read_initial_admin config with
+  | Some admin -> String.equal agent_name admin
+  | None -> false
+then (ignore permission; Ok ())   (* no token check at all *)
+```
+
+`agent_name` reaching this function is not authenticated. On the HTTP path
+(`lib/server/server_auth.ml`, `authorize_permission_request` /
+`authorize_tool_request`), it comes from `agent_from_request`, which reads
+the client-controlled `x-gate-agent` / `x-masc-agent` / `x-masc-agent-name`
+headers or `agent`/`agent_name` query params verbatim, with no signature or
+token binding. When no such header is present at all, those call sites
+additionally default the unresolved identity to the literal string
+`"dashboard"`.
+
+Net effect: any HTTP request that sets `X-MASC-Agent: <initial_admin value>`
+(or, on instances where the unauthenticated default `"dashboard"` happens to
+equal the `initial_admin` file's contents, any request with **no**
+identifying header at all) was granted Admin — including on
+`/api/v1/operator/action`, which can boot/recover keepers — with **zero**
+token, credential, or secret presented. Confirmed live on this machine's
+running instance (`~/.masc/auth/initial_admin` = `"dashboard"`, matching the
+unauthenticated-request default in `server_auth.ml`).
+
+`enable_auth` already mints a real, verifiable Admin credential for that
+agent via `create_token` at the moment auth is enabled, so the bare
+string-match branch was also redundant with the normal, token-verified
+path in the common case — it only mattered once that credential's token
+expired or was lost, i.e. exactly the BUG-025 recovery scenario it was
+built for.
+
+## 2. Fix
+
+Require proof of possession instead of a self-declared name. `enable_auth`
+already mints a **workspace secret** (`init_workspace_secret`) at the same
+time as the bootstrap admin token, hashes and persists it
+(`workspace_secret_hash`), and returns the raw value once for the operator
+to keep. `verify_workspace_secret` (defined, but with zero callers before
+this change — a second, independent audit finding) already implements
+constant-effort hash comparison against that stored value.
+
+The bootstrap/recovery grace branch in both `check_permission` and
+`resolve_role_with_auth_config` now requires the caller's `token` to verify
+against the workspace secret, not `agent_name` to string-match
+`read_initial_admin`:
+
+```ocaml
+else if
+  match token with
+  | Some raw -> verify_workspace_secret config raw
+  | None -> false
+then (ignore permission; Ok ())
+```
+
+This preserves the original recovery property (whoever holds the workspace
+secret — shown once, out of band, to the operator at `enable_auth` time —
+can always regain Admin, so BUG-025's deadlock is still prevented) while
+closing the self-assertion hole: an attacker who does not know the secret
+gets `Unauthorized`/`InvalidToken`, not `Ok ()`.
+
+`read_initial_admin` itself is untouched and keeps its other, legitimate
+consumers (`lib/workspace_goals.ml`, `lib/tool_workspace.ml`,
+`lib/workspace_metric_hooks.ml`, `lib/server/server_runtime_startup_credentials.ml`)
+that use it purely to look up "who is the recorded admin name" for
+domain logic, not to authorize a request.
+
+## 3. Non-goals
+
+- `server_auth.ml`'s `Option.value ~default:"dashboard"` fallback for an
+  unresolved agent name is unchanged. With this fix it is no longer a
+  privilege-escalation vector (the defaulted identity can no longer reach
+  Admin without the workspace secret), but the fallback itself is still a
+  hardcoded literal worth revisiting separately — out of scope here to keep
+  this change to the actual vulnerability.
+- The `lib/` vs `lib/auth/` module de-duplication (RFC-0292) is unrelated:
+  `lib/auth.ml` is already a thin `include Auth_leaf` facade over the single
+  real implementation in `lib/auth/auth.ml` that this RFC changes, so there
+  is only one copy of `check_permission`/`resolve_role_with_auth_config` to
+  fix.
+- Per-tool permission granularity (`tool_catalog` `requiredPermission` not
+  being consulted by `authorize_tool_for_role`) and `Auth_strict_mode`'s
+  Phase B (reject, not just count) are real, separately-scoped gaps found in
+  the same audit — not addressed by this RFC.
+
+## 4. Verification
+
+- `test/test_auth.ml`: 5 new regression cases — impersonation via bare
+  `agent_name` with no token is rejected (`Unauthorized`), impersonation
+  with a wrong/guessed token is rejected (`InvalidToken`), and presenting
+  the actual workspace secret grants Admin via both `check_permission` and
+  `resolve_role`/`resolve_role_with_auth_config`. All 51 `test_auth.ml`
+  cases pass (46 pre-existing + 5 new).
+- `dune build` (full project) and `test_server_auth_warn_log_bound.exe`,
+  `test_masc_error_dashboard_auth_code.exe` pass unchanged.

--- a/docs/rfc/auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/auth-bootstrap-grace-token-proof.md
@@ -40,7 +40,7 @@ equal the `initial_admin` file's contents, any request with **no**
 identifying header at all) was granted Admin — including on
 `/api/v1/operator/action`, which can boot/recover keepers — with **zero**
 token, credential, or secret presented. Confirmed live on this machine's
-running instance (`~/.masc/auth/initial_admin` = `"dashboard"`, matching the
+running instance (`<base-path>/.masc/auth/initial_admin` = `"dashboard"`, matching the
 unauthenticated-request default in `server_auth.ml`).
 
 `enable_auth` already mints a real, verifiable Admin credential for that

--- a/docs/rfc/auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/auth-bootstrap-grace-token-proof.md
@@ -1,4 +1,4 @@
-# RFC-0302: Auth bootstrap-grace requires proof of token possession
+# Auth bootstrap-grace requires proof of token possession
 
 - Status: Implemented
 - Author: Claude (Sonnet 5), on behalf of jeong-sik (vincent)

--- a/docs/rfc/auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/auth-bootstrap-grace-token-proof.md
@@ -57,8 +57,12 @@ already mints a **workspace secret** (`init_workspace_secret`) at the same
 time as the bootstrap admin token, hashes and persists it
 (`workspace_secret_hash`), and returns the raw value once for the operator
 to keep. `verify_workspace_secret` (defined, but with zero callers before
-this change — a second, independent audit finding) already implements
-constant-effort hash comparison against that stored value.
+this change — a second, independent audit finding) compares the caller's
+hashed secret against the caller's already-loaded `auth_config.
+workspace_secret_hash` using `Auth_credential_token.constant_time_string_equal`
+(XOR-accumulated over every byte, no early exit on the first mismatch),
+falling back to a guarded read of the on-disk hash file only when the
+config predates the cache.
 
 The bootstrap/recovery grace branch in both `check_permission` and
 `resolve_role_with_auth_config` now requires the caller's `token` to verify
@@ -68,7 +72,8 @@ against the workspace secret, not `agent_name` to string-match
 ```ocaml
 else if
   match token with
-  | Some raw -> verify_workspace_secret config raw
+  | Some raw ->
+    verify_workspace_secret config ~cached_hash:auth_cfg.workspace_secret_hash raw
   | None -> false
 then (ignore permission; Ok ())
 ```

--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -108,6 +108,20 @@ let verify_optional_token config ~agent_name ~token
      | Error e -> Error e)
 ;;
 
+(** Verify a caller-presented secret against the workspace root secret
+    minted once by [init_workspace_secret] (and shown to the operator at
+    that time). This is the only proof-of-possession the bootstrap/recovery
+    grace below accepts. *)
+let verify_workspace_secret config secret : bool =
+  let hash = sha256_hash secret in
+  let file = workspace_secret_file config in
+  if Sys.file_exists file
+  then (
+    let stored_hash = String.trim (In_channel.with_open_text file In_channel.input_all) in
+    hash = stored_hash)
+  else false
+;;
+
 let check_permission config ~agent_name ~token ~permission : (unit, masc_error) result =
   let auth_cfg = load_auth_config config in
   if not auth_cfg.enabled
@@ -115,11 +129,18 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
     (* Auth disabled - allow everything *)
     Ok ()
   else if
-    match read_initial_admin config with
-    | Some admin -> String.equal agent_name admin
+    match token with
+    | Some raw -> verify_workspace_secret config raw
     | None -> false
   then (
-    (* Bootstrap grace: the agent who enabled auth always has full access *)
+    (* Recovery grace: presenting the workspace secret proves possession of
+       the root credential minted at [enable_auth] time, so the caller can
+       always regain admin access (prevents BUG-025's circular permission
+       deadlock if the bootstrap admin's own token has expired/been lost).
+       The previous version of this branch matched [agent_name] against
+       [read_initial_admin] with no proof of possession at all — any
+       unauthenticated caller could self-declare that name via a plain
+       request header and be granted Admin outright. *)
     ignore permission;
     Ok ())
   else if
@@ -219,10 +240,10 @@ let resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token
   if not auth_cfg.enabled
   then Ok Admin (* Auth disabled = full access *)
   else if
-    match read_initial_admin config with
-    | Some admin -> String.equal agent_name admin
+    match token with
+    | Some raw -> verify_workspace_secret config raw
     | None -> false
-  then Ok Admin (* Bootstrap admin = full access *)
+  then Ok Admin (* Recovery grace via workspace secret possession; see check_permission *)
   else if
     match token with
     | Some raw -> verify_internal_keeper_token config ~token:raw
@@ -286,16 +307,9 @@ let init_workspace_secret config : string =
   secret (* Return raw secret to show user once *)
 ;;
 
-(** Verify workspace secret *)
-let verify_workspace_secret config secret : bool =
-  let hash = sha256_hash secret in
-  let file = workspace_secret_file config in
-  if Sys.file_exists file
-  then (
-    let stored_hash = String.trim (In_channel.with_open_text file In_channel.input_all) in
-    hash = stored_hash)
-  else false
-;;
+(* [verify_workspace_secret] now lives earlier in this file, above
+   [check_permission], since the bootstrap/recovery grace branch there
+   depends on it. *)
 
 (* ============================================ *)
 (* High-level auth operations                   *)

--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -111,15 +111,28 @@ let verify_optional_token config ~agent_name ~token
 (** Verify a caller-presented secret against the workspace root secret
     minted once by [init_workspace_secret] (and shown to the operator at
     that time). This is the only proof-of-possession the bootstrap/recovery
-    grace below accepts. *)
-let verify_workspace_secret config secret : bool =
+    grace below accepts.
+
+    Compares against [cached_hash] (the [auth_config.workspace_secret_hash]
+    the caller already loaded via [load_auth_config]/[resolve_role_with_
+    auth_config]) instead of re-reading [workspace_secret_file] on every
+    call - this sits on the hot path for every authenticated request, and a
+    per-call blocking read can raise on a permission error or a partial
+    write, turning an auth check into a request failure. Falls back to a
+    guarded on-disk read only when the config predates the cache (or a
+    concurrent write raced this read); that read fails closed (verification
+    fails) rather than raising. *)
+let verify_workspace_secret config ~cached_hash secret : bool =
   let hash = sha256_hash secret in
-  let file = workspace_secret_file config in
-  if Sys.file_exists file
-  then (
-    let stored_hash = String.trim (In_channel.with_open_text file In_channel.input_all) in
-    hash = stored_hash)
-  else false
+  match cached_hash with
+  | Some stored_hash -> constant_time_string_equal hash stored_hash
+  | None ->
+    let file = workspace_secret_file config in
+    (try
+       if Sys.file_exists file
+       then constant_time_string_equal hash (String.trim (In_channel.with_open_text file In_channel.input_all))
+       else false
+     with _ -> false)
 ;;
 
 let check_permission config ~agent_name ~token ~permission : (unit, masc_error) result =
@@ -130,7 +143,8 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
     Ok ()
   else if
     match token with
-    | Some raw -> verify_workspace_secret config raw
+    | Some raw ->
+      verify_workspace_secret config ~cached_hash:auth_cfg.workspace_secret_hash raw
     | None -> false
   then (
     (* Recovery grace: presenting the workspace secret proves possession of
@@ -241,7 +255,8 @@ let resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token
   then Ok Admin (* Auth disabled = full access *)
   else if
     match token with
-    | Some raw -> verify_workspace_secret config raw
+    | Some raw ->
+      verify_workspace_secret config ~cached_hash:auth_cfg.workspace_secret_hash raw
     | None -> false
   then Ok Admin (* Recovery grace via workspace secret possession; see check_permission *)
   else if

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -320,7 +320,13 @@ val init_workspace_secret : string -> string
 (** [init_workspace_secret config] generates and persists a workspace secret.
     Returns the raw secret (shown once). *)
 
-val verify_workspace_secret : string -> string -> bool
+val verify_workspace_secret : string -> cached_hash:string option -> string -> bool
+(** [verify_workspace_secret config ~cached_hash secret] checks [secret]
+    against [cached_hash] (the caller's already-loaded [auth_config.
+    workspace_secret_hash]) using a constant-time comparison. Falls back to
+    a guarded read of the on-disk workspace-secret file only when
+    [cached_hash] is [None]; that fallback fails closed on any read error
+    rather than raising. *)
 
 (** {1 Auth Toggle} *)
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -809,6 +809,75 @@ let test_permission_denied_for_worker_admin_action () =
   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
 
+(* Regression for the bootstrap-grace bypass: the grace branch used to match
+   a bare, unauthenticated [agent_name] string against [read_initial_admin]
+   with no proof of possession. Any caller could self-declare that name via
+   an unauthenticated request header (server_auth.ml's x-masc-agent) and be
+   granted Admin outright. It must now require the workspace secret. *)
+let test_bootstrap_grace_rejects_agent_name_impersonation_without_token () =
+  let dir = setup_test_workspace () in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let result =
+    Auth.check_permission dir ~agent_name:"test-admin" ~token:None
+      ~permission:Masc_domain.CanAdmin
+  in
+  cleanup_test_workspace dir;
+  match result with
+  | Ok () -> fail "agent_name impersonation without a token must not grant access"
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _)) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
+
+let test_bootstrap_grace_rejects_agent_name_impersonation_with_wrong_token () =
+  let dir = setup_test_workspace () in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let result =
+    Auth.check_permission dir ~agent_name:"test-admin" ~token:(Some "not-the-secret")
+      ~permission:Masc_domain.CanAdmin
+  in
+  cleanup_test_workspace dir;
+  match result with
+  | Ok () -> fail "a wrong/guessed token must not grant recovery admin"
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
+
+let test_workspace_secret_grants_recovery_admin () =
+  let dir = setup_test_workspace () in
+  let secret, _bootstrap_token =
+    Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin"
+  in
+  (* Proof of possession of the workspace secret must grant recovery admin
+     regardless of the caller's self-declared agent_name. *)
+  let result =
+    Auth.check_permission dir ~agent_name:"anyone" ~token:(Some secret)
+      ~permission:Masc_domain.CanAdmin
+  in
+  cleanup_test_workspace dir;
+  match result with
+  | Ok () -> ()
+  | Error e -> fail (Masc_domain.masc_error_to_string e)
+
+let test_resolve_role_rejects_agent_name_impersonation_without_token () =
+  let dir = setup_test_workspace () in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let result = Auth.resolve_role dir ~agent_name:"test-admin" ~token:None in
+  cleanup_test_workspace dir;
+  match result with
+  | Ok role ->
+    fail (Printf.sprintf "impersonation without a token must not resolve a role, got %s"
+      (Masc_domain.show_agent_role role))
+  | Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _)) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
+
+let test_resolve_role_workspace_secret_grants_admin () =
+  let dir = setup_test_workspace () in
+  let secret, _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let result = Auth.resolve_role dir ~agent_name:"anyone" ~token:(Some secret) in
+  cleanup_test_workspace dir;
+  match result with
+  | Ok Masc_domain.Admin -> ()
+  | Ok role -> fail (Printf.sprintf "expected Admin, got %s" (Masc_domain.show_agent_role role))
+  | Error e -> fail (Masc_domain.masc_error_to_string e)
+
 let test_authorize_unknown_masc_tool_strict_worker_allowed () =
   let dir = setup_test_workspace () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
@@ -1068,6 +1137,16 @@ let () =
       test_case "auth enabled with valid token" `Quick test_auth_enabled_with_valid_token;
       test_case "permission denied for worker admin action" `Quick
         test_permission_denied_for_worker_admin_action;
+      test_case "bootstrap grace rejects agent_name impersonation without token"
+        `Quick test_bootstrap_grace_rejects_agent_name_impersonation_without_token;
+      test_case "bootstrap grace rejects agent_name impersonation with wrong token"
+        `Quick test_bootstrap_grace_rejects_agent_name_impersonation_with_wrong_token;
+      test_case "workspace secret grants recovery admin"
+        `Quick test_workspace_secret_grants_recovery_admin;
+      test_case "resolve_role rejects agent_name impersonation without token"
+        `Quick test_resolve_role_rejects_agent_name_impersonation_without_token;
+      test_case "resolve_role workspace secret grants admin"
+        `Quick test_resolve_role_workspace_secret_grants_admin;
       test_case "strict unknown masc tool allows worker"
         `Quick test_authorize_unknown_masc_tool_strict_worker_allowed;
       test_case "strict unknown non-masc tool denied"

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -244,6 +244,51 @@ let test_workspace_secret_saved_private () =
       check int "workspace secret mode 0600" 0o600
         (permission_bits (Auth.workspace_secret_file dir)))
 
+(* Every check_permission/resolve_role_with_auth_config call now threads
+   auth_cfg.workspace_secret_hash through, so this cached path is exercised
+   indirectly by test_workspace_secret_grants_recovery_admin. This test pins
+   the ~cached_hash:None fallback directly, since nothing else reaches it. *)
+let test_verify_workspace_secret_falls_back_to_file_when_uncached () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      let secret = Auth.init_workspace_secret dir in
+      check bool "correct secret verifies via on-disk fallback"
+        true
+        (Auth.verify_workspace_secret dir ~cached_hash:None secret);
+      check bool "wrong secret is rejected via on-disk fallback"
+        false
+        (Auth.verify_workspace_secret dir ~cached_hash:None "not-the-secret"))
+
+let test_verify_workspace_secret_uses_cached_hash () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      let secret = "a-known-secret-value" in
+      let hash = Auth.sha256_hash secret in
+      check bool "matching cached hash verifies without reading the file"
+        true
+        (Auth.verify_workspace_secret dir ~cached_hash:(Some hash) secret);
+      check bool "mismatched cached hash is rejected"
+        false
+        (Auth.verify_workspace_secret dir ~cached_hash:(Some hash) "wrong-secret"))
+
+let test_verify_workspace_secret_fails_closed_when_file_unreadable () =
+  let dir = setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_workspace dir)
+    (fun () ->
+      let secret = Auth.init_workspace_secret dir in
+      (* Directory in place of the secret file: the on-disk fallback must
+         reject cleanly rather than raise into the caller. *)
+      Sys.remove (Auth.workspace_secret_file dir);
+      Unix.mkdir (Auth.workspace_secret_file dir) 0o755;
+      check bool "unreadable secret file fails closed, does not raise"
+        false
+        (Auth.verify_workspace_secret dir ~cached_hash:None secret))
+
 let test_verify_token () =
   let dir = setup_test_workspace () in
   let create_result = Auth.create_token dir ~agent_name:"claude" ~role:Masc_domain.Admin in
@@ -1169,5 +1214,11 @@ let () =
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;
       test_case "workspace secret saved private" `Quick test_workspace_secret_saved_private;
+      test_case "verify_workspace_secret falls back to file when uncached" `Quick
+        test_verify_workspace_secret_falls_back_to_file_when_uncached;
+      test_case "verify_workspace_secret uses cached hash" `Quick
+        test_verify_workspace_secret_uses_cached_hash;
+      test_case "verify_workspace_secret fails closed when file unreadable" `Quick
+        test_verify_workspace_secret_fails_closed_when_file_unreadable;
     ];
   ]


### PR DESCRIPTION
## Summary
- `Auth.check_permission`/`resolve_role_with_auth_config` granted Admin to any caller whose (client-supplied, unauthenticated) `agent_name` string-matched `read_initial_admin`, with no token/secret check at all — confirmed reachable with zero credentials on this machine's live instance (`initial_admin` = `"dashboard"`, matching `server_auth.ml`'s unauthenticated-request default).
- Bootstrap/recovery grace now requires the caller to present the workspace secret (`verify_workspace_secret`, previously defined with zero callers) instead of self-asserting a name. Preserves the original BUG-025 recovery property; closes the self-assertion bypass.

## RFC
`docs/rfc/auth-bootstrap-grace-token-proof.md` (new, Status: Implemented) — documents the finding and fix. Filename corrected from an earlier `RFC-0302-` prefix, which collided with #22866's own RFC-0302; this doc has no RFC number. Related: RFC-0292 (lib/auth de-dup, explicitly out-of-scope for auth *behavior*, which is exactly what this PR changes).

## Follow-up fix (this push)
Review flagged that `verify_workspace_secret` re-read `workspace_secret.hash` from disk on every call (blocking I/O on the request hot path, can raise on a permission/partial-write error) using plain `=` (not constant-time, despite the RFC's original claim). Fixed: compare against the caller's already-loaded `auth_cfg.workspace_secret_hash` via the existing `Auth_credential_token.constant_time_string_equal`, falling back to a guarded (fail-closed, non-raising) file read only when the config predates the cache.

## Test plan
- [x] Local `dune build` + `test/test_auth.ml` — 54/54 pass (46 pre-existing + 5 prior regression cases + 3 new: cached-hash path, on-disk fallback accept/reject, fail-closed on unreadable secret file). CI is the authoritative build/test gate — see checks below.
- [x] `test_server_auth_warn_log_bound.exe`, `test_masc_error_dashboard_auth_code.exe` — unaffected
- [ ] Live instance still needs a restart with this build to actually close the exposure (deployment step, out of scope of this PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

