### PR TITLE
fix(server): route FD pressure state under workspace

### DIFF
--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -27,15 +27,20 @@ let state_file_source_to_string = function
   | Legacy_env -> Env_config_core.legacy_host_fd_pressure_state_file_env_key
   | Default -> "default"
 
-let resolve_state_file_path () =
+let default_state_file_path ~base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "masc-host-pressure.state"
+;;
+
+let resolve_state_file_path ~base_path () =
   match
     ( Env_config_core.host_fd_pressure_state_file_path_opt ()
     , Env_config_core.legacy_host_fd_pressure_state_file_path_opt () )
   with
   | Some path, _ -> { path; source = Canonical_env }
   | None, Some path -> { path; source = Legacy_env }
-  | None, None ->
-    { path = Env_config_core.default_host_fd_pressure_state_file_path; source = Default }
+  | None, None -> { path = default_state_file_path ~base_path; source = Default }
 ;;
 
 let state_file_env_conflict () =
@@ -196,9 +201,9 @@ let one_tick path =
            truncated))
 ;;
 
-let start ~sw ~clock =
+let start ~sw ~clock ~base_path =
   Eio.Fiber.fork ~sw (fun () ->
-    let resolution = resolve_state_file_path () in
+    let resolution = resolve_state_file_path ~base_path () in
     let path = resolution.path in
     let interval = poll_interval_sec () in
     (match state_file_env_conflict () with

--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -29,14 +29,14 @@ type state_file_resolution =
   ; source : state_file_source
   }
 
-val resolve_state_file_path : unit -> state_file_resolution
-(** Resolve the state-file path via
-    {!Env_config_core.host_fd_pressure_state_file_path}. *)
+val resolve_state_file_path : base_path:string -> unit -> state_file_resolution
+(** Resolve the state-file path. Explicit env overrides win; otherwise the
+    default state file lives under [<base_path>/.masc]. *)
 
 val state_file_env_conflict : unit -> (string * string) option
 (** [Some (canonical, legacy)] when both env vars are set to different paths. *)
 
-val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
-(** [start ~sw ~clock] forks the poller fiber under [sw]. Wired from
+val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:string -> unit
+(** [start ~sw ~clock ~base_path] forks the poller fiber under [sw]. Wired from
     [Server_bootstrap_loops.start_background_maintenance]. Cancelled
     when [sw] terminates. *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -154,7 +154,11 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      [MASC_HOST_FD_PRESSURE_POLLER_DISABLED=1]. Sunsets when RFC-0097
      (sandbox container reuse) reaches steady state — see RFC-0137 §9. *)
   let poller_disabled = Env_config_core.host_fd_pressure_poller_disabled () in
-  if not poller_disabled then Host_fd_pressure_poller.start ~sw ~clock;
+  if not poller_disabled then
+    Host_fd_pressure_poller.start
+      ~sw
+      ~clock
+      ~base_path:(Mcp_server.workspace_config state).base_path;
   (* Deterministic output budget enforcement: truncate oversized tool outputs
      with structured metadata before metrics/OTEL hooks see them. *)
   Tool_output_validation.install ();

--- a/scripts/monitor-system-health.sh
+++ b/scripts/monitor-system-health.sh
@@ -40,8 +40,11 @@ ALERT_COOLDOWN="${MASC_SYSMON_ALERT_COOLDOWN:-300}"
 # Pressure flag file. masc server (future) is expected to poll this
 # and engage Keeper_fd_pressure when level=CRIT. We always rewrite it
 # atomically so a reader sees a consistent snapshot.
-PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-${MASC_SYSMON_PRESSURE_STATE:-/tmp/masc-host-pressure.state}}"
-PRESSURE_EVENTS_FILE="${MASC_SYSMON_PRESSURE_EVENTS:-/tmp/masc-host-pressure.events.jsonl}"
+DEFAULT_MASC_BASE_PATH="${MASC_BASE_PATH:-$REPO_ROOT}"
+PRESSURE_STATE_DEFAULT="$DEFAULT_MASC_BASE_PATH/.masc/masc-host-pressure.state"
+PRESSURE_EVENTS_DEFAULT="$DEFAULT_MASC_BASE_PATH/.masc/masc-host-pressure.events.jsonl"
+PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-${MASC_SYSMON_PRESSURE_STATE:-$PRESSURE_STATE_DEFAULT}}"
+PRESSURE_EVENTS_FILE="${MASC_SYSMON_PRESSURE_EVENTS:-$PRESSURE_EVENTS_DEFAULT}"
 
 usage() {
   cat <<'EOF'
@@ -70,9 +73,11 @@ Logs:
   <log-dir>/sysmon-alerts.log  one line per fired alert
 
 Pressure flag (for masc server integration, future):
-  /tmp/masc-host-pressure.state    latest snapshot when level != OK;
+  <base-path>/.masc/masc-host-pressure.state
+                                   latest snapshot when level != OK;
                                    removed when system is OK.
-  /tmp/masc-host-pressure.events.jsonl  append-only history.
+  <base-path>/.masc/masc-host-pressure.events.jsonl
+                                   append-only history.
   Override state path via MASC_HOST_FD_PRESSURE_STATE_FILE.
   Override events path via MASC_SYSMON_PRESSURE_EVENTS.
   Reader contract: parse JSON line for level/kinds/summary/ts/pid.
@@ -105,6 +110,7 @@ if [ "$(uname)" != "Darwin" ]; then
 fi
 
 mkdir -p "$LOG_DIR"
+mkdir -p "$(dirname "$PRESSURE_STATE_FILE")" "$(dirname "$PRESSURE_EVENTS_FILE")" 2>/dev/null || true
 LOG="$LOG_DIR/sysmon.log"
 ALERT_LOG="$LOG_DIR/sysmon-alerts.log"
 COOLDOWN_DIR="${TMPDIR:-/tmp}/masc-sysmon-cooldown.$$"

--- a/test/test_host_fd_pressure_poller.ml
+++ b/test/test_host_fd_pressure_poller.ml
@@ -6,7 +6,12 @@ external unsetenv : string -> unit = "masc_test_unsetenv"
 
 let canonical_env = Env_config_core.host_fd_pressure_state_file_env_key
 let legacy_env = Env_config_core.legacy_host_fd_pressure_state_file_env_key
-let default_path = Env_config_core.default_host_fd_pressure_state_file_path
+let base_path = Filename.concat (Filename.get_temp_dir_name ()) "masc-fd-pressure-test"
+
+let default_path =
+  Filename.concat
+    (Workspace_utils.masc_dir_from_base_path ~base_path)
+    "masc-host-pressure.state"
 
 let restore_env name = function
   | Some value -> Unix.putenv name value
@@ -25,7 +30,7 @@ let with_env bindings f =
     List.iter (fun (name, value) -> restore_env name value) original)
 
 let check_resolution label expected_path expected_source =
-  let actual = Poller.resolve_state_file_path () in
+  let actual = Poller.resolve_state_file_path ~base_path () in
   check string (label ^ " path") expected_path actual.path;
   check bool (label ^ " source") true (actual.source = expected_source)
 


### PR DESCRIPTION
## Summary
- Refs #21961. This is a narrow FD-pressure state-file slice of the broader path/env SSOT issue.
- Make `Host_fd_pressure_poller` require `~base_path` and derive its no-env default from `<base-path>/.masc/masc-host-pressure.state`.
- Pass the active server workspace base path from background maintenance startup.
- Align `scripts/monitor-system-health.sh` producer defaults with the same `.masc` state/events paths while preserving `MASC_HOST_FD_PRESSURE_STATE_FILE`, legacy `MASC_SYSMON_PRESSURE_STATE`, and `MASC_SYSMON_PRESSURE_EVENTS` overrides.

## Validation
- `ocamlformat --check lib/server/host_fd_pressure_poller.ml lib/server/host_fd_pressure_poller.mli lib/server/server_bootstrap_maintenance.ml test/test_host_fd_pressure_poller.ml`
- `bash -n scripts/monitor-system-health.sh`
- `scripts/check-ssot.sh`
- `scripts/audit-path-ssot.sh`
- `python3 scripts/check_test_coverage.py`
- `scripts/ci/check-determinism-contract.sh` (PASS; existing warnings only)
- `git diff --check`

## Not Run
- Local Dune build/tests per operator direction; CI is the build authority for this slice.

## Notes
- #21961 is broad. This PR only handles the host FD pressure state-file default; host_config, sandbox, path_scope, LSP PATH splitting, and startup-shell cleanup remain follow-up slices.