### PR TITLE
fix: redact supplied rich chat block strings

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -343,10 +343,18 @@ let redact_block redaction = function
       ; meta = redact_string redaction meta
       }
   | Keeper_chat_blocks.Fusion { board_post_id; run_id } ->
-    Keeper_chat_blocks.Fusion
-      { board_post_id = redact_string redaction board_post_id
-      ; run_id = redact_string redaction run_id
-      }
+    (* board_post_id/run_id are opaque, system-generated lookup keys
+       (Board.Post_id.to_string -> "p-<hex>", and the fusion run id), not
+       free-form content. The dashboard fetches the board post by
+       board_post_id and renders its meta_json; these strings are never
+       displayed as text. Redacting a key that is never shown cannot
+       protect a secret — it can only corrupt the fusion linkage so the
+       lazy-fetch by id fails. Skip redaction at the field level: both
+       fields are destructured and reconstructed (not [Fusion _]) so
+       adding a new fusion field breaks compilation and forces a redaction
+       decision. This is a structural exclusion of an id field, not a
+       string-pattern exception. *)
+    Keeper_chat_blocks.Fusion { board_post_id; run_id }
   | Keeper_chat_blocks.Trace { trace } ->
     Keeper_chat_blocks.Trace
       { trace = List.map (redact_trace_step redaction) trace }

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -223,9 +223,13 @@ let rec redact_yojson_strings redaction (json : Yojson.Safe.t) : Yojson.Safe.t =
   match json with
   | `String value -> `String (redact_string redaction value)
   | `Assoc fields ->
+    (* Caller-supplied trace tool args/results can carry a secret embedded in
+       a key name (e.g. a header/param used as a dict key), not only in
+       values -- redact both sides of each field. *)
     `Assoc
       (List.map
-         (fun (key, value) -> key, redact_yojson_strings redaction value)
+         (fun (key, value) ->
+           redact_string redaction key, redact_yojson_strings redaction value)
          fields)
   | `List items -> `List (List.map (redact_yojson_strings redaction) items)
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -219,20 +219,27 @@ let redact_string redaction value =
 let redact_string_opt redaction =
   Option.map (redact_string redaction)
 
-let rec redact_yojson_strings redaction (json : Yojson.Safe.t) : Yojson.Safe.t =
+let rec redact_yojson_keys redaction (json : Yojson.Safe.t) : Yojson.Safe.t =
   match json with
-  | `String value -> `String (redact_string redaction value)
+  | `String _ as value -> value
   | `Assoc fields ->
     (* Caller-supplied trace tool args/results can carry a secret embedded in
        a key name (e.g. a header/param used as a dict key), not only in
-       values -- redact both sides of each field. *)
+       values. Keeper_secret_redaction.redact_json owns value and sensitive-key
+       value redaction; this pass only scrubs projected secret literals in
+       field names. *)
     `Assoc
       (List.map
          (fun (key, value) ->
-           redact_string redaction key, redact_yojson_strings redaction value)
+           redact_string redaction key, redact_yojson_keys redaction value)
          fields)
-  | `List items -> `List (List.map (redact_yojson_strings redaction) items)
+  | `List items -> `List (List.map (redact_yojson_keys redaction) items)
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value
+
+let redact_trace_json redaction json =
+  json
+  |> redact_yojson_keys redaction
+  |> Keeper_secret_redaction.redact_json redaction
 
 let redact_table_cell redaction = function
   | Keeper_chat_blocks.Cell_text value ->
@@ -260,8 +267,8 @@ let redact_trace_step redaction = function
       ; tool_call_id = redact_string_opt redaction tool_call_id
       ; status
       ; dur = redact_string_opt redaction dur
-      ; args = Option.map (redact_yojson_strings redaction) args
-      ; result = Option.map (redact_yojson_strings redaction) result
+      ; args = Option.map (redact_trace_json redaction) args
+      ; result = Option.map (redact_trace_json redaction) result
       ; ts = redact_string_opt redaction ts
       ; oas_block_index
       }

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -213,13 +213,135 @@ let persisted_attachment (att : attachment) =
 let redact_tool_call redaction tc =
   { tc with args = Keeper_secret_redaction.redact_text redaction tc.args }
 
-let redact_block redaction = function
-  | Keeper_chat_blocks.Thinking thinking ->
-    Keeper_chat_blocks.Thinking
-      { thinking with
-        content = Keeper_secret_redaction.redact_text redaction thinking.content
+let redact_string redaction value =
+  Keeper_secret_redaction.redact_text redaction value
+
+let redact_string_opt redaction =
+  Option.map (redact_string redaction)
+
+let rec redact_yojson_strings redaction (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
+  | `String value -> `String (redact_string redaction value)
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (key, value) -> key, redact_yojson_strings redaction value)
+         fields)
+  | `List items -> `List (List.map (redact_yojson_strings redaction) items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value
+
+let redact_table_cell redaction = function
+  | Keeper_chat_blocks.Cell_text value ->
+    Keeper_chat_blocks.Cell_text (redact_string redaction value)
+  | Keeper_chat_blocks.Cell_value { v; num; muted } ->
+    Keeper_chat_blocks.Cell_value { v = redact_string redaction v; num; muted }
+
+let redact_trace_step redaction = function
+  | Keeper_chat_blocks.Trace_think { text; ts; oas_block_index } ->
+    Keeper_chat_blocks.Trace_think
+      { text = redact_string redaction text
+      ; ts = redact_string_opt redaction ts
+      ; oas_block_index
       }
-  | block -> block
+  | Keeper_chat_blocks.Trace_reason { text; detail; ts } ->
+    Keeper_chat_blocks.Trace_reason
+      { text = redact_string redaction text
+      ; detail = redact_string_opt redaction detail
+      ; ts = redact_string_opt redaction ts
+      }
+  | Keeper_chat_blocks.Trace_tool
+      { name; tool_call_id; status; dur; args; result; ts; oas_block_index } ->
+    Keeper_chat_blocks.Trace_tool
+      { name = redact_string redaction name
+      ; tool_call_id = redact_string_opt redaction tool_call_id
+      ; status
+      ; dur = redact_string_opt redaction dur
+      ; args = Option.map (redact_yojson_strings redaction) args
+      ; result = Option.map (redact_yojson_strings redaction) result
+      ; ts = redact_string_opt redaction ts
+      ; oas_block_index
+      }
+
+let redact_block redaction = function
+  | Keeper_chat_blocks.Text { html } ->
+    Keeper_chat_blocks.Text { html = redact_string redaction html }
+  | Keeper_chat_blocks.Heading { html } ->
+    Keeper_chat_blocks.Heading { html = redact_string redaction html }
+  | Keeper_chat_blocks.Unordered_list { items } ->
+    Keeper_chat_blocks.Unordered_list
+      { items = List.map (redact_string redaction) items }
+  | Keeper_chat_blocks.Callout { severity; html } ->
+    Keeper_chat_blocks.Callout
+      { severity = redact_string_opt redaction severity
+      ; html = redact_string redaction html
+      }
+  | Keeper_chat_blocks.Table { head; rows } ->
+    Keeper_chat_blocks.Table
+      { head = List.map (redact_table_cell redaction) head
+      ; rows = List.map (List.map (redact_table_cell redaction)) rows
+      }
+  | Keeper_chat_blocks.Code { cap; html; source } ->
+    Keeper_chat_blocks.Code
+      { cap = redact_string_opt redaction cap
+      ; html = redact_string redaction html
+      ; source = redact_string_opt redaction source
+      }
+  | Keeper_chat_blocks.Mermaid { source; caption } ->
+    Keeper_chat_blocks.Mermaid
+      { source = redact_string redaction source
+      ; caption = redact_string_opt redaction caption
+      }
+  | Keeper_chat_blocks.Svg { svg; cap } ->
+    Keeper_chat_blocks.Svg
+      { svg = redact_string redaction svg
+      ; cap = redact_string_opt redaction cap
+      }
+  | Keeper_chat_blocks.Voice { secs; wave; via; size; transcript; src } ->
+    Keeper_chat_blocks.Voice
+      { secs
+      ; wave
+      ; via = redact_string_opt redaction via
+      ; size = redact_string_opt redaction size
+      ; transcript = redact_string_opt redaction transcript
+      ; src = redact_string_opt redaction src
+      }
+  | Keeper_chat_blocks.Attach
+      { name; dims; src; svg; ph; via; size; data; mime_type; size_bytes; kind } ->
+    Keeper_chat_blocks.Attach
+      { name = redact_string redaction name
+      ; dims = redact_string_opt redaction dims
+      ; src = redact_string_opt redaction src
+      ; svg = redact_string_opt redaction svg
+      ; ph = redact_string_opt redaction ph
+      ; via = redact_string_opt redaction via
+      ; size = redact_string_opt redaction size
+      ; data = redact_string_opt redaction data
+      ; mime_type = redact_string_opt redaction mime_type
+      ; size_bytes
+      ; kind = redact_string_opt redaction kind
+      }
+  | Keeper_chat_blocks.Image { src; cap } ->
+    Keeper_chat_blocks.Image
+      { src = redact_string redaction src
+      ; cap = redact_string_opt redaction cap
+      }
+  | Keeper_chat_blocks.Link { url; title; meta } ->
+    Keeper_chat_blocks.Link
+      { url = redact_string redaction url
+      ; title = redact_string redaction title
+      ; meta = redact_string redaction meta
+      }
+  | Keeper_chat_blocks.Fusion { board_post_id; run_id } ->
+    Keeper_chat_blocks.Fusion
+      { board_post_id = redact_string redaction board_post_id
+      ; run_id = redact_string redaction run_id
+      }
+  | Keeper_chat_blocks.Trace { trace } ->
+    Keeper_chat_blocks.Trace
+      { trace = List.map (redact_trace_step redaction) trace }
+  | Keeper_chat_blocks.Thinking { content; redacted } ->
+    Keeper_chat_blocks.Thinking
+      { content = redact_string redaction content; redacted }
 
 let redact_blocks redaction =
   Option.map (List.map (redact_block redaction))

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -365,13 +365,23 @@ let redact_block redaction = function
 let redact_blocks redaction =
   Option.map (List.map (redact_block redaction))
 
+let redact_audio redaction a =
+  { a with
+    audio_url = Option.map (redact_string redaction) a.audio_url;
+    message_text = redact_string redaction a.message_text;
+  }
+
 let redact_message redaction msg =
   let attachments =
     Option.map (List.map (redact_attachment redaction)) msg.attachments
   in
+  let blocks = redact_blocks redaction msg.blocks in
+  let audio = Option.map (redact_audio redaction) msg.audio in
   { msg with
     content = Keeper_secret_redaction.redact_text redaction msg.content;
     attachments;
+    blocks;
+    audio;
   }
 
 let opt_string_field key = function
@@ -631,6 +641,7 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let redaction = redaction_for ~base_dir ~keeper_name in
     let content = Keeper_secret_redaction.redact_text redaction content in
     let blocks = redact_blocks redaction blocks in
+    let audio = Option.map (redact_audio redaction) audio in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -219,26 +219,13 @@ let redact_string redaction value =
 let redact_string_opt redaction =
   Option.map (redact_string redaction)
 
-let rec redact_yojson_keys redaction (json : Yojson.Safe.t) : Yojson.Safe.t =
-  match json with
-  | `String _ as value -> value
-  | `Assoc fields ->
-    (* Caller-supplied trace tool args/results can carry a secret embedded in
-       a key name (e.g. a header/param used as a dict key), not only in
-       values. Keeper_secret_redaction.redact_json owns value and sensitive-key
-       value redaction; this pass only scrubs projected secret literals in
-       field names. *)
-    `Assoc
-      (List.map
-         (fun (key, value) ->
-           redact_string redaction key, redact_yojson_keys redaction value)
-         fields)
-  | `List items -> `List (List.map (redact_yojson_keys redaction) items)
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value
-
 let redact_trace_json redaction json =
+  (* Caller-supplied trace tool args/results can carry a secret embedded in a
+     key name (e.g. a header/param used as a dict key), not only in values.
+     Use the SSOT JSON redactor for keys and values so the traversal policy has
+     a single owner. *)
   json
-  |> redact_yojson_keys redaction
+  |> Keeper_secret_redaction.redact_json_keys redaction
   |> Keeper_secret_redaction.redact_json redaction
 
 let redact_table_cell redaction = function

--- a/lib/keeper/keeper_secret_redaction.ml
+++ b/lib/keeper/keeper_secret_redaction.ml
@@ -130,5 +130,15 @@ let rec redact_json_exact t = function
   | `List items -> `List (List.map (redact_json_exact t) items)
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as json -> json
 
+let rec redact_json_keys t = function
+  | `String _ as value -> value
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) -> redact_text t key, redact_json_keys t value)
+           fields)
+  | `List items -> `List (List.map (redact_json_keys t) items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as value -> value
+
 let redact_json t json =
   json |> redact_json_exact t |> Observability_redact.redact_json_strings

--- a/lib/keeper/keeper_secret_redaction.mli
+++ b/lib/keeper/keeper_secret_redaction.mli
@@ -20,3 +20,8 @@ val redact_text : t -> string -> string
 
 val redact_json : t -> Yojson.Safe.t -> Yojson.Safe.t
 (** Redact all string leaves in a JSON value, preserving shape. *)
+
+val redact_json_keys : t -> Yojson.Safe.t -> Yojson.Safe.t
+(** Redact string literals that appear as JSON object keys. Values are left
+    untouched so this can be composed with {!redact_json} for full key+value
+    coverage without duplicating the traversal. *)

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1211,6 +1211,7 @@ let test_append_turn_redacts_all_supplied_block_strings () =
                             (`Assoc
                               [ "token", `String secret
                               ; "nested", `List [ `String ("nested " ^ secret) ]
+                              ; "key " ^ secret, `String "benign value"
                               ])
                       ; result = Some (`String ("result " ^ secret))
                       ; ts = Some ("ts " ^ secret)

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1300,6 +1300,123 @@ let test_append_turn_preserves_fusion_lookup_ids () =
       | Some _ -> Alcotest.fail "expected exactly one fusion block"
       | None -> Alcotest.fail "assistant fusion block missing")
 
+(* Read-boundary redaction: rows written before this PR (or by any path that
+   bypasses the write-boundary redactors) must still have caller-supplied
+   blocks and audio scrubbed before they are served by [load] / [to_json_array]. *)
+let test_load_redacts_legacy_raw_blocks_and_audio () =
+  let base_dir = temp_base_path "keeper-chat-store-legacy-blocks-audio-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-legacy-blocks-audio-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "legacy-blocks-audio.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      let path = chat_path ~base_dir ~keeper_name in
+      let audio_json =
+        `Assoc
+          [ ("token", `String "voice-token-legacy")
+          ; ("mime", `String "audio/mpeg")
+          ; ("message_text", `String ("caption " ^ secret))
+          ; ("audio_url", `String ("https://cdn.example.com/audio?sig=" ^ secret))
+          ]
+      in
+      let blocks_json =
+        B.blocks_to_yojson
+          [ B.Text { html = "paragraph " ^ secret }
+          ; B.Code { cap = None; html = "code " ^ secret; source = None }
+          ]
+      in
+      let row =
+        `Assoc
+          [ ("role", `String "assistant")
+          ; ("content", `String ("content " ^ secret))
+          ; ("ts", `Float 1.0)
+          ; ("audio", audio_json)
+          ; ("blocks", blocks_json)
+          ]
+      in
+      write_file path (Yojson.Safe.to_string row ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      match messages with
+      | [ msg ] ->
+        Alcotest.(check bool) "legacy content redacted on load" false
+          (contains_substring msg.K.content secret);
+        (match msg.K.audio with
+         | Some audio ->
+           Alcotest.(check bool) "legacy audio message_text redacted on load" false
+             (contains_substring audio.message_text secret);
+           Alcotest.(check bool) "legacy audio audio_url redacted on load" false
+             (match audio.audio_url with
+              | Some url -> contains_substring url secret
+              | None -> false))
+         | None -> Alcotest.fail "legacy audio missing");
+        Alcotest.(check bool) "legacy blocks redacted on load" false
+          (match msg.K.blocks with
+           | Some blocks ->
+             contains_substring (Yojson.Safe.to_string (B.blocks_to_yojson blocks)) secret
+           | None -> true);
+        let json = K.to_json_array messages in
+        let s = Yojson.Safe.to_string json in
+        Alcotest.(check bool) "to_json_array hides legacy secret" false
+          (contains_substring s secret);
+        Alcotest.(check bool) "redaction marker present in served payload" true
+          (contains_substring s "[REDACTED]")
+      | messages ->
+        Alcotest.failf "expected 1 message, got %d" (List.length messages))
+
+(* Write-boundary redaction: assistant-initiated messages can carry a synthesized
+   voice clip; [message_text] and [audio_url] are caller/free-form surfaces and
+   must be scrubbed before [encode_line] persists them. *)
+let test_append_assistant_message_redacts_audio () =
+  let base_dir = temp_base_path "keeper-chat-store-assistant-audio-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-assistant-audio-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "assistant-audio.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:("spoken " ^ secret)
+        ~audio:
+          { K.token = "voice-token-redact"
+          ; audio_url = Some ("https://cdn.example.com/audio?sig=" ^ secret)
+          ; mime = "audio/mpeg"
+          ; duration_sec = Some 1.23
+          ; message_text = "caption " ^ secret
+          ; device_id = Some "device-1"
+          ; expired = false
+          }
+        ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "assistant content secret not persisted" false
+        (contains_substring raw secret);
+      Alcotest.(check bool) "assistant audio_url secret not persisted" false
+        (contains_substring raw ("https://cdn.example.com/audio?sig=" ^ secret));
+      Alcotest.(check bool) "assistant audio message_text secret not persisted" false
+        (contains_substring raw ("caption " ^ secret));
+      Alcotest.(check bool) "redaction marker persisted" true
+        (contains_substring raw "[REDACTED]");
+      let messages = K.load ~base_dir ~keeper_name in
+      match messages with
+      | [ msg ] ->
+        Alcotest.(check bool) "loaded assistant content redacted" false
+          (contains_substring msg.K.content secret);
+        (match msg.K.audio with
+         | Some audio ->
+           Alcotest.(check bool) "loaded audio message_text redacted" false
+             (contains_substring audio.message_text secret);
+           Alcotest.(check bool) "loaded audio audio_url redacted" false
+             (match audio.audio_url with
+              | Some url -> contains_substring url secret
+              | None -> false))
+         | None -> Alcotest.fail "loaded audio missing")
+      | messages ->
+        Alcotest.failf "expected 1 message, got %d" (List.length messages))
+
 (* RFC-0233 §7: append_turn stamps the supplied turn_ref on every row of the
    completed turn, it round-trips through load, and to_json_array exposes it
    for the history endpoint. *)
@@ -1527,6 +1644,10 @@ let () =
             test_append_turn_redacts_all_supplied_block_strings;
           Alcotest.test_case "fusion lookup ids survive redaction" `Quick
             test_append_turn_preserves_fusion_lookup_ids;
+          Alcotest.test_case "legacy raw blocks and audio redacted on load" `Quick
+            test_load_redacts_legacy_raw_blocks_and_audio;
+          Alcotest.test_case "assistant message audio redacted on append" `Quick
+            test_append_assistant_message_redacts_audio;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
         ] );

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1255,6 +1255,51 @@ let test_append_turn_redacts_all_supplied_block_strings () =
           (contains_substring json "[REDACTED]")
       | None -> Alcotest.fail "assistant rich blocks missing")
 
+(* Fusion board_post_id/run_id are opaque lookup keys the dashboard uses to
+   lazy-fetch the board post; they are never rendered as text. They must
+   survive redaction byte-for-byte so the fusion linkage stays resolvable,
+   even for an id that happens to embed a value the redactor would otherwise
+   rewrite (a projected keeper secret literal, or a structural secret prefix
+   like [sk-]). Free-form content in the same turn is still redacted. *)
+let test_append_turn_preserves_fusion_lookup_ids () =
+  let base_dir = temp_base_path "keeper-chat-store-fusion-ids" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-fusion-ids" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "fusion-id.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      (* Synthetic ids chosen to trigger redaction if the field were not
+         skipped: [board_post_id] embeds the projected secret literal, and
+         [run_id] matches the [sk-] structural prefix. *)
+      let board_post_id = "p-" ^ secret ^ "-board" in
+      let run_id = "sk-run-" ^ secret in
+      K.append_turn
+        ~base_dir
+        ~keeper_name
+        ~user_content:"render"
+        ~user_attachments:[]
+        ~assistant_content:("leak " ^ secret)
+        ~blocks:[ B.Fusion { board_post_id; run_id } ]
+        ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let assistant =
+        List.find
+          (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.Assistant)
+          messages
+      in
+      Alcotest.(check bool) "free-form assistant content still redacted" false
+        (contains_substring assistant.K.content secret);
+      match assistant.K.blocks with
+      | Some [ B.Fusion fusion ] ->
+        Alcotest.(check string) "board_post_id preserved verbatim"
+          board_post_id fusion.board_post_id;
+        Alcotest.(check string) "run_id preserved verbatim" run_id fusion.run_id
+      | Some _ -> Alcotest.fail "expected exactly one fusion block"
+      | None -> Alcotest.fail "assistant fusion block missing")
+
 (* RFC-0233 §7: append_turn stamps the supplied turn_ref on every row of the
    completed turn, it round-trips through load, and to_json_array exposes it
    for the history endpoint. *)
@@ -1480,6 +1525,8 @@ let () =
             test_append_turn_redacts_supplied_thinking_blocks;
           Alcotest.test_case "supplied rich block strings are redacted" `Quick
             test_append_turn_redacts_all_supplied_block_strings;
+          Alcotest.test_case "fusion lookup ids survive redaction" `Quick
+            test_append_turn_preserves_fusion_lookup_ids;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
         ] );

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1347,10 +1347,13 @@ let test_load_redacts_legacy_raw_blocks_and_audio () =
          | Some audio ->
            Alcotest.(check bool) "legacy audio message_text redacted on load" false
              (contains_substring audio.message_text secret);
+           let audio_url_contains_secret =
+             match audio.audio_url with
+             | Some url -> contains_substring url secret
+             | None -> false
+           in
            Alcotest.(check bool) "legacy audio audio_url redacted on load" false
-             (match audio.audio_url with
-              | Some url -> contains_substring url secret
-              | None -> false))
+             audio_url_contains_secret
          | None -> Alcotest.fail "legacy audio missing");
         Alcotest.(check bool) "legacy blocks redacted on load" false
           (match msg.K.blocks with
@@ -1409,10 +1412,13 @@ let test_append_assistant_message_redacts_audio () =
          | Some audio ->
            Alcotest.(check bool) "loaded audio message_text redacted" false
              (contains_substring audio.message_text secret);
+           let audio_url_contains_secret =
+             match audio.audio_url with
+             | Some url -> contains_substring url secret
+             | None -> false
+           in
            Alcotest.(check bool) "loaded audio audio_url redacted" false
-             (match audio.audio_url with
-              | Some url -> contains_substring url secret
-              | None -> false))
+             audio_url_contains_secret
          | None -> Alcotest.fail "loaded audio missing")
       | messages ->
         Alcotest.failf "expected 1 message, got %d" (List.length messages))

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1210,10 +1210,16 @@ let test_append_turn_redacts_all_supplied_block_strings () =
                           Some
                             (`Assoc
                               [ "token", `String secret
+                              ; "api_token", `String "plain-non-pattern-value"
                               ; "nested", `List [ `String ("nested " ^ secret) ]
                               ; "key " ^ secret, `String "benign value"
                               ])
-                      ; result = Some (`String ("result " ^ secret))
+                      ; result =
+                          Some
+                            (`Assoc
+                              [ "password", `String "ordinary-value"
+                              ; "summary", `String ("result " ^ secret)
+                              ])
                       ; ts = Some ("ts " ^ secret)
                       ; oas_block_index = None
                       }
@@ -1224,6 +1230,10 @@ let test_append_turn_redacts_all_supplied_block_strings () =
       let raw = read_file (chat_path ~base_dir ~keeper_name) in
       Alcotest.(check bool) "rich block secret not persisted" false
         (contains_substring raw secret);
+      Alcotest.(check bool) "sensitive keyed value not persisted" false
+        (contains_substring raw "plain-non-pattern-value");
+      Alcotest.(check bool) "sensitive password value not persisted" false
+        (contains_substring raw "ordinary-value");
       Alcotest.(check bool) "rich block redaction marker persisted" true
         (contains_substring raw "[REDACTED]");
       let messages = K.load ~base_dir ~keeper_name in
@@ -1237,6 +1247,10 @@ let test_append_turn_redacts_all_supplied_block_strings () =
         let json = Yojson.Safe.to_string (B.blocks_to_yojson blocks) in
         Alcotest.(check bool) "loaded blocks hide secret" false
           (contains_substring json secret);
+        Alcotest.(check bool) "loaded blocks hide sensitive keyed value" false
+          (contains_substring json "plain-non-pattern-value");
+        Alcotest.(check bool) "loaded blocks hide sensitive password value" false
+          (contains_substring json "ordinary-value");
         Alcotest.(check bool) "loaded blocks keep redaction marker" true
           (contains_substring json "[REDACTED]")
       | None -> Alcotest.fail "assistant rich blocks missing")

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1163,6 +1163,83 @@ let test_append_turn_redacts_supplied_thinking_blocks () =
       | Some _ -> Alcotest.fail "expected exactly one thinking block"
       | None -> Alcotest.fail "assistant thinking block missing")
 
+let test_append_turn_redacts_all_supplied_block_strings () =
+  let base_dir = temp_base_path "keeper-chat-store-rich-block-redact" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-rich-block-redact" in
+      let root = secret_root_default ~base_dir ~keeper_name in
+      let secret = "rich-block.secret!" in
+      write_file (Filename.concat (Filename.concat root "env") "GH_TOKEN") secret;
+      K.append_turn
+        ~base_dir
+        ~keeper_name
+        ~user_content:"render"
+        ~user_attachments:[]
+        ~assistant_content:"done"
+        ~blocks:
+          [ B.Code
+              { cap = Some ("shell " ^ secret)
+              ; html = "echo " ^ secret
+              ; source = Some ("source " ^ secret)
+              }
+          ; B.Mermaid
+              { source = "graph TD\nA[" ^ secret ^ "]"
+              ; caption = Some ("flow " ^ secret)
+              }
+          ; B.Trace
+              { trace =
+                  [ B.Trace_think
+                      { text = "thinking " ^ secret
+                      ; ts = Some ("ts-" ^ secret)
+                      ; oas_block_index = None
+                      }
+                  ; B.Trace_reason
+                      { text = "reason " ^ secret
+                      ; detail = Some ("detail " ^ secret)
+                      ; ts = None
+                      }
+                  ; B.Trace_tool
+                      { name = "tool " ^ secret
+                      ; tool_call_id = Some ("call " ^ secret)
+                      ; status = Some B.Trace_tool_err
+                      ; dur = Some ("dur " ^ secret)
+                      ; args =
+                          Some
+                            (`Assoc
+                              [ "token", `String secret
+                              ; "nested", `List [ `String ("nested " ^ secret) ]
+                              ])
+                      ; result = Some (`String ("result " ^ secret))
+                      ; ts = Some ("ts " ^ secret)
+                      ; oas_block_index = None
+                      }
+                  ]
+              }
+          ]
+        ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "rich block secret not persisted" false
+        (contains_substring raw secret);
+      Alcotest.(check bool) "rich block redaction marker persisted" true
+        (contains_substring raw "[REDACTED]");
+      let messages = K.load ~base_dir ~keeper_name in
+      let assistant =
+        List.find
+          (fun (m : K.chat_message) -> K.Role.equal m.role K.Role.Assistant)
+          messages
+      in
+      match assistant.K.blocks with
+      | Some blocks ->
+        let json = Yojson.Safe.to_string (B.blocks_to_yojson blocks) in
+        Alcotest.(check bool) "loaded blocks hide secret" false
+          (contains_substring json secret);
+        Alcotest.(check bool) "loaded blocks keep redaction marker" true
+          (contains_substring json "[REDACTED]")
+      | None -> Alcotest.fail "assistant rich blocks missing")
+
 (* RFC-0233 §7: append_turn stamps the supplied turn_ref on every row of the
    completed turn, it round-trips through load, and to_json_array exposes it
    for the history endpoint. *)
@@ -1386,6 +1463,8 @@ let () =
             test_blocks_roundtrip_and_drop_malformed;
           Alcotest.test_case "supplied thinking blocks are redacted" `Quick
             test_append_turn_redacts_supplied_thinking_blocks;
+          Alcotest.test_case "supplied rich block strings are redacted" `Quick
+            test_append_turn_redacts_all_supplied_block_strings;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
         ] );


### PR DESCRIPTION
Follow-up for #22878 review feedback. The merged PR redacted caller-supplied Thinking blocks, but other caller-supplied chat_block variants can also carry free-form strings. This change makes the keeper chat store redact every persisted chat_block string field, including nested trace steps and Yojson string values in trace tool args/results, before encode_line writes blocks to JSONL. Verification: ocamlformat --check lib/keeper/keeper_chat_store.ml test/test_keeper_chat_store.ml; git diff --check origin/main...HEAD. Per local workflow, Dune build/test is left to CI.