### PR TITLE
[codex] Fix keeper retry-after fixture type

### DIFF
--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2149,7 +2149,7 @@ let test_capacity_failure_exhaustion_classifies_as_capacity_exhausted () =
       { kind =
           Llm_provider.Http_client.Capacity_exhausted
             { scope = Llm_provider.Http_client.Failure_scope_provider
-            ; retry_after = Some "30"
+            ; retry_after = Some 30.0
             ; model = Some "test-model"
             }
       ; message = "capacity exhausted"


### PR DESCRIPTION
## Summary
- update the capacity-exhaustion keeper test fixture to pass retry_after as a float
- align the fixture with the current Llm_provider.Http_client.Capacity_exhausted type

## Root cause
- the test still used Some "30" after retry_after became float option, so OCaml rejected the fixture during compilation

## Validation
- scripts/dune-local.sh build test/test_keeper_turn_driver_accept.exe
- ./_build/default/test/test_keeper_turn_driver_accept.exe