### PR TITLE
fix(operator): propagate pending confirm write failures

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -12,9 +12,13 @@ open Keeper_keepalive
 type tool_result = Keeper_types_profile.tool_result
 
 let remove_pending_confirms_by_target_callback
-    : (Workspace.config -> target_type:string -> target_id:string option -> int) Atomic.t
+    : (Workspace.config ->
+       target_type:string ->
+       target_id:string option ->
+       (int, string) result)
+        Atomic.t
   =
-  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> 0)
+  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
 
 let register_remove_pending_confirms_by_target fn =
   Atomic.set remove_pending_confirms_by_target_callback fn
@@ -35,10 +39,17 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
     | Error e -> tool_result_error e
     | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
-      let pending_confirms_removed =
-        Atomic.get remove_pending_confirms_by_target_callback config
-          ~target_type:"keeper" ~target_id:(Some name)
-      in
+      (match
+         Atomic.get remove_pending_confirms_by_target_callback config
+           ~target_type:"keeper" ~target_id:(Some name)
+       with
+       | Error msg ->
+         tool_result_error
+           (Printf.sprintf
+              "keeper pending-confirm cleanup failed for %s: %s"
+              name
+              msg)
+       | Ok pending_confirms_removed ->
       Log.Misc.info
         "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
          remove_meta=%b remove_session=%b"
@@ -110,7 +121,7 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
         ("remove_session", `Bool remove_session);
         ("pending_confirms_removed", `Int pending_confirms_removed);
       ] in
-      tool_result_ok (Yojson.Safe.to_string json)
+      tool_result_ok (Yojson.Safe.to_string json))
 
 let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
 
@@ -119,5 +130,6 @@ module For_testing = struct
     Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
 
   let reset_remove_pending_confirms_by_target () =
-    Atomic.set remove_pending_confirms_by_target_callback (fun _config ~target_type:_ ~target_id:_ -> 0)
+    Atomic.set remove_pending_confirms_by_target_callback
+      (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
 end

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -15,13 +15,19 @@ val handle_keeper_down_config :
   config:Workspace.config -> Yojson.Safe.t -> tool_result
 
 val register_remove_pending_confirms_by_target :
-  (Workspace.config -> target_type:string -> target_id:string option -> int) ->
+  (Workspace.config ->
+   target_type:string ->
+   target_id:string option ->
+   (int, string) result) ->
   unit
 
 (** Test-only hooks for the Atomic-backed callback. *)
 module For_testing : sig
   val remove_pending_confirms_by_target
-    : config:Workspace.config -> target_type:string -> target_id:string option -> int
+    : config:Workspace.config ->
+      target_type:string ->
+      target_id:string option ->
+      (int, string) result
 
   val reset_remove_pending_confirms_by_target : unit -> unit
 end

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -401,7 +401,7 @@ let action_json ?actor_hint (ctx : _ context) args :
         expires_at = Some expires_at;
       }
     in
-    upsert_pending_confirm ctx.config entry;
+    let* () = upsert_pending_confirm ctx.config entry in
     append_action_log ctx.config
       {
         trace_id;
@@ -473,7 +473,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       with
       | None -> Error "pending confirmation not found"
       | Some entry when pending_confirm_expired entry ->
-          remove_pending_confirm ctx.config confirm_token;
+          let* () = remove_pending_confirm ctx.config confirm_token in
           append_action_log ctx.config
             {
               trace_id = entry.trace_id;
@@ -517,7 +517,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
           Error "actor is not allowed to confirm this action"
       | Some entry ->
           if String.equal decision "deny" then (
-            let goal_denial_result =
+            let goal_denial_request =
               if
                 String.equal
                   entry.action_type
@@ -528,18 +528,23 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                     Operator_action_constants.goal_decision_reject
                     entry.payload
                 in
-                execute_action
-                  ctx
-                  { actor = entry.actor
-                  ; action_type = entry.action_type
-                  ; target_type = entry.target_type
-                  ; target_id = entry.target_id
-                  ; payload
-                  }
-                |> Result.map Option.some
+                Ok
+                  (Some
+                     { actor = entry.actor
+                     ; action_type = entry.action_type
+                     ; target_type = entry.target_type
+                     ; target_id = entry.target_id
+                     ; payload
+                     })
               else Ok None
             in
-            remove_pending_confirm ctx.config confirm_token;
+            let* goal_denial_request = goal_denial_request in
+            let* () = remove_pending_confirm ctx.config confirm_token in
+            let goal_denial_result =
+              match goal_denial_request with
+              | Some request -> execute_action ctx request |> Result.map Option.some
+              | None -> Ok None
+            in
             append_action_log ctx.config
               {
                 trace_id = entry.trace_id;
@@ -586,8 +591,8 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 payload = entry.payload;
               }
             in
+            let* () = remove_pending_confirm ctx.config confirm_token in
             let* executed = execute_action ctx request in
-            remove_pending_confirm ctx.config confirm_token;
             let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
             append_action_log ctx.config
               {

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -147,9 +147,12 @@ let raw_pending_confirms config : pending_confirm list =
         entries
   | Some _ -> []
 
+let pending_confirms_to_yojson entries =
+  `List (List.map pending_confirm_to_yojson entries)
+
 let write_pending_confirms config (entries : pending_confirm list) =
-  Workspace_utils.write_json config (pending_confirms_path config)
-    (`List (List.map pending_confirm_to_yojson entries))
+  Workspace_utils.write_json_result config (pending_confirms_path config)
+    (pending_confirms_to_yojson entries)
 
 let pending_confirm_expired (entry : pending_confirm) =
   match entry.expires_at with
@@ -159,7 +162,15 @@ let pending_confirm_expired (entry : pending_confirm) =
 let read_pending_confirms config : pending_confirm list =
   let entries = raw_pending_confirms config in
   let active = List.filter (fun entry -> not (pending_confirm_expired entry)) entries in
-  if List.length active <> List.length entries then write_pending_confirms config active;
+  let () =
+    if List.length active <> List.length entries then
+      match write_pending_confirms config active with
+      | Ok () -> ()
+      | Error msg ->
+        Log.Misc.warn
+          "[operator_pending_confirm] failed to persist expired cleanup: %s"
+          msg
+  in
   active
 
 let upsert_pending_confirm config entry =
@@ -187,8 +198,9 @@ let remove_pending_confirms_by_target config ~target_type ~target_id =
       all
   in
   let removed = List.length all - List.length remaining in
-  if removed > 0 then write_pending_confirms config remaining;
-  removed
+  if removed > 0 then
+    write_pending_confirms config remaining |> Result.map (fun () -> removed)
+  else Ok 0
 
 let normalize_pending_confirm_actor_filter = function
   | Some raw ->

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -38,13 +38,15 @@ val preview_of_pending_confirm : pending_confirm -> Yojson.Safe.t
 val pending_confirm_to_yojson : pending_confirm -> Yojson.Safe.t
 val pending_confirm_of_yojson : Yojson.Safe.t -> (pending_confirm, string) result
 val raw_pending_confirms : Workspace.config -> pending_confirm list
-val write_pending_confirms : Workspace.config -> pending_confirm list -> unit
+val write_pending_confirms :
+  Workspace.config -> pending_confirm list -> (unit, string) result
 val pending_confirm_expired : pending_confirm -> bool
 val read_pending_confirms : Workspace.config -> pending_confirm list
-val upsert_pending_confirm : Workspace.config -> pending_confirm -> unit
-val remove_pending_confirm : Workspace.config -> string -> unit
+val upsert_pending_confirm :
+  Workspace.config -> pending_confirm -> (unit, string) result
+val remove_pending_confirm : Workspace.config -> string -> (unit, string) result
 val remove_pending_confirms_by_target :
-  Workspace.config -> target_type:string -> target_id:string option -> int
+  Workspace.config -> target_type:string -> target_id:string option -> (int, string) result
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Workspace.config -> pending_confirm_scope

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -413,20 +413,19 @@ let () =
   Atomic.set
     Workspace_hooks.operator_pending_confirm_upsert_fn
     (fun config (entry : Workspace_hooks.operator_pending_confirm_request) ->
-       Operator_pending_confirm.upsert_pending_confirm
-         config
-         { token = entry.token
-         ; trace_id = entry.trace_id
-         ; actor = entry.actor
-         ; action_type = entry.action_type
-         ; target_type = entry.target_type
-         ; target_id = entry.target_id
-         ; payload = entry.payload
-         ; delegated_tool = entry.delegated_tool
-         ; created_at = entry.created_at
-         ; expires_at = entry.expires_at
-         };
-       Ok ());
+      Operator_pending_confirm.upsert_pending_confirm
+        config
+        { token = entry.token
+        ; trace_id = entry.trace_id
+        ; actor = entry.actor
+        ; action_type = entry.action_type
+        ; target_type = entry.target_type
+        ; target_id = entry.target_id
+        ; payload = entry.payload
+        ; delegated_tool = entry.delegated_tool
+        ; created_at = entry.created_at
+        ; expires_at = entry.expires_at
+        });
   Atomic.set
     Workspace_hooks.operator_pending_confirm_remove_fn
     Operator_pending_confirm.remove_pending_confirm;

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -56,6 +56,30 @@ let respond_error ?(status = `Bad_request) ~request reqd message =
     reqd
 ;;
 
+let sum_pending_confirm_removals config ~target_type target_ids =
+  target_ids
+  |> List.fold_left
+       (fun acc target_id ->
+         match acc with
+         | Error _ -> acc
+         | Ok total -> (
+           match
+             Operator_pending_confirm.remove_pending_confirms_by_target
+               config
+               ~target_type
+               ~target_id:(Some target_id)
+           with
+           | Ok removed -> Ok (total + removed)
+           | Error msg ->
+             Error
+               (Printf.sprintf
+                  "pending-confirm cleanup failed for %s %s: %s"
+                  target_type
+                  target_id
+                  msg)))
+       (Ok 0)
+;;
+
 let rec rm_rf path =
   if Fs_compat.file_exists path
   then if Sys.is_directory path
@@ -236,37 +260,41 @@ let resolve_agent_purge_targets config agent_names =
 let purge_agent_filesystem_artifacts config agent_names =
   agent_names
   |> resolve_agent_purge_targets config
-  |> List.map (fun { agent_name; aliases } ->
-       let pending_confirms_removed =
-         aliases
-         |> List.map (fun alias ->
-              Operator_pending_confirm.remove_pending_confirms_by_target config
-                ~target_type:"agent" ~target_id:(Some alias))
-         |> List.fold_left ( + ) 0
-       in
-       let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
-       let workspace_unbind_result =
-         Workspace.end_session ~stop_heartbeats:false config ~agent_name
-       in
-       let aliases_label = String.concat "," aliases in
-       Log.Misc.info
-         "[agent_purge] cleanup agent=%s aliases=%s pending_confirms_removed=%d heartbeats_stopped=%d workspace_unbind=%S"
-         agent_name aliases_label pending_confirms_removed heartbeats_stopped
-         workspace_unbind_result;
-       aliases
-       |> List.iter (fun alias ->
-            remove_path_if_exists ~context:"agent_purge"
-              (agent_file_path config alias);
-            remove_path_if_exists ~context:"agent_purge"
-              (Metrics_store_eio.agent_metrics_dir config alias);
-            Tool_shard.remove_agent_shards alias;
-            credential_aliases alias
-            |> List.iter (Auth.delete_credential config.base_path));
-       { agent_name
-       ; pending_confirms_removed
-       ; heartbeats_stopped
-       ; workspace_unbind_result
-       })
+  |> List.fold_left
+       (fun acc { agent_name; aliases } ->
+         match acc with
+         | Error _ -> acc
+         | Ok results -> (
+           match sum_pending_confirm_removals config ~target_type:"agent" aliases with
+           | Error msg -> Error msg
+           | Ok pending_confirms_removed ->
+             let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
+             let workspace_unbind_result =
+               Workspace.end_session ~stop_heartbeats:false config ~agent_name
+             in
+             let aliases_label = String.concat "," aliases in
+             Log.Misc.info
+               "[agent_purge] cleanup agent=%s aliases=%s pending_confirms_removed=%d heartbeats_stopped=%d workspace_unbind=%S"
+               agent_name aliases_label pending_confirms_removed heartbeats_stopped
+               workspace_unbind_result;
+             aliases
+             |> List.iter (fun alias ->
+                  remove_path_if_exists ~context:"agent_purge"
+                    (agent_file_path config alias);
+                  remove_path_if_exists ~context:"agent_purge"
+                    (Metrics_store_eio.agent_metrics_dir config alias);
+                  Tool_shard.remove_agent_shards alias;
+                  credential_aliases alias
+                  |> List.iter (Auth.delete_credential config.base_path));
+             Ok
+               ({ agent_name
+                ; pending_confirms_removed
+                ; heartbeats_stopped
+                ; workspace_unbind_result
+                }
+                :: results)))
+       (Ok [])
+  |> Result.map List.rev
 ;;
 
 let purge_keeper_artifacts config requested_name
@@ -281,17 +309,26 @@ let purge_keeper_artifacts config requested_name
   cleanup_names
   |> List.iter (fun name ->
        Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
-  let keeper_pending_confirms_removed =
-    Operator_pending_confirm.remove_pending_confirms_by_target config
-      ~target_type:"keeper" ~target_id:(Some keeper_name)
-  in
+  match
+    Operator_pending_confirm.remove_pending_confirms_by_target
+      config
+      ~target_type:"keeper"
+      ~target_id:(Some keeper_name)
+  with
+  | Error msg ->
+    Error
+      (Printf.sprintf
+         "pending-confirm cleanup failed for keeper %s: %s"
+         keeper_name
+         msg)
+  | Ok keeper_pending_confirms_removed ->
   Log.Misc.info
     "[keeper_purge] cleanup keeper=%s pending_confirms_removed=%d"
     keeper_name keeper_pending_confirms_removed;
   Keeper_registry.unregister ~base_path:config.base_path keeper_name;
-  let agent_cleanup_results =
-    purge_agent_filesystem_artifacts config [ agent_name; keeper_name ]
-  in
+  (match purge_agent_filesystem_artifacts config [ agent_name; keeper_name ] with
+   | Error _ as err -> err
+   | Ok agent_cleanup_results ->
   List.iter
     (remove_path_if_exists ~context:"keeper_purge")
     [
@@ -311,7 +348,7 @@ let purge_keeper_artifacts config requested_name
          (Keeper_types_support.keeper_session_dir config keeper_trace_id))
     trace_id;
   Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path;
-  { keeper_pending_confirms_removed; agent_cleanup_results }
+  Ok { keeper_pending_confirms_removed; agent_cleanup_results })
 ;;
 
 let add_delete_action_routes router =
@@ -455,9 +492,14 @@ let add_delete_action_routes router =
                (match resolve_keeper_purge_target config requested_name with
                 | Some keeper_target ->
                   let toml_deleted = Option.is_some keeper_target.toml_path in
-                  let purge_result =
-                    purge_keeper_artifacts config requested_name keeper_target
-                  in
+                  (match purge_keeper_artifacts config requested_name keeper_target with
+                   | Error msg ->
+                     respond_error
+                       ~status:`Internal_server_error
+                       ~request:req
+                       reqd
+                       msg
+                   | Ok purge_result ->
                   Http.Response.json_value ~compress:true ~request:req
                     (`Assoc
                        [
@@ -473,14 +515,21 @@ let add_delete_action_routes router =
                              (List.map agent_purge_cleanup_result_to_json
                                 purge_result.agent_cleanup_results) );
                        ])
-                    reqd
+                    reqd)
                 | None -> (
                   match resolve_plain_agent_target config requested_name with
                   | Some agent_name ->
-                    let cleanup_results =
-                      purge_agent_filesystem_artifacts config
-                        [ requested_name; agent_name ]
-                    in
+                    (match
+                       purge_agent_filesystem_artifacts config
+                         [ requested_name; agent_name ]
+                     with
+                     | Error msg ->
+                       respond_error
+                         ~status:`Internal_server_error
+                         ~request:req
+                         reqd
+                         msg
+                     | Ok cleanup_results ->
                     Http.Response.json_value ~compress:true ~request:req
                       (`Assoc
                          [
@@ -492,7 +541,7 @@ let add_delete_action_routes router =
                                (List.map agent_purge_cleanup_result_to_json
                                   cleanup_results) );
                          ])
-                      reqd
+                      reqd)
                   | None ->
                     respond_error ~status:`Not_found ~request:req reqd
                       "agent or keeper not found"))

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -170,9 +170,9 @@ let operator_pending_confirm_upsert_fn
       Error "operator pending-confirm callback is not connected")
 
 let operator_pending_confirm_remove_fn
-  : (Workspace_utils_backend_setup.config -> string -> unit) Atomic.t
+  : (Workspace_utils_backend_setup.config -> string -> (unit, string) result) Atomic.t
   =
-  Atomic.make (fun _config _token -> ())
+  Atomic.make (fun _config _token -> Ok ())
 
 
 (** Auto-subscribe agent to messages on session binding — wraps Subscriptions.SubscriptionStore. *)

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -172,7 +172,9 @@ let operator_pending_confirm_upsert_fn
 let operator_pending_confirm_remove_fn
   : (Workspace_utils_backend_setup.config -> string -> (unit, string) result) Atomic.t
   =
-  Atomic.make (fun _config _token -> Ok ())
+  Atomic.make
+    (fun _config _token ->
+      Error "operator pending-confirm callback is not connected")
 
 
 (** Auto-subscribe agent to messages on session binding — wraps Subscriptions.SubscriptionStore. *)

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -75,7 +75,7 @@ val operator_pending_confirm_upsert_fn :
     Atomic.t
 
 val operator_pending_confirm_remove_fn :
-  (Workspace_utils_backend_setup.config -> string -> unit) Atomic.t
+  (Workspace_utils_backend_setup.config -> string -> (unit, string) result) Atomic.t
 
 val subscribe_messages_fn : (subscriber:string -> unit) Atomic.t
 val fsm_drift_observer_fn : (variant:string -> force:bool -> agent_name:string -> unit)

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -154,6 +154,26 @@ let clear_goal_approval_pending_confirm_best_effort ctx ~goal_id =
       msg
 ;;
 
+let clear_goal_approval_pending_confirm_required
+      ctx
+      ~goal_id
+      ~tool_name
+      ~start_time
+      ~on_cleared
+  =
+  match clear_goal_approval_pending_confirm ctx ~goal_id with
+  | Ok () -> on_cleared ()
+  | Error msg ->
+    error_result_typed
+      ~tool_name
+      ~start_time
+      ~code:Internal_error
+      (Printf.sprintf
+         "failed to clear goal approval pending confirm for %s: %s"
+         goal_id
+         msg)
+;;
+
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
 
 (* RFC-0089: derive the accepted-value sets from the Goal_phase ADT (the goal
@@ -813,26 +833,35 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                   | Error msg ->
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
+                    let on_cleared () =
+                      emit_goal_event
+                        ctx
+                        ~goal_id
+                        ~event_type:"goal_phase"
+                        ~payload:
+                          (`Assoc
+                              [ "phase", Goal_phase.to_yojson updated_goal.phase
+                              ; "actor", Goal_verification.goal_principal_to_yojson actor
+                              ]);
+                      ok_result
+                        ~tool_name
+                        ~start_time
+                        [ "goal_id", `String goal_id
+                        ; "action", `String (Goal_phase.action_to_string action)
+                        ; "goal", Goal_store.goal_to_yojson updated_goal
+                        ; ( "verification_summary"
+                          , verification_summary_json updated_goal effective_policy None )
+                        ]
+                    in
                     if goal.phase = Goal_phase.Awaiting_approval
-                    then clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
-                    emit_goal_event
-                      ctx
-                      ~goal_id
-                      ~event_type:"goal_phase"
-                      ~payload:
-                        (`Assoc
-                            [ "phase", Goal_phase.to_yojson updated_goal.phase
-                            ; "actor", Goal_verification.goal_principal_to_yojson actor
-                            ]);
-                    ok_result
-                      ~tool_name
-                      ~start_time
-                      [ "goal_id", `String goal_id
-                      ; "action", `String (Goal_phase.action_to_string action)
-                      ; "goal", Goal_store.goal_to_yojson updated_goal
-                      ; ( "verification_summary"
-                        , verification_summary_json updated_goal effective_policy None )
-                      ])
+                    then
+                      clear_goal_approval_pending_confirm_required
+                        ctx
+                        ~goal_id
+                        ~tool_name
+                        ~start_time
+                        ~on_cleared
+                    else on_cleared ())
                | Ok (Goal_phase.Move_to next_phase) ->
                  (match goal.active_verification_request_id, next_phase with
                   | ( Some request_id
@@ -880,42 +909,51 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                   | Error msg ->
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
-                    if goal.phase = Goal_phase.Awaiting_approval
-                    then clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
-                    emit_goal_event
-                      ctx
-                      ~goal_id
-                      ~event_type:"goal_phase"
-                      ~payload:
-                        (`Assoc
-                            [ "phase", Goal_phase.to_yojson updated_goal.phase
-                            ; "actor", Goal_verification.goal_principal_to_yojson actor
-                            ]);
-                    if
-                      action = Goal_phase.Approve_completion
-                      || action = Goal_phase.Reject_completion
-                    then
+                    let on_cleared () =
                       emit_goal_event
                         ctx
                         ~goal_id
-                        ~event_type:"goal_approval_resolved"
+                        ~event_type:"goal_phase"
                         ~payload:
                           (`Assoc
-                              [ ( "decision"
-                                , `String
-                                    (if action = Goal_phase.Approve_completion
-                                     then "approve"
-                                     else "reject") )
+                              [ "phase", Goal_phase.to_yojson updated_goal.phase
+                              ; "actor", Goal_verification.goal_principal_to_yojson actor
                               ]);
-                    ok_result
-                      ~tool_name
-                      ~start_time
-                      [ "goal_id", `String goal_id
-                      ; "action", `String (Goal_phase.action_to_string action)
-                      ; "goal", Goal_store.goal_to_yojson updated_goal
-                      ; ( "verification_summary"
-                        , verification_summary_json updated_goal effective_policy None )
-                      ])))))
+                      if
+                        action = Goal_phase.Approve_completion
+                        || action = Goal_phase.Reject_completion
+                      then
+                        emit_goal_event
+                          ctx
+                          ~goal_id
+                          ~event_type:"goal_approval_resolved"
+                          ~payload:
+                            (`Assoc
+                                [ ( "decision"
+                                  , `String
+                                      (if action = Goal_phase.Approve_completion
+                                       then "approve"
+                                       else "reject") )
+                                ]);
+                      ok_result
+                        ~tool_name
+                        ~start_time
+                        [ "goal_id", `String goal_id
+                        ; "action", `String (Goal_phase.action_to_string action)
+                        ; "goal", Goal_store.goal_to_yojson updated_goal
+                        ; ( "verification_summary"
+                          , verification_summary_json updated_goal effective_policy None )
+                        ]
+                    in
+                    if goal.phase = Goal_phase.Awaiting_approval
+                    then
+                      clear_goal_approval_pending_confirm_required
+                        ctx
+                        ~goal_id
+                        ~tool_name
+                        ~start_time
+                        ~on_cleared
+                    else on_cleared ())))))
   | Ok _, Ok None, _ ->
     validation_error_result
       ~tool_name

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -144,6 +144,16 @@ let clear_goal_approval_pending_confirm ctx ~goal_id =
     (goal_approval_pending_confirm_token goal_id)
 ;;
 
+let clear_goal_approval_pending_confirm_best_effort ctx ~goal_id =
+  match clear_goal_approval_pending_confirm ctx ~goal_id with
+  | Ok () -> ()
+  | Error msg ->
+    Log.Misc.warn
+      "failed to clear goal approval pending confirm for %s: %s"
+      goal_id
+      msg
+;;
+
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
 
 (* RFC-0089: derive the accepted-value sets from the Goal_phase ADT (the goal
@@ -762,7 +772,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                          ()
                      with
                   | Error msg ->
-                    clear_goal_approval_pending_confirm ctx ~goal_id;
+                    clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
                     emit_goal_event
@@ -804,7 +814,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
                     if goal.phase = Goal_phase.Awaiting_approval
-                    then clear_goal_approval_pending_confirm ctx ~goal_id;
+                    then clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
                     emit_goal_event
                       ctx
                       ~goal_id
@@ -871,7 +881,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
                     if goal.phase = Goal_phase.Awaiting_approval
-                    then clear_goal_approval_pending_confirm ctx ~goal_id;
+                    then clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
                     emit_goal_event
                       ctx
                       ~goal_id
@@ -1097,7 +1107,7 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                        ~goal_id
                        ~event_type:"goal_approval_opened"
                        ~payload:(`Assoc [ "request_id", `String request.id ])
-                   else clear_goal_approval_pending_confirm ctx ~goal_id;
+                   else clear_goal_approval_pending_confirm_best_effort ctx ~goal_id;
                    result)
                 else finalize ~phase:Goal_phase.Completed ~event_status:"approved"
               | Goal_verification.Failed ->

--- a/test/dune
+++ b/test/dune
@@ -83,6 +83,7 @@
   test_host_fd_pressure_poller
   test_operator_control_snapshot_state
   test_operator_control_snapshot
+  test_operator_control_judgment
   test_with_cleanups_on_release
   test_auth_login
   test_audit_log
@@ -412,6 +413,7 @@
   test_host_fd_pressure_poller
   test_operator_control_snapshot_state
   test_operator_control_snapshot
+  test_operator_control_judgment
   test_operator_control_support
   test_with_cleanups_on_release
   test_auth_login

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1016,6 +1016,51 @@ let test_goal_approval_drop_clears_pending_confirm () =
          (List.length (Operator_pending_confirm.read_pending_confirms config)))
 ;;
 
+let test_goal_approval_clear_failure_is_reported () =
+  with_goal_awaiting_completion_approval
+    ~title:"Reject approval clear failure"
+    (fun config goal ->
+       let previous_remove =
+         Atomic.get Workspace_hooks.operator_pending_confirm_remove_fn
+       in
+       Fun.protect
+         ~finally:(fun () ->
+           Atomic.set Workspace_hooks.operator_pending_confirm_remove_fn previous_remove)
+         (fun () ->
+            Atomic.set
+              Workspace_hooks.operator_pending_confirm_remove_fn
+              (fun _config _token -> Error "forced pending-confirm clear failure");
+            let rejected =
+              Tool_workspace.dispatch
+                (workspace_ctx ~agent_name:"operator" config)
+                ~name:"masc_goal_transition"
+                ~args:
+                  (`Assoc
+                      [ "goal_id", `String goal.id
+                      ; "action", `String "reject_completion"
+                      ; "actor", principal_json ~id:"operator"
+                      ])
+            in
+            let error_json = expect_error rejected in
+            check
+              string
+              "clear failure is surfaced"
+              "internal_error"
+              (get_string_field error_json "error_code");
+            check
+              bool
+              "error names pending confirm clear"
+              true
+              (contains_substring
+                 (get_error_message_field error_json)
+                 "failed to clear goal approval pending confirm");
+            check
+              int
+              "approval request remains when clear fails"
+              1
+              (List.length (Operator_pending_confirm.read_pending_confirms config))))
+;;
+
 let test_goal_principal_display_name_canonicalized () =
   with_workspace
   @@ fun config ->
@@ -1776,6 +1821,10 @@ let () =
             "approval drop clears pending confirm"
             `Quick
             test_goal_approval_drop_clears_pending_confirm
+        ; test_case
+            "approval clear failure is reported"
+            `Quick
+            test_goal_approval_clear_failure_is_reported
         ; test_case
             "principal display labels are canonicalized"
             `Quick

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -68,20 +68,19 @@ let with_operator_pending_confirm_hooks f =
   Atomic.set
     Workspace_hooks.operator_pending_confirm_upsert_fn
     (fun config (entry : Workspace_hooks.operator_pending_confirm_request) ->
-       Operator_pending_confirm.upsert_pending_confirm
-         config
-         { token = entry.token
-         ; trace_id = entry.trace_id
-         ; actor = entry.actor
-         ; action_type = entry.action_type
-         ; target_type = entry.target_type
-         ; target_id = entry.target_id
-         ; payload = entry.payload
-         ; delegated_tool = entry.delegated_tool
-         ; created_at = entry.created_at
-         ; expires_at = entry.expires_at
-         };
-       Ok ());
+      Operator_pending_confirm.upsert_pending_confirm
+        config
+        { token = entry.token
+        ; trace_id = entry.trace_id
+        ; actor = entry.actor
+        ; action_type = entry.action_type
+        ; target_type = entry.target_type
+        ; target_id = entry.target_id
+        ; payload = entry.payload
+        ; delegated_tool = entry.delegated_tool
+        ; created_at = entry.created_at
+        ; expires_at = entry.expires_at
+        });
   Atomic.set
     Workspace_hooks.operator_pending_confirm_remove_fn
     Operator_pending_confirm.remove_pending_confirm;
@@ -1694,19 +1693,23 @@ let test_operator_goal_decision_requires_explicit_decision () =
        ignore (Workspace.init config ~agent_name:(Some "operator"));
        let ctx = operator_ctx env sw config "operator" in
        let assert_rejected ~token payload =
-         Operator_pending_confirm.upsert_pending_confirm
-           config
-           { token
-           ; trace_id = "goal_missing_decision"
-           ; actor = "operator"
-           ; action_type = Operator_action_constants.goal_completion_decision
-           ; target_type = Operator_action_constants.goal_target_type
-           ; target_id = Some "goal-1"
-           ; payload
-           ; delegated_tool = Operator_action_constants.goal_transition_tool
-           ; created_at = Masc_domain.now_iso ()
-           ; expires_at = None
-           };
+        (match
+           Operator_pending_confirm.upsert_pending_confirm
+             config
+             { token
+             ; trace_id = "goal_missing_decision"
+             ; actor = "operator"
+             ; action_type = Operator_action_constants.goal_completion_decision
+             ; target_type = Operator_action_constants.goal_target_type
+             ; target_id = Some "goal-1"
+             ; payload
+             ; delegated_tool = Operator_action_constants.goal_transition_tool
+             ; created_at = Masc_domain.now_iso ()
+             ; expires_at = None
+             }
+         with
+         | Ok () -> ()
+         | Error msg -> fail msg);
          match
            Operator_control.confirm_json
              ctx

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -183,10 +183,10 @@ let test_turn_lifecycle_callback () =
   let called = ref false in
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target (fun _config ~target_type:_ ~target_id:_ ->
     called := true;
-    7);
+    Ok 7);
   let n = Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target ~config:(Obj.magic ()) ~target_type:"keeper" ~target_id:(Some "k") in
   check bool "remove pending confirms callback invoked" true !called;
-  check int "remove pending confirms returned value" 7 n;
+  check (result int string) "remove pending confirms returned value" (Ok 7) n;
   Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ()
 ;;
 

--- a/test/test_normalized_actor.ml
+++ b/test/test_normalized_actor.ml
@@ -64,7 +64,7 @@ let test_upsert_reports_persistence_failure () =
       | Error msg ->
           check bool "error mentions local write" true
             (String.contains msg ':'
-            && String.contains msg '/'
+            && String.contains msg Filename.dir_sep.[0]
             && String.length msg > 0))
 
 let test_remove_reports_persistence_failure () =
@@ -87,7 +87,7 @@ let test_remove_reports_persistence_failure () =
       | Error msg ->
           check bool "error mentions local write" true
             (String.contains msg ':'
-            && String.contains msg '/'
+            && String.contains msg Filename.dir_sep.[0]
             && String.length msg > 0))
 
 let tests =

--- a/test/test_normalized_actor.ml
+++ b/test/test_normalized_actor.ml
@@ -1,7 +1,21 @@
 open Alcotest
+open Masc
 module Opc = Operator_pending_confirm
 
 let na = Opc.normalized_actor
+
+let temp_dir () =
+  Filename.temp_dir "test_operator_pending_confirm_" ""
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
 
 let test_explicit_raw () =
   check string "explicit raw" "alice" (na ~context_actor:"" (Some "alice"))
@@ -24,6 +38,58 @@ let test_unknown_context_returns_unknown () =
 let test_whitespace_context_returns_unknown () =
   check string "whitespace context" "unknown" (na ~context_actor:"  " None)
 
+let pending_confirm_fixture token =
+  { Opc.token = token
+  ; trace_id = "ops_test"
+  ; actor = "operator"
+  ; action_type = "namespace_pause"
+  ; target_type = "root"
+  ; target_id = None
+  ; payload = `Assoc []
+  ; delegated_tool = "masc_pause"
+  ; created_at = Masc_domain.now_iso ()
+  ; expires_at = None
+  }
+
+let test_upsert_reports_persistence_failure () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      Workspace_utils.mkdir_p (Opc.operator_dir config);
+      Unix.mkdir (Opc.pending_confirms_path config) 0o755;
+      match Opc.upsert_pending_confirm config (pending_confirm_fixture "token-upsert") with
+      | Ok () -> fail "upsert should report persistence failure"
+      | Error msg ->
+          check bool "error mentions local write" true
+            (String.contains msg ':'
+            && String.contains msg '/'
+            && String.length msg > 0))
+
+let test_remove_reports_persistence_failure () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      Workspace_utils.mkdir_p (Opc.operator_dir config);
+      (match
+         Opc.write_pending_confirms config
+           [ pending_confirm_fixture "token-remove" ]
+       with
+      | Ok () -> ()
+      | Error msg -> fail msg);
+      Sys.remove (Opc.pending_confirms_path config);
+      Unix.mkdir (Opc.pending_confirms_path config) 0o755;
+      match Opc.remove_pending_confirm config "token-remove" with
+      | Ok () -> fail "remove should report persistence failure"
+      | Error msg ->
+          check bool "error mentions local write" true
+            (String.contains msg ':'
+            && String.contains msg '/'
+            && String.length msg > 0))
+
 let tests =
   [
     test_case "explicit raw" `Quick test_explicit_raw;
@@ -33,6 +99,8 @@ let tests =
     test_case "blank context returns unknown" `Quick test_blank_context_returns_unknown;
     test_case "unknown context returns unknown" `Quick test_unknown_context_returns_unknown;
     test_case "whitespace context returns unknown" `Quick test_whitespace_context_returns_unknown;
+    test_case "upsert reports persistence failure" `Quick test_upsert_reports_persistence_failure;
+    test_case "remove reports persistence failure" `Quick test_remove_reports_persistence_failure;
   ]
 
 let () = run "normalized_actor" [ ("normalized_actor", tests) ]

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -200,7 +200,7 @@ let test_operator_judgment_rejects_retired_target_type_aliases () =
             "write rejects namespace"
             "target_type must be root" err)
 
-let test_confirm_keeps_pending_token_when_delegated_action_fails () =
+let test_confirm_consumes_pending_token_before_delegated_action_fails () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -229,7 +229,16 @@ let test_confirm_keeps_pending_token_when_delegated_action_fails () =
             ("expires_at", `Null);
           ]
       in
-      Workspace_utils.write_json config path (`List [ entry_json ]);
+      (match Workspace_utils.write_json_result config path (`List [ entry_json ]) with
+       | Ok () -> ()
+       | Error err -> Alcotest.failf "failed to persist pending confirm fixture: %s" err);
+      let initial_pending_confirms =
+        Operator_control.pending_confirms_json ~actor:"operator" config
+        |> Yojson.Safe.Util.to_list
+      in
+      Alcotest.(check int)
+        "pending confirm fixture persisted" 1
+        (List.length initial_pending_confirms);
       let ctx = operator_ctx env sw config "operator" in
       (match
          Operator_control.confirm_json ctx
@@ -242,9 +251,25 @@ let test_confirm_keeps_pending_token_when_delegated_action_fails () =
         Operator_control.pending_confirms_json ~actor:"operator" config
         |> Yojson.Safe.Util.to_list
       in
-      Alcotest.(check int) "pending confirm retained" 1 (List.length pending_confirms);
-      Alcotest.(check string) "same token retained" token
-        Yojson.Safe.Util.(List.hd pending_confirms |> member "token" |> to_string))
+      Alcotest.(check int) "pending confirm consumed" 0 (List.length pending_confirms))
 
 (* test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn
    removed: depended on team session start/update which is no longer available. *)
+
+let tests =
+  [
+    Alcotest.test_case "digest prefers fresh operator judgment" `Quick
+      test_digest_workspace_prefers_fresh_operator_judgment;
+    Alcotest.test_case "digest ignores stale operator judgment" `Quick
+      test_digest_workspace_ignores_stale_operator_judgment;
+    Alcotest.test_case "guidance ignores unsupported target type" `Quick
+      test_guidance_ignores_unsupported_target_type;
+    Alcotest.test_case "operator judgment write/latest roundtrip" `Quick
+      test_operator_judgment_write_and_latest_roundtrip;
+    Alcotest.test_case "rejects retired target type aliases" `Quick
+      test_operator_judgment_rejects_retired_target_type_aliases;
+    Alcotest.test_case "confirm consumes token before delegated action failure" `Quick
+      test_confirm_consumes_pending_token_before_delegated_action_fails;
+  ]
+
+let () = Alcotest.run "operator_control_judgment" [ ("operator_control_judgment", tests) ]

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -136,7 +136,7 @@ let test_operator_judgment_write_and_latest_roundtrip () =
             (`Assoc
               [
                 ("surface", `String "command.namespace");
-                ("target_type", `String "root");
+                ("target_type", `String "workspace");
                 ("summary", `String "Operator judge requests a human checkpoint.");
                 ("confidence", `Float 0.88);
                 ("fresh_ttl_sec", `Int 90);
@@ -151,7 +151,8 @@ let test_operator_judgment_write_and_latest_roundtrip () =
       let latest =
         match
           Operator_control.judgment_latest_json ctx
-            (`Assoc [ ("surface", `String "command.namespace"); ("target_type", `String "root") ])
+            (`Assoc
+              [ ("surface", `String "command.namespace"); ("target_type", `String "workspace") ])
         with
         | Ok json -> json
         | Error err -> Alcotest.fail err


### PR DESCRIPTION
## Summary
- migrate operator pending-confirm write/upsert/remove paths from silent write_json to write_json_result
- propagate pending-confirm persistence failures through operator action/confirm, keeper cleanup, and dashboard purge surfaces
- consume confirmed tokens durably before delegated action execution to prevent replay after delete failure
- update hook contracts and regression tests for persistence failures

## Validation
- ocamlformat --check lib/operator/operator_pending_confirm.ml lib/operator/operator_pending_confirm.mli lib/operator/operator_control.ml lib/workspace/workspace_hooks.ml lib/workspace/workspace_hooks.mli lib/operator/operator_tool.ml lib/keeper/keeper_turn_lifecycle.ml lib/keeper/keeper_turn_lifecycle.mli lib/server/server_dashboard_http_delete_actions.ml lib/workspace_goals.ml test/test_goal_tools.ml test/test_keeper_global_shared_refs_atomic.ml test/test_normalized_actor.ml test/test_operator_control_judgment.ml
- git diff --check

Not run: local Dune build/tests, per operator request; CI is the build authority for this slice.

Refs #21990