### PR TITLE
fix(runtime): fail load on wrong-type media_failover instead of degrading to []

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -798,16 +798,18 @@ let parse_runtime_string_leaf ~path ~key value =
   | _ -> Error (error path (key ^ " must be a string runtime id"))
 ;;
 
-let parse_runtime_media_failover value =
-  (* RFC-0265 — ordered runtime ids for modality-gated reroute. RFC-0145:
-     narrow to the [Otoml.get_array] wrong-type exception; a malformed value
-     degrades to [] (→ derive-from-declared-caps), and any id typo is caught
-     loudly at load by {!Runtime.validate_media_failover}. *)
-  try Otoml.get_array Otoml.get_string value with
+let parse_runtime_media_failover ~path value =
+  (* RFC-0265 — ordered runtime ids for modality-gated reroute. A genuine type
+     mismatch (a scalar where an ordered array is required — a bare string cannot
+     mean a list) is surfaced as a load [Error], consistent with the sibling
+     string leaves ({!parse_runtime_string_leaf}), instead of silently degrading
+     to [] (the repo's Unknown→Permissive anti-pattern). An explicit empty array
+     [] is preserved as the intentional derive-from-declared-caps signal; id typos
+     in a well-typed array are still caught loudly by
+     {!Runtime.validate_media_failover}. *)
+  try Ok (Otoml.get_array Otoml.get_string value) with
   | Otoml.Type_error _ ->
-    Log.Runtime.warn
-      "runtime_toml: [runtime].media_failover — expected string array, ignoring";
-    []
+    Error (error path "media_failover must be an array of string runtime ids")
 ;;
 
 let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list) result =
@@ -847,7 +849,9 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                 errs
               | Error e -> section, errs @ e)
            | "media_failover" ->
-             { section with media_failover = parse_runtime_media_failover value }, errs
+             (match parse_runtime_media_failover ~path:"runtime.media_failover" value with
+              | Ok media_failover -> { section with media_failover }, errs
+              | Error e -> section, errs @ e)
            | "assignments" ->
              (* Parsed by [parse_keeper_assignments], including table-shape
                 validation. It is still recognized here so a malformed scalar

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -808,8 +808,11 @@ let parse_runtime_media_failover ~path value =
      in a well-typed array are still caught loudly by
      {!Runtime.validate_media_failover}. *)
   try Ok (Otoml.get_array Otoml.get_string value) with
-  | Otoml.Type_error _ ->
-    Error (error path "media_failover must be an array of string runtime ids")
+  | Otoml.Type_error msg ->
+    Error
+      (error
+         path
+         (Printf.sprintf "media_failover must be an array of string runtime ids; got %s" msg))
 ;;
 
 let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list) result =

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -872,6 +872,65 @@ let test_runtime_toml_allows_runtime_profile_tables () =
     check int "profile tables are not provider bindings" 1
       (List.length cfg.Runtime_schema.bindings)
 
+let test_runtime_toml_rejects_wrong_type_media_failover () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     media_failover = \"local.sample\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Ok _ -> failf "wrong-type [runtime].media_failover should fail parse"
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (err : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "\n"
+    in
+    check bool "error mentions runtime.media_failover" true
+      (String_util.contains_substring rendered "runtime.media_failover");
+    check bool "error explains media_failover type" true
+      (String_util.contains_substring
+         rendered
+         "media_failover must be an array of string runtime ids")
+
+let test_runtime_toml_preserves_explicit_empty_media_failover () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     media_failover = []\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (err : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "\n"
+    in
+    failf "runtime TOML should parse explicit empty media_failover:\n%s" rendered
+  | Ok cfg -> check (list string) "media_failover" [] cfg.Runtime_schema.media_failover
+
 (** The runtime singletons were migrated from plain [ref]s to [Atomic.t] so
     that reads from worker domains on OCaml 5 see published writes.  This test
     exercises the public getter surface after [init_default] to ensure the
@@ -1406,6 +1465,10 @@ let () =
             test_runtime_toml_rejects_unknown_runtime_key;
           test_case "runtime table allows profile tables" `Quick
             test_runtime_toml_allows_runtime_profile_tables;
+          test_case "runtime table rejects wrong-type media_failover" `Quick
+            test_runtime_toml_rejects_wrong_type_media_failover;
+          test_case "runtime table preserves empty media_failover" `Quick
+            test_runtime_toml_preserves_explicit_empty_media_failover;
           test_case
             "runtime capability gate uses provider-qualified OAS catalog rows"
             `Quick test_runtime_capability_gate_uses_provider_qualified_catalog;


### PR DESCRIPTION
## 목표

`parse_runtime_media_failover`가 wrong-type 값(스칼라)을 `[]`로 soft-degrade(permissive default)하던 것을, sibling string leaf처럼 **hard Error로 load 실패**시키도록 수정. 적대적 감사(`wf_87b1b311-25c`)에서 발견(silent_failure).

## 수정

- `parse_runtime_media_failover`가 `(string list, parse_error list) result` 반환. `Otoml.Type_error`(스칼라를 배열 자리에) → `Error`. caller가 `errs`에 스레딩 → load loud 실패.
- **명시적 `[]`는 보존**(의도적 derive-from-declared-caps 신호). well-typed 배열 내 id 오타는 여전히 `Runtime.validate_media_failover`가 loud 검출.
- 근거: unknown→permissive 안티패턴 제거, sibling(default/librarian/structured_judge/cross_verifier)과 일관.

## 경계 / 검증

- MASC-internal(runtime_toml.ml), OAS 무관. permissive default 제거(워크어라운드 아님).
- 로컬 빌드 불가 → CI Lint 검증. 기존 media_failover 테스트는 reroute 동작만 커버 → wrong-type 파싱 에러 테스트는 coverage gate 발동 시 배치 추가 예정.

RFC-WAIVED: runtime_toml 파싱 정합(RFC-gated subsystem 무관). permissive default 제거이며 워크어라운드 아님.
