### PR TITLE
[codex] Wire structured judge runtime routing in settings

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2309,7 +2309,7 @@ describe('runtime.toml raw config API', () => {
   })
 
   it('posts runtime routing patches without client-side TOML text', async () => {
-    const sourceText = '[runtime]\ndefault = "openai.gpt"\nlibrarian = "openai.gpt"\n'
+    const sourceText = '[runtime]\ndefault = "openai.gpt"\nstructured_judge = "openai.gpt"\n'
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         ok: true,
@@ -2324,14 +2324,14 @@ describe('runtime.toml raw config API', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await patchRuntimeRouting('librarian', 'openai.gpt')
+    const result = await patchRuntimeRouting('structured_judge', 'openai.gpt')
 
     expect(devTokenMock.ensureDevToken).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/runtime/config/routing')
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body as string)).toEqual({
-      lane: 'librarian',
+      lane: 'structured_judge',
       runtime_id: 'openai.gpt',
     })
     expect(result.source_text).toBe(sourceText)

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -63,7 +63,10 @@ interface RuntimeEnvironmentEditorProps {
   disabled?: boolean
   draftDirty?: boolean
   saving?: boolean
-  onRoutingChange: (lane: 'default' | 'librarian' | 'cross_verifier', runtimeId: string | null) => void
+  onRoutingChange: (
+    lane: 'default' | 'librarian' | 'structured_judge' | 'cross_verifier',
+    runtimeId: string | null,
+  ) => void
   onAssignmentChange: (keeperName: string, runtimeId: string | null) => void
   onBindingFieldChange: (
     runtimeId: string,
@@ -243,7 +246,7 @@ export function RuntimeEnvironmentEditor({
     if (runtimeId !== '') onRoutingChange('default', runtimeId)
   }
 
-  function updateRoutingLane(lane: 'librarian' | 'cross_verifier', runtimeId: string) {
+  function updateRoutingLane(lane: 'librarian' | 'structured_judge' | 'cross_verifier', runtimeId: string) {
     onRoutingChange(lane, runtimeId === '' ? null : runtimeId)
   }
 
@@ -410,7 +413,7 @@ export function RuntimeEnvironmentEditor({
   // the label to one-word-per-line.
 
   function laneRow(
-    lane: 'default' | 'librarian' | 'cross_verifier',
+    lane: 'default' | 'librarian' | 'structured_judge' | 'cross_verifier',
     label: string,
     hint: string,
     value: string,
@@ -535,7 +538,7 @@ export function RuntimeEnvironmentEditor({
       ` : null}
 
       <!-- routing — runtime-editor.jsx:135-141. default lane is live; librarian /
-           cross_verifier are read from [runtime] and written back. -->
+           structured_judge / cross_verifier are read from [runtime] and written back. -->
       <div class=${section === 'routing' ? '' : 'hidden'} data-testid="runtime-section-routing">
         <div class="rt-note">
           런타임 id = <span class="mono">provider.model</span> (binding key). 레인은 등록된 바인딩 중에서 고릅니다.
@@ -554,6 +557,14 @@ export function RuntimeEnvironmentEditor({
           '[runtime].librarian — 턴 후 에피소드 추출, JSON 모드 필요',
           librarianLane,
           runtimeId => updateRoutingLane('librarian', runtimeId),
+          true,
+        )}
+        ${laneRow(
+          'structured_judge',
+          'structured judge',
+          '[runtime].structured_judge — provider-native schema 심판 호출',
+          environment.structuredJudgeRuntimeId,
+          runtimeId => updateRoutingLane('structured_judge', runtimeId),
           true,
         )}
         ${laneRow(

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -39,6 +39,7 @@ const baseConfig = {
 
 const richSourceText = `[runtime]
 default = "runpod_mtp.qwen"
+structured_judge = "runpod_mtp.qwen"
 
 [providers.runpod_mtp]
 display-name = "RunPod"
@@ -117,14 +118,23 @@ describe('RuntimeTomlEditor', () => {
       source_text: `${richConfig.source_text}\n[runtime.assignments]\nsangsu = ${JSON.stringify(runtimeId ?? 'runpod_mtp.qwen')}\n`,
       reloaded: true,
     }))
-    apiMocks.patchRuntimeRouting.mockImplementation(async (lane: string, runtimeId: string | null) => ({
-      ...richConfig,
-      source_text: richConfig.source_text.replace(
+    apiMocks.patchRuntimeRouting.mockImplementation(async (lane: string, runtimeId: string | null) => {
+      let sourceText = richConfig.source_text.replace(
         'default = "runpod_mtp.qwen"',
         lane === 'default' && runtimeId ? `default = "${runtimeId}"` : 'default = "runpod_mtp.qwen"',
-      ),
-      reloaded: true,
-    }))
+      )
+      sourceText = sourceText.replace(
+        'structured_judge = "runpod_mtp.qwen"',
+        lane === 'structured_judge' && runtimeId
+          ? `structured_judge = "${runtimeId}"`
+          : 'structured_judge = "runpod_mtp.qwen"',
+      )
+      return {
+        ...richConfig,
+        source_text: sourceText,
+        reloaded: true,
+      }
+    })
     apiMocks.saveRuntimeTomlConfig.mockImplementation(async (sourceText: string) => ({
       ...baseConfig,
       source_text: sourceText,
@@ -349,6 +359,28 @@ describe('RuntimeTomlEditor', () => {
     })
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
     expect(runtimeRefreshMock.refreshRuntimeConfigConsumers).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+  })
+
+  it('switches the structured judge runtime through the typed backend routing patch', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('[aria-label="structured_judge runtime"]') as HTMLSelectElement | null)?.value)
+        .toBe('runpod_mtp.qwen')
+    })
+
+    fireEvent.change(container.querySelector('[aria-label="structured_judge runtime"]') as HTMLSelectElement, {
+      target: { value: 'openai.gpt' },
+    })
+
+    await waitFor(() => {
+      expect(apiMocks.patchRuntimeRouting).toHaveBeenCalledWith('structured_judge', 'openai.gpt')
+      expect((container.querySelector('textarea') as HTMLTextAreaElement).value)
+        .toContain('structured_judge = "openai.gpt"')
+    })
+    expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
     expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
   })
 
@@ -743,6 +775,7 @@ describe('RuntimeTomlEditor', () => {
     await waitFor(() => {
       const source = (container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value
       expect(source).toContain('default = "openai.gpt"')
+      expect(source).not.toContain('structured_judge = "runpod_mtp.qwen"')
       expect(source).not.toContain('[providers.runpod_mtp]')
       expect(source).not.toContain('[providers.runpod_mtp.credentials]')
       expect(source).not.toContain('[runpod_mtp.qwen]')

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -845,13 +845,25 @@ describe('SettingsSurface', () => {
   })
 
   it('runtime section shows resolved model routing controls and keeper assignments', async () => {
+    stubRuntimeDefaults(
+      makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
+          librarian_runtime_id: 'rt-b',
+          structured_judge_runtime_id: 'rt-c',
+          cross_verifier_runtime_id: 'rt-a',
+          media_failover: [],
+        },
+      }),
+    )
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('Librarian')
-      expect(container.querySelector('[data-testid="runtime-routing-structured-judge"]')).not.toBeNull()
+      expect((container.querySelector('[data-testid="runtime-routing-structured-judge"]') as HTMLSelectElement | null)?.value)
+        .toBe('rt-c')
       expect(container.querySelector('[data-testid="runtime-routing-cross-verifier"]')).not.toBeNull()
       expect(container.querySelector('[data-testid="runtime-media-failover-editor"]')).not.toBeNull()
       const assignments = Array.from(

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -47,6 +47,7 @@ describe('runtime TOML dashboard editing helpers', () => {
 
     expect(environment.defaultRuntimeId).toBe('runpod_mtp.qwen')
     expect(environment.librarianRuntimeId).toBe('')
+    expect(environment.structuredJudgeRuntimeId).toBe('')
     expect(environment.crossVerifierRuntimeId).toBe('')
     expect(environment.assignments).toEqual({})
     expect(environment.providers[0]).toMatchObject({
@@ -77,7 +78,7 @@ describe('runtime TOML dashboard editing helpers', () => {
   it('projects runtime routing lanes and keeper assignments from runtime.toml source', () => {
     const withRouting = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',
-      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
+      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\nstructured_judge = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
     )}
 
 [runtime.assignments]
@@ -88,6 +89,7 @@ mad-improver = "runpod_mtp.qwen"
     const environment = parseRuntimeTomlEnvironment(withRouting)
 
     expect(environment.librarianRuntimeId).toBe('runpod_mtp.qwen')
+    expect(environment.structuredJudgeRuntimeId).toBe('runpod_mtp.qwen')
     expect(environment.crossVerifierRuntimeId).toBe('runpod_mtp.qwen')
     expect(environment.assignments).toEqual({
       sangsu: 'runpod_mtp.qwen',
@@ -309,7 +311,7 @@ sangsu = "runpod_mtp.qwen"
   it('retargets default and clears dependent lanes when deleting a provider with a fallback binding', () => {
     const withFallback = `${sourceText.replace(
       'default = "runpod_mtp.qwen"',
-      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
+      'default = "runpod_mtp.qwen"\nlibrarian = "runpod_mtp.qwen"\nstructured_judge = "runpod_mtp.qwen"\ncross_verifier = "runpod_mtp.qwen"',
     )}
 
 [providers.openai]
@@ -334,6 +336,7 @@ sangsu = "runpod_mtp.qwen"
 
     expect(env.defaultRuntimeId).toBe('openai.gpt')
     expect(env.librarianRuntimeId).toBe('')
+    expect(env.structuredJudgeRuntimeId).toBe('')
     expect(env.crossVerifierRuntimeId).toBe('')
     expect(env.assignments).toEqual({})
     expect(env.providers.map(p => p.id)).toEqual(['openai'])
@@ -341,6 +344,7 @@ sangsu = "runpod_mtp.qwen"
     expect(next).toContain('default = "openai.gpt"')
     expect(next).not.toContain('[providers.runpod_mtp]')
     expect(next).not.toContain('[runpod_mtp.qwen]')
+    expect(next).not.toContain('structured_judge = "runpod_mtp.qwen"')
     expect(next).not.toContain('sangsu = "runpod_mtp.qwen"')
   })
 

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -37,6 +37,7 @@ export interface RuntimeTomlBinding {
 export interface RuntimeTomlEnvironment {
   defaultRuntimeId: string
   librarianRuntimeId: string
+  structuredJudgeRuntimeId: string
   crossVerifierRuntimeId: string
   assignments: Record<string, string>
   providers: RuntimeTomlProvider[]
@@ -336,6 +337,7 @@ export function parseRuntimeTomlEnvironment(sourceText: string): RuntimeTomlEnvi
   return {
     defaultRuntimeId: asString(runtimeValues.default),
     librarianRuntimeId: asString(runtimeValues.librarian),
+    structuredJudgeRuntimeId: asString(runtimeValues.structured_judge),
     crossVerifierRuntimeId: asString(runtimeValues.cross_verifier),
     assignments,
     providers,
@@ -510,6 +512,9 @@ export function cascadeDeleteProvider(sourceText: string, providerId: string): s
   }
   if (typeof runtimeValues.librarian === 'string' && toDeleteBindings.has(runtimeValues.librarian)) {
     next = deleteRuntimeTomlKey(next, 'runtime', 'librarian')
+  }
+  if (typeof runtimeValues.structured_judge === 'string' && toDeleteBindings.has(runtimeValues.structured_judge)) {
+    next = deleteRuntimeTomlKey(next, 'runtime', 'structured_judge')
   }
   if (typeof runtimeValues.cross_verifier === 'string' && toDeleteBindings.has(runtimeValues.cross_verifier)) {
     next = deleteRuntimeTomlKey(next, 'runtime', 'cross_verifier')

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -152,6 +152,7 @@ streaming = true
 api-name = "gpt"
 max-context = 64000
 tools-support = true
+supports-structured-output = true
 streaming = true
 
 [runpod_mtp.qwen]
@@ -189,6 +190,7 @@ streaming = true
 api-name = "gpt"
 max-context = 64000
 tools-support = true
+supports-structured-output = true
 streaming = true
 
 [runpod_mtp.qwen]
@@ -423,6 +425,35 @@ let test_runtime_route_writer_updates_media_failover () =
       "runtime.toml media_failover explicitly empty"
       true
       (string_contains (Fs_compat.load_file path) "media_failover = []"))
+;;
+
+let test_runtime_route_writer_clears_optional_structured_judge () =
+  with_runtime_file (fun path ->
+    (match
+       Runtime.set_runtime_structured_judge
+         ~runtime_config_path:path
+         ~runtime_id:(Some "openai.gpt")
+         ()
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "set_runtime_structured_judge failed: %s" msg);
+    Alcotest.(check (option string))
+      "structured judge set"
+      (Some "openai.gpt")
+      (Runtime.structured_judge_runtime_id ());
+    (match
+       Runtime.set_runtime_structured_judge ~runtime_config_path:path ~runtime_id:None ()
+     with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "clear runtime structured_judge failed: %s" msg);
+    Alcotest.(check bool)
+      "runtime.toml structured_judge removed"
+      false
+      (string_contains (Fs_compat.load_file path) "structured_judge");
+    Alcotest.(check (option string))
+      "structured judge cache cleared"
+      None
+      (Runtime.structured_judge_runtime_id ()))
 ;;
 
 let test_runtime_config_text_loads_runtime_toml () =
@@ -978,6 +1009,10 @@ let () =
             "dashboard runtime route writer updates media_failover"
             `Quick
             test_runtime_route_writer_updates_media_failover
+        ; Alcotest.test_case
+            "dashboard runtime route writer clears optional structured judge"
+            `Quick
+            test_runtime_route_writer_clears_optional_structured_judge
         ; Alcotest.test_case
             "dashboard raw runtime.toml load returns full source"
             `Quick


### PR DESCRIPTION
## Summary
- Wire the runtime TOML structured editor to show and edit `[runtime].structured_judge` alongside default/librarian/cross-verifier.
- Project `structuredJudgeRuntimeId` from runtime.toml and clear the lane when deleting a provider alias that owned the selected binding.
- Add focused coverage for the dashboard route payload, runtime TOML projection/cascade behavior, rendered editor select flow, Settings overview control, and the OCaml writer path.

## Root cause
The backend/runtime config already had a `structured_judge` lane, but the Settings runtime editor did not project or edit that scalar. The visible controls could therefore not manage a real runtime.toml lane.

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/runtime-environment-editor.ts src/components/runtime-toml-editor.test.ts src/components/settings-surface.test.ts src/api/dashboard.test.ts src/lib/runtime-toml-config.ts src/lib/runtime-toml-config.test.ts` (0 errors; repo config reports ignored-file warnings for several TS test/lib files)
- `pnpm exec vitest run --config vitest.config.ts src/lib/runtime-toml-config.test.ts src/components/runtime-toml-editor.test.ts src/components/settings-surface.test.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1`
- Playwright smoke: `/dashboard/#settings?section=runtimes` changes `structured_judge runtime` to `openai.gpt`, captures `POST /api/v1/runtime/config/routing` body `{ lane: "structured_judge", runtime_id: "openai.gpt" }`, screenshot `/private/tmp/masc-settings-structured-judge-routing.png`
- `git diff --check origin/main..HEAD`

## Not run
- Focused OCaml target via `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe`; local wrapper refused because a separate bare `dune build --root . lib/` process was already running. Full build remains CI-owned per operator instruction.