### PR TITLE
fix(dashboard): drop messages-http from creatable protocols (follow-up #22875)

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -732,9 +732,13 @@ describe('RuntimeTomlEditor', () => {
     const protocolOptions = Array.from(
       container.querySelectorAll('[aria-label="새 provider protocol"] option'),
     ).map(option => (option as HTMLOptionElement).value)
-    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http', 'messages-http'])
+    expect(protocolOptions).toEqual(['openai-compatible-http', 'ollama-http'])
     expect(protocolOptions).not.toContain('openai-compatible-cli')
     expect(protocolOptions).not.toContain('messages-cli')
+    // messages-http maps to Messages_api, which provider_kind_for_http_provider
+    // resolves to None, so a created binding would be silently dropped by
+    // materialize_config. It must not be offered by the add-provider form.
+    expect(protocolOptions).not.toContain('messages-http')
     // No transport-kind selector left to switch to 'command'.
     expect(container.querySelector('[aria-label="새 provider transport 종류"]')).toBeNull()
   })

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -609,12 +609,20 @@ export type RuntimeTomlProtocol = (typeof RUNTIME_TOML_PROTOCOLS)[number]
 // (lib/runtime/runtime_adapter.ml:183-189, lib/runtime/runtime.ml:239). The
 // *-cli protocol labels parse fine but pair naturally with `command`
 // transport, so they are excluded here too until CLI materialization is
-// restored. This is an allow-list, not a filter-out of known-bad entries, so
-// a future 6th protocol defaults to non-creatable until reviewed.
+// restored. `messages-http` is excluded for the same reason: it maps to
+// `Messages_api`, and `Runtime_adapter.provider_kind_for_http_provider`
+// returns `None` for `Messages_api` (the runtime dispatches only via Ollama /
+// OpenAI-compat transports; there is no Messages-API runtime provider_kind),
+// so a `messages-http` provider created through this form would save but then
+// be silently dropped by the same `Runtime.materialize_config` `List.filter_map`
+// and never appear in the live runtime list. It stays in RUNTIME_TOML_PROTOCOLS
+// (hand-edited configs still parse) but is not offered for creation until
+// Messages_api materialization exists. This is an allow-list, not a filter-out
+// of known-bad entries, so a future protocol defaults to non-creatable until
+// reviewed.
 export const RUNTIME_TOML_CREATABLE_PROTOCOLS = [
   'openai-compatible-http',
   'ollama-http',
-  'messages-http',
 ] as const
 
 // runtime.toml ids become TOML table headers ([providers.<id>], [models.<id>],


### PR DESCRIPTION
## 목적

#22875에서 머지된 provider 생성 폼의 **create-then-vanish silent-drop (P1)** 을 근본 수정한다.

`messages-http` 프로토콜은 `RUNTIME_TOML_CREATABLE_PROTOCOLS`(폼 생성 허용 집합)에 포함돼 있으나, 백엔드에서 materialize되지 않는다:

- `lib/runtime/runtime_adapter.ml` `provider_kind_for_http_provider`: `| Messages_api -> None`
- 그 결과 `binding_to_provider_config`가 `Error`를 반환하고, `lib/runtime/runtime.ml` `of_binding`이 이를 `None`으로 흡수 → `materialize_config`의 `List.filter_map`이 조용히 드롭.

즉 사용자가 폼으로 `messages-http` provider를 만들면 저장은 성공하나 **런타임 목록에 절대 나타나지 않는다** (product-boundary silent failure).

## 변경

- `RUNTIME_TOML_CREATABLE_PROTOCOLS`에서 `messages-http` 제거. `messages-http`는 `RUNTIME_TOML_PROTOCOLS`(파싱 집합)에는 유지 → hand-edit된 TOML은 계속 파싱됨.
- 제외 사유를 기존 `*-cli` 제외 주석과 병렬로 명시(백엔드 `provider_kind_for_http_provider` → `None` 인용).
- 폼 드롭다운(`runtime-environment-editor.ts:628`)은 상수를 map하므로 자동 반영.
- 테스트 `runtime-toml-editor.test.ts`: 프로토콜 옵션 기대값을 `['openai-compatible-http', 'ollama-http']`로 수정 + `not.toContain('messages-http')` regression 가드 추가.

이는 **Parse, don't validate** 적용이다: materialize 불가한 protocol을 애초에 생성 불가로 만든다. 기존 `*-cli` 제외와 동일한 allow-list 규칙을 `messages-http`에 적용한다.

## 심각도

- **P0**: 없음 (빌드/main 차단 아님).
- **P1 (해소)**: 폼 생성 경로의 create-then-vanish silent-drop.
  - 개선점: 생성 허용 집합을 백엔드 materializable 집합과 정렬.
  - 남은점: **hand-edit된 `messages-http` provider에 대한 binding 생성 경로는 이 PR 범위 밖.** `command`-transport(CLI) provider는 이미 binding 거부 테스트가 있으나, `messages-http`는 endpoint transport라 그 가드에 걸리지 않는다. 후속으로 binding 생성 시 api_format materializability 검사를 추가하면 hand-edit 케이스까지 닫힌다.
- **P2**: SSOT — 현재 creatable/materializable 정렬은 hand-maintained allow-list + 주석. 완전한 컴파일타임 SSOT(백엔드 materializer에서 파생)는 codegen이 필요해 별도 과제.
- **P3**: 없음.

## 병합 가능성

CI(dashboard test) green 시 병합 가능. 로컬 빌드는 미실행 — CI가 build authority.

## 검증

- 로컬 빌드/테스트는 실행하지 않음(프로젝트 정책: CI에서 확인).
- 추가된 `not.toContain('messages-http')`가 회귀 가드.

Follow-up to #22875.

RFC-WAIVED: dashboard runtime-toml 폼 allow-list 정렬 — credential/identity/operator subsystem 미해당(RFC 게이트 대상 아님).

WORKAROUND-WAIVED: root fix — creatable allow-list를 백엔드 materializable 집합과 정렬(엔트리 제거). 새 분류기/카운터/catch-all/우회 추가 없음. 시그니처 키워드 false positive.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
