### PR TITLE
fix(keeper): passive-only turn is a pass, not an operator page (RFC-0303 P0)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -106,6 +106,14 @@ type operator_disposition_reason =
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
   | Reason_completion_contract_unsatisfied
+  | Reason_passive_no_action
+      (* RFC-0303 Phase 0: a passive-only turn is activity (thinking / deciding
+         to defer / choosing to wait), not an operator-pageable failure. It maps
+         to [Disp_pass] with this reason so the dashboard keeps the "was passive"
+         telemetry WITHOUT raising needs_attention. Distinct from
+         [Reason_completion_contract_unsatisfied], which stays a pause for the
+         genuinely-unsatisfied contract variants (violated / claim-only /
+         needs-execution-progress). *)
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled
@@ -123,6 +131,7 @@ let operator_disposition_reason_to_string = function
   | Reason_internal_error -> "internal_error"
   | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
   | Reason_completion_contract_unsatisfied -> "completion_contract_unsatisfied"
+  | Reason_passive_no_action -> "passive_no_action"
   | Reason_turn_budget_exhausted -> "turn_budget_exhausted"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
@@ -361,6 +370,17 @@ let operator_disposition (receipt : t)
             && receipt.runtime_outcome = Runtime_completed
             && terminal_reason_is_success receipt
     then Disp_pass, Reason_healthy
+    else if receipt.completion_contract_result = Contract_passive_only
+    then
+      (* RFC-0303 Phase 0: passive-only is NOT an operator page. The turn still
+         produced activity (thinking / defer / choosing to wait); "should it have
+         acted on available work?" is a goal-layer semantic judgment, not a
+         per-turn pause. This carve-out precedes [completion_contract_unsatisfied]
+         so the genuinely-unsatisfied variants (violated / claim-only /
+         needs-execution-progress) still page via the branch below. The prior
+         [passive_only_without_work_scope] arm above already passed the no-work
+         case; this extends Disp_pass to passive-WITH-work-scope turns too. *)
+      Disp_pass, Reason_passive_no_action
     else if completion_contract_unsatisfied receipt.completion_contract_result
     then Disp_pause_human, Reason_completion_contract_unsatisfied
     else if

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -361,8 +361,18 @@ let operator_disposition (receipt : t)
       | Pre_dispatch_success _
       | Other _ -> false
     then
-      if completion_contract_satisfied receipt.completion_contract_result
-         || (passive_only_without_work_scope receipt && receipt.outcome = `Ok)
+      (* RFC-0303 Phase 0: a passive-only turn is not an operator page even
+         when it also exhausted its turn budget. Without this, the
+         [Contract_passive_only] carve-out below is unreachable for any
+         turn_budget_exhausted terminal_reason, since this branch already
+         returns first -- exactly the gap review-flagged for this PR.
+         [passive_only_without_work_scope] implies [Contract_passive_only],
+         so checking the result variant directly subsumes it here (the
+         work-scope/outcome refinement only matters for the [Reason_healthy]
+         branch below, which this arm never reaches). *)
+      if receipt.completion_contract_result = Contract_passive_only
+      then Disp_pass, Reason_passive_no_action
+      else if completion_contract_satisfied receipt.completion_contract_result
       then Disp_pass, Reason_turn_budget_exhausted
       else Disp_alert_exhausted, Reason_turn_budget_exhausted
     else if passive_only_without_work_scope receipt

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -258,6 +258,13 @@ type operator_disposition_reason =
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
   | Reason_completion_contract_unsatisfied
+  | Reason_passive_no_action
+  (** RFC-0303 Phase 0: a passive-only turn ([Contract_passive_only]) paired with
+      [Disp_pass]. The turn produced activity (thinking / defer / choosing to
+      wait) but took no execution/completion action; it is not an operator page.
+      Distinct from [Reason_completion_contract_unsatisfied] ([Disp_pause_human]),
+      which remains for the genuinely-unsatisfied contract variants. Kept as
+      inert dashboard telemetry — it does not raise needs_attention. *)
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -346,24 +346,21 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
-let composite_execution_passive_only_without_work_scope execution =
-  match completion_contract_result_of_execution execution with
-  | Some Completion_contract_result.Passive_only ->
-    Option.is_none (json_string "current_task_id" execution)
-    && Json_util.json_string_list_member "goal_ids" execution = []
-  | Some _ | None -> false
-;;
-
 let composite_execution_completion_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Completion_contract_result.Passive_only
-    when composite_execution_passive_only_without_work_scope execution ->
+  | Some Completion_contract_result.Passive_only ->
+    (* RFC-0303 Phase 0: a passive-only turn is activity (thinking / defer /
+       choosing to wait), NOT a dashboard block — regardless of whether the
+       keeper held a claimed task or the world offered work. "Should it have
+       acted on available work?" is a goal-layer semantic judgment, not a
+       per-turn attention flag. The prior work-scope carve-out
+       ([passive_only_without_work_scope]) is removed: passive is uniformly
+       non-blocking now. *)
     None
   | Some
       ( Completion_contract_result.Violated
       | Completion_contract_result.Claim_only_after_owned_task
-      | Completion_contract_result.Needs_execution_progress
-      | Completion_contract_result.Passive_only as result ) ->
+      | Completion_contract_result.Needs_execution_progress as result ) ->
     Some ("completion_contract_result:" ^ Completion_contract_result.to_string result)
   | Some _
   | None -> None
@@ -371,8 +368,11 @@ let composite_execution_completion_unsatisfied_reason execution =
 
 let composite_execution_budget_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Completion_contract_result.Passive_only
-    when composite_execution_passive_only_without_work_scope execution ->
+  | Some Completion_contract_result.Passive_only ->
+    (* RFC-0303 Phase 0: passive-only under turn-budget exhaustion is not a
+       block. A budget-exhausted turn that only did passive things is still
+       activity; the exhaustion itself is surfaced via the budget disposition,
+       not by re-classifying passive as an unsatisfied contract. *)
     None
   | Some
       (* TEL-OK: pure dashboard classifier; maps typed receipt labels to a
@@ -383,8 +383,7 @@ let composite_execution_budget_unsatisfied_reason execution =
       | Completion_contract_result.Surface_mismatch
       | Completion_contract_result.No_capable_provider
       | Completion_contract_result.Claim_only_after_owned_task
-      | Completion_contract_result.Needs_execution_progress
-      | Completion_contract_result.Passive_only as result ) ->
+      | Completion_contract_result.Needs_execution_progress as result ) ->
     Some ("completion_contract_result:" ^ Completion_contract_result.to_string result)
   | Some _
   | None -> None

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -602,7 +602,13 @@ let () =
     }
   in
   let got = R.operator_disposition passive_receipt in
-  let want = R.Disp_pass, R.Reason_turn_budget_exhausted in
+  (* RFC-0303 Phase 0: passive-only is not an operator page even when the
+     turn also exhausted its budget (review-flagged gap on this PR: the
+     turn_budget_exhausted branch used to return before ever reaching the
+     Contract_passive_only carve-out, so its Disp_pass carried the
+     misleading [Reason_turn_budget_exhausted] instead of
+     [Reason_passive_no_action]). *)
+  let want = R.Disp_pass, R.Reason_passive_no_action in
   check
     (Printf.sprintf
        "no-work passive turn budget exhaustion want=%s got=%s"
@@ -613,7 +619,11 @@ let () =
     { passive_receipt with current_task_id = Some "TASK-1" }
   in
   let got = R.operator_disposition active_passive_receipt in
-  let want = R.Disp_alert_exhausted, R.Reason_turn_budget_exhausted in
+  (* Same carve-out extends to passive-WITH-work-scope turns (current_task_id
+     set): before this fix this case fell through to
+     [Disp_alert_exhausted, Reason_turn_budget_exhausted], paging an operator
+     for activity RFC-0303 says should never page. *)
+  let want = R.Disp_pass, R.Reason_passive_no_action in
   check
     (Printf.sprintf
        "active passive turn budget exhaustion want=%s got=%s"

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -431,22 +431,37 @@ let () =
     (R.operator_disposition_kind_of_string "blocked_runtime" = None)
 ;;
 
-let intentional_passive_only_no_work_policy_change (receipt : R.t) got =
-  if
-    receipt.completion_contract_result = R.Contract_passive_only
-    && Option.is_none receipt.current_task_id
-    && receipt.actionable_signal = Some C.No_actionable_signal
-  then (
-    let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
-    match terminal_reason, receipt.outcome, got with
-    | code, `Ok, (R.Disp_pass, R.Reason_turn_budget_exhausted)
-      when String.starts_with ~prefix:"turn_budget_exhausted" code ->
+let intentional_passive_only_policy_change (receipt : R.t) got =
+  if receipt.completion_contract_result <> R.Contract_passive_only
+  then false
+  else
+    match got with
+    (* RFC-0303 Phase 0: passive-only is activity, not a page. Wherever the
+       frozen oracle routed a passive turn to the contract-unsatisfied pause
+       ([Disp_pause_human]/[completion_contract_unsatisfied]), the live function
+       now returns a non-paging [Disp_pass]/[passive_no_action] — regardless of
+       work scope. This is the intended reversal of the albini "85 pages/day"
+       classification. *)
+    | R.Disp_pass, R.Reason_passive_no_action -> true
+    (* Pre-existing no-work carve-outs (frozen oracle predates them): a passive
+       turn with no claimed task and no actionable signal already passed. *)
+    | R.Disp_pass, R.Reason_turn_budget_exhausted
+      when Option.is_none receipt.current_task_id
+           && receipt.actionable_signal = Some C.No_actionable_signal
+           && receipt.outcome = `Ok
+           && String.starts_with
+                ~prefix:"turn_budget_exhausted"
+                (String.lowercase_ascii receipt.terminal_reason_code) ->
       true
-    | ("completed" | "success"), `Ok, (R.Disp_pass, R.Reason_healthy)
-      when receipt.runtime_outcome = R.Runtime_completed ->
+    | R.Disp_pass, R.Reason_healthy
+      when Option.is_none receipt.current_task_id
+           && receipt.actionable_signal = Some C.No_actionable_signal
+           && receipt.outcome = `Ok
+           && receipt.runtime_outcome = R.Runtime_completed
+           && (let c = String.lowercase_ascii receipt.terminal_reason_code in
+               c = "completed" || c = "success") ->
       true
-    | _ -> false)
-  else false
+    | _ -> false
 ;;
 
 (* To keep the product bounded we vary the most behaviour-determining axes
@@ -489,7 +504,7 @@ let () =
                                      in
                                      if want <> got
                                         && not
-                                             (intentional_passive_only_no_work_policy_change
+                                             (intentional_passive_only_policy_change
                                                 receipt
                                                 got)
                                      then (
@@ -637,15 +652,22 @@ let () =
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want);
+  (* RFC-0303 Phase 0: a passive-only turn is activity, not a page — even when
+     the keeper holds a claimed task. It maps to [Disp_pass]/[passive_no_action],
+     NOT [Disp_pause_human]. "Should it have worked the claimed task?" is a
+     goal-layer judgment, not a per-turn contract failure. *)
   let active_receipt = { receipt with current_task_id = Some "TASK-1" } in
   let got = R.operator_disposition active_receipt in
-  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  let want = R.Disp_pass, R.Reason_passive_no_action in
   check
     (Printf.sprintf
-       "completed active passive-only receipt want=%s got=%s"
+       "completed active passive-only receipt is pass (not a page) want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
-    (got = want)
+    (got = want);
+  check
+    "active passive-only turn does NOT need an operator broadcast"
+    (not (R.needs_operator_broadcast (fst got)))
 ;;
 
 (* Root B (#22710) regression: a coordination keeper always carries goals
@@ -679,21 +701,29 @@ let () =
     R.operator_disposition
       (coordination_passive ~actionable_signal:(Some C.Has_unclaimed_tasks) ())
   in
-  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  (* RFC-0303 Phase 0: the albini "85 pages/day" root. A coordination keeper
+     that saw unclaimed tasks but chose not to claim one this turn is NOT a
+     page — choosing not to act on available work is a decision, not a contract
+     failure. Passive-only is uniformly [Disp_pass]/[passive_no_action]. *)
+  let want = R.Disp_pass, R.Reason_passive_no_action in
   check
     (Printf.sprintf
-       "coordination keeper with unclaimed tasks still pages an operator want=%s got=%s"
+       "coordination keeper with unclaimed tasks does NOT page (passive is a \
+        decision, not a failure) want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want);
   check
-    "unclaimed-task passive turn needs an operator broadcast"
-    (R.needs_operator_broadcast (fst got));
+    "unclaimed-task passive turn does NOT need an operator broadcast"
+    (not (R.needs_operator_broadcast (fst got)));
+  (* RFC-0303 Phase 0: with no world observation threaded, a passive-only turn
+     is still not a page. Observability loss is a runtime concern (surfaced on
+     the runtime error path), not a manufactured passive-turn operator page. *)
   let got = R.operator_disposition (coordination_passive ~actionable_signal:None ()) in
-  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  let want = R.Disp_pass, R.Reason_passive_no_action in
   check
     (Printf.sprintf
-       "coordination keeper with no observation falls back to broadcast-required \
+       "coordination keeper with no observation is pass (passive is not a page) \
         want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -210,20 +210,20 @@ let test_passive_budget_exhaustion_without_work_scope_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
-let test_active_passive_budget_exhaustion_is_blocked () =
+let test_active_passive_budget_exhaustion_is_not_blocked () =
+  (* RFC-0303 Phase 0: passive-only is activity, not a block — even with a
+     claimed task (work scope) under turn-budget exhaustion. The budget
+     disposition ("pass") is not an operator page, and passive no longer
+     re-classifies as an unsatisfied contract. *)
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
       ~execution:active_passive_budget_execution
   in
-  check bool "blocked" true attention.cra_blocked;
-  check bool "needs_attention" true attention.cra_needs_attention;
-  check string "state" "blocked" attention.cra_state;
-  check
-    (option string)
-    "reason"
-    (Some "completion_contract_result:passive_only")
-    attention.cra_reason
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
 ;;
 
 let test_completed_passive_receipt_without_work_scope_is_not_blocked () =
@@ -238,20 +238,19 @@ let test_completed_passive_receipt_without_work_scope_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
-let test_active_completed_passive_receipt_is_blocked () =
+let test_active_completed_passive_receipt_is_not_blocked () =
+  (* RFC-0303 Phase 0: a completed passive-only turn with work scope is not a
+     block. "Should it have acted on the claimed task?" is a goal-layer semantic
+     judgment, not a per-turn dashboard attention flag. *)
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
       ~execution:active_completed_passive_execution
   in
-  check bool "blocked" true attention.cra_blocked;
-  check bool "needs_attention" true attention.cra_needs_attention;
-  check string "state" "blocked" attention.cra_state;
-  check
-    (option string)
-    "reason"
-    (Some "completion_contract_result:passive_only")
-    attention.cra_reason
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
 ;;
 
 let test_not_dispatched_budget_exhaustion_is_blocked () =
@@ -290,17 +289,17 @@ let () =
             `Quick
             test_passive_budget_exhaustion_without_work_scope_is_not_blocked
         ; test_case
-            "active passive turn-budget exhaustion is blocked"
+            "active passive turn-budget exhaustion is not blocked"
             `Quick
-            test_active_passive_budget_exhaustion_is_blocked
+            test_active_passive_budget_exhaustion_is_not_blocked
         ; test_case
             "completed passive receipt without work scope is not blocked"
             `Quick
             test_completed_passive_receipt_without_work_scope_is_not_blocked
         ; test_case
-            "active completed passive receipt is blocked"
+            "active completed passive receipt is not blocked"
             `Quick
-            test_active_completed_passive_receipt_is_blocked
+            test_active_completed_passive_receipt_is_not_blocked
         ; test_case
             "not-dispatched turn-budget exhaustion is blocked"
             `Quick


### PR DESCRIPTION
## 무엇을 / 왜

**passive-only 턴은 "주의(pause_human)"가 아니라 "통과(pass)"입니다.** 프롬프트를 받은 에이전트 턴은 항상 활동(생각 / defer / 대기 선택 / 지금은 claim 안 함)을 산출합니다. "무진행 턴은 없다" — passive를 실패로 분류하는 건 범주 오류입니다.

기존에는 **두 개의 독립 attention surface**가 passive를 실패로 올렸습니다:

1. **런타임 페이지 경로** — `keeper_execution_receipt.operator_disposition`이 work scope 있는 passive를 `Disp_pause_human`/`completion_contract_unsatisfied`로 라우팅 → `needs_operator_broadcast = true` (= albini "하루 ~85회 페이지"의 근원).
2. **대시보드 composite 경로** — `server_dashboard_http_composite_claims`가 `Passive_only`(work scope 有)를 `completion_contract_result:passive_only` 블록으로 재분류 → 로스터 "주의".

## 변경

- `keeper_execution_receipt`: `completion_contract_unsatisfied` 분기 **앞에** passive carve-out 추가 → `Disp_pass, Reason_passive_no_action` (신규 reason). 진짜 unsatisfied variant(violated / claim-only / needs-execution-progress)는 **계속 페이지**.
- `server_dashboard_http_composite_claims`: `completion`/`budget` unsatisfied 분류기의 blocked variant 목록에서 `Passive_only` 제거. work-scope 예외 헬퍼 제거(이제 passive는 균일하게 non-blocking).
- `Reason_passive_no_action`은 **inert telemetry** — 대시보드는 "passive였음" 사유를 유지하되 needs_attention은 올리지 않음.

"available work에 대해 행동했어야 했나?"는 goal 레이어의 semantic 판단이지, per-turn 휴리스틱 pause가 아닙니다.

## 범위 (RFC-0303 Phase 0)

- **런타임 lifecycle 무변경**: no-progress detector, wake tombstone 미변경 (Phase 2-3).
- `Contract_passive_only` / `made_progress` 삭제 안 함.
- 독립 revert 가능.

## 검증

- `dune build lib/ test/` green (새 variant가 어떤 exhaustive match도 안 깸).
- `test_keeper_terminal_reason_typed`: drift-guard 매트릭스 **230400 케이스 0 mismatch** (passive→pass deviation을 intentional로 승인).
- `test_server_dashboard_composite_attention`: active passive budget/completed 턴이 이제 not-blocked 단언.
- `test_no_progress_loop_detector` (35), `test_keeper_auto_pause_blocker_persist_12683` (26): 미변경, green — 검출기는 disposition과 분리됨을 확인.

RFC-0303: `docs/rfc/RFC-0303-stimulus-gated-keeper-wake.md` (Phase 0). 원 RFC PR #22934 (번호 정정 #22936).

⚠️ 운영자 hot area(#22882/#22892/#22926 passive/no-progress 연쇄 fix)와 겹칩니다. 이 PR은 그 밴드에이드 연쇄가 겨냥한 근원(passive를 페이지로 취급)을 되돌립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
