### PR TITLE
[codex] Make settings theme switch reach Paper

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -418,7 +418,7 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="log-viewer"]')).not.toBeNull()
   })
 
-  it('renders the theme switch inside the display section (moved out of the top bar)', () => {
+  it('renders a live theme switch inside the display section that can reach Paper', async () => {
     route.value = { tab: 'settings', params: { section: 'display' }, postId: null }
 
     render(html`<${SettingsSurface} />`, container)
@@ -427,6 +427,13 @@ describe('SettingsSurface', () => {
     const themeButton = [...container.querySelectorAll('button')]
       .find(b => /DARK|STYLESEED|PAPER/.test(b.textContent ?? ''))
     expect(themeButton).toBeTruthy()
+
+    await fireEvent.click(themeButton as HTMLButtonElement)
+    expect(document.documentElement.dataset.theme).toBe('styleseed')
+
+    await fireEvent.click(themeButton as HTMLButtonElement)
+    expect(document.documentElement.dataset.theme).toBe('paper')
+    expect(localStorage.getItem('dashboardTheme')).toBe('paper')
   })
 
   it('wires display density to the dashboard density signal without fake locale previews', async () => {

--- a/dashboard/src/components/theme-switch.test.ts
+++ b/dashboard/src/components/theme-switch.test.ts
@@ -24,7 +24,7 @@ describe('ThemeSwitch', () => {
     expect(container.textContent).toContain('SEED')
   })
 
-  it('toggles from styleseed to dark on click', () => {
+  it('toggles from styleseed to paper on click', () => {
     document.documentElement.dataset.theme = 'styleseed'
     window.history.replaceState(null, '', '/?theme=styleseed')
     const container = document.createElement('div')
@@ -32,9 +32,9 @@ describe('ThemeSwitch', () => {
     const btn = container.querySelector('button')
     expect(btn).not.toBeNull()
     btn!.click()
-    expect(document.documentElement.dataset.theme).toBeUndefined()
-    expect(localStorage.getItem('dashboardTheme')).toBeNull()
-    expect(window.location.search).not.toContain('theme=')
+    expect(document.documentElement.dataset.theme).toBe('paper')
+    expect(localStorage.getItem('dashboardTheme')).toBe('paper')
+    expect(window.location.search).toContain('theme=paper')
   })
 
   it('toggles from dark to styleseed on click', () => {
@@ -71,16 +71,15 @@ describe('ThemeSwitch', () => {
     expect(btn!.classList.contains('v2-shell-action')).toBe(true)
   })
 
-  it('migrates paper to styleseed on click', () => {
+  it('toggles from paper to dark on click', () => {
     document.documentElement.dataset.theme = 'paper'
     window.history.replaceState(null, '', '/?theme=paper')
     const container = document.createElement('div')
     render(h(ThemeSwitch), container)
     const btn = container.querySelector('button')
     btn!.click()
-    expect(document.documentElement.dataset.theme).toBe('styleseed')
-    expect(localStorage.getItem('dashboardTheme')).toBe('styleseed')
-    expect(window.location.search).toContain('theme=styleseed')
+    expect(document.documentElement.dataset.theme).toBeUndefined()
+    expect(localStorage.getItem('dashboardTheme')).toBeNull()
     expect(window.location.search).not.toContain('theme=paper')
   })
 })

--- a/dashboard/src/components/theme-switch.ts
+++ b/dashboard/src/components/theme-switch.ts
@@ -1,6 +1,6 @@
 // ThemeSwitch — compact header theme toggle.
 //
-// Cycles between the default StyleSeed palette and the legacy dark palette.
+// Cycles between the default dark palette, StyleSeed, and Paper.
 // The actual token swaps live in styles/styleseed-theme.css and
 // styles/paper-theme.css; this component only flips
 // document.documentElement.dataset.theme and persists the choice to
@@ -59,8 +59,14 @@ function syncThemeSearchParam(next: ThemeId): void {
   history.replaceState(null, '', url.toString())
 }
 
+function nextTheme(current: ThemeId): ThemeId {
+  if (current === null) return 'styleseed'
+  if (current === 'styleseed') return 'paper'
+  return null
+}
+
 function toggleTheme(): void {
-  applyTheme(currentTheme.value === 'styleseed' ? null : 'styleseed')
+  applyTheme(nextTheme(currentTheme.value))
 }
 
 const LABEL: Record<'default' | 'styleseed' | 'paper', string> = {
@@ -71,8 +77,8 @@ const LABEL: Record<'default' | 'styleseed' | 'paper', string> = {
 
 const TITLE: Record<'default' | 'styleseed' | 'paper', string> = {
   default: '현재 테마: Dark · 클릭하여 StyleSeed 테마로 전환',
-  styleseed: '현재 테마: StyleSeed · 클릭하여 Dark 테마로 전환',
-  paper: '현재 테마: Paper · 클릭하여 StyleSeed 테마로 전환',
+  styleseed: '현재 테마: StyleSeed · 클릭하여 Paper 테마로 전환',
+  paper: '현재 테마: Paper · 클릭하여 Dark 테마로 전환',
 }
 
 export function ThemeSwitch() {


### PR DESCRIPTION
## Summary

- Fix the dashboard ThemeSwitch cycle so the Settings Display theme control can reach every advertised theme: Dark -> StyleSeed -> Paper -> Dark.
- Update the button titles to describe the actual next theme.
- Add focused coverage for ThemeSwitch and the Settings Display integration path reaching Paper.

## Impact

The Settings Display page no longer advertises Paper as a theme option while making it unreachable from the theme button. `?theme=paper` and persisted `paper` were already supported by bootstrap; this wires the live control to that existing state.

## Validation

- `vitest run --config vitest.config.ts src/components/theme-switch.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit`
- `eslint src/components/theme-switch.ts src/components/theme-switch.test.ts src/components/settings-surface.test.ts` (test files are ignored by current ESLint config; source file passed)
- `git diff --check`
- Playwright smoke: `/dashboard/#settings?section=display`, click Theme twice, verify `html[data-theme="paper"]`, `localStorage.dashboardTheme = "paper"`, and `?theme=paper`.

Full build is left to CI.
