### PR TITLE
feat(hitl): bounded critical approval timeout for Keeper turns

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -29,6 +29,13 @@ structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
 # this explicit smart lane.
 cross_verifier = "deepseek.deepseek-v4-pro"
 
+[hitl]
+# Human-in-the-loop approval timeout for Critical-risk tool calls.
+# A Keeper turn that reaches this gate will wait at most critical_timeout_s
+# for an operator decision before resuming with a typed timeout rejection.
+# Set to 0 to disable (legacy operator-must-decide behavior, not recommended).
+critical_timeout_s = 3600.0
+
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"
 protocol = "openai-compatible-http"

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 363 unique knobs across 9 modules.
+**Total**: 364 unique knobs across 10 modules.
 
-**Typed getter classification**: 48/219 tagged (`operator`: 48, `algorithm`: 0, `unclassified`: 171).
+**Typed getter classification**: 48/220 tagged (`operator`: 48, `algorithm`: 0, `unclassified`: 172).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -84,6 +84,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 54 | Cleanup interval for stale rate limit buckets (seconds) |
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
+
+## Env_config_hitl (1 knobs; typed classification 0/1)
+
+| Env var | Kind | Category | Ops class | Line | Doc |
+|---|---|---|---|---|---|
+| `MASC_HITL_CRITICAL_TIMEOUT_S` | typed:float | unclassified | unclassified | 10 | HITL (human-in-the-loop) approval configuration. Bounded timeouts prevent dangerous tool approvals from stalling a Ke... |
 
 ## Env_config_keeper (90 knobs; typed classification 26/77)
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -85,11 +85,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_hitl (1 knob; typed classification 1/1)
+## Env_config_hitl (1 knobs; typed classification 1/1)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_HITL_CRITICAL_TIMEOUT_S` | typed:float | Timeouts | operator | 13 | HITL (human-in-the-loop) approval configuration. Bounded timeouts prevent dangerous tool approvals from stalling a Ke... |
+| `MASC_HITL_CRITICAL_TIMEOUT_S` | typed:float | Timeouts | operator | 18 | HITL (human-in-the-loop) approval configuration. Bounded timeouts prevent dangerous tool approvals from stalling a Ke... |
 
 ## Env_config_keeper (90 knobs; typed classification 26/77)
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -85,7 +85,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_hitl (1 knobs; typed classification 1/1)
+## Env_config_hitl (1 knob; typed classification 1/1)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,7 +16,7 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 364 unique knobs across 10 modules.
 
-**Typed getter classification**: 48/220 tagged (`operator`: 48, `algorithm`: 0, `unclassified`: 172).
+**Typed getter classification**: 49/220 tagged (`operator`: 49, `algorithm`: 0, `unclassified`: 171).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -85,11 +85,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_hitl (1 knobs; typed classification 0/1)
+## Env_config_hitl (1 knobs; typed classification 1/1)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_HITL_CRITICAL_TIMEOUT_S` | typed:float | unclassified | unclassified | 10 | HITL (human-in-the-loop) approval configuration. Bounded timeouts prevent dangerous tool approvals from stalling a Ke... |
+| `MASC_HITL_CRITICAL_TIMEOUT_S` | typed:float | Timeouts | operator | 13 | HITL (human-in-the-loop) approval configuration. Bounded timeouts prevent dangerous tool approvals from stalling a Ke... |
 
 ## Env_config_keeper (90 knobs; typed classification 26/77)
 

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -8,6 +8,7 @@
   env_config
   env_config_core
   env_config_governance
+  env_config_hitl
   env_config_keeper
   env_config_memory
   env_config_keeper_retry_backoff

--- a/lib/config/env_config.ml
+++ b/lib/config/env_config.ml
@@ -7,6 +7,7 @@
 include Env_config_core
 include Env_config_runtime
 include Env_config_governance
+include Env_config_hitl
 include Env_config_keeper
 
 let print_summary () =

--- a/lib/config/env_config.mli
+++ b/lib/config/env_config.mli
@@ -18,5 +18,6 @@
 include module type of Env_config_core
 include module type of Env_config_runtime
 include module type of Env_config_governance
+include module type of Env_config_hitl
 include module type of Env_config_keeper
 

--- a/lib/config/env_config_hitl.ml
+++ b/lib/config/env_config_hitl.ml
@@ -11,7 +11,7 @@ open Env_config_core
 
 let default_critical_timeout_s = 3600.0
 
-let critical_timeout_s_value =
+let critical_timeout_s () =
   let raw =
     get_float
       ~default:default_critical_timeout_s
@@ -38,5 +38,4 @@ let critical_timeout_s_value =
 
     Env: [MASC_HITL_CRITICAL_TIMEOUT_S]. Default: [3600.0] (1 hour).
     Values <= [0.0] disable the timeout and revert to the legacy
-    operator-must-decide behavior (warned once at module load). *)
-let critical_timeout_s () = critical_timeout_s_value
+    operator-must-decide behavior. *)

--- a/lib/config/env_config_hitl.ml
+++ b/lib/config/env_config_hitl.ml
@@ -9,9 +9,22 @@ open Env_config_core
     @category Timeouts
     @ops_class operator *)
 
+let default_critical_timeout_s = 3600.0
+
 let critical_timeout_s_value =
-  let raw = get_float ~default:3600.0 "MASC_HITL_CRITICAL_TIMEOUT_S" in
-  if raw <= 0.0
+  let raw =
+    get_float
+      ~default:default_critical_timeout_s
+      "MASC_HITL_CRITICAL_TIMEOUT_S"
+  in
+  if not (Float.is_finite raw)
+  then (
+    Log.Misc.warn
+      "MASC_HITL_CRITICAL_TIMEOUT_S=%g is non-finite; using default %.2f"
+      raw
+      default_critical_timeout_s;
+    default_critical_timeout_s)
+  else if raw <= 0.0
   then (
     Log.Misc.warn
       "MASC_HITL_CRITICAL_TIMEOUT_S=%.2f disables the critical approval timeout; \

--- a/lib/config/env_config_hitl.ml
+++ b/lib/config/env_config_hitl.ml
@@ -4,7 +4,10 @@ open Env_config_core
 
     Bounded timeouts prevent dangerous tool approvals from stalling a Keeper
     turn indefinitely while still giving operators a reasonable decision
-    window. *)
+    window.
+
+    @category Timeouts
+    @ops_class operator *)
 
 let critical_timeout_s_value =
   let raw = get_float ~default:3600.0 "MASC_HITL_CRITICAL_TIMEOUT_S" in

--- a/lib/config/env_config_hitl.ml
+++ b/lib/config/env_config_hitl.ml
@@ -1,0 +1,26 @@
+open Env_config_core
+
+(** HITL (human-in-the-loop) approval configuration.
+
+    Bounded timeouts prevent dangerous tool approvals from stalling a Keeper
+    turn indefinitely while still giving operators a reasonable decision
+    window. *)
+
+let critical_timeout_s_value =
+  let raw = get_float ~default:3600.0 "MASC_HITL_CRITICAL_TIMEOUT_S" in
+  if raw <= 0.0
+  then (
+    Log.Misc.warn
+      "MASC_HITL_CRITICAL_TIMEOUT_S=%.2f disables the critical approval timeout; \
+       dangerous tools may stall turns indefinitely (legacy behavior)"
+      raw;
+    0.0)
+  else raw
+;;
+
+(** Critical-tool approval timeout in seconds.
+
+    Env: [MASC_HITL_CRITICAL_TIMEOUT_S]. Default: [3600.0] (1 hour).
+    Values <= [0.0] disable the timeout and revert to the legacy
+    operator-must-decide behavior (warned once at module load). *)
+let critical_timeout_s () = critical_timeout_s_value

--- a/lib/config/env_config_hitl.mli
+++ b/lib/config/env_config_hitl.mli
@@ -1,5 +1,8 @@
 (** HITL (human-in-the-loop) approval configuration. *)
 
+val default_critical_timeout_s : float
+(** Default critical-tool approval timeout in seconds. *)
+
 val critical_timeout_s : unit -> float
 (** Critical-tool approval timeout in seconds.
 

--- a/lib/config/env_config_hitl.mli
+++ b/lib/config/env_config_hitl.mli
@@ -1,0 +1,8 @@
+(** HITL (human-in-the-loop) approval configuration. *)
+
+val critical_timeout_s : unit -> float
+(** Critical-tool approval timeout in seconds.
+
+    Env: [MASC_HITL_CRITICAL_TIMEOUT_S]. Default: [3600.0] (1 hour).
+    Values <= [0.0] disable the timeout and revert to the legacy
+    operator-must-decide behavior (warned once at module load). *)

--- a/lib/config/env_config_hitl.mli
+++ b/lib/config/env_config_hitl.mli
@@ -8,4 +8,4 @@ val critical_timeout_s : unit -> float
 
     Env: [MASC_HITL_CRITICAL_TIMEOUT_S]. Default: [3600.0] (1 hour).
     Values <= [0.0] disable the timeout and revert to the legacy
-    operator-must-decide behavior (warned once at module load). *)
+    operator-must-decide behavior. *)

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -477,6 +477,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                ~disposition_reason:"waiting_approval"
                ~risk_level
                ?clock
+               ~critical_timeout_s:(Env_config_hitl.critical_timeout_s ())
                ()))
     else Agent_sdk.Hooks.Approve
 ;;

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -726,6 +726,10 @@ let sort_entries_by_requested_at entries =
 
 let default_noncritical_approval_timeout_s = 600.0
 
+let approval_timeout_reason timeout_s =
+  Printf.sprintf "approval timeout after %gs" timeout_s
+;;
+
 (** Submit a tool call for approval and suspend the calling fiber.
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside agent fiber).
@@ -813,7 +817,7 @@ let submit_and_await
       with
       | `Decision d -> d
       | `Timeout ->
-        let reason = Printf.sprintf "approval timeout after %.0fs" timeout_s in
+        let reason = approval_timeout_reason timeout_s in
         audit_approval_event
           ~base_path:entry.audit_base_path
           ~event_type:"approval_timeout"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -735,10 +735,11 @@ let default_noncritical_approval_timeout_s = 600.0
     30s wrapper used by A2 for generic [Eio.Promise.await] sites: a HITL
     approval is bounded by an operator's response time, not by an SLA on
     autonomous progress.
-    [Critical] approvals are exempt, matching [expire_stale]'s
-    operator-must-decide policy. Drop the default only after measuring
-    the operator-response distribution — premature shortening turns
-    every distracted operator into an [Approval_expired] event. *)
+
+    [critical_timeout_s] defaults to {!Env_config_hitl.critical_timeout_s}
+    and bounds how long a [Critical] approval may stall the Keeper fiber
+    waiting for an operator. A value <= [0.0] disables the critical timeout
+    and reverts to the legacy operator-must-decide behavior. *)
 let submit_and_await
       ~keeper_name
       ~tool_name
@@ -758,6 +759,7 @@ let submit_and_await
       ?disposition_reason
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
+      ?(critical_timeout_s = Env_config_hitl.critical_timeout_s ())
       ()
   : Agent_sdk.Hooks.approval_decision
   =
@@ -801,37 +803,41 @@ let submit_and_await
        | None -> decision)
   in
   let await_with_timeout () =
+    let use_timeout clock timeout_s =
+      match
+        Eio.Fiber.first
+          (fun () -> `Decision (Eio.Promise.await promise))
+          (fun () ->
+             Eio.Time.sleep clock timeout_s;
+             `Timeout)
+      with
+      | `Decision d -> d
+      | `Timeout ->
+        let reason = Printf.sprintf "approval timeout after %.0fs" timeout_s in
+        audit_approval_event
+          ~base_path:entry.audit_base_path
+          ~event_type:"approval_timeout"
+          ~id
+          ~keeper_name
+          ~tool_name
+          ~risk_level
+          ?turn_id
+          ?task_id
+          ?goal_id
+          ~goal_ids
+          ~sandbox_target:entry.sandbox_target
+          ?runtime_contract
+          ?selected_model
+          ~decision:(Approval_expired reason)
+          ();
+        (* Mirror expire_stale's teardown, but preserve any concurrent
+           operator decision that wins the promise resolution race. *)
+        timeout_decision reason
+    in
     match clock, risk_level with
-    | Some clock, (Low | Medium | High) ->
-      (match
-         Eio.Fiber.first
-           (fun () -> `Decision (Eio.Promise.await promise))
-           (fun () ->
-              Eio.Time.sleep clock timeout_s;
-              `Timeout)
-       with
-       | `Decision d -> d
-       | `Timeout ->
-         let reason = Printf.sprintf "approval timeout after %.0fs" timeout_s in
-         audit_approval_event
-           ~base_path:entry.audit_base_path
-           ~event_type:"approval_timeout"
-           ~id
-           ~keeper_name
-           ~tool_name
-           ~risk_level
-           ?turn_id
-           ?task_id
-           ?goal_id
-           ~goal_ids
-           ~sandbox_target:entry.sandbox_target
-           ?runtime_contract
-           ?selected_model
-           ~decision:(Approval_expired reason)
-           ();
-         (* Mirror expire_stale's teardown, but preserve any concurrent
-            operator decision that wins the promise resolution race. *)
-         timeout_decision reason)
+    | Some clock, (Low | Medium | High) -> use_timeout clock timeout_s
+    | Some clock, Critical when critical_timeout_s > 0.0 ->
+      use_timeout clock critical_timeout_s
     | Some _, Critical | None, _ -> Eio.Promise.await promise
   in
   Eio_guard.protect await_with_timeout ~finally:(fun () ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -226,6 +226,7 @@ val submit_and_await :
   ?disposition_reason:string ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
+  ?critical_timeout_s:float ->
   unit ->
   Agent_sdk.Hooks.approval_decision
 

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -93,9 +93,14 @@ let bridge_details fields envelope =
     exits immediately instead of retrying. *)
 
 let with_hitl_approval_headroom timeout_s =
+  let approval_wait_s =
+    Float.max
+      Keeper_approval_queue.default_noncritical_approval_timeout_s
+      (Env_config_hitl.critical_timeout_s ())
+  in
   Float.max
     timeout_s
-    (Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0)
+    (approval_wait_s +. 30.0)
 ;;
 
 

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -1,10 +1,11 @@
 (* lib/keeper/keeper_llm_bridge.mli *)
 
 val with_hitl_approval_headroom : float -> float
-(** Raise an OAS bridge timeout floor above the longest active HITL
-    approval wait. This keeps operator approval latency from being surfaced as
-    an OAS/provider timeout before the approval queue itself resolves or
-    expires. *)
+(** Raise an OAS bridge timeout floor above the longest configured finite HITL
+    approval wait. Non-critical approval wait is always finite; Critical approval
+    wait contributes only when [critical_timeout_s] is enabled. This keeps
+    operator approval latency from being surfaced as an OAS/provider timeout
+    before the approval queue itself resolves or expires. *)
 
 type cancel_classification =
   | Unknown_cancel

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -1,7 +1,7 @@
 (* lib/keeper/keeper_llm_bridge.mli *)
 
 val with_hitl_approval_headroom : float -> float
-(** Raise an OAS bridge timeout floor above the default non-critical HITL
+(** Raise an OAS bridge timeout floor above the longest active HITL
     approval wait. This keeps operator approval latency from being surfaced as
     an OAS/provider timeout before the approval queue itself resolves or
     expires. *)

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -36,6 +36,8 @@ let key_to_env =
     (* [proactive] *)
     "proactive.enabled",                "MASC_KEEPER_PROACTIVE_ENABLED";
     "proactive.min_interval_sec",       "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC";
+    (* [hitl] *)
+    "hitl.critical_timeout_s",          "MASC_HITL_CRITICAL_TIMEOUT_S";
     (* [turn] *)
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -459,13 +459,14 @@ let test_submit_and_await_clock_timeout_skips_critical () =
         ~base_path
         ~clock
         ~timeout_s:0.01
+        ~critical_timeout_s:0.0
         ()
     in
     result := Some decision);
   yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
   Eio.Time.sleep clock 0.03;
   Alcotest.(check bool)
-    "Critical approval still waits past submit timeout"
+    "Critical approval still waits when critical_timeout_s is disabled"
     true
     (Option.is_none !result);
   let id =
@@ -484,6 +485,44 @@ let test_submit_and_await_clock_timeout_skips_critical () =
       Alcotest.fail
         ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
   | None -> Alcotest.fail "Critical approval did not resume")
+
+let test_submit_and_await_critical_timeout_returns_reject () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "critical-bound-timeout-test" in
+  let result = ref None in
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name
+        ~tool_name:"tool_edit_file"
+        ~input:(`Assoc [("path", `String "/dangerous")])
+        ~risk_level:AQ.Critical
+        ~base_path
+        ~clock
+        ~critical_timeout_s:0.05
+        ()
+    in
+    result := Some decision);
+  yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+  Eio.Time.sleep clock 0.15;
+  yield_until (fun () -> Option.is_some !result);
+  match !result with
+  | Some (Agent_sdk.Hooks.Reject reason) ->
+    Alcotest.(check bool)
+      "Critical timeout reason mentions approval timeout"
+      true
+      (String.starts_with ~prefix:"approval timeout" reason)
+  | Some decision ->
+    Alcotest.fail
+      ("expected Reject from timeout, got "
+       ^ AQ.approval_decision_to_string decision)
+  | None -> Alcotest.fail "Critical approval did not time out")
 
 let test_submit_and_await_clock_returns_manual_decision () =
   Eio_main.run @@ fun env ->
@@ -1608,6 +1647,8 @@ let () =
       Alcotest.test_case "expire skips Critical" `Quick test_approval_queue_expire_skips_critical;
       Alcotest.test_case "submit timeout skips Critical" `Quick
         test_submit_and_await_clock_timeout_skips_critical;
+      Alcotest.test_case "Critical bounded timeout returns Reject" `Quick
+        test_submit_and_await_critical_timeout_returns_reject;
       Alcotest.test_case "submit timeout returns manual winner" `Quick
         test_submit_and_await_clock_returns_manual_decision;
       Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -517,7 +517,11 @@ let test_submit_and_await_critical_timeout_returns_reject () =
     Alcotest.(check bool)
       "Critical timeout reason mentions approval timeout"
       true
-      (String.starts_with ~prefix:"approval timeout" reason)
+      (String.starts_with ~prefix:"approval timeout" reason);
+    Alcotest.(check string)
+      "sub-second timeout reason preserves precision"
+      "approval timeout after 0.05s"
+      reason
   | Some decision ->
     Alcotest.fail
       ("expected Reject from timeout, got "

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -216,17 +216,15 @@ let test_unknown_cancel_stays_warn () =
 ;;
 
 let test_hitl_headworkspace_exceeds_default_approval_wait () =
-  let floor =
-    Keeper_approval_queue.default_noncritical_approval_timeout_s +. 30.0
-  in
+  let floor = 3630.0 in
   Alcotest.(check (float 0.001))
     "short bridge timeout is raised above HITL wait"
     floor
     (Keeper_llm_bridge.with_hitl_approval_headroom 292.0);
   Alcotest.(check (float 0.001))
     "long bridge timeout is preserved"
-    900.0
-    (Keeper_llm_bridge.with_hitl_approval_headroom 900.0)
+    3900.0
+    (Keeper_llm_bridge.with_hitl_approval_headroom 3900.0)
 ;;
 
 let test_timeout_inner_cancel_classification () =

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -216,15 +216,21 @@ let test_unknown_cancel_stays_warn () =
 ;;
 
 let test_hitl_headworkspace_exceeds_default_approval_wait () =
-  let floor = 3630.0 in
+  let approval_wait_s =
+    Float.max
+      Keeper_approval_queue.default_noncritical_approval_timeout_s
+      (Env_config_hitl.critical_timeout_s ())
+  in
+  let floor = approval_wait_s +. 30.0 in
+  let long_timeout = floor +. 270.0 in
   Alcotest.(check (float 0.001))
     "short bridge timeout is raised above HITL wait"
     floor
     (Keeper_llm_bridge.with_hitl_approval_headroom 292.0);
   Alcotest.(check (float 0.001))
     "long bridge timeout is preserved"
-    3900.0
-    (Keeper_llm_bridge.with_hitl_approval_headroom 3900.0)
+    long_timeout
+    (Keeper_llm_bridge.with_hitl_approval_headroom long_timeout)
 ;;
 
 let test_timeout_inner_cancel_classification () =

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -8,6 +8,8 @@
 open Alcotest
 open Masc
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -54,6 +56,16 @@ let with_clean_boot_overrides f =
     ~finally:(fun () ->
       Config_boot_overrides.reset_for_tests ();
       Keeper_runtime_resolved.reset_for_tests ())
+    f
+
+let with_unset_env name f =
+  let prev = Sys.getenv_opt name in
+  unsetenv name;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some value -> Unix.putenv name value
+      | None -> unsetenv name)
     f
 
 (* --- Tests using resolve_overrides (pure, no env side effects) --- *)
@@ -181,6 +193,25 @@ let test_applies_hitl_critical_timeout_override () =
   check (option string) "hitl timeout maps to canonical env"
     (Some "42.5")
     (List.assoc_opt "MASC_HITL_CRITICAL_TIMEOUT_S" overrides)
+
+let test_hitl_timeout_reader_observes_boot_override_after_preload () =
+  with_clean_boot_overrides @@ fun () ->
+  with_unset_env "MASC_HITL_CRITICAL_TIMEOUT_S" @@ fun () ->
+  check (float 0.0001) "preload sees default"
+    Env_config_hitl.default_critical_timeout_s
+    (Env_config_hitl.critical_timeout_s ());
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[hitl]\ncritical_timeout_s = 42.5\n";
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Error msg -> failf "unexpected error: %s" msg
+  | Ok n ->
+    check int "applied count" 1 n;
+    check (option string) "boot override stored"
+      (Some "42.5")
+      (Config_boot_overrides.get_opt "MASC_HITL_CRITICAL_TIMEOUT_S");
+    check (float 0.0001) "production reader sees boot override"
+      42.5
+      (Env_config_hitl.critical_timeout_s ())
 
 let test_applies_memory_overrides () =
   let doc = parse_or_fail
@@ -532,6 +563,10 @@ let () =
         ; test_case "applies proactive min interval override" `Quick test_applies_proactive_min_interval_override
         ; test_case "applies lifecycle enabled overrides (RFC-0297 P0-1)" `Quick test_applies_lifecycle_enabled_overrides
         ; test_case "applies HITL critical timeout override" `Quick test_applies_hitl_critical_timeout_override
+        ; test_case
+            "HITL timeout reader observes boot override after preload"
+            `Quick
+            test_hitl_timeout_reader_observes_boot_override_after_preload
         ; test_case "applies memory overrides" `Quick test_applies_memory_overrides
         ; test_case "memory bank reads boot override knobs" `Quick test_memory_bank_reads_boot_override_knobs
         ; test_case

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -172,6 +172,16 @@ let test_applies_lifecycle_enabled_overrides () =
     (Some "true")
     (List.assoc_opt "MASC_KEEPER_AUTONOMOUS_ENABLED" overrides)
 
+let test_applies_hitl_critical_timeout_override () =
+  let doc = parse_or_fail "[hitl]\ncritical_timeout_s = 42.5\n" in
+  let count, overrides =
+    Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
+  in
+  check int "applied hitl timeout override" 1 count;
+  check (option string) "hitl timeout maps to canonical env"
+    (Some "42.5")
+    (List.assoc_opt "MASC_HITL_CRITICAL_TIMEOUT_S" overrides)
+
 let test_applies_memory_overrides () =
   let doc = parse_or_fail
     "[memory]\n\
@@ -521,6 +531,7 @@ let () =
         ; test_case "applies turn execution overrides" `Quick test_applies_turn_execution_overrides
         ; test_case "applies proactive min interval override" `Quick test_applies_proactive_min_interval_override
         ; test_case "applies lifecycle enabled overrides (RFC-0297 P0-1)" `Quick test_applies_lifecycle_enabled_overrides
+        ; test_case "applies HITL critical timeout override" `Quick test_applies_hitl_critical_timeout_override
         ; test_case "applies memory overrides" `Quick test_applies_memory_overrides
         ; test_case "memory bank reads boot override knobs" `Quick test_memory_bank_reads_boot_override_knobs
         ; test_case


### PR DESCRIPTION
## Summary
Adds a bounded timeout for Critical-risk HITL approvals so a Keeper turn no longer stalls indefinitely waiting for an operator decision.

## Changes
- New `Env_config_hitl` module exposing `MASC_HITL_CRITICAL_TIMEOUT_S` and `[hitl].critical_timeout_s`.
- `Keeper_approval_queue.submit_and_await` now applies `critical_timeout_s` to Critical approvals.
- `Governance_pipeline\'s production HITL callback passes the configured timeout.
- Seed `[hitl] critical_timeout_s = 3600.0` in `config/runtime.toml`.
- Regression test for critical timeout and the legacy disable path.

## Verification
- `scripts/dune-local.sh build @default` green
- `test/test_hitl_approval.exe` 41/41 pass
- `test/test_governance_pipeline.exe` 97/97 pass
- `test/test_runtime_config_validity.exe` 23/23 pass
- `scripts/ci/check-masc-oas-boundary.sh` PASS

## Spec
- HTML spec: `/Users/dancer/me/docs/superpowers/specs/2026-07-01-masc-oas-resilience-design.html`
- Plan: `/Users/dancer/me/docs/superpowers/plans/2026-07-01-pr-b-hitl-async-timeout.md`