### PR TITLE
fix(keeper): require progress evidence for no-progress resume

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -215,16 +215,7 @@ let direct_success_may_clear_no_progress_pause
   : bool
   =
   direct_success_disposition_allows_no_progress_resume result
-  &&
-  match
-    Keeper_turn_outcome.of_result_surface
-      ~response_text:result.response_text
-      result.stop_reason
-  with
-  | Keeper_turn_outcome.Visible_reply -> true
-  | Keeper_turn_outcome.Continuation_checkpoint
-  | Keeper_turn_outcome.No_visible_reply ->
-    direct_success_has_progress_evidence result
+  && direct_success_has_progress_evidence result
 
 let clear_direct_success_no_progress_pause
       ~(config : Workspace.config)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -46,8 +46,9 @@ module For_testing : sig
   val direct_success_may_clear_no_progress_pause :
     Keeper_agent_run.run_result -> bool
   (** Typed recovery predicate for direct-message success: only a healthy
-      operator disposition plus visible reply or non-passive typed progress
-      / validated run evidence may clear a no-progress forced pause. *)
+      operator disposition plus non-passive typed progress or validated run
+      evidence may clear a no-progress forced pause. Text-only visible replies
+      are not sufficient. *)
 
   val clear_direct_success_no_progress_pause :
     config:Workspace.config ->

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -900,11 +900,19 @@ let test_direct_success_clears_no_progress_pause () =
                ; runtime_id = None
                ; reason = None
                }));
+       let progress_result =
+         run_result
+           ~tool_calls:
+             [ tool_call
+                 ~typed_outcome:Keeper_tool_outcome.Progress
+                 "masc_deliver" ]
+           ()
+       in
        let recovered_meta =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:meta
-           ~result:(run_result ())
+           ~result:progress_result
            meta
        in
        check bool "direct success resumes no-progress pause" false recovered_meta.paused;
@@ -922,9 +930,17 @@ let test_direct_success_clears_no_progress_pause () =
            false
            entry.Masc.Keeper_registry.meta.paused;
          (match entry.Masc.Keeper_registry.last_failure_reason with
-          | None -> ()
+         | None -> ()
          | Some _ -> fail "expected direct success to clear no_progress failure reason")
        | None -> fail "expected registered keeper")
+
+let test_direct_success_visible_text_only_keeps_no_progress_pause () =
+  let result = run_result ~response_text:"direct reply" () in
+  check bool
+    "visible text without typed progress cannot clear no-progress pause"
+    false
+    (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
+       result)
 
 let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
   Eio_main.run
@@ -973,11 +989,19 @@ let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
                ; runtime_id = None
                ; reason = None
                }));
+       let progress_result =
+         run_result
+           ~tool_calls:
+             [ tool_call
+                 ~typed_outcome:Keeper_tool_outcome.Progress
+                 "masc_deliver" ]
+           ()
+       in
        let recovered_meta =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:meta
-           ~result:(run_result ())
+           ~result:progress_result
            meta
        in
        check bool
@@ -1211,11 +1235,19 @@ let test_direct_success_persist_failure_keeps_no_progress_pause () =
                ; reason = None
                }));
        let invalid_meta = { meta with agent_name = "" } in
+       let progress_result =
+         run_result
+           ~tool_calls:
+             [ tool_call
+                 ~typed_outcome:Keeper_tool_outcome.Progress
+                 "masc_deliver" ]
+           ()
+       in
        let recovered_meta =
          Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
            ~config
            ~pre_turn_meta:invalid_meta
-           ~result:(run_result ())
+           ~result:progress_result
            invalid_meta
        in
        check bool "failed persistence keeps returned meta paused" true recovered_meta.paused;
@@ -1483,6 +1515,10 @@ let () =
             test_resume_directive_persist_failure_keeps_completion_contract_pause;
           test_case "direct success clears no-progress pause" `Quick
             test_direct_success_clears_no_progress_pause;
+          test_case
+            "direct success visible text-only keeps no-progress pause"
+            `Quick
+            test_direct_success_visible_text_only_keeps_no_progress_pause;
           test_case
             "direct success clears no-progress pause after blocker overwrite"
             `Quick

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -158,11 +158,36 @@ let pass_next_model_operator_disposition
   ; reason = Masc.Keeper_execution_receipt.Reason_runtime_fallback
   }
 
+let run_ref : Agent_sdk.Raw_trace.run_ref =
+  { worker_run_id = "test-run"
+  ; path = "/tmp/test-raw-trace.jsonl"
+  ; start_seq = 1
+  ; end_seq = 2
+  ; agent_name = "test-keeper"
+  ; session_id = None
+  }
+
+let file_write_run_validation : Agent_sdk.Raw_trace.run_validation =
+  { run_ref
+  ; ok = true
+  ; checks = []
+  ; evidence = []
+  ; paired_tool_result_count = 0
+  ; evidence_roles = []
+  ; has_file_write = true
+  ; verification_pass_after_file_write = false
+  ; final_text = Some "validated"
+  ; tool_names = []
+  ; stop_reason = Some "completed"
+  ; failure_reason = None
+  }
+
 let run_result
       ?(response_text = "direct reply")
       ?(stop_reason = Runtime_agent.Completed)
       ?(operator_disposition = Some healthy_operator_disposition)
       ?(tool_calls = [])
+      ?run_validation
       ()
   : Masc.Keeper_agent_run.run_result
   =
@@ -180,7 +205,7 @@ let run_result
   ; operator_disposition
   ; checkpoint = None
   ; trace_ref = None
-  ; run_validation = None
+  ; run_validation
   ; stop_reason
   ; inference_telemetry = None
   ; tool_surface
@@ -942,6 +967,16 @@ let test_direct_success_visible_text_only_keeps_no_progress_pause () =
     (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
        result)
 
+let test_direct_success_run_validation_clears_no_progress_pause () =
+  let result =
+    run_result ~response_text:"" ~run_validation:file_write_run_validation ()
+  in
+  check bool
+    "validated file write can clear no-progress pause"
+    true
+    (Masc.Keeper_turn.For_testing.direct_success_may_clear_no_progress_pause
+       result)
+
 let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
   Eio_main.run
   @@ fun env ->
@@ -1519,6 +1554,9 @@ let () =
             "direct success visible text-only keeps no-progress pause"
             `Quick
             test_direct_success_visible_text_only_keeps_no_progress_pause;
+          test_case "direct success validated run clears no-progress pause"
+            `Quick
+            test_direct_success_run_validation_clears_no_progress_pause;
           test_case
             "direct success clears no-progress pause after blocker overwrite"
             `Quick


### PR DESCRIPTION
## Summary

Direct `keeper_msg` success no longer clears a no-progress pause/blocker just because the model produced visible text.

The resume gate now requires existing typed progress evidence:

- non-passive `Keeper_tool_outcome.Progress` from a material tool, or
- `visible_run_validation` evidence.

This keeps direct replies visible, but prevents text-only "I will continue" / no-action responses from resetting the no-progress latch.

## Why

Runtime Albini traces showed repeated visible/prose-only replies and replay payloads with no material tool progress. The prior direct success gate treated every healthy `Visible_reply` as recovery, which let a keeper escape the no-progress pause without proving progress.

This change avoids hardcoded text matching and uses the existing typed progress axis.

## Validation

- `scripts/dune-local.sh build test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_no_progress_loop_detector.exe test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe` (25 tests)
- `./_build/default/test/test_no_progress_loop_detector.exe` (32 tests)
- `./_build/default/test/test_keeper_state_snapshot_json.exe` (32 tests)
- `opam exec -- ocamlformat --check lib/keeper/keeper_turn.ml test/test_keeper_auto_pause_blocker_persist_12683.ml`
- `git diff --check`

Note: full `@fmt` currently reports pre-existing dune stanza formatting differences outside this patch.
