### PR TITLE
fix(core): centralize executable PATH separator

### DIFF
--- a/lib/core/executable_path.ml
+++ b/lib/core/executable_path.ml
@@ -21,12 +21,18 @@ let regular_file_is_executable path =
   | Unix.Unix_error _ | Sys_error _ -> false
 ;;
 
+let search_path_separator = if Sys.win32 then ';' else ':'
+
+let split_search_path ?(separator = search_path_separator) raw_path =
+  String.split_on_char separator raw_path
+;;
+
 let path_has_executable ?(getenv = Sys.getenv_opt) name =
   match getenv "PATH" with
   | None -> false
   | Some raw_path ->
     raw_path
-    |> String.split_on_char ':'
+    |> split_search_path
     |> List.exists (fun dir ->
       (not (String.equal dir ""))
       && regular_file_is_executable (Filename.concat dir name))

--- a/lib/core/executable_path.mli
+++ b/lib/core/executable_path.mli
@@ -8,6 +8,14 @@ val regular_file_is_executable : string -> bool
 (** [regular_file_is_executable path] returns [true] when [path] is an
     executable regular file. *)
 
+val search_path_separator : char
+(** Platform search-path separator for [PATH]-style variables. *)
+
+val split_search_path : ?separator:char -> string -> string list
+(** [split_search_path raw] splits [raw] with {!search_path_separator}.
+    Empty entries are preserved so callers can explicitly reject shell-style
+    current-directory segments. *)
+
 val path_has_executable : ?getenv:(string -> string option) -> string -> bool
 (** [path_has_executable name] returns [true] when [PATH] contains a non-empty
     directory with an executable regular file named [name]. *)

--- a/lib/core/executable_path.mli
+++ b/lib/core/executable_path.mli
@@ -12,9 +12,11 @@ val search_path_separator : char
 (** Platform search-path separator for [PATH]-style variables. *)
 
 val split_search_path : ?separator:char -> string -> string list
-(** [split_search_path raw] splits [raw] with {!search_path_separator}.
-    Empty entries are preserved so callers can explicitly reject shell-style
-    current-directory segments. *)
+(** [split_search_path ?separator raw] splits [raw] on [separator], which
+    defaults to {!search_path_separator}. Pass [separator] explicitly only to
+    parse a non-native layout (e.g. a Windows [';'] list on a POSIX host in
+    tests). Empty entries are preserved so callers can explicitly reject
+    shell-style current-directory segments. *)
 
 val path_has_executable : ?getenv:(string -> string option) -> string -> bool
 (** [path_has_executable name] returns [true] when [PATH] contains a non-empty

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -16,8 +16,8 @@ let docker_command () =
      | Some path ->
        let rec loop = function
          | [] -> bin
+         | dir :: rest when String.equal dir "" -> loop rest
          | dir :: rest ->
-           let dir = if dir = "" then "." else dir in
            let candidate = Filename.concat dir bin in
            (try
               Unix.access candidate [ Unix.X_OK ];

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -25,7 +25,7 @@ let docker_command () =
             with
             | Unix.Unix_error _ -> loop rest)
        in
-       loop (String.split_on_char ':' path))
+       loop (Executable_path.split_search_path path))
 ;;
 
 let docker_command_argv () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -44,6 +44,11 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
+let with_cwd path f =
+  let prior = Sys.getcwd () in
+  Sys.chdir path;
+  Fun.protect ~finally:(fun () -> Sys.chdir prior) f
+
 let with_config_dir config_dir f =
   let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
   Fun.protect
@@ -339,6 +344,28 @@ let with_fake_docker script f =
   with_env "PATH" path @@ fun () ->
   with_env "MASC_KEEPER_SYSTEM_FD_HEADROOM" "0" @@ fun () ->
   with_env "MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM" "0" f
+
+let test_docker_command_skips_empty_path_segment () =
+  let cwd = temp_dir () in
+  let path_dir = temp_dir () in
+  let cwd_docker = Filename.concat cwd "docker" in
+  let path_docker = Filename.concat path_dir "docker" in
+  write_file cwd_docker "#!/bin/sh\nexit 66\n";
+  write_file path_docker "#!/bin/sh\nexit 0\n";
+  Unix.chmod cwd_docker 0o755;
+  Unix.chmod path_docker 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir cwd;
+      cleanup_dir path_dir)
+  @@ fun () ->
+  with_cwd cwd @@ fun () ->
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" "" @@ fun () ->
+  with_env "PATH" (":" ^ path_dir) @@ fun () ->
+  Alcotest.(check string)
+    "empty PATH segment skipped"
+    path_docker
+    (Masc.Keeper_sandbox_runtime.docker_command ())
 
 let with_tool_policy_config f = f ()
 
@@ -2266,6 +2293,9 @@ let () =
           Alcotest.test_case
             "turn sandbox factory uses refreshed registry meta"
             `Quick test_turn_sandbox_factory_uses_refreshed_registry_meta;
+          Alcotest.test_case
+            "docker command skips empty PATH segment"
+            `Quick test_docker_command_skips_empty_path_segment;
           Alcotest.test_case
             "tool_execute typed pipeline uses local shell ir dispatch"
             `Quick test_execute_typed_pipeline_uses_local_shell_ir_dispatch;

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -143,7 +143,7 @@ let test_shell_command_available_rejects_empty_path_segment_cwd () =
          (Filename.concat dir tool_name)
          "#!/bin/sh\nexit 0\n";
        Sys.chdir dir;
-       with_env "PATH" ":" @@ fun () ->
+       with_env "PATH" (String.make 1 Executable_path.search_path_separator) @@ fun () ->
        Alcotest.(check bool)
          "empty PATH entry not cwd"
          false

--- a/test/test_lsp_process_manager.ml
+++ b/test/test_lsp_process_manager.ml
@@ -32,11 +32,21 @@ let touch path =
 let test_executable_path_split_search_path () =
   check
     (list string)
-    "preserves empty entries"
+    "preserves empty entries (explicit separator)"
     [ ""; "/opt/bin"; "/usr/bin" ]
     (Executable_path.split_search_path
        ~separator:';'
-       ";/opt/bin;/usr/bin")
+       ";/opt/bin;/usr/bin");
+  (* Also exercise the default: build the input from the SSOT
+     [search_path_separator] so this asserts the platform-default split (a
+     regression setting the wrong default would fail here) while staying
+     platform-independent. *)
+  let sep = String.make 1 Executable_path.search_path_separator in
+  check
+    (list string)
+    "preserves empty entries (default separator)"
+    [ ""; "/opt/bin"; "/usr/bin" ]
+    (Executable_path.split_search_path (sep ^ "/opt/bin" ^ sep ^ "/usr/bin"))
 ;;
 
 let test_executable_path_lookup_requires_executable_file () =

--- a/test/test_lsp_process_manager.ml
+++ b/test/test_lsp_process_manager.ml
@@ -29,6 +29,16 @@ let touch path =
   close_out oc
 ;;
 
+let test_executable_path_split_search_path () =
+  check
+    (list string)
+    "preserves empty entries"
+    [ ""; "/opt/bin"; "/usr/bin" ]
+    (Executable_path.split_search_path
+       ~separator:';'
+       ";/opt/bin;/usr/bin")
+;;
+
 let test_executable_path_lookup_requires_executable_file () =
   let dir = temp_dir "executable-path-bits-" in
   let executable = Filename.concat dir "masc-test-tool" in
@@ -76,7 +86,8 @@ let test_executable_path_ignores_empty_path_entries () =
           | _ -> None
         in
         let explicit_path = function
-          | "PATH" -> Some (":" ^ dir)
+          | "PATH" ->
+            Some (String.make 1 Executable_path.search_path_separator ^ dir)
           | _ -> None
         in
         check
@@ -216,6 +227,10 @@ let () =
     "lsp_process_manager"
     [ ( "executable-path"
       , [ test_case
+            "splits PATH with SSOT separator"
+            `Quick
+            test_executable_path_split_search_path
+        ; test_case
             "requires executable files"
             `Quick
             test_executable_path_lookup_requires_executable_file


### PR DESCRIPTION
## Summary
- Refs #21961. This is the PATH separator slice of the broader path/env SSOT issue.
- Add `Executable_path.search_path_separator` and `Executable_path.split_search_path` as the shared PATH-list separator SSOT.
- Replace executable lookup PATH splitting with the helper, and route docker runtime preflight splitting through the same helper.
- Update LSP/keeper tests to avoid hardcoded `:` when constructing PATH values.

## Validation
- `ocamlformat --check lib/core/executable_path.ml lib/core/executable_path.mli lib/keeper/keeper_sandbox_runtime_setup.ml test/test_lsp_process_manager.ml test/test_keeper_tool_search_files_containment.ml`
- `scripts/check-ssot.sh`
- `scripts/audit-path-ssot.sh`
- `python3 scripts/check_test_coverage.py`
- `scripts/ci/check-determinism-contract.sh` (PASS; existing warnings only)
- `git diff --check`

## Not Run
- Local Dune build/tests per operator direction; CI is the build authority for this slice.

## Notes
- #21961 is broad. This PR only handles executable PATH-list splitting; host_config, sandbox path_scope defaults, and startup-shell cleanup remain follow-up slices.