### PR TITLE
fix(catalog): add missing openai_compat/deepseek-v4-pro provider-qualified row

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -30,6 +30,43 @@ output_per_million = 0.87
 cache_write_multiplier = 1.0
 cache_read_multiplier = 0.008333333333333333
 
+# WORKAROUND: same gap as the deepseek-v4-flash row below (see its comment for
+# the full explanation) — provider_config.ml has no base_url recognizer for
+# api.deepseek.com, so capabilities_for_config_model looks up
+# "openai_compat/deepseek-v4-pro" and the bare row above cannot satisfy it.
+# This provider-qualified row was missing here while the flash sibling had
+# already been fixed, which left [cross_verifier = "deepseek.deepseek-v4-pro"]
+# (config/runtime.toml) failing test_repo_runtime_bindings_resolve_through_oas_catalog
+# and breaking Runtime.init_default_strict / the CI "Runtime TOML gate" for
+# every PR built off main.
+# Root fix: same as deepseek-v4-flash's — a base_url recognizer for
+# api.deepseek.com in OAS (jeong-sik/oas#2374 precedent for runpod_mtp).
+# Removal target: after that OAS recognizer is pinned here and proven stable.
+# Capabilities mirror the bare deepseek-v4-pro row above.
+[[models]]
+id_prefix = "openai_compat/deepseek-v4-pro"
+base = "openai_chat"
+provider_name = "deepseek"
+max_context_tokens = 1000000
+max_output_tokens = 384000
+supports_tools = true
+supports_tool_choice = true
+supports_required_tool_choice = false
+supports_named_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "thinking_object"
+supports_response_format_json = true
+supports_structured_output = false
+supports_native_streaming = true
+supports_caching = true
+supports_prompt_caching = false
+input_per_million = 0.435
+output_per_million = 0.87
+cache_write_multiplier = 1.0
+cache_read_multiplier = 0.008333333333333333
+
 [[models]]
 id_prefix = "deepseek-v4-flash"
 base = "openai_chat"


### PR DESCRIPTION
## 목표

main HEAD 자체가 `test_repo_runtime_bindings_resolve_through_oas_catalog`("Runtime TOML gate" CI job)에서 실패하고 있어, main에서 브랜치를 딴 모든 PR의 필수 체크가 red입니다. `config/runtime.toml`의 `cross_verifier = "deepseek.deepseek-v4-pro"` 바인딩이 `oas-models.toml` 카탈로그에서 해석되지 않습니다.

## 근본 원인

`provider_config.ml`이 `api.deepseek.com`에 대한 base_url recognizer가 없어 generic `openai_compat` label로 fall-through합니다. `capabilities_for_config_model`은 `"openai_compat/deepseek-v4-pro"`(provider-qualified)를 찾는데, `oas-models.toml`엔 bare `"deepseek-v4-pro"` row만 있고 qualified row가 없습니다.

형제 모델 `deepseek-v4-flash`는 이미 동일 문제를 겪었고 이미 qualified row로 고쳐져 있습니다(`oas-models.toml:53-66`의 기존 WORKAROUND 주석 참고). `deepseek-v4-pro`만 그 수정이 누락되어 있었습니다.

## 변경

`oas-models.toml`에 `id_prefix = "openai_compat/deepseek-v4-pro"` row를 추가(bare `deepseek-v4-pro` row의 capability를 그대로 미러링 + flash qualified row와 동일한 `provider_name`/`supports_required_tool_choice`/`supports_named_tool_choice` 필드 추가). 코드 변경 없음, 데이터 카탈로그 파일만 수정.

## 검증

- `python3 -c "import tomllib; tomllib.load(open('oas-models.toml','rb'))"` — 문법 검증 통과.
- 로컬 dune 빌드 락이 다른 프로세스에 점유되어 있어(`scripts/dune-local.sh` 안내 메시지) 로컬 테스트 실행은 스킵 — CI의 "Runtime TOML gate" job으로 확인 요망.

## RFC / Workaround

WORKAROUND: production-blocking (main CI가 모든 PR에 대해 red). 근본 수정은 flash row와 동일 — OAS의 `api.deepseek.com` base_url recognizer 추가(jeong-sik/oas#2374가 runpod_mtp에 대해 이미 적용한 선례). removal target: 그 recognizer가 OAS에 머지되고 이 repo에 pin된 이후.

RFC-WAIVED: credential/identity/repo_manager/operator control-plane 미해당(data-only 모델 카탈로그 TOML). `docs/rfc/` 검색 결과 이 gap을 직접 다루는 RFC 없음 — 형제 `deepseek-v4-flash` row가 이미 동일 패턴으로 선례를 남겼고 이 PR은 그 선례를 `deepseek-v4-pro`에 동형 적용.
