### PR TITLE
Fix keeper stream terminal reconciliation

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -11,6 +11,7 @@ import {
   CHAT_COMPOSER_DROP_PLACEHOLDER,
   ChatComposer,
   ChatTranscript,
+  THINKING_TRACE_PREVIEW_CHARS,
   type ChatComposerSendPayload,
 } from './primitives'
 import { _resetChatStoreForTests, readKeeperDraft } from '../../keeper-chat-store'
@@ -1958,6 +1959,39 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(renderedThink?.textContent).toContain('둘째 줄')
     // Untrusted model markup is stripped (no executable script element).
     expect(renderedThink?.querySelector('script')).toBeNull()
+  })
+
+  it('keeps long thinking traces collapsed until the operator expands them', () => {
+    const hiddenTail = 'TAIL-MARKER-KEEPER-THINKING'
+    const longThinking = `${'reasoning '.repeat(Math.ceil(THINKING_TRACE_PREVIEW_CHARS / 10) + 20)}${hiddenTail}`
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [{ kind: 'think', text: longThinking }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const think = container.querySelector('[data-chat-trace-step="think"]') as HTMLElement | null
+    expect(think).not.toBeNull()
+    expect(think?.textContent).toContain('chars hidden')
+    expect(think?.textContent).not.toContain(hiddenTail)
+
+    const expand = think?.querySelector('button') as HTMLButtonElement | null
+    expect(expand).not.toBeNull()
+    fireEvent.click(expand!)
+
+    expect(think?.textContent).toContain(hiddenTail)
   })
 
   it('renders board post ids in assistant prose as board detail links', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -177,6 +177,8 @@ type ChatTranscriptAction = {
   onClick: (entry: KeeperConversationEntry) => void
 }
 
+export const THINKING_TRACE_PREVIEW_CHARS = 2400
+
 function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
   const value = new Date(timestamp)
@@ -1221,17 +1223,42 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
   const [open, setOpen] = useState(false)
 
   if (step.kind === 'think') {
+    const longThinking = step.text.length > THINKING_TRACE_PREVIEW_CHARS
+    const previewText = longThinking
+      ? `${step.text.slice(0, THINKING_TRACE_PREVIEW_CHARS).trimEnd()}\n\n... ${step.text.length - THINKING_TRACE_PREVIEW_CHARS} chars hidden`
+      : step.text
     return html`
       <div class="chat-block-tstep think" data-chat-trace-step="think">
         <span class="chat-block-tnode"></span>
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row">
             <span class="chat-block-tstep-kind">Thinking</span>
+            ${longThinking
+              ? html`
+                  <button
+                    type="button"
+                    class="chat-block-tstep-chev"
+                    aria-expanded=${open}
+                    onClick=${() => setOpen((o) => !o)}
+                  >
+                    ${open ? '접기' : '전체 보기'}
+                  </button>
+                `
+              : null}
           </div>
-          <${AsyncMarkdownDiv}
-            text=${step.text}
-            className="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
-          />
+          ${longThinking && !open
+            ? html`
+                <div
+                  class="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
+                  dangerouslySetInnerHTML=${renderPlainLinkedHtml(previewText)}
+                />
+              `
+            : html`
+                <${AsyncMarkdownDiv}
+                  text=${step.text}
+                  className="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
+                />
+              `}
         </div>
       </div>
     `
@@ -2725,7 +2752,14 @@ function ToolTraceCard({
   `
 }
 
-function TurnWorkBundle({
+function sameEntryRefs(
+  left: readonly KeeperConversationEntry[],
+  right: readonly KeeperConversationEntry[],
+): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index])
+}
+
+const TurnWorkBundle = memo(function TurnWorkBundle({
   tools,
   assistant,
   showMetadata,
@@ -2767,7 +2801,16 @@ function TurnWorkBundle({
       />
     </div>
   `
-}
+}, (prev, next) =>
+  prev.assistant === next.assistant
+  && sameEntryRefs(prev.tools, next.tools)
+  && prev.showMetadata === next.showMetadata
+  && prev.variant === next.variant
+  && prev.showSourceBadge === next.showSourceBadge
+  && prev.toolOutputsCoveredSinceMs === next.toolOutputsCoveredSinceMs
+  && prev.toolOutputsCoveredThroughMs === next.toolOutputsCoveredThroughMs
+  && prev.action === next.action
+)
 
 // A reader within this distance of the bottom is considered "pinned":
 // new content keeps auto-scrolling. Scrolling further up unpins so the

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1923,10 +1923,9 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
 // regardless of memo (the test 're-renders the settled bubble when action is a
 // new object…' locks this).
 //
-// KNOWN GAP: tool/thinking turns render through the un-memoized TurnWorkBundle,
-// whose `tools` array is rebuilt every render (buildChatRenderUnits), so its
-// trace cards are NOT yet skipped on a stream chunk. Closing that needs the
-// unit arrays stabilized first — a separate follow-up.
+// Tool/thinking turns render through TurnWorkBundle. buildChatRenderUnits
+// rebuilds `tools` arrays each render, so the bundle comparator compares entry
+// references inside those arrays instead of the array object itself.
 const ChatMessageBubble = memo(function ChatMessageBubble({
   entry,
   showMetadata = true,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -171,6 +171,48 @@ describe('KeeperWorkspaceChat', () => {
     expect(container.querySelector('[data-testid="kw-chat-command-config"]')).not.toBeNull()
   })
 
+  it('keeps utility commands usable while a lifecycle command is pending', async () => {
+    const { KeeperWorkspaceChat } = await loadChat()
+    const { runKeeperAction } = await import('../keeper-action-panel')
+    let resolveAction: () => void = () => {}
+    vi.mocked(runKeeperAction).mockImplementationOnce(async () => new Promise<void>(resolve => {
+      resolveAction = resolve
+    }))
+
+    await act(async () => {
+      render(html`
+        <${KeeperWorkspaceChat}
+          keeper=${mockKeeper}
+        />
+      `, container)
+    })
+
+    const pause = container.querySelector('[data-testid="kw-chat-command-pause"]') as HTMLButtonElement
+    const turn = container.querySelector('[data-testid="kw-chat-command-turn"]') as HTMLButtonElement
+    expect(pause).not.toBeNull()
+    expect(turn).not.toBeNull()
+
+    await act(async () => {
+      pause.click()
+      await Promise.resolve()
+    })
+
+    expect(runKeeperAction).toHaveBeenCalledWith('sangsu', 'pause')
+    expect(pause.disabled).toBe(true)
+    expect(turn.disabled).toBe(false)
+
+    await act(async () => {
+      turn.click()
+    })
+
+    expect(container.querySelector('[role="dialog"]')?.textContent).toContain('턴 검사')
+
+    await act(async () => {
+      resolveAction()
+      await Promise.resolve()
+    })
+  })
+
   it('keeps runtime scope/path out of the slim chat header', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
     const keeperWithSlug = { ...mockKeeper, sandbox_target: '~/wt/sangsu', skill_primary: 'skill-primary' }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -176,6 +176,10 @@ function workspaceCommandGroup(command: WorkspaceCommand): string {
   return command.id in LIFECYCLE_COPY ? '명령' : '이동'
 }
 
+function isLifecycleWorkspaceCommand(command: WorkspaceCommand): boolean {
+  return command.id in LIFECYCLE_COPY
+}
+
 function WorkspaceCommandButtons({
   keeper,
   mobile,
@@ -215,6 +219,11 @@ function WorkspaceCommandButtons({
   const commands = [...lifecycleCommands(keeper), ...utilities]
 
   async function run(command: WorkspaceCommand) {
+    if (!isLifecycleWorkspaceCommand(command)) {
+      await command.onClick()
+      setMenuOpen(false)
+      return
+    }
     if (busyAction) return
     setBusyAction(command.id)
     try {
@@ -255,7 +264,7 @@ function WorkspaceCommandButtons({
                         type="button"
                         role="menuitem"
                         class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
-                        disabled=${busyAction !== null}
+                        disabled=${isLifecycleWorkspaceCommand(command) && busyAction !== null}
                         onClick=${() => { void run(command) }}
                         data-testid=${`kw-chat-command-${command.id}`}
                       >
@@ -284,7 +293,7 @@ function WorkspaceCommandButtons({
             aria-label=${command.label}
             aria-pressed=${command.active ? 'true' : undefined}
             title=${command.title}
-            disabled=${busyAction !== null}
+            disabled=${isLifecycleWorkspaceCommand(command) && busyAction !== null}
             onClick=${() => { void run(command) }}
             data-testid=${`kw-chat-command-${command.id}`}
           >
@@ -490,9 +499,15 @@ export function KeeperWorkspaceChat({
     hint: command.title,
     glyph: COMMAND_GLYPHS[command.id],
     danger: command.danger,
-    disabled: composerBusyAction !== null,
-    disabledReason: composerBusyAction !== null ? '다른 keeper 명령 실행 중' : undefined,
+    disabled: isLifecycleWorkspaceCommand(command) && composerBusyAction !== null,
+    disabledReason: isLifecycleWorkspaceCommand(command) && composerBusyAction !== null
+      ? '다른 keeper lifecycle 명령 실행 중'
+      : undefined,
     run: async () => {
+      if (!isLifecycleWorkspaceCommand(command)) {
+        await command.onClick()
+        return
+      }
       if (composerBusyAction !== null) return
       setComposerBusyAction(command.id)
       try {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -340,6 +340,49 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps another keeper lane available while one keeper stream is in flight', async () => {
+    let resolveEcho: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage.mockImplementation(async (
+      name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      if (name === 'echo') {
+        opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: 'echo reply' })
+        return new Promise<{ terminal: boolean }>(resolve => {
+          resolveEcho = resolve
+        })
+      }
+      opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: `${name} reply` })
+      return { terminal: true }
+    })
+
+    const echoSend = sendKeeperThreadMessage('echo', 'slow turn')
+    await Promise.resolve()
+
+    expect(keeperSending.value.echo).toBe(true)
+    expect(activeStreamEntryId('echo')).not.toBeNull()
+
+    await sendKeeperThreadMessage('rama', 'status?')
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+    expect(streamKeeperMessage.mock.calls.map(call => call[0])).toEqual(['echo', 'rama'])
+    expect(keeperSending.value.echo).toBe(true)
+    expect(activeStreamEntryId('echo')).not.toBeNull()
+    expect(keeperSending.value.rama).toBe(false)
+    expect(activeStreamEntryId('rama')).toBeNull()
+    expect((keeperThreads.value.rama ?? []).map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', 'status?', 'delivered'],
+      ['assistant', 'rama reply', 'delivered'],
+    ])
+
+    resolveEcho({ terminal: true })
+    await echoSend
+
+    expect(keeperSending.value.echo).toBe(false)
+    expect(activeStreamEntryId('echo')).toBeNull()
+  })
+
   it('keeps queued client action ids guarded while a batched queue send is in flight', async () => {
     let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
     streamKeeperMessage.mockImplementationOnce(async () => new Promise<{ terminal: boolean }>(resolve => {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -147,6 +147,9 @@ describe('applyKeeperStreamEvent', () => {
         ok: true,
       },
     })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_END',
+    })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.text).toBe('완료했습니다.')
@@ -186,6 +189,9 @@ describe('applyKeeperStreamEvent', () => {
         ok: true,
       },
     })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_END',
+    })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.text).toBe('큐에서 완료했습니다.')
@@ -215,6 +221,9 @@ describe('applyKeeperStreamEvent', () => {
         ok: true,
       },
     })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_END',
+    })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.text).toBe('')
@@ -241,6 +250,9 @@ describe('applyKeeperStreamEvent', () => {
         status: 'done',
         ok: true,
       },
+    })).toBeNull()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_END',
     })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -156,6 +156,74 @@ describe('applyKeeperStreamEvent', () => {
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 
+  it('finalizes queued visible replies when a successful terminal follows reply details', () => {
+    assistantEntry()
+    setActiveStreamRequestId('sangsu', 'kmsg_current')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_QUEUE_REQUEST',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'queued',
+      },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        request_id: 'kmsg_current',
+        reply: '큐에서 완료했습니다.',
+        turn_outcome: 'visible_reply',
+      },
+    })
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'done',
+        ok: true,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('큐에서 완료했습니다.')
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.error).toBeNull()
+    expect(activeStreamRequestId('sangsu')).toBeNull()
+  })
+
+  it('keeps explicit continuation checkpoints queued when a successful terminal follows', () => {
+    assistantEntry()
+    setActiveStreamRequestId('sangsu', 'kmsg_current')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTINUATION_CHECKPOINT',
+      value: {
+        message: 'Continuation checkpoint saved; keeper remains scheduled.',
+      },
+    })
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'done',
+        ok: true,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('')
+    expect(entry?.delivery).toBe('queued')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.details?.turnOutcome).toBe('continuation_checkpoint')
+    expect(activeStreamRequestId('sangsu')).toBeNull()
+  })
+
   it('does not leave successful terminal events in a live thinking state without reply details', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -120,6 +120,70 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('요청이 취소되었습니다.')
   })
 
+  it('finalizes successful request terminal events after streamed thinking', () => {
+    assistantEntry()
+    setActiveStreamRequestId('sangsu', 'kmsg_current')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'checking state' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REPLY_DETAILS',
+      value: {
+        request_id: 'kmsg_current',
+        reply: '완료했습니다.',
+        turn_outcome: 'visible_reply',
+      },
+    })
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'done',
+        ok: true,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('완료했습니다.')
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.error).toBeNull()
+    expect(activeStreamRequestId('sangsu')).toBeNull()
+  })
+
+  it('does not leave successful terminal events in a live thinking state without reply details', () => {
+    assistantEntry()
+    setActiveStreamRequestId('sangsu', 'kmsg_current')
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'checking state' },
+    })
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_REQUEST_TERMINAL',
+      value: {
+        request_id: 'kmsg_current',
+        status: 'done',
+        ok: true,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'checking state', ts: expect.any(String) },
+    ])
+    expect(activeStreamRequestId('sangsu')).toBeNull()
+  })
+
   it('ignores terminal events for a different active request id', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -461,6 +461,17 @@ export function applyKeeperStreamEvent(
           }))
           return message
         }
+        if (status === 'done' && terminal?.ok !== false) {
+          updateThreadEntry(keeperName, assistantEntryId, entry => ({
+            ...entry,
+            delivery:
+              entry.delivery === 'queued' || entry.delivery === 'no_reply'
+                ? entry.delivery
+                : 'delivered',
+            streamState: null,
+            error: null,
+          }))
+        }
         return null
       }
       if (event.name === 'KEEPER_REPLY_DETAILS') {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -411,6 +411,10 @@ export function applyKeeperStreamEvent(
           : ''
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
+          details: {
+            ...(entry.details ?? {}),
+            turnOutcome: 'continuation_checkpoint',
+          },
           text: '',
           rawText: rawText || entry.rawText,
           delivery: 'queued',
@@ -462,15 +466,20 @@ export function applyKeeperStreamEvent(
           return message
         }
         if (status === 'done' && terminal?.ok !== false) {
-          updateThreadEntry(keeperName, assistantEntryId, entry => ({
-            ...entry,
-            delivery:
-              entry.delivery === 'queued' || entry.delivery === 'no_reply'
+          updateThreadEntry(keeperName, assistantEntryId, entry => {
+            const delivery =
+              entry.delivery === 'no_reply'
+                || (entry.delivery === 'queued'
+                  && keeperTurnOutcomeSuppressesReply(entry.details?.turnOutcome))
                 ? entry.delivery
-                : 'delivered',
-            streamState: null,
-            error: null,
-          }))
+                : 'delivered'
+            return {
+              ...entry,
+              delivery,
+              streamState: null,
+              error: null,
+            }
+          })
         }
         return null
       }

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -207,6 +207,17 @@ export function applyKeeperStreamEvent(
     if (typeof payload !== 'string') return
     if (payload) appendAssistantDelta(keeperName, assistantEntryId, payload)
   }
+  const markFinalizingIfLive = (): void => {
+    updateThreadEntry(keeperName, assistantEntryId, entry => {
+      if (entry.streamState === null) return entry
+      if (entry.delivery !== 'sending' && entry.delivery !== 'streaming') return entry
+      return {
+        ...entry,
+        streamState: 'finalizing',
+        delivery: 'streaming',
+      }
+    })
+  }
 
   switch (event.type) {
     case 'RUN_STARTED':
@@ -221,7 +232,7 @@ export function applyKeeperStreamEvent(
     }
     case 'TEXT_MESSAGE_END':
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-      setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
+      markFinalizingIfLive()
       return null
     case 'TOOL_CALL_START': {
       const toolCallId = event.toolCallId?.trim()
@@ -327,12 +338,12 @@ export function applyKeeperStreamEvent(
         if (usage) patch.usage = usage
         if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
         if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
-        if (stopReason) setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
+        if (stopReason) markFinalizingIfLive()
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
         clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-        setAssistantStreamState(keeperName, assistantEntryId, 'finalizing', 'streaming')
+        markFinalizingIfLive()
         return null
       }
       if (event.name === 'KEEPER_STREAM_PING') {


### PR DESCRIPTION
## Summary
- finalize successful KEEPER_REQUEST_TERMINAL events in the dashboard stream reducer
- prevent live thinking/streaming UI from staying active after the server reports request status=done
- add regressions for thinking + reply-details completion, done terminals without reply details, and independent per-keeper chat lanes

## Evidence
- Live request kmsg_sangsu_3_1782896331751 completed server-side with status=done, but the dashboard screenshot still showed THINKING later.
- Server stream emits KEEPER_REPLY_DETAILS before KEEPER_REQUEST_TERMINAL status=done; the dashboard previously treated done terminal as a no-op for the assistant entry.
- Other keepers continued to complete turns during the sangsu request, and the new dashboard action regression keeps another keeper lane available while one keeper stream is in flight.
- Current live health still reports degraded reaction capacity from durable-paused keepers, which is a separate operator/runtime state from the stale dashboard terminal bug.

## Verification
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false
- git diff --check