### PR TITLE
feat(board): add comment pagination to masc_board_post_get

### DIFF
--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -403,15 +403,39 @@ let handle_post_get ~tool_name ~start_time args : Tool_result.result =
     Board_tool_format.error_of_board_error ~tool_name ~start_time e
   | Ok (post, comments) ->
     let post_str = Board_tool_format.format_post post in
+    let total_comments = List.length comments in
+    let comment_offset = get_int args "comment_offset" 0 in
+    let comment_limit = min (get_int args "comment_limit" 50) 100 in
+    let clamped_offset = max 0 (min comment_offset total_comments) in
+    let sliced =
+      List.filteri
+        (fun i _ -> i >= clamped_offset && i < clamped_offset + comment_limit)
+        comments
+    in
+    let has_more = clamped_offset + comment_limit < total_comments in
     let comments_str =
-      if Stdlib.List.length comments = 0
+      if total_comments = 0
       then "\n\nNo comments."
       else (
-        let formatted = Board_tool_format.format_comment_tree comments in
+        let formatted = Board_tool_format.format_comment_tree sliced in
+        let pagination =
+          if has_more
+          then
+            Printf.sprintf
+              "\n[Showing comments %d-%d of %d. Use comment_offset=%d to \
+               see more.]"
+              (clamped_offset + 1)
+              (clamped_offset + List.length sliced)
+              total_comments
+              (clamped_offset + comment_limit)
+          else Printf.sprintf "\n[Showing all %d comments.]" total_comments
+        in
         Printf.sprintf
-          "\n\n**Comments (%d)**:\n%s"
-          (List.length comments)
-          (String.concat "\n" formatted))
+          "\n\n**Comments (%d of %d)**:\n%s%s"
+          (List.length sliced)
+          total_comments
+          (String.concat "\n" formatted)
+          pagination)
     in
     Tool_result.make_ok
       ~tool_name

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -405,7 +405,7 @@ let handle_post_get ~tool_name ~start_time args : Tool_result.result =
     let post_str = Board_tool_format.format_post post in
     let total_comments = List.length comments in
     let comment_offset = get_int args "comment_offset" 0 in
-    let comment_limit = min (get_int args "comment_limit" 50) 100 in
+    let comment_limit = max 1 (min (get_int args "comment_limit" 50) 100) in
     let clamped_offset = max 0 (min comment_offset total_comments) in
     let sliced =
       List.filteri

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -417,6 +417,7 @@ let handle_post_get ~tool_name ~start_time args : Tool_result.result =
       if total_comments = 0
       then "\n\nNo comments."
       else (
+        let shown_count = List.length sliced in
         let formatted = Board_tool_format.format_comment_tree sliced in
         let pagination =
           if has_more
@@ -425,14 +426,26 @@ let handle_post_get ~tool_name ~start_time args : Tool_result.result =
               "\n[Showing comments %d-%d of %d. Use comment_offset=%d to \
                see more.]"
               (clamped_offset + 1)
-              (clamped_offset + List.length sliced)
+              (clamped_offset + shown_count)
               total_comments
               (clamped_offset + comment_limit)
-          else Printf.sprintf "\n[Showing all %d comments.]" total_comments
+          else if clamped_offset = 0 && shown_count = total_comments
+          then Printf.sprintf "\n[Showing all %d comments.]" total_comments
+          else if shown_count = 0
+          then
+            Printf.sprintf
+              "\n[Showing comments 0 of %d. No more comments.]"
+              total_comments
+          else
+            Printf.sprintf
+              "\n[Showing comments %d-%d of %d. No more comments.]"
+              (clamped_offset + 1)
+              (clamped_offset + shown_count)
+              total_comments
         in
         Printf.sprintf
           "\n\n**Comments (%d of %d)**:\n%s%s"
-          (List.length sliced)
+          shown_count
           total_comments
           (String.concat "\n" formatted)
           pagination)

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -338,6 +338,22 @@ let tool_post_get : Masc_domain.tool_schema =
                            masc_board_list, masc_board_search, or visible board context \
                            before calling masc_board_post_get." )
                     ] )
+              ; ( "comment_offset"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; ( "description"
+                      , `String
+                          "Zero-based offset into the comment thread (default: 0). \
+                           Use to paginate through long threads." )
+                    ] )
+              ; ( "comment_limit"
+                , `Assoc
+                    [ "type", `String "integer"
+                    ; ( "description"
+                      , `String
+                          "Max comments to return (default: 50, max: 100). \
+                           Response includes pagination metadata when truncated." )
+                    ] )
               ] )
         ; "required", `List [ `String "post_id" ]
         ]

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -319,8 +319,9 @@ let tool_post_list : Masc_domain.tool_schema =
 let tool_post_get : Masc_domain.tool_schema =
   { name = "masc_board_post_get"
   ; description =
-      "Read one existing board post by exact post_id, including its full comment \
-       thread. Use only after you already have a post_id from masc_board_list, \
+      "Read one existing board post by exact post_id. Comments are paginated by \
+       default; use comment_offset and comment_limit to continue through long \
+       threads. Use only after you already have a post_id from masc_board_list, \
        masc_board_search, or visible board context. If no post_id is visible, call \
        masc_board_list or masc_board_search first; never call this tool with empty \
        arguments."
@@ -341,6 +342,8 @@ let tool_post_get : Masc_domain.tool_schema =
               ; ( "comment_offset"
                 , `Assoc
                     [ "type", `String "integer"
+                    ; "minimum", `Int 0
+                    ; "default", `Int 0
                     ; ( "description"
                       , `String
                           "Zero-based offset into the comment thread (default: 0). \
@@ -349,6 +352,9 @@ let tool_post_get : Masc_domain.tool_schema =
               ; ( "comment_limit"
                 , `Assoc
                     [ "type", `String "integer"
+                    ; "minimum", `Int 1
+                    ; "maximum", `Int 100
+                    ; "default", `Int 50
                     ; ( "description"
                       , `String
                           "Max comments to return (default: 50, max: 100). \

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -253,6 +253,11 @@ let schema_property_description schema name =
   |> to_string_option
 ;;
 
+let schema_property_int schema name field =
+  let open Yojson.Safe.Util in
+  schema |> member "properties" |> member name |> member field |> to_int_option
+;;
+
 let schema_required_fields schema =
   match schema with
   | `Assoc fields ->
@@ -491,9 +496,21 @@ let test_masc_board_descriptions_disambiguate_post_id_flow () =
     schema_property_description get_schema.input_schema "post_id"
     |> Option.value ~default:""
   in
+  let comment_offset_description =
+    schema_property_description get_schema.input_schema "comment_offset"
+    |> Option.value ~default:""
+  in
+  let comment_limit_description =
+    schema_property_description get_schema.input_schema "comment_limit"
+    |> Option.value ~default:""
+  in
   check_contains
     "masc_board_post_get schema points to list/search first"
     ~sub:"masc_board_list or masc_board_search first"
+    get_schema.description;
+  check_contains
+    "masc_board_post_get schema advertises pagination"
+    ~sub:"Comments are paginated by default"
     get_schema.description;
   check_contains
     "masc_board_post_get schema forbids empty args"
@@ -503,6 +520,26 @@ let test_masc_board_descriptions_disambiguate_post_id_flow () =
     "masc_board_post_get post_id field says exact ID is required"
     ~sub:"Required exact board post ID"
     get_post_id_description;
+  check_contains
+    "masc_board_post_get offset description mentions default"
+    ~sub:"default: 0"
+    comment_offset_description;
+  check_contains
+    "masc_board_post_get limit description mentions bounds"
+    ~sub:"default: 50, max: 100"
+    comment_limit_description;
+  Alcotest.(check (option int))
+    "masc_board_post_get offset minimum"
+    (Some 0)
+    (schema_property_int get_schema.input_schema "comment_offset" "minimum");
+  Alcotest.(check (option int))
+    "masc_board_post_get limit minimum"
+    (Some 1)
+    (schema_property_int get_schema.input_schema "comment_limit" "minimum");
+  Alcotest.(check (option int))
+    "masc_board_post_get limit maximum"
+    (Some 100)
+    (schema_property_int get_schema.input_schema "comment_limit" "maximum");
   check_contains
     "masc_board_list schema says it returns post_id"
     ~sub:"return post_id values"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1511,6 +1511,70 @@ let test_post_get_success () =
   Alcotest.(check bool) "get ok" true ok2;
   Alcotest.(check bool) "get has content" true (String.length body2 > 0)
 
+let create_post_with_comments ~count =
+  let ok, body =
+    dispatch
+      "masc_board_post"
+      (make_args [ "content", `String "Get comments"; "author", `String "tester" ])
+  in
+  Alcotest.(check bool) "create ok" true ok;
+  let post_id =
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
+  in
+  for i = 1 to count do
+    let ok, _body =
+      dispatch
+        "masc_board_comment"
+        (make_args
+           [ "post_id", `String post_id
+           ; "content", `String (Printf.sprintf "comment-%03d" i)
+           ; "author", `String (Printf.sprintf "commenter-%03d" i)
+           ])
+    in
+    Alcotest.(check bool) (Printf.sprintf "comment %d ok" i) true ok
+  done;
+  post_id
+
+let check_get_footer ~label post_id args expected =
+  let ok, body =
+    dispatch "masc_board_post_get" (make_args (("post_id", `String post_id) :: args))
+  in
+  Alcotest.(check bool) (label ^ " get ok") true ok;
+  Alcotest.(check bool) label true (contains_substring body expected)
+
+let test_post_get_comment_pagination_clamps_and_advances () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post_id = create_post_with_comments ~count:105 in
+  check_get_footer
+    ~label:"default limit"
+    post_id
+    []
+    "Showing comments 1-50 of 105. Use comment_offset=50 to see more.";
+  check_get_footer
+    ~label:"over max limit"
+    post_id
+    [ "comment_limit", `Int 999 ]
+    "Showing comments 1-100 of 105. Use comment_offset=100 to see more.";
+  check_get_footer
+    ~label:"zero limit clamps to one"
+    post_id
+    [ "comment_limit", `Int 0 ]
+    "Showing comments 1-1 of 105. Use comment_offset=1 to see more.";
+  check_get_footer
+    ~label:"negative limit clamps to one"
+    post_id
+    [ "comment_limit", `Int (-10) ]
+    "Showing comments 1-1 of 105. Use comment_offset=1 to see more.";
+  check_get_footer
+    ~label:"normal page advances"
+    post_id
+    [ "comment_offset", `Int 2; "comment_limit", `Int 2 ]
+    "Showing comments 3-4 of 105. Use comment_offset=4 to see more."
+
 let test_post_get_not_found () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2033,6 +2097,10 @@ let () =
           Alcotest.test_case "list filter combinations" `Quick
             test_post_list_filter_combinations;
           Alcotest.test_case "get success" `Quick test_post_get_success;
+          Alcotest.test_case
+            "get comment pagination clamps and advances"
+            `Quick
+            test_post_get_comment_pagination_clamps_and_advances;
           Alcotest.test_case "get not found" `Quick test_post_get_not_found;
         ] );
       ( "voting",

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1573,7 +1573,23 @@ let test_post_get_comment_pagination_clamps_and_advances () =
     ~label:"normal page advances"
     post_id
     [ "comment_offset", `Int 2; "comment_limit", `Int 2 ]
-    "Showing comments 3-4 of 105. Use comment_offset=4 to see more."
+    "Showing comments 3-4 of 105. Use comment_offset=4 to see more.";
+  check_get_footer
+    ~label:"final page names returned range"
+    post_id
+    [ "comment_offset", `Int 100; "comment_limit", `Int 100 ]
+    "Showing comments 101-105 of 105. No more comments.";
+  check_get_footer
+    ~label:"offset at end is empty final page"
+    post_id
+    [ "comment_offset", `Int 105; "comment_limit", `Int 100 ]
+    "Showing comments 0 of 105. No more comments.";
+  let small_post_id = create_post_with_comments ~count:2 in
+  check_get_footer
+    ~label:"all comments only when first page spans whole thread"
+    small_post_id
+    []
+    "Showing all 2 comments."
 
 let test_post_get_not_found () =
   with_eio @@ fun env ->

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1515,7 +1515,10 @@ let create_post_with_comments ~count =
   let ok, body =
     dispatch
       "masc_board_post"
-      (make_args [ "content", `String "Get comments"; "author", `String "tester" ])
+      (make_args
+         [ "content", `String (Printf.sprintf "Get comments %d" count)
+         ; "author", `String (Printf.sprintf "tester-%d" count)
+         ])
   in
   Alcotest.(check bool) "create ok" true ok;
   let post_id =


### PR DESCRIPTION
## Summary
Add `comment_offset` and `comment_limit` optional params to `masc_board_post_get` so long comment threads are paginated with explicit range metadata instead of relying on one oversized response.

## Problem
`keeper_board_post_get` previously returned every comment in one call. Long threads could exceed the response budget with no way for the caller to request the next slice.

## Changes
- `board_tool_schemas.ml`: added `comment_offset` (default 0, minimum 0) and `comment_limit` (default 50, min 1, max 100) to `tool_post_get` schema.
- `board_tool_post.ml`: clamps offset/limit, slices comments, and emits authoritative footer metadata for early pages, final pages, empty final pages, and full-thread first pages.
- `test_tool_board_coverage.ml`: covers default, over-max, zero/negative limit lower-bound clamp, normal page advancement, final-page range, offset-at-end, and full-thread first-page behavior.

## Behavior
- Default long thread: first 50 comments, e.g. `[Showing comments 1-50 of 120. Use comment_offset=50 to see more.]`
- Final non-empty page: returned range, e.g. `[Showing comments 101-105 of 105. No more comments.]`
- Offset at end: `[Showing comments 0 of 105. No more comments.]`
- Full thread only when the first page spans all comments: `[Showing all N comments.]`
- `comment_offset` is clamped to `[0, total_comments]`.
- `comment_limit` is clamped to `[1, 100]`.

## Verification
- CI is green on current head.
- Test Coverage Check is green.
- Build and Test is green.

Closes task-1605