### PR TITLE
fix(keeper): persist contract-failed turn usage

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -246,10 +246,6 @@ let terminal_outcome_is_completed_turn = function
   | Terminal_failed_completion_contract _ -> false
 ;;
 
-let terminal_outcome_persists_turn_usage = function
-  | Terminal_done | Terminal_checkpoint | Terminal_failed_completion_contract _ -> true
-;;
-
 let terminal_outcome_to_activity_kind = function
   | Terminal_failed_completion_contract _ -> "keeper.turn_failed"
   | Terminal_done | Terminal_checkpoint -> "keeper.turn_completed"
@@ -293,7 +289,6 @@ module For_testing = struct
 
   let terminal_outcome_of_result = terminal_outcome_of_result
   let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
-  let terminal_outcome_persists_turn_usage = terminal_outcome_persists_turn_usage
 end
 
 let append_metrics_snapshot
@@ -892,16 +887,15 @@ let handle
     ~turn_mode_label
     ~lifecycle
     ~terminal_outcome;
+  (* Every terminal outcome has consumed a keeper turn id. Persist the updated
+     usage even for completion-contract failures so the next cycle cannot
+     allocate the same turn id again. *)
   let updated_meta =
-    if terminal_outcome_persists_turn_usage terminal_outcome
-    then
-      persist_terminal_turn_meta
-        ~config
-        ~original_meta:meta
-        ~clear_auto_resume_after_sec:
-          (terminal_outcome_is_completed_turn terminal_outcome)
-        ~updated_meta
-    else updated_meta
+    persist_terminal_turn_meta
+      ~config
+      ~original_meta:meta
+      ~clear_auto_resume_after_sec:(terminal_outcome_is_completed_turn terminal_outcome)
+      ~updated_meta
   in
   let tool_call_summaries =
     let max_tool_calls = 10 in

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -260,37 +260,6 @@ let terminal_outcome_to_log_label = function
   | Terminal_checkpoint -> "checkpoint"
   | Terminal_failed_completion_contract _ -> "failed"
 
-module For_testing = struct
-  let budget_exhausted_no_progress_threshold_override =
-    budget_exhausted_no_progress_threshold_override
-
-  type nonrec turn_delivery = turn_delivery =
-    | Peer_only
-    | User_facing
-    | Internal_prose
-    | Task_claim
-
-  type nonrec reply_delivery = reply_delivery =
-    | Internal_only
-    | Externally_delivered
-
-  let classify_delivery = classify_delivery
-  let delivery_requires_evidence = delivery_requires_evidence
-  let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
-  let claim_bound_work = claim_bound_work
-
-  let completion_contract_terminal_failure_reason_code =
-    completion_contract_terminal_failure_reason_code
-
-  type nonrec terminal_outcome = terminal_outcome =
-    | Terminal_done
-    | Terminal_checkpoint
-    | Terminal_failed_completion_contract of { reason_code : string }
-
-  let terminal_outcome_of_result = terminal_outcome_of_result
-  let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
-end
-
 let append_metrics_snapshot
       ~config
       ~meta
@@ -643,6 +612,49 @@ let persist_terminal_turn_meta
     ();
   updated_meta
 ;;
+
+module For_testing = struct
+  let budget_exhausted_no_progress_threshold_override =
+    budget_exhausted_no_progress_threshold_override
+
+  type nonrec turn_delivery = turn_delivery =
+    | Peer_only
+    | User_facing
+    | Internal_prose
+    | Task_claim
+
+  type nonrec reply_delivery = reply_delivery =
+    | Internal_only
+    | Externally_delivered
+
+  let classify_delivery = classify_delivery
+  let delivery_requires_evidence = delivery_requires_evidence
+  let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
+  let claim_bound_work = claim_bound_work
+
+  let completion_contract_terminal_failure_reason_code =
+    completion_contract_terminal_failure_reason_code
+
+  type nonrec terminal_outcome = terminal_outcome =
+    | Terminal_done
+    | Terminal_checkpoint
+    | Terminal_failed_completion_contract of { reason_code : string }
+
+  let terminal_outcome_of_result = terminal_outcome_of_result
+  let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
+
+  let persist_terminal_turn_meta_for_outcome
+        ~config
+        ~original_meta
+        ~updated_meta
+        ~terminal_outcome
+    =
+    persist_terminal_turn_meta
+      ~config
+      ~original_meta
+      ~clear_auto_resume_after_sec:(terminal_outcome_is_completed_turn terminal_outcome)
+      ~updated_meta
+end
 
 let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
   let reset_failure_state () =

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -246,6 +246,10 @@ let terminal_outcome_is_completed_turn = function
   | Terminal_failed_completion_contract _ -> false
 ;;
 
+let terminal_outcome_persists_turn_usage = function
+  | Terminal_done | Terminal_checkpoint | Terminal_failed_completion_contract _ -> true
+;;
+
 let terminal_outcome_to_activity_kind = function
   | Terminal_failed_completion_contract _ -> "keeper.turn_failed"
   | Terminal_done | Terminal_checkpoint -> "keeper.turn_completed"
@@ -289,6 +293,7 @@ module For_testing = struct
 
   let terminal_outcome_of_result = terminal_outcome_of_result
   let terminal_outcome_is_completed_turn = terminal_outcome_is_completed_turn
+  let terminal_outcome_persists_turn_usage = terminal_outcome_persists_turn_usage
 end
 
 let append_metrics_snapshot
@@ -602,9 +607,14 @@ let terminal_reason_of_outcome result = function
       ~source:"completion_contract"
       Keeper_turn_disposition.Completion_contract_unsatisfied
 
-let persist_success_meta ~config ~original_meta ~updated_meta =
+let persist_terminal_turn_meta
+      ~config
+      ~original_meta
+      ~clear_auto_resume_after_sec
+      ~updated_meta
+  =
   let updated_meta =
-    if updated_meta.auto_resume_after_sec <> None
+    if clear_auto_resume_after_sec && updated_meta.auto_resume_after_sec <> None
     then { updated_meta with auto_resume_after_sec = None }
     else updated_meta
   in
@@ -883,10 +893,15 @@ let handle
     ~lifecycle
     ~terminal_outcome;
   let updated_meta =
-    match terminal_outcome with
-    | Terminal_failed_completion_contract _ -> updated_meta
-    | Terminal_done | Terminal_checkpoint ->
-      persist_success_meta ~config ~original_meta:meta ~updated_meta
+    if terminal_outcome_persists_turn_usage terminal_outcome
+    then
+      persist_terminal_turn_meta
+        ~config
+        ~original_meta:meta
+        ~clear_auto_resume_after_sec:
+          (terminal_outcome_is_completed_turn terminal_outcome)
+        ~updated_meta
+    else updated_meta
   in
   let tool_call_summaries =
     let max_tool_calls = 10 in

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -64,6 +64,7 @@ module For_testing : sig
 
   val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
   val terminal_outcome_is_completed_turn : terminal_outcome -> bool
+  val terminal_outcome_persists_turn_usage : terminal_outcome -> bool
 end
 
 val handle

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -64,7 +64,6 @@ module For_testing : sig
 
   val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
   val terminal_outcome_is_completed_turn : terminal_outcome -> bool
-  val terminal_outcome_persists_turn_usage : terminal_outcome -> bool
 end
 
 val handle

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -64,6 +64,13 @@ module For_testing : sig
 
   val terminal_outcome_of_result : Keeper_agent_run.run_result -> terminal_outcome
   val terminal_outcome_is_completed_turn : terminal_outcome -> bool
+
+  val persist_terminal_turn_meta_for_outcome
+    :  config:Workspace.config
+    -> original_meta:Keeper_meta_contract.keeper_meta
+    -> updated_meta:Keeper_meta_contract.keeper_meta
+    -> terminal_outcome:terminal_outcome
+    -> Keeper_meta_contract.keeper_meta
 end
 
 val handle

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -20,9 +20,47 @@ module R = Masc.Keeper_execution_receipt
 module C = Masc.Keeper_contract_classifier
 module Tr = Keeper_terminal_reason
 module UTS = Masc.Keeper_unified_turn_success.For_testing
+module KMC = Masc.Keeper_meta_contract
+module KMS = Masc.Keeper_meta_store
 
 let failures = ref []
 let check name cond = if not cond then failures := name :: !failures
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+;;
+
+let meta_fixture_exn json =
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> failwith ("meta fixture parse failed: " ^ err)
+;;
+
+let write_meta_exn config meta =
+  match KMS.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> failwith ("write_meta failed: " ^ err)
+;;
+
+let read_meta_exn config keeper_name =
+  match KMS.read_meta config keeper_name with
+  | Ok (Some meta) -> meta
+  | Ok None -> failwith ("missing persisted meta for " ^ keeper_name)
+  | Error err -> failwith ("read_meta failed: " ^ err)
+;;
 
 (* ------------------------------------------------------------------ *)
 (* 1. Wire round-trip corpus: built from the PRODUCER sites, not from   *)
@@ -749,6 +787,58 @@ let () =
   check
     "completion-contract terminal failure is not a completed activity turn"
     (not (UTS.terminal_outcome_is_completed_turn completion_contract_failure))
+;;
+
+let () =
+  with_temp_dir "keeper-contract-failed-turn-persist" @@ fun workspace_dir ->
+  let keeper_name = "contract-failed-turn-persist" in
+  let config = Masc.Workspace.default_config workspace_dir in
+  let meta : KMC.keeper_meta =
+    meta_fixture_exn
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String keeper_name
+        ; "trace_id", `String "trace-contract-failed-turn-persist"
+        ; "goal", `String "Persist contract-failed turn usage"
+        ])
+  in
+  write_meta_exn config meta;
+  let original_meta = read_meta_exn config keeper_name in
+  let usage = original_meta.runtime.usage in
+  let updated_meta =
+    { original_meta with
+      auto_resume_after_sec = Some 30.0
+    ; runtime =
+        { original_meta.runtime with
+          usage =
+            { usage with
+              total_turns = usage.total_turns + 1
+            ; last_turn_ts = 12345.0
+            }
+        }
+    }
+  in
+  let terminal_outcome =
+    UTS.Terminal_failed_completion_contract
+      { reason_code = "needs_execution_progress" }
+  in
+  let returned =
+    UTS.persist_terminal_turn_meta_for_outcome
+      ~config
+      ~original_meta
+      ~updated_meta
+      ~terminal_outcome
+  in
+  let persisted = read_meta_exn config keeper_name in
+  check
+    "completion-contract terminal failure keeps auto-resume on returned meta"
+    (returned.auto_resume_after_sec = Some 30.0);
+  check
+    "completion-contract terminal failure persists advanced turn usage"
+    (persisted.runtime.usage.total_turns = updated_meta.runtime.usage.total_turns);
+  check
+    "completion-contract terminal failure does not clear durable auto-resume"
+    (persisted.auto_resume_after_sec = Some 30.0)
 ;;
 
 let () =

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -748,10 +748,7 @@ let () =
   in
   check
     "completion-contract terminal failure is not a completed activity turn"
-    (not (UTS.terminal_outcome_is_completed_turn completion_contract_failure));
-  check
-    "completion-contract terminal failure persists keeper turn usage"
-    (UTS.terminal_outcome_persists_turn_usage completion_contract_failure)
+    (not (UTS.terminal_outcome_is_completed_turn completion_contract_failure))
 ;;
 
 let () =

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -19,6 +19,7 @@
 module R = Masc.Keeper_execution_receipt
 module C = Masc.Keeper_contract_classifier
 module Tr = Keeper_terminal_reason
+module UTS = Masc.Keeper_unified_turn_success.For_testing
 
 let failures = ref []
 let check name cond = if not cond then failures := name :: !failures
@@ -738,6 +739,19 @@ let () =
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want)
+;;
+
+let () =
+  let completion_contract_failure =
+    UTS.Terminal_failed_completion_contract
+      { reason_code = "needs_execution_progress" }
+  in
+  check
+    "completion-contract terminal failure is not a completed activity turn"
+    (not (UTS.terminal_outcome_is_completed_turn completion_contract_failure));
+  check
+    "completion-contract terminal failure persists keeper turn usage"
+    (UTS.terminal_outcome_persists_turn_usage completion_contract_failure)
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- persist keeper turn usage for terminal completion-contract failures
- keep completion-contract failures classified as failed activity, not completed turns
- add a focused regression assertion that the failed completion-contract outcome stays non-completed activity

## Root Cause

Live `sangsu` reused keeper turn `4157` after terminal `completion_contract_unsatisfied` outcomes. The source path updated metrics in memory, but skipped the durable meta write for `Terminal_failed_completion_contract`.

The next keeper cycle allocates `turn_id = meta.runtime.usage.total_turns + 1`, so a non-persisted failure reuses the previous keeper turn id. That can make the composite surface show `last_outcome.turn_id` and `live_turn.turn_id` as the same value.

This patch keeps the existing activity semantics:

- `Terminal_failed_completion_contract` is still not a completed activity turn.
- Terminal turn meta is persisted for every terminal outcome, including completion-contract failures, so the next cycle receives a fresh keeper turn id.
- `auto_resume_after_sec` clearing remains limited to completed/checkpoint outcomes, matching the previous success-path behavior.

Fixes #22960.

## Validation

- `ocamlformat --check lib/keeper/keeper_unified_turn_success.ml lib/keeper/keeper_unified_turn_success.mli test/test_keeper_terminal_reason_typed.ml`
- `git diff --check`

`dune` build/test intentionally left to CI per operator instruction.
