### PR TITLE
[codex] batch keeper thinking stream deltas

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1994,6 +1994,38 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(think?.textContent).toContain(hiddenTail)
   })
 
+  it('bounds live thinking preview without parsing markdown on every stream chunk', () => {
+    const longThinking = `old heading **gone**\n${'x'.repeat(6_500)}\nlatest **tail**`
+
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a',
+            text: '응답 작성 중',
+            role: 'assistant',
+            source: 'direct_assistant',
+            streamState: 'streaming',
+            delivery: 'streaming',
+            traceSteps: [{ kind: 'think', text: longThinking }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const think = container.querySelector('[data-chat-trace-step="think"] .chat-block-tstep-text') as HTMLElement | null
+    expect(think).not.toBeNull()
+    expect(think?.getAttribute('data-chat-thinking-preview')).toBe('truncated')
+    expect(think?.textContent).not.toContain('old heading')
+    expect(think?.textContent).toContain('latest **tail**')
+    expect(think?.querySelector('strong')).toBeNull()
+    expect((think?.textContent ?? '').length).toBeLessThan(longThinking.length)
+  })
+
   it('renders board post ids in assistant prose as board detail links', () => {
     const postId = 'p-59e2917e15de5367e81b2244a8f5095a'
     const label = postId.slice(0, 8)

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -70,6 +70,7 @@ const TRACE_TOOL_STATUS_UI: Record<TraceToolStatus, { className: 'ok' | 'bad' | 
 }
 
 export const CHAT_SUGGESTIONS_LABEL = '추천 후속 질문'
+const STREAMING_THINKING_PREVIEW_CHARS = 6_000
 
 function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'ok' | 'bad' | 'pending'; title: string } {
   return TRACE_TOOL_STATUS_UI[status ?? 'pending']
@@ -552,6 +553,29 @@ function AsyncMarkdownDiv({
   return rendered === null
     ? html`<div class=${className} dangerouslySetInnerHTML=${renderPlainLinkedHtml(text)} />`
     : html`<div class=${className} dangerouslySetInnerHTML=${{ __html: rendered }} />`
+}
+
+function streamingThinkingPreview(text: string): string {
+  if (text.length <= STREAMING_THINKING_PREVIEW_CHARS) return text
+  return `...\n${text.slice(-STREAMING_THINKING_PREVIEW_CHARS)}`
+}
+
+function ChatThinkingText({ text, streaming }: { text: string; streaming: boolean }) {
+  if (streaming) {
+    return html`
+      <div
+        class="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
+        data-chat-thinking-preview=${text.length > STREAMING_THINKING_PREVIEW_CHARS ? 'truncated' : 'full'}
+        dangerouslySetInnerHTML=${renderPlainLinkedHtml(streamingThinkingPreview(text))}
+      />
+    `
+  }
+  return html`
+    <${AsyncMarkdownDiv}
+      text=${text}
+      className="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
+    />
+  `
 }
 
 function renderInlineHtml(raw: string): { __html: string } {
@@ -1219,11 +1243,11 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   `
 }
 
-function ChatTraceStep({ step }: { step: ChatTraceStep }) {
+function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; streaming?: boolean }) {
   const [open, setOpen] = useState(false)
 
   if (step.kind === 'think') {
-    const longThinking = step.text.length > THINKING_TRACE_PREVIEW_CHARS
+    const longThinking = !streaming && step.text.length > THINKING_TRACE_PREVIEW_CHARS
     const previewText = longThinking
       ? `${step.text.slice(0, THINKING_TRACE_PREVIEW_CHARS).trimEnd()}\n\n... ${step.text.length - THINKING_TRACE_PREVIEW_CHARS} chars hidden`
       : step.text
@@ -1246,7 +1270,9 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
                 `
               : null}
           </div>
-          ${longThinking && !open
+          ${streaming
+            ? html`<${ChatThinkingText} text=${step.text} streaming=${true} />`
+            : longThinking && !open
             ? html`
                 <div
                   class="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
@@ -2724,7 +2750,11 @@ function ToolTraceCard({
               <span class="chat-block-trace-rail"></span>
               ${ordered.map((item, index) =>
                 item.kind === 'trace'
-                  ? html`<${ChatTraceStep} key=${`trace-${index}`} step=${item.step} />`
+                  ? html`<${ChatTraceStep}
+                      key=${`trace-${index}`}
+                      step=${item.step}
+                      streaming=${assistant !== null && !turnComplete}
+                    />`
                   : item.kind === 'tool'
                     ? (() => {
                         const entry = item.entry ?? toolEntryFromTraceStep(item.step)

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -59,6 +59,7 @@ import {
   keeperRecovering,
   keeperSending,
   keeperStatusDetails,
+  keeperStreamLastEventAt,
   keeperStreamStartedAt,
   keeperThreads,
   activeStreamRequestId,
@@ -249,6 +250,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
   beforeEach(() => {
     keeperThreads.value = {}
     keeperActionErrors.value = {}
+    keeperStreamLastEventAt.value = {}
     _clearPendingKeeperChatRequestsForTests()
     _resetKeeperThreadMessageSendGuardsForTests()
     _resetLiveSendRequestOwnersForTests()
@@ -764,6 +766,43 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
+  })
+
+  it('throttles stream heartbeat signal updates during dense event bursts', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const observed: Array<number | null> = []
+      streamKeeperMessage.mockImplementation(async (
+        _name: string,
+        _message: string,
+        opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+      ) => {
+        vi.setSystemTime(1_000)
+        opts.onEvent({ type: 'RUN_STARTED' })
+        observed.push(keeperStreamLastEventAt.value.echo ?? null)
+
+        vi.setSystemTime(1_200)
+        opts.onEvent({ type: 'TEXT_MESSAGE_START' })
+        observed.push(keeperStreamLastEventAt.value.echo ?? null)
+
+        vi.setSystemTime(1_500)
+        opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: 'ok' })
+        observed.push(keeperStreamLastEventAt.value.echo ?? null)
+
+        vi.setSystemTime(2_100)
+        opts.onEvent({ type: 'RUN_FINISHED' })
+        observed.push(keeperStreamLastEventAt.value.echo ?? null)
+        return { terminal: true }
+      })
+
+      await sendKeeperThreadMessage('echo', '진행 상황?')
+
+      expect(observed).toEqual([1_000, 1_000, 1_000, 2_100])
+      expect(keeperStreamLastEventAt.value.echo).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('hydrates tool outputs when a live stream finishes a tool call', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -80,6 +80,8 @@ const EMPTY_VISIBLE_REPLY_TEXT =
 const pendingKeeperThreadCancels = new Map<string, Promise<boolean>>()
 const KEEPER_THREAD_CANCEL_TIMEOUT_MS = 5_000
 const KEEPER_THREAD_CANCEL_SETTLE_GRACE_MS = 500
+const KEEPER_STREAM_SIGNAL_THROTTLE_MS = 1_000
+const keeperStreamSignalWrites = new Map<string, number>()
 
 interface KeeperInterjectCommand {
   readonly kind: KeeperInterjectActionKind
@@ -106,6 +108,7 @@ function keeperThreadCancelFailureMessage(keeperName: string, requestId: string,
 
 export function _resetCancelledKeeperThreadRequestsForTests(): void {
   pendingKeeperThreadCancels.clear()
+  keeperStreamSignalWrites.clear()
 }
 
 function keeperThreadCancelSignal(): AbortSignal {
@@ -114,6 +117,30 @@ function keeperThreadCancelSignal(): AbortSignal {
 
 function releaseKeeperThreadCancelTracking(requestId: string): void {
   pendingKeeperThreadCancels.delete(requestId)
+}
+
+function markKeeperStreamSignal(keeperName: string, opts: { force?: boolean } = {}): void {
+  const name = keeperName.trim()
+  if (!name) return
+  const now = Date.now()
+  const previous = keeperStreamSignalWrites.get(name)
+  if (
+    !opts.force
+    && previous !== undefined
+    && now >= previous
+    && now - previous < KEEPER_STREAM_SIGNAL_THROTTLE_MS
+  ) {
+    return
+  }
+  keeperStreamSignalWrites.set(name, now)
+  setRecordValue(keeperStreamLastEventAt, name, now)
+}
+
+function clearKeeperStreamSignal(keeperName: string): void {
+  const name = keeperName.trim()
+  if (!name) return
+  keeperStreamSignalWrites.delete(name)
+  setRecordValue(keeperStreamLastEventAt, name, null)
 }
 
 function cancelTrackingTimeoutMs(): number {
@@ -504,11 +531,11 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
   setRecordValue(keeperSending, request.keeperName, true)
   setRecordValue(keeperActionErrors, request.keeperName, null)
   setRecordValue(keeperStreamStartedAt, request.keeperName, request.submittedAt)
-  setRecordValue(keeperStreamLastEventAt, request.keeperName, Date.now())
+  markKeeperStreamSignal(request.keeperName, { force: true })
   try {
     for (;;) {
       const result = await fetchQueuedKeeperMessageResult(request.requestId)
-      setRecordValue(keeperStreamLastEventAt, request.keeperName, Date.now())
+      markKeeperStreamSignal(request.keeperName)
       if (!isTerminalQueuedKeeperMessage(result)) {
         await sleep(PENDING_KEEPER_CHAT_POLL_MS)
         continue
@@ -609,7 +636,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
     if (!hasPendingKeeperChatRequest(request.keeperName)) {
       setRecordValue(keeperSending, request.keeperName, false)
       setRecordValue(keeperStreamStartedAt, request.keeperName, null)
-      setRecordValue(keeperStreamLastEventAt, request.keeperName, null)
+      clearKeeperStreamSignal(request.keeperName)
     }
   }
 }
@@ -823,7 +850,7 @@ export async function sendKeeperThreadMessage(
       attachments,
       userBlocks,
       onEvent: event => {
-        setRecordValue(keeperStreamLastEventAt, keeperName, Date.now())
+        markKeeperStreamSignal(keeperName)
         if (event.type === 'CUSTOM' && event.name === 'KEEPER_QUEUE_REQUEST') {
           const nextRequestId = isRecord(event.value)
             ? asString(event.value.request_id, '').trim()
@@ -1024,7 +1051,7 @@ export async function sendKeeperThreadMessage(
       clearActiveStream(keeperName)
       setRecordValue(keeperSending, keeperName, false)
       setRecordValue(keeperStreamStartedAt, keeperName, null)
-      setRecordValue(keeperStreamLastEventAt, keeperName, null)
+      clearKeeperStreamSignal(keeperName)
     }
     // No refreshDashboardState() here: forcing a full dashboard
     // refetch after every chat message re-rendered every panel and was

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -3,10 +3,16 @@ import {
   _resetLiveSendRequestOwnersForTests,
   activeStreamRequestId,
   appendThreadEntry,
+  setActiveStream,
   setActiveStreamRequestId,
 } from './keeper-state'
 import { keeperThreads } from './keeper-state'
-import { applyKeeperStreamEvent } from './keeper-stream'
+import {
+  _flushPendingKeeperStreamDeltasForTests,
+  _resetKeeperStreamBuffersForTests,
+  abortKeeperThreadMessage,
+  applyKeeperStreamEvent,
+} from './keeper-stream'
 
 function assistantEntry(): void {
   appendThreadEntry('sangsu', {
@@ -25,6 +31,7 @@ function assistantEntry(): void {
 
 describe('applyKeeperStreamEvent', () => {
   beforeEach(() => {
+    _resetKeeperStreamBuffersForTests()
     keeperThreads.value = {}
     _resetLiveSendRequestOwnersForTests()
   })
@@ -480,6 +487,7 @@ describe('applyKeeperStreamEvent', () => {
       value: { delta: 'reasoning about the problem...' },
     })).toBeNull()
 
+    _flushPendingKeeperStreamDeltasForTests()
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.streamState).toBe('thinking')
     expect(entry?.delivery).toBe('streaming')
@@ -501,10 +509,30 @@ describe('applyKeeperStreamEvent', () => {
       value: { delta: 'tools' },
     })
 
+    expect(keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')?.traceSteps).toBeUndefined()
+    _flushPendingKeeperStreamDeltasForTests()
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.traceSteps).toEqual([
       { kind: 'think', text: 'checking tools', ts: expect.any(String) },
     ])
+  })
+
+  it('drops pending thinking deltas when aborting a live stream', () => {
+    assistantEntry()
+    setActiveStream('sangsu', 'reply-1', new AbortController())
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'half-written reasoning' },
+    })
+
+    abortKeeperThreadMessage('sangsu')
+    _flushPendingKeeperStreamDeltasForTests()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.delivery).toBe('cancelled')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.traceSteps).toBeUndefined()
   })
 
   it('splits thinking trace steps by OAS content block index', () => {
@@ -525,6 +553,7 @@ describe('applyKeeperStreamEvent', () => {
       value: { index: 2, delta: 'next block' },
     })
 
+    _flushPendingKeeperStreamDeltasForTests()
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.traceSteps).toEqual([
       { kind: 'think', text: 'checking tools', ts: expect.any(String), oasBlockIndex: 1 },
@@ -535,6 +564,7 @@ describe('applyKeeperStreamEvent', () => {
 
 describe('applyKeeperStreamEvent tool calls', () => {
   beforeEach(() => {
+    _resetKeeperStreamBuffersForTests()
     keeperThreads.value = {}
     _resetLiveSendRequestOwnersForTests()
   })
@@ -639,6 +669,7 @@ describe('applyKeeperStreamEvent tool calls', () => {
       value: { delta: 'think B' },
     })
 
+    _flushPendingKeeperStreamDeltasForTests()
     const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
     expect(reply?.traceSteps).toEqual([
       { kind: 'think', text: 'think A', ts: expect.any(String) },

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -517,6 +517,32 @@ describe('applyKeeperStreamEvent', () => {
     ])
   })
 
+  it('flushes pending thinking deltas at TEXT_MESSAGE_START without reverting stream state', () => {
+    assistantEntry()
+    // Thinking delta schedules a pending flush.
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'thinking before text' },
+    })
+    // Text phase begins before the scheduled flush runs.
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: 'hello',
+    })
+    // A still-scheduled flush must be a no-op: START already flushed it, so it
+    // cannot revert streamState to 'thinking' after text streaming began.
+    _flushPendingKeeperStreamDeltasForTests()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.streamState).toBe('streaming')
+    expect(entry?.text).toBe('hello')
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'thinking before text', ts: expect.any(String) },
+    ])
+  })
+
   it('drops pending thinking deltas when aborting a live stream', () => {
     assistantEntry()
     setActiveStream('sangsu', 'reply-1', new AbortController())

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -347,6 +347,11 @@ export function applyKeeperStreamEvent(
       setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'sending')
       return null
     case 'TEXT_MESSAGE_START':
+      // Flush any buffered thinking deltas before entering the text phase so a
+      // pending scheduled flush cannot run later and revert streamState to
+      // 'thinking' after text streaming has begun. Mirrors TEXT_MESSAGE_END and
+      // TOOL_CALL_START, which flush at their phase boundaries.
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
       setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
       return null
     case 'TEXT_MESSAGE_CONTENT': {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -35,6 +35,125 @@ const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
 
 const pendingOasToolBlockIndexes = new Map<string, number>()
+type ScheduledFlushHandle = ReturnType<typeof setTimeout> | number
+interface PendingThinkingBatch {
+  text: string
+  oasBlockIndex?: number
+}
+interface PendingThinkingState {
+  batches: PendingThinkingBatch[]
+  flushHandle: ScheduledFlushHandle | null
+  flushViaAnimationFrame: boolean
+}
+
+const pendingThinkingDeltas = new Map<string, PendingThinkingState>()
+
+function streamEntryKey(keeperName: string, assistantEntryId: string): string {
+  return `${keeperName}\u0000${assistantEntryId}`
+}
+
+function scheduleStreamFlush(callback: () => void): {
+  handle: ScheduledFlushHandle
+  viaAnimationFrame: boolean
+} {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    return {
+      handle: globalThis.requestAnimationFrame(callback),
+      viaAnimationFrame: true,
+    }
+  }
+  return {
+    handle: setTimeout(callback, 16),
+    viaAnimationFrame: false,
+  }
+}
+
+function cancelStreamFlush(handle: ScheduledFlushHandle, viaAnimationFrame: boolean): void {
+  if (viaAnimationFrame && typeof globalThis.cancelAnimationFrame === 'function') {
+    globalThis.cancelAnimationFrame(handle as number)
+    return
+  }
+  clearTimeout(handle as ReturnType<typeof setTimeout>)
+}
+
+function sameOasBlockIndex(left: number | undefined, right: number | undefined): boolean {
+  return left === undefined ? right === undefined : left === right
+}
+
+function flushPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {
+  const key = streamEntryKey(keeperName, assistantEntryId)
+  const pending = pendingThinkingDeltas.get(key)
+  if (!pending) return
+  pendingThinkingDeltas.delete(key)
+  if (pending.flushHandle !== null) {
+    cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+  }
+  for (const batch of pending.batches) {
+    appendAssistantThinkingDelta(keeperName, assistantEntryId, batch.text, {
+      oasBlockIndex: batch.oasBlockIndex,
+    })
+  }
+}
+
+function dropPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {
+  const key = streamEntryKey(keeperName, assistantEntryId)
+  const pending = pendingThinkingDeltas.get(key)
+  if (!pending) return
+  pendingThinkingDeltas.delete(key)
+  if (pending.flushHandle !== null) {
+    cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+  }
+}
+
+function flushAllPendingThinkingDeltas(): void {
+  for (const key of Array.from(pendingThinkingDeltas.keys())) {
+    const [keeperName, assistantEntryId] = key.split('\u0000')
+    if (keeperName && assistantEntryId) {
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
+    }
+  }
+}
+
+function enqueueThinkingDelta(
+  keeperName: string,
+  assistantEntryId: string,
+  delta: string,
+  meta: { oasBlockIndex?: number } = {},
+): void {
+  if (!delta.trim()) return
+  const key = streamEntryKey(keeperName, assistantEntryId)
+  let pending = pendingThinkingDeltas.get(key)
+  if (!pending) {
+    pending = { batches: [], flushHandle: null, flushViaAnimationFrame: false }
+    pendingThinkingDeltas.set(key, pending)
+  }
+  const last = pending.batches[pending.batches.length - 1]
+  if (last && sameOasBlockIndex(last.oasBlockIndex, meta.oasBlockIndex)) {
+    last.text += delta
+  } else {
+    pending.batches.push({ text: delta, oasBlockIndex: meta.oasBlockIndex })
+  }
+  if (pending.flushHandle !== null) return
+  const scheduled = scheduleStreamFlush(() => {
+    flushPendingThinkingDeltas(keeperName, assistantEntryId)
+  })
+  pending.flushHandle = scheduled.handle
+  pending.flushViaAnimationFrame = scheduled.viaAnimationFrame
+}
+
+export function _flushPendingKeeperStreamDeltasForTests(): void {
+  flushAllPendingThinkingDeltas()
+}
+
+export function _resetKeeperStreamBuffersForTests(): void {
+  for (const pending of pendingThinkingDeltas.values()) {
+    if (pending.flushHandle !== null) {
+      cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+    }
+  }
+  pendingThinkingDeltas.clear()
+  pendingOasToolBlockIndexes.clear()
+}
 
 export interface KeeperThreadAbortResult {
   readonly keeperName: string
@@ -177,6 +296,7 @@ export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult 
   console.debug(`[keeper-stream] aborting stream for ${keeperName}${entryId ? ` (entry=${entryId})` : ''}${requestId ? ` request=${requestId}` : ''}`)
   if (controller) controller.abort()
   if (entryId) {
+    dropPendingThinkingDeltas(keeperName, entryId)
     finalizeAssistantEntry(keeperName, entryId, {
       text: KEEPER_MESSAGE_CANCELLED_TEXT,
       rawText: KEEPER_MESSAGE_CANCELLED_TEXT,
@@ -205,7 +325,10 @@ export function applyKeeperStreamEvent(
 ): string | null {
   const applyTextDelta = (payload: unknown): void => {
     if (typeof payload !== 'string') return
-    if (payload) appendAssistantDelta(keeperName, assistantEntryId, payload)
+    if (payload) {
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
+      appendAssistantDelta(keeperName, assistantEntryId, payload)
+    }
   }
   const markFinalizingIfLive = (): void => {
     updateThreadEntry(keeperName, assistantEntryId, entry => {
@@ -231,10 +354,12 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TEXT_MESSAGE_END':
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
       markFinalizingIfLive()
       return null
     case 'TOOL_CALL_START': {
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
       const toolCallId = event.toolCallId?.trim()
       const toolName = (event.toolCallName ?? event.name)?.trim()
       if (!toolCallId || !toolName) {
@@ -267,6 +392,7 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TOOL_CALL_ARGS': {
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
       const toolCallId = event.toolCallId?.trim()
       if (!toolCallId) {
         recordStreamProtocolError(
@@ -295,6 +421,7 @@ export function applyKeeperStreamEvent(
       return null
     }
     case 'TOOL_CALL_END': {
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
       const toolCallId = event.toolCallId?.trim()
       if (!toolCallId) {
         recordStreamProtocolError(
@@ -316,6 +443,7 @@ export function applyKeeperStreamEvent(
     }
     case 'CUSTOM':
       if (event.name === 'KEEPER_STREAM_MESSAGE_START') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         const patch: Partial<KeeperConversationDetails> = {}
         const providerMessageId = asString(value?.provider_message_id)
@@ -330,6 +458,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_DELTA') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         const patch: Partial<KeeperConversationDetails> = {}
         const stopReason = asString(value?.stop_reason)
@@ -342,6 +471,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
         markFinalizingIfLive()
         return null
@@ -351,6 +481,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_START') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         const oasBlockIndex = asNumber(value?.index) ?? asNumber(value?.block_index)
         const toolCallId = asString(value?.tool_call_id)
@@ -362,6 +493,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_STOP') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         forgetOasToolBlockIndexByIndex(
           keeperName,
@@ -385,11 +517,12 @@ export function applyKeeperStreamEvent(
         const oasBlockIndex = value
           ? asNumber(value.index) ?? asNumber(value.block_index)
           : undefined
-        if (delta) appendAssistantThinkingDelta(keeperName, assistantEntryId, delta, { oasBlockIndex })
+        if (delta) enqueueThinkingDelta(keeperName, assistantEntryId, delta, { oasBlockIndex })
         else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
         return null
       }
       if (event.name === 'KEEPER_STREAM_PROTOCOL_ERROR') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         forgetOasToolBlockIndexByIndex(
           keeperName,
@@ -405,18 +538,23 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_THINKING_SIGNATURE_DELTA') {
-        setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        if (!pendingThinkingDeltas.has(streamEntryKey(keeperName, assistantEntryId))) {
+          setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        }
         return null
       }
       if (event.name === 'KEEPER_MEDIA_DELTA') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'queued')
         return null
       }
       if (event.name === 'KEEPER_CONTINUATION_CHECKPOINT') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const rawText = isRecord(event.value)
           ? asString(event.value.message, '')
           : ''
@@ -434,6 +572,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_REQUEST_TERMINAL') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const terminal = isRecord(event.value) ? event.value : null
         const terminalRequestId = asString(terminal?.request_id, '').trim()
         const currentRequestId = activeStreamRequestId(keeperName)
@@ -495,6 +634,7 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_REPLY_DETAILS') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const details = normalizeKeeperConversationDetails(event.value)
         if (details) {
           updateThreadEntry(keeperName, assistantEntryId, entry => {
@@ -533,7 +673,13 @@ export function applyKeeperStreamEvent(
         }
       }
       return null
+    case 'RUN_FINISHED':
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
+      clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
+      return null
     case 'RUN_ERROR':
+      flushPendingThinkingDeltas(keeperName, assistantEntryId)
+      clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
       return typeof event.value === 'string'
         ? event.value
         : (isRecord(event.value) ? asString(event.value.message) : null) ?? 'Keeper stream failed'

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -83,9 +83,57 @@ let test_chat_turns_serialize () =
   check "all 4 chat turns completed" (!completed = 4)
 ;;
 
+let test_distinct_keepers_do_not_block_each_other () =
+  reset ();
+  Printf.printf "Test 4: distinct keepers have independent turn slots\n%!";
+  let keeper_a = keeper_name ^ "-a" in
+  let keeper_b = keeper_name ^ "-b" in
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name:keeper_a (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "first keeper chat turn admitted" false);
+    Eio.Promise.await started;
+    (match
+       Keeper_turn_admission.run_if_free ~base_path ~keeper_name:keeper_b (fun () ->
+         true)
+     with
+     | `Ran true ->
+       check "autonomous lane for another keeper runs while first keeper is busy" true
+     | `Ran false | `Busy _ ->
+       check "autonomous lane for another keeper runs while first keeper is busy" false);
+    let other_chat_entered = ref false in
+    let other_chat_completed = ref false in
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name:keeper_b (fun () ->
+          other_chat_entered := true;
+          Eio.Fiber.yield ();
+          other_chat_completed := true)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "other keeper chat turn is not rejected" false);
+    for _ = 1 to 4 do
+      Eio.Fiber.yield ()
+    done;
+    check
+      "chat lane for another keeper enters while first keeper is in flight"
+      !other_chat_entered;
+    check
+      "chat lane for another keeper completes before first keeper releases"
+      !other_chat_completed;
+    Eio.Promise.resolve set_release ())
+;;
+
 let test_waiting_cap_rejects () =
   reset ();
-  Printf.printf "Test 4: chat requests beyond the waiting cap are rejected\n%!";
+  Printf.printf "Test 5: chat requests beyond the waiting cap are rejected\n%!";
   Eio.Switch.run (fun sw ->
     let started, set_started = Eio.Promise.create () in
     let release, set_release = Eio.Promise.create () in
@@ -132,7 +180,7 @@ let test_waiting_cap_rejects () =
 
 let test_exception_releases_slot () =
   reset ();
-  Printf.printf "Test 5: an exception inside the turn releases the slot\n%!";
+  Printf.printf "Test 6: an exception inside the turn releases the slot\n%!";
   (try
      ignore
        (Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
@@ -146,7 +194,7 @@ let test_exception_releases_slot () =
 
 let test_cancelled_waiter_leaves_queue () =
   reset ();
-  Printf.printf "Test 6: a cancelled waiter leaves the queue\n%!";
+  Printf.printf "Test 7: a cancelled waiter leaves the queue\n%!";
   Eio.Switch.run (fun sw ->
     let started, set_started = Eio.Promise.create () in
     let release, set_release = Eio.Promise.create () in
@@ -176,6 +224,7 @@ let () =
   test_free_slot_admits ();
   test_autonomous_skips_in_flight_chat ();
   test_chat_turns_serialize ();
+  test_distinct_keepers_do_not_block_each_other ();
   test_waiting_cap_rejects ();
   test_exception_releases_slot ();
   test_cancelled_waiter_leaves_queue ();


### PR DESCRIPTION
## What changed

- Batch `KEEPER_THINKING_DELTA` updates per stream entry until the next animation frame instead of mutating dashboard state for every SSE delta.
- Drop pending thinking batches on local abort so a cancelled assistant row cannot be revived as `streaming` by a delayed flush.
- Throttle the `keeperStreamLastEventAt` heartbeat signal to 1 second during dense stream bursts so the stall badge stays useful without re-rendering the panel on every SSE frame.
- Render live thinking traces as a bounded plain-text preview while the turn is still streaming, avoiding repeated full markdown parse/sanitize work on growing thinking text.
- Flush pending thinking batches before ordering-sensitive boundaries such as tool calls, media/text transitions, reply details, and terminal events.
- Rebase onto current `origin/main`, preserving the existing settled long-trace collapse/expand behavior.
- Add a keeper turn admission regression test proving a busy turn for one keeper does not block autonomous or chat turns for another keeper.
- Update keeper stream/actions/chat tests to make the new batched, throttled, and bounded-preview behavior explicit.

## Why

A long thinking-only/image turn can emit many small stream events. Each one previously caused immediate signal/thread updates, which can monopolize the browser main thread and make other keeper panels feel unresponsive even though backend turn admission is per keeper.

## Validation

- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/components/chat/primitives.ts src/components/chat/primitives.test.ts src/keeper-actions.ts src/keeper-actions.test.ts`
- `ocamlformat --check test/test_keeper_turn_admission.ml`

Dune build/test intentionally left to CI.

## Browser evidence

Verified the PR dashboard via local Vite (`127.0.0.1:5174`) proxied to the live `8935` API:

- Injected the actual `ChatTranscript` from this PR and grew one streaming thinking trace to 259,230 characters over 120 renders.
- The streaming preview stayed bounded at 6,004 characters, `data-chat-thinking-preview="truncated"`.
- Max render time was 3.8 ms and max timer drift was 2.3 ms during the synthetic stream.
- While that long streaming thinking trace was updating, clicking the real `sangsu` keeper row changed the active composer from `analyst` to `sangsu` in 15.6 ms.
