### PR TITLE
[codex] Remove fake fusion settings preview

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -5,7 +5,6 @@ import { html } from 'htm/preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import {
   SettingsSurface,
-  checkSettingsMcpEndpoint,
   mcpExposedToolNames,
   logEntryToSysRow,
   logRowStatus,
@@ -36,6 +35,8 @@ const apiMock = vi.hoisted(() => ({
   fetchDashboardTools: vi.fn(),
   fetchRuntimeDefaults: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
+  fetchRuntimeTomlConfig: vi.fn(),
+  saveRuntimeTomlConfig: vi.fn(),
 }))
 
 const mcpMock = vi.hoisted(() => ({
@@ -77,6 +78,8 @@ vi.mock('../api/dashboard.js', async () => {
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
     fetchRuntimeProviders: apiMock.fetchRuntimeProviders,
+    fetchRuntimeTomlConfig: apiMock.fetchRuntimeTomlConfig,
+    saveRuntimeTomlConfig: apiMock.saveRuntimeTomlConfig,
   }
 })
 
@@ -278,6 +281,20 @@ function stubEmptyApi() {
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
   stubRuntimeDefaults()
   apiMock.fetchRuntimeProviders.mockResolvedValue(makeRuntimeProviders())
+  apiMock.fetchRuntimeTomlConfig.mockResolvedValue({
+    ok: true,
+    path: MOCK_RUNTIME_PATH,
+    file_name: 'runtime.toml',
+    source_text: '[runtime]\ndefault = "rt-a"\n',
+    reloaded: false,
+  })
+  apiMock.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
+    ok: true,
+    path: MOCK_RUNTIME_PATH,
+    file_name: 'runtime.toml',
+    source_text: sourceText,
+    reloaded: true,
+  }))
 }
 
 const navigate = vi.fn()
@@ -303,6 +320,8 @@ describe('SettingsSurface', () => {
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
+    apiMock.fetchRuntimeTomlConfig.mockReset()
+    apiMock.saveRuntimeTomlConfig.mockReset()
     mcpMock.callMcpTool.mockClear()
     promptApiMock.clearPromptOverride.mockClear()
     promptApiMock.fetchDashboardPrompts.mockClear()
@@ -815,61 +834,44 @@ describe('SettingsSurface', () => {
     expect(allRows().length).toBe(7)
   })
 
-  it('renders the fusion preset section (panel families + judge) as read-only defaults', async () => {
+  it('renders fusion as a no-writer handoff instead of hardcoded defaults', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-fusion"]') as HTMLElement)
 
     expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('패널·심판 심의')
-    expect(container.querySelector('[data-testid="fusion-readonly-preview"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="fusion-readonly-enabled"]')?.textContent).toBe('enabled')
-    expect(container.querySelector('[data-testid="fusion-readonly-preset"]')?.textContent).toBe('trio')
-    expect(container.querySelector('[data-testid="fusion-readonly-panels"]')?.textContent).toBe('2')
-    expect(container.querySelector('[data-testid="fusion-readonly-web-tools"]')?.textContent).toBe('disabled')
-    // trio preset lanes: 3 panel models + 1 judge, with prototype labels.
-    const lanes = container.querySelectorAll('.set-fus-lane')
-    expect(lanes.length).toBe(2)
-    const models = Array.from(container.querySelectorAll('.set-fus-model')).map(n => n.textContent)
-    expect(models).toContain('ollama_cloud.ollama-cloud-devstral-2-123b')
-    expect(models).toContain('ollama_cloud.ollama-cloud-devstral-small-2-24b')
-    expect(models).toContain('ollama_cloud.ollama-cloud-ministral-3-14b')
-    expect(container.querySelector('.set-fus-model.judge')?.textContent).toBe('ollama_cloud.ollama-cloud-devstral-2-123b')
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('documented defaults preview')
+    expect(container.querySelector('[data-testid="fusion-readonly-no-writer"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="fusion-no-writer"]')?.textContent).toContain('no hardcoded preview')
+    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('dedicated writer disabled')
+    expect(container.querySelector('[data-testid="fusion-readonly-enabled"]')).toBeNull()
+    expect(container.querySelector('[data-testid="fusion-readonly-preset"]')).toBeNull()
+    expect(container.querySelector('.set-fus-model')).toBeNull()
     expect(container.querySelector('[data-testid="set-toggle"]')).toBeNull()
     expect(container.querySelector('[data-testid="set-seg"]')).toBeNull()
     expect(container.querySelector('[data-testid="set-stepper"]')).toBeNull()
     expect(container.querySelector('[data-testid="fusion-settings-editor"]')).toBeNull()
     expect(container.textContent).not.toContain('per_hour_budget')
+
+    await fireEvent.click(container.querySelector('[data-testid="fusion-open-runtime-toml"]') as HTMLButtonElement)
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임 관리')
+    expect(navigate).toHaveBeenLastCalledWith('settings', { section: 'runtimes' })
   })
 
   it('renders the live fusion settings writer only behind VITE_FUSION_SETTINGS_WRITABLE', async () => {
     vi.stubEnv('VITE_FUSION_SETTINGS_WRITABLE', 'true')
-    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
-      const path = String(url)
-      if (path === '/api/v1/runtime/config/raw') {
-        return new Response(JSON.stringify({
-          ok: true,
-          path: MOCK_RUNTIME_PATH,
-          file_name: 'runtime.toml',
-          source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\nmax_concurrent_panels = 2\n\n[fusion.presets.trio]\nmin_answered = 2\n',
-          reloaded: false,
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return new Response(JSON.stringify({ message: `unexpected ${path}` }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
+    apiMock.fetchRuntimeTomlConfig.mockResolvedValueOnce({
+      ok: true,
+      path: MOCK_RUNTIME_PATH,
+      file_name: 'runtime.toml',
+      source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\nmax_concurrent_panels = 2\n\n[fusion.presets.trio]\nmin_answered = 2\n',
+      reloaded: false,
     })
-    vi.stubGlobal('fetch', fetchMock)
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-fusion"]') as HTMLElement)
 
     await waitFor(() => expect(container.querySelector('[data-testid="fusion-settings-editor"]')).not.toBeNull())
-    expect(fetchMock).toHaveBeenCalledWith('/api/v1/runtime/config/raw', expect.any(Object))
+    expect(apiMock.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
     expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
@@ -884,36 +886,7 @@ describe('SettingsSurface', () => {
       source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
       reloaded: false,
     }
-    const fetchMock = vi.fn(async (input: unknown) => {
-      const requestUrl =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : typeof (input as { url?: unknown }).url === 'string'
-              ? (input as { url: string }).url
-              : ''
-      const path = requestUrl.startsWith('http')
-        ? new URL(requestUrl).pathname
-        : requestUrl.split('?')[0] ?? requestUrl
-      if (path === '/api/v1/dashboard/dev-token') {
-        return new Response(JSON.stringify({ token: 'dev-token', actor: 'dashboard' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      if (path === '/api/v1/runtime/config/raw') {
-        return new Response(JSON.stringify(runtimeConfig), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return new Response(JSON.stringify({ message: `unexpected ${path}` }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    })
-    vi.stubGlobal('fetch', fetchMock)
+    apiMock.fetchRuntimeTomlConfig.mockResolvedValueOnce(runtimeConfig)
 
     render(html`<${SettingsSurface} />`, container)
 
@@ -926,12 +899,7 @@ describe('SettingsSurface', () => {
       expect(container.textContent).toContain(MOCK_RUNTIME_PATH)
     })
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/runtime/config/raw',
-      expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: 'Bearer dev-token' }),
-      }),
-    )
+    expect(apiMock.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -973,21 +941,6 @@ describe('SettingsSurface shell route', () => {
 })
 
 describe('settings read-surface helpers', () => {
-  it('checks Settings MCP endpoint preview values by format only', () => {
-    expect(checkSettingsMcpEndpoint('https://masc.local/mcp')).toEqual({
-      ok: true,
-      message: 'valid MCP URL',
-    })
-    expect(checkSettingsMcpEndpoint('ftp://masc.local/mcp')).toEqual({
-      ok: false,
-      message: 'expected http(s) URL',
-    })
-    expect(checkSettingsMcpEndpoint('https://masc.local/api')).toEqual({
-      ok: false,
-      message: 'path should include /mcp',
-    })
-  })
-
   it('mcpExposedToolNames keeps only public_mcp tools, sorted', () => {
     const names = mcpExposedToolNames([
       makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -35,10 +35,6 @@ import type { ComponentChildren } from 'preact'
 type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
-type PathCheckResult = {
-  readonly ok: boolean
-  readonly message: string
-}
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const DEFAULT_SETTINGS_SECTION: SectionId = 'runtime'
 
@@ -80,56 +76,6 @@ export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]
     .filter(item => item.surfaces.includes(MCP_PUBLIC_SURFACE))
     .map(item => item.name)
     .sort((a, b) => a.localeCompare(b))
-}
-
-export function checkSettingsMcpEndpoint(value: string): PathCheckResult {
-  const trimmed = value.trim()
-  if (trimmed === '') return { ok: false, message: 'URL required' }
-  try {
-    const url = new URL(trimmed)
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return { ok: false, message: 'expected http(s) URL' }
-    }
-    if (url.hostname.trim() === '') return { ok: false, message: 'host required' }
-    if (!url.pathname.toLowerCase().includes('mcp')) {
-      return { ok: false, message: 'path should include /mcp' }
-    }
-    return { ok: true, message: 'valid MCP URL' }
-  } catch {
-    return { ok: false, message: 'invalid URL' }
-  }
-}
-
-// [fusion] preset shape from config/runtime.toml [fusion] — keeper-v2
-// settings.jsx:68-81 (FUSION). Describes the trio preset structure (panel
-// families, judge, timeouts). Read-only preview; no fusion config write
-// endpoint exists yet, so these are the documented config defaults, not live
-// values.
-type FusionConfig = {
-  readonly enabled: boolean
-  readonly defaultPreset: string
-  readonly maxConcurrentPanels: number
-  readonly webTools: boolean
-  readonly panel: readonly string[]
-  readonly judge: string
-  readonly panelTimeoutS: number
-  readonly judgeTimeoutS: number
-  readonly maxToolCallsPerPanel: number
-}
-const FUSION: FusionConfig = {
-  enabled: true,
-  defaultPreset: 'trio',
-  maxConcurrentPanels: 2,
-  webTools: false,
-  panel: [
-    'ollama_cloud.ollama-cloud-devstral-2-123b',
-    'ollama_cloud.ollama-cloud-devstral-small-2-24b',
-    'ollama_cloud.ollama-cloud-ministral-3-14b',
-  ],
-  judge: 'ollama_cloud.ollama-cloud-devstral-2-123b',
-  panelTimeoutS: 300,
-  judgeTimeoutS: 300,
-  maxToolCallsPerPanel: 0,
 }
 
 // System-log row: [time, level, identity, message, status, isTool]. Derived from live
@@ -446,7 +392,7 @@ function settingsSectionState(
   if (section === 'fusion' && fusionSettingsWritable) {
     return { mode: 'live', label: 'runtime.toml live-backed' }
   }
-  if (section === 'fusion') return { mode: 'local', label: 'documented defaults preview' }
+  if (section === 'fusion') return { mode: 'local', label: 'dedicated writer disabled' }
   if (section === 'paths') return { mode: 'live', label: 'resolved by server' }
   if (section === 'mcp') return { mode: 'mixed', label: 'live MCP check + inventory' }
   if (section === 'logs') return { mode: 'mixed', label: 'live logs + local filters' }
@@ -934,45 +880,24 @@ export function SettingsSurface() {
               ${fusionSettingsWritable
                 ? html`<${FusionSettingsPanel} />`
                 : html`
-                <div data-testid="fusion-readonly-preview">
-                  <${SetRow} label="Fusion 심의" hint="[fusion].enabled · 문서화된 기본값">
-                    <div class="set-truth-value">
-                      <span class="mono" data-testid="fusion-readonly-enabled">${FUSION.enabled ? 'enabled' : 'disabled'}</span>
-                      <span class="set-truth-source">read-only</span>
+                <div data-testid="fusion-readonly-no-writer">
+                  <${SetRow} label="Fusion settings" hint="[fusion] in runtime.toml">
+                    <div class="set-truth-value" data-testid="fusion-no-writer">
+                      <span class="mono">dedicated writer disabled</span>
+                      <span class="set-truth-source">no hardcoded preview</span>
                     </div>
                   <//>
-                  <${SetRow} label="기본 프리셋" hint="default_preset">
-                    <div class="set-truth-value">
-                      <span class="mono" data-testid="fusion-readonly-preset">${FUSION.defaultPreset}</span>
-                      <span class="set-truth-source">read-only</span>
-                    </div>
-                  <//>
-                  <${SetRow} label="동시 패널 수" hint="max_concurrent_panels · Async_agent.all 상한">
-                    <div class="set-truth-value">
-                      <span class="mono" data-testid="fusion-readonly-panels">${FUSION.maxConcurrentPanels}</span>
-                      <span class="set-truth-source">read-only</span>
-                    </div>
-                  <//>
-                  <${SetRow} label="패널·심판 웹 도구" hint="web_search / web_fetch 주입 여부">
-                    <div class="set-truth-value">
-                      <span class="mono" data-testid="fusion-readonly-web-tools">${FUSION.webTools ? 'enabled' : 'disabled'}</span>
-                      <span class="set-truth-source">read-only</span>
-                    </div>
-                  <//>
-                  <div class="set-sub-h">trio 프리셋</div>
-                  <div class="set-fus-preset">
-                    <div class="set-fus-lane">
-                      <div class="set-fus-lane-h">panel · ${FUSION.panel.length}</div>
-                      ${FUSION.panel.map(id => html`<div key=${id} class="set-fus-model mono">${id}</div>`)}
-                    </div>
-                    <div class="set-fus-lane">
-                      <div class="set-fus-lane-h">judge</div>
-                      <div class="set-fus-model judge mono">${FUSION.judge}</div>
-                    </div>
+                  <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                    이 섹션은 live 값을 읽지 못할 때 문서 기본값을 흉내 내지 않습니다. 실제 값 확인·수정은 runtime.toml editor에서 합니다.
                   </div>
-                  <div class="set-mcp-detail mono" style=${{ marginTop: '10px' }}>
-                    panel_timeout ${FUSION.panelTimeoutS}s · judge_timeout ${FUSION.judgeTimeoutS}s · max_tool_calls_per_panel ${FUSION.maxToolCallsPerPanel} (0 = 무제한)
-                  </div>
+                  <button
+                    type="button"
+                    class="set-rt-open"
+                    data-testid="fusion-open-runtime-toml"
+                    onClick=${() => openSection('runtimes')}
+                  >
+                    runtime.toml 열기
+                  </button>
                 </div>
               `}
             `}


### PR DESCRIPTION
## Summary
- Remove the hardcoded Fusion Settings defaults preview from Settings when the dedicated fusion writer is disabled.
- Replace it with an explicit no-writer state and a real `runtime.toml` handoff button into Runtime management.
- Remove the unused Settings MCP endpoint format-only helper/test; the visible MCP check is the live `masc_status` button.

## Validation
- `vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit --pretty false`
- `eslint src/components/settings-surface.ts src/components/settings-surface.test.ts` (source clean; test file is ignored by current eslint config)
- Playwright smoke on `http://127.0.0.1:5188/dashboard/#settings?section=fusion`: verified no hardcoded Fusion model/default preview leaks, clicked `runtime.toml 열기`, and confirmed Runtime management editor opens with the mocked runtime.toml path. Screenshot: `/private/tmp/masc-settings-fusion-no-writer.png`
