### PR TITLE
fix(keeper): exclude stale InProgress/Claimed tasks from WIP admission count

### DIFF
--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -96,9 +96,17 @@ type active_item = {
 }
 
 let task_is_active_wip (task : Masc_domain.task) =
+  let threshold_sec = 1800.0 in
+  let now = Unix.gettimeofday () in
   match task.task_status with
-  | Masc_domain.Claimed _
-  | Masc_domain.InProgress _ -> true
+  | Masc_domain.InProgress { started_at; _ } ->
+      (match Masc_domain.parse_iso8601_opt started_at with
+       | Some started_ts -> now -. started_ts < threshold_sec
+       | None -> true)
+  | Masc_domain.Claimed { claimed_at; _ } ->
+      (match Masc_domain.parse_iso8601_opt claimed_at with
+       | Some claimed_ts -> now -. claimed_ts < threshold_sec
+       | None -> true)
   | Masc_domain.Todo
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -363,25 +363,25 @@ let test_goalless_tasks_never_goal_capped () =
 
 let test_task_is_active_wip_inprogress_fresh () =
   let now = Unix.gettimeofday () in
-  let started_at = Masc_domain.format_iso8601 now in
+  let started_at = Masc_domain.iso8601_of_unix_seconds now in
   let t = task ~status:(Masc_domain.InProgress { assignee = "executor"; started_at }) "t1" in
   check bool "fresh InProgress is active" true (Admission.task_is_active_wip t)
 
 let test_task_is_active_wip_inprogress_stale () =
   let long_ago = Unix.gettimeofday () -. 3600.0 in
-  let started_at = Masc_domain.format_iso8601 long_ago in
+  let started_at = Masc_domain.iso8601_of_unix_seconds long_ago in
   let t = task ~status:(Masc_domain.InProgress { assignee = "executor"; started_at }) "t2" in
   check bool "stale InProgress (>30min) is inactive" false (Admission.task_is_active_wip t)
 
 let test_task_is_active_wip_claimed_fresh () =
   let now = Unix.gettimeofday () in
-  let claimed_at = Masc_domain.format_iso8601 now in
+  let claimed_at = Masc_domain.iso8601_of_unix_seconds now in
   let t = task ~status:(Masc_domain.Claimed { assignee = "executor"; claimed_at }) "t3" in
   check bool "fresh Claimed is active" true (Admission.task_is_active_wip t)
 
 let test_task_is_active_wip_claimed_stale () =
   let long_ago = Unix.gettimeofday () -. 3600.0 in
-  let claimed_at = Masc_domain.format_iso8601 long_ago in
+  let claimed_at = Masc_domain.iso8601_of_unix_seconds long_ago in
   let t = task ~status:(Masc_domain.Claimed { assignee = "executor"; claimed_at }) "t4" in
   check bool "stale Claimed (>30min) is inactive" false (Admission.task_is_active_wip t)
 

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -359,6 +359,44 @@ let test_goalless_tasks_never_goal_capped () =
       (Printf.sprintf "goalless claim unexpectedly rejected by %s"
          (Admission.reject_reason_to_string rejection.reason))
 
+(* ── task_is_active_wip tests ── *)
+
+let test_task_is_active_wip_inprogress_fresh () =
+  let now = Unix.gettimeofday () in
+  let started_at = Masc_domain.format_iso8601 now in
+  let t = task ~status:(Masc_domain.InProgress { assignee = "executor"; started_at }) "t1" in
+  check bool "fresh InProgress is active" true (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_inprogress_stale () =
+  let long_ago = Unix.gettimeofday () -. 3600.0 in
+  let started_at = Masc_domain.format_iso8601 long_ago in
+  let t = task ~status:(Masc_domain.InProgress { assignee = "executor"; started_at }) "t2" in
+  check bool "stale InProgress (>30min) is inactive" false (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_claimed_fresh () =
+  let now = Unix.gettimeofday () in
+  let claimed_at = Masc_domain.format_iso8601 now in
+  let t = task ~status:(Masc_domain.Claimed { assignee = "executor"; claimed_at }) "t3" in
+  check bool "fresh Claimed is active" true (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_claimed_stale () =
+  let long_ago = Unix.gettimeofday () -. 3600.0 in
+  let claimed_at = Masc_domain.format_iso8601 long_ago in
+  let t = task ~status:(Masc_domain.Claimed { assignee = "executor"; claimed_at }) "t4" in
+  check bool "stale Claimed (>30min) is inactive" false (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_todo () =
+  let t = task ~status:Masc_domain.Todo "t5" in
+  check bool "Todo is inactive" false (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_done () =
+  let t = task ~status:(Masc_domain.Done { completed_at = "2026-01-01T00:00:00Z"; outcome = "success" }) "t6" in
+  check bool "Done is inactive" false (Admission.task_is_active_wip t)
+
+let test_task_is_active_wip_unparseable () =
+  let t = task ~status:(Masc_domain.InProgress { assignee = "executor"; started_at = "not-a-timestamp" }) "t7" in
+  check bool "unparseable timestamp defaults to active" true (Admission.task_is_active_wip t)
+
 let test_goalless_still_bounded_by_global_cap () =
   (* RFC-0245 non-goal: exempting goalless from the *goal* cap must NOT remove
      the global blast-radius cap. With max_global=1 and one active item, a
@@ -405,5 +443,21 @@ let () =
             test_goalless_tasks_never_goal_capped
         ; test_case "goalless still bounded by global cap" `Quick
             test_goalless_still_bounded_by_global_cap
+        ] )
+    ; ( "task_is_active_wip"
+      , [ test_case "fresh InProgress is active" `Quick
+            test_task_is_active_wip_inprogress_fresh
+        ; test_case "stale InProgress (>30min) is inactive" `Quick
+            test_task_is_active_wip_inprogress_stale
+        ; test_case "fresh Claimed is active" `Quick
+            test_task_is_active_wip_claimed_fresh
+        ; test_case "stale Claimed (>30min) is inactive" `Quick
+            test_task_is_active_wip_claimed_stale
+        ; test_case "Todo is inactive" `Quick
+            test_task_is_active_wip_todo
+        ; test_case "Done is inactive" `Quick
+            test_task_is_active_wip_done
+        ; test_case "unparseable timestamp defaults to active" `Quick
+            test_task_is_active_wip_unparseable
         ] )
     ]


### PR DESCRIPTION
## Problem

Orphaned InProgress and Claimed tasks hold repo_cap slots indefinitely, causing a deadlock where no new tasks can be claimed even though the claiming keeper fiber has long since terminated. This is the root cause of the persistent `repo_cap=6/6` deadlock observed across multiple keeper agents.

## Solution

Add a 30-minute staleness threshold to `task_is_active_wip` in `keeper_wip_admission.ml`:

- **InProgress** tasks older than 30 min → excluded from WIP count
- **Claimed** tasks older than 30 min → excluded from WIP count
- Tasks with unparseable timestamps → default to active (conservative)
- Todo/AwaitingVerification/Done/Cancelled → remain inactive (unchanged)

## Implementation

```ocaml
let task_is_active_wip (task : Masc_domain.task) =
  let threshold_sec = 1800.0 in
  let now = Unix.gettimeofday () in
  match task.task_status with
  | Masc_domain.InProgress { started_at; _ } ->
      (match Masc_domain.parse_iso8601_opt started_at with
       | Some started_ts -> now -. started_ts < threshold_sec
       | None -> true)
  | Masc_domain.Claimed { claimed_at; _ } ->
      (match Masc_domain.parse_iso8601_opt claimed_at with
       | Some claimed_ts -> now -. claimed_ts < threshold_sec
       | None -> true)
  | Masc_domain.Todo
  | Masc_domain.AwaitingVerification _
  | Masc_domain.Done _
  | Masc_domain.Cancelled _ -> false
```

## Testing

- [x] Builds successfully with `dune build`
- [x] Uses existing `Masc_domain.parse_iso8601_opt` — no new dependency
- [x] Conservative default: unparseable timestamps count as active

## Related

- Relates to: task-1574, task-1579
- Addresses the `repo_cap` deadlock root cause identified in multiple board posts