### PR TITLE
Fix runtime provider alias deletion in settings

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -73,6 +73,7 @@ interface RuntimeEnvironmentEditorProps {
   onAddProvider: (input: NewRuntimeProviderInput) => void
   onAddModel: (input: NewRuntimeModelInput) => void
   onAddBinding: (providerId: string, modelId: string) => void
+  onDeleteProvider: (providerId: string) => void
   onProviderTransportChange: (
     providerId: string,
     field: RuntimeProviderTransportEditableField,
@@ -203,6 +204,7 @@ export function RuntimeEnvironmentEditor({
   onAddProvider,
   onAddModel,
   onAddBinding,
+  onDeleteProvider,
   onProviderTransportChange,
   onProviderCredentialChange,
 }: RuntimeEnvironmentEditorProps) {
@@ -212,6 +214,7 @@ export function RuntimeEnvironmentEditor({
   const [providerFormOpen, setProviderFormOpen] = useState(false)
   const [newProvider, setNewProvider] = useState<NewProviderDraft>(DEFAULT_NEW_PROVIDER)
   const [providerFormError, setProviderFormError] = useState<string | null>(null)
+  const [providerDeleteError, setProviderDeleteError] = useState<string | null>(null)
 
   const [modelFormOpen, setModelFormOpen] = useState(false)
   const [newModel, setNewModel] = useState<NewModelDraft>(DEFAULT_NEW_MODEL)
@@ -306,7 +309,21 @@ export function RuntimeEnvironmentEditor({
     })
     setNewProvider(DEFAULT_NEW_PROVIDER)
     setProviderFormError(null)
+    setProviderDeleteError(null)
     setProviderFormOpen(false)
+  }
+
+  function deleteProvider(providerId: string) {
+    const providerBindings = environment.bindings.filter(b => b.providerId === providerId)
+    const remainingBindings = environment.bindings.filter(b => b.providerId !== providerId)
+    if (providerBindings.length > 0 && remainingBindings.length === 0) {
+      setProviderDeleteError(
+        '마지막 runtime binding을 가진 provider alias는 삭제할 수 없습니다. 새 provider/model/binding을 먼저 추가하세요.',
+      )
+      return
+    }
+    setProviderDeleteError(null)
+    onDeleteProvider(providerId)
   }
 
   function submitAddModel() {
@@ -530,6 +547,9 @@ export function RuntimeEnvironmentEditor({
            save. -->
       <div class=${section === 'providers' ? '' : 'hidden'} data-testid="runtime-section-providers">
         <div class="rt-cards">
+          ${providerDeleteError ? html`
+            <div class="rt-warn" role="alert" data-testid="runtime-delete-provider-error">${providerDeleteError}</div>
+          ` : null}
           ${environment.providers.map(provider => {
             const providerTransportField = transportField(provider)
             return html`
@@ -538,6 +558,13 @@ export function RuntimeEnvironmentEditor({
                 <span class="rt-card-id mono">${provider.id}</span>
                 <span class="rt-card-name">${provider.displayName}</span>
                 <span class="rt-proto mono">${provider.protocol || '—'}</span>
+                <button
+                  type="button"
+                  class="rt-delete-provider"
+                  disabled=${isDisabled}
+                  data-testid=${`runtime-provider-${provider.id}-delete`}
+                  onClick=${() => deleteProvider(provider.id)}
+                >삭제</button>
               </div>
               <div class="rt-field">
                 <span class="sub-k">${providerTransportField}</span>

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -719,6 +719,59 @@ describe('RuntimeTomlEditor', () => {
     })
   })
 
+  it('deletes a provider alias as a draft and retargets the default runtime to a remaining binding', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-provider-runpod_mtp-delete"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+      expect(source).toContain('default = "openai.gpt"')
+      expect(source).not.toContain('[providers.runpod_mtp]')
+      expect(source).not.toContain('[providers.runpod_mtp.credentials]')
+      expect(source).not.toContain('[runpod_mtp.qwen]')
+      expect(source).toContain('[providers.openai]')
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+    await waitFor(() => {
+      const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
+      expect(savedSource).toContain('default = "openai.gpt"')
+      expect(savedSource).not.toContain('[providers.runpod_mtp]')
+    })
+  })
+
+  it('blocks deleting the final runtime-bearing provider alias from the structured view', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce({
+      ...baseConfig,
+      source_text: `${richSourceText
+        .replace(/\n\[providers\.openai\][\s\S]*?\n\[models\.qwen\]/, '\n[models.qwen]')
+        .replace(/\n\[models\.gpt\][\s\S]*?\n\[runpod_mtp\.qwen\]/, '\n[runpod_mtp.qwen]')
+        .replace(/\n\[openai\.gpt\][\s\S]*$/m, '\n')}`,
+    })
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-providers"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-providers"]') as HTMLButtonElement)
+    fireEvent.click(container.querySelector('[data-testid="runtime-provider-runpod_mtp-delete"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-delete-provider-error"]')?.textContent)
+        .toContain('마지막 runtime binding')
+    })
+    expect(container.querySelector('[data-testid="runtime-delete-provider-error"]')?.getAttribute('role')).toBe('alert')
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).not.toContain('modified')
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+  })
+
   it('does not offer messages protocols or command transport in the add-provider form', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -11,6 +11,7 @@ import {
 } from '../api/dashboard'
 import { errorToString } from '../lib/format-string'
 import {
+  cascadeDeleteProvider,
   createRuntimeTomlBinding,
   parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
@@ -329,6 +330,13 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     setError(null)
   }
 
+  function handleDeleteProvider(providerId: string) {
+    if (saving || loadState !== 'loaded') return
+    setDraft(current => cascadeDeleteProvider(current, providerId))
+    setNotice(null)
+    setError(null)
+  }
+
   function handleProviderTransportChange(
     providerId: string,
     field: RuntimeProviderTransportEditableField,
@@ -616,6 +624,7 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
                 onAddProvider=${handleAddProvider}
                 onAddModel=${handleAddModel}
                 onAddBinding=${handleAddBinding}
+                onDeleteProvider=${handleDeleteProvider}
                 onProviderTransportChange=${handleProviderTransportChange}
                 onProviderCredentialChange=${handleProviderCredentialChange}
               />

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -299,17 +299,78 @@ sangsu = "runpod_mtp.qwen"
   it('cascades provider deletion to credentials, bindings, and default runtime', () => {
     const next = cascadeDeleteProvider(sourceText, 'runpod_mtp')
     const env = parseRuntimeTomlEnvironment(next)
-    
+
     expect(env.providers.length).toBe(0)
     expect(env.bindings.length).toBe(0)
     expect(next).not.toContain('default = "runpod_mtp.qwen"')
     expect(next).not.toContain('[providers.runpod_mtp.credentials]')
   })
 
+  it('retargets default and clears dependent lanes when deleting a provider with a fallback binding', () => {
+    const withFallback = `${sourceText.replace(
+      'default = "runpod_mtp.qwen"',
+      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
+    )}
+
+[providers.openai]
+display-name = "OpenAI"
+protocol = "openai-compatible-http"
+endpoint = "https://api.openai.example/v1"
+
+[models.gpt]
+api-name = "gpt"
+max-context = 64000
+streaming = true
+
+[openai.gpt]
+max-concurrent = 1
+
+[runtime.assignments]
+sangsu = "runpod_mtp.qwen"
+`
+
+    const next = cascadeDeleteProvider(withFallback, 'runpod_mtp')
+    const env = parseRuntimeTomlEnvironment(next)
+
+    expect(env.defaultRuntimeId).toBe('openai.gpt')
+    expect(env.librarianRuntimeId).toBe('')
+    expect(env.crossVerifierRuntimeId).toBe('')
+    expect(env.assignments).toEqual({})
+    expect(env.providers.map(p => p.id)).toEqual(['openai'])
+    expect(env.bindings.map(b => b.id)).toEqual(['openai.gpt'])
+    expect(next).toContain('default = "openai.gpt"')
+    expect(next).not.toContain('[providers.runpod_mtp]')
+    expect(next).not.toContain('[runpod_mtp.qwen]')
+    expect(next).not.toContain('sangsu = "runpod_mtp.qwen"')
+  })
+
+  it('does not delete reserved runtime namespaces when a legacy provider id is reserved', () => {
+    const withReservedProvider = `${sourceText}
+
+[providers.runtime]
+display-name = "Legacy Reserved"
+protocol = "openai-compatible-http"
+endpoint = "https://reserved.example/v1"
+
+[runtime.assignments]
+sangsu = "runpod_mtp.qwen"
+`
+
+    const next = cascadeDeleteProvider(withReservedProvider, 'runtime')
+    const env = parseRuntimeTomlEnvironment(next)
+
+    expect(next).not.toContain('[providers.runtime]')
+    expect(next).toContain('[runtime.assignments]')
+    expect(env.defaultRuntimeId).toBe('runpod_mtp.qwen')
+    expect(env.assignments).toEqual({ sangsu: 'runpod_mtp.qwen' })
+    expect(env.providers.map(provider => provider.id)).toEqual(['runpod_mtp'])
+    expect(env.bindings.map(binding => binding.id)).toEqual(['runpod_mtp.qwen'])
+  })
+
   it('can delete max-context field by setting it to null', () => {
     const next = setRuntimeTomlModelField(sourceText, 'qwen', 'max-context', null)
     const env = parseRuntimeTomlEnvironment(next)
-    
+
     expect(env.models[0]?.maxContext).toBeNull()
     expect(next).not.toContain('max-context =')
   })

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -482,9 +482,14 @@ export function cascadeDeleteProvider(sourceText: string, providerId: string): s
   const prefix = `providers.${providerId}`
   const prefixDot = `providers.${providerId}.`
   const bindingPrefixDot = `${providerId}.`
+  const canDeleteBindingNamespace = !isReservedRuntimeTomlId(providerId)
   const sectionsToDelete = document.sections
     .map(s => s.name)
-    .filter(name => name === prefix || name.startsWith(prefixDot) || name.startsWith(bindingPrefixDot))
+    .filter(name =>
+      name === prefix ||
+      name.startsWith(prefixDot) ||
+      (canDeleteBindingNamespace && name.startsWith(bindingPrefixDot)),
+    )
   
   let next = sourceText
   for (const sec of sectionsToDelete) {
@@ -495,9 +500,13 @@ export function cascadeDeleteProvider(sourceText: string, providerId: string): s
   const nextDocument = parseDocument(next)
   const runtimeValues = sectionValues(nextDocument, 'runtime')
   const toDeleteBindings = new Set(env.bindings.filter(b => b.providerId === providerId).map(b => b.id))
+  const remainingBindings = parseRuntimeTomlEnvironment(next).bindings.map(binding => binding.id)
   
   if (typeof runtimeValues.default === 'string' && toDeleteBindings.has(runtimeValues.default)) {
-    next = deleteRuntimeTomlKey(next, 'runtime', 'default')
+    const fallback = remainingBindings[0]
+    next = fallback
+      ? setRuntimeTomlKey(next, 'runtime', 'default', fallback)
+      : deleteRuntimeTomlKey(next, 'runtime', 'default')
   }
   if (typeof runtimeValues.librarian === 'string' && toDeleteBindings.has(runtimeValues.librarian)) {
     next = deleteRuntimeTomlKey(next, 'runtime', 'librarian')

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -53,6 +53,9 @@
 .rt-card-id { font-size: var(--fs-13); color: var(--volt-strong); }
 .rt-card-name { font-size: 12.5px; color: var(--text-bright); }
 .rt-proto { margin-left: auto; font-size: var(--fs-10); color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
+.rt-delete-provider { flex: none; border: 1px solid var(--err-border); border-radius: var(--radius-sm); background: var(--bad-soft); color: var(--bad-light); font-family: var(--font-ui); font-size: var(--fs-11); padding: 4px 9px; cursor: pointer; transition: 0.14s; }
+.rt-delete-provider:hover { background: color-mix(in oklab, var(--bad-light) 18%, transparent); color: var(--text-bright); }
+.rt-delete-provider:disabled { cursor: not-allowed; opacity: 0.55; }
 .rt-field { display: flex; align-items: center; gap: 10px; margin-top: 7px; }
 .rt-field .sub-k { min-width: 78px; }
 .rt-field .rt-input { flex: 1; }


### PR DESCRIPTION
## Summary
- add a provider alias delete action in Settings > Runtime management > Providers
- cascade the deletion through draft runtime.toml state before the existing validated save path
- retarget `[runtime].default` to the first remaining binding when the deleted provider owned the default
- guard reserved top-level namespaces so deleting a legacy `[providers.runtime]` style alias cannot delete `[runtime.*]`
- block deleting the final provider that still owns all runtime bindings

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/lib/runtime-toml-config.test.ts src/components/runtime-toml-editor.test.ts --no-file-parallelism --maxWorkers=1` (76 tests passed)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/lib/runtime-toml-config.ts src/components/runtime-environment-editor.ts src/components/runtime-toml-editor.ts src/lib/runtime-toml-config.test.ts src/components/runtime-toml-editor.test.ts` (0 errors; existing ignored-file warnings)
- `git diff --check origin/main...HEAD`
- Python Playwright smoke against `http://127.0.0.1:5195/dashboard/#settings?section=runtimes`, with mocked dashboard APIs, verifying provider deletion, saved payload, and screenshot `/private/tmp/masc-runtime-provider-delete.png`

## Notes
- The older provider/model/binding creation commits are already in `main`; this branch was rebased so the current PR diff is focused on provider deletion.
- The prior reserved-namespace deletion review comment is addressed here. The broader frontend-vocabulary/backend-metadata SSOT concern is not fixed by this deletion slice.
