### PR TITLE
fix(runtime): deepseek-v4-pro를 OAS 카탈로그에 추가 (validity gate 복구, #22935 N-of-M 완결)

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -87,6 +87,36 @@ output_per_million = 0.28
 cache_write_multiplier = 1.0
 cache_read_multiplier = 0.02
 
+# Same WORKAROUND class as the openai_compat/deepseek-v4-flash row above: the
+# pinned OAS emits provider_label "openai_compat" for api.deepseek.com, so the
+# [deepseek.deepseek-v4-pro] runtime binding (config/runtime.toml cross_verifier)
+# resolves against "openai_compat/deepseek-v4-pro". Without this row the
+# test_runtime_config_validity gate fails. Capabilities mirror the canonical
+# ../oas/models.toml deepseek-v4-pro row. Removal target: same OAS base_url
+# recognizer for api.deepseek.com that retires the flash row.
+[[models]]
+id_prefix = "openai_compat/deepseek-v4-pro"
+base = "openai_chat"
+provider_name = "deepseek"
+max_context_tokens = 1000000
+max_output_tokens = 384000
+supports_tools = true
+supports_tool_choice = true
+supports_required_tool_choice = false
+supports_named_tool_choice = false
+supports_reasoning = true
+supports_extended_thinking = true
+supports_reasoning_budget = true
+thinking_control_format = "thinking_object"
+supports_response_format_json = true
+supports_native_streaming = true
+supports_caching = true
+supports_prompt_caching = false
+input_per_million = 0.435
+output_per_million = 0.87
+cache_write_multiplier = 1.0
+cache_read_multiplier = 0.008333333333333333
+
 # MiniMax Models
 [[models]]
 id_prefix = "minimax-m3"


### PR DESCRIPTION
## 목적
main의 `test_runtime_config_validity` 게이트 실패 복구 (모든 열린 PR CI를 base-drift로 red 만듦).

```
FAIL runtime binding deepseek.deepseek-v4-pro provider/model
openai_compat/deepseek-v4-pro must resolve through repo OAS catalog
```

## 근본 원인
`config/runtime.toml`이 `deepseek.deepseek-v4-pro`를 `cross_verifier`로 활성 바인딩하는데, pinned OAS가 api.deepseek.com에 base_url 인식기가 없어 provider_label을 `openai_compat`로 잡음 → `openai_compat/deepseek-v4-pro` 조회 → `oas-models.toml`에 해당 행 부재 → 게이트 실패.

**N-of-M 자인**: #22935가 deepseek-direct 2개(flash+pro) 중 flash만 추가하고 pro를 남긴 1-of-2 누락. 이 PR이 pro를 추가해 deepseek-direct 세트를 완결합니다 (남은 site 0 — config/runtime.toml의 전체 provider-qualified 바인딩을 catalog와 전수 대조해 pro만 미해결임을 확인).

## 변경
- `oas-models.toml`에 `openai_compat/deepseek-v4-pro` 행 추가. capability는 canonical `../oas/models.toml` deepseek-v4-pro 행 미러 (pricing 0.435/0.87 포함).

## 검증
- `dune build --root . @test/runtest-test_runtime_config_validity` → **22 tests, all OK** (직전 실패한 test 3 "repo runtime bindings resolve" 포함).
- `python3 tomllib` 파싱 OK.

## P0-P3
- **P0**: main CI 게이트 red 해소 (전 PR 머지 차단 해제).
- **P1**: 없음. capability는 canonical 미러라 thinking/sampling drift 없음.
- **P2 (남은점)**: 이 openai_compat/ 우회 행은 근본적으로 OAS base_url 인식기 부재(api.deepseek.com) 때문. 근본 해결은 oas #2424/#2426(packaged catalog) + api.deepseek.com 인식기. 그때 flash/pro 두 행 동시 제거.
- **P3**: WORKAROUND 주석에 제거 조건 명시 (flash 행과 동일 클래스).

## 병합 가능성
main 복구용, 데이터 전용(코드 영향 0). 게이트 로컬 통과 확인 → CI green 시 즉시 머지 권고.

WORKAROUND: main-blocking CI gate. root fix: OAS base_url recognizer for api.deepseek.com (oas#2374 analogue).
removal target: 해당 인식기 pin 후 openai_compat/deepseek-v4-{flash,pro} 두 행 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
