### PR TITLE
fix(slack): centralize message limit constants

### DIFF
--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -22,9 +22,12 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
+from .constants import SLACK_MESSAGE_LIMIT as SLACK_MESSAGE_LIMIT
+
 DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/slack"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/slack/bindings.json"
 DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/slack/status.json"
+
 
 def _runtime_toml_path() -> Path:
     raw = os.getenv("MASC_BASE_PATH", "").strip()
@@ -66,7 +69,13 @@ class BotConfig(BaseSettings):
         toml_source = TomlConfigSettingsSource(
             settings_cls, toml_file=_runtime_toml_path()
         )
-        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            toml_source,
+            file_secret_settings,
+        )
 
     # Required: Slack Bot Token (xoxb-...)
     slack_bot_token: str = Field(
@@ -108,7 +117,9 @@ class BotConfig(BaseSettings):
     )
     gate_breaker_reset_sec: int = Field(
         default=30,
-        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
+        validation_alias=AliasChoices(
+            "GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"
+        ),
     )
     status_cache_ttl_sec: int = Field(
         default=15,
@@ -138,6 +149,7 @@ class BotConfig(BaseSettings):
             "status_path",
         ),
     )
+
     @field_validator("slack_bot_token")
     @classmethod
     def bot_token_not_empty(cls, v: str) -> str:
@@ -172,8 +184,6 @@ class BotConfig(BaseSettings):
 
 
 _config: BotConfig | None = None
-
-SLACK_MESSAGE_LIMIT: Final[int] = 4000  # Slack blocks text limit
 
 
 def get_config() -> BotConfig:

--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -22,7 +22,15 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
-from .constants import SLACK_MESSAGE_LIMIT as SLACK_MESSAGE_LIMIT
+from .constants import SLACK_MESSAGE_LIMIT
+
+__all__ = [
+    "BotConfig",
+    "DEFAULT_BINDING_STORE_PATH",
+    "DEFAULT_STATE_DIR",
+    "DEFAULT_STATUS_PATH",
+    "SLACK_MESSAGE_LIMIT",
+]
 
 DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/slack"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/slack/bindings.json"

--- a/sidecars/slack-bot/src/constants.py
+++ b/sidecars/slack-bot/src/constants.py
@@ -1,0 +1,9 @@
+"""Shared Slack API limits for the Slack Gate Bot."""
+
+from __future__ import annotations
+
+from typing import Final
+
+SLACK_MESSAGE_LIMIT: Final[int] = 4000
+SLACK_MAX_BLOCKS: Final[int] = 50
+SLACK_BLOCK_TEXT_LIMIT: Final[int] = 3000

--- a/sidecars/slack-bot/src/formatters.py
+++ b/sidecars/slack-bot/src/formatters.py
@@ -10,18 +10,15 @@ import html
 import re
 from typing import Any
 
-SLACK_MESSAGE_LIMIT = 4000
-SLACK_MAX_BLOCKS = 50
-SLACK_BLOCK_TEXT_LIMIT = 3000
+from .constants import SLACK_BLOCK_TEXT_LIMIT, SLACK_MAX_BLOCKS, SLACK_MESSAGE_LIMIT
+
 TRUNCATION_NOTICE = "\n[truncated: Slack block limit]"
 STRUCTURED_TRUNCATION_TEMPLATE = (
     ":warning: {count} structured block(s) omitted because Slack allows "
     f"at most {SLACK_MAX_BLOCKS} blocks per message."
 )
 
-_RE_STATE_BLOCK = re.compile(
-    r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL
-)
+_RE_STATE_BLOCK = re.compile(r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL)
 
 
 def strip_state_blocks(text: str) -> str:
@@ -230,7 +227,10 @@ def _attach_block(raw: dict[str, Any]) -> dict[str, Any] | None:
 
 def _video_block(raw: dict[str, Any]) -> dict[str, Any] | None:
     src = _structured_text(raw.get("src")).strip()
-    caption = _structured_text(raw.get("cap")).strip() or _structured_text(raw.get("name")).strip()
+    caption = (
+        _structured_text(raw.get("cap")).strip()
+        or _structured_text(raw.get("name")).strip()
+    )
     if not src and not caption:
         return None
     lines = [f"*Video:* {escape_mrkdwn_text(caption or src)}"]
@@ -265,7 +265,9 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
             return None
         return _image_block(src, _structured_text(raw.get("cap")))
     if block_type == "code":
-        source = _structured_raw_text(raw.get("source")) or _structured_text(raw.get("html"))
+        source = _structured_raw_text(raw.get("source")) or _structured_text(
+            raw.get("html")
+        )
         if not source:
             return None
         return _code_block(source, _structured_raw_text(raw.get("cap")).strip())
@@ -300,7 +302,9 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
     return None
 
 
-def structured_response_blocks(structured: dict[str, Any] | None) -> list[dict[str, Any]]:
+def structured_response_blocks(
+    structured: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
     """Project GateResponse structured chat blocks into Slack Block Kit blocks."""
     if not isinstance(structured, dict):
         return []


### PR DESCRIPTION
## Summary

- add a dependency-free Slack constants module for Slack text/block limits
- keep `config.SLACK_MESSAGE_LIMIT` as an explicit re-export while removing its literal copy
- make `formatters.py` import Slack limits from the shared constants SSOT

## Scope

Refs #21700.

This addresses #21700 item 1 (`SLACK_MESSAGE_LIMIT` / Slack block-limit duplication). It intentionally does not change the model-catalog discovery path from item 2: current `jeong-sik/oas` main exposes `Model_catalog` as `OAS_MODEL_CATALOG` env-driven loading, so removing MASC's cwd/argv0 seeding needs a separate current-design decision.

## Validation

- `ruff check sidecars/slack-bot/src/constants.py sidecars/slack-bot/src/config.py sidecars/slack-bot/src/formatters.py`
- `ruff format --check sidecars/slack-bot/src/constants.py sidecars/slack-bot/src/config.py sidecars/slack-bot/src/formatters.py`
- `python3 -m py_compile sidecars/slack-bot/src/constants.py sidecars/slack-bot/src/config.py sidecars/slack-bot/src/formatters.py`
- `python3 -m pytest sidecars/slack-bot/tests/test_formatters.py`
- `pyright --outputjson sidecars/slack-bot/src/constants.py sidecars/slack-bot/src/formatters.py`
- `git diff --check`

Not run:

- local Dune build/tests, per CI-build-authority preference
- `pyright --outputjson sidecars/slack-bot/src/config.py` still fails in this local environment because `pydantic_settings` is not resolved by pyright; `sidecars/slack-bot/requirements.txt` declares `pydantic-settings>=2.0`
