### PR TITLE
fix(gate): share channel binding store

### DIFF
--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -1,0 +1,169 @@
+type binding = {
+  channel_id : string;
+  keeper_name : string;
+}
+
+type guild_id_field =
+  | Omit
+  | Include_empty
+  | Include_event_value
+
+type audit_event = {
+  timestamp : string;
+  action : string;
+  guild_id : string option;
+  channel_id : string;
+  keeper_name : string;
+  actor_id : string;
+  actor_name : string;
+  previous_keeper : string;
+}
+
+type t = {
+  binding_store_path : unit -> string;
+  binding_store_read_path : unit -> string;
+  binding_audit_path : unit -> string;
+  binding_audit_read_path : unit -> string;
+  guild_id_field : guild_id_field;
+}
+
+let create ~binding_store_path ~binding_store_read_path ~binding_audit_path
+    ~binding_audit_read_path ~guild_id_field =
+  {
+    binding_store_path;
+    binding_store_read_path;
+    binding_audit_path;
+    binding_audit_read_path;
+    guild_id_field;
+  }
+
+let read_json_file_opt path =
+  try Some (Yojson.Safe.from_file path) with
+  | Sys_error _ | Yojson.Json_error _ -> None
+
+let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
+  match json with
+  | `Assoc items ->
+      items
+      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
+             let channel_id = String.trim raw_channel_id in
+             let keeper_name =
+               match raw_keeper_name with
+               | `String value -> String.trim value
+               | _ -> ""
+             in
+             if channel_id = "" || keeper_name = "" then None
+             else Some ({ channel_id; keeper_name } : binding))
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+  | _ -> []
+
+let read_bindings store : binding list =
+  match read_json_file_opt (store.binding_store_read_path ()) with
+  | Some json -> normalize_bindings_json json
+  | None -> []
+
+let binding_json (binding : binding) =
+  `Assoc
+    [
+      ("channel_id", `String binding.channel_id);
+      ("keeper_name", `String binding.keeper_name);
+    ]
+
+let save_bindings store (bindings : binding list) =
+  let path = store.binding_store_path () in
+  let normalized =
+    bindings
+    |> List.sort (fun (a : binding) (b : binding) ->
+           String.compare a.channel_id b.channel_id)
+    |> List.fold_left
+         (fun acc (binding : binding) ->
+           (binding.channel_id, `String binding.keeper_name) :: acc)
+         []
+    |> List.rev
+    |> fun items -> `Assoc items
+  in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
+  Sys.rename tmp path
+
+let guild_id_items store event =
+  match store.guild_id_field with
+  | Omit -> []
+  | Include_empty -> [ ("guild_id", `String "") ]
+  | Include_event_value ->
+      let guild_id =
+        match event.guild_id with
+        | Some value -> value
+        | None -> ""
+      in
+      [ ("guild_id", `String guild_id) ]
+
+let audit_event_json store event =
+  `Assoc
+    ([
+       ("timestamp", `String event.timestamp);
+       ("action", `String event.action);
+     ]
+    @ guild_id_items store event
+    @ [
+        ("channel_id", `String event.channel_id);
+        ("keeper_name", `String event.keeper_name);
+        ("actor_id", `String event.actor_id);
+        ("actor_name", `String event.actor_name);
+        ("previous_keeper", `String event.previous_keeper);
+      ])
+
+let append_audit_event store event =
+  let path = store.binding_audit_path () in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let oc =
+    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (Yojson.Safe.to_string (audit_event_json store event));
+      output_char oc '\n';
+      flush oc;
+      Unix.fsync (Unix.descr_of_out_channel oc))
+
+let rec drop_left n xs =
+  if n <= 0 then xs
+  else
+    match xs with
+    | [] -> []
+    | _ :: tl -> drop_left (n - 1) tl
+
+let read_recent_audit store ~limit =
+  let path = store.binding_audit_read_path () in
+  if limit <= 0 || not (Sys.file_exists path) then
+    []
+  else
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let rec loop acc =
+          match input_line ic with
+          | line -> loop (line :: acc)
+          | exception End_of_file -> acc
+        in
+        loop []
+        |> List.filter_map (fun line ->
+               let trimmed = String.trim line in
+               if trimmed = "" then None
+               else
+                 try Some (Yojson.Safe.from_string trimmed) with
+                 | Yojson.Json_error _ -> None)
+        |> List.rev
+        |> fun rows ->
+        let total = List.length rows in
+        if total <= limit then List.rev rows
+        else rows |> drop_left (total - limit) |> List.rev)

--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -70,6 +70,15 @@ let binding_json (binding : binding) =
       ("keeper_name", `String binding.keeper_name);
     ]
 
+(* Durable atomic write delegated to the Fs_compat durability SSOT:
+   tmp -> fsync(tmp) -> rename -> best-effort fsync(parent dir), the same
+   primitive board/event-queue/Memory-OS persistence use. A local hand-rolled
+   tmp+rename here (as before) skips both fsyncs, so a crash between rename
+   and the kernel's dirty-page flush can leave the binding file truncated
+   even though [append_audit_event] already fsynced an audit entry claiming
+   the change landed. Mapping [Error] to [Sys_error] preserves this
+   function's existing raise-on-failure contract, which [bind]/[unbind] in
+   the 3 caller modules already catch via [try ... with Sys_error _ -> ...]. *)
 let save_bindings store (bindings : binding list) =
   let path = store.binding_store_path () in
   let normalized =
@@ -85,12 +94,10 @@ let save_bindings store (bindings : binding list) =
   in
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
-  let tmp = path ^ ".tmp" in
-  let oc = open_out_bin tmp in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
-  Sys.rename tmp path
+  let content = Yojson.Safe.pretty_to_string normalized ^ "\n" in
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> raise (Sys_error msg)
 
 let guild_id_items store event =
   match store.guild_id_field with

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -1,0 +1,42 @@
+(** Shared file-backed binding store and audit log for Channel Gate
+    connectors. *)
+
+type binding = {
+  channel_id : string;
+  keeper_name : string;
+}
+
+type guild_id_field =
+  | Omit
+  | Include_empty
+  | Include_event_value
+
+type audit_event = {
+  timestamp : string;
+  action : string;
+  guild_id : string option;
+  channel_id : string;
+  keeper_name : string;
+  actor_id : string;
+  actor_name : string;
+  previous_keeper : string;
+}
+
+type t
+
+val create :
+  binding_store_path:(unit -> string) ->
+  binding_store_read_path:(unit -> string) ->
+  binding_audit_path:(unit -> string) ->
+  binding_audit_read_path:(unit -> string) ->
+  guild_id_field:guild_id_field ->
+  t
+
+val read_json_file_opt : string -> Yojson.Safe.t option
+val normalize_bindings_json : Yojson.Safe.t -> binding list
+val read_bindings : t -> binding list
+val binding_json : binding -> Yojson.Safe.t
+val save_bindings : t -> binding list -> unit
+val audit_event_json : t -> audit_event -> Yojson.Safe.t
+val append_audit_event : t -> audit_event -> unit
+val read_recent_audit : t -> limit:int -> Yojson.Safe.t list

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -48,7 +48,6 @@ let binding_store =
   Store.create ~binding_store_path ~binding_store_read_path ~binding_audit_path
     ~binding_audit_read_path ~guild_id_field:Store.Include_event_value
 
-let read_json_file_opt = Store.read_json_file_opt
 let read_bindings () = Store.read_bindings binding_store
 let binding_json = Store.binding_json
 let save_bindings bindings = Store.save_bindings binding_store bindings

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -1,19 +1,9 @@
 module U = Yojson.Safe.Util
+module Store = Channel_gate_binding_store
 
-type binding = {
+type binding = Store.binding = {
   channel_id : string;
   keeper_name : string;
-}
-
-type audit_event = {
-  timestamp : string;
-  action : string;
-  guild_id : string;
-  channel_id : string;
-  keeper_name : string;
-  actor_id : string;
-  actor_name : string;
-  previous_keeper : string;
 }
 
 module Names = Channel_gate_discord_names
@@ -54,95 +44,16 @@ let binding_audit_read_path () =
   Names.configured_write_path "MASC_DISCORD_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path
 
-let read_json_file_opt path =
-  try Some (Yojson.Safe.from_file path) with
-  | Sys_error _ | Yojson.Json_error _ -> None
+let binding_store =
+  Store.create ~binding_store_path ~binding_store_read_path ~binding_audit_path
+    ~binding_audit_read_path ~guild_id_field:Store.Include_event_value
 
-let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
-  match json with
-  | `Assoc items ->
-      items
-      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
-             let channel_id = String.trim raw_channel_id in
-             let keeper_name =
-               match raw_keeper_name with
-               | `String value -> String.trim value
-               | _ -> ""
-             in
-             if channel_id = "" || keeper_name = "" then None
-             else Some ({ channel_id; keeper_name } : binding))
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-  | _ -> []
-
-let read_bindings () : binding list =
-  match read_json_file_opt (binding_store_read_path ()) with
-  | Some json -> normalize_bindings_json json
-  | None -> []
-
-let binding_json (binding : binding) =
-  `Assoc
-    [
-      ("channel_id", `String binding.channel_id);
-      ("keeper_name", `String binding.keeper_name);
-    ]
-
-let save_bindings (bindings : binding list) =
-  let path = binding_store_path () in
-  let normalized =
-    bindings
-    |> List.sort (fun (a : binding) (b : binding) ->
-           String.compare a.channel_id b.channel_id)
-    |> List.fold_left
-         (fun acc (binding : binding) ->
-           (binding.channel_id, `String binding.keeper_name) :: acc)
-         []
-    |> List.rev
-    |> fun items -> `Assoc items
-  in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let tmp = path ^ ".tmp" in
-  let oc = open_out_bin tmp in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
-  Sys.rename tmp path
-
-let audit_event_json event =
-  `Assoc
-    [
-      ("timestamp", `String event.timestamp);
-      ("action", `String event.action);
-      ("guild_id", `String event.guild_id);
-      ("channel_id", `String event.channel_id);
-      ("keeper_name", `String event.keeper_name);
-      ("actor_id", `String event.actor_id);
-      ("actor_name", `String event.actor_name);
-      ("previous_keeper", `String event.previous_keeper);
-    ]
-
-let append_audit_event event =
-  let path = binding_audit_path () in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let oc =
-    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
-  in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-      output_string oc (Yojson.Safe.to_string (audit_event_json event));
-      output_char oc '\n';
-      flush oc;
-      Unix.fsync (Unix.descr_of_out_channel oc))
-
-let rec drop_left n xs =
-  if n <= 0 then xs
-  else
-    match xs with
-    | [] -> []
-    | _ :: tl -> drop_left (n - 1) tl
+let read_json_file_opt = Store.read_json_file_opt
+let read_bindings () = Store.read_bindings binding_store
+let binding_json = Store.binding_json
+let save_bindings bindings = Store.save_bindings binding_store bindings
+let append_audit_event event = Store.append_audit_event binding_store event
+let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 (* ── Thread registry ──────────────────────────────────────────────
    Thread→parent mapping populated from THREAD_CREATE gateway events.
@@ -196,33 +107,6 @@ let set_trigger_policy (policy : Discord_gateway_state.trigger_policy) =
   trigger_policy_ref := Some policy
 
 let get_trigger_policy () = !trigger_policy_ref
-
-let read_recent_audit ~limit =
-  let path = binding_audit_read_path () in
-  if limit <= 0 || not (Sys.file_exists path) then
-    []
-  else
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let rec loop acc =
-          match input_line ic with
-          | line -> loop (line :: acc)
-          | exception End_of_file -> acc
-        in
-        loop []
-        |> List.filter_map (fun line ->
-               let trimmed = String.trim line in
-               if trimmed = "" then None
-               else
-                 try Some (Yojson.Safe.from_string trimmed) with
-                 | Yojson.Json_error _ -> None)
-        |> List.rev
-        |> fun rows ->
-        let total = List.length rows in
-        if total <= limit then List.rev rows
-        else rows |> drop_left (total - limit) |> List.rev)
 
 let string_member json key =
   Json_util.get_string_with_default json ~key ~default:""
@@ -519,10 +403,10 @@ let bind ~channel_id ~keeper_name ~actor_name =
         Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
       in
       append_audit_event
-        {
+        Store.{
           timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
           action = "bind";
-          guild_id;
+          guild_id = Some guild_id;
           channel_id;
           keeper_name;
           actor_id = actor_name;
@@ -560,10 +444,10 @@ let unbind ~channel_id ~actor_name =
             Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
           in
           append_audit_event
-            {
+            Store.{
               timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
               action = "unbind";
-              guild_id;
+              guild_id = Some guild_id;
               channel_id;
               keeper_name = removed_binding.keeper_name;
               actor_id = actor_name;

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -4,15 +4,10 @@
     can be registered at server startup via
     [Channel_gate_connector.register (module Channel_gate_discord_state)].
 
-    Internal helpers (the [U] / [Names] aliases, the [binding] /
-    [audit_event] records, the [default_*_path] / [legacy_*_path] /
-    [status_path] / [status_write_path] / [binding_store_path] /
-    [binding_store_read_path] / [binding_audit_path] /
-    [binding_audit_read_path] resolvers, [stale_after_sec],
-    [read_json_file_opt], [normalize_bindings_json],
-    [read_bindings] / [save_bindings] / [binding_json] /
-    [audit_event_json] / [append_audit_event] / [read_recent_audit] /
-    [drop_left], the [string_member] / [int_member] / [bool_member] /
+    Internal helpers (the [U] / [Names] / [Store] aliases, the
+    [binding] record, the [default_*_path] / [legacy_*_path] /
+    path resolvers, the shared binding-store wrappers, the
+    [string_member] / [int_member] / [bool_member] /
     [bool_option_member] yojson lookups, [stale_of_updated_at],
     [connector_state_label], [list_assoc_field],
     [find_assoc_by_string_field], and [rollback_bindings]) are

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -1,18 +1,9 @@
 module U = Yojson.Safe.Util
+module Store = Channel_gate_binding_store
 
-type binding = {
+type binding = Store.binding = {
   channel_id : string;
   keeper_name : string;
-}
-
-type audit_event = {
-  timestamp : string;
-  action : string;
-  channel_id : string;
-  keeper_name : string;
-  actor_id : string;
-  actor_name : string;
-  previous_keeper : string;
 }
 
 let connector_id = "imessage"
@@ -68,121 +59,16 @@ let binding_audit_read_path () =
   configured_write_path "MASC_IMESSAGE_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path
 
-let read_json_file_opt path =
-  try Some (Yojson.Safe.from_file path) with
-  | Sys_error _ | Yojson.Json_error _ -> None
+let binding_store =
+  Store.create ~binding_store_path ~binding_store_read_path ~binding_audit_path
+    ~binding_audit_read_path ~guild_id_field:Store.Omit
 
-let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
-  match json with
-  | `Assoc items ->
-      items
-      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
-             let channel_id = String.trim raw_channel_id in
-             let keeper_name =
-               match raw_keeper_name with
-               | `String value -> String.trim value
-               | _ -> ""
-             in
-             if channel_id = "" || keeper_name = "" then None
-             else Some ({ channel_id; keeper_name } : binding))
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-  | _ -> []
-
-let read_bindings () : binding list =
-  match read_json_file_opt (binding_store_read_path ()) with
-  | Some json -> normalize_bindings_json json
-  | None -> []
-
-let binding_json (binding : binding) =
-  `Assoc
-    [
-      ("channel_id", `String binding.channel_id);
-      ("keeper_name", `String binding.keeper_name);
-    ]
-
-let save_bindings (bindings : binding list) =
-  let path = binding_store_path () in
-  let normalized =
-    bindings
-    |> List.sort (fun (a : binding) (b : binding) ->
-           String.compare a.channel_id b.channel_id)
-    |> List.fold_left
-         (fun acc (binding : binding) ->
-           (binding.channel_id, `String binding.keeper_name) :: acc)
-         []
-    |> List.rev
-    |> fun items -> `Assoc items
-  in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let tmp = path ^ ".tmp" in
-  let oc = open_out_bin tmp in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
-  Sys.rename tmp path
-
-let audit_event_json event =
-  `Assoc
-    [
-      ("timestamp", `String event.timestamp);
-      ("action", `String event.action);
-      ("channel_id", `String event.channel_id);
-      ("keeper_name", `String event.keeper_name);
-      ("actor_id", `String event.actor_id);
-      ("actor_name", `String event.actor_name);
-      ("previous_keeper", `String event.previous_keeper);
-    ]
-
-let append_audit_event event =
-  let path = binding_audit_path () in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let oc =
-    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
-  in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-      output_string oc (Yojson.Safe.to_string (audit_event_json event));
-      output_char oc '\n';
-      flush oc;
-      Unix.fsync (Unix.descr_of_out_channel oc))
-
-let rec drop_left n xs =
-  if n <= 0 then xs
-  else
-    match xs with
-    | [] -> []
-    | _ :: tl -> drop_left (n - 1) tl
-
-let read_recent_audit ~limit =
-  let path = binding_audit_read_path () in
-  if limit <= 0 || not (Sys.file_exists path) then
-    []
-  else
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let rec loop acc =
-          match input_line ic with
-          | line -> loop (line :: acc)
-          | exception End_of_file -> acc
-        in
-        loop []
-        |> List.filter_map (fun line ->
-               let trimmed = String.trim line in
-               if trimmed = "" then None
-               else
-                 try Some (Yojson.Safe.from_string trimmed) with
-                 | Yojson.Json_error _ -> None)
-        |> List.rev
-        |> fun rows ->
-        let total = List.length rows in
-        if total <= limit then List.rev rows
-        else rows |> drop_left (total - limit) |> List.rev)
+let read_json_file_opt = Store.read_json_file_opt
+let read_bindings () = Store.read_bindings binding_store
+let binding_json = Store.binding_json
+let save_bindings bindings = Store.save_bindings binding_store bindings
+let append_audit_event event = Store.append_audit_event binding_store event
+let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 let string_member json key =
   Json_util.get_string_with_default json ~key ~default:""
@@ -388,9 +274,10 @@ let bind ~channel_id ~keeper_name ~actor_name =
     try
       save_bindings updated_bindings;
       append_audit_event
-        {
+        Store.{
           timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
           action = "bind";
+          guild_id = None;
           channel_id;
           keeper_name;
           actor_id = actor_name;
@@ -425,9 +312,10 @@ let unbind ~channel_id ~actor_name =
         try
           save_bindings updated_bindings;
           append_audit_event
-            {
+            Store.{
               timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
               action = "unbind";
+              guild_id = None;
               channel_id;
               keeper_name = removed_binding.keeper_name;
               actor_id = actor_name;

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -1,6 +1,7 @@
 (** Generic file-backed Channel Gate connector state for Python sidecars. *)
 
 module U = Yojson.Safe.Util
+module Store = Channel_gate_binding_store
 
 module type Config = sig
   val connector_id : string
@@ -16,19 +17,9 @@ module type Config = sig
 end
 
 module Make (Config : Config) = struct
-  type binding = {
+  type binding = Store.binding = {
     channel_id : string;
     keeper_name : string;
-  }
-
-  type audit_event = {
-    timestamp : string;
-    action : string;
-    channel_id : string;
-    keeper_name : string;
-    actor_id : string;
-    actor_name : string;
-    previous_keeper : string;
   }
 
   let connector_id = Config.connector_id
@@ -67,123 +58,17 @@ module Make (Config : Config) = struct
 
   let binding_audit_read_path = binding_audit_path
 
-  let read_json_file_opt path =
-    try Some (Yojson.Safe.from_file path) with
-    | Sys_error _ | Yojson.Json_error _ -> None
+  let binding_store =
+    Store.create ~binding_store_path ~binding_store_read_path
+      ~binding_audit_path ~binding_audit_read_path
+      ~guild_id_field:Store.Include_empty
 
-  let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
-    match json with
-    | `Assoc items ->
-        items
-        |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
-               let channel_id = String.trim raw_channel_id in
-               let keeper_name =
-                 match raw_keeper_name with
-                 | `String value -> String.trim value
-                 | _ -> ""
-               in
-               if channel_id = "" || keeper_name = "" then None
-               else Some ({ channel_id; keeper_name } : binding))
-        |> List.sort (fun (a : binding) (b : binding) ->
-               String.compare a.channel_id b.channel_id)
-    | _ -> []
-
-  let read_bindings () : binding list =
-    match read_json_file_opt (binding_store_read_path ()) with
-    | Some json -> normalize_bindings_json json
-    | None -> []
-
-  let binding_json (binding : binding) =
-    `Assoc
-      [
-        ("channel_id", `String binding.channel_id);
-        ("keeper_name", `String binding.keeper_name);
-      ]
-
-  let save_bindings (bindings : binding list) =
-    let path = binding_store_path () in
-    let normalized =
-      bindings
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-      |> List.fold_left
-           (fun acc (binding : binding) ->
-             (binding.channel_id, `String binding.keeper_name) :: acc)
-           []
-      |> List.rev
-      |> fun items -> `Assoc items
-    in
-    let dir = Filename.dirname path in
-    Fs_compat.mkdir_p dir;
-    let tmp = path ^ ".tmp" in
-    let oc = open_out_bin tmp in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
-    Sys.rename tmp path
-
-  let audit_event_json event =
-    `Assoc
-      [
-        ("timestamp", `String event.timestamp);
-        ("action", `String event.action);
-        ("guild_id", `String "");
-        ("channel_id", `String event.channel_id);
-        ("keeper_name", `String event.keeper_name);
-        ("actor_id", `String event.actor_id);
-        ("actor_name", `String event.actor_name);
-        ("previous_keeper", `String event.previous_keeper);
-      ]
-
-  let append_audit_event event =
-    let path = binding_audit_path () in
-    let dir = Filename.dirname path in
-    Fs_compat.mkdir_p dir;
-    let oc =
-      open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644
-        path
-    in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () ->
-        output_string oc (Yojson.Safe.to_string (audit_event_json event));
-        output_char oc '\n';
-        flush oc;
-        Unix.fsync (Unix.descr_of_out_channel oc))
-
-  let rec drop_left n xs =
-    if n <= 0 then xs
-    else
-      match xs with
-      | [] -> []
-      | _ :: tl -> drop_left (n - 1) tl
-
-  let read_recent_audit ~limit =
-    let path = binding_audit_read_path () in
-    if limit <= 0 || not (Sys.file_exists path) then
-      []
-    else
-      let ic = open_in_bin path in
-      Fun.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () ->
-          let rec loop acc =
-            match input_line ic with
-            | line -> loop (line :: acc)
-            | exception End_of_file -> acc
-          in
-          loop []
-          |> List.filter_map (fun line ->
-                 let trimmed = String.trim line in
-                 if trimmed = "" then None
-                 else
-                   try Some (Yojson.Safe.from_string trimmed) with
-                   | Yojson.Json_error _ -> None)
-          |> List.rev
-          |> fun rows ->
-          let total = List.length rows in
-          if total <= limit then List.rev rows
-          else rows |> drop_left (total - limit) |> List.rev)
+  let read_json_file_opt = Store.read_json_file_opt
+  let read_bindings () = Store.read_bindings binding_store
+  let binding_json = Store.binding_json
+  let save_bindings bindings = Store.save_bindings binding_store bindings
+  let append_audit_event event = Store.append_audit_event binding_store event
+  let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
   let string_member json key =
     Json_util.get_string_with_default json ~key ~default:""
@@ -448,9 +333,10 @@ module Make (Config : Config) = struct
       try
         save_bindings updated_bindings;
         append_audit_event
-          {
+          Store.{
             timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
             action = "bind";
+            guild_id = None;
             channel_id;
             keeper_name;
             actor_id = actor_name;
@@ -484,9 +370,10 @@ module Make (Config : Config) = struct
           try
             save_bindings updated_bindings;
             append_audit_event
-              {
+              Store.{
                 timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
                 action = "unbind";
+                guild_id = None;
                 channel_id;
                 keeper_name = previous.keeper_name;
                 actor_id = actor_name;

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -6,6 +6,7 @@
  (wrapped false)
  (modules
   channel_gate
+  channel_gate_binding_store
   channel_gate_connector
   channel_gate_discord_names
   channel_gate_discord_state

--- a/test/dune
+++ b/test/dune
@@ -127,6 +127,7 @@
   test_progress
   test_validation
   test_response
+  test_channel_gate_binding_store
   test_channel_gate_connector_routes
   test_sidecar_lifecycle_routes
   test_channel_gate_imessage_state
@@ -458,6 +459,7 @@
   test_progress
   test_validation
   test_response
+  test_channel_gate_binding_store
   test_channel_gate_connector_routes
   test_sidecar_lifecycle_routes
   test_channel_gate_imessage_state

--- a/test/test_channel_gate_binding_store.ml
+++ b/test/test_channel_gate_binding_store.ml
@@ -1,0 +1,124 @@
+open Alcotest
+
+module Store = Channel_gate_binding_store
+module U = Yojson.Safe.Util
+
+let temp_dir_counter = ref 0
+
+let with_temp_dir f =
+  incr temp_dir_counter;
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "channel-gate-binding-store-%d-%06d" (Unix.getpid ())
+         !temp_dir_counter)
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Sys.readdir path
+            |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          ) else Sys.remove path
+      in
+      rm_rf base)
+    (fun () -> f base)
+
+let store_for_dir dir ~guild_id_field =
+  let binding_path = Filename.concat dir "bindings.json" in
+  let audit_path = Filename.concat dir "binding_audit.jsonl" in
+  Store.create
+    ~binding_store_path:(fun () -> binding_path)
+    ~binding_store_read_path:(fun () -> binding_path)
+    ~binding_audit_path:(fun () -> audit_path)
+    ~binding_audit_read_path:(fun () -> audit_path)
+    ~guild_id_field
+
+let sample_event ?guild_id ~action () =
+  Store.
+    {
+      timestamp = "2026-07-01T00:00:00Z";
+      action;
+      guild_id;
+      channel_id = "channel-1";
+      keeper_name = "luna";
+      actor_id = "dashboard";
+      actor_name = "dashboard";
+      previous_keeper = "";
+    }
+
+let test_normalizes_bindings_json () =
+  let bindings =
+    Store.normalize_bindings_json
+      (`Assoc
+        [
+          ("z-channel", `String " luna ");
+          ("", `String "ignored");
+          ("bad-channel", `Int 1);
+          ("a-channel", `String " arya ");
+        ])
+  in
+  check int "valid bindings only" 2 (List.length bindings);
+  let first = List.hd bindings in
+  check string "sorted by channel id" "a-channel" first.channel_id;
+  check string "trims keeper name" "arya" first.keeper_name
+
+let test_save_and_read_bindings_round_trip () =
+  with_temp_dir @@ fun dir ->
+  let store = store_for_dir dir ~guild_id_field:Store.Omit in
+  Store.save_bindings store
+    [
+      ({ channel_id = "z-channel"; keeper_name = "luna" } : Store.binding);
+      ({ channel_id = "a-channel"; keeper_name = "arya" } : Store.binding);
+    ];
+  let bindings = Store.read_bindings store in
+  check int "two bindings" 2 (List.length bindings);
+  let first = List.hd bindings in
+  check string "read sorted channel" "a-channel" first.channel_id;
+  check string "read sorted keeper" "arya" first.keeper_name
+
+let test_audit_guild_id_policy () =
+  with_temp_dir @@ fun dir ->
+  let omit = store_for_dir dir ~guild_id_field:Store.Omit in
+  let empty = store_for_dir dir ~guild_id_field:Store.Include_empty in
+  let value = store_for_dir dir ~guild_id_field:Store.Include_event_value in
+  let event = sample_event ~guild_id:"guild-1" ~action:"bind" () in
+  check bool "omits guild_id"
+    true
+    (Store.audit_event_json omit event |> U.member "guild_id" = `Null);
+  check string "keeps empty sidecar guild_id" ""
+    (Store.audit_event_json empty event |> U.member "guild_id" |> U.to_string);
+  check string "keeps discord guild_id" "guild-1"
+    (Store.audit_event_json value event |> U.member "guild_id" |> U.to_string)
+
+let test_append_and_read_recent_audit () =
+  with_temp_dir @@ fun dir ->
+  let store = store_for_dir dir ~guild_id_field:Store.Include_empty in
+  Store.append_audit_event store (sample_event ~action:"bind" ());
+  Store.append_audit_event store (sample_event ~action:"rebind" ());
+  Store.append_audit_event store (sample_event ~action:"unbind" ());
+  let recent = Store.read_recent_audit store ~limit:2 in
+  check int "limit applied" 2 (List.length recent);
+  check string "newest first" "unbind"
+    (List.hd recent |> U.member "action" |> U.to_string);
+  check string "second newest" "rebind"
+    (List.nth recent 1 |> U.member "action" |> U.to_string)
+
+let () =
+  run "channel_gate_binding_store"
+    [
+      ( "bindings",
+        [
+          test_case "normalizes binding JSON" `Quick test_normalizes_bindings_json;
+          test_case "saves and reads bindings" `Quick
+            test_save_and_read_bindings_round_trip;
+        ] );
+      ( "audit",
+        [
+          test_case "preserves guild_id policy" `Quick test_audit_guild_id_policy;
+          test_case "reads recent audit newest first" `Quick
+            test_append_and_read_recent_audit;
+        ] );
+    ]


### PR DESCRIPTION
Refs #21080

## Summary
- add `Channel_gate_binding_store` as the shared file-backed bindings/audit SSOT
- wire Discord, iMessage, Slack, and Telegram sidecar state through the shared store
- preserve channel-specific audit shape: Discord writes resolved `guild_id`, sidecars keep the existing empty `guild_id`, and iMessage omits it
- add direct coverage for binding normalization, file round-trip, audit `guild_id` policy, and recent-audit ordering

## Scope
- addresses #21080 T9 only
- leaves #21080 T8 single-flight cache duplication out of scope because the issue calls it non-mechanical and requiring parameterized design

## Validation
- `python3 scripts/check_test_coverage.py`
- `scripts/ci/check-determinism-contract.sh`
- `ocamlformat --check lib/gate/channel_gate_binding_store.ml lib/gate/channel_gate_binding_store.mli lib/gate/channel_gate_discord_state.ml lib/gate/channel_gate_discord_state.mli lib/gate/channel_gate_imessage_state.ml lib/gate/channel_gate_sidecar_state.ml test/test_channel_gate_binding_store.ml`
- `git diff --check origin/main..HEAD`
- `rg -n "let normalize_bindings_json|let audit_event_json|let rec drop_left|open_out_gen|Yojson.Safe.pretty_to_string normalized|Unix.fsync" lib/gate/channel_gate_*_state.ml lib/gate/channel_gate_binding_store.ml` now reports the binding/audit implementation only in the shared module
- local Dune build/tests not run; CI is the build authority for this slice per maintainer instruction
