### PR TITLE
fix(keeper): route passive-only turns through no-progress

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -307,9 +307,15 @@ let completion_contract_terminal_failure_reason_code result =
       { disposition = Keeper_execution_receipt.Disp_pause_human
       ; reason = Keeper_execution_receipt.Reason_completion_contract_unsatisfied
       } ->
-    Some
-      (Keeper_execution_receipt.completion_contract_result_to_string
-         result.Keeper_agent_run.completion_contract_result)
+    (match result.Keeper_agent_run.completion_contract_result with
+     | Keeper_execution_receipt.Contract_passive_only ->
+       (* A passive-only runtime success is the no-progress detector's input,
+          not a second, shorter completion-contract auto-pause path. Other
+          unsatisfied contract results still mean the runtime violated the
+          execution/completion contract and remain terminal failures. *)
+       None
+     | result ->
+       Some (Keeper_execution_receipt.completion_contract_result_to_string result))
   | Some _ -> None
   | None ->
     Some

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -721,19 +721,37 @@ let test_completion_contract_terminal_failure_reason_code () =
               : Masc.Keeper_agent_result.operator_disposition))
       []
   in
+  Alcotest.(check bool)
+    "passive-only routes through no-progress, not contract auto-pause"
+    true
+    (Option.is_none
+       (Success.completion_contract_terminal_failure_reason_code
+          failed_passive_only));
+  Alcotest.(check bool)
+    "passive-only remains a completed turn for terminal bookkeeping"
+    true
+    (Success.terminal_outcome_is_completed_turn
+       (Success.terminal_outcome_of_result failed_passive_only));
+  let needs_execution_progress =
+    run_result
+      ~completion_contract_result:
+        Masc.Keeper_execution_receipt.Contract_needs_execution_progress
+      ~operator_disposition:
+        (Some
+           ({ disposition = Masc.Keeper_execution_receipt.Disp_pause_human
+            ; reason =
+                Masc.Keeper_execution_receipt.Reason_completion_contract_unsatisfied
+            }
+              : Masc.Keeper_agent_result.operator_disposition))
+      []
+  in
   Alcotest.(check string)
-    "failed passive-only reason is the typed contract label"
-    "passive_only"
+    "execution-progress failure still uses completion-contract terminal path"
+    "needs_execution_progress"
     (Option.value
        ~default:""
        (Success.completion_contract_terminal_failure_reason_code
-          failed_passive_only))
-  ;
-  Alcotest.(check bool)
-    "failed passive-only is not counted as completed turn"
-    false
-    (Success.terminal_outcome_is_completed_turn
-       (Success.terminal_outcome_of_result failed_passive_only));
+          needs_execution_progress));
   let no_capable_provider =
     run_result
       ~completion_contract_result:


### PR DESCRIPTION
## Summary
- Route `Contract_passive_only` runtime successes through the no-progress detector instead of the shorter completion-contract auto-pause path.
- Keep execution-progress contract failures on the completion-contract terminal path.
- Add regression coverage for passive-only vs needs-execution-progress terminal routing.

## Why
`passive_only` and repeated no-evidence turns share the same no-progress signal family, but the previous terminal routing let `passive_only` auto-pause via the completion-contract failure counter before the no-progress latch could own the case. This split one behavior across two pause reasons.

## Tests
- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_no_progress_loop_detector.exe test/test_keeper_auto_pause_blocker_persist_12683.exe`
- `./_build/default/test/test_no_progress_loop_detector.exe`
- `./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe`
- `git diff --check HEAD~1..HEAD`
