### PR TITLE
fix(workspace): surface double-write persistence failures

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -333,7 +333,14 @@ let write_state_result config state =
   ensure_dirs config;
   let json = state_to_yojson state in
   let* () = Workspace_utils.write_json_result config (goals_path config) json in
-  Workspace_utils.write_json_result config (goals_recovery_path config) json
+  (match Workspace_utils.write_json_result config (goals_recovery_path config) json with
+   | Ok () -> ()
+   | Error msg ->
+     Log.Misc.warn
+       "goal_store: primary goals.json committed; recovery mirror write failed for %s: %s"
+       (goals_recovery_path config)
+       msg);
+  Ok ()
 
 let write_state config state =
   match write_state_result config state with

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -2,6 +2,8 @@
    Legacy [status] remains persisted for compatibility, but it is derived
    from [phase] on write and inferred on read for old rows. *)
 
+let ( let* ) = Result.bind
+
 type goal_status =
   | Active
   | Paused
@@ -327,11 +329,19 @@ let read_state config =
   else
     default_state ()
 
-let write_state config state =
+let write_state_result config state =
   ensure_dirs config;
   let json = state_to_yojson state in
-  Workspace_utils.write_json config (goals_path config) json;
-  Workspace_utils.write_json config (goals_recovery_path config) json
+  let* () = Workspace_utils.write_json_result config (goals_path config) json in
+  Workspace_utils.write_json_result config (goals_recovery_path config) json
+
+let write_state config state =
+  match write_state_result config state with
+  | Ok () -> ()
+  | Error msg ->
+    Log.Misc.warn "goal_store.write_state failed for %s: %s"
+      (goals_path config)
+      msg
 
 let now_ms () =
   int_of_float (Time_compat.now () *. 1000.0)
@@ -351,8 +361,8 @@ let update_state config f =
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
-      write_state config next_state;
-      next_state)
+      let* () = write_state_result config next_state in
+      Ok next_state)
 
 let get_goal config ~goal_id =
   read_state config |> fun state -> find_goal state.goals goal_id
@@ -373,7 +383,7 @@ let update_goal config ~goal_id f =
               goals = replace_goal state.goals updated_goal;
             }
           in
-          write_state config next_state;
+          let* () = write_state_result config next_state in
           Ok updated_goal)
 
 type delete_goal_outcome =
@@ -382,9 +392,11 @@ type delete_goal_outcome =
 
 type delete_goal_error =
   | Unknown_goal of string
+  | Persistence_failed of string
 
 let delete_goal_error_to_string = function
   | Unknown_goal msg -> msg
+  | Persistence_failed msg -> "goal persistence failed: " ^ msg
 
 let delete_goal config ~goal_id =
   let deleted =
@@ -393,13 +405,19 @@ let delete_goal config ~goal_id =
       if not (List.exists (fun goal -> String.equal goal.id goal_id) state.goals) then
         Error (Unknown_goal "Goal not found")
       else (
-        write_state
-          config
-          { version = state.version + 1
-          ; goals = List.filter (fun goal -> not (String.equal goal.id goal_id)) state.goals
-          ; updated_at = Masc_domain.now_iso ()
-          };
-        Ok ()))
+        match
+          write_state_result
+            config
+            { version = state.version + 1
+            ; goals =
+                List.filter
+                  (fun goal -> not (String.equal goal.id goal_id))
+                  state.goals
+            ; updated_at = Masc_domain.now_iso ()
+            }
+        with
+        | Ok () -> Ok ()
+        | Error msg -> Error (Persistence_failed msg)))
   in
   match deleted with
   | Error _ as error -> error
@@ -527,7 +545,7 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
          | Error msg -> Error msg
          | Ok () ->
         let was_created = ref false in
-        let state =
+        let state_result =
           update_state config (fun state ->
               match find_goal state.goals resolved_id with
               | Some existing ->
@@ -608,11 +626,14 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                     goals = state.goals @ [ new_goal ];
                   })
         in
-        match find_goal state.goals resolved_id with
-        | Some goal ->
-            Ok (goal, if !was_created then `created else `updated)
-        | None ->
-            Error "failed to save goal")
+        match state_result with
+        | Error msg -> Error msg
+        | Ok state ->
+          match find_goal state.goals resolved_id with
+          | Some goal ->
+              Ok (goal, if !was_created then `created else `updated)
+          | None ->
+              Error "failed to save goal")
 
 let compute_rollup goals =
   let count predicate =

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -158,7 +158,12 @@ val write_state : Workspace_utils.config -> state -> unit
     Does *not* acquire the file lock; callers that need atomicity
     should use {!update_state} instead. *)
 
-val update_state : Workspace_utils.config -> (state -> state) -> state
+val write_state_result :
+  Workspace_utils.config -> state -> (unit, string) result
+(** Result-returning variant of {!write_state}. *)
+
+val update_state :
+  Workspace_utils.config -> (state -> state) -> (state, string) result
 (** Atomic read-modify-write under the goals file lock.
     [f] receives the current state and returns the next state.
     The file lock protects against concurrent truncation races
@@ -183,6 +188,7 @@ type delete_goal_outcome =
 
 type delete_goal_error =
   | Unknown_goal of string
+  | Persistence_failed of string
 
 val delete_goal_error_to_string : delete_goal_error -> string
 

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -469,7 +469,14 @@ let read_state config =
 let write_state_result config (state : state) =
   let json = state_to_yojson state in
   let* () = Workspace_utils.write_json_result config (requests_path config) json in
-  Workspace_utils.write_json_result config (requests_recovery_path config) json
+  (match Workspace_utils.write_json_result config (requests_recovery_path config) json with
+   | Ok () -> ()
+   | Error msg ->
+     Log.Misc.warn
+       "goal_verification: primary requests committed; recovery mirror write failed for %s: %s"
+       (requests_recovery_path config)
+       msg);
+  Ok ()
 
 let principal_key (principal : goal_principal) =
   principal.id

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -466,10 +466,10 @@ let read_state config =
   else
     default_state ()
 
-let write_state config (state : state) =
+let write_state_result config (state : state) =
   let json = state_to_yojson state in
-  Workspace_utils.write_json config (requests_path config) json;
-  Workspace_utils.write_json config (requests_recovery_path config) json
+  let* () = Workspace_utils.write_json_result config (requests_path config) json in
+  Workspace_utils.write_json_result config (requests_recovery_path config) json
 
 let principal_key (principal : goal_principal) =
   principal.id
@@ -572,8 +572,8 @@ let update_state config f =
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
-      write_state config next_state;
-      next_state)
+      let* () = write_state_result config next_state in
+      Ok next_state)
 
 let gen_request_id () =
   Printf.sprintf "gvr-%d-%04x"
@@ -596,7 +596,7 @@ let create_request config ~(goal_id : string) ~(requested_by : goal_principal)
       resolved_at = None;
     }
   in
-  let state =
+  let state_result =
     update_state config (fun state ->
         {
           version = state.version + 1;
@@ -604,9 +604,8 @@ let create_request config ~(goal_id : string) ~(requested_by : goal_principal)
           requests = state.requests @ [ request ];
         })
   in
-  let saved =
-    List.find_opt (fun row -> String.equal row.id request.id) state.requests
-  in
+  let* state = state_result in
+  let saved = List.find_opt (fun row -> String.equal row.id request.id) state.requests in
   match saved with
   | Some saved -> Ok saved
   | None -> Error "failed to persist goal verification request"
@@ -665,8 +664,10 @@ let cancel_request_if_open config ~(request_id : string) =
                 if String.equal row.id request_id then updated_request else row)
               state.requests
           in
-          write_state config
-            { version = state.version + 1; updated_at = resolved_at; requests };
+          let* () =
+            write_state_result config
+              { version = state.version + 1; updated_at = resolved_at; requests }
+          in
           Ok (Cancelled_request updated_request))
 
 let cancel_request config ~(request_id : string) =
@@ -729,6 +730,8 @@ let submit_vote config ~(goal_id : string) ~(request_id : string) ~(principal : 
                 if String.equal row.id request_id then next_request else row)
               state.requests
           in
-          write_state config
-            { version = state.version + 1; updated_at = submitted_at; requests };
+          let* () =
+            write_state_result config
+              { version = state.version + 1; updated_at = submitted_at; requests }
+          in
           Ok (next_request, outcome))

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -14,4 +14,4 @@
   schedule_store
   schedule_service
   schedule_runner)
- (libraries digestif masc_workspace dated_jsonl unix yojson))
+ (libraries digestif masc_workspace dated_jsonl masc_log unix yojson))

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -17,6 +17,7 @@ type store_error =
   | Schedule_not_due_candidate
   | Schedule_not_running
   | Grant_validation_failed of Schedule_domain.grant_error
+  | Persistence_failed of string
   | Corrupt_ledger of
       { primary_err : string
       ; recovery_err : string option
@@ -73,6 +74,7 @@ let store_error_to_string = function
   | Schedule_not_running -> "schedule is not running"
   | Grant_validation_failed err ->
     "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
+  | Persistence_failed msg -> "schedule persistence failed: " ^ msg
   | Corrupt_ledger { primary_err; recovery_err } ->
     corrupt_message ~primary_err ~recovery_err
 ;;
@@ -236,8 +238,12 @@ let load_for_mutation config : (state, store_error) result =
 let write_state config state =
   ensure_dirs config;
   let json = state_to_yojson state in
-  Workspace_utils.write_json config (schedules_path config) json;
-  Workspace_utils.write_json config (recovery_path config) json
+  let* () =
+    Workspace_utils.write_json_result config (schedules_path config) json
+    |> Result.map_error (fun msg -> Persistence_failed msg)
+  in
+  Workspace_utils.write_json_result config (recovery_path config) json
+  |> Result.map_error (fun msg -> Persistence_failed msg)
 ;;
 
 let bump_state state ~schedules ~grants ~executions =
@@ -397,7 +403,7 @@ let insert_request config (request : Schedule_domain.schedule_request) =
         bump_state state ~schedules ~grants:state.grants
           ~executions:state.executions
       in
-      write_state config next_state;
+      let* () = write_state config next_state in
       Ok request)
 ;;
 
@@ -418,7 +424,7 @@ let record_grant config (grant : Schedule_domain.execution_grant) =
           let next_state =
             bump_state state ~schedules ~grants ~executions:state.executions
           in
-          write_state config next_state;
+          let* () = write_state config next_state in
           Ok updated_request))
 ;;
 
@@ -442,7 +448,7 @@ let cancel_request config ~schedule_id =
           bump_state state ~schedules ~grants:state.grants
             ~executions:state.executions
         in
-        write_state config next_state;
+        let* () = write_state config next_state in
         Ok updated_request)
 ;;
 
@@ -466,7 +472,7 @@ let refresh_due config ~now =
         bump_state state ~schedules ~grants:state.grants
           ~executions:state.executions
       in
-      write_state config next_state;
+      let* () = write_state config next_state in
       Ok (next_state, !changed)))
 ;;
 
@@ -496,7 +502,7 @@ let reschedule_due_recurring config ~now ~schedule_ids =
         bump_state state ~schedules ~grants:state.grants
           ~executions:state.executions
       in
-      write_state config next_state;
+      let* () = write_state config next_state in
       Ok (next_state, !changed)))
 ;;
 
@@ -513,7 +519,7 @@ let start_due_candidate config ~now ~schedule_id =
         let schedules = replace_schedule state.schedules updated in
         let executions = make_execution_record ~now request :: state.executions in
         let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
-        write_state config next_state;
+        let* () = write_state config next_state in
         Ok updated)
 ;;
 
@@ -543,7 +549,7 @@ let complete_running config ~now ~schedule_id ?detail () =
                })
         in
         let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
-        write_state config next_state;
+        let* () = write_state config next_state in
         Ok updated)
 ;;
 
@@ -569,7 +575,7 @@ let fail_running config ~now ~schedule_id ~error =
                })
         in
         let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
-        write_state config next_state;
+        let* () = write_state config next_state in
         Ok updated)
 ;;
 
@@ -593,7 +599,7 @@ let fail_due_candidate config ~now ~schedule_id ~error =
         let schedules = replace_schedule state.schedules updated in
         let executions = execution :: state.executions in
         let next_state = bump_state state ~schedules ~grants:state.grants ~executions in
-        write_state config next_state;
+        let* () = write_state config next_state in
         Ok updated)
 ;;
 

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -242,8 +242,14 @@ let write_state config state =
     Workspace_utils.write_json_result config (schedules_path config) json
     |> Result.map_error (fun msg -> Persistence_failed msg)
   in
-  Workspace_utils.write_json_result config (recovery_path config) json
-  |> Result.map_error (fun msg -> Persistence_failed msg)
+  (match Workspace_utils.write_json_result config (recovery_path config) json with
+   | Ok () -> ()
+   | Error msg ->
+     Log.Misc.warn
+       "schedule_store: primary ledger committed; recovery mirror write failed for %s: %s"
+       (recovery_path config)
+       msg);
+  Ok ()
 ;;
 
 let bump_state state ~schedules ~grants ~executions =

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -20,6 +20,7 @@ type store_error =
   | Schedule_not_due_candidate
   | Schedule_not_running
   | Grant_validation_failed of Schedule_domain.grant_error
+  | Persistence_failed of string
   | Corrupt_ledger of
       { primary_err : string
       ; recovery_err : string option

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -470,8 +470,11 @@ let add_delete_action_routes router =
              | Ok Goal_store.Deleted -> respond_ok ~request:req reqd
              | Ok (Goal_store.Deleted_with_orphaned_links warning) ->
                  respond_ok_with_warning ~request:req reqd warning
-             | Error err ->
+             | Error (Goal_store.Unknown_goal _ as err) ->
                  respond_error ~status:`Not_found ~request:req reqd
+                  (Goal_store.delete_goal_error_to_string err)
+             | Error (Goal_store.Persistence_failed _ as err) ->
+                 respond_error ~status:`Internal_server_error ~request:req reqd
                    (Goal_store.delete_goal_error_to_string err)
            with Yojson.Json_error _ ->
              respond_error ~request:req reqd (invalid_request "goal_id")

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -863,97 +863,109 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                         ~on_cleared
                     else on_cleared ())
                | Ok (Goal_phase.Move_to next_phase) ->
-                 (match goal.active_verification_request_id, next_phase with
-                  | ( Some request_id
-                    , ( Goal_phase.Blocked
-                      | Goal_phase.Dropped
-                      | Goal_phase.Executing ) )
-                    when goal.phase = Goal_phase.Awaiting_verification ->
-                    (* Leaving verification through an operator transition is
-                       not a quorum verdict. Seal the open request as cancelled;
-                       quorum failure is handled in [handle_goal_verify] as
-                       [Rejected] and moves the goal back to [Executing]. *)
-                    (match Goal_verification.cancel_request_if_open ctx.config ~request_id with
-                     | Ok (Goal_verification.Cancelled_request _) ->
-                       emit_goal_event
-                         ctx
-                         ~goal_id
-                         ~event_type:"goal_verification_resolved"
-                         ~payload:
-                           (`Assoc
-                               [ "request_id", `String request_id
-                               ; "status", `String "cancelled"
-                               ])
-                     | Ok (Goal_verification.Already_resolved_request request) ->
-                       Log.Misc.warn
-                         "goal verification cancel_request skipped for %s: already %s"
-                         request_id
-                         (goal_verification_request_status_label request.status)
-                     | Error msg ->
-                       Log.Misc.warn
-                         "goal verification cancel_request failed for %s: %s"
-                         request_id
-                         msg)
-                  | None, _ -> ()
-                  | Some _, _ -> ());
-                 (match
-                    update_goal_phase
-                      ctx
-                      goal
-                      ~phase:next_phase
-                      ?note
-                      ~clear_active_verification_request:
-                        (not (next_phase = Goal_phase.Awaiting_verification))
-                      ()
-                  with
-                  | Error msg ->
-                    error_result_typed ~tool_name ~start_time ~code:Internal_error msg
-                  | Ok updated_goal ->
-                    let on_cleared () =
-                      emit_goal_event
-                        ctx
-                        ~goal_id
-                        ~event_type:"goal_phase"
-                        ~payload:
-                          (`Assoc
-                              [ "phase", Goal_phase.to_yojson updated_goal.phase
-                              ; "actor", Goal_verification.goal_principal_to_yojson actor
-                              ]);
-                      if
-                        action = Goal_phase.Approve_completion
-                        || action = Goal_phase.Reject_completion
-                      then
+                 let cancel_result =
+                   match goal.active_verification_request_id, next_phase with
+                   | ( Some request_id
+                     , ( Goal_phase.Blocked
+                       | Goal_phase.Dropped
+                       | Goal_phase.Executing ) )
+                     when goal.phase = Goal_phase.Awaiting_verification ->
+                     (* Leaving verification through an operator transition is
+                        not a quorum verdict. Seal the open request as cancelled;
+                        quorum failure is handled in [handle_goal_verify] as
+                        [Rejected] and moves the goal back to [Executing]. *)
+                     (match
+                        Goal_verification.cancel_request_if_open ctx.config ~request_id
+                      with
+                      | Ok (Goal_verification.Cancelled_request _) ->
                         emit_goal_event
                           ctx
                           ~goal_id
-                          ~event_type:"goal_approval_resolved"
+                          ~event_type:"goal_verification_resolved"
                           ~payload:
                             (`Assoc
-                                [ ( "decision"
-                                  , `String
-                                      (if action = Goal_phase.Approve_completion
-                                       then "approve"
-                                       else "reject") )
+                                [ "request_id", `String request_id
+                                ; "status", `String "cancelled"
                                 ]);
-                      ok_result
-                        ~tool_name
-                        ~start_time
-                        [ "goal_id", `String goal_id
-                        ; "action", `String (Goal_phase.action_to_string action)
-                        ; "goal", Goal_store.goal_to_yojson updated_goal
-                        ; ( "verification_summary"
-                          , verification_summary_json updated_goal effective_policy None )
-                        ]
-                    in
-                    if goal.phase = Goal_phase.Awaiting_approval
-                    then
-                      clear_goal_approval_pending_confirm_required
-                        ctx
-                        ~goal_id
-                        ~tool_name
-                        ~start_time
-                        ~on_cleared
-                    else on_cleared ())))))
+                        Ok ()
+                      | Ok (Goal_verification.Already_resolved_request request) ->
+                        Log.Misc.warn
+                          "goal verification cancel_request skipped for %s: already %s"
+                          request_id
+                          (goal_verification_request_status_label request.status);
+                        Ok ()
+                      | Error msg ->
+                        Error
+                          (Printf.sprintf
+                             "goal verification cancel_request failed for %s: %s"
+                             request_id
+                             msg))
+                   | None, _ -> Ok ()
+                   | Some _, _ -> Ok ()
+                 in
+                 (match cancel_result with
+                  | Error msg ->
+                    error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                  | Ok () ->
+                    (match
+                       update_goal_phase
+                         ctx
+                         goal
+                         ~phase:next_phase
+                         ?note
+                         ~clear_active_verification_request:
+                           (not (next_phase = Goal_phase.Awaiting_verification))
+                         ()
+                     with
+                     | Error msg ->
+                       error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                     | Ok updated_goal ->
+                       let on_cleared () =
+                         emit_goal_event
+                           ctx
+                           ~goal_id
+                           ~event_type:"goal_phase"
+                           ~payload:
+                             (`Assoc
+                                 [ "phase", Goal_phase.to_yojson updated_goal.phase
+                                 ; ( "actor"
+                                   , Goal_verification.goal_principal_to_yojson actor )
+                                 ]);
+                         if
+                           action = Goal_phase.Approve_completion
+                           || action = Goal_phase.Reject_completion
+                         then
+                           emit_goal_event
+                             ctx
+                             ~goal_id
+                             ~event_type:"goal_approval_resolved"
+                             ~payload:
+                               (`Assoc
+                                   [ ( "decision"
+                                     , `String
+                                         (if action = Goal_phase.Approve_completion
+                                          then "approve"
+                                          else "reject") )
+                                   ]);
+                         ok_result
+                           ~tool_name
+                           ~start_time
+                           [ "goal_id", `String goal_id
+                           ; "action", `String (Goal_phase.action_to_string action)
+                           ; "goal", Goal_store.goal_to_yojson updated_goal
+                           ; ( "verification_summary"
+                             , verification_summary_json updated_goal effective_policy None )
+                           ]
+                       in
+                       if goal.phase = Goal_phase.Awaiting_approval
+                       then
+                         clear_goal_approval_pending_confirm_required
+                           ctx
+                           ~goal_id
+                           ~tool_name
+                           ~start_time
+                           ~on_cleared
+                       else on_cleared ())))))
   | Ok _, Ok None, _ ->
     validation_error_result
       ~tool_name

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -37,6 +37,9 @@ let with_workspace f =
 
 let iso_now () = Masc_domain.now_iso ()
 
+let goals_recovery_path config =
+  Goal_store.goals_path config ^ ".last-good"
+
 let make_goal id title =
   let ts = iso_now () in
   {
@@ -269,6 +272,19 @@ let test_write_state_sanitizes_invalid_utf8_before_persisting () =
   let stats = Safe_ops.persistence_utf8_repair_stats () in
   check int "read path did not repair goal store" 0 stats.repaired_reads
 
+let test_write_state_result_keeps_primary_commit_when_recovery_write_fails () =
+  with_workspace @@ fun config ->
+  Unix.mkdir (goals_recovery_path config) 0o755;
+  let goal = make_goal "recovery-mirror-fail" "recovery mirror fail" in
+  let state = { Goal_store.version = 3; updated_at = iso_now (); goals = [ goal ] } in
+  (match Goal_store.write_state_result config state with
+   | Ok () -> ()
+   | Error msg ->
+     fail ("recovery mirror failure should not fail committed primary write: " ^ msg));
+  match Goal_store.get_goal config ~goal_id:goal.Goal_store.id with
+  | Some stored -> check string "primary has goal" goal.title stored.title
+  | None -> fail "primary goal missing after recovery mirror failure"
+
 let () =
   run "Goal_store.delete_goal"
     [ ( "regression-7690",
@@ -292,4 +308,6 @@ let () =
           test_case "missing update: no bump" `Quick
             test_update_missing_goal_does_not_bump;
           test_case "write_state sanitizes invalid utf8" `Quick
-            test_write_state_sanitizes_invalid_utf8_before_persisting ] ) ]
+            test_write_state_sanitizes_invalid_utf8_before_persisting;
+          test_case "recovery mirror write failure preserves primary" `Quick
+            test_write_state_result_keeps_primary_commit_when_recovery_write_fails ] ) ]

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -87,6 +87,8 @@ let test_delete_nonexistent_does_not_bump () =
   let v_before = (Goal_store.read_state config).version in
   (match Goal_store.delete_goal config ~goal_id:"ghost" with
    | Error (Goal_store.Unknown_goal _) -> ()
+   | Error err ->
+     fail ("expected Unknown_goal, got: " ^ Goal_store.delete_goal_error_to_string err)
    | Ok _ -> fail "expected error for missing goal");
   let v_after = (Goal_store.read_state config).version in
   check int "version unchanged on error" v_before v_after

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -749,6 +749,85 @@ let test_goal_transition_manual_reject_blocks_and_cancels_request () =
     (saved_request.status = Goal_verification.Cancelled)
 ;;
 
+let test_goal_transition_manual_reject_aborts_when_cancel_fails () =
+  with_workspace
+  @@ fun config ->
+  let verifier_policy =
+    { Goal_verification.inherit_mode = Goal_verification.Extend
+    ; principals =
+        [ { id = "agent-alpha"; display_name = Some "agent-alpha" } ]
+    ; required_verdicts = Some 1
+    }
+  in
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Reject with missing request" ~verifier_policy () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Reject missing request task";
+  let transitioned =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "action", `String "request_complete"
+            ; "actor", principal_json ~id:"planner"
+            ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let request_id =
+    transitioned_json
+    |> Yojson.Safe.Util.member "verification_request"
+    |> fun json -> get_string_field json "id"
+  in
+  Sys.remove (Goal_verification.requests_path config);
+  seed_goal_operator config ~agent_name:"operator";
+  let rejected =
+    Tool_workspace.dispatch
+      (workspace_ctx ~agent_name:"operator" config)
+      ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "action", `String "reject_completion"
+            ; "actor", principal_json ~id:"operator"
+            ; "note", `String "operator rejected the completion claim"
+            ])
+  in
+  let result =
+    match rejected with
+    | Some result -> result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  check bool "reject fails when cancel fails" false (Tool_result.is_success result);
+  check
+    bool
+    "failure reports cancel"
+    true
+    (contains_substring (Tool_result.message result) request_id);
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after failed reject"
+  in
+  check
+    string
+    "phase preserved"
+    "awaiting_verification"
+    (Goal_phase.to_string saved_goal.phase);
+  check
+    (option string)
+    "active request preserved"
+    (Some request_id)
+    saved_goal.active_verification_request_id
+;;
+
 let test_goal_transition_approval_gate () =
   with_operator_pending_confirm_hooks
   @@ fun () ->
@@ -1812,6 +1891,10 @@ let () =
             "manual reject cancels verification"
             `Quick
             test_goal_transition_manual_reject_blocks_and_cancels_request
+        ; test_case
+            "manual reject aborts when cancel fails"
+            `Quick
+            test_goal_transition_manual_reject_aborts_when_cancel_fails
         ; test_case "approval gate" `Quick test_goal_transition_approval_gate
         ; test_case
             "approval reject clears pending confirm"

--- a/test/test_goal_verification.ml
+++ b/test/test_goal_verification.ml
@@ -36,6 +36,9 @@ let operator ?display_name id : Goal_verification.goal_principal =
 let agent ?display_name id : Goal_verification.goal_principal =
   { id; display_name }
 
+let requests_recovery_path config =
+  Goal_verification.requests_path config ^ ".last-good"
+
 let request_snapshot ~requested_by =
   let reviewer = operator "reviewer-1" in
   let verifier = agent "agent-a" in
@@ -133,6 +136,27 @@ let test_cancel_if_open_reports_already_resolved () =
   check bool "saved status still approved" true
     (saved.status = Goal_verification.Approved)
 
+let test_create_request_keeps_primary_commit_when_recovery_write_fails () =
+  with_workspace @@ fun config ->
+  Unix.mkdir (requests_recovery_path config) 0o755;
+  let requested_by = operator "planner" in
+  let request =
+    match
+      Goal_verification.create_request
+        config
+        ~goal_id:"goal-1"
+        ~requested_by
+        ~policy_snapshot:(request_snapshot ~requested_by)
+    with
+    | Ok request -> request
+    | Error msg ->
+      fail
+        ("recovery mirror failure should not fail committed primary write: " ^ msg)
+  in
+  match Goal_verification.find_request config ~request_id:request.id with
+  | Some stored -> check string "primary has request" request.id stored.id
+  | None -> fail "primary request missing after recovery mirror failure"
+
 let () =
   run "Goal_verification"
     [
@@ -144,5 +168,7 @@ let () =
             test_invalid_vote_does_not_bump;
           test_case "cancel if open reports already resolved" `Quick
             test_cancel_if_open_reports_already_resolved;
+          test_case "recovery mirror write failure preserves primary" `Quick
+            test_create_request_keeps_primary_commit_when_recovery_write_fails;
         ] );
     ]

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -494,15 +494,27 @@ let test_mutation_refused_and_preserves_corrupt_ledger () =
 let test_insert_surfaces_primary_write_failure () =
   with_workspace
   @@ fun config ->
-  Unix.mkdir (schedules_path config) 0o755;
-  let request =
-    make_request ~schedule_id:"persist-fail" ~risk_class:Read_only ()
-  in
-  match insert_request config request with
-  | Error (Persistence_failed msg) ->
-    check bool "failure detail is surfaced" true (String.length msg > 0)
-  | Error err -> fail ("expected Persistence_failed, got: " ^ store_error_to_string err)
-  | Ok _ -> fail "insert unexpectedly succeeded when schedule path is a directory"
+  (* A directory at schedules_path breaks the *read* load_for_mutation does
+     before ever reaching write_state (Eio.Io reports "Is a directory" on the
+     readv, which load classifies as Corrupt_ledger) - it never exercises the
+     write-failure path this test names. Inject a write-only failure instead:
+     the ledger directory itself is made read-only *after* the (nonexistent-
+     file / Fresh) read succeeds, so save_file_atomic's temp-file creation for
+     the write is what fails. *)
+  let masc_dir = Workspace_utils.masc_dir config in
+  Unix.chmod masc_dir 0o500;
+  Fun.protect
+    ~finally:(fun () -> Unix.chmod masc_dir 0o755)
+    (fun () ->
+       let request =
+         make_request ~schedule_id:"persist-fail" ~risk_class:Read_only ()
+       in
+       match insert_request config request with
+       | Error (Persistence_failed msg) ->
+         check bool "failure detail is surfaced" true (String.length msg > 0)
+       | Error err ->
+         fail ("expected Persistence_failed, got: " ^ store_error_to_string err)
+       | Ok _ -> fail "insert unexpectedly succeeded when the ledger dir is read-only")
 ;;
 
 let test_cancel_refused_on_corrupt_ledger () =

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -491,6 +491,20 @@ let test_mutation_refused_and_preserves_corrupt_ledger () =
   check string "corrupt recovery preserved" recovery_before recovery_after
 ;;
 
+let test_insert_surfaces_primary_write_failure () =
+  with_workspace
+  @@ fun config ->
+  Unix.mkdir (schedules_path config) 0o755;
+  let request =
+    make_request ~schedule_id:"persist-fail" ~risk_class:Read_only ()
+  in
+  match insert_request config request with
+  | Error (Persistence_failed msg) ->
+    check bool "failure detail is surfaced" true (String.length msg > 0)
+  | Error err -> fail ("expected Persistence_failed, got: " ^ store_error_to_string err)
+  | Ok _ -> fail "insert unexpectedly succeeded when schedule path is a directory"
+;;
+
 let test_cancel_refused_on_corrupt_ledger () =
   with_workspace
   @@ fun config ->
@@ -537,6 +551,8 @@ let () =
             test_read_state_raises_on_corrupt;
           test_case "mutation refused and corrupt ledger preserved" `Quick
             test_mutation_refused_and_preserves_corrupt_ledger;
+          test_case "primary write failure is surfaced" `Quick
+            test_insert_surfaces_primary_write_failure;
           test_case "cancel refused on corrupt ledger" `Quick
             test_cancel_refused_on_corrupt_ledger;
           test_case "last-good is parseable after good write" `Quick

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -35,6 +35,8 @@ let with_workspace f =
   f config
 ;;
 
+let schedules_recovery_path config = schedules_path config ^ ".last-good"
+
 let human ?display_name id = { id; kind = Human_operator; display_name }
 
 let payload_json () =
@@ -480,13 +482,13 @@ let test_mutation_refused_and_preserves_corrupt_ledger () =
   ignore (insert_ok config req);
   corrupt_both config;
   let primary_before = Workspace_core.read_text config (schedules_path config) in
-  let recovery_before = Workspace_core.read_text config (recovery_path config) in
+  let recovery_before = Workspace_core.read_text config (schedules_recovery_path config) in
   (match insert_request config (make_request ~schedule_id:"sched-2" ~risk_class:Read_only ()) with
    | Ok _ -> fail "insert on corrupt ledger unexpectedly succeeded"
    | Error (Corrupt_ledger _) -> ()
    | Error err -> fail ("expected Corrupt_ledger, got: " ^ store_error_to_string err));
   let primary_after = Workspace_core.read_text config (schedules_path config) in
-  let recovery_after = Workspace_core.read_text config (recovery_path config) in
+  let recovery_after = Workspace_core.read_text config (schedules_recovery_path config) in
   check string "corrupt primary preserved" primary_before primary_after;
   check string "corrupt recovery preserved" recovery_before recovery_after
 ;;
@@ -517,6 +519,24 @@ let test_insert_surfaces_primary_write_failure () =
        | Ok _ -> fail "insert unexpectedly succeeded when the ledger dir is read-only")
 ;;
 
+let test_insert_keeps_primary_commit_when_recovery_write_fails () =
+  with_workspace
+  @@ fun config ->
+  Unix.mkdir (schedules_recovery_path config) 0o755;
+  let request =
+    make_request ~schedule_id:"recovery-mirror-fail" ~risk_class:Read_only ()
+  in
+  (match insert_request config request with
+   | Ok stored -> check string "stored id" request.schedule_id stored.schedule_id
+   | Error err ->
+     fail
+       ("recovery mirror failure should not fail committed primary write: "
+        ^ store_error_to_string err));
+  match get_schedule config ~schedule_id:request.schedule_id with
+  | Some stored -> check string "primary has schedule" request.schedule_id stored.schedule_id
+  | None -> fail "primary schedule missing after recovery mirror failure"
+;;
+
 let test_cancel_refused_on_corrupt_ledger () =
   with_workspace
   @@ fun config ->
@@ -535,7 +555,7 @@ let test_last_good_is_parseable_after_good_write () =
   @@ fun config ->
   let req = make_request ~risk_class:Read_only () in
   ignore (insert_ok config req);
-  let recovery_json = Workspace_core.read_json config (recovery_path config) in
+  let recovery_json = Workspace_core.read_json config (schedules_recovery_path config) in
   match Schedule_store.state_of_yojson recovery_json with
   | Ok state -> check int "last-good holds the schedule" 1 (List.length state.schedules)
   | Error msg -> fail (".last-good is not parseable: " ^ msg)
@@ -565,6 +585,8 @@ let () =
             test_mutation_refused_and_preserves_corrupt_ledger;
           test_case "primary write failure is surfaced" `Quick
             test_insert_surfaces_primary_write_failure;
+          test_case "recovery mirror write failure preserves primary" `Quick
+            test_insert_keeps_primary_commit_when_recovery_write_fails;
           test_case "cancel refused on corrupt ledger" `Quick
             test_cancel_refused_on_corrupt_ledger;
           test_case "last-good is parseable after good write" `Quick


### PR DESCRIPTION
## Summary
- Route schedule, goal, and goal-verification double-write state stores through `Workspace_utils.write_json_result` instead of silent `write_json`.
- Propagate persistence failures through existing mutation Result channels so callers no longer treat failed durable writes as committed state.
- Split dashboard goal-delete persistence failures from missing-goal 404s, returning server error for failed goal-store writes.
- Add schedule-store regression coverage for a primary write failure surfacing as `Persistence_failed`.

## Scope
This is the first #21990 slice for the double-write atomicity cluster only: `schedule_store`, `goal_store`, and `goal_verification`. It does not retire every remaining unit-returning `write_json` caller.

## Validation
- `ocamlformat --check lib/schedule/schedule_store.ml lib/schedule/schedule_store.mli lib/goal/goal_store.ml lib/goal/goal_store.mli lib/goal/goal_verification.ml lib/server/server_dashboard_http_delete_actions.ml test/test_schedule_store.ml`
- `git diff --check`
- `rg -n "Workspace_utils\\.write_json config \\((schedules_path|recovery_path|goals_path|goals_recovery_path|requests_path|requests_recovery_path)" lib/schedule lib/goal` returned no matches
- Local Dune build/test intentionally not run; CI is build authority per operator instruction.

Refs #21990