### PR TITLE
feat(runtime): restore ordered provider failover for keeper turns

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -914,6 +914,18 @@ supports-multimodal-inputs = false
 [ollama.gemma4-26b-a4b-qat]
 max-concurrent = 1
 
+# ── Runtime lanes (ordered failover) ─────────────────────────────────
+# A lane is an ordered list of runtime candidates. When a keeper is assigned
+# to a lane, the turn attempts candidates in order until one succeeds or the
+# lane is exhausted. Lanes are resolved at config load; unknown candidate ids
+# abort startup. Only the "ordered" strategy is implemented today.
+[runtime.lanes.default]
+strategy = "ordered"
+candidates = [
+  "ollama_cloud.deepseek-v4-flash",
+  "deepseek.deepseek-v4-pro",
+]
+
 # ── Keeper assignments ──────────────────────────────────────────────
 # Keepers are assigned to a model by provider.model key. Unassigned
 # keepers fall back to [runtime].default. Per-keeper overrides in the
@@ -925,6 +937,8 @@ max-concurrent = 1
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
 nick0cave = "ollama.gemma4-26b-a4b-qat"
+# example: route a test keeper through the failover lane
+# canary = "default"
 
 # ── Discord ──────────────────────────────────────────────────────────
 # Trigger policy controls which inbound Discord events the bot responds to.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -315,6 +315,7 @@ let run_turn
       ~generation
       ()
   in
+  let requested_max_tokens = max_tokens in
   let meta = ctx.meta in
   let temperature = ctx.temperature in
   let max_output_ceiling =
@@ -577,6 +578,13 @@ let run_turn
               let keeper_oas_guardrails =
                 keeper_oas_visibility_neutral_guardrails ?guardrails ()
               in
+              let max_tokens_for_runtime ~runtime_id =
+                Keeper_run_context.resolve_max_tokens_for_runtime
+                  ~keeper_name:meta.name
+                  ~runtime_id
+                  ?max_tokens:requested_max_tokens
+                  ()
+              in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* The keeper turn deadline must own the OAS Agent.run switch.
                    Stream/body idle budgets catch liveness gaps; this hard
@@ -616,6 +624,7 @@ let run_turn
                     ~body_timeout_s:timeout_s
                     ~temperature
                     ~max_tokens
+                    ~max_tokens_for_runtime
                     ~accept:
                       Keeper_tool_response.response_has_text_or_tool_progress
                     ~guardrails:keeper_oas_guardrails

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -68,6 +68,36 @@ let build_base_system_prompt
     ~home_ground:config.base_path
     ()
 
+let max_tokens_fallback ~keeper_name profile_defaults () =
+  match
+    Keeper_types_profile.unified_max_tokens_override_of_oas_env
+      ~keeper_name
+      profile_defaults.oas_env
+  with
+  | Some value -> value
+  | None -> 8192
+
+let resolve_max_tokens_for_runtime_with_profile ~keeper_name ~profile_defaults
+      ?max_tokens ~runtime_id ()
+  =
+  match max_tokens with
+  | Some t ->
+    Runtime_inference.cap_max_tokens_to_runtime_ceiling
+      ~runtime_id
+      ~source:"caller_override"
+      t
+  | None ->
+    Runtime_inference.resolve_max_tokens
+      ~runtime_id
+      ~fallback:(max_tokens_fallback ~keeper_name profile_defaults)
+
+let resolve_max_tokens_for_runtime ~keeper_name ~runtime_id ?max_tokens () =
+  let profile_defaults =
+    Keeper_types_profile.load_keeper_profile_defaults keeper_name
+  in
+  resolve_max_tokens_for_runtime_with_profile
+    ~keeper_name ~profile_defaults ?max_tokens ~runtime_id ()
+
 let prepare_run_context
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -101,26 +131,12 @@ let prepare_run_context
         ~runtime_id ~fallback:(fun () -> 0.3)
   in
   let max_tokens =
-    match max_tokens with
-    | Some t ->
-      Runtime_inference.cap_max_tokens_to_runtime_ceiling
-        ~runtime_id
-        ~source:"caller_override"
-        t
-    | None ->
-      Runtime_inference.resolve_max_tokens
-        ~runtime_id
-          (* 8192 allows complex multi-tool reasoning per turn.
-           Cloudflare tunnel 100s is no longer a constraint with
-           streaming responses. *)
-        ~fallback:(fun () ->
-          match
-            Keeper_types_profile.unified_max_tokens_override_of_oas_env
-              ~keeper_name:meta.name
-              profile_defaults.oas_env
-          with
-          | Some value -> value
-          | None -> 8192)
+    resolve_max_tokens_for_runtime_with_profile
+      ~keeper_name:meta.name
+      ~profile_defaults
+      ?max_tokens
+      ~runtime_id
+      ()
   in
   (* 0b. Create context injector for temporal awareness *)
   let injector_config = Masc_context_injector.default_config () in

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -36,6 +36,19 @@ val build_base_system_prompt :
 (** Build the keeper base system prompt from the same persisted meta/profile
     inputs used by {!prepare_run_context}. *)
 
+val resolve_max_tokens_for_runtime :
+     keeper_name:string
+  -> runtime_id:string
+  -> ?max_tokens:int
+  -> unit
+  -> int
+(** Resolve the keeper turn max-token budget for a concrete runtime id.
+
+    [max_tokens] is an explicit caller override and is capped through
+    {!Runtime_inference.cap_max_tokens_to_runtime_ceiling}. When absent, the
+    keeper profile/env fallback is passed through
+    {!Runtime_inference.resolve_max_tokens} for the supplied runtime. *)
+
 val prepare_run_context :
      config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -211,6 +211,8 @@ let clock_lane_of_event = function
   | Turn_finished ->
     "keeper"
   | Runtime_routed
+  | Runtime_completed
+  | Runtime_failed
   | Provider_lane_resolved ->
     "masc_policy_runtime"
   | Provider_attempt_started

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -3,6 +3,8 @@ type event_kind =
     Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_completed
+  | Runtime_failed
   | Pre_dispatch_blocked
   | Provider_lane_resolved
   | Provider_attempt_started

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -70,6 +70,52 @@ let media_degrade_manifest_decision ~(runtime_id : string)
         ("media_dropped_counts", `String summary);
       ])
 
+let runtime_attempt_decision ~idx ~runtime_id =
+  `Assoc [ ("idx", `Int idx); ("runtime_id", `String runtime_id) ]
+
+let runtime_failed_decision ~idx ~runtime_id error =
+  `Assoc
+    [
+      ("idx", `Int idx);
+      ("runtime_id", `String runtime_id);
+      ("error_kind", `String (Oas_compat.error_kind error));
+    ]
+
+let attempt_runtime_candidates ~runtime_id ~runtime_id_of
+    ~(emit_runtime_manifest :
+       ?status:string ->
+       ?decision:Yojson.Safe.t ->
+       Keeper_runtime_manifest.event_kind ->
+       unit) ~run_attempt candidates =
+  let rec loop idx = function
+    | [] ->
+      Error
+        (Agent_sdk.Error.Internal
+           (Printf.sprintf "runtime lane %S exhausted all candidates" runtime_id))
+    | candidate :: rest ->
+      let attempt_runtime_id = runtime_id_of candidate in
+      emit_runtime_manifest
+        ~status:"attempt"
+        ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
+        Keeper_runtime_manifest.Runtime_routed;
+      (match run_attempt ~idx ~runtime_id:attempt_runtime_id candidate with
+       | Ok _ as ok ->
+         emit_runtime_manifest
+           ~status:"completed"
+           ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
+           Keeper_runtime_manifest.Runtime_completed;
+         ok
+       | Error error ->
+         emit_runtime_manifest
+           ~status:"failed"
+           ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
+           Keeper_runtime_manifest.Runtime_failed;
+         (match rest with
+          | [] -> Error error
+          | _ :: _ -> loop (idx + 1) rest))
+  in
+  loop 0 candidates
+
 let run_named
     ~runtime_id
     ?(keeper_name = "")
@@ -339,19 +385,11 @@ let run_named
      dead compatibility knob. *)
   let execution_idle_timeout_s = None in
   (* Sequential candidate attempt loop. On failure we record a manifest row and
-     move to the next candidate; on success we record completion and return.
-     All candidates exhausted yields a typed lane-exhausted error. *)
-  let rec attempt_candidates idx = function
-    | [] ->
-      Error
-        (Agent_sdk.Error.Internal
-           (Printf.sprintf "runtime lane %S exhausted all candidates" runtime_id))
-    | runtime :: rest ->
-      let attempt_runtime_id = runtime.Runtime.id in
-      emit_runtime_manifest
-        ~status:"attempt"
-        ~decision:(`Assoc [ ("idx", `Int idx) ])
-        Keeper_runtime_manifest.Runtime_routed;
+     move to the next candidate; on success we record completion and return. *)
+  attempt_runtime_candidates ~runtime_id
+    ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
+    ~emit_runtime_manifest
+    ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
       let error_runtime_id = attempt_runtime_id in
       let* provider_config =
         match provider_config_transform with
@@ -426,25 +464,8 @@ let run_named
         Keeper_turn_driver_try_provider.run_try_provider
           try_provider_ctx ?per_provider_timeout_s candidate
       in
-      (match result with
-       | Ok _ as ok ->
-         emit_runtime_manifest
-           ~status:"completed"
-           ~decision:(`Assoc [ ("idx", `Int idx) ])
-           Keeper_runtime_manifest.Runtime_completed;
-         ok
-       | Error e ->
-         emit_runtime_manifest
-           ~status:"failed"
-           ~decision:
-             (`Assoc
-                [ ("idx", `Int idx)
-                ; ("error_kind", `String (Oas_compat.error_kind e))
-                ])
-           Keeper_runtime_manifest.Runtime_failed;
-         attempt_candidates (idx + 1) rest)
-  in
-  attempt_candidates 0 attempt_runtimes
+      result)
+    attempt_runtimes
 
 
 module For_testing = struct
@@ -464,6 +485,7 @@ module For_testing = struct
     Keeper_turn_driver_try_runtime.sdk_error_of_nonretryable_attempt_error
 
   let media_degrade_manifest_decision = media_degrade_manifest_decision
+  let attempt_runtime_candidates = attempt_runtime_candidates
 
   let accept_no_progress_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing.accept_no_progress_should_try_next

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -136,6 +136,22 @@ let resolve_runtime_candidates ids =
   in
   loop [] ids
 
+let first_runtime_after_modality_reroute ~keeper_name ~assignment_id
+    ~first_candidate_id ~first_candidate = function
+  | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
+    first_candidate_id, first_candidate
+  | Runtime_agent.Reroute { to_runtime_id; reason } ->
+    (match Runtime.get_runtime_by_id to_runtime_id with
+     | None -> first_candidate_id, first_candidate
+     | Some rerouted ->
+       Log.Keeper.warn
+         "%s: RFC-0265 modality reroute %s -> %s (%s)"
+         keeper_name
+         assignment_id
+         to_runtime_id
+         reason;
+       to_runtime_id, rerouted)
+
 let run_named
     ~runtime_id
     ?(keeper_name = "")
@@ -286,20 +302,8 @@ let run_named
       current_goal_blocks
   in
   let first_runtime_id, first_runtime =
-    match reroute_decision with
-    | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
-      runtime_id, first_candidate
-    | Runtime_agent.Reroute { to_runtime_id; reason } ->
-      (match Runtime.get_runtime_by_id to_runtime_id with
-       | None -> runtime_id, first_candidate
-       | Some rerouted ->
-         Log.Keeper.warn
-           "%s: RFC-0265 modality reroute %s -> %s (%s)"
-           keeper_name
-           runtime_id
-           to_runtime_id
-           reason;
-         to_runtime_id, rerouted)
+    first_runtime_after_modality_reroute ~keeper_name ~assignment_id:runtime_id
+      ~first_candidate_id ~first_candidate reroute_decision
   in
   let* remaining_runtimes = resolve_runtime_candidates remaining_candidate_ids in
   let attempt_runtimes = first_runtime :: remaining_runtimes in
@@ -470,6 +474,9 @@ module For_testing = struct
 
   let sdk_error_of_nonretryable_attempt_error =
     Keeper_turn_driver_try_runtime.sdk_error_of_nonretryable_attempt_error
+
+  let first_runtime_after_modality_reroute =
+    first_runtime_after_modality_reroute
 
   let media_degrade_manifest_decision = media_degrade_manifest_decision
   let attempt_runtime_candidates = attempt_runtime_candidates

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -198,6 +198,34 @@ let first_runtime_after_modality_reroute ~keeper_name ~assignment_id
          reason;
        to_runtime_id, rerouted)
 
+type attempt_inference_policy =
+  { attempt_enable_thinking : bool option
+  ; attempt_preserve_thinking : bool option
+  ; attempt_max_tokens : int
+  }
+
+let attempt_inference_policy
+    ?max_tokens_for_runtime
+    ~runtime_id
+    ~fallback_enable_thinking
+    ~fallback_max_tokens
+  =
+  let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
+  let attempt_enable_thinking =
+    match runtime_seed.thinking_enabled with
+    | Some _ as enabled -> enabled
+    | None -> fallback_enable_thinking
+  in
+  let attempt_max_tokens =
+    match max_tokens_for_runtime with
+    | Some resolver -> resolver ~runtime_id
+    | None -> fallback_max_tokens
+  in
+  { attempt_enable_thinking
+  ; attempt_preserve_thinking = runtime_seed.preserve_thinking
+  ; attempt_max_tokens
+  }
+
 let run_named
     ~runtime_id
     ?(keeper_name = "")
@@ -215,6 +243,7 @@ let run_named
     ?body_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
     ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+    ?max_tokens_for_runtime
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -254,19 +283,12 @@ let run_named
   match require_eio ?sw ?net () with
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
-  (* Lane-aware dispatch: resolve a runtime id or ordered failover lane, then
-     attempt candidates sequentially with manifest evidence per attempt. *)
-  let runtime_id = String.trim runtime_id in
-  let runtime_mcp_policy = runtime_mcp_policy_for_tools ~base_path ~keeper_name tools in
-  let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
-  let enable_thinking =
-    match runtime_seed.thinking_enabled with
-    | Some enabled -> Some enabled
-    | None -> enable_thinking
-  in
-  let preserve_thinking = runtime_seed.preserve_thinking in
-  (* Audit F8: removed dead routing knobs from the signature so callers cannot
-     pass values that would be silently ignored. *)
+	  (* Lane-aware dispatch: resolve a runtime id or ordered failover lane, then
+	     attempt candidates sequentially with manifest evidence per attempt. *)
+	  let runtime_id = String.trim runtime_id in
+	  let runtime_mcp_policy = runtime_mcp_policy_for_tools ~base_path ~keeper_name tools in
+	  (* Audit F8: removed dead routing knobs from the signature so callers cannot
+	     pass values that would be silently ignored. *)
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
   let emit_runtime_manifest ?status ?decision event =
@@ -426,14 +448,21 @@ let run_named
   let execution_idle_timeout_s = None in
   (* Sequential candidate attempt loop. On failure we record a manifest row and
      move to the next candidate; on success we record completion and return. *)
-  attempt_runtime_candidates ~runtime_id
-    ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
-    ~emit_runtime_manifest
-    ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
-      let error_runtime_id = attempt_runtime_id in
-      match
-        match provider_config_transform with
-        | None -> Ok runtime.Runtime.provider_config
+	  attempt_runtime_candidates ~runtime_id
+	    ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
+	    ~emit_runtime_manifest
+	    ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
+	      let error_runtime_id = attempt_runtime_id in
+      let inference_policy =
+        attempt_inference_policy
+          ?max_tokens_for_runtime
+          ~runtime_id:attempt_runtime_id
+          ~fallback_enable_thinking:enable_thinking
+	          ~fallback_max_tokens:max_tokens
+	      in
+	      match
+	        match provider_config_transform with
+	        | None -> Ok runtime.Runtime.provider_config
         | Some transform -> transform runtime.Runtime.provider_config
       with
       | Error err -> Error err, None
@@ -459,11 +488,11 @@ let run_named
           ; initial_messages
           ; max_turns
           ; max_idle_turns
-          ; stream_idle_timeout_s
-          ; execution_idle_timeout_s
-          ; body_timeout_s
-          ; temperature
-          ; max_tokens
+	          ; stream_idle_timeout_s
+	          ; execution_idle_timeout_s
+	          ; body_timeout_s
+	          ; temperature
+	          ; max_tokens = inference_policy.attempt_max_tokens
           ; accept
           ; guardrails
           ; hooks
@@ -477,11 +506,11 @@ let run_named
           ; yield_on_tool
           ; compact_ratio
           ; oas_auto_context_overflow_retry
-          ; checkpoint_dir
-          ; context_injector
-          ; context
-          ; enable_thinking
-          ; preserve_thinking
+	          ; checkpoint_dir
+	          ; context_injector
+	          ; context
+	          ; enable_thinking = inference_policy.attempt_enable_thinking
+	          ; preserve_thinking = inference_policy.attempt_preserve_thinking
           ; approval
           ; exit_condition
           ; exit_condition_result
@@ -531,8 +560,9 @@ module For_testing = struct
 
   let lane_modality_reroute_decision = lane_modality_reroute_decision
   let dedupe_runtimes_preserve_order = dedupe_runtimes_preserve_order
-  let media_degrade_manifest_decision = media_degrade_manifest_decision
-  let attempt_runtime_candidates = attempt_runtime_candidates
+	  let media_degrade_manifest_decision = media_degrade_manifest_decision
+	  let attempt_inference_policy = attempt_inference_policy
+	  let attempt_runtime_candidates = attempt_runtime_candidates
 
   let accept_no_progress_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing.accept_no_progress_should_try_next

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -126,12 +126,11 @@ let run_named
   match require_eio ?sw ?net () with
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
-  (* Single-runtime dispatch (RFC-0206 runtime purge).  The former named-runtime
-     resolution + multi-candidate selection / health / capacity / strategy /
-     cycle / admission-rotation machinery is deleted.  There is exactly one
-     default Runtime: resolve its provider config, build one execution
-     candidate, and run a single provider attempt.  A failed runtime surfaces
-     its [sdk_error] directly — there is nothing left to "exhaust". *)
+  (* Lane-aware dispatch (PR-A provider failover).  The requested runtime id
+     resolves to either a single runtime or an ordered runtime lane.  Lanes
+     provide sequential failover: each candidate is attempted in order, and a
+     manifest row is emitted per attempt.  A failed turn is the result of
+     exhausting all candidates, never of a single provider hiccup. *)
   let runtime_id = String.trim runtime_id in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~base_path ~keeper_name tools in
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
@@ -182,29 +181,30 @@ let run_named
       |> append
     | _ -> ()
   in
-  (* RFC-0207: dispatch to the *requested* runtime (a keeper's persona [model]
-     selection or the global default, both produced by [runtime_id_of_meta])
-     instead of unconditionally the default.  A requested id that does not
-     resolve is a config/validation bug — fail-fast rather than silently
-     substituting the default (RFC-0206 §2.1: no Unknown→Permissive fallback). *)
-  match Runtime.get_runtime_by_id runtime_id with
-  | None ->
+  (* RFC-0207 / RFC-0206: resolve the requested assignment to either a single
+     runtime or an ordered runtime lane. Lanes shadow runtimes: a lane id takes
+     precedence so operators can route through explicit failover groups. A
+     requested id that names neither is a config/validation bug — fail-fast
+     rather than silently substituting the default (RFC-0206 §2.1). *)
+  let lane_resolution = Runtime.resolve_assignment runtime_id in
+  let lane_candidate_ids =
+    match lane_resolution with
+    | `Missing -> []
+    | `Single_runtime runtime -> [ runtime.Runtime.id ]
+    | `Lane lane -> Runtime_lane.ordered_candidates lane
+  in
+  if lane_candidate_ids = []
+  then
     Error
       (Agent_sdk.Error.Internal
          (Printf.sprintf
-            "requested runtime %S not found among configured runtimes \
-             (no silent fallback to default — RFC-0207/RFC-0206 §2.1)"
+            "requested runtime or lane %S not found among configured runtimes"
             runtime_id))
-  | Some assigned_runtime ->
-  (* RFC-0265: proactively reroute a turn whose active input modality
-     (image/audio/document) the assigned runtime cannot accept to a capable
-     configured runtime ([\[runtime\].media_failover] order, else declaration
-     order). The active input includes both the current goal and prior
-     [initial_messages]; otherwise an image in history can poison the next
-     text-only follow-up and leak as a provider 400. Modality-satisfied turns are
-     untouched; when no runtime qualifies the assigned runtime stands and the
-     loud capability gate in [Runtime_agent.run_blocks] rejects (the floor). The
-     reroute is visible via a WARN log (non-silent — RFC-0126/0145). *)
+  else
+  (* RFC-0265: proactively reroute a turn whose active input modality exceeds
+     the first candidate's capabilities. The reroute is applied to the first
+     candidate only; subsequent lane candidates are attempted as declared. The
+     active input includes both the current goal and prior [initial_messages]. *)
   let current_goal_blocks =
     match goal_blocks with
     | Some blocks -> blocks
@@ -218,20 +218,32 @@ let run_named
     | None -> []
     | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
   in
+  let first_candidate_id = List.hd lane_candidate_ids in
+  let first_candidate =
+    match Runtime.get_runtime_by_id first_candidate_id with
+    | Some rt -> rt
+    | None ->
+      (* [resolve_assignment] validated ids against loaded runtimes; a missing
+         id here indicates a race with config reload. Fail fast. *)
+      failwith
+        (Printf.sprintf
+           "keeper_turn_driver: resolved candidate %S disappeared from runtimes"
+           first_candidate_id)
+  in
   let reroute_decision =
     Runtime_agent.decide_modality_reroute_for_runtime
-      ~assigned:assigned_runtime
+      ~assigned:first_candidate
       ~checkpoint_messages
       ~initial_messages
       current_goal_blocks
   in
-  let runtime_id, runtime =
+  let first_runtime_id, first_runtime =
     match reroute_decision with
     | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
-      runtime_id, assigned_runtime
+      runtime_id, first_candidate
     | Runtime_agent.Reroute { to_runtime_id; reason } ->
       (match Runtime.get_runtime_by_id to_runtime_id with
-       | None -> runtime_id, assigned_runtime
+       | None -> runtime_id, first_candidate
        | Some rerouted ->
          Log.Keeper.warn
            "%s: RFC-0265 modality reroute %s -> %s (%s)"
@@ -240,6 +252,23 @@ let run_named
            to_runtime_id
            reason;
          to_runtime_id, rerouted)
+  in
+  (* Build ordered attempt list: rerouted first candidate, then remaining lane
+     candidates. This preserves the lane order while honoring the capability
+     override for the first attempt. *)
+  let attempt_runtimes =
+    let resolve_runtime id =
+      match Runtime.get_runtime_by_id id with
+      | Some rt -> rt
+      | None ->
+        failwith
+          (Printf.sprintf
+             "keeper_turn_driver: lane candidate %S disappeared from runtimes"
+             id)
+    in
+    match lane_candidate_ids with
+    | [] -> [ first_runtime ]
+    | _ :: rest -> first_runtime :: List.map resolve_runtime rest
   in
   (* RFC-0265 follow-up — graceful media degrade floor. When no configured
      runtime can accept the turn's input modality ([No_capable_runtime]), strip
@@ -254,7 +283,7 @@ let run_named
   let goal_blocks, initial_messages, oas_checkpoint =
     match reroute_decision with
     | Runtime_agent.No_capable_runtime _ ->
-      let caps = Runtime_agent.input_capabilities_of_runtime runtime in
+      let caps = Runtime_agent.input_capabilities_of_runtime first_runtime in
       let stripped_goal, goal_dropped =
         Runtime_agent.strip_unsupported_modality_blocks caps current_goal_blocks
       in
@@ -277,7 +306,7 @@ let run_named
           (Runtime_agent.merge_modality_counts goal_dropped initial_dropped)
           checkpoint_dropped
       in
-      (match Runtime_agent.media_degrade_note ~runtime_id dropped with
+      (match Runtime_agent.media_degrade_note ~runtime_id:first_runtime_id dropped with
        | None ->
          (* Nothing strippable (e.g. only ToolResult-nested media): keep the
             inputs unchanged so the loud capability floor still applies. *)
@@ -286,11 +315,11 @@ let run_named
          Log.Keeper.warn
            "%s: RFC-0265 media degrade on %s — dropped %s, continuing text-only"
            keeper_name
-           runtime_id
+           first_runtime_id
            (modality_counts_summary dropped);
          emit_runtime_manifest
            ~status:"degraded"
-           ~decision:(media_degrade_manifest_decision ~runtime_id dropped)
+           ~decision:(media_degrade_manifest_decision ~runtime_id:first_runtime_id dropped)
            Keeper_runtime_manifest.Runtime_routed;
          let goal_with_note =
            stripped_goal @ [ Agent_sdk.Types.text_block note ]
@@ -299,18 +328,6 @@ let run_named
     | Runtime_agent.No_reroute_needed | Runtime_agent.Reroute _ ->
       goal_blocks, initial_messages, oas_checkpoint
   in
-  let error_runtime_id = runtime_id in
-  let* provider_config =
-    match provider_config_transform with
-    | None -> Ok runtime.Runtime.provider_config
-    | Some transform -> transform runtime.Runtime.provider_config
-  in
-  let candidate =
-    Runtime_candidate.of_provider_config
-      ~max_concurrent:runtime.Runtime.binding.max_concurrent
-      provider_config
-  in
-  let name = Printf.sprintf "oas-%s" runtime_id in
   let transport_resolved =
     match transport with
     | Some t -> t
@@ -321,68 +338,113 @@ let run_named
      accounting. Passing [None] keeps the previous behavior without exposing a
      dead compatibility knob. *)
   let execution_idle_timeout_s = None in
-	  let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
-	    runtime_id;
-	    error_runtime_id;
-	    base_path;
-	    keeper_name;
-    name;
-    goal;
-    goal_blocks;
-    priority;
-    session_id;
-    system_prompt;
-    tools;
-    initial_messages;
-    max_turns;
-    max_idle_turns;
-    stream_idle_timeout_s;
-    execution_idle_timeout_s;
-    body_timeout_s;
-    temperature;
-    max_tokens;
-    accept;
-    guardrails;
-    hooks;
-    context_reducer;
-    raw_trace;
-    transport_resolved;
-    runtime_mcp_policy;
-    allowed_paths;
-    checkpoint_sidecar;
-    cache_system_prompt;
-    yield_on_tool;
-    compact_ratio;
-    oas_auto_context_overflow_retry;
-    checkpoint_dir;
-    context_injector;
-    context;
-    enable_thinking;
-    preserve_thinking;
-    approval;
-    exit_condition;
-    exit_condition_result;
-    summarizer;
-    oas_checkpoint;
-    trace_link;
-    sw;
-    net;
-    on_event;
-    on_yield;
-    on_resume;
-    agent_ref;
-    on_runtime_observation;
-    event_bus;
-    runtime_manifest_context;
-    runtime_manifest_append;
-    turn_start;
-    seq_ref;
-  } in
-  let result, _checkpoint, _success_sample =
-    Keeper_turn_driver_try_provider.run_try_provider
-      try_provider_ctx ?per_provider_timeout_s candidate
+  (* Sequential candidate attempt loop. On failure we record a manifest row and
+     move to the next candidate; on success we record completion and return.
+     All candidates exhausted yields a typed lane-exhausted error. *)
+  let rec attempt_candidates idx = function
+    | [] ->
+      Error
+        (Agent_sdk.Error.Internal
+           (Printf.sprintf "runtime lane %S exhausted all candidates" runtime_id))
+    | runtime :: rest ->
+      let attempt_runtime_id = runtime.Runtime.id in
+      emit_runtime_manifest
+        ~status:"attempt"
+        ~decision:(`Assoc [ ("idx", `Int idx) ])
+        Keeper_runtime_manifest.Runtime_routed;
+      let error_runtime_id = attempt_runtime_id in
+      let* provider_config =
+        match provider_config_transform with
+        | None -> Ok runtime.Runtime.provider_config
+        | Some transform -> transform runtime.Runtime.provider_config
+      in
+      let candidate =
+        Runtime_candidate.of_provider_config
+          ~max_concurrent:runtime.Runtime.binding.max_concurrent
+          provider_config
+      in
+      let name = Printf.sprintf "oas-%s" attempt_runtime_id in
+      let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
+        { runtime_id = attempt_runtime_id
+        ; error_runtime_id
+        ; base_path
+        ; keeper_name
+        ; name
+        ; goal
+        ; goal_blocks
+        ; priority
+        ; session_id
+        ; system_prompt
+        ; tools
+        ; initial_messages
+        ; max_turns
+        ; max_idle_turns
+        ; stream_idle_timeout_s
+        ; execution_idle_timeout_s
+        ; body_timeout_s
+        ; temperature
+        ; max_tokens
+        ; accept
+        ; guardrails
+        ; hooks
+        ; context_reducer
+        ; raw_trace
+        ; transport_resolved
+        ; runtime_mcp_policy
+        ; allowed_paths
+        ; checkpoint_sidecar
+        ; cache_system_prompt
+        ; yield_on_tool
+        ; compact_ratio
+        ; oas_auto_context_overflow_retry
+        ; checkpoint_dir
+        ; context_injector
+        ; context
+        ; enable_thinking
+        ; preserve_thinking
+        ; approval
+        ; exit_condition
+        ; exit_condition_result
+        ; summarizer
+        ; oas_checkpoint
+        ; trace_link
+        ; sw
+        ; net
+        ; on_event
+        ; on_yield
+        ; on_resume
+        ; agent_ref
+        ; on_runtime_observation
+        ; event_bus
+        ; runtime_manifest_context
+        ; runtime_manifest_append
+        ; turn_start
+        ; seq_ref
+        }
+      in
+      let result, _checkpoint, _success_sample =
+        Keeper_turn_driver_try_provider.run_try_provider
+          try_provider_ctx ?per_provider_timeout_s candidate
+      in
+      (match result with
+       | Ok _ as ok ->
+         emit_runtime_manifest
+           ~status:"completed"
+           ~decision:(`Assoc [ ("idx", `Int idx) ])
+           Keeper_runtime_manifest.Runtime_completed;
+         ok
+       | Error e ->
+         emit_runtime_manifest
+           ~status:"failed"
+           ~decision:
+             (`Assoc
+                [ ("idx", `Int idx)
+                ; ("error_kind", `String (Oas_compat.error_kind e))
+                ])
+           Keeper_runtime_manifest.Runtime_failed;
+         attempt_candidates (idx + 1) rest)
   in
-  result
+  attempt_candidates 0 attempt_runtimes
 
 
 module For_testing = struct

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -116,6 +116,26 @@ let attempt_runtime_candidates ~runtime_id ~runtime_id_of
   in
   loop 0 candidates
 
+let runtime_candidate_missing_error id =
+  Agent_sdk.Error.Internal
+    (Printf.sprintf
+       "keeper_turn_driver: lane candidate %S disappeared from runtimes"
+       id)
+
+let resolve_runtime_candidate id =
+  match Runtime.get_runtime_by_id id with
+  | Some runtime -> Ok runtime
+  | None -> Error (runtime_candidate_missing_error id)
+
+let resolve_runtime_candidates ids =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | id :: rest ->
+      let* runtime = resolve_runtime_candidate id in
+      loop (runtime :: acc) rest
+  in
+  loop [] ids
+
 let run_named
     ~runtime_id
     ?(keeper_name = "")
@@ -172,11 +192,8 @@ let run_named
   match require_eio ?sw ?net () with
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
-  (* Lane-aware dispatch (PR-A provider failover).  The requested runtime id
-     resolves to either a single runtime or an ordered runtime lane.  Lanes
-     provide sequential failover: each candidate is attempted in order, and a
-     manifest row is emitted per attempt.  A failed turn is the result of
-     exhausting all candidates, never of a single provider hiccup. *)
+  (* Lane-aware dispatch: resolve a runtime id or ordered failover lane, then
+     attempt candidates sequentially with manifest evidence per attempt. *)
   let runtime_id = String.trim runtime_id in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~base_path ~keeper_name tools in
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
@@ -186,10 +203,8 @@ let run_named
     | None -> enable_thinking
   in
   let preserve_thinking = runtime_seed.preserve_thinking in
-  (* Audit F8: the former [?provider_filter] / [?base_path] /
-     [?wait_timeout_sec] parameters only fed the deleted multi-candidate
-     machinery and were silently ignored here; they are removed from the
-     signature so callers cannot pass dead routing knobs. *)
+  (* Audit F8: removed dead routing knobs from the signature so callers cannot
+     pass values that would be silently ignored. *)
   let turn_start = Mtime_clock.now () in
   let seq_ref = ref 0 in
   let emit_runtime_manifest ?status ?decision event =
@@ -227,11 +242,8 @@ let run_named
       |> append
     | _ -> ()
   in
-  (* RFC-0207 / RFC-0206: resolve the requested assignment to either a single
-     runtime or an ordered runtime lane. Lanes shadow runtimes: a lane id takes
-     precedence so operators can route through explicit failover groups. A
-     requested id that names neither is a config/validation bug — fail-fast
-     rather than silently substituting the default (RFC-0206 §2.1). *)
+  (* Lanes shadow runtimes: a lane id takes precedence over a runtime id so
+     operators can route through explicit failover groups. *)
   let lane_resolution = Runtime.resolve_assignment runtime_id in
   let lane_candidate_ids =
     match lane_resolution with
@@ -247,16 +259,12 @@ let run_named
             "requested runtime or lane %S not found among configured runtimes"
             runtime_id))
   else
-  (* RFC-0265: proactively reroute a turn whose active input modality exceeds
-     the first candidate's capabilities. The reroute is applied to the first
-     candidate only; subsequent lane candidates are attempted as declared. The
-     active input includes both the current goal and prior [initial_messages]. *)
+  (* RFC-0265: reroute when active input modality exceeds the first candidate's
+     capabilities; later lane candidates remain in declared order. *)
   let current_goal_blocks =
     match goal_blocks with
     | Some blocks -> blocks
     | None ->
-      (* A missing current block payload means the current keeper goal is
-         text-only; [initial_messages] still participate in reroute below. *)
       []
   in
   let checkpoint_messages =
@@ -264,18 +272,12 @@ let run_named
     | None -> []
     | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
   in
-  let first_candidate_id = List.hd lane_candidate_ids in
-  let first_candidate =
-    match Runtime.get_runtime_by_id first_candidate_id with
-    | Some rt -> rt
-    | None ->
-      (* [resolve_assignment] validated ids against loaded runtimes; a missing
-         id here indicates a race with config reload. Fail fast. *)
-      failwith
-        (Printf.sprintf
-           "keeper_turn_driver: resolved candidate %S disappeared from runtimes"
-           first_candidate_id)
+  let first_candidate_id, remaining_candidate_ids =
+    match lane_candidate_ids with
+    | first :: rest -> first, rest
+    | [] -> runtime_id, []
   in
+  let* first_candidate = resolve_runtime_candidate first_candidate_id in
   let reroute_decision =
     Runtime_agent.decide_modality_reroute_for_runtime
       ~assigned:first_candidate
@@ -299,23 +301,8 @@ let run_named
            reason;
          to_runtime_id, rerouted)
   in
-  (* Build ordered attempt list: rerouted first candidate, then remaining lane
-     candidates. This preserves the lane order while honoring the capability
-     override for the first attempt. *)
-  let attempt_runtimes =
-    let resolve_runtime id =
-      match Runtime.get_runtime_by_id id with
-      | Some rt -> rt
-      | None ->
-        failwith
-          (Printf.sprintf
-             "keeper_turn_driver: lane candidate %S disappeared from runtimes"
-             id)
-    in
-    match lane_candidate_ids with
-    | [] -> [ first_runtime ]
-    | _ :: rest -> first_runtime :: List.map resolve_runtime rest
-  in
+  let* remaining_runtimes = resolve_runtime_candidates remaining_candidate_ids in
+  let attempt_runtimes = first_runtime :: remaining_runtimes in
   (* RFC-0265 follow-up — graceful media degrade floor. When no configured
      runtime can accept the turn's input modality ([No_capable_runtime]), strip
      the unsupported media blocks from the goal, prior [initial_messages], and

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -81,40 +81,65 @@ let runtime_failed_decision ~idx ~runtime_id error =
       ("error_kind", `String (Oas_compat.error_kind error));
     ]
 
+let lane_retry_checkpoint ~is_last ~resume_checkpoint ~checkpoint_after error =
+  if is_last then
+    None
+  else if Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next error
+  then
+    Some
+      (Keeper_turn_driver_try_runtime.checkpoint_for_accept_rejected_retry
+         ~resume_checkpoint
+         ~checkpoint_after
+         error)
+  else
+    match Keeper_turn_driver_try_runtime.sdk_error_to_http_error error with
+    | Some http_err when Runtime_attempt_fsm.should_try_next http_err ->
+      Some checkpoint_after
+    | _ -> None
+
 let attempt_runtime_candidates ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
        ?decision:Yojson.Safe.t ->
        Keeper_runtime_manifest.event_kind ->
        unit) ~run_attempt candidates =
-  let rec loop idx = function
+  let rec loop idx resume_checkpoint = function
     | [] ->
       Error
         (Agent_sdk.Error.Internal
            (Printf.sprintf "runtime lane %S exhausted all candidates" runtime_id))
     | candidate :: rest ->
+      let is_last = rest = [] in
       let attempt_runtime_id = runtime_id_of candidate in
       emit_runtime_manifest
         ~status:"attempt"
         ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
         Keeper_runtime_manifest.Runtime_routed;
-      (match run_attempt ~idx ~runtime_id:attempt_runtime_id candidate with
-       | Ok _ as ok ->
+      (match
+         run_attempt ?resume_checkpoint ~idx ~runtime_id:attempt_runtime_id candidate
+       with
+       | Ok value, _checkpoint_after ->
          emit_runtime_manifest
            ~status:"completed"
            ~decision:(runtime_attempt_decision ~idx ~runtime_id:attempt_runtime_id)
            Keeper_runtime_manifest.Runtime_completed;
-         ok
-       | Error error ->
+         Ok value
+       | Error error, checkpoint_after ->
          emit_runtime_manifest
            ~status:"failed"
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
-         (match rest with
-          | [] -> Error error
-          | _ :: _ -> loop (idx + 1) rest))
+         (match
+            lane_retry_checkpoint
+              ~is_last
+              ~resume_checkpoint
+              ~checkpoint_after
+              error
+          with
+          | Some retry_checkpoint -> loop (idx + 1) retry_checkpoint rest
+          | None -> Error error))
   in
-  loop 0 candidates
+  loop 0 None candidates
 
 let runtime_candidate_missing_error id =
   Agent_sdk.Error.Internal
@@ -135,6 +160,27 @@ let resolve_runtime_candidates ids =
       loop (runtime :: acc) rest
   in
   loop [] ids
+
+let dedupe_runtimes_preserve_order runtimes =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | runtime :: rest ->
+      let runtime_id = runtime.Runtime.id in
+      if List.exists (String.equal runtime_id) seen then
+        loop seen acc rest
+      else
+        loop (runtime_id :: seen) (runtime :: acc) rest
+  in
+  loop [] [] runtimes
+
+let lane_modality_reroute_decision ~checkpoint_messages ~initial_messages
+    ~goal_blocks ~first_candidate ~remaining_runtimes =
+  Runtime_agent.decide_modality_reroute_for_runtime_candidates
+    ~assigned:first_candidate
+    ~candidates:remaining_runtimes
+    ~checkpoint_messages
+    ~initial_messages
+    goal_blocks
 
 let first_runtime_after_modality_reroute ~keeper_name ~assignment_id
     ~first_candidate_id ~first_candidate = function
@@ -294,19 +340,22 @@ let run_named
     | [] -> runtime_id, []
   in
   let* first_candidate = resolve_runtime_candidate first_candidate_id in
+  let* remaining_runtimes = resolve_runtime_candidates remaining_candidate_ids in
   let reroute_decision =
-    Runtime_agent.decide_modality_reroute_for_runtime
-      ~assigned:first_candidate
+    lane_modality_reroute_decision
       ~checkpoint_messages
       ~initial_messages
-      current_goal_blocks
+      ~goal_blocks:current_goal_blocks
+      ~first_candidate
+      ~remaining_runtimes
   in
   let first_runtime_id, first_runtime =
     first_runtime_after_modality_reroute ~keeper_name ~assignment_id:runtime_id
       ~first_candidate_id ~first_candidate reroute_decision
   in
-  let* remaining_runtimes = resolve_runtime_candidates remaining_candidate_ids in
-  let attempt_runtimes = first_runtime :: remaining_runtimes in
+  let attempt_runtimes =
+    dedupe_runtimes_preserve_order (first_runtime :: remaining_runtimes)
+  in
   (* RFC-0265 follow-up — graceful media degrade floor. When no configured
      runtime can accept the turn's input modality ([No_capable_runtime]), strip
      the unsupported media blocks from the goal, prior [initial_messages], and
@@ -380,82 +429,84 @@ let run_named
   attempt_runtime_candidates ~runtime_id
     ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
     ~emit_runtime_manifest
-    ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
+    ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
       let error_runtime_id = attempt_runtime_id in
-      let* provider_config =
+      match
         match provider_config_transform with
         | None -> Ok runtime.Runtime.provider_config
         | Some transform -> transform runtime.Runtime.provider_config
-      in
-      let candidate =
-        Runtime_candidate.of_provider_config
-          ~max_concurrent:runtime.Runtime.binding.max_concurrent
-          provider_config
-      in
-      let name = Printf.sprintf "oas-%s" attempt_runtime_id in
-      let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
-        { runtime_id = attempt_runtime_id
-        ; error_runtime_id
-        ; base_path
-        ; keeper_name
-        ; name
-        ; goal
-        ; goal_blocks
-        ; priority
-        ; session_id
-        ; system_prompt
-        ; tools
-        ; initial_messages
-        ; max_turns
-        ; max_idle_turns
-        ; stream_idle_timeout_s
-        ; execution_idle_timeout_s
-        ; body_timeout_s
-        ; temperature
-        ; max_tokens
-        ; accept
-        ; guardrails
-        ; hooks
-        ; context_reducer
-        ; raw_trace
-        ; transport_resolved
-        ; runtime_mcp_policy
-        ; allowed_paths
-        ; checkpoint_sidecar
-        ; cache_system_prompt
-        ; yield_on_tool
-        ; compact_ratio
-        ; oas_auto_context_overflow_retry
-        ; checkpoint_dir
-        ; context_injector
-        ; context
-        ; enable_thinking
-        ; preserve_thinking
-        ; approval
-        ; exit_condition
-        ; exit_condition_result
-        ; summarizer
-        ; oas_checkpoint
-        ; trace_link
-        ; sw
-        ; net
-        ; on_event
-        ; on_yield
-        ; on_resume
-        ; agent_ref
-        ; on_runtime_observation
-        ; event_bus
-        ; runtime_manifest_context
-        ; runtime_manifest_append
-        ; turn_start
-        ; seq_ref
-        }
-      in
-      let result, _checkpoint, _success_sample =
-        Keeper_turn_driver_try_provider.run_try_provider
-          try_provider_ctx ?per_provider_timeout_s candidate
-      in
-      result)
+      with
+      | Error err -> Error err, None
+      | Ok provider_config ->
+        let candidate =
+          Runtime_candidate.of_provider_config
+            ~max_concurrent:runtime.Runtime.binding.max_concurrent
+            provider_config
+        in
+        let name = Printf.sprintf "oas-%s" attempt_runtime_id in
+        let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
+          { runtime_id = attempt_runtime_id
+          ; error_runtime_id
+          ; base_path
+          ; keeper_name
+          ; name
+          ; goal
+          ; goal_blocks
+          ; priority
+          ; session_id
+          ; system_prompt
+          ; tools
+          ; initial_messages
+          ; max_turns
+          ; max_idle_turns
+          ; stream_idle_timeout_s
+          ; execution_idle_timeout_s
+          ; body_timeout_s
+          ; temperature
+          ; max_tokens
+          ; accept
+          ; guardrails
+          ; hooks
+          ; context_reducer
+          ; raw_trace
+          ; transport_resolved
+          ; runtime_mcp_policy
+          ; allowed_paths
+          ; checkpoint_sidecar
+          ; cache_system_prompt
+          ; yield_on_tool
+          ; compact_ratio
+          ; oas_auto_context_overflow_retry
+          ; checkpoint_dir
+          ; context_injector
+          ; context
+          ; enable_thinking
+          ; preserve_thinking
+          ; approval
+          ; exit_condition
+          ; exit_condition_result
+          ; summarizer
+          ; oas_checkpoint
+          ; trace_link
+          ; sw
+          ; net
+          ; on_event
+          ; on_yield
+          ; on_resume
+          ; agent_ref
+          ; on_runtime_observation
+          ; event_bus
+          ; runtime_manifest_context
+          ; runtime_manifest_append
+          ; turn_start
+          ; seq_ref
+          }
+        in
+        let result, checkpoint_after, _success_sample =
+          Keeper_turn_driver_try_provider.run_try_provider
+            try_provider_ctx ?resume_checkpoint ?per_provider_timeout_s candidate
+        in
+        result, checkpoint_after)
     attempt_runtimes
 
 
@@ -478,6 +529,8 @@ module For_testing = struct
   let first_runtime_after_modality_reroute =
     first_runtime_after_modality_reroute
 
+  let lane_modality_reroute_decision = lane_modality_reroute_decision
+  let dedupe_runtimes_preserve_order = dedupe_runtimes_preserve_order
   let media_degrade_manifest_decision = media_degrade_manifest_decision
   let attempt_runtime_candidates = attempt_runtime_candidates
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -209,6 +209,7 @@ let attempt_inference_policy
     ~runtime_id
     ~fallback_enable_thinking
     ~fallback_max_tokens
+    ()
   =
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
   let attempt_enable_thinking =
@@ -458,8 +459,9 @@ let run_named
           ?max_tokens_for_runtime
           ~runtime_id:attempt_runtime_id
           ~fallback_enable_thinking:enable_thinking
-	          ~fallback_max_tokens:max_tokens
-	      in
+          ~fallback_max_tokens:max_tokens
+          ()
+      in
 	      match
 	        match provider_config_transform with
 	        | None -> Ok runtime.Runtime.provider_config

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -183,6 +183,14 @@ module For_testing : sig
     Llm_provider.Http_client.http_error ->
     Agent_sdk.Error.sdk_error
 
+  val first_runtime_after_modality_reroute :
+    keeper_name:string ->
+    assignment_id:string ->
+    first_candidate_id:string ->
+    first_candidate:Runtime.t ->
+    Runtime_agent.reroute_decision ->
+    string * Runtime.t
+
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -186,6 +186,22 @@ module For_testing : sig
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
 
+  val attempt_runtime_candidates :
+    runtime_id:string ->
+    runtime_id_of:('candidate -> string) ->
+    emit_runtime_manifest:
+      (?status:string ->
+      ?decision:Yojson.Safe.t ->
+      Keeper_runtime_manifest.event_kind ->
+      unit) ->
+    run_attempt:
+      (idx:int ->
+      runtime_id:string ->
+      'candidate ->
+      ('result, Agent_sdk.Error.sdk_error) result) ->
+    'candidate list ->
+    ('result, Agent_sdk.Error.sdk_error) result
+
   val accept_no_progress_should_try_next : Agent_sdk.Error.sdk_error -> bool
 
   val accept_no_progress_read_only_should_try_next :

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -110,6 +110,7 @@ val run_named :
   ?body_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
+  ?max_tokens_for_runtime:(runtime_id:string -> int) ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
@@ -152,6 +153,12 @@ val run_named :
     MASC drives the runtime FSM directly: resolves runtime providers,
     tries each with OAS, and uses [Runtime_fsm.decide] on failure.
     The runtime loop runs inside a capacity-managed queue permit. *)
+
+type attempt_inference_policy =
+  { attempt_enable_thinking : bool option
+  ; attempt_preserve_thinking : bool option
+  ; attempt_max_tokens : int
+  }
 
 module For_testing : sig
   val checkpoint_after_attempt :
@@ -203,6 +210,13 @@ module For_testing : sig
 
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
+
+  val attempt_inference_policy :
+    ?max_tokens_for_runtime:(runtime_id:string -> int) ->
+    runtime_id:string ->
+    fallback_enable_thinking:bool option ->
+    fallback_max_tokens:int ->
+    attempt_inference_policy
 
   val attempt_runtime_candidates :
     runtime_id:string ->

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -216,6 +216,7 @@ module For_testing : sig
     runtime_id:string ->
     fallback_enable_thinking:bool option ->
     fallback_max_tokens:int ->
+    unit ->
     attempt_inference_policy
 
   val attempt_runtime_candidates :

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -191,6 +191,16 @@ module For_testing : sig
     Runtime_agent.reroute_decision ->
     string * Runtime.t
 
+  val lane_modality_reroute_decision :
+    checkpoint_messages:Agent_sdk.Types.message list ->
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    first_candidate:Runtime.t ->
+    remaining_runtimes:Runtime.t list ->
+    Runtime_agent.reroute_decision
+
+  val dedupe_runtimes_preserve_order : Runtime.t list -> Runtime.t list
+
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
 
@@ -203,10 +213,11 @@ module For_testing : sig
       Keeper_runtime_manifest.event_kind ->
       unit) ->
     run_attempt:
-      (idx:int ->
+      (?resume_checkpoint:Agent_sdk.Checkpoint.t ->
+      idx:int ->
       runtime_id:string ->
       'candidate ->
-      ('result, Agent_sdk.Error.sdk_error) result) ->
+      ('result, Agent_sdk.Error.sdk_error) result * Agent_sdk.Checkpoint.t option) ->
     'candidate list ->
     ('result, Agent_sdk.Error.sdk_error) result
 

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -9,6 +9,8 @@ type event_kind =
   | Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_completed
+  | Runtime_failed
   | Pre_dispatch_blocked
   | Provider_lane_resolved
   | Provider_attempt_started
@@ -28,6 +30,8 @@ let all_event_kinds =
     Turn_started;
     Phase_gate_decided;
     Runtime_routed;
+    Runtime_completed;
+    Runtime_failed;
     Pre_dispatch_blocked;
     Provider_lane_resolved;
     Provider_attempt_started;
@@ -47,6 +51,8 @@ let event_kind_to_string = function
   | Turn_started -> "turn_started"
   | Phase_gate_decided -> "phase_gate_decided"
   | Runtime_routed -> "runtime_routed"
+  | Runtime_completed -> "runtime_completed"
+  | Runtime_failed -> "runtime_failed"
   | Pre_dispatch_blocked -> "pre_dispatch_blocked"
   | Provider_lane_resolved -> "provider_lane_resolved"
   | Provider_attempt_started -> "provider_attempt_started"
@@ -65,6 +71,8 @@ let event_kind_of_string = function
   | "turn_started" -> Some Turn_started
   | "phase_gate_decided" -> Some Phase_gate_decided
   | "runtime_routed" -> Some Runtime_routed
+  | "runtime_completed" -> Some Runtime_completed
+  | "runtime_failed" -> Some Runtime_failed
   | "pre_dispatch_blocked" -> Some Pre_dispatch_blocked
   | "provider_lane_resolved" -> Some Provider_lane_resolved
   | "provider_attempt_started" -> Some Provider_attempt_started
@@ -105,6 +113,8 @@ let classify_compaction_snapshot_typed_event = function
   | Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_completed
+  | Runtime_failed
   | Pre_dispatch_blocked
   | Provider_lane_resolved
   | Provider_attempt_started

--- a/lib/keeper_registry/keeper_runtime_manifest_types.mli
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.mli
@@ -2,6 +2,8 @@ type event_kind =
     Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_completed
+  | Runtime_failed
   | Pre_dispatch_blocked
   | Provider_lane_resolved
   | Provider_attempt_started

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -1,0 +1,21 @@
+(** MASC-side OAS compatibility projections.
+
+    OAS owns provider/model identity and error detail. This module exposes only
+    non-identifying, lane-scoped classifications that MASC is allowed to use for
+    routing and observability. It never unwraps OAS-private error payloads. *)
+
+(** Classify an OAS sdk_error into a non-identifying kind string suitable for
+    runtime lane manifest logging. The mapping is structural over the public
+    [Agent_sdk.Error.sdk_error] variant only. *)
+let error_kind (e : Agent_sdk.Error.sdk_error) =
+  match e with
+  | Agent_sdk.Error.Api _ -> "api"
+  | Agent_sdk.Error.Provider _ -> "provider"
+  | Agent_sdk.Error.Agent _ -> "agent"
+  | Agent_sdk.Error.Mcp _ -> "mcp"
+  | Agent_sdk.Error.Config _ -> "config"
+  | Agent_sdk.Error.Serialization _ -> "serialization"
+  | Agent_sdk.Error.Io _ -> "io"
+  | Agent_sdk.Error.Orchestration _ -> "orchestration"
+  | Agent_sdk.Error.Internal _ -> "internal"
+;;

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -1,0 +1,8 @@
+(** MASC-side OAS compatibility projections.
+
+    OAS owns provider/model identity and error detail. This module exposes only
+    non-identifying, lane-scoped classifications that MASC is allowed to use for
+    routing and observability. It never unwraps OAS-private error payloads. *)
+
+val error_kind : Agent_sdk.Error.sdk_error -> string
+(** Non-identifying error kind for runtime lane manifest logging. *)

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -173,6 +173,49 @@ let validate_media_failover ~(config_path : string) (runtimes : t list)
          (List.length runtimes))
 ;;
 
+(* [runtime.lanes.<id>] candidate ids must resolve to configured runtimes.
+   Empty candidate lists are rejected at parse time; here we reject unknown ids
+   as operator typos (mirrors [runtime].default validation). *)
+let validate_lanes ~(config_path : string) (runtimes : t list)
+    (lane_decls : Runtime_schema.lane_decl list)
+  : (unit, string) result
+  =
+  let runtime_exists id =
+    List.exists (fun (r : t) -> String.equal r.id id) runtimes
+  in
+  let rec first_unknown = function
+    | [] -> None
+    | { Runtime_schema.id = lane_id; candidate_ids; _ } :: rest ->
+      (match List.find_opt (fun id -> not (runtime_exists id)) candidate_ids with
+       | Some id -> Some (lane_id, id)
+       | None -> first_unknown rest)
+  in
+  match first_unknown lane_decls with
+  | None -> Ok ()
+  | Some (lane_id, id) ->
+    Error
+      (Printf.sprintf
+         "%s: [runtime.lanes.%s] candidate %S not found among %d runtimes"
+         config_path
+         lane_id
+         id
+         (List.length runtimes))
+;;
+
+let lanes_of_decls ~(config_path : string) (runtimes : t list)
+    (lane_decls : Runtime_schema.lane_decl list)
+  : (Runtime_lane.t list, string) result
+  =
+  let* () = validate_lanes ~config_path runtimes lane_decls in
+  Ok
+    (List.map
+       (fun ({ Runtime_schema.id; strategy; candidate_ids } : Runtime_schema.lane_decl) ->
+          match strategy with
+          | Runtime_schema.Ordered ->
+            Runtime_lane.make ~id ~strategy:Runtime_lane.Ordered candidate_ids)
+       lane_decls)
+;;
+
 (* Pure decision for the capability gate, separated from the global OAS catalog
    lookup so it is unit-testable. [entries] is [(label, known_to_oas)] per runtime.
 
@@ -294,6 +337,7 @@ let materialize_config ~(config_path : string) (cfg : config)
       * string option
       * string option
       * string list
+      * Runtime_lane.t list
     , string )
     result
   =
@@ -333,6 +377,7 @@ let materialize_config ~(config_path : string) (cfg : config)
   let* () =
     validate_media_failover ~config_path runtimes cfg.media_failover
   in
+  let* lanes = lanes_of_decls ~config_path runtimes cfg.lane_decls in
   (* The OAS catalog membership gate is intentionally not called here:
      [load_list] stays a routing-validity parser for tests and config probes.
      Production startup applies the stricter gate via [init_default_strict]. *)
@@ -343,7 +388,8 @@ let materialize_config ~(config_path : string) (cfg : config)
     , cfg.librarian_runtime_id
     , cfg.structured_judge_runtime_id
     , cfg.cross_verifier_runtime_id
-    , cfg.media_failover )
+    , cfg.media_failover
+    , lanes )
 ;;
 
 let load_list ~(config_path : string)
@@ -354,6 +400,7 @@ let load_list ~(config_path : string)
        * string option
        * string option
        * string list
+       * Runtime_lane.t list
     , string )
     result
   =
@@ -381,6 +428,7 @@ type loaded_state =
   ; structured_judge_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
+  ; lanes : Runtime_lane.t list
   ; config_path : string option
   }
 
@@ -392,6 +440,7 @@ let empty_loaded_state =
   ; structured_judge_runtime_id = None
   ; cross_verifier_runtime_id = None
   ; media_failover = []
+  ; lanes = []
   ; config_path = None
   }
 
@@ -407,7 +456,8 @@ let set_loaded
     , librarian_id
     , structured_judge_id
     , cross_verifier_id
-    , media_failover ) =
+    , media_failover
+    , lanes ) =
   Atomic.set loaded_state_ref
     { default_runtime = Some rt
     ; runtimes
@@ -416,6 +466,7 @@ let set_loaded
     ; structured_judge_runtime_id = structured_judge_id
     ; cross_verifier_runtime_id = cross_verifier_id
     ; media_failover
+    ; lanes
     ; config_path = Some config_path
     }
 
@@ -432,7 +483,7 @@ let init_default ~config_path =
 let init_default_strict_report ~config_path =
   match load_list ~config_path with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok ((runtimes, _, _, _, _, _, _) as loaded) ->
+  | Ok ((runtimes, _, _, _, _, _, _, _) as loaded) ->
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | Some report -> Error (Missing_catalog_models report)
      | None ->
@@ -509,6 +560,15 @@ let cross_verifier_runtime_id () = (runtime_state ()).cross_verifier_runtime_id
    Atomic ref set by [init_default]. *)
 let media_failover () = (runtime_state ()).media_failover
 
+(* [runtime.lanes.<id>] ordered failover candidate lists. Reads the Atomic ref
+   set by [init_default]. *)
+let lanes () = (runtime_state ()).lanes
+
+let get_lane_by_id (id : string) : Runtime_lane.t option =
+  List.find_opt (fun (lane : Runtime_lane.t) -> String.equal lane.id id)
+    (runtime_state ()).lanes
+;;
+
 (* RFC-0207: resolve a runtime by its binding-key id ["provider.model"].  The
    keeper turn driver dispatches to the *requested* runtime (a keeper's persona
    [model] selection or the default) instead of unconditionally the default; an
@@ -516,6 +576,19 @@ let media_failover () = (runtime_state ()).media_failover
    RFC-0206 §2.1).  Reads [runtimes_ref], never a module-level eager binding. *)
 let get_runtime_by_id (id : string) : t option =
   List.find_opt (fun (rt : t) -> String.equal rt.id id) (runtime_state ()).runtimes
+;;
+
+(* Resolve a keeper assignment to either a lane or a single runtime. Lanes are
+   preferred so a lane id can shadow a runtime id (lanes are explicit operator
+   routing constructs). [Missing] means the assignment does not name a known
+   lane or runtime. *)
+let resolve_assignment (assigned_id : string) =
+  match get_lane_by_id assigned_id with
+  | Some lane -> `Lane lane
+  | None ->
+    (match get_runtime_by_id assigned_id with
+     | Some runtime -> `Single_runtime runtime
+     | None -> `Missing)
 ;;
 
 let max_context_of_runtime_id (id : string) : int option =
@@ -1007,7 +1080,8 @@ let validate_runtime_config_text ~config_path content =
            * string option
            * string option
            * string option
-           * string list) =
+           * string list
+           * Runtime_lane.t list) =
     materialize_config ~config_path cfg
   in
   Ok ()

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -59,19 +59,21 @@ val load_list :
        * string option
        * string option
        * string list
+       * Runtime_lane.t list
      , string )
      result
 (** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
     keeper_assignments, librarian_runtime_id, structured_judge_runtime_id,
-    cross_verifier_runtime_id, media_failover)]. Fails ([Error]) if
+    cross_verifier_runtime_id, media_failover, lanes)]. Fails ([Error]) if
     [\[runtime\].default] is missing / unresolved, if any
     [\[runtime.assignments\]] target does not resolve to a configured runtime, if
     [\[runtime\].librarian] / [\[runtime\].structured_judge] /
-    [\[runtime\].cross_verifier] is set to an unresolved id, or if any
-    [\[runtime\].media_failover] entry does not resolve (mirrors default
+    [\[runtime\].cross_verifier] is set to an unresolved id, if any
+    [\[runtime\].media_failover] entry does not resolve, or if any
+    [\[runtime.lanes.<id>\]] candidate does not resolve (mirrors default
     validation — no silent fallback for a typo'd id). [keeper_assignments] is the
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
-    list. *)
+    list; [lanes] is the ordered failover candidate lists. *)
 
 val runtime_ids : t list -> string list
 
@@ -158,6 +160,19 @@ val media_failover : unit -> string list
     the turn reroutes to the first that admits it. [[]] = derive capable runtimes
     from declared [\[models.*.capabilities\]] in declaration order. Every entry is
     validated at load so each resolves to a configured runtime. *)
+
+val lanes : unit -> Runtime_lane.t list
+(** [\[runtime.lanes.<id>\]] ordered failover candidate lists. Each lane carries
+    an ordered list of runtime ids validated at load. *)
+
+val get_lane_by_id : string -> Runtime_lane.t option
+(** Lane with the given id, or [None] if no such lane is configured. *)
+
+val resolve_assignment :
+  string -> [ `Lane of Runtime_lane.t | `Single_runtime of t | `Missing ]
+(** Resolve a keeper assignment id to either a lane or a single runtime. Lanes
+    shadow runtimes. [Missing] means the id does not name a known lane or
+    runtime. *)
 
 val pause_threshold : unit -> pause_threshold
 (** [\[pause\]] threshold knobs from runtime.toml, or

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -776,6 +776,23 @@ let decide_modality_reroute_for_runtime ~(assigned : Runtime.t)
          ~goal_blocks:blocks)
     ~candidates:(media_reroute_candidates ~exclude:assigned.Runtime.id)
 
+let decide_modality_reroute_for_runtime_candidates ~(assigned : Runtime.t)
+    ~(candidates : Runtime.t list)
+    ?(checkpoint_messages = [])
+    ?(initial_messages = [])
+    (blocks : Agent_sdk.Types.content_block list) : reroute_decision =
+  decide_modality_reroute
+    ~assigned_caps:(input_capabilities_of_runtime assigned)
+    ~required_modalities:
+      (required_modalities_for_run_with_checkpoint ~checkpoint_messages
+         ~initial_messages ~goal_blocks:blocks)
+    ~candidates:
+      (candidates
+       |> List.filter (fun (runtime : Runtime.t) ->
+         not (String.equal runtime.Runtime.id assigned.Runtime.id))
+       |> List.map (fun (runtime : Runtime.t) ->
+         runtime.Runtime.id, input_capabilities_of_runtime runtime))
+
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -261,6 +261,17 @@ val decide_modality_reroute_for_runtime :
     content blocks. Composes [input_capabilities_of_runtime] /
     [media_reroute_candidates] / [decide_modality_reroute]. *)
 
+val decide_modality_reroute_for_runtime_candidates :
+  assigned:Runtime.t ->
+  candidates:Runtime.t list ->
+  ?checkpoint_messages:Agent_sdk.Types.message list ->
+  ?initial_messages:Agent_sdk.Types.message list ->
+  Agent_sdk.Types.content_block list ->
+  reroute_decision
+(** Keeper-dispatch variant for scoped candidate sets such as explicit runtime
+    lanes. It preserves the caller-provided candidate order and does not consult
+    global [runtime.media_failover]. *)
+
 val strip_unsupported_modality_blocks :
   Llm_provider.Capabilities.capabilities ->
   Agent_sdk.Types.content_block list ->

--- a/lib/runtime/runtime_lane.ml
+++ b/lib/runtime/runtime_lane.ml
@@ -1,0 +1,23 @@
+(** Runtime lane — ordered list of candidate runtime ids for keeper turn routing.
+
+    A lane is an opaque routing label (the lane id) plus an ordered candidate
+    list of runtime ids.  When a keeper assignment resolves to a lane, the
+    keeper turn driver resolves each id to a materialized {!Runtime.t} and
+    attempts them sequentially until one succeeds or the lane is exhausted.
+    Keeping ids here breaks the [Runtime <-> Runtime_lane] module cycle.
+
+    Only the [Ordered] strategy is implemented today; the type is extensible
+    for future health/capacity strategies. *)
+
+type strategy = Ordered
+
+type t =
+  { id : string
+  ; strategy : strategy
+  ; candidates : string list
+  }
+
+let make ~id ~strategy candidates = { id; strategy; candidates }
+let id t = t.id
+let strategy t = t.strategy
+let ordered_candidates t = t.candidates

--- a/lib/runtime/runtime_lane.mli
+++ b/lib/runtime/runtime_lane.mli
@@ -1,0 +1,18 @@
+(** Runtime lane — ordered candidate list for keeper turn failover.
+
+    Candidates are opaque runtime ids ("provider.model" binding keys).  The
+    [Runtime] module resolves ids to materialized runtimes, keeping this module
+    free of the [Runtime] dependency cycle. *)
+
+type strategy = Ordered
+
+type t =
+  { id : string
+  ; strategy : strategy
+  ; candidates : string list
+  }
+
+val make : id:string -> strategy:strategy -> string list -> t
+val id : t -> string
+val strategy : t -> strategy
+val ordered_candidates : t -> string list

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -200,6 +200,22 @@ let pause_threshold_default =
   }
 ;;
 
+(** {1 Lanes}
+
+    Lanes are ordered failover candidate lists declared in [runtime.lanes.<id>].
+    The declaration carries opaque runtime ids; resolution to materialized
+    runtimes happens in [Runtime] so this module stays dependency-free. *)
+
+type lane_strategy = Ordered
+[@@deriving show, eq]
+
+type lane_decl =
+  { id : string
+  ; strategy : lane_strategy
+  ; candidate_ids : string list
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config}
 
     Routes/aliases/profiles/system_targets/strategy from the deleted
@@ -253,6 +269,10 @@ type config =
         [Pause_threshold.default]. Wrong-type value → load-time warn + fallback
         to default (fail-soft: wrong value is not catastrophic at boot).
         Operational callers read this through [Runtime.pause_threshold]. *)
+  ; lane_decls : lane_decl list
+    (** [\[runtime.lanes.<id>\]] — ordered failover candidate lists.
+        Declarations are resolved against materialized runtimes at load time;
+        an unknown candidate id is rejected like [\[runtime\].default]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -146,6 +146,22 @@ type pause_threshold =
 
 val pause_threshold_default : pause_threshold
 
+(** {1 Lanes}
+
+    Ordered failover candidate lists declared in [runtime.lanes.<id>].
+    Declarations carry opaque runtime ids; [Runtime] resolves them to
+    materialized runtimes at load time. *)
+
+type lane_strategy = Ordered
+[@@deriving show, eq]
+
+type lane_decl =
+  { id : string
+  ; strategy : lane_strategy
+  ; candidate_ids : string list
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config} *)
 
 type config =
@@ -191,6 +207,10 @@ type config =
   ; pause_threshold : pause_threshold
     (** [\[pause\]] — typed SSOT for keeper pause / regime threshold knobs.
         Missing or wrong-typed values fall back to [pause_threshold_default]. *)
+  ; lane_decls : lane_decl list
+    (** [\[runtime.lanes.<id>\]] — ordered failover candidate lists.
+        Declarations are resolved against materialized runtimes at load time;
+        an unknown candidate id is rejected like [\[runtime\].default]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -860,6 +860,9 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                 validation. It is still recognized here so a malformed scalar
                 does not get reported as an unknown key first. *)
              section, errs
+           | "lanes" ->
+             (* Parsed by [parse_lanes] after the runtime section is shaped. *)
+             section, errs
            | _ when is_toml_table value ->
              (* [runtime.<profile>] tables are reserved for runtime profiles and
                 intentionally ignored by this parser layer. *)
@@ -871,8 +874,8 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                    ("runtime." ^ key)
                    (Printf.sprintf
                       "unknown [runtime] key %S; expected default, librarian, \
-                       cross_verifier, media_failover, [runtime.assignments], or \
-                       a table-valued [runtime.<profile>]"
+                       cross_verifier, media_failover, [runtime.lanes], \
+                       [runtime.assignments], or a table-valued [runtime.<profile>]"
                       key) )
         )
         (empty_runtime_section, [])
@@ -882,12 +885,70 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
   | Some _ -> Error (error "runtime" "[runtime] must be a TOML table")
 ;;
 
+(* [\[runtime.lanes.<id>\]] — ordered failover candidate lists. Each lane is a
+   table with [strategy] (only "ordered" supported) and [candidates] (array of
+   runtime ids). Candidate ids are resolved against materialized runtimes at
+   load time, not here, so the parser returns declarations only. *)
+let parse_lane ~(id : string) (tbl : Otoml.t)
+  : (Runtime_schema.lane_decl, parse_error list) result
+  =
+  let path = Printf.sprintf "runtime.lanes.%s" id in
+  let strategy_result =
+    match Otoml.find_opt tbl Otoml.get_string [ "strategy" ] with
+    | None | Some "ordered" -> Ok Runtime_schema.Ordered
+    | Some other ->
+      Error
+        (error
+           (path ^ ".strategy")
+           (Printf.sprintf "unsupported lane strategy %S" other))
+  in
+  let candidate_ids_result =
+    match Otoml.find_opt tbl Fun.id [ "candidates" ] with
+    | None -> Error (error (path ^ ".candidates") "lane candidates is required")
+    | Some value ->
+      (try Ok (Otoml.get_array Otoml.get_string value) with
+       | Otoml.Type_error msg ->
+         Error
+           (error
+              (path ^ ".candidates")
+              (Printf.sprintf
+                 "lane candidates must be an array of string runtime ids; got %s"
+                 msg)))
+  in
+  match strategy_result, candidate_ids_result with
+  | Error e, _ | _, Error e -> Error e
+  | Ok strategy, Ok candidate_ids ->
+    if candidate_ids = []
+    then Error (error path "lane must have at least one candidate")
+    else Ok { Runtime_schema.id; strategy; candidate_ids }
+;;
+
+let parse_lanes (toml : Otoml.t) : (Runtime_schema.lane_decl list, parse_error list) result =
+  match Otoml.find_opt toml Fun.id [ "runtime"; "lanes" ] with
+  | None -> Ok []
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) ->
+    partition_results
+      (List.map
+         (fun (id, value) ->
+            match value with
+            | Otoml.TomlTable _ | Otoml.TomlInlineTable _ -> parse_lane ~id value
+            | _ ->
+              Error
+                (error
+                   (Printf.sprintf "runtime.lanes.%s" id)
+                   "lane must be a table"))
+         entries)
+  | Some _ ->
+    Error (error "runtime.lanes" "[runtime.lanes] must be a table of lane tables")
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
   let runtime_section_result = parse_runtime_section toml in
   let assignments_result = parse_keeper_assignments toml in
   let bindings_result = parse_bindings toml in
+  let lanes_result = parse_lanes toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs providers_result
@@ -895,6 +956,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     @ errs runtime_section_result
     @ errs assignments_result
     @ errs bindings_result
+    @ errs lanes_result
   in
   if all_errors <> []
   then Error all_errors
@@ -912,6 +974,9 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     let runtime_section =
       extract_after_all_errors_guard ~label:"runtime" runtime_section_result
     in
+    let lane_decls =
+      extract_after_all_errors_guard ~label:"lanes" lanes_result
+    in
     let pause_threshold = parse_pause_threshold toml in
     Ok
       { Runtime_schema.providers
@@ -924,6 +989,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; keeper_assignments
       ; media_failover = runtime_section.media_failover
       ; pause_threshold
+      ; lane_decls
       })
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -91,6 +91,8 @@ let event_started_at row =
   | Keeper_runtime_manifest.Event_bus_correlated
   | Keeper_runtime_manifest.Checkpoint_loaded ->
     Some row.Keeper_runtime_manifest.ts
+  | Keeper_runtime_manifest.Runtime_completed
+  | Keeper_runtime_manifest.Runtime_failed
   | Keeper_runtime_manifest.Provider_attempt_finished
   | Keeper_runtime_manifest.State_snapshot_sidecar_saved
   | Keeper_runtime_manifest.Working_state_sidecar_saved
@@ -102,6 +104,8 @@ let event_started_at row =
 
 let event_finished_at row =
   match row.Keeper_runtime_manifest.event with
+  | Keeper_runtime_manifest.Runtime_completed
+  | Keeper_runtime_manifest.Runtime_failed
   | Keeper_runtime_manifest.Provider_attempt_finished
   | Keeper_runtime_manifest.State_snapshot_sidecar_saved
   | Keeper_runtime_manifest.Working_state_sidecar_saved

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -145,6 +145,8 @@ let event_lane = function
   | Keeper_runtime_manifest.Turn_finished ->
     "keeper"
   | Keeper_runtime_manifest.Runtime_routed
+  | Keeper_runtime_manifest.Runtime_completed
+  | Keeper_runtime_manifest.Runtime_failed
   | Keeper_runtime_manifest.Provider_lane_resolved ->
     "masc_policy_runtime"
   | Keeper_runtime_manifest.Provider_attempt_started

--- a/test/dune
+++ b/test/dune
@@ -121,6 +121,7 @@
   test_attempt_state
   test_runtime_attempt_fsm
   test_keeper_turn_driver_accept
+  test_keeper_turn_driver_failover
   test_domain_pool
   test_sse
   test_graphql_api
@@ -458,6 +459,7 @@
   test_attempt_state
   test_runtime_attempt_fsm
   test_keeper_turn_driver_accept
+  test_keeper_turn_driver_failover
   test_domain_pool
   test_sse
   test_graphql_api

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -5198,6 +5198,8 @@ let expected_compaction_snapshot_event_class = function
   | Runtime_manifest.Turn_started
   | Runtime_manifest.Phase_gate_decided
   | Runtime_manifest.Runtime_routed
+  | Runtime_manifest.Runtime_completed
+  | Runtime_manifest.Runtime_failed
   | Runtime_manifest.Pre_dispatch_blocked
   | Runtime_manifest.Provider_lane_resolved
   | Runtime_manifest.Provider_attempt_started

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -378,51 +378,6 @@ let test_repo_fusion_seed_judge_contract_is_total () =
          policy.Fusion_policy.presets)
 ;;
 
-let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
-  let runtime = runtime_by_id_or_fail runtimes runtime_id in
-  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
-  | Ok _ -> ()
-  | Error msg ->
-    failf
-      "fusion preset %s panel runtime %s must accept native schema: %s"
-      preset
-      runtime_id
-      msg
-;;
-
-let test_repo_fusion_panel_presets_are_schema_capable () =
-  with_repo_oas_model_catalog @@ fun _catalog ->
-  let path = Ast_grep.resolve_path "config/runtime.toml" in
-  match Runtime.load_list ~config_path:path with
-  | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok
-      ( runtimes
-      , _default
-      , _assignments
-      , _librarian
-      , _structured_judge
-      , _cross
-      , _media , _lanes ) ->
-    let runtime_cfg = fusion_toml_or_fail path in
-    (match Fusion_config.of_toml runtime_cfg with
-     | Error errs ->
-       failf
-         "repo fusion config should load: %s"
-         (String.concat ", " (List.map Fusion_config.show_config_error errs))
-     | Ok policy ->
-       List.iter
-         (fun validated_preset ->
-            let preset = Fusion_policy.Validated_preset.preset validated_preset in
-            List.iter
-              (fun (group : Fusion_policy.panel_group) ->
-                 List.iter
-                   (assert_panel_runtime_accepts_native_schema
-                      runtimes
-                      ~preset:preset.Fusion_policy.name)
-                   group.Fusion_policy.models)
-              preset.Fusion_policy.panels)
-         policy.Fusion_policy.presets)
-;;
 let test_all_fusion_agent_build_files_are_classified () =
   check
     (list string)

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -343,7 +343,7 @@ let test_repo_fusion_seed_judge_contract_is_total () =
       , _librarian
       , _structured_judge
       , _cross_verifier
-      , _media_failover ) ->
+      , _media_failover , _lanes ) ->
     let runtime_cfg = fusion_toml_or_fail path in
     (match Fusion_config.of_toml runtime_cfg with
      | Error errs ->
@@ -378,6 +378,51 @@ let test_repo_fusion_seed_judge_contract_is_total () =
          policy.Fusion_policy.presets)
 ;;
 
+let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
+  let runtime = runtime_by_id_or_fail runtimes runtime_id in
+  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
+  | Ok _ -> ()
+  | Error msg ->
+    failf
+      "fusion preset %s panel runtime %s must accept native schema: %s"
+      preset
+      runtime_id
+      msg
+;;
+
+let test_repo_fusion_panel_presets_are_schema_capable () =
+  with_repo_oas_model_catalog @@ fun _catalog ->
+  let path = Ast_grep.resolve_path "config/runtime.toml" in
+  match Runtime.load_list ~config_path:path with
+  | Error msg -> failf "repo runtime.toml should load: %s" msg
+  | Ok
+      ( runtimes
+      , _default
+      , _assignments
+      , _librarian
+      , _structured_judge
+      , _cross
+      , _media , _lanes ) ->
+    let runtime_cfg = fusion_toml_or_fail path in
+    (match Fusion_config.of_toml runtime_cfg with
+     | Error errs ->
+       failf
+         "repo fusion config should load: %s"
+         (String.concat ", " (List.map Fusion_config.show_config_error errs))
+     | Ok policy ->
+       List.iter
+         (fun validated_preset ->
+            let preset = Fusion_policy.Validated_preset.preset validated_preset in
+            List.iter
+              (fun (group : Fusion_policy.panel_group) ->
+                 List.iter
+                   (assert_panel_runtime_accepts_native_schema
+                      runtimes
+                      ~preset:preset.Fusion_policy.name)
+                   group.Fusion_policy.models)
+              preset.Fusion_policy.panels)
+         policy.Fusion_policy.presets)
+;;
 let test_all_fusion_agent_build_files_are_classified () =
   check
     (list string)

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1024,6 +1024,15 @@ let test_rfc_0190_allowlist_has_no_descriptor () =
 
 (* ── effective_core_tools universe-aware behaviour ─────────────── *)
 
+let with_masc_schemas schemas f =
+  let prior = Registry.masc_schemas_snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Registry.set_masc_schemas prior)
+    (fun () ->
+       Registry.set_masc_schemas schemas;
+       f ())
+;;
+
 let test_effective_core_tools_is_subset_of_discovery () =
   let effective = Registry.effective_core_tools () in
   let discovery = Registry.core_discovery_tools in
@@ -1043,17 +1052,17 @@ let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
      absent from the universe. Mcp_server_eio's module-load bootstrap injects
      the full schema universe when it is linked into this executable, so the
      universe cannot be assumed to start empty. *)
-  Registry.set_masc_schemas [];
-  let effective = Registry.effective_core_tools () in
-  let descriptor_publics = Descriptor.public_names () in
-  List.iter
-    (fun name ->
-       if List.mem name effective
-       then
-         Alcotest.failf
-           "effective_core_tools contains descriptor public %S when universe is empty"
-           name)
-    descriptor_publics
+  with_masc_schemas [] (fun () ->
+    let effective = Registry.effective_core_tools () in
+    let descriptor_publics = Descriptor.public_names () in
+    List.iter
+      (fun name ->
+         if List.mem name effective
+         then
+           Alcotest.failf
+             "effective_core_tools contains descriptor public %S when universe is empty"
+             name)
+      descriptor_publics)
 ;;
 
 let test_effective_core_tools_with_full_universe_matches_discovery () =
@@ -1066,13 +1075,13 @@ let test_effective_core_tools_with_full_universe_matches_discovery () =
          })
       (all_descriptors ())
   in
-  Registry.set_masc_schemas all_schemas;
-  let effective = Registry.effective_core_tools () in
-  let discovery = Registry.core_discovery_tools in
-  Alcotest.(check (list string))
-    "effective_core_tools with full universe matches core_discovery_tools"
-    (List.sort String.compare discovery)
-    (List.sort String.compare effective)
+  with_masc_schemas all_schemas (fun () ->
+    let effective = Registry.effective_core_tools () in
+    let discovery = Registry.core_discovery_tools in
+    Alcotest.(check (list string))
+      "effective_core_tools with full universe matches core_discovery_tools"
+      (List.sort String.compare discovery)
+      (List.sort String.compare effective))
 ;;
 
 let () =

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -135,10 +135,13 @@ let test_lanes_accessor_returns_declared_lanes () =
   with_runtime_config runtime_toml_with_lane (fun () ->
     let lanes = Runtime.lanes () in
     Alcotest.(check int) "one lane declared" 1 (List.length lanes);
-    Alcotest.(check string)
-      "lane id via lanes ()"
-      "resilient"
-      (Runtime_lane.id (List.hd lanes)))
+    match lanes with
+    | [ lane ] ->
+      Alcotest.(check string)
+        "lane id via lanes ()"
+        "resilient"
+        (Runtime_lane.id lane)
+    | _ -> Alcotest.fail "expected exactly one lane")
 
 let test_resolve_assignment_prefers_lane_over_runtime () =
   with_runtime_config runtime_toml_lane_shadows_runtime (fun () ->

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -327,7 +327,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
   with_model_catalog_content runtime_thinking_lane_model_catalog @@ fun () ->
   with_runtime_config runtime_toml_thinking_lane (fun () ->
     let max_tokens_for_runtime ~runtime_id =
-      Keeper_run_context.resolve_max_tokens_for_runtime
+      Masc.Keeper_run_context.resolve_max_tokens_for_runtime
         ~keeper_name:"policy-test"
         ~runtime_id
         ()
@@ -338,6 +338,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id:"mixed"
         ~fallback_enable_thinking:None
         ~fallback_max_tokens:8192
+        ()
     in
     Alcotest.(check (option bool))
       "lane id has no runtime thinking policy"
@@ -357,6 +358,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id:"thinking.reasoning_big"
         ~fallback_enable_thinking:(Some false)
         ~fallback_max_tokens:8192
+        ()
     in
     Alcotest.(check (option bool))
       "thinking candidate enables thinking"
@@ -376,6 +378,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id:"plain.non_reasoning"
         ~fallback_enable_thinking:(Some true)
         ~fallback_max_tokens:8192
+        ()
     in
     Alcotest.(check (option bool))
       "non-thinking candidate forces thinking off"

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -16,6 +16,24 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let with_model_catalog_content content f =
+  let original = Llm_provider.Model_catalog.global () in
+  let path = Filename.temp_file "runtime-failover-oas-models" ".toml" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match original with
+       | Some catalog -> Llm_provider.Model_catalog.set_global catalog
+       | None -> Llm_provider.Model_catalog.clear_global ());
+      try Sys.remove path with
+      | _ -> ())
+    (fun () ->
+      write_file path content;
+      match Llm_provider.Model_catalog.load_file path with
+      | Error msg -> Alcotest.failf "test OAS model catalog should load: %s" msg
+      | Ok catalog ->
+        Llm_provider.Model_catalog.set_global catalog;
+        f ())
+
 let checkpoint_with_session_id session_id : Agent_sdk.Checkpoint.t =
   { version = Agent_sdk.Checkpoint.checkpoint_version
   ; session_id
@@ -79,6 +97,62 @@ max-concurrent = 1
 
 [fallback.test_model]
 max-concurrent = 1
+|}
+
+let runtime_toml_thinking_lane =
+  {|
+[runtime]
+default = "thinking.reasoning_big"
+
+[runtime.lanes.mixed]
+strategy = "ordered"
+candidates = [ "thinking.reasoning_big", "plain.non_reasoning" ]
+
+[providers.thinking]
+display-name = "Thinking Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.plain]
+display-name = "Plain Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[models.reasoning_big]
+api-name = "reasoning-big-out"
+max-context = 1000000
+tools-support = true
+thinking-support = true
+preserve-thinking = true
+streaming = true
+
+[models.non_reasoning]
+api-name = "non-reasoning"
+max-context = 8192
+tools-support = true
+thinking-support = false
+preserve-thinking = false
+streaming = true
+
+[thinking.reasoning_big]
+is-default = true
+max-concurrent = 1
+
+[plain.non_reasoning]
+max-concurrent = 1
+|}
+
+let runtime_thinking_lane_model_catalog =
+  {|
+[[models]]
+id_prefix = "openai_compat/reasoning-big-out"
+base = "openai_chat"
+max_context_tokens = 1000000
+max_output_tokens = 200000
+supports_tools = true
+supports_reasoning = true
+supports_extended_thinking = true
+supports_native_streaming = true
 |}
 
 let runtime_toml_media_lane_with_global_outside =
@@ -248,6 +322,73 @@ let test_resolve_assignment_to_single_runtime () =
     | `Lane _ -> Alcotest.fail "expected single runtime, not lane"
     | `Single_runtime rt ->
       Alcotest.(check string) "runtime id" "fallback.test_model" rt.Runtime.id)
+
+let test_attempt_inference_policy_uses_attempt_runtime () =
+  with_model_catalog_content runtime_thinking_lane_model_catalog @@ fun () ->
+  with_runtime_config runtime_toml_thinking_lane (fun () ->
+    let max_tokens_for_runtime ~runtime_id =
+      Keeper_run_context.resolve_max_tokens_for_runtime
+        ~keeper_name:"policy-test"
+        ~runtime_id
+        ()
+    in
+    let lane_policy =
+      Driver.For_testing.attempt_inference_policy
+        ~max_tokens_for_runtime
+        ~runtime_id:"mixed"
+        ~fallback_enable_thinking:None
+        ~fallback_max_tokens:8192
+    in
+    Alcotest.(check (option bool))
+      "lane id has no runtime thinking policy"
+      None
+      lane_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (option bool))
+      "lane id has no preserve thinking policy"
+      None
+      lane_policy.Driver.attempt_preserve_thinking;
+    Alcotest.(check int)
+      "lane id keeps caller max_tokens fallback"
+      8192
+      lane_policy.Driver.attempt_max_tokens;
+    let thinking_policy =
+      Driver.For_testing.attempt_inference_policy
+        ~max_tokens_for_runtime
+        ~runtime_id:"thinking.reasoning_big"
+        ~fallback_enable_thinking:(Some false)
+        ~fallback_max_tokens:8192
+    in
+    Alcotest.(check (option bool))
+      "thinking candidate enables thinking"
+      (Some true)
+      thinking_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (option bool))
+      "thinking candidate preserves thinking when configured"
+      (Some true)
+      thinking_policy.Driver.attempt_preserve_thinking;
+    Alcotest.(check int)
+      "thinking candidate sizes from catalog ceiling"
+      32768
+      thinking_policy.Driver.attempt_max_tokens;
+    let non_thinking_policy =
+      Driver.For_testing.attempt_inference_policy
+        ~max_tokens_for_runtime
+        ~runtime_id:"plain.non_reasoning"
+        ~fallback_enable_thinking:(Some true)
+        ~fallback_max_tokens:8192
+    in
+    Alcotest.(check (option bool))
+      "non-thinking candidate forces thinking off"
+      (Some false)
+      non_thinking_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (option bool))
+      "non-thinking candidate disables preserve thinking"
+      (Some false)
+      non_thinking_policy.Driver.attempt_preserve_thinking;
+    Alcotest.(check int)
+      "non-thinking candidate keeps caller max_tokens fallback"
+      8192
+      non_thinking_policy.Driver.attempt_max_tokens)
 
 let test_resolve_assignment_missing () =
   with_runtime_config runtime_toml_with_lane (fun () ->
@@ -582,6 +723,10 @@ let () =
             "runtime dedupe preserves first occurrence"
             `Quick
             test_runtime_dedupe_preserves_first_occurrence;
+          Alcotest.test_case
+            "attempt inference policy uses attempt runtime"
+            `Quick
+            test_attempt_inference_policy_uses_attempt_runtime;
           Alcotest.test_case
             "attempt loop stops on nonretryable failure"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -56,7 +56,7 @@ let checkpoint_with_session_id session_id : Agent_sdk.Checkpoint.t =
   ; response_format = Agent_sdk.Types.Off
   ; thinking_budget = None
   ; cache_system_prompt = false
-  ; context = Agent_sdk.Context.create ~eio:false ()
+  ; context = Agent_sdk.Context.create_sync ()
   ; mcp_sessions = []
   ; working_context = None
   }

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1,3 +1,6 @@
+module Runtime_manifest = Masc.Keeper_runtime_manifest
+module Driver = Masc.Keeper_turn_driver
+
 let contains ~needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in
@@ -181,6 +184,107 @@ let test_unknown_lane_candidate_rejected_at_load () =
            true
            (contains ~needle:"missing.test_model" msg))
 
+let assoc_member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let string_member key json =
+  match assoc_member key json with
+  | Some (`String value) -> value
+  | _ -> Alcotest.failf "expected string member %S in %s" key (Yojson.Safe.to_string json)
+
+let emit_manifest_collector events ?status ?decision event =
+  events := (event, status, decision) :: !events
+
+let event_name event = Runtime_manifest.event_kind_to_string event
+
+let decision_runtime_id = function
+  | _, _, Some decision -> string_member "runtime_id" decision
+  | event, _, None ->
+    Alcotest.failf "missing decision for event %s" (event_name event)
+
+let test_attempt_loop_tries_fallback_after_failure () =
+  let attempts = ref [] in
+  let events = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          Error (Agent_sdk.Error.Internal "primary transport failed")
+        | "fallback.test_model" -> Ok runtime_id
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok runtime_id ->
+     Alcotest.(check string) "fallback selected" "fallback.test_model" runtime_id
+   | Error e ->
+     Alcotest.failf
+       "expected fallback success, got %s"
+       (Agent_sdk.Error.to_string e));
+  Alcotest.(check (list string))
+    "attempted candidates"
+    [ "primary.test_model"; "fallback.test_model" ]
+    !attempts;
+  let events = List.rev !events in
+  Alcotest.(check (list string))
+    "manifest events"
+    (List.map event_name
+       [
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_failed;
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_completed;
+       ])
+    (List.map (fun (event, _, _) -> event_name event) events);
+  Alcotest.(check (list string))
+    "manifest runtime ids"
+    [
+      "primary.test_model";
+      "primary.test_model";
+      "fallback.test_model";
+      "fallback.test_model";
+    ]
+    (List.map decision_runtime_id events)
+
+let test_attempt_loop_preserves_last_sdk_error () =
+  let events = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
+        Error (Agent_sdk.Error.Internal (runtime_id ^ " failed")))
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "expected final candidate error"
+   | Error (Agent_sdk.Error.Internal msg) ->
+     Alcotest.(check string)
+       "last candidate error preserved"
+       "fallback.test_model failed"
+       msg
+   | Error e ->
+     Alcotest.failf
+       "expected Internal final error, got %s"
+       (Agent_sdk.Error.to_string e));
+  let events = List.rev !events in
+  Alcotest.(check (list string))
+    "failed runtime ids"
+    [ "primary.test_model"; "fallback.test_model" ]
+    (events
+     |> List.filter (fun (event, _, _) ->
+       match event with
+       | Runtime_manifest.Runtime_failed -> true
+       | _ -> false)
+     |> List.map decision_runtime_id)
+
 let () =
   Alcotest.run
     "keeper_turn_driver_failover"
@@ -211,5 +315,13 @@ let () =
             "unknown lane candidate rejected at load"
             `Quick
             test_unknown_lane_candidate_rejected_at_load;
+          Alcotest.test_case
+            "attempt loop tries fallback after failure"
+            `Quick
+            test_attempt_loop_tries_fallback_after_failure;
+          Alcotest.test_case
+            "attempt loop preserves last SDK error"
+            `Quick
+            test_attempt_loop_preserves_last_sdk_error;
         ] );
     ]

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -206,6 +206,49 @@ let decision_runtime_id = function
   | event, _, None ->
     Alcotest.failf "missing decision for event %s" (event_name event)
 
+let test_lane_media_degrade_uses_first_candidate_runtime_id () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    match Runtime.resolve_assignment "resilient" with
+    | `Missing | `Single_runtime _ ->
+      Alcotest.fail "expected resilient assignment to resolve to a lane"
+    | `Lane lane ->
+      let first_candidate_id =
+        match Runtime_lane.ordered_candidates lane with
+        | first :: _ -> first
+        | [] -> Alcotest.fail "expected non-empty lane candidates"
+      in
+      let first_candidate =
+        match Runtime.get_runtime_by_id first_candidate_id with
+        | Some runtime -> runtime
+        | None ->
+          Alcotest.failf
+            "expected first candidate runtime %S to be configured"
+            first_candidate_id
+      in
+      let selected_runtime_id, selected_runtime =
+        Driver.For_testing.first_runtime_after_modality_reroute
+          ~keeper_name:"test-keeper" ~assignment_id:"resilient"
+          ~first_candidate_id ~first_candidate
+          (Runtime_agent.No_capable_runtime { required = [ "image" ] })
+      in
+      Alcotest.(check string)
+        "selected runtime id"
+        "primary.test_model"
+        selected_runtime_id;
+      Alcotest.(check string)
+        "selected runtime binding"
+        "primary.test_model"
+        selected_runtime.Runtime.id;
+      let decision =
+        Driver.For_testing.media_degrade_manifest_decision
+          ~runtime_id:selected_runtime_id
+          [ "image", 1 ]
+      in
+      Alcotest.(check string)
+        "degraded runtime id"
+        "primary.test_model"
+        (string_member "degraded_runtime_id" decision))
+
 let test_attempt_loop_tries_fallback_after_failure () =
   let attempts = ref [] in
   let events = ref [] in
@@ -318,6 +361,10 @@ let () =
             "unknown lane candidate rejected at load"
             `Quick
             test_unknown_lane_candidate_rejected_at_load;
+          Alcotest.test_case
+            "lane media degrade uses first candidate runtime id"
+            `Quick
+            test_lane_media_degrade_uses_first_candidate_runtime_id;
           Alcotest.test_case
             "attempt loop tries fallback after failure"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1,0 +1,215 @@
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.sub haystack i needle_len = needle || loop (i + 1))
+  in
+  needle_len = 0 || loop 0
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let runtime_toml_with_lane =
+  {|
+[runtime]
+default = "primary.test_model"
+
+[runtime.lanes.resilient]
+strategy = "ordered"
+candidates = [ "primary.test_model", "fallback.test_model" ]
+
+[providers.primary]
+display-name = "Primary Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.fallback]
+display-name = "Fallback Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[primary.test_model]
+is-default = true
+max-concurrent = 1
+
+[fallback.test_model]
+max-concurrent = 1
+|}
+
+let runtime_toml_unknown_lane_candidate =
+  {|
+[runtime]
+default = "primary.test_model"
+
+[runtime.lanes.resilient]
+strategy = "ordered"
+candidates = [ "primary.test_model", "missing.test_model" ]
+
+[providers.primary]
+display-name = "Primary Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[primary.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let runtime_toml_lane_shadows_runtime =
+  {|
+[runtime]
+default = "primary.test_model"
+
+[runtime.lanes."primary.test_model"]
+strategy = "ordered"
+candidates = [ "fallback.test_model" ]
+
+[providers.primary]
+display-name = "Primary Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.fallback]
+display-name = "Fallback Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[primary.test_model]
+is-default = true
+max-concurrent = 1
+
+[fallback.test_model]
+max-concurrent = 1
+|}
+
+let with_runtime_config toml f =
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "runtime_failover_" ".toml" in
+  write_file path toml;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       match Runtime.init_default ~config_path:path with
+       | Ok () -> f ()
+       | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e)
+
+let test_lane_loads_ordered_candidates () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    match Runtime.get_lane_by_id "resilient" with
+    | None -> Alcotest.fail "expected lane 'resilient' to be configured"
+    | Some lane ->
+      Alcotest.(check string) "lane id" "resilient" (Runtime_lane.id lane);
+      Alcotest.(check (list string))
+        "ordered candidates"
+        [ "primary.test_model"; "fallback.test_model" ]
+        (Runtime_lane.ordered_candidates lane))
+
+let test_lanes_accessor_returns_declared_lanes () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    let lanes = Runtime.lanes () in
+    Alcotest.(check int) "one lane declared" 1 (List.length lanes);
+    Alcotest.(check string)
+      "lane id via lanes ()"
+      "resilient"
+      (Runtime_lane.id (List.hd lanes)))
+
+let test_resolve_assignment_prefers_lane_over_runtime () =
+  with_runtime_config runtime_toml_lane_shadows_runtime (fun () ->
+    match Runtime.resolve_assignment "primary.test_model" with
+    | `Missing -> Alcotest.fail "expected assignment to resolve"
+    | `Single_runtime _ -> Alcotest.fail "expected lane to shadow runtime"
+    | `Lane lane ->
+      Alcotest.(check string)
+        "lane id shadows runtime id"
+        "primary.test_model"
+        (Runtime_lane.id lane);
+      Alcotest.(check (list string))
+        "lane candidates"
+        [ "fallback.test_model" ]
+        (Runtime_lane.ordered_candidates lane))
+
+let test_resolve_assignment_to_single_runtime () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    match Runtime.resolve_assignment "fallback.test_model" with
+    | `Missing -> Alcotest.fail "expected runtime to resolve"
+    | `Lane _ -> Alcotest.fail "expected single runtime, not lane"
+    | `Single_runtime rt ->
+      Alcotest.(check string) "runtime id" "fallback.test_model" rt.Runtime.id)
+
+let test_resolve_assignment_missing () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    match Runtime.resolve_assignment "not.configured" with
+    | `Missing -> ()
+    | `Single_runtime _ | `Lane _ ->
+      Alcotest.fail "expected missing assignment")
+
+let test_unknown_lane_candidate_rejected_at_load () =
+  let path = Filename.temp_file "runtime_failover_bad_" ".toml" in
+  write_file path runtime_toml_unknown_lane_candidate;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> Alcotest.fail "expected load to fail on unknown lane candidate"
+       | Error msg ->
+         Alcotest.(check bool)
+           "error names unknown candidate"
+           true
+           (contains ~needle:"missing.test_model" msg))
+
+let () =
+  Alcotest.run
+    "keeper_turn_driver_failover"
+    [
+      ( "runtime_lane_resolution"
+      , [
+          Alcotest.test_case
+            "lane loads ordered candidate ids"
+            `Quick
+            test_lane_loads_ordered_candidates;
+          Alcotest.test_case
+            "lanes accessor returns declared lanes"
+            `Quick
+            test_lanes_accessor_returns_declared_lanes;
+          Alcotest.test_case
+            "resolve_assignment prefers lane over runtime"
+            `Quick
+            test_resolve_assignment_prefers_lane_over_runtime;
+          Alcotest.test_case
+            "resolve_assignment returns single runtime"
+            `Quick
+            test_resolve_assignment_to_single_runtime;
+          Alcotest.test_case
+            "resolve_assignment reports missing id"
+            `Quick
+            test_resolve_assignment_missing;
+          Alcotest.test_case
+            "unknown lane candidate rejected at load"
+            `Quick
+            test_unknown_lane_candidate_rejected_at_load;
+        ] );
+    ]

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -16,6 +16,38 @@ let write_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let checkpoint_with_session_id session_id : Agent_sdk.Checkpoint.t =
+  { version = Agent_sdk.Checkpoint.checkpoint_version
+  ; session_id
+  ; agent_name = "agent-test"
+  ; model = "model-test"
+  ; system_prompt = None
+  ; messages = []
+  ; usage = Agent_sdk.Types.empty_usage
+  ; turn_count = 1
+  ; created_at = 0.0
+  ; tools = []
+  ; tool_choice = None
+  ; disable_parallel_tool_use = false
+  ; temperature = None
+  ; top_p = None
+  ; top_k = None
+  ; min_p = None
+  ; enable_thinking = None
+  ; preserve_thinking = None
+  ; response_format = Agent_sdk.Types.Off
+  ; thinking_budget = None
+  ; cache_system_prompt = false
+  ; context = Agent_sdk.Context.create ~eio:false ()
+  ; mcp_sessions = []
+  ; working_context = None
+  }
+
+let retryable_network_error message =
+  Agent_sdk.Error.Api
+    (Agent_sdk.Retry.NetworkError
+       { message; kind = Llm_provider.Http_client.Unknown })
+
 let runtime_toml_with_lane =
   {|
 [runtime]
@@ -46,6 +78,57 @@ is-default = true
 max-concurrent = 1
 
 [fallback.test_model]
+max-concurrent = 1
+|}
+
+let runtime_toml_media_lane_with_global_outside =
+  {|
+[runtime]
+default = "primary.text_model"
+media_failover = [ "outsidevision.vision_model" ]
+
+[runtime.lanes.resilient]
+strategy = "ordered"
+candidates = [ "primary.text_model", "lanevision.vision_model" ]
+
+[providers.primary]
+display-name = "Primary Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[providers.lanevision]
+display-name = "Lane Vision Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:2"
+
+[providers.outsidevision]
+display-name = "Outside Vision Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:3"
+
+[models.text_model]
+api-name = "text-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[models.vision_model]
+api-name = "vision-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[models.vision_model.capabilities]
+supports-image-input = true
+
+[primary.text_model]
+is-default = true
+max-concurrent = 1
+
+[lanevision.vision_model]
+max-concurrent = 1
+
+[outsidevision.vision_model]
 max-concurrent = 1
 |}
 
@@ -249,7 +332,82 @@ let test_lane_media_degrade_uses_first_candidate_runtime_id () =
         "primary.test_model"
         (string_member "degraded_runtime_id" decision))
 
-let test_attempt_loop_tries_fallback_after_failure () =
+let test_lane_media_reroute_stays_within_lane () =
+  with_runtime_config runtime_toml_media_lane_with_global_outside (fun () ->
+    match Runtime.resolve_assignment "resilient" with
+    | `Missing | `Single_runtime _ ->
+      Alcotest.fail "expected resilient assignment to resolve to a lane"
+    | `Lane lane ->
+      let first_candidate_id, remaining_candidate_ids =
+        match Runtime_lane.ordered_candidates lane with
+        | first :: rest -> first, rest
+        | [] -> Alcotest.fail "expected non-empty lane candidates"
+      in
+      let first_candidate =
+        match Runtime.get_runtime_by_id first_candidate_id with
+        | Some runtime -> runtime
+        | None -> Alcotest.fail "missing first candidate"
+      in
+      let remaining_runtimes =
+        List.map
+          (fun runtime_id ->
+             match Runtime.get_runtime_by_id runtime_id with
+             | Some runtime -> runtime
+             | None -> Alcotest.failf "missing lane candidate %s" runtime_id)
+          remaining_candidate_ids
+      in
+      let image_block =
+        Agent_sdk.Types.Image
+          { media_type = "image/png"
+          ; data = Base64.encode_string "image"
+          ; source_type = Agent_sdk.Types.Base64
+          }
+      in
+      match
+        Driver.For_testing.lane_modality_reroute_decision
+          ~checkpoint_messages:[]
+          ~initial_messages:[]
+          ~goal_blocks:[ image_block ]
+          ~first_candidate
+          ~remaining_runtimes
+      with
+      | Runtime_agent.Reroute { to_runtime_id; _ } ->
+        Alcotest.(check string)
+          "reroute uses lane candidate, not global media_failover"
+          "lanevision.vision_model"
+          to_runtime_id
+      | Runtime_agent.No_reroute_needed ->
+        Alcotest.fail "text-only first candidate should require image reroute"
+      | Runtime_agent.No_capable_runtime _ ->
+        Alcotest.fail "lane second candidate should be image-capable")
+
+let test_runtime_dedupe_preserves_first_occurrence () =
+  with_runtime_config runtime_toml_media_lane_with_global_outside (fun () ->
+    let runtime id =
+      match Runtime.get_runtime_by_id id with
+      | Some runtime -> runtime
+      | None -> Alcotest.failf "missing runtime %s" id
+    in
+    let deduped =
+      Driver.For_testing.dedupe_runtimes_preserve_order
+        [
+          runtime "lanevision.vision_model";
+          runtime "lanevision.vision_model";
+          runtime "outsidevision.vision_model";
+          runtime "primary.text_model";
+          runtime "outsidevision.vision_model";
+        ]
+    in
+    Alcotest.(check (list string))
+      "dedupe preserves first occurrence order"
+      [
+        "lanevision.vision_model";
+        "outsidevision.vision_model";
+        "primary.text_model";
+      ]
+      (List.map (fun (runtime : Runtime.t) -> runtime.Runtime.id) deduped))
+
+let test_attempt_loop_stops_on_nonretryable_failure () =
   let attempts = ref [] in
   let events = ref [] in
   let result =
@@ -257,12 +415,68 @@ let test_attempt_loop_tries_fallback_after_failure () =
       ~runtime_id:"resilient"
       ~runtime_id_of:(fun runtime_id -> runtime_id)
       ~emit_runtime_manifest:(emit_manifest_collector events)
-      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+      ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
+        Alcotest.(check bool)
+          "nonretryable attempt does not receive resume checkpoint"
+          false
+          (Option.is_some resume_checkpoint);
         attempts := !attempts @ [ runtime_id ];
         match candidate with
         | "primary.test_model" ->
-          Error (Agent_sdk.Error.Internal "primary transport failed")
-        | "fallback.test_model" -> Ok runtime_id
+          Error (Agent_sdk.Error.Internal "primary terminal failure"), None
+        | "fallback.test_model" -> Ok runtime_id, None
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok runtime_id -> Alcotest.failf "unexpected fallback success: %s" runtime_id
+   | Error (Agent_sdk.Error.Internal msg) ->
+     Alcotest.(check string) "primary error preserved" "primary terminal failure" msg
+   | Error e ->
+     Alcotest.failf "expected primary Internal error, got %s" (Agent_sdk.Error.to_string e));
+  Alcotest.(check (list string))
+    "attempted candidates"
+    [ "primary.test_model" ]
+    !attempts;
+  let events = List.rev !events in
+  Alcotest.(check (list string))
+    "manifest events"
+    (List.map event_name
+       [
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_failed;
+       ])
+    (List.map (fun (event, _, _) -> event_name event) events);
+  Alcotest.(check (list string))
+    "manifest runtime ids"
+    [ "primary.test_model"; "primary.test_model" ]
+    (List.map decision_runtime_id events)
+
+let test_attempt_loop_retries_network_error_with_checkpoint () =
+  let attempts = ref [] in
+  let fallback_resume_session = ref None in
+  let events = ref [] in
+  let checkpoint_after_primary = checkpoint_with_session_id "after-primary" in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          Alcotest.(check bool)
+            "primary starts from initial checkpoint"
+            false
+            (Option.is_some resume_checkpoint);
+          Error (retryable_network_error "primary network failed"), Some checkpoint_after_primary
+        | "fallback.test_model" ->
+          fallback_resume_session :=
+            Option.map
+              (fun (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.session_id)
+              resume_checkpoint;
+          Ok runtime_id, None
         | other -> Alcotest.failf "unexpected candidate %s" other)
       [ "primary.test_model"; "fallback.test_model" ]
   in
@@ -277,6 +491,10 @@ let test_attempt_loop_tries_fallback_after_failure () =
     "attempted candidates"
     [ "primary.test_model"; "fallback.test_model" ]
     !attempts;
+  Alcotest.(check (option string))
+    "fallback receives post-attempt checkpoint"
+    (Some "after-primary")
+    !fallback_resume_session;
   let events = List.rev !events in
   Alcotest.(check (list string))
     "manifest events"
@@ -287,16 +505,7 @@ let test_attempt_loop_tries_fallback_after_failure () =
          Runtime_manifest.Runtime_routed;
          Runtime_manifest.Runtime_completed;
        ])
-    (List.map (fun (event, _, _) -> event_name event) events);
-  Alcotest.(check (list string))
-    "manifest runtime ids"
-    [
-      "primary.test_model";
-      "primary.test_model";
-      "fallback.test_model";
-      "fallback.test_model";
-    ]
-    (List.map decision_runtime_id events)
+    (List.map (fun (event, _, _) -> event_name event) events)
 
 let test_attempt_loop_preserves_last_sdk_error () =
   let events = ref [] in
@@ -305,20 +514,20 @@ let test_attempt_loop_preserves_last_sdk_error () =
       ~runtime_id:"resilient"
       ~runtime_id_of:(fun runtime_id -> runtime_id)
       ~emit_runtime_manifest:(emit_manifest_collector events)
-      ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
-        Error (Agent_sdk.Error.Internal (runtime_id ^ " failed")))
+      ~run_attempt:(fun ?resume_checkpoint:_ ~idx:_ ~runtime_id _candidate ->
+        Error (retryable_network_error (runtime_id ^ " failed")), None)
       [ "primary.test_model"; "fallback.test_model" ]
   in
   (match result with
    | Ok _ -> Alcotest.fail "expected final candidate error"
-   | Error (Agent_sdk.Error.Internal msg) ->
+   | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.NetworkError { message; _ })) ->
      Alcotest.(check string)
        "last candidate error preserved"
        "fallback.test_model failed"
-       msg
+       message
    | Error e ->
      Alcotest.failf
-       "expected Internal final error, got %s"
+       "expected final network error, got %s"
        (Agent_sdk.Error.to_string e));
   let events = List.rev !events in
   Alcotest.(check (list string))
@@ -366,9 +575,21 @@ let () =
             `Quick
             test_lane_media_degrade_uses_first_candidate_runtime_id;
           Alcotest.test_case
-            "attempt loop tries fallback after failure"
+            "lane media reroute stays within lane"
             `Quick
-            test_attempt_loop_tries_fallback_after_failure;
+            test_lane_media_reroute_stays_within_lane;
+          Alcotest.test_case
+            "runtime dedupe preserves first occurrence"
+            `Quick
+            test_runtime_dedupe_preserves_first_occurrence;
+          Alcotest.test_case
+            "attempt loop stops on nonretryable failure"
+            `Quick
+            test_attempt_loop_stops_on_nonretryable_failure;
+          Alcotest.test_case
+            "attempt loop retries network error with checkpoint"
+            `Quick
+            test_attempt_loop_retries_network_error_with_checkpoint;
           Alcotest.test_case
             "attempt loop preserves last SDK error"
             `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -507,7 +507,7 @@ let test_repo_runtime_bindings_resolve_through_oas_catalog () =
       , _librarian
       , _structured_judge
       , _cross_verifier
-      , _media_failover ) ->
+      , _media_failover , _lanes ) ->
     check bool "at least one runtime binding" true (List.length runtimes > 0);
     List.iter
       (fun (runtime : Runtime.t) ->
@@ -580,7 +580,7 @@ let test_repo_runtime_toml_loads () =
       , _librarian
       , structured_judge
       , _cross_verifier
-      , _media_failover ) ->
+      , _media_failover , _lanes ) ->
     check bool "at least one runtime" true (List.length runtimes > 0);
     check string "default runtime" "ollama_cloud.deepseek-v4-flash"
       default.Runtime.id;
@@ -1245,7 +1245,7 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
         , _librarian
         , _structured_judge
         , _cross_verifier
-        , _media_failover ) ->
+        , _media_failover , _lanes ) ->
       let expect id expected =
         match
           List.find_opt (fun (rt : Runtime.t) -> String.equal rt.id id) runtimes
@@ -1310,12 +1310,12 @@ let test_librarian_runtime_routing () =
         , librarian
         , _structured_judge
         , _cross_verifier
-        , _media_failover ) ->
+        , _media_failover , _lanes ) ->
       check (option string) "librarian runtime id" (Some "local.libr") librarian);
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent librarian should load: %s" msg
-    | Ok (_, _, _, librarian, _structured_judge, _cross_verifier, _media_failover) ->
+    | Ok (_, _, _, librarian, _structured_judge, _cross_verifier, _media_failover, _lanes) ->
       check (option string) "librarian unset is None" None librarian);
   with_temp_runtime_toml (base ^ "librarian = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
@@ -1331,13 +1331,13 @@ let test_librarian_runtime_routing () =
         , _librarian
         , _structured_judge
         , cross_verifier
-        , _media_failover ) ->
+        , _media_failover , _lanes ) ->
       check (option string) "cross_verifier runtime id" (Some "local.libr")
         cross_verifier);
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent cross_verifier should load: %s" msg
-    | Ok (_, _, _, _, _structured_judge, cross_verifier, _media_failover) ->
+    | Ok (_, _, _, _, _structured_judge, cross_verifier, _media_failover, _lanes) ->
       check (option string) "cross_verifier unset is None" None cross_verifier);
   with_temp_runtime_toml (base ^ "cross_verifier = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
@@ -1381,7 +1381,7 @@ let test_structured_judge_runtime_routing () =
   with_temp_runtime_toml (base ^ "structured_judge = \"local.judge\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "structured_judge routing should load: %s" msg
-    | Ok (_, _, _, _, structured_judge, _, _) ->
+    | Ok (_, _, _, _, structured_judge, _, _, _) ->
       check
         (option string)
         "structured_judge runtime id"
@@ -1390,7 +1390,7 @@ let test_structured_judge_runtime_routing () =
   with_temp_runtime_toml base (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "absent structured_judge should load: %s" msg
-    | Ok (_, _, _, _, structured_judge, _, _) ->
+    | Ok (_, _, _, _, structured_judge, _, _, _) ->
       check (option string) "structured_judge unset is None" None structured_judge);
   with_temp_runtime_toml (base ^ "structured_judge = \"local.nope\"\n") (fun path ->
     match Runtime.load_list ~config_path:path with

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -541,6 +541,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; lane_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -575,6 +576,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; lane_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -610,6 +612,7 @@ let provider_cfg () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; lane_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -690,6 +693,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; lane_decls = []
     }
   in
   match Runtime.of_binding cfg runpod_binding with

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -9,6 +9,20 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+let test_schema tool =
+  { Masc_domain.name = tool
+  ; description = "test tool " ^ tool
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"; "properties", `Assoc []; "required", `List [] ]
+  }
+;;
+
+let register_test_tool ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_module_tag ~schemas:[ test_schema tool_name ] ~tag:Mod_misc
+;;
+
 let str_contains haystack needle =
   let hlen = String.length haystack in
   let nlen = String.length needle in
@@ -203,20 +217,8 @@ let test_message_json_roundtrip () =
 
 let test_dispatch_structured () =
   (* Register a test handler *)
-  Tool_dispatch.register ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
+  register_test_tool ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
     Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
-  (* Register a schema (not just a tag) so the tool clears the input-schema
-     validation pre-hook that Mcp_server_eio installs at module load. An
-     empty-object schema dispatched with no args passes validation, keeping the
-     test focused on structured dispatch while matching production, where every
-     dispatchable tool carries a schema. *)
-  Tool_dispatch.register_module_tag
-    ~schemas:
-      [ { Masc_domain.name = "__test_tool"
-        ; description = "test dispatch tool"
-        ; input_schema = `Assoc [ "type", `String "object" ]
-        } ]
-    ~tag:Mod_misc;
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with
     | Ok t -> t

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -19,6 +19,20 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+let test_schema tool =
+  { Masc_domain.name = tool
+  ; description = "test tool " ^ tool
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"; "properties", `Assoc []; "required", `List [] ]
+  }
+;;
+
+let register_test_tool ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_module_tag ~schemas:[ test_schema tool_name ] ~tag:Mod_misc
+;;
+
 (* ================================================================ *)
 (* mint — table variant                                              *)
 (* ================================================================ *)
@@ -84,9 +98,8 @@ let test_token_name_readable () =
 
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
-  Tool_dispatch.register ~tool_name:tool
+  register_test_tool ~tool_name:tool
     ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
-  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
   | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
@@ -98,20 +111,8 @@ let test_mint_token_unregistered () =
 
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
-  Tool_dispatch.register ~tool_name:tool
+  register_test_tool ~tool_name:tool
     ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
-  (* Register a schema (not just a tag) so the tool clears the input-schema
-     validation pre-hook that Mcp_server_eio installs at module load. An
-     empty-object schema dispatched with no args passes validation, so this
-     keeps the test focused on token dispatch while matching production, where
-     every dispatchable tool carries a schema. *)
-  Tool_dispatch.register_module_tag
-    ~schemas:
-      [ { Masc_domain.name = tool
-        ; description = "test dispatch tool"
-        ; input_schema = `Assoc [ "type", `String "object" ]
-        } ]
-    ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## Summary
Restores ordered provider failover so a Keeper turn survives a single runtime failure by routing to the next configured candidate.

## Changes
- Introduces `Runtime_lane` with ordered candidate lists.
- Parses `[runtime.lanes.<id>]` from `runtime.toml`.
- Updates `Keeper_turn_driver` to attempt candidates sequentially and emit `Runtime_manifest` rows per attempt.
- Keeps concrete provider/model identities redacted at MASC boundaries via `lib/oas_compat`.
- Adds a failover simulation test.

## Verification
- `scripts/dune-local.sh build @default` green
- `test/test_keeper_turn_driver_failover.exe` green
- `scripts/ci/check-masc-oas-boundary.sh` PASS

## Spec
- HTML spec: `/Users/dancer/me/docs/superpowers/specs/2026-07-01-masc-oas-resilience-design.html`
- Plan: `/Users/dancer/me/docs/superpowers/plans/2026-07-01-pr-a-provider-failover.md`

Closes roadmap item #2 (Provider Failover).