### PR TITLE
[codex] Surface notify config load failures

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -623,6 +623,25 @@ describe('SettingsSurface', () => {
     expect(sessionStorage.getItem('masc.settings.local.notifyChannel')).toBeNull()
   })
 
+  it('notify page surfaces config projection failures instead of rendering missing thresholds', async () => {
+    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config projection offline'))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-notify"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="notify-config-error"]')?.textContent)
+        .toContain('config projection offline')
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent)
+        .toContain('config unavailable')
+    })
+
+    expect(container.querySelector('[data-testid="notify-thresholds"]')).toBeNull()
+    expect(container.textContent).not.toContain('MASC_DASHBOARD_CTX_PREPARING')
+    expect(container.querySelector('[data-testid="notify-routing-readonly"]')).toBeNull()
+  })
+
   it('renders runtime settings as a live-backed entry point instead of fake local controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -526,20 +526,24 @@ export function SettingsSurface() {
   // Server config projection — used by Paths, MCP and Notifications.
   const [dashboardConfig, setDashboardConfig] = useState<DashboardConfigResponse | null>(null)
   const [dashboardConfigStatus, setDashboardConfigStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [dashboardConfigError, setDashboardConfigError] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
     setDashboardConfigStatus('loading')
+    setDashboardConfigError(null)
     void (async () => {
       try {
         const resp = await fetchDashboardConfig()
         if (!active) return
         setDashboardConfig(resp)
         setDashboardConfigStatus('ready')
-      } catch {
+        setDashboardConfigError(null)
+      } catch (err) {
         if (!active) return
         setDashboardConfig(null)
         setDashboardConfigStatus('error')
+        setDashboardConfigError(err instanceof Error ? err.message : String(err))
       }
     })()
     return () => { active = false }
@@ -640,7 +644,13 @@ export function SettingsSurface() {
     }
   }
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
-  const sectionState = settingsSectionState(sec, fusionSettingsWritable)
+  const baseSectionState = settingsSectionState(sec, fusionSettingsWritable)
+  const sectionState =
+    sec === 'notify' && dashboardConfigStatus === 'loading'
+      ? { mode: 'mixed' as const, label: 'thresholds loading' }
+      : sec === 'notify' && dashboardConfigStatus === 'error'
+        ? { mode: 'mixed' as const, label: 'config unavailable' }
+        : baseSectionState
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -950,30 +960,42 @@ export function SettingsSurface() {
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
                 알림 임계값은 현재 서버 config projection에서 읽습니다. 이 화면은 아직 알림 라우팅 writer를 노출하지 않으므로 브라우저-only 토글을 만들지 않습니다.
               </div>
-              <div class="set-sub-h">Live alert thresholds</div>
-              <${ThresholdTruthRow}
-                label="Preparing context"
-                entry=${ctxPreparingEntry}
-                value=${formatThresholdPercent(configEntryDisplayValue(ctxPreparingEntry))}
-              />
-              <${ThresholdTruthRow}
-                label="Handoff imminent"
-                entry=${ctxHandoffEntry}
-                value=${formatThresholdPercent(configEntryDisplayValue(ctxHandoffEntry))}
-              />
-              <${ThresholdTruthRow}
-                label="Runtime warning"
-                entry=${runtimeWarningEntry}
-                value=${formatThresholdPercent(configEntryDisplayValue(runtimeWarningEntry))}
-              />
-              <${ConfigTruthRow} label="Signal stale seconds" entry=${signalStaleEntry} />
-              <${ConfigTruthRow} label="Alert dedup window" entry=${alertDedupEntry} />
-              <${SetRow} label="Notification routing" hint="No dashboard writer is exposed for alert channels or event toggles yet">
-                <div class="set-truth-value" data-testid="notify-routing-readonly">
-                  <span class="mono">read-only</span>
-                  <span class="set-truth-source">no writer</span>
-                </div>
-              <//>
+              ${dashboardConfigStatus === 'loading'
+                ? html`<div class="set-hint" data-testid="notify-config-loading">알림 임계값을 불러오는 중...</div>`
+                : dashboardConfigStatus === 'error'
+                  ? html`
+                    <div class="set-hint" data-testid="notify-config-error">
+                      dashboard config projection을 불러오지 못했습니다${dashboardConfigError ? `: ${dashboardConfigError}` : ''}.
+                    </div>
+                  `
+                  : html`
+                    <div data-testid="notify-thresholds">
+                      <div class="set-sub-h">Live alert thresholds</div>
+                      <${ThresholdTruthRow}
+                        label="Preparing context"
+                        entry=${ctxPreparingEntry}
+                        value=${formatThresholdPercent(configEntryDisplayValue(ctxPreparingEntry))}
+                      />
+                      <${ThresholdTruthRow}
+                        label="Handoff imminent"
+                        entry=${ctxHandoffEntry}
+                        value=${formatThresholdPercent(configEntryDisplayValue(ctxHandoffEntry))}
+                      />
+                      <${ThresholdTruthRow}
+                        label="Runtime warning"
+                        entry=${runtimeWarningEntry}
+                        value=${formatThresholdPercent(configEntryDisplayValue(runtimeWarningEntry))}
+                      />
+                      <${ConfigTruthRow} label="Signal stale seconds" entry=${signalStaleEntry} />
+                      <${ConfigTruthRow} label="Alert dedup window" entry=${alertDedupEntry} />
+                      <${SetRow} label="Notification routing" hint="No dashboard writer is exposed for alert channels or event toggles yet">
+                        <div class="set-truth-value" data-testid="notify-routing-readonly">
+                          <span class="mono">read-only</span>
+                          <span class="set-truth-source">no writer</span>
+                        </div>
+                      <//>
+                    </div>
+                  `}
             `}
 
             ${sec === 'display' && html`


### PR DESCRIPTION
## Summary
- Make Settings > Notify stop rendering fake `missing` threshold rows while the dashboard config projection is still loading or has failed.
- Show an explicit loading state, an explicit config error state, and change the section badge to `config unavailable` when `/api/v1/dashboard/config` fails.

## User impact
Operators can now tell the alert thresholds are unavailable instead of mistaking missing rows for real live config values.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1` (33 passed)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/settings-surface.ts src/components/settings-surface.test.ts` (0 errors; test file ignored by current eslint config)
- `git diff --check origin/main...HEAD`
- Python Playwright smoke: `#settings?section=notify` with `/api/v1/dashboard/config` mocked as 503; verified `notify-config-error` visible and `notify-thresholds`/`notify-routing-readonly` absent.
- Screenshot: `/private/tmp/masc-settings-notify-config-error.png`

Browser plugin was not available in this session, so rendered validation used regular Playwright via Python.