### PR TITLE
fix(keeper): mark execute dispatch rejects deterministic

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -266,12 +266,53 @@ let typed_execute_response_cwd_json
     | None -> `String cwd
   else `String cwd
 
+let path_reject_deterministic_reason msg =
+  match Keeper_path_check_error.parse_prefix msg with
+  | Some (Keeper_path_check_error.Path_outside_whitelist _) ->
+    Some Keeper_tool_deterministic_error.Path_outside_sandbox
+  | Some (Keeper_path_check_error.Cwd_not_directory _) ->
+    Some Keeper_tool_deterministic_error.Cwd_not_directory
+  | None ->
+    (match Keeper_path_rejection.parse_rejection_prefix msg with
+     | Some Keeper_path_rejection.Path_required ->
+       Some Keeper_tool_deterministic_error.Command_shape_blocked
+     | Some (Keeper_path_rejection.Not_found_relative _) ->
+       Some Keeper_tool_deterministic_error.Path_not_found
+     | Some (Keeper_path_rejection.Task_state_file_path_blocked _) ->
+       Some Keeper_tool_deterministic_error.Task_state_probe_blocked
+     | Some
+         (Keeper_path_rejection.Absolute_path_rejected _
+         | Keeper_path_rejection.Outside_project_root _
+         | Keeper_path_rejection.Allowed_paths_normalized_empty _
+         | Keeper_path_rejection.Outside_sandbox _
+         | Keeper_path_rejection.Ambiguous_relative_read_path _) ->
+       Some Keeper_tool_deterministic_error.Path_outside_sandbox
+     | None -> None)
+
+let dispatch_error_deterministic_reason = function
+  | Keeper_tool_execute_shell_ir.Gate_reject _
+  | Keeper_tool_execute_shell_ir.Cannot_parse
+  | Keeper_tool_execute_shell_ir.Too_complex ->
+    Some Keeper_tool_deterministic_error.Command_shape_blocked
+  | Keeper_tool_execute_shell_ir.Path_reject msg ->
+    path_reject_deterministic_reason msg
+  | Keeper_tool_execute_shell_ir.Approval_required _
+  | Keeper_tool_execute_shell_ir.Policy_denied _ ->
+    Some Keeper_tool_deterministic_error.Policy_blocked
+
+let dispatch_error_deterministic_retry_fields error =
+  match dispatch_error_deterministic_reason error with
+  | Some reason -> Keeper_tool_deterministic_error.deterministic_retry_fields reason
+  | None -> []
+
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
   let path_probe_json ~cwd path = path_probe_json ~cwd (path_probe ~cwd path)
   let repo_root_public_prefix_from_cwd = repo_root_public_prefix_from_cwd
   let repo_cwd_relative_rewrite = repo_cwd_relative_rewrite
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
+  let dispatch_error_deterministic_retry_fields =
+    dispatch_error_deterministic_retry_fields
 end
 
 (* Typed Execute input projections extracted to
@@ -618,7 +659,17 @@ let handle_tool_execute_typed
                ())
         in
         let envelope = Keeper_tool_execute_shell_ir.classify ir in
-        let typed_error_json msg = error_json ~fields:typed_error_fields msg in
+        let typed_error_json ?dispatch_error ?(extra_fields = []) msg =
+          let deterministic_retry_fields =
+            match dispatch_error with
+            | Some dispatch_error ->
+              dispatch_error_deterministic_retry_fields dispatch_error
+            | None -> []
+          in
+          error_json
+            ~fields:(typed_error_fields @ deterministic_retry_fields @ extra_fields)
+            msg
+        in
         if Masc_exec.Shell_ir_risk.is_destructive envelope
         then
           blocked_result
@@ -754,41 +805,46 @@ let handle_tool_execute_typed
                 envelope
           in
           match dispatch_result with
-          | Error (Keeper_tool_execute_shell_ir.Gate_reject diagnostic) ->
+          | Error (Keeper_tool_execute_shell_ir.Gate_reject diagnostic as err) ->
             (* RFC-0208 P1: gate denial audit line. *)
             Log.Keeper.warn
               "shell_ir gate_reject keeper=%s cmd=%s diagnostic=%s"
               meta.name
               cmd_for_log
               (message_for_log diagnostic);
-            typed_error_json diagnostic
-          | Error Keeper_tool_execute_shell_ir.Cannot_parse -> typed_error_json "Cannot parse command"
-          | Error Keeper_tool_execute_shell_ir.Too_complex -> typed_error_json "Command too complex"
-          | Error (Keeper_tool_execute_shell_ir.Path_reject e) ->
+            typed_error_json ~dispatch_error:err diagnostic
+          | Error (Keeper_tool_execute_shell_ir.Cannot_parse as err) ->
+            typed_error_json ~dispatch_error:err "Cannot parse command"
+          | Error (Keeper_tool_execute_shell_ir.Too_complex as err) ->
+            typed_error_json ~dispatch_error:err "Command too complex"
+          | Error (Keeper_tool_execute_shell_ir.Path_reject e as err) ->
             (* RFC-0208 P1: path-policy denial audit line. *)
             Log.Keeper.warn
               "shell_ir path_reject keeper=%s cmd=%s reason=%s"
               meta.name
               cmd_for_log
               (message_for_log e);
-            error_json
-              ~fields:(("blocked_cmd", `String cmd_for_log) :: typed_error_fields)
+            typed_error_json
+              ~dispatch_error:err
+              ~extra_fields:[ "blocked_cmd", `String cmd_for_log ]
               e
-          | Error (Keeper_tool_execute_shell_ir.Approval_required { summary; bin }) ->
+          | Error
+              (Keeper_tool_execute_shell_ir.Approval_required { summary; bin } as err)
+            ->
             Log.Keeper.warn
               "shell_ir approval_required keeper=%s cmd=%s bin=%s summary=%s"
               meta.name
               cmd_for_log
               bin
               summary;
-            typed_error_json summary
-          | Error (Keeper_tool_execute_shell_ir.Policy_denied { reason }) ->
+            typed_error_json ~dispatch_error:err summary
+          | Error (Keeper_tool_execute_shell_ir.Policy_denied { reason } as err) ->
             Log.Keeper.warn
               "shell_ir policy_denied keeper=%s cmd=%s reason=%s"
               meta.name
               cmd_for_log
               reason;
-            typed_error_json reason
+            typed_error_json ~dispatch_error:err reason
           | Ok result ->
             let elapsed_ms =
               (* NDT-OK: second wall-clock read closes the elapsed telemetry

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -22,4 +22,6 @@ module For_testing : sig
     cwd:string ->
     sandbox_extra_fields:(string * Yojson.Safe.t) list ->
     Yojson.Safe.t
+  val dispatch_error_deterministic_retry_fields :
+    Keeper_tool_execute_shell_ir.dispatch_error -> (string * Yojson.Safe.t) list
 end

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -10,6 +10,8 @@
     reducer. *)
 
 module D = Masc.Keeper_tool_deterministic_error
+module Execute_runtime = Masc.Keeper_tool_execute_runtime.For_testing
+module Shell_dispatch = Keeper_tool_execute_shell_ir
 
 let reason_testable =
   let pp ppf reason = Format.pp_print_string ppf (D.to_telemetry_key reason) in
@@ -46,6 +48,13 @@ let deterministic_marker_raw ?(error = "timeout") reason =
     (`Assoc
        ([ "ok", `Bool false; "error", `String error ]
         @ D.deterministic_retry_fields reason))
+;;
+
+let dispatch_error_marker_raw error =
+  Yojson.Safe.to_string
+    (`Assoc
+       ([ "ok", `Bool false; "error", `String "execute_dispatch_rejected" ]
+        @ Execute_runtime.dispatch_error_deterministic_retry_fields error))
 ;;
 
 let test_command_shape_blocked () =
@@ -145,6 +154,74 @@ let test_typed_deterministic_retry_marker_reports_source () =
     ~expected_reason:D.Write_operation_gated
     ~expected_source:D.Deterministic_retry_marker
     raw
+;;
+
+let test_dispatch_gate_reject_marks_command_shape_blocked () =
+  let raw =
+    dispatch_error_marker_raw
+      (Shell_dispatch.Gate_reject "shell operator token rejected")
+  in
+  check_classify
+    ~name:"dispatch gate reject marker"
+    ~expected:(Some D.Command_shape_blocked)
+    raw
+;;
+
+let test_dispatch_parse_rejects_mark_command_shape_blocked () =
+  List.iter
+    (fun (name, error) ->
+      check_classify
+        ~name
+        ~expected:(Some D.Command_shape_blocked)
+        (dispatch_error_marker_raw error))
+    [ "dispatch cannot_parse marker", Shell_dispatch.Cannot_parse
+    ; "dispatch too_complex marker", Shell_dispatch.Too_complex
+    ]
+;;
+
+let test_dispatch_path_reject_marks_path_reason () =
+  List.iter
+    (fun (name, error, expected) ->
+      check_classify
+        ~name
+        ~expected:(Some expected)
+        (dispatch_error_marker_raw (Shell_dispatch.Path_reject error)))
+    [ ( "dispatch path outside whitelist marker"
+      , "Path blocked: /etc/passwd (outside allowed directories)"
+      , D.Path_outside_sandbox )
+    ; ( "dispatch cwd_not_directory marker"
+      , "cwd_not_directory: /tmp/missing (directory does not exist under cwd)"
+      , D.Cwd_not_directory )
+    ; ( "dispatch path_not_found_under_allowed_roots marker"
+      , "path_not_found_under_allowed_roots: repos/masc/nope.ml"
+      , D.Path_not_found )
+    ; ( "dispatch task state path marker"
+      , "task_state_file_path_blocked: .masc/tasks.json"
+      , D.Task_state_probe_blocked )
+    ]
+;;
+
+let test_dispatch_unknown_path_reject_stays_observed () =
+  check_classify
+    ~name:"dispatch unknown path reject observed"
+    ~expected:None
+    (dispatch_error_marker_raw
+       (Shell_dispatch.Path_reject "new_path_error_without_typed_prefix"))
+;;
+
+let test_dispatch_policy_rejects_mark_policy_blocked () =
+  List.iter
+    (fun (name, error) ->
+      check_classify
+        ~name
+        ~expected:(Some D.Policy_blocked)
+        (dispatch_error_marker_raw error))
+    [ ( "dispatch approval_required marker"
+      , Shell_dispatch.Approval_required
+          { summary = "approval required"; bin = "gh" } )
+    ; ( "dispatch policy_denied marker"
+      , Shell_dispatch.Policy_denied { reason = "policy denied" } )
+    ]
 ;;
 
 let test_plain_error_codes_are_observed_only () =
@@ -408,6 +485,26 @@ let () =
             "typed_deterministic_retry_marker_reports_source"
             `Quick
             test_typed_deterministic_retry_marker_reports_source
+        ; Alcotest.test_case
+            "dispatch_gate_reject_marker"
+            `Quick
+            test_dispatch_gate_reject_marks_command_shape_blocked
+        ; Alcotest.test_case
+            "dispatch_parse_reject_markers"
+            `Quick
+            test_dispatch_parse_rejects_mark_command_shape_blocked
+        ; Alcotest.test_case
+            "dispatch_path_reject_markers"
+            `Quick
+            test_dispatch_path_reject_marks_path_reason
+        ; Alcotest.test_case
+            "dispatch_unknown_path_reject_observed"
+            `Quick
+            test_dispatch_unknown_path_reject_stays_observed
+        ; Alcotest.test_case
+            "dispatch_policy_reject_markers"
+            `Quick
+            test_dispatch_policy_rejects_mark_policy_blocked
         ; Alcotest.test_case
             "plain_error_codes_observed_only"
             `Quick


### PR DESCRIPTION
## Summary

- mark typed Execute dispatch gate/path/policy rejections with `deterministic_retry.retry_same_args=false`
- classify dispatch rejections into existing deterministic reasons: command shape, path outside sandbox, cwd not directory, path not found, task-state probe, and policy blocked
- add focused classifier regression coverage so the producer marker is consumed by `Keeper_tool_deterministic_error`

## Verification

- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_execute_runtime.ml lib/keeper/keeper_tool_execute_runtime.mli test/test_keeper_tool_execute_retry_deterministic_close.ml`
- `scripts/dune-local.sh build @test/runtest-test_keeper_tool_execute_retry_deterministic_close` (36 tests)
