### PR TITLE
fix(workspace): require base path for RFC-0274 wave A

### DIFF
--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -151,17 +151,12 @@ let request_to_json (req : V.verification_request) : Yojson.Safe.t =
 
 (* ── Snapshot assembly ──────────────────────────────── *)
 
-(** Load the raw verification request list from the current MASC base_path.
+(** Load the raw verification request list from the supplied MASC base_path.
 
-    Protected against missing base_path or filesystem errors — failures
-    surface as an empty list plus a log line, matching the tolerance
+    Protected against filesystem errors — failures surface as an empty
+    list plus a log line, matching the tolerance
     [Verification.list_requests] already offers on a missing dir. *)
-let load_requests ?base_path () : V.verification_request list =
-  let base_path =
-    match base_path with
-    | Some value -> value
-    | None -> Env_config_core.base_path ()
-  in
+let load_requests ~base_path () : V.verification_request list =
   try V.list_requests base_path
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -204,9 +199,9 @@ let requests_json_of_requests ?task_id ~limit all : Yojson.Safe.t =
      ]
      @ fd_pressure_fields ())
 
-let requests_json ?base_path ?task_id ?limit () : Yojson.Safe.t =
+let requests_json ~base_path ?task_id ?limit () : Yojson.Safe.t =
   let limit = clamp_limit limit in
-  let all = load_requests ?base_path () in
+  let all = load_requests ~base_path () in
   requests_json_of_requests ?task_id ~limit all
 
 (* ── Summary projection ─────────────────────────────── *)
@@ -282,9 +277,9 @@ let summary_json_of_requests ~recent all : Yojson.Safe.t =
      ]
      @ fd_pressure_fields ())
 
-let summary_json ?base_path ?recent () : Yojson.Safe.t =
+let summary_json ~base_path ?recent () : Yojson.Safe.t =
   let recent = Option.value recent ~default:default_recent in
-  let all = load_requests ?base_path () in
+  let all = load_requests ~base_path () in
   summary_json_of_requests ~recent all
 
 (* Single-load companion for handlers that emit both projections
@@ -294,10 +289,10 @@ let summary_json ?base_path ?recent () : Yojson.Safe.t =
    the historic proof handler scanned the verification store twice
    per refresh.  This helper performs one scan and folds the two
    projections from the shared list. *)
-let proof_compose ?base_path ?recent ?limit () : Yojson.Safe.t * Yojson.Safe.t =
+let proof_compose ~base_path ?recent ?limit () : Yojson.Safe.t * Yojson.Safe.t =
   let recent = Option.value recent ~default:default_recent in
   let limit = clamp_limit limit in
-  let all = load_requests ?base_path () in
+  let all = load_requests ~base_path () in
   let summary = summary_json_of_requests ~recent all in
   let requests = requests_json_of_requests ~limit all in
   summary, requests

--- a/lib/dashboard/dashboard_verification.mli
+++ b/lib/dashboard/dashboard_verification.mli
@@ -47,17 +47,16 @@
 
 (** Build the JSON snapshot of verification requests.
 
-    - [base_path]: when provided, read that runtime root instead of the
-      process-wide fallback. HTTP routes pass the active server config so a
-      dashboard bound to a non-default base path does not show stale
-      verification state.
+    - [base_path]: read this runtime root. HTTP routes pass the active
+      server config so a dashboard bound to a non-default base path does not
+      show stale verification state.
     - [task_id]: when [Some id] (non-empty), return only requests whose
       [task_id] equals [id]. When absent or empty, return all tasks.
     - [limit]: clamped into [\[1, 500\]]; defaults to 100. Sort is
       reverse-chronological by [created_at] so the newest request wins
       when the cap trims. *)
 val requests_json :
-  ?base_path:string ->
+  base_path:string ->
   ?task_id:string ->
   ?limit:int ->
   unit ->
@@ -89,7 +88,7 @@ val requests_json :
         ]
       }
     ]} *)
-val summary_json : ?base_path:string -> ?recent:int -> unit -> Yojson.Safe.t
+val summary_json : base_path:string -> ?recent:int -> unit -> Yojson.Safe.t
 
 (** Single-load companion to {!summary_json} + {!requests_json}.
 
@@ -103,7 +102,7 @@ val summary_json : ?base_path:string -> ?recent:int -> unit -> Yojson.Safe.t
     The two returned values use the same shapes documented on
     {!summary_json} and {!requests_json}. *)
 val proof_compose :
-  ?base_path:string ->
+  base_path:string ->
   ?recent:int ->
   ?limit:int ->
   unit ->

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -380,7 +380,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
       let runtime_contract =
         Option.map
           (fun keeper_meta ->
-             Keeper_runtime_contract.runtime_contract_json ?config:(Some config) keeper_meta)
+             Keeper_runtime_contract.runtime_contract_json ~config keeper_meta)
           meta
       in
       let sandbox_profile, backend, sandbox_target =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -143,19 +143,7 @@ let task_is_blocked (task : Masc_domain.task) =
   | Masc_domain.Cancelled _ ->
     false
 
-let goal_progress_json ?config (meta : keeper_meta) =
-  match config with
-  | None ->
-      `Assoc
-        [
-          ("active_goal_count", `Int (List.length meta.active_goal_ids));
-          ("linked_task_count", `Int 0);
-          ("done_task_count", `Int 0);
-          ("open_task_count", `Int 0);
-          ("blocked_task_count", `Int 0);
-          ("convergence", `Null);
-        ]
-  | Some config ->
+let goal_progress_json ~(config : Workspace.config) (meta : keeper_meta) =
       let task_goal_index =
         Workspace_goal_index.build_task_goal_index_for_config config
       in
@@ -199,12 +187,7 @@ let goal_progress_json ?config (meta : keeper_meta) =
           ("convergence", convergence);
         ]
 
-let approval_policy_effective_json ?config (meta : keeper_meta) =
-  let base_path =
-    match config with
-    | Some (config : Workspace.config) -> config.base_path
-    | None -> Env_config_core.base_path ()
-  in
+let approval_policy_effective_json ~base_path (meta : keeper_meta) =
   Keeper_approval_queue.policy_summary_json ~base_path ~keeper_name:meta.name
 
 let string_opt_json = function
@@ -374,8 +357,8 @@ let action_radius_json ~tool_name ~input ~success ~duration_ms ?error
       ("error", string_opt_json error);
     ]
 
-let runtime_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
-  let goal_progress = goal_progress_json ?config meta in
+let runtime_contract_json ~(config : Workspace.config) (meta : keeper_meta) : Yojson.Safe.t =
+  let goal_progress = goal_progress_json ~config meta in
   let blocked_task_count =
     Safe_ops.json_int "blocked_task_count" ~default:0 goal_progress
   in
@@ -386,12 +369,12 @@ let runtime_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
       ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
       ("goal_progress", goal_progress);
       ("blocked_task_count", `Int blocked_task_count);
-      ("approval_policy_effective", approval_policy_effective_json ?config meta);
+      ("approval_policy_effective", approval_policy_effective_json ~base_path:config.base_path meta);
     ]
 
-let runtime_observability_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
+let runtime_observability_contract_json ~(config : Workspace.config) (meta : keeper_meta) : Yojson.Safe.t =
   let sandbox_target = backend_of_meta meta in
-  match runtime_contract_json ?config meta with
+  match runtime_contract_json ~config meta with
   | `Assoc fields ->
     `Assoc
       ([

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -34,14 +34,14 @@ val resolve_observation_claim_goal_scope :
 (** Signal-only claim scope for world observations. *)
 
 val runtime_contract_json :
-  ?config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+  config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
 (** Keeper-visible runtime contract. Backend implementation details such as
     [sandbox_profile], [network_mode], [backend], and [sandbox_target] are
     intentionally omitted; use [runtime_observability_contract_json] for
     operator-facing status, receipts, and debugging. *)
 
 val runtime_observability_contract_json :
-  ?config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+  config:Workspace.config -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
 (** Operator-facing runtime contract with sandbox backend details included. *)
 
 val runtime_contract_json_from_fields :

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -2,10 +2,9 @@
     verification requests.
 
     The projection reads [Verification.list_requests] against
-    [Env_config_core.base_path ()], so these tests override
-    [MASC_BASE_PATH] with a throwaway temp dir before invoking the
-    projection. That keeps the tests independent from whatever is sitting
-    in the user's real [.masc/verifications/] directory. *)
+    the explicitly supplied base path. Tests use a throwaway temp dir so
+    they stay independent from whatever is sitting in the user's real
+    [.masc/verifications/] directory. *)
 
 (* Mirage_crypto_rng is consumed by Verification.generate_id. *)
 let () = Mirage_crypto_rng_unix.use_default ()
@@ -129,7 +128,7 @@ let test_temp_base_path_overrides_and_restores_env_inputs () =
             ~worker:"keeper-alpha" ~criteria:[V.Custom "env isolated"]
             ~evidence:["ref-env"]
         in
-        let j = D.requests_json () in
+        let j = D.requests_json ~base_path () in
         match member "total" j with
         | `Int 1 -> ()
         | `Int n ->
@@ -153,7 +152,7 @@ let test_requests_json_shape () =
           V.Custom "Must pass integration tests";
         ]
         ~evidence:["artifacts/lsof.before"; "artifacts/lsof.after"] in
-    let j = D.requests_json () in
+    let j = D.requests_json ~base_path () in
     (* Envelope: updated_at, total, requests *)
     (match member "updated_at" j with
      | `String _ -> ()
@@ -225,6 +224,49 @@ let test_requests_json_shape () =
          Alcotest.fail (Printf.sprintf "task_title mismatch: got %S" s)
      | _ -> Alcotest.fail "task_title should be string"))
 
+let test_requests_json_uses_explicit_base_path_not_env () =
+  let workspace_base = Filename.temp_dir "masc_dashboard_verify_workspace" "" in
+  let env_base = Filename.temp_dir "masc_dashboard_verify_env" "" in
+  let prior_base = snapshot_config_input "MASC_BASE_PATH" in
+  let prior_input = snapshot_config_input "MASC_BASE_PATH_INPUT" in
+  override_config_input "MASC_BASE_PATH" env_base;
+  override_config_input "MASC_BASE_PATH_INPUT" env_base;
+  Fun.protect
+    ~finally:(fun () ->
+      restore_config_input "MASC_BASE_PATH" prior_base;
+      restore_config_input "MASC_BASE_PATH_INPUT" prior_input;
+      rm_rf workspace_base;
+      rm_rf env_base)
+    (fun () ->
+      let _ =
+        create_pending_request ~base_path:workspace_base
+          ~task_id:"task-workspace"
+          ~worker:"keeper-workspace"
+          ~criteria:[V.Custom "workspace criterion"]
+          ~evidence:["ref-workspace"]
+      in
+      let _ =
+        create_pending_request ~base_path:env_base
+          ~task_id:"task-env"
+          ~worker:"keeper-env"
+          ~criteria:[V.Custom "env criterion"]
+          ~evidence:["ref-env"]
+      in
+      let j = D.requests_json ~base_path:workspace_base () in
+      Alcotest.(check int) "explicit base path total"
+        1
+        (match member "total" j with
+         | `Int n -> n
+         | _ -> Alcotest.fail "total should be int");
+      match member "requests" j with
+      | `List [row] ->
+          Alcotest.(check string) "workspace task visible"
+            "task-workspace"
+            (match member "task_id" row with
+             | `String value -> value
+             | _ -> Alcotest.fail "task_id should be string")
+      | _ -> Alcotest.fail "expected one explicit-base request")
+
 let test_task_id_filter () =
   with_temp_base_path (fun base_path ->
     let _ = create_pending_request ~base_path
@@ -238,7 +280,7 @@ let test_task_id_filter () =
         ~criteria:[V.Custom "B criterion"] ~evidence:["ref-B"] in
 
     (* Unfiltered: all 3 requests *)
-    let j_all = D.requests_json () in
+    let j_all = D.requests_json ~base_path () in
     (match member "total" j_all with
      | `Int 3 -> ()
      | `Int n ->
@@ -246,7 +288,7 @@ let test_task_id_filter () =
      | _ -> Alcotest.fail "total not int");
 
     (* Filter task_id="task-A": exactly 2 requests, all with task_id = task-A *)
-    let j_a = D.requests_json ~task_id:"task-A" () in
+    let j_a = D.requests_json ~base_path ~task_id:"task-A" () in
     (match member "total" j_a with
      | `Int 2 -> ()
      | `Int n ->
@@ -265,7 +307,7 @@ let test_task_id_filter () =
      | _ -> Alcotest.fail "requests not list");
 
     (* Filter task_id="nonexistent": 0 entries *)
-    let j_none = D.requests_json ~task_id:"task-missing" () in
+    let j_none = D.requests_json ~base_path ~task_id:"task-missing" () in
     (match member "total" j_none with
      | `Int 0 -> ()
      | `Int n ->
@@ -288,7 +330,7 @@ let test_requests_json_ignores_legacy_root_entries () =
       {|{"id":"vrf-foreign","task_id":"task-legacy","evaluator":"oracle","overall_verdict":"approve"}|};
     Alcotest.(check bool) "active store exists" true
       (Sys.file_exists (active_verifications_dir base_path));
-    let j = D.requests_json () in
+    let j = D.requests_json ~base_path () in
     (match member "total" j with
      | `Int 1 -> ()
      | `Int n -> Alcotest.fail (Printf.sprintf "expected 1 live row, got %d" n)
@@ -319,7 +361,7 @@ let test_requests_json_surfaces_conflict_triage_fields () =
       | Ok req -> req
       | Error e -> Alcotest.fail (Printf.sprintf "create_request failed: %s" e)
     in
-    let j = D.requests_json ~task_id:"task-conflict" () in
+    let j = D.requests_json ~base_path ~task_id:"task-conflict" () in
     let reqs =
       match member "requests" j with
       | `List xs -> xs
@@ -370,7 +412,7 @@ let test_requests_and_summary_degrade_under_fd_pressure () =
     Fun.protect
       ~finally:FD.reset_for_tests
       (fun () ->
-        let requests = D.requests_json () in
+        let requests = D.requests_json ~base_path () in
         Alcotest.(check int) "requests total degraded" 0 (int_field "total" requests);
         Alcotest.(check bool)
           "requests degraded flag"
@@ -379,7 +421,7 @@ let test_requests_and_summary_degrade_under_fd_pressure () =
         (match member "requests" requests with
          | `List [] -> ()
          | _ -> Alcotest.fail "requests should be empty during fd pressure");
-        let summary = D.summary_json () in
+        let summary = D.summary_json ~base_path () in
         Alcotest.(check int) "summary total degraded" 0 (int_field "total" summary);
         Alcotest.(check bool)
           "summary degraded flag"
@@ -387,8 +429,8 @@ let test_requests_and_summary_degrade_under_fd_pressure () =
           (bool_field "degraded" summary)))
 
 let test_summary_empty () =
-  with_temp_base_path (fun _base_path ->
-    let j = D.summary_json () in
+  with_temp_base_path (fun base_path ->
+    let j = D.summary_json ~base_path () in
     Alcotest.(check int) "total" 0 (int_field "total" j);
     let by = member "by_status" j in
     Alcotest.(check int) "pending" 0 (int_field "pending" by);
@@ -422,7 +464,7 @@ let test_summary_bucket_counts () =
     verdict_of r1 ~verdict:(V.Fail "r1 reason");
     verdict_of r2 ~verdict:(V.Fail "r2 reason");
 
-    let j = D.summary_json () in
+    let j = D.summary_json ~base_path () in
     Alcotest.(check int) "total" 5 (int_field "total" j);
     let by = member "by_status" j in
     Alcotest.(check int) "pending" 2 (int_field "pending" by);
@@ -447,12 +489,12 @@ let test_summary_recent_clamp () =
     (match V.submit_verdict ~base_path ~req_id:r.V.id
              ~verifier:"v" ~verdict:(V.Fail "x") with
      | Ok _ -> () | Error e -> Alcotest.fail e);
-    let j = D.summary_json ~recent:0 () in
+    let j = D.summary_json ~base_path ~recent:0 () in
     (match member "recent_rejections" j with
      | `List [] -> ()
      | _ -> Alcotest.fail "expected empty list at recent=0");
     (* recent > 20 clamps to 20 (smoke: ensures no crash) *)
-    let _ = D.summary_json ~recent:999 () in ())
+    let _ = D.summary_json ~base_path ~recent:999 () in ())
 
 (* ── Registration ───────────────────────────────────── *)
 
@@ -464,6 +506,8 @@ let () =
       Alcotest.test_case "overrides and restores env inputs" `Quick
         test_temp_base_path_overrides_and_restores_env_inputs;
       Alcotest.test_case "shape" `Quick test_requests_json_shape;
+      Alcotest.test_case "uses explicit base_path, not env" `Quick
+        test_requests_json_uses_explicit_base_path_not_env;
       Alcotest.test_case "task_id filter" `Quick test_task_id_filter;
       Alcotest.test_case "ignores legacy root entries" `Quick
         test_requests_json_ignores_legacy_root_entries;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -910,6 +910,67 @@ let test_resolve_with_policy_does_not_remember_high_allow () =
       | Error err ->
           Alcotest.fail ("resolve_with_policy failed: " ^ AQ.resolve_error_to_string err)
 
+let test_runtime_contract_policy_uses_workspace_base_path () =
+  let env_base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir env_base)
+    (fun () ->
+      with_test_config @@ fun config ->
+      AQ.For_testing.reset_audit_store ();
+      Fun.protect
+        ~finally:AQ.For_testing.reset_audit_store
+        (fun () ->
+          with_env "MASC_BASE_PATH" env_base @@ fun () ->
+          with_env "MASC_BASE_PATH_INPUT" env_base @@ fun () ->
+          let keeper_name = "runtime-contract-policy-keeper" in
+          let id =
+            AQ.submit_pending
+              ~base_path:config.base_path
+              ~keeper_name
+              ~tool_name:"masc_transition"
+              ~input:(`Assoc [ ("action", `String "claim") ])
+              ~risk_level:AQ.Medium
+              ~on_resolution:(fun _ -> ())
+              ()
+          in
+          (match
+             AQ.resolve_with_policy ~base_path:config.base_path ~id
+               ~decision:Agent_sdk.Hooks.Approve ~remember_rule:true ()
+           with
+           | Ok { remembered_rule = Some _ } -> ()
+           | Ok { remembered_rule = None } ->
+               Alcotest.fail "expected remembered workspace approval rule"
+           | Error err ->
+               Alcotest.fail
+                 ("resolve_with_policy failed: "
+                  ^ AQ.resolve_error_to_string err));
+          let meta =
+            meta_from_json
+              (`Assoc
+                [
+                  ("name", `String keeper_name);
+                  ("trace_id", `String "runtime-contract-policy-trace");
+                  ("sandbox_profile", `String "docker");
+                  ("network_mode", `String "inherit");
+                ])
+          in
+          let runtime_contract =
+            Masc.Keeper_runtime_contract.runtime_contract_json ~config meta
+          in
+          let open Yojson.Safe.Util in
+          let policy =
+            runtime_contract |> member "approval_policy_effective"
+          in
+          Alcotest.(check int) "workspace policy allow rule"
+            1
+            (policy |> member "allow_rules" |> to_int);
+          let env_policy =
+            AQ.policy_summary_json ~base_path:env_base ~keeper_name
+          in
+          Alcotest.(check int) "env fallback has no allow rule"
+            0
+            (env_policy |> member "allow_rules" |> to_int)))
+
 let test_dashboard_resolve_and_delete_rules_use_workspace_base_path () =
   let env_base = temp_dir () in
   let workspace_base = temp_dir () in
@@ -1571,6 +1632,8 @@ let () =
         test_resolve_with_policy_remembers_medium_allow;
       Alcotest.test_case "resolve_with_policy skips high allow memory" `Quick
         test_resolve_with_policy_does_not_remember_high_allow;
+      Alcotest.test_case "runtime_contract policy uses workspace base_path" `Quick
+        test_runtime_contract_policy_uses_workspace_base_path;
       Alcotest.test_case "dashboard approve-always rules use workspace base_path" `Quick
         test_dashboard_resolve_and_delete_rules_use_workspace_base_path;
       Alcotest.test_case "submit_pending audit uses workspace base_path" `Quick


### PR DESCRIPTION
## Summary
- Refs #21976 (RFC-0274 Wave A).
- Remove the `Env_config_core.base_path ()` runtime fallback from `Dashboard_verification`; callers must pass the active workspace `base_path`.
- Make `Keeper_runtime_contract` require `Workspace.config` so approval-policy projection reads `config.base_path` instead of process env.
- Add stale-env regression tests for both migrated surfaces.

## Validation
- `ocamlformat --check lib/dashboard/dashboard_verification.ml lib/dashboard/dashboard_verification.mli lib/keeper/keeper_runtime_contract.ml lib/keeper/keeper_runtime_contract.mli lib/governance_pipeline.ml test/test_dashboard_verification.ml test/test_hitl_approval.ml`
- `scripts/check-ssot.sh`
- `scripts/audit-path-ssot.sh`
- `python3 scripts/check_test_coverage.py`
- `scripts/ci/check-determinism-contract.sh` (PASS; existing warnings only)
- `git diff --check`

## Not Run
- Local Dune build/tests per operator direction; CI is the build authority for this slice.

## Notes
- This is intentionally a Wave A slice. Wave B-E `Env_config_core.base_path ()` and direct `MASC_BASE_PATH` reads remain for follow-up PRs.