### PR TITLE
[codex] Optimize draft skill index checks

### DIFF
--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -117,66 +117,31 @@ let index_event_json (c : Skill_candidate_projection.skill_candidate) ~dir ~json
 
 let ( let* ) = Result.bind
 
-let candidate_json_content candidate =
-  Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate) ^ "\n"
-;;
-
 let json_string_opt name json =
   match Yojson.Safe.Util.member name json with
   | `String s -> Some s
   | _ -> None
 ;;
 
-let candidate_artifacts ~base_path candidate =
-  [ candidate_json_path ~base_path candidate, candidate_json_content candidate
-  ; candidate_toml_path ~base_path candidate, render_candidate_toml candidate
-  ; ( candidate_skill_md_path ~base_path candidate
-    , Skill_candidate_projection.render_skill_draft candidate )
-  ]
+let candidate_index_key
+      (c : Skill_candidate_projection.skill_candidate)
+      ~dir
+      ~json_path
+      ~toml_path
+      ~skill_md_path
+  =
+  ( c.id
+  , c.agent_name
+  , c.source_kind
+  , c.source_ref
+  , Skill_candidate_projection.promotion_state_to_string c.promotion_state
+  , dir
+  , json_path
+  , toml_path
+  , skill_md_path )
 ;;
 
-let stored_candidate ~base_path candidate =
-  { candidate
-  ; dir = draft_dir ~base_path candidate
-  ; json_path = candidate_json_path ~base_path candidate
-  ; toml_path = candidate_toml_path ~base_path candidate
-  ; skill_md_path = candidate_skill_md_path ~base_path candidate
-  ; index_path = index_path ~base_path
-  }
-;;
-
-let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
-  let stored = stored_candidate ~base_path candidate in
-  let* () =
-    Review_artifact_store.write_artifacts
-      ~index_path:stored.index_path
-      ~artifacts:(candidate_artifacts ~base_path candidate)
-      ~index_event:
-        (index_event_json candidate
-           ~dir:stored.dir
-           ~json_path:stored.json_path
-           ~toml_path:stored.toml_path
-           ~skill_md_path:stored.skill_md_path)
-  in
-  Ok stored
-;;
-
-let write_candidates ~base_path candidates =
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | candidate :: rest ->
-      let* stored = write_candidate ~base_path candidate in
-      loop (stored :: acc) rest
-  in
-  loop [] candidates
-;;
-
-let index_event_matches_candidate ~base_path
-    (candidate : Skill_candidate_projection.skill_candidate) json =
-  let dir = draft_dir ~base_path candidate in
-  let json_path = candidate_json_path ~base_path candidate in
-  let toml_path = candidate_toml_path ~base_path candidate in
-  let skill_md_path = candidate_skill_md_path ~base_path candidate in
+let index_key_of_json json =
   match
     ( json_string_opt "id" json
     , json_string_opt "agent_name" json
@@ -193,42 +158,121 @@ let index_event_matches_candidate ~base_path
     , Some source_kind
     , Some source_ref
     , Some promotion_state
-    , Some indexed_dir
-    , Some indexed_json_path
-    , Some indexed_toml_path
-    , Some indexed_skill_md_path ) ->
-    String.equal id candidate.id
-    && String.equal agent_name candidate.agent_name
-    && String.equal source_kind candidate.source_kind
-    && String.equal source_ref candidate.source_ref
-    && String.equal promotion_state
-         (Skill_candidate_projection.promotion_state_to_string
-            candidate.promotion_state)
-    && String.equal indexed_dir dir
-    && String.equal indexed_json_path json_path
-    && String.equal indexed_toml_path toml_path
-    && String.equal indexed_skill_md_path skill_md_path
-  | _ -> false
+    , Some dir
+    , Some json_path
+    , Some toml_path
+    , Some skill_md_path ) ->
+    Some
+      ( id
+      , agent_name
+      , source_kind
+      , source_ref
+      , promotion_state
+      , dir
+      , json_path
+      , toml_path
+      , skill_md_path )
+  | _ -> None
 ;;
 
-let write_candidate_if_changed ~base_path candidate =
+let load_index_keys ~index_path =
+  try
+    let keys = Hashtbl.create 1024 in
+    let keys =
+      Fs_compat.fold_jsonl_lines index_path ~init:keys
+        ~f:(fun keys ~line_no:_ json ->
+          match index_key_of_json json with
+          | Some key ->
+            Hashtbl.replace keys key ();
+            keys
+          | None -> keys)
+    in
+    Ok keys
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let candidate_json_content candidate =
+  Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate) ^ "\n"
+;;
+
+let stored_candidate ~base_path candidate =
+  { candidate
+  ; dir = draft_dir ~base_path candidate
+  ; json_path = candidate_json_path ~base_path candidate
+  ; toml_path = candidate_toml_path ~base_path candidate
+  ; skill_md_path = candidate_skill_md_path ~base_path candidate
+  ; index_path = index_path ~base_path
+  }
+;;
+
+let stored_candidate_artifacts (stored : stored_draft) =
+  [ stored.json_path, candidate_json_content stored.candidate
+  ; stored.toml_path, render_candidate_toml stored.candidate
+  ; stored.skill_md_path, Skill_candidate_projection.render_skill_draft stored.candidate
+  ]
+;;
+
+let stored_candidate_index_event (stored : stored_draft) =
+  index_event_json stored.candidate
+    ~dir:stored.dir
+    ~json_path:stored.json_path
+    ~toml_path:stored.toml_path
+    ~skill_md_path:stored.skill_md_path
+;;
+
+let stored_candidate_index_key (stored : stored_draft) =
+  candidate_index_key stored.candidate
+    ~dir:stored.dir
+    ~json_path:stored.json_path
+    ~toml_path:stored.toml_path
+    ~skill_md_path:stored.skill_md_path
+;;
+
+let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
+  let stored = stored_candidate ~base_path candidate in
+  let* () =
+    Review_artifact_store.write_artifacts
+      ~index_path:stored.index_path
+      ~artifacts:(stored_candidate_artifacts stored)
+      ~index_event:(stored_candidate_index_event stored)
+  in
+  Ok stored
+;;
+
+let write_candidates ~base_path candidates =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | candidate :: rest ->
+      let* stored = write_candidate ~base_path candidate in
+      loop (stored :: acc) rest
+  in
+  loop [] candidates
+;;
+
+let write_candidate_if_changed_with_index ~index_keys ~base_path candidate =
   (* Artifact files and the index are intentionally checked together: a prior
      write can leave complete artifacts but miss the final index append. The
      next post-turn pass should repair that listing row instead of treating the
      draft as fully persisted. This is a safety net until #21871 makes the
      index/artifact persistence atomic or derives one side from the other. *)
   let stored = stored_candidate ~base_path candidate in
+  let key = stored_candidate_index_key stored in
+  let indexed = Hashtbl.mem index_keys key in
+  let artifacts = stored_candidate_artifacts stored in
   let* changed =
-    Review_artifact_store.write_if_changed
-      ~index_path:stored.index_path
-      ~artifacts:(candidate_artifacts ~base_path candidate)
-      ~index_event:
-        (index_event_json candidate
-           ~dir:stored.dir
-           ~json_path:stored.json_path
-           ~toml_path:stored.toml_path
-           ~skill_md_path:stored.skill_md_path)
-      ~matches:(index_event_matches_candidate ~base_path candidate)
+    if Review_artifact_store.artifacts_unchanged artifacts && indexed
+    then Ok false
+    else
+      let* () =
+        Review_artifact_store.write_artifacts
+          ~index_path:stored.index_path
+          ~artifacts
+          ~index_event:(stored_candidate_index_event stored)
+      in
+      Hashtbl.replace index_keys key ();
+      Ok true
   in
   if changed then Ok (Some stored) else Ok None
 ;;
@@ -265,10 +309,11 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
         ~limit:procedure_limit
   in
   let candidates = dedup_candidates (fact_candidates @ procedure_candidates) in
+  let* index_keys = load_index_keys ~index_path:(index_path ~base_path) in
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
     | candidate :: rest ->
-      let* stored = write_candidate_if_changed ~base_path candidate in
+      let* stored = write_candidate_if_changed_with_index ~index_keys ~base_path candidate in
       let acc =
         match stored with
         | Some stored -> stored :: acc

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -408,6 +408,89 @@ let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
   check int "unchanged candidate skipped" 0 (List.length second)
 ;;
 
+let noisy_index_event ~i =
+  let suffix = Printf.sprintf "%03d" i in
+  let noise_path name = Filename.concat "/tmp/masc-skill-candidate-noise" name in
+  `Assoc
+    [ "schema", `String "masc.skill_candidate.index.v1"
+    ; "id", `String ("noise-" ^ suffix)
+    ; "agent_name", `String "noise"
+    ; "source_kind", `String "memory_os_fact"
+    ; "source_ref", `String ("noise-ref-" ^ suffix)
+    ; "promotion_state", `String "candidate"
+    ; "dir", `String (noise_path suffix)
+    ; "json_path", `String (noise_path (suffix ^ "/candidate.json"))
+    ; "toml_path", `String (noise_path (suffix ^ "/candidate.toml"))
+    ; "skill_md_path", `String (noise_path (suffix ^ "/SKILL.md"))
+    ; "ts", `Float 0.0
+    ]
+;;
+
+let append_noisy_index_rows ~base_path ~count =
+  let index_path = Store.index_path ~base_path in
+  for i = 1 to count do
+    Fs_compat.append_file index_path
+      (Yojson.Safe.to_string (noisy_index_event ~i) ^ "\n")
+  done
+;;
+
+let skill_candidate_index_row_matches candidate json =
+  let open Yojson.Safe.Util in
+  match
+    ( member "id" json
+    , member "agent_name" json
+    , member "source_kind" json
+    , member "source_ref" json )
+  with
+  | `String id, `String agent_name, `String source_kind, `String source_ref ->
+    String.equal id candidate.S.id
+    && String.equal agent_name candidate.agent_name
+    && String.equal source_kind candidate.source_kind
+    && String.equal source_ref candidate.source_ref
+  | _ -> false
+;;
+
+let test_skill_candidate_store_skips_unchanged_candidate_with_noisy_index () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-noisy-index-skill" ~turn:14
+      ~tool_call_id:"tool-noisy-index-skill"
+      "When draft skill indexes grow, keep unchanged candidate checks bounded"
+  in
+  let candidate =
+    match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
+    | [ candidate ] -> candidate
+    | _ -> fail "expected one projected candidate"
+  in
+  write_facts_for_base_path ~base_path ~keeper_id:"keeper" [ fact ];
+  let first =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "initial candidate written" 1 (List.length first);
+  append_noisy_index_rows ~base_path ~count:250;
+  let second =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "unchanged candidate skipped despite noisy index" 0 (List.length second);
+  let index_rows = Fs_compat.load_jsonl (Store.index_path ~base_path) in
+  let candidate_rows =
+    List.filter (skill_candidate_index_row_matches candidate) index_rows
+  in
+  check int "no duplicate index append" 251 (List.length index_rows);
+  check int "candidate indexed once" 1 (List.length candidate_rows)
+;;
+
 let test_skill_candidate_store_recovers_partial_candidate_artifacts () =
   with_temp_base_path
   @@ fun base_path ->
@@ -677,6 +760,8 @@ let () =
             test_skill_candidate_store_keeps_same_id_distinct_sources;
           test_case "writes post-turn memory fact candidates" `Quick
             test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
+          test_case "skips unchanged candidate with noisy index" `Quick
+            test_skill_candidate_store_skips_unchanged_candidate_with_noisy_index;
           test_case "recovers partial candidate artifacts" `Quick
             test_skill_candidate_store_recovers_partial_candidate_artifacts;
           test_case "recovers missing index for complete artifacts" `Quick


### PR DESCRIPTION
## Summary

- Batch-load draft skill index membership once per post-turn candidate write pass.
- Replace per-candidate full `index.jsonl` reparsing with exact tuple-key `Hashtbl` membership.
- Preserve the existing repair behavior for complete artifacts with a missing index row.
- Add a noisy-index regression test so unchanged candidates are not appended again when the index already contains their exact row.

## Root Cause

Live `main_eio` samples showed the serving runtime spending time in `Yojson` parsing through `Keeper_agent_run_post_turn_memory -> Skill_candidate_store -> Review_artifact_store.index_contains`. The live `~/me/.masc/draft-skills/index.jsonl` was being loaded and parsed once for each projected candidate, which made the post-turn path scale as candidates times index size and could starve dashboard/log HTTP responses.

## Impact

The post-turn draft-skill persistence path now scans the index once, then checks each candidate via in-memory exact keys. This keeps dashboard log and health endpoints responsive while keepers continue writing draft skill candidates.

## Validation

- `git diff --check`
- `opam exec -- ocamlformat --check lib/skill_candidate_store.ml test/test_procedural_memory.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_procedural_memory.exe`
- `./_build/default/test/test_procedural_memory.exe test "skill candidates"`
- Live patched runtime smoke on `127.0.0.1:8935`: `/health`, `/api/v1/dashboard/logs?limit=200`, `/health?full=1`, and `/dashboard/shell?light=true` all returned under 1s during verification.

## Not Run

- `scripts/dune-local.sh build bin/main_eio.exe` after the final source cleanup was blocked by an unrelated bare `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc ./bin/main_eio.exe --` process outside `scripts/dune-local.sh`.
