### PR TITLE
fix(keeper): decouple no-progress resume from recovery-stimulus drop failure (KLV-2)

### DIFF
--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -106,69 +106,81 @@ let clear_if_recovered ~(config : Workspace.config) meta ~previous_streak ~was_l
 
 let clear_for_operator_resume ~base_path meta =
   let keeper_name = meta.Keeper_meta_contract.name in
-  match
-    Keeper_registry_event_queue.drop_by_post_id
-      ~base_path
-      keeper_name
-      ~post_id:(recovery_post_id ~keeper_name)
-  with
-  | Error msg ->
-    Log.Keeper.warn
-      "%s: operator resume kept no_progress latch/blocker because recovery stimulus removal failed: %s"
-      keeper_name
-      msg;
-    Error msg
-  | Ok dropped_recovery_stimuli ->
-    let was_latched = Keeper_no_progress_loop_detector.is_latched ~keeper_name in
-    Keeper_no_progress_loop_detector.reset ~keeper_name;
-    List.iter
-      (fun stimulus ->
-        try
-          Keeper_reaction_ledger.record_event_queue_reaction
-            ~base_path
-            ~keeper_name
-            ~reaction_kind:Keeper_reaction_ledger.Operator_escalation
-            stimulus
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-          Log.Keeper.warn
-            "%s: failed to persist operator-resume no-progress recovery reaction: %s"
-            keeper_name
-            (Printexc.to_string exn))
-      dropped_recovery_stimuli;
-    let cleared_failure_reason =
-      match Keeper_registry.get ~base_path keeper_name with
-      | Some { Keeper_registry.last_failure_reason =
-                 Some (Keeper_registry.Provider_runtime_error { code; _ })
-             ; _
-             }
-        when String.equal code failure_reason_code ->
-        Keeper_registry.set_failure_reason ~base_path keeper_name None;
-        true
-      | _ -> false
-    in
-    let cleared_meta_blocker =
-      match meta.runtime.last_blocker with
-      | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
-        true
-      | _ -> false
-    in
-    if
-      was_latched
-      || cleared_failure_reason
-      || cleared_meta_blocker
-      || dropped_recovery_stimuli <> []
-    then
-      Log.Keeper.info
-        "%s: operator resume cleared no_progress loop latch/blocker (latched=%b failure_reason=%b meta_blocker=%b dropped_recovery_stimuli=%d)"
+  (* KLV-2 (RFC-keeper-liveness-ssot §3): dropping the recovery stimulus
+     from the event queue is best-effort bookkeeping, not a precondition
+     for resume. It used to gate the critical clears below (detector
+     latch, registry failure_reason, meta.last_blocker) behind an [Error]
+     return — a transient disk failure on this cosmetic step permanently
+     blocked every operator resume path (dashboard directive, masc_keeper_up,
+     keepalive persist all treat [Error] here as "resume failed"), since
+     Manual_resume_required pauses have no other recovery route. Log and
+     continue with an empty stimulus list instead of failing the resume. *)
+  let dropped_recovery_stimuli =
+    match
+      Keeper_registry_event_queue.drop_by_post_id
+        ~base_path
         keeper_name
-        was_latched
-        cleared_failure_reason
-        cleared_meta_blocker
-        (List.length dropped_recovery_stimuli);
-    Ok
-      (if cleared_meta_blocker then
-         Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
-       else meta)
+        ~post_id:(recovery_post_id ~keeper_name)
+    with
+    | Ok dropped -> dropped
+    | Error msg ->
+      Log.Keeper.warn
+        "%s: operator resume could not drop recovery stimulus (best-effort \
+         cleanup; resume proceeds): %s"
+        keeper_name
+        msg;
+      []
+  in
+  let was_latched = Keeper_no_progress_loop_detector.is_latched ~keeper_name in
+  Keeper_no_progress_loop_detector.reset ~keeper_name;
+  List.iter
+    (fun stimulus ->
+      try
+        Keeper_reaction_ledger.record_event_queue_reaction
+          ~base_path
+          ~keeper_name
+          ~reaction_kind:Keeper_reaction_ledger.Operator_escalation
+          stimulus
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Log.Keeper.warn
+          "%s: failed to persist operator-resume no-progress recovery reaction: %s"
+          keeper_name
+          (Printexc.to_string exn))
+    dropped_recovery_stimuli;
+  let cleared_failure_reason =
+    match Keeper_registry.get ~base_path keeper_name with
+    | Some { Keeper_registry.last_failure_reason =
+               Some (Keeper_registry.Provider_runtime_error { code; _ })
+           ; _
+           }
+      when String.equal code failure_reason_code ->
+      Keeper_registry.set_failure_reason ~base_path keeper_name None;
+      true
+    | _ -> false
+  in
+  let cleared_meta_blocker =
+    match meta.runtime.last_blocker with
+    | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
+      true
+    | _ -> false
+  in
+  if
+    was_latched
+    || cleared_failure_reason
+    || cleared_meta_blocker
+    || dropped_recovery_stimuli <> []
+  then
+    Log.Keeper.info
+      "%s: operator resume cleared no_progress loop latch/blocker (latched=%b failure_reason=%b meta_blocker=%b dropped_recovery_stimuli=%d)"
+      keeper_name
+      was_latched
+      cleared_failure_reason
+      cleared_meta_blocker
+      (List.length dropped_recovery_stimuli);
+  Ok
+    (if cleared_meta_blocker then
+       Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
+     else meta)
 ;;

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -124,7 +124,7 @@ let clear_for_operator_resume ~base_path meta =
     with
     | Ok dropped -> dropped
     | Error msg ->
-      Log.Keeper.warn
+      Log.Keeper.info
         "%s: operator resume could not drop recovery stimulus (best-effort \
          cleanup; resume proceeds): %s"
         keeper_name

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -628,7 +628,16 @@ let test_operator_resume_clears_no_progress_loop_latch () =
           | Some _ -> fail "expected no_progress failure reason to clear")
        | None -> fail "expected registered keeper")
 
-let test_operator_resume_keeps_no_progress_state_on_drop_failure () =
+(* KLV-2 (RFC-keeper-liveness-ssot §3): [clear_for_operator_resume] used to
+   propagate a recovery-stimulus drop failure as [Error], leaving the
+   detector latch, meta blocker, and failure_reason all in place — so a
+   keeper paused by [Manual_resume_required] could never actually be
+   resumed if that one disk write kept failing (server_dashboard_http_*,
+   masc_keeper_up, and keepalive persist all treat this [Error] as "resume
+   failed" and refuse to unpause). The drop is now best-effort: the
+   critical clears below must succeed regardless of whether the stimulus
+   removal did. *)
+let test_operator_resume_survives_recovery_stimulus_drop_failure () =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -659,11 +668,11 @@ let test_operator_resume_keeps_no_progress_state_on_drop_failure () =
        in
        let recovery_post_id = "no-progress-loop:" ^ keeper_name in
        check bool
-         "detector latched before failed resume"
+         "detector latched before resume"
          true
          (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
        check bool
-         "no synthetic recovery stimulus before failed resume"
+         "no synthetic recovery stimulus before resume"
          false
          (queue_contains_post_id
             (Masc.Keeper_registry_event_queue.snapshot
@@ -680,38 +689,26 @@ let test_operator_resume_keeps_no_progress_state_on_drop_failure () =
             ~base_path:config.base_path
             paused_meta
         with
-        | Ok _ -> fail "expected operator resume clear to fail"
-        | Error err -> check bool "failure is surfaced" true (String.length err > 0));
-       check bool
-         "detector remains latched after failed resume"
-         true
-         (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
-       check bool
-         "live recovery stimulus remains absent after failed resume"
-         false
-         (queue_contains_post_id
-            (Masc.Keeper_registry_event_queue.snapshot
-               ~base_path:config.base_path
-               keeper_name)
-            recovery_post_id);
-       (match paused_meta.runtime.last_blocker with
-        | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
-          ()
-        | Some _ -> fail "expected no_progress meta blocker to remain"
-        | None -> fail "expected meta blocker to remain");
-       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
-       | Some entry ->
-         (match entry.Masc.Keeper_registry.last_failure_reason with
-          | Some
-              (Masc.Keeper_registry.Provider_runtime_error
-                { code = failure_code; _ })
-            when String.equal
-                   failure_code
-                   Masc.Keeper_unified_turn_no_progress.failure_reason_code ->
-            ()
-          | Some _ -> fail "expected no_progress failure reason to remain"
-          | None -> fail "expected failure reason to remain")
-       | None -> fail "expected registered keeper")
+        | Error err ->
+          fail
+            (Printf.sprintf
+               "expected operator resume to succeed even when the recovery \
+                stimulus drop fails (best-effort cleanup), got Error %s"
+               err)
+        | Ok resumed_meta ->
+          check bool
+            "detector unlatched after resume despite drop failure"
+            false
+            (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
+          (match resumed_meta.runtime.last_blocker with
+           | None -> ()
+           | Some _ -> fail "expected no_progress meta blocker to be cleared");
+          (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+           | Some entry ->
+             (match entry.Masc.Keeper_registry.last_failure_reason with
+              | None -> ()
+              | Some _ -> fail "expected no_progress failure reason to be cleared")
+           | None -> fail "expected registered keeper")))
 
 let test_wakeup_directive_persists_no_progress_meta_clear () =
   Eio_main.run
@@ -1472,9 +1469,9 @@ let () =
           test_case "operator resume clears no-progress latch" `Quick
             test_operator_resume_clears_no_progress_loop_latch;
           test_case
-            "operator resume keeps no-progress state on drop failure"
+            "operator resume survives recovery-stimulus drop failure (KLV-2)"
             `Quick
-            test_operator_resume_keeps_no_progress_state_on_drop_failure;
+            test_operator_resume_survives_recovery_stimulus_drop_failure;
           test_case "wakeup directive persists no-progress meta clear" `Quick
             test_wakeup_directive_persists_no_progress_meta_clear;
           test_case


### PR DESCRIPTION
## Summary
- `clear_for_operator_resume` (`Keeper_unified_turn_no_progress`) cleared 4 stores in sequence and returned `Error` immediately if the *first, cosmetic* one (dropping an event-queue recovery stimulus — disk I/O) failed — before touching the actually-critical detector latch / registry `failure_reason` / `meta.last_blocker`.
- All 4 callers (dashboard directive endpoint, `masc_keeper_up`, boot-resume, keepalive persist) treat that `Error` as "resume failed" and refuse to unpause. Since the no-progress pause class is `Manual_resume_required` (no automatic backoff), this could leave a keeper permanently stuck if that one disk write keeps failing.
- This is audit finding **KLV-2** (`docs/rfc/RFC-keeper-liveness-ssot.md` §3, already diagnosed, not yet fixed). Make the stimulus drop best-effort: log and continue with an empty list; always clear the 3 critical stores regardless of that step's outcome.

## RFC
Not required — keeper-runtime bug fix (`lib/keeper/keeper_unified_turn_no_progress.ml`), not credential/identity/operator-control/sandbox/hooks/workflow. `bash scripts/pr-rfc-check.sh` passes.

## Test plan
- [x] `dune build` (full project) — clean
- [x] `test_keeper_auto_pause_blocker_persist_12683.exe` — 24/24 pass. Replaced `test_operator_resume_keeps_no_progress_state_on_drop_failure` (which asserted the *old* fail-closed behavior as correct — same forced-unwritable-path setup, asserted `Error` + all 4 stores untouched) with `test_operator_resume_survives_recovery_stimulus_drop_failure` (same setup, asserts `Ok` + detector/blocker/failure_reason all cleared).
- [x] `test_keeper_pause_silent_failure_source.exe` — 15/15 pass unchanged
- [x] `test_no_progress_loop_detector.exe` — 32/32 pass unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
