### PR TITLE
docs(rfc): renumber stimulus-gated keeper wake 0302 -> 0303

### DIFF
--- a/docs/rfc/RFC-0303-stimulus-gated-keeper-wake.md
+++ b/docs/rfc/RFC-0303-stimulus-gated-keeper-wake.md
@@ -1,6 +1,7 @@
-# RFC-0302 — Stimulus-gated Keeper Wake (retire self-cadence no-progress detect/pause/tombstone)
+# RFC-0303 — Stimulus-gated Keeper Wake (retire self-cadence no-progress detect/pause/tombstone)
 
 - Status: Draft
+- Renumbered from RFC-0302: `0302` was already claimed by "keeper memory I/O off-main-domain offload (HOL fix)" (`b7d9072b1c9`, phase-1/2a/2b implemented, referenced by `lib/keeper/keeper_chat_blocks.mli`). This RFC (merged as #22934 under the wrong number) is moved to 0303.
 - Area: `lib/keeper/` (keeper lifecycle, heartbeat/keepalive wake, no-progress loop, wake-tombstone), `lib/dashboard/` (attention projection)
 - Supersedes: RFC-0246 (Wake-cascade Recovery Tombstone) — inverts its remedy
 - Builds on / touches: RFC-0239 (no-progress), RFC-0020 (typed wake carrier), RFC-0246 (tombstone)


### PR DESCRIPTION
## 무엇을 / 왜

RFC-0302 번호가 **이미 선점**돼 있었습니다: `keeper memory I/O off-main-domain offload (HOL fix)` (`b7d9072b1c9`, phase-1/2a/2b 구현 완료, `lib/keeper/keeper_chat_blocks.mli`가 참조). stimulus-gated keeper wake RFC가 #22934에서 **같은 0302로 머지**되어 충돌했습니다.

다음 빈 번호 **0303**으로 이동합니다.

## 변경
- `docs/rfc/RFC-0302-stimulus-gated-keeper-wake.md` → `RFC-0303-stimulus-gated-keeper-wake.md` (git mv, 히스토리 보존)
- 헤더 title `0302 → 0303` + 재번호 사유 1줄 추가

docs-only. 코드/런타임 무변경.

RFC-WAIVED: 문서 자체가 RFC (docs/rfc). credential/operator/hooks subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)