### PR TITLE
fix(board): propagate append persistence failures

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -4,6 +4,32 @@
 
 include Board_core_persist
 
+let rollback_fresh_comment store ~(comment : comment) ~(previous_post : post) =
+  with_lock store (fun () ->
+    let post_key = Post_id.to_string comment.post_id in
+    let comment_key = Comment_id.to_string comment.id in
+    Hashtbl.remove store.comments comment_key;
+    (match Hashtbl.find_opt store.comments_by_post post_key with
+     | None -> ()
+     | Some ids ->
+       (match List.filter (fun id -> not (String.equal id comment_key)) ids with
+        | [] -> Hashtbl.remove store.comments_by_post post_key
+        | filtered -> Hashtbl.replace store.comments_by_post post_key filtered));
+    (match Hashtbl.find_opt store.posts post_key with
+     | None -> ()
+     | Some current ->
+       let updated_at =
+         if Stdlib.Float.equal current.updated_at comment.created_at
+         then previous_post.updated_at
+         else current.updated_at
+       in
+       Hashtbl.replace
+         store.posts
+         post_key
+         { current with reply_count = max 0 (current.reply_count - 1); updated_at });
+    invalidate_post_caches store;
+    invalidate_comment_caches store)
+;;
 
 let get_post store ~post_id : (post, board_error) Result.t =
   maybe_sweep store;
@@ -397,20 +423,31 @@ let add_comment_with_status
                       { post with reply_count = post.reply_count + 1; updated_at = now };
                     mark_dirty_post store post_key;
                     mark_dirty_comment store (Comment_id.to_string comment.id);
-                    record_comment_timestamp ~author:author_str ~now;
                     invalidate_post_caches store;
                     invalidate_comment_caches store;
-                    Ok (`Fresh (comment, posts_jsonl_unlocked store))))))
+                    Ok (`Fresh (comment, post, posts_jsonl_unlocked store))))))
             in
             match board_result with
-            | Ok (`Fresh (comment, posts_jsonl)) ->
-              with_persist_lock store (fun () ->
-                append_comment comment;
-                save_posts_jsonl posts_jsonl);
-              with_lock store (fun () ->
-                mark_dirty_post store (Post_id.to_string comment.post_id);
-                mark_dirty_comment store (Comment_id.to_string comment.id));
-              Ok (comment, `Fresh)
+            | Ok (`Fresh (comment, previous_post, posts_jsonl)) ->
+              (match
+                 with_persist_lock store (fun () ->
+                   match append_comment comment with
+                   | Error _ as e -> e
+                   | Ok () ->
+                     save_posts_jsonl posts_jsonl;
+                     Ok ())
+               with
+               | Ok () ->
+                 record_comment_timestamp
+                   ~author:(Agent_id.to_string comment.author)
+                   ~now:comment.created_at;
+                 with_lock store (fun () ->
+                   mark_dirty_post store (Post_id.to_string comment.post_id);
+                   mark_dirty_comment store (Comment_id.to_string comment.id));
+                 Ok (comment, `Fresh)
+               | Error e ->
+                 rollback_fresh_comment store ~comment ~previous_post;
+                 Error e)
             | Ok (`Dedup_hit existing) -> Ok (existing, `Dedup)
             | Error _ as e -> e)))
 ;;

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -148,7 +148,7 @@ val rotate_if_needed : string -> unit
 (** {1 Append-only persistence} *)
 
 (** Appends one post snapshot to {!persist_path}. *)
-val append_post : post -> unit
+val append_post : post -> (unit, board_error) result
 
 (** RFC-0233 §7: maintain the origin secondary indexes ([posts_by_turn_ref] /
     [posts_by_run_id]) from a post's [origin].  Used by the load path to
@@ -157,7 +157,7 @@ val append_post : post -> unit
 val index_post_origin : store -> post -> unit
 
 (** Appends one comment snapshot to {!comments_path}. *)
-val append_comment : comment -> unit
+val append_comment : comment -> (unit, board_error) result
 
 (** {1 Whole-state JSONL rewrite} *)
 

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -32,6 +32,12 @@ let record_persist_error ~where msg =
   Atomic.incr persist_errors;
   Log.BoardLog.error "persist error (%s): %s" where msg
 ;;
+
+let persist_io_error ~where msg =
+  record_persist_error ~where msg;
+  Error (Io_error (Printf.sprintf "%s: %s" where msg))
+;;
+
 let create_store () =
   { posts = Hashtbl.create 1024
   ; comments = Hashtbl.create 4096
@@ -416,18 +422,35 @@ let append_post (p : post) =
     ensure_masc_dir ();
     let path = persist_path () in
     Fs_compat.append_file path (Yojson.Safe.to_string (post_to_yojson p) ^ "\n");
-    rotate_if_needed path
+    rotate_if_needed path;
+    Ok ()
   with
-  | Sys_error msg -> record_persist_error ~where:"append_post" msg
+  | Sys_error msg -> persist_io_error ~where:"append_post" msg
 ;;
 let append_comment (c : comment) =
   try
     ensure_masc_dir ();
     let path = comments_path () in
     Fs_compat.append_file path (Yojson.Safe.to_string (comment_to_yojson c) ^ "\n");
-    rotate_if_needed path
+    rotate_if_needed path;
+    Ok ()
   with
-  | Sys_error msg -> record_persist_error ~where:"append_comment" msg
+  | Sys_error msg -> persist_io_error ~where:"append_comment" msg
+;;
+
+let rollback_fresh_post store (post : post) =
+  with_lock store (fun () ->
+    let key = Post_id.to_string post.id in
+    match Hashtbl.find_opt store.posts key with
+    | None -> ()
+    | Some current
+      when Stdlib.Float.equal current.created_at post.created_at
+           && Stdlib.Float.equal current.updated_at post.updated_at ->
+      Hashtbl.remove store.posts key;
+      unindex_post_origin store post;
+      store.post_count := max 0 (!(store.post_count) - 1);
+      invalidate_post_caches store
+    | Some _ -> ())
 ;;
 let sub_board_access_to_string = Board_sub_board_json.sub_board_access_to_string
 let sub_board_access_of_string_opt = Board_sub_board_json.sub_board_access_of_string_opt
@@ -677,18 +700,22 @@ let create_post_with_outcome
       in
       match board_result with
       | Ok (`Fresh post) ->
-        with_persist_lock store (fun () -> append_post post);
-        (match
-           Board_effect_hooks.earn
-             ~base_path:(board_base_path ())
-             ~agent_name:author
-             ~kind:Board_post
-             ~reason:"board post"
-             ()
-         with
-         | Ok () -> ()
-         | Error msg -> Log.BoardLog.warn "economy earn (post): %s" msg);
-        Ok (Fresh_post post)
+        (match with_persist_lock store (fun () -> append_post post) with
+         | Ok () ->
+           (match
+              Board_effect_hooks.earn
+                ~base_path:(board_base_path ())
+                ~agent_name:author
+                ~kind:Board_post
+                ~reason:"board post"
+                ()
+            with
+            | Ok () -> ()
+            | Error msg -> Log.BoardLog.warn "economy earn (post): %s" msg);
+           Ok (Fresh_post post)
+         | Error e ->
+           rollback_fresh_post store post;
+           Error e)
       | Ok (`Rolled_up (post, posts_jsonl)) ->
         with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
         Ok (Rolled_up_post post)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -65,8 +65,8 @@ val reactions_jsonl_unlocked : store -> string
 val save_reactions_jsonl : string -> unit
 val rewrite_reactions_unlocked : store -> unit
 val rewrite_reactions : store -> unit
-val append_post : post -> unit
-val append_comment : comment -> unit
+val append_post : post -> (unit, board_error) result
+val append_comment : comment -> (unit, board_error) result
 
 val sub_board_access_to_string : sub_board_access -> string
 val sub_board_access_of_string_opt : string -> sub_board_access option

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -593,13 +593,24 @@ let set_pinned store ~post_id ~pinned : (unit, board_error) Result.t =
               let updated = { post with pinned; updated_at = now } in
               Hashtbl.replace store.posts (Post_id.to_string pid) updated;
               invalidate_post_caches store;
-              Ok updated)
+              Ok (post, updated))
       in
       match result with
       | Error e -> Error e
-      | Ok updated ->
-          with_persist_lock store (fun () -> append_post updated);
-          Ok ()
+      | Ok (previous, updated) ->
+          (match with_persist_lock store (fun () -> append_post updated) with
+           | Ok () -> Ok ()
+           | Error e ->
+               with_lock store (fun () ->
+                 let key = Post_id.to_string previous.id in
+                 (match Hashtbl.find_opt store.posts key with
+                  | Some current
+                    when current.pinned = updated.pinned
+                         && Stdlib.Float.equal current.updated_at updated.updated_at ->
+                    Hashtbl.replace store.posts key previous;
+                    invalidate_post_caches store
+                  | _ -> ()));
+               Error e)
 
 let posts_jsonl_snapshot store =
   let buf = Buffer.create 4096 in

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -24,6 +24,18 @@ let with_eio f () =
   Board_dispatch.init_jsonl ();
   f ()
 
+let block_board_masc_dir_with_file () =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-persist-blocked-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" base;
+  let masc_dir = Filename.dirname (Board.persist_path ()) in
+  Fs_compat.mkdir_p (Filename.dirname masc_dir);
+  Fs_compat.save_file masc_dir "not a directory";
+  base
+
 let seed_legacy_keeper_post () =
   let now = Time_compat.now () in
   let post_id = Printf.sprintf "legacy-keeper-%06x" (Random.bits ()) in
@@ -206,6 +218,15 @@ let contains_substring ~(needle : string) (haystack : string) : bool =
   in
   nlen = 0 || scan 0
 
+let check_io_error ~where = function
+  | Error (Board.Io_error msg) ->
+      Alcotest.(check bool)
+        ("error includes " ^ where)
+        true
+        (contains_substring ~needle:where msg)
+  | Error e -> Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e)
+  | Ok _ -> Alcotest.fail "expected Io_error"
+
 let test_update_post_lifts_state_block_into_meta () =
   match
     Board_dispatch.create_post ~author:"stateful-agent"
@@ -281,6 +302,33 @@ let test_dedup_hit_does_not_emit_post_created_fanout () =
     (Board.Post_id.to_string second.id);
   Alcotest.(check int) "keeper signal emitted once" 1 !keeper_signals;
   Alcotest.(check int) "SSE post_created emitted once" 1 !sse_post_created
+
+let test_create_post_persistence_failure_returns_error_without_fanout () =
+  let keeper_signals = ref 0 in
+  let sse_post_created = ref 0 in
+  Board_dispatch.set_board_signal_hook (fun _ -> incr keeper_signals);
+  Board_dispatch.set_board_sse_hook (function
+    | Board_dispatch.Post_created _ -> incr sse_post_created
+    | _ -> ());
+  ignore (block_board_masc_dir_with_file ());
+  let before_errors = Board.persist_error_count () in
+  check_io_error
+    ~where:"append_post"
+    (Board_dispatch.create_post
+       ~author:"persist-fail-agent"
+       ~content:"this post must not survive a failed append"
+       ~post_kind:Board.Human_post
+       ());
+  Alcotest.(check bool)
+    "persist error counter incremented"
+    true
+    (Board.persist_error_count () > before_errors);
+  Alcotest.(check int) "keeper signal not emitted" 0 !keeper_signals;
+  Alcotest.(check int) "SSE post_created not emitted" 0 !sse_post_created;
+  Alcotest.(check int)
+    "failed create rolled back in-memory post"
+    0
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
 
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
@@ -568,6 +616,52 @@ let test_comment_persists_post_reply_count () =
   | Error e -> Alcotest.fail (Board.show_board_error e)
   | Ok fetched ->
     Alcotest.(check int) "reply_count survives restart" 1 fetched.reply_count
+
+let test_add_comment_persistence_failure_rolls_back_without_fanout () =
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:"comment-persist-fail-author"
+        ~content:"post before comment append failure"
+        ~post_kind:Board.Human_post
+        ()
+    with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok post -> post
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let keeper_signals = ref 0 in
+  let sse_comment_added = ref 0 in
+  Board_dispatch.set_board_signal_hook (fun _ -> incr keeper_signals);
+  Board_dispatch.set_board_sse_hook (function
+    | Board_dispatch.Comment_added _ -> incr sse_comment_added
+    | _ -> ());
+  ignore (block_board_masc_dir_with_file ());
+  let before_errors = Board.persist_error_count () in
+  check_io_error
+    ~where:"append_comment"
+    (Board_dispatch.add_comment
+       ~post_id
+       ~author:"comment-persist-fail-responder"
+       ~content:"this comment must not survive a failed append"
+       ());
+  Alcotest.(check bool)
+    "persist error counter incremented"
+    true
+    (Board.persist_error_count () > before_errors);
+  Alcotest.(check int) "keeper signal not emitted" 0 !keeper_signals;
+  Alcotest.(check int) "SSE comment_added not emitted" 0 !sse_comment_added;
+  (match Board_dispatch.get_post ~post_id with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok fetched ->
+       Alcotest.(check int) "reply_count rolled back" 0 fetched.reply_count);
+  match Board_dispatch.get_comments ~post_id with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok comments ->
+      Alcotest.(check int)
+        "failed comment rolled back in-memory comment"
+        0
+        (List.length comments)
 
 let test_get_post_and_comments_atomic () =
   match
@@ -1077,6 +1171,33 @@ let test_set_pinned_missing_post () =
   | Error (Board.Post_not_found _) -> ()
   | Error e -> Alcotest.fail (Board.show_board_error e)
 
+let test_set_pinned_persistence_failure_rolls_back () =
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:"pin-persist-fail-author"
+        ~content:"pin must roll back on failed append"
+        ~post_kind:Board.Human_post
+        ()
+    with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok post -> post
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  ignore (block_board_masc_dir_with_file ());
+  let before_errors = Board.persist_error_count () in
+  check_io_error
+    ~where:"append_post"
+    (Board_dispatch.set_pinned ~post_id ~pinned:true);
+  Alcotest.(check bool)
+    "persist error counter incremented"
+    true
+    (Board.persist_error_count () > before_errors);
+  match Board_dispatch.get_post ~post_id with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok fetched ->
+      Alcotest.(check bool) "pinned rolled back" false fetched.pinned
+
 let test_flush () =
   Board_dispatch.flush ()
 
@@ -1470,6 +1591,8 @@ let () =
         (with_eio test_keeper_signal_hook_cancellation_propagates);
       Alcotest.test_case "dedup hit does not fan out post_created" `Quick
         (with_eio test_dedup_hit_does_not_emit_post_created_fanout);
+      Alcotest.test_case "create append failure returns error without fanout" `Quick
+        (with_eio test_create_post_persistence_failure_returns_error_without_fanout);
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
       Alcotest.test_case "SSE post_created includes post_kind" `Quick
         (with_eio test_board_sse_post_created_includes_post_kind);
@@ -1489,6 +1612,8 @@ let () =
       Alcotest.test_case "add and get" `Quick (with_eio test_add_and_get_comments);
       Alcotest.test_case "comment persists post reply_count" `Quick
         (with_eio test_comment_persists_post_reply_count);
+      Alcotest.test_case "comment append failure rolls back without fanout" `Quick
+        (with_eio test_add_comment_persistence_failure_rolls_back_without_fanout);
       Alcotest.test_case "get_post_and_comments atomic" `Quick
         (with_eio test_get_post_and_comments_atomic);
       Alcotest.test_case "get_post_and_comments missing post" `Quick
@@ -1528,6 +1653,8 @@ let () =
       Alcotest.test_case "set_thread_id" `Quick (with_eio test_set_thread_id);
       Alcotest.test_case "set_pinned toggle + restart" `Quick (with_eio test_set_pinned);
       Alcotest.test_case "set_pinned missing post" `Quick (with_eio test_set_pinned_missing_post);
+      Alcotest.test_case "set_pinned append failure rolls back" `Quick
+        (with_eio test_set_pinned_persistence_failure_rolls_back);
       Alcotest.test_case "flush" `Quick (with_eio test_flush);
     ];
     "validation", [


### PR DESCRIPTION
## Summary
- make board post/comment append helpers return typed `Io_error` instead of only logging persistence failures
- propagate append failures through create/comment/pin paths so success fanout is not emitted on failed writes
- roll back in-memory fresh post/comment/pin state on append failure and cover those regressions in board dispatch tests

## Verification
- `ocamlformat --check lib/board/board_core_persist.ml lib/board/board_core_persist.mli lib/board/board_core.ml lib/board/board_core.mli lib/board/board_votes.ml test/test_board_dispatch.ml`
- `git diff --check`
- local Dune build/test intentionally not run; CI is the build authority for this slice

Fixes part of #21990.