### PR TITLE
[RFC-0302 P1] chat_store Thinking variant + codec

### DIFF
--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -723,7 +723,7 @@ let block_of_yojson json : chat_block option =
          Option.bind (trace_steps_of_yojson trace_json) (fun trace ->
            if trace = [] then None else Some (Trace { trace })))
      | Some "thinking" ->
-       (* content is required ([""] for signature-only redacted thinking);
+       (* content is required (empty string for signature-only redacted thinking);
           redacted defaults to false and is only honoured when explicitly
           [true], matching the encoder's omission rule. *)
        Option.bind (get_string "content") (fun content ->

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -547,8 +547,15 @@ let block_to_yojson = function
   | Thinking { content; redacted } ->
     (* redacted defaults to false (omitted); only emit when true so the
        common non-redacted case stays minimal and legacy decoders that do
-       not know "thinking" still parse the rest of the list. *)
-    let base = [ ("t", `String "thinking"); ("content", `String content) ] in
+       not know "thinking" still parse the rest of the list.
+
+       [redacted = true] is a signature-only marker: force [content] to ""
+       at the wire boundary regardless of what the in-memory record holds,
+       so a caller-side bug that builds [Thinking { content = <real text>;
+       redacted = true }] can never persist or transmit the reasoning text
+       behind a flag that claims it was scrubbed. *)
+    let wire_content = if redacted then "" else content in
+    let base = [ ("t", `String "thinking"); ("content", `String wire_content) ] in
     `Assoc (if redacted then base @ [ ("redacted", `Bool true) ] else base)
 ;;
 
@@ -732,6 +739,13 @@ let block_of_yojson json : chat_block option =
            | Some (`Bool true) -> true
            | _ -> false
          in
+         (* Scrub any smuggled content at the decode boundary too: a legacy
+            writer, a hand-crafted payload, or a replayed record could carry
+            [redacted=true] alongside non-empty content. The in-memory
+            [Thinking] value must never expose reasoning text behind a flag
+            that claims it was redacted, regardless of how the JSON reached
+            this decoder. *)
+         let content = if redacted then "" else content in
          Some (Thinking { content; redacted }))
      | _ -> None)
   | _ -> None

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -110,6 +110,11 @@ type trace_step =
 
 type trace_block = { trace : trace_step list }
 
+type thinking_block = {
+  content : string;
+  redacted : bool;
+}
+
 type chat_block =
   | Text of text_block
   | Heading of text_block
@@ -125,6 +130,7 @@ type chat_block =
   | Link of link_block
   | Fusion of fusion_block
   | Trace of trace_block
+  | Thinking of thinking_block
 
 let escape_html raw =
   raw
@@ -538,6 +544,12 @@ let block_to_yojson = function
       [ ("t", `String "trace")
       ; ("trace", `List (List.map trace_step_to_yojson trace))
       ]
+  | Thinking { content; redacted } ->
+    (* redacted defaults to false (omitted); only emit when true so the
+       common non-redacted case stays minimal and legacy decoders that do
+       not know "thinking" still parse the rest of the list. *)
+    let base = [ ("t", `String "thinking"); ("content", `String content) ] in
+    `Assoc (if redacted then base @ [ ("redacted", `Bool true) ] else base)
 ;;
 
 let blocks_to_yojson blocks = `List (List.map block_to_yojson blocks)
@@ -710,6 +722,17 @@ let block_of_yojson json : chat_block option =
        Option.bind (List.assoc_opt "trace" fields) (fun trace_json ->
          Option.bind (trace_steps_of_yojson trace_json) (fun trace ->
            if trace = [] then None else Some (Trace { trace })))
+     | Some "thinking" ->
+       (* content is required ([""] for signature-only redacted thinking);
+          redacted defaults to false and is only honoured when explicitly
+          [true], matching the encoder's omission rule. *)
+       Option.bind (get_string "content") (fun content ->
+         let redacted =
+           match List.assoc_opt "redacted" fields with
+           | Some (`Bool true) -> true
+           | _ -> false
+         in
+         Some (Thinking { content; redacted }))
      | _ -> None)
   | _ -> None
 ;;

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -134,7 +134,12 @@ type trace_block = { trace : trace_step list }
     [redacted] marks that case so the dashboard renders a placeholder rather
     than an empty card. Not produced by [parse_text_to_blocks] — text-only
     input — and kept out of [content] so the role/content observation
-    projection is not polluted, mirroring [fusion_block]. *)
+    projection is not polluted, mirroring [fusion_block].
+
+    [block_to_yojson]/[block_of_yojson] enforce [redacted = true ==> content
+    = ""] at both the encode and decode boundary, so a caller building or a
+    payload carrying [redacted = true] with non-empty [content] can never
+    round-trip the reasoning text through the wire format. *)
 type thinking_block = {
   content : string;
   redacted : bool;

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -9,7 +9,8 @@
       codec: p, h4, ul, callout, table, code, mermaid, svg, voice, attach,
       image, link, and fusion. Thinking (RFC-0302) carries assistant
       reasoning content (empty string for a signature-only [RedactedThinking]) so
-      reload replays the trace; not produced by [parse_text_to_blocks].
+      reload can restore the dashboard thinking UI; not produced by
+      [parse_text_to_blocks].
     - Matched fenced code blocks become code blocks with escaped HTML and raw source.
     - Mermaid fenced code blocks become mermaid blocks with raw source.
     - Markdown images [![alt](url)] become image blocks.
@@ -129,7 +130,7 @@ type trace_step =
 type trace_block = { trace : trace_step list }
 
 (** A block of keeper/assistant reasoning persisted so the dashboard can
-    replay the thinking trace on reload (RFC-0302). [content] is the
+    replay assistant thinking on reload (RFC-0302). [content] is the
     thinking/reasoning text (empty string for a signature-only [RedactedThinking]);
     [redacted] marks that case so the dashboard renders a placeholder rather
     than an empty card. Not produced by [parse_text_to_blocks] — text-only

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -7,7 +7,9 @@
     Supported shapes:
     - Explicit server-provided dashboard blocks round-trip through the
       codec: p, h4, ul, callout, table, code, mermaid, svg, voice, attach,
-      image, link, and fusion.
+      image, link, and fusion. Thinking (RFC-0302) carries assistant
+      reasoning content ([""] for a signature-only [RedactedThinking]) so
+      reload replays the trace; not produced by [parse_text_to_blocks].
     - Matched fenced code blocks become code blocks with escaped HTML and raw source.
     - Mermaid fenced code blocks become mermaid blocks with raw source.
     - Markdown images [![alt](url)] become image blocks.
@@ -126,6 +128,18 @@ type trace_step =
 
 type trace_block = { trace : trace_step list }
 
+(** A block of keeper/assistant reasoning persisted so the dashboard can
+    replay the thinking trace on reload (RFC-0302). [content] is the
+    thinking/reasoning text ([""] for a signature-only [RedactedThinking]);
+    [redacted] marks that case so the dashboard renders a placeholder rather
+    than an empty card. Not produced by [parse_text_to_blocks] — text-only
+    input — and kept out of [content] so the role/content observation
+    projection is not polluted, mirroring [fusion_block]. *)
+type thinking_block = {
+  content : string;
+  redacted : bool;
+}
+
 type chat_block =
   | Text of text_block
   | Heading of text_block
@@ -141,6 +155,7 @@ type chat_block =
   | Link of link_block
   | Fusion of fusion_block
   | Trace of trace_block
+  | Thinking of thinking_block
 
 type dropped_http_url_reason =
   | Missing_scheme

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -8,7 +8,7 @@
     - Explicit server-provided dashboard blocks round-trip through the
       codec: p, h4, ul, callout, table, code, mermaid, svg, voice, attach,
       image, link, and fusion. Thinking (RFC-0302) carries assistant
-      reasoning content ([""] for a signature-only [RedactedThinking]) so
+      reasoning content (empty string for a signature-only [RedactedThinking]) so
       reload replays the trace; not produced by [parse_text_to_blocks].
     - Matched fenced code blocks become code blocks with escaped HTML and raw source.
     - Mermaid fenced code blocks become mermaid blocks with raw source.
@@ -130,7 +130,7 @@ type trace_block = { trace : trace_step list }
 
 (** A block of keeper/assistant reasoning persisted so the dashboard can
     replay the thinking trace on reload (RFC-0302). [content] is the
-    thinking/reasoning text ([""] for a signature-only [RedactedThinking]);
+    thinking/reasoning text (empty string for a signature-only [RedactedThinking]);
     [redacted] marks that case so the dashboard renders a placeholder rather
     than an empty card. Not produced by [parse_text_to_blocks] — text-only
     input — and kept out of [content] so the role/content observation

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -283,7 +283,8 @@ let rich_embed_of_chat_block = function
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
   | Keeper_chat_blocks.Fusion _
-  | Keeper_chat_blocks.Trace _ -> None
+  | Keeper_chat_blocks.Trace _
+  | Keeper_chat_blocks.Thinking _ -> None
 
 let rich_embeds_of_text text =
   text

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -152,7 +152,8 @@ let slack_block_of_chat_block = function
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _
   | Keeper_chat_blocks.Fusion _
-  | Keeper_chat_blocks.Trace _ -> None
+  | Keeper_chat_blocks.Trace _
+  | Keeper_chat_blocks.Thinking _ -> None
 
 let content_blocks_of_text text =
   text

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -213,6 +213,17 @@ let persisted_attachment (att : attachment) =
 let redact_tool_call redaction tc =
   { tc with args = Keeper_secret_redaction.redact_text redaction tc.args }
 
+let redact_block redaction = function
+  | Keeper_chat_blocks.Thinking thinking ->
+    Keeper_chat_blocks.Thinking
+      { thinking with
+        content = Keeper_secret_redaction.redact_text redaction thinking.content
+      }
+  | block -> block
+
+let redact_blocks redaction =
+  Option.map (List.map (redact_block redaction))
+
 let redact_message redaction msg =
   let attachments =
     Option.map (List.map (redact_attachment redaction)) msg.attachments
@@ -424,6 +435,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     let assistant_content =
       Keeper_secret_redaction.redact_text redaction assistant_content
     in
+    let blocks = redact_blocks redaction blocks in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     (* Speaker identity belongs to the user line only: tool and
@@ -477,6 +489,7 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
     let content = Keeper_secret_redaction.redact_text redaction content in
+    let blocks = redact_blocks redaction blocks in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -412,7 +412,7 @@ let test_thinking_block_roundtrip () =
   | None -> Alcotest.fail "blocks_of_yojson rejected valid thinking block"
 
 let test_redacted_thinking_block_roundtrip () =
-  (* Signature-only RedactedThinking: content is [""] and redacted is emitted
+  (* Signature-only RedactedThinking: content is an empty string and redacted is emitted
      so the dashboard renders a placeholder rather than an empty card. *)
   let original = [ B.Thinking { content = ""; redacted = true } ] in
   Alcotest.(check (list yojson_testable))

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -425,6 +425,37 @@ let test_redacted_thinking_block_roundtrip () =
    | Some [ B.Thinking { content = ""; redacted = true } ] -> ()
    | _ -> Alcotest.fail "redacted thinking block should roundtrip with redacted=true")
 
+let test_redacted_thinking_block_encoder_scrubs_smuggled_content () =
+  (* A caller-side bug could build [Thinking { content = <real text>; redacted
+     = true }]. The encoder must never emit that content on the wire just
+     because the in-memory record carries it - [redacted] is a promise that
+     no reasoning text crosses this boundary. *)
+  let original = [ B.Thinking { content = "leaked reasoning"; redacted = true } ] in
+  Alcotest.(check (list yojson_testable))
+    "redacted thinking with smuggled content is scrubbed to empty on encode"
+    [ `Assoc
+        [ ("t", `String "thinking"); ("content", `String ""); ("redacted", `Bool true) ]
+    ]
+    (blocks_to_json_list original)
+
+let test_redacted_thinking_block_decoder_scrubs_smuggled_content () =
+  (* A legacy writer, hand-crafted payload, or replayed record could carry
+     [redacted=true] alongside non-empty content. The decoded in-memory value
+     must never expose that text just because the JSON did. *)
+  match
+    B.blocks_of_yojson
+      (`List
+         [ `Assoc
+             [ ("t", `String "thinking")
+             ; ("content", `String "leaked reasoning")
+             ; ("redacted", `Bool true)
+             ]
+         ])
+  with
+  | Some [ B.Thinking { content = ""; redacted = true } ] -> ()
+  | _ ->
+    Alcotest.fail "decoder must scrub non-empty content when redacted=true, not preserve it"
+
 let test_thinking_block_requires_content () =
   Alcotest.(check bool) "missing content rejected"
     true
@@ -492,6 +523,10 @@ let () =
             test_thinking_block_roundtrip;
           Alcotest.test_case "redacted thinking block roundtrip" `Quick
             test_redacted_thinking_block_roundtrip;
+          Alcotest.test_case "redacted thinking encoder scrubs smuggled content" `Quick
+            test_redacted_thinking_block_encoder_scrubs_smuggled_content;
+          Alcotest.test_case "redacted thinking decoder scrubs smuggled content" `Quick
+            test_redacted_thinking_block_decoder_scrubs_smuggled_content;
           Alcotest.test_case "thinking block requires content" `Quick
             test_thinking_block_requires_content;
         ] );

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -394,6 +394,44 @@ let test_fusion_block_tolerates_missing_run_id () =
   | Some [ B.Fusion { board_post_id = "p-1"; run_id = "" } ] -> ()
   | _ -> Alcotest.fail "fusion block with board_post_id only should decode with empty run_id"
 
+(* RFC-0302: the thinking block wire shape is the contract the dashboard
+   schema mirrors (t=thinking, content required, redacted omitted when
+   false). Pin it so a drift breaks here. *)
+let test_thinking_block_roundtrip () =
+  let original = [ B.Thinking { content = "considering options"; redacted = false } ] in
+  Alcotest.(check (list yojson_testable))
+    "thinking block json shape (redacted false omitted)"
+    [ `Assoc [ ("t", `String "thinking"); ("content", `String "considering options") ] ]
+    (blocks_to_json_list original);
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some parsed ->
+    Alcotest.(check (list yojson_testable))
+      "thinking roundtrip json"
+      (blocks_to_json_list original)
+      (blocks_to_json_list parsed)
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid thinking block"
+
+let test_redacted_thinking_block_roundtrip () =
+  (* Signature-only RedactedThinking: content is [""] and redacted is emitted
+     so the dashboard renders a placeholder rather than an empty card. *)
+  let original = [ B.Thinking { content = ""; redacted = true } ] in
+  Alcotest.(check (list yojson_testable))
+    "redacted thinking block json shape"
+    [ `Assoc
+        [ ("t", `String "thinking"); ("content", `String ""); ("redacted", `Bool true) ]
+    ]
+    (blocks_to_json_list original);
+  (match B.blocks_of_yojson (B.blocks_to_yojson original) with
+   | Some [ B.Thinking { content = ""; redacted = true } ] -> ()
+   | _ -> Alcotest.fail "redacted thinking block should roundtrip with redacted=true")
+
+let test_thinking_block_requires_content () =
+  Alcotest.(check bool) "missing content rejected"
+    true
+    (B.blocks_of_yojson
+       (`List [ `Assoc [ ("t", `String "thinking"); ("redacted", `Bool true) ] ])
+     = None)
+
 let () =
   Alcotest.run "keeper_chat_blocks"
     [
@@ -450,5 +488,11 @@ let () =
             test_fusion_block_requires_board_post_id;
           Alcotest.test_case "fusion block tolerates missing run_id" `Quick
             test_fusion_block_tolerates_missing_run_id;
+          Alcotest.test_case "thinking block roundtrip" `Quick
+            test_thinking_block_roundtrip;
+          Alcotest.test_case "redacted thinking block roundtrip" `Quick
+            test_redacted_thinking_block_roundtrip;
+          Alcotest.test_case "thinking block requires content" `Quick
+            test_thinking_block_requires_content;
         ] );
     ]

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1122,6 +1122,47 @@ let test_blocks_roundtrip_and_drop_malformed () =
           | None -> Alcotest.fail "blocks missing")
       | messages -> Alcotest.failf "expected 1 row, got %d" (List.length messages))
 
+let test_append_turn_redacts_supplied_thinking_blocks () =
+  let base_dir = temp_base_path "keeper-chat-store-thinking-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-thinking-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "thinking.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      K.append_turn
+        ~base_dir
+        ~keeper_name
+        ~user_content:"think"
+        ~user_attachments:[]
+        ~assistant_content:"done"
+        ~blocks:
+          [ B.Thinking
+              { content = "private reasoning uses " ^ secret; redacted = false }
+          ]
+        ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "thinking secret not persisted" false
+        (contains_substring raw secret);
+      Alcotest.(check bool) "redaction marker persisted" true
+        (contains_substring raw "[REDACTED]");
+      let messages = K.load ~base_dir ~keeper_name in
+      let assistant =
+        List.find
+          (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.Assistant)
+          messages
+      in
+      match assistant.K.blocks with
+      | Some [ B.Thinking thinking ] ->
+        Alcotest.(check bool) "thinking content redacted on load" false
+          (contains_substring thinking.content secret);
+        Alcotest.(check bool) "thinking redaction marker visible" true
+          (contains_substring thinking.content "[REDACTED]")
+      | Some _ -> Alcotest.fail "expected exactly one thinking block"
+      | None -> Alcotest.fail "assistant thinking block missing")
+
 (* RFC-0233 §7: append_turn stamps the supplied turn_ref on every row of the
    completed turn, it round-trips through load, and to_json_array exposes it
    for the history endpoint. *)
@@ -1343,6 +1384,8 @@ let () =
             test_user_and_tool_rows_have_no_blocks;
           Alcotest.test_case "blocks roundtrip and malformed dropped" `Quick
             test_blocks_roundtrip_and_drop_malformed;
+          Alcotest.test_case "supplied thinking blocks are redacted" `Quick
+            test_append_turn_redacts_supplied_thinking_blocks;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
         ] );


### PR DESCRIPTION
[RFC-0302 Phase 1] chat_store Thinking variant + codec

## Context

dashboard 멀티턴 reload 시 과거 thinking이 채팅 surface에서 사라지고 assistant 텍스트가 단일 블록으로 평탄화된다 (task-1591/1592). 근인: `keeper_chat_store`가 thinking을 persist하지 않는다 — `append_turn`이 thinking을 수신하지 않고, thinking은 별도 trajectory(`.masc/keeper_trajectory/<name>.jsonl`)에만 저장. dashboard 라이브는 history API + trajectory API를 client-side join하지만 reload 시 이 조인이 깨진다.

RFC-0302 (Draft)가 chat_store를 단일 SSOT로 통합하는 설계를 다룬다. 이 PR은 그 중 **Phase 1 (Codec)**.

## Phase 1 변경

- `chat_block` open sum에 `Thinking of thinking_block` variant 추가 (`thinking_block = { content; redacted }`). `Role.t` sum(`{User|Assistant|Tool}`, RFC-0232)은 불변.
- codec (Fusion 패턴 대칭): encode는 `redacted=false` 생략, `true`일 때만 `("redacted", `Bool true)`; decode는 `Some (`Bool true)`만 true, 나머진 false. `content` 필수(`Option.bind`). legacy row 호환 (blocks optional, `None`=legacy).
- `keeper_chat_slack.ml` / `keeper_chat_discord.ml`의 image-extract exhaustive match에 `Thinking _ -> None` 추가 (variant 추가로 `-warn-error +8`가 강제).
- `parse_text_to_blocks`는 thinking을 생산하지 않는다 (text-only 입력). producer는 Phase 2 `thinking_blocks_of_content`.

`redacted`는 signature-only `RedactedThinking`(content=`""`) 마커. `content`는 thinking/reasoning 텍스트.

## 테스트

`test_keeper_chat_blocks`: 26/26 green (기존 23 + 신규 3).
- `thinking block roundtrip` (redacted=false 생략)
- `redacted thinking block roundtrip` (content="", redacted=true)
- `thinking block requires content` (content 누락 시 reject)

로컬 검증 메모: mascot의 `dune` 파일이 `.worktrees`를 빌드에서 제외하므로, worktree 코드는 메인 repo throwaway branch에서 빌드/테스트 검증(`dune build test/test_keeper_chat_blocks.exe` + `dune exec`, 26/26).

## 남은 phase (RFC-0302, 별도 PR로 분할)

- **P2**: `thinking_blocks_of_content : Agent_sdk.Types.content list -> chat_block list` helper.
- **P3**: `run_result.thinking_blocks` 필드 + after_turn hook accumulator + reply JSON 직렬화.
- **P4**: 4 caller(`keeper_tool_surface_ops`, `server_routes_http_keeper_stream`)가 `?blocks`로 전달.
- **P5**: dashboard schema(`KeeperChatBlockSchema` thinking variant) + `normalizeBlocks` case + reload 시 blocks→traceSteps lift.
- **P6**: RFC-0302 문서화 + trajectory 축소 스코프(transition dual-write 후).

## 설계 논의 환영

- `thinking_blocks_of_content` 위치: `keeper_chat_blocks`(OAS 결합 추가) vs 별도 bridge 모듈(순수 codec 유지). 현재 전자 가정하나 P2에서 확정.
- interleaving 순서: assistant row의 blocks에 `[Thinking*; Text*]` (tool은 별도 row 유지, RFC-0233 execution_id join 보존). 라이브 `interleaveTraceAndTools`와 동일 구조.

## RFC

RFC-0302 (Draft). 이 PR이 phase 1이며, 전체 RFC는 Phase 6에서 문서화. `keeper_chat_blocks`는 RFC-check subsystem(credential/identity/repo/operator/sandbox/hooks)에 직접 해당하지 않으나, 전체 chat_store 스키마 확장의 첫 단계로 맥락 명시.

Co-Authored-By: Claude <noreply@anthropic.com>
