### PR TITLE
fix(dashboard,metrics): surface malformed trajectory rows and wire dead contract-violations counter

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -807,6 +807,28 @@ let run_keeper_cycle
                         ~raw_error:e_str
                     with
                     | Some failure_reason ->
+                      (* masc_keeper_contract_violations_total (RFC exhaustive
+                         match, not [_ -> ()]): a new failure_reason variant
+                         must explicitly opt in or out of this counter rather
+                         than silently landing in a catch-all. *)
+                      (match failure_reason with
+                       | Keeper_registry.Completion_contract_violation _ ->
+                         Otel_metric_store.inc_counter
+                           Keeper_metrics.(to_string ContractViolations)
+                           ~labels:[ "keeper", meta.name ]
+                           ()
+                       | Keeper_registry.Heartbeat_consecutive_failures _
+                       | Keeper_registry.Turn_consecutive_failures _
+                       | Keeper_registry.Stale_turn_timeout _
+                       | Keeper_registry.Stale_termination_storm _
+                       | Keeper_registry.Stale_fleet_batch _
+                       | Keeper_registry.Provider_timeout_loop _
+                       | Keeper_registry.Provider_runtime_error _
+                       | Keeper_registry.Ambiguous_partial_commit _
+                       | Keeper_registry.Fiber_unresolved _
+                       | Keeper_registry.Exception _
+                       | Keeper_registry.Turn_overflow_pause
+                       | Keeper_registry.Turn_livelock_pause -> ());
                       Keeper_registry.set_failure_reason
                         ~base_path:config.base_path
                         meta.name

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -770,6 +770,10 @@ let record_completion_contract_attention_failure
     ~base_path
     updated_meta.name
     (Some (Keeper_registry.Completion_contract_violation { detail }));
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ContractViolations)
+    ~labels:[ "keeper", updated_meta.name ]
+    ();
   Health.record_failure
     ~agent_name:updated_meta.name
     ~reason:(Keeper_types_profile.short_preview detail);

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -787,12 +787,37 @@ let trajectory_line_of_json json =
        | None -> None)
 ;;
 
-let trajectory_lines_of_jsonl_lines lines =
-  List.filter_map
-    (fun line ->
-       try Yojson.Safe.from_string line |> trajectory_line_of_json with
-       | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
-    lines
+(* Rows that fail to parse or decode here are silently dropped from the
+   dashboard's /trajectory response with no signal at all -- unlike the
+   internal_history merge path (see
+   [Server_dashboard_http_keeper_api_trace.log_internal_history_skips]),
+   which already tracks skipped/total and logs a per-read summary. Follow
+   the same summarized-WARN pattern rather than warn-per-row: a busy trace
+   file re-read on every dashboard poll would otherwise flood the log the
+   same way the internal_history path did before that fix. *)
+let log_trajectory_line_skips ~trace_id ~skipped ~total =
+  if skipped > 0 then
+    Log.Keeper.warn
+      "trajectory trace %s: %d of %d rows did not decode to a trajectory \
+       line (malformed JSON or unrecognized shape)"
+      trace_id skipped total
+;;
+
+let trajectory_lines_of_jsonl_lines ~trace_id lines =
+  let lines_rev, skipped, total =
+    List.fold_left
+      (fun (acc, skipped, total) line ->
+         match
+           try Yojson.Safe.from_string line |> trajectory_line_of_json with
+           | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+         with
+         | Some parsed -> parsed :: acc, skipped, total + 1
+         | None -> acc, skipped + 1, total + 1)
+      ([], 0, 0)
+      lines
+  in
+  log_trajectory_line_skips ~trace_id ~skipped ~total;
+  List.rev lines_rev
 ;;
 
 (** Read all trajectory lines including thinking entries. *)
@@ -804,7 +829,7 @@ let read_all_lines ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
     let content = Fs_compat.load_file path in
     String.split_on_char '\n' content
     |> List.filter (fun line -> String.trim line <> "")
-    |> trajectory_lines_of_jsonl_lines
+    |> trajectory_lines_of_jsonl_lines ~trace_id
 
 let read_recent_lines
       ~(masc_root : string)
@@ -814,4 +839,5 @@ let read_recent_lines
   : trajectory_line list
   =
   let path = trajectory_path masc_root keeper_name trace_id in
-  Dated_jsonl.load_tail_lines path ~max_lines |> trajectory_lines_of_jsonl_lines
+  Dated_jsonl.load_tail_lines path ~max_lines
+  |> trajectory_lines_of_jsonl_lines ~trace_id

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -577,6 +577,51 @@ let test_read_entries_since_no_dir () =
     let entries = Trajectory.read_entries_since ~masc_root:dir ~keeper_name:"nonexistent" ~since:0.0 in
     Alcotest.(check int) "no dir" 0 (List.length entries))
 
+(* P2 silent-failure fix: a malformed/corrupted row in the trajectory JSONL
+   used to vanish from [read_recent_lines]/[read_all_lines] with zero
+   signal (bare [List.filter_map] swallowing the parse exception). This
+   pins the still-correct filtering behavior (malformed rows drop, valid
+   rows survive) after switching to a fold that also tracks skipped/total
+   for a per-read WARN summary (mirrors
+   [Server_dashboard_http_keeper_api_trace.log_internal_history_skips]). *)
+let write_raw_line ~masc_root ~keeper_name ~trace_id raw_line =
+  let dir = Trajectory.trajectories_dir masc_root keeper_name in
+  Fs_compat.mkdir_p dir;
+  let path = Trajectory.trajectory_path masc_root keeper_name trace_id in
+  let oc = open_out_gen [ Open_append; Open_creat ] 0o644 path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc raw_line;
+    output_char oc '\n')
+
+let test_read_recent_lines_skips_malformed_rows () =
+  with_tmpdir (fun dir ->
+    let acc =
+      Trajectory.create_accumulator
+        ~masc_root:dir ~keeper_name:"test-keeper" ~trace_id:"trace-malformed"
+        ~generation:0 ()
+    in
+    Trajectory.record_entry acc
+      (mk_entry "tool_execute" 10 0.0 "2026-07-01T00:00:00Z");
+    Trajectory.flush_pending acc;
+    write_raw_line ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-malformed" "{not valid json";
+    let recent =
+      Trajectory.read_recent_lines ~masc_root:dir ~keeper_name:"test-keeper"
+        ~trace_id:"trace-malformed" ~max_lines:100
+    in
+    Alcotest.(check int)
+      "malformed row dropped, valid row kept (read_recent_lines)"
+      1
+      (List.length recent);
+    let all_lines =
+      Trajectory.read_all_lines ~masc_root:dir ~keeper_name:"test-keeper"
+        ~trace_id:"trace-malformed"
+    in
+    Alcotest.(check int)
+      "malformed row dropped, valid row kept (read_all_lines)"
+      1
+      (List.length all_lines))
+
 let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
   Trajectory.Thinking
     {
@@ -751,6 +796,8 @@ let () =
       Alcotest.test_case "parses persisted gate summary" `Quick
         test_read_entries_since_result_parses_gate_summary;
       Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
+      Alcotest.test_case "read_recent_lines/read_all_lines skip malformed rows" `Quick
+        test_read_recent_lines_skips_malformed_rows;
     ]);
     ("keeper_trace", [
       Alcotest.test_case "dedupe_thinking_lines uses structural key" `Quick


### PR DESCRIPTION
## Summary
Two independent P2 silent-failure fixes bundled in one PR (same repo, low blast radius, no shared code path):

1. **`/trajectory` dashboard endpoint silently dropped malformed rows** — `Trajectory.trajectory_lines_of_jsonl_lines` (`lib/trajectory/trajectory.ml`) used a bare `List.filter_map` that swallowed `Yojson.Json_error`/`Type_error` with zero signal. Every keeper's `/trajectory` response and the chat-trace builder dropped corrupted/malformed rows with no indication anything was lost. The sibling `internal_history` merge path (`Server_dashboard_http_keeper_api_trace.log_internal_history_skips`) already tracks `skipped`/`total` and logs a per-read WARN summary — applied the same pattern here.
2. **`masc_keeper_contract_violations_total` was a dead metric** — declared, given a wire name, registered in the zero-fill catalog, but never incremented anywhere (confirmed via `rg`, zero non-declaration references). Wired the increment at both construction/application sites of `Keeper_registry.Completion_contract_violation`.

## Details

### 1. Trajectory malformed-row visibility
- Added `log_trajectory_line_skips` (mirrors `log_internal_history_skips`'s summarized-not-per-row pattern — a busy re-polled trace file would otherwise flood the log the same way `internal_history` did before its own fix).
- `trajectory_lines_of_jsonl_lines` now takes `~trace_id` and folds skipped/total instead of a bare `filter_map`. Public signatures of `read_all_lines`/`read_recent_lines` unchanged (both already had `trace_id` in scope).

### 2. `ContractViolations` counter wiring
- `keeper_unified_turn_success.ml`'s `record_completion_contract_attention_failure` (constructs `Completion_contract_violation` directly) — added the increment as a direct sibling to its existing `increment_turn_failures`/`set_failure_reason` calls.
- `keeper_unified_turn.ml`'s `registry_failure_reason_of_terminal_reason` application site (a generic `failure_reason` sink used for many reason types) — gated with an **exhaustive match**, not `_ -> ()`, so a future `failure_reason` variant must explicitly decide whether it also bumps this counter rather than silently landing in a catch-all.

## RFC
Not required — dashboard trajectory read path + keeper metrics wiring, not credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow. `bash scripts/pr-rfc-check.sh` passes.

## Test plan
- [x] `dune build` (full project) — clean
- [x] `test_trajectory.exe` — 38/38 pass, incl. new `test_read_recent_lines_skips_malformed_rows` proving both `read_recent_lines` and `read_all_lines` still drop a malformed row while keeping the valid one. Manually verified (`MASC_LOG_LEVEL=debug --verbose`) the new WARN fires: `trajectory trace X: 1 of 2 rows did not decode to a trajectory line`.
- [x] `test_dashboard_keeper_metrics_10286`, `test_gate_keeper_backend`, `test_keeper_overflow_recovery`, `test_keeper_pause_silent_failure_source`, `test_keeper_receipt_authoritative_matrix`, `test_keeper_state_machine`, `test_keeper_turn_fsm_wired_sites`, `test_keeper_unified_tool_event_order_source`, `test_keeper_validation_breaker_exempt`, `test_no_progress_loop_detector`, `test_operator_control_snapshot`, `test_telemetry_unified` — all pass unchanged
- [ ] **Not covered by a dedicated unit test**: the `ContractViolations` counter increment itself has no isolated test harness for `record_completion_contract_attention_failure` (needs full `Workspace.config` + `keeper_meta` scaffolding to drive an actual completion-contract-violation turn failure). Verified by code inspection + the exhaustive match compiling, not by an assertion against `Otel_metric_store.metric_value_or_zero`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
