### PR TITLE
[codex] Fix passive keeper attention drift guard

### DIFF
--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -97,6 +97,7 @@ function executionReceiptAttentionReasons(): string[] {
 // out of the attention label union unless the backend changes that contract.
 const EXECUTION_RECEIPT_PASS_ONLY_REASONS: ReadonlySet<string> = new Set([
   'healthy',
+  'passive_no_action',
   'runtime_fallback',
   'phase_skipped',
 ])


### PR DESCRIPTION
## Summary
- classify `passive_no_action` as a pass-only execution receipt reason in the dashboard drift guard
- keep it out of the attention label union because backend maps it to `Disp_pass`, not an operator-pageable attention state

## Validation
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/lib/keeper-attention-labels.drift.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`

No local Dune build/test run; CI is the Dune build authority per request.