### PR TITLE
fix(runtime): keep missing catalog validation fail-closed

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -198,10 +198,10 @@ let decide_capability_gate ~(config_path : string) (entries : (string * bool) li
       (Printf.sprintf
          "%s: %d runtime model(s) absent from the OAS capability catalog; they \
           would use provider_default and silently drop thinking/sampling control. \
-          Add them to models.toml (OAS catalog): %s"
+          Add them to oas-models.toml (OAS catalog): %s"
          config_path
          (List.length unknown)
-	         (String.concat ", " (List.map fst unknown)))
+         (String.concat ", " (List.map fst unknown)))
 ;;
 
 type missing_catalog_model =
@@ -209,7 +209,6 @@ type missing_catalog_model =
   ; provider_id : string
   ; provider_label : string
   ; model_id : string
-  ; source_catalog_entry : Llm_provider.Model_catalog.model_entry option
   }
 
 type missing_catalog_report =
@@ -229,7 +228,7 @@ let missing_catalog_report_to_string (report : missing_catalog_report) =
   Printf.sprintf
     "%s: %d runtime model(s) absent from the OAS capability catalog; they \
      would use provider_default and silently drop thinking/sampling control. \
-     Add them to models.toml (OAS catalog): %s"
+     Add them to oas-models.toml (OAS catalog): %s"
     report.config_path
     (List.length report.missing_models)
     (String.concat ", " (List.map missing_catalog_model_label report.missing_models))
@@ -238,237 +237,6 @@ let missing_catalog_report_to_string (report : missing_catalog_report) =
 let strict_init_error_to_string = function
   | Runtime_config_error msg -> msg
   | Missing_catalog_models report -> missing_catalog_report_to_string report
-;;
-
-type model_catalog_backfill_entry =
-  { runtime_id : string
-  ; id_prefix : string
-  ; source_id_prefix : string
-  ; toml : string
-  }
-
-let toml_quote value =
-  let buffer = Buffer.create (String.length value + 2) in
-  Buffer.add_char buffer '"';
-  String.iter
-    (function
-      | '"' -> Buffer.add_string buffer "\\\""
-      | '\\' -> Buffer.add_string buffer "\\\\"
-      | '\n' -> Buffer.add_string buffer "\\n"
-      | '\r' -> Buffer.add_string buffer "\\r"
-      | '\t' -> Buffer.add_string buffer "\\t"
-      | ch when Char.code ch < 0x20 ->
-        Buffer.add_string buffer (Printf.sprintf "\\u%04X" (Char.code ch))
-      | ch -> Buffer.add_char buffer ch)
-    value;
-  Buffer.add_char buffer '"';
-  Buffer.contents buffer
-;;
-
-let toml_float value =
-  let rendered = Printf.sprintf "%.17g" value in
-  if String.contains rendered '.' || String.contains rendered 'e'
-     || String.contains rendered 'E'
-  then rendered
-  else rendered ^ ".0"
-;;
-
-let add_toml_string buffer key value =
-  Buffer.add_string buffer (Printf.sprintf "%s = %s\n" key (toml_quote value))
-;;
-
-let add_toml_string_opt buffer key = function
-  | None -> ()
-  | Some value -> add_toml_string buffer key value
-;;
-
-let add_toml_int_opt buffer key = function
-  | None -> ()
-  | Some value -> Buffer.add_string buffer (Printf.sprintf "%s = %d\n" key value)
-;;
-
-let add_toml_float_opt buffer key = function
-  | None -> ()
-  | Some value ->
-    Buffer.add_string buffer (Printf.sprintf "%s = %s\n" key (toml_float value))
-;;
-
-let add_toml_bool_opt buffer key = function
-  | None -> ()
-  | Some value ->
-    Buffer.add_string
-      buffer
-      (Printf.sprintf "%s = %s\n" key (if value then "true" else "false"))
-;;
-
-let add_toml_string_list_opt buffer key = function
-  | None -> ()
-  | Some values ->
-    Buffer.add_string
-      buffer
-      (Printf.sprintf
-         "%s = [%s]\n"
-         key
-         (String.concat ", " (List.map toml_quote values)))
-;;
-
-let render_model_catalog_entry ~(source_id_prefix : string)
-    (entry : Llm_provider.Model_catalog.model_entry) =
-  let buffer = Buffer.create 512 in
-  Buffer.add_string buffer "\n";
-  Buffer.add_string buffer "# MASC runtime catalog backfill.\n";
-  Buffer.add_string buffer
-    (Printf.sprintf "# Source OAS catalog row: %s\n" source_id_prefix);
-  Buffer.add_string buffer "[[models]]\n";
-  add_toml_string buffer "id_prefix" entry.id_prefix;
-  add_toml_string_opt buffer "base" entry.base_label;
-  add_toml_string_opt buffer "provider_name" entry.provider_name;
-  add_toml_int_opt buffer "max_context_tokens" entry.max_context_tokens;
-  add_toml_int_opt buffer "max_output_tokens" entry.max_output_tokens;
-  add_toml_bool_opt buffer "supports_tools" entry.supports_tools;
-  add_toml_bool_opt buffer "supports_tool_choice" entry.supports_tool_choice;
-  add_toml_bool_opt buffer "supports_required_tool_choice"
-    entry.supports_required_tool_choice;
-  add_toml_bool_opt buffer "supports_named_tool_choice"
-    entry.supports_named_tool_choice;
-  add_toml_bool_opt buffer "supports_parallel_tool_calls"
-    entry.supports_parallel_tool_calls;
-  add_toml_string_opt buffer "assistant_tool_content_format"
-    entry.assistant_tool_content_format;
-  add_toml_bool_opt buffer "supports_reasoning" entry.supports_reasoning;
-  add_toml_bool_opt buffer "supports_extended_thinking"
-    entry.supports_extended_thinking;
-  add_toml_bool_opt buffer "supports_reasoning_budget"
-    entry.supports_reasoning_budget;
-  add_toml_string_list_opt buffer "accepted_reasoning_efforts"
-    entry.accepted_reasoning_efforts;
-  add_toml_bool_opt buffer "supports_response_format_json"
-    entry.supports_response_format_json;
-  add_toml_bool_opt buffer "supports_structured_output"
-    entry.supports_structured_output;
-  add_toml_bool_opt buffer "supports_multimodal_inputs"
-    entry.supports_multimodal_inputs;
-  add_toml_bool_opt buffer "supports_image_input" entry.supports_image_input;
-  add_toml_bool_opt buffer "supports_audio_input" entry.supports_audio_input;
-  add_toml_bool_opt buffer "supports_video_input" entry.supports_video_input;
-  add_toml_string_opt buffer "modality_priority" entry.modality_priority;
-  add_toml_bool_opt buffer "supports_native_streaming"
-    entry.supports_native_streaming;
-  add_toml_bool_opt buffer "supports_system_prompt" entry.supports_system_prompt;
-  add_toml_bool_opt buffer "supports_caching" entry.supports_caching;
-  add_toml_bool_opt buffer "supports_prompt_caching"
-    entry.supports_prompt_caching;
-  add_toml_bool_opt buffer "supports_top_k" entry.supports_top_k;
-  add_toml_bool_opt buffer "supports_min_p" entry.supports_min_p;
-  add_toml_bool_opt buffer "supports_seed" entry.supports_seed;
-  add_toml_bool_opt buffer "supports_computer_use" entry.supports_computer_use;
-  add_toml_bool_opt buffer "supports_code_execution" entry.supports_code_execution;
-  add_toml_string_opt buffer "thinking_control_format"
-    entry.thinking_control_format;
-  add_toml_string_opt buffer "thinking_control_token"
-    entry.thinking_control_token;
-  add_toml_string_opt buffer "preserve_thinking_control_format"
-    entry.preserve_thinking_control_format;
-  add_toml_string_opt buffer "reasoning_output_format"
-    entry.reasoning_output_format;
-  add_toml_string_opt buffer "reasoning_streaming_format"
-    entry.reasoning_streaming_format;
-  add_toml_string_opt buffer "reasoning_replay" entry.reasoning_replay;
-  add_toml_float_opt buffer "input_per_million" entry.input_per_million;
-  add_toml_float_opt buffer "output_per_million" entry.output_per_million;
-  add_toml_float_opt buffer "cache_write_multiplier"
-    entry.cache_write_multiplier;
-  add_toml_float_opt buffer "cache_read_multiplier" entry.cache_read_multiplier;
-  Buffer.contents buffer
-;;
-
-let provider_qualified_id_prefix (missing : missing_catalog_model) =
-  let provider_label = String.trim missing.provider_label in
-  if String.equal provider_label ""
-  then missing.model_id
-  else provider_label ^ "/" ^ missing.model_id
-;;
-
-let model_catalog_backfill_entries missing_models =
-  let missing_without_source =
-    List.filter
-      (fun (missing : missing_catalog_model) ->
-         Option.is_none missing.source_catalog_entry)
-      missing_models
-  in
-  match missing_without_source with
-  | _ :: _ ->
-    Error
-      (Printf.sprintf
-         "cannot backfill %d runtime model(s) because no source OAS catalog row \
-          matched their bare model id: %s"
-         (List.length missing_without_source)
-         (String.concat
-            ", "
-            (List.map missing_catalog_model_label missing_without_source)))
-  | [] ->
-    Ok
-      (List.filter_map
-         (fun (missing : missing_catalog_model) ->
-            match missing.source_catalog_entry with
-            | None -> None
-            | Some source ->
-              let id_prefix = provider_qualified_id_prefix missing in
-              let source_id_prefix = source.id_prefix in
-              let entry = { source with id_prefix } in
-              Some
-                { runtime_id = missing.runtime_id
-                ; id_prefix
-                ; source_id_prefix
-                ; toml = render_model_catalog_entry ~source_id_prefix entry
-                })
-         missing_models)
-;;
-
-let dedupe_backfill_entries entries =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | (entry : model_catalog_backfill_entry) :: rest ->
-      if List.exists (String.equal entry.id_prefix) seen
-      then loop seen acc rest
-      else loop (entry.id_prefix :: seen) (entry :: acc) rest
-  in
-  loop [] [] entries
-;;
-
-let append_model_catalog_backfill ~catalog_path missing_models =
-  let* entries = model_catalog_backfill_entries missing_models in
-  let entries = dedupe_backfill_entries entries in
-  let* catalog =
-    Llm_provider.Model_catalog.load_file catalog_path
-    |> Result.map_error (fun msg ->
-      Printf.sprintf "cannot load OAS model catalog %s: %s" catalog_path msg)
-  in
-  let entries_to_append =
-    List.filter
-      (fun (entry : model_catalog_backfill_entry) ->
-         Option.is_none (Llm_provider.Model_catalog.lookup catalog entry.id_prefix))
-      entries
-  in
-  match entries_to_append with
-  | [] -> Ok []
-  | _ ->
-    (try
-       let oc =
-         open_out_gen
-           [ Open_wronly; Open_append; Open_creat; Open_text ]
-           0o644
-           catalog_path
-       in
-       Fun.protect
-         ~finally:(fun () -> close_out_noerr oc)
-         (fun () ->
-            List.iter (fun entry -> output_string oc entry.toml) entries_to_append);
-       Llm_provider.Model_catalog.clear_global ();
-       Ok entries_to_append
-     with
-     | Sys_error msg ->
-       Error (Printf.sprintf "cannot append OAS model catalog %s: %s" catalog_path msg))
 ;;
 
 let capabilities_for_runtime (rt : t) =
@@ -489,13 +257,12 @@ let validate_runtime_model_capabilities ~(config_path : string) (runtimes : t li
        (fun (r : t) ->
           ( Printf.sprintf "%s (model=%s)" r.id r.provider_config.model_id
           , Option.is_some (capabilities_for_runtime r) ))
-	       runtimes)
+       runtimes)
 ;;
 
 let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t list)
   : missing_catalog_report option
   =
-  let catalog = Llm_provider.Model_catalog.global () in
   let missing_models =
     List.filter_map
       (fun (r : t) ->
@@ -506,17 +273,11 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
              Llm_provider.Provider_config.capability_provider_label r.provider_config
            in
            let model_id = r.provider_config.model_id in
-           let source_catalog_entry =
-             match catalog with
-             | None -> None
-             | Some catalog -> Llm_provider.Model_catalog.lookup catalog model_id
-           in
            Some
              { runtime_id = r.id
              ; provider_id = r.provider.id
              ; provider_label
              ; model_id
-             ; source_catalog_entry
              })
       runtimes
   in

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -201,7 +201,274 @@ let decide_capability_gate ~(config_path : string) (entries : (string * bool) li
           Add them to models.toml (OAS catalog): %s"
          config_path
          (List.length unknown)
-         (String.concat ", " (List.map fst unknown)))
+	         (String.concat ", " (List.map fst unknown)))
+;;
+
+type missing_catalog_model =
+  { runtime_id : string
+  ; provider_id : string
+  ; provider_label : string
+  ; model_id : string
+  ; source_catalog_entry : Llm_provider.Model_catalog.model_entry option
+  }
+
+type missing_catalog_report =
+  { config_path : string
+  ; missing_models : missing_catalog_model list
+  }
+
+type strict_init_error =
+  | Runtime_config_error of string
+  | Missing_catalog_models of missing_catalog_report
+
+let missing_catalog_model_label (missing : missing_catalog_model) =
+  Printf.sprintf "%s (model=%s)" missing.runtime_id missing.model_id
+;;
+
+let missing_catalog_report_to_string (report : missing_catalog_report) =
+  Printf.sprintf
+    "%s: %d runtime model(s) absent from the OAS capability catalog; they \
+     would use provider_default and silently drop thinking/sampling control. \
+     Add them to models.toml (OAS catalog): %s"
+    report.config_path
+    (List.length report.missing_models)
+    (String.concat ", " (List.map missing_catalog_model_label report.missing_models))
+;;
+
+let strict_init_error_to_string = function
+  | Runtime_config_error msg -> msg
+  | Missing_catalog_models report -> missing_catalog_report_to_string report
+;;
+
+type model_catalog_backfill_entry =
+  { runtime_id : string
+  ; id_prefix : string
+  ; source_id_prefix : string
+  ; toml : string
+  }
+
+let toml_quote value =
+  let buffer = Buffer.create (String.length value + 2) in
+  Buffer.add_char buffer '"';
+  String.iter
+    (function
+      | '"' -> Buffer.add_string buffer "\\\""
+      | '\\' -> Buffer.add_string buffer "\\\\"
+      | '\n' -> Buffer.add_string buffer "\\n"
+      | '\r' -> Buffer.add_string buffer "\\r"
+      | '\t' -> Buffer.add_string buffer "\\t"
+      | ch when Char.code ch < 0x20 ->
+        Buffer.add_string buffer (Printf.sprintf "\\u%04X" (Char.code ch))
+      | ch -> Buffer.add_char buffer ch)
+    value;
+  Buffer.add_char buffer '"';
+  Buffer.contents buffer
+;;
+
+let toml_float value =
+  let rendered = Printf.sprintf "%.17g" value in
+  if String.contains rendered '.' || String.contains rendered 'e'
+     || String.contains rendered 'E'
+  then rendered
+  else rendered ^ ".0"
+;;
+
+let add_toml_string buffer key value =
+  Buffer.add_string buffer (Printf.sprintf "%s = %s\n" key (toml_quote value))
+;;
+
+let add_toml_string_opt buffer key = function
+  | None -> ()
+  | Some value -> add_toml_string buffer key value
+;;
+
+let add_toml_int_opt buffer key = function
+  | None -> ()
+  | Some value -> Buffer.add_string buffer (Printf.sprintf "%s = %d\n" key value)
+;;
+
+let add_toml_float_opt buffer key = function
+  | None -> ()
+  | Some value ->
+    Buffer.add_string buffer (Printf.sprintf "%s = %s\n" key (toml_float value))
+;;
+
+let add_toml_bool_opt buffer key = function
+  | None -> ()
+  | Some value ->
+    Buffer.add_string
+      buffer
+      (Printf.sprintf "%s = %s\n" key (if value then "true" else "false"))
+;;
+
+let add_toml_string_list_opt buffer key = function
+  | None -> ()
+  | Some values ->
+    Buffer.add_string
+      buffer
+      (Printf.sprintf
+         "%s = [%s]\n"
+         key
+         (String.concat ", " (List.map toml_quote values)))
+;;
+
+let render_model_catalog_entry ~(source_id_prefix : string)
+    (entry : Llm_provider.Model_catalog.model_entry) =
+  let buffer = Buffer.create 512 in
+  Buffer.add_string buffer "\n";
+  Buffer.add_string buffer "# MASC runtime catalog backfill.\n";
+  Buffer.add_string buffer
+    (Printf.sprintf "# Source OAS catalog row: %s\n" source_id_prefix);
+  Buffer.add_string buffer "[[models]]\n";
+  add_toml_string buffer "id_prefix" entry.id_prefix;
+  add_toml_string_opt buffer "base" entry.base_label;
+  add_toml_string_opt buffer "provider_name" entry.provider_name;
+  add_toml_int_opt buffer "max_context_tokens" entry.max_context_tokens;
+  add_toml_int_opt buffer "max_output_tokens" entry.max_output_tokens;
+  add_toml_bool_opt buffer "supports_tools" entry.supports_tools;
+  add_toml_bool_opt buffer "supports_tool_choice" entry.supports_tool_choice;
+  add_toml_bool_opt buffer "supports_required_tool_choice"
+    entry.supports_required_tool_choice;
+  add_toml_bool_opt buffer "supports_named_tool_choice"
+    entry.supports_named_tool_choice;
+  add_toml_bool_opt buffer "supports_parallel_tool_calls"
+    entry.supports_parallel_tool_calls;
+  add_toml_string_opt buffer "assistant_tool_content_format"
+    entry.assistant_tool_content_format;
+  add_toml_bool_opt buffer "supports_reasoning" entry.supports_reasoning;
+  add_toml_bool_opt buffer "supports_extended_thinking"
+    entry.supports_extended_thinking;
+  add_toml_bool_opt buffer "supports_reasoning_budget"
+    entry.supports_reasoning_budget;
+  add_toml_string_list_opt buffer "accepted_reasoning_efforts"
+    entry.accepted_reasoning_efforts;
+  add_toml_bool_opt buffer "supports_response_format_json"
+    entry.supports_response_format_json;
+  add_toml_bool_opt buffer "supports_structured_output"
+    entry.supports_structured_output;
+  add_toml_bool_opt buffer "supports_multimodal_inputs"
+    entry.supports_multimodal_inputs;
+  add_toml_bool_opt buffer "supports_image_input" entry.supports_image_input;
+  add_toml_bool_opt buffer "supports_audio_input" entry.supports_audio_input;
+  add_toml_bool_opt buffer "supports_video_input" entry.supports_video_input;
+  add_toml_string_opt buffer "modality_priority" entry.modality_priority;
+  add_toml_bool_opt buffer "supports_native_streaming"
+    entry.supports_native_streaming;
+  add_toml_bool_opt buffer "supports_system_prompt" entry.supports_system_prompt;
+  add_toml_bool_opt buffer "supports_caching" entry.supports_caching;
+  add_toml_bool_opt buffer "supports_prompt_caching"
+    entry.supports_prompt_caching;
+  add_toml_bool_opt buffer "supports_top_k" entry.supports_top_k;
+  add_toml_bool_opt buffer "supports_min_p" entry.supports_min_p;
+  add_toml_bool_opt buffer "supports_seed" entry.supports_seed;
+  add_toml_bool_opt buffer "supports_computer_use" entry.supports_computer_use;
+  add_toml_bool_opt buffer "supports_code_execution" entry.supports_code_execution;
+  add_toml_string_opt buffer "thinking_control_format"
+    entry.thinking_control_format;
+  add_toml_string_opt buffer "thinking_control_token"
+    entry.thinking_control_token;
+  add_toml_string_opt buffer "preserve_thinking_control_format"
+    entry.preserve_thinking_control_format;
+  add_toml_string_opt buffer "reasoning_output_format"
+    entry.reasoning_output_format;
+  add_toml_string_opt buffer "reasoning_streaming_format"
+    entry.reasoning_streaming_format;
+  add_toml_string_opt buffer "reasoning_replay" entry.reasoning_replay;
+  add_toml_float_opt buffer "input_per_million" entry.input_per_million;
+  add_toml_float_opt buffer "output_per_million" entry.output_per_million;
+  add_toml_float_opt buffer "cache_write_multiplier"
+    entry.cache_write_multiplier;
+  add_toml_float_opt buffer "cache_read_multiplier" entry.cache_read_multiplier;
+  Buffer.contents buffer
+;;
+
+let provider_qualified_id_prefix (missing : missing_catalog_model) =
+  let provider_label = String.trim missing.provider_label in
+  if String.equal provider_label ""
+  then missing.model_id
+  else provider_label ^ "/" ^ missing.model_id
+;;
+
+let model_catalog_backfill_entries missing_models =
+  let missing_without_source =
+    List.filter
+      (fun (missing : missing_catalog_model) ->
+         Option.is_none missing.source_catalog_entry)
+      missing_models
+  in
+  match missing_without_source with
+  | _ :: _ ->
+    Error
+      (Printf.sprintf
+         "cannot backfill %d runtime model(s) because no source OAS catalog row \
+          matched their bare model id: %s"
+         (List.length missing_without_source)
+         (String.concat
+            ", "
+            (List.map missing_catalog_model_label missing_without_source)))
+  | [] ->
+    Ok
+      (List.filter_map
+         (fun (missing : missing_catalog_model) ->
+            match missing.source_catalog_entry with
+            | None -> None
+            | Some source ->
+              let id_prefix = provider_qualified_id_prefix missing in
+              let source_id_prefix = source.id_prefix in
+              let entry = { source with id_prefix } in
+              Some
+                { runtime_id = missing.runtime_id
+                ; id_prefix
+                ; source_id_prefix
+                ; toml = render_model_catalog_entry ~source_id_prefix entry
+                })
+         missing_models)
+;;
+
+let dedupe_backfill_entries entries =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | (entry : model_catalog_backfill_entry) :: rest ->
+      if List.exists (String.equal entry.id_prefix) seen
+      then loop seen acc rest
+      else loop (entry.id_prefix :: seen) (entry :: acc) rest
+  in
+  loop [] [] entries
+;;
+
+let append_model_catalog_backfill ~catalog_path missing_models =
+  let* entries = model_catalog_backfill_entries missing_models in
+  let entries = dedupe_backfill_entries entries in
+  let* catalog =
+    Llm_provider.Model_catalog.load_file catalog_path
+    |> Result.map_error (fun msg ->
+      Printf.sprintf "cannot load OAS model catalog %s: %s" catalog_path msg)
+  in
+  let entries_to_append =
+    List.filter
+      (fun (entry : model_catalog_backfill_entry) ->
+         Option.is_none (Llm_provider.Model_catalog.lookup catalog entry.id_prefix))
+      entries
+  in
+  match entries_to_append with
+  | [] -> Ok []
+  | _ ->
+    (try
+       let oc =
+         open_out_gen
+           [ Open_wronly; Open_append; Open_creat; Open_text ]
+           0o644
+           catalog_path
+       in
+       Fun.protect
+         ~finally:(fun () -> close_out_noerr oc)
+         (fun () ->
+            List.iter (fun entry -> output_string oc entry.toml) entries_to_append);
+       Llm_provider.Model_catalog.clear_global ();
+       Ok entries_to_append
+     with
+     | Sys_error msg ->
+       Error (Printf.sprintf "cannot append OAS model catalog %s: %s" catalog_path msg))
 ;;
 
 let capabilities_for_runtime (rt : t) =
@@ -222,7 +489,40 @@ let validate_runtime_model_capabilities ~(config_path : string) (runtimes : t li
        (fun (r : t) ->
           ( Printf.sprintf "%s (model=%s)" r.id r.provider_config.model_id
           , Option.is_some (capabilities_for_runtime r) ))
-       runtimes)
+	       runtimes)
+;;
+
+let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t list)
+  : missing_catalog_report option
+  =
+  let catalog = Llm_provider.Model_catalog.global () in
+  let missing_models =
+    List.filter_map
+      (fun (r : t) ->
+         match capabilities_for_runtime r with
+         | Some _ -> None
+         | None ->
+           let provider_label =
+             Llm_provider.Provider_config.capability_provider_label r.provider_config
+           in
+           let model_id = r.provider_config.model_id in
+           let source_catalog_entry =
+             match catalog with
+             | None -> None
+             | Some catalog -> Llm_provider.Model_catalog.lookup catalog model_id
+           in
+           Some
+             { runtime_id = r.id
+             ; provider_id = r.provider.id
+             ; provider_label
+             ; model_id
+             ; source_catalog_entry
+             })
+      runtimes
+  in
+  match missing_models with
+  | [] -> None
+  | first :: rest -> Some { config_path; missing_models = first :: rest }
 ;;
 
 let materialize_config ~(config_path : string) (cfg : config)
@@ -368,15 +668,19 @@ let init_default ~config_path =
    so an operator runtime.toml whose model is absent from the catalog is rejected
    before boot — the gate that load_list intentionally no longer applies, kept out
    of load_list so unit tests stay catalog-independent. *)
-let init_default_strict ~config_path =
+let init_default_strict_report ~config_path =
   match load_list ~config_path with
-  | Error _ as e -> e
+  | Error msg -> Error (Runtime_config_error msg)
   | Ok ((runtimes, _, _, _, _, _, _) as loaded) ->
-    (match validate_runtime_model_capabilities ~config_path runtimes with
-     | Error _ as e -> e
-     | Ok () ->
+    (match missing_runtime_model_capabilities ~config_path runtimes with
+     | Some report -> Error (Missing_catalog_models report)
+     | None ->
        set_loaded ~config_path loaded;
        Ok ())
+
+let init_default_strict ~config_path =
+  init_default_strict_report ~config_path
+  |> Result.map_error strict_init_error_to_string
 
 let runtime_state () = Atomic.get loaded_state_ref
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -29,6 +29,52 @@ val decide_capability_gate :
     (corrupted the memory-os librarian for minimax-m3, 2026-06-19). Empty entries
     are allowed for focused config probes. *)
 
+type missing_catalog_model =
+  { runtime_id : string
+  ; provider_id : string
+  ; provider_label : string
+  ; model_id : string
+  ; source_catalog_entry : Llm_provider.Model_catalog.model_entry option
+  }
+(** Runtime binding whose concrete provider/model pair is absent from the OAS
+    capability catalog. [provider_label] is the exact OAS capability namespace
+    used for lookup, and [source_catalog_entry] is the bare model-family entry
+    found in the active catalog, when one exists. A present source entry means
+    MASC can propose a provider-qualified catalog projection without inventing
+    capabilities. *)
+
+type missing_catalog_report =
+  { config_path : string
+  ; missing_models : missing_catalog_model list
+  }
+
+type strict_init_error =
+  | Runtime_config_error of string
+  | Missing_catalog_models of missing_catalog_report
+
+val strict_init_error_to_string : strict_init_error -> string
+
+type model_catalog_backfill_entry =
+  { runtime_id : string
+  ; id_prefix : string
+  ; source_id_prefix : string
+  ; toml : string
+  }
+
+val model_catalog_backfill_entries :
+  missing_catalog_model list -> (model_catalog_backfill_entry list, string) result
+(** Build provider-qualified OAS model-catalog rows from existing catalog source
+    rows. Returns [Error] when any missing runtime lacks a source catalog row;
+    the caller must not invent capabilities in that case. *)
+
+val append_model_catalog_backfill :
+  catalog_path:string ->
+  missing_catalog_model list ->
+  (model_catalog_backfill_entry list, string) result
+(** Append the generated rows to [catalog_path], skipping rows already present
+    at write time. Clears the OAS global model catalog cache after writing so a
+    subsequent strict init observes the new rows. *)
+
 val load_list :
   config_path:string
   -> ( t list
@@ -69,6 +115,12 @@ val init_default_strict : config_path:string -> (unit, string) result
 (** Production startup entry point: {!init_default} PLUS the OAS capability-catalog
     gate ({!decide_capability_gate}). Rejects ([Error]) a runtime whose model is
     absent from the catalog before boot. Used by server boot and fusion run. *)
+
+val init_default_strict_report :
+  config_path:string -> (unit, strict_init_error) result
+(** Typed form of {!init_default_strict}. Server bootstrap uses this to offer an
+    explicit catalog-backfill repair path without string-matching the fatal
+    error message. *)
 
 module For_testing : sig
   type snapshot

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -34,14 +34,10 @@ type missing_catalog_model =
   ; provider_id : string
   ; provider_label : string
   ; model_id : string
-  ; source_catalog_entry : Llm_provider.Model_catalog.model_entry option
   }
 (** Runtime binding whose concrete provider/model pair is absent from the OAS
     capability catalog. [provider_label] is the exact OAS capability namespace
-    used for lookup, and [source_catalog_entry] is the bare model-family entry
-    found in the active catalog, when one exists. A present source entry means
-    MASC can propose a provider-qualified catalog projection without inventing
-    capabilities. *)
+    used for lookup. *)
 
 type missing_catalog_report =
   { config_path : string
@@ -53,27 +49,6 @@ type strict_init_error =
   | Missing_catalog_models of missing_catalog_report
 
 val strict_init_error_to_string : strict_init_error -> string
-
-type model_catalog_backfill_entry =
-  { runtime_id : string
-  ; id_prefix : string
-  ; source_id_prefix : string
-  ; toml : string
-  }
-
-val model_catalog_backfill_entries :
-  missing_catalog_model list -> (model_catalog_backfill_entry list, string) result
-(** Build provider-qualified OAS model-catalog rows from existing catalog source
-    rows. Returns [Error] when any missing runtime lacks a source catalog row;
-    the caller must not invent capabilities in that case. *)
-
-val append_model_catalog_backfill :
-  catalog_path:string ->
-  missing_catalog_model list ->
-  (model_catalog_backfill_entry list, string) result
-(** Append the generated rows to [catalog_path], skipping rows already present
-    at write time. Clears the OAS global model catalog cache after writing so a
-    subsequent strict init observes the new rows. *)
 
 val load_list :
   config_path:string
@@ -118,9 +93,8 @@ val init_default_strict : config_path:string -> (unit, string) result
 
 val init_default_strict_report :
   config_path:string -> (unit, strict_init_error) result
-(** Typed form of {!init_default_strict}. Server bootstrap uses this to offer an
-    explicit catalog-backfill repair path without string-matching the fatal
-    error message. *)
+(** Typed form of {!init_default_strict}. Server bootstrap uses this to log
+    missing catalog models without string-matching the fatal error message. *)
 
 module For_testing : sig
   type snapshot

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -45,9 +45,6 @@ let model_catalog_env_source_to_string = function
 
 let models_toml_filename = "models.toml"
 let oas_models_toml_filename = "oas-models.toml"
-let model_catalog_resolution_ref : model_catalog_env_resolution option Atomic.t =
-  Atomic.make None
-;;
 
 let nonempty_env env name =
   match env name with
@@ -142,11 +139,9 @@ let configure_oas_model_catalog_env
   =
   match resolve_oas_model_catalog_path ~env ?cwd ?argv0 () with
   | Some { source = Env_var Oas_model_catalog; path } as resolution ->
-    Atomic.set model_catalog_resolution_ref resolution;
     Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s already configured" path;
     resolution
   | Some { source; path } as resolution ->
-    Atomic.set model_catalog_resolution_ref resolution;
     putenv (model_catalog_env_var_name Oas_model_catalog) path;
     Log.Misc.info
       "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s"
@@ -154,7 +149,6 @@ let configure_oas_model_catalog_env
       (model_catalog_env_source_to_string source);
     resolution
   | None ->
-    Atomic.set model_catalog_resolution_ref None;
     preload_agent_sdk_catalog ();
     (match agent_sdk_catalog () with
      | Some _ ->
@@ -255,68 +249,6 @@ let record_runtime_toml_load_failure msg =
          ~labels:[ "reason", reason ]
       ())
     reason
-
-let stdin_is_interactive () =
-  try Unix.isatty Unix.stdin with
-  | Unix.Unix_error _ -> false
-;;
-
-let operator_approved_runtime_catalog_backfill () =
-  Printf.eprintf "Backfill missing OAS model-catalog rows now and retry startup? [y/N] %!";
-  match read_line () with
-  | exception End_of_file -> false
-  | answer ->
-    (match String.lowercase_ascii (String.trim answer) with
-     | "y" | "yes" -> true
-     | _ -> false)
-;;
-
-let maybe_backfill_runtime_catalog (report : Runtime.missing_catalog_report) =
-  match Atomic.get model_catalog_resolution_ref with
-  | None ->
-    Error
-      "no writable OAS model catalog path was resolved; set OAS_MODEL_CATALOG or \
-       start from a directory containing oas-models.toml/models.toml"
-  | Some { path = catalog_path; source } ->
-    (match Runtime.model_catalog_backfill_entries report.missing_models with
-     | Error msg -> Error msg
-     | Ok entries ->
-       if entries = []
-       then Ok []
-       else (
-         Log.Server.warn
-           "Runtime catalog backfill available for %d missing model row(s) in %s \
-            (%s)"
-           (List.length entries)
-           catalog_path
-           (model_catalog_env_source_to_string source);
-         List.iter
-           (fun (entry : Runtime.model_catalog_backfill_entry) ->
-              Log.Server.warn
-                "Runtime catalog backfill candidate: %s from source row %s \
-                 (runtime=%s)"
-                entry.id_prefix
-                entry.source_id_prefix
-                entry.runtime_id)
-           entries;
-         if not (stdin_is_interactive ())
-         then
-           Error
-             "runtime catalog backfill requires an interactive terminal; edit the \
-              catalog row explicitly or restart in the foreground to approve"
-         else if not (operator_approved_runtime_catalog_backfill ())
-         then Error "operator declined runtime catalog backfill"
-         else (
-           match Runtime.append_model_catalog_backfill ~catalog_path report.missing_models with
-           | Error msg -> Error msg
-           | Ok appended ->
-             Log.Server.warn
-               "Runtime catalog backfilled %d model row(s) into %s; retrying \
-                strict runtime init"
-               (List.length appended)
-               catalog_path;
-             Ok appended)))
-;;
 
 let thompson_shutdown_hook_registered = Atomic.make false
 
@@ -727,43 +659,20 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          is fatal — the server cannot route turns without a default Runtime, so
          booting into a half-configured state only defers the failure to the
          first turn (runtime→Runtime vision: no silent fallback). *)
-	      (match Runtime.config_path () with
-	       | Some config_path ->
-	         (match Runtime.init_default_strict_report ~config_path with
-	          | Ok () ->
-	            Log.Server.info "Runtime default initialized: %s"
-	              (Runtime.get_default_runtime_id ())
-	          | Error (Runtime.Missing_catalog_models report as err) ->
-	            Log.Server.error
-	              "Runtime.init_default_strict requires OAS model-catalog \
-	               backfill: %s"
-	              (Runtime.strict_init_error_to_string err);
-	            (match maybe_backfill_runtime_catalog report with
-	             | Ok _ ->
-	               (match Runtime.init_default_strict_report ~config_path with
-	                | Ok () ->
-	                  Log.Server.info "Runtime default initialized after catalog backfill: %s"
-	                    (Runtime.get_default_runtime_id ())
-	                | Error retry_err ->
-	                  Log.Server.error
-	                    "Runtime.init_default_strict failed after catalog \
-	                     backfill (fatal, refusing to boot): %s"
-	                    (Runtime.strict_init_error_to_string retry_err);
-	                  exit 1)
-	             | Error repair_msg ->
-	               Log.Server.error
-	                 "Runtime catalog backfill unavailable or declined (fatal, \
-	                  refusing to boot): %s"
-	                 repair_msg;
-	               exit 1)
-	          | Error err ->
-	            Log.Server.error
-	              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
-	              (Runtime.strict_init_error_to_string err);
-	            exit 1)
-	       | None ->
-	         Log.Server.error
-	           "No runtime config path; cannot initialize default Runtime \
+      (match Runtime.config_path () with
+       | Some config_path ->
+         (match Runtime.init_default_strict_report ~config_path with
+          | Ok () ->
+            Log.Server.info "Runtime default initialized: %s"
+              (Runtime.get_default_runtime_id ())
+          | Error err ->
+            Log.Server.error
+              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
+              (Runtime.strict_init_error_to_string err);
+            exit 1)
+       | None ->
+         Log.Server.error
+           "No runtime config path; cannot initialize default Runtime \
             (fatal, refusing to boot)";
          exit 1);
       let t1 = Eio.Time.now clock in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -45,6 +45,9 @@ let model_catalog_env_source_to_string = function
 
 let models_toml_filename = "models.toml"
 let oas_models_toml_filename = "oas-models.toml"
+let model_catalog_resolution_ref : model_catalog_env_resolution option Atomic.t =
+  Atomic.make None
+;;
 
 let nonempty_env env name =
   match env name with
@@ -139,9 +142,11 @@ let configure_oas_model_catalog_env
   =
   match resolve_oas_model_catalog_path ~env ?cwd ?argv0 () with
   | Some { source = Env_var Oas_model_catalog; path } as resolution ->
+    Atomic.set model_catalog_resolution_ref resolution;
     Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s already configured" path;
     resolution
   | Some { source; path } as resolution ->
+    Atomic.set model_catalog_resolution_ref resolution;
     putenv (model_catalog_env_var_name Oas_model_catalog) path;
     Log.Misc.info
       "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s"
@@ -149,6 +154,7 @@ let configure_oas_model_catalog_env
       (model_catalog_env_source_to_string source);
     resolution
   | None ->
+    Atomic.set model_catalog_resolution_ref None;
     preload_agent_sdk_catalog ();
     (match agent_sdk_catalog () with
      | Some _ ->
@@ -249,6 +255,68 @@ let record_runtime_toml_load_failure msg =
          ~labels:[ "reason", reason ]
       ())
     reason
+
+let stdin_is_interactive () =
+  try Unix.isatty Unix.stdin with
+  | Unix.Unix_error _ -> false
+;;
+
+let operator_approved_runtime_catalog_backfill () =
+  Printf.eprintf "Backfill missing OAS model-catalog rows now and retry startup? [y/N] %!";
+  match read_line () with
+  | exception End_of_file -> false
+  | answer ->
+    (match String.lowercase_ascii (String.trim answer) with
+     | "y" | "yes" -> true
+     | _ -> false)
+;;
+
+let maybe_backfill_runtime_catalog (report : Runtime.missing_catalog_report) =
+  match Atomic.get model_catalog_resolution_ref with
+  | None ->
+    Error
+      "no writable OAS model catalog path was resolved; set OAS_MODEL_CATALOG or \
+       start from a directory containing oas-models.toml/models.toml"
+  | Some { path = catalog_path; source } ->
+    (match Runtime.model_catalog_backfill_entries report.missing_models with
+     | Error msg -> Error msg
+     | Ok entries ->
+       if entries = []
+       then Ok []
+       else (
+         Log.Server.warn
+           "Runtime catalog backfill available for %d missing model row(s) in %s \
+            (%s)"
+           (List.length entries)
+           catalog_path
+           (model_catalog_env_source_to_string source);
+         List.iter
+           (fun (entry : Runtime.model_catalog_backfill_entry) ->
+              Log.Server.warn
+                "Runtime catalog backfill candidate: %s from source row %s \
+                 (runtime=%s)"
+                entry.id_prefix
+                entry.source_id_prefix
+                entry.runtime_id)
+           entries;
+         if not (stdin_is_interactive ())
+         then
+           Error
+             "runtime catalog backfill requires an interactive terminal; edit the \
+              catalog row explicitly or restart in the foreground to approve"
+         else if not (operator_approved_runtime_catalog_backfill ())
+         then Error "operator declined runtime catalog backfill"
+         else (
+           match Runtime.append_model_catalog_backfill ~catalog_path report.missing_models with
+           | Error msg -> Error msg
+           | Ok appended ->
+             Log.Server.warn
+               "Runtime catalog backfilled %d model row(s) into %s; retrying \
+                strict runtime init"
+               (List.length appended)
+               catalog_path;
+             Ok appended)))
+;;
 
 let thompson_shutdown_hook_registered = Atomic.make false
 
@@ -659,20 +727,43 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          is fatal — the server cannot route turns without a default Runtime, so
          booting into a half-configured state only defers the failure to the
          first turn (runtime→Runtime vision: no silent fallback). *)
-      (match Runtime.config_path () with
-       | Some config_path ->
-         (match Runtime.init_default_strict ~config_path with
-          | Ok () ->
-            Log.Server.info "Runtime default initialized: %s"
-              (Runtime.get_default_runtime_id ())
-          | Error msg ->
-            Log.Server.error
-              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
-              msg;
-            exit 1)
-       | None ->
-         Log.Server.error
-           "No runtime config path; cannot initialize default Runtime \
+	      (match Runtime.config_path () with
+	       | Some config_path ->
+	         (match Runtime.init_default_strict_report ~config_path with
+	          | Ok () ->
+	            Log.Server.info "Runtime default initialized: %s"
+	              (Runtime.get_default_runtime_id ())
+	          | Error (Runtime.Missing_catalog_models report as err) ->
+	            Log.Server.error
+	              "Runtime.init_default_strict requires OAS model-catalog \
+	               backfill: %s"
+	              (Runtime.strict_init_error_to_string err);
+	            (match maybe_backfill_runtime_catalog report with
+	             | Ok _ ->
+	               (match Runtime.init_default_strict_report ~config_path with
+	                | Ok () ->
+	                  Log.Server.info "Runtime default initialized after catalog backfill: %s"
+	                    (Runtime.get_default_runtime_id ())
+	                | Error retry_err ->
+	                  Log.Server.error
+	                    "Runtime.init_default_strict failed after catalog \
+	                     backfill (fatal, refusing to boot): %s"
+	                    (Runtime.strict_init_error_to_string retry_err);
+	                  exit 1)
+	             | Error repair_msg ->
+	               Log.Server.error
+	                 "Runtime catalog backfill unavailable or declined (fatal, \
+	                  refusing to boot): %s"
+	                 repair_msg;
+	               exit 1)
+	          | Error err ->
+	            Log.Server.error
+	              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
+	              (Runtime.strict_init_error_to_string err);
+	            exit 1)
+	       | None ->
+	         Log.Server.error
+	           "No runtime config path; cannot initialize default Runtime \
             (fatal, refusing to boot)";
          exit 1);
       let t1 = Eio.Time.now clock in

--- a/test/dune
+++ b/test/dune
@@ -250,6 +250,7 @@
   test_keeper_secret_projection
   test_keeper_secret_redaction
   test_keeper_toml
+  test_runtime_missing_catalog_report
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
   test_dashboard_runtime_probe_nonblocking
@@ -583,6 +584,7 @@
   test_keeper_secret_projection
   test_keeper_secret_redaction
   test_keeper_toml
+  test_runtime_missing_catalog_report
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
   test_dashboard_runtime_probe_nonblocking

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1165,23 +1165,15 @@ let test_runtime_capability_gate_uses_provider_qualified_catalog () =
               capability gate: %s"
              msg
          | Ok () ->
-	       check (option bool) "provider-qualified preserve policy" None
-	         (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
+           check (option bool) "provider-qualified preserve policy" None
+             (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
 
-let test_runtime_catalog_backfill_projects_bare_catalog_row () =
+let test_runtime_capability_gate_reports_missing_catalog_models () =
   let catalog =
     "[[models]]\n\
-     id_prefix = \"sample-family-\"\n\
+     id_prefix = \"other-family\"\n\
      base = \"openai_chat\"\n\
-     max_context_tokens = 2048\n\
-     max_output_tokens = 1024\n\
-     supports_tools = true\n\
-     supports_tool_choice = true\n\
-     supports_reasoning = true\n\
-     supports_extended_thinking = true\n\
-     supports_reasoning_budget = false\n\
-     thinking_control_format = \"chat_template_token\"\n\
-     supports_native_streaming = true\n"
+     max_context_tokens = 1024\n"
   in
   let runtime_toml =
     "[providers.custom]\n\
@@ -1189,10 +1181,8 @@ let test_runtime_catalog_backfill_projects_bare_catalog_row () =
      endpoint = \"https://custom.example/v1\"\n\
      \n\
      [models.sample]\n\
-     api-name = \"sample-family-123\"\n\
+     api-name = \"missing-family-123\"\n\
      max-context = 2048\n\
-     tools-support = true\n\
-     thinking-support = true\n\
      \n\
      [custom.sample]\n\
      \n\
@@ -1200,83 +1190,27 @@ let test_runtime_catalog_backfill_projects_bare_catalog_row () =
      default = \"custom.sample\"\n"
   in
   let snapshot = Runtime.For_testing.snapshot () in
-  let with_backfill_catalog catalog_path f =
-    let oc = open_out catalog_path in
-    output_string oc catalog;
-    close_out oc;
-    Fun.protect
-      ~finally:(fun () ->
-        Llm_provider.Model_catalog.clear_global ();
-        (try Sys.remove catalog_path with
-         | _ -> ()))
-      f
-  in
-  Fun.protect ~finally:(fun () -> Runtime.For_testing.restore snapshot) @@ fun () ->
-  with_model_catalog_content catalog @@ fun () ->
-  with_temp_runtime_toml runtime_toml @@ fun path ->
-  match Runtime.init_default_strict_report ~config_path:path with
-  | Ok () -> fail "provider-qualified catalog row should be required"
-  | Error (Runtime.Runtime_config_error msg) ->
-    failf "expected missing catalog diagnostic, got config error: %s" msg
-  | Error (Runtime.Missing_catalog_models report) ->
-    check int "one missing runtime" 1 (List.length report.missing_models);
-    let missing = List.hd report.missing_models in
-    check string "runtime id" "custom.sample" missing.runtime_id;
-    check string "provider label" "openai_compat" missing.provider_label;
-    check bool "source catalog row found" true
-      (Option.is_some missing.source_catalog_entry);
-    (match Runtime.model_catalog_backfill_entries report.missing_models with
-     | Error msg -> failf "backfill entries should render: %s" msg
-     | Ok [ entry ] ->
-       check string "provider-qualified id_prefix"
-         "openai_compat/sample-family-123"
-         entry.id_prefix;
-       check string "source id_prefix" "sample-family-" entry.source_id_prefix;
-       check bool "toml carries source row" true
-         (String_util.contains_substring entry.toml
-            "Source OAS catalog row: sample-family-");
-       check bool "toml carries provider-qualified id" true
-         (String_util.contains_substring entry.toml
-            "id_prefix = \"openai_compat/sample-family-123\"");
-       check bool "toml preserves thinking control" true
-         (String_util.contains_substring entry.toml
-            "thinking_control_format = \"chat_template_token\"");
-       let catalog_path = Filename.temp_file "oas-backfill" ".toml" in
-       with_backfill_catalog catalog_path @@ fun () ->
-       (match
-          Runtime.append_model_catalog_backfill
-            ~catalog_path
-            report.missing_models
-        with
-        | Error msg -> failf "append backfill should succeed: %s" msg
-        | Ok appended ->
-          check int "one appended row" 1 (List.length appended));
-       (match Llm_provider.Model_catalog.load_file catalog_path with
-        | Error msg -> failf "backfilled catalog should load: %s" msg
-        | Ok catalog -> Llm_provider.Model_catalog.set_global catalog);
-       (match Runtime.init_default_strict_report ~config_path:path with
-        | Error err ->
-          failf
-            "strict init should pass after backfill: %s"
-            (Runtime.strict_init_error_to_string err)
-        | Ok () -> ())
-     | Ok entries ->
-       failf "expected one backfill entry, got %d" (List.length entries))
-
-let test_runtime_catalog_backfill_refuses_missing_source_row () =
-  let missing : Runtime.missing_catalog_model =
-    { runtime_id = "custom.uncatalogued"
-    ; provider_id = "custom"
-    ; provider_label = "openai_compat"
-    ; model_id = "uncatalogued"
-    ; source_catalog_entry = None
-    }
-  in
-  match Runtime.model_catalog_backfill_entries [ missing ] with
-  | Ok _ -> fail "backfill must not invent capabilities without a source row"
-  | Error msg ->
-    check bool "error names runtime" true
-      (String_util.contains_substring msg "custom.uncatalogued")
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content catalog @@ fun () ->
+       with_temp_runtime_toml runtime_toml @@ fun path ->
+       match Runtime.init_default_strict_report ~config_path:path with
+       | Ok () -> fail "missing provider-qualified catalog row should fail strict init"
+       | Error (Runtime.Runtime_config_error msg) ->
+         failf "expected missing catalog report, got config error: %s" msg
+       | Error (Runtime.Missing_catalog_models report) ->
+         check int "one missing runtime" 1 (List.length report.missing_models);
+         let missing = List.hd report.missing_models in
+         check string "runtime id" "custom.sample" missing.runtime_id;
+         check string "provider id" "custom" missing.provider_id;
+         check string "provider label" "openai_compat" missing.provider_label;
+         check string "model id" "missing-family-123" missing.model_id;
+         check bool "diagnostic names OAS catalog file" true
+           (String_util.contains_substring
+              (Runtime.strict_init_error_to_string
+                 (Runtime.Missing_catalog_models report))
+              "oas-models.toml"))
 
 let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_fake_runtime_model_catalog @@ fun () ->
@@ -1653,11 +1587,8 @@ let () =
             "runtime capability gate uses provider-qualified OAS catalog rows"
             `Quick test_runtime_capability_gate_uses_provider_qualified_catalog;
           test_case
-            "runtime catalog backfill projects bare catalog rows"
-            `Quick test_runtime_catalog_backfill_projects_bare_catalog_row;
-          test_case
-            "runtime catalog backfill refuses missing source rows"
-            `Quick test_runtime_catalog_backfill_refuses_missing_source_row;
+            "runtime capability gate reports missing catalog models"
+            `Quick test_runtime_capability_gate_reports_missing_catalog_models;
           test_case "atomic runtime getters are consistent after init" `Quick
             test_runtime_atomic_getters_are_consistent_after_init;
           test_case "max-concurrent is optional opt-in" `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1165,8 +1165,118 @@ let test_runtime_capability_gate_uses_provider_qualified_catalog () =
               capability gate: %s"
              msg
          | Ok () ->
-           check (option bool) "provider-qualified preserve policy" None
-             (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
+	       check (option bool) "provider-qualified preserve policy" None
+	         (Runtime.preserve_thinking_of_runtime_id "ollama_cloud.shared")))
+
+let test_runtime_catalog_backfill_projects_bare_catalog_row () =
+  let catalog =
+    "[[models]]\n\
+     id_prefix = \"sample-family-\"\n\
+     base = \"openai_chat\"\n\
+     max_context_tokens = 2048\n\
+     max_output_tokens = 1024\n\
+     supports_tools = true\n\
+     supports_tool_choice = true\n\
+     supports_reasoning = true\n\
+     supports_extended_thinking = true\n\
+     supports_reasoning_budget = false\n\
+     thinking_control_format = \"chat_template_token\"\n\
+     supports_native_streaming = true\n"
+  in
+  let runtime_toml =
+    "[providers.custom]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"https://custom.example/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample-family-123\"\n\
+     max-context = 2048\n\
+     tools-support = true\n\
+     thinking-support = true\n\
+     \n\
+     [custom.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"custom.sample\"\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  let with_backfill_catalog catalog_path f =
+    let oc = open_out catalog_path in
+    output_string oc catalog;
+    close_out oc;
+    Fun.protect
+      ~finally:(fun () ->
+        Llm_provider.Model_catalog.clear_global ();
+        (try Sys.remove catalog_path with
+         | _ -> ()))
+      f
+  in
+  Fun.protect ~finally:(fun () -> Runtime.For_testing.restore snapshot) @@ fun () ->
+  with_model_catalog_content catalog @@ fun () ->
+  with_temp_runtime_toml runtime_toml @@ fun path ->
+  match Runtime.init_default_strict_report ~config_path:path with
+  | Ok () -> fail "provider-qualified catalog row should be required"
+  | Error (Runtime.Runtime_config_error msg) ->
+    failf "expected missing catalog diagnostic, got config error: %s" msg
+  | Error (Runtime.Missing_catalog_models report) ->
+    check int "one missing runtime" 1 (List.length report.missing_models);
+    let missing = List.hd report.missing_models in
+    check string "runtime id" "custom.sample" missing.runtime_id;
+    check string "provider label" "openai_compat" missing.provider_label;
+    check bool "source catalog row found" true
+      (Option.is_some missing.source_catalog_entry);
+    (match Runtime.model_catalog_backfill_entries report.missing_models with
+     | Error msg -> failf "backfill entries should render: %s" msg
+     | Ok [ entry ] ->
+       check string "provider-qualified id_prefix"
+         "openai_compat/sample-family-123"
+         entry.id_prefix;
+       check string "source id_prefix" "sample-family-" entry.source_id_prefix;
+       check bool "toml carries source row" true
+         (String_util.contains_substring entry.toml
+            "Source OAS catalog row: sample-family-");
+       check bool "toml carries provider-qualified id" true
+         (String_util.contains_substring entry.toml
+            "id_prefix = \"openai_compat/sample-family-123\"");
+       check bool "toml preserves thinking control" true
+         (String_util.contains_substring entry.toml
+            "thinking_control_format = \"chat_template_token\"");
+       let catalog_path = Filename.temp_file "oas-backfill" ".toml" in
+       with_backfill_catalog catalog_path @@ fun () ->
+       (match
+          Runtime.append_model_catalog_backfill
+            ~catalog_path
+            report.missing_models
+        with
+        | Error msg -> failf "append backfill should succeed: %s" msg
+        | Ok appended ->
+          check int "one appended row" 1 (List.length appended));
+       (match Llm_provider.Model_catalog.load_file catalog_path with
+        | Error msg -> failf "backfilled catalog should load: %s" msg
+        | Ok catalog -> Llm_provider.Model_catalog.set_global catalog);
+       (match Runtime.init_default_strict_report ~config_path:path with
+        | Error err ->
+          failf
+            "strict init should pass after backfill: %s"
+            (Runtime.strict_init_error_to_string err)
+        | Ok () -> ())
+     | Ok entries ->
+       failf "expected one backfill entry, got %d" (List.length entries))
+
+let test_runtime_catalog_backfill_refuses_missing_source_row () =
+  let missing : Runtime.missing_catalog_model =
+    { runtime_id = "custom.uncatalogued"
+    ; provider_id = "custom"
+    ; provider_label = "openai_compat"
+    ; model_id = "uncatalogued"
+    ; source_catalog_entry = None
+    }
+  in
+  match Runtime.model_catalog_backfill_entries [ missing ] with
+  | Ok _ -> fail "backfill must not invent capabilities without a source row"
+  | Error msg ->
+    check bool "error names runtime" true
+      (String_util.contains_substring msg "custom.uncatalogued")
 
 let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_fake_runtime_model_catalog @@ fun () ->
@@ -1542,6 +1652,12 @@ let () =
           test_case
             "runtime capability gate uses provider-qualified OAS catalog rows"
             `Quick test_runtime_capability_gate_uses_provider_qualified_catalog;
+          test_case
+            "runtime catalog backfill projects bare catalog rows"
+            `Quick test_runtime_catalog_backfill_projects_bare_catalog_row;
+          test_case
+            "runtime catalog backfill refuses missing source rows"
+            `Quick test_runtime_catalog_backfill_refuses_missing_source_row;
           test_case "atomic runtime getters are consistent after init" `Quick
             test_runtime_atomic_getters_are_consistent_after_init;
           test_case "max-concurrent is optional opt-in" `Quick

--- a/test/test_runtime_missing_catalog_report.ml
+++ b/test/test_runtime_missing_catalog_report.ml
@@ -1,0 +1,54 @@
+open Alcotest
+
+let contains = String_util.contains_substring
+
+let missing_model ?(runtime_id = "custom.uncatalogued")
+    ?(provider_id = "custom")
+    ?(provider_label = "openai_compat")
+    ?(model_id = "uncatalogued") () : Runtime.missing_catalog_model =
+  { runtime_id; provider_id; provider_label; model_id }
+;;
+
+let report missing_models : Runtime.missing_catalog_report =
+  { config_path = "/tmp/runtime.toml"; missing_models }
+;;
+
+let message missing_models =
+  Runtime.strict_init_error_to_string (Runtime.Missing_catalog_models (report missing_models))
+;;
+
+let test_missing_catalog_report_names_runtime_and_model () =
+  let msg = message [ missing_model () ] in
+  check bool "runtime/model label" true
+    (contains msg "custom.uncatalogued (model=uncatalogued)");
+  check bool "count" true (contains msg "1 runtime model(s)");
+  check bool "catalog filename" true (contains msg "oas-models.toml")
+;;
+
+let test_missing_catalog_report_joins_multiple_models () =
+  let msg =
+    message
+      [ missing_model ~runtime_id:"custom.alpha" ~model_id:"alpha" ()
+      ; missing_model ~runtime_id:"custom.beta" ~model_id:"beta" ()
+      ]
+  in
+  check bool "count" true (contains msg "2 runtime model(s)");
+  check bool "alpha label" true (contains msg "custom.alpha (model=alpha)");
+  check bool "beta label" true (contains msg "custom.beta (model=beta)")
+;;
+
+let () =
+  Alcotest.run
+    "Runtime Missing Catalog Report"
+    [ ( "strict_init_error_to_string"
+      , [ test_case
+            "names runtime and model"
+            `Quick
+            test_missing_catalog_report_names_runtime_and_model
+        ; test_case
+            "joins multiple models"
+            `Quick
+            test_missing_catalog_report_joins_multiple_models
+        ] )
+    ]
+;;

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -230,14 +230,18 @@ supports_native_streaming = true
 ;;
 
 let with_runtime_file f =
-  with_model_catalog_content runtime_route_model_catalog @@ fun () ->
-  with_temp_dir "runtime-per-keeper-routing-runtime" @@ fun dir ->
-  let path = Filename.concat dir "runtime.toml" in
-  write_file path runtime_config;
-  (match Runtime.init_default ~config_path:path with
-   | Ok () -> ()
-   | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
-  f path
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore runtime_snapshot)
+    (fun () ->
+       with_model_catalog_content runtime_route_model_catalog @@ fun () ->
+       with_temp_dir "runtime-per-keeper-routing-runtime" @@ fun dir ->
+       let path = Filename.concat dir "runtime.toml" in
+       write_file path runtime_config;
+       (match Runtime.init_default ~config_path:path with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "runtime init_default failed: %s" msg);
+       f path)
 ;;
 
 let with_runtime_initialized f =


### PR DESCRIPTION
## Summary
- keep runtime strict catalog validation fail-closed, with typed missing-model diagnostics instead of string-matching fatal text
- remove the boot-time interactive OAS catalog backfill/append path, so server startup never blocks an Eio domain on stdin or mutates the tracked catalog
- keep the openai_compat/gemma4-coder- projection row so the current RunPod RTX A6000 Gemma4 coder binding resolves without provider_default
- refresh the runtime routing fixture catalog so structured-judge routing tests use explicit OAS capability rows

## Validation
- `opam exec -- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli lib/server/server_runtime_bootstrap.ml test/test_runtime_config_validity.ml test/test_runtime_per_keeper_routing.ml`
- `git diff --check`
- `scripts/dune-local.sh build @test/runtest-test_runtime_config_validity @test/runtest-test_runtime_per_keeper_routing`

## Review Response
- Removed the boot-time prompt/read_line path instead of offloading it: startup stays fail-closed, and catalog repair must be an explicit operator/source change.
- Updated missing-catalog diagnostics from `models.toml` to `oas-models.toml`.
- Removed the generated backfill entry/append API and its stale source-catalog snapshot/write-time doc contract.
- Resolved the hard-tab review threads after formatting the touched files.
