### PR TITLE
feat(keeper): tag wake origin on turn decisions (RFC-0303 P1)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -56,10 +56,12 @@ let decide_keepalive_scheduling
      reported as tombstone suppressions.
      Reactive turns are gated upstream in the registry, so only the autonomous
      channel is gated here. *)
+  let self_cadence_evaluated =
+    requested_should_run_turn
+    && Keeper_world_observation.is_autonomous turn_decision.channel
+  in
   let self_cadence_wake : Keeper_wake_tombstone.wake_decision =
-    if
-      requested_should_run_turn
-      && Keeper_world_observation.is_autonomous turn_decision.channel
+    if self_cadence_evaluated
     then
       wake_tombstone_decide ~origin:Keeper_wake_tombstone.Self_cadence
         ~keeper_name:meta.name
@@ -93,6 +95,18 @@ let decide_keepalive_scheduling
   in
   let verdict_reasons =
     let base = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
+    (* RFC-0303 Phase 1: tag the wake origin on every autonomous self-cadence
+       turn decision (allowed OR suppressed) so the share of blind self-cadence
+       wakes — the ones that manufacture passive turns — is observable before
+       Phase 2 gates wakes on a real stimulus. *)
+    let base =
+      if self_cadence_evaluated
+      then
+        ("wake_origin:"
+         ^ Keeper_wake_tombstone.origin_label Keeper_wake_tombstone.Self_cadence)
+        :: base
+      else base
+    in
     let base =
       match self_cadence_wake with
       | Keeper_wake_tombstone.Suppressed reason ->

--- a/lib/keeper/keeper_wake_tombstone.ml
+++ b/lib/keeper/keeper_wake_tombstone.ml
@@ -56,3 +56,15 @@ let decide ~(origin : wake_origin) ~keeper_name =
 (** Stable label for metrics/logs. *)
 let suppression_label (s : wake_suppression) =
   match s with Tombstoned_no_progress_loop -> "tombstone_no_progress_loop"
+
+(** Stable wake-origin label for metrics/logs (RFC-0303 Phase 1). Lets the turn
+    decision surface record WHY a keeper woke, so the share of automatic
+    [Self_cadence] wakes (the ones that manufacture passive turns) is
+    observable before Phase 2 gates them on a stimulus. *)
+let origin_label (o : wake_origin) =
+  match o with
+  | Mention -> "mention"
+  | Board_reactive -> "board_reactive"
+  | Heartbeat -> "heartbeat"
+  | Operator_direct -> "operator_direct"
+  | Self_cadence -> "self_cadence"

--- a/lib/keeper/keeper_wake_tombstone.mli
+++ b/lib/keeper/keeper_wake_tombstone.mli
@@ -33,3 +33,6 @@ val bypasses_tombstone : wake_origin -> bool
 val decide : origin:wake_origin -> keeper_name:string -> wake_decision
 
 val suppression_label : wake_suppression -> string
+
+(** Stable wake-origin label for metrics/logs (RFC-0303 Phase 1). *)
+val origin_label : wake_origin -> string

--- a/test/test_keeper_wake_tombstone.ml
+++ b/test/test_keeper_wake_tombstone.ml
@@ -93,6 +93,19 @@ let test_self_cadence_not_paused_when_not_latched () =
     "self-cadence wake allowed for non-latched (recovered) keeper"
     false (is_suppressed T.Self_cadence "tombstone-recover")
 
+(* RFC-0303 Phase 1: stable origin labels for the turn-decision observability
+   tag (wake_origin:<label>). Pin every constructor so a new origin cannot ship
+   without a label, and so the dashboard/log parser keys stay stable. *)
+let test_origin_label_is_stable () =
+  Alcotest.(check string) "mention" "mention" (T.origin_label T.Mention);
+  Alcotest.(check string)
+    "board_reactive" "board_reactive" (T.origin_label T.Board_reactive);
+  Alcotest.(check string) "heartbeat" "heartbeat" (T.origin_label T.Heartbeat);
+  Alcotest.(check string)
+    "operator_direct" "operator_direct" (T.origin_label T.Operator_direct);
+  Alcotest.(check string)
+    "self_cadence" "self_cadence" (T.origin_label T.Self_cadence)
+
 let () =
   Alcotest.run "keeper_wake_tombstone"
     [
@@ -119,5 +132,8 @@ let () =
           ( "R2b self-cadence allowed when not latched (recovered)",
             `Quick,
             with_eio test_self_cadence_not_paused_when_not_latched );
+          ( "origin_label is stable per constructor",
+            `Quick,
+            test_origin_label_is_stable );
         ] );
     ]


### PR DESCRIPTION
## 무엇을 / 왜

Phase 2가 wake를 자극 기반으로 게이트하기 **전에**, blind `Self_cadence` wake(= passive 턴을 만들어내는 그 wake)의 비중을 **관측 가능**하게 만듭니다.

## 변경 (계측 전용, lifecycle 무변경)

- `Keeper_wake_tombstone.origin_label : wake_origin -> string` 추가 — 모든 origin의 안정 라벨.
- autonomous 턴에서 self-cadence wake가 평가될 때(allowed/suppressed 무관) `verdict_reasons`에 `wake_origin:self_cadence` 태깅 → 턴 decision surface/로그에서 origin 집계 가능.
- `decide`는 순수 유지. `origin_label`은 Phase 2 stimulus 로깅에서 재사용.

## 검증

- `dune build lib/ test/` green.
- `test_keeper_wake_tombstone`: `origin_label` 모든 constructor 고정(drift guard) + 기존 게이트 7개 = **8 green**.
- `test_heartbeat_integration`: **31 green** (verdict_reasons 태깅이 기존 단언 안 깸).

RFC-0303 Phase 1. Phase 0 = #22942.

RFC-WAIVED: RFC-0303 Phase 1. keeper wake 계측, credential/operator-control/hooks subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
