### PR TITLE
[codex] Fix runtime routing controls and audit

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -477,7 +477,7 @@ export async function saveRuntimeTomlConfig(sourceText: string): Promise<Runtime
   }).then(normalizeRuntimeTomlConfig)
 }
 
-export type RuntimeRoutingLane = 'default' | 'librarian' | 'cross_verifier'
+export type RuntimeRoutingLane = 'default' | 'librarian' | 'structured_judge' | 'cross_verifier'
 
 export async function patchRuntimeRouting(
   lane: RuntimeRoutingLane,
@@ -487,6 +487,16 @@ export async function patchRuntimeRouting(
   return post<unknown>('/api/v1/runtime/config/routing', {
     lane,
     runtime_id: runtimeId,
+  }).then(normalizeRuntimeTomlConfig)
+}
+
+export async function patchRuntimeMediaFailover(
+  runtimeIds: readonly string[],
+): Promise<RuntimeTomlConfig> {
+  await ensureDevToken()
+  return post<unknown>('/api/v1/runtime/config/routing', {
+    lane: 'media_failover',
+    runtime_ids: [...runtimeIds],
   }).then(normalizeRuntimeTomlConfig)
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -39,6 +39,7 @@ import {
   fetchRuntimeDefaults,
   fetchRuntimeModelMetrics,
   patchRuntimeAssignment,
+  patchRuntimeMediaFailover,
   patchRuntimeRouting,
   patchKeeperConfig,
   saveRuntimeTomlConfig,
@@ -2336,6 +2337,35 @@ describe('runtime.toml raw config API', () => {
     expect(result.source_text).toBe(sourceText)
   })
 
+  it('posts ordered media failover routing patches', async () => {
+    const sourceText = '[runtime]\nmedia_failover = ["rt-a", "rt-b"]\n'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        path: '/tmp/.masc/config/runtime.toml',
+        file_name: 'runtime.toml',
+        source_text: sourceText,
+        reloaded: true,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await patchRuntimeMediaFailover(['rt-a', 'rt-b'])
+
+    expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/runtime/config/routing')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      lane: 'media_failover',
+      runtime_ids: ['rt-a', 'rt-b'],
+    })
+    expect(result.source_text).toBe(sourceText)
+  })
+
   it('posts runtime assignment patches without client-side TOML text', async () => {
     const sourceText = '[runtime.assignments]\nsangsu = "openai.gpt"\n'
     const fetchMock = vi.fn().mockResolvedValue(
@@ -2767,6 +2797,7 @@ describe('fetchRuntimeDefaults', () => {
       model_routing: {
         keeper_assignments: [{ keeper: 'analyst', runtime_id: 'openai.gpt-4o' }],
         librarian_runtime_id: null,
+        structured_judge_runtime_id: null,
         cross_verifier_runtime_id: null,
         media_failover: [],
       },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -140,6 +140,7 @@ export {
   fetchRuntimeDefaults,
   saveRuntimeTomlConfig,
   patchRuntimeAssignment,
+  patchRuntimeMediaFailover,
   patchRuntimeRouting,
 } from './dashboard-runtime'
 

--- a/dashboard/src/api/schemas/runtime-defaults.test.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.test.ts
@@ -21,6 +21,7 @@ function validResponse(overrides: Record<string, unknown> = {}): Record<string, 
     model_routing: {
       keeper_assignments: [{ keeper: 'analyst', runtime_id: 'anthropic.sonnet' }],
       librarian_runtime_id: 'openai.gpt-4o',
+      structured_judge_runtime_id: 'openai.gpt-4o',
       cross_verifier_runtime_id: null,
       media_failover: ['openai.gpt-4o'],
     },
@@ -39,6 +40,7 @@ describe('parseRuntimeDefaultsResponse', () => {
       keeper: 'analyst',
       runtime_id: 'anthropic.sonnet',
     })
+    expect(out.model_routing.structured_judge_runtime_id).toBe('openai.gpt-4o')
     expect(out.model_routing.cross_verifier_runtime_id).toBeNull()
   })
 
@@ -53,6 +55,7 @@ describe('parseRuntimeDefaultsResponse', () => {
         model_routing: {
           keeper_assignments: [],
           librarian_runtime_id: null,
+          structured_judge_runtime_id: null,
           cross_verifier_runtime_id: null,
           media_failover: [],
         },

--- a/dashboard/src/api/schemas/runtime-defaults.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.ts
@@ -37,6 +37,7 @@ const KeeperAssignmentSchema = object({
 const ModelRoutingSchema = object({
   keeper_assignments: array(KeeperAssignmentSchema),
   librarian_runtime_id: nullable(string()),
+  structured_judge_runtime_id: nullable(string()),
   cross_verifier_runtime_id: nullable(string()),
   media_failover: array(string()),
 })

--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -33,9 +33,13 @@ const cfg = (over: { ok?: boolean; source_text?: string; reloaded?: boolean }) =
 
 const fetchMock = vi.fn()
 const saveMock = vi.fn()
+const runtimeRefreshMock = vi.fn(async () => undefined)
 vi.mock('../api/dashboard', () => ({
   fetchRuntimeTomlConfig: () => fetchMock(),
   saveRuntimeTomlConfig: (text: string) => saveMock(text),
+}))
+vi.mock('../lib/runtime-config-refresh', () => ({
+  refreshRuntimeConfigConsumers: () => runtimeRefreshMock(),
 }))
 
 let container: HTMLDivElement
@@ -44,6 +48,7 @@ const q = (sel: string) => container.querySelector(sel)
 beforeEach(() => {
   fetchMock.mockReset()
   saveMock.mockReset()
+  runtimeRefreshMock.mockClear()
   container = document.createElement('div')
   document.body.appendChild(container)
 })
@@ -74,6 +79,7 @@ describe('FusionSettingsPanel', () => {
     await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
     const posted = saveMock.mock.calls[0]?.[0] as string
     expect(posted.split('[fusion.presets.trio]')[1]).toContain('min_answered = 2')
+    expect(runtimeRefreshMock).toHaveBeenCalledTimes(1)
   })
 
   it('surfaces a backend validation rejection (ok=false) instead of claiming success', async () => {

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -20,6 +20,7 @@ import {
   type FusionSettings,
   type FusionSettingsParseIssue,
 } from '../lib/fusion-settings'
+import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
 
 type EditorState = 'loading' | 'idle' | 'saving' | 'saved' | 'error'
 type FusionSettingsDraft = {
@@ -193,7 +194,14 @@ export function FusionSettingsPanel() {
       }
       setSource(cfg.source_text)
       setDraft(draftFromSettings(parsed.settings))
-      setSavedMessage(cfg.reloaded ? '저장됨 (reload 완료)' : '저장됨')
+      try {
+        await refreshRuntimeConfigConsumers()
+        setSavedMessage(cfg.reloaded ? '저장됨 (reload 완료)' : '저장됨')
+      } catch (err) {
+        setError(`저장됨, 대시보드 런타임 갱신 실패: ${errorToString(err)}`)
+        setState('error')
+        return
+      }
       setState('saved')
     } catch (err) {
       if (!mountedRef.current) return

--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, describe, expect, it } from 'vitest'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
 import { keepers } from '../store'
 import type { Keeper } from '../types/core'
@@ -37,13 +38,24 @@ streaming = true
 "nick0cave" = "ollama_cloud.deepseek-v4-flash"
 `
 
-function mountEditor(container: HTMLElement) {
+const sourceTextWithDefaultPinnedAssignment = sourceTextWithQuotedAssignments.replace(
+  '"nick0cave" = "ollama_cloud.deepseek-v4-flash"',
+  '"nick0cave" = "ollama_cloud.minimax-m3"',
+)
+
+function mountEditor(
+  container: HTMLElement,
+  options: {
+    sourceText?: string
+    onAssignmentChange?: (keeperName: string, runtimeId: string | null) => void
+  } = {},
+) {
   render(
     html`<${RuntimeEnvironmentEditor}
-      sourceText=${sourceTextWithQuotedAssignments}
+      sourceText=${options.sourceText ?? sourceTextWithQuotedAssignments}
       section="assignments"
       onRoutingChange=${() => {}}
-      onAssignmentChange=${() => {}}
+      onAssignmentChange=${options.onAssignmentChange ?? (() => {})}
       onBindingFieldChange=${() => {}}
     />`,
     container,
@@ -76,6 +88,70 @@ describe('RuntimeEnvironmentEditor assignments section', () => {
     const fallbackGroup = container.querySelector('[data-testid="runtime-assignments-group-fallback"]')
     expect(fallbackGroup?.textContent).toContain('issue_king')
     expect(fallbackGroup?.textContent).toContain('default 폴백')
+
+    render(null, container)
+  })
+
+  it('keeps an explicit assignment pinned even when it matches the current default', () => {
+    const fixtureKeepers: Keeper[] = [
+      { name: 'nick0cave', status: 'idle' },
+      { name: 'issue_king', status: 'idle' },
+    ]
+    keepers.value = fixtureKeepers
+
+    const container = document.createElement('div')
+    mountEditor(container, { sourceText: sourceTextWithDefaultPinnedAssignment })
+
+    const summary = container.querySelector('[data-testid="runtime-assignments-summary"]')
+    expect(summary?.textContent).toContain('고정 1개')
+    expect(summary?.textContent).toContain('default 폴백 1개')
+
+    const pinnedGroup = container.querySelector('[data-testid="runtime-assignments-group-pinned"]')
+    expect(pinnedGroup?.textContent).toContain('nick0cave')
+    expect(pinnedGroup?.textContent).toContain('고정')
+    expect(pinnedGroup?.textContent).toContain('default와 같음')
+
+    const fallbackGroup = container.querySelector('[data-testid="runtime-assignments-group-fallback"]')
+    expect(fallbackGroup?.textContent).not.toContain('nick0cave')
+
+    render(null, container)
+  })
+
+  it('uses explicit controls for pinning and clearing runtime assignments', () => {
+    keepers.value = [
+      { name: 'nick0cave', status: 'idle' },
+      { name: 'issue_king', status: 'idle' },
+    ]
+    const onAssignmentChange = vi.fn()
+
+    const container = document.createElement('div')
+    mountEditor(container, { onAssignmentChange })
+
+    fireEvent.click(
+      container.querySelector(
+        '[data-testid="runtime-assignment-issue_king-pin-current"]',
+      ) as HTMLButtonElement,
+    )
+    expect(onAssignmentChange).toHaveBeenLastCalledWith(
+      'issue_king',
+      'ollama_cloud.minimax-m3',
+    )
+
+    fireEvent.change(
+      container.querySelector('[aria-label="issue_king 런타임 배정"]') as HTMLSelectElement,
+      { target: { value: 'ollama_cloud.deepseek-v4-flash' } },
+    )
+    expect(onAssignmentChange).toHaveBeenLastCalledWith(
+      'issue_king',
+      'ollama_cloud.deepseek-v4-flash',
+    )
+
+    fireEvent.click(
+      container.querySelector(
+        '[data-testid="runtime-assignment-nick0cave-clear"]',
+      ) as HTMLButtonElement,
+    )
+    expect(onAssignmentChange).toHaveBeenLastCalledWith('nick0cave', null)
 
     render(null, container)
   })

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -248,11 +248,11 @@ export function RuntimeEnvironmentEditor({
   }
 
   function updateAssignment(keeperName: string, runtimeId: string) {
-    if (runtimeId === environment.defaultRuntimeId) {
-      onAssignmentChange(keeperName, null)
-      return
-    }
     onAssignmentChange(keeperName, runtimeId)
+  }
+
+  function clearAssignment(keeperName: string) {
+    onAssignmentChange(keeperName, null)
   }
 
   function updateBindingNumber(
@@ -457,13 +457,21 @@ export function RuntimeEnvironmentEditor({
   // at a glance which keepers actually have a pinned runtime vs. which are
   // just inheriting whatever [runtime].default happens to be.
   const assignmentRows = keeperList.map(keeper => {
-    const current = assignments[keeper.name] ?? environment.defaultRuntimeId
-    return { keeper, current, isDefault: current === environment.defaultRuntimeId }
+    const explicitRuntime = assignments[keeper.name]
+    const isPinned = explicitRuntime !== undefined
+    const current = explicitRuntime ?? environment.defaultRuntimeId
+    return {
+      keeper,
+      current,
+      isPinned,
+      matchesDefault: isPinned && explicitRuntime === environment.defaultRuntimeId,
+    }
   })
-  const pinnedAssignments = assignmentRows.filter(row => !row.isDefault)
-  const fallbackAssignments = assignmentRows.filter(row => row.isDefault)
+  const pinnedAssignments = assignmentRows.filter(row => row.isPinned)
+  const fallbackAssignments = assignmentRows.filter(row => !row.isPinned)
 
   function assignRow(row: (typeof assignmentRows)[number]) {
+    const canPinCurrent = row.current !== ''
     return html`
       <div key=${row.keeper.name} class="rt-assign">
         <span class="rt-assign-k">
@@ -479,9 +487,30 @@ export function RuntimeEnvironmentEditor({
         >
           ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
         </select>
-        ${row.isDefault
-          ? html`<span class="rt-assign-tag mono">↳ default 폴백</span>`
-          : html`<span class="rt-assign-tag pin mono">고정</span>`}
+        ${row.isPinned
+          ? html`<span class="rt-assign-tag pin mono">
+              고정${row.matchesDefault ? ' · default와 같음' : ''}
+            </span>`
+          : html`<span class="rt-assign-tag mono">↳ default 폴백</span>`}
+        ${row.isPinned
+          ? html`
+              <button
+                type="button"
+                class="rt-add-cancel"
+                disabled=${typedPatchDisabled}
+                data-testid=${`runtime-assignment-${row.keeper.name}-clear`}
+                onClick=${() => clearAssignment(row.keeper.name)}
+              >폴백</button>
+            `
+          : html`
+              <button
+                type="button"
+                class="rt-save"
+                disabled=${typedPatchDisabled || !canPinCurrent}
+                data-testid=${`runtime-assignment-${row.keeper.name}-pin-current`}
+                onClick=${() => updateAssignment(row.keeper.name, row.current)}
+              >고정</button>
+            `}
       </div>
     `
   }
@@ -1006,7 +1035,7 @@ export function RuntimeEnvironmentEditor({
       <div class=${section === 'assignments' ? '' : 'hidden'} data-testid="runtime-section-assignments">
         <div class="rt-assigns">
           <div class="rt-note">
-            [runtime.assignments] — keeper → 런타임 id. <span class="mono">default</span>와 같으면 toml에서 생략(폴백).
+            [runtime.assignments] — keeper → 런타임 id.
           </div>
           ${keeperList.length === 0 ? html`
             <div class="rt-note" data-testid="runtime-assignments-empty">표시할 keeper가 없습니다.</div>

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -10,11 +10,19 @@ const apiMocks = vi.hoisted(() => ({
   saveRuntimeTomlConfig: vi.fn(),
 }))
 
+const runtimeRefreshMock = vi.hoisted(() => ({
+  refreshRuntimeConfigConsumers: vi.fn(async () => undefined),
+}))
+
 vi.mock('../api/dashboard', () => ({
   fetchRuntimeTomlConfig: apiMocks.fetchRuntimeTomlConfig,
   patchRuntimeAssignment: apiMocks.patchRuntimeAssignment,
   patchRuntimeRouting: apiMocks.patchRuntimeRouting,
   saveRuntimeTomlConfig: apiMocks.saveRuntimeTomlConfig,
+}))
+
+vi.mock('../lib/runtime-config-refresh', () => ({
+  refreshRuntimeConfigConsumers: runtimeRefreshMock.refreshRuntimeConfigConsumers,
 }))
 
 import { RuntimeTomlEditor } from './runtime-toml-editor'
@@ -102,6 +110,7 @@ describe('RuntimeTomlEditor', () => {
     apiMocks.patchRuntimeAssignment.mockReset()
     apiMocks.patchRuntimeRouting.mockReset()
     apiMocks.saveRuntimeTomlConfig.mockReset()
+    runtimeRefreshMock.refreshRuntimeConfigConsumers.mockClear()
     apiMocks.fetchRuntimeTomlConfig.mockResolvedValue(baseConfig)
     apiMocks.patchRuntimeAssignment.mockImplementation(async (_keeperName: string, runtimeId: string | null) => ({
       ...richConfig,
@@ -181,6 +190,7 @@ describe('RuntimeTomlEditor', () => {
     expect(saveButton.disabled).toBe(true)
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe(nextSource)
     expect(container.querySelector('[data-testid="runtime-toml-impact-preview"]')).toBeNull()
+    expect(runtimeRefreshMock.refreshRuntimeConfigConsumers).toHaveBeenCalledTimes(1)
   })
 
   it('renders runtime environment fields as structured projections', async () => {
@@ -338,6 +348,7 @@ describe('RuntimeTomlEditor', () => {
       expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('default = "openai.gpt"')
     })
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
+    expect(runtimeRefreshMock.refreshRuntimeConfigConsumers).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
   })
 

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -22,6 +22,7 @@ import {
   type RuntimeTomlCredentialType,
   type RuntimeTomlImpactSummary,
 } from '../lib/runtime-toml-config'
+import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
 import { ActionButton } from './common/button'
 import { SectionCard } from './common/card'
 import { copyToClipboard } from './common/copyable-code'
@@ -193,6 +194,18 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
 
   const dirty = config !== null && draft !== config.source_text
 
+  async function adoptSavedRuntimeConfig(saved: RuntimeTomlConfig) {
+    setConfig(saved)
+    setDraft(saved.source_text)
+    try {
+      await refreshRuntimeConfigConsumers()
+      setNotice('적용됨')
+    } catch (err: unknown) {
+      setNotice('적용됨')
+      setError(`대시보드 런타임 갱신 실패: ${errorToString(err)}`)
+    }
+  }
+
   const refresh = useCallback(async () => {
     setLoadState('loading')
     setError(null)
@@ -231,9 +244,7 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     setNotice(null)
     try {
       const saved = await saveRuntimeTomlConfig(nextSourceText)
-      setConfig(saved)
-      setDraft(saved.source_text)
-      setNotice('적용됨')
+      await adoptSavedRuntimeConfig(saved)
     } catch (err: unknown) {
       setError(errorToString(err))
     } finally {
@@ -248,9 +259,7 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     setNotice(null)
     try {
       const saved = await patchRuntimeRouting(lane, runtimeId)
-      setConfig(saved)
-      setDraft(saved.source_text)
-      setNotice('적용됨')
+      await adoptSavedRuntimeConfig(saved)
     } catch (err: unknown) {
       setError(errorToString(err))
     } finally {
@@ -265,9 +274,7 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     setNotice(null)
     try {
       const saved = await patchRuntimeAssignment(keeperName, runtimeId)
-      setConfig(saved)
-      setDraft(saved.source_text)
-      setNotice('적용됨')
+      await adoptSavedRuntimeConfig(saved)
     } catch (err: unknown) {
       setError(errorToString(err))
     } finally {

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -36,6 +36,8 @@ const apiMock = vi.hoisted(() => ({
   fetchRuntimeDefaults: vi.fn(),
   fetchRuntimeProviders: vi.fn(),
   fetchRuntimeTomlConfig: vi.fn(),
+  patchRuntimeMediaFailover: vi.fn(),
+  patchRuntimeRouting: vi.fn(),
   saveRuntimeTomlConfig: vi.fn(),
 }))
 
@@ -69,6 +71,10 @@ const promptApiMock = vi.hoisted(() => ({
   savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
 }))
 
+const runtimeRefreshMock = vi.hoisted(() => ({
+  refreshRuntimeConfigConsumers: vi.fn(async () => undefined),
+}))
+
 vi.mock('../api/dashboard.js', async () => {
   const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
   return {
@@ -79,9 +85,15 @@ vi.mock('../api/dashboard.js', async () => {
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
     fetchRuntimeProviders: apiMock.fetchRuntimeProviders,
     fetchRuntimeTomlConfig: apiMock.fetchRuntimeTomlConfig,
+    patchRuntimeMediaFailover: apiMock.patchRuntimeMediaFailover,
+    patchRuntimeRouting: apiMock.patchRuntimeRouting,
     saveRuntimeTomlConfig: apiMock.saveRuntimeTomlConfig,
   }
 })
+
+vi.mock('../lib/runtime-config-refresh', () => ({
+  refreshRuntimeConfigConsumers: runtimeRefreshMock.refreshRuntimeConfigConsumers,
+}))
 
 vi.mock('../api/mcp', () => ({
   callMcpTool: mcpMock.callMcpTool,
@@ -150,6 +162,7 @@ function makeRuntimeDefaults(
     model_routing: {
       keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
       librarian_runtime_id: null,
+      structured_judge_runtime_id: null,
       cross_verifier_runtime_id: null,
       media_failover: [],
     },
@@ -288,6 +301,20 @@ function stubEmptyApi() {
     source_text: '[runtime]\ndefault = "rt-a"\n',
     reloaded: false,
   })
+  apiMock.patchRuntimeMediaFailover.mockImplementation(async () => ({
+    ok: true,
+    path: MOCK_RUNTIME_PATH,
+    file_name: 'runtime.toml',
+    source_text: '[runtime]\ndefault = "rt-a"\n',
+    reloaded: true,
+  }))
+  apiMock.patchRuntimeRouting.mockImplementation(async () => ({
+    ok: true,
+    path: MOCK_RUNTIME_PATH,
+    file_name: 'runtime.toml',
+    source_text: '[runtime]\ndefault = "rt-a"\n',
+    reloaded: true,
+  }))
   apiMock.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
     ok: true,
     path: MOCK_RUNTIME_PATH,
@@ -321,7 +348,10 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeDefaults.mockReset()
     apiMock.fetchRuntimeProviders.mockReset()
     apiMock.fetchRuntimeTomlConfig.mockReset()
+    apiMock.patchRuntimeMediaFailover.mockReset()
+    apiMock.patchRuntimeRouting.mockReset()
     apiMock.saveRuntimeTomlConfig.mockReset()
+    runtimeRefreshMock.refreshRuntimeConfigConsumers.mockClear()
     mcpMock.callMcpTool.mockClear()
     promptApiMock.clearPromptOverride.mockClear()
     promptApiMock.fetchDashboardPrompts.mockClear()
@@ -814,17 +844,96 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="runtime-catalog-fallback"]')).toBeNull()
   })
 
-  it('runtime section shows resolved keeper assignments read-only', async () => {
+  it('runtime section shows resolved model routing controls and keeper assignments', async () => {
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('librarian')
+      expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('Librarian')
+      expect(container.querySelector('[data-testid="runtime-routing-structured-judge"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-routing-cross-verifier"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-media-failover-editor"]')).not.toBeNull()
       const assignments = Array.from(
         container.querySelectorAll('[data-testid="routing-assignment"]'),
       ).map(n => n.textContent)
       expect(assignments).toEqual(['rt-b'])
+    })
+  })
+
+  it('patches scalar model routing lanes from settings and refreshes the projection', async () => {
+    apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.fetchRuntimeDefaults
+      .mockResolvedValueOnce(makeRuntimeDefaults())
+      .mockResolvedValueOnce(makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
+          librarian_runtime_id: 'rt-b',
+          structured_judge_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: [],
+        },
+      }))
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
+    await waitFor(() => {
+      const select = container.querySelector('[data-testid="runtime-routing-librarian"]') as HTMLSelectElement | null
+      expect(select).not.toBeNull()
+      expect(select?.disabled).toBe(false)
+      expect(select?.options.length).toBeGreaterThan(1)
+    })
+
+    const librarian = container.querySelector('[data-testid="runtime-routing-librarian"]') as HTMLSelectElement
+    await fireEvent.input(librarian, { target: { value: 'rt-b' } })
+
+    await waitFor(() => {
+      expect(apiMock.patchRuntimeRouting).toHaveBeenCalledWith('librarian', 'rt-b')
+      expect(runtimeRefreshMock.refreshRuntimeConfigConsumers).toHaveBeenCalledTimes(1)
+      expect((container.querySelector('[data-testid="runtime-routing-librarian"]') as HTMLSelectElement).value)
+        .toBe('rt-b')
+    })
+    expect(container.querySelector('[data-testid="runtime-routing-message"]')?.textContent).toContain('저장됨')
+  })
+
+  it('patches ordered media failover from settings', async () => {
+    apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.fetchRuntimeDefaults
+      .mockResolvedValueOnce(makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
+          librarian_runtime_id: null,
+          structured_judge_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: ['rt-b'],
+        },
+      }))
+      .mockResolvedValueOnce(makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
+          librarian_runtime_id: null,
+          structured_judge_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: ['rt-b', 'rt-c'],
+        },
+      }))
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
+    await waitFor(() => {
+      const select = container.querySelector('[data-testid="runtime-media-failover-add"]') as HTMLSelectElement | null
+      expect(select).not.toBeNull()
+      expect(select?.disabled).toBe(false)
+      expect(select?.options.length).toBeGreaterThan(1)
+    })
+
+    const add = container.querySelector('[data-testid="runtime-media-failover-add"]') as HTMLSelectElement
+    await fireEvent.input(add, { target: { value: 'rt-c' } })
+
+    await waitFor(() => {
+      expect(apiMock.patchRuntimeMediaFailover).toHaveBeenCalledWith(['rt-b', 'rt-c'])
+      expect(container.querySelector('[data-testid="runtime-media-failover-editor"]')?.textContent)
+        .toContain('rt-c')
     })
   })
 
@@ -834,6 +943,7 @@ describe('SettingsSurface', () => {
         model_routing: {
           keeper_assignments: [],
           librarian_runtime_id: null,
+          structured_judge_runtime_id: null,
           cross_verifier_runtime_id: null,
           media_failover: [],
         },
@@ -917,31 +1027,7 @@ describe('SettingsSurface', () => {
     expect(allRows().length).toBe(7)
   })
 
-  it('renders fusion as a no-writer handoff instead of hardcoded defaults', async () => {
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-fusion"]') as HTMLElement)
-
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('패널·심판 심의')
-    expect(container.querySelector('[data-testid="fusion-readonly-no-writer"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="fusion-no-writer"]')?.textContent).toContain('no hardcoded preview')
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('dedicated writer disabled')
-    expect(container.querySelector('[data-testid="fusion-readonly-enabled"]')).toBeNull()
-    expect(container.querySelector('[data-testid="fusion-readonly-preset"]')).toBeNull()
-    expect(container.querySelector('.set-fus-model')).toBeNull()
-    expect(container.querySelector('[data-testid="set-toggle"]')).toBeNull()
-    expect(container.querySelector('[data-testid="set-seg"]')).toBeNull()
-    expect(container.querySelector('[data-testid="set-stepper"]')).toBeNull()
-    expect(container.querySelector('[data-testid="fusion-settings-editor"]')).toBeNull()
-    expect(container.textContent).not.toContain('per_hour_budget')
-
-    await fireEvent.click(container.querySelector('[data-testid="fusion-open-runtime-toml"]') as HTMLButtonElement)
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임 관리')
-    expect(navigate).toHaveBeenLastCalledWith('settings', { section: 'runtimes' })
-  })
-
-  it('renders the live fusion settings writer only behind VITE_FUSION_SETTINGS_WRITABLE', async () => {
-    vi.stubEnv('VITE_FUSION_SETTINGS_WRITABLE', 'true')
+  it('renders the live fusion settings writer from runtime.toml without an env gate', async () => {
     apiMock.fetchRuntimeTomlConfig.mockResolvedValueOnce({
       ok: true,
       path: MOCK_RUNTIME_PATH,
@@ -956,8 +1042,10 @@ describe('SettingsSurface', () => {
     await waitFor(() => expect(container.querySelector('[data-testid="fusion-settings-editor"]')).not.toBeNull())
     expect(apiMock.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
+    expect(container.querySelector('[data-testid="fusion-readonly-no-writer"]')).toBeNull()
     expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
+    expect(container.textContent).not.toContain('per_hour_budget')
     expect(container.textContent).not.toContain('ollama_cloud.ollama-cloud-devstral-2-123b')
   })
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -20,8 +20,12 @@ import type {
   RuntimeEntry,
   RuntimeDefaultsResponse,
 } from '../api/dashboard.js'
+import {
+  patchRuntimeMediaFailover,
+  patchRuntimeRouting,
+  type RuntimeRoutingLane,
+} from '../api/dashboard.js'
 import { callMcpTool } from '../api/mcp'
-import { envBool } from '../config/env'
 import { shellConfigResolution, shellRuntimeResolution } from '../store'
 import type { DashboardConfigResolutionItem } from '../types'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
@@ -31,10 +35,17 @@ import { ThemeSwitch } from './theme-switch'
 import { logDisplayKind } from './log-classification'
 import { tweaksDensity, type Density } from './tweaks-panel'
 import type { ComponentChildren } from 'preact'
+import { errorToString } from '../lib/format-string'
+import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
 
 type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
+type RuntimeRoutingSaveState = 'idle' | 'saving' | 'saved' | 'error'
+type RuntimeSelectOption = {
+  readonly id: string
+  readonly label: string
+}
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const DEFAULT_SETTINGS_SECTION: SectionId = 'runtime'
 
@@ -264,6 +275,167 @@ function RuntimeCatalogCard({
   `
 }
 
+function uniqueRuntimeSelectOptions(options: RuntimeSelectOption[]): RuntimeSelectOption[] {
+  const seen = new Set<string>()
+  const result: RuntimeSelectOption[] = []
+  for (const option of options) {
+    const id = option.id.trim()
+    if (id === '' || seen.has(id)) continue
+    seen.add(id)
+    result.push({ id, label: option.label })
+  }
+  return result
+}
+
+function runtimeSelectOptionsFromDefaults(entries: readonly RuntimeEntry[]): RuntimeSelectOption[] {
+  return uniqueRuntimeSelectOptions(entries.map(entry => ({
+    id: entry.id,
+    label: `${entry.id} · ${entry.model}`,
+  })))
+}
+
+function runtimeSelectOptionsFromCatalog(entries: readonly DashboardRuntimeProviderSnapshot[]): RuntimeSelectOption[] {
+  return uniqueRuntimeSelectOptions(entries.map(entry => {
+    const id = runtimeCatalogKey(entry)
+    const model = entry.model_api_name ?? entry.model_id ?? entry.models[0] ?? 'model 미수집'
+    return { id, label: `${id} · ${model}` }
+  }))
+}
+
+function RuntimeRoutingSelect({
+  label,
+  hint,
+  value,
+  fallbackLabel,
+  options,
+  disabled,
+  testId,
+  onChange,
+}: {
+  label: string
+  hint: string
+  value: string | null
+  fallbackLabel: string
+  options: readonly RuntimeSelectOption[]
+  disabled: boolean
+  testId: string
+  onChange: (runtimeId: string | null) => void
+}) {
+  return html`
+    <${SetRow} label=${label} hint=${hint}>
+      <select
+        class="set-input mono set-runtime-route-select"
+        data-testid=${testId}
+        value=${value ?? ''}
+        disabled=${disabled || options.length === 0}
+        onInput=${(event: Event) => {
+          const next = (event.currentTarget as HTMLSelectElement).value.trim()
+          onChange(next === '' ? null : next)
+        }}
+      >
+        <option value="">${fallbackLabel}</option>
+        ${options.map(option => html`
+          <option key=${option.id} value=${option.id}>${option.label}</option>
+        `)}
+      </select>
+    <//>
+  `
+}
+
+function RuntimeMediaFailoverEditor({
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  value: readonly string[]
+  options: readonly RuntimeSelectOption[]
+  disabled: boolean
+  onChange: (runtimeIds: string[]) => void
+}) {
+  const selected = new Set(value)
+  const addOptions = options.filter(option => !selected.has(option.id))
+  const move = (index: number, delta: number) => {
+    const target = index + delta
+    if (target < 0 || target >= value.length) return
+    const next = [...value]
+    const current = next[index]
+    if (current === undefined) return
+    next[index] = next[target] ?? current
+    next[target] = current
+    onChange(next)
+  }
+  const remove = (runtimeId: string) => {
+    onChange(value.filter(id => id !== runtimeId))
+  }
+
+  return html`
+    <${SetRow} label="Media failover" hint="[runtime].media_failover ordered reroute list">
+      <div class="set-runtime-media" data-testid="runtime-media-failover-editor">
+        <div class="set-runtime-media-list">
+          ${value.length === 0
+            ? html`<span class="set-hint" data-testid="runtime-media-failover-empty">none</span>`
+            : value.map((runtimeId, index) => html`
+              <span class="set-runtime-media-chip" key=${`${runtimeId}-${index}`}>
+                <span class="mono">${runtimeId}</span>
+                <button
+                  type="button"
+                  class="set-route-icon"
+                  disabled=${disabled || index === 0}
+                  aria-label=${`${runtimeId} 위로 이동`}
+                  onClick=${() => move(index, -1)}
+                >↑</button>
+                <button
+                  type="button"
+                  class="set-route-icon"
+                  disabled=${disabled || index === value.length - 1}
+                  aria-label=${`${runtimeId} 아래로 이동`}
+                  onClick=${() => move(index, 1)}
+                >↓</button>
+                <button
+                  type="button"
+                  class="set-route-icon danger"
+                  disabled=${disabled}
+                  data-testid="runtime-media-failover-remove"
+                  aria-label=${`${runtimeId} 제거`}
+                  onClick=${() => remove(runtimeId)}
+                >×</button>
+              </span>
+            `)}
+        </div>
+        <div class="set-runtime-media-actions">
+          <select
+            class="set-input mono set-runtime-route-select"
+            data-testid="runtime-media-failover-add"
+            value=""
+            disabled=${disabled || addOptions.length === 0}
+            onInput=${(event: Event) => {
+              const select = event.currentTarget as HTMLSelectElement
+              const next = select.value.trim()
+              select.value = ''
+              if (next !== '') onChange([...value, next])
+            }}
+          >
+            <option value="">failover 추가</option>
+            ${addOptions.map(option => html`
+              <option key=${option.id} value=${option.id}>${option.label}</option>
+            `)}
+          </select>
+          <button
+            type="button"
+            class="set-route-clear"
+            disabled=${disabled || value.length === 0}
+            data-testid="runtime-media-failover-clear"
+            onClick=${() => onChange([])}
+          >
+            비우기
+          </button>
+        </div>
+      </div>
+    <//>
+  `
+}
+
 function configEntry(data: DashboardConfigResponse | null, env: string): ConfigEntry | null {
   if (!data) return null
   for (const entries of Object.values(data.categories)) {
@@ -385,16 +557,12 @@ type PathResolutionAvailability = 'ready' | 'partial' | 'loading' | 'unavailable
 
 function settingsSectionState(
   section: SectionId,
-  fusionSettingsWritable: boolean,
   pathResolutionAvailability: PathResolutionAvailability = 'ready',
 ): { mode: SettingsSectionMode; label: string } {
   if (section === 'runtime') return { mode: 'live', label: 'runtime.toml + provider catalog' }
   if (section === 'runtimes') return { mode: 'live', label: 'runtime.toml live-backed' }
   if (section === 'prompts') return { mode: 'live', label: 'prompt registry live-backed' }
-  if (section === 'fusion' && fusionSettingsWritable) {
-    return { mode: 'live', label: 'runtime.toml live-backed' }
-  }
-  if (section === 'fusion') return { mode: 'local', label: 'dedicated writer disabled' }
+  if (section === 'fusion') return { mode: 'live', label: 'runtime.toml live-backed' }
   if (section === 'paths') {
     if (pathResolutionAvailability === 'ready') return { mode: 'live', label: 'resolved by server' }
     if (pathResolutionAvailability === 'partial') return { mode: 'mixed', label: 'partial path resolution' }
@@ -617,6 +785,8 @@ export function SettingsSurface() {
   const [runtimeDefaults, setRuntimeDefaults] = useState<RuntimeDefaultsResponse | null>(null)
   const [runtimeProviders, setRuntimeProviders] = useState<DashboardRuntimeProvidersResponse | null>(null)
   const [runtimeCatalogStatus, setRuntimeCatalogStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [runtimeRoutingStatus, setRuntimeRoutingStatus] = useState<RuntimeRoutingSaveState>('idle')
+  const [runtimeRoutingMessage, setRuntimeRoutingMessage] = useState('')
 
   useEffect(() => {
     let active = true
@@ -651,8 +821,82 @@ export function SettingsSurface() {
     return () => { active = false }
   }, [])
 
-  // fusion (config/runtime.toml [fusion]) — keeper-v2 settings.jsx:178-182
-  const fusionSettingsWritable = envBool('VITE_FUSION_SETTINGS_WRITABLE', false)
+  async function reloadRuntimeDefaultsSnapshot(): Promise<void> {
+    try {
+      const resp = await fetchRuntimeDefaults()
+      setRuntimeDefaults(resp)
+    } catch (err) {
+      setRuntimeDefaults(null)
+      throw err
+    }
+  }
+
+  async function reloadRuntimeProvidersSnapshot(): Promise<void> {
+    setRuntimeCatalogStatus('loading')
+    try {
+      const resp = await fetchRuntimeProviders()
+      setRuntimeProviders(resp)
+      setRuntimeCatalogStatus('ready')
+    } catch (err) {
+      setRuntimeProviders(null)
+      setRuntimeCatalogStatus('error')
+      throw err
+    }
+  }
+
+  async function refreshRuntimeSettingsSnapshot(): Promise<void> {
+    await Promise.all([
+      reloadRuntimeDefaultsSnapshot(),
+      reloadRuntimeProvidersSnapshot(),
+    ])
+  }
+
+  async function finishRuntimeRoutingWrite(): Promise<void> {
+    await refreshRuntimeSettingsSnapshot()
+    await refreshRuntimeConfigConsumers()
+  }
+
+  async function applyRuntimeRoutingPatch(lane: RuntimeRoutingLane, runtimeId: string | null): Promise<void> {
+    if (runtimeRoutingStatus === 'saving') return
+    setRuntimeRoutingStatus('saving')
+    setRuntimeRoutingMessage('')
+    try {
+      await patchRuntimeRouting(lane, runtimeId)
+    } catch (err) {
+      setRuntimeRoutingStatus('error')
+      setRuntimeRoutingMessage(errorToString(err))
+      return
+    }
+    try {
+      await finishRuntimeRoutingWrite()
+      setRuntimeRoutingStatus('saved')
+      setRuntimeRoutingMessage('runtime.toml routing 저장됨')
+    } catch (err) {
+      setRuntimeRoutingStatus('error')
+      setRuntimeRoutingMessage(`저장됨, 대시보드 런타임 갱신 실패: ${errorToString(err)}`)
+    }
+  }
+
+  async function applyMediaFailoverPatch(runtimeIds: string[]): Promise<void> {
+    if (runtimeRoutingStatus === 'saving') return
+    setRuntimeRoutingStatus('saving')
+    setRuntimeRoutingMessage('')
+    try {
+      await patchRuntimeMediaFailover(runtimeIds)
+    } catch (err) {
+      setRuntimeRoutingStatus('error')
+      setRuntimeRoutingMessage(errorToString(err))
+      return
+    }
+    try {
+      await finishRuntimeRoutingWrite()
+      setRuntimeRoutingStatus('saved')
+      setRuntimeRoutingMessage('runtime.toml media_failover 저장됨')
+    } catch (err) {
+      setRuntimeRoutingStatus('error')
+      setRuntimeRoutingMessage(`저장됨, 대시보드 런타임 갱신 실패: ${errorToString(err)}`)
+    }
+  }
 
   // display
   const density = tweaksDensity.value
@@ -683,8 +927,13 @@ export function SettingsSurface() {
     ? keeperAssignments.length
     : runtimeProviders?.assignment_governance?.assignment_count ?? 0
   const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
+  const structuredJudgeRuntime = runtimeDefaults?.model_routing.structured_judge_runtime_id ?? null
   const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
   const mediaFailover = runtimeDefaults?.model_routing.media_failover ?? []
+  const runtimeSelectOptions = runtimeEntries.length > 0
+    ? runtimeSelectOptionsFromDefaults(runtimeEntries)
+    : runtimeSelectOptionsFromCatalog(runtimeCatalogEntries)
+  const runtimeRoutingSaving = runtimeRoutingStatus === 'saving'
   const runtimeResolution = shellRuntimeResolution.value
   const configResolution = shellConfigResolution.value
   const hasRuntimePathResolution = runtimeResolution !== null
@@ -692,7 +941,7 @@ export function SettingsSurface() {
   const hasShellPathResolution = hasRuntimePathResolution || hasConfigPathResolution
   const hasPartialPathProjection = dashboardConfigStatus === 'ready' || runtimeConfigPath !== null
   const pathAvailability = pathResolutionAvailability(dashboardConfigStatus, hasShellPathResolution, hasPartialPathProjection)
-  const baseSectionState = settingsSectionState(sec, fusionSettingsWritable, pathAvailability)
+  const baseSectionState = settingsSectionState(sec, pathAvailability)
   const sectionState =
     sec === 'notify' && dashboardConfigStatus === 'loading'
       ? { mode: 'mixed' as const, label: 'thresholds loading' }
@@ -883,14 +1132,48 @@ export function SettingsSurface() {
 
                 <div class="settings-runtime-section" data-runtime-section="routing" data-testid="runtime-routing-section">
                   <div class="set-sub-h">Model routing</div>
-                  <div class="set-route-summary" data-testid="runtime-routing-summary">
-                    ${librarianRuntime
-                      ? html`<span><span class="sub-k">librarian</span><span class="mono">${librarianRuntime}</span></span>`
-                      : html`<span><span class="sub-k">librarian</span><span class="mono">default runtime</span></span>`}
-                    ${crossVerifierRuntime
-                      ? html`<span><span class="sub-k">cross verifier</span><span class="mono">${crossVerifierRuntime}</span></span>`
-                      : html`<span><span class="sub-k">cross verifier</span><span class="mono">default runtime</span></span>`}
-                    <span><span class="sub-k">media failover</span><span class="mono">${mediaFailover.length > 0 ? mediaFailover.join(', ') : 'none'}</span></span>
+                  <div class="settings-runtime-routing-editor" data-testid="runtime-routing-summary">
+                    <${RuntimeRoutingSelect}
+                      label="Librarian"
+                      hint="[runtime].librarian"
+                      value=${librarianRuntime}
+                      fallbackLabel="default runtime"
+                      options=${runtimeSelectOptions}
+                      disabled=${runtimeRoutingSaving}
+                      testId="runtime-routing-librarian"
+                      onChange=${(runtimeId: string | null) => void applyRuntimeRoutingPatch('librarian', runtimeId)}
+                    />
+                    <${RuntimeRoutingSelect}
+                      label="Structured judge"
+                      hint="[runtime].structured_judge"
+                      value=${structuredJudgeRuntime}
+                      fallbackLabel="librarian/default fallback"
+                      options=${runtimeSelectOptions}
+                      disabled=${runtimeRoutingSaving}
+                      testId="runtime-routing-structured-judge"
+                      onChange=${(runtimeId: string | null) => void applyRuntimeRoutingPatch('structured_judge', runtimeId)}
+                    />
+                    <${RuntimeRoutingSelect}
+                      label="Cross verifier"
+                      hint="[runtime].cross_verifier"
+                      value=${crossVerifierRuntime}
+                      fallbackLabel="default runtime"
+                      options=${runtimeSelectOptions}
+                      disabled=${runtimeRoutingSaving}
+                      testId="runtime-routing-cross-verifier"
+                      onChange=${(runtimeId: string | null) => void applyRuntimeRoutingPatch('cross_verifier', runtimeId)}
+                    />
+                    <${RuntimeMediaFailoverEditor}
+                      value=${mediaFailover}
+                      options=${runtimeSelectOptions}
+                      disabled=${runtimeRoutingSaving}
+                      onChange=${(runtimeIds: string[]) => void applyMediaFailoverPatch(runtimeIds)}
+                    />
+                    ${runtimeRoutingStatus === 'saving'
+                      ? html`<div class="set-hint" data-testid="runtime-routing-saving">runtime.toml 저장 중...</div>`
+                      : runtimeRoutingMessage
+                        ? html`<div class=${runtimeRoutingStatus === 'error' ? 'set-err' : 'set-ok'} data-testid="runtime-routing-message">${runtimeRoutingMessage}</div>`
+                        : null}
                   </div>
                 </div>
 
@@ -923,29 +1206,7 @@ export function SettingsSurface() {
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
                 <span class="mono">masc_fusion</span> 의 out-of-band 심의 루프 (RFC-0252). 서로 다른 모델 패밀리로 패널을 구성해 관점 다양성을 확보하고, 심판이 종합합니다. fusion이 발화 가치 있는지는 keeper가 판단하고 게이트는 남용만 막습니다.
               </div>
-              ${fusionSettingsWritable
-                ? html`<${FusionSettingsPanel} />`
-                : html`
-                <div data-testid="fusion-readonly-no-writer">
-                  <${SetRow} label="Fusion settings" hint="[fusion] in runtime.toml">
-                    <div class="set-truth-value" data-testid="fusion-no-writer">
-                      <span class="mono">dedicated writer disabled</span>
-                      <span class="set-truth-source">no hardcoded preview</span>
-                    </div>
-                  <//>
-                  <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                    이 섹션은 live 값을 읽지 못할 때 문서 기본값을 흉내 내지 않습니다. 실제 값 확인·수정은 runtime.toml editor에서 합니다.
-                  </div>
-                  <button
-                    type="button"
-                    class="set-rt-open"
-                    data-testid="fusion-open-runtime-toml"
-                    onClick=${() => openSection('runtimes')}
-                  >
-                    runtime.toml 열기
-                  </button>
-                </div>
-              `}
+              <${FusionSettingsPanel} />
             `}
 
             ${sec === 'paths' && html`

--- a/dashboard/src/lib/runtime-catalog-resource.ts
+++ b/dashboard/src/lib/runtime-catalog-resource.ts
@@ -27,6 +27,11 @@ export function resetRuntimeCatalog(): void {
   runtimeCatalogResource.reset()
 }
 
+export function reloadRuntimeCatalog(): void {
+  runtimeCatalogResource.reset()
+  loadRuntimeCatalog()
+}
+
 export function findRuntimeCatalogEntry(
   catalog: readonly DashboardRuntimeProviderSnapshot[],
   runtimeId: string,

--- a/dashboard/src/lib/runtime-config-refresh.ts
+++ b/dashboard/src/lib/runtime-config-refresh.ts
@@ -1,0 +1,7 @@
+import { refreshKeeperRuntimeStatus } from '../store'
+import { reloadRuntimeCatalog } from './runtime-catalog-resource'
+
+export async function refreshRuntimeConfigConsumers(): Promise<void> {
+  reloadRuntimeCatalog()
+  await refreshKeeperRuntimeStatus({ force: true })
+}

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -318,6 +318,11 @@
   gap: 8px;
 }
 
+.settings-runtime-routing-editor {
+  display: grid;
+  gap: 10px;
+}
+
 .set-route-summary {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
@@ -341,6 +346,84 @@
 .set-routing-arrow {
   color: var(--text-dim);
   flex: none;
+}
+
+.set-runtime-route-select {
+  min-width: 220px;
+  width: min(100%, 420px);
+}
+
+.set-runtime-media {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+}
+
+.set-runtime-media-list,
+.set-runtime-media-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.set-runtime-media-chip {
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 5px 7px;
+}
+
+.set-runtime-media-chip .mono {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.set-route-icon,
+.set-route-clear {
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  color: var(--text-mid);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--font-ui);
+  font-size: var(--fs-11);
+  justify-content: center;
+  min-height: 24px;
+  padding: 3px 7px;
+}
+
+.set-route-icon {
+  aspect-ratio: 1;
+  padding: 0;
+  width: 24px;
+}
+
+.set-route-icon:hover,
+.set-route-clear:hover {
+  border-color: var(--volt-dim);
+  color: var(--volt);
+}
+
+.set-route-icon.danger:hover {
+  border-color: color-mix(in oklab, var(--status-fail) 55%, transparent);
+  color: var(--status-fail);
+}
+
+.set-route-icon:disabled,
+.set-route-clear:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .set-runtime-transport {

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -341,6 +341,13 @@ let audit_summary ~action ~details =
       | _ -> None)
     | _ -> None
   in
+  let extract_bool key =
+    match details with
+    | `Assoc fields -> (match List.assoc_opt key fields with
+      | Some (`Bool v) -> Some v
+      | _ -> None)
+    | _ -> None
+  in
   match action with
   | ToolCall name ->
     (match extract_str "error_msg" with
@@ -364,9 +371,37 @@ let audit_summary ~action ~details =
      | Some id -> Printf.sprintf "cancel_task %s" id
      | None -> "cancel_task")
   | RuntimeConfigWrite ->
-    (match extract_str "path" with
-     | Some p -> Printf.sprintf "runtime.toml updated: %s" p
-     | None -> "runtime.toml updated")
+    (match extract_str "operation" with
+     | Some "assignment" ->
+       (match extract_str "keeper_name", extract_str "runtime_id", extract_bool "cleared" with
+        | Some keeper, _, Some true ->
+          Printf.sprintf "runtime.toml assignment cleared: %s" keeper
+        | Some keeper, Some runtime_id, _ ->
+          Printf.sprintf "runtime.toml assignment updated: %s -> %s" keeper runtime_id
+        | Some keeper, None, _ ->
+          Printf.sprintf "runtime.toml assignment updated: %s" keeper
+        | None, _, _ -> "runtime.toml assignment updated")
+     | Some "routing" ->
+       (match extract_str "lane", extract_str "runtime_id", extract_bool "cleared" with
+        | Some lane, _, Some true ->
+          Printf.sprintf "runtime.toml routing cleared: %s" lane
+        | Some lane, Some runtime_id, _ ->
+          Printf.sprintf "runtime.toml routing updated: %s -> %s" lane runtime_id
+        | Some lane, None, _ ->
+          Printf.sprintf "runtime.toml routing updated: %s" lane
+        | None, _, _ -> "runtime.toml routing updated")
+     | Some "raw_save" ->
+       (match extract_str "path" with
+        | Some p -> Printf.sprintf "runtime.toml raw save: %s" p
+        | None -> "runtime.toml raw save")
+     | Some "reload" ->
+       (match extract_str "path" with
+        | Some p -> Printf.sprintf "runtime.toml reloaded: %s" p
+        | None -> "runtime.toml reloaded")
+     | _ ->
+       (match extract_str "path" with
+        | Some p -> Printf.sprintf "runtime.toml updated: %s" p
+        | None -> "runtime.toml updated"))
   | _ -> kind
 
 (** Extract primary target from action + details, if any. *)

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -348,6 +348,21 @@ let audit_summary ~action ~details =
       | _ -> None)
     | _ -> None
   in
+  let extract_string_list key =
+    match details with
+    | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`List values) ->
+         let rec loop acc = function
+           | [] -> Some (List.rev acc)
+           | `String v :: rest ->
+             loop (String.sub v 0 (min (String.length v) 80) :: acc) rest
+           | _ :: _ -> None
+         in
+         loop [] values
+       | _ -> None)
+    | _ -> None
+  in
   match action with
   | ToolCall name ->
     (match extract_str "error_msg" with
@@ -382,14 +397,24 @@ let audit_summary ~action ~details =
           Printf.sprintf "runtime.toml assignment updated: %s" keeper
         | None, _, _ -> "runtime.toml assignment updated")
      | Some "routing" ->
-       (match extract_str "lane", extract_str "runtime_id", extract_bool "cleared" with
-        | Some lane, _, Some true ->
+       (match
+          ( extract_str "lane"
+          , extract_str "runtime_id"
+          , extract_string_list "runtime_ids"
+          , extract_bool "cleared" )
+        with
+        | Some lane, _, _, Some true ->
           Printf.sprintf "runtime.toml routing cleared: %s" lane
-        | Some lane, Some runtime_id, _ ->
+        | Some lane, Some runtime_id, _, _ ->
           Printf.sprintf "runtime.toml routing updated: %s -> %s" lane runtime_id
-        | Some lane, None, _ ->
+        | Some lane, None, Some runtime_ids, _ ->
+          Printf.sprintf
+            "runtime.toml routing updated: %s -> [%s]"
+            lane
+            (String.concat ", " runtime_ids)
+        | Some lane, None, None, _ ->
           Printf.sprintf "runtime.toml routing updated: %s" lane
-        | None, _, _ -> "runtime.toml routing updated")
+        | None, _, _, _ -> "runtime.toml routing updated")
      | Some "raw_save" ->
        (match extract_str "path" with
         | Some p -> Printf.sprintf "runtime.toml raw save: %s" p

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -611,6 +611,15 @@ let runtime_scalar_line ~key ~runtime_id =
   Printf.sprintf "%s = \"%s\"" key (toml_escape_string runtime_id)
 ;;
 
+let runtime_string_array_line ~key ~values =
+  let rendered =
+    values
+    |> List.map (fun value -> Printf.sprintf "\"%s\"" (toml_escape_string value))
+    |> String.concat ", "
+  in
+  Printf.sprintf "%s = [%s]" key rendered
+;;
+
 let split_lines content =
   if String.equal content "" then [], false
   else (
@@ -765,6 +774,19 @@ let replace_or_append_runtime_scalar section_lines ~key ~runtime_id =
   loop [] section_lines
 ;;
 
+let replace_or_append_runtime_string_array section_lines ~key ~values =
+  let line = runtime_string_array_line ~key ~values in
+  let rec loop acc = function
+    | [] -> List.rev_append acc [ line ]
+    | existing :: rest ->
+      (match assignment_key_of_line existing with
+       | Some existing_key when String.equal existing_key key ->
+         List.rev_append acc (line :: rest)
+       | _ -> loop (existing :: acc) rest)
+  in
+  loop [] section_lines
+;;
+
 let remove_runtime_scalar section_lines ~key =
   List.filter
     (fun existing ->
@@ -776,6 +798,14 @@ let remove_runtime_scalar section_lines ~key =
 
 let append_runtime_section lines ~key ~runtime_id =
   let section = [ "[runtime]"; runtime_scalar_line ~key ~runtime_id ] in
+  match List.rev lines with
+  | [] -> section
+  | last :: _ when String.equal (String.trim last) "" -> lines @ section
+  | _ -> lines @ ("" :: section)
+;;
+
+let append_runtime_string_array_section lines ~key ~values =
+  let section = [ "[runtime]"; runtime_string_array_line ~key ~values ] in
   match List.rev lines with
   | [] -> section
   | last :: _ when String.equal (String.trim last) "" -> lines @ section
@@ -843,6 +873,28 @@ let update_runtime_scalar_text content ~key ~runtime_id =
            | Some runtime_id -> replace_or_append_runtime_scalar section_lines ~key ~runtime_id
          in
          before @ (header :: next_section_lines) @ after_section)
+  in
+  join_lines updated_lines ~trailing_newline:true
+;;
+
+let update_runtime_string_array_text content ~key ~values =
+  let lines, _trailing_newline = split_lines content in
+  let updated_lines =
+    match find_index is_runtime_header lines with
+    | None -> append_runtime_string_array_section lines ~key ~values
+    | Some header_index ->
+      let before, from_header = split_at header_index lines in
+      (match from_header with
+       | [] -> append_runtime_string_array_section lines ~key ~values
+       | header :: after_header ->
+         let section_lines, after_section =
+           match find_index is_toml_table_header after_header with
+           | None -> after_header, []
+           | Some next_header_index -> split_at next_header_index after_header
+         in
+         before
+         @ (header :: replace_or_append_runtime_string_array section_lines ~key ~values)
+         @ after_section)
   in
   join_lines updated_lines ~trailing_newline:true
 ;;
@@ -964,6 +1016,27 @@ let set_runtime_scalar ?runtime_config_path ~key ~runtime_id () =
       Ok ()
 ;;
 
+let set_runtime_string_array ?runtime_config_path ~key ~runtime_ids () =
+  let key = String.trim key in
+  let runtime_ids = List.map String.trim runtime_ids in
+  if String.equal key ""
+  then Error "runtime key must not be empty"
+  else if contains_newline key
+  then Error "runtime key must not contain newlines"
+  else if List.exists (String.equal "") runtime_ids
+  then Error "runtime_ids must not contain empty entries"
+  else if List.exists contains_newline runtime_ids
+  then Error "runtime_ids must not contain newlines"
+  else (
+    let* path = runtime_config_path_result ?runtime_config_path () in
+    let* content = load_file_result path in
+    let next = update_runtime_string_array_text content ~key ~values:runtime_ids in
+    let* () = validate_runtime_config_text ~config_path:path next in
+    let* () = Fs_compat.save_file_atomic path next in
+    let* () = init_default ~config_path:path in
+    Ok ())
+;;
+
 let set_runtime_default ?runtime_config_path ~runtime_id () =
   set_runtime_scalar ?runtime_config_path ~key:"default" ~runtime_id:(Some runtime_id) ()
 ;;
@@ -972,8 +1045,16 @@ let set_runtime_librarian ?runtime_config_path ~runtime_id () =
   set_runtime_scalar ?runtime_config_path ~key:"librarian" ~runtime_id ()
 ;;
 
+let set_runtime_structured_judge ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar ?runtime_config_path ~key:"structured_judge" ~runtime_id ()
+;;
+
 let set_runtime_cross_verifier ?runtime_config_path ~runtime_id () =
   set_runtime_scalar ?runtime_config_path ~key:"cross_verifier" ~runtime_id ()
+;;
+
+let set_runtime_media_failover ?runtime_config_path ~runtime_ids () =
+  set_runtime_string_array ?runtime_config_path ~key:"media_failover" ~runtime_ids ()
 ;;
 
 (* RFC-0206 single-binding: the deleted [Runtime_runtime.resolve_*_max_context]

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -229,11 +229,23 @@ val set_runtime_librarian :
     writer, validate the resulting config, atomically write it, and refresh the
     in-process runtime cache. *)
 
+val set_runtime_structured_judge :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+(** Persist or clear [\[runtime\]].structured_judge through the runtime.toml
+    SSOT writer, validate the resulting config, atomically write it, and refresh
+    the in-process runtime cache. *)
+
 val set_runtime_cross_verifier :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
 (** Persist or clear [\[runtime\]].cross_verifier through the runtime.toml SSOT
     writer, validate the resulting config, atomically write it, and refresh the
     in-process runtime cache. *)
+
+val set_runtime_media_failover :
+  ?runtime_config_path:string -> runtime_ids:string list -> unit -> (unit, string) result
+(** Persist [\[runtime\]].media_failover through the runtime.toml SSOT writer,
+    validate the resulting config, atomically write it, and refresh the
+    in-process runtime cache. The list order is preserved. *)
 
 val default_max_context : unit -> int
 (** Context-window budget of the default runtime's model (RFC-0206

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -198,6 +198,11 @@ type runtime_route_lane =
   | Runtime_librarian
   | Runtime_cross_verifier
 
+let runtime_route_lane_to_string = function
+  | Runtime_default -> "default"
+  | Runtime_librarian -> "librarian"
+  | Runtime_cross_verifier -> "cross_verifier"
+
 let parse_runtime_route_lane = function
   | "default" -> Ok Runtime_default
   | "librarian" -> Ok Runtime_librarian
@@ -256,7 +261,43 @@ let runtime_config_path_error_status message =
   then `Not_found
   else `Internal_server_error
 
-let audit_runtime_config_write state agent_name ?path ~text ~outcome () =
+type runtime_config_write_operation =
+  | Runtime_config_reload
+  | Runtime_config_raw_save
+  | Runtime_config_routing of runtime_route_lane * string option
+  | Runtime_config_assignment of string * string option
+
+let runtime_config_write_operation_details = function
+  | Runtime_config_reload -> [ ("operation", `String "reload") ]
+  | Runtime_config_raw_save -> [ ("operation", `String "raw_save") ]
+  | Runtime_config_routing (lane, runtime_id) ->
+    [ ("operation", `String "routing")
+    ; ("lane", `String (runtime_route_lane_to_string lane))
+    ; ( "cleared"
+      , `Bool
+          (match runtime_id with
+           | None -> true
+           | Some _ -> false) )
+    ]
+    @
+    (match runtime_id with
+     | None -> []
+     | Some id -> [ ("runtime_id", `String id) ])
+  | Runtime_config_assignment (keeper_name, runtime_id) ->
+    [ ("operation", `String "assignment")
+    ; ("keeper_name", `String keeper_name)
+    ; ( "cleared"
+      , `Bool
+          (match runtime_id with
+           | None -> true
+           | Some _ -> false) )
+    ]
+    @
+    (match runtime_id with
+     | None -> []
+     | Some id -> [ ("runtime_id", `String id) ])
+
+let audit_runtime_config_write state agent_name ?path ~operation ~text ~outcome () =
   try
     Audit_log.log_action
       (Mcp_server.workspace_config state)
@@ -267,6 +308,7 @@ let audit_runtime_config_write state agent_name ?path ~text ~outcome () =
            ((match path with
              | Some p -> [ ("path", `String p) ]
              | None -> [])
+            @ runtime_config_write_operation_details operation
             @ [ ("bytes", `Int (String.length text))
               ; ("lines", `Int (runtime_config_line_count text))
               ]))
@@ -279,10 +321,10 @@ let audit_runtime_config_write state agent_name ?path ~text ~outcome () =
       "runtime.toml audit log failed: %s"
       (Printexc.to_string exn)
 
-let respond_runtime_config_reload state agent_name request reqd =
+let respond_runtime_config_reload state agent_name ~operation request reqd =
   match Runtime_config_file.load_config_text () with
   | Ok (path, saved_text) ->
-    audit_runtime_config_write state agent_name ~path ~text:saved_text
+    audit_runtime_config_write state agent_name ~path ~operation ~text:saved_text
       ~outcome:Audit_log.Success ();
     Http.Response.json_value ~compress:true ~request
       (runtime_config_raw_json ~path ~source_text:saved_text ~reloaded:true)
@@ -472,10 +514,13 @@ let add_routes ~sw ~clock router =
                   provider secrets (RFC-0132 redaction). *)
                (match Runtime_config_file.save_config_text source_text with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:source_text
+                  audit_runtime_config_write state agent_name
+                    ~operation:Runtime_config_raw_save ~text:source_text
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:Runtime_config_raw_save req reqd)
            )
          ) request reqd)
   |> Http.Router.post "/api/v1/runtime/config/routing" (fun request reqd ->
@@ -488,27 +533,44 @@ let add_routes ~sw ~clock router =
              | Ok (Runtime_default, Some runtime_id) ->
                (match Runtime_config_file.set_runtime_default ~runtime_id () with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:body_str
+                  audit_runtime_config_write state agent_name
+                    ~operation:(Runtime_config_routing (Runtime_default, Some runtime_id))
+                    ~text:body_str
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:(Runtime_config_routing (Runtime_default, Some runtime_id))
+                    req reqd)
              | Ok (Runtime_default, None) ->
                respond_dashboard_error ~status:`Bad_request ~request:req reqd
                  "default runtime_id required"
              | Ok (Runtime_librarian, runtime_id) ->
                (match Runtime_config_file.set_runtime_librarian ~runtime_id () with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:body_str
+                  audit_runtime_config_write state agent_name
+                    ~operation:(Runtime_config_routing (Runtime_librarian, runtime_id))
+                    ~text:body_str
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:(Runtime_config_routing (Runtime_librarian, runtime_id))
+                    req reqd)
              | Ok (Runtime_cross_verifier, runtime_id) ->
                (match Runtime_config_file.set_runtime_cross_verifier ~runtime_id () with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:body_str
+                  audit_runtime_config_write state agent_name
+                    ~operation:
+                      (Runtime_config_routing (Runtime_cross_verifier, runtime_id))
+                    ~text:body_str
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:
+                      (Runtime_config_routing (Runtime_cross_verifier, runtime_id))
+                    req reqd)
            )
          ) request reqd)
   |> Http.Router.post "/api/v1/runtime/config/assignment" (fun request reqd ->
@@ -526,17 +588,27 @@ let add_routes ~sw ~clock router =
                     ()
                 with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:body_str
+                  audit_runtime_config_write state agent_name
+                    ~operation:(Runtime_config_assignment (keeper_name, Some runtime_id))
+                    ~text:body_str
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:(Runtime_config_assignment (keeper_name, Some runtime_id))
+                    req reqd)
              | Ok (keeper_name, None) ->
                (match Runtime_config_file.clear_runtime_id_for_keeper ~keeper_name () with
                 | Error msg ->
-                  audit_runtime_config_write state agent_name ~text:body_str
+                  audit_runtime_config_write state agent_name
+                    ~operation:(Runtime_config_assignment (keeper_name, None))
+                    ~text:body_str
                     ~outcome:(Audit_log.Failure msg) ();
                   respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-                | Ok () -> respond_runtime_config_reload state agent_name req reqd)
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:(Runtime_config_assignment (keeper_name, None))
+                    req reqd)
            )
          ) request reqd)
   (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -269,10 +269,10 @@ let parse_runtime_route_body body_str =
                | Ok runtime_ids ->
                  Ok (Runtime_route_runtime_ids (parsed_lane, runtime_ids)))
             | _ ->
-              (match optional_string_field json "runtime_id" with
-               | Error _ as err -> err
-               | Ok runtime_id ->
-                 Ok (Runtime_route_runtime_id (parsed_lane, runtime_id)))))
+	      (match optional_string_field json "runtime_id" with
+	       | Error _ as err -> err
+	       | Ok runtime_id ->
+	         Ok (Runtime_route_runtime_id (parsed_lane, runtime_id))))))
     | _ -> Error "JSON object body required"
   with
   | Yojson.Json_error err -> Error ("invalid json: " ^ err)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -196,18 +196,28 @@ let parse_runtime_config_raw_body body_str =
 type runtime_route_lane =
   | Runtime_default
   | Runtime_librarian
+  | Runtime_structured_judge
   | Runtime_cross_verifier
+  | Runtime_media_failover
 
 let runtime_route_lane_to_string = function
   | Runtime_default -> "default"
   | Runtime_librarian -> "librarian"
+  | Runtime_structured_judge -> "structured_judge"
   | Runtime_cross_verifier -> "cross_verifier"
+  | Runtime_media_failover -> "media_failover"
 
 let parse_runtime_route_lane = function
   | "default" -> Ok Runtime_default
   | "librarian" -> Ok Runtime_librarian
+  | "structured_judge" -> Ok Runtime_structured_judge
   | "cross_verifier" -> Ok Runtime_cross_verifier
+  | "media_failover" -> Ok Runtime_media_failover
   | lane -> Error (Printf.sprintf "unknown runtime routing lane: %s" lane)
+
+type runtime_route_body =
+  | Runtime_route_runtime_id of runtime_route_lane * string option
+  | Runtime_route_runtime_ids of runtime_route_lane * string list
 
 let required_string_field json name =
   match Json_util.assoc_member_opt name json with
@@ -225,6 +235,23 @@ let optional_string_field json name =
     if String.equal trimmed "" then Ok None else Ok (Some trimmed)
   | Some _ -> Error (name ^ " must be a string or null")
 
+let required_string_array_field json name =
+  match Json_util.assoc_member_opt name json with
+  | Some (`List values) ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest ->
+        let trimmed = String.trim value in
+        if String.equal trimmed ""
+        then Error (name ^ " must not contain empty entries")
+        else loop (trimmed :: acc) rest
+      | _ :: _ -> Error (name ^ " must be an array of strings")
+    in
+    loop [] values
+  | Some _ -> Error (name ^ " must be an array of strings")
+  | None -> Error (name ^ " required")
+;;
+
 let parse_runtime_route_body body_str =
   try
     match Yojson.Safe.from_string body_str with
@@ -233,11 +260,19 @@ let parse_runtime_route_body body_str =
        | Error _ as err -> err
        | Ok lane ->
          (match parse_runtime_route_lane lane with
-          | Error _ as err -> err
-          | Ok parsed_lane ->
-            (match optional_string_field json "runtime_id" with
-             | Error _ as err -> err
-             | Ok runtime_id -> Ok (parsed_lane, runtime_id))))
+         | Error _ as err -> err
+         | Ok parsed_lane ->
+           (match parsed_lane with
+            | Runtime_media_failover ->
+              (match required_string_array_field json "runtime_ids" with
+               | Error _ as err -> err
+               | Ok runtime_ids ->
+                 Ok (Runtime_route_runtime_ids (parsed_lane, runtime_ids)))
+            | _ ->
+              (match optional_string_field json "runtime_id" with
+               | Error _ as err -> err
+               | Ok runtime_id ->
+                 Ok (Runtime_route_runtime_id (parsed_lane, runtime_id)))))
     | _ -> Error "JSON object body required"
   with
   | Yojson.Json_error err -> Error ("invalid json: " ^ err)
@@ -265,6 +300,7 @@ type runtime_config_write_operation =
   | Runtime_config_reload
   | Runtime_config_raw_save
   | Runtime_config_routing of runtime_route_lane * string option
+  | Runtime_config_routing_list of runtime_route_lane * string list
   | Runtime_config_assignment of string * string option
 
 let runtime_config_write_operation_details = function
@@ -283,6 +319,12 @@ let runtime_config_write_operation_details = function
     (match runtime_id with
      | None -> []
      | Some id -> [ ("runtime_id", `String id) ])
+  | Runtime_config_routing_list (lane, runtime_ids) ->
+    [ ("operation", `String "routing")
+    ; ("lane", `String (runtime_route_lane_to_string lane))
+    ; ("cleared", `Bool (List.length runtime_ids = 0))
+    ; "runtime_ids", `List (List.map (fun id -> `String id) runtime_ids)
+    ]
   | Runtime_config_assignment (keeper_name, runtime_id) ->
     [ ("operation", `String "assignment")
     ; ("keeper_name", `String keeper_name)
@@ -530,7 +572,7 @@ let add_routes ~sw ~clock router =
              match parse_runtime_route_body body_str with
              | Error msg ->
                respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
-             | Ok (Runtime_default, Some runtime_id) ->
+             | Ok (Runtime_route_runtime_id (Runtime_default, Some runtime_id)) ->
                (match Runtime_config_file.set_runtime_default ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
@@ -542,10 +584,10 @@ let add_routes ~sw ~clock router =
                   respond_runtime_config_reload state agent_name
                     ~operation:(Runtime_config_routing (Runtime_default, Some runtime_id))
                     req reqd)
-             | Ok (Runtime_default, None) ->
+             | Ok (Runtime_route_runtime_id (Runtime_default, None)) ->
                respond_dashboard_error ~status:`Bad_request ~request:req reqd
                  "default runtime_id required"
-             | Ok (Runtime_librarian, runtime_id) ->
+             | Ok (Runtime_route_runtime_id (Runtime_librarian, runtime_id)) ->
                (match Runtime_config_file.set_runtime_librarian ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
@@ -557,7 +599,21 @@ let add_routes ~sw ~clock router =
                   respond_runtime_config_reload state agent_name
                     ~operation:(Runtime_config_routing (Runtime_librarian, runtime_id))
                     req reqd)
-             | Ok (Runtime_cross_verifier, runtime_id) ->
+             | Ok (Runtime_route_runtime_id (Runtime_structured_judge, runtime_id)) ->
+               (match Runtime_config_file.set_runtime_structured_judge ~runtime_id () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name
+                    ~operation:
+                      (Runtime_config_routing (Runtime_structured_judge, runtime_id))
+                    ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:
+                      (Runtime_config_routing (Runtime_structured_judge, runtime_id))
+                    req reqd)
+             | Ok (Runtime_route_runtime_id (Runtime_cross_verifier, runtime_id)) ->
                (match Runtime_config_file.set_runtime_cross_verifier ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
@@ -571,6 +627,28 @@ let add_routes ~sw ~clock router =
                     ~operation:
                       (Runtime_config_routing (Runtime_cross_verifier, runtime_id))
                     req reqd)
+             | Ok (Runtime_route_runtime_id (Runtime_media_failover, _)) ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd
+                 "media_failover runtime_ids required"
+             | Ok (Runtime_route_runtime_ids (Runtime_media_failover, runtime_ids)) ->
+               (match Runtime_config_file.set_runtime_media_failover ~runtime_ids () with
+                | Error msg ->
+                  audit_runtime_config_write state agent_name
+                    ~operation:
+                      (Runtime_config_routing_list (Runtime_media_failover, runtime_ids))
+                    ~text:body_str
+                    ~outcome:(Audit_log.Failure msg) ();
+                  respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+                | Ok () ->
+                  respond_runtime_config_reload state agent_name
+                    ~operation:
+                      (Runtime_config_routing_list (Runtime_media_failover, runtime_ids))
+                    req reqd)
+             | Ok (Runtime_route_runtime_ids (lane, _)) ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd
+                 (Printf.sprintf
+                    "%s runtime_id required"
+                    (runtime_route_lane_to_string lane))
            )
          ) request reqd)
   |> Http.Router.post "/api/v1/runtime/config/assignment" (fun request reqd ->

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -235,6 +235,45 @@ let test_runtime_config_write_assignment_projection () =
   check string "target" "/x/config/runtime.toml" (field "target");
   check string "severity" "warn" (field "severity")
 
+let test_runtime_config_write_routing_list_projection () =
+  let entry : Audit_log.audit_entry =
+    {
+      timestamp = 1_700_000_002.0;
+      agent_id = "dashboard";
+      action = Audit_log.RuntimeConfigWrite;
+      workspace_id = None;
+      details =
+        `Assoc
+          [
+            ("path", `String "/x/config/runtime.toml");
+            ("operation", `String "routing");
+            ("lane", `String "media_failover");
+            ("runtime_ids", `List [ `String "rt-a"; `String "rt-b" ]);
+            ("cleared", `Bool false);
+            ("bytes", `Int 18783);
+            ("lines", `Int 464);
+          ];
+      outcome = Audit_log.Success;
+      cost_estimate = None;
+      token_count = None;
+      trace_id = None;
+    }
+  in
+  let json = Audit_log.audit_event_json entry in
+  let field key =
+    match json with
+    | `Assoc fields -> (
+        match List.assoc_opt key fields with
+        | Some (`String v) -> v
+        | _ -> failf "missing string field %s" key)
+    | _ -> failf "audit_event_json is not an object"
+  in
+  check string "summary"
+    "runtime.toml routing updated: media_failover -> [rt-a, rt-b]"
+    (field "summary");
+  check string "target" "/x/config/runtime.toml" (field "target");
+  check string "severity" "warn" (field "severity")
+
 let () =
   run "Audit_log"
     [
@@ -259,5 +298,7 @@ let () =
             test_runtime_config_write_event_projection;
           test_case "runtime_config_write assignment projection" `Quick
             test_runtime_config_write_assignment_projection;
+          test_case "runtime_config_write routing list projection" `Quick
+            test_runtime_config_write_routing_list_projection;
         ] );
     ]

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -196,6 +196,45 @@ let test_runtime_config_write_event_projection () =
   check string "target" "/x/config/runtime.toml" (field "target");
   check string "severity" "warn" (field "severity")
 
+let test_runtime_config_write_assignment_projection () =
+  let entry : Audit_log.audit_entry =
+    {
+      timestamp = 1_700_000_001.0;
+      agent_id = "dashboard";
+      action = Audit_log.RuntimeConfigWrite;
+      workspace_id = None;
+      details =
+        `Assoc
+          [
+            ("path", `String "/x/config/runtime.toml");
+            ("operation", `String "assignment");
+            ("keeper_name", `String "verifier");
+            ("runtime_id", `String "ollama_cloud.deepseek-v4-flash");
+            ("cleared", `Bool false);
+            ("bytes", `Int 18783);
+            ("lines", `Int 464);
+          ];
+      outcome = Audit_log.Success;
+      cost_estimate = None;
+      token_count = None;
+      trace_id = None;
+    }
+  in
+  let json = Audit_log.audit_event_json entry in
+  let field key =
+    match json with
+    | `Assoc fields -> (
+        match List.assoc_opt key fields with
+        | Some (`String v) -> v
+        | _ -> failf "missing string field %s" key)
+    | _ -> failf "audit_event_json is not an object"
+  in
+  check string "summary"
+    "runtime.toml assignment updated: verifier -> ollama_cloud.deepseek-v4-flash"
+    (field "summary");
+  check string "target" "/x/config/runtime.toml" (field "target");
+  check string "severity" "warn" (field "severity")
+
 let () =
   run "Audit_log"
     [
@@ -218,5 +257,7 @@ let () =
             test_codec_empty_payload;
           test_case "runtime_config_write event projection" `Quick
             test_runtime_config_write_event_projection;
+          test_case "runtime_config_write assignment projection" `Quick
+            test_runtime_config_write_assignment_projection;
         ] );
     ]

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1347,6 +1347,40 @@ let test_structured_judge_runtime_routing () =
         (Runtime.structured_judge_runtime_id ());
       check string "resolved structured judge runtime" "local.judge"
         (Runtime.runtime_id_for_structured_judge ()))
+  ;
+  with_temp_runtime_toml base (fun path ->
+    match
+      Runtime.set_runtime_structured_judge
+        ~runtime_config_path:path
+        ~runtime_id:(Some "local.judge")
+        ()
+    with
+    | Error msg -> failf "set_runtime_structured_judge should validate: %s" msg
+    | Ok () ->
+      check
+        (option string)
+        "writer saved structured_judge runtime id"
+        (Some "local.judge")
+        (Runtime.structured_judge_runtime_id ());
+      check bool "runtime.toml structured_judge persisted" true
+        (String_util.contains_substring
+           (Fs_compat.load_file path)
+           "structured_judge = \"local.judge\""));
+  with_temp_runtime_toml (base ^ "structured_judge = \"local.judge\"\n") (fun path ->
+    match
+      Runtime.set_runtime_structured_judge
+        ~runtime_config_path:path
+        ~runtime_id:None
+        ()
+    with
+    | Error msg -> failf "clear structured_judge should validate: %s" msg
+    | Ok () ->
+      check (option string) "writer cleared structured_judge" None
+        (Runtime.structured_judge_runtime_id ());
+      check bool "runtime.toml structured_judge removed" false
+        (String_util.contains_substring
+           (Fs_compat.load_file path)
+           "structured_judge"))
 
 let test_save_config_text_refreshes_cross_verifier_runtime () =
   with_fake_runtime_model_catalog @@ fun () ->

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -387,6 +387,44 @@ let test_runtime_route_writer_clears_optional_librarian () =
       (Runtime.librarian_runtime_id ()))
 ;;
 
+let test_runtime_route_writer_updates_media_failover () =
+  with_runtime_file (fun path ->
+    (match
+       Runtime.set_runtime_media_failover
+         ~runtime_config_path:path
+         ~runtime_ids:[ "openai.gpt"; "runpod_mtp.qwen" ]
+         ()
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "set_runtime_media_failover failed: %s" msg);
+    Alcotest.(check (list string))
+      "media failover cache"
+      [ "openai.gpt"; "runpod_mtp.qwen" ]
+      (Runtime.media_failover ());
+    Alcotest.(check bool)
+      "runtime.toml media_failover persisted"
+      true
+      (string_contains
+         (Fs_compat.load_file path)
+         "media_failover = [\"openai.gpt\", \"runpod_mtp.qwen\"]");
+    (match
+       Runtime.set_runtime_media_failover
+         ~runtime_config_path:path
+         ~runtime_ids:[]
+         ()
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "clear runtime media_failover failed: %s" msg);
+    Alcotest.(check (list string))
+      "media failover cleared"
+      []
+      (Runtime.media_failover ());
+    Alcotest.(check bool)
+      "runtime.toml media_failover explicitly empty"
+      true
+      (string_contains (Fs_compat.load_file path) "media_failover = []"))
+;;
+
 let test_runtime_config_text_loads_runtime_toml () =
   with_runtime_file (fun path ->
     match Runtime.load_config_text ~runtime_config_path:path () with
@@ -936,6 +974,10 @@ let () =
             "dashboard runtime route writer clears optional librarian"
             `Quick
             test_runtime_route_writer_clears_optional_librarian
+        ; Alcotest.test_case
+            "dashboard runtime route writer updates media_failover"
+            `Quick
+            test_runtime_route_writer_updates_media_failover
         ; Alcotest.test_case
             "dashboard raw runtime.toml load returns full source"
             `Quick


### PR DESCRIPTION
## What changed

- Fix the dashboard runtime assignment editor so selecting the current default runtime writes an explicit keeper assignment instead of silently clearing it.
- Add explicit `고정` / `폴백` controls for keeper runtime assignments, including the case where a keeper is pinned to the same runtime as `[runtime].default`.
- Expose Settings → Runtime model routing controls for:
  - `[runtime].librarian`
  - `[runtime].structured_judge`
  - `[runtime].cross_verifier`
  - ordered `[runtime].media_failover`
- Remove the `VITE_FUSION_SETTINGS_WRITABLE` gate so Settings → Fusion opens the live runtime.toml-backed Fusion editor by default.
- Refresh runtime consumers after runtime.toml writes: runtime catalog singleton, keeper shell runtime status, and execution slice.
- Extend runtime.toml writers and the routing API for `structured_judge` and ordered `media_failover` without adding a parallel TOML writer.
- Enrich `runtime_config_write` audit events with non-secret operation metadata, including list-valued routing updates.

## Why

The Settings runtime routing section was a read-only projection even though the dashboard already had write-capable runtime.toml endpoints. Operators could see librarian/cross-verifier/media-failover values but could not change them there.

The Fusion editor existed, but Settings hid it behind an env flag, so the live writer looked unavailable by default.

Runtime saves also reloaded the server config but did not invalidate dashboard runtime consumers, which left surfaces like the right rail showing stale runtime labels until a later refresh.

## Validation

- `ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli lib/server/server_routes_http_routes_dashboard.ml lib/audit_log.ml test/test_runtime_per_keeper_routing.ml test/test_runtime_config_validity.ml test/test_audit_log.ml`
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts src/components/runtime-toml-editor.test.ts src/components/fusion-settings-panel.test.ts src/api/dashboard.test.ts src/api/schemas/runtime-defaults.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit`

## Not run

- `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe test/test_runtime_config_validity.exe test/test_audit_log.exe`

Blocked by an existing bare Dune process:

```text
[dune-local] live Dune process outside scripts/dune-local.sh detected:
[dune-local]   61599 61587 dune build --root . lib/
[dune-local] refusing to start another local build while the machine-wide Dune lock is bypassed
```

Rendered Playwright validation was attempted against a worktree Vite dev server, but the local Playwright JS package is not installed and the PATH Playwright shim points at a missing pipx interpreter.
