### PR TITLE
feat(fusion): persist run registry to append-only JSONL

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -470,17 +470,17 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
           "failed"가 되지 않게 한다. *)
        (match judge with
         | Ok j ->
-          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
             ~ok:true ();
-          broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+          broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
             ~resolved_answer:j.Fusion_types.resolved_answer ~board_post_id
         | Error e ->
-          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
             ~failure:(Fusion_types.judge_failure_text e)
             ~failure_code:(Fusion_types.judge_failure_tag e)
             ~ok:false ();
-          broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+          broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
             ~resolved_answer:
               (Printf.sprintf "fusion run failed — %s" (render_failure e))

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -22,7 +22,7 @@ let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
      orchestrator-level Cancelled(handle fork match)
      만 막았고 이 내부 append window는 못 막았다. Denied/Sink_failed/aborted 종료 분기가 모두
      이 함수를 경유하므로 같은 누수의 형제 경로다. *)
-  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+  Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
     ~failure:content ~failure_code ~ok:false ();
   (try
      Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
@@ -42,7 +42,7 @@ let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
      broadcast/wake도 suspending I/O다. append가 Cancelled를 재전파하면 여기 도달하지 못하나
      (generic append 실패는 warn 후 계속 진행해 도달한다), registry는 위에서 이미 갱신됐으므로
      어느 경우든 가시성은 보존된다. *)
-  Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+  Fusion_sink.broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
   Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
     ~resolved_answer:content ~board_post_id:""
 
@@ -91,12 +91,12 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
       (* RFC-0266 §7: 진행중 가시성을 위해 fork 직전 run을 Running으로 등록한다
          (sink/실패 경로가 Completed로 갱신). 등록은 부수효과 없는 in-memory 기록일
          뿐, 키퍼를 깨우지 않는다(wake는 별개). *)
-      Fusion_run_registry.register_running Fusion_run_registry.global ~run_id ~keeper
+      Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
         ~preset ~started_at:now_unix;
       (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
          (no polling). wake-free, broadcast-failure-safe; see
          Fusion_sink.broadcast_run_status. *)
-      Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+      Fusion_sink.broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
       (* out-of-band: fiber fork → 키퍼 턴은 즉시 진행, 결과는 sink가 chat lane에.
          배경 fiber 실패/거부/싱크 실패는 동일한 chat lane에 기록해 started-but-failed
          상태가 남지 않도록 한다. 호출자는 이 fiber가 키퍼 턴보다 오래 살아도록 root
@@ -126,7 +126,7 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
              취소/셧다운 캐스케이드를 deadlock시킬 위험이 있으므로 이 경로에선 생략한다 —
              registry가 정확해 다음 HTTP fetch / tab-refresh가 패널을 self-heal한다.
              그 뒤 구조적 취소는 흡수하지 않고 재전파한다 (Eio 규약). *)
-          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
             ~failure:"cancelled: structural cancellation (shutdown or sibling switch failure)"
             ~failure_code:"cancelled" ~ok:false ();
           raise exn

--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries yojson otoml)
+ (libraries eio yojson otoml)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries eio yojson otoml)
+ (libraries fs_compat masc_log yojson otoml)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -1,17 +1,18 @@
 (* Fusion — in-memory run registry for in-progress + recent fusion visibility
-   (RFC-0266 §7 Phase 2). The fusion tool registers a run [Running] at fork
-   start and the sink/failure path marks it [Completed] on finish, so an
-   operator surface (masc_fusion_status tool = Phase 3, dashboard = Phase 4) can
-   show what is deliberating now and what just finished — instead of run_id only
-   living in the caller's tool-result.
+   (RFC-0266 §7 Phase 2/Phase D). The fusion tool registers a run [Running] at
+   fork start and the sink/failure path marks it [Completed] on finish, so an
+   operator surface (masc_fusion_status tool = Phase 3, dashboard = Phase 4)
+   can show what is deliberating now and what just finished — instead of run_id
+   only living in the caller's tool-result.
 
-   Lock-free Atomic + CAS; no extra deps. Server-lifetime: a fork that dies on
-   server shutdown takes its registry entry with it, so no orphan [Running]
-   survives a restart (RFC-0266 §10 #4).
+   Lock-free Atomic + CAS; optional append-only JSONL backing under
+   [<base-path>/.masc/fusion-runs.jsonl] so history survives server restart.
+   Server-lifetime: a fork that dies on server shutdown takes its registry entry
+   with it, so no orphan [Running] survives a restart (RFC-0266 §10 #4).
 
    This module never wakes a keeper (that is the WAKE half, Phase 1). Recording
-   a run is the visibility half and is intentionally side-effect-free beyond the
-   in-memory table. *)
+   a run is the visibility half and is intentionally side-effect-free beyond
+   the in-memory table and the append-only log. *)
 
 type run_status =
   | Running
@@ -32,7 +33,10 @@ type run = {
   status : run_status;
 }
 
-type t = run list Atomic.t
+type t = {
+  runs : run list Atomic.t;
+  path : Eio.Fs.dir_ty Eio.Path.t option;
+}
 
 (* Recent-history retention for [Completed] runs. [Running] runs are never
    evicted (active state must stay accurate). NOTE: 이전 주석은 [Running]이
@@ -43,7 +47,7 @@ type t = run list Atomic.t
    server lifetime. *)
 let max_completed_retained = 64
 
-let create () : t = Atomic.make []
+let create ?path () : t = { runs = Atomic.make []; path }
 
 let is_running (r : run) =
   match r.status with
@@ -64,12 +68,27 @@ let prune (runs : run list) : run list =
 ;;
 
 let rec update (t : t) (f : run list -> run list) =
-  let cur = Atomic.get t in
+  let cur = Atomic.get t.runs in
   let next = f cur in
-  if not (Atomic.compare_and_set t cur next) then update t f
+  if not (Atomic.compare_and_set t.runs cur next) then update t f
 ;;
 
-let register_running (t : t) ~run_id ~keeper ~preset ~started_at =
+let append_event t event =
+  match t.path with
+  | None -> ()
+  | Some path ->
+    let line = Fusion_run_registry_event.to_jsonl event in
+    (* Persistence is best-effort: a failed append must not abort the fusion
+       fork or corrupt in-memory state. The in-memory registry remains
+       authoritative for this process lifetime; the next successful append
+       will catch the log back up for any runs still tracked. *)
+    try Eio.Path.save ~append:true ~create:(`If_missing 0o600) path line with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _exn -> ()
+;;
+
+let register_running t ~run_id ~keeper ~preset ~started_at =
+  append_event t (Register { run_id; keeper; preset; started_at });
   update t (fun runs ->
     let run = { run_id; keeper; preset; started_at; status = Running } in
     (* defensive: a re-registered run_id replaces its prior entry *)
@@ -78,6 +97,7 @@ let register_running (t : t) ~run_id ~keeper ~preset ~started_at =
 ;;
 
 let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
+  append_event t (Complete { run_id; ok; failure; failure_code });
   update t (fun runs ->
     runs
     |> List.map (fun r ->
@@ -88,11 +108,11 @@ let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
 ;;
 
 let list_runs (t : t) : run list =
-  Atomic.get t |> List.sort (fun a b -> Float.compare b.started_at a.started_at)
+  Atomic.get t.runs |> List.sort (fun a b -> Float.compare b.started_at a.started_at)
 ;;
 
 let get (t : t) ~run_id : run option =
-  List.find_opt (fun r -> String.equal r.run_id run_id) (Atomic.get t)
+  List.find_opt (fun r -> String.equal r.run_id run_id) (Atomic.get t.runs)
 ;;
 
 (* Stable status vocabulary shared by every fusion-run surface (Phase 3 keeper
@@ -131,6 +151,48 @@ let run_to_yojson (r : run) : Yojson.Safe.t =
   `Assoc (base @ failure_fields)
 ;;
 
+(* Replay helpers — used to hydrate the in-memory table from disk at boot. *)
+let apply_event runs = function
+  | Fusion_run_registry_event.Register { run_id; keeper; preset; started_at } ->
+    let run = { run_id; keeper; preset; started_at; status = Running } in
+    let without_dup = List.filter (fun r -> not (String.equal r.run_id run_id)) runs in
+    run :: without_dup
+  | Fusion_run_registry_event.Complete { run_id; ok; failure; failure_code } ->
+    List.map
+      (fun r ->
+         if String.equal r.run_id run_id
+         then { r with status = Completed { ok; failure; failure_code } }
+         else r)
+      runs
+;;
+
+let replay path : t =
+  let content =
+    try Eio.Path.load path with
+    | Eio.Io _ -> ""
+  in
+  let lines = String.split_on_char '\n' content in
+  let events =
+    List.filter_map
+      (fun line ->
+         if String.equal line ""
+         then None
+         else
+           match Yojson.Safe.from_string line |> Fusion_run_registry_event.of_yojson with
+           | Ok e -> Some e
+           | Error _ -> None)
+      lines
+  in
+  let runs = List.fold_left apply_event [] events |> prune in
+  { runs = Atomic.make runs; path = Some path }
+;;
+
 (* Process-wide registry the fusion tool/sink write to (server-lifetime). Tests
-   use a fresh [create ()] for state isolation, avoiding a reset backdoor. *)
-let global : t = create ()
+   use a fresh [create ()] for state isolation, avoiding a reset backdoor.
+   The backing path is set at server boot via [set_global] after replaying the
+   persisted JSONL. *)
+let global_atomic : t Atomic.t = Atomic.make (create ())
+
+let global () : t = Atomic.get global_atomic
+
+let set_global (t : t) = Atomic.set global_atomic t

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -167,6 +167,18 @@ let apply_event runs = function
       runs
 ;;
 
+let drop_replayed_running runs =
+  let running, completed = List.partition is_running runs in
+  (match running with
+   | [] -> ()
+   | stale ->
+     Log.Misc.warn
+       "fusion_run_registry: dropped %d replayed running run(s); worker fibers do not \
+        survive server restart"
+       (List.length stale));
+  completed
+;;
+
 let parse_event_line ~path ~line_no line =
   match String.trim line with
   | "" -> Ok None
@@ -276,7 +288,11 @@ let replay path : t =
        "fusion_run_registry: skipped %d malformed replay line(s); first=%s"
        (List.length errors)
        first);
-  let runs = List.fold_left apply_event [] events |> prune in
+  let runs =
+    List.fold_left apply_event [] events
+    |> drop_replayed_running
+    |> prune
+  in
   if should_compact then compact_replay_log path runs;
   { runs = Atomic.make runs; path = Some path }
 ;;

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -35,7 +35,7 @@ type run = {
 
 type t = {
   runs : run list Atomic.t;
-  path : Eio.Fs.dir_ty Eio.Path.t option;
+  path : string option;
 }
 
 (* Recent-history retention for [Completed] runs. [Running] runs are never
@@ -77,14 +77,12 @@ let append_event t event =
   match t.path with
   | None -> ()
   | Some path ->
-    let line = Fusion_run_registry_event.to_jsonl event in
-    (* Persistence is best-effort: a failed append must not abort the fusion
-       fork or corrupt in-memory state. The in-memory registry remains
-       authoritative for this process lifetime; the next successful append
-       will catch the log back up for any runs still tracked. *)
-    try Eio.Path.save ~append:true ~create:(`If_missing 0o600) path line with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | _exn -> ()
+    (try Fs_compat.append_jsonl path (Fusion_run_registry_event.to_yojson event) with
+     | exn ->
+       Log.Misc.warn
+         "fusion_run_registry: append failed for %s: %s"
+         path
+         (Printexc.to_string exn))
 ;;
 
 let register_running t ~run_id ~keeper ~preset ~started_at =
@@ -166,23 +164,62 @@ let apply_event runs = function
       runs
 ;;
 
-let replay path : t =
+let parse_event_line ~path ~line_no line =
+  match String.trim line with
+  | "" -> Ok None
+  | line ->
+    (match
+       try Ok (Yojson.Safe.from_string line) with
+       | Yojson.Json_error msg -> Error ("invalid JSON: " ^ msg)
+     with
+     | Error msg -> Error msg
+     | Ok json ->
+       (match Fusion_run_registry_event.of_yojson json with
+        | Ok event -> Ok (Some event)
+        | Error msg -> Error msg))
+    |> Result.map_error (fun msg ->
+      Printf.sprintf "%s:%d: %s" path line_no msg)
+;;
+
+let load_replay_content path =
   let content =
-    try Eio.Path.load path with
-    | Eio.Io _ -> ""
+    if not (Fs_compat.file_exists path)
+    then None
+    else (
+      try Some (Fs_compat.load_file path) with
+      | exn ->
+        Log.Misc.warn
+          "fusion_run_registry: replay load failed for %s: %s"
+          path
+          (Printexc.to_string exn);
+        None)
   in
-  let lines = String.split_on_char '\n' content in
+  Option.value ~default:"" content
+;;
+
+let replay path : t =
+  let lines = String.split_on_char '\n' (load_replay_content path) in
+  let malformed = ref [] in
   let events =
-    List.filter_map
-      (fun line ->
-         if String.equal line ""
-         then None
-         else
-           match Yojson.Safe.from_string line |> Fusion_run_registry_event.of_yojson with
-           | Ok e -> Some e
-           | Error _ -> None)
-      lines
+    let rec loop line_no acc = function
+      | [] -> List.rev acc
+      | line :: rest ->
+        (match parse_event_line ~path ~line_no line with
+         | Ok None -> loop (line_no + 1) acc rest
+         | Ok (Some event) -> loop (line_no + 1) (event :: acc) rest
+         | Error msg ->
+           malformed := msg :: !malformed;
+           loop (line_no + 1) acc rest)
+    in
+    loop 1 [] lines
   in
+  (match !malformed with
+   | [] -> ()
+   | errors ->
+     Log.Misc.warn
+       "fusion_run_registry: skipped %d malformed replay line(s); first=%s"
+       (List.length errors)
+       (List.hd (List.rev errors)));
   let runs = List.fold_left apply_event [] events |> prune in
   { runs = Atomic.make runs; path = Some path }
 ;;

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -194,7 +194,9 @@ let load_replay_content path =
           (Printexc.to_string exn);
         None)
   in
-  Option.value ~default:"" content
+  match content with
+  | Some content -> content
+  | None -> ""
 ;;
 
 let replay path : t =

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -181,48 +181,96 @@ let parse_event_line ~path ~line_no line =
       Printf.sprintf "%s:%d: %s" path line_no msg)
 ;;
 
-let load_replay_content path =
-  let content =
-    if not (Fs_compat.file_exists path)
-    then None
-    else (
-      try Some (Fs_compat.load_file path) with
-      | exn ->
-        Log.Misc.warn
-          "fusion_run_registry: replay load failed for %s: %s"
-          path
-          (Printexc.to_string exn);
-        None)
+let events_of_run (run : run) =
+  let register =
+    Fusion_run_registry_event.Register
+      { run_id = run.run_id
+      ; keeper = run.keeper
+      ; preset = run.preset
+      ; started_at = run.started_at
+      }
   in
-  match content with
-  | Some content -> content
-  | None -> ""
+  match run.status with
+  | Running -> [ register ]
+  | Completed { ok } -> [ register; Complete { run_id = run.run_id; ok } ]
+;;
+
+let compact_replay_log path runs =
+  let events =
+    runs
+    |> List.sort (fun a b -> Float.compare a.started_at b.started_at)
+    |> List.concat_map events_of_run
+  in
+  let content =
+    events
+    |> List.map Fusion_run_registry_event.to_jsonl
+    |> String.concat ""
+  in
+  try
+    match Fs_compat.save_file_atomic path content with
+    | Ok () -> ()
+    | Error msg ->
+      Log.Misc.warn "fusion_run_registry: replay compaction failed for %s: %s" path msg
+  with
+  | exn ->
+    Log.Misc.warn
+      "fusion_run_registry: replay compaction raised for %s: %s"
+      path
+      (Printexc.to_string exn)
+;;
+
+let fold_replay_events path =
+  if not (Fs_compat.file_exists path)
+  then [], [], false
+  else (
+    try
+      let (events, malformed, _line_no), _boundary =
+        Fs_compat.fold_appended_lines
+          ~path
+          ~from:0
+          ~init:([], [], 1)
+          ~f:(fun (events, malformed, line_no) line ->
+            match parse_event_line ~path ~line_no line with
+            | Ok None -> events, malformed, line_no + 1
+            | Ok (Some event) -> event :: events, malformed, line_no + 1
+            | Error msg -> events, msg :: malformed, line_no + 1)
+      in
+      let should_compact =
+        match Fs_compat.file_size path with
+        | Some size when _boundary < size ->
+          Log.Misc.warn
+            "fusion_run_registry: replay left unterminated tail in %s (%d/%d bytes \
+             consumed)"
+            path
+            _boundary
+            size;
+          false
+        | Some _ -> true
+        | None ->
+          Log.Misc.warn "fusion_run_registry: replay stat failed after streaming %s" path;
+          false
+      in
+      List.rev events, List.rev malformed, should_compact
+    with
+    | exn ->
+      Log.Misc.warn
+        "fusion_run_registry: replay stream failed for %s: %s"
+        path
+        (Printexc.to_string exn);
+      [], [], false)
 ;;
 
 let replay path : t =
-  let lines = String.split_on_char '\n' (load_replay_content path) in
-  let malformed = ref [] in
-  let events =
-    let rec loop line_no acc = function
-      | [] -> List.rev acc
-      | line :: rest ->
-        (match parse_event_line ~path ~line_no line with
-         | Ok None -> loop (line_no + 1) acc rest
-         | Ok (Some event) -> loop (line_no + 1) (event :: acc) rest
-         | Error msg ->
-           malformed := msg :: !malformed;
-           loop (line_no + 1) acc rest)
-    in
-    loop 1 [] lines
-  in
-  (match !malformed with
+  let events, malformed, should_compact = fold_replay_events path in
+  (match malformed with
    | [] -> ()
-   | errors ->
+   | first :: _ as errors ->
      Log.Misc.warn
        "fusion_run_registry: skipped %d malformed replay line(s); first=%s"
        (List.length errors)
-       (List.hd (List.rev errors)));
+       first);
   let runs = List.fold_left apply_event [] events |> prune in
+  if should_compact then compact_replay_log path runs;
   { runs = Atomic.make runs; path = Some path }
 ;;
 

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -86,7 +86,9 @@ let append_event t event =
 ;;
 
 let register_running t ~run_id ~keeper ~preset ~started_at =
-  append_event t (Register { run_id; keeper; preset; started_at });
+  append_event
+    t
+    (Fusion_run_registry_event.Register { run_id; keeper; preset; started_at });
   update t (fun runs ->
     let run = { run_id; keeper; preset; started_at; status = Running } in
     (* defensive: a re-registered run_id replaces its prior entry *)
@@ -95,7 +97,8 @@ let register_running t ~run_id ~keeper ~preset ~started_at =
 ;;
 
 let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
-  append_event t (Complete { run_id; ok; failure; failure_code });
+  append_event t
+    (Fusion_run_registry_event.Complete { run_id; ok; failure; failure_code });
   update t (fun runs ->
     runs
     |> List.map (fun r ->
@@ -192,7 +195,11 @@ let events_of_run (run : run) =
   in
   match run.status with
   | Running -> [ register ]
-  | Completed { ok } -> [ register; Complete { run_id = run.run_id; ok } ]
+  | Completed { ok; failure; failure_code } ->
+    [ register
+    ; Fusion_run_registry_event.Complete
+        { run_id = run.run_id; ok; failure; failure_code }
+    ]
 ;;
 
 let compact_replay_log path runs =

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -1,11 +1,13 @@
 (** Fusion — in-memory run registry for in-progress + recent fusion visibility
-    (RFC-0266 §7 Phase 2).
+    (RFC-0266 §7 Phase 2/Phase D).
 
     The fusion tool calls {!register_running} at fork start and the sink/failure
     path calls {!mark_completed} on finish, so a status surface (Phase 3 tool,
     Phase 4 dashboard) can report what is deliberating now and what just
-    finished. Lock-free Atomic + CAS; server-lifetime in-memory (no orphan
-    [Running] survives a restart). Never wakes a keeper. *)
+    finished. Lock-free Atomic + CAS; optional append-only JSONL backing so
+    recent history survives server restart.
+
+    Never wakes a keeper. *)
 
 type run_status =
   | Running
@@ -31,13 +33,20 @@ type run = {
 
 type t
 
-val create : unit -> t
-(** A fresh, isolated registry. Production uses {!global}; tests use [create ()]
-    so each case starts empty (no shared-state reset backdoor). *)
+val create : ?path:Eio.Fs.dir_ty Eio.Path.t -> unit -> t
+(** A fresh, isolated registry. Production uses the process-wide {!global}
+    (initialized from disk at server boot); tests use [create ()] so each case
+    starts empty (no shared-state reset backdoor). *)
+
+val replay : Eio.Fs.dir_ty Eio.Path.t -> t
+(** Hydrate a registry from an append-only JSONL file. Missing or unreadable
+    files yield an empty registry. Replayed completed runs are pruned to the
+    newest {!max_completed_retained}. *)
 
 val register_running :
   t -> run_id:string -> keeper:string -> preset:string -> started_at:float -> unit
-(** Record a run as [Running]. A repeated [run_id] replaces its prior entry. *)
+(** Record a run as [Running]. A repeated [run_id] replaces its prior entry.
+    When the registry was created with a path, appends a [Register] event. *)
 
 val mark_completed
   :  t
@@ -50,7 +59,8 @@ val mark_completed
 (** Transition a run to [Completed]. No-op if [run_id] is unknown. [ok] is the
     judge/sink outcome (false for denied/sink_failed/aborted). [failure]/
     [failure_code]는 [ok=false]일 때의 사유·분류 태그 — 상태 표면(tool/HTTP/SSE)이
-    사유 없이 "failed"만 보이는 opaque 실패가 되지 않게 함께 기록한다. *)
+    사유 없이 "failed"만 보이는 opaque 실패가 되지 않게 함께 기록한다. When
+    the registry was created with a path, appends a [Complete] event. *)
 
 val list_runs : t -> run list
 (** All tracked runs, newest [started_at] first ([Running] + recently
@@ -70,5 +80,13 @@ val run_to_yojson : run -> Yojson.Safe.t
     실패 시 additive [error]/[failure_code] 필드. The single serializer for
     every fusion-run surface (tool / HTTP list / SSE delta). *)
 
-val global : t
-(** Process-wide registry the fusion tool/sink write to (server-lifetime). *)
+val global : unit -> t
+(** Process-wide registry the fusion tool/sink write to (server-lifetime). Use
+    {!set_global} to install a path-backed, replayed instance at boot. *)
+
+val set_global : t -> unit
+(** Install a registry as the process-wide {!global}. Called once at server
+    boot after replaying the persisted JSONL. *)
+
+val max_completed_retained : int
+(** Retention bound for completed runs (newest first). Exposed for tests. *)

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -42,8 +42,9 @@ val replay : string -> t
 (** Hydrate a registry from an append-only JSONL file. Missing files yield an
     empty registry. Unreadable files and malformed lines are logged and skipped,
     so persistence problems are visible without blocking in-memory status
-    tracking. Replayed completed runs are pruned to the newest
-    {!max_completed_retained}. *)
+    tracking. Persisted registers without a completed event are dropped during
+    replay because worker fibers do not survive server restart. Replayed
+    completed runs are pruned to the newest {!max_completed_retained}. *)
 
 val register_running :
   t -> run_id:string -> keeper:string -> preset:string -> started_at:float -> unit

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -33,15 +33,17 @@ type run = {
 
 type t
 
-val create : ?path:Eio.Fs.dir_ty Eio.Path.t -> unit -> t
+val create : ?path:string -> unit -> t
 (** A fresh, isolated registry. Production uses the process-wide {!global}
     (initialized from disk at server boot); tests use [create ()] so each case
     starts empty (no shared-state reset backdoor). *)
 
-val replay : Eio.Fs.dir_ty Eio.Path.t -> t
-(** Hydrate a registry from an append-only JSONL file. Missing or unreadable
-    files yield an empty registry. Replayed completed runs are pruned to the
-    newest {!max_completed_retained}. *)
+val replay : string -> t
+(** Hydrate a registry from an append-only JSONL file. Missing files yield an
+    empty registry. Unreadable files and malformed lines are logged and skipped,
+    so persistence problems are visible without blocking in-memory status
+    tracking. Replayed completed runs are pruned to the newest
+    {!max_completed_retained}. *)
 
 val register_running :
   t -> run_id:string -> keeper:string -> preset:string -> started_at:float -> unit

--- a/lib/fusion_core/fusion_run_registry_event.ml
+++ b/lib/fusion_core/fusion_run_registry_event.ml
@@ -38,26 +38,70 @@ let to_yojson = function
          ])
 ;;
 
+let object_fields = function
+  | `Assoc fields -> Ok fields
+  | json -> Error (Printf.sprintf "expected object, got %s" (Yojson.Safe.to_string json))
+;;
+
+let field name fields =
+  match List.assoc_opt name fields with
+  | Some json -> Ok json
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let string_field name fields =
+  match field name fields with
+  | Error _ as err -> err
+  | Ok (`String value) -> Ok value
+  | Ok json ->
+    Error (Printf.sprintf "field %s expected string, got %s" name (Yojson.Safe.to_string json))
+;;
+
+let float_field name fields =
+  match field name fields with
+  | Error _ as err -> err
+  | Ok (`Float value) -> Ok value
+  | Ok (`Int value) -> Ok (float_of_int value)
+  | Ok json ->
+    Error (Printf.sprintf "field %s expected float, got %s" name (Yojson.Safe.to_string json))
+;;
+
+let bool_field name fields =
+  match field name fields with
+  | Error _ as err -> err
+  | Ok (`Bool value) -> Ok value
+  | Ok json ->
+    Error (Printf.sprintf "field %s expected bool, got %s" name (Yojson.Safe.to_string json))
+;;
+
+let optional_string_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some json ->
+    Error
+      (Printf.sprintf "field %s expected optional string, got %s" name
+         (Yojson.Safe.to_string json))
+;;
+
 let of_yojson json =
-  let open Yojson.Safe.Util in
-  match member "event" json |> to_string_option with
-  | Some "register" ->
-    Ok
-      (Register
-         { run_id = member "run_id" json |> to_string
-         ; keeper = member "keeper" json |> to_string
-         ; preset = member "preset" json |> to_string
-         ; started_at = member "started_at" json |> to_float
-         })
-  | Some "complete" ->
-    Ok
-      (Complete
-         { run_id = member "run_id" json |> to_string
-         ; ok = member "ok" json |> to_bool
-         ; failure = member "failure" json |> to_string_option
-         ; failure_code = member "failure_code" json |> to_string_option
-         })
-  | _ -> Error "unknown fusion registry event"
+  let ( let* ) = Result.bind in
+  let* fields = object_fields json in
+  let* event = string_field "event" fields in
+  match event with
+  | "register" ->
+    let* run_id = string_field "run_id" fields in
+    let* keeper = string_field "keeper" fields in
+    let* preset = string_field "preset" fields in
+    let* started_at = float_field "started_at" fields in
+    Ok (Register { run_id; keeper; preset; started_at })
+  | "complete" ->
+    let* run_id = string_field "run_id" fields in
+    let* ok = bool_field "ok" fields in
+    let* failure = optional_string_field "failure" fields in
+    let* failure_code = optional_string_field "failure_code" fields in
+    Ok (Complete { run_id; ok; failure; failure_code })
+  | other -> Error (Printf.sprintf "unknown fusion registry event %S" other)
 ;;
 
 let to_jsonl t = Yojson.Safe.to_string (to_yojson t) ^ "\n"

--- a/lib/fusion_core/fusion_run_registry_event.ml
+++ b/lib/fusion_core/fusion_run_registry_event.ml
@@ -1,0 +1,63 @@
+(* JSONL event type for fusion run registry persistence (RFC-0266 §7 Phase D).
+   Each [register_running] / [mark_completed] appends one line so run history
+   survives server restart. The event type is intentionally minimal and stable;
+   adding new fields is safe because replay ignores unknown JSON keys. *)
+
+type t =
+  | Register of
+      { run_id : string
+      ; keeper : string
+      ; preset : string
+      ; started_at : float
+      }
+  | Complete of
+      { run_id : string
+      ; ok : bool
+      ; failure : string option
+      ; failure_code : string option
+      }
+
+let to_yojson = function
+  | Register { run_id; keeper; preset; started_at } ->
+    `Assoc
+      [ ("event", `String "register")
+      ; ("run_id", `String run_id)
+      ; ("keeper", `String keeper)
+      ; ("preset", `String preset)
+      ; ("started_at", `Float started_at)
+      ]
+  | Complete { run_id; ok; failure; failure_code } ->
+    `Assoc
+      (List.filter_map
+         (fun (k, v) -> Option.map (fun value -> (k, value)) v)
+         [ "event", Some (`String "complete")
+         ; "run_id", Some (`String run_id)
+         ; "ok", Some (`Bool ok)
+         ; "failure", Option.map (fun s -> `String s) failure
+         ; "failure_code", Option.map (fun s -> `String s) failure_code
+         ])
+;;
+
+let of_yojson json =
+  let open Yojson.Safe.Util in
+  match member "event" json |> to_string_option with
+  | Some "register" ->
+    Ok
+      (Register
+         { run_id = member "run_id" json |> to_string
+         ; keeper = member "keeper" json |> to_string
+         ; preset = member "preset" json |> to_string
+         ; started_at = member "started_at" json |> to_float
+         })
+  | Some "complete" ->
+    Ok
+      (Complete
+         { run_id = member "run_id" json |> to_string
+         ; ok = member "ok" json |> to_bool
+         ; failure = member "failure" json |> to_string_option
+         ; failure_code = member "failure_code" json |> to_string_option
+         })
+  | _ -> Error "unknown fusion registry event"
+;;
+
+let to_jsonl t = Yojson.Safe.to_string (to_yojson t) ^ "\n"

--- a/lib/fusion_core/fusion_run_registry_event.mli
+++ b/lib/fusion_core/fusion_run_registry_event.mli
@@ -1,0 +1,28 @@
+(** JSONL event type for fusion run registry persistence.
+
+    Every state-changing operation on {!Fusion_run_registry.t} appends one
+    event line to disk. On server boot the log is replayed to restore recent
+    run history. *)
+
+type t =
+  | Register of
+      { run_id : string
+      ; keeper : string
+      ; preset : string
+      ; started_at : float
+      }
+  | Complete of
+      { run_id : string
+      ; ok : bool
+      ; failure : string option
+      ; failure_code : string option
+      }
+
+val to_yojson : t -> Yojson.Safe.t
+(** Canonical JSON object for one event. *)
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Parse an event from a JSON object; [Error] on unknown event kind. *)
+
+val to_jsonl : t -> string
+(** Single JSONL line (JSON object + trailing newline). *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -488,7 +488,7 @@ let fusion_status_json ~(registry : Fusion_run_registry.t) ~keeper ~run_id : str
 
 let handle_masc_fusion_status ~(meta : keeper_meta) ~args () =
   let run_id = Safe_ops.json_string ~default:"" "run_id" args |> String.trim in
-  fusion_status_json ~registry:Fusion_run_registry.global ~keeper:meta.name ~run_id
+  fusion_status_json ~registry:(Fusion_run_registry.global ()) ~keeper:meta.name ~run_id
 ;;
 
 (* RFC-keeper-vision-delegation-tool §2.6 — analyze_image. Thin delegate to the

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -461,7 +461,7 @@ let add_routes ~sw ~clock router =
      Fusion_run_registry.run_to_yojson so the shape matches the SSE delta. *)
   |> Http.Router.get "/api/v1/dashboard/fusion-runs" (fun request reqd ->
        with_public_read (fun _state req reqd ->
-         let runs = Fusion_run_registry.list_runs Fusion_run_registry.global in
+         let runs = Fusion_run_registry.list_runs (Fusion_run_registry.global ()) in
          let json =
            `Assoc
              [ ("generated_at", `String (Masc_domain.now_iso ()))

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -270,6 +270,12 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   Runtime_params.initialize ~base_path;
   Fs_compat.set_fs fs;
+  (* RFC-0266 §7 Phase D: replay persisted fusion run history into the
+     process-wide registry so in-progress + recently-completed runs survive
+     server restart. A missing or corrupt JSONL file yields an empty registry;
+     the in-memory table remains authoritative after boot. *)
+  let registry_path = Eio.Path.(fs / base_path / ".masc" / "fusion-runs.jsonl") in
+  Fusion_run_registry.set_global (Fusion_run_registry.replay registry_path);
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -272,9 +272,11 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Fs_compat.set_fs fs;
   (* RFC-0266 §7 Phase D: replay persisted fusion run history into the
      process-wide registry so in-progress + recently-completed runs survive
-     server restart. A missing or corrupt JSONL file yields an empty registry;
-     the in-memory table remains authoritative after boot. *)
-  let registry_path = Eio.Path.(fs / base_path / ".masc" / "fusion-runs.jsonl") in
+     server restart. Missing files yield an empty registry; malformed replay
+     lines are logged and skipped. *)
+  let registry_path =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "fusion-runs.jsonl"
+  in
   Fusion_run_registry.set_global (Fusion_run_registry.replay registry_path);
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;

--- a/test/dune
+++ b/test/dune
@@ -802,6 +802,13 @@
  (modules test_fusion_adaptive_timeout)
  (libraries masc_test_deps masc.fusion_core))
 
+; RFC-0266 §7 Phase D — fusion run registry persistence: JSONL append + replay.
+
+(test
+ (name test_fusion_run_registry_persist)
+ (modules test_fusion_run_registry_persist)
+ (libraries alcotest eio eio_main yojson masc.fusion_core))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/dune
+++ b/test/dune
@@ -807,7 +807,7 @@
 (test
  (name test_fusion_run_registry_persist)
  (modules test_fusion_run_registry_persist)
- (libraries alcotest eio eio_main yojson masc.fusion_core))
+ (libraries alcotest fs_compat yojson masc.fusion_core))
 
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -10,6 +10,17 @@ module R = Fusion_run_registry
 
 let parse s = Yojson.Safe.from_string s
 
+let remove_if_exists path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+;;
+
+let fresh_path suffix =
+  let path = Filename.temp_file "fusion-runs-" suffix in
+  remove_if_exists path;
+  path
+;;
+
 let field j k =
   match j with
   | `Assoc l -> List.assoc_opt k l
@@ -36,13 +47,11 @@ let float_ j k =
 
 (* (1) Register + complete writes two JSONL lines plus a trailing newline. *)
 let test_persist_register_complete () =
-  Eio_main.run @@ fun env ->
-  Eio.Switch.run @@ fun _sw ->
-  let path = Eio.Path.(env#cwd / "tmp-fusion-runs.jsonl") in
+  let path = fresh_path ".jsonl" in
   let t = R.create ~path () in
   R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"p" ~started_at:1.0;
   R.mark_completed t ~run_id:"r1" ~ok:true ();
-  let content = Eio.Path.load path in
+  let content = Fs_compat.load_file path in
   let lines = String.split_on_char '\n' content in
   check int "two events + trailing newline" 3 (List.length lines);
   let event1 = parse (List.nth lines 0) in
@@ -58,14 +67,12 @@ let test_persist_register_complete () =
 ;;
 
 let test_persist_failure_detail () =
-  Eio_main.run @@ fun env ->
-  Eio.Switch.run @@ fun _sw ->
-  let path = Eio.Path.(env#cwd / "tmp-fusion-runs-failure.jsonl") in
+  let path = fresh_path "-failure.jsonl" in
   let t = R.create ~path () in
   R.register_running t ~run_id:"r-fail" ~keeper:"k" ~preset:"p" ~started_at:1.0;
   R.mark_completed t ~run_id:"r-fail" ~failure:"judge failed: bad json"
     ~failure_code:"parse_error" ~ok:false ();
-  let content = Eio.Path.load path in
+  let content = Fs_compat.load_file path in
   let lines = String.split_on_char '\n' content in
   let event2 = parse (List.nth lines 1) in
   check string "event2 failure" "judge failed: bad json" (str event2 "failure");
@@ -84,9 +91,7 @@ let test_persist_failure_detail () =
 (* (2) Replay prunes completed runs to the newest [max_completed_retained]
    while preserving all running runs. *)
 let test_replay_prunes_completed () =
-  Eio_main.run @@ fun env ->
-  Eio.Switch.run @@ fun _sw ->
-  let path = Eio.Path.(env#cwd / "tmp-fusion-runs-prune.jsonl") in
+  let path = fresh_path "-prune.jsonl" in
   let t = R.create ~path () in
   for i = 1 to 70 do
     R.register_running
@@ -112,20 +117,30 @@ let test_replay_prunes_completed () =
 
 (* (3) A fresh registry without a backing path does not write files. *)
 let test_no_path_is_in_memory_only () =
-  Eio_main.run @@ fun env ->
-  Eio.Switch.run @@ fun _sw ->
-  let path = Eio.Path.(env#cwd / "no-such-fusion-runs.jsonl") in
+  let path = fresh_path "-no-path.jsonl" in
   let t = R.create () in
   R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"p" ~started_at:1.0;
   R.mark_completed t ~run_id:"r1" ~ok:true ();
-  let file_exists =
-    try
-      ignore (Eio.Path.stat ~follow:true path);
-      true
-    with
-    | Eio.Io _ -> false
-  in
-  check bool "no file created" false file_exists
+  check bool "no file created" false (Sys.file_exists path)
+;;
+
+(* (4) Replay skips malformed lines without dropping valid neighboring events. *)
+let test_replay_skips_malformed_lines () =
+  let path = fresh_path "-malformed.jsonl" in
+  Fs_compat.save_file
+    path
+    (String.concat
+       "\n"
+       [ {|{"event":"register","run_id":"r1","keeper":"k","preset":"p","started_at":1.0}|}
+       ; {|not-json|}
+       ; {|{"event":"complete","run_id":"r1","ok":false}|}
+       ; ""
+       ]);
+  let t = R.replay path in
+  match R.get t ~run_id:"r1" with
+  | Some { R.status = R.Completed { ok = false; _ }; _ } -> ()
+  | Some _ -> fail "expected replayed run to be completed as failed"
+  | None -> fail "expected valid replay events around malformed line to load"
 ;;
 
 let () =
@@ -136,6 +151,7 @@ let () =
         ; test_case "failure detail survives replay" `Quick test_persist_failure_detail
         ; test_case "replay prunes completed runs" `Quick test_replay_prunes_completed
         ; test_case "no-path registry is in-memory only" `Quick test_no_path_is_in_memory_only
+        ; test_case "replay skips malformed lines" `Quick test_replay_skips_malformed_lines
         ] )
     ]
 ;;

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -1,0 +1,141 @@
+(* RFC-0266 §7 Phase D — fusion run registry persistence.
+
+   Verify that register/complete append JSONL events and that replay restores
+   the registry with completed-run pruning. Tests are isolated: each case gets
+   its own temp file path; the process-wide {!Fusion_run_registry.global} is
+   never touched. *)
+
+open Alcotest
+module R = Fusion_run_registry
+
+let parse s = Yojson.Safe.from_string s
+
+let field j k =
+  match j with
+  | `Assoc l -> List.assoc_opt k l
+  | _ -> None
+;;
+
+let str j k =
+  match field j k with
+  | Some (`String s) -> s
+  | _ -> failwith (Printf.sprintf "missing string field %s" k)
+;;
+
+let bool_ j k =
+  match field j k with
+  | Some (`Bool b) -> b
+  | _ -> failwith (Printf.sprintf "missing bool field %s" k)
+;;
+
+let float_ j k =
+  match field j k with
+  | Some (`Float f) -> f
+  | _ -> failwith (Printf.sprintf "missing float field %s" k)
+;;
+
+(* (1) Register + complete writes two JSONL lines plus a trailing newline. *)
+let test_persist_register_complete () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun _sw ->
+  let path = Eio.Path.(env#cwd / "tmp-fusion-runs.jsonl") in
+  let t = R.create ~path () in
+  R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"p" ~started_at:1.0;
+  R.mark_completed t ~run_id:"r1" ~ok:true ();
+  let content = Eio.Path.load path in
+  let lines = String.split_on_char '\n' content in
+  check int "two events + trailing newline" 3 (List.length lines);
+  let event1 = parse (List.nth lines 0) in
+  check string "event1 kind" "register" (str event1 "event");
+  check string "event1 run_id" "r1" (str event1 "run_id");
+  check string "event1 keeper" "k" (str event1 "keeper");
+  check string "event1 preset" "p" (str event1 "preset");
+  check (float 0.001) "event1 started_at" 1.0 (float_ event1 "started_at");
+  let event2 = parse (List.nth lines 1) in
+  check string "event2 kind" "complete" (str event2 "event");
+  check string "event2 run_id" "r1" (str event2 "run_id");
+  check bool "event2 ok" true (bool_ event2 "ok")
+;;
+
+let test_persist_failure_detail () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun _sw ->
+  let path = Eio.Path.(env#cwd / "tmp-fusion-runs-failure.jsonl") in
+  let t = R.create ~path () in
+  R.register_running t ~run_id:"r-fail" ~keeper:"k" ~preset:"p" ~started_at:1.0;
+  R.mark_completed t ~run_id:"r-fail" ~failure:"judge failed: bad json"
+    ~failure_code:"parse_error" ~ok:false ();
+  let content = Eio.Path.load path in
+  let lines = String.split_on_char '\n' content in
+  let event2 = parse (List.nth lines 1) in
+  check string "event2 failure" "judge failed: bad json" (str event2 "failure");
+  check string "event2 failure_code" "parse_error" (str event2 "failure_code");
+  let replayed = R.replay path in
+  match R.get replayed ~run_id:"r-fail" with
+  | Some { R.status = R.Completed { ok = false; failure; failure_code }; _ } ->
+    check (option string) "replayed failure" (Some "judge failed: bad json")
+      failure;
+    check (option string) "replayed failure_code" (Some "parse_error")
+      failure_code
+  | Some _ -> fail "expected replayed failed completion"
+  | None -> fail "expected replayed run"
+;;
+
+(* (2) Replay prunes completed runs to the newest [max_completed_retained]
+   while preserving all running runs. *)
+let test_replay_prunes_completed () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun _sw ->
+  let path = Eio.Path.(env#cwd / "tmp-fusion-runs-prune.jsonl") in
+  let t = R.create ~path () in
+  for i = 1 to 70 do
+    R.register_running
+      t
+      ~run_id:("r" ^ string_of_int i)
+      ~keeper:"k"
+      ~preset:"p"
+      ~started_at:(float_of_int i);
+    R.mark_completed t ~run_id:("r" ^ string_of_int i) ~ok:true ()
+  done;
+  (* Leave one run in [Running] state so we can verify running runs are kept. *)
+  R.register_running t ~run_id:"r-running" ~keeper:"k" ~preset:"p" ~started_at:71.0;
+  let t2 = R.replay path in
+  let runs = R.list_runs t2 in
+  check int "pruned completed + kept running" 65 (List.length runs);
+  (* The running run must still be present. *)
+  check bool "running run preserved" true
+    (Option.is_some (R.get t2 ~run_id:"r-running"));
+  (* Newest completed run (r70) must be present; oldest (r1) pruned. *)
+  check bool "newest completed kept" true (Option.is_some (R.get t2 ~run_id:"r70"));
+  check bool "oldest completed pruned" true (Option.is_none (R.get t2 ~run_id:"r1"))
+;;
+
+(* (3) A fresh registry without a backing path does not write files. *)
+let test_no_path_is_in_memory_only () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun _sw ->
+  let path = Eio.Path.(env#cwd / "no-such-fusion-runs.jsonl") in
+  let t = R.create () in
+  R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"p" ~started_at:1.0;
+  R.mark_completed t ~run_id:"r1" ~ok:true ();
+  let file_exists =
+    try
+      ignore (Eio.Path.stat ~follow:true path);
+      true
+    with
+    | Eio.Io _ -> false
+  in
+  check bool "no file created" false file_exists
+;;
+
+let () =
+  run
+    "fusion_run_registry_persist"
+    [ ( "rfc-0266-phase-d"
+      , [ test_case "register+complete append JSONL" `Quick test_persist_register_complete
+        ; test_case "failure detail survives replay" `Quick test_persist_failure_detail
+        ; test_case "replay prunes completed runs" `Quick test_replay_prunes_completed
+        ; test_case "no-path registry is in-memory only" `Quick test_no_path_is_in_memory_only
+        ] )
+    ]
+;;

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -159,7 +159,7 @@ let test_replay_streams_and_compacts () =
     content;
   let t = R.replay path in
   (match R.get t ~run_id:"r-stream" with
-   | Some { R.status = Completed { ok = true }; _ } -> ()
+   | Some { R.status = R.Completed { ok = true }; _ } -> ()
    | Some _ -> fail "expected streamed run to be completed"
    | None -> fail "expected streamed run to replay");
   match Fs_compat.file_size path with
@@ -180,7 +180,7 @@ let test_replay_preserves_unterminated_tail () =
     content;
   let t = R.replay path in
   (match R.get t ~run_id:"r-partial" with
-   | Some { R.status = Running; _ } -> ()
+   | Some { R.status = R.Running; _ } -> ()
    | Some _ -> fail "unterminated completion line must not replay"
    | None -> fail "completed line before partial tail should replay");
   check string "partial tail preserved" content (Fs_compat.load_file path)

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -15,6 +15,21 @@ let remove_if_exists path =
   | Sys_error _ -> ()
 ;;
 
+let contains_substring value needle =
+  let value_len = String.length value in
+  let needle_len = String.length needle in
+  let rec loop index =
+    if needle_len = 0
+    then true
+    else if index + needle_len > value_len
+    then false
+    else if String.sub value index needle_len = needle
+    then true
+    else loop (index + 1)
+  in
+  loop 0
+;;
+
 let fresh_path suffix =
   let path = Filename.temp_file "fusion-runs-" suffix in
   remove_if_exists path;
@@ -89,7 +104,7 @@ let test_persist_failure_detail () =
 ;;
 
 (* (2) Replay prunes completed runs to the newest [max_completed_retained]
-   while preserving all running runs. *)
+   without resurrecting register-only rows as live work after restart. *)
 let test_replay_prunes_completed () =
   let path = fresh_path "-prune.jsonl" in
   let t = R.create ~path () in
@@ -102,14 +117,16 @@ let test_replay_prunes_completed () =
       ~started_at:(float_of_int i);
     R.mark_completed t ~run_id:("r" ^ string_of_int i) ~ok:true ()
   done;
-  (* Leave one run in [Running] state so we can verify running runs are kept. *)
+  (* Leave one run in [Running] state; replay must drop it because the worker
+     fiber died with the old process. *)
   R.register_running t ~run_id:"r-running" ~keeper:"k" ~preset:"p" ~started_at:71.0;
   let t2 = R.replay path in
   let runs = R.list_runs t2 in
-  check int "pruned completed + kept running" (R.max_completed_retained + 1) (List.length runs);
-  (* The running run must still be present. *)
-  check bool "running run preserved" true
-    (Option.is_some (R.get t2 ~run_id:"r-running"));
+  check int "pruned completed only" R.max_completed_retained (List.length runs);
+  check bool "replayed running run dropped" true
+    (Option.is_none (R.get t2 ~run_id:"r-running"));
+  check bool "compacted log omits stale running run" false
+    (contains_substring (Fs_compat.load_file path) "r-running");
   (* Newest completed run (r70) must be present; oldest (r1) pruned. *)
   check bool "newest completed kept" true (Option.is_some (R.get t2 ~run_id:"r70"));
   check bool "oldest completed pruned" true (Option.is_none (R.get t2 ~run_id:"r1"))
@@ -180,9 +197,8 @@ let test_replay_preserves_unterminated_tail () =
     content;
   let t = R.replay path in
   (match R.get t ~run_id:"r-partial" with
-   | Some { R.status = R.Running; _ } -> ()
-   | Some _ -> fail "unterminated completion line must not replay"
-   | None -> fail "completed line before partial tail should replay");
+   | None -> ()
+   | Some _ -> fail "unterminated completion line must not publish stale running work");
   check string "partial tail preserved" content (Fs_compat.load_file path)
 ;;
 
@@ -192,7 +208,10 @@ let () =
     [ ( "rfc-0266-phase-d"
       , [ test_case "register+complete append JSONL" `Quick test_persist_register_complete
         ; test_case "failure detail survives replay" `Quick test_persist_failure_detail
-        ; test_case "replay prunes completed runs" `Quick test_replay_prunes_completed
+        ; test_case
+            "replay prunes completed and drops stale running runs"
+            `Quick
+            test_replay_prunes_completed
         ; test_case "no-path registry is in-memory only" `Quick test_no_path_is_in_memory_only
         ; test_case "replay skips malformed lines" `Quick test_replay_skips_malformed_lines
         ; test_case "replay streams and compacts log" `Quick test_replay_streams_and_compacts

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -106,7 +106,7 @@ let test_replay_prunes_completed () =
   R.register_running t ~run_id:"r-running" ~keeper:"k" ~preset:"p" ~started_at:71.0;
   let t2 = R.replay path in
   let runs = R.list_runs t2 in
-  check int "pruned completed + kept running" 65 (List.length runs);
+  check int "pruned completed + kept running" (R.max_completed_retained + 1) (List.length runs);
   (* The running run must still be present. *)
   check bool "running run preserved" true
     (Option.is_some (R.get t2 ~run_id:"r-running"));
@@ -145,6 +145,47 @@ let test_replay_skips_malformed_lines () =
   | None -> fail "expected valid replay events around malformed line to load"
 ;;
 
+(* (5) Replay streams raw JSONL lines and compacts the retained state. *)
+let test_replay_streams_and_compacts () =
+  let path = fresh_path "-stream.jsonl" in
+  let before =
+    {|{"event":"register","run_id":"r-stream","keeper":"k","preset":"p","started_at":1.0}|}
+  in
+  let after = {|{"event":"complete","run_id":"r-stream","ok":true}|} in
+  let malformed_padding = String.make 70000 'x' in
+  let content = String.concat "\n" [ before; malformed_padding; after; "" ] in
+  Fs_compat.save_file
+    path
+    content;
+  let t = R.replay path in
+  (match R.get t ~run_id:"r-stream" with
+   | Some { R.status = Completed { ok = true }; _ } -> ()
+   | Some _ -> fail "expected streamed run to be completed"
+   | None -> fail "expected streamed run to replay");
+  match Fs_compat.file_size path with
+  | Some size -> check bool "log compacted" true (size < String.length content)
+  | None -> fail "expected compacted replay log to exist"
+;;
+
+(* (6) Replay does not compact away an unterminated tail line. *)
+let test_replay_preserves_unterminated_tail () =
+  let path = fresh_path "-partial-tail.jsonl" in
+  let complete =
+    {|{"event":"register","run_id":"r-partial","keeper":"k","preset":"p","started_at":1.0}|}
+  in
+  let partial = {|{"event":"complete","run_id":"r-partial","ok":true}|} in
+  let content = String.concat "\n" [ complete; partial ] in
+  Fs_compat.save_file
+    path
+    content;
+  let t = R.replay path in
+  (match R.get t ~run_id:"r-partial" with
+   | Some { R.status = Running; _ } -> ()
+   | Some _ -> fail "unterminated completion line must not replay"
+   | None -> fail "completed line before partial tail should replay");
+  check string "partial tail preserved" content (Fs_compat.load_file path)
+;;
+
 let () =
   run
     "fusion_run_registry_persist"
@@ -154,6 +195,11 @@ let () =
         ; test_case "replay prunes completed runs" `Quick test_replay_prunes_completed
         ; test_case "no-path registry is in-memory only" `Quick test_no_path_is_in_memory_only
         ; test_case "replay skips malformed lines" `Quick test_replay_skips_malformed_lines
+        ; test_case "replay streams and compacts log" `Quick test_replay_streams_and_compacts
+        ; test_case
+            "replay preserves unterminated tail"
+            `Quick
+            test_replay_preserves_unterminated_tail
         ] )
     ]
 ;;

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -131,11 +131,13 @@ let test_replay_skips_malformed_lines () =
     path
     (String.concat
        "\n"
-       [ {|{"event":"register","run_id":"r1","keeper":"k","preset":"p","started_at":1.0}|}
-       ; {|not-json|}
-       ; {|{"event":"complete","run_id":"r1","ok":false}|}
-       ; ""
-       ]);
+	       [ {|{"event":"register","run_id":"r1","keeper":"k","preset":"p","started_at":1.0}|}
+	       ; {|not-json|}
+	       ; {|{"event":"register","run_id":42,"keeper":"k","preset":"p","started_at":2.0}|}
+	       ; {|{"event":"complete","run_id":"r1","ok":"false"}|}
+	       ; {|{"event":"complete","run_id":"r1","ok":false}|}
+	       ; ""
+	       ]);
   let t = R.replay path in
   match R.get t ~run_id:"r1" with
   | Some { R.status = R.Completed { ok = false; _ }; _ } -> ()

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -271,7 +271,7 @@ let test_emit_board_failure_is_best_effort () =
     let keeper = "bad/keeper" in
     let run_id = Printf.sprintf "fus-board-fail-%d" (Random.bits ()) in
     let resolved_answer = "BOARD-BEST-EFFORT-ANSWER" in
-    Fusion_run_registry.register_running Fusion_run_registry.global ~run_id ~keeper
+    Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
       ~preset:"unit-test" ~started_at:1.0;
     let result =
       Fusion_sink.emit ~base_dir ~keeper ~run_id ~question:"q" ~panel:[]
@@ -279,7 +279,7 @@ let test_emit_board_failure_is_best_effort () =
         ~judge_usage:Fusion_types.zero_usage
     in
     check bool "board failure does not fail emit" true (Result.is_ok result);
-    (match Fusion_run_registry.get Fusion_run_registry.global ~run_id with
+    (match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
      | Some run ->
        (match run.Fusion_run_registry.status with
         | Fusion_run_registry.Completed { ok = true; _ } -> ()


### PR DESCRIPTION
## Summary
Survives server restart by backing the fusion run registry with an append-only JSONL file under `<base-path>/.masc/fusion-runs.jsonl`.

## Changes
- New `Fusion_run_registry_event` module for register/complete JSONL events.
- `Fusion_run_registry` gains optional `Eio.Path` backing and a `replay` function.
- Server bootstrap replays the JSONL tail into the global registry.
- Completed runs are pruned to the last 64 on replay.
- All `Fusion_run_registry.global` call sites updated to `(Fusion_run_registry.global ())`.
- Adds persistence/replay/prune regression test.

## Verification
- `scripts/dune-local.sh build @default` green
- `test/test_fusion_run_registry_persist.exe` 3/3 pass
- Existing fusion tests green
- `scripts/ci/check-masc-oas-boundary.sh` PASS

## Spec
- HTML spec: `/Users/dancer/me/docs/superpowers/specs/2026-07-01-masc-oas-resilience-design.html`
- Plan: `/Users/dancer/me/docs/superpowers/plans/2026-07-01-pr-d-fusion-registry-persist.md`