### PR TITLE
[codex] fix keeper budget-exhausted tool-only contract

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -624,6 +624,7 @@ let run_turn
                    Contract_helpers.observed_completion_contract_status
                      ~had_owned_active_task_at_turn_start
                      ~actual_keeper_tool_names:progress_keeper_tool_names
+                     ~stop_reason:result.stop_reason
                      ~response_text_present:(String.trim text <> "")
                  in
                  let contract_status = completion_contract_status () in

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -39,17 +39,40 @@ let progress_keeper_tool_names_for_contract
   | _ :: _ -> keeper_tool_names_for_outcome ~tool_calls ~outcome:"ok"
 ;;
 
+let visible_response_text_present ~stop_reason ~response_text_present =
+  match stop_reason with
+  | Runtime_agent.TurnBudgetExhausted _ -> false
+  | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ ->
+    response_text_present
+;;
+
+let budget_exhausted_contract_status ~stop_reason status =
+  match stop_reason, status with
+  | ( Runtime_agent.TurnBudgetExhausted _
+    , Keeper_execution_receipt.Contract_satisfied_execution ) ->
+    Keeper_execution_receipt.Contract_needs_execution_progress
+  | (Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _), _
+  | Runtime_agent.TurnBudgetExhausted _, _ ->
+    status
+;;
+
 let observed_completion_contract_status
       ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
-      ~response_text_present
+      ~stop_reason ~response_text_present
   : Keeper_execution_receipt.completion_contract_result
   =
-  if (not response_text_present) && actual_keeper_tool_names = []
-  then Contract_violated
-  else
-    Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
-      ~had_owned_active_task_at_turn_start
-      ~actual_keeper_tool_names
+  let response_text_present =
+    visible_response_text_present ~stop_reason ~response_text_present
+  in
+  let status =
+    if (not response_text_present) && actual_keeper_tool_names = []
+    then Keeper_execution_receipt.Contract_violated
+    else
+      Keeper_agent_run_turn_helpers.completion_contract_result_for_progress_evidence
+        ~had_owned_active_task_at_turn_start
+        ~actual_keeper_tool_names
+  in
+  budget_exhausted_contract_status ~stop_reason status
 ;;
 
 let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -16,5 +16,6 @@ val progress_keeper_tool_names_for_contract :
 val observed_completion_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
+  stop_reason:Runtime_agent.stop_reason ->
   response_text_present:bool ->
   Keeper_execution_receipt.completion_contract_result

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -301,21 +301,36 @@ type terminal_outcome =
   | Terminal_checkpoint
   | Terminal_failed_completion_contract of { reason_code : string }
 
+let completion_contract_attention_reason_code result =
+  match result with
+  | Keeper_execution_receipt.Contract_passive_only ->
+    (* Passive-only turns are no-progress detector input, not completion-contract
+       auto-failures. *)
+    None
+  | result
+    when Keeper_execution_receipt.completion_contract_result_requires_attention
+           result ->
+    Some (Keeper_execution_receipt.completion_contract_result_to_string result)
+  | _ -> None
+;;
+
 let completion_contract_terminal_failure_reason_code result =
   match result.Keeper_agent_run.operator_disposition with
   | Some
       { disposition = Keeper_execution_receipt.Disp_pause_human
       ; reason = Keeper_execution_receipt.Reason_completion_contract_unsatisfied
       } ->
-    (match result.Keeper_agent_run.completion_contract_result with
-     | Keeper_execution_receipt.Contract_passive_only ->
-       (* A passive-only runtime success is the no-progress detector's input,
-          not a second, shorter completion-contract auto-pause path. Other
-          unsatisfied contract results still mean the runtime violated the
-          execution/completion contract and remain terminal failures. *)
-       None
-     | result ->
-       Some (Keeper_execution_receipt.completion_contract_result_to_string result))
+    completion_contract_attention_reason_code
+      result.Keeper_agent_run.completion_contract_result
+  | Some
+      { disposition = Keeper_execution_receipt.Disp_alert_exhausted
+      ; reason = Keeper_execution_receipt.Reason_turn_budget_exhausted
+      } ->
+    (match result.Keeper_agent_run.stop_reason with
+     | Runtime_agent.TurnBudgetExhausted _ ->
+       completion_contract_attention_reason_code
+         result.Keeper_agent_run.completion_contract_result
+     | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> None)
   | Some _ -> None
   | None ->
     Some

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -4,7 +4,8 @@
     turns whose authoritative receipt/operator disposition is healthy emit
     [Streaming -> Completing -> Done]. Runtime-success turns whose typed
     receipt/operator disposition requires human pause for an unsatisfied
-    completion contract emit
+    completion contract, or whose turn budget is exhausted while the completion
+    contract still requires attention, emit
     [Streaming -> Completing -> Failed completion_contract_violation] instead.
     This function is the single source of truth for those transitions on the
     success path and must be called at most once per turn.

--- a/reports/rondo-tool-only-budget-exhaustion-2026-07-01.md
+++ b/reports/rondo-tool-only-budget-exhaustion-2026-07-01.md
@@ -1,0 +1,73 @@
+# Rondo Tool-Only Budget Exhaustion Report
+
+- `작성일시`: 2026-07-01T19:02:58+09:00
+- `대상`: MASC keeper runtime, `rondo` on `ollama_cloud.deepseek-v4-flash`
+- `GitHub issue`: https://github.com/jeong-sik/masc/issues/22910
+- `상태`: 코드 수정 및 focused regression 통과
+
+## 요약
+
+라이브 `~/me/.masc`에서 `rondo`가 budget-exhausted tool-only turn을 반복했고, 화면에는 `Tool-only turn ended without a final reply.`가 보였다. 문제는 provider가 반복 tool call을 만든 것만이 아니라, MASC success path가 `TurnBudgetExhausted + response_text_present=false + execution-classified tool`을 `satisfied_execution` 및 `Disp_pass`로 받아들일 수 있었다는 점이다.
+
+이번 수정은 두 경계를 고정한다.
+
+1. `TurnBudgetExhausted`에서는 raw text가 있어도 visible reply가 suppressed 되므로 completion contract 판정에서도 visible reply 없음으로 취급한다.
+2. budget-exhausted turn이 completion tool 없이 execution-classified tool만 남기면 `satisfied_execution`이 아니라 `needs_execution_progress`가 된다.
+3. 그렇게 내려온 `alert_exhausted + needs_execution_progress` 결과는 success handler에서 `Terminal_checkpoint`로 세탁되지 않고 completion-contract failure로 종료된다.
+
+## 근거
+
+- `GitHub issue #22910`: live evidence archived. `gh issue view 22910 --repo jeong-sik/masc --json number,title,state,url,createdAt,updatedAt,body`, 확인일시 2026-07-01T19:02:58+09:00, 신뢰도 High.
+- `focused build`: `scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe test/test_no_progress_loop_detector.exe`, 확인일시 2026-07-01T19:11:39+09:00, 신뢰도 High.
+- `regression run`: `_build/default/test/test_keeper_unified_claim_progress.exe` passed 13 tests, 확인일시 2026-07-01T19:11:39+09:00, 신뢰도 High.
+- `regression run`: `_build/default/test/test_no_progress_loop_detector.exe` passed 32 tests, 확인일시 2026-07-01T19:11:39+09:00, 신뢰도 High.
+
+## 변경 내용
+
+- `lib/keeper/keeper_agent_run_contract_helpers.ml`
+  - `observed_completion_contract_status`에 `stop_reason`을 전달한다.
+  - `TurnBudgetExhausted`이면 raw response text를 visible response evidence로 보지 않는다.
+  - `TurnBudgetExhausted + Contract_satisfied_execution`을 `Contract_needs_execution_progress`로 낮춘다.
+  - explicit completion tool은 여전히 `satisfied_completion`으로 인정한다.
+
+- `lib/keeper/keeper_agent_run.ml`
+  - contract helper 호출에 runtime `stop_reason`을 전달한다.
+
+- `lib/keeper/keeper_unified_turn_success.ml`
+  - `Disp_alert_exhausted + Reason_turn_budget_exhausted`가 unsatisfied completion contract를 동반하면 terminal failure reason으로 승격한다.
+  - `Contract_passive_only`는 기존처럼 no-progress detector 입력으로 남기고 completion-contract auto-failure로 승격하지 않는다.
+
+- `test/test_keeper_unified_claim_progress.ml`
+  - `turn_budget_exhausted + tool_execute + no visible reply`가 `satisfied_execution`으로 통과하지 못하는 회귀 테스트를 추가했다.
+  - raw text가 있어도 budget exhaustion으로 visible text가 suppressed 되는 경우를 같이 고정했다.
+  - completion tool은 차단하지 않는 것을 고정했다.
+
+- `test/test_no_progress_loop_detector.ml`
+  - `alert_exhausted + needs_execution_progress + TurnBudgetExhausted`가 `Terminal_checkpoint`/`ContractOk`로 끝나지 않는 것을 고정했다.
+
+## 적대적 검증
+
+- OAS 책임으로만 돌릴 수 있는가: 아니다. OAS가 `stop=tools_executed`를 반복하더라도, MASC가 completion contract와 terminal FSM에서 이를 pass로 바꾸면 MASC boundary 문제다.
+- 모든 budget-exhausted tool turn을 실패시키는가: 아니다. explicit completion tool은 `satisfied_completion`으로 유지된다.
+- passive idle/no-work 경로를 깨는가: 아니다. `Contract_passive_only`는 기존처럼 no-progress detector 경로에 남는다.
+- raw text가 있는 provider 응답이면 안전한가: 아니다. 기존 finalize path는 budget exhaustion에서 visible response를 suppress 하므로, contract도 raw text가 아니라 visible reply semantics를 따라야 한다.
+- `Disp_pass`만 막으면 충분한가: 아니다. terminal success path가 `Terminal_checkpoint`로 `ContractOk`를 낼 수 있어, `alert_exhausted + attention contract`도 terminal failure로 고정했다.
+
+## 검증 결과
+
+```text
+scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe test/test_no_progress_loop_detector.exe
+=> exit 0
+
+_build/default/test/test_keeper_unified_claim_progress.exe
+=> 13 tests run, Test Successful
+
+_build/default/test/test_no_progress_loop_detector.exe
+=> 32 tests run, Test Successful
+```
+
+## 남은 리스크
+
+- 라이브 `~/me/.masc` 런타임에는 아직 이 branch가 배포되지 않았다. 이 보고서는 source-level fix와 focused regression 결과다.
+- material progress identity의 장기 개선은 여전히 필요하다. 이번 패치는 “no visible final reply인데 execution tool만으로 pass 되는” 즉시 루프를 막는 좁은 방어다.
+- `rondo`가 같은 provider에서 다른 형태의 반복을 만들 수 있으므로, 배포 후 live receipts에서 `operator_disposition=pass`가 사라졌는지 재측정해야 한다.

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -155,6 +155,7 @@ let test_empty_no_tool_response_violates_contract () =
     KAR.Contract_helpers.observed_completion_contract_status
       ~had_owned_active_task_at_turn_start:false
       ~actual_keeper_tool_names:[]
+      ~stop_reason:Runtime_agent.Completed
       ~response_text_present
     |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
   in
@@ -168,6 +169,42 @@ let test_empty_no_tool_response_violates_contract () =
     "visible no-tool response remains completion"
     "satisfied_completion"
     (result ~response_text_present:true)
+;;
+
+let test_budget_exhausted_tool_only_execution_does_not_satisfy_contract () =
+  let result ?(response_text_present = false) tools =
+    KAR.Contract_helpers.observed_completion_contract_status
+      ~had_owned_active_task_at_turn_start:false
+      ~actual_keeper_tool_names:tools
+      ~stop_reason:(Runtime_agent.TurnBudgetExhausted { turns_used = 60; limit = 60 })
+      ~response_text_present
+    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
+  in
+  check
+    string
+    "execution tool with no deliverable reply is not satisfied execution"
+    "needs_execution_progress"
+    (result [ "tool_execute" ]);
+  check
+    string
+    "raw text is ignored when the stop reason suppresses visible text"
+    "needs_execution_progress"
+    (result ~response_text_present:true [ "tool_execute" ]);
+  check
+    string
+    "initial claim also cannot satisfy a budget-exhausted empty reply"
+    "needs_execution_progress"
+    (result [ "keeper_task_claim" ]);
+  check
+    string
+    "explicit completion tool remains completion evidence"
+    "satisfied_completion"
+    (result [ "keeper_task_done" ]);
+  check
+    string
+    "empty no-tool budget exhaustion remains a violation"
+    "violated"
+    (result [])
 ;;
 
 let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
@@ -267,6 +304,10 @@ let () =
             "empty no-tool response violates completion contract"
             `Quick
             test_empty_no_tool_response_violates_contract
+        ; test_case
+            "budget-exhausted tool-only execution does not satisfy contract"
+            `Quick
+            test_budget_exhausted_tool_only_execution_does_not_satisfy_contract
         ; test_case
             "contract progress filters no-progress tool results"
             `Quick

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -566,6 +566,7 @@ let run_result
            ; reason = Masc.Keeper_execution_receipt.Reason_healthy
            }
              : Masc.Keeper_agent_result.operator_disposition))
+      ?(stop_reason = Runtime_agent.Completed)
       tool_calls
     : Masc.Keeper_agent_run.run_result
   =
@@ -583,7 +584,7 @@ let run_result
   ; checkpoint = None
   ; trace_ref = None
   ; run_validation = None
-  ; stop_reason = Runtime_agent.Completed
+  ; stop_reason
   ; inference_telemetry = None
   ; tool_surface
   ; pre_dispatch_compacted = false
@@ -732,6 +733,39 @@ let test_completion_contract_terminal_failure_reason_code () =
     true
     (Success.terminal_outcome_is_completed_turn
        (Success.terminal_outcome_of_result failed_passive_only));
+  let budget_exhausted_needs_progress =
+    run_result
+      ~completion_contract_result:
+        Masc.Keeper_execution_receipt.Contract_needs_execution_progress
+      ~operator_disposition:
+        (Some
+           ({ disposition = Masc.Keeper_execution_receipt.Disp_alert_exhausted
+            ; reason = Masc.Keeper_execution_receipt.Reason_turn_budget_exhausted
+            }
+              : Masc.Keeper_agent_result.operator_disposition))
+      ~stop_reason:(Runtime_agent.TurnBudgetExhausted { turns_used = 60; limit = 60 })
+      [ tool_call "tool_execute" ]
+  in
+  Alcotest.(check string)
+    "budget-exhausted contract attention is terminally visible"
+    "needs_execution_progress"
+    (Option.value
+       ~default:""
+       (Success.completion_contract_terminal_failure_reason_code
+          budget_exhausted_needs_progress));
+  (match Success.terminal_outcome_of_result budget_exhausted_needs_progress with
+   | Success.Terminal_failed_completion_contract { reason_code } ->
+     Alcotest.(check string)
+       "budget-exhausted unsatisfied contract cannot become ContractOk"
+       "needs_execution_progress"
+       reason_code
+   | Success.Terminal_done | Success.Terminal_checkpoint ->
+     Alcotest.fail "expected budget-exhausted unsatisfied contract failure");
+  Alcotest.(check bool)
+    "budget-exhausted unsatisfied contract is not a completed turn"
+    false
+    (Success.terminal_outcome_is_completed_turn
+       (Success.terminal_outcome_of_result budget_exhausted_needs_progress));
   let needs_execution_progress =
     run_result
       ~completion_contract_result:


### PR DESCRIPTION
## Summary

Fixes #22910.

This tightens the keeper completion-contract boundary for `TurnBudgetExhausted` tool-only turns:

- treats budget-exhausted raw response text as non-visible reply evidence, matching the response finalization path
- downgrades budget-exhausted `satisfied_execution` to `needs_execution_progress` unless explicit completion evidence is present
- prevents `alert_exhausted + needs_execution_progress` from being surfaced as a successful checkpoint / `ContractOk`
- adds an incident report with live evidence and adversarial validation notes

## Root Cause

The runtime could exhaust the turn budget after repeated tool calls with no final visible reply. MASC then classified execution-classified tools as `satisfied_execution`, allowing `Disp_pass` and later `ContractOk` even though the operator-visible turn ended without a final reply.

## Validation

- `scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe test/test_no_progress_loop_detector.exe`
- `_build/default/test/test_keeper_unified_claim_progress.exe` — 13 tests passed
- `_build/default/test/test_no_progress_loop_detector.exe` — 32 tests passed
- `git diff --check`

## Notes

This is a narrow source-level fix and regression coverage. It does not restart or mutate the live `~/me/.masc` runtime; after deployment, receipts should be remeasured for `turn_budget_exhausted + response_text_present=false + operator_disposition=pass`.