### PR TITLE
Fix queued keeper lane blocking

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -6,7 +6,51 @@ let poll_interval_sec =
       try float_of_string s with Failure _ -> 1.0)
   | None -> 1.0
 
+type dispatch_state = {
+  mutex : Eio.Mutex.t;
+  running_by_keeper : (string, unit) Hashtbl.t;
+}
+
+let create_dispatch_state () =
+  { mutex = Eio.Mutex.create (); running_by_keeper = Hashtbl.create 16 }
+
+let with_dispatch_state state f =
+  Eio.Mutex.use_rw ~protect:true state.mutex f
+
+let is_dispatching state keeper_name =
+  with_dispatch_state state (fun () ->
+      Hashtbl.mem state.running_by_keeper keeper_name)
+
+let mark_dispatching state keeper_name =
+  with_dispatch_state state (fun () ->
+      if Hashtbl.mem state.running_by_keeper keeper_name
+      then false
+      else (
+        Hashtbl.replace state.running_by_keeper keeper_name ();
+        true))
+
+let clear_dispatching state keeper_name =
+  with_dispatch_state state (fun () ->
+      Hashtbl.remove state.running_by_keeper keeper_name)
+
+let dispatch_queued_turn state ~sw ~handle_turn ~keeper_name ~queued =
+  Eio.Fiber.fork ~sw (fun () ->
+      try
+        handle_turn ~sw ~keeper_name ~queued_message:queued;
+        clear_dispatching state keeper_name
+      with
+      | Eio.Cancel.Cancelled _ as e ->
+          clear_dispatching state keeper_name;
+          raise e
+      | exn ->
+          clear_dispatching state keeper_name;
+          Log.Keeper.warn
+            "keeper_chat_consumer: handle_turn failed for keeper=%s: %s"
+            keeper_name
+            (Printexc.to_string exn))
+
 let start ~sw ~clock ~base_path ~handle_turn =
+  let dispatch_state = create_dispatch_state () in
   let rec poll_loop () =
     let keeper_names = Keeper_chat_queue.all_keeper_names () in
     List.iter
@@ -16,37 +60,55 @@ let start ~sw ~clock ~base_path ~handle_turn =
             turn instead of one turn per message — the keeper then answers
             with the full accumulated context (RFC-0225 single-flight
             makes the in-flight state observable). *)
-         match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
-         | Some _ -> ()
-         | None -> (
-             let batch =
-               try Keeper_chat_queue.dequeue_batch ~keeper_name with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn ->
-                 Log.Keeper.warn
-                   "keeper_chat_consumer: dequeue_batch failed for keeper=%s: %s"
-                   keeper_name
-                   (Printexc.to_string exn);
-                 []
-             in
-             (match batch with
-              | _ :: _ :: _ ->
-                  Log.Keeper.info
-                    "keeper_chat_consumer: coalesced %d queued messages into \
-                     one turn for keeper=%s"
-                    (List.length batch)
-                    keeper_name
-              | [] | [ _ ] -> ());
-             match Keeper_chat_queue.merge_batch batch with
-             | None -> ()
-             | Some queued ->
-                 (try handle_turn ~sw ~keeper_name ~queued_message:queued with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                      Log.Keeper.warn
-                        "keeper_chat_consumer: handle_turn failed for keeper=%s: %s"
+         if is_dispatching dispatch_state keeper_name
+         then ()
+         else
+           match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
+           | Some _ -> ()
+           | None -> (
+               if mark_dispatching dispatch_state keeper_name
+               then (
+                 let batch =
+                   try Keeper_chat_queue.dequeue_batch ~keeper_name with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                       Log.Keeper.warn
+                         "keeper_chat_consumer: dequeue_batch failed for \
+                          keeper=%s: %s"
+                         keeper_name
+                         (Printexc.to_string exn);
+                       []
+                 in
+                 (match batch with
+                  | _ :: _ :: _ ->
+                      Log.Keeper.info
+                        "keeper_chat_consumer: coalesced %d queued messages \
+                         into one turn for keeper=%s"
+                        (List.length batch)
                         keeper_name
-                        (Printexc.to_string exn))))
+                  | [] | [ _ ] -> ());
+                 match Keeper_chat_queue.merge_batch batch with
+                 | None -> clear_dispatching dispatch_state keeper_name
+                 | Some queued ->
+                     (try
+                        dispatch_queued_turn dispatch_state ~sw ~handle_turn
+                          ~keeper_name ~queued
+                      with
+                      | Eio.Cancel.Cancelled _ as e ->
+                          clear_dispatching dispatch_state keeper_name;
+                          raise e
+                      | exn ->
+                          clear_dispatching dispatch_state keeper_name;
+                          Log.Keeper.warn
+                            "keeper_chat_consumer: dispatch fork failed for \
+                             keeper=%s: %s"
+                            keeper_name
+                            (Printexc.to_string exn)))
+               else
+                 Log.Keeper.warn
+                   "keeper_chat_consumer: duplicate dispatch suppressed for \
+                    keeper=%s"
+                   keeper_name))
       keeper_names;
     Eio.Time.sleep clock poll_interval_sec;
     poll_loop ()

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -30,8 +30,9 @@ let mark_dispatching state keeper_name =
         true))
 
 let clear_dispatching state keeper_name =
-  with_dispatch_state state (fun () ->
-      Hashtbl.remove state.running_by_keeper keeper_name)
+  Eio.Cancel.protect (fun () ->
+      with_dispatch_state state (fun () ->
+          Hashtbl.remove state.running_by_keeper keeper_name))
 
 let dispatch_queued_turn state ~sw ~handle_turn ~keeper_name ~queued =
   Eio.Fiber.fork ~sw (fun () ->

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -17,9 +17,11 @@
     ([Keeper_turn_admission.in_flight]), queued messages are left to
     accumulate; once the slot is free, the head run of same-source
     messages is drained ([Keeper_chat_queue.dequeue_batch]) and merged
-    into ONE coalesced message ([Keeper_chat_queue.merge_batch]) before
-    [handle_turn] runs — messages sent during a turn answer together in
-    a single follow-up turn instead of one turn each.
+    into ONE coalesced message ([Keeper_chat_queue.merge_batch]).  The
+    merged turn then runs in a keeper-scoped child fiber, so a slow queued
+    turn for one keeper does not block polling or delivery for other
+    keepers.  A keeper-local dispatch gate preserves the single follow-up
+    turn contract for messages sent during an existing queued turn.
 
     The fiber runs until [sw] is released.
 

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -168,10 +168,66 @@ let test_gates_while_turn_in_flight () =
        | `Timeout -> check "consumer drains once the slot frees" false));
     check "delivered exactly once after release" (List.length !captured = 1))
 
+let test_queued_dispatch_is_per_keeper () =
+  Printf.printf "Test: queued dispatch is independent per keeper\n%!";
+  with_env (fun ~base ~clock ->
+    let keeper_a = keeper_name ^ "-a" in
+    let keeper_b = keeper_name ^ "-b" in
+    Keeper_chat_queue.clear ~keeper_name:keeper_a;
+    Keeper_chat_queue.clear ~keeper_name:keeper_b;
+    Keeper_chat_queue.enqueue ~keeper_name:keeper_a
+      (discord_msg ~content:"alpha waits" ~channel_id:"chan-a" ~user_id:"u-a"
+         ~ts:1.0);
+    Keeper_chat_queue.enqueue ~keeper_name:keeper_b
+      (discord_msg ~content:"beta should pass" ~channel_id:"chan-b"
+         ~user_id:"u-b" ~ts:2.0);
+    let first_keeper = ref None in
+    let second_keeper = ref None in
+    let first_started, set_first_started = Eio.Promise.create () in
+    let release_first, set_release_first = Eio.Promise.create () in
+    let second_seen, set_second_seen = Eio.Promise.create () in
+    let first_resolved = ref false in
+    let second_resolved = ref false in
+    let handle_turn ~sw:_ ~keeper_name:kn ~queued_message:_ =
+      match !first_keeper with
+      | None ->
+          first_keeper := Some kn;
+          if not !first_resolved then (
+            first_resolved := true;
+            Eio.Promise.resolve set_first_started ());
+          Eio.Promise.await release_first
+      | Some first when String.equal first kn ->
+          check "same keeper is not dispatched again while its queued turn runs"
+            false
+      | Some _ ->
+          second_keeper := Some kn;
+          if not !second_resolved then (
+            second_resolved := true;
+            Eio.Promise.resolve set_second_seen ())
+    in
+    with_consumer_switch (fun sw ->
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+      (match await_or_timeout ~clock ~secs:5.0 first_started with
+       | `Got -> ()
+       | `Timeout -> check "first queued keeper dispatch started" false);
+      (match await_or_timeout ~clock ~secs:0.5 second_seen with
+       | `Got ->
+           check "another keeper dispatches while first handler is blocked" true
+       | `Timeout ->
+           check "another keeper dispatches while first handler is blocked" false);
+      Eio.Promise.resolve set_release_first);
+    match (!first_keeper, !second_keeper) with
+    | Some first, Some second ->
+        check "second dispatch uses the other keeper"
+          ((String.equal first keeper_a && String.equal second keeper_b)
+          || (String.equal first keeper_b && String.equal second keeper_a))
+    | _ -> check "both keeper dispatches were observed" false)
+
 let () =
   test_drains_discord_to_handle_turn ();
   test_coalesces_same_source_run ();
   test_gates_while_turn_in_flight ();
+  test_queued_dispatch_is_per_keeper ();
   if !failures > 0 then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
     exit 1)


### PR DESCRIPTION
## Summary
- dispatch queued keeper chat turns in keeper-scoped child fibers instead of running `handle_turn` synchronously inside the global poll loop
- keep a per-keeper dispatch gate so queued messages still coalesce into one follow-up turn for the same keeper
- add a regression check proving a blocked queued turn for one keeper does not block another keeper queue

## Validation
- `git diff --check`
- `rg -n "\t" lib/keeper/keeper_chat_consumer.ml lib/keeper/keeper_chat_consumer.mli test/test_keeper_chat_consumer_delivery.ml`
- `ocamlformat --check lib/keeper/keeper_chat_consumer.ml lib/keeper/keeper_chat_consumer.mli test/test_keeper_chat_consumer_delivery.ml`
- Full build/test intentionally left to CI per operator instruction.