### PR TITLE
feat(keeper): MASC→OAS request wire capture 관측 하네스 (Phase O)

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -55,8 +55,8 @@
  (public_name masc-stdio)
  (package masc)
  (libraries
- masc
- masc.server
+  masc
+  masc.server
   masc.config
   masc_core
   cmdliner

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 362 unique knobs across 9 modules.
+**Total**: 363 unique knobs across 9 modules.
 
 **Typed getter classification**: 48/219 tagged (`operator`: 48, `algorithm`: 0, `unclassified`: 171).
 
@@ -85,36 +85,36 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (89 knobs; typed classification 26/77)
+## Env_config_keeper (90 knobs; typed classification 26/77)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 581 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 905 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 940 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 941 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 942 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 943 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 946 |  |
-| `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 144 | Board fanout configuration |
-| `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 141 | Board fanout configuration |
-| `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 147 |  |
-| `MASC_KEEPER_ALERT_BOARD_VISIBILITY` | typed:string | unclassified | unclassified | 150 |  |
-| `MASC_KEEPER_ALERT_ENABLED` | feature_flag | n/a | n/a | 124 | Master switch for keeper interesting alert detection/fanout |
-| `MASC_KEEPER_ALERT_GITHUB_ENABLED` | feature_flag | n/a | n/a | 166 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_LABEL` | typed:string | unclassified | unclassified | 169 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` | typed:float | unclassified | unclassified | 170 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_REPO` | typed:string | unclassified | unclassified | 168 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_MAX_BODY_CHARS` | typed:int | unclassified | unclassified | 130 | Maximum alert body chars used for external fanout payloads |
-| `MASC_KEEPER_ALERT_MAX_RETRIES` | typed:int | unclassified | unclassified | 133 | Retry count for each fanout channel (in addition to initial attempt) |
-| `MASC_KEEPER_ALERT_MIN_SCORE` | typed:float | unclassified | unclassified | 127 | Minimum score required to trigger alert fanout |
-| `MASC_KEEPER_ALERT_RETRY_BASE_DELAY_MS` | typed:int | unclassified | unclassified | 137 | Base retry delay in milliseconds (exponential backoff) |
-| `MASC_KEEPER_ALERT_SLACK_DM_ENABLED` | feature_flag | n/a | n/a | 160 | Slack DM fanout configuration |
-| `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 163 |  |
-| `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 154 | Slack fanout configuration |
-| `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 156 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 767 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 819 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 585 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 909 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 944 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 945 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 946 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 947 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 950 |  |
+| `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 148 | Board fanout configuration |
+| `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 145 | Board fanout configuration |
+| `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 151 |  |
+| `MASC_KEEPER_ALERT_BOARD_VISIBILITY` | typed:string | unclassified | unclassified | 154 |  |
+| `MASC_KEEPER_ALERT_ENABLED` | feature_flag | n/a | n/a | 128 | Master switch for keeper interesting alert detection/fanout |
+| `MASC_KEEPER_ALERT_GITHUB_ENABLED` | feature_flag | n/a | n/a | 170 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_LABEL` | typed:string | unclassified | unclassified | 173 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` | typed:float | unclassified | unclassified | 174 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_REPO` | typed:string | unclassified | unclassified | 172 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_MAX_BODY_CHARS` | typed:int | unclassified | unclassified | 134 | Maximum alert body chars used for external fanout payloads |
+| `MASC_KEEPER_ALERT_MAX_RETRIES` | typed:int | unclassified | unclassified | 137 | Retry count for each fanout channel (in addition to initial attempt) |
+| `MASC_KEEPER_ALERT_MIN_SCORE` | typed:float | unclassified | unclassified | 131 | Minimum score required to trigger alert fanout |
+| `MASC_KEEPER_ALERT_RETRY_BASE_DELAY_MS` | typed:int | unclassified | unclassified | 141 | Base retry delay in milliseconds (exponential backoff) |
+| `MASC_KEEPER_ALERT_SLACK_DM_ENABLED` | feature_flag | n/a | n/a | 164 | Slack DM fanout configuration |
+| `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 167 |  |
+| `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 158 | Slack fanout configuration |
+| `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 160 | Slack fanout configuration |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 771 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 823 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,62 +122,63 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 839 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 411 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 437 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 427 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 447 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 417 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
-| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 197 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
-| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 205 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 211 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 800 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 534 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 523 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 545 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 859 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 867 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 586 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 660 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 849 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 634 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 894 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 641 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 675 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 682 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 601 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 385 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 395 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 374 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 294 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 306 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 362 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 318 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 340 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 350 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 328 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 282 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 843 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 415 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 441 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 431 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 451 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 421 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 201 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
+| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 209 | Enable keeper debug logging. Default: false. |
+| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 215 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 804 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 538 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 527 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 549 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 863 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 871 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 590 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 664 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 853 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 638 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 898 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 645 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 679 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 686 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 605 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 389 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 399 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 378 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 298 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 310 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 366 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 322 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 344 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 354 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 332 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 286 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 728 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 877 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 564 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 573 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 652 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 611 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 215 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 883 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 776 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 714 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 618 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 484 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 494 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 474 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 115 | Maximum total bytes retained below [<masc_root>/wire-capture] after opportunistic cleanup. The current day file is pr... |
-| `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 104 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 595 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 964 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 978 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 732 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 881 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 568 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 577 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 656 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 615 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 219 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 887 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 780 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 718 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 622 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 488 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 498 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 478 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 93 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
+| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 119 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
+| `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 108 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 599 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 968 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 982 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 360 unique knobs across 9 modules.
+**Total**: 362 unique knobs across 9 modules.
 
-**Typed getter classification**: 46/217 tagged (`operator`: 46, `algorithm`: 0, `unclassified`: 171).
+**Typed getter classification**: 48/219 tagged (`operator`: 48, `algorithm`: 0, `unclassified`: 171).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -85,36 +85,36 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (87 knobs; typed classification 24/75)
+## Env_config_keeper (89 knobs; typed classification 26/77)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 545 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 869 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 904 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 905 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 906 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 907 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 910 |  |
-| `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
-| `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
-| `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
-| `MASC_KEEPER_ALERT_BOARD_VISIBILITY` | typed:string | unclassified | unclassified | 114 |  |
-| `MASC_KEEPER_ALERT_ENABLED` | feature_flag | n/a | n/a | 88 | Master switch for keeper interesting alert detection/fanout |
-| `MASC_KEEPER_ALERT_GITHUB_ENABLED` | feature_flag | n/a | n/a | 130 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_LABEL` | typed:string | unclassified | unclassified | 133 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` | typed:float | unclassified | unclassified | 134 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_GITHUB_REPO` | typed:string | unclassified | unclassified | 132 | GitHub issue fanout configuration |
-| `MASC_KEEPER_ALERT_MAX_BODY_CHARS` | typed:int | unclassified | unclassified | 94 | Maximum alert body chars used for external fanout payloads |
-| `MASC_KEEPER_ALERT_MAX_RETRIES` | typed:int | unclassified | unclassified | 97 | Retry count for each fanout channel (in addition to initial attempt) |
-| `MASC_KEEPER_ALERT_MIN_SCORE` | typed:float | unclassified | unclassified | 91 | Minimum score required to trigger alert fanout |
-| `MASC_KEEPER_ALERT_RETRY_BASE_DELAY_MS` | typed:int | unclassified | unclassified | 101 | Base retry delay in milliseconds (exponential backoff) |
-| `MASC_KEEPER_ALERT_SLACK_DM_ENABLED` | feature_flag | n/a | n/a | 124 | Slack DM fanout configuration |
-| `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
-| `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
-| `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 731 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 783 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 581 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 905 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 940 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 941 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 942 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 943 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 946 |  |
+| `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 144 | Board fanout configuration |
+| `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 141 | Board fanout configuration |
+| `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 147 |  |
+| `MASC_KEEPER_ALERT_BOARD_VISIBILITY` | typed:string | unclassified | unclassified | 150 |  |
+| `MASC_KEEPER_ALERT_ENABLED` | feature_flag | n/a | n/a | 124 | Master switch for keeper interesting alert detection/fanout |
+| `MASC_KEEPER_ALERT_GITHUB_ENABLED` | feature_flag | n/a | n/a | 166 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_LABEL` | typed:string | unclassified | unclassified | 169 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` | typed:float | unclassified | unclassified | 170 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_GITHUB_REPO` | typed:string | unclassified | unclassified | 168 | GitHub issue fanout configuration |
+| `MASC_KEEPER_ALERT_MAX_BODY_CHARS` | typed:int | unclassified | unclassified | 130 | Maximum alert body chars used for external fanout payloads |
+| `MASC_KEEPER_ALERT_MAX_RETRIES` | typed:int | unclassified | unclassified | 133 | Retry count for each fanout channel (in addition to initial attempt) |
+| `MASC_KEEPER_ALERT_MIN_SCORE` | typed:float | unclassified | unclassified | 127 | Minimum score required to trigger alert fanout |
+| `MASC_KEEPER_ALERT_RETRY_BASE_DELAY_MS` | typed:int | unclassified | unclassified | 137 | Base retry delay in milliseconds (exponential backoff) |
+| `MASC_KEEPER_ALERT_SLACK_DM_ENABLED` | feature_flag | n/a | n/a | 160 | Slack DM fanout configuration |
+| `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 163 |  |
+| `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 154 | Slack fanout configuration |
+| `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 156 | Slack fanout configuration |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 767 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 819 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,60 +122,62 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 803 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 375 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 401 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 391 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 411 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 381 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
-| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
-| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 764 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 498 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 487 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 509 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 823 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 831 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 550 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 624 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 813 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 598 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 858 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 605 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 639 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 646 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 565 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 349 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 359 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 338 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 258 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 270 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 326 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 282 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 304 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 314 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 292 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 246 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 839 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 411 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 437 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 427 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 447 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 417 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 197 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
+| `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 205 | Enable keeper debug logging. Default: false. |
+| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 211 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 800 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 534 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 523 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 545 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 859 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 867 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 586 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 660 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 849 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 634 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 894 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 641 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 675 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 682 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 601 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 385 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 395 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 374 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 294 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 306 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 362 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 318 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 340 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 350 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 328 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 282 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 692 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 841 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 528 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 537 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 616 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 575 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 847 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 740 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 678 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 582 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 448 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 458 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 438 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 559 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 928 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 942 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 728 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 877 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 564 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 573 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 652 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 611 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 215 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 883 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 776 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 714 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 618 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 484 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 494 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 474 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 115 | Maximum total bytes retained below [<masc_root>/wire-capture] after opportunistic cleanup. The current day file is pr... |
+| `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 104 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 595 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 964 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 978 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -81,6 +81,42 @@ module KeeperMetrics = struct
   let max_rotated_files = get_int_nonneg ~default:1 "MASC_KEEPER_METRICS_MAX_ROTATED"
 end
 
+(** {1 Keeper Wire Capture Configuration} *)
+
+module KeeperWireCapture = struct
+  let clamp_int ~min_value ~max_value value =
+    max min_value (min max_value value)
+  ;;
+
+  let retention_days_default = 3
+  let retention_days_ceiling = 30
+  let max_bytes_default = 64 * 1024 * 1024
+  let max_bytes_ceiling = 1024 * 1024 * 1024
+
+  (** Maximum age for [<masc_root>/wire-capture] day files retained by the
+      diagnostic MASC->OAS wire-capture harness. Default is 3 days. Range:
+      [1, 30] days.
+
+      @category Policies @ops_class operator *)
+  let retention_days () =
+    get_int_nonneg
+      ~default:retention_days_default
+      "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS"
+    |> clamp_int ~min_value:1 ~max_value:retention_days_ceiling
+  ;;
+
+  (** Maximum total bytes retained below [<masc_root>/wire-capture] after
+      opportunistic cleanup. The current day file is preserved by
+      {!Dated_jsonl}, so this is a cross-day retention guard rather than a
+      per-record truncation policy. Default is 64 MiB. Range: [1, 1024] MiB.
+
+      @category Policies @ops_class operator *)
+  let max_bytes () =
+    get_int_nonneg ~default:max_bytes_default "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES"
+    |> clamp_int ~min_value:1 ~max_value:max_bytes_ceiling
+  ;;
+end
+
 (** {1 Keeper Interesting Alert Configuration} *)
 
 module KeeperAlert = struct

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -88,6 +88,10 @@ module KeeperWireCapture = struct
     max min_value (min max_value value)
   ;;
 
+  (** Master switch for diagnostic MASC->OAS wire capture. Default off.
+      @category Policies @ops_class operator *)
+  let enabled () = Feature_flag_registry.get_bool "MASC_KEEPER_WIRE_CAPTURE"
+
   let retention_days_default = 3
   let retention_days_ceiling = 30
   let max_bytes_default = 64 * 1024 * 1024
@@ -105,10 +109,10 @@ module KeeperWireCapture = struct
     |> clamp_int ~min_value:1 ~max_value:retention_days_ceiling
   ;;
 
-  (** Maximum total bytes retained below [<masc_root>/wire-capture] after
-      opportunistic cleanup. The current day file is preserved by
-      {!Dated_jsonl}, so this is a cross-day retention guard rather than a
-      per-record truncation policy. Default is 64 MiB. Range: [1, 1024] MiB.
+  (** Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl]
+      file and maximum total bytes retained below [<masc_root>/wire-capture]
+      after opportunistic completed-day cleanup. Default is 64 MiB. Range:
+      [1, 1024] MiB.
 
       @category Policies @ops_class operator *)
   let max_bytes () =

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -28,6 +28,13 @@ module KeeperMetrics : sig
   val max_rotated_files : int
 end
 
+(** {1 Keeper wire capture} *)
+
+module KeeperWireCapture : sig
+  val retention_days : unit -> int
+  val max_bytes : unit -> int
+end
+
 (** {1 Keeper interesting-alert fanout} *)
 
 module KeeperAlert : sig

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -31,6 +31,7 @@ end
 (** {1 Keeper wire capture} *)
 
 module KeeperWireCapture : sig
+  val enabled : unit -> bool
   val retention_days : unit -> int
   val max_bytes : unit -> int
 end

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -120,6 +120,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.250.0" };
 
+  { env_name = "MASC_KEEPER_WIRE_CAPTURE";
+    description = "Default-off diagnostic MASC-to-OAS request/response wire capture";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.254.0" };
+
   { env_name = "MASC_CONNECTOR_AMBIENT_WAKE_ENABLED";
     description = "Wake an idle keeper on an ambient connector message via an external-attention edge stimulus (RFC-connector-ambient-attention-wake). Off until the spurious-wake throttle (P4) lands; enabling without it would run a turn on every ambient line.";
     default = false; category = "keeper";

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -288,7 +288,7 @@ let prune_to_max_bytes_unlocked t ~max_bytes ~keep_path =
 
 (* ── Public API ───────────────────────────────────────── *)
 
-let append_inner t json =
+let append_unlocked ?max_current_file_bytes t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
      IO failure, so retry paths can keep using the same registry entry.
@@ -300,28 +300,50 @@ let append_inner t json =
      was a pre-emptive duplicate of that guarantee — removed here. *)
   Eio.Mutex.use_ro mutex (fun () ->
     let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
-    Jsonl_writer.append_jsonl ~path:dated.path json;
-    (match t.retention_days with
-     | None -> ()
-     | Some days ->
-       let today = dated.month_dir ^ "/" ^ dated.day_file in
-       if
-         not
-           (Option.equal String.equal
-              (Atomic.get t.last_prune_day)
-              (Some today))
-       then begin
-         ignore (prune_unlocked t ~days : int);
-         Atomic.set t.last_prune_day (Some today)
-       end);
-    match t.max_bytes with
-    | None -> ()
-    | Some max_bytes ->
-      ignore
-        (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int))
+    let fits_current_file =
+      match max_current_file_bytes with
+      | Some max_bytes when max_bytes > 0 ->
+        let row_bytes = String.length (Yojson.Safe.to_string json) + 1 in
+        file_size dated.path + row_bytes <= max_bytes
+      | _ -> true
+    in
+    if not fits_current_file
+    then false
+    else begin
+      Jsonl_writer.append_jsonl ~path:dated.path json;
+      (match t.retention_days with
+       | None -> ()
+       | Some days ->
+         let today = dated.month_dir ^ "/" ^ dated.day_file in
+         if
+           not
+             (Option.equal String.equal
+                (Atomic.get t.last_prune_day)
+                (Some today))
+         then begin
+           (* See retention pruning is opportunistic after append durability. *)
+           ignore (prune_unlocked t ~days : int);
+           Atomic.set t.last_prune_day (Some today)
+         end);
+      (match t.max_bytes with
+       | None -> ()
+       | Some max_bytes ->
+         (* See byte-budget pruning is best-effort cleanup after append. *)
+         ignore
+           (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int));
+      true
+    end)
+
+let append_inner t json = ignore (append_unlocked t json : bool)
 
 let append t json =
   (Atomic.get append_guard) (fun () -> append_inner t json)
+
+let append_if_current_file_fits t ~max_current_file_bytes json =
+  let appended = ref false in
+  (Atomic.get append_guard) (fun () ->
+    appended := append_unlocked ~max_current_file_bytes t json);
+  !appended
 
 let set_append_guard guard = Atomic.set append_guard guard
 

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -29,6 +29,14 @@ val append : t -> Yojson.Safe.t -> unit
 (** Append [json] to today's [DD.jsonl] inside [YYYY-MM/].
     Creates directories as needed.  Thread-safe via internal mutex. *)
 
+val append_if_current_file_fits :
+  t -> max_current_file_bytes:int -> Yojson.Safe.t -> bool
+(** Append [json] only when today's current [DD.jsonl] would remain at or
+    below [max_current_file_bytes] after the row is added. Returns [true] when
+    appended and [false] when skipped. The size check and append share the
+    same internal mutex as {!append}. Retention and completed-file byte pruning
+    still run after a successful append. *)
+
 val set_append_guard : ((unit -> unit) -> unit) -> unit
 (** [set_append_guard guard] installs a process-wide wrapper around
     {!append}.  The default guard runs the callback immediately.  Higher-level

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,6 @@
 (library
  (name masc)
  (public_name masc)
-
  (libraries
   mcp_protocol
   mcp_protocol.eio

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -682,6 +682,15 @@ let run_turn
           Agent.run. Post-run episode creation requires an explicit
           flush_incremental call since AfterTurn already fired. *)
                  let text = Agent_sdk.Types.text_of_content result.response.content in
+                 (* Phase O observability (iter-2): pair this turn's response
+                    with the request captured pre-run under the same turn_id, so
+                    the feedback loop (turn N output -> turn N+1 replayed history)
+                    is directly analyzable. No-op unless MASC_KEEPER_WIRE_CAPTURE. *)
+                 Keeper_wire_capture.capture_response
+                   ~base_path:config.base_path
+                   ~keeper_name:meta.name
+                   ~turn_id:manifest_keeper_turn_id
+                   ~response_text:text;
                  (* RFC-0132 PR-2: receipt model surface = external boundary; redact via SSOT. *)
                  let model =
                    Boundary_redaction.to_string

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -457,6 +457,18 @@ let run_turn
             ("context_digest", `String context_digest);
           ]))
     Keeper_runtime_manifest.Context_injected;
+  (* Phase O observability: env-gated ([MASC_KEEPER_WIRE_CAPTURE]) redacted
+     capture of the full assembled request. The digest block above proves
+     context changed; this records WHAT it was so the repetition feedback loop
+     (keeper's own prior text replayed into [history_messages]) is observable.
+     No-op and no filesystem access unless the env flag is set. *)
+  Keeper_wire_capture.capture_request
+    ~base_path:config.base_path
+    ~keeper_name:meta.name
+    ~turn_id:manifest_keeper_turn_id
+    ~system_prompt:turn_system_prompt
+    ~user_message
+    ~history_messages;
   (* 7. Set up agent — delegated to Keeper_run_tools *)
   let setup =
     Keeper_run_tools.prepare_agent_setup

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -457,18 +457,6 @@ let run_turn
             ("context_digest", `String context_digest);
           ]))
     Keeper_runtime_manifest.Context_injected;
-  (* Phase O observability: env-gated ([MASC_KEEPER_WIRE_CAPTURE]) redacted
-     capture of the full assembled request. The digest block above proves
-     context changed; this records WHAT it was so the repetition feedback loop
-     (keeper's own prior text replayed into [history_messages]) is observable.
-     No-op and no filesystem access unless the env flag is set. *)
-  Keeper_wire_capture.capture_request
-    ~base_path:config.base_path
-    ~keeper_name:meta.name
-    ~turn_id:manifest_keeper_turn_id
-    ~system_prompt:turn_system_prompt
-    ~user_message
-    ~history_messages;
   (* 7. Set up agent — delegated to Keeper_run_tools *)
   let setup =
     Keeper_run_tools.prepare_agent_setup
@@ -687,7 +675,7 @@ let run_turn
                     the feedback loop (turn N output -> turn N+1 replayed history)
                     is directly analyzable. No-op unless MASC_KEEPER_WIRE_CAPTURE. *)
                  Keeper_wire_capture.capture_response
-                   ~base_path:config.base_path
+                   ~masc_root:(Workspace.masc_root_dir config)
                    ~keeper_name:meta.name
                    ~turn_id:manifest_keeper_turn_id
                    ~response_text:text;

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -56,6 +56,7 @@ let relax_strict_tool_choice_for_keeper = function
 let assemble_hooks
       ~(ctx : ctx)
       ~(session : Keeper_types.session_context)
+      ~(turn_system_prompt : string)
       ~(user_message : string)
       ~(dynamic_context : string)
       ~(history_messages : Agent_sdk.Types.message list)
@@ -513,6 +514,21 @@ let assemble_hooks
                        !recorded_blocks;
                 acc.extra_system_context_digest <- Option.map sha256_hex ctx;
                 acc.extra_system_context_size <- Option.map String.length ctx;
+                (* Phase O observability: capture the effective OAS request
+                   boundary after keeper-owned context injection has finalized
+                   [extra_system_context]. *)
+                Option.iter
+                  (fun turn_id ->
+                     Keeper_wire_capture.capture_request
+                       ~masc_root:(Workspace.masc_root_dir config)
+                       ~keeper_name:meta.name
+                       ~turn_id
+                       ~sdk_turn:turn
+                       ~system_prompt:turn_system_prompt
+                       ~extra_system_context:ctx
+                       ~user_message
+                       ~history_messages:messages)
+                  manifest_keeper_turn_id;
                 Eio.Fiber.yield ();
                 Agent_sdk.Hooks.AdjustParams
                   { current_params with

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -617,7 +617,7 @@ let prepare_agent_setup
     }
   in
   Keeper_run_tools_hooks.assemble_hooks
-    ~ctx ~session ~user_message ~dynamic_context
+    ~ctx ~session ~turn_system_prompt ~user_message ~dynamic_context
     ~history_messages ~prompt_metrics ~shared_context
     ~start_turn_count ~generation
     ~runtime_id_string ~is_retry ~turn_affordances

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -18,6 +18,14 @@ let redact = Llm_provider.Secret_redactor.redact_string
 let wire_capture_dir base_path =
   Filename.concat (Common.masc_dir_from_base_path ~base_path) "wire-capture"
 
+let write_payload ~base_path (payload : Yojson.Safe.t) =
+  let store = Dated_jsonl.create ~base_dir:(wire_capture_dir base_path) () in
+  try Dated_jsonl.append store payload with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.error "keeper_wire_capture: write failed to %s: %s"
+        (Dated_jsonl.base_dir store) (Printexc.to_string exn)
+
 let capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
     ~user_message ~history_messages =
   if not (enabled ()) then ()
@@ -33,6 +41,7 @@ let capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
       `Assoc
         [
           ("ts", `String (Masc_domain.now_iso ()));
+          ("kind", `String "request");
           ("keeper", `String keeper_name);
           ("turn_id", `Int turn_id);
           ("system_prompt", `String (redact system_prompt));
@@ -41,9 +50,19 @@ let capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
           ("history", `List history);
         ]
     in
-    let store = Dated_jsonl.create ~base_dir:(wire_capture_dir base_path) () in
-    try Dated_jsonl.append store payload with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-        Log.Keeper.error "keeper_wire_capture: write failed to %s: %s"
-          (Dated_jsonl.base_dir store) (Printexc.to_string exn)
+    write_payload ~base_path payload
+
+let capture_response ~base_path ~keeper_name ~turn_id ~response_text =
+  if not (enabled ()) then ()
+  else
+    let payload : Yojson.Safe.t =
+      `Assoc
+        [
+          ("ts", `String (Masc_domain.now_iso ()));
+          ("kind", `String "response");
+          ("keeper", `String keeper_name);
+          ("turn_id", `Int turn_id);
+          ("response_text", `String (redact response_text));
+        ]
+    in
+    write_payload ~base_path payload

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -1,14 +1,6 @@
 (** See [keeper_wire_capture.mli]. *)
 
-let env_flag = "MASC_KEEPER_WIRE_CAPTURE"
-
-let enabled () =
-  match Sys.getenv_opt env_flag with
-  | Some v -> (
-      match String.lowercase_ascii (String.trim v) with
-      | "1" | "true" | "yes" | "on" -> true
-      | _ -> false)
-  | None -> false
+let enabled () = Env_config_keeper.KeeperWireCapture.enabled ()
 
 let redact = Llm_provider.Secret_redactor.redact_string
 
@@ -18,14 +10,26 @@ let redact = Llm_provider.Secret_redactor.redact_string
 let wire_capture_dir masc_root = Filename.concat masc_root "wire-capture"
 
 let write_payload ~masc_root (payload : Yojson.Safe.t) =
+  let max_bytes = Env_config_keeper.KeeperWireCapture.max_bytes () in
   let store =
     Dated_jsonl.create
       ~base_dir:(wire_capture_dir masc_root)
       ~retention_days:(Env_config_keeper.KeeperWireCapture.retention_days ())
-      ~max_bytes:(Env_config_keeper.KeeperWireCapture.max_bytes ())
+      ~max_bytes
       ()
   in
-  Dated_jsonl.append store payload
+  if
+    not
+      (Dated_jsonl.append_if_current_file_fits
+         store
+         ~max_current_file_bytes:max_bytes
+         payload)
+  then
+    Log.Keeper.warn
+      "keeper_wire_capture: skipped record because current day file would exceed %d \
+       bytes under %s"
+      max_bytes
+      (Dated_jsonl.base_dir store)
 
 let best_effort ~masc_root f =
   let base_dir = wire_capture_dir masc_root in

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -1,0 +1,49 @@
+(** See [keeper_wire_capture.mli]. *)
+
+let env_flag = "MASC_KEEPER_WIRE_CAPTURE"
+
+let enabled () =
+  match Sys.getenv_opt env_flag with
+  | Some v -> (
+      match String.lowercase_ascii (String.trim v) with
+      | "1" | "true" | "yes" | "on" -> true
+      | _ -> false)
+  | None -> false
+
+let redact = Llm_provider.Secret_redactor.redact_string
+
+(* Dated per-day store, mirroring the cost-ledger appender
+   ([Keeper_hooks_oas_cost_events.emit_cost_event]); concurrent keepers
+   serialise on a per-day file rather than one global blob. *)
+let wire_capture_dir base_path =
+  Filename.concat (Common.masc_dir_from_base_path ~base_path) "wire-capture"
+
+let capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
+    ~user_message ~history_messages =
+  if not (enabled ()) then ()
+  else
+    let history =
+      List.map
+        (fun m ->
+          `Assoc
+            [ ("text", `String (redact (Agent_sdk.Types.text_of_message m))) ])
+        history_messages
+    in
+    let payload : Yojson.Safe.t =
+      `Assoc
+        [
+          ("ts", `String (Masc_domain.now_iso ()));
+          ("keeper", `String keeper_name);
+          ("turn_id", `Int turn_id);
+          ("system_prompt", `String (redact system_prompt));
+          ("user_message", `String (redact user_message));
+          ("history_message_count", `Int (List.length history_messages));
+          ("history", `List history);
+        ]
+    in
+    let store = Dated_jsonl.create ~base_dir:(wire_capture_dir base_path) () in
+    try Dated_jsonl.append store payload with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Keeper.error "keeper_wire_capture: write failed to %s: %s"
+          (Dated_jsonl.base_dir store) (Printexc.to_string exn)

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -15,54 +15,67 @@ let redact = Llm_provider.Secret_redactor.redact_string
 (* Dated per-day store, mirroring the cost-ledger appender
    ([Keeper_hooks_oas_cost_events.emit_cost_event]); concurrent keepers
    serialise on a per-day file rather than one global blob. *)
-let wire_capture_dir base_path =
-  Filename.concat (Common.masc_dir_from_base_path ~base_path) "wire-capture"
+let wire_capture_dir masc_root = Filename.concat masc_root "wire-capture"
 
-let write_payload ~base_path (payload : Yojson.Safe.t) =
-  let store = Dated_jsonl.create ~base_dir:(wire_capture_dir base_path) () in
-  try Dated_jsonl.append store payload with
+let write_payload ~masc_root (payload : Yojson.Safe.t) =
+  let store = Dated_jsonl.create ~base_dir:(wire_capture_dir masc_root) () in
+  Dated_jsonl.append store payload
+
+let best_effort ~masc_root f =
+  let base_dir = wire_capture_dir masc_root in
+  try f () with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Log.Keeper.error "keeper_wire_capture: write failed to %s: %s"
-        (Dated_jsonl.base_dir store) (Printexc.to_string exn)
+    Log.Keeper.error "keeper_wire_capture: write failed to %s: %s" base_dir
+      (Printexc.to_string exn)
 
-let capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
-    ~user_message ~history_messages =
+let json_string_opt = function
+  | Some value -> `String (redact value)
+  | None -> `Null
+
+let capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
+    ~extra_system_context ~user_message ~history_messages =
   if not (enabled ()) then ()
   else
-    let history =
-      List.map
-        (fun m ->
-          `Assoc
-            [ ("text", `String (redact (Agent_sdk.Types.text_of_message m))) ])
-        history_messages
-    in
-    let payload : Yojson.Safe.t =
-      `Assoc
-        [
-          ("ts", `String (Masc_domain.now_iso ()));
-          ("kind", `String "request");
-          ("keeper", `String keeper_name);
-          ("turn_id", `Int turn_id);
-          ("system_prompt", `String (redact system_prompt));
-          ("user_message", `String (redact user_message));
-          ("history_message_count", `Int (List.length history_messages));
-          ("history", `List history);
-        ]
-    in
-    write_payload ~base_path payload
+    best_effort ~masc_root (fun () ->
+      let history =
+        List.map
+          (fun (m : Agent_sdk.Types.message) ->
+             `Assoc
+               [ ("role", `String (Agent_sdk.Types.role_to_string m.role))
+               ; ("text", `String (redact (Agent_sdk.Types.text_of_message m)))
+               ])
+          history_messages
+      in
+      let payload : Yojson.Safe.t =
+        `Assoc
+          [ ("ts", `String (Masc_domain.now_iso ()))
+          ; ("kind", `String "request")
+          ; ("keeper", `String keeper_name)
+          ; ("turn_id", `Int turn_id)
+          ; ("sdk_turn", `Int sdk_turn)
+          ; ("system_prompt", `String (redact system_prompt))
+          ; ("extra_system_context", json_string_opt extra_system_context)
+          ; ( "extra_system_context_present"
+            , `Bool (Option.is_some extra_system_context) )
+          ; ("user_message", `String (redact user_message))
+          ; ("history_message_count", `Int (List.length history_messages))
+          ; ("history", `List history)
+          ]
+      in
+      write_payload ~masc_root payload)
 
-let capture_response ~base_path ~keeper_name ~turn_id ~response_text =
+let capture_response ~masc_root ~keeper_name ~turn_id ~response_text =
   if not (enabled ()) then ()
   else
-    let payload : Yojson.Safe.t =
-      `Assoc
-        [
-          ("ts", `String (Masc_domain.now_iso ()));
-          ("kind", `String "response");
-          ("keeper", `String keeper_name);
-          ("turn_id", `Int turn_id);
-          ("response_text", `String (redact response_text));
-        ]
-    in
-    write_payload ~base_path payload
+    best_effort ~masc_root (fun () ->
+      let payload : Yojson.Safe.t =
+        `Assoc
+          [ ("ts", `String (Masc_domain.now_iso ()))
+          ; ("kind", `String "response")
+          ; ("keeper", `String keeper_name)
+          ; ("turn_id", `Int turn_id)
+          ; ("response_text", `String (redact response_text))
+          ]
+      in
+      write_payload ~masc_root payload)

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -18,7 +18,13 @@ let redact = Llm_provider.Secret_redactor.redact_string
 let wire_capture_dir masc_root = Filename.concat masc_root "wire-capture"
 
 let write_payload ~masc_root (payload : Yojson.Safe.t) =
-  let store = Dated_jsonl.create ~base_dir:(wire_capture_dir masc_root) () in
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(wire_capture_dir masc_root)
+      ~retention_days:(Env_config_keeper.KeeperWireCapture.retention_days ())
+      ~max_bytes:(Env_config_keeper.KeeperWireCapture.max_bytes ())
+      ()
+  in
   Dated_jsonl.append store payload
 
 let best_effort ~masc_root f =

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -34,5 +34,17 @@ val capture_request :
   history_messages:Agent_sdk.Types.message list ->
   unit
 (** [capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
-    ~user_message ~history_messages] appends one redacted request record.
-    No-op unless {!enabled}. [turn_id] is the 1-based keeper turn index. *)
+    ~user_message ~history_messages] appends one redacted request record
+    ([kind:"request"]). No-op unless {!enabled}. [turn_id] is the 1-based
+    keeper turn index. *)
+
+val capture_response :
+  base_path:string ->
+  keeper_name:string ->
+  turn_id:int ->
+  response_text:string ->
+  unit
+(** [capture_response ~base_path ~keeper_name ~turn_id ~response_text] appends
+    one redacted response record ([kind:"response"]) paired with the request of
+    the same [turn_id]. This closes the loop for analysis: turn N's response is
+    turn N+1's replayed history input. No-op unless {!enabled}. *)

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -9,7 +9,8 @@
 
     Writes are best-effort and dated under
     [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] (same [Dated_jsonl] per-day
-    store the cost ledger uses). Retention is bounded by
+    store the cost ledger uses). The active day file and completed-file
+    retention are bounded by
     [MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS] and
     [MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES]. A write failure is logged and never
     interrupts the turn.
@@ -20,12 +21,13 @@
     capture makes that input observable. See
     [docs/masc-keeper-repetition-blast-radius-design-2026-07-02.html] (Phase O).
 
-    Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is [1]/[true]/[yes]/[on]. *)
+    Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is enabled through the feature
+    flag registry / runtime config. *)
 
 val enabled : unit -> bool
-(** [enabled ()] is [true] when [MASC_KEEPER_WIRE_CAPTURE] is set to an
-    affirmative value ([1], [true], [yes], [on], case-insensitive). When [false],
-    {!capture_request} is a no-op with no filesystem access. *)
+(** [enabled ()] is [true] when [MASC_KEEPER_WIRE_CAPTURE] is enabled through
+    {!Env_config_keeper.KeeperWireCapture}. When [false], {!capture_request} is
+    a no-op with no filesystem access. *)
 
 val capture_request :
   masc_root:string ->

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -9,8 +9,10 @@
 
     Writes are best-effort and dated under
     [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] (same [Dated_jsonl] per-day
-    store the cost ledger uses). A write failure is logged and never interrupts
-    the turn.
+    store the cost ledger uses). Retention is bounded by
+    [MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS] and
+    [MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES]. A write failure is logged and never
+    interrupts the turn.
 
     Motivation: the request boundary is the primary suspect for
     self-reinforcing repetition — the keeper's own prior visible text is

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -1,0 +1,38 @@
+(** Env-gated capture of the MASC->OAS request boundary (redacted).
+
+    Records the exact request MASC assembles and hands to OAS per keeper turn —
+    system prompt, user message, and the replayed conversation history
+    ([initial_messages]) — so degenerate-repetition feedback loops can be
+    diagnosed from the actual input rather than from digests/sizes (the only
+    signal available today). String content is passed through
+    {!Llm_provider.Secret_redactor} before it is written.
+
+    Writes are best-effort and dated under
+    [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] (same [Dated_jsonl] per-day
+    store the cost ledger uses). A write failure is logged and never interrupts
+    the turn.
+
+    Motivation: the request boundary is the primary suspect for
+    self-reinforcing repetition — the keeper's own prior visible text is
+    replayed into [initial_messages] with no content-level dedup guard. This
+    capture makes that input observable. See
+    [docs/masc-keeper-repetition-blast-radius-design-2026-07-02.html] (Phase O).
+
+    Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is [1]/[true]/[yes]. *)
+
+val enabled : unit -> bool
+(** [enabled ()] is [true] when [MASC_KEEPER_WIRE_CAPTURE] is set to an
+    affirmative value ([1], [true], [yes], case-insensitive). When [false],
+    {!capture_request} is a no-op with no filesystem access. *)
+
+val capture_request :
+  base_path:string ->
+  keeper_name:string ->
+  turn_id:int ->
+  system_prompt:string ->
+  user_message:string ->
+  history_messages:Agent_sdk.Types.message list ->
+  unit
+(** [capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
+    ~user_message ~history_messages] appends one redacted request record.
+    No-op unless {!enabled}. [turn_id] is the 1-based keeper turn index. *)

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -1,10 +1,10 @@
 (** Env-gated capture of the MASC->OAS request boundary (redacted).
 
-    Records the exact request MASC assembles and hands to OAS per keeper turn —
-    system prompt, user message, and the replayed conversation history
-    ([initial_messages]) — so degenerate-repetition feedback loops can be
-    diagnosed from the actual input rather than from digests/sizes (the only
-    signal available today). String content is passed through
+    Records the effective request parameters MASC hands to OAS per SDK turn —
+    system prompt, extra system context, user message, and the replayed
+    conversation history ([initial_messages]) — so degenerate-repetition
+    feedback loops can be diagnosed from the actual input rather than from
+    digests/sizes (the only signal available today). String content is passed through
     {!Llm_provider.Secret_redactor} before it is written.
 
     Writes are best-effort and dated under
@@ -18,33 +18,37 @@
     capture makes that input observable. See
     [docs/masc-keeper-repetition-blast-radius-design-2026-07-02.html] (Phase O).
 
-    Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is [1]/[true]/[yes]. *)
+    Disabled unless [MASC_KEEPER_WIRE_CAPTURE] is [1]/[true]/[yes]/[on]. *)
 
 val enabled : unit -> bool
 (** [enabled ()] is [true] when [MASC_KEEPER_WIRE_CAPTURE] is set to an
-    affirmative value ([1], [true], [yes], case-insensitive). When [false],
+    affirmative value ([1], [true], [yes], [on], case-insensitive). When [false],
     {!capture_request} is a no-op with no filesystem access. *)
 
 val capture_request :
-  base_path:string ->
+  masc_root:string ->
   keeper_name:string ->
   turn_id:int ->
+  sdk_turn:int ->
   system_prompt:string ->
+  extra_system_context:string option ->
   user_message:string ->
   history_messages:Agent_sdk.Types.message list ->
   unit
-(** [capture_request ~base_path ~keeper_name ~turn_id ~system_prompt
-    ~user_message ~history_messages] appends one redacted request record
-    ([kind:"request"]). No-op unless {!enabled}. [turn_id] is the 1-based
-    keeper turn index. *)
+(** [capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
+    ~extra_system_context ~user_message ~history_messages] appends one redacted
+    request record ([kind:"request"]). No-op unless {!enabled}. [turn_id] is the
+    1-based keeper turn index; [sdk_turn] disambiguates multiple OAS/provider
+    calls inside that keeper turn. [masc_root] must already be the effective
+    cluster-aware MASC root. *)
 
 val capture_response :
-  base_path:string ->
+  masc_root:string ->
   keeper_name:string ->
   turn_id:int ->
   response_text:string ->
   unit
-(** [capture_response ~base_path ~keeper_name ~turn_id ~response_text] appends
+(** [capture_response ~masc_root ~keeper_name ~turn_id ~response_text] appends
     one redacted response record ([kind:"response"]) paired with the request of
     the same [turn_id]. This closes the loop for analysis: turn N's response is
     turn N+1's replayed history input. No-op unless {!enabled}. *)

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -31,6 +31,8 @@ let key_to_env =
     "heartbeat.jitter_factor",          "MASC_KEEPER_HEARTBEAT_JITTER_FACTOR";
     "heartbeat.sleep_chunk_sec",        "MASC_KEEPER_SLEEP_CHUNK_SEC";
     "heartbeat.board_wakeup_max",       "MASC_KEEPER_BOARD_WAKEUP_MAX";
+    (* [wire_capture] *)
+    "wire_capture.enabled",             "MASC_KEEPER_WIRE_CAPTURE";
     (* [proactive] *)
     "proactive.enabled",                "MASC_KEEPER_PROACTIVE_ENABLED";
     "proactive.min_interval_sec",       "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC";

--- a/test/dune
+++ b/test/dune
@@ -1306,7 +1306,15 @@
 (test
  (name test_keeper_stream_media_accum)
  (modules test_keeper_stream_media_accum)
- (libraries alcotest masc masc_server agent_sdk base64 digestif eio_main unix))
+ (libraries
+  alcotest
+  masc
+  masc_server
+  agent_sdk
+  base64
+  digestif
+  eio_main
+  unix))
 
 ; RFC-0284: goal-loop status SSE broadcast is change-gated (new content emits
 ; one event; unchanged / generated_at-only change emits none).
@@ -1957,6 +1965,7 @@
 (include stanzas/test_keeper_personality_round_trip.inc)
 
 (include stanzas/test_keeper_post_turn_wirein_order.inc)
+
 (include stanzas/test_keeper_post_turn_snapshot_goal_log.inc)
 
 (include stanzas/test_keeper_readonly_hints.inc)

--- a/test/dune
+++ b/test/dune
@@ -356,7 +356,8 @@
   test_env_keeper_scrub
   test_event_log
   test_relation_materializer
-  test_keeper_behavior_trace)
+  test_keeper_behavior_trace
+  test_keeper_wire_capture)
  (modules
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
@@ -694,7 +695,8 @@
   test_env_keeper_scrub
   test_event_log
   test_relation_materializer
-  test_keeper_behavior_trace)
+  test_keeper_behavior_trace
+  test_keeper_wire_capture)
  (libraries masc_test_deps multimodal))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -161,7 +161,7 @@ let response_capture_writes_redacted () =
 let capture_prunes_old_files () =
   with_flag "1" (fun () ->
     with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "1" (fun () ->
-      with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "128" (fun () ->
+      with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "4096" (fun () ->
         let base = Filename.temp_dir "wirecap_prune" "" in
         let capture_dir = Filename.concat base "wire-capture" in
         let old_month = Filename.concat capture_dir "2000-01" in
@@ -175,6 +175,23 @@ let capture_prunes_old_files () =
           (Sys.file_exists old_file);
         Alcotest.(check int) "only current capture remains" 1
           (List.length (find_jsonl base)))))
+
+let capture_skips_when_current_file_cap_would_be_exceeded () =
+  with_flag "1" (fun () ->
+    with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "512" (fun () ->
+      let base = Filename.temp_dir "wirecap_cap" "" in
+      Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:11
+        ~response_text:"small";
+      let files = find_jsonl base in
+      Alcotest.(check int) "small record written" 1 (List.length files);
+      let before = read_file (List.hd files) in
+      Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:12
+        ~response_text:(String.make 4096 'x');
+      let after = read_file (List.hd files) in
+      Alcotest.(check string)
+        "oversized record skipped without mutating current day file"
+        before
+        after))
 
 let () =
   Alcotest.run "keeper_wire_capture"
@@ -200,5 +217,7 @@ let () =
             response_capture_writes_redacted;
           Alcotest.test_case "capture store prunes old files" `Quick
             capture_prunes_old_files;
+          Alcotest.test_case "current file cap skips oversized record" `Quick
+            capture_skips_when_current_file_cap_would_be_exceeded;
         ] );
     ]

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -6,7 +6,20 @@
 module Wire = Masc.Keeper_wire_capture
 
 let flag = "MASC_KEEPER_WIRE_CAPTURE"
-let set v = Unix.putenv flag v
+
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> unsetenv key)
+    f
+
+let with_flag value f = with_env flag value f
 
 let contains ~needle haystack =
   let nl = String.length needle and hl = String.length haystack in
@@ -37,93 +50,119 @@ let rec find_jsonl dir =
    [ghp_] prefix regardless. *)
 let fake_github_token = "ghp_" ^ String.make 36 '7'
 
+let check_enabled_value label value expected =
+  with_flag value (fun () -> Alcotest.(check bool) label expected (Wire.enabled ()))
+
 let enabled_parsing () =
-  set "1";
-  Alcotest.(check bool) "1 enables" true (Wire.enabled ());
-  set "true";
-  Alcotest.(check bool) "true enables" true (Wire.enabled ());
-  set "YES";
-  Alcotest.(check bool) "YES (case-insensitive) enables" true (Wire.enabled ());
-  set "on";
-  Alcotest.(check bool) "on enables" true (Wire.enabled ());
-  set "";
-  Alcotest.(check bool) "empty disables" false (Wire.enabled ());
-  set "0";
-  Alcotest.(check bool) "0 disables" false (Wire.enabled ());
-  set "nope";
-  Alcotest.(check bool) "unknown value disables" false (Wire.enabled ())
+  check_enabled_value "1 enables" "1" true;
+  check_enabled_value "true enables" "true" true;
+  check_enabled_value "YES (case-insensitive) enables" "YES" true;
+  check_enabled_value "on enables" "on" true;
+  check_enabled_value "empty disables" "" false;
+  check_enabled_value "0 disables" "0" false;
+  check_enabled_value "unknown value disables" "nope" false
+
+let env_is_restored () =
+  unsetenv flag;
+  Alcotest.(check (option string)) "starts unset" None (Sys.getenv_opt flag);
+  with_flag "1" (fun () ->
+    Alcotest.(check bool) "enabled inside scope" true (Wire.enabled ()));
+  Alcotest.(check (option string)) "restored unset" None (Sys.getenv_opt flag)
 
 let disabled_is_noop () =
-  set "";
-  let base = Filename.temp_dir "wirecap_off" "" in
-  Wire.capture_request ~base_path:base ~keeper_name:"sangsu" ~turn_id:1
-    ~system_prompt:"sys" ~user_message:"u" ~history_messages:[];
-  Alcotest.(check (list string))
-    "no jsonl written when disabled" [] (find_jsonl base)
+  with_flag "" (fun () ->
+    let base = Filename.temp_dir "wirecap_off" "" in
+    Wire.capture_request ~masc_root:base ~keeper_name:"sangsu" ~turn_id:1
+      ~sdk_turn:0 ~system_prompt:"sys" ~extra_system_context:None
+      ~user_message:"u" ~history_messages:[];
+    Alcotest.(check (list string))
+      "no jsonl written when disabled" [] (find_jsonl base))
 
 let enabled_writes_redacted () =
-  set "1";
-  let base = Filename.temp_dir "wirecap_on" "" in
-  let history =
-    [
-      Agent_sdk.Types.assistant_msg "좋아, 연구 시작한다";
-      Agent_sdk.Types.user_msg "continue";
-    ]
-  in
-  Wire.capture_request ~base_path:base ~keeper_name:"sangsu" ~turn_id:7
-    ~system_prompt:("token " ^ fake_github_token ^ " end")
-    ~user_message:"hello world" ~history_messages:history;
-  let files = find_jsonl base in
-  Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
-  let content = read_file (List.hd files) in
-  Alcotest.(check bool) "raw github token is redacted" false
-    (contains ~needle:fake_github_token content);
-  Alcotest.(check bool) "redaction marker present" true
-    (contains ~needle:"[REDACTED]" content);
-  Alcotest.(check bool) "history_message_count recorded" true
-    (contains ~needle:"\"history_message_count\":2" content);
-  Alcotest.(check bool) "keeper name recorded" true
-    (contains ~needle:"sangsu" content);
-  Alcotest.(check bool) "turn_id recorded" true
-    (contains ~needle:"\"turn_id\":7" content);
-  Alcotest.(check bool) "replayed history text recorded" true
-    (contains ~needle:"좋아, 연구 시작한다" content);
-  Alcotest.(check bool) "request kind recorded" true
-    (contains ~needle:"\"kind\":\"request\"" content)
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_on" "" in
+    let history =
+      [
+        Agent_sdk.Types.assistant_msg "좋아, 연구 시작한다";
+        Agent_sdk.Types.user_msg "continue";
+      ]
+    in
+    Wire.capture_request ~masc_root:base ~keeper_name:"sangsu" ~turn_id:7
+      ~sdk_turn:3
+      ~system_prompt:("token " ^ fake_github_token ^ " end")
+      ~extra_system_context:(Some "dynamic context")
+      ~user_message:"hello world" ~history_messages:history;
+    let files = find_jsonl base in
+    Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+    let content = read_file (List.hd files) in
+    Alcotest.(check bool) "raw github token is redacted" false
+      (contains ~needle:fake_github_token content);
+    Alcotest.(check bool) "redaction marker present" true
+      (contains ~needle:"[REDACTED]" content);
+    Alcotest.(check bool) "history_message_count recorded" true
+      (contains ~needle:"\"history_message_count\":2" content);
+    Alcotest.(check bool) "keeper name recorded" true
+      (contains ~needle:"sangsu" content);
+    Alcotest.(check bool) "turn_id recorded" true
+      (contains ~needle:"\"turn_id\":7" content);
+    Alcotest.(check bool) "sdk_turn recorded" true
+      (contains ~needle:"\"sdk_turn\":3" content);
+    Alcotest.(check bool) "assistant role recorded" true
+      (contains ~needle:"\"role\":\"assistant\"" content);
+    Alcotest.(check bool) "user role recorded" true
+      (contains ~needle:"\"role\":\"user\"" content);
+    Alcotest.(check bool) "extra context recorded" true
+      (contains ~needle:"dynamic context" content);
+    Alcotest.(check bool) "replayed history text recorded" true
+      (contains ~needle:"좋아, 연구 시작한다" content);
+    Alcotest.(check bool) "request kind recorded" true
+      (contains ~needle:"\"kind\":\"request\"" content))
+
+let request_capture_failure_is_best_effort () =
+  with_flag "1" (fun () ->
+    let root_file = Filename.temp_file "wirecap_root_file" "" in
+    Wire.capture_request ~masc_root:root_file ~keeper_name:"sangsu" ~turn_id:1
+      ~sdk_turn:0 ~system_prompt:"sys" ~extra_system_context:None
+      ~user_message:"hello" ~history_messages:[])
 
 let response_disabled_is_noop () =
-  set "";
-  let base = Filename.temp_dir "wirecap_resp_off" "" in
-  Wire.capture_response ~base_path:base ~keeper_name:"sangsu" ~turn_id:1
-    ~response_text:"anything";
-  Alcotest.(check (list string))
-    "no jsonl written when disabled" [] (find_jsonl base)
+  with_flag "" (fun () ->
+    let base = Filename.temp_dir "wirecap_resp_off" "" in
+    Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:1
+      ~response_text:"anything";
+    Alcotest.(check (list string))
+      "no jsonl written when disabled" [] (find_jsonl base))
 
 let response_capture_writes_redacted () =
-  set "1";
-  let base = Filename.temp_dir "wirecap_resp_on" "" in
-  Wire.capture_response ~base_path:base ~keeper_name:"sangsu" ~turn_id:9
-    ~response_text:("out " ^ fake_github_token ^ " done");
-  let files = find_jsonl base in
-  Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
-  let content = read_file (List.hd files) in
-  Alcotest.(check bool) "response kind recorded" true
-    (contains ~needle:"\"kind\":\"response\"" content);
-  Alcotest.(check bool) "raw github token is redacted" false
-    (contains ~needle:fake_github_token content);
-  Alcotest.(check bool) "turn_id recorded" true
-    (contains ~needle:"\"turn_id\":9" content)
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_resp_on" "" in
+    Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:9
+      ~response_text:("out " ^ fake_github_token ^ " done");
+    let files = find_jsonl base in
+    Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+    let content = read_file (List.hd files) in
+    Alcotest.(check bool) "response kind recorded" true
+      (contains ~needle:"\"kind\":\"response\"" content);
+    Alcotest.(check bool) "raw github token is redacted" false
+      (contains ~needle:fake_github_token content);
+    Alcotest.(check bool) "turn_id recorded" true
+      (contains ~needle:"\"turn_id\":9" content))
 
 let () =
   Alcotest.run "keeper_wire_capture"
     [
       ( "enabled",
-        [ Alcotest.test_case "env flag parsing" `Quick enabled_parsing ] );
+        [
+          Alcotest.test_case "env flag parsing" `Quick enabled_parsing;
+          Alcotest.test_case "env scope restores unset" `Quick env_is_restored;
+        ] );
       ( "capture_request",
         [
           Alcotest.test_case "disabled is a no-op" `Quick disabled_is_noop;
           Alcotest.test_case "enabled writes redacted jsonl" `Quick
             enabled_writes_redacted;
+          Alcotest.test_case "write failure is best effort" `Quick
+            request_capture_failure_is_best_effort;
         ] );
       ( "capture_response",
         [

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -87,7 +87,32 @@ let enabled_writes_redacted () =
   Alcotest.(check bool) "turn_id recorded" true
     (contains ~needle:"\"turn_id\":7" content);
   Alcotest.(check bool) "replayed history text recorded" true
-    (contains ~needle:"좋아, 연구 시작한다" content)
+    (contains ~needle:"좋아, 연구 시작한다" content);
+  Alcotest.(check bool) "request kind recorded" true
+    (contains ~needle:"\"kind\":\"request\"" content)
+
+let response_disabled_is_noop () =
+  set "";
+  let base = Filename.temp_dir "wirecap_resp_off" "" in
+  Wire.capture_response ~base_path:base ~keeper_name:"sangsu" ~turn_id:1
+    ~response_text:"anything";
+  Alcotest.(check (list string))
+    "no jsonl written when disabled" [] (find_jsonl base)
+
+let response_capture_writes_redacted () =
+  set "1";
+  let base = Filename.temp_dir "wirecap_resp_on" "" in
+  Wire.capture_response ~base_path:base ~keeper_name:"sangsu" ~turn_id:9
+    ~response_text:("out " ^ fake_github_token ^ " done");
+  let files = find_jsonl base in
+  Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+  let content = read_file (List.hd files) in
+  Alcotest.(check bool) "response kind recorded" true
+    (contains ~needle:"\"kind\":\"response\"" content);
+  Alcotest.(check bool) "raw github token is redacted" false
+    (contains ~needle:fake_github_token content);
+  Alcotest.(check bool) "turn_id recorded" true
+    (contains ~needle:"\"turn_id\":9" content)
 
 let () =
   Alcotest.run "keeper_wire_capture"
@@ -99,5 +124,12 @@ let () =
           Alcotest.test_case "disabled is a no-op" `Quick disabled_is_noop;
           Alcotest.test_case "enabled writes redacted jsonl" `Quick
             enabled_writes_redacted;
+        ] );
+      ( "capture_response",
+        [
+          Alcotest.test_case "disabled is a no-op" `Quick
+            response_disabled_is_noop;
+          Alcotest.test_case "enabled writes redacted jsonl" `Quick
+            response_capture_writes_redacted;
         ] );
     ]

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -1,0 +1,103 @@
+(** Tests for [Keeper_wire_capture] (Phase O observability).
+
+    Covers: env-flag parsing, disabled = no filesystem writes, and enabled =
+    one redacted dated jsonl with the expected fields. *)
+
+module Wire = Masc.Keeper_wire_capture
+
+let flag = "MASC_KEEPER_WIRE_CAPTURE"
+let set v = Unix.putenv flag v
+
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl = 0 then true
+  else
+    let rec loop i =
+      i + nl <= hl && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
+    in
+    loop 0
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+(* Recursively collect every *.jsonl under [dir]. *)
+let rec find_jsonl dir =
+  if not (Sys.file_exists dir) then []
+  else if Sys.is_directory dir then
+    Sys.readdir dir |> Array.to_list
+    |> List.concat_map (fun e -> find_jsonl (Filename.concat dir e))
+  else if Filename.check_suffix dir ".jsonl" then [ dir ]
+  else []
+
+(* Built at runtime so no literal secret appears in the source (the pre-commit
+   secret scanner rejects literal [ghp_...] tokens). Secret_redactor detects the
+   [ghp_] prefix regardless. *)
+let fake_github_token = "ghp_" ^ String.make 36 '7'
+
+let enabled_parsing () =
+  set "1";
+  Alcotest.(check bool) "1 enables" true (Wire.enabled ());
+  set "true";
+  Alcotest.(check bool) "true enables" true (Wire.enabled ());
+  set "YES";
+  Alcotest.(check bool) "YES (case-insensitive) enables" true (Wire.enabled ());
+  set "on";
+  Alcotest.(check bool) "on enables" true (Wire.enabled ());
+  set "";
+  Alcotest.(check bool) "empty disables" false (Wire.enabled ());
+  set "0";
+  Alcotest.(check bool) "0 disables" false (Wire.enabled ());
+  set "nope";
+  Alcotest.(check bool) "unknown value disables" false (Wire.enabled ())
+
+let disabled_is_noop () =
+  set "";
+  let base = Filename.temp_dir "wirecap_off" "" in
+  Wire.capture_request ~base_path:base ~keeper_name:"sangsu" ~turn_id:1
+    ~system_prompt:"sys" ~user_message:"u" ~history_messages:[];
+  Alcotest.(check (list string))
+    "no jsonl written when disabled" [] (find_jsonl base)
+
+let enabled_writes_redacted () =
+  set "1";
+  let base = Filename.temp_dir "wirecap_on" "" in
+  let history =
+    [
+      Agent_sdk.Types.assistant_msg "좋아, 연구 시작한다";
+      Agent_sdk.Types.user_msg "continue";
+    ]
+  in
+  Wire.capture_request ~base_path:base ~keeper_name:"sangsu" ~turn_id:7
+    ~system_prompt:("token " ^ fake_github_token ^ " end")
+    ~user_message:"hello world" ~history_messages:history;
+  let files = find_jsonl base in
+  Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+  let content = read_file (List.hd files) in
+  Alcotest.(check bool) "raw github token is redacted" false
+    (contains ~needle:fake_github_token content);
+  Alcotest.(check bool) "redaction marker present" true
+    (contains ~needle:"[REDACTED]" content);
+  Alcotest.(check bool) "history_message_count recorded" true
+    (contains ~needle:"\"history_message_count\":2" content);
+  Alcotest.(check bool) "keeper name recorded" true
+    (contains ~needle:"sangsu" content);
+  Alcotest.(check bool) "turn_id recorded" true
+    (contains ~needle:"\"turn_id\":7" content);
+  Alcotest.(check bool) "replayed history text recorded" true
+    (contains ~needle:"좋아, 연구 시작한다" content)
+
+let () =
+  Alcotest.run "keeper_wire_capture"
+    [
+      ( "enabled",
+        [ Alcotest.test_case "env flag parsing" `Quick enabled_parsing ] );
+      ( "capture_request",
+        [
+          Alcotest.test_case "disabled is a no-op" `Quick disabled_is_noop;
+          Alcotest.test_case "enabled writes redacted jsonl" `Quick
+            enabled_writes_redacted;
+        ] );
+    ]

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -36,6 +36,16 @@ let read_file path =
     ~finally:(fun () -> close_in ic)
     (fun () -> really_input_string ic (in_channel_length ic))
 
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc content)
+
+let ensure_dir path =
+  if Sys.file_exists path then ()
+  else Unix.mkdir path 0o755
+
 (* Recursively collect every *.jsonl under [dir]. *)
 let rec find_jsonl dir =
   if not (Sys.file_exists dir) then []
@@ -148,6 +158,24 @@ let response_capture_writes_redacted () =
     Alcotest.(check bool) "turn_id recorded" true
       (contains ~needle:"\"turn_id\":9" content))
 
+let capture_prunes_old_files () =
+  with_flag "1" (fun () ->
+    with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "1" (fun () ->
+      with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "128" (fun () ->
+        let base = Filename.temp_dir "wirecap_prune" "" in
+        let capture_dir = Filename.concat base "wire-capture" in
+        let old_month = Filename.concat capture_dir "2000-01" in
+        ensure_dir capture_dir;
+        ensure_dir old_month;
+        let old_file = Filename.concat old_month "01.jsonl" in
+        write_file old_file (String.make 1024 'x');
+        Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:10
+          ~response_text:"bounded";
+        Alcotest.(check bool) "old capture file pruned" false
+          (Sys.file_exists old_file);
+        Alcotest.(check int) "only current capture remains" 1
+          (List.length (find_jsonl base)))))
+
 let () =
   Alcotest.run "keeper_wire_capture"
     [
@@ -170,5 +198,7 @@ let () =
             response_disabled_is_noop;
           Alcotest.test_case "enabled writes redacted jsonl" `Quick
             response_capture_writes_redacted;
+          Alcotest.test_case "capture store prunes old files" `Quick
+            capture_prunes_old_files;
         ] );
     ]


### PR DESCRIPTION
## 목표

keeper `sangsu`(deepseek-v4-flash)가 동일 문장을 반복 생성하는 현상의 **인과 방향을 실측으로 확정**하기 위한 관측 하네스(Phase O). 현재 MASC→OAS 경계는 digest/size만 남기고 **실제 내용을 버려서**, 반복이 입력(replay된 history / extra system context)에서 씨앗되는지 확인할 수 없다.

설계서: `docs/masc-keeper-repetition-blast-radius-design-2026-07-02.html`

## 변경

- `lib/keeper/keeper_wire_capture.ml` / `.mli` (신규) — env-gated, redacted 요청/응답 캡처.
- `lib/keeper/keeper_run_tools_hooks.ml` — OAS `BeforeTurnParams`에서 keeper context injection이 끝난 뒤 effective request boundary를 캡처.
- `lib/keeper/keeper_agent_run.ml` — turn response text를 같은 keeper turn id로 pairing 캡처.
- `docs/runtime-tunables.md` — `env_config_*.ml` 기준으로 재생성.

SDK turn마다 조립된 **effective 요청**(system prompt + effective `extra_system_context` + user message + replay된 `history_messages`와 role)을 `<masc_root>/wire-capture/YYYY-MM/DD.jsonl`에 기록한다. 응답 캡처는 같은 keeper `turn_id`로 request/response 분석을 묶는다. cost ledger가 쓰는 `Dated_jsonl` 일자별 store를 그대로 재사용하고, 문자열은 `Llm_provider.Secret_redactor`로 redact한다.

## 안전

- **기본 비활성**: `MASC_KEEPER_WIRE_CAPTURE`가 `1`/`true`/`yes`/`on`일 때만 동작. 미설정 시 no-op이며 파일시스템 접근 0.
- capture API는 raw `base_path`가 아니라 cluster-aware `Workspace.masc_root_dir config` 결과를 받는다.
- 캡처 경로 전체(payload construction, redaction, timestamp, store create, append)가 best-effort로 감싸져 write/capture 실패가 turn을 중단하지 않는다. `Eio.Cancel.Cancelled`는 재전파.
- redaction SSOT 경유(Bearer/API key/PEM 등).
- 테스트는 `MASC_KEEPER_WIRE_CAPTURE`를 `Fun.protect`로 scope하고 이전 env 상태를 복원한다.

## 이건 fix가 아니라 관측이다 (Harness First)

이 PR은 silent failure를 fix하지 않는다. 반복 자체의 근본 fix는 별도로 추적된다:
- **F1** content-level 반복 detector (`agent_turn.ml` idle detection 확장) — 키스톤.
- **F2** `initial_messages` 축자 replay 완화 (continuity 필터를 축자 채널에 확장).
- **F3** librarian empty-response memory 오염(×87) 근본 fix.

관측 없이 F1을 짜면 어느 채널이 지배적인지 모른 채 추측이 되므로, 설계상 O → F2/F3 → F1 순서다. 따라서 telemetry-as-fix 안티패턴이 아니라 진단용 하네스다.

WORKAROUND-WAIVED: 진단 관측 하네스(Phase O), fix 아님. 근본 fix는 F1/F2/F3로 분리 추적. default-off env-gated.

## 검증

로컬 focused gates:
- `scripts/dune-local.sh build @fmt`
- `scripts/dune-local.sh build @test/runtest-test_keeper_wire_capture test/test_keeper_wire_capture.exe`
- `scripts/silent-failure-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `bash scripts/ocaml-structure-ratchet.sh`
- `bash scripts/oas-boundary-ratchet.sh`
- `bash scripts/lint/tool-keeper-boundary-ratchet.sh`
- `scripts/audit-path-ssot.sh`
- `git diff --check`

CI is the merge authority; current push is waiting for GitHub checks.

## 미검증 / 남은 것

- 배포 전이라 라이브 wire 미수집.
- OAS→provider raw wire capture는 후속 iteration.
