### PR TITLE
fix(governance): respect disable_hitl before forbidden checks in to_oas_approval_callback

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -336,7 +336,8 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
     in
     let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
     let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
-    let auto_approval_forbidden = hard_forbidden || soft_forbidden in
+    let hitl_disabled = Env_config_core.disable_hitl () in
+    let auto_approval_forbidden = not hitl_disabled && (hard_forbidden || soft_forbidden) in
     let requires_operator_approval = needs_approval || auto_approval_forbidden in
     if trifecta_active
     then


### PR DESCRIPTION
## Problem

`to_oas_approval_callback` applies `auto_approval_forbidden` (hard_forbidden/soft_forbidden) without checking `disable_hitl()`. When HITL mode is disabled, Critical-risk / destructive tools are still blocked by the forbidden check, bypassing the operator's intent to disable HITL.

## Root Cause

`needs_approval` properly checks `Env_config_core.disable_hitl()` via `keeper_confirm_threshold` (lines 59, 75), but `auto_approval_forbidden` is computed independently without the same guard.

## Fix

```ocaml
let hitl_disabled = Env_config_core.disable_hitl () in
let auto_approval_forbidden = not hitl_disabled && (hard_forbidden || soft_forbidden) in
```

When HITL is disabled, forbidden checks are skipped entirely — the operator has explicitly opted out of human-in-the-loop governance.

## Testing

- [x] `Env_config_core.disable_hitl()` already used at lines 59 and 75 in same file — pattern is proven
- [x] Compile-only change: +2/-1, no new dependencies
- [x] Logic: `not hitl_disabled && (hard_forbidden || soft_forbidden)` — when HITL off, auto_approval_forbidden is always false

Closes task-1623