### PR TITLE
fix(test): align OAS reasoning projection expectations

### DIFF
--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -659,10 +659,9 @@ let provider_kind_label (call : Agent_sdk.Canonical_tool.provider_tool_call) =
   Option.map Llm_provider.Provider_config.string_of_provider_kind
     call.provider_kind
 
-let check_visible_reasoning label expected_order expected_content expected_signature
+let check_visible_reasoning label expected_order expected_signature
     (block : Agent_sdk.Canonical_tool.provider_reasoning_block) =
   check int (label ^ " order") expected_order block.order_index;
-  check string (label ^ " content") expected_content block.content;
   check (option string) (label ^ " signature") expected_signature
     block.signature;
   match block.kind with
@@ -670,10 +669,9 @@ let check_visible_reasoning label expected_order expected_content expected_signa
   | Agent_sdk.Canonical_tool.Redacted_thinking ->
       fail (label ^ " expected visible thinking")
 
-let check_redacted_reasoning label expected_order expected_content
+let check_redacted_reasoning label expected_order
     (block : Agent_sdk.Canonical_tool.provider_reasoning_block) =
   check int (label ^ " order") expected_order block.order_index;
-  check string (label ^ " content") expected_content block.content;
   check (option string) (label ^ " signature") None block.signature;
   match block.kind with
   | Agent_sdk.Canonical_tool.Redacted_thinking -> ()
@@ -790,8 +788,8 @@ let test_oas_tool_call_projection_preserves_adjacent_reasoning_groups () =
         (provider_kind_label first);
       (match first.adjacent_reasoning with
       | Agent_sdk.Canonical_tool.Adjacent_reasoning [ r0; r1 ] ->
-          check_visible_reasoning "first reasoning 0" 0 "think 1.1" None r0;
-          check_redacted_reasoning "first reasoning 1" 1 "sealed 1.2" r1
+          check_visible_reasoning "first reasoning 0" 0 None r0;
+          check_redacted_reasoning "first reasoning 1" 1 r1
       | _ -> fail "first tool call should carry contiguous adjacent reasoning");
       check string "second call id" "tc-2" second.call_id;
       check int "second order" 6 second.order_index;
@@ -803,8 +801,7 @@ let test_oas_tool_call_projection_preserves_adjacent_reasoning_groups () =
       check int "third order" 8 third.order_index;
       (match third.adjacent_reasoning with
       | Agent_sdk.Canonical_tool.Adjacent_reasoning [ r0 ] ->
-          check_visible_reasoning "third reasoning" 7 "think 2.1"
-            (Some "sig-2.1") r0
+          check_visible_reasoning "third reasoning" 7 (Some "sig-2.1") r0
       | _ -> fail "third tool call should carry only its adjacent thinking")
   | _ ->
       failf "expected three projected tool calls, got %d" (List.length calls)
@@ -900,14 +897,14 @@ let test_oas_interleaving_matches_masc_receipt_and_progress_facts () =
       (match first.adjacent_reasoning with
        | Agent_sdk.Canonical_tool.Adjacent_reasoning [ r ] ->
            check_visible_reasoning "first adjacent thinking" 0
-             "inspect board first" (Some "sig-read") r
+             (Some "sig-read") r
        | _ -> fail "first call should carry preceding thinking");
       check string "second canonical call" "keeper_task_done" second.name;
       check int "second canonical order" 3 second.order_index;
       (match second.adjacent_reasoning with
        | Agent_sdk.Canonical_tool.Adjacent_reasoning [ r ] ->
            check_visible_reasoning "second adjacent thinking" 2
-             "complete after evidence" (Some "sig-done") r
+             (Some "sig-done") r
        | _ -> fail "second call should carry preceding thinking");
       let receipt_details = List.map receipt_detail_of_provider_call calls in
       check (list string) "MASC receipt detail order matches OAS canonical order"


### PR DESCRIPTION
## Summary
- update MASC test expectations for OAS provider reasoning projections after the agent_sdk v0.208.10 pin
- stop reading raw reasoning text from provider_reasoning_block; the projection exposes order/kind/signature metadata only
- keep raw reasoning content validation on stream/content-block paths rather than the provider tool-call projection

## Evidence
- CI failure source: Health job on #22921 failed at test/test_gate_keeper_backend.ml:665 because provider_reasoning_block no longer has a content field
- OAS SSOT: Agent_sdk.Canonical_tool.provider_reasoning_block intentionally exposes metadata only; raw provider reasoning payload replay uses Types.content_block directly

## Local checks
- opam exec -- ocamlformat --check test/test_gate_keeper_backend.ml
- git diff --check

## Not run
- focused Dune build: scripts/dune-local.sh refused to start because existing bare dune processes are active on this machine
