### PR TITLE
fix(keeper): keep passive reads out of watchdog progress

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -214,6 +214,16 @@ include Keeper_hooks_oas_cost_events
 
 include Keeper_hooks_oas_idle
 
+(* Passive observations are receipt evidence, not semantic watchdog progress.
+   Active tool execution is tracked separately by the in-flight tool state. *)
+let tool_completion_records_watchdog_progress tool_name =
+  match Keeper_tool_progress.classify_tool_progress tool_name with
+  | Keeper_tool_progress.Passive_status -> false
+  | Keeper_tool_progress.Claim_context
+  | Keeper_tool_progress.Execution
+  | Keeper_tool_progress.Completion ->
+    true
+
 let make_hooks
     ~(config : Workspace.config)
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
@@ -522,7 +532,8 @@ let make_hooks
       match event with
       | Agent_sdk.Hooks.PostToolUse
           { tool_name; input; output; duration_ms = hook_duration_ms; tool_use_id; _ } ->
-        record_progress ("tool_completed:" ^ tool_name);
+        if tool_completion_records_watchdog_progress tool_name then
+          record_progress ("tool_completed:" ^ tool_name);
         incr tool_call_count_ref;
         (* Extract typed_outcome from structured tool output JSON and strip it
            from the LLM-facing output so the internal metadata does not leak
@@ -901,4 +912,6 @@ let hook_introspection_json
 module For_testing = struct
   let tool_input_shape_for_log = tool_input_shape_for_log
   let tool_input_keys_for_log = tool_input_keys_for_log
+  let tool_completion_records_watchdog_progress =
+    tool_completion_records_watchdog_progress
 end

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -198,4 +198,5 @@ val hook_introspection_json :
 module For_testing : sig
   val tool_input_shape_for_log : Yojson.Safe.t -> string
   val tool_input_keys_for_log : Yojson.Safe.t -> string
+  val tool_completion_records_watchdog_progress : string -> bool
 end

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -21,6 +21,38 @@ let test_tool_arg_shapes_keep_field_names () =
   check string "keys preserve input order" "argv,cwd,executable"
     (Under_test.tool_input_keys_for_log input)
 
+let keeper_tool_name name = Keeper_tool_name.to_string name
+
+let check_watchdog_completion_progress name expected =
+  check bool name expected
+    (Under_test.tool_completion_records_watchdog_progress name)
+
+let test_tool_completion_watchdog_progress_policy () =
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Tasks_list)
+    false;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Board_list)
+    false;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Board_post_get)
+    false;
+  List.iter
+    (fun tool_name -> check_watchdog_completion_progress tool_name false)
+    Keeper_tool_capability_axis.polling_read_tool_names;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Task_claim)
+    true;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Task_done)
+    true;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Board_comment)
+    true;
+  check_watchdog_completion_progress
+    (keeper_tool_name Keeper_tool_name.Execute)
+    true
+
 (* F2 canonical projection consumption: block counting in
    [summarize_thinking_blocks] is delegated to OAS [Response_shape.summarize_blocks];
    MASC keeps the policy shaping (thinking_present + thinking_kind classifier).
@@ -77,6 +109,8 @@ let () =
             test_empty_tool_args_are_explicit_object_shape
         ; test_case "field shapes are explicit" `Quick
             test_tool_arg_shapes_keep_field_names
+        ; test_case "watchdog progress ignores passive reads" `Quick
+            test_tool_completion_watchdog_progress_policy
         ] )
     ; ( "thinking-summary-classifier"
       , [ test_case "empty -> none" `Quick test_thinking_summary_none_empty


### PR DESCRIPTION
## Summary
- Stop counting passive read-only tool completions as keeper watchdog progress.
- Keep active execution/progress classes wired through `Keeper_tool_progress.classify_tool_progress` instead of tool-name string matching.
- Add regression coverage for passive polling reads and active tools.

## Why
Live Albini traces still show repeated passive observation turns after the OAS reasoning projection fix. The post-turn no-progress detector already sees passive-only/no-visible-output turns, but `post_tool_use` refreshed the in-turn watchdog clock for every completed tool. That conflated receipt evidence with semantic progress and can keep passive read loops alive longer than intended.

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_hooks_oas.ml lib/keeper/keeper_hooks_oas.mli test/test_keeper_hooks_oas_log_shape.ml`
- `git diff --check origin/main...HEAD`
- `./scripts/check-oas-pin.sh --local-only` confirms repo pin manifests match v0.208.10, but local installed `agent_sdk` is 0.208.7.
- Focused Dune build reached compilation after the local lock cleared, then failed on local CMI drift (`Llm_provider__Secret`) from the stale installed `agent_sdk`; CI is the build authority for this PR.