### PR TITLE
[codex] Fix settings log tool filter

### DIFF
--- a/dashboard/src/components/log-classification.ts
+++ b/dashboard/src/components/log-classification.ts
@@ -1,0 +1,52 @@
+import type { LogEntry } from '../api/dashboard.js'
+
+export type LogDisplayKind =
+  | 'tool'
+  | 'turn'
+  | 'lifecycle'
+  | 'approval'
+  | 'broadcast'
+  | 'telemetry'
+  | 'task'
+  | 'log'
+
+export function entryDetails(entry: LogEntry): Record<string, unknown> | null {
+  const details = entry.details
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return null
+  return details
+}
+
+export function detailLabel(details: Record<string, unknown> | null, key: string): string | null {
+  if (!details) return null
+  const value = details[key]
+  if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return null
+}
+
+export function logDisplayKind(entry: LogEntry): LogDisplayKind {
+  const details = entryDetails(entry)
+  const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')
+  if (toolName) return 'tool'
+  switch (entry.category) {
+    case 'tool':
+      return 'tool'
+    case 'task':
+      return 'task'
+    case 'lifecycle':
+    case 'fsm':
+    case 'heartbeat':
+    case 'presence':
+      return 'lifecycle'
+    case 'directive':
+    case 'boundary':
+      return 'approval'
+    case 'telemetry':
+    case 'memory':
+      return 'telemetry'
+    case 'routine':
+      return entry.turn_id ? 'turn' : 'log'
+    default:
+      return entry.turn_id ? 'turn' : 'log'
+  }
+}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -22,6 +22,12 @@ import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
 import { StatusChip } from './common/status-chip'
 import {
+  detailLabel,
+  entryDetails,
+  logDisplayKind,
+  type LogDisplayKind,
+} from './log-classification'
+import {
   openIdeContextRouteLink,
   routeLinksForContext,
   type IdeContextRouteLink,
@@ -146,16 +152,6 @@ function categoryLabel(category: string | null | undefined): string | null {
   return CATEGORY_LABELS[category] ?? category
 }
 
-type LogDisplayKind =
-  | 'tool'
-  | 'turn'
-  | 'lifecycle'
-  | 'approval'
-  | 'broadcast'
-  | 'telemetry'
-  | 'task'
-  | 'log'
-
 const LOG_KIND_LABELS: Record<LogDisplayKind, string> = {
   tool: 'TOOL',
   turn: 'TURN',
@@ -232,47 +228,6 @@ export function deltaMergeCap(
 
 function sourceLabel(source: string): string {
   return SOURCE_LABELS[source] ?? (source || '(unknown source)')
-}
-
-function entryDetails(entry: LogEntry): Record<string, unknown> | null {
-  const details = entry.details
-  if (!details || typeof details !== 'object' || Array.isArray(details)) return null
-  return details
-}
-
-function detailLabel(details: Record<string, unknown> | null, key: string): string | null {
-  if (!details) return null
-  const value = details[key]
-  if (typeof value === 'string' && value.trim() !== '') return value.trim()
-  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
-  return null
-}
-
-function logDisplayKind(entry: LogEntry): LogDisplayKind {
-  const details = entryDetails(entry)
-  const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')
-  if (toolName) return 'tool'
-  switch (entry.category) {
-    case 'tool':
-      return 'tool'
-    case 'task':
-      return 'task'
-    case 'lifecycle':
-    case 'fsm':
-    case 'heartbeat':
-    case 'presence':
-      return 'lifecycle'
-    case 'directive':
-    case 'boundary':
-      return 'approval'
-    case 'telemetry':
-    case 'memory':
-      return 'telemetry'
-    case 'routine':
-      return entry.turn_id ? 'turn' : 'log'
-    default:
-      return entry.turn_id ? 'turn' : 'log'
-  }
 }
 
 function logSeverity(entry: LogEntry): 'ok' | 'warn' | 'bad' | 'busy' | 'info' {

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -768,10 +768,18 @@ describe('SettingsSurface', () => {
   })
 
   it('log filter chips filter live rows from the ring', async () => {
-    // 6 ring entries mapped to rows: tool(/masc_/)=3, success(ok)=3, failure(fail)=2.
+    // 7 ring entries mapped to rows: tool(category/details or /masc_/)=4,
+    // success(ok)=4, failure(fail)=2.
     apiMock.fetchLogs.mockResolvedValue({
-      total: 6,
+      total: 7,
       entries: [
+        makeLogEntry({
+          seq: 7,
+          level: 'INFO',
+          message: 'shell exec completed',
+          category: 'tool',
+          details: { tool_name: 'shell.exec' },
+        }),
         makeLogEntry({ seq: 6, level: 'INFO', message: 'masc_start 완료' }),
         makeLogEntry({ seq: 5, level: 'INFO', message: 'masc_compact 완료' }),
         makeLogEntry({ seq: 4, level: 'WARN', message: '컨텍스트 91% — compact 예약' }),
@@ -787,15 +795,16 @@ describe('SettingsSurface', () => {
     await fireEvent.click(logsNav)
 
     const allRows = () => container.querySelectorAll('[data-testid="log-row"]')
-    await waitFor(() => expect(allRows().length).toBe(6))
+    await waitFor(() => expect(allRows().length).toBe(7))
 
     const toolFilter = container.querySelector('[data-filter="tool"]') as HTMLButtonElement
     await fireEvent.click(toolFilter)
-    expect(allRows().length).toBe(3)
+    expect(allRows().length).toBe(4)
+    expect(container.textContent).toContain('shell exec completed')
 
     const successFilter = container.querySelector('[data-filter="success"]') as HTMLButtonElement
     await fireEvent.click(successFilter)
-    expect(allRows().length).toBe(3)
+    expect(allRows().length).toBe(4)
 
     const failureFilter = container.querySelector('[data-filter="failure"]') as HTMLButtonElement
     await fireEvent.click(failureFilter)
@@ -803,7 +812,7 @@ describe('SettingsSurface', () => {
 
     const allFilter = container.querySelector('[data-filter="all"]') as HTMLButtonElement
     await fireEvent.click(allFilter)
-    expect(allRows().length).toBe(6)
+    expect(allRows().length).toBe(7)
   })
 
   it('renders the fusion preset section (panel families + judge) as read-only defaults', async () => {
@@ -1011,7 +1020,18 @@ describe('settings read-surface helpers', () => {
         message: 'masc_trace_window 실패',
       }),
     )
-    expect(row).toEqual(['16:24:51', 'error', 'drifter', 'masc_trace_window 실패', 'fail'])
+    expect(row).toEqual(['16:24:51', 'error', 'drifter', 'masc_trace_window 실패', 'fail', true])
+  })
+
+  it('logEntryToSysRow preserves structured tool classification for filters', () => {
+    const row = logEntryToSysRow(
+      makeLogEntry({
+        category: 'tool',
+        details: { tool_name: 'shell.exec' },
+        message: 'shell exec completed',
+      }),
+    )
+    expect(row[5]).toBe(true)
   })
 
   it('logEntryToSysRow falls back to module then (root) for identity', () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -28,6 +28,7 @@ import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
 import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
+import { logDisplayKind } from './log-classification'
 import { tweaksDensity, type Density } from './tweaks-panel'
 import type { ComponentChildren } from 'preact'
 
@@ -131,12 +132,12 @@ const FUSION: FusionConfig = {
   maxToolCallsPerPanel: 0,
 }
 
-// System-log row: [time, level, identity, message, status]. Derived from live
+// System-log row: [time, level, identity, message, status, isTool]. Derived from live
 // ring entries (`/api/v1/dashboard/logs`) — the same source the Logs surface
 // polls. Status is derived from the entry level only (error→fail, warn→warn,
 // else→ok); the in-progress "run" state is not knowable from a settled ring
 // entry, so it is never fabricated.
-type SysLogRow = [string, string, string, string, string]
+type SysLogRow = [string, string, string, string, string, boolean]
 
 const SETTINGS_LOG_LEVEL_FAIL = 'error'
 const SETTINGS_LOG_LEVEL_WARN = 'warn'
@@ -166,7 +167,8 @@ function logRowClock(ts: string): string {
 export function logEntryToSysRow(entry: LogEntry): SysLogRow {
   const level = entry.level.toLowerCase()
   const identity = entry.keeper_name?.trim() || entry.module?.trim() || '(root)'
-  return [logRowClock(entry.ts), level, identity, entry.message, logRowStatus(entry.level)]
+  const isTool = logDisplayKind(entry) === 'tool' || /masc_/.test(entry.message)
+  return [logRowClock(entry.ts), level, identity, entry.message, logRowStatus(entry.level), isTool]
 }
 
 function SetSeg({
@@ -517,7 +519,7 @@ function LogViewer() {
 
   const rows = allRows.filter(r => {
     if (filter === 'all') return true
-    if (filter === 'tool') return /masc_/.test(r[3])
+    if (filter === 'tool') return r[5]
     if (filter === 'success') return r[4] === 'ok'
     if (filter === 'failure') return r[4] === 'fail'
     return true


### PR DESCRIPTION
## Summary
- Extract the dashboard log display-kind classifier into a shared helper used by both Logs and Settings.
- Preserve structured tool classification in Settings log rows so the Tool filter catches `category: "tool"` / `details.tool_name` entries, not only messages containing `masc_`.
- Extend Settings tests for structured tool log rows.

## Validation
- `vitest run --config vitest.config.ts src/components/settings-surface.test.ts src/components/logs.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit --pretty false`
- `eslint src/components/log-classification.ts src/components/logs.ts src/components/settings-surface.ts src/components/settings-surface.test.ts` (source files clean; test file is ignored by the current eslint config)
- Playwright smoke on `http://127.0.0.1:5187/dashboard/#settings?section=logs`: clicked Tool filter and verified `category: "tool"` row without `masc_` remains visible while a non-tool failure row is filtered out. Screenshot: `/private/tmp/masc-settings-log-tool-filter.png`
