### PR TITLE
fix: block non-materializable runtime provider bindings

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
+  isRuntimeTomlNonMaterializableProtocol,
   isReservedRuntimeTomlId,
   isValidRuntimeTomlIdFormat,
   parseRuntimeTomlEnvironment,
@@ -352,17 +353,24 @@ export function RuntimeEnvironmentEditor({
       setBindingFormError(`"${bindingProviderId}"는 예약된 이름이라 바인딩 provider로 쓸 수 없습니다`)
       return
     }
-    // Same non-materializable-provider trap as the add-provider form (see
-    // RUNTIME_TOML_CREATABLE_PROTOCOLS): a `command` transport provider always
-    // resolves to no provider_kind on the backend, so materialize_config's
-    // filter_map silently drops any binding pinned to it from the live runtime
-    // list. The add-provider form can no longer create one, but this dropdown
-    // lists every parsed provider, including a `command` one that already
-    // exists via raw TOML / legacy config.
+    // A `command` transport provider always resolves to no provider_kind on the
+    // backend, so materialize_config's filter_map silently drops any binding
+    // pinned to it from the live runtime list. The add-provider form can no
+    // longer create one, but this dropdown lists every parsed provider,
+    // including a `command` one that already exists via raw TOML / legacy config.
     const selectedProvider = environment.providers.find(p => p.id === bindingProviderId)
     if (selectedProvider?.transportKind === 'command') {
       setBindingFormError(
         `"${bindingProviderId}"는 command(CLI) transport라 바인딩을 생성할 수 없습니다 (백엔드가 아직 CLI provider를 라우팅하지 못합니다)`,
+      )
+      return
+    }
+    // Protocol-only non-materialization is limited to Messages_api. Other
+    // protocols, including openai-compatible-cli, are valid when the provider
+    // uses endpoint/HTTP transport.
+    if (selectedProvider && isRuntimeTomlNonMaterializableProtocol(selectedProvider.protocol)) {
+      setBindingFormError(
+        `"${bindingProviderId}"는 ${selectedProvider.protocol} protocol이라 바인딩을 생성할 수 없습니다 (백엔드가 아직 이 provider를 라우팅하지 못합니다)`,
       )
       return
     }

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -719,7 +719,7 @@ describe('RuntimeTomlEditor', () => {
     })
   })
 
-  it('does not offer CLI protocols or command transport in the add-provider form', async () => {
+  it('does not offer messages protocols or command transport in the add-provider form', async () => {
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
     render(html`<${RuntimeTomlEditor} />`, container)
 
@@ -732,8 +732,8 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'messages-http'])
-    expect(protocolOptions).not.toContain('openai-compatible-cli')
+    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'openai-compatible-cli'])
+    expect(protocolOptions).not.toContain('messages-http')
     expect(protocolOptions).not.toContain('messages-cli')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
@@ -891,6 +891,47 @@ command = "provider-runtime --serve"
     await waitFor(() => {
       expect(container.querySelector('[data-testid="runtime-add-binding-error"]')?.textContent).toContain(
         'command(CLI)',
+      )
+    })
+    const sourceAfter = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+    expect(sourceAfter).toBe(sourceBefore)
+  })
+
+  it('rejects a binding to an existing non-materializable messages-http provider', async () => {
+    // Legacy/hand-edited data: messages-http providers parse and can be rendered
+    // in the structured binding dropdown, but Runtime_adapter currently returns
+    // no Provider_config for Messages_api, so materialize_config would silently
+    // drop a binding pinned to one.
+    const configWithMessagesProvider = {
+      ...richConfig,
+      source_text: `${richConfig.source_text}
+[providers.messages_api]
+display-name = "Messages API"
+protocol = "messages-http"
+endpoint = "https://messages.example/v1"
+`,
+    }
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(configWithMessagesProvider)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-bindings"]')).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-bindings"]') as HTMLButtonElement)
+
+    const sourceBefore = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
+
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-provider"]') as HTMLSelectElement, {
+      target: { value: 'messages_api' },
+    })
+    fireEvent.change(container.querySelector('[data-testid="runtime-add-binding-model"]') as HTMLSelectElement, {
+      target: { value: 'gpt' },
+    })
+    fireEvent.click(container.querySelector('[data-testid="runtime-add-binding-submit"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-add-binding-error"]')?.textContent).toContain(
+        'messages-http',
       )
     })
     const sourceAfter = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -601,21 +601,35 @@ export const RUNTIME_TOML_PROTOCOLS = [
 export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 
 // Subset of RUNTIME_TOML_PROTOCOLS the add-provider form is allowed to offer.
-// `Runtime_adapter.provider_kind_of_cli_provider` is hardcoded to `None` (CLI
-// subprocess provider kinds were removed), so any provider using `Cli`
-// transport (the `command` field) resolves to no provider_kind and
-// `Runtime.materialize_config`'s `List.filter_map` silently drops its
-// bindings from the live runtime list instead of failing the save
-// (lib/runtime/runtime_adapter.ml:183-189, lib/runtime/runtime.ml:239). The
-// *-cli protocol labels parse fine but pair naturally with `command`
-// transport, so they are excluded here too until CLI materialization is
-// restored. This is an allow-list, not a filter-out of known-bad entries, so
-// a future 6th protocol defaults to non-creatable until reviewed.
+// The add-provider form only creates endpoint-backed providers. Command
+// transport is blocked at the binding form via transportKind, while
+// `provider_kind_for_http_provider` still returns `None` for `Messages_api`.
+// Messages providers parse and save, but resolve to no provider_kind and
+// `Runtime.materialize_config`'s `List.filter_map` silently drops their bindings
+// from the live runtime list instead of failing the save
+// (lib/runtime/runtime_adapter.ml:183-203, lib/runtime/runtime.ml:239).
+// This is an allow-list of materializable endpoint protocols, so a future 6th
+// protocol defaults to non-creatable until reviewed.
 export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
-  'messages-http',
+  'openai-compatible-cli',
 ] as const
+
+export type RuntimeTomlCreatableProtocol = (typeof RUNTIME_TOML_CREATABLE_PROTOCOLS)[number]
+
+export function isRuntimeTomlCreatableProtocol(protocol: string): protocol is RuntimeTomlCreatableProtocol {
+  return (RUNTIME_TOML_CREATABLE_PROTOCOLS as readonly string[]).includes(protocol)
+}
+
+const RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS = new Set([
+  'messages-http',
+  'messages-cli',
+])
+
+export function isRuntimeTomlNonMaterializableProtocol(protocol: string): boolean {
+  return RUNTIME_TOML_NON_MATERIALIZABLE_PROTOCOLS.has(protocol)
+}
 
 // runtime.toml ids become TOML table headers ([providers.<id>], [models.<id>],
 // and the binding pin [<providerId>.<modelId>]). parseDocument's section regex


### PR DESCRIPTION
Follow-up for #22875 review feedback. The merged PR already fixed the ID pattern mismatch, but messages-http was still offered as a creatable/bindable provider even though the backend cannot materialize Messages_api providers into a Provider_config. This removes non-materializable protocols from the creatable protocol list and rejects bindings to existing non-materializable providers. Verification: pnpm --dir dashboard typecheck; pnpm --dir dashboard lint; pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-toml-editor.test.ts src/lib/runtime-toml-config.test.ts --no-file-parallelism --maxWorkers=1.