### PR TITLE
fix(keeper): exclude paused keepers from fleet capacity

### DIFF
--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -175,9 +175,10 @@ val make_health_json :
     whether FD pressure is active, and each resource kind's in-flight,
     configured-concurrency, and effective-concurrency counts.
 
-    [keeper_fleet_safety] compares configured autoboot-enabled keepers
-    with the live healthy-running keeper fiber count while separately reporting
-    [bootable_keeper_*] after durable pause filtering.  It distinguishes
+    [keeper_fleet_safety] compares configured, unpaused autoboot-enabled
+    keepers with the live healthy-running keeper fiber count while separately
+    reporting durable paused keepers via [paused_autoboot_enabled_*] and
+    bootable keepers via [bootable_keeper_*].  It distinguishes
     [running_keeper_fiber_count] / [healthy_running_keeper_fiber_count] from
     [failing_keeper_fiber_count] and [executable_keeper_fiber_count] because
     the FSM intentionally allows [Failing] keepers to finish or attempt turns.
@@ -185,8 +186,8 @@ val make_health_json :
     fiber remains, and [degraded] when executable fibers remain but healthy
     running capacity is zero, below the safety margin, or below
     [target_reaction_capacity_count].
-    [paused_autoboot_enabled_keeper_count] makes the intended fleet size
-    visible even when durable pauses suppress every bootable keeper.
+    [paused_autoboot_enabled_keeper_count] keeps operator-paused autoboot
+    keepers visible without counting them as reaction-capacity targets.
 
     [keeper_reaction_ledger] summarizes recent durable stimulus -> reaction
     rows per keeper.  It reports [degraded] when a persisted stimulus has no

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -104,8 +104,8 @@ let running_keeper_names ?base_path () =
   Keeper_registry.all ?base_path ()
   |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
        match e.phase with
-       | Keeper_state_machine.Running when not e.meta.paused -> Some e.name
-       | Keeper_state_machine.Running -> None
+       | Keeper_state_machine.Running ->
+         if e.meta.paused then None else Some e.name
        | Keeper_state_machine.Offline
        | Keeper_state_machine.Overflowed
        | Keeper_state_machine.Failing

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -104,7 +104,8 @@ let running_keeper_names ?base_path () =
   Keeper_registry.all ?base_path ()
   |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
        match e.phase with
-       | Keeper_state_machine.Running -> Some e.name
+       | Keeper_state_machine.Running when not e.meta.paused -> Some e.name
+       | Keeper_state_machine.Running -> None
        | Keeper_state_machine.Offline
        | Keeper_state_machine.Overflowed
        | Keeper_state_machine.Failing
@@ -272,7 +273,10 @@ let keeper_fleet_meta_scan ?(include_paused_details = true) config =
            | Ok (Some meta) ->
              let autoboot_enabled = effective_autoboot_enabled config name meta in
              let acc =
-               if autoboot_enabled && should_count_autoboot_target meta.name
+               if
+                 (not meta.paused)
+                 && autoboot_enabled
+                 && should_count_autoboot_target meta.name
                then add_autoboot acc meta.name
                else acc
              in
@@ -376,7 +380,7 @@ let autoboot_enabled_keeper_scan config =
        (fun acc name ->
          match Keeper_meta_store.read_meta config name with
          | Ok (Some meta) ->
-             if effective_autoboot_enabled config name meta then
+             if (not meta.paused) && effective_autoboot_enabled config name meta then
                { acc with autoboot_names = meta.name :: acc.autoboot_names }
              else acc
          | Ok None ->
@@ -454,7 +458,10 @@ let keeper_phase_snapshot ?base_path () =
             }
           in
           let counts = acc.counts in
-          let can_execute = Keeper_state_machine.can_execute_turn entry.phase in
+          let capacity_eligible = not entry.meta.paused in
+          let can_execute =
+            capacity_eligible && Keeper_state_machine.can_execute_turn entry.phase
+          in
           let executable = if can_execute then counts.executable + 1 else counts.executable in
           let executable_names =
             if can_execute then entry.name :: acc.executable_names
@@ -467,7 +474,8 @@ let keeper_phase_snapshot ?base_path () =
           let is_recovering =
             match entry.phase with
             | Keeper_state_machine.Failing
-              when entry.conditions.restart_budget_remaining -> true
+              when capacity_eligible && entry.conditions.restart_budget_remaining ->
+              true
             | _ -> false
           in
           let recovering =
@@ -478,7 +486,7 @@ let keeper_phase_snapshot ?base_path () =
             else acc.recovering_names
           in
           match entry.phase with
-          | Keeper_state_machine.Running ->
+          | Keeper_state_machine.Running when capacity_eligible ->
             {
               acc with
               counts = { counts with running = counts.running + 1; executable };
@@ -486,7 +494,9 @@ let keeper_phase_snapshot ?base_path () =
               recovering_names;
               executable_names;
             }
-          | Keeper_state_machine.Failing ->
+          | Keeper_state_machine.Running ->
+            { acc with counts = { counts with executable }; executable_names }
+          | Keeper_state_machine.Failing when capacity_eligible ->
             {
               acc with
               counts =
@@ -494,6 +504,8 @@ let keeper_phase_snapshot ?base_path () =
               recovering_names;
               executable_names;
             }
+          | Keeper_state_machine.Failing ->
+            { acc with counts = { counts with executable }; executable_names }
           | Keeper_state_machine.Offline
           | Keeper_state_machine.Overflowed
           | Keeper_state_machine.Compacting

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1346,13 +1346,13 @@ let test_health_json_surfaces_durable_paused_keepers () =
             Fd_accountant.all_kinds;
           Alcotest.(check int) "health exposes bootable keeper count" 1
             (fleet_safety |> member "bootable_keeper_count" |> to_int);
-          Alcotest.(check int) "health exposes autoboot keeper count" 2
+          Alcotest.(check int) "health exposes autoboot keeper count" 1
             (fleet_safety |> member "autoboot_enabled_keeper_count" |> to_int);
           Alcotest.(check int) "health exposes paused autoboot keeper count" 1
             (fleet_safety |> member "paused_autoboot_enabled_keeper_count" |> to_int);
-          Alcotest.(check int) "health exposes target reaction capacity" 2
+          Alcotest.(check int) "health exposes target reaction capacity" 1
             (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
-          Alcotest.(check int) "health exposes minimum running fibers" 2
+          Alcotest.(check int) "health exposes minimum running fibers" 1
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
           Alcotest.(check string) "health marks fleet blocked" "blocked"
             (fleet_safety |> member "status" |> to_string);
@@ -1363,7 +1363,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
             (fleet_safety |> member "no_executable_keeper_fibers" |> to_bool);
           Alcotest.(check bool) "health marks capacity below target" true
             (fleet_safety |> member "reaction_capacity_below_target" |> to_bool);
-          Alcotest.(check int) "health exposes capacity shortfall" 2
+          Alcotest.(check int) "health exposes capacity shortfall" 1
             (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
           Alcotest.(check bool) "health fleet asks for operator action" true
             (fleet_safety |> member "operator_action_required" |> to_bool);
@@ -1957,7 +1957,12 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
     let config_root = make_config_root dir in
     List.iter
       (write_config_root_keeper_toml config_root)
-      [ "capacity-paused"; "capacity-running-a"; "capacity-running-b" ];
+      [
+        "capacity-paused";
+        "capacity-running-a";
+        "capacity-running-b";
+        "capacity-missing";
+      ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
     let previous_state = !Server_auth.server_state in
     Config_dir_resolver.reset ();
@@ -2001,19 +2006,36 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
         List.iter
           (write_keeper_meta_exn config)
           [ paused; running_a; running_b; runtime_only ];
-        with_running_keeper_metas config [ running_a; running_b; runtime_only ] (fun () ->
+        with_running_keeper_metas config
+          [ paused; running_a; running_b; runtime_only ]
+          (fun () ->
           let request = Httpun.Request.create `GET "/health" in
           let json = Server_routes_http_runtime.make_health_json request in
           let open Yojson.Safe.Util in
-          let fleet_safety = json |> member "keeper_fleet_safety" in
-          Alcotest.(check int) "health exposes running reaction capacity" 3
-            (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
-          Alcotest.(check int) "health exposes executable reaction capacity" 3
-            (fleet_safety |> member "executable_reaction_capacity_count" |> to_int);
-          Alcotest.(check int) "health exposes failing keeper count" 0
-            (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
-          Alcotest.(check int) "health exposes target reaction capacity" 4
-            (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+	          let paused_keepers = json |> member "paused_keepers" in
+	          let fleet_safety = json |> member "keeper_fleet_safety" in
+	          Alcotest.(check int) "health exposes running reaction capacity" 3
+	            (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
+	          Alcotest.(check int) "health exposes executable reaction capacity" 3
+	            (fleet_safety |> member "executable_reaction_capacity_count" |> to_int);
+	          Alcotest.(check (list string))
+	            "health excludes paused registry entries from running capacity"
+	            [ "capacity-running-a"; "capacity-running-b"; "runtime-only" ]
+	            (fleet_safety |> member "running_keeper_names" |> to_list
+	             |> List.map to_string);
+	          Alcotest.(check int) "health exposes failing keeper count" 0
+	            (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
+	          Alcotest.(check int) "health exposes target reaction capacity" 4
+	            (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+	          Alcotest.(check int) "health exposes paused autoboot target separately" 1
+	            (fleet_safety
+	             |> member "paused_autoboot_enabled_keeper_count"
+	             |> to_int);
+	          Alcotest.(check (list string))
+	            "health keeps durable paused keeper in paused inventory"
+	            [ "capacity-paused" ]
+	            (paused_keepers |> member "durable_names" |> to_list
+	             |> List.map to_string);
           Alcotest.(check int) "health exposes minimum running fibers" 2
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
           Alcotest.(check bool) "health is not below minimum margin" false
@@ -2029,40 +2051,25 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
           Alcotest.(check int) "health exposes blocked keeper count" 2
             (fleet_safety |> member "blocked_count" |> to_int);
           Alcotest.(check (list string)) "health exposes blocked keeper names"
-            [ "capacity-paused"; "example" ]
+            [ "capacity-missing"; "example" ]
             (fleet_safety |> member "blocked_keeper_names" |> to_list
              |> List.map to_string);
           Alcotest.(check (list (pair string string)))
             "health explains blocked keeper reasons"
-            [ ("capacity-paused", "durable_paused_autoboot_enabled")
-            ; ("example", "not_registered")
-            ]
+            [ ("capacity-missing", "not_registered"); ("example", "not_registered") ]
             (fleet_safety |> member "blocked_keeper_reasons" |> to_list
              |> List.map (fun row ->
-                  ( row |> member "keeper" |> to_string
-                  , row |> member "reason" |> to_string )));
+                  (row |> member "keeper" |> to_string, row |> member "reason" |> to_string)));
           let blocked_detail name =
             fleet_safety |> member "blocked_keeper_reasons" |> to_list
             |> List.find (fun row -> row |> member "keeper" |> to_string = name)
           in
           Alcotest.(check string) "health keeps typed row name alias"
-            "capacity-paused"
-            (blocked_detail "capacity-paused" |> member "name" |> to_string);
-          Alcotest.(check string) "health suggests paused action"
-            "resume_or_leave_paused"
-            (blocked_detail "capacity-paused" |> member "action" |> to_string);
-          Alcotest.(check string) "health preserves paused blocker class"
-            "no_progress_loop"
-            (blocked_detail "capacity-paused"
-             |> member "last_blocker"
-             |> member "klass"
-             |> to_string);
-          Alcotest.(check string) "health preserves paused blocker detail"
-            "no_progress loop detected"
-            (blocked_detail "capacity-paused"
-             |> member "last_blocker"
-             |> member "detail"
-             |> to_string);
+            "capacity-missing"
+            (blocked_detail "capacity-missing" |> member "name" |> to_string);
+          Alcotest.(check string) "health suggests missing target action"
+            "start_or_recover_keeper"
+            (blocked_detail "capacity-missing" |> member "action" |> to_string);
           Alcotest.(check string) "health suggests unregistered action"
             "start_or_recover_keeper"
             (blocked_detail "example" |> member "action" |> to_string);

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2009,33 +2009,33 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
         with_running_keeper_metas config
           [ paused; running_a; running_b; runtime_only ]
           (fun () ->
-          let request = Httpun.Request.create `GET "/health" in
-          let json = Server_routes_http_runtime.make_health_json request in
-          let open Yojson.Safe.Util in
-	          let paused_keepers = json |> member "paused_keepers" in
-	          let fleet_safety = json |> member "keeper_fleet_safety" in
-	          Alcotest.(check int) "health exposes running reaction capacity" 3
-	            (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
-	          Alcotest.(check int) "health exposes executable reaction capacity" 3
-	            (fleet_safety |> member "executable_reaction_capacity_count" |> to_int);
-	          Alcotest.(check (list string))
-	            "health excludes paused registry entries from running capacity"
-	            [ "capacity-running-a"; "capacity-running-b"; "runtime-only" ]
-	            (fleet_safety |> member "running_keeper_names" |> to_list
-	             |> List.map to_string);
-	          Alcotest.(check int) "health exposes failing keeper count" 0
-	            (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
-	          Alcotest.(check int) "health exposes target reaction capacity" 4
-	            (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
-	          Alcotest.(check int) "health exposes paused autoboot target separately" 1
-	            (fleet_safety
-	             |> member "paused_autoboot_enabled_keeper_count"
-	             |> to_int);
-	          Alcotest.(check (list string))
-	            "health keeps durable paused keeper in paused inventory"
-	            [ "capacity-paused" ]
-	            (paused_keepers |> member "durable_names" |> to_list
-	             |> List.map to_string);
+            let request = Httpun.Request.create `GET "/health" in
+            let json = Server_routes_http_runtime.make_health_json request in
+            let open Yojson.Safe.Util in
+            let paused_keepers = json |> member "paused_keepers" in
+            let fleet_safety = json |> member "keeper_fleet_safety" in
+            Alcotest.(check int) "health exposes running reaction capacity" 3
+              (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
+            Alcotest.(check int) "health exposes executable reaction capacity" 3
+              (fleet_safety |> member "executable_reaction_capacity_count" |> to_int);
+            Alcotest.(check (list string))
+              "health excludes paused registry entries from running capacity"
+              [ "capacity-running-a"; "capacity-running-b"; "runtime-only" ]
+              (fleet_safety |> member "running_keeper_names" |> to_list
+               |> List.map to_string);
+            Alcotest.(check int) "health exposes failing keeper count" 0
+              (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
+            Alcotest.(check int) "health exposes target reaction capacity" 4
+              (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+            Alcotest.(check int) "health exposes paused autoboot target separately" 1
+              (fleet_safety
+               |> member "paused_autoboot_enabled_keeper_count"
+               |> to_int);
+            Alcotest.(check (list string))
+              "health keeps durable paused keeper in paused inventory"
+              [ "capacity-paused" ]
+              (paused_keepers |> member "durable_names" |> to_list
+               |> List.map to_string);
           Alcotest.(check int) "health exposes minimum running fibers" 2
             (fleet_safety |> member "minimum_running_fibers" |> to_int);
           Alcotest.(check bool) "health is not below minimum margin" false


### PR DESCRIPTION
## Summary

- Exclude durable paused keepers from Keeper Fleet reaction-capacity targets.
- Exclude registry entries with `meta.paused=true` from running/executable/recovering capacity counts even if their FSM phase is still `Running` or `Failing`.
- Keep paused autoboot keepers visible via `paused_autoboot_enabled_*` and paused inventory fields instead of treating them as blocked capacity targets.

## Why

Live dashboard state showed paused keepers counted as running/executable capacity and target capacity at the same time. That made Keeper Fleet show confusing values like many paused keepers while still reporting them as running capacity, then degrading against a target that included operator-paused keepers.

## Validation

- `ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check`

Per operator instruction, local Dune build/test is left to CI.

## Follow-up

Separate issue filed for the live turn lifecycle inconsistency observed during diagnosis: #22960.
