### PR TITLE
chore(dashboard): name keeper-chat stream magic numbers

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -389,6 +389,9 @@ let parse_keeper_chat_stream_request body_str =
         | Some (`Int value) when value > 0 ->
             Ok (Some (clamp_keeper_msg_timeout_sec value))
         | Some (`Float value) when value > 0.0 ->
+            (* int_of_float is unspecified (not exception-raising) for
+               out-of-range floats (e.g. 1e300, infinity); clamp_keeper_msg_timeout_sec
+               below bounds whatever int comes out into [5, 300] regardless. *)
             Ok (Some (clamp_keeper_msg_timeout_sec (int_of_float (Float.ceil value))))
         | Some (`Int _) | Some (`Float _) -> Ok None
         | Some _ -> Error "timeout_sec must be a positive number"

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -4,6 +4,32 @@ open Server_auth
 module Http = Http_server_eio
 module Mcp_eio = Mcp_server_eio
 
+(* Keeper-chat stream tunables (CLAUDE.md Magic Number 규칙: 의미를 드러내는 리터럴은
+   named constant로). Bounds are keeper-message-specific and distinct from the
+   env_config turn/orchestrator clamps. *)
+
+(* Clamp bounds for the client-supplied per-message timeout (seconds). *)
+let keeper_msg_timeout_sec_min = 5
+let keeper_msg_timeout_sec_max = 300
+
+let clamp_keeper_msg_timeout_sec v =
+  max keeper_msg_timeout_sec_min (min keeper_msg_timeout_sec_max v)
+;;
+
+(* Progressive-render hard-wrap width (characters) for streamed keeper replies —
+   a UI readability chunk width, NOT an SSE/transport line-length limit. *)
+let keeper_reply_chunk_hard_wrap_chars = 180
+
+(* Bounded producer-consumer capacity for the worker-event stream; [Eio.Stream.add]
+   blocks (backpressure) when the consumer lags. *)
+let worker_events_buffer_size = 512
+
+(* SSE reconnect backoff (ms) primed on the dashboard keeper-chat streams. Shared
+   with {!Server_routes_http_routes_dashboard} (via [open]) so the two dashboard
+   priming sites cannot silently diverge. Intentionally distinct from
+   {!Server_mcp_transport_http_headers.sse_retry_ms} (3000, the MCP transport). *)
+let sse_dashboard_retry_backoff_ms = 1500
+
 type user_media_block = Keeper_multimodal_input.user_media_block = {
   attachment_id : string;
   name : string;
@@ -360,9 +386,10 @@ let parse_keeper_chat_stream_request body_str =
       let timeout_sec =
         match Json_util.assoc_member_opt "timeout_sec" json with
         | None | Some `Null -> Ok None
-        | Some (`Int value) when value > 0 -> Ok (Some (max 5 (min 300 value)))
+        | Some (`Int value) when value > 0 ->
+            Ok (Some (clamp_keeper_msg_timeout_sec value))
         | Some (`Float value) when value > 0.0 ->
-            Ok (Some (max 5 (min 300 (int_of_float (Float.ceil value)))))
+            Ok (Some (clamp_keeper_msg_timeout_sec (int_of_float (Float.ceil value))))
         | Some (`Int _) | Some (`Float _) -> Ok None
         | Some _ -> Error "timeout_sec must be a positive number"
       in
@@ -444,7 +471,7 @@ let split_keeper_reply_chunks (text : string) : string list =
         i + 1 >= len || whitespace text.[i + 1]
       in
       let hard_wrap =
-        i - !start >= 180
+        i - !start >= keeper_reply_chunk_hard_wrap_chars
         &&
         match !last_space with
         | Some idx -> idx > !start
@@ -733,7 +760,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
      [Keeper_stream_text_accum]; see its interface for the #20825/#20854/
      #20869 history this guards against. *)
   let text_accum = Keeper_stream_text_accum.create () in
-  let worker_events = Eio.Stream.create 512 in
+  let worker_events = Eio.Stream.create worker_events_buffer_size in
   let terminal_pushed = Atomic.make false in
   let client_disconnected = Atomic.make false in
   let push_worker_event event =
@@ -1361,7 +1388,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
 
   ignore
     (keeper_stream_send_raw ~on_closed:notify_disconnect writer mutex closed
-       "retry: 1500\n\n");
+       (Printf.sprintf "retry: %d\n\n" sse_dashboard_retry_backoff_ms));
   Eio.Fiber.fork ~sw (fun () ->
       ignore
         (Eio.Switch.run @@ fun stream_sw ->

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -38,6 +38,14 @@
     framing, connector-context and legacy model-argument
     payload guards). *)
 
+(** {1 Stream tunables} *)
+
+(** SSE reconnect backoff (ms) primed on the dashboard keeper-chat streams.
+    Shared with {!Server_routes_http_routes_dashboard} (reached via [open]) so the
+    two dashboard priming sites cannot silently diverge; intentionally distinct
+    from {!Server_mcp_transport_http_headers.sse_retry_ms} (the MCP transport). *)
+val sse_dashboard_retry_backoff_ms : int
+
 (** {1 Request record} *)
 
 type user_media_block = Keeper_multimodal_input.user_media_block = {

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -15,7 +15,9 @@
     keep working through the type-passthrough but do not
     add to the surface here.
 
-    External surface (3 entries + 1 record):
+    External surface (4 entries + 1 record):
+    - {b stream tunable} ({!sse_dashboard_retry_backoff_ms}) — SSE
+      reconnect backoff shared with the dashboard route.
     - {b request record} ({!keeper_chat_stream_request})
       returned by the parser, consumed by the handler;
       the dashboard route reaches the [.name] field via

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -120,7 +120,8 @@ let handle_execute_output_stream ~sw ~clock request reqd =
            close_stream ()
          | Some subscriber ->
            let wrote_initial =
-             write_string "retry: 1500\n\n"
+             write_string
+               (Printf.sprintf "retry: %d\n\n" sse_dashboard_retry_backoff_ms)
              && write_json (Dashboard_execute_output.event_json ~keeper_name)
            in
            if not wrote_initial


### PR DESCRIPTION
## 목표

keeper-chat 스트리밍 경로의 매직 넘버 4종을 named constant로 추출(CLAUDE.md Magic Number 규칙). 적대적 감사(`wf_87b1b311-25c`)에서 발견(standard_violation ×4).

## 변경 (no behavior change)

- **`sse_dashboard_retry_backoff_ms` (1500)** — keeper_stream.ml:1391 + routes_dashboard.ml:123 **두 사이트 공유**(.mli export, 기존 `open`으로 접근). 과거 두 곳 inline `"retry: 1500"`이 divergence 가능했음(문서화된 `sse_retry_ms=3000` SSOT와 동일 위험). N-of-M 부분패치 회피 위해 양쪽 동시 수정.
- **`keeper_msg_timeout_sec_{min,max}` (5, 300)** + `clamp_keeper_msg_timeout_sec` helper — Int/Float 브랜치 drift 방지.
- **`worker_events_buffer_size` (512)** — worker-event 스트림 backpressure 용량.
- **`keeper_reply_chunk_hard_wrap_chars` (180)** — progressive-render 청크 폭(UI 가독성, SSE/transport 라인 제한 아님).

## 경계 / 검증

- MASC-internal(lib/server), OAS 무관. 순수 상수 추출(동작 불변).
- 로컬 빌드 불가 → CI Lint(컴파일+ocamlformat) 검증. 포맷 불일치 시 배치 수정 예정.

RFC-WAIVED: 매직넘버 명명(RFC-gated subsystem 무관). 동작 불변, 워크어라운드 아님.
