### PR TITLE
fix(governance): add unconditional hard_forbidden gate at decide() entry for Critical risk tools

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -91,15 +91,23 @@ let decide ~governance_level ~tool_name ~input =
   let risk = assess_risk ~tool_name ~input in
   let trace_id = generate_trace_id () in
   let action =
-    match confirm_threshold governance_level with
-    | Some threshold when risk_level_to_int risk >= risk_level_to_int threshold ->
-      `Require_confirm
+    if risk = Critical then
+      `Deny
         (Printf.sprintf
-           "Governance (%s): %s risk tool %S requires confirmation"
+           "Governance (%s): %s risk tool %S unconditionally denied (hard_forbidden)"
            governance_level
            (risk_level_to_string risk)
            tool_name)
-    | _ -> `Allow
+    else
+      match confirm_threshold governance_level with
+      | Some threshold when risk_level_to_int risk >= risk_level_to_int threshold ->
+        `Require_confirm
+          (Printf.sprintf
+             "Governance (%s): %s risk tool %S requires confirmation"
+             governance_level
+             (risk_level_to_string risk)
+             tool_name)
+      | _ -> `Allow
   in
   { tool_name; risk; action; trace_id }
 ;;


### PR DESCRIPTION
## Problem

`decide()` never returns `Deny` — even Critical-risk tools (Board_sub_board_delete, Execute shell, git push --force) pass through as `Allow` or at worst `Require_confirm`. This means an operator who types `git push --force origin main` in a tool call gets no hard block.

## Fix

Add a `risk = Critical` guard at the top of `decide()` that unconditionally returns `Deny` with a descriptive message. This is the **hard_forbidden gate** — Critical tools are always denied regardless of governance level or HITL mode.

```ocaml
if risk = Critical then
  `Deny (Printf.sprintf ...)
else
  ...existing confirm_threshold logic...
```

## Risk Assessment

- `Board_sub_board_delete` → Critical → now Denied ✅
- `Execute` (shell) → High → still uses confirm_threshold (unchanged) ⚠️
- `Fs_write` / `Fs_edit` → High → still uses confirm_threshold (unchanged)
- `Read` / `Board_post` → Low → still Allow (unchanged)

## Testing

- [x] Critical = Deny (new gate)
- [x] High/Medium/Low = confirm_threshold (unchanged)
- [x] +13/-5 in `lib/governance_pipeline.ml`, no new deps

Closes task-1626