### PR TITLE
fix(runtime): keep preserve thinking policy explicit

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -122,9 +122,10 @@ api-name = "glm-4.7"
 max-context = 200000
 tools-support = true
 thinking-support = true
-# GLM Coding Plan uses Z.AI's preserved-thinking path. OAS maps this runtime
-# seed to thinking.clear_thinking=false when preserve-thinking is enabled.
-preserve-thinking = true
+# Keep long-running keeper turns on non-preserved reasoning by default. OAS owns
+# GLM's clear_thinking wire contract; enabling preserved thinking here replays
+# historical reasoning into every subsequent keeper turn.
+preserve-thinking = false
 streaming = true
 
 [models.glm-4-7-coding.capabilities]
@@ -172,7 +173,10 @@ api-name = "GLM-5-Turbo"
 max-context = 203000
 tools-support = true
 thinking-support = true
-preserve-thinking = true
+# Keep long-running keeper turns on non-preserved reasoning by default. OAS owns
+# GLM's clear_thinking wire contract; enabling preserved thinking here replays
+# historical reasoning into every subsequent keeper turn.
+preserve-thinking = false
 streaming = true
 
 [models.glm-5-turbo.capabilities]

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -481,19 +481,12 @@ let thinking_support_of_runtime_id (id : string) : bool option =
   | None -> None
 ;;
 
-let default_preserve_thinking_for_model (rt : t) : bool option =
-  if not rt.model.thinking_support
-  then None
-  else (
-    match capabilities_for_runtime rt with
-    | None -> None
-    | Some caps ->
-      (match caps.preserve_thinking_control_format with
-       | Llm_provider.Capabilities.Thinking_object_keep_all
-       | Llm_provider.Capabilities.Chat_template_kwargs_preserve_thinking
-       | Llm_provider.Capabilities.Top_level_preserve_thinking -> Some true
-       | Llm_provider.Capabilities.No_preserve_thinking_control
-       | Llm_provider.Capabilities.Always_preserved_thinking -> None))
+let default_preserve_thinking_for_model (_rt : t) : bool option =
+  (* OAS owns provider/model capability truth and can preserve reasoning when
+     the provider contract requires it. MASC must not turn "request-side
+     preserve is supported" into a fleet-wide replay policy; long-running
+     keepers otherwise accumulate hidden reasoning across unrelated turns. *)
+  None
 ;;
 
 let preserve_thinking_of_runtime_id (id : string) : bool option =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -165,10 +165,12 @@ val thinking_support_of_runtime_id : string -> bool option
     runtime.toml SSOT. *)
 
 val preserve_thinking_of_runtime_id : string -> bool option
-(** Explicit [preserve-thinking] for runtime [id], or the OAS typed default for
-    models whose capability declares a request-side preserve-thinking control.
-    [None] means unknown runtime, uninitialized cache, no explicit TOML field,
-    and no OAS request-side preserve control.  Consumed by
+(** Explicit [preserve-thinking] for runtime [id]. [None] means unknown runtime,
+    uninitialized cache, or no explicit TOML field.
+
+    OAS owns provider/model capability truth and applies provider-required
+    reasoning replay internally. MASC does not promote a request-side preserve
+    capability into default keeper policy. Consumed by
     {!Runtime_inference.for_runtime} without provider/model string matching. *)
 
 val pricing_of_runtime_id : string -> float option * float option

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -610,8 +610,8 @@ let test_repo_runtime_toml_loads () =
        check int "GLM Coding Plan context" 200000 runtime.model.max_context;
        check bool "GLM Coding Plan thinking enabled" true
          runtime.model.thinking_support;
-       check (option bool) "GLM Coding Plan preserves thinking" (Some true)
-         runtime.model.preserve_thinking;
+      check (option bool) "GLM Coding Plan does not preserve thinking by default" (Some false)
+        runtime.model.preserve_thinking;
        (match runtime.model.capabilities with
         | Some caps ->
           check (option int) "GLM Coding Plan output cap" (Some 128000)
@@ -1073,7 +1073,7 @@ let test_runtime_capability_gate_uses_provider_qualified_catalog () =
               capability gate: %s"
              msg
          | Ok () ->
-           check (option bool) "provider-qualified preserve default" (Some true)
+           check (option bool) "provider-qualified preserve policy" None
              (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
 
 let test_runtime_toml_max_concurrent_flows_to_candidate () =

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -18,14 +18,12 @@ open Masc
 module J = Yojson.Safe.Util
 module KMC = Keeper_meta_contract
 
-(* Test hermeticity: the per-model thinking gate resolves capabilities through
-   the OAS [Model_catalog], which is loaded once (memoized via Atomic) from the
-   [OAS_MODEL_CATALOG] env var.  Production seeds this in
-   server_runtime_bootstrap; without it [Model_catalog.global ()] is [None], so
-   qwen36's [preserve_thinking_control_format] misses the catalog row and the
-   gate defaults [preserve_thinking] to [None] instead of [Some true].  Set at
-   module top so it precedes the first [global ()] access regardless of test
-   ordering, and only when unset so an external/CI value is honored. *)
+(* Test hermeticity: runtime capability checks resolve through the OAS
+   [Model_catalog], which is loaded once (memoized via Atomic) from the
+   [OAS_MODEL_CATALOG] env var. Production seeds this in
+   server_runtime_bootstrap. Set at module top so it precedes the first
+   [global ()] access regardless of test ordering, and only when unset so an
+   external/CI value is honored. *)
 let () =
   match Sys.getenv_opt "OAS_MODEL_CATALOG" with
   | Some _ -> ()
@@ -738,12 +736,12 @@ let test_thinking_support_true_enables_thinking_and_preserves () =
       seed.Runtime_inference.preserve_thinking)
 ;;
 
-let test_thinking_support_true_defaults_preserve_when_unset () =
+let test_thinking_support_true_leaves_preserve_unset () =
   with_runtime_thinking (fun () ->
     let seed = Runtime_inference.for_runtime ~name:"ollama_cloud.thinkdefault" in
     Alcotest.(check (option bool))
-      "OAS request-side preserve capability defaults preserve to Some true"
-      (Some true)
+      "OAS request-side preserve capability does not auto-enable preserve"
+      None
       seed.Runtime_inference.preserve_thinking)
 ;;
 
@@ -987,11 +985,11 @@ let () =
             `Quick
             test_thinking_support_true_enables_thinking_and_preserves
         ; Alcotest.test_case
-            "request-side preserve capability defaults preserve on"
+            "request-side preserve capability stays policy-neutral"
             `Quick
-            test_thinking_support_true_defaults_preserve_when_unset
+            test_thinking_support_true_leaves_preserve_unset
         ; Alcotest.test_case
-            "explicit preserve-thinking=false overrides capability default"
+            "explicit preserve-thinking=false stays explicit"
             `Quick
             test_explicit_preserve_false_overrides_capability_default
         ; Alcotest.test_case


### PR DESCRIPTION
## Summary
- stop promoting OAS request-side preserve-thinking capability into MASC default runtime policy
- keep GLM keeper runtime bindings on non-preserved reasoning by default to avoid long-lived reasoning replay accumulation
- update runtime tests so explicit preserve-thinking remains honored while unset preserve stays policy-neutral

## Verification
- git diff --check origin/main...HEAD
- opam exec -- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli test/test_runtime_config_validity.ml test/test_runtime_per_keeper_routing.ml
- scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe test/test_runtime_config_validity.exe
- ./_build/default/test/test_runtime_per_keeper_routing.exe
- ./_build/default/test/test_runtime_config_validity.exe

Note: full @fmt was not used as completion evidence because local runs were repeatedly blocked by unrelated concurrent/bare Dune activity; changed OCaml files were checked directly.