### PR TITLE
fix(oas-bridge): reject infinite timeouts

### DIFF
--- a/docs/oas-bridge-clock-timeout-contract.md
+++ b/docs/oas-bridge-clock-timeout-contract.md
@@ -18,7 +18,7 @@ That would preserve the unsafe behavior this contract removes.
 
 Callers registered in `Env_config_oas_bridge.known_callers` must have finite
 checked-in defaults. The bridge rejects `Float.infinity` even when supplied
-directly, and env parsing treats `infinity` as invalid so a checked-in finite
+directly, and env parsing treats `infinity` as invalid so the finite global
 fallback is used instead. Advisory dashboard judges are still separately
 bounded, but they no longer bypass the bridge timeout wrapper.
 

--- a/docs/oas-bridge-clock-timeout-contract.md
+++ b/docs/oas-bridge-clock-timeout-contract.md
@@ -16,11 +16,11 @@ into unbounded execution.
 Do not add a default-off opt-out flag that restores clockless bridge execution.
 That would preserve the unsafe behavior this contract removes.
 
-Request-path callers registered in `Env_config_oas_bridge.known_callers` must
-have finite checked-in defaults. Advisory dashboard judges keep their
-pre-#22402 `Float.infinity` default until they move to a dedicated no-wrapper
-path; this avoids changing fleet-wide idle behavior in the clock-required
-bridge PR.
+Callers registered in `Env_config_oas_bridge.known_callers` must have finite
+checked-in defaults. The bridge rejects `Float.infinity` even when supplied
+directly, and env parsing treats `infinity` as invalid so a checked-in finite
+fallback is used instead. Advisory dashboard judges are still separately
+bounded, but they no longer bypass the bridge timeout wrapper.
 
 ## Migration
 

--- a/docs/oas-bridge-clock-timeout-contract.md
+++ b/docs/oas-bridge-clock-timeout-contract.md
@@ -18,9 +18,11 @@ That would preserve the unsafe behavior this contract removes.
 
 Callers registered in `Env_config_oas_bridge.known_callers` must have finite
 checked-in defaults. The bridge rejects `Float.infinity` even when supplied
-directly, and env parsing treats `infinity` as invalid so the finite global
-fallback is used instead. Advisory dashboard judges are still separately
-bounded, but they no longer bypass the bridge timeout wrapper.
+directly, and env parsing treats `infinity` as invalid so resolution falls
+through to the next lookup step. Known callers keep their checked-in defaults;
+unknown callers fall through to the global env/default fallback. Advisory
+dashboard judges are still separately bounded, but they no longer bypass the
+bridge timeout wrapper.
 
 ## Migration
 

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -3,8 +3,8 @@
     Each remaining caller is named so:
 
       1. anti-rationalization keeps its compute-heavy default (180s);
-      2. dashboard judge daemons keep their no-wrapper default until the
-         dedicated advisory no-wrapper path lands;
+      2. dashboard judge daemons use a bounded advisory default so stale
+         dashboard work cannot pin the bridge indefinitely;
       3. the operator can override any single caller's budget via
          [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC];
       4. the operator can set a fallback for unknown / future callers
@@ -26,10 +26,10 @@ type caller =
 (** Hardcoded default seconds for each known caller. *)
 let global_default_sec = 300.0
 
-(** Default for advisory dashboard judge callers. This intentionally preserves
-    the pre-#22402 no-wrapper behavior while the dedicated advisory no-wrapper
-    path is split into its own PR. Per-caller env overrides still win. *)
-let dashboard_judge_default_sec = Float.infinity
+(** Default for advisory dashboard judge callers. This stays above the old
+    30/60s warning-prone path, but remains finite so dashboard work cannot
+    pin the bridge indefinitely. Per-caller env overrides still win. *)
+let dashboard_judge_default_sec = 180.0
 
 let caller_key = function
   | Anti_rationalization -> "anti_rationalization"
@@ -79,16 +79,18 @@ let trimmed_value_opt name =
   | None -> None
 ;;
 
-(** Accept positive floats including [Float.infinity]. The OAS bridge treats
-    [infinity] as no-fire, so the helper name intentionally does not claim
-    finiteness. *)
-let positive_or_default ~default value =
-  if Float.compare value 0.0 > 0 then value else default
+(** Accept only positive finite floats. [infinity] would bypass the bridge
+    timeout wrapper, so it is treated like any other invalid env value. *)
+let positive_finite_or_default ~default value =
+  match Float.classify_float value with
+  | FP_nan | FP_infinite -> default
+  | FP_normal | FP_subnormal | FP_zero ->
+    if Float.compare value 0.0 > 0 then value else default
 ;;
 
 let timeout_env_value ~default raw =
   Safe_ops.float_of_string_with_default ~default raw
-  |> positive_or_default ~default
+  |> positive_finite_or_default ~default
 ;;
 
 (** [timeout_sec ~caller ()] resolves the OAS bridge timeout for
@@ -96,13 +98,12 @@ let timeout_env_value ~default raw =
 
       1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC]
          — wins unconditionally.  Lets the operator tune one
-         caller without touching others. Positive [Float.infinity] passes
-         through as a no-wrapper override.
+         caller without touching others. Invalid values, including
+         [Float.infinity], fall back.
       2. Per-caller checked-in default ([known_default_sec]).
          Preserves intentional 180s budgets for compute-heavy callers;
-         dashboard judge callers temporarily resolve to
-         [dashboard_judge_default_sec] ([Float.infinity]) until they move
-         to a dedicated advisory no-wrapper path.
+         dashboard judge callers resolve to a finite
+         [dashboard_judge_default_sec].
       3. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only
          consulted for UNKNOWN callers (typo, future caller
          without a default entry).  Treating it as an override

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -81,16 +81,20 @@ let trimmed_value_opt name =
 
 (** Accept only positive finite floats. [infinity] would bypass the bridge
     timeout wrapper, so it is treated like any other invalid env value. *)
-let positive_finite_or_default ~default value =
-  match Float.classify_float value with
-  | FP_nan | FP_infinite -> default
-  | FP_normal | FP_subnormal | FP_zero ->
-    if Float.compare value 0.0 > 0 then value else default
-;;
-
-let timeout_env_value ~default raw =
-  Safe_ops.float_of_string_with_default ~default raw
-  |> positive_finite_or_default ~default
+let timeout_env_value_opt ~name raw =
+  let reject () =
+    Env_config_core.reject_malformed_env
+      ~name
+      ~raw
+      ~type_name:"positive finite float";
+    None
+  in
+  match Safe_ops.float_of_string_safe raw with
+  | None -> reject ()
+  | Some value ->
+    if Float.is_finite value && Float.compare value 0.0 > 0
+    then Some value
+    else reject ()
 ;;
 
 (** [timeout_sec ~caller ()] resolves the OAS bridge timeout for
@@ -99,7 +103,8 @@ let timeout_env_value ~default raw =
       1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC]
          — wins unconditionally.  Lets the operator tune one
          caller without touching others. Invalid values, including
-         [Float.infinity], fall back.
+         [Float.infinity], are treated as an invalid override and
+         fall through to the next lookup step.
       2. Per-caller checked-in default ([known_default_sec]).
          Preserves intentional 180s budgets for compute-heavy callers;
          dashboard judge callers resolve to a finite
@@ -112,14 +117,22 @@ let timeout_env_value ~default raw =
       4. [global_default_sec] (300s) hardcoded final fallback. *)
 let timeout_sec ~caller () =
   let per_caller_env = per_caller_env_var ~caller in
+  let fallback () =
+    match known_default_sec caller with
+    | Some d -> d
+    | None ->
+      (* Unknown caller: fall to global env, then global default. *)
+      (match trimmed_value_opt global_env_var with
+       | Some v ->
+         (match timeout_env_value_opt ~name:global_env_var v with
+          | Some value -> value
+          | None -> global_default_sec)
+       | None -> global_default_sec)
+  in
   match trimmed_value_opt per_caller_env with
-  | Some v -> timeout_env_value ~default:global_default_sec v
-  | None ->
-    (match known_default_sec caller with
-     | Some d -> d
-     | None ->
-       (* Unknown caller: fall to global env, then global default. *)
-       (match trimmed_value_opt global_env_var with
-        | Some v -> timeout_env_value ~default:global_default_sec v
-        | None -> global_default_sec))
+  | Some v ->
+    (match timeout_env_value_opt ~name:per_caller_env v with
+     | Some value -> value
+     | None -> fallback ())
+  | None -> fallback ()
 ;;

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -85,7 +85,7 @@ let timeout_env_value_opt ~name raw =
   let reject () =
     let type_name = "positive finite float" in
     Log.Misc.warn
-      "malformed env %s=%S (expected %s); using default"
+      "malformed env %s=%S (expected %s); falling back"
       name
       raw
       type_name;

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -83,10 +83,17 @@ let trimmed_value_opt name =
     timeout wrapper, so it is treated like any other invalid env value. *)
 let timeout_env_value_opt ~name raw =
   let reject () =
-    Env_config_core.reject_malformed_env
-      ~name
-      ~raw
-      ~type_name:"positive finite float";
+    let type_name = "positive finite float" in
+    Log.Misc.warn
+      "malformed env %s=%S (expected %s); using default"
+      name
+      raw
+      type_name;
+    if Env_config_core.parse_warn_enabled ()
+    then
+      raise
+        (Env_config_core.Config_error
+           (Printf.sprintf "malformed env %s=%S (expected %s)" name raw type_name));
     None
   in
   match Safe_ops.float_of_string_safe raw with

--- a/lib/config/env_config_oas_bridge.mli
+++ b/lib/config/env_config_oas_bridge.mli
@@ -30,8 +30,8 @@ val caller_key : caller -> string
 
 (** Resolve the OAS bridge timeout (seconds) for [caller] using the
     four-step lookup order documented above. Invalid env values, including
-    non-positive floats and [nan], fall back to [global_default_sec].
-    Positive [Float.infinity] is accepted as a no-wrapper timeout value. *)
+    non-positive floats, [nan], and [infinity], fall back to
+    [global_default_sec]. *)
 val timeout_sec : caller:caller -> unit -> float
 
 (** [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — env var consulted in
@@ -50,8 +50,6 @@ val known_callers : unit -> caller list
     fallback without hardcoding the literal. *)
 val global_default_sec : float
 
-(** Current checked-in default for advisory dashboard judge callers
-    ({!Governance_judge} / {!Operator_judge}). This preserves the
-    pre-#22402 no-wrapper behavior until those callers move to a dedicated
-    advisory no-wrapper path. *)
+(** Current checked-in finite default for advisory dashboard judge callers
+    ({!Governance_judge} / {!Operator_judge}). *)
 val dashboard_judge_default_sec : float

--- a/lib/config/env_config_oas_bridge.mli
+++ b/lib/config/env_config_oas_bridge.mli
@@ -31,7 +31,9 @@ val caller_key : caller -> string
 (** Resolve the OAS bridge timeout (seconds) for [caller] using the
     four-step lookup order documented above. Invalid env values, including
     non-positive floats, [nan], and [infinity], fall back to
-    [global_default_sec]. *)
+    the next lookup step; known callers therefore keep their checked-in
+    defaults, while unknown callers fall through to the global/default
+    fallback. *)
 val timeout_sec : caller:caller -> unit -> float
 
 (** [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — env var consulted in

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -17,10 +17,14 @@
 let timeout_overshoot_warn_ratio = 2.0
 
 let run_safe ~caller ~timeout_s fn =
-  if Float.classify_float timeout_s = FP_nan || Float.compare timeout_s 0.0 <= 0 then
+  if
+    Float.classify_float timeout_s = FP_nan
+    || Float.classify_float timeout_s = FP_infinite
+    || Float.compare timeout_s 0.0 <= 0
+  then
     invalid_arg
       (Printf.sprintf
-         "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite \
+         "Masc_oas_bridge.run_safe: timeout_s must be positive and finite \
           (got %.6g)"
          timeout_s);
   match Masc_eio_env.get_opt () with
@@ -39,13 +43,8 @@ let run_safe ~caller ~timeout_s fn =
   | Some { Masc_eio_env.clock; _ } ->
     let t0 = Eio.Time.now clock in
     let elapsed () = Eio.Time.now clock -. t0 in
-    let do_timeout fn =
-      match Float.classify_float timeout_s with
-      | FP_infinite -> fn ()
-      | _ -> Eio.Time.with_timeout_exn clock timeout_s fn
-    in
     try
-      do_timeout fn
+      Eio.Time.with_timeout_exn clock timeout_s fn
     with
   | Eio.Time.Timeout ->
     (* #10094: per-caller timeout counter so the operator can see

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -12,12 +12,8 @@
     Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
     [caller] (#10094) labels the Otel_metric_store timeout counter so the
     operator can attribute timeouts to specific call sites.
-    Raises [Invalid_argument] when [timeout_s] is not positive or is [NaN].
-    [Float.infinity] is accepted only as an explicit no-wrapper timeout
-    budget for advisory callers whose protection lives at the provider
-    boundary; checked-in production defaults in {!Env_config_oas_bridge}
-    should stay finite. A missing Eio environment fails closed without
-    running [fn]. *)
+    Raises [Invalid_argument] when [timeout_s] is not positive, finite, or is
+    [NaN]. A missing Eio environment fails closed without running [fn]. *)
 val run_safe
   :  caller:string
   -> timeout_s:float
@@ -31,10 +27,9 @@ val run_safe
     env-overridable per-caller budget.  See [Env_config_oas_bridge]
     for the per-caller default table, env-var layout, and invalid-env fallback.
 
-    Inherits the [Invalid_argument] contract from [run_safe]. The env
-    parser accepts positive finite values and [Float.infinity], while
-    invalid values such as ["0"], ["-1"], or ["nan"] fall back before this
-    boundary. *)
+    Inherits the [Invalid_argument] contract from [run_safe]. The env parser
+    accepts only positive finite values; invalid values such as ["0"], ["-1"],
+    ["nan"], or ["infinity"] fall back before this boundary. *)
 val run_with_caller
   :  caller:Env_config_oas_bridge.caller
   -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -12,8 +12,8 @@
     Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
     [caller] (#10094) labels the Otel_metric_store timeout counter so the
     operator can attribute timeouts to specific call sites.
-    Raises [Invalid_argument] when [timeout_s] is not positive, finite, or is
-    [NaN]. A missing Eio environment fails closed without running [fn]. *)
+    Raises [Invalid_argument] when [timeout_s] is [NaN], infinite, or not
+    positive. A missing Eio environment fails closed without running [fn]. *)
 val run_safe
   :  caller:string
   -> timeout_s:float

--- a/test/test_masc_oas_bridge_timeout_guard.ml
+++ b/test/test_masc_oas_bridge_timeout_guard.ml
@@ -3,7 +3,7 @@ open Masc
 let expected_invalid_timeout timeout_s =
   Invalid_argument
     (Printf.sprintf
-       "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite \
+       "Masc_oas_bridge.run_safe: timeout_s must be positive and finite \
         (got %.6g)"
        timeout_s)
 ;;
@@ -27,6 +27,11 @@ let test_rejects_non_positive_timeout () =
 
 let test_rejects_nan_timeout () =
   check_rejects_timeout ~name:"nan timeout rejected" Float.nan
+;;
+
+let test_rejects_infinite_timeout () =
+  check_rejects_timeout ~name:"infinite timeout rejected" Float.infinity;
+  check_rejects_timeout ~name:"negative infinite timeout rejected" Float.neg_infinity
 ;;
 
 let test_missing_eio_env_fails_closed_without_calling_fn () =
@@ -71,22 +76,6 @@ let test_clocked_env_times_out_sleep () =
     | Ok other -> failwith ("unexpected success: " ^ other))
 ;;
 
-let test_accepts_infinite_timeout_with_clock () =
-  with_eio_env (fun _clock ->
-    let called = ref false in
-    match
-      Masc_oas_bridge.run_safe
-        ~caller:"test_timeout_guard"
-        ~timeout_s:Float.infinity
-        (fun () ->
-           called := true;
-           Ok "ok")
-    with
-    | Ok "ok" -> Alcotest.(check bool) "fn was called" true !called
-    | Ok other -> failwith ("unexpected result: " ^ other)
-    | Error err -> failwith (Agent_sdk.Error.to_string err))
-;;
-
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -119,7 +108,7 @@ let test_run_with_caller_resolves_env_timeouts_at_boundary () =
   check_run_with_caller_uses_resolved_env_timeout ~name:"negative env fallback" "-1";
   check_run_with_caller_uses_resolved_env_timeout ~name:"nan env fallback" "nan";
   check_run_with_caller_uses_resolved_env_timeout
-    ~name:"infinite env no-wrapper"
+    ~name:"infinite env fallback"
     "infinity"
 ;;
 
@@ -136,6 +125,10 @@ let () =
             `Quick
             test_rejects_nan_timeout
         ; Alcotest.test_case
+            "rejects infinite timeout"
+            `Quick
+            test_rejects_infinite_timeout
+        ; Alcotest.test_case
             "missing eio env fails closed"
             `Quick
             test_missing_eio_env_fails_closed_without_calling_fn
@@ -143,10 +136,6 @@ let () =
             "clocked env times out sleep"
             `Quick
             test_clocked_env_times_out_sleep
-        ; Alcotest.test_case
-            "infinite timeout is explicit no-wrapper"
-            `Quick
-            test_accepts_infinite_timeout_with_clock
         ; Alcotest.test_case
             "run_with_caller resolves env timeouts"
             `Quick

--- a/test/test_oas_bridge_judge_callers_9629.ml
+++ b/test/test_oas_bridge_judge_callers_9629.ml
@@ -17,16 +17,14 @@
    checked-in default is bounded separately while env overrides stay
    available.
 
-   2026-06-27 follow-up (#22402): the dashboard judge default flip to 300s
-   is reverted here as an interim compatibility step.  A dedicated
-   advisory no-wrapper path should handle the contract split separately,
-   without changing fleet-wide idle behavior in the clock-required bridge PR.
+   2026-07-01 follow-up: the no-wrapper default is retired. Dashboard
+   judges are still advisory, but they must use a finite bridge budget so
+   stale dashboard work cannot pin OAS bridge execution indefinitely.
 
    This test pins:
 
      1. Both judges resolve to [dashboard_judge_default_sec] by default,
-        preserving the advisory no-wrapper behavior until the dedicated
-        path lands.
+        preserving one shared advisory default.
      2. The canonical per-caller env var
         ([MASC_OAS_BRIDGE_TIMEOUT_GOVERNANCE_JUDGE_SEC] etc.) is the
         only per-judge override surface. *)
@@ -55,14 +53,18 @@ let check_timeout_equal label expected actual =
       (Float.is_infinite actual && Float.compare expected actual = 0)
   else Alcotest.(check (float 0.0001)) label expected actual
 
-let test_dashboard_judge_default_is_no_wrapper () =
+let test_dashboard_judge_default_is_finite () =
   Alcotest.(check bool)
-    "dashboard_judge_default_sec preserves no-wrapper default"
+    "dashboard_judge_default_sec is finite"
     true
-    (Float.is_infinite Cfg.dashboard_judge_default_sec
-     && Cfg.dashboard_judge_default_sec > 0.0)
+    (not (Float.is_infinite Cfg.dashboard_judge_default_sec)
+     && Cfg.dashboard_judge_default_sec > 0.0);
+  Alcotest.(check (float 0.0001))
+    "dashboard_judge_default_sec"
+    180.0
+    Cfg.dashboard_judge_default_sec
 
-let test_judge_defaults_preserve_no_wrapper_timeout () =
+let test_judge_defaults_preserve_bounded_timeout () =
   clear_all_envs ();
   check_timeout_equal
     "Governance_judge default equals dashboard_judge_default_sec"
@@ -102,10 +104,10 @@ let () =
     [
       ( "defaults",
         [
-          Alcotest.test_case "dashboard_judge_default_sec is no-wrapper"
-            `Quick test_dashboard_judge_default_is_no_wrapper;
-          Alcotest.test_case "judge defaults preserve no-wrapper timeout"
-            `Quick test_judge_defaults_preserve_no_wrapper_timeout;
+          Alcotest.test_case "dashboard_judge_default_sec is finite"
+            `Quick test_dashboard_judge_default_is_finite;
+          Alcotest.test_case "judge defaults preserve bounded timeout"
+            `Quick test_judge_defaults_preserve_bounded_timeout;
           Alcotest.test_case "judges listed in known_callers"
             `Quick test_judges_listed_in_known_callers;
         ] );

--- a/test/test_oas_bridge_timeout_ssot_10094.ml
+++ b/test/test_oas_bridge_timeout_ssot_10094.ml
@@ -67,6 +67,23 @@ let test_per_caller_env_override () =
   clear_envs ()
 ;;
 
+let test_infinite_env_falls_back () =
+  clear_envs ();
+  Unix.putenv
+    (Cfg.per_caller_env_var ~caller:Cfg.Anti_rationalization)
+    "infinity";
+  Alcotest.(check (float 0.0001))
+    "infinite per-caller env falls back"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:Cfg.Anti_rationalization ());
+  Unix.putenv Cfg.global_env_var "infinity";
+  Alcotest.(check (float 0.0001))
+    "infinite global env falls back"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:(Cfg.Unknown "unknown_caller_test_10094") ());
+  clear_envs ()
+;;
+
 let test_global_env_does_not_override_known_callers () =
   clear_envs ();
   Unix.putenv Cfg.global_env_var "999.0";
@@ -128,6 +145,10 @@ let () =
             "per-caller env wins over global env"
             `Quick
             test_per_caller_env_beats_global_env
+        ; Alcotest.test_case
+            "infinite env falls back"
+            `Quick
+            test_infinite_env_falls_back
         ] )
     ; ( "naming_contract"
       , [ Alcotest.test_case

--- a/test/test_oas_bridge_timeout_ssot_10094.ml
+++ b/test/test_oas_bridge_timeout_ssot_10094.ml
@@ -16,6 +16,7 @@ let () =
 module Cfg = Env_config_oas_bridge
 
 let clear_envs () =
+  Unix.putenv Env_config_core.parse_warn_env_key "";
   Unix.putenv Cfg.global_env_var "";
   List.iter
     (fun caller -> Unix.putenv (Cfg.per_caller_env_var ~caller) "")
@@ -67,20 +68,27 @@ let test_per_caller_env_override () =
   clear_envs ()
 ;;
 
-let test_infinite_env_falls_back () =
-  clear_envs ();
-  Unix.putenv
-    (Cfg.per_caller_env_var ~caller:Cfg.Anti_rationalization)
-    "infinity";
-  Alcotest.(check (float 0.0001))
-    "infinite per-caller env falls back"
-    Cfg.global_default_sec
-    (Cfg.timeout_sec ~caller:Cfg.Anti_rationalization ());
-  Unix.putenv Cfg.global_env_var "infinity";
-  Alcotest.(check (float 0.0001))
-    "infinite global env falls back"
-    Cfg.global_default_sec
-    (Cfg.timeout_sec ~caller:(Cfg.Unknown "unknown_caller_test_10094") ());
+let test_invalid_known_per_caller_env_falls_back_to_known_default () =
+  [ "not-a-float"; "nan"; "infinity"; "0"; "-1.0" ]
+  |> List.iter (fun raw ->
+    clear_envs ();
+    Unix.putenv (Cfg.per_caller_env_var ~caller:Cfg.Anti_rationalization) raw;
+    Alcotest.(check (float 0.0001))
+      (Printf.sprintf "invalid per-caller env %S falls back to known default" raw)
+      180.0
+      (Cfg.timeout_sec ~caller:Cfg.Anti_rationalization ()));
+  clear_envs ()
+;;
+
+let test_invalid_global_env_falls_back_to_global_default () =
+  [ "not-a-float"; "nan"; "infinity"; "0"; "-1.0" ]
+  |> List.iter (fun raw ->
+    clear_envs ();
+    Unix.putenv Cfg.global_env_var raw;
+    Alcotest.(check (float 0.0001))
+      (Printf.sprintf "invalid global env %S falls back to global default" raw)
+      Cfg.global_default_sec
+      (Cfg.timeout_sec ~caller:(Cfg.Unknown "unknown_caller_test_10094") ()));
   clear_envs ()
 ;;
 
@@ -146,9 +154,13 @@ let () =
             `Quick
             test_per_caller_env_beats_global_env
         ; Alcotest.test_case
-            "infinite env falls back"
+            "invalid known per-caller env falls back to known default"
             `Quick
-            test_infinite_env_falls_back
+            test_invalid_known_per_caller_env_falls_back_to_known_default
+        ; Alcotest.test_case
+            "invalid global env falls back to global default"
+            `Quick
+            test_invalid_global_env_falls_back_to_global_default
         ] )
     ; ( "naming_contract"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- reject `Float.infinity` in `Masc_oas_bridge.run_safe`
- change dashboard OAS judge defaults from no-wrapper `Float.infinity` to finite `180.0s`
- treat env `infinity` values as invalid and fall back to the finite default
- update the bridge timeout contract and regression tests

## Report Item

Starts the P0 improvement from `reports/masc-oas-comprehensive-status-2026-07-01.html`:

- `OAS bridge timeout 기본값 = infinity`
- `OAS bridge env.clock option 제거 및 init ~clock mandatory`

The clockless path was already fail-closed. This PR removes the remaining timeout bypass: checked-in dashboard judge defaults and direct `run_safe` calls can no longer use `Float.infinity`.

## Validation

- `ocamlformat --check lib/masc_oas_bridge.ml lib/masc_oas_bridge.mli lib/config/env_config_oas_bridge.ml lib/config/env_config_oas_bridge.mli test/test_masc_oas_bridge_timeout_guard.ml test/test_oas_bridge_judge_callers_9629.ml test/test_oas_bridge_timeout_ssot_10094.ml`
- `git diff --check`
- `rg -n 'timeout_s:Float\.infinity|dashboard_judge_default_sec = Float\.infinity|Positive \[Float\.infinity\] is accepted|pre-#22402.*Float\.infinity.*default|infinite timeout is explicit no-wrapper|infinite env no-wrapper' docs lib test`

`dune` build/test intentionally left to CI per operator instruction.
