### PR TITLE
test(keeper): add dispatch_state unit tests for PR #22964 lane gating

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -34,6 +34,15 @@ let clear_dispatching state keeper_name =
       with_dispatch_state state (fun () ->
           Hashtbl.remove state.running_by_keeper keeper_name))
 
+module For_testing = struct
+  type nonrec dispatch_state = dispatch_state
+
+  let create_dispatch_state = create_dispatch_state
+  let is_dispatching = is_dispatching
+  let mark_dispatching = mark_dispatching
+  let clear_dispatching = clear_dispatching
+end
+
 let dispatch_queued_turn state ~sw ~handle_turn ~keeper_name ~queued =
   Eio.Fiber.fork ~sw (fun () ->
       try

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -34,3 +34,12 @@ val start :
   base_path:string ->
   handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
   unit
+
+module For_testing : sig
+  type dispatch_state
+
+  val create_dispatch_state : unit -> dispatch_state
+  val is_dispatching : dispatch_state -> string -> bool
+  val mark_dispatching : dispatch_state -> string -> bool
+  val clear_dispatching : dispatch_state -> string -> unit
+end

--- a/test/dune
+++ b/test/dune
@@ -877,6 +877,7 @@
  (names
   test_keeper_busy_connector_deferred
   test_keeper_chat_consumer_delivery
+  test_keeper_chat_consumer_dispatch
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage
@@ -1070,6 +1071,7 @@
  (modules
   test_keeper_busy_connector_deferred
   test_keeper_chat_consumer_delivery
+  test_keeper_chat_consumer_dispatch
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage

--- a/test/test_keeper_chat_consumer_dispatch.ml
+++ b/test/test_keeper_chat_consumer_dispatch.ml
@@ -1,0 +1,19 @@
+(* dispatch_state unit tests for PR #22964 *)
+open Masc
+let failures = ref 0
+let check n c = if c then Printf.printf "PASS %s\n%!" n else (incr failures; Printf.printf "FAIL %s\n%!" n)
+let tf = Keeper_chat_consumer.For_testing
+let () =
+  let s = tf.create_dispatch_state () in
+  check "fresh" (not (tf.is_dispatching s "a"));
+  check "mark" (tf.mark_dispatching s "a");
+  check "is" (tf.is_dispatching s "a");
+  check "dup" (not (tf.mark_dispatching s "a"));
+  tf.clear_dispatching s "a";
+  check "clear" (not (tf.is_dispatching s "a"));
+  check "b_independent" (not (tf.is_dispatching s "b"));
+  ignore (tf.mark_dispatching s "b");
+  check "b_marked" (tf.is_dispatching s "b");
+  tf.clear_dispatching s "nonexistent";
+  check "noop" true;
+  if !failures > 0 then exit 1 else Printf.printf "All tests passed.\n%!"

--- a/test/test_keeper_chat_consumer_dispatch.ml
+++ b/test/test_keeper_chat_consumer_dispatch.ml
@@ -1,19 +1,32 @@
 (* dispatch_state unit tests for PR #22964 *)
 open Masc
+
+module Tf = Keeper_chat_consumer.For_testing
+
 let failures = ref 0
-let check n c = if c then Printf.printf "PASS %s\n%!" n else (incr failures; Printf.printf "FAIL %s\n%!" n)
-let tf = Keeper_chat_consumer.For_testing
-let () =
-  let s = tf.create_dispatch_state () in
-  check "fresh" (not (tf.is_dispatching s "a"));
-  check "mark" (tf.mark_dispatching s "a");
-  check "is" (tf.is_dispatching s "a");
-  check "dup" (not (tf.mark_dispatching s "a"));
-  tf.clear_dispatching s "a";
-  check "clear" (not (tf.is_dispatching s "a"));
-  check "b_independent" (not (tf.is_dispatching s "b"));
-  ignore (tf.mark_dispatching s "b");
-  check "b_marked" (tf.is_dispatching s "b");
-  tf.clear_dispatching s "nonexistent";
+
+let check n c =
+  if c
+  then Printf.printf "PASS %s\n%!" n
+  else (
+    incr failures;
+    Printf.printf "FAIL %s\n%!" n)
+;;
+
+let run () =
+  let s = Tf.create_dispatch_state () in
+  check "fresh" (not (Tf.is_dispatching s "a"));
+  check "mark" (Tf.mark_dispatching s "a");
+  check "is" (Tf.is_dispatching s "a");
+  check "dup" (not (Tf.mark_dispatching s "a"));
+  Tf.clear_dispatching s "a";
+  check "clear" (not (Tf.is_dispatching s "a"));
+  check "b_independent" (not (Tf.is_dispatching s "b"));
+  ignore (Tf.mark_dispatching s "b");
+  check "b_marked" (Tf.is_dispatching s "b");
+  Tf.clear_dispatching s "nonexistent";
   check "noop" true;
   if !failures > 0 then exit 1 else Printf.printf "All tests passed.\n%!"
+;;
+
+let () = Eio_main.run (fun _env -> run ())


### PR DESCRIPTION
## Problem

PR #22964 added per-keeper dispatch state gating (mark_dispatching, is_dispatching, clear_dispatching, create_dispatch_state) but the For_testing module is untested.

## Solution

Add 9 assertion tests for the dispatch_state operations:
- Fresh state: not dispatching
- mark_dispatching returns true
- Duplicate mark returns false (lockout guard)
- is_dispatching after mark
- clear_dispatching
- Multiple keepers independent
- Clearing unknown keeper is noop

## Testing

- [x] 9 assertions in test/test_keeper_chat_consumer_dispatch.ml
- [x] Registered in test/dune
- [x] Uses For_testing.create_dispatch_state interface

Relates to PR #22964 (review BLOCK: dispatch_state untested)