### PR TITLE
fix(dashboard): classify passive no-action as pass-only

### DIFF
--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -99,6 +99,7 @@ const EXECUTION_RECEIPT_PASS_ONLY_REASONS: ReadonlySet<string> = new Set([
   'healthy',
   'runtime_fallback',
   'phase_skipped',
+  'passive_no_action',
 ])
 
 function completionContractAttentionLabels(): string[] {


### PR DESCRIPTION
## Summary
- Treat `passive_no_action` as a pass-only execution receipt reason in the dashboard attention drift guard.
- Avoid incorrectly requiring a frontend attention label for a `Disp_pass` reason.

Fixes #22955.

## Why
Current main Dashboard CI fails with:

```text
execution receipt attention_reason codes with no union arm: passive_no_action
```

`passive_no_action` is emitted for `Reason_passive_no_action` under `Disp_pass`, so it belongs beside `healthy`, `runtime_fallback`, and `phase_skipped` in the pass-only exclusion set rather than in the attention label union.

## Validation
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-attention-labels.drift.test.ts`
- `pnpm typecheck`
- `git diff --check`

Dune was not run locally per operator direction; OCaml build remains CI-owned.