### PR TITLE
fix(server): delegate missing OAS model catalog to agent_sdk

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -12,8 +12,39 @@ let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
 
 type model_catalog_env_resolution =
   { path : string
-  ; source : string
+  ; source : model_catalog_env_source
   }
+
+and model_catalog_env_source =
+  | Env_var of model_catalog_env_var
+  | Parent_file of
+      { origin : model_catalog_parent_origin
+      ; filename : string
+      }
+
+and model_catalog_env_var =
+  | Oas_model_catalog
+  | Masc_model_catalog
+
+and model_catalog_parent_origin =
+  | Cwd_parent
+  | Argv0_parent
+
+let model_catalog_env_var_name = function
+  | Oas_model_catalog -> "OAS_MODEL_CATALOG"
+  | Masc_model_catalog -> "MASC_MODEL_CATALOG"
+
+let model_catalog_parent_origin_label = function
+  | Cwd_parent -> "cwd-parent"
+  | Argv0_parent -> "argv0-parent"
+
+let model_catalog_env_source_to_string = function
+  | Env_var var -> model_catalog_env_var_name var
+  | Parent_file { origin; filename } ->
+    Printf.sprintf "%s:%s" (model_catalog_parent_origin_label origin) filename
+
+let models_toml_filename = "models.toml"
+let oas_models_toml_filename = "oas-models.toml"
 
 let nonempty_env env name =
   match env name with
@@ -36,19 +67,21 @@ let rec find_in_parents filename dir depth =
   if depth <= 0 then
     None
   else
-    let path = Filename.concat dir filename in
-    match existing_file path with
-    | Some _ as found -> found
-    | None ->
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then None else find_in_parents filename parent (depth - 1)
+      let path = Filename.concat dir filename in
+      match existing_file path with
+      | Some _ as found -> found
+      | None ->
+        let parent = Filename.dirname dir in
+        if String.equal parent dir then None else find_in_parents filename parent (depth - 1)
 
-let find_catalog_in_parents ~source dir =
-  match find_in_parents "models.toml" dir 10 with
-  | Some path -> Some { path; source = source ^ ":models.toml" }
+let find_catalog_in_parents ~origin dir =
+  match find_in_parents models_toml_filename dir 10 with
+  | Some path ->
+    Some { path; source = Parent_file { origin; filename = models_toml_filename } }
   | None ->
-    (match find_in_parents "oas-models.toml" dir 10 with
-     | Some path -> Some { path; source = source ^ ":oas-models.toml" }
+    (match find_in_parents oas_models_toml_filename dir 10 with
+     | Some path ->
+       Some { path; source = Parent_file { origin; filename = oas_models_toml_filename } }
      | None -> None)
 
 let absolute_or_cwd ~cwd path =
@@ -66,11 +99,11 @@ let argv0_parent_dir ~cwd argv0 =
   | Some path -> Some (Filename.dirname path)
 
 let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
-  match nonempty_env env "OAS_MODEL_CATALOG" with
-  | Some path -> Some { path; source = "OAS_MODEL_CATALOG" }
+  match nonempty_env env (model_catalog_env_var_name Oas_model_catalog) with
+  | Some path -> Some { path; source = Env_var Oas_model_catalog }
   | None ->
-    (match nonempty_env env "MASC_MODEL_CATALOG" with
-     | Some path -> Some { path; source = "MASC_MODEL_CATALOG" }
+    (match nonempty_env env (model_catalog_env_var_name Masc_model_catalog) with
+     | Some path -> Some { path; source = Env_var Masc_model_catalog }
      | None ->
        let search_cwd =
          match cwd with
@@ -85,29 +118,47 @@ let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
          | Some argv0 -> argv0
          | None ->
            (match Array.to_list Sys.argv with
-            | head :: _ -> head
-            | [] -> "")
+           | head :: _ -> head
+           | [] -> "")
        in
-       (match find_catalog_in_parents ~source:"cwd-parent" search_cwd with
+       (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
         | Some _ as found -> found
         | None ->
           (match argv0_parent_dir ~cwd:process_cwd argv0 with
-           | Some dir -> find_catalog_in_parents ~source:"argv0-parent" dir
+           | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
            | None -> None)))
 
-let configure_oas_model_catalog_env () =
-  match resolve_oas_model_catalog_path () with
-  | Some { source = "OAS_MODEL_CATALOG"; path } as resolution ->
+let configure_oas_model_catalog_env
+      ?(env = Sys.getenv_opt)
+      ?cwd
+      ?argv0
+      ?(putenv = Unix.putenv)
+      ?(preload_agent_sdk_catalog = Llm_provider.Model_catalog.preload_global)
+      ?(agent_sdk_catalog = Llm_provider.Model_catalog.global)
+      ()
+  =
+  match resolve_oas_model_catalog_path ~env ?cwd ?argv0 () with
+  | Some { source = Env_var Oas_model_catalog; path } as resolution ->
     Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s already configured" path;
     resolution
   | Some { source; path } as resolution ->
-    Unix.putenv "OAS_MODEL_CATALOG" path;
-    Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s" path source;
+    putenv (model_catalog_env_var_name Oas_model_catalog) path;
+    Log.Misc.info
+      "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s"
+      path
+      (model_catalog_env_source_to_string source);
     resolution
   | None ->
-    Log.Misc.warn
-      "model_catalog: no OAS model catalog resolved; capability lookups may fall \
-       back to provider_default";
+    preload_agent_sdk_catalog ();
+    (match agent_sdk_catalog () with
+     | Some _ ->
+       Log.Misc.info
+         "model_catalog: no explicit catalog path resolved; using agent_sdk ambient \
+          model catalog"
+     | None ->
+       Log.Misc.warn
+         "model_catalog: no explicit or agent_sdk ambient model catalog resolved; \
+          capability lookups may fall back to provider_default");
     None
 
 (* GC tuning for long-running server with bursty allocation.

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -12,8 +12,25 @@ val startup_config_resolution : base_path:string -> Config_dir_resolver.resoluti
 
 type model_catalog_env_resolution =
   { path : string
-  ; source : string
+  ; source : model_catalog_env_source
   }
+
+and model_catalog_env_source =
+  | Env_var of model_catalog_env_var
+  | Parent_file of
+      { origin : model_catalog_parent_origin
+      ; filename : string
+      }
+
+and model_catalog_env_var =
+  | Oas_model_catalog
+  | Masc_model_catalog
+
+and model_catalog_parent_origin =
+  | Cwd_parent
+  | Argv0_parent
+
+val model_catalog_env_source_to_string : model_catalog_env_source -> string
 
 val resolve_oas_model_catalog_path :
   ?env:(string -> string option) ->
@@ -22,7 +39,15 @@ val resolve_oas_model_catalog_path :
   unit ->
   model_catalog_env_resolution option
 
-val configure_oas_model_catalog_env : unit -> model_catalog_env_resolution option
+val configure_oas_model_catalog_env :
+  ?env:(string -> string option) ->
+  ?cwd:string ->
+  ?argv0:string ->
+  ?putenv:(string -> string -> unit) ->
+  ?preload_agent_sdk_catalog:(unit -> unit) ->
+  ?agent_sdk_catalog:(unit -> Llm_provider.Model_catalog.t option) ->
+  unit ->
+  model_catalog_env_resolution option
 
 (** {1 Runtime Context}
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -125,6 +125,10 @@ let make_config_root root =
   write_file (Filename.concat config "personas/example.txt") "persona";
   config
 
+let model_catalog_resolution_source_label resolution =
+  Server_runtime_bootstrap.model_catalog_env_source_to_string
+    resolution.Server_runtime_bootstrap.source
+
 let test_model_catalog_resolution_prefers_explicit_env () =
   let env = function
     | "OAS_MODEL_CATALOG" -> Some "/explicit/oas-models.toml"
@@ -143,7 +147,7 @@ let test_model_catalog_resolution_prefers_explicit_env () =
      Alcotest.(check string)
        "source"
        "OAS_MODEL_CATALOG"
-       resolution.Server_runtime_bootstrap.source;
+       (model_catalog_resolution_source_label resolution);
      Alcotest.(check string)
        "path"
        "/explicit/oas-models.toml"
@@ -164,7 +168,7 @@ let test_model_catalog_resolution_prefers_explicit_env () =
     Alcotest.(check string)
       "source"
       "MASC_MODEL_CATALOG"
-      resolution.Server_runtime_bootstrap.source;
+      (model_catalog_resolution_source_label resolution);
     Alcotest.(check string)
       "path"
       "/explicit/masc-models.toml"
@@ -195,7 +199,7 @@ let test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path (
       Alcotest.(check string)
         "source"
         "argv0-parent:oas-models.toml"
-        resolution.Server_runtime_bootstrap.source;
+        (model_catalog_resolution_source_label resolution);
       Alcotest.(check string)
         "path"
         (canonical_path catalog)
@@ -226,11 +230,31 @@ let test_model_catalog_resolution_resolves_relative_argv0_from_process_cwd () =
       Alcotest.(check string)
         "source"
         "argv0-parent:oas-models.toml"
-        resolution.Server_runtime_bootstrap.source;
+        (model_catalog_resolution_source_label resolution);
       Alcotest.(check string)
         "path"
         (canonical_path catalog)
         (canonical_path resolution.Server_runtime_bootstrap.path))
+
+let test_model_catalog_configuration_delegates_to_agent_sdk_ambient () =
+  with_temp_dir "model-catalog-bootstrap-agent-sdk" (fun dir ->
+    let putenv_calls = ref [] in
+    let preload_calls = ref 0 in
+    let env _ = None in
+    let result =
+      Server_runtime_bootstrap.configure_oas_model_catalog_env
+        ~env
+        ~cwd:dir
+        ~argv0:(Filename.concat dir "main_eio.exe")
+        ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
+        ~preload_agent_sdk_catalog:(fun () -> incr preload_calls)
+        ~agent_sdk_catalog:(fun () -> Some [])
+        ()
+    in
+    Alcotest.(check bool) "no explicit path resolution" true (Option.is_none result);
+    Alcotest.(check int) "preload called once" 1 !preload_calls;
+    Alcotest.(check int) "does not write OAS_MODEL_CATALOG" 0
+      (List.length !putenv_calls))
 
 let write_config_root_keeper_toml config_root name =
   write_file
@@ -4160,6 +4184,10 @@ let () =
             "model catalog resolution uses process cwd for relative argv0"
             `Quick
             test_model_catalog_resolution_resolves_relative_argv0_from_process_cwd;
+          Alcotest.test_case
+            "model catalog configuration delegates to agent_sdk ambient catalog"
+            `Quick
+            test_model_catalog_configuration_delegates_to_agent_sdk_ambient;
           Alcotest.test_case
             "bootstrap base-path config copies shared seed only"
             `Quick


### PR DESCRIPTION
## Summary
- Keep explicit `OAS_MODEL_CATALOG`, `MASC_MODEL_CATALOG`, and repo-local catalog resolution as the first-class override path.
- Replace stringly source handling with typed catalog source variants in server bootstrap.
- When no explicit/local catalog path resolves, call `Llm_provider.Model_catalog.preload_global()` and report whether agent_sdk ambient catalog resolution is available instead of warning directly about provider-default fallback.
- Add a bootstrap regression proving the missing-explicit-catalog path delegates to agent_sdk ambient catalog resolution without writing `OAS_MODEL_CATALOG`.

## Boundary
- MASC remains the OAS consumer; OAS has no MASC dependency.
- This PR intentionally does not bump the OAS pin yet. OAS #2424 is green but still draft/open, and MASC pin SSOT requires the pinned SHA to be reachable from OAS `main`.

## Validation
- `opam exec -- ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check origin/main...HEAD`
- Full build/test: CI authority per repo workflow.

## CI Notes
- Initial Build and Test failed on stale base before `origin/main` included #22947 (`openai_compat/deepseek-v4-pro` catalog row).
- Rebased on `origin/main` at `960565f99fd`; current head is `c0347fea751`.
