### PR TITLE
fix(runtime): deepseek-v4-flash를 OAS 카탈로그 projection에 추가 (부팅 차단 해소)

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -50,6 +50,43 @@ output_per_million = 0.28
 cache_write_multiplier = 1.0
 cache_read_multiplier = 0.02
 
+# WORKAROUND: the pinned OAS emits provider_label "openai_compat" for the
+# DeepSeek direct endpoint (https://api.deepseek.com) because provider_config.ml
+# has no base_url recognizer for it — only ollama_cloud and openai are matched,
+# everything else falls through to string_of_provider_kind OpenAI_compat =
+# "openai_compat". capabilities_for_config_model therefore looks up
+# "openai_compat/deepseek-v4-flash", and the bare "deepseek-v4-flash" row above
+# cannot satisfy it (bare fallback is refused for tool-capable openai_compat
+# models via catalog_entry_requires_endpoint_declaration, provider_config.ml:293).
+# Without this provider-qualified row Runtime.init_default_strict refuses to boot
+# for the [deepseek.deepseek-v4-flash] runtime binding.
+# Root fix: add a base_url recognizer for api.deepseek.com in OAS so the label
+# is semantic ("deepseek"), mirroring jeong-sik/oas#2374 for runpod_mtp.
+# Removal target: after that OAS recognizer is pinned here and proven stable.
+# Capabilities mirror the canonical ../oas/models.toml deepseek-v4-flash row.
+[[models]]
+id_prefix = "openai_compat/deepseek-v4-flash"
+base = "openai_chat"
+provider_name = "deepseek"
+max_context_tokens = 1000000
+max_output_tokens = 384000
+supports_tools = true
+supports_tool_choice = true
+supports_required_tool_choice = false
+supports_named_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "thinking_object"
+supports_response_format_json = true
+supports_native_streaming = true
+supports_caching = true
+supports_prompt_caching = false
+input_per_million = 0.14
+output_per_million = 0.28
+cache_write_multiplier = 1.0
+cache_read_multiplier = 0.02
+
 # MiniMax Models
 [[models]]
 id_prefix = "minimax-m3"


### PR DESCRIPTION
## 목적
MASC 로컬 서버가 부팅을 거부하는 문제 해결. `Runtime.init_default_strict`가 `runtime.toml`의 `[deepseek.deepseek-v4-flash]` 바인딩을 OAS capability 카탈로그에서 못 찾아 fatal exit.

```
Runtime.init_default_strict failed (fatal, refusing to boot): ...: 1 runtime model(s)
absent from the OAS capability catalog ...: deepseek.deepseek-v4-flash
```

## 근본 원인
- pinned OAS의 `capability_provider_label`은 `api.deepseek.com`용 base_url 인식기가 없어 `string_of_provider_kind OpenAI_compat = "openai_compat"`로 폴백.
- 따라서 `capabilities_for_config_model`은 `openai_compat/deepseek-v4-flash`를 조회하는데 projection엔 bare `deepseek-v4-flash` 행뿐.
- bare 폴백은 tool 지원 openai_compat 모델에 대해 `catalog_entry_requires_endpoint_declaration`(provider_config.ml:293)으로 거부 → `None` → 부팅 거부 (no-silent-fallback fail-closed, 의도된 동작).

## 변경
- `oas-models.toml`에 `id_prefix = "openai_compat/deepseek-v4-flash"` provider-qualified 행 추가. capability는 canonical `../oas/models.toml`의 deepseek-v4-flash 행을 그대로 반영.
- 이 파일에 이미 존재하는 `runpod_mtp`/`openai_compat` 이중 행과 동일한 클래스·관용구.

## 검증
- `python3 tomllib` 파싱 OK, 신규 행 1개 확인.
- 매칭 로직(capabilities.ml:1194 `for_provider_model_id_catalog`): provider_label `openai_compat` → 후보 키 `openai_compat/deepseek-v4-flash` → id_prefix 매치 → provider-qualified 경로에서 caps 반환(endpoint-declaration 거부 우회).
- CI에서 빌드/테스트 확인.

## P0-P3
- **P0**: 부팅 차단 해소 (config-only, 코드 변경 없음).
- **P1**: 없음. capability는 canonical 미러라 thinking/sampling drift 없음.
- **P2 (남은점)**: `runtime.toml`이 untracked(#1226)라 재생성 시 tracked projection과 계속 drift (runpod_mtp에 이어 2번째 동일 클래스). 근본 해결은 OAS base_url 인식기 또는 projection 자동생성.
- **P3**: WORKAROUND 주석에 근본 fix(OAS deepseek 인식기, oas#2374 analogue) + 제거 조건 명시.

WORKAROUND: production-blocking — 로컬 masc 서버가 부팅 불가(Runtime.init_default_strict fatal).
root fix: OAS base_url recognizer for api.deepseek.com (oas#2374 runpod_mtp analogue). RFC 미작성.
removal target: 해당 OAS 인식기가 여기 pin되어 안정 확인된 후 openai_compat 행 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
