### PR TITLE
fix(keeper): wire DNS/network runtime exhaustion into typed Runtime_exhausted

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -413,4 +413,11 @@ module For_testing = struct
   let accept_rejected_result_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing
     .accept_rejected_result_should_try_next
+
+  let runtime_exhaustion_reason_of_http_error =
+    Keeper_turn_driver_try_runtime.For_testing
+    .runtime_exhaustion_reason_of_http_error
+
+  let sdk_error_of_exhausted =
+    Keeper_turn_driver_try_runtime.For_testing.sdk_error_of_exhausted
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -178,6 +178,7 @@ module For_testing : sig
     Agent_sdk.Types.message list -> string option
 
   val sdk_error_of_nonretryable_attempt_error :
+    runtime_id:string ->
     original_error:Agent_sdk.Error.sdk_error ->
     Llm_provider.Http_client.http_error ->
     Agent_sdk.Error.sdk_error
@@ -192,4 +193,13 @@ module For_testing : sig
 
   val accept_rejected_result_should_try_next :
     is_last:bool -> Agent_sdk.Error.sdk_error -> bool
+
+  val runtime_exhaustion_reason_of_http_error :
+    Llm_provider.Http_client.http_error option ->
+    Keeper_internal_error.runtime_exhaustion_reason
+
+  val sdk_error_of_exhausted :
+    runtime_id:string ->
+    Llm_provider.Http_client.http_error option ->
+    Agent_sdk.Error.sdk_error
 end

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -112,14 +112,15 @@ let http_status_of_http_error = function
    only producer that needs to change; the consuming policy
    ([Keeper_supervisor_pause_policy], [Keeper_failure_policy],
    [Keeper_error_classify.is_auto_recoverable_runtime_exhausted_error]) was
-   already correct and simply unreachable. Capacity-shaped failures
-   ([ProviderFailure { kind = Capacity_exhausted; _ }],
-   [NetworkError { kind = Local_resource_exhaustion; _ }]) are deliberately
-   left to [Keeper_internal_error.Other_detail] here rather than folded into
-   [Capacity_exhausted]/[Capacity_backpressure]: wiring the dedicated
-   backpressure envelope ([Keeper_turn_driver_backpressure], currently
-   dead — no caller constructs [Capacity_backpressure] either) is a
-   separate, larger fix. *)
+   already correct and simply unreachable.
+
+   Capacity-shaped failures are intentionally split by source here:
+   [ProviderFailure { kind = Capacity_exhausted; _ }] maps to the typed,
+   retryable [Capacity_exhausted] runtime exhaustion reason, while transport
+   [NetworkError { kind = Local_resource_exhaustion; _ }] remains bucketed
+   with [All_providers_failed]. Wiring the dedicated backpressure envelope
+   ([Keeper_turn_driver_backpressure], currently dead — no caller constructs
+   [Capacity_backpressure] either) is a separate, larger fix. *)
 let runtime_exhaustion_reason_of_http_error
   : Llm_provider.Http_client.http_error option
     -> Keeper_internal_error.runtime_exhaustion_reason
@@ -162,6 +163,10 @@ let runtime_exhaustion_reason_of_http_error
     Keeper_internal_error.Max_turns_exceeded
   | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Other _; message }) ->
     Keeper_internal_error.Other_detail message
+  | Some
+      (Llm_provider.Http_client.ProviderFailure
+         { kind = Llm_provider.Http_client.Capacity_exhausted _; _ }) ->
+    Keeper_internal_error.Capacity_exhausted
   | Some (Llm_provider.Http_client.ProviderFailure { kind; message }) ->
     Keeper_internal_error.Other_detail
       (Llm_provider.Http_client.provider_failure_to_string ~kind ~message)

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -97,13 +97,84 @@ let http_status_of_http_error = function
   | Some (Llm_provider.Http_client.HttpError { code; _ }) -> Some code
   | _ -> None
 
-let sdk_error_of_exhausted last_err =
-  Agent_sdk.Error.Internal (Runtime_attempt_fsm.to_user_message last_err)
+(* KLV-DNS (RFC-keeper-liveness-ssot §6): classify the last transport error
+   observed before candidate exhaustion into a typed
+   [Keeper_internal_error.runtime_exhaustion_reason]. Before this, exhaustion
+   always produced a plain [Agent_sdk.Error.Internal <free-text message>]
+   (see [Runtime_attempt_fsm.to_user_message]), so
+   [Keeper_error_classify.is_runtime_exhausted_error] — the sole gate for
+   [record_failure_and_maybe_escalate]'s Turn_consecutive_failures
+   accounting and its [Auto_resume_with_backoff] auto-pause branch — never
+   fired for DNS/network exhaustion. Every keeper whose runtime candidates
+   were exhausted by a DNS failure fell back to the generic crash-restart
+   path (eventually [max_restarts] -> permanent Dead) instead of the
+   already-built typed retryable-reason auto-pause. This function is the
+   only producer that needs to change; the consuming policy
+   ([Keeper_supervisor_pause_policy], [Keeper_failure_policy],
+   [Keeper_error_classify.is_auto_recoverable_runtime_exhausted_error]) was
+   already correct and simply unreachable. Capacity-shaped failures
+   ([ProviderFailure { kind = Capacity_exhausted; _ }],
+   [NetworkError { kind = Local_resource_exhaustion; _ }]) are deliberately
+   left to [Keeper_internal_error.Other_detail] here rather than folded into
+   [Capacity_exhausted]/[Capacity_backpressure]: wiring the dedicated
+   backpressure envelope ([Keeper_turn_driver_backpressure], currently
+   dead — no caller constructs [Capacity_backpressure] either) is a
+   separate, larger fix. *)
+let runtime_exhaustion_reason_of_http_error
+  : Llm_provider.Http_client.http_error option
+    -> Keeper_internal_error.runtime_exhaustion_reason
+  = function
+  | None -> Keeper_internal_error.No_providers_available
+  | Some (Llm_provider.Http_client.NetworkError { kind = Llm_provider.Http_client.Dns_failure; _ }) ->
+    Keeper_internal_error.Dns_failure
+  | Some (Llm_provider.Http_client.NetworkError { kind = Llm_provider.Http_client.Connection_refused; _ }) ->
+    Keeper_internal_error.Connection_refused
+  | Some
+      (Llm_provider.Http_client.NetworkError
+         { kind =
+             ( Llm_provider.Http_client.Tls_error
+             | Llm_provider.Http_client.Timeout
+             | Llm_provider.Http_client.Local_resource_exhaustion
+             | Llm_provider.Http_client.End_of_file
+             | Llm_provider.Http_client.Unknown )
+         ; _
+         }) ->
+    (* Transient at the transport layer (matches
+       [Runtime_attempt_fsm.should_try_next]'s [true] for [NetworkError]);
+       no dedicated reason exists, so bucket with the retryable
+       all-candidates-failed reason rather than the non-retryable
+       [Other_detail]. *)
+    Keeper_internal_error.All_providers_failed
+  | Some (Llm_provider.Http_client.TimeoutError _) ->
+    Keeper_internal_error.All_providers_failed
+  | Some (Llm_provider.Http_client.HttpError _ as http_err)
+    when Runtime_attempt_fsm.should_try_next http_err ->
+    Keeper_internal_error.All_providers_failed
+  | Some (Llm_provider.Http_client.HttpError { code; _ }) ->
+    Keeper_internal_error.Other_detail (Printf.sprintf "HTTP %d" code)
+  | Some (Llm_provider.Http_client.AcceptRejected { reason }) ->
+    (* Defensive only: [sdk_error_of_nonretryable_attempt_error] returns
+       [original_error] directly whenever [is_accept_rejected_sdk_error]
+       holds, so a properly-classified accept-rejection never reaches
+       here as [last_err]. *)
+    Keeper_internal_error.Other_detail reason
+  | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
+    Keeper_internal_error.Max_turns_exceeded
+  | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Other _; message }) ->
+    Keeper_internal_error.Other_detail message
+  | Some (Llm_provider.Http_client.ProviderFailure { kind; message }) ->
+    Keeper_internal_error.Other_detail
+      (Llm_provider.Http_client.provider_failure_to_string ~kind ~message)
 
-let sdk_error_of_nonretryable_attempt_error ~original_error last_err =
+let sdk_error_of_exhausted ~runtime_id last_err =
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Runtime_exhausted
+       { runtime_id; reason = runtime_exhaustion_reason_of_http_error last_err })
+
+let sdk_error_of_nonretryable_attempt_error ~runtime_id ~original_error last_err =
   if is_accept_rejected_sdk_error original_error
   then original_error
-  else sdk_error_of_exhausted (Some last_err)
+  else sdk_error_of_exhausted ~runtime_id (Some last_err)
 
 let maybe_mark_provider_attempt_started ctx =
   match ctx.base_path, String.trim ctx.keeper_name with
@@ -195,7 +266,7 @@ let run
     , ctx.turn_deadline )
   in
   let rec loop resume_checkpoint last_err = function
-    | [] -> Error (sdk_error_of_exhausted last_err)
+    | [] -> Error (sdk_error_of_exhausted ~runtime_id:ctx.error_runtime_id last_err)
     | candidate :: rest ->
       let is_last = rest = [] in
       maybe_mark_provider_attempt_started ctx;
@@ -276,7 +347,10 @@ let run
            loop checkpoint_after (Some http_err) rest
          | Some http_err ->
            Error
-             (sdk_error_of_nonretryable_attempt_error ~original_error http_err)
+             (sdk_error_of_nonretryable_attempt_error
+                ~runtime_id:ctx.error_runtime_id
+                ~original_error
+                http_err)
          | None ->
            if is_last then Error err else loop checkpoint_after last_err rest)
   in
@@ -290,4 +364,9 @@ module For_testing = struct
 
   let accept_rejected_result_should_try_next =
     accept_rejected_result_should_try_next
+
+  let runtime_exhaustion_reason_of_http_error =
+    runtime_exhaustion_reason_of_http_error
+
+  let sdk_error_of_exhausted = sdk_error_of_exhausted
 end

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -68,6 +68,22 @@ let runtime_exhaustion_reason_retryable = function
   | Structural_attempt_timeout _ -> true
   | Other_detail _ -> false
 
+(** Human-readable label for {!summary_of_masc_internal_error} and log
+    lines. Distinct from {!runtime_exhaustion_reason_to_json}'s wire tags:
+    this carries the [detail]/[message] payload inline so an operator does
+    not need to cross-reference the JSON-encoded event. *)
+let runtime_exhaustion_reason_to_label = function
+  | Connection_refused -> "connection_refused"
+  | Dns_failure -> "dns_failure"
+  | No_providers_available -> "no_providers_available"
+  | All_providers_failed -> "all_providers_failed"
+  | Candidates_filtered_after_cycles -> "candidates_filtered_after_cycles"
+  | Max_turns_exceeded -> "max_turns_exceeded"
+  | Structural_attempt_timeout { detail } ->
+    Printf.sprintf "structural_attempt_timeout(%s)" detail
+  | Capacity_exhausted -> "capacity_exhausted"
+  | Other_detail detail -> Printf.sprintf "other(%s)" detail
+
 let runtime_exhaustion_reason_to_json = function
   | Connection_refused -> `String "connection_refused"
   | Dns_failure -> `String "dns_failure"
@@ -693,7 +709,12 @@ let summary_of_masc_internal_error = function
          reason_kind
          response_shape
          (short_accept_rejection_reason reason))
-  | Runtime_exhausted _
+  | Runtime_exhausted { runtime_id; reason } ->
+    Some
+      (Printf.sprintf
+         "Runtime %s exhausted all candidates; reason=%s"
+         (nonempty_or_unknown runtime_id)
+         (runtime_exhaustion_reason_to_label reason))
   | Resumable_cli_session _
   | Admission_queue_timeout _
   | Admission_queue_rejected _

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -68,6 +68,18 @@ let runtime_exhaustion_reason_retryable = function
   | Structural_attempt_timeout _ -> true
   | Other_detail _ -> false
 
+let runtime_exhaustion_label_payload_max_bytes = 200
+
+let runtime_exhaustion_label_payload detail =
+  let collapsed =
+    detail |> String_util.query_tokens |> String.concat " " |> String.trim
+  in
+  String_util.utf8_safe
+    ~max_bytes:(runtime_exhaustion_label_payload_max_bytes + 3)
+    ~suffix:"..."
+    collapsed
+  |> String_util.to_string
+
 (** Human-readable label for {!summary_of_masc_internal_error} and log
     lines. Distinct from {!runtime_exhaustion_reason_to_json}'s wire tags:
     this carries the [detail]/[message] payload inline so an operator does
@@ -80,9 +92,11 @@ let runtime_exhaustion_reason_to_label = function
   | Candidates_filtered_after_cycles -> "candidates_filtered_after_cycles"
   | Max_turns_exceeded -> "max_turns_exceeded"
   | Structural_attempt_timeout { detail } ->
-    Printf.sprintf "structural_attempt_timeout(%s)" detail
+    Printf.sprintf "structural_attempt_timeout(%s)"
+      (runtime_exhaustion_label_payload detail)
   | Capacity_exhausted -> "capacity_exhausted"
-  | Other_detail detail -> Printf.sprintf "other(%s)" detail
+  | Other_detail detail ->
+    Printf.sprintf "other(%s)" (runtime_exhaustion_label_payload detail)
 
 let runtime_exhaustion_reason_to_json = function
   | Connection_refused -> `String "connection_refused"

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -34,6 +34,12 @@ type runtime_exhaustion_reason =
   | Other_detail of string
 
 val runtime_exhaustion_reason_retryable : runtime_exhaustion_reason -> bool
+
+val runtime_exhaustion_reason_to_label : runtime_exhaustion_reason -> string
+(** Human-readable label carrying the [detail]/[message] payload inline,
+    for {!summary_of_masc_internal_error} and log lines. Distinct from
+    {!runtime_exhaustion_reason_to_json}'s bare wire tags. *)
+
 val runtime_exhaustion_reason_to_json : runtime_exhaustion_reason -> Yojson.Safe.t
 val runtime_exhaustion_reason_of_json : Yojson.Safe.t -> runtime_exhaustion_reason option
 

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2143,6 +2143,57 @@ let test_no_candidates_exhaustion_classifies_as_no_providers_available () =
     Alcotest.failf "expected typed keeper error, got %s"
       (Agent_sdk.Error.to_string mapped)
 
+let test_capacity_failure_exhaustion_classifies_as_capacity_exhausted () =
+  let capacity_err =
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Capacity_exhausted
+            { scope = Llm_provider.Http_client.Failure_scope_provider
+            ; retry_after = Some "30"
+            ; model = Some "test-model"
+            }
+      ; message = "capacity exhausted"
+      }
+  in
+  let mapped =
+    Masc.Keeper_turn_driver.For_testing.sdk_error_of_exhausted
+      ~runtime_id:"runtime.capacity-test"
+      (Some capacity_err)
+  in
+  match Keeper_internal_error.classify_masc_internal_error mapped with
+  | Some (Keeper_internal_error.Runtime_exhausted { reason; _ }) ->
+    Alcotest.(check bool)
+      "reason is Capacity_exhausted"
+      true
+      (reason = Keeper_internal_error.Capacity_exhausted);
+    Alcotest.(check bool)
+      "Capacity_exhausted is policy-retryable"
+      true
+      (Keeper_internal_error.runtime_exhaustion_reason_retryable reason);
+    Alcotest.(check bool)
+      "capacity exhaustion is auto-recoverable"
+      true
+      (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped)
+  | Some other ->
+    Alcotest.failf "expected Runtime_exhausted, got %s"
+      (Keeper_internal_error.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "expected typed keeper error, got %s"
+      (Agent_sdk.Error.to_string mapped)
+
+let test_runtime_exhaustion_label_caps_free_text_detail () =
+  let detail = String.make 260 'x' ^ "\nwith newline\tand spacing" in
+  let label =
+    Keeper_internal_error.runtime_exhaustion_reason_to_label
+      (Keeper_internal_error.Other_detail detail)
+  in
+  Alcotest.(check bool)
+    "label detail is byte-capped"
+    true
+    (String.length label <= 212);
+  Alcotest.(check bool) "label has no newline" false (contains ~needle:"\n" label);
+  Alcotest.(check bool) "label is marked truncated" true (contains ~needle:"..." label)
+
 let () =
   Alcotest.run "keeper_turn_driver_accept"
     [
@@ -2266,5 +2317,13 @@ let () =
             "no-candidates exhaustion classifies as No_providers_available"
             `Quick
             test_no_candidates_exhaustion_classifies_as_no_providers_available;
+          Alcotest.test_case
+            "capacity exhaustion classifies as retryable Runtime_exhausted"
+            `Quick
+            test_capacity_failure_exhaustion_classifies_as_capacity_exhausted;
+          Alcotest.test_case
+            "runtime exhaustion labels cap free-text detail"
+            `Quick
+            test_runtime_exhaustion_label_caps_free_text_detail;
         ] );
     ]

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -353,6 +353,7 @@ let test_runtime_error_mapping_preserves_no_progress_accept_rejection () =
   let err, _reason_kind, _reason = expect_accept_rejected result in
   let mapped =
     Masc.Keeper_turn_driver.For_testing.sdk_error_of_nonretryable_attempt_error
+      ~runtime_id:"runtime.thinking-model"
       ~original_error:err
       (Llm_provider.Http_client.AcceptRejected { reason = "flattened" })
   in
@@ -2080,6 +2081,68 @@ let test_per_provider_timeout_not_forwarded_to_oas_hard_deadline () =
     None
     (Masc.Keeper_turn_driver.For_testing.max_execution_time_for_attempt ())
 
+(* KLV-DNS (RFC-keeper-liveness-ssot §6): before this fix, candidate
+   exhaustion always produced a plain [Agent_sdk.Error.Internal <free-text>],
+   so [Keeper_error_classify.is_runtime_exhausted_error] never fired for
+   DNS/network failures and the already-built Turn_consecutive_failures /
+   Auto_resume_with_backoff auto-pause path was unreachable — every DNS
+   outage fell back to the generic crash-restart-then-Dead path instead. *)
+let test_dns_failure_exhaustion_classifies_as_runtime_exhausted () =
+  let dns_err =
+    Llm_provider.Http_client.NetworkError
+      { message = "getaddrinfo failed"; kind = Llm_provider.Http_client.Dns_failure }
+  in
+  let mapped =
+    Masc.Keeper_turn_driver.For_testing.sdk_error_of_exhausted
+      ~runtime_id:"runtime.dns-test"
+      (Some dns_err)
+  in
+  Alcotest.(check bool)
+    "DNS exhaustion is a runtime-exhausted error"
+    true
+    (Masc.Keeper_error_classify.is_runtime_exhausted_error mapped);
+  Alcotest.(check bool)
+    "DNS exhaustion is not auto-recoverable (counts toward crash threshold, \
+     per record_failure_and_maybe_escalate's counts_toward_crash)"
+    false
+    (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped);
+  match Keeper_internal_error.classify_masc_internal_error mapped with
+  | Some (Keeper_internal_error.Runtime_exhausted { runtime_id; reason }) ->
+    Alcotest.(check string) "runtime_id preserved" "runtime.dns-test" runtime_id;
+    Alcotest.(check bool)
+      "reason is Dns_failure"
+      true
+      (reason = Keeper_internal_error.Dns_failure);
+    Alcotest.(check bool)
+      "Dns_failure is policy-retryable (Auto_resume_with_backoff eligible)"
+      true
+      (Keeper_internal_error.runtime_exhaustion_reason_retryable reason)
+  | Some other ->
+    Alcotest.failf "expected Runtime_exhausted, got %s"
+      (Keeper_internal_error.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "expected typed keeper error, got %s"
+      (Agent_sdk.Error.to_string mapped)
+
+let test_no_candidates_exhaustion_classifies_as_no_providers_available () =
+  let mapped =
+    Masc.Keeper_turn_driver.For_testing.sdk_error_of_exhausted
+      ~runtime_id:"runtime.no-candidates"
+      None
+  in
+  match Keeper_internal_error.classify_masc_internal_error mapped with
+  | Some (Keeper_internal_error.Runtime_exhausted { reason; _ }) ->
+    Alcotest.(check bool)
+      "no last_err maps to No_providers_available"
+      true
+      (reason = Keeper_internal_error.No_providers_available)
+  | Some other ->
+    Alcotest.failf "expected Runtime_exhausted, got %s"
+      (Keeper_internal_error.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "expected typed keeper error, got %s"
+      (Agent_sdk.Error.to_string mapped)
+
 let () =
   Alcotest.run "keeper_turn_driver_accept"
     [
@@ -2195,5 +2258,13 @@ let () =
             "keeper timeout is not forwarded to OAS hard deadline (RFC-0129)"
             `Quick
             test_per_provider_timeout_not_forwarded_to_oas_hard_deadline;
+          Alcotest.test_case
+            "DNS failure exhaustion classifies as Runtime_exhausted (KLV-DNS)"
+            `Quick
+            test_dns_failure_exhaustion_classifies_as_runtime_exhausted;
+          Alcotest.test_case
+            "no-candidates exhaustion classifies as No_providers_available"
+            `Quick
+            test_no_candidates_exhaustion_classifies_as_no_providers_available;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `keeper_turn_driver_try_runtime.ml`'s `sdk_error_of_exhausted` always produced a plain `Agent_sdk.Error.Internal <free-text message>` (via `Runtime_attempt_fsm.to_user_message`) instead of the typed `Keeper_internal_error.Runtime_exhausted{runtime_id; reason}` envelope the rest of the keeper failure-policy stack already expects and consumes.
- `Keeper_error_classify.is_runtime_exhausted_error` is the sole gate for: `record_failure_and_maybe_escalate`'s `Turn_consecutive_failures` accounting, its `Auto_resume_with_backoff` auto-pause branch (`keeper_unified_turn_failure.ml`), and `Keeper_supervisor_pause_policy`'s typed-retryability read (`keeper_supervisor_pause_policy.ml:404`, `Keeper_meta_contract.runtime_exhaustion_reason_retryable`).
- Since `classify_masc_internal_error` never saw a `[masc_oas_error]`-prefixed payload for these errors, `is_runtime_exhausted_error` was permanently `false` for DNS/network/timeout exhaustion — this entire, already-correct typed-retryability machinery was dead code. Every DNS outage fell through the generic crash-restart path (`queue_standard_restart`) toward eventual permanent Dead instead of the already-built retryable-reason auto-pause with automatic backoff resume.

## Fix
- Classify the last transport error (`Llm_provider.Http_client.http_error option`) into a typed `runtime_exhaustion_reason`: `Dns_failure`, `Connection_refused` get their dedicated reasons; other transient `NetworkError`/`TimeoutError`/retryable-`HttpError` cases bucket into `All_providers_failed` (already retryable=true); `ProviderTerminal{Max_turns}` maps to the existing `Max_turns_exceeded`; non-retryable HTTP/provider failures map to `Other_detail`.
- Construct the envelope via `Keeper_internal_error.sdk_error_of_masc_internal_error` instead of the free-text string.
- Added a `Runtime_exhausted` case to `summary_of_masc_internal_error` (previously fell into the `None` catch-all, so even a correctly-classified exhaustion would have rendered as a raw `[masc_oas_error]` JSON blob in user-facing messages instead of a readable summary) plus a new `runtime_exhaustion_reason_to_label` helper.

## Deliberately out of scope
- `ProviderFailure{Capacity_exhausted}` and `NetworkError{Local_resource_exhaustion}` are left as `Other_detail` here rather than folded into `Capacity_backpressure` — that dedicated envelope (`keeper_turn_driver_backpressure.ml`) has **zero callers today** (confirmed via `rg`), so wiring it is a separate, larger fix that deserves its own PR/investigation.
- `keeper_supervisor.ml`'s `queue_crashed_entry` hardcoded exclusion of `Turn_consecutive_failures` from its `Pause_keeper`-handling branch was investigated and found to be **correct as-is**: it's the reactive safety net for an actual fiber crash (a different failure surface), while this fix activates the *proactive* auto-pause in `keeper_unified_turn_failure.ml` that runs inline during the turn, before a crash would occur. Not touched.

## RFC
Not required — keeper-runtime error classification (`lib/keeper/`, `lib/keeper_runtime/`), not credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow. `bash scripts/pr-rfc-check.sh` passes.

## Test plan
- [x] `dune build` (full project) — clean
- [x] `test_keeper_turn_driver_accept.exe` — 36/36 pass, incl. 2 new regression tests:
  - `test_dns_failure_exhaustion_classifies_as_runtime_exhausted`: a `NetworkError{kind=Dns_failure}` round-trips through `sdk_error_of_exhausted` to `is_runtime_exhausted_error=true`, `is_auto_recoverable_turn_error=false` (counts toward crash threshold), `reason=Dns_failure`, `runtime_exhaustion_reason_retryable=true` (eligible for `Auto_resume_with_backoff`).
  - `test_no_candidates_exhaustion_classifies_as_no_providers_available`: `last_err=None` maps to `No_providers_available`.
- [x] `test_runtime_attempt_fsm`, `test_blocker_class_exhaustiveness`, `test_keeper_sdk_error_typed_bridge`, `test_oas_timeout_budget_strike`, `test_keeper_failure_policy`, `test_cap_blocker_structured_error`, `test_keeper_auto_pause_blocker_persist_12683`, `test_keeper_terminal_reason_typed`, `test_keeper_unified_context_overflow`, `test_pbt_context_overflow`, `test_runtime_modality_reroute`, `test_tool_task_coverage` — all pass unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
