### PR TITLE
feat(keeper): stimulus-gate the self-cadence wake (RFC-0303 P2)

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1168,12 +1168,18 @@ let keeper_cycle_decision
            observable backlog state.  This breaks the "no signal → no turn →
            no signal" bootstrap deadlock. *)
         let is_bootstrap = since_last_scheduled_autonomous = max_int in
-        (* Phase 2 — Minimum proactive cadence: even with no observable work
-           signals, fire a housekeeping turn once the minimum interval has
-           elapsed.  Default: 900s (15 min).  Prevents permanent silence when
-           external events never arrive and decouples liveness from signal
-           availability.  Controlled by MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC
-           / keeper.proactive.min_interval_sec. *)
+        (* Phase 2 — Minimum proactive cadence rate-limit: tracks whether the
+           minimum interval has elapsed since the last scheduled-autonomous
+           turn.  Default: 900s (15 min).  Controlled by
+           MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC
+           / keeper.proactive.min_interval_sec.
+           RFC-0303 Phase 2: this no longer fires a housekeeping turn on its
+           own with no work signals.  It is stimulus-gated behind
+           [proactive_work_ready] at the should_run site below, so it only
+           rate-limits cadence turns when the keeper already has an
+           opportunity.  Liveness under genuine silence is preserved by the
+           bootstrap turn and by external Reactive-channel wakes, not by this
+           blind cadence. *)
         let proactive_min_interval_sec =
           Keeper_config.keeper_proactive_min_interval_sec ()
         in
@@ -1201,14 +1207,19 @@ let keeper_cycle_decision
            picked up on the keeper's own cadence (sleep Timeout) and by the
            supervisor sweep. Per-keeper signals (mention/board/scope) are handled
            by the Reactive channel above and are unaffected. Time-based liveness
-           reasons (bootstrap / min_interval / idle_gate+cooldown / oscillation)
-           key on the keeper's own clock, so they stay ungated. *)
+           reasons key on the keeper's own clock, so they stay ungated BY THIS
+           reactive-wake check. Note this is a separate axis from the RFC-0303
+           Phase 2 gate below: [min_interval] and [idle_gate+cooldown] are
+           additionally stimulus-gated behind [proactive_work_ready], so they
+           cannot independently drive a scheduled-autonomous run. Only
+           [bootstrap] and a due schedule remain fully self-driving stimuli. *)
         let backlog_drives_turn =
           (not reactive_wake) && (backlog_fresh || backlog_elapsed)
         in
         let schedule_drives_turn = (not reactive_wake) && schedule_elapsed in
-        (* RFC-0303 Phase 2: stimulus-gate the self-cadence wake. [min_interval_
-           elapsed] no longer drives a turn ON ITS OWN — a blind cadence turn
+        (* RFC-0303 Phase 2: stimulus-gate the self-cadence wake.
+           [min_interval_elapsed] no longer drives a turn ON ITS OWN — a blind
+           cadence turn
            with no work signal is what manufactured the "passive" turns the
            no-progress stack then chased (detect -> pause -> tombstone). It is
            now a rate-limit INSIDE the [proactive_work_ready] guard: a keeper

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1207,12 +1207,25 @@ let keeper_cycle_decision
           (not reactive_wake) && (backlog_fresh || backlog_elapsed)
         in
         let schedule_drives_turn = (not reactive_wake) && schedule_elapsed in
+        (* RFC-0303 Phase 2: stimulus-gate the self-cadence wake. [min_interval_
+           elapsed] no longer drives a turn ON ITS OWN — a blind cadence turn
+           with no work signal is what manufactured the "passive" turns the
+           no-progress stack then chased (detect -> pause -> tombstone). It is
+           now a rate-limit INSIDE the [proactive_work_ready] guard: a keeper
+           spends a cadence turn only when it actually has an opportunity (a
+           claimed task, mentions, board/scope activity, or task backlog). With
+           no opportunity the keeper stays idle (verdict [No_signal]) instead of
+           spending a passive turn. Bootstrap (first warm-up turn) and a due
+           schedule remain ungated — each is itself the stimulus. External
+           signals still wake the keeper via the Reactive channel, so gating the
+           blind cadence cannot cause a deadlock. *)
         let should_run =
           is_bootstrap
-          || min_interval_elapsed
           || schedule_drives_turn
           || (proactive_work_ready
-              && (backlog_drives_turn || (idle_gate_elapsed && cooldown_elapsed)))
+              && (min_interval_elapsed
+                  || backlog_drives_turn
+                  || (idle_gate_elapsed && cooldown_elapsed)))
         in
         let runtime_id = runtime_id_of_meta meta in
         let provider_cooldown_remaining_sec =

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -238,6 +238,85 @@ let test_no_progress_event_queue_trigger_runs_warm_keeper () =
   check bool "reason includes no-progress stimulus" true
     (has_run_reason WO.No_progress_recovery_stimulus_pending d)
 
+(* RFC-0303 Phase 2 stimulus-gate: a warm keeper whose [min_interval] HAS
+   elapsed but that has NO opportunity (no signal, no claimed task, no backlog)
+   now stays silent. Before Phase 2, [min_interval_elapsed] drove a blind
+   housekeeping turn (verdict [Min_interval_elapsed]) with nothing to do, which
+   manufactured the "passive" turns the no-progress stack then chased. Now
+   [min_interval] is a rate-limit inside the proactive-work guard, not a
+   standalone trigger. *)
+let elapsed_min_interval_meta () =
+  let meta = make_meta "silence-elapsed" in
+  let now = Time_compat.now () in
+  { meta with
+    proactive = { enabled = true; idle_sec = 600; cooldown_sec = 1800 }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt =
+          { meta.runtime.proactive_rt with
+            last_ts = now -. 100_000.0 (* well past the 900s default min interval *)
+          ; consecutive_noop_count = 0
+          }
+      }
+  }
+;;
+
+let skip_reasons d =
+  match d.WO.verdict with
+  | WO.Skip { reasons = first, rest } -> first :: rest
+  | WO.Run _ -> []
+;;
+
+let test_elapsed_min_interval_no_signal_stays_silent () =
+  let meta = elapsed_min_interval_meta () in
+  let d =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:no_provider_cooldown
+      ~reactive_wake:false
+      ~meta
+      no_signal_obs
+  in
+  check
+    bool
+    "elapsed min_interval + no opportunity stays silent (RFC-0303 P2 stimulus-gate)"
+    false
+    d.should_run;
+  check
+    bool
+    "silence carries the No_signal skip reason"
+    true
+    (List.exists (( = ) WO.No_signal) (skip_reasons d))
+;;
+
+(* Guard: gating the blind cadence must NOT silence a keeper that actually has
+   work. A keeper holding a claimed task is proactive-work-ready, so an elapsed
+   min_interval still drives its cadence turn. *)
+let test_elapsed_min_interval_with_claimed_task_runs () =
+  let task_id =
+    match Keeper_id.Task_id.of_string "TASK-1" with
+    | Ok id -> id
+    | Error e -> Alcotest.failf "Task_id.of_string failed: %s" e
+  in
+  let meta = { (elapsed_min_interval_meta ()) with current_task_id = Some task_id } in
+  let d =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:no_provider_cooldown
+      ~reactive_wake:false
+      ~meta
+      no_signal_obs
+  in
+  check
+    bool
+    "keeper with a claimed task still runs on cadence (proactive work preserved)"
+    true
+    d.should_run;
+  check
+    bool
+    "run reason includes Min_interval_elapsed"
+    true
+    (has_run_reason WO.Min_interval_elapsed d)
+;;
+
 let () = init_runtime_default_for_tests ()
 
 let () =
@@ -264,6 +343,14 @@ let () =
             "no-progress event queue trigger runs warm keeper"
             `Quick
             test_no_progress_event_queue_trigger_runs_warm_keeper
+        ; test_case
+            "elapsed min_interval + no opportunity stays silent (RFC-0303 P2)"
+            `Quick
+            test_elapsed_min_interval_no_signal_stays_silent
+        ; test_case
+            "elapsed min_interval + claimed task still runs (RFC-0303 P2)"
+            `Quick
+            test_elapsed_min_interval_with_claimed_task_runs
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇을 / 왜

scheduled-autonomous keeper가 **blind min-interval 타이머**로 깨어났습니다: `should_run`에서 `min_interval_elapsed`가 **독립 트리거**여서, 인터벌만 지나면 (코드 주석 그대로) *"even with no observable work signals, fire a housekeeping turn"* — 즉 할 일 없이도 턴을 소비. 이게 no-progress stack(detect→pause→tombstone)이 쫓던 **passive 턴을 제조**한 근원입니다.

## 변경 (외과적, lib 1파일)

`keeper_world_observation.ml`의 `should_run`에서 `min_interval_elapsed`를 **`proactive_work_ready &&` 가드 안으로 이동**:

```
- is_bootstrap || min_interval_elapsed || schedule_drives_turn
-   || (proactive_work_ready && (backlog_drives_turn || (idle_gate && cooldown)))
+ is_bootstrap || schedule_drives_turn
+   || (proactive_work_ready && (min_interval_elapsed || backlog_drives_turn || (idle_gate && cooldown)))
```

- min_interval은 이제 **opportunity 기반 턴의 rate-limit**이지 트리거가 아님.
- opportunity(claimed task / mention / board·scope / task backlog) 있을 때만 cadence 실행. 없으면 idle 유지(verdict `No_signal`).
- **bootstrap / due schedule은 ungated** — 그 자체가 stimulus.
- Reactive/event-queue wake(mention·board·bootstrap·no-progress-recovery)는 무관 → **deadlock 불가** (외부 신호는 여전히 keeper를 깨움).

기존 타입(`proactive_work_signal_present`/`No_signal`)만 사용 — 새 wake_trigger variant 불필요.

## 범위

lifecycle 머신(made_progress/no-progress detector/tombstone)은 **여기서 건드리지 않음**. 이 PR이 그것들을 먹여살리던 unprompted wake를 제거하면, **Phase 3**가 그 dead 머신을 폐기합니다.

⚠️ **머지 순서**: 이 PR(Phase 2)은 **Phase 3(#TBD)보다 먼저** 머지돼야 합니다. Phase 3가 tombstone을 제거하는데, blind wake가 살아있는 상태에서 tombstone만 사라지면 thrash가 복귀합니다.

## 검증

- `dune build lib/ test/` green.
- `test_keeper_no_signal_silence` 신규 불변식: elapsed min_interval + no opportunity → **silent(No_signal)**; elapsed min_interval + claimed task → **여전히 run**(proactive 보존). 총 7 green.
- `test_keeper_reactive_wake_backlog_gate`(4) / `test_keeper_proactive_skip_counter`(2) / `test_keeper_failed_task_not_proactive_driver`(3) / `test_heartbeat_integration`(31) green.

RFC-0303 Phase 2. Phase 0 #22942 · Phase 1 #22944.

RFC-WAIVED: RFC-0303 Phase 2. keeper wake 결정 로직, credential/operator-control/hooks subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
