### PR TITLE
[codex] Preserve unbounded turn budget on resume

### DIFF
--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -387,7 +387,9 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   : prepared_resume
   =
 
-  let max_turns_for_resume = checkpoint.turn_count + config.max_turns in
+  let max_turns_for_resume =
+    if config.max_turns = 0 then 0 else checkpoint.turn_count + config.max_turns
+  in
   let patched_checkpoint =
     { checkpoint with
       Agent_sdk.Checkpoint.model = config.model_id

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -143,9 +143,9 @@ type prepared_resume = {
 }
 (** Output of {!prepare_resume}.  [patched_checkpoint] has
     runtime identity fields adjusted, and [agent_config.max_turns]
-    is extended past the checkpoint [turn_count] so resume picks
-    up where the previous run left off without re-counting
-    consumed turns. *)
+    preserves [0] as unbounded; otherwise it is extended past the checkpoint
+    [turn_count] so resume picks up where the previous run left off without
+    re-counting consumed turns. *)
 
 val set_oas_tracer : Agent_sdk.Tracing.t -> unit
 (** Set the OAS tracer used by {!builder_without_approval}.  Called once
@@ -157,6 +157,7 @@ val prepare_resume :
 (** [prepare_resume ~config ~checkpoint] computes the patched
     checkpoint + agent_config + options for an
     [Agent.resume] call.  Pure — no side effects.  The patched
-    agent config extends [config.max_turns] beyond the consumed
-    [checkpoint.turn_count] so the resumed run gets a fresh
-    turn budget instead of inheriting the exhausted one. *)
+    agent config preserves [config.max_turns = 0] as unbounded; otherwise it
+    extends [config.max_turns] beyond the consumed [checkpoint.turn_count] so
+    the resumed run gets a fresh turn budget instead of inheriting the
+    exhausted one. *)

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -958,6 +958,46 @@ let test_runtime_agent_context_uses_configured_turn_budget () =
   check int "resume adds fresh per-call turn budget" 31
     prepared.agent_config.max_turns
 
+let test_runtime_agent_context_preserves_unbounded_resume_budget () =
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg:(provider_cfg ())
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let config = { config with max_turns = 0 } in
+  let checkpoint =
+    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
+    ; session_id = "session"
+    ; agent_name = "oas-runpod_mtp.qwen"
+    ; model = "qwen"
+    ; system_prompt = Some ""
+    ; messages = []
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count = 24
+    ; created_at = 0.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = Some 0.3
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.default_config.response_format
+    ; thinking_budget = None
+    ; cache_system_prompt = false
+    ; context = Agent_sdk.Context.create ~eio:false ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+  in
+  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
+  check int "resume preserves unbounded turn budget" 0
+    prepared.agent_config.max_turns
+
 let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
   let tool =
     Agent_sdk.Tool.create
@@ -1169,6 +1209,10 @@ let () =
             "runtime agent context uses configured turn budget"
             `Quick
             test_runtime_agent_context_uses_configured_turn_budget
+        ; test_case
+            "runtime agent context preserves unbounded resume budget"
+            `Quick
+            test_runtime_agent_context_preserves_unbounded_resume_budget
         ; test_case
             "runtime agent context leaves tool_choice unset with tools"
             `Quick


### PR DESCRIPTION
## Summary

Preserves OAS `max_turns = 0` as an unbounded turn budget when MASC resumes an agent from a checkpoint.

- Keeps finite resume behavior unchanged: positive `config.max_turns` still becomes `checkpoint.turn_count + config.max_turns`.
- Adds an explicit unbounded branch: `config.max_turns = 0` stays `0` instead of becoming `checkpoint.turn_count`.
- Updates the `Runtime_agent_context.prepare_resume` interface docs.
- Adds a regression test for the unbounded resume case.

## Root Cause

OAS PR #2417 makes `max_turns = 0` mean "no turn-count limit." MASC resume preparation previously always computed:

```ocaml
checkpoint.turn_count + config.max_turns
```

That is correct for finite per-call budgets, but would convert `0` into a finite cap equal to the already-consumed checkpoint turn count.

## Dependency

This is the MASC compatibility patch for https://github.com/jeong-sik/oas/pull/2417.

The live default only becomes unbounded after MASC consumes an agent_sdk release/pin that contains OAS PR #2417. This PR prevents the MASC resume path from breaking that sentinel once the pin is updated.

## Validation

- `git diff --check`

Per operator direction, Dune build/test validation is delegated to CI.
