### PR TITLE
[codex] Show runtime defaults catalog fallback

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -664,6 +664,30 @@ describe('SettingsSurface', () => {
     expect(container.textContent).not.toContain('oas·seoul-1')
   })
 
+  it('runtime overview falls back to runtime-defaults when the rich provider catalog is unavailable', async () => {
+    apiMock.fetchRuntimeProviders.mockRejectedValueOnce(new Error('provider catalog unavailable'))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-catalog-fallback"]')?.textContent)
+        .toContain('runtime defaults')
+      const cards = Array.from(container.querySelectorAll('[data-testid="runtime-catalog-card"]'))
+      expect(cards.length).toBe(3)
+      expect(cards.map(card => card.textContent)).toEqual([
+        expect.stringContaining('rt-a'),
+        expect.stringContaining('rt-b'),
+        expect.stringContaining('rt-c'),
+      ])
+      expect(cards[0]?.textContent).toContain('P')
+      expect(cards[0]?.textContent).toContain('m1')
+      expect(cards[0]?.textContent).toContain('128K ctx')
+    })
+    expect(container.querySelector('[data-testid="runtime-catalog-error"]')).toBeNull()
+  })
+
   it('runtime section shows resolved keeper assignments read-only', async () => {
     render(html`<${SettingsSurface} />`, container)
 

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -684,8 +684,25 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('P')
       expect(cards[0]?.textContent).toContain('m1')
       expect(cards[0]?.textContent).toContain('128K ctx')
+      expect(cards[0]?.textContent).toContain('? tools')
+      expect(cards[0]?.textContent).toContain('? thinking')
+      expect(cards[0]?.textContent).toContain('? streaming')
     })
     expect(container.querySelector('[data-testid="runtime-catalog-error"]')).toBeNull()
+  })
+
+  it('runtime overview does not show the fallback warning while provider catalog is still loading', async () => {
+    apiMock.fetchRuntimeProviders.mockReturnValueOnce(new Promise(() => {}))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
+
+    await waitFor(() => {
+      const cards = Array.from(container.querySelectorAll('[data-testid="runtime-catalog-card"]'))
+      expect(cards.length).toBe(3)
+    })
+    expect(container.querySelector('[data-testid="runtime-catalog-fallback"]')).toBeNull()
   })
 
   it('runtime section shows resolved keeper assignments read-only', async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -693,7 +693,8 @@ export function SettingsSurface() {
   const runtimeCatalogEntries = richRuntimeCatalogEntries.length > 0
     ? richRuntimeCatalogEntries
     : fallbackRuntimeCatalogEntries
-  const runtimeCatalogIsFallback = richRuntimeCatalogEntries.length === 0 && fallbackRuntimeCatalogEntries.length > 0
+  const runtimeCatalogIsFallback =
+    runtimeCatalogStatus === 'error' && richRuntimeCatalogEntries.length === 0 && fallbackRuntimeCatalogEntries.length > 0
   const runtimeConfigPath = runtimeProviders?.config_path ?? runtimeDefaults?.config_path ?? null
   const defaultRuntimeId = runtimeDefaults?.default_runtime_id ?? runtimeProviders?.summary?.default_runtime_id ?? null
   const defaultCatalogEntry = findRuntimeCatalogSnapshot(runtimeCatalogEntries, defaultRuntimeId)
@@ -864,7 +865,7 @@ export function SettingsSurface() {
                   <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
                   ${runtimeCatalogIsFallback ? html`
                     <div class="set-hint" data-testid="runtime-catalog-fallback">
-                      provider catalog를 불러오지 못해 live runtime defaults projection으로 표시합니다.
+                      provider 카탈로그를 불러오지 못해 live runtime defaults projection으로 표시합니다.
                     </div>
                   ` : null}
                   ${runtimeCatalogStatus === 'loading' && runtimeCatalogEntries.length === 0

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -17,6 +17,7 @@ import type {
   DashboardRuntimeProvidersResponse,
   DashboardToolInventoryItem,
   LogEntry,
+  RuntimeEntry,
   RuntimeDefaultsResponse,
 } from '../api/dashboard.js'
 import { callMcpTool } from '../api/mcp'
@@ -239,8 +240,33 @@ function findRuntimeCatalogSnapshot(
 }
 
 function RuntimeCatalogCapability({ label, value }: { label: string; value: boolean | undefined }) {
+  if (value === undefined) {
+    return html`<span class="rt-cap unknown" title="capability not reported">? ${label}</span>`
+  }
   const isOn = value === true
   return html`<span class=${`rt-cap ${isOn ? 'on' : ''}`}>${isOn ? '✓' : '·'} ${label}</span>`
+}
+
+function runtimeCatalogFromDefaults(defaults: RuntimeDefaultsResponse | null): DashboardRuntimeProviderSnapshot[] {
+  if (!defaults) return []
+  return defaults.runtimes.map((entry: RuntimeEntry) => ({
+    provider: entry.id,
+    runtime_id: entry.id,
+    provider_display_name: entry.provider,
+    model_id: entry.model,
+    model_api_name: entry.model,
+    transport: 'runtime-defaults',
+    kind: 'resolved',
+    runtime_kind: 'runtime',
+    status: entry.is_default ? 'default' : 'resolved',
+    is_default_runtime: entry.is_default,
+    max_context: entry.max_context,
+    model_count: 1,
+    models: [entry.model],
+    source: defaults.source ?? 'runtime-defaults',
+    endpoint_url: null,
+    note: 'fallback from /api/v1/dashboard/runtime-defaults',
+  }))
 }
 
 function RuntimeCatalogCard({
@@ -662,7 +688,12 @@ export function SettingsSurface() {
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
-  const runtimeCatalogEntries = runtimeProviders?.providers ?? []
+  const richRuntimeCatalogEntries = runtimeProviders?.providers ?? []
+  const fallbackRuntimeCatalogEntries = runtimeCatalogFromDefaults(runtimeDefaults)
+  const runtimeCatalogEntries = richRuntimeCatalogEntries.length > 0
+    ? richRuntimeCatalogEntries
+    : fallbackRuntimeCatalogEntries
+  const runtimeCatalogIsFallback = richRuntimeCatalogEntries.length === 0 && fallbackRuntimeCatalogEntries.length > 0
   const runtimeConfigPath = runtimeProviders?.config_path ?? runtimeDefaults?.config_path ?? null
   const defaultRuntimeId = runtimeDefaults?.default_runtime_id ?? runtimeProviders?.summary?.default_runtime_id ?? null
   const defaultCatalogEntry = findRuntimeCatalogSnapshot(runtimeCatalogEntries, defaultRuntimeId)
@@ -831,9 +862,14 @@ export function SettingsSurface() {
 
                 <div class="settings-runtime-section" data-runtime-section="catalog" data-testid="runtime-catalog-section">
                   <div class="set-sub-h">Runtime catalog (${runtimeCatalogEntries.length})</div>
-                  ${runtimeCatalogStatus === 'loading'
+                  ${runtimeCatalogIsFallback ? html`
+                    <div class="set-hint" data-testid="runtime-catalog-fallback">
+                      provider catalog를 불러오지 못해 live runtime defaults projection으로 표시합니다.
+                    </div>
+                  ` : null}
+                  ${runtimeCatalogStatus === 'loading' && runtimeCatalogEntries.length === 0
                     ? html`<div class="set-hint" data-testid="runtime-catalog-loading">runtime catalog 불러오는 중...</div>`
-                    : runtimeCatalogStatus === 'error'
+                    : runtimeCatalogStatus === 'error' && runtimeCatalogEntries.length === 0
                       ? html`<div class="set-hint" data-testid="runtime-catalog-error">runtime catalog를 불러오지 못했습니다.</div>`
                       : runtimeCatalogEntries.length === 0
                         ? html`<div class="set-hint" data-testid="runtime-catalog-empty">표시할 runtime catalog entry가 없습니다.</div>`


### PR DESCRIPTION
## Summary

- Show a live runtime-defaults fallback catalog in Settings when the rich provider catalog is unavailable or empty.
- Keep fallback capability chips explicit as unknown (`? tools`, `? thinking`, `? streaming`) instead of presenting missing capability data as disabled.
- Add focused coverage for the provider-catalog failure path so runtime entries from `/api/v1/dashboard/runtime-defaults` remain visible.

## Why

The Settings runtime overview already depends on live server projections, but the catalog area could still collapse to an error/empty state when `/api/v1/providers` failed even though `/api/v1/dashboard/runtime-defaults` had usable live runtime data. This made the catalog look broken in one degraded-but-recoverable path.

## Validation

- `vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit`
- `eslint src/components/settings-surface.ts`
- `git diff --check`
- Playwright fallback smoke for `/dashboard/#settings` with `/api/v1/providers` mocked as 503 and `/api/v1/dashboard/runtime-defaults` returning three live-style runtimes.

Build is left to GitHub CI per project workflow.
