### PR TITLE
[codex] keep direct passive keeper replies visible

### DIFF
--- a/config/prompts/keeper.reply_guidelines.md
+++ b/config/prompts/keeper.reply_guidelines.md
@@ -7,6 +7,7 @@ This turn is a direct chat with the user.
 Prioritize the keeper's authored persona, tone, relationship style, and examples over generic autonomous narration.
 Reply as the keeper, not as a neutral assistant, control-plane operator, or world-state summarizer.
 Do not expose hidden world state, board scans, metrics, token budgets, or internal workflow unless the user explicitly asks for them.
+Do not repeat trigger checks, re-verification wording, tool-count summaries, or no-tool-call reasoning as a direct chat answer.
 Keep the reply in the user's language and preserve the keeper's natural speech patterns.
 Do not emit SKILL:, SKILL_REASON:, [STATE], or generic world-state summaries.
 If a tool is needed, use it first, then answer in-character with the result.

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -25,21 +25,6 @@ let completion_contract_drops_current_turn_replay
     completion_contract_result
 ;;
 
-let direct_assistant_source = "direct_assistant"
-
-let completion_contract_suppresses_visible_response
-      ~history_assistant_source
-      (completion_contract_result :
-         Keeper_execution_receipt.completion_contract_result)
-  =
-  match completion_contract_result with
-  | Keeper_execution_receipt.Contract_passive_only ->
-    not (String.equal history_assistant_source direct_assistant_source)
-  | _ ->
-    Keeper_execution_receipt.completion_contract_result_requires_attention
-      completion_contract_result
-;;
-
 type replay_suffix_prune_reason =
   | Completion_contract_requires_attention
   | Synthetic_empty_state_snapshot
@@ -235,7 +220,7 @@ module For_testing = struct
     completion_contract_drops_current_turn_replay
 
   let completion_contract_suppresses_visible_response =
-    completion_contract_suppresses_visible_response
+    Keeper_agent_run_response_text.completion_contract_suppresses_visible_response
 
   let replay_suffix_prune_reason_to_string =
     replay_suffix_prune_reason_to_string
@@ -278,7 +263,7 @@ let finalize
   in
   let completion_contract_result = acc.receipt_completion_contract_result in
   let contract_suppresses_visible_response =
-    completion_contract_suppresses_visible_response
+    Keeper_agent_run_response_text.completion_contract_suppresses_visible_response
       ~history_assistant_source
       completion_contract_result
   in

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -25,6 +25,21 @@ let completion_contract_drops_current_turn_replay
     completion_contract_result
 ;;
 
+let direct_assistant_source = "direct_assistant"
+
+let completion_contract_suppresses_visible_response
+      ~history_assistant_source
+      (completion_contract_result :
+         Keeper_execution_receipt.completion_contract_result)
+  =
+  match completion_contract_result with
+  | Keeper_execution_receipt.Contract_passive_only ->
+    not (String.equal history_assistant_source direct_assistant_source)
+  | _ ->
+    Keeper_execution_receipt.completion_contract_result_requires_attention
+      completion_contract_result
+;;
+
 type replay_suffix_prune_reason =
   | Completion_contract_requires_attention
   | Synthetic_empty_state_snapshot
@@ -219,6 +234,9 @@ module For_testing = struct
   let completion_contract_drops_current_turn_replay =
     completion_contract_drops_current_turn_replay
 
+  let completion_contract_suppresses_visible_response =
+    completion_contract_suppresses_visible_response
+
   let replay_suffix_prune_reason_to_string =
     replay_suffix_prune_reason_to_string
 
@@ -259,15 +277,18 @@ let finalize
       result.stop_reason
   in
   let completion_contract_result = acc.receipt_completion_contract_result in
-  let contract_requires_attention =
-    Keeper_execution_receipt.completion_contract_result_requires_attention
+  let contract_suppresses_visible_response =
+    completion_contract_suppresses_visible_response
+      ~history_assistant_source
       completion_contract_result
   in
-  let suppress_visible_response = budget_exhausted || contract_requires_attention in
+  let suppress_visible_response =
+    budget_exhausted || contract_suppresses_visible_response
+  in
   let raw_response_text_present =
     (not budget_exhausted) && String.trim raw_response_text <> ""
   in
-  if contract_requires_attention && raw_response_text_present
+  if contract_suppresses_visible_response && raw_response_text_present
   then
     Log.Keeper.info ~keeper_name:meta.name
       "suppressing keeper-visible response for completion_contract_result=%s"
@@ -290,6 +311,7 @@ let finalize
       ~completion_contract_result
       ~stop_reason:result.stop_reason
       ~raw_response_text
+      ~suppress_response_text:suppress_visible_response
       ()
   in
   (* Gate the working-state resume merge (ResumeFromDigest) to turns where active

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -60,6 +60,7 @@ let response_text ~state_snapshot_source ~raw_response_text =
 
 let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
       ~completion_contract_result ~stop_reason ~raw_response_text
+      ?suppress_response_text
       ()
   =
   let budget_exhausted = stop_reason_is_turn_budget_exhausted stop_reason in
@@ -67,7 +68,11 @@ let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_nam
     Keeper_execution_receipt.completion_contract_result_requires_attention
       completion_contract_result
   in
-  let suppress_response_text = budget_exhausted || contract_requires_attention in
+  let suppress_response_text =
+    match suppress_response_text with
+    | Some suppress -> suppress
+    | None -> budget_exhausted || contract_requires_attention
+  in
   let raw_response_text = if suppress_response_text then "" else raw_response_text in
   let state_snapshot, state_snapshot_source =
     state_snapshot

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -20,6 +20,17 @@ let stop_reason_is_turn_budget_exhausted = function
   | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
 ;;
 
+let direct_assistant_source = "direct_assistant"
+
+let completion_contract_suppresses_visible_response
+      ~history_assistant_source
+  = function
+  | Keeper_execution_receipt.Contract_passive_only ->
+    not (String.equal history_assistant_source direct_assistant_source)
+  | result ->
+    Keeper_execution_receipt.completion_contract_result_requires_attention result
+;;
+
 let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
       ~stop_reason ~raw_response_text
       ()

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -21,5 +21,6 @@ val finalize :
   completion_contract_result:Keeper_execution_receipt.completion_contract_result ->
   stop_reason:Runtime_agent.stop_reason ->
   raw_response_text:string ->
+  ?suppress_response_text:bool ->
   unit ->
   finalized

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -13,6 +13,11 @@ val stop_reason_label : Runtime_agent.stop_reason -> string
     mutation-boundary stop). Used by finalize to tag budget-limited turns. *)
 val stop_reason_is_turn_budget_exhausted : Runtime_agent.stop_reason -> bool
 
+val completion_contract_suppresses_visible_response :
+  history_assistant_source:string ->
+  Keeper_execution_receipt.completion_contract_result ->
+  bool
+
 val finalize :
   reported_state_snapshot:Keeper_memory_policy.keeper_state_snapshot option ->
   keeper_name:string ->

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -1027,6 +1027,63 @@ let test_contract_attention_finalizer_drops_raw_response_text () =
        (fun text -> contains_substring text "edit it, and commit")
        finalized.state_snapshot.decisions)
 
+let passive_suppresses_for_source source =
+  Finalize.completion_contract_suppresses_visible_response
+    ~history_assistant_source:source
+    Receipt.Contract_passive_only
+
+let test_direct_passive_only_finalizer_preserves_raw_response_text () =
+  let raw_response_text =
+    "I cannot act on that from the current keeper state, but I am still here."
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"sangsu"
+      ~goal:"Maintain direct conversation"
+      ~actual_keeper_tool_names:["keeper_context_status"]
+      ~completion_contract_result:Receipt.Contract_passive_only
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text
+      ~suppress_response_text:
+        (passive_suppresses_for_source "direct_assistant")
+      ()
+  in
+  Alcotest.(check bool)
+    "direct passive-only is not suppressed"
+    false
+    (passive_suppresses_for_source "direct_assistant");
+  Alcotest.(check string)
+    "direct passive-only keeps visible response"
+    raw_response_text
+    finalized.response_text
+
+let test_internal_passive_only_finalizer_still_drops_raw_response_text () =
+  let raw_response_text =
+    "No actionable signal. I will wait for a future autonomous cycle."
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"sangsu"
+      ~goal:"Maintain direct conversation"
+      ~actual_keeper_tool_names:["keeper_context_status"]
+      ~completion_contract_result:Receipt.Contract_passive_only
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text
+      ~suppress_response_text:
+        (passive_suppresses_for_source "internal_assistant")
+      ()
+  in
+  Alcotest.(check bool)
+    "internal passive-only remains suppressed"
+    true
+    (passive_suppresses_for_source "internal_assistant");
+  Alcotest.(check string)
+    "internal passive-only drops visible response"
+    ""
+    finalized.response_text
+
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -1132,5 +1189,13 @@ let () =
             "contract attention finalizer drops raw response text"
             `Quick
             test_contract_attention_finalizer_drops_raw_response_text;
+          Alcotest.test_case
+            "direct passive-only finalizer preserves raw response text"
+            `Quick
+            test_direct_passive_only_finalizer_preserves_raw_response_text;
+          Alcotest.test_case
+            "internal passive-only finalizer still drops raw response text"
+            `Quick
+            test_internal_passive_only_finalizer_still_drops_raw_response_text;
         ] );
     ]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -155,6 +155,7 @@ tools-support = true
 streaming = true
 
 [models.gpt.capabilities]
+supports-response-format-json = true
 supports-structured-output = true
 
 [runpod_mtp.qwen]
@@ -195,6 +196,7 @@ tools-support = true
 streaming = true
 
 [models.gpt.capabilities]
+supports-response-format-json = true
 supports-structured-output = true
 
 [runpod_mtp.qwen]
@@ -207,7 +209,28 @@ max-concurrent = 1
 |}
 ;;
 
+let runtime_route_model_catalog =
+  {|
+[[models]]
+id_prefix = "openai_compat/qwen"
+base = "openai_chat"
+max_context_tokens = 128000
+supports_tools = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "openai_compat/gpt"
+base = "openai_chat"
+max_context_tokens = 64000
+supports_tools = true
+supports_response_format_json = true
+supports_structured_output = true
+supports_native_streaming = true
+|}
+;;
+
 let with_runtime_file f =
+  with_model_catalog_content runtime_route_model_catalog @@ fun () ->
   with_temp_dir "runtime-per-keeper-routing-runtime" @@ fun dir ->
   let path = Filename.concat dir "runtime.toml" in
   write_file path runtime_config;


### PR DESCRIPTION
## Summary

- Keep direct-chat `Contract_passive_only` responses visible instead of suppressing them as silent no-ops.
- Preserve existing internal/autonomous passive-only suppression by making the finalizer decision source-aware.
- Add a direct-reply prompt guard against exposing repeated trigger checks, re-verification prose, tool-count summaries, or no-tool-call reasoning.
- Add regression coverage for direct vs internal passive-only finalization.

## Root Cause

Recent `.masc` runtime logs showed direct/user-triggered keeper turns that either repeated internal re-verification/no-tool-call reasoning or completed as passive-only while the finalization path suppressed the visible assistant text. The suppression logic treated direct chat and internal autonomous turns the same, even though internal passive-only no-ops should remain suppressible while direct chat still needs a visible reply.

## Validation

- `ocamlformat --check lib/keeper/keeper_agent_run_finalize_response.ml lib/keeper/keeper_agent_run_response_text.ml lib/keeper/keeper_agent_run_response_text.mli test/test_keeper_state_snapshot_json.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe test/test_prompt_no_silent_reply_contract.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe` (34 tests)
- `./_build/default/test/test_prompt_no_silent_reply_contract.exe` (2 tests)
