### PR TITLE
[codex] Keep runtime TOML overlay controls clickable

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -549,6 +549,26 @@ describe('RuntimeTomlEditor', () => {
     expect((container.querySelector('[data-testid="runtime-toml-section"]') as HTMLElement).classList.contains('hidden')).toBe(false)
   })
 
+  it('does not close overlay mode when interacting with editor controls', async () => {
+    const onClose = vi.fn()
+    render(html`<${RuntimeTomlEditor} onClose=${onClose} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-models"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-models"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('모델')
+    })
+    expect(onClose).not.toHaveBeenCalled()
+
+    fireEvent.click(container.querySelector('.rt-overlay') as HTMLElement)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps the raw-TOML editor path working after navigating into the toml section', async () => {
     render(html`<${RuntimeTomlEditor} />`, container)
 

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -155,6 +155,10 @@ function runtimeStatusToneClass(statusLabel: string): string {
   return ''
 }
 
+function stopOverlayContentClick(event: MouseEvent) {
+  event.stopPropagation()
+}
+
 export interface RuntimeTomlEditorProps {
   onClose?: () => void
 }
@@ -616,7 +620,9 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
   if (onClose) {
     return html`
       <div class="rt-overlay" data-testid="runtime-toml-editor" onClick=${onClose}>
-        ${body}
+        <div class="rt-overlay-content" onClick=${stopOverlayContentClick}>
+          ${body}
+        </div>
       </div>
     `
   }

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -2,6 +2,7 @@
    MASC v2 — Runtime config editor (full-screen overlay). v2 tokens only.
    ══════════════════════════════════════════════════════════════ */
 .rt-overlay { position: fixed; inset: 0; z-index: 95; background: rgba(4,5,8,0.55); display: flex; align-items: stretch; justify-content: center; padding: 28px; animation: rt-fade 0.16s ease; }
+.rt-overlay-content { display: flex; width: min(1080px, 100%); height: 100%; min-width: 0; }
 @keyframes rt-fade { from { opacity: 0; } to { opacity: 1; } }
 .rt-shell { display: grid; grid-template-columns: 218px minmax(0,1fr); width: min(1080px, 100%); height: 100%; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-lg); overflow: hidden; box-shadow: 0 18px 60px rgba(0,0,0,0.55); }
 

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -2,7 +2,7 @@
    MASC v2 — Runtime config editor (full-screen overlay). v2 tokens only.
    ══════════════════════════════════════════════════════════════ */
 .rt-overlay { position: fixed; inset: 0; z-index: 95; background: rgba(4,5,8,0.55); display: flex; align-items: stretch; justify-content: center; padding: 28px; animation: rt-fade 0.16s ease; }
-.rt-overlay-content { display: flex; width: min(1080px, 100%); height: 100%; min-width: 0; }
+.rt-overlay-content { width: min(1080px, 100%); height: 100%; min-width: 0; }
 @keyframes rt-fade { from { opacity: 0; } to { opacity: 1; } }
 .rt-shell { display: grid; grid-template-columns: 218px minmax(0,1fr); width: min(1080px, 100%); height: 100%; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-lg); overflow: hidden; box-shadow: 0 18px 60px rgba(0,0,0,0.55); }
 


### PR DESCRIPTION
## Summary

- Stop clicks inside the runtime TOML editor overlay from bubbling to the backdrop close handler.
- Preserve backdrop click-to-close by wrapping only the overlay content.
- Add a focused regression test that clicks an editor nav control in overlay mode and verifies the overlay stays open.

## Impact

The runtime TOML overlay can now be used without nav/buttons immediately closing the panel. Inline settings/runtime TOML rendering is unchanged.

## Validation

- `vitest run --config vitest.config.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit`
- `eslint src/components/runtime-toml-editor.ts`
- `git diff --check`
- Playwright smoke: `/dashboard/#monitoring/runtime?view=config` renders runtime TOML editor, switches to `모델`, returns to `runtime.toml`, and shows the raw editor without browser errors.

Full build is left to CI.
