### PR TITLE
[codex] Surface unavailable path resolution in settings

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -603,6 +603,45 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="settings-worktree-base-input"]')).toBeNull()
   })
 
+  it('paths page does not fabricate unknown rows when path resolution is unavailable', async () => {
+    shellRuntimeResolution.value = null
+    shellConfigResolution.value = null
+    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config unavailable'))
+    stubRuntimeDefaults(makeRuntimeDefaults({ config_path: null }))
+    apiMock.fetchRuntimeProviders.mockResolvedValueOnce(makeRuntimeProviders({ config_path: null }))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('path resolution unavailable')
+      expect(container.querySelector('[data-testid="settings-path-resolution-error"]')?.textContent).toContain('추정값으로 표시하지 않습니다')
+    })
+    expect(container.textContent).not.toContain('미수집')
+    expect(container.textContent).not.toContain('Runtime path resolution')
+    expect(container.textContent).not.toContain('Config env inputs')
+  })
+
+  it('paths page labels provider-only path data as partial resolution', async () => {
+    shellRuntimeResolution.value = null
+    shellConfigResolution.value = null
+    apiMock.fetchDashboardConfig.mockRejectedValueOnce(new Error('config unavailable'))
+
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-paths"]') as HTMLElement)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('partial path resolution')
+      expect(container.querySelector('[data-testid="settings-runtime-path-resolution-missing"]')?.textContent).toContain('확인 가능한 값만 표시합니다')
+      expect(container.textContent).toContain('/cfg/runtime.toml')
+    })
+    expect(container.querySelector('[data-testid="settings-config-error"]')?.textContent).toContain('dashboard config projection')
+    expect(container.textContent).not.toContain('MASC_BASE_PATH')
+    expect(container.textContent).not.toContain('미수집')
+  })
+
   it('notify page shows live thresholds without fake local routing controls', async () => {
     render(html`<${SettingsSurface} />`, container)
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -381,10 +381,12 @@ function PathTruthRow({
 }
 
 type SettingsSectionMode = 'live' | 'mixed' | 'local'
+type PathResolutionAvailability = 'ready' | 'partial' | 'loading' | 'unavailable'
 
 function settingsSectionState(
   section: SectionId,
   fusionSettingsWritable: boolean,
+  pathResolutionAvailability: PathResolutionAvailability = 'ready',
 ): { mode: SettingsSectionMode; label: string } {
   if (section === 'runtime') return { mode: 'live', label: 'runtime.toml + provider catalog' }
   if (section === 'runtimes') return { mode: 'live', label: 'runtime.toml live-backed' }
@@ -393,12 +395,28 @@ function settingsSectionState(
     return { mode: 'live', label: 'runtime.toml live-backed' }
   }
   if (section === 'fusion') return { mode: 'local', label: 'dedicated writer disabled' }
-  if (section === 'paths') return { mode: 'live', label: 'resolved by server' }
+  if (section === 'paths') {
+    if (pathResolutionAvailability === 'ready') return { mode: 'live', label: 'resolved by server' }
+    if (pathResolutionAvailability === 'partial') return { mode: 'mixed', label: 'partial path resolution' }
+    if (pathResolutionAvailability === 'loading') return { mode: 'mixed', label: 'path resolution loading' }
+    return { mode: 'local', label: 'path resolution unavailable' }
+  }
   if (section === 'mcp') return { mode: 'mixed', label: 'live MCP check + inventory' }
   if (section === 'logs') return { mode: 'mixed', label: 'live logs + local filters' }
   if (section === 'notify') return { mode: 'live', label: 'live thresholds read-only' }
   if (section === 'display') return { mode: 'live', label: 'theme/density live' }
   return { mode: 'local', label: 'read-only preview' }
+}
+
+function pathResolutionAvailability(
+  dashboardConfigStatus: 'loading' | 'ready' | 'error',
+  hasShellPathResolution: boolean,
+  hasPartialPathProjection: boolean,
+): PathResolutionAvailability {
+  if (hasShellPathResolution) return 'ready'
+  if (hasPartialPathProjection) return 'partial'
+  if (dashboardConfigStatus === 'loading') return 'loading'
+  return 'unavailable'
 }
 
 function LogFilter({
@@ -644,13 +662,6 @@ export function SettingsSurface() {
     }
   }
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
-  const baseSectionState = settingsSectionState(sec, fusionSettingsWritable)
-  const sectionState =
-    sec === 'notify' && dashboardConfigStatus === 'loading'
-      ? { mode: 'mixed' as const, label: 'thresholds loading' }
-      : sec === 'notify' && dashboardConfigStatus === 'error'
-        ? { mode: 'mixed' as const, label: 'config unavailable' }
-        : baseSectionState
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -676,6 +687,18 @@ export function SettingsSurface() {
   const mediaFailover = runtimeDefaults?.model_routing.media_failover ?? []
   const runtimeResolution = shellRuntimeResolution.value
   const configResolution = shellConfigResolution.value
+  const hasRuntimePathResolution = runtimeResolution !== null
+  const hasConfigPathResolution = configResolution !== null
+  const hasShellPathResolution = hasRuntimePathResolution || hasConfigPathResolution
+  const hasPartialPathProjection = dashboardConfigStatus === 'ready' || runtimeConfigPath !== null
+  const pathAvailability = pathResolutionAvailability(dashboardConfigStatus, hasShellPathResolution, hasPartialPathProjection)
+  const baseSectionState = settingsSectionState(sec, fusionSettingsWritable, pathAvailability)
+  const sectionState =
+    sec === 'notify' && dashboardConfigStatus === 'loading'
+      ? { mode: 'mixed' as const, label: 'thresholds loading' }
+      : sec === 'notify' && dashboardConfigStatus === 'error'
+        ? { mode: 'mixed' as const, label: 'config unavailable' }
+        : baseSectionState
   const mcpEndpoint = mcpEndpointFromConfig(dashboardConfig)
   const mcpToolCountLabel = mcpToolsStatus === 'ready' ? String(mcpTools.length) : '—'
   const mcpUrlEntry = configEntry(dashboardConfig, 'MASC_URL')
@@ -929,23 +952,58 @@ export function SettingsSurface() {
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
                 서버가 실제로 해석한 base path, data/config root, runtime.toml 경로입니다. 값은 dashboard shell/config projection에서 읽고, 입력 필드로 덮어쓰지 않습니다.
               </div>
-              ${dashboardConfigStatus === 'error'
+              ${pathAvailability === 'loading'
+                ? html`<div class="set-hint" data-testid="settings-path-resolution-loading">dashboard shell path resolution을 기다리는 중입니다.</div>`
+                : null}
+              ${pathAvailability === 'unavailable'
+                ? html`
+                  <div class="set-hint" data-testid="settings-path-resolution-error">
+                    dashboard shell path resolution과 config projection을 불러오지 못했습니다. 경로 행을 추정값으로 표시하지 않습니다.
+                  </div>
+                `
+                : null}
+              ${pathAvailability === 'partial'
+                ? html`
+                  <div class="set-hint" data-testid="settings-runtime-path-resolution-missing">
+                    dashboard shell path resolution을 아직 받지 못했습니다. config projection/runtime provider에서 확인 가능한 값만 표시합니다.
+                  </div>
+                `
+                : null}
+              ${dashboardConfigStatus === 'error' && pathAvailability !== 'unavailable'
                 ? html`<div class="set-hint" data-testid="settings-config-error">dashboard config projection을 불러오지 못했습니다.</div>`
                 : null}
-              <div class="set-sub-h">Runtime path resolution</div>
-              <${PathTruthRow} label="Base path" item=${runtimeResolution?.base_path ?? null} fallback=${concreteConfigValue(basePathEntry)} />
-              <${PathTruthRow} label="Resolved base path" item=${runtimeResolution?.resolved_base_path ?? null} />
-              <${PathTruthRow} label="Workspace path" item=${runtimeResolution?.workspace_path ?? null} />
-              <${PathTruthRow} label="Data root" item=${runtimeResolution?.data_root ?? null} fallback=${concreteConfigValue(dataDirEntry)} />
-              <${PathTruthRow} label="Prompt markdown dir" item=${runtimeResolution?.prompt_markdown_dir ?? null} />
-              <${PathTruthRow} label="Runtime TOML" item=${configResolution?.runtime ?? null} fallback=${runtimeConfigPath} />
-              <${PathTruthRow} label="Config root" item=${configResolution?.config_root ?? null} fallback=${concreteConfigValue(configDirEntry)} />
-
-              <div class="set-sub-h">Config env inputs</div>
-              <${ConfigTruthRow} label="MASC_BASE_PATH" entry=${basePathEntry} />
-              <${ConfigTruthRow} label="MASC_CONFIG_DIR" entry=${configDirEntry} />
-              <${ConfigTruthRow} label="MASC_DATA_DIR" entry=${dataDirEntry} />
-              <${ConfigTruthRow} label="MCP endpoint" entry=${mcpUrlEntry} fallback=${mcpEndpoint} />
+              ${pathAvailability === 'loading' || pathAvailability === 'unavailable'
+                ? null
+                : html`
+                  ${hasRuntimePathResolution
+                    ? html`
+                      <div class="set-sub-h">Runtime path resolution</div>
+                      <${PathTruthRow} label="Base path" item=${runtimeResolution?.base_path ?? null} fallback=${concreteConfigValue(basePathEntry)} />
+                      <${PathTruthRow} label="Resolved base path" item=${runtimeResolution?.resolved_base_path ?? null} />
+                      <${PathTruthRow} label="Workspace path" item=${runtimeResolution?.workspace_path ?? null} />
+                      <${PathTruthRow} label="Data root" item=${runtimeResolution?.data_root ?? null} fallback=${concreteConfigValue(dataDirEntry)} />
+                      <${PathTruthRow} label="Prompt markdown dir" item=${runtimeResolution?.prompt_markdown_dir ?? null} />
+                    `
+                    : null}
+                  ${hasConfigPathResolution || runtimeConfigPath
+                    ? html`
+                      <div class="set-sub-h">Config path resolution</div>
+                      <${PathTruthRow} label="Runtime TOML" item=${configResolution?.runtime ?? null} fallback=${runtimeConfigPath} />
+                      ${hasConfigPathResolution || dashboardConfigStatus === 'ready'
+                        ? html`<${PathTruthRow} label="Config root" item=${configResolution?.config_root ?? null} fallback=${concreteConfigValue(configDirEntry)} />`
+                        : null}
+                    `
+                    : null}
+                  ${dashboardConfigStatus === 'ready'
+                    ? html`
+                      <div class="set-sub-h">Config env inputs</div>
+                      <${ConfigTruthRow} label="MASC_BASE_PATH" entry=${basePathEntry} />
+                      <${ConfigTruthRow} label="MASC_CONFIG_DIR" entry=${configDirEntry} />
+                      <${ConfigTruthRow} label="MASC_DATA_DIR" entry=${dataDirEntry} />
+                      <${ConfigTruthRow} label="MCP endpoint" entry=${mcpUrlEntry} fallback=${mcpEndpoint} />
+                    `
+                    : null}
+                `}
             `}
 
             ${sec === 'logs' && html`


### PR DESCRIPTION
## Summary
- Make Settings > Paths stop presenting missing shell path resolution as fully `resolved by server`.
- Add explicit loading, partial, and unavailable states so the page only renders path rows backed by shell/config/provider data.
- Hide unsupported fallback rows instead of showing fabricated `미수집` values when config projection is unavailable.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/settings-surface.ts src/components/settings-surface.test.ts` (0 errors; test file is ignored by eslint config)
- `git diff --check origin/main...HEAD`
- Python Playwright smoke for Settings > Paths partial-resolution rendering; screenshot: `/private/tmp/masc-settings-paths-partial-resolution.png`