### PR TITLE
[codex] Fix keeper visible reply finalization

### DIFF
--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -53,8 +53,8 @@ let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_to
 
 let response_text ~state_snapshot_source ~raw_response_text =
   match (state_snapshot_source : Keeper_memory_policy.state_snapshot_source) with
-  | Synthesized | Structured_state_reply -> ""
-  | Structured_state_tool | State_block ->
+  | Structured_state_reply -> ""
+  | Synthesized | Structured_state_tool | State_block ->
     Keeper_text_processing.strip_internal_reply_markup raw_response_text
 ;;
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -642,13 +642,16 @@ let assoc_replace key value fields =
   (key, value)
   :: List.filter (fun (field_key, _) -> not (String.equal field_key key)) fields
 
-let reply_payload_with_streamed_visible_reply payload_json_opt ~visible_reply =
+let reply_payload_with_streamed_visible_reply payload_json_opt ~visible_reply
+    ~streamed_text_present =
   match String_util.trim_to_option visible_reply with
   | None -> payload_json_opt
   | Some visible_reply -> (
       match Keeper_turn_outcome.of_reply_payload payload_json_opt with
       | Keeper_turn_outcome.Continuation_checkpoint -> payload_json_opt
-      | Keeper_turn_outcome.No_visible_reply -> payload_json_opt
+      | Keeper_turn_outcome.No_visible_reply when not streamed_text_present ->
+          payload_json_opt
+      | Keeper_turn_outcome.No_visible_reply
       | Keeper_turn_outcome.Visible_reply -> (
           match payload_json_opt with
           | Some (`Assoc fields) ->
@@ -876,15 +879,21 @@ let process_single_turn ~connector_user_line_recorded_upstream
         match dispatch_result with
         | Ok (true, body) ->
             let payload_json_opt, visible_reply = extract_visible_reply body in
+            let streamed_text =
+              Keeper_stream_text_accum.streamed_text worker_text_accum
+            in
+            let streamed_text_present =
+              Option.is_some (String_util.trim_to_option streamed_text)
+            in
             let visible_reply =
               redacted_visible_reply_with_stream_fallback
                 ~redact:redact_text
-                ~streamed_text:(Keeper_stream_text_accum.streamed_text worker_text_accum)
+                ~streamed_text
                 visible_reply
             in
             let payload_json_opt =
               reply_payload_with_streamed_visible_reply payload_json_opt
-                ~visible_reply
+                ~visible_reply ~streamed_text_present
             in
             let body =
               body_with_rewritten_payload ~fallback:body payload_json_opt

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -202,7 +202,10 @@ module For_testing : sig
   val redacted_visible_reply_with_stream_fallback :
     redact:(string -> string) -> streamed_text:string -> string -> string
   val reply_payload_with_streamed_visible_reply :
-    Yojson.Safe.t option -> visible_reply:string -> Yojson.Safe.t option
+    Yojson.Safe.t option ->
+    visible_reply:string ->
+    streamed_text_present:bool ->
+    Yojson.Safe.t option
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   val empty_stream_bridge_state : keeper_stream_bridge_state

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1649,7 +1649,7 @@ let test_visible_reply_stream_fallback_redacts_before_persist () =
   in
   check string "terminal reply redacted" "terminal [redacted]" explicit
 
-let test_streamed_visible_reply_preserves_no_visible_payload () =
+let test_streamed_visible_reply_promotes_no_visible_payload_when_text_streamed () =
   let payload_json =
     `Assoc
       [
@@ -1664,7 +1664,32 @@ let test_streamed_visible_reply_preserves_no_visible_payload () =
   in
   let rewritten =
     Server_routes_http_keeper_stream.For_testing.reply_payload_with_streamed_visible_reply
-      (Some payload_json) ~visible_reply
+      (Some payload_json) ~visible_reply ~streamed_text_present:true
+  in
+  check string "streamed visible reply is preserved" "streamed final"
+    (json_string_field "reply" rewritten);
+  check string "streamed visible reply wins terminal outcome" "visible_reply"
+    (json_string_field Keeper_turn_outcome.wire_key rewritten);
+  let err =
+    Server_routes_http_keeper_stream.For_testing.direct_reply_terminal_error
+      rewritten visible_reply
+  in
+  check bool "typed text stream avoids no-visible terminal error" true
+    (Option.is_none err)
+
+let test_visible_reply_without_stream_preserves_no_visible_payload () =
+  let payload_json =
+    `Assoc
+      [
+        ("runtime_class", `String "keeper");
+        ("turn_outcome", `String "no_visible_reply");
+        ("reply", `String "");
+      ]
+  in
+  let rewritten =
+    Server_routes_http_keeper_stream.For_testing.reply_payload_with_streamed_visible_reply
+      (Some payload_json) ~visible_reply:"terminal fallback"
+      ~streamed_text_present:false
   in
   check string "declared no-visible reply remains empty" ""
     (json_string_field "reply" rewritten);
@@ -1672,9 +1697,9 @@ let test_streamed_visible_reply_preserves_no_visible_payload () =
     (json_string_field Keeper_turn_outcome.wire_key rewritten);
   let err =
     Server_routes_http_keeper_stream.For_testing.direct_reply_terminal_error
-      rewritten visible_reply
+      rewritten "terminal fallback"
   in
-  check bool "stream fallback cannot override no-visible terminal contract" true
+  check bool "non-stream fallback cannot override no-visible terminal contract" true
     (Option.is_some err)
 
 let test_streamed_visible_reply_preserves_checkpoint_payload () =
@@ -1689,6 +1714,7 @@ let test_streamed_visible_reply_preserves_checkpoint_payload () =
   let rewritten =
     Server_routes_http_keeper_stream.For_testing.reply_payload_with_streamed_visible_reply
       (Some payload_json) ~visible_reply:"streamed final"
+      ~streamed_text_present:true
   in
   check string "checkpoint outcome is semantic" "continuation_checkpoint"
     (json_string_field Keeper_turn_outcome.wire_key rewritten);
@@ -2390,8 +2416,10 @@ let () =
             test_visible_reply_uses_streamed_text_fallback;
           test_case "visible reply stream fallback redacts before persist" `Quick
             test_visible_reply_stream_fallback_redacts_before_persist;
-          test_case "streamed visible reply preserves no-visible payload" `Quick
-            test_streamed_visible_reply_preserves_no_visible_payload;
+          test_case "streamed visible reply promotes no-visible payload" `Quick
+            test_streamed_visible_reply_promotes_no_visible_payload_when_text_streamed;
+          test_case "no-visible payload still wins without text stream" `Quick
+            test_visible_reply_without_stream_preserves_no_visible_payload;
           test_case "streamed visible reply preserves checkpoint payload" `Quick
             test_streamed_visible_reply_preserves_checkpoint_payload;
           test_case "runtime run_blocks appends multimodal input to OAS agent" `Quick

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -955,7 +955,7 @@ let test_attention_contract_does_not_resume_working_state_digest () =
     true
     budget_resume
 
-let test_synthetic_finalizer_drops_generated_response_text () =
+let test_synthetic_finalizer_preserves_generated_response_text () =
   let raw_response_text =
     String.concat
       "\n"
@@ -983,12 +983,12 @@ let test_synthetic_finalizer_drops_generated_response_text () =
     "synthesized"
     (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
   Alcotest.(check string)
-    "synthetic source is not a user-visible reply"
-    ""
+    "synthetic state source preserves typed response text"
+    raw_response_text
     finalized.response_text;
   Alcotest.(check bool)
-    "raw repeated text not persisted as response"
-    false
+    "raw repeated text remains visible response"
+    true
     (contains_substring finalized.response_text "What should I do next?");
   Alcotest.(check (list string))
     "raw repeated text not persisted as synthetic decisions"
@@ -1125,9 +1125,9 @@ let () =
             `Quick
             test_attention_contract_does_not_resume_working_state_digest;
           Alcotest.test_case
-            "synthetic finalizer drops generated response text"
+            "synthetic finalizer preserves generated response text"
             `Quick
-            test_synthetic_finalizer_drops_generated_response_text;
+            test_synthetic_finalizer_preserves_generated_response_text;
           Alcotest.test_case
             "contract attention finalizer drops raw response text"
             `Quick


### PR DESCRIPTION
## Summary

- Preserve keeper visible response text when the state snapshot is synthesized from run metadata.
- Promote a final `no_visible_reply` payload to `visible_reply` only when the stream already emitted typed visible `TextDelta`.
- Keep continuation checkpoints and true no-visible/thinking-only responses hidden.

## Root Cause

The runtime could stream visible answer text, then MASC finalization would synthesize keeper state because the model did not emit state metadata. That synthetic state source caused `response_text` to become empty, which later produced `turn_outcome=no_visible_reply` and replaced the dashboard-visible answer with:

`Keeper completed without a visible reply; the runtime returned only thinking or internal state.`

This was a MASC finalization/terminal-contract bug, not proof that the OAS provider stream was empty.

## Provider/OAS Contract

This PR does not claim every OAS provider adapter is universally correct. It preserves the provider-agnostic typed contract: if OAS emits visible output as `Text`/`TextDelta`, MASC must keep it visible; if OAS emits only thinking/reasoning blocks, MASC must not fabricate a visible answer.

If a provider adapter misclassifies visible text as thinking, that remains an OAS adapter contract bug and should be fixed with OAS provider-level tests.

## Validation

- `scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe test/test_gate_keeper_backend.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_state_snapshot_json.exe`
- `git diff --check`

Per operator direction, broader build/test coverage is left to CI as the build authority.
