### PR TITLE
fix(build): main 컴파일 복구 (paren 불균형 + wrapped 모듈 참조)

### DIFF
--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -965,7 +965,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                            ~tool_name
                            ~start_time
                            ~on_cleared
-                       else on_cleared ())))))
+                       else on_cleared ()))))))
   | Ok _, Ok None, _ ->
     validation_error_result
       ~tool_name

--- a/test/test_keeper_hooks_oas_log_shape.ml
+++ b/test/test_keeper_hooks_oas_log_shape.ml
@@ -39,7 +39,7 @@ let test_tool_completion_watchdog_progress_policy () =
     false;
   List.iter
     (fun tool_name -> check_watchdog_completion_progress tool_name false)
-    Keeper_tool_capability_axis.polling_read_tool_names;
+    Masc.Keeper_tool_capability_axis.polling_read_tool_names;
   check_watchdog_completion_progress
     (keeper_tool_name Keeper_tool_name.Task_claim)
     true;


### PR DESCRIPTION
## 목적
origin/main이 컴파일되지 않는 상태를 복구. 독립적인 broken merge 2건.

```
lib/workspace_goals.ml:991  Syntax error: ) expected  (641의 ( 미매칭)
test/test_keeper_hooks_oas_log_shape.ml:42  Unbound module Keeper_tool_capability_axis
```

## 근본 원인

### 1. `lib/workspace_goals.ml` — paren 불균형 (#22871 fix(workspace) double-write)
`(match verif...); (match update...)` (형제)를 `let cancel_result = match ... in (match cancel_result with ... | Ok () -> (match update_goal_phase ...))` (중첩)으로 리팩터하며 match nesting이 1단계 늘었으나 tail 닫는 괄호는 5개 그대로. `handle_goal_transition`은 6개 필요 (get_goal · completion · effective_policy · decide_transition · cancel_result · update_goal_phase). `)` 1개 추가.

### 2. `test/test_keeper_hooks_oas_log_shape.ml` — wrapped 모듈 참조 (#22926 passive reads watchdog)
`Keeper_tool_capability_axis`는 wrapped `Masc` lib 소속인데 테스트가 bare로 참조. 테스트는 `Masc.Keeper_tool_capability_axis` 사용해야 함 (기존 `test_no_progress_loop_detector.ml:16`, `test_keeper_tool_capability_axis.ml:3`과 동일 관용구).

## 검증
- `dune build --root . @check` → **exit 0, 에러 0** (worktree 로컬).
- CI에서 전체 빌드/테스트 재확인.

## P0-P3
- **P0**: main 컴파일 불가 해소. 두 파일 모두 mechanical fix, 동작 변경 없음.
- **P1**: 없음.
- **P2 (남은점)**: 두 PR(#22871, #22926) 모두 컴파일 안 되는 상태로 main에 도달. CI required check 통과 없이 머지된 정황 — required checks 강제 재점검 권고.
- **P3**: 없음.

## 병합 가능성
main 복구용이므로 CI green 확인 즉시 머지 권고. 지연 시 후속 모든 PR의 base가 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
