### PR TITLE
fix(keeper): wire pause_keeper_for_overflow into context-overflow retry path

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -751,10 +751,49 @@ let degraded_rotation_after_recoverable_error
          (* Contract violation or quota/rate-limit exhaustion: cap rotation. *)
          None)
 
+(** [true] when a structured error indicates context overflow. *)
+let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Api (ContextOverflow _) -> true
+  (* Other API error variants do not indicate context overflow. *)
+  | Agent_sdk.Error.Api (RateLimited _)
+  | Agent_sdk.Error.Api (Overloaded _)
+  | Agent_sdk.Error.Api (ServerError _)
+  | Agent_sdk.Error.Api (AuthError _)
+  | Agent_sdk.Error.Api (InvalidRequest _)
+  | Agent_sdk.Error.Api (NotFound _)
+  | Agent_sdk.Error.Api (NetworkError _)
+  | Agent_sdk.Error.Api (Timeout _) -> false
+  | Agent_sdk.Error.Provider _ -> false
+  (* Other agent error variants. *)
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
+  | Agent_sdk.Error.Agent (AgentExecutionIdleTimeout _)
+  | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Agent (InputRequired _) -> false
+  (* Non-API / non-Agent error families. *)
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ -> false
+
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
   || is_auto_recoverable_runtime_exhausted_error err
+  (* Context overflow is handled explicitly by
+     [Keeper_turn_runtime_budget.pause_keeper_for_overflow] at the point of
+     detection (Overflowed/Compacting FSM retry-exhausted path, auto-resume
+     with backoff) rather than by accumulating turn_consecutive_failures
+     toward a hard crash — counting it here too would double-penalize an
+     event that already has its own graceful pause. *)
+  || is_context_overflow err
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   if Keeper_provider_runtime_boundary.is_provider_timeout_error err
@@ -797,37 +836,8 @@ let max_transient_retries () =
 let transient_backoff_sec (attempt : int) : float =
   Env_config_keeper.KeeperRetryBackoff.transient_backoff_sec attempt
 
-(** [true] when a structured error indicates context overflow. *)
-let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
-  match err with
-  | Agent_sdk.Error.Api (ContextOverflow _) -> true
-  (* Other API error variants do not indicate context overflow. *)
-  | Agent_sdk.Error.Api (RateLimited _)
-  | Agent_sdk.Error.Api (Overloaded _)
-  | Agent_sdk.Error.Api (ServerError _)
-  | Agent_sdk.Error.Api (AuthError _)
-  | Agent_sdk.Error.Api (InvalidRequest _)
-  | Agent_sdk.Error.Api (NotFound _)
-  | Agent_sdk.Error.Api (NetworkError _)
-  | Agent_sdk.Error.Api (Timeout _) -> false
-  | Agent_sdk.Error.Provider _ -> false
-  (* Other agent error variants. *)
-  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
-  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
-  | Agent_sdk.Error.Agent (AgentExecutionIdleTimeout _)
-  | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
-  | Agent_sdk.Error.Agent (IdleDetected _)
-  | Agent_sdk.Error.Agent (GuardrailViolation _)
-  | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
-  | Agent_sdk.Error.Agent (InputRequired _) -> false
-  (* Non-API / non-Agent error families. *)
-  | Agent_sdk.Error.Mcp _
-  | Agent_sdk.Error.Config _
-  | Agent_sdk.Error.Serialization _
-  | Agent_sdk.Error.Io _
-  | Agent_sdk.Error.Orchestration _
-  | Agent_sdk.Error.Internal _ -> false
+(* [is_context_overflow] now lives earlier in this file, above
+   [is_auto_recoverable_turn_error], since that predicate depends on it. *)
 
 (** Extract the [InputRequired] payload from an [sdk_error], if any.
     Typed companion to {!is_input_required_error}; callers that need

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -661,9 +661,27 @@ let run (ctx : ctx)
             ();
           Log.Keeper.warn
             "%s: OAS returned context overflow after its owned retry \
-             path; MASC will not compact/retry at keeper layer: %s"
+             path; MASC will not compact/retry within this turn — \
+             pausing with auto-resume-with-backoff: %s"
             meta.name
             (short_preview (Agent_sdk.Error.to_string err));
+          (* OAS already exhausted its own proactive + emergency compaction
+             for this turn (that's what [Degraded_retry_step_not_allowed]
+             plus [is_context_overflow] means here), so there is nothing
+             left for MASC to retry within this turn. Rather than letting
+             this fall through to the generic turn_consecutive_failures
+             counter (which has no auto-recovery and only escalates to a
+             hard [Keeper_fiber_crash]), drive the already-implemented
+             Overflowed/Compacting FSM's retry-exhausted path directly:
+             this pauses the keeper with [Auto_resume_with_backoff] so it
+             comes back on its own once the backoff elapses, instead of
+             requiring operator intervention. *)
+          let (_ : keeper_meta) =
+            pause_keeper_for_overflow
+              ~config
+              ~meta
+              ~reason:"context_overflow_after_oas_retry"
+          in
           mark_terminal_error err;
           Error err, turn_state
         | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed ->

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -328,6 +328,8 @@ let run (ctx : ctx)
         let reason =
           if EC.is_server_rejected_parse_error err
           then "server parse rejection"
+          else if EC.is_context_overflow err
+          then "context overflow"
           else "transient error"
         in
         Log.Keeper.warn

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -660,7 +660,7 @@ let run (ctx : ctx)
               ]
             ();
           Log.Keeper.warn
-            "%s: OAS returned context overflow after its owned retry \
+            "%s: OAS returned context overflow after its own retry \
              path; MASC will not compact/retry within this turn — \
              pausing with auto-resume-with-backoff: %s"
             meta.name
@@ -676,11 +676,14 @@ let run (ctx : ctx)
              this pauses the keeper with [Auto_resume_with_backoff] so it
              comes back on its own once the backoff elapses, instead of
              requiring operator intervention. *)
-          let (_ : keeper_meta) =
+          let paused_meta =
             pause_keeper_for_overflow
               ~config
               ~meta
               ~reason:"context_overflow_after_oas_retry"
+          in
+          let turn_state =
+            { turn_state with paused_meta_override = Some paused_meta }
           in
           mark_terminal_error err;
           Error err, turn_state

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -60,6 +60,25 @@ let test_is_context_overflow_only_for_overflow_errors () =
     (EC.is_context_overflow (Agent_sdk.Error.Internal "some error"))
 ;;
 
+(* Regression: ContextOverflow used to fall through to the generic
+   turn_consecutive_failures counter (no auto-recovery, escalates to a hard
+   Keeper_fiber_crash after keeper_max_turn_failures). Now that the retry
+   loop (keeper_unified_turn_execution.ml) drives
+   Keeper_turn_runtime_budget.pause_keeper_for_overflow at the point of
+   detection — the Overflowed/Compacting FSM's retry-exhausted path,
+   auto-resume-with-backoff — this error must be classified as
+   auto-recoverable so [record_failure_and_maybe_escalate] does not also
+   count it toward that same crash threshold. *)
+let test_context_overflow_is_auto_recoverable () =
+  check
+    bool
+    "ContextOverflow is auto-recoverable at turn level (handled by \
+     pause_keeper_for_overflow, not the generic crash counter)"
+    true
+    (EC.is_auto_recoverable_turn_error
+       (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 })))
+;;
+
 let test_summarize_turn_event_bus_extracts_overflow_signal () =
   let events =
     [ Agent_sdk.Event_bus.mk_event
@@ -197,6 +216,11 @@ let () =
             "is_context_overflow only matches ContextOverflow"
             `Quick
             test_is_context_overflow_only_for_overflow_errors
+        ; test_case
+            "context overflow is auto-recoverable (handled by \
+             pause_keeper_for_overflow)"
+            `Quick
+            test_context_overflow_is_auto_recoverable
         ; test_case
             "summarize_turn_event_bus extracts overflow signal"
             `Quick


### PR DESCRIPTION
## Summary
- The `ContextOverflow` branch in `keeper_unified_turn_execution.ml` (reached after OAS exhausts its own proactive + emergency compaction) only logged and returned `Error err`, which fell through to the generic `turn_consecutive_failures` counter — no auto-recovery, hard `Keeper_fiber_crash` after 10 accumulated failures. The already-designed `Overflowed`/`Compacting` FSM and `Keeper_turn_runtime_budget.pause_keeper_for_overflow` (defined, zero callers before this change) never ran.
- Wire `pause_keeper_for_overflow` at the point of detection: pauses the keeper with `Auto_resume_with_backoff` instead of accumulating toward a hard, manual-intervention crash.
- Add `is_context_overflow` to `is_auto_recoverable_turn_error` so the generic crash counter doesn't double-penalize an event now handled gracefully.

## RFC
Not required — this is a keeper-runtime bug fix (`lib/keeper/keeper_unified_turn_execution.ml`, `lib/keeper/keeper_error_classify.ml`), not a credential/identity/operator-control/sandbox/hooks/workflow surface. `bash scripts/pr-rfc-check.sh` passes with no matches.

## Test plan
- [x] `dune build` (full project) — clean
- [x] New regression test in `test_keeper_unified_context_overflow.ml`: `ContextOverflow` is now `is_auto_recoverable_turn_error`
- [x] `test_keeper_overflow_recovery.exe` — 9/9 pass (FSM unchanged)
- [x] `test_keeper_turn_driver_accept.exe` — 34/34 pass
- [x] `test_keeper_unified_context_overflow.exe`, `test_keeper_state_machine_correspondence.exe`, `test_keeper_sdk_error_typed_bridge.exe`, `test_pbt_context_overflow.exe` — pass
- [x] 9 other `test_keeper_unified_*` suites — pass unchanged
- [ ] No integration test exercises `keeper_unified_turn_execution.ml`'s retry_loop end-to-end (would need to mock `Agent_sdk.Agent.run` to synthesize `Degraded_retry_step_not_allowed` + `ContextOverflow`) — flagged as a follow-up, not added here to keep this change surgical.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
