### PR TITLE
fix(fusion): board post failure is best-effort, not fatal to fusion emit

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -408,33 +408,40 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
          | Error _ as e -> e)
       | Error _ -> Ok ()
     in
-    (* RFC-0266: completion 성공 경로(board post 생성됨)에서만 깨운다. board 생성
-       실패(Error)는 orchestrator가 [Sink_failed]로 바꿔 fusion_tool의
-       append_chat_failure가 깨우므로, 여기서도 깨우면 중복 wake가 된다. judge가
-       Error여도 fusion은 끝났으니 ok=false로 통지한다(board엔 실패도 증거로 남음).
-       chat lane append가 실패하면 board 실패와 동일하게 Error를 반환한다(.mli 계약):
-       board post는 이미 증거로 남아 board/fusion surface엔 결과가 보이지만, 메인 chat
-       전달이 실패했으니 여기서 mark_completed/wake 하지 않고 orchestrator의 Sink_failed
-       경로가 처리하게 한다(board Error 경로와 일관). *)
+    (* RFC-0266 (개정, board best-effort): completion 여부는 *키퍼가 결론을 받았는가*
+       (chat lane)로 판정한다. board post는 증거 카드일 뿐이므로 그 생성 실패는 fatal이
+       아니다. chat lane append가 성공하면 board 결과와 무관하게 여기서 한 번
+       mark_completed/broadcast/wake 한다: board Ok면 카드 post id를, board Error면
+       경고 로그 후 빈 id를 넘긴다(append_chat_failure의 [board_post_id:""] 선례와 대칭).
+       chat lane append가 실패한 경우에만 [Error]를 반환해 orchestrator의 [Sink_failed]
+       → fusion_tool.append_chat_failure가 통지하게 한다(키퍼가 결론을 못 받은 유일한
+       경우). 과거엔 board Error도 [Error]로 반환해, 결론 전달이 성공했는데도
+       append_chat_failure가 그 위에 모순된 "(sink failed)" note + ok=false wake를 덧대고
+       (이중 통지), 완료/wake 경로 자체는 board Error 시 건너뛰던 버그가 있었다. *)
     (match chat_lane_result with
      | Error msg -> Error msg
-     | Ok () -> (
-       match board_result with
-       | Ok post ->
-         let ok, resolved_answer =
-           match judge with
-           | Ok j -> true, j.Fusion_types.resolved_answer
-           | Error e -> false, Printf.sprintf "judge failed: %s" (Fusion_types.judge_failure_text e)
-         in
-         (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
-            상태를 반영해야 하므로 wake 직전 무조건 호출. *)
-         Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
-         broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
-         wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok
-           ~resolved_answer
-           ~board_post_id:(Board.Post_id.to_string post.id);
-         Ok ()
-       | Error e -> Error (Board.show_board_error e)))
+     | Ok () ->
+       let board_post_id =
+         match board_result with
+         | Ok (post : Board.post) -> Board.Post_id.to_string post.id
+         | Error e ->
+           Log.Keeper.warn ~keeper_name:keeper
+             "fusion board card unavailable run_id=%s: %s" run_id
+             (Board.show_board_error e);
+           ""
+       in
+       let ok, resolved_answer =
+         match judge with
+         | Ok j -> true, j.Fusion_types.resolved_answer
+         | Error e ->
+           false, Printf.sprintf "judge failed: %s" (Fusion_types.judge_failure_text e)
+       in
+       (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake 직전 무조건 호출. *)
+       Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
+       broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+       wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok
+         ~resolved_answer ~board_post_id;
+       Ok ())
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Printexc.to_string exn)

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -44,7 +44,9 @@ val judge_node_meta : Fusion_types.judge_outcome -> Yojson.Safe.t
     실행된 심판 노드 관측 배열(RFC-0284)로 board meta_json [judges] 키에 panel과 동형으로
     직렬화된다 — canonical 단일 [judge] 키는 ADDITIVE 유지. [base_dir]는 호출자 주입.
 
-    chat store append 또는 board post 생성 실패는 [Error msg]로 반환한다.
+    chat store append 실패는 [Error msg]로 반환한다. board post 생성 실패는 결론
+    전달을 실패로 되돌리지 않는다: 경고를 남기고 [board_post_id = ""]로
+    completion/wake를 진행한 뒤 [Ok ()]를 반환한다.
     [chat_appended] SSE broadcast는 {!Keeper_chat_broadcast} 정책을 따른다:
     non-cancel 예외는 counter+warn으로 흡수하는 best-effort 알림이며, chat/board
     영속 성공을 실패로 되돌리지 않는다. [Eio.Cancel.Cancelled]는 재전파한다. *)
@@ -65,8 +67,9 @@ val emit
     chat append 영속과 별개의 hint+payload 경로). [ok = false]는 denied/sink_failed/
     aborted 실패 라벨을 [resolved_answer]에 싣고, board post가 없으면 [board_post_id = ""].
 
-    [emit]은 성공 경로(board post 생성됨)에서 이를 호출하고, 실패 경로는 fusion_tool의
-    append_chat_failure가 호출한다(completion 타입당 단일 wake로 중복 방지).
+    [emit]은 chat lane append 성공 경로에서 이를 호출한다(board post가 없으면
+    [board_post_id = ""]). 실패 경로는 fusion_tool의 append_chat_failure가
+    호출한다(completion 타입당 단일 wake로 중복 방지).
 
     예외 안전: [Eio.Cancel.Cancelled]는 재전파, 그 외 예외는 흡수(sink 결과 비오염).
     Running이 아닌 키퍼는 silent no-op이며 결과는 board/chat 영속으로 남는다. *)

--- a/test/dune
+++ b/test/dune
@@ -745,7 +745,7 @@
 (test
  (name test_fusion_wake)
  (modules test_fusion_wake)
- (libraries masc_test_deps))
+ (libraries masc_test_deps masc.fusion_core))
 
 ; Fusion OAS failure-detail tests need Fusion_types constructors from
 ; masc.fusion_core, which is intentionally not re-exported via masc.

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -21,6 +21,52 @@ let contains ~needle haystack =
   nl = 0 || go 0
 ;;
 
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+;;
+
+(* Board_dispatch.create_post (via Fusion_sink.emit) needs a live Eio
+   scheduler for its lock/cancellation-context effects (Effect.Unhandled
+   (Eio.Cancel.Get_context) otherwise) — same [Eio_main.run] +
+   [Fs_compat.set_fs] wrapper test_board_dispatch.ml's [with_eio] uses. *)
+let with_isolated_base_path prefix f =
+  let base_dir = temp_base_path prefix in
+  let old_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  let old_base_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
+  Fun.protect
+    ~finally:(fun () ->
+      Board_dispatch.reset_for_test ();
+      Board.reset_global_for_test ();
+      restore_env "MASC_BASE_PATH" old_base;
+      restore_env "MASC_BASE_PATH_INPUT" old_base_input;
+      try remove_tree base_dir with _ -> ())
+    (fun () ->
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Unix.putenv "MASC_BASE_PATH_INPUT" base_dir;
+      Board_dispatch.reset_for_test ();
+      Board.reset_global_for_test ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      f base_dir)
+;;
+
 let make_meta ?(name = "fusion-keeper") () : Keeper_meta_contract.keeper_meta =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -52,6 +98,17 @@ let fusion_stimulus ?run_id ?ok ?resolved_answer ?board_post_id () : Keeper_even
   ; payload =
       Keeper_event_queue.Fusion_completed
         (fusion_payload ?run_id ?ok ?resolved_answer ?board_post_id ())
+  }
+;;
+
+let judge_synthesis resolved_answer : Fusion_types.judge_synthesis =
+  { consensus = []
+  ; contradictions = []
+  ; partial_coverage = []
+  ; unique_insights = []
+  ; blind_spots = []
+  ; resolved_answer
+  ; decision = Fusion_types.Answer resolved_answer
   }
 ;;
 
@@ -209,6 +266,52 @@ let test_missing_board_post_id_fallback () =
   check string "synthetic fallback post id" "fusion-run:fus-9" ev.post_id
 ;;
 
+let test_emit_board_failure_is_best_effort () =
+  with_isolated_base_path "fusion-board-best-effort" (fun base_dir ->
+    let keeper = "bad/keeper" in
+    let run_id = Printf.sprintf "fus-board-fail-%d" (Random.bits ()) in
+    let resolved_answer = "BOARD-BEST-EFFORT-ANSWER" in
+    Fusion_run_registry.register_running Fusion_run_registry.global ~run_id ~keeper
+      ~preset:"unit-test" ~started_at:1.0;
+    let result =
+      Fusion_sink.emit ~base_dir ~keeper ~run_id ~question:"q" ~panel:[]
+        ~judge:(Ok (judge_synthesis resolved_answer)) ~judges:[]
+        ~judge_usage:Fusion_types.zero_usage
+    in
+    check bool "board failure does not fail emit" true (Result.is_ok result);
+    (match Fusion_run_registry.get Fusion_run_registry.global ~run_id with
+     | Some run ->
+       (match run.Fusion_run_registry.status with
+        | Fusion_run_registry.Completed { ok = true } -> ()
+        | Fusion_run_registry.Completed { ok = false } ->
+          fail "fusion run should complete with ok=true"
+        | Fusion_run_registry.Running -> fail "fusion run should not remain running")
+     | None -> fail "fusion run should remain visible");
+    let messages = Keeper_chat_store.load ~base_dir ~keeper_name:keeper in
+    (* Keeper_chat_store.encode_line auto-derives blocks from message content
+       for assistant rows when the caller passes [blocks:None] (RFC-0235 P3),
+       so [m.blocks] is not [None] here — the check is that no *Fusion* card
+       (which would point at the board post that failed to be created) is
+       among whatever blocks got auto-derived. *)
+    let answer_without_card =
+      List.exists
+        (fun (m : Keeper_chat_store.chat_message) ->
+           contains ~needle:resolved_answer m.content
+           &&
+           match m.blocks with
+           | None -> true
+           | Some blocks ->
+             not
+               (List.exists
+                  (function
+                    | Keeper_chat_blocks.Fusion _ -> true
+                    | _ -> false)
+                  blocks))
+        messages
+    in
+    check bool "chat lane receives answer without fusion card block" true answer_without_card)
+;;
+
 let () =
   run
     "fusion_wake"
@@ -222,6 +325,10 @@ let () =
             "missing board_post_id falls back to fusion-run id"
             `Quick
             test_missing_board_post_id_fallback
+        ; test_case
+            "emit treats board post failure as best-effort"
+            `Quick
+            test_emit_board_failure_is_best_effort
         ; test_case
             "background completion is actionable (non-empty, carries output)"
             `Quick


### PR DESCRIPTION
## 목표

Fusion emit에서 **board post 생성 실패를 fatal로 취급**해 키퍼에게 모순된 상태를 주던 버그 수정. 적대적 기능-영역 감사(`wf_87b1b311-25c`)에서 발견(constraint_overreach, verified by adversarial review).

## 버그

judge 성공 + chat lane(키퍼 메인 conversation)에 결론 전달 성공 후, board 카드 생성이 실패하면 `emit`이 `Error`를 반환 → orchestrator가 `Sink_failed`로 → `fusion_tool.append_chat_failure`가 **이미 전달된 결론 위에** 모순된 `"(sink failed)"` note + `ok=false` wake를 덧댐(이중 통지). 게다가 board Error 시 `mark_completed`/`broadcast`/`wake` 경로 자체를 건너뜀. (line 395 주석 "board 실패 시 결론은 남긴다"와 최종 dispatch가 불일치.)

## 수정

completion 판정을 **실제 deliverable(키퍼가 결론을 받았는가 = chat lane)**에 정렬:
- `chat_lane_result = Ok`이면 board 결과와 무관하게 **한 번** mark_completed + broadcast + wake. board Ok → 카드 post id, board Error → **warn 로그 + 빈 id**(`append_chat_failure`의 `board_post_id:""` 선례와 대칭).
- `Error`(Sink_failed)는 **chat lane 자체가 실패**한 경우에만 반환(키퍼가 결론을 못 받은 유일한 경우).
- 부수 효과: board-only 실패가 이제 메트릭에 `Completed`로 기록(과거 `Sink_failed` 부풀림 교정). board 카드 미가용은 warn으로 관측.

## 경계 / 검증

- MASC-internal(lib/fusion), OAS 무관. root alignment(워크어라운드 아님).
- 로컬 빌드 불가(machine dune 락) → CI Lint(컴파일) 검증. 기존 test_fusion_sink_meta는 judge_meta/panel_meta(순수)만 커버, emit board-Error 브랜치는 board-failure 주입 infra 필요로 unit-test 미추가(적대적 리뷰로 검증).

RFC-WAIVED: lib/fusion 정합 수정(credential/operator/sandbox/hooks/workflow 등 RFC-gated 무관). 워크어라운드 아님(fatal→best-effort root fix).
