### PR TITLE
[codex] Fix prompts settings filter selection

### DIFF
--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -165,6 +165,27 @@ describe('PromptRegistryPanel', () => {
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('dry run prompt')
   })
 
+  it('rebinds the clean editor draft to the first visible prompt when filters hide the selection', async () => {
+    render(html`<${PromptRegistryPanel} />`, container)
+    await flush()
+    await flush()
+
+    const textarea = () => container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea().value).toBe('override world')
+
+    const fileChip = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('파일'),
+    ) as HTMLButtonElement | undefined
+    expect(fileChip).toBeTruthy()
+    await fireEvent.click(fileChip!)
+
+    await waitFor(() => {
+      expect(textarea().value).toBe('dry run prompt')
+    })
+    expect(container.textContent).toContain('governance.dry_run')
+    expect(container.textContent).toContain('fixture/config/prompts/governance.dry_run.md')
+  })
+
   it('keeps dirty draft text across filters and confirms before discarding on row selection', async () => {
     render(html`<${PromptRegistryPanel} />`, container)
     await flush()

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
+import { useSignal } from '@preact/signals'
 import { Markdown } from "../common/markdown"
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import {
@@ -208,10 +208,9 @@ export function promptSourceCounts(
   return counts
 }
 
-const sourceFilter = signal<PromptSourceFilter>('all')
-const searchQuery = signal('')
-
 export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean } = {}) {
+  const sourceFilter = useSignal<PromptSourceFilter>('all')
+  const searchQuery = useSignal('')
   const [prompts, setPrompts] = useState<DashboardPromptItem[]>([])
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -226,8 +225,11 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
   const presets = promptPresetOptions(prompts, report)
   const activePreset = presets.some(item => item.id === preset) ? preset : 'all'
   const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value, report, activePreset)
-  const selectedPrompt =
-    (selectedKey ? prompts.find(prompt => prompt.key === selectedKey) : null) ?? visiblePrompts[0] ?? null
+  const selectedPromptFromKey = selectedKey ? prompts.find(prompt => prompt.key === selectedKey) ?? null : null
+  const selectedPromptVisible = selectedPromptFromKey
+    ? visiblePrompts.some(prompt => prompt.key === selectedPromptFromKey.key)
+    : false
+  const selectedPrompt = selectedPromptFromKey ?? visiblePrompts[0] ?? null
   const selectedDestinations = selectedPrompt ? promptDestinationsForKey(report, selectedPrompt.key) : []
   const counts = promptSourceCounts(prompts)
   const draftDirty = selectedPrompt
@@ -240,6 +242,16 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
     setDraft(normalizeDraft(prompt))
     setDraftPromptKey(draftKeyForPrompt(prompt))
   }
+
+  useEffect(() => {
+    if (draftDirty || selectedPromptVisible) return
+    const nextPrompt = visiblePrompts[0] ?? null
+    const nextKey = nextPrompt?.key ?? null
+    if (selectedKey === nextKey) return
+    setSelectedKey(nextKey)
+    setDraftForPrompt(nextPrompt)
+    setStatus(null)
+  }, [draftDirty, selectedKey, selectedPromptVisible, visiblePrompts])
 
   async function loadPrompts(preferredKey?: string | null) {
     setLoading(true)

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -243,15 +243,24 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
     setDraftPromptKey(draftKeyForPrompt(prompt))
   }
 
+  // Depend on the first visible prompt's stable key (a string) rather than the
+  // freshly-allocated [visiblePrompts] array, which changes identity every
+  // render (filterPrompts returns a new array) and would otherwise schedule
+  // this effect after every render/keystroke. [prompts] is stable useState
+  // identity, so re-selection only fires when the fallback target actually
+  // changes.
+  const firstVisibleKey = visiblePrompts[0]?.key ?? null
+
   useEffect(() => {
     if (draftDirty || selectedPromptVisible) return
-    const nextPrompt = visiblePrompts[0] ?? null
-    const nextKey = nextPrompt?.key ?? null
-    if (selectedKey === nextKey) return
-    setSelectedKey(nextKey)
+    if (selectedKey === firstVisibleKey) return
+    const nextPrompt = firstVisibleKey
+      ? prompts.find(prompt => prompt.key === firstVisibleKey) ?? null
+      : null
+    setSelectedKey(firstVisibleKey)
     setDraftForPrompt(nextPrompt)
     setStatus(null)
-  }, [draftDirty, selectedKey, selectedPromptVisible, visiblePrompts])
+  }, [draftDirty, selectedKey, selectedPromptVisible, firstVisibleKey, prompts])
 
   async function loadPrompts(preferredKey?: string | null) {
     setLoading(true)


### PR DESCRIPTION
## Summary

Fixes the Settings > Prompts filter flow so a clean editor draft follows the filtered prompt list. When the active source/search filter hides the current selection, the panel now selects the first visible prompt and refreshes the editor/detail pane to match it.

## Root cause

The left prompt list was filtered, but `selectedPrompt` still preferred `selectedKey` from the full prompt set. That let the list show only file prompts while the right-side editor remained bound to a hidden override prompt.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/tools/prompt-registry-panel.ts src/components/tools/prompt-registry-panel.test.ts`
- `pnpm exec vitest run --config vitest.config.ts src/components/tools/prompt-registry-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check HEAD~1..HEAD`
- Playwright smoke: `/dashboard/#settings?section=prompts` -> click `파일` -> editor/detail rebinding verified for `governance.dry_run`

Full build is left to CI.