### PR TITLE
perf(server): reduce dashboard execution serving contention

### DIFF
--- a/lib/core/domain_pool.ml
+++ b/lib/core/domain_pool.ml
@@ -4,7 +4,7 @@ type t = {
 }
 
 let recommended_domain_count () =
-  max 2 (Domain.recommended_domain_count () - 1)
+  max 1 (Domain.recommended_domain_count () - 2)
 
 let weight_io = 0.05
 let weight_cpu = 1.0

--- a/lib/core/domain_pool.mli
+++ b/lib/core/domain_pool.mli
@@ -4,9 +4,9 @@
     library leaves up to each caller:
 
     {ol
-    {- A default [domain_count] that reserves one core for the Eio
-       scheduler driving HTTP / SSE / fiber dispatch on the main
-       domain.}
+    {- A default [domain_count] that reserves the main Eio scheduler
+       domain plus one spare domain for HTTP / SSE / keeper dispatch
+       under host pressure.}
     {- Named submit variants for IO-bound vs CPU-bound work, fixing
        the [~weight] argument that [Eio.Executor_pool] requires per
        call.  Centralising weight policy here keeps it consistent
@@ -27,13 +27,14 @@ type t
     plus the resolved [domain_count] for telemetry. *)
 
 val recommended_domain_count : unit -> int
-(** [max 2 (Domain.recommended_domain_count () - 1)].
+(** [max 1 (Domain.recommended_domain_count () - 2)].
 
-    The [-1] reserves the original main domain for the Eio scheduler
-    so HTTP listeners, SSE drains, and fiber dispatch don't compete
-    with worker domains for OS-thread time.  The floor of [2] keeps
-    the default sensible on 1- or 2-core systems where the
-    recommendation can be [1]. *)
+    The [-2] reserves the original main domain for the Eio scheduler
+    and one additional domain of host scheduling headroom, so HTTP
+    listeners, SSE drains, keeper dispatch, and response finalisation
+    are not competing with a pool that claims every recommended
+    domain.  The floor of [1] preserves a usable executor on small
+    systems. *)
 
 val create :
   sw:Eio.Switch.t ->

--- a/lib/core/domain_pool.mli
+++ b/lib/core/domain_pool.mli
@@ -4,8 +4,9 @@
     library leaves up to each caller:
 
     {ol
-    {- A default [domain_count] that reserves the main Eio scheduler
-       domain plus one spare domain for HTTP / SSE / keeper dispatch
+    {- A default [domain_count] that always leaves the main Eio scheduler
+       domain outside the worker pool and, when host capacity allows,
+       leaves one additional spare domain for HTTP / SSE / keeper dispatch
        under host pressure.}
     {- Named submit variants for IO-bound vs CPU-bound work, fixing
        the [~weight] argument that [Eio.Executor_pool] requires per
@@ -29,12 +30,12 @@ type t
 val recommended_domain_count : unit -> int
 (** [max 1 (Domain.recommended_domain_count () - 2)].
 
-    The [-2] reserves the original main domain for the Eio scheduler
-    and one additional domain of host scheduling headroom, so HTTP
-    listeners, SSE drains, keeper dispatch, and response finalisation
-    are not competing with a pool that claims every recommended
-    domain.  The floor of [1] preserves a usable executor on small
-    systems. *)
+    The [-2] keeps the original main domain outside the executor pool
+    and, when available, leaves one additional domain of host scheduling
+    headroom, so HTTP listeners, SSE drains, keeper dispatch, and response
+    finalisation are not competing with a pool that claims every recommended
+    domain.  The floor of [1] preserves a usable executor on small systems,
+    where the extra headroom domain may not exist. *)
 
 val create :
   sw:Eio.Switch.t ->

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -143,6 +143,20 @@ let execution_cache : cached_surface =
         ])
 ;;
 
+let execution_default_light_cache_key = "execution:default:light"
+let execution_default_light_http_body : string option Atomic.t = Atomic.make None
+
+let clear_execution_default_light_http_body () =
+  Atomic.set execution_default_light_http_body None
+;;
+
+let execution_surface_has_fresh_success () =
+  match execution_cache.last_success_unix, execution_cache.last_error_unix with
+  | Some success_ts, Some error_ts when error_ts > success_ts -> false
+  | Some _, _ -> true
+  | None, _ -> false
+;;
+
 let execution_trust_cache_key = "execution-trust:default"
 
 let execution_trust_cache : cached_surface =
@@ -207,9 +221,11 @@ let invalidate_execution_cache_with_hooks_for_testing
 
 let invalidate_execution_cache () =
   invalidate_execution_cache_with_hooks_for_testing
-    ~invalidate_execution_surface:(fun () -> Server_dashboard_http_cache.invalidate_cached_surface execution_cache)
+    ~invalidate_execution_surface:(fun () ->
+      clear_execution_default_light_http_body ();
+      Server_dashboard_http_cache.invalidate_cached_surface execution_cache)
     ~invalidate_light_cache:(fun () ->
-      Dashboard_cache.invalidate "execution:default:light")
+      Dashboard_cache.invalidate execution_default_light_cache_key)
     ()
 ;;
 
@@ -365,6 +381,16 @@ let execution_query_json ~actor ~fixture ~full_mode ~light ~default_light_reques
     ]
 ;;
 
+let default_light_execution_query =
+  execution_query_json
+    ~actor:None
+    ~fixture:None
+    ~full_mode:false
+    ~light:true
+    ~default_light_request:true
+    ~force:false
+;;
+
 let with_execution_metadata ~config ?cache_key ~query json =
   with_cached_dashboard_surface_metadata
     ~config
@@ -379,6 +405,29 @@ let with_execution_metadata ~config ?cache_key ~query json =
     ~background_refresh_interval_s:60.0
     ~query
     json
+;;
+
+let execution_default_light_response_json ~config =
+  Server_dashboard_http_cache.cached_surface_json execution_cache
+  |> with_execution_metadata
+       ~config
+       ~cache_key:execution_default_light_cache_key
+       ~query:default_light_execution_query
+;;
+
+let cache_execution_default_light_http_body response_json =
+  if execution_surface_has_fresh_success ()
+  then
+    Atomic.set
+      execution_default_light_http_body
+      (Some (Yojson.Safe.to_string response_json))
+  else clear_execution_default_light_http_body ()
+;;
+
+let refresh_execution_default_light_http_body ~config =
+  let response_json = execution_default_light_response_json ~config in
+  cache_execution_default_light_http_body response_json;
+  response_json
 ;;
 
 let transport_health_query_json () =
@@ -616,6 +665,7 @@ let patch_surface_json_for_running_keepers (config : Workspace.config) = functio
 ;;
 
 let patchexecution_cache_for_keeper ~keeper_name ~event ~keepalive_running =
+  clear_execution_default_light_http_body ();
   match execution_cache.json with
   | `Assoc fields ->
     (match List.assoc_opt "keepers" fields with
@@ -684,6 +734,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
       ~max_v:300.0
   in
   let compute () =
+    clear_execution_default_light_http_body ();
     Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
     let started_at = Unix.gettimeofday () in
     try
@@ -707,6 +758,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
+      clear_execution_default_light_http_body ();
       Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
       raise exn
   in
@@ -716,7 +768,11 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     ~config:
       { (Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0) with
         timeout_s = execution_refresh_timeout_s
-      ; on_error = Some (Server_dashboard_http_cache.mark_cached_surface_error execution_cache)
+      ; on_error =
+          Some
+            (fun exn ->
+              clear_execution_default_light_http_body ();
+              Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn)
       ; warm_delay_s = 0.0
       }
     ~compute
@@ -724,18 +780,20 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
       Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
       broadcast_cached_surface
         ~event_type:"execution_snapshot"
-        (Server_dashboard_http_cache.cached_surface_json execution_cache
-         |> with_execution_metadata
-              ~config:workspace_config
-              ~query:
-                (execution_query_json
-                   ~actor:None
-                   ~fixture:None
-                   ~full_mode:false
-                   ~light:true
-                   ~default_light_request:true
-                   ~force:false));
+        (refresh_execution_default_light_http_body ~config:workspace_config);
       !broadcast_namespace_truth_ref state)
+;;
+
+let dashboard_execution_cached_http_body ~state request =
+  let config = Mcp_server.workspace_config state in
+  let fixture = query_param request "fixture" in
+  let actor = execution_actor_for_request ~base_path:config.base_path request in
+  let full_mode = bool_query_param request "full" ~default:false in
+  let force = bool_query_param request "force" ~default:false in
+  match fixture, actor, full_mode, force, Atomic.get execution_default_light_http_body with
+  | None, None, false, false, Some body when execution_surface_has_fresh_success () ->
+    Some body
+  | _ -> None
 ;;
 
 let start_transport_health_refresh_loop ~state ~sw ~clock =
@@ -847,7 +905,6 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       ~default_light_request:(fixture = None && actor = None && not full_mode && not force)
       ~force
   in
-  let default_light_cache_key = "execution:default:light" in
   let compute ?actor ?fixture ~light () =
     let started_at = Unix.gettimeofday () in
     run_dashboard_compute
@@ -879,14 +936,17 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
   | None, None, false when force ->
     let timeout_sec = Env_config_runtime.Dashboard.execution_timeout_sec in
     let compute_and_track () =
+      clear_execution_default_light_http_body ();
       Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
       try
         let json = compute ~light:true () in
         Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
+        ignore (refresh_execution_default_light_http_body ~config);
         Server_dashboard_http_cache.cached_surface_json execution_cache
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
+        clear_execution_default_light_http_body ();
         Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
         raise exn
     in
@@ -895,11 +955,14 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
      with
      | Ok json -> json
      | Error `Timeout ->
-       let exn = Dashboard_cache.Compute_timeout (default_light_cache_key, false) in
+       let exn =
+         Dashboard_cache.Compute_timeout (execution_default_light_cache_key, false)
+       in
+       clear_execution_default_light_http_body ();
        Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
        Log.Dashboard.warn
          "dashboard execution force refresh timed out: %s (%.0fs)"
-         default_light_cache_key
+         execution_default_light_cache_key
          timeout_sec;
        `Assoc
          [ "error", `String "computation_timeout"
@@ -907,32 +970,39 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
            `String
              (Printf.sprintf
                 "Dashboard %s timed out after %.0fs"
-                default_light_cache_key
+                execution_default_light_cache_key
                 timeout_sec)
          ; "generated_at", `String (Masc_domain.now_iso ())
          ; "timeout_kind", `String "owner"
          ; "timeout_sec", `Float timeout_sec
-         ; "key", `String default_light_cache_key
+         ; "key", `String execution_default_light_cache_key
          ])
     |> with_execution_metadata
          ~config
-         ~cache_key:default_light_cache_key
+         ~cache_key:execution_default_light_cache_key
          ~query
   | None, None, false ->
     (* Default light mode: stay instant after first success, but avoid
          serving the empty initializing payload forever when proactive warm-up
          misses its first build window. *)
-    Server_dashboard_http_cache.cached_surface_or_first_success_json
-      execution_cache
-      ~cache_key:default_light_cache_key
-      ~ttl:deep_surface_cache_ttl_s
-      ~clock
-      ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
-      (compute ~light:true)
-    |> with_execution_metadata
-         ~config
-         ~cache_key:default_light_cache_key
-         ~query
+    let json =
+      Server_dashboard_http_cache.cached_surface_or_first_success_json
+        execution_cache
+        ~cache_key:execution_default_light_cache_key
+        ~ttl:deep_surface_cache_ttl_s
+        ~clock
+        ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
+        (compute ~light:true)
+    in
+    let response_json =
+      with_execution_metadata
+        ~config
+        ~cache_key:execution_default_light_cache_key
+        ~query
+        json
+    in
+    cache_execution_default_light_http_body response_json;
+    response_json
   | _ ->
     (* Parameterized requests (fixture/actor/full): on-demand with SWR cache.
          These are rare (test fixtures, actor-specific views, full mode). *)

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -941,7 +941,9 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       try
         let json = compute ~light:true () in
         Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
-        ignore (refresh_execution_default_light_http_body ~config);
+        let (_ : Yojson.Safe.t) =
+          refresh_execution_default_light_http_body ~config
+        in
         Server_dashboard_http_cache.cached_surface_json execution_cache
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -12,7 +12,7 @@
     [test/test_types.ml] for the
     lifecycle-event patcher family.
 
-    External surface (21 entries):
+    External surface (22 entries):
     - {b cache cells} ({!execution_cache},
       {!broadcast_namespace_truth_ref}) reached by
       [server_dashboard_http_namespace_truth] for
@@ -34,7 +34,8 @@
       ({!dashboard_execution_snapshot_json},
       {!dashboard_transport_health_snapshot_json}).
     - {b HTTP route entries}
-      ({!dashboard_execution_http_json},
+      ({!dashboard_execution_cached_http_body},
+      {!dashboard_execution_http_json},
       {!dashboard_execution_trust_http_json},
       {!dashboard_transport_health_http_json}).
     - {b lifecycle-event patchers}
@@ -177,6 +178,14 @@ val dashboard_transport_health_snapshot_json :
 (** Returns the most recent transport-health snapshot. *)
 
 (** {1 HTTP route entries} *)
+
+val dashboard_execution_cached_http_body :
+  state:Mcp_server.server_state -> Httpun.Request.t -> string option
+(** Returns a pre-serialized response body for the default light
+    [/api/v1/dashboard/execution] request when the proactive execution
+    cache has a fresh successful snapshot.  Returns [None] for actor,
+    fixture, full, force, initializing, or stale/error requests so callers
+    fall back to {!dashboard_execution_http_json}. *)
 
 val dashboard_execution_http_json :
   state:Mcp_server.server_state ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -685,8 +685,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/execution" ->
           with_h2_public_read h2_reqd (fun state ->
-            let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
-            h2_respond_json_value h2_reqd json ~compress:false ~extra_headers:cors)
+            match dashboard_execution_cached_http_body ~state httpun_request with
+            | Some body ->
+              h2_respond_json h2_reqd body ~compress:false ~extra_headers:cors
+            | None ->
+              let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
+              h2_respond_json_value h2_reqd json ~compress:false ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution-trust" ->
           with_h2_public_read h2_reqd (fun state ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -686,7 +686,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/execution" ->
           with_h2_public_read h2_reqd (fun state ->
             let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
-            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+            h2_respond_json_value h2_reqd json ~compress:false ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution-trust" ->
           with_h2_public_read h2_reqd (fun state ->

--- a/lib/server/server_h2_gateway_helpers.ml
+++ b/lib/server/server_h2_gateway_helpers.ml
@@ -22,20 +22,20 @@ let h2_respond_body
   H2.Body.Writer.write_string writer final_body;
   H2.Body.Writer.close writer
 
-let h2_respond_json_string ?status ?extra_headers h2_reqd body =
+let h2_respond_json_string ?status ?extra_headers ?(compress = true) h2_reqd body =
   h2_respond_body
     ?status
     ?extra_headers
-    ~compress:true
+    ~compress
     ~content_type:"application/json; charset=utf-8"
     h2_reqd
     body
 
-let h2_respond_json ?status ?extra_headers h2_reqd body =
-  h2_respond_json_string ?status ?extra_headers h2_reqd body
+let h2_respond_json ?status ?extra_headers ?compress h2_reqd body =
+  h2_respond_json_string ?status ?extra_headers ?compress h2_reqd body
 
-let h2_respond_json_value ?status ?extra_headers h2_reqd json =
-  h2_respond_json_string ?status ?extra_headers h2_reqd
+let h2_respond_json_value ?status ?extra_headers ?compress h2_reqd json =
+  h2_respond_json_string ?status ?extra_headers ?compress h2_reqd
     (Yojson.Safe.to_string json)
 
 let h2_respond_text ?(status = `OK) ?(extra_headers = []) h2_reqd body =

--- a/lib/server/server_h2_gateway_helpers.mli
+++ b/lib/server/server_h2_gateway_helpers.mli
@@ -10,11 +10,13 @@ val h2_respond_body :
 val h2_respond_json :
   ?status:H2.Status.t ->
   ?extra_headers:(string * string) list ->
+  ?compress:bool ->
   H2.Reqd.t -> string -> unit
 
 val h2_respond_json_value :
   ?status:H2.Status.t ->
   ?extra_headers:(string * string) list ->
+  ?compress:bool ->
   H2.Reqd.t -> Yojson.Safe.t -> unit
 
 val h2_respond_text :

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -905,7 +905,12 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_execution_http_json ~state ~sw ~clock request in
-         Http.Response.json_value ~compress:true ~request:req json reqd
+         (* The default execution surface is a large proactive cached snapshot.
+            Re-compressing it on every dashboard poll burns the same serving
+            domain that accepts health/chat/keeper requests; serve identity JSON
+            here and keep the compute/cache policy in
+            [dashboard_execution_http_json]. *)
+         Http.Response.json_value ~compress:false ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution-trust" (fun request reqd ->
        with_public_read (fun state req reqd ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -904,13 +904,16 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_execution_http_json ~state ~sw ~clock request in
          (* The default execution surface is a large proactive cached snapshot.
             Re-compressing it on every dashboard poll burns the same serving
             domain that accepts health/chat/keeper requests; serve identity JSON
             here and keep the compute/cache policy in
             [dashboard_execution_http_json]. *)
-         Http.Response.json_value ~compress:false ~request:req json reqd
+         match dashboard_execution_cached_http_body ~state request with
+         | Some body -> Http.Response.json ~compress:false ~request:req body reqd
+         | None ->
+           let json = dashboard_execution_http_json ~state ~sw ~clock request in
+           Http.Response.json_value ~compress:false ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution-trust" (fun request reqd ->
        with_public_read (fun state req reqd ->

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -100,6 +100,7 @@ SERVER_LOG="$RUN_DIR/server.log"
 MOCK_LOG="$RUN_DIR/mock_requests.jsonl"
 MOCK_ERR="$RUN_DIR/mock_stderr.log"
 INJECT_LOG="$RUN_DIR/board_inject.log"
+CURL_ERROR_FILE="$RUN_DIR/curl_errors.log"
 BASE_PATH="$(harness_mktemp_dir "masc-keeperload-base")"
 echo "level_hogs,probes,p50_ms,p95_ms,max_ms,timeouts,turns_during" > "$CSV_FILE"
 
@@ -175,8 +176,12 @@ kill_hogs() { if [[ ${#HOG_PIDS[@]} -gt 0 ]]; then kill "${HOG_PIDS[@]}" 2>/dev/
 
 probe_once() {
   local url="$1" t
-  t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>/dev/null)" || t="$PROBE_MAX_SEC"
-  [[ "$t" =~ ^[0-9]+([.][0-9]+)?$ ]] || t="$PROBE_MAX_SEC"
+  if ! t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>>"$CURL_ERROR_FILE")"; then
+    printf '%s\n' "$PROBE_MAX_SEC"
+    return
+  fi
+  awk -v v="$t" 'BEGIN { exit !(v ~ /^[0-9]+([.][0-9]+)?$/) }' \
+    || t="$PROBE_MAX_SEC"
   printf '%s\n' "$t"
 }
 

--- a/scripts/harness/perf/scheduler_starvation_gate.sh
+++ b/scripts/harness/perf/scheduler_starvation_gate.sh
@@ -106,6 +106,7 @@ mkdir -p "$RUN_DIR"
 CSV_FILE="$RUN_DIR/levels.csv"
 SUMMARY_FILE="$RUN_DIR/summary.json"
 SERVER_LOG="$RUN_DIR/server.log"
+CURL_ERROR_FILE="$RUN_DIR/curl_errors.log"
 echo "level_hogs,probes,p50_ms,p95_ms,max_ms,timeouts" > "$CSV_FILE"
 
 HOG_PIDS=()
@@ -163,9 +164,12 @@ kill_inproc_load() {
 # One probe -> prints TTFB in seconds (a timeout/failure prints PROBE_MAX_SEC).
 probe_once() {
   local url="$1" t
-  t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>/dev/null)" \
+  if ! t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>>"$CURL_ERROR_FILE")"; then
+    printf '%s\n' "$PROBE_MAX_SEC"
+    return
+  fi
+  awk -v v="$t" 'BEGIN { exit !(v ~ /^[0-9]+([.][0-9]+)?$/) }' \
     || t="$PROBE_MAX_SEC"
-  [[ "$t" =~ ^[0-9]+([.][0-9]+)?$ ]] || t="$PROBE_MAX_SEC"
   printf '%s\n' "$t"
 }
 

--- a/test/test_domain_pool.ml
+++ b/test/test_domain_pool.ml
@@ -14,19 +14,17 @@ module R = Domain_pool_ref
 
 let test_recommended_domain_count_floor () =
   let n = D.recommended_domain_count () in
-  check bool "floor of 2 holds even on 1-core systems" true (n >= 2)
+  check bool "at least one worker domain" true (n >= 1)
 
-let test_recommended_domain_count_reserves_main () =
-  (* Sanity: on any host with >= 3 recommended domains we expect
-     [recommended_domain_count] to subtract one for the main fiber.
-     On a 1- or 2-core system the floor of 2 dominates and this
-     property reduces to [n >= 2], which the prior test covers. *)
+let test_recommended_domain_count_reserves_scheduler_headroom () =
+  (* Keep the pool below OCaml's recommended domain count so the main Eio
+     scheduler and response finalisation do not compete with a saturated
+     executor pool.  On tiny hosts, preserve one worker domain. *)
   let raw = Domain.recommended_domain_count () in
   let ours = D.recommended_domain_count () in
-  if raw >= 3 then
-    check int "subtract one main domain" (raw - 1) ours
+  if raw >= 3 then check int "subtract scheduler headroom" (raw - 2) ours
   else
-    check bool "floor applies on small hosts" true (ours = 2)
+    check bool "floor applies on small hosts" true (ours = 1)
 
 (* ── create ────────────────────────────────────────────── *)
 
@@ -180,9 +178,9 @@ let test_ref_submits_to_shared_pool () =
 let () =
   Alcotest.run "Domain_pool" [
     "recommended", [
-      test_case "floor 2" `Quick test_recommended_domain_count_floor;
-      test_case "reserves main" `Quick
-        test_recommended_domain_count_reserves_main;
+      test_case "positive floor" `Quick test_recommended_domain_count_floor;
+      test_case "reserves scheduler headroom" `Quick
+        test_recommended_domain_count_reserves_scheduler_headroom;
     ];
     "create", [
       test_case "default count" `Quick test_create_default;


### PR DESCRIPTION
## Summary
- reserve Domain_pool headroom so the shared executor no longer claims every recommended domain except the main scheduler
- serve the large dashboard execution snapshot without per-request zstd compression on H1/H2
- cache the default light execution response body as a derived projection of the execution cache, so fresh default polls skip metadata wrapping and Yojson serialization
- make perf gates persist curl stderr so connection failures are auditable instead of silent 20s samples
- refresh the generated runtime-tunables catalog that CI checks against `lib/config/env_config_*.ml`

## Validation
- ocamlformat --check lib/core/domain_pool.ml lib/core/domain_pool.mli test/test_domain_pool.ml lib/server/server_h2_gateway_helpers.mli lib/server/server_h2_gateway_helpers.ml lib/server/server_routes_http_routes_dashboard.ml lib/server/server_h2_gateway.ml
- ocamlformat --check lib/server/server_dashboard_http_execution_surfaces.ml lib/server/server_dashboard_http_execution_surfaces.mli lib/server/server_routes_http_routes_dashboard.ml lib/server/server_h2_gateway.ml
- bash -n scripts/harness/perf/scheduler_starvation_gate.sh scripts/harness/perf/keeper_load_gate.sh
- bash scripts/ci/check-ignore-without-comment-diff.sh --base fa7bd52db237a0b8fb57ccba222b297a9812a356 --head HEAD
- ocaml -I +str str.cma bin/env_knob_catalog.ml docs/runtime-tunables.md
- git diff --check
- rg -n "failwith|assert false|TODO|FIXME|Sys\.(readdir|command)|Fun\.protect|Mutex\.(lock|unlock)|Stdlib\.Lazy\.(force|from_val)" lib/server/server_dashboard_http_execution_surfaces.ml lib/server/server_dashboard_http_execution_surfaces.mli lib/server/server_routes_http_routes_dashboard.ml lib/server/server_h2_gateway.ml
- live current-binary bottleneck confirmation before this PR binary was deployed: /api/v1/dashboard/execution identity total ~0.506s vs Accept-Encoding:zstd total ~0.645s

## Not run
- local dune build/test, per CI-build-authority instruction
