### PR TITLE
feat(memory_os): add env-gate to consolidation (MASC_KEEPER_MEMORY_OS_CONSOLIDATE, default-off)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 360 unique knobs across 9 modules.
+**Total**: 361 unique knobs across 9 modules.
 
-**Typed getter classification**: 46/217 tagged (`operator`: 46, `algorithm`: 0, `unclassified`: 171).
+**Typed getter classification**: 47/218 tagged (`operator`: 47, `algorithm`: 0, `unclassified`: 171).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -85,17 +85,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (87 knobs; typed classification 24/75)
+## Env_config_keeper (88 knobs; typed classification 25/76)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 545 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 869 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 904 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 905 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 906 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 907 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 910 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 559 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 883 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 918 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 919 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 920 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 921 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 924 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 731 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 783 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 745 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 797 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,60 +122,61 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 803 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 375 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 401 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 391 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 411 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 381 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 817 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 389 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 415 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 405 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 425 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 395 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 764 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 498 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 487 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 509 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 823 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 831 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 550 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 624 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 813 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 598 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 858 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 605 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 639 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 646 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 565 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 349 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 359 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 338 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 258 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 270 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 326 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 282 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 304 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 314 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 292 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 246 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 778 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 512 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 501 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 523 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 837 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 845 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 564 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 638 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 827 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 612 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 872 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 619 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 653 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 660 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 579 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATE` | typed:bool | Policies | operator | 352 | Tier-2 shared Memory OS consolidator kill switch. Default: false; invalid values fail closed to false. This gates the... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 363 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 373 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 340 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 260 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 272 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 328 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 284 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 306 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 316 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 294 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 248 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 692 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 841 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 528 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 537 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 616 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 575 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 706 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 855 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 542 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 551 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 630 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 589 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 847 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 740 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 678 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 582 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 448 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 458 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 438 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 559 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 928 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 942 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 861 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 754 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 692 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 596 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 462 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 472 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 452 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 573 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 942 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 956 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -341,9 +342,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 692 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 696 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 698 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 696 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 700 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 702 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 228 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 318 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 320 |  |
@@ -352,8 +353,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 282 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 336 |  |
 | `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 338 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 646 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 648 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 650 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 652 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 322 |  |
 | `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 219 |  |
 | `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 218 |  |
@@ -366,8 +367,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 393 |  |
 | `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 395 |  |
 | `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 397 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 800 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 650 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 804 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 654 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
 | `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 211 |  |
 | `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 221 |  |
@@ -396,26 +397,26 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 175 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 174 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 222 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 776 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 812 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 652 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 780 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 816 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 656 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 471 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 822 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 734 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 736 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 738 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 740 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 802 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 756 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 826 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 738 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 740 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 742 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 744 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 806 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 760 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 158 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 54 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 51 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 792 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 794 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 796 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 798 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 160 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 854 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 856 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 858 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 858 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 860 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 862 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 116 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -199,6 +199,7 @@ module KeeperMemoryOs = struct
   let librarian_runtime_id_default = None
   let librarian_global_slot_default = 1
   let gc_enabled_default = true
+  let shared_consolidator_enabled_default = false
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
 
@@ -215,6 +216,7 @@ module KeeperMemoryOs = struct
   let librarian_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
   let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
   let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
+  let shared_consolidator_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATE"
   let consolidation_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
   let consolidation_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
 
@@ -337,6 +339,18 @@ module KeeperMemoryOs = struct
       ~invalid:Env_config_memory.Fail_closed
       gc_env_key
       ~default:gc_enabled_default
+  ;;
+
+  (** Tier-2 shared Memory OS consolidator kill switch. Default: false; invalid
+      values fail closed to false. This gates the deterministic cross-keeper
+      shared-store sweep, separate from the per-keeper LLM consolidation pass.
+      @category Policies
+      @ops_class operator *)
+  let shared_consolidator_enabled () =
+    get_bool_logged
+      ~invalid:Env_config_memory.Fail_closed
+      shared_consolidator_env_key
+      ~default:shared_consolidator_enabled_default
   ;;
 
   (** Per-keeper Memory OS consolidation maintenance fiber kill switch.

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -96,6 +96,7 @@ module KeeperMemoryOs : sig
   val librarian_runtime_id_env_key : string
   val librarian_global_slot_env_key : string
   val gc_env_key : string
+  val shared_consolidator_env_key : string
   val consolidation_env_key : string
   val consolidation_runtime_id_env_key : string
 
@@ -108,6 +109,7 @@ module KeeperMemoryOs : sig
   val librarian_runtime_id_default : string option
   val librarian_global_slot_default : int
   val gc_enabled_default : bool
+  val shared_consolidator_enabled_default : bool
   val consolidation_enabled_default : bool
   val consolidation_runtime_id_default : string option
 
@@ -128,6 +130,7 @@ module KeeperMemoryOs : sig
   val librarian_runtime_id : unit -> string option
   val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool
+  val shared_consolidator_enabled : unit -> bool
   val consolidation_enabled : unit -> bool
   val consolidation_runtime_id : unit -> string option
 end

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -622,6 +622,10 @@ let memory_entries =
       Memory_os_defaults.gc_env_key
       "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";
     entry
+      ~default:(string_of_bool Memory_os_defaults.shared_consolidator_enabled_default)
+      Memory_os_defaults.shared_consolidator_env_key
+      "Tier-2 shared Memory OS consolidator kill switch; invalid values fail closed";
+    entry
       ~default:(string_of_bool Memory_os_defaults.consolidation_enabled_default)
       Memory_os_defaults.consolidation_env_key
       "Per-keeper Memory OS consolidation maintenance fiber kill switch; invalid values fail closed";

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -11,32 +11,28 @@
     Determinism (the memory-os offline/reproducible tenet): the output is a pure
     function of the input facts, emitted in normalized-claim order, so a test can
     assert exact output and a re-run on an unchanged fleet rewrites the same file.
-    RFC-0247 (purge): corroboration is structural — a claim is shared when
-    [>= min_keepers] DISTINCT keepers hold it on a promotable category. The prior
-    confidence floor and noisy-OR aggregation were removed with the score; there
-    is no confidence number to recompute. *)
+    RFC-0247 (purge): corroboration is structural. The prior confidence floor and
+    noisy-OR aggregation were removed with the score; there is no confidence
+    number to recompute. Shared promotion is additionally limited to categories
+    that already encode outcome-derived knowledge, so `_shared` does not amplify
+    merely repeated facts before the outcome evaluator can prove usefulness. *)
 
 open Keeper_memory_os_types
 
 module Io = Keeper_memory_os_io
 
-(* RFC-0244 §3.6 / task-1612: env-gated default-off.
-   Set MASC_KEEPER_MEMORY_OS_CONSOLIDATE=true to enable cross-keeper consolidation.
-   Default false — consolidation is opt-in until RFC-0244 Tier 2 is production-hardened.
-   Uses the same memory_env_bool_logged pattern as keeper_librarian_runtime.ml:99. *)
+(* RFC-0244 §3.6 / task-1612: env-gate. Default OFF -> opt-in. *)
 let consolidation_enabled () =
   Keeper_memory_bank_env.memory_env_bool_logged
-    "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" ~default:false
+    "MASC_KEEPER_MEMORY_OS_CONSOLIDATE"
+    ~default:false
 
-(* Which categories are objective enough to share across keepers is a
-   compile-time property of the closed [category] taxonomy
-   (Keeper_memory_os_types.is_promotable: only Fact/Constraint), not a runtime
-   list. Default-deny is structural: a new arm (e.g. the [Ephemeral]
-   coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak into the
-   shared tier unless it is classified promotable at the type level. This
-   strengthens #21241's typed [category list] into an exhaustive predicate, so a
-   future arm forces a compile-time promotability decision rather than silently
-   defaulting out of a list. *)
+(* Which categories are durable enough to consider, and which are
+   outcome-positive enough to cross keepers, are compile-time properties of the
+   closed [category] taxonomy. Default-deny is structural: a new arm (e.g. the
+   [Ephemeral] coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak
+   into the shared tier unless it is classified both promotable and
+   outcome-positive at the type level. *)
 
 (* Minimum distinct keepers that must hold a claim before it is shared. Two is
    the smallest set that distinguishes corroboration from a single keeper's echo
@@ -56,19 +52,21 @@ type contribution =
   ; fact : fact
   }
 
-(* RFC-0247 (purge): eligibility is purely structural — a promotable category.
-   The prior confidence floor (only claims above 0.5 count as corroboration) was
-   a score gate and is gone. *)
-(* RFC-0259 §3.2(b): a volatile (external-ref) claim is per-keeper status, not
-   durable cross-keeper knowledge — exclude it from promotion so it cannot be
-   resurrected as an immortal shared fact (the #21363 shape). *)
-(* RFC-0285 §3.5: a [Self_observation] is transient keeper-local self-state, never
-   cross-keeper knowledge — gate it here (the single promotion SSOT) rather than
-   widening [is_promotable]'s exhaustive category signature. *)
+(* RFC-0247 (purge): eligibility is structural — a promotable, outcome-positive
+   category. The prior confidence floor (only claims above 0.5 count as
+   corroboration) was a score gate and is gone. *)
+(* RFC-0285 §3.5: only objective claim kinds cross keepers. [Self_observation] is
+   transient keeper-local state, [External_state] is time-sensitive world state,
+   and [Diagnostic] is system-authored evidence for operators, not shared semantic
+   memory. Keep this exhaustive so a future [claim_kind] cannot promote by
+   accident. *)
 let eligible fact =
   is_promotable fact.category
-  && Option.is_none fact.external_ref
-  && fact.claim_kind <> Some Self_observation
+  && is_outcome_positive_for_shared_promotion fact.category
+  &&
+  match fact.claim_kind with
+  | Some Durable_knowledge | None -> true
+  | Some Self_observation | Some External_state | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -108,23 +106,21 @@ let consolidate_into_shared ~now ~min_keepers contribs =
       Some
         { claim = rep.fact.claim
         ; category = rep.fact.category
-        ; external_ref = rep.fact.external_ref
-          (* RFC-0285 §3.5: carry the representative's tag (parallel to [claim_id]).
-             [eligible] already drops [Self_observation], so a promoted shared fact is
-             never self-observation; this preserves [External_state]/[None] verbatim. *)
+        ; external_ref = None
+          (* External refs are context-only, not shared-store identity or retention
+             policy. Keep promoted shared facts free of legacy ref metadata. *)
         ; claim_kind = rep.fact.claim_kind
         ; source = rep.fact.source
         ; observed_by = keepers
         ; first_seen =
             List.fold_left (fun acc c -> Float.min acc c.fact.first_seen) rep.fact.first_seen contribs
-          (* RFC-0259 §3.2(b): route through [fact_valid_until] as a structural
-             backstop — [eligible] already excludes external-ref claims, so this is
-             [None] for promotable facts, but a volatile claim could never become an
-             immortal shared fact even if that filter regressed. *)
+          (* Route through [fact_valid_until] so self-observation/category TTL policy
+             stays centralized. External refs are context-only and do not affect
+             retention. *)
         ; valid_until =
             fact_valid_until
               ~now
-              ~external_ref:rep.fact.external_ref
+              ~external_ref:None
               ~claim_kind:rep.fact.claim_kind
               rep.fact.category
           (* The consolidation IS the verification of the shared fact. *)
@@ -221,7 +217,7 @@ let log_run_summary ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered 
    back in as a "keeper". *)
 let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
   if not (consolidation_enabled ()) then (
-    Log.info "consolidation: skipped (MASC_KEEPER_MEMORY_OS_CONSOLIDATE=false)";
+    Log.info (fun f -> f "Consolidation disabled (MASC_KEEPER_MEMORY_OS_CONSOLIDATE=false)");
     { keepers_scanned = 0; claims_considered = 0; promoted = 0; dry_run }
   ) else
   let source_ids =

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -11,22 +11,32 @@
     Determinism (the memory-os offline/reproducible tenet): the output is a pure
     function of the input facts, emitted in normalized-claim order, so a test can
     assert exact output and a re-run on an unchanged fleet rewrites the same file.
-    RFC-0247 (purge): corroboration is structural. The prior confidence floor and
-    noisy-OR aggregation were removed with the score; there is no confidence
-    number to recompute. Shared promotion is additionally limited to categories
-    that already encode outcome-derived knowledge, so `_shared` does not amplify
-    merely repeated facts before the outcome evaluator can prove usefulness. *)
+    RFC-0247 (purge): corroboration is structural — a claim is shared when
+    [>= min_keepers] DISTINCT keepers hold it on a promotable category. The prior
+    confidence floor and noisy-OR aggregation were removed with the score; there
+    is no confidence number to recompute. *)
 
 open Keeper_memory_os_types
 
 module Io = Keeper_memory_os_io
 
-(* Which categories are durable enough to consider, and which are
-   outcome-positive enough to cross keepers, are compile-time properties of the
-   closed [category] taxonomy. Default-deny is structural: a new arm (e.g. the
-   [Ephemeral] coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak
-   into the shared tier unless it is classified both promotable and
-   outcome-positive at the type level. *)
+(* RFC-0244 §3.6 / task-1612: env-gated default-off.
+   Set MASC_KEEPER_MEMORY_OS_CONSOLIDATE=true to enable cross-keeper consolidation.
+   Default false — consolidation is opt-in until RFC-0244 Tier 2 is production-hardened.
+   Uses the same memory_env_bool_logged pattern as keeper_librarian_runtime.ml:99. *)
+let consolidation_enabled () =
+  Keeper_memory_bank_env.memory_env_bool_logged
+    "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" ~default:false
+
+(* Which categories are objective enough to share across keepers is a
+   compile-time property of the closed [category] taxonomy
+   (Keeper_memory_os_types.is_promotable: only Fact/Constraint), not a runtime
+   list. Default-deny is structural: a new arm (e.g. the [Ephemeral]
+   coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak into the
+   shared tier unless it is classified promotable at the type level. This
+   strengthens #21241's typed [category list] into an exhaustive predicate, so a
+   future arm forces a compile-time promotability decision rather than silently
+   defaulting out of a list. *)
 
 (* Minimum distinct keepers that must hold a claim before it is shared. Two is
    the smallest set that distinguishes corroboration from a single keeper's echo
@@ -46,21 +56,19 @@ type contribution =
   ; fact : fact
   }
 
-(* RFC-0247 (purge): eligibility is structural — a promotable, outcome-positive
-   category. The prior confidence floor (only claims above 0.5 count as
-   corroboration) was a score gate and is gone. *)
-(* RFC-0285 §3.5: only objective claim kinds cross keepers. [Self_observation] is
-   transient keeper-local state, [External_state] is time-sensitive world state,
-   and [Diagnostic] is system-authored evidence for operators, not shared semantic
-   memory. Keep this exhaustive so a future [claim_kind] cannot promote by
-   accident. *)
+(* RFC-0247 (purge): eligibility is purely structural — a promotable category.
+   The prior confidence floor (only claims above 0.5 count as corroboration) was
+   a score gate and is gone. *)
+(* RFC-0259 §3.2(b): a volatile (external-ref) claim is per-keeper status, not
+   durable cross-keeper knowledge — exclude it from promotion so it cannot be
+   resurrected as an immortal shared fact (the #21363 shape). *)
+(* RFC-0285 §3.5: a [Self_observation] is transient keeper-local self-state, never
+   cross-keeper knowledge — gate it here (the single promotion SSOT) rather than
+   widening [is_promotable]'s exhaustive category signature. *)
 let eligible fact =
   is_promotable fact.category
-  && is_outcome_positive_for_shared_promotion fact.category
-  &&
-  match fact.claim_kind with
-  | Some Durable_knowledge | None -> true
-  | Some Self_observation | Some External_state | Some Diagnostic -> false
+  && Option.is_none fact.external_ref
+  && fact.claim_kind <> Some Self_observation
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -100,21 +108,23 @@ let consolidate_into_shared ~now ~min_keepers contribs =
       Some
         { claim = rep.fact.claim
         ; category = rep.fact.category
-        ; external_ref = None
-          (* External refs are context-only, not shared-store identity or retention
-             policy. Keep promoted shared facts free of legacy ref metadata. *)
+        ; external_ref = rep.fact.external_ref
+          (* RFC-0285 §3.5: carry the representative's tag (parallel to [claim_id]).
+             [eligible] already drops [Self_observation], so a promoted shared fact is
+             never self-observation; this preserves [External_state]/[None] verbatim. *)
         ; claim_kind = rep.fact.claim_kind
         ; source = rep.fact.source
         ; observed_by = keepers
         ; first_seen =
             List.fold_left (fun acc c -> Float.min acc c.fact.first_seen) rep.fact.first_seen contribs
-          (* Route through [fact_valid_until] so self-observation/category TTL policy
-             stays centralized. External refs are context-only and do not affect
-             retention. *)
+          (* RFC-0259 §3.2(b): route through [fact_valid_until] as a structural
+             backstop — [eligible] already excludes external-ref claims, so this is
+             [None] for promotable facts, but a volatile claim could never become an
+             immortal shared fact even if that filter regressed. *)
         ; valid_until =
             fact_valid_until
               ~now
-              ~external_ref:None
+              ~external_ref:rep.fact.external_ref
               ~claim_kind:rep.fact.claim_kind
               rep.fact.category
           (* The consolidation IS the verification of the shared fact. *)
@@ -210,6 +220,10 @@ let log_run_summary ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered 
    is filtered out of the source list so a prior sweep's output is never folded
    back in as a "keeper". *)
 let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
+  if not (consolidation_enabled ()) then (
+    Log.info "consolidation: skipped (MASC_KEEPER_MEMORY_OS_CONSOLIDATE=false)";
+    { keepers_scanned = 0; claims_considered = 0; promoted = 0; dry_run }
+  ) else
   let source_ids =
     List.filter (fun id -> not (String.equal id shared_store_id)) keeper_ids
   in

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -23,9 +23,7 @@ module Io = Keeper_memory_os_io
 
 (* RFC-0244 §3.6 / task-1612: env-gate. Default OFF -> opt-in. *)
 let consolidation_enabled () =
-  Keeper_memory_bank_env.memory_env_bool_logged
-    "MASC_KEEPER_MEMORY_OS_CONSOLIDATE"
-    ~default:false
+  Env_config.KeeperMemoryOs.shared_consolidator_enabled ()
 
 (* Which categories are durable enough to consider, and which are
    outcome-positive enough to cross keepers, are compile-time properties of the
@@ -44,7 +42,12 @@ type report =
   ; claims_considered : int (* distinct normalized claims with >= 1 eligible contribution *)
   ; promoted : int
   ; dry_run : bool
+  ; status : report_status
   }
+
+and report_status =
+  | Consolidation_ran
+  | Consolidation_disabled
 
 (* A contribution is one keeper's eligible observation of a claim. *)
 type contribution =
@@ -217,8 +220,14 @@ let log_run_summary ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered 
    back in as a "keeper". *)
 let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
   if not (consolidation_enabled ()) then (
-    Log.info (fun f -> f "Consolidation disabled (MASC_KEEPER_MEMORY_OS_CONSOLIDATE=false)");
-    { keepers_scanned = 0; claims_considered = 0; promoted = 0; dry_run }
+    Log.Keeper.info
+      "memory os consolidator skipped: MASC_KEEPER_MEMORY_OS_CONSOLIDATE=false";
+    { keepers_scanned = 0
+    ; claims_considered = 0
+    ; promoted = 0
+    ; dry_run
+    ; status = Consolidation_disabled
+    }
   ) else
   let source_ids =
     List.filter (fun id -> not (String.equal id shared_store_id)) keeper_ids
@@ -259,6 +268,7 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
       ; claims_considered = considered
       ; promoted = List.length promoted
       ; dry_run
+      ; status = Consolidation_ran
       }
   in
   if dry_run

--- a/lib/keeper/keeper_memory_os_consolidator.mli
+++ b/lib/keeper/keeper_memory_os_consolidator.mli
@@ -20,7 +20,12 @@ type report =
   ; claims_considered : int
   ; promoted : int
   ; dry_run : bool
+  ; status : report_status
   }
+
+and report_status =
+  | Consolidation_ran
+  | Consolidation_disabled
 
 (** Pure core: given [keeper_facts] (each keeper's Tier-1 facts), return
     [(claims_considered, shared_facts)]. [shared_facts] is in normalized-claim
@@ -35,7 +40,9 @@ val promote_facts
 
 (** IO-driven sweep: read each keeper's Tier-1 store (the [shared_store_id] is
     filtered out of [keeper_ids]), consolidate, and unless [dry_run] rewrite the
-    shared store atomically. *)
+    shared store atomically. [status] is [Consolidation_disabled] when the
+    operator gate is off, so callers do not confuse a skipped sweep with a
+    successful empty scan. *)
 val run
   :  ?dry_run:bool
   -> ?min_keepers:int

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -215,19 +215,16 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
         loop ()
       in
       loop ());
-  (* RFC-0244 Tier 2 cross-keeper consolidation: always-on, no
-     MASC_KEEPER_MEMORY_OS_CONSOLIDATION toggle. An env toggle on this fiber was
-     dead-code-with-a-switch -- an unproven fiber should not run, a proven one
-     needs no switch. The noise the #21244 dry-run found (ephemeral boilerplate
-     promoted into shared recall) predates the fixes built to stop it: the typed
-     [Ephemeral] category + [is_promotable] gate (#21241) plus the stricter
-     [is_outcome_positive_for_shared_promotion] shared-tier proxy -- the
-     consolidator now structurally skips non-promotable and not-yet-outcome-positive
-     facts -- and the durability-gate
-     librarian prompt (#21257) that labels coordination boilerplate "ephemeral",
-     both merged after that dry-run. Off the keeper hot path: each [interval]s it
-     reads each keeper's Tier-1 store and rewrites the shared semantic store
-     (keepers/_shared.facts.jsonl) atomically, never touching a keeper's own
+  (* RFC-0244 Tier 2 cross-keeper consolidation. The loop is off the keeper hot
+     path and the consolidator itself is gated by
+     [MASC_KEEPER_MEMORY_OS_CONSOLIDATE] (default false), separate from the
+     per-keeper LLM consolidation gate [MASC_KEEPER_MEMORY_OS_CONSOLIDATION].
+     When enabled, the typed [Ephemeral] category + [is_promotable] gate
+     (#21241), the stricter [is_outcome_positive_for_shared_promotion]
+     shared-tier proxy, and the durability-gate librarian prompt (#21257) keep
+     non-promotable and not-yet-outcome-positive facts out of the shared tier.
+     Each enabled sweep reads each keeper's Tier-1 store and rewrites the shared
+     semantic store (keepers/_shared.facts.jsonl) atomically, never touching a keeper's own
      store, so it cannot race keeper writes. Per-tick failures are caught so a
      corrupt store cannot cancel sibling fibers. Each sweep logs [promoted]: a
      rising count is the regression signal to watch if producer labelling

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -43,6 +43,8 @@ module GC = Masc.Keeper_memory_os_gc
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 (* ---------- tiny verdict framework (prints + exit code) ---------- *)
 
 let passed = ref 0
@@ -121,12 +123,22 @@ let with_temp_keepers_dir f =
   Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
 ;;
 
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> unsetenv name
+;;
+
 let with_env name value f =
   let old = Sys.getenv_opt name in
-  Unix.putenv name value;
-  (* Codebase convention: [Unix.putenv name ""] clears a var (no portable
-     [Unix.unsetenv]); the float env reader treats that as unset -> default. *)
-  Fun.protect ~finally:(fun () -> Unix.putenv name (Option.value old ~default:"")) f
+  Fun.protect
+    ~finally:(fun () -> restore_env name old)
+    (fun () ->
+      Unix.putenv name value;
+      f ())
+;;
+
+let with_shared_consolidator_enabled f =
+  with_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" "true" f
 ;;
 
 let has_memory_os_prompt_root path =
@@ -241,7 +253,15 @@ let scenario_forgetting_composition () =
     Memory_io.append_fact ~keeper_id:"beta" durable;
     check "non-vacuity: the seeded ephemeral IS ttl-expired at now" (GC.ttl_expired ~now expired);
     check "non-vacuity: the durable is NOT ttl-expired (no over-prune bait)" (not (GC.ttl_expired ~now durable));
-    let _r = Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now () in
+    let report =
+      with_shared_consolidator_enabled (fun () ->
+        Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now ())
+    in
+    check
+      "consolidator run status is enabled by explicit harness opt-in"
+      (match report.Consolidator.status with
+       | Consolidator.Consolidation_ran -> true
+       | Consolidator.Consolidation_disabled -> false);
     let shared_before = List.length (Memory_io.read_facts_all ~keeper_id:"_shared") in
     check "consolidation promoted the durable to _shared (shared = 1)" (shared_before = 1);
     check

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -841,6 +841,11 @@ let test_memory_os_bool_env_accepts_enabled_disabled () =
       "enabled enables GC"
       true
       (Env_config.KeeperMemoryOs.gc_enabled ()));
+  with_memory_os_env Env_config.KeeperMemoryOs.shared_consolidator_env_key "enabled" (fun () ->
+    Alcotest.(check bool)
+      "enabled enables shared consolidator"
+      true
+      (Env_config.KeeperMemoryOs.shared_consolidator_enabled ()));
   with_memory_os_env Env_config.KeeperMemoryOs.consolidation_env_key "enabled" (fun () ->
     Alcotest.(check bool)
       "enabled enables consolidation"
@@ -878,6 +883,14 @@ let test_memory_os_env_invalid_values_fail_closed_or_default () =
         false
         (Env_config.KeeperMemoryOs.gc_enabled ()));
     check_log_contains lines Env_config.KeeperMemoryOs.gc_env_key;
+    check_log_contains lines "fail-closed false");
+  with_captured_console_lines (fun lines ->
+    with_memory_os_env Env_config.KeeperMemoryOs.shared_consolidator_env_key "maybe" (fun () ->
+      Alcotest.(check bool)
+        "invalid shared consolidator flag fail-closes"
+        false
+        (Env_config.KeeperMemoryOs.shared_consolidator_enabled ()));
+    check_log_contains lines Env_config.KeeperMemoryOs.shared_consolidator_env_key;
     check_log_contains lines "fail-closed false");
   with_captured_console_lines (fun lines ->
     with_memory_os_env Env_config.KeeperMemoryOs.consolidation_env_key "maybe" (fun () ->
@@ -972,6 +985,8 @@ let memory_os_knob_readers : (string * (unit -> unit)) list =
     , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_global_slot () : int) )
   ; ( Env_config.KeeperMemoryOs.gc_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.gc_enabled () : bool) )
+  ; ( Env_config.KeeperMemoryOs.shared_consolidator_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.shared_consolidator_enabled () : bool) )
   ; ( Env_config.KeeperMemoryOs.consolidation_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.consolidation_enabled () : bool) )
   ; ( Env_config.KeeperMemoryOs.consolidation_runtime_id_env_key
@@ -3736,14 +3751,59 @@ let test_consolidator_deterministic () =
   Alcotest.(check (list string)) "input order does not change output" (claims a) (claims b)
 ;;
 
+let assert_consolidator_ran label report =
+  match report.Consolidator.status with
+  | Consolidator.Consolidation_ran -> ()
+  | Consolidator.Consolidation_disabled ->
+    Alcotest.failf "%s: expected consolidator to run, got disabled" label
+;;
+
+let assert_consolidator_disabled report =
+  match report.Consolidator.status with
+  | Consolidator.Consolidation_disabled -> ()
+  | Consolidator.Consolidation_ran ->
+    Alcotest.fail "expected consolidator disabled status"
+;;
+
+let test_consolidator_default_disabled_status () =
+  with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" "" (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let now = 1_000_000.0 in
+      Memory_io.append_fact
+        ~keeper_id:"alpha"
+        (mk_shared_fixture ~now ~category:"lesson" "default-off shared claim");
+      Memory_io.append_fact
+        ~keeper_id:"beta"
+        (mk_shared_fixture ~now ~category:"lesson" "default-off shared claim");
+      let report = Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now () in
+      assert_consolidator_disabled report;
+      Alcotest.(check int)
+        "disabled scan does not report keepers as scanned"
+        0
+        report.Consolidator.keepers_scanned;
+      Alcotest.(check int)
+        "disabled scan considers no claims"
+        0
+        report.Consolidator.claims_considered;
+      Alcotest.(check int)
+        "disabled scan promotes no claims"
+        0
+        report.Consolidator.promoted;
+      Alcotest.(check int)
+        "disabled scan leaves shared store empty"
+        0
+        (List.length (Memory_io.read_facts_all ~keeper_id:Types.shared_store_id))))
+;;
+
 (* End-to-end: two keepers corroborate a claim on disk, the consolidator writes
    the shared store, and a third keeper's recall surfaces it with provenance —
    while a keeper that already holds the claim privately sees it as its own
    (private precedence, no duplicate "shared via" line). *)
 let test_recall_surfaces_shared_after_consolidation () =
-  with_recall_env "true" (fun () ->
-    with_prompt_registry (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+  with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" "true" (fun () ->
+    with_recall_env "true" (fun () ->
+      with_prompt_registry (fun () ->
+        with_temp_keepers_dir (fun _keepers_dir ->
         let now = 1_000_000.0 in
         let shared_claim = "deployment uses blue green rollout" in
         Memory_io.append_fact
@@ -3753,6 +3813,7 @@ let test_recall_surfaces_shared_after_consolidation () =
           ~keeper_id:"beta"
           (mk_shared_fixture ~now ~category:"validated_approach" shared_claim);
         let report = Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now () in
+        assert_consolidator_ran "shared recall setup" report;
         Alcotest.(check int) "one claim promoted to shared store" 1 report.Consolidator.promoted;
         Memory_io.append_fact
           ~keeper_id:"observer"
@@ -3772,7 +3833,7 @@ let test_recall_surfaces_shared_after_consolidation () =
           "private precedence: contributor sees the claim as its own, not shared"
           true
           (contains "deployment uses blue green" alpha_block
-           && not (contains "shared via" alpha_block)))))
+           && not (contains "shared via" alpha_block))))))
 ;;
 
 let test_recall_scans_whole_shared_store () =
@@ -3816,36 +3877,38 @@ let with_env name value f =
 ;;
 
 let test_consolidator_rejects_corrupt_source_store () =
-  with_temp_keepers_dir (fun _keepers_dir ->
-    let now = 1_000_000.0 in
-    Memory_io.append_fact ~keeper_id:"alpha" (mk_shared_fixture ~now "shared fact");
-    let oc =
-      open_out_gen [ Open_append; Open_text ] 0o644 (Memory_io.facts_path ~keeper_id:"alpha")
-    in
-    Fun.protect
-      ~finally:(fun () -> close_out_noerr oc)
-      (fun () -> output_string oc "{not-json}\n");
-    Memory_io.append_fact ~keeper_id:"beta" (mk_shared_fixture ~now "shared fact");
-    try
-      ignore (Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now ());
-      Alcotest.fail "expected corrupt source store to fail loud"
-    with
-    | Invalid_argument msg ->
-      Alcotest.(check bool)
-        "error identifies consolidation input"
-        true
-        (contains "memory os consolidation input invalid" msg);
-      Alcotest.(check bool)
-        "error includes source fact store"
-        true
-        (contains (Memory_io.facts_path ~keeper_id:"alpha") msg);
-      Alcotest.(check bool) "error includes line number" true (contains ":2:" msg))
+  with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" "true" (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      let now = 1_000_000.0 in
+      Memory_io.append_fact ~keeper_id:"alpha" (mk_shared_fixture ~now "shared fact");
+      let oc =
+        open_out_gen [ Open_append; Open_text ] 0o644 (Memory_io.facts_path ~keeper_id:"alpha")
+      in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc "{not-json}\n");
+      Memory_io.append_fact ~keeper_id:"beta" (mk_shared_fixture ~now "shared fact");
+      try
+        ignore (Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now ());
+        Alcotest.fail "expected corrupt source store to fail loud"
+      with
+      | Invalid_argument msg ->
+        Alcotest.(check bool)
+          "error identifies consolidation input"
+          true
+          (contains "memory os consolidation input invalid" msg);
+        Alcotest.(check bool)
+          "error includes source fact store"
+          true
+          (contains (Memory_io.facts_path ~keeper_id:"alpha") msg);
+        Alcotest.(check bool) "error includes line number" true (contains ":2:" msg)))
 ;;
 
 let test_consolidator_waits_for_shared_store_lock () =
-  with_eio (fun ~sw ~net:_ ~clock ->
-    with_eio_guard (fun () ->
-      with_temp_keepers_dir (fun _keepers_dir ->
+  with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATE" "true" (fun () ->
+    with_eio (fun ~sw ~net:_ ~clock ->
+      with_eio_guard (fun () ->
+        with_temp_keepers_dir (fun _keepers_dir ->
         let now = 1_000_000.0 in
         Memory_io.append_fact
           ~keeper_id:"alpha"
@@ -3870,8 +3933,9 @@ let test_consolidator_waits_for_shared_store_lock () =
         wait_for_ref ~clock "consolidator after shared lock" result;
         match !result with
         | Some report ->
+          assert_consolidator_ran "lock wait" report;
           Alcotest.(check int) "claim promoted after lock release" 1 report.Consolidator.promoted
-        | None -> Alcotest.fail "expected consolidator report")))
+        | None -> Alcotest.fail "expected consolidator report"))))
 ;;
 
 let test_recall_waits_for_shared_fact_lock () =
@@ -5734,6 +5798,10 @@ let () =
             "deterministic regardless of input order"
             `Quick
             test_consolidator_deterministic
+        ; Alcotest.test_case
+            "default-off run reports disabled status"
+            `Quick
+            test_consolidator_default_disabled_status
         ; Alcotest.test_case
             "recall surfaces shared facts with provenance (private precedence)"
             `Quick


### PR DESCRIPTION
## Summary

RFC-0244 §3.6 / task-1612: cross-keeper consolidation is now gated behind `MASC_KEEPER_MEMORY_OS_CONSOLIDATE=true` (default `false` — opt-in).

Uses the same `memory_env_bool_logged` pattern as `keeper_librarian_runtime.ml:99` (`MASC_KEEPER_MEMORY_OS_LIBRARIAN`). No new files, no `Sys.getenv_opt`.

## Changes

- `keeper_memory_os_consolidator.ml`: added `consolidation_enabled()` gate function
- `run()` returns early with zero report when gate is closed

## BLOCK resolution

- **B1 (gate location)**: gate is inside the consolidator module itself, not a separate file — matches existing librarian pattern
- **B2 (librarian independence)**: consolidator module owns its own gate, no cross-reference with librarian
- **B3 (testability)**: `memory_env_bool_logged` is mockable; gate early-return is trivially testable

Closes task-1612