### PR TITLE
fix(keeper): resolve tool failure classes and upgrade tool resilience

### DIFF
--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -580,18 +580,10 @@ let run_docker_shell_command_with_status_internal
                           in
                           (try
                              let run_once () =
-                               Docker_spawn_throttle.with_slot (fun () ->
-                                 Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-                                   ~actor:`System_sandbox
-                                   ~raw_source:(String.concat " " argv)
-                                   ~summary:"keeper docker command"
-                                   ~env:
-                                     (Env_keeper_scrub.filter_environment
-                                        (Unix.environment ()))
-                                   ~cwd:(Config_dir_resolver.current_working_dir ())
-                                   ~timeout_sec
-                                   ~stdin_content:cmd
-                                   argv)
+                               Keeper_turn_sandbox_runtime.run_argv_with_stdin_and_status_retry_eintr
+                                 ~timeout_sec
+                                 ~stdin_content:cmd
+                                 argv
                              in
                              Eio_guard.protect
                                ~finally:(fun () -> secret_projection.cleanup ())

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -325,6 +325,7 @@ let docker_run_argv
   @ Keeper_sandbox_runtime.docker_workspace_state_mount_args
       ~base_path:config.base_path
       ~container_root
+  @ Keeper_sandbox_runtime.docker_gitconfig_mount_args ()
   @ secret_args
   @ network_args
   @ identity_mounts
@@ -579,12 +580,7 @@ let run_docker_shell_command_with_status_internal
                               ~ttl_sec:(docker_oneshot_ttl_sec ~timeout_sec)
                           in
                           (try
-                             let status, output =
-                               Eio_guard.protect
-                                 ~finally:(fun () ->
-                                   secret_projection.cleanup ();
-                                   cleanup_oneshot_container ~container_name)
-                               @@ fun () ->
+                             let run_once () =
                                Docker_spawn_throttle.with_slot (fun () ->
                                  Masc_exec.Exec_gate.run_argv_with_stdin_and_status
                                    ~actor:`System_sandbox
@@ -598,33 +594,61 @@ let run_docker_shell_command_with_status_internal
                                    ~stdin_content:cmd
                                    argv)
                              in
-                             let semantic_status =
-                               docker_command_semantic_status ~cmd ~status ~output
-                             in
-                             let semantic_ok = semantic_ok_of_status semantic_status in
-                             if not semantic_ok
-                             then
-                               Keeper_sandbox_exec_failure.record_docker_failure
-                                 ~config
-                                 ~meta
-                                 ~image
-                                 ~container_kind:"oneshot"
-                                 ~network_label
-                                 ~status
-                                 ~output
-                             else
-                               Keeper_registry.clear_error
-                                 ~base_path:config.base_path
-                                 meta.name;
-                             Ok
-                               { status
-                               ; output
-                               ; image
-                               ; network_label
-                               ; cwd
-                               ; semantic_status = Some semantic_status
-                               ; semantic_ok
-                               }
+                             Eio_guard.protect
+                               ~finally:(fun () -> secret_projection.cleanup ())
+                               (fun () ->
+                                  let rec attempt ~retries_left =
+                                    let status, output =
+                                      Eio_guard.protect
+                                        ~finally:(fun () ->
+                                          cleanup_oneshot_container ~container_name)
+                                        (fun () -> run_once ())
+                                    in
+                                    let semantic_status =
+                                      docker_command_semantic_status ~cmd ~status ~output
+                                    in
+                                    let semantic_ok =
+                                      semantic_ok_of_status semantic_status
+                                    in
+                                    if (not semantic_ok)
+                                       && retries_left > 0
+                                       && Keeper_sandbox_runtime.docker_run_looks_daemon_pressure
+                                            ~status
+                                            ~output
+                                    then (
+                                      Log.Keeper.info
+                                        "keeper docker command for %s hit daemon pressure \
+                                         (%s), retrying once"
+                                        meta.name
+                                        (Exec_core.string_of_semantic_status semantic_status);
+                                      Eio_guard.yield_if_ready ();
+                                      attempt ~retries_left:(retries_left - 1))
+                                    else (
+                                      if not semantic_ok
+                                      then
+                                        Keeper_sandbox_exec_failure.record_docker_failure
+                                          ~config
+                                          ~meta
+                                          ~image
+                                          ~container_kind:"oneshot"
+                                          ~network_label
+                                          ~status
+                                          ~output
+                                      else
+                                        Keeper_registry.clear_error
+                                          ~base_path:config.base_path
+                                          meta.name;
+                                      Ok
+                                        { status
+                                        ; output
+                                        ; image
+                                        ; network_label
+                                        ; cwd
+                                        ; semantic_status = Some semantic_status
+                                        ; semantic_ok
+                                        })
+                                  in
+                                  attempt ~retries_left:1)
                            with
                            | Eio.Cancel.Cancelled _ as exn -> raise exn
                            | Failure err -> sandbox_error err

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -325,7 +325,6 @@ let docker_run_argv
   @ Keeper_sandbox_runtime.docker_workspace_state_mount_args
       ~base_path:config.base_path
       ~container_root
-  @ Keeper_sandbox_runtime.docker_gitconfig_mount_args ()
   @ secret_args
   @ network_args
   @ identity_mounts

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -85,6 +85,11 @@ val docker_image_missing_next_action : string
     daemon/socket access failures as well as missing-image failures. *)
 val docker_image_present : image:string -> timeout_sec:float -> (unit, string) result
 
+(** [true] when a docker run result/status/output looks like daemon back-pressure
+    or a daemon-side timeout, i.e. when a single retry may succeed once the
+    Docker daemon drains. *)
+val docker_run_looks_daemon_pressure : status:Unix.process_status -> output:string -> bool
+
 (** Docker [--label] argv fragment for containers owned by the keeper
     sandbox runtime. *)
 val docker_label_args
@@ -223,6 +228,16 @@ val docker_config_mount_args
   :  base_path:string
   -> container_root:string
   -> string list
+
+(** Host-side gitconfig path resolved from [$HOME]. *)
+val host_gitconfig_path : unit -> string
+
+(** Container-side gitconfig path ([/tmp/.gitconfig]). *)
+val container_gitconfig_path : unit -> string
+
+(** Docker [-v ...] argv fragment that exposes the host gitconfig read-only
+    at {!container_gitconfig_path} when it exists. *)
+val docker_gitconfig_mount_args : unit -> string list
 
 (** Docker [-v ...] specs for the read-only workspace-state subset that keeper
     task worktrees may read through their container-side runtime [.masc]

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -85,9 +85,10 @@ val docker_image_missing_next_action : string
     daemon/socket access failures as well as missing-image failures. *)
 val docker_image_present : image:string -> timeout_sec:float -> (unit, string) result
 
-(** [true] when a docker run result/status/output looks like daemon back-pressure
-    or a daemon-side timeout, i.e. when a single retry may succeed once the
-    Docker daemon drains. *)
+(** [true] when a docker run result/status/output proves Docker daemon
+    unavailability or back-pressure before command execution. Generic
+    [docker run] timeouts are terminal because the container command may have
+    already started and replaying it can duplicate side effects. *)
 val docker_run_looks_daemon_pressure : status:Unix.process_status -> output:string -> bool
 
 (** Docker [--label] argv fragment for containers owned by the keeper

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -229,16 +229,6 @@ val docker_config_mount_args
   -> container_root:string
   -> string list
 
-(** Host-side gitconfig path resolved from [$HOME]. *)
-val host_gitconfig_path : unit -> string
-
-(** Container-side gitconfig path ([/tmp/.gitconfig]). *)
-val container_gitconfig_path : unit -> string
-
-(** Docker [-v ...] argv fragment that exposes the host gitconfig read-only
-    at {!container_gitconfig_path} when it exists. *)
-val docker_gitconfig_mount_args : unit -> string list
-
 (** Docker [-v ...] specs for the read-only workspace-state subset that keeper
     task worktrees may read through their container-side runtime [.masc]
     projection. This intentionally excludes auth, credentials, locks,

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -78,6 +78,11 @@ let classify_image_inspect_failure =
 let classify_image_inventory_failure =
   Keeper_sandbox_runtime_classify.classify_image_inventory_failure
 
+let docker_run_looks_daemon_pressure ~status ~output =
+  match classify_docker_runtime_failure ~status ~output with
+  | "docker_daemon_timeout" | "docker_daemon_unavailable" -> true
+  | _ -> false
+
 let docker_info_security_options_with_class ~timeout_sec =
   let argv =
     docker_command_argv () @ [ "info"; "--format"; "{{json .SecurityOptions}}" ]
@@ -345,6 +350,23 @@ let docker_config_mount_args ~base_path ~container_root =
     [ "-v"
     ; host_config_root ^ ":" ^ docker_config_container_root ~container_root ^ ":ro"
     ]
+;;
+
+let host_gitconfig_path () =
+  match Sys.getenv_opt "HOME" with
+  | None -> ""
+  | Some home -> Filename.concat home ".gitconfig"
+;;
+
+let container_gitconfig_path () = "/tmp/.gitconfig"
+
+let docker_gitconfig_mount_args () =
+  let host = host_gitconfig_path () in
+  if host = ""
+  then []
+  else if not (Sys.file_exists host)
+  then []
+  else [ "-v"; host ^ ":" ^ container_gitconfig_path () ^ ":ro" ]
 ;;
 
 type workspace_state_mount_kind =

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -352,23 +352,6 @@ let docker_config_mount_args ~base_path ~container_root =
     ]
 ;;
 
-let host_gitconfig_path () =
-  match Sys.getenv_opt "HOME" with
-  | None -> ""
-  | Some home -> Filename.concat home ".gitconfig"
-;;
-
-let container_gitconfig_path () = "/tmp/.gitconfig"
-
-let docker_gitconfig_mount_args () =
-  let host = host_gitconfig_path () in
-  if host = ""
-  then []
-  else if not (Sys.file_exists host)
-  then []
-  else [ "-v"; host ^ ":" ^ container_gitconfig_path () ^ ":ro" ]
-;;
-
 type workspace_state_mount_kind =
   | Workspace_state_file
   | Workspace_state_dir

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -80,7 +80,7 @@ let classify_image_inventory_failure =
 
 let docker_run_looks_daemon_pressure ~status ~output =
   match classify_docker_runtime_failure ~status ~output with
-  | "docker_daemon_timeout" | "docker_daemon_unavailable" -> true
+  | "docker_daemon_unavailable" -> true
   | _ -> false
 
 let docker_info_security_options_with_class ~timeout_sec =

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -110,9 +110,6 @@ val docker_config_container_root : container_root:'a -> string
 val docker_config_available : string -> bool
 val docker_config_mount_args :
   base_path:string -> container_root:'a -> string list
-val host_gitconfig_path : unit -> string
-val container_gitconfig_path : unit -> string
-val docker_gitconfig_mount_args : unit -> string list
 type workspace_state_mount_kind = Workspace_state_file | Workspace_state_dir
 val docker_workspace_state_mounts : (workspace_state_mount_kind * string) list
 val workspace_state_path_available : workspace_state_mount_kind -> string -> bool

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -18,6 +18,8 @@ val classify_image_inspect_failure :
   status:Unix.process_status -> output:string -> string
 val classify_image_inventory_failure :
   status:Unix.process_status -> output:string -> string
+val docker_run_looks_daemon_pressure :
+  status:Unix.process_status -> output:string -> bool
 val docker_info_security_options_with_class :
   timeout_sec:float -> (string list, classified_error) result
 val docker_info_security_options :
@@ -108,6 +110,9 @@ val docker_config_container_root : container_root:'a -> string
 val docker_config_available : string -> bool
 val docker_config_mount_args :
   base_path:string -> container_root:'a -> string list
+val host_gitconfig_path : unit -> string
+val container_gitconfig_path : unit -> string
+val docker_gitconfig_mount_args : unit -> string list
 type workspace_state_mount_kind = Workspace_state_file | Workspace_state_dir
 val docker_workspace_state_mounts : (workspace_state_mount_kind * string) list
 val workspace_state_path_available : workspace_state_mount_kind -> string -> bool

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1627,6 +1627,8 @@ let internal_descriptors : t list =
       "Transition a task to a new status." ~readonly:false
   ; masc_task_descriptor "update_priority" "masc_update_priority"
       "Update the priority of a task." ~readonly:false
+  ; masc_task_descriptor "set_goal" "masc_task_set_goal"
+      "Assign an existing, currently goalless task to a goal." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_plan_* + note + deliver (8 entries) ── *)
   ; masc_plan_descriptor "init" "masc_plan_init"
       "Initialise a workspace plan." ~readonly:false

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -410,16 +410,23 @@ let check_env env =
   loop env
 ;;
 
+(* Keeper frequently emits typed Execute inputs where argv[0] repeats the
+   executable name because many command examples include it.  In execve-style
+   argv the executable is implicit, so a leading duplicate is a harmless
+   schema mismatch.  Drop it automatically instead of forcing a costly
+   self-correction round-trip. *)
+let drop_duplicate_argv0 ~executable argv =
+  match argv with
+  | first :: rest when String.equal first executable -> rest
+  | _ -> argv
+;;
+
 let check_exec ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
   let trimmed = String.trim executable in
   if String.length trimmed = 0 then Error (Empty_executable { argv })
-  else if
-    match argv with
-    | first :: _ -> String.equal first trimmed
-    | [] -> false
-  then Error (Executable_repeated_in_argv0 { executable = trimmed; argv })
   else (
+    let argv = drop_duplicate_argv0 ~executable:trimmed argv in
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
     in
@@ -523,14 +530,23 @@ let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) input 
   let ( let* ) = Result.bind in
   match input with
   | Exec { executable; argv; cwd; env; stdin; stdout; stderr } ->
-    let stage = { executable; argv } in
+    let stage =
+      { executable
+      ; argv = drop_duplicate_argv0 ~executable:(String.trim executable) argv
+      }
+    in
     let redirects = redirects_of ~cwd ~stdin ~stdout ~stderr in
     shell_simple ~sandbox ?cwd ~env ~redirects stage
   | Pipeline { stages; cwd; env } ->
     let* simples =
       let rec loop acc = function
         | [] -> Ok (List.rev acc)
-        | stage :: rest ->
+        | { executable; argv } :: rest ->
+          let stage =
+            { executable
+            ; argv = drop_duplicate_argv0 ~executable:(String.trim executable) argv
+            }
+          in
           let* simple = shell_simple ~sandbox ?cwd ~env stage in
           loop (simple :: acc) rest
       in

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -417,7 +417,7 @@ let check_env env =
    self-correction round-trip. *)
 let drop_duplicate_argv0 ~executable argv =
   match argv with
-  | first :: rest when String.equal first executable -> rest
+  | first :: (_ :: _ as rest) when String.equal first executable -> rest
   | _ -> argv
 ;;
 

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -410,23 +410,11 @@ let check_env env =
   loop env
 ;;
 
-(* Keeper frequently emits typed Execute inputs where argv[0] repeats the
-   executable name because many command examples include it.  In execve-style
-   argv the executable is implicit, so a leading duplicate is a harmless
-   schema mismatch.  Drop it automatically instead of forcing a costly
-   self-correction round-trip. *)
-let drop_duplicate_argv0 ~executable argv =
-  match argv with
-  | first :: (_ :: _ as rest) when String.equal first executable -> rest
-  | _ -> argv
-;;
-
 let check_exec ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
   let trimmed = String.trim executable in
   if String.length trimmed = 0 then Error (Empty_executable { argv })
   else (
-    let argv = drop_duplicate_argv0 ~executable:trimmed argv in
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
     in
@@ -530,11 +518,7 @@ let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) input 
   let ( let* ) = Result.bind in
   match input with
   | Exec { executable; argv; cwd; env; stdin; stdout; stderr } ->
-    let stage =
-      { executable
-      ; argv = drop_duplicate_argv0 ~executable:(String.trim executable) argv
-      }
-    in
+    let stage = { executable; argv } in
     let redirects = redirects_of ~cwd ~stdin ~stdout ~stderr in
     shell_simple ~sandbox ?cwd ~env ~redirects stage
   | Pipeline { stages; cwd; env } ->
@@ -542,11 +526,7 @@ let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) input 
       let rec loop acc = function
         | [] -> Ok (List.rev acc)
         | { executable; argv } :: rest ->
-          let stage =
-            { executable
-            ; argv = drop_duplicate_argv0 ~executable:(String.trim executable) argv
-            }
-          in
+          let stage = { executable; argv } in
           let* simple = shell_simple ~sandbox ?cwd ~env stage in
           loop (simple :: acc) rest
       in

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -129,14 +129,16 @@ val of_json : Yojson.Safe.t -> (execute_input, string) result
     [timeout_sec] is accepted at this layer and consumed by the caller.
     [executable] and [pipeline] together, raw command-string fields, [{stages =
     ...}], and other unsupported fields are intentionally rejected here.  No
-    compatibility normalization is applied: missing [find .] paths, empty
-    [executable] fields, and duplicated executable tokens in [argv] remain
-    caller errors. *)
+    compatibility normalization is applied at parse time: missing [find .]
+    paths, empty [executable] fields, and duplicated executable tokens in
+    [argv] remain caller-authored input for validation/lowering. *)
 
 val validate : execute_input -> (unit, validation_error) result
 (** Run all structural checks against [input].  Returns [Ok ()] on
-    success, or the first {!validation_error} encountered.  No side
-    effects, no exceptions. *)
+    success, or the first {!validation_error} encountered.  Validation
+    mirrors lowering's bounded argv0 autocorrection: a leading executable
+    duplicate with at least one following argument is tolerated, while the
+    caller-authored input is not mutated.  No side effects, no exceptions. *)
 
 val to_shell_ir_unvalidated :
   ?sandbox:Masc_exec.Sandbox_target.t ->
@@ -144,7 +146,10 @@ val to_shell_ir_unvalidated :
   (Masc_exec.Shell_ir.t, validation_error) result
 (** Lower [input] into {!Masc_exec.Shell_ir.t} without structural validation.
     Callers that use the Shell IR facade ([Shell_command_gate.gate_typed])
-    may use this entrypoint when the boundary has already been checked. *)
+    may use this entrypoint when the boundary has already been checked.
+    Lowering drops a leading duplicated executable token only when at least
+    one real argument remains after it; a single argument equal to the
+    executable is preserved as caller-authored data. *)
 
 val to_shell_ir :
   ?sandbox:Masc_exec.Sandbox_target.t ->
@@ -154,10 +159,10 @@ val to_shell_ir :
     inputs become an explicit {!Masc_exec.Shell_ir.Pipeline}; embedded pipe
     characters inside payload argv tokens remain ordinary argument data, while
     standalone pipe operator argv tokens are rejected before lowering.  [Exec]
-    argv is passed through as authored after validation; duplicated executable
-    tokens at [argv[0]] are rejected rather than silently stripped.  [sandbox]
-    defaults to host execution; keeper callers may provide Docker runtime
-    targets after sandbox/profile resolution. *)
+    and pipeline-stage argv are lowered with the same bounded argv0
+    autocorrection as {!to_shell_ir_unvalidated}.  [sandbox] defaults to host
+    execution; keeper callers may provide Docker runtime targets after
+    sandbox/profile resolution. *)
 
 val pp_validation_error : Format.formatter -> validation_error -> unit
 (** Human-readable formatter for {!validation_error}.  Stable across

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -220,85 +220,100 @@ let handle_read_file
       ~fallback_dir
       ~error
   | Ok target ->
-    let run_read () =
-      (* RFC-0006 Phase B-1: Docker keepers are always contained to their
-         playground bundle on the host before any read-side I/O proceeds.
-         The resolver-level allowed_paths check is augmented by this
-         strict containment so host FS cannot leak through Read
-         while Execute is container-isolated. *)
-      let* () = Keeper_sandbox_containment.check_read_target ~config ~meta ~target in
-      (* Multi-repository Phase 2: repository-level access restriction.
-         If the resolved path is under a registered repository, enforce
-         keeper-to-repo mapping.  Paths outside all registered repos are
-         allowed (playground general files). *)
-      let* () =
-        Keeper_repo_mapping.validate_path_access
-          ~keeper_id:meta.name
-          ~base_path:(Keeper_alerting_path.project_root_of_config config)
-          ~path:target
-      in
-      (* RFC-0006 Phase B-2: sandbox-backed keepers route the actual
-         byte read through the backend read runner so the backend mount
-         restrictions are the load-bearing isolation. The host containment
-         check above remains as defense-in-depth. *)
-      if Keeper_sandbox_read_runner.should_route_read ~meta
-      then (
-        let timeout_sec =
-          Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ()
-        in
-        let+ body =
-          Keeper_sandbox_read_runner.read_file
-            ?turn_sandbox_factory
-            ~config
-            ~meta
-            ~host_path:target
-            ~max_bytes
-            ~timeout_sec
-            ()
-        in
-        let total = String.length body in
-        let truncated = total >= max_bytes in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool true
-              ; "path", `String target
-              ; "bytes", `Int total
-              ; "truncated", `Bool truncated
-              ; "content", `String body
-              ; "via", `String Keeper_sandbox_read_runner.backend_via
-              ]))
-      else (
-        match Safe_ops.read_file_safe target with
-        | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
-          Ok
-            (missing_file_error_json
-               ~cwd
-               ~raw_path:(Some path)
+    (* Multi-repository Phase 2: repository-level access restriction.
+       If the resolved path is under a registered repository, enforce
+       keeper-to-repo mapping.  Paths outside all registered repos are
+       allowed (playground general files).  Denials are surfaced as a
+       deterministic policy block so the supervisor does not retry the
+       same failing path. *)
+    (match
+       Keeper_repo_mapping.validate_path_access
+         ~keeper_id:meta.name
+         ~base_path:(Keeper_alerting_path.project_root_of_config config)
+         ~path:target
+     with
+     | Error msg ->
+       Yojson.Safe.to_string
+         (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String msg
+            ; "path", `String target
+            ; ( "deterministic_retry"
+              , `Assoc
+                  [ "reason", `String "policy_blocked"
+                  ; "retry_same_args", `Bool false
+                  ] )
+            ])
+     | Ok () ->
+       let run_read () =
+         (* RFC-0006 Phase B-1: Docker keepers are always contained to their
+            playground bundle on the host before any read-side I/O proceeds.
+            The resolver-level allowed_paths check is augmented by this
+            strict containment so host FS cannot leak through Read
+            while Execute is container-isolated. *)
+         let* () = Keeper_sandbox_containment.check_read_target ~config ~meta ~target in
+         (* RFC-0006 Phase B-2: sandbox-backed keepers route the actual
+            byte read through the backend read runner so the backend mount
+            restrictions are the load-bearing isolation. The host containment
+            check above remains as defense-in-depth. *)
+         if Keeper_sandbox_read_runner.should_route_read ~meta
+         then (
+           let timeout_sec =
+             Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ()
+           in
+           let+ body =
+             Keeper_sandbox_read_runner.read_file
+               ?turn_sandbox_factory
                ~config
                ~meta
-               ~target
-               ~fallback_dir
-               ~error:e)
-        | Error e -> Error e
-        | Ok content ->
-          let total = String.length content in
-          let truncated = total > max_bytes in
-          let body =
-            if truncated then String.sub content 0 max_bytes else content
-          in
-          Ok
-            (Yojson.Safe.to_string
-               (`Assoc
-                    [ "ok", `Bool true
-                    ; "path", `String target
-                    ; "bytes", `Int total
-                    ; "truncated", `Bool truncated
-                    ; "content", `String body
-                    ])))
-    in
-    match run_read () with
-    | Ok json -> json
-    | Error msg -> error_json ~fields:[ "path", `String target ] msg
+               ~host_path:target
+               ~max_bytes
+               ~timeout_sec
+               ()
+           in
+           let total = String.length body in
+           let truncated = total >= max_bytes in
+           Yojson.Safe.to_string
+             (`Assoc
+                 [ "ok", `Bool true
+                 ; "path", `String target
+                 ; "bytes", `Int total
+                 ; "truncated", `Bool truncated
+                 ; "content", `String body
+                 ; "via", `String Keeper_sandbox_read_runner.backend_via
+                 ]))
+         else (
+           match Safe_ops.read_file_safe target with
+           | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
+             Ok
+               (missing_file_error_json
+                  ~cwd
+                  ~raw_path:(Some path)
+                  ~config
+                  ~meta
+                  ~target
+                  ~fallback_dir
+                  ~error:e)
+           | Error e -> Error e
+           | Ok content ->
+             let total = String.length content in
+             let truncated = total > max_bytes in
+             let body =
+               if truncated then String.sub content 0 max_bytes else content
+             in
+             Ok
+               (Yojson.Safe.to_string
+                  (`Assoc
+                       [ "ok", `Bool true
+                       ; "path", `String target
+                       ; "bytes", `Int total
+                       ; "truncated", `Bool truncated
+                       ; "content", `String body
+                       ])))
+       in
+       match run_read () with
+       | Ok json -> json
+       | Error msg -> error_json ~fields:[ "path", `String target ] msg)
 ;;
 
 (* RFC-0006 Phase A.4: replace [old] with [new] in [text]. When

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -318,8 +318,15 @@ let dispatch_option_to_string ~name = function
     if Tool_result.is_success result
     then Tool_result.message result
     else
-      Yojson.Safe.to_string
-        (`Assoc [ "error", `String (Tool_result.message result) ])
+      let fields =
+        match Tool_result.failure_class result with
+        | None -> [ "error", `String (Tool_result.message result) ]
+        | Some cls ->
+          [ "error", `String (Tool_result.message result)
+          ; "failure_class", `String (Tool_result.tool_failure_class_to_string cls)
+          ]
+      in
+      Yojson.Safe.to_string (`Assoc fields)
   | None ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -835,6 +835,16 @@ let () =
               ~tool_name:name
               (handle_keeper_sandbox_status ctx args))
        | _ -> eio_context_missing name)
+    | "masc_keeper_sandbox_start" ->
+      Some
+        (tool_result_with_tool_name
+           ~tool_name:name
+           (keeper_sandbox_start_body ~config args))
+    | "masc_keeper_sandbox_stop" ->
+      Some
+        (tool_result_with_tool_name
+           ~tool_name:name
+           (keeper_sandbox_stop_body ~config args))
     | "masc_keeper_down" ->
       Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
       Keeper_tool_surface_ops.invalidate_status_cache (Tool_args.get_string args "name" "");

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -44,6 +44,17 @@ val container_cwd_of_host :
 val host_cwd_of_container :
   t -> container_cwd:string -> (string, string) result
 
+val run_argv_with_stdin_and_status_retry_eintr :
+  ?timeout_sec:float ->
+  stdin_content:string ->
+  string list ->
+  Unix.process_status * string
+(** Run a sandbox-management argv with stdin through the owned Docker execution
+    boundary and retry transient EINTR-shaped failures. This is intentionally
+    lower-level than the turn-scoped [t] operations because one-shot sandbox
+    startup paths need the same execution boundary before a reusable container
+    exists. *)
+
 val run_command_with_status :
   ?ok_exit_codes:int list ->
   timeout_sec:float ->

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -10,6 +10,38 @@ open Keeper_types_profile
 open Keeper_tool_shared_runtime
 open Keeper_workspace_ops_setup
 
+(* Ripgrep input validation: reject malformed --type values and regex
+   patterns before any Docker spawn or host rg execution. *)
+let rg_type_name_re = Re.Pcre.re {|^[a-zA-Z0-9_-]+$|} |> Re.compile
+
+let validate_rg_type file_type =
+  if file_type = "" || Re.execp rg_type_name_re file_type
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "invalid ripgrep --type value %S. Type names may contain only letters, \
+          digits, hyphens, and underscores."
+         file_type)
+;;
+
+let validate_rg_pattern pattern =
+  try
+    ignore (Re.Pcre.re pattern |> Re.compile);
+    Ok ()
+  with exn ->
+    Error
+      (Printf.sprintf
+         "invalid regex pattern %S: %s"
+         pattern
+         (Printexc.to_string exn))
+;;
+
+let validate_rg_inputs ~pattern ~file_type =
+  match validate_rg_type file_type with
+  | Error _ as e -> e
+  | Ok () -> validate_rg_pattern pattern
+;;
 let try_handle
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Workspace.config)
@@ -105,40 +137,43 @@ let try_handle
   | "rg" ->
     Some
       (let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
+       let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
        if pattern = ""
        then error_json ~fields:[ "op", `String op ] "pattern is required for rg. Good: pattern='handle_request'. Bad: pattern=''."
        else (
-         match read_target () with
-         | Error e -> path_error e
-         | Ok target ->
-           let limit = shell_readonly_limit args in
-           let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
-           let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
-           if Keeper_sandbox_read_runner.should_route_read ~meta then
-             let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
-             let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
-             let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
-             (match
-                run_readonly_in_sandbox ~target
-                  ~command_argv:(fun cpath ->
-                    base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
-                  ~ok_exit_codes:[ 0; 1 ]
-                  ~max_bytes:1_000_000
-                  ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ())
-                  ()
-              with
-              | Error response -> response
-              | Ok (st, out) ->
-                Yojson.Safe.to_string
-                  (`Assoc
-                      [ "ok", `Bool true
-                      ; "op", `String op
-                      ; "path", `String target
-                      ; "pattern", `String pattern
-                      ; "via", `String Keeper_sandbox_read_runner.backend_via
-                      ; "status", Keeper_alerting_path.process_status_to_json st
-                      ; "matches", lines_to_json ~limit out
-                      ]))
+         match validate_rg_inputs ~pattern ~file_type with
+         | Error msg -> error_json ~fields:[ "op", `String op ] msg
+         | Ok () -> (
+           match read_target () with
+           | Error e -> path_error e
+           | Ok target ->
+             let limit = shell_readonly_limit args in
+             let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
+             if Keeper_sandbox_read_runner.should_route_read ~meta then
+               let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
+               let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
+               let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
+               (match
+                  run_readonly_in_sandbox ~target
+                    ~command_argv:(fun cpath ->
+                      base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
+                    ~ok_exit_codes:[ 0; 1 ]
+                    ~max_bytes:1_000_000
+                    ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ())
+                    ()
+                with
+                | Error response -> response
+                | Ok (st, out) ->
+                  Yojson.Safe.to_string
+                    (`Assoc
+                        [ "ok", `Bool true
+                        ; "op", `String op
+                        ; "path", `String target
+                        ; "pattern", `String pattern
+                        ; "via", `String Keeper_sandbox_read_runner.backend_via
+                        ; "status", Keeper_alerting_path.process_status_to_json st
+                        ; "matches", lines_to_json ~limit out
+                        ]))
            else
              let rg_available = Keeper_tool_execute_path.shell_command_available "rg" in
              if not rg_available then
@@ -192,6 +227,6 @@ let try_handle
                           ; "status", Keeper_alerting_path.process_status_to_json result.status
                           ; "matches", lines_to_json ~limit result.stdout
                           ]
-                         @ error_detail)))))
+                         @ error_detail))))))
   | _ -> None
 ;;

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -27,7 +27,7 @@ let validate_rg_type file_type =
 
 let validate_rg_pattern pattern =
   try
-    ignore (Re.Pcre.re pattern |> Re.compile);
+    let _ = Re.Pcre.re pattern |> Re.compile in
     Ok ()
   with exn ->
     Error

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -11,7 +11,7 @@ open Keeper_tool_shared_runtime
 open Keeper_workspace_ops_setup
 
 (* Ripgrep input validation: reject malformed --type values and regex
-   patterns before any Docker spawn or host rg execution. *)
+   patterns before any Docker spawn or workspace search. *)
 let rg_type_name_re = Re.Pcre.re {|^[a-zA-Z0-9_-]+$|} |> Re.compile
 
 let validate_rg_type file_type =
@@ -25,14 +25,53 @@ let validate_rg_type file_type =
          file_type)
 ;;
 
+let read_process_channel ic =
+  let buf = Buffer.create 256 in
+  let chunk = Bytes.create 4096 in
+  let rec loop () =
+    match input ic chunk 0 (Bytes.length chunk) with
+    | 0 -> Buffer.contents buf
+    | n ->
+      Buffer.add_subbytes buf chunk 0 n;
+      loop ()
+    | exception End_of_file -> Buffer.contents buf
+  in
+  loop ()
+;;
+
 let validate_rg_pattern pattern =
+  let argv = [| "rg"; "--regexp"; pattern; "--files-with-matches"; "/dev/null" |] in
   try
-    let _ = Re.Pcre.re pattern |> Re.compile in
-    Ok ()
-  with exn ->
+    let ic, oc, ec = Unix.open_process_args_full "rg" argv (Unix.environment ()) in
+    let _stdout = read_process_channel ic in
+    let stderr = read_process_channel ec in
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED 0 | Unix.WEXITED 1 -> Ok ()
+    | Unix.WEXITED code ->
+      let detail =
+        String.trim stderr
+        |> String_util.utf8_safe ~max_bytes:240 ~suffix:"..."
+        |> String_util.to_string
+      in
+      Error
+        (Printf.sprintf
+           "invalid ripgrep regex pattern %S: rg exited %d%s"
+           pattern
+           code
+           (if detail = "" then "" else ": " ^ detail))
+    | Unix.WSIGNALED signal | Unix.WSTOPPED signal ->
+      Error
+        (Printf.sprintf
+           "invalid ripgrep regex pattern %S: rg interrupted by signal %d"
+           pattern
+           signal)
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) ->
+    Error "ripgrep executable not found while validating regex pattern"
+  | exn ->
     Error
       (Printf.sprintf
-         "invalid regex pattern %S: %s"
+         "ripgrep regex validation failed for %S: %s"
          pattern
          (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -10,8 +10,10 @@ open Keeper_types_profile
 open Keeper_tool_shared_runtime
 open Keeper_workspace_ops_setup
 
-(* Ripgrep input validation: reject malformed --type values and regex
-   patterns before any Docker spawn or workspace search. *)
+(* Ripgrep input validation for arguments that can be checked without
+   crossing the execution boundary. Regex/glob semantics stay with the
+   actual rg invocation so sandboxed keepers do not depend on a host rg
+   preflight. *)
 let rg_type_name_re = Re.Pcre.re {|^[a-zA-Z0-9_-]+$|} |> Re.compile
 
 let validate_rg_type file_type =
@@ -25,61 +27,10 @@ let validate_rg_type file_type =
          file_type)
 ;;
 
-let read_process_channel ic =
-  let buf = Buffer.create 256 in
-  let chunk = Bytes.create 4096 in
-  let rec loop () =
-    match input ic chunk 0 (Bytes.length chunk) with
-    | 0 -> Buffer.contents buf
-    | n ->
-      Buffer.add_subbytes buf chunk 0 n;
-      loop ()
-    | exception End_of_file -> Buffer.contents buf
-  in
-  loop ()
-;;
-
-let validate_rg_pattern pattern =
-  let argv = [| "rg"; "--regexp"; pattern; "--files-with-matches"; "/dev/null" |] in
-  try
-    let ic, oc, ec = Unix.open_process_args_full "rg" argv (Unix.environment ()) in
-    let _stdout = read_process_channel ic in
-    let stderr = read_process_channel ec in
-    match Unix.close_process_full (ic, oc, ec) with
-    | Unix.WEXITED 0 | Unix.WEXITED 1 -> Ok ()
-    | Unix.WEXITED code ->
-      let detail =
-        String.trim stderr
-        |> String_util.utf8_safe ~max_bytes:240 ~suffix:"..."
-        |> String_util.to_string
-      in
-      Error
-        (Printf.sprintf
-           "invalid ripgrep regex pattern %S: rg exited %d%s"
-           pattern
-           code
-           (if detail = "" then "" else ": " ^ detail))
-    | Unix.WSIGNALED signal | Unix.WSTOPPED signal ->
-      Error
-        (Printf.sprintf
-           "invalid ripgrep regex pattern %S: rg interrupted by signal %d"
-           pattern
-           signal)
-  with
-  | Unix.Unix_error (Unix.ENOENT, _, _) ->
-    Error "ripgrep executable not found while validating regex pattern"
-  | exn ->
-    Error
-      (Printf.sprintf
-         "ripgrep regex validation failed for %S: %s"
-         pattern
-         (Printexc.to_string exn))
-;;
-
-let validate_rg_inputs ~pattern ~file_type =
+let validate_rg_inputs ~pattern:_ ~file_type =
   match validate_rg_type file_type with
   | Error _ as e -> e
-  | Ok () -> validate_rg_pattern pattern
+  | Ok () -> Ok ()
 ;;
 let try_handle
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -280,10 +280,14 @@ let keeper_tool_failure_error_detail ~duration_ms ~error_body =
   Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated
 
 (** Structured details for the dashboard [tool_call_failure] log event.
-    Includes the typed [failure_class] and the actual error body so the
-    dashboard can surface classification and the full message. *)
+    Includes the typed [failure_class] and a bounded error preview. The full
+    provider/tool body can be large or sensitive, so log rows carry size and
+    truncation metadata instead of the raw body. *)
 let keeper_tool_failure_log_details ~tool_name ~agent_name ~duration_ms
     ~streaming ~error_body ~failure_class =
+  let preview =
+    String_util.utf8_safe ~max_bytes:200 ~suffix:"..." error_body
+  in
   `Assoc
     [
       ("event_family", `String "tool_call_failure");
@@ -293,7 +297,9 @@ let keeper_tool_failure_log_details ~tool_name ~agent_name ~duration_ms
       ("agent_name", `String agent_name);
       ("duration_ms", `Int duration_ms);
       ("streaming", `Bool streaming);
-      ("error_body", `String error_body);
+      ("error_body_preview", `String (String_util.to_string preview));
+      ("error_body_truncated", `Bool (String_util.was_truncated preview));
+      ("error_body_bytes", `Int (String.length error_body));
     ]
 
 let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~arguments =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -267,9 +267,38 @@ let handle_keeper_chat_request_cancel state request reqd =
    A fixed external timeout conflicts with multi-turn tool-use loops and
    causes lost turn metrics when the timeout fires mid-Agent.run().
    Aligned with MCP path (mcp_server_eio_call_tool.ml:139-143). *)
+
+(** Build a compact error-detail string for audit/telemetry, mirroring the
+    MCP tool path.  Keeps long error bodies from dominating log/JSONL rows
+    while preserving a diagnostic preview. *)
+let keeper_tool_failure_error_detail ~duration_ms ~error_body =
+  let error_preview_max = 200 in
+  let truncated =
+    String_util.utf8_safe ~max_bytes:(error_preview_max + 3) ~suffix:"..." error_body
+    |> String_util.to_string
+  in
+  Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated
+
+(** Structured details for the dashboard [tool_call_failure] log event.
+    Includes the typed [failure_class] and the actual error body so the
+    dashboard can surface classification and the full message. *)
+let keeper_tool_failure_log_details ~tool_name ~agent_name ~duration_ms
+    ~streaming ~error_body ~failure_class =
+  `Assoc
+    [
+      ("event_family", `String "tool_call_failure");
+      ( "failure_class",
+        `String (Tool_result.tool_failure_class_to_string failure_class) );
+      ("tool_name", `String tool_name);
+      ("agent_name", `String agent_name);
+      ("duration_ms", `Int duration_ms);
+      ("streaming", `Bool streaming);
+      ("error_body", `String error_body);
+    ]
+
 let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~arguments =
   let start_time = Eio.Time.now clock in
-  let success, body =
+  let success, body, failure_class =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
@@ -282,36 +311,41 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
         }
       in
       match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args:arguments with
-      | Some result -> Tool_result.is_success result, Tool_result.message result
-      | None -> (false, "masc_keeper_msg dispatch unavailable")
+      | Some result ->
+          let success = Tool_result.is_success result in
+          let body = Tool_result.message result in
+          let failure_class =
+            match Tool_result.failure_class result with
+            | Some cls -> cls
+            | None -> Tool_result.Runtime_failure
+          in
+          success, body, failure_class
+      | None -> false, "masc_keeper_msg dispatch unavailable", Tool_result.Runtime_failure
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Workspace.Not_initialized ->
-        (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
+        ( false,
+          Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized),
+          Tool_result.Runtime_failure )
     | exn ->
         let err = Printexc.to_string exn in
         Log.Mcp.error "tools/call crashed: %s" err;
-        (false, Printf.sprintf "Internal error: %s" err)
+        false, Printf.sprintf "Internal error: %s" err, Tool_result.Runtime_failure
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
-  let error_msg =
+  let error_detail =
     if success then None
-    else Some (Printf.sprintf "duration_ms=%d" duration_ms)
+    else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
   in
   Audit_log.log_tool_call (Mcp_server.workspace_config state)
-    ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
+    ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg:error_detail ();
   if not success then
     Log.Keeper.emit Log.Error
       ~details:
-        (`Assoc
-          [
-            ("event_family", `String "tool_call_failure");
-            ("tool_name", `String "masc_keeper_msg");
-            ("agent_name", `String agent_name);
-            ("duration_ms", `Int duration_ms);
-            ("streaming", `Bool false);
-          ])
+        (keeper_tool_failure_log_details ~tool_name:"masc_keeper_msg"
+           ~agent_name ~duration_ms ~streaming:false ~error_body:body
+           ~failure_class)
       "keeper tool call failed: masc_keeper_msg";
   let telemetry_enabled = Env_config_core.telemetry_enabled () in
   if telemetry_enabled then (
@@ -322,10 +356,14 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
+           let telemetry_failure_class =
+             if success then None else Some failure_class
+           in
            Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
              ~source:(Tool_registry.string_of_source Agent_internal)
-             ?error_kind:telemetry_error_kind ?error_message:error_msg ()
+             ?failure_class:telemetry_failure_class
+             ?error_kind:telemetry_error_kind ?error_message:error_detail ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -535,7 +573,7 @@ let keeper_stream_send_event ?on_closed writer mutex closed event =
 let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event state
     ~agent_name ~arguments ~on_text_delta =
   let start_time = Eio.Time.now clock in
-  let success, body =
+  let success, body, failure_class =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
@@ -551,36 +589,41 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
         Keeper_tool_surface.dispatch_stream ~on_text_delta ?on_event keeper_ctx
           ~name:"masc_keeper_msg" ~args:arguments
       with
-      | Some result -> Tool_result.is_success result, Tool_result.message result
-      | None -> (false, "masc_keeper_msg stream dispatch unavailable")
+      | Some result ->
+          let success = Tool_result.is_success result in
+          let body = Tool_result.message result in
+          let failure_class =
+            match Tool_result.failure_class result with
+            | Some cls -> cls
+            | None -> Tool_result.Runtime_failure
+          in
+          success, body, failure_class
+      | None -> false, "masc_keeper_msg stream dispatch unavailable", Tool_result.Runtime_failure
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Workspace.Not_initialized ->
-        (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
+        ( false,
+          Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized),
+          Tool_result.Runtime_failure )
     | exn ->
         let err = Printexc.to_string exn in
         Log.Mcp.error "tools/call crashed (stream): %s" err;
-        (false, Printf.sprintf "Internal error: %s" err)
+        false, Printf.sprintf "Internal error: %s" err, Tool_result.Runtime_failure
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
-  let error_msg =
+  let error_detail =
     if success then None
-    else Some (Printf.sprintf "duration_ms=%d" duration_ms)
+    else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
   in
   Audit_log.log_tool_call (Mcp_server.workspace_config state) ~agent_id:agent_name
-    ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
+    ~tool_name:"masc_keeper_msg" ~success ~error_msg:error_detail ();
   if not success then
     Log.Keeper.emit Log.Error
       ~details:
-        (`Assoc
-          [
-            ("event_family", `String "tool_call_failure");
-            ("tool_name", `String "masc_keeper_msg");
-            ("agent_name", `String agent_name);
-            ("duration_ms", `Int duration_ms);
-            ("streaming", `Bool true);
-          ])
+        (keeper_tool_failure_log_details ~tool_name:"masc_keeper_msg"
+           ~agent_name ~duration_ms ~streaming:true ~error_body:body
+           ~failure_class)
       "keeper tool call failed: masc_keeper_msg";
   let telemetry_enabled = Env_config_core.telemetry_enabled () in
   if telemetry_enabled then (
@@ -591,10 +634,14 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
              if success then None
              else Some (Telemetry_eio.error_kind_of_string "tool_failure")
            in
+           let telemetry_failure_class =
+             if success then None else Some failure_class
+           in
            Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
              ~duration_ms ~source:(Tool_registry.string_of_source Agent_internal)
-             ?error_kind:telemetry_error_kind ?error_message:error_msg ()
+             ?failure_class:telemetry_failure_class
+             ?error_kind:telemetry_error_kind ?error_message:error_detail ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -1495,4 +1542,5 @@ module For_testing = struct
   let surface_context_to_instructions = surface_context_to_instructions
   let empty_stream_bridge_state = empty_keeper_stream_bridge_state
   let translate_oas_stream_event = translate_oas_stream_event
+  let keeper_tool_failure_log_details = keeper_tool_failure_log_details
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -227,4 +227,12 @@ module For_testing : sig
     keeper_stream_bridge_state ->
     Agent_sdk.Types.sse_event ->
     translated_keeper_stream_event
+  val keeper_tool_failure_log_details :
+    tool_name:string ->
+    agent_name:string ->
+    duration_ms:int ->
+    streaming:bool ->
+    error_body:string ->
+    failure_class:Tool_result.tool_failure_class ->
+    Yojson.Safe.t
 end

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -335,6 +335,28 @@ and handle_transition ~tool_name ~start_time ctx args =
          message)
   | None ->
   match client_side_transition_gate_error ~task_opt ~action ~action_s with
+  | Some (Masc_domain.Task_error.InvalidState message as err) ->
+    log_task_transition_failed ~agent_name:ctx.agent_name (Masc_domain.Task err);
+    Tool_result.error
+      ~failure_class:(Some Tool_result.Workflow_rejection)
+      ~tool_name
+      ~start_time
+      (workflow_rejection_payload_json
+         ~rule_id:"task_transition_invalid_state"
+         ~tool_suggestion:"keeper_tasks_list"
+         ~hint:
+           "The requested lifecycle transition is not valid for the task's current \
+            state. Inspect the task status and use a valid next action instead of \
+            retrying the same transition."
+         ~scope_policy:"observe"
+         ~recoverable:false
+         ~alternatives:[ "keeper_tasks_list"; "masc_tasks"; "masc_transition" ]
+         ~extra_fields:
+           [ "task_id", `String task_id
+           ; "action", `String action_s
+           ; "requested_agent", `String ctx.agent_name
+           ]
+         (Printf.sprintf "Invalid task state: %s" message))
   | Some err ->
     log_task_transition_failed ~agent_name:ctx.agent_name (Masc_domain.Task err);
     result_to_response ~tool_name ~start_time (Error (Masc_domain.Task err))

--- a/lib/tool_surface/tool_shard_types_schemas_search_files.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_search_files.ml
@@ -20,7 +20,7 @@ let tool_search_files_schema : Masc_domain.tool_schema =
                 [ ( "pattern"
                   , `Assoc
                       [ "type", `String "string"
-                      ; "description", `String "Regular expression to search file contents for."
+                      ; "description", `String "Regular expression to search file contents for. Must be a syntactically valid regex."
                       ] )
                 ; ( "path"
                   , `Assoc
@@ -36,7 +36,7 @@ let tool_search_files_schema : Masc_domain.tool_schema =
                 ; ( "type"
                   , `Assoc
                       [ "type", `String "string"
-                      ; "description", `String "Ripgrep file-type filter, e.g. 'ml', 'py'."
+                      ; "description", `String "Ripgrep file-type filter, e.g. 'ml', 'py'. May contain only letters, digits, hyphens, and underscores."
                       ] )
                 ; ( "limit"
                   , `Assoc

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -749,11 +749,16 @@ let read_entries ~(masc_root : string) ~(keeper_name : string) ~(trace_id : stri
           | None -> None
         with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
 
+type trajectory_line_decode_result =
+  | Parsed_line of trajectory_line
+  | Skipped_line
+  | Malformed_line
+
 let trajectory_line_of_json json =
   match Json_util.assoc_member_opt "type" json with
-  | Some (`String "trajectory_summary") -> None
+  | Some (`String "trajectory_summary") -> Skipped_line
   | Some (`String "thinking") ->
-      Some
+      Parsed_line
         (Thinking
            { ts =
                (match Json_util.assoc_member_opt "ts" json with
@@ -783,8 +788,8 @@ let trajectory_line_of_json json =
            })
   | _ ->
       (match tool_call_entry_of_json json with
-       | Some (entry, _parsed_gate) -> Some (Tool_call entry)
-       | None -> None)
+       | Some (entry, _parsed_gate) -> Parsed_line (Tool_call entry)
+       | None -> Malformed_line)
 ;;
 
 (* Rows that fail to parse or decode here are silently dropped from the
@@ -807,17 +812,19 @@ let trajectory_lines_of_jsonl_lines ~trace_id lines =
   let lines_rev, skipped, total =
     List.fold_left
       (fun (acc, skipped, total) line ->
-         match
+         let decode =
            try Yojson.Safe.from_string line |> trajectory_line_of_json with
-           | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
-         with
-         | Some parsed -> parsed :: acc, skipped, total + 1
-         | None -> acc, skipped + 1, total + 1)
+           | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> Malformed_line
+         in
+         match decode with
+         | Parsed_line parsed -> parsed :: acc, skipped, total + 1
+         | Skipped_line -> acc, skipped, total + 1
+         | Malformed_line -> acc, skipped + 1, total + 1)
       ([], 0, 0)
       lines
   in
   log_trajectory_line_skips ~trace_id ~skipped ~total;
-  List.rev lines_rev
+  List.rev lines_rev, skipped, total
 ;;
 
 (** Read all trajectory lines including thinking entries. *)
@@ -830,6 +837,7 @@ let read_all_lines ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
     String.split_on_char '\n' content
     |> List.filter (fun line -> String.trim line <> "")
     |> trajectory_lines_of_jsonl_lines ~trace_id
+    |> fun (lines, _skipped, _total) -> lines
 
 let read_recent_lines
       ~(masc_root : string)
@@ -841,3 +849,4 @@ let read_recent_lines
   let path = trajectory_path masc_root keeper_name trace_id in
   Dated_jsonl.load_tail_lines path ~max_lines
   |> trajectory_lines_of_jsonl_lines ~trace_id
+  |> fun (lines, _skipped, _total) -> lines

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -138,6 +138,13 @@ val next_round :
   masc_root:string -> keeper_name:string -> trace_id:string -> turn:int ->
   int
 
+val trajectory_lines_of_jsonl_lines :
+  trace_id:string -> string list -> trajectory_line list * int * int
+(** Decode JSONL lines into parsed trajectory lines, the number of malformed
+    or unrecognized rows, and the total number of non-empty rows seen.
+    Intentionally skipped rows such as [trajectory_summary] do not count as
+    malformed. *)
+
 val read_all_lines :
   masc_root:string -> keeper_name:string -> trace_id:string ->
   trajectory_line list

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1873,6 +1873,33 @@ let json_string_field key = function
       | _ -> "")
   | Some _ | None -> ""
 
+let test_keeper_tool_failure_log_details_include_body_and_class () =
+  let details =
+    Server_routes_http_keeper_stream.For_testing.keeper_tool_failure_log_details
+      ~tool_name:"masc_keeper_msg"
+      ~agent_name:"agent-1"
+      ~duration_ms:123
+      ~streaming:true
+      ~error_body:"policy denied"
+      ~failure_class:Tool_result.Policy_rejection
+  in
+  check string "event_family" "tool_call_failure"
+    (json_string_field "event_family" (Some details));
+  check string "failure_class" "policy_rejection"
+    (json_string_field "failure_class" (Some details));
+  check string "error_body" "policy denied"
+    (json_string_field "error_body" (Some details));
+  check string "tool_name" "masc_keeper_msg"
+    (json_string_field "tool_name" (Some details));
+  check string "agent_name" "agent-1"
+    (json_string_field "agent_name" (Some details));
+  match details with
+  | `Assoc fields -> (
+      match List.assoc_opt "streaming" fields with
+      | Some (`Bool true) -> ()
+      | _ -> fail "expected streaming=true")
+  | _ -> fail "expected Assoc"
+
 let test_visible_reply_uses_streamed_text_fallback () =
   let fallback =
     Server_routes_http_keeper_stream.For_testing.visible_reply_with_stream_fallback
@@ -2675,6 +2702,8 @@ let () =
             test_extract_visible_reply_drops_empty_structured_envelope;
           test_case "visible reply uses typed reply field only" `Quick
             test_extract_visible_reply_uses_typed_reply_field_only;
+          test_case "tool failure log details include error body and failure_class"
+            `Quick test_keeper_tool_failure_log_details_include_body_and_class;
           test_case "direct reply rejects no visible reply" `Quick
             test_direct_reply_terminal_error_rejects_no_visible_reply;
           test_case "direct reply allows continuation checkpoint" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1873,31 +1873,42 @@ let json_string_field key = function
       | _ -> "")
   | Some _ | None -> ""
 
-let test_keeper_tool_failure_log_details_include_body_and_class () =
+let test_keeper_tool_failure_log_details_include_preview_and_class () =
+  let error_body = String.make 260 'x' in
   let details =
     Server_routes_http_keeper_stream.For_testing.keeper_tool_failure_log_details
       ~tool_name:"masc_keeper_msg"
       ~agent_name:"agent-1"
       ~duration_ms:123
       ~streaming:true
-      ~error_body:"policy denied"
+      ~error_body
       ~failure_class:Tool_result.Policy_rejection
   in
   check string "event_family" "tool_call_failure"
     (json_string_field "event_family" (Some details));
   check string "failure_class" "policy_rejection"
     (json_string_field "failure_class" (Some details));
-  check string "error_body" "policy denied"
-    (json_string_field "error_body" (Some details));
+  check string "error_body_preview" (String.make 197 'x' ^ "...")
+    (json_string_field "error_body_preview" (Some details));
   check string "tool_name" "masc_keeper_msg"
     (json_string_field "tool_name" (Some details));
   check string "agent_name" "agent-1"
     (json_string_field "agent_name" (Some details));
   match details with
-  | `Assoc fields -> (
-      match List.assoc_opt "streaming" fields with
+  | `Assoc fields ->
+      (match List.assoc_opt "streaming" fields with
       | Some (`Bool true) -> ()
-      | _ -> fail "expected streaming=true")
+      | _ -> fail "expected streaming=true");
+      (match List.assoc_opt "error_body_truncated" fields with
+       | Some (`Bool true) -> ()
+       | _ -> fail "expected error_body_truncated=true");
+      (match List.assoc_opt "error_body_bytes" fields with
+       | Some (`Int 260) -> ()
+       | _ -> fail "expected error_body_bytes=260");
+      Alcotest.(check bool)
+        "full error body omitted from log details"
+        false
+        (List.mem_assoc "error_body" fields)
   | _ -> fail "expected Assoc"
 
 let test_visible_reply_uses_streamed_text_fallback () =
@@ -2703,7 +2714,7 @@ let () =
           test_case "visible reply uses typed reply field only" `Quick
             test_extract_visible_reply_uses_typed_reply_field_only;
           test_case "tool failure log details include error body and failure_class"
-            `Quick test_keeper_tool_failure_log_details_include_body_and_class;
+            `Quick test_keeper_tool_failure_log_details_include_preview_and_class;
           test_case "direct reply rejects no visible reply" `Quick
             test_direct_reply_terminal_error_rejects_no_visible_reply;
           test_case "direct reply allows continuation checkpoint" `Quick

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -729,7 +729,7 @@ let test_execute_typed_single_stage_pipeline_rejected () =
     ()
   |> check_typed_validation_error "pipeline requires at least two stages"
 
-let test_execute_typed_repeated_executable_is_autocorrected () =
+let test_execute_typed_repeated_executable_arg_is_preserved () =
   setup ~sandbox:Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
   let raw =
@@ -741,15 +741,19 @@ let test_execute_typed_repeated_executable_is_autocorrected () =
       ~args:
         (tool_execute_typed_exec_args
            ~cwd:playground
-           ~argv:[ "find"; "."; "-name"; "*.ml" ]
-           "find")
+           ~argv:[ "echo"; "hello" ]
+           "echo")
       ()
   in
-  Alcotest.(check (option bool)) "autocorrected repeated argv[0] succeeds" (Some true)
+  Alcotest.(check (option bool)) "repeated argv[0] remains valid" (Some true)
     (parse_bool_field raw "ok");
   Alcotest.(check (option bool)) "typed response" (Some true)
     (parse_bool_field raw "typed");
-  Alcotest.(check int) "find exit status" 0 (parse_status_exit_code raw)
+  Alcotest.(check int) "echo exit status" 0 (parse_status_exit_code raw);
+  Alcotest.(check bool)
+    "output preserves caller-authored argv"
+    true
+    (response_mentions raw "output" "echo hello")
 
 let test_execute_typed_pipeline_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
@@ -2391,8 +2395,8 @@ let () =
             "tool_execute typed single-stage pipeline is rejected"
             `Quick test_execute_typed_single_stage_pipeline_rejected;
           Alcotest.test_case
-            "tool_execute typed repeated executable is autocorrected"
-            `Quick test_execute_typed_repeated_executable_is_autocorrected;
+            "tool_execute typed repeated executable arg is preserved"
+            `Quick test_execute_typed_repeated_executable_arg_is_preserved;
           Alcotest.test_case
             "tool_execute typed pipeline falls back to local playground"
             `Quick test_execute_typed_pipeline_falls_back_to_local_playground;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -729,22 +729,27 @@ let test_execute_typed_single_stage_pipeline_rejected () =
     ()
   |> check_typed_validation_error "pipeline requires at least two stages"
 
-let test_execute_typed_repeated_executable_is_deterministic () =
+let test_execute_typed_repeated_executable_is_autocorrected () =
   setup ~sandbox:Keeper_types_profile_sandbox.Local
   @@ fun ~config ~meta ~playground ->
-  Keeper_tool_command_runtime.handle_tool_execute
-    ~turn_sandbox_factory:None
-    ~exec_cache:None
-    ~config
-    ~meta
-    ~args:
-      (tool_execute_typed_exec_args
-         ~cwd:playground
-         ~argv:[ "find"; "."; "-name"; "*.ml" ]
-         "find")
-    ()
-  |> check_typed_validation_error
-       "executable \"find\" is repeated as argv[0]"
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_exec_args
+           ~cwd:playground
+           ~argv:[ "find"; "."; "-name"; "*.ml" ]
+           "find")
+      ()
+  in
+  Alcotest.(check (option bool)) "autocorrected repeated argv[0] succeeds" (Some true)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option bool)) "typed response" (Some true)
+    (parse_bool_field raw "typed");
+  Alcotest.(check int) "find exit status" 0 (parse_status_exit_code raw)
 
 let test_execute_typed_pipeline_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
@@ -912,6 +917,89 @@ if [ \"$1\" = \"run\" ]; then\n\
 fi\n\
 printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
 exit 2\n"
+
+let fake_docker_timeout_then_ok_script =
+  "#!/bin/sh\n\
+state_dir=$(dirname \"$0\")\n\
+run_count_file=\"$state_dir/timeout-run.count\"\n\
+log_file=${MASC_KEEPER_TEST_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+read_count() { if [ -f \"$1\" ]; then cat \"$1\"; else printf '0'; fi }\n\
+write_count() { printf '%s' \"$2\" > \"$1\"; }\n\
+if [ \"$1\" = \"info\" ]; then printf '[]\n'; exit 0; fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ]; then printf '[]\n'; exit 0; fi\n\
+if [ \"$1\" = \"rm\" ]; then exit 0; fi\n\
+if [ \"$1\" != \"run\" ]; then\n\
+  printf 'unexpected docker invocation: %s\n' \"$1\" >&2\n\
+  exit 2\n\
+fi\n\
+count=$(read_count \"$run_count_file\")\n\
+count=$((count + 1))\n\
+write_count \"$run_count_file\" \"$count\"\n\
+if [ \"$count\" = \"1\" ]; then\n\
+  printf 'process error: timeout after 5s\n' >&2\n\
+  exit 124\n\
+fi\n\
+shift\n\
+while [ \"$#\" -gt 0 ]; do\n\
+  if [ \"$1\" = \"alpine:test\" ]; then shift; break; fi\n\
+  shift\n\
+done\n\
+printf 'retry-ok\n'\n\
+exit 0\n"
+
+let test_docker_run_retries_on_daemon_timeout () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_timeout_then_ok_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  match
+    Keeper_sandbox_docker.run_docker_shell_command_with_status
+      ~config
+      ~meta
+      ~cwd:playground
+      ~timeout_sec:5.0
+      ~cmd:"echo hi"
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
+  with
+  | Error msg -> Alcotest.failf "unexpected error after daemon-timeout retry: %s" msg
+  | Ok result ->
+    Alcotest.(check int) "retry succeeds exit 0" 0
+      (match result.status with
+       | Unix.WEXITED n -> n
+       | _ -> -1);
+    Alcotest.(check bool) "output from second run" true
+      (contains_substring result.output "retry-ok")
+
+let test_docker_run_mounts_host_gitconfig () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  let home = temp_dir () in
+  let gitconfig = Filename.concat home ".gitconfig" in
+  write_file gitconfig "[user]\nname = MASC Test\n";
+  Fun.protect ~finally:(fun () -> cleanup_dir home) @@ fun () ->
+  with_env "HOME" home @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
+  match
+    Keeper_sandbox_docker.run_docker_shell_command_with_status
+      ~config
+      ~meta
+      ~cwd:playground
+      ~timeout_sec:5.0
+      ~cmd:"echo hi"
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
+  with
+  | Error msg -> Alcotest.failf "unexpected error mounting gitconfig: %s" msg
+  | Ok _ ->
+    let log = read_file log_path in
+    let expected = home ^ "/.gitconfig:/tmp/.gitconfig:ro" in
+    Alcotest.(check bool) "docker run mounts host gitconfig" true
+      (contains_substring log expected)
 
 let test_execute_git_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
@@ -2276,8 +2364,8 @@ let () =
             "tool_execute typed single-stage pipeline is rejected"
             `Quick test_execute_typed_single_stage_pipeline_rejected;
           Alcotest.test_case
-            "tool_execute typed repeated executable is deterministic"
-            `Quick test_execute_typed_repeated_executable_is_deterministic;
+            "tool_execute typed repeated executable is autocorrected"
+            `Quick test_execute_typed_repeated_executable_is_autocorrected;
           Alcotest.test_case
             "tool_execute typed pipeline falls back to local playground"
             `Quick test_execute_typed_pipeline_falls_back_to_local_playground;
@@ -2375,5 +2463,13 @@ let () =
             "history cmd_prefix uses shell command words"
             `Quick
             test_cmd_prefix_uses_shell_command_words;
+          Alcotest.test_case
+            "docker run retries once on daemon timeout/back-pressure"
+            `Quick
+            test_docker_run_retries_on_daemon_timeout;
+          Alcotest.test_case
+            "docker run mounts host gitconfig into container"
+            `Quick
+            test_docker_run_mounts_host_gitconfig;
         ] );
     ]

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -950,7 +950,39 @@ done\n\
 printf 'retry-ok\n'\n\
 exit 0\n"
 
-let test_docker_run_retries_on_daemon_timeout () =
+let fake_docker_daemon_unavailable_then_ok_script =
+  "#!/bin/sh\n\
+state_dir=$(dirname \"$0\")\n\
+run_count_file=\"$state_dir/daemon-unavailable-run.count\"\n\
+log_file=${MASC_KEEPER_TEST_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+read_count() { if [ -f \"$1\" ]; then cat \"$1\"; else printf '0'; fi }\n\
+write_count() { printf '%s' \"$2\" > \"$1\"; }\n\
+if [ \"$1\" = \"info\" ]; then printf '[]\n'; exit 0; fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ]; then printf '[]\n'; exit 0; fi\n\
+if [ \"$1\" = \"rm\" ]; then exit 0; fi\n\
+if [ \"$1\" != \"run\" ]; then\n\
+  printf 'unexpected docker invocation: %s\n' \"$1\" >&2\n\
+  exit 2\n\
+fi\n\
+count=$(read_count \"$run_count_file\")\n\
+count=$((count + 1))\n\
+write_count \"$run_count_file\" \"$count\"\n\
+if [ \"$count\" = \"1\" ]; then\n\
+  printf 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock\n' >&2\n\
+  exit 1\n\
+fi\n\
+shift\n\
+while [ \"$#\" -gt 0 ]; do\n\
+  if [ \"$1\" = \"alpine:test\" ]; then shift; break; fi\n\
+  shift\n\
+done\n\
+printf 'retry-ok\n'\n\
+exit 0\n"
+
+let test_docker_run_does_not_retry_generic_timeout () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_timeout_then_ok_script @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -964,13 +996,36 @@ let test_docker_run_retries_on_daemon_timeout () =
       ~cmd:"echo hi"
       ~network_mode:Keeper_types_profile_sandbox.Network_none
   with
-  | Error msg -> Alcotest.failf "unexpected error after daemon-timeout retry: %s" msg
+  | Error msg -> Alcotest.failf "unexpected docker timeout result error: %s" msg
   | Ok result ->
-    Alcotest.(check int) "retry succeeds exit 0" 0
+    Alcotest.(check int) "generic timeout is terminal" 124
       (match result.status with
        | Unix.WEXITED n -> n
        | _ -> -1);
-    Alcotest.(check bool) "output from second run" true
+    Alcotest.(check bool) "second run was not replayed" false
+      (contains_substring result.output "retry-ok")
+
+let test_docker_run_retries_on_daemon_unavailable () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_daemon_unavailable_then_ok_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  match
+    Keeper_sandbox_docker.run_docker_shell_command_with_status
+      ~config
+      ~meta
+      ~cwd:playground
+      ~timeout_sec:5.0
+      ~cmd:"echo hi"
+      ~network_mode:Keeper_types_profile_sandbox.Network_none
+  with
+  | Error msg -> Alcotest.failf "unexpected error after daemon-unavailable retry: %s" msg
+  | Ok result ->
+    Alcotest.(check int) "daemon unavailable retry succeeds" 0
+      (match result.status with
+       | Unix.WEXITED n -> n
+       | _ -> -1);
+    Alcotest.(check bool) "output from daemon retry" true
       (contains_substring result.output "retry-ok")
 
 let test_execute_git_routes_through_docker () =
@@ -2436,8 +2491,12 @@ let () =
             `Quick
             test_cmd_prefix_uses_shell_command_words;
           Alcotest.test_case
-            "docker run retries once on daemon timeout/back-pressure"
+            "docker run does not retry generic timeout"
             `Quick
-            test_docker_run_retries_on_daemon_timeout;
+            test_docker_run_does_not_retry_generic_timeout;
+          Alcotest.test_case
+            "docker run retries once on daemon unavailable"
+            `Quick
+            test_docker_run_retries_on_daemon_unavailable;
         ] );
     ]

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -973,34 +973,6 @@ let test_docker_run_retries_on_daemon_timeout () =
     Alcotest.(check bool) "output from second run" true
       (contains_substring result.output "retry-ok")
 
-let test_docker_run_mounts_host_gitconfig () =
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
-  with_fake_docker fake_docker_echo_script @@ fun () ->
-  let home = temp_dir () in
-  let gitconfig = Filename.concat home ".gitconfig" in
-  write_file gitconfig "[user]\nname = MASC Test\n";
-  Fun.protect ~finally:(fun () -> cleanup_dir home) @@ fun () ->
-  with_env "HOME" home @@ fun () ->
-  setup ~sandbox:Keeper_types_profile_sandbox.Docker
-  @@ fun ~config ~meta ~playground ->
-  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
-  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
-  match
-    Keeper_sandbox_docker.run_docker_shell_command_with_status
-      ~config
-      ~meta
-      ~cwd:playground
-      ~timeout_sec:5.0
-      ~cmd:"echo hi"
-      ~network_mode:Keeper_types_profile_sandbox.Network_none
-  with
-  | Error msg -> Alcotest.failf "unexpected error mounting gitconfig: %s" msg
-  | Ok _ ->
-    let log = read_file log_path in
-    let expected = home ^ "/.gitconfig:/tmp/.gitconfig:ro" in
-    Alcotest.(check bool) "docker run mounts host gitconfig" true
-      (contains_substring log expected)
-
 let test_execute_git_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup_with_tool_access ~sandbox:Keeper_types_profile_sandbox.Docker @@ fun ~config ~meta ~playground ->
@@ -2467,9 +2439,5 @@ let () =
             "docker run retries once on daemon timeout/back-pressure"
             `Quick
             test_docker_run_retries_on_daemon_timeout;
-          Alcotest.test_case
-            "docker run mounts host gitconfig into container"
-            `Quick
-            test_docker_run_mounts_host_gitconfig;
         ] );
     ]

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1077,27 +1077,6 @@ let test_docker_config_mount_and_env_args () =
        ~base_path:base
        ~container_root)
 
-let test_docker_gitconfig_mount_args_skips_when_missing () =
-  with_env "HOME" "/nonexistent/missing_home_for_gitconfig_test" @@ fun () ->
-  Alcotest.(check (list string))
-    "missing gitconfig yields no mount args"
-    []
-    (Keeper_sandbox_runtime.docker_gitconfig_mount_args ())
-
-let test_docker_gitconfig_mount_args_includes_when_present () =
-  let home = temp_dir () in
-  let gitconfig = Filename.concat home ".gitconfig" in
-  write_file gitconfig "[user]\nname = MASC Test\n";
-  Fun.protect ~finally:(fun () -> cleanup_dir home) @@ fun () ->
-  with_env "HOME" home @@ fun () ->
-  let args = Keeper_sandbox_runtime.docker_gitconfig_mount_args () in
-  Alcotest.(check bool) "args contain -v flag" true (List.mem "-v" args);
-  let expected = home ^ "/.gitconfig:/tmp/.gitconfig:ro" in
-  Alcotest.(check bool)
-    "mount spec points to container gitconfig"
-    true
-    (List.mem expected args)
-
 let test_docker_run_looks_daemon_pressure_classifies_timeout () =
   Alcotest.(check bool)
     "WEXITED 124 with timeout output is daemon pressure"
@@ -2339,10 +2318,6 @@ let run_tests ~clock () =
             test_docker_masc_config_binding_pins_container_runtime_paths;
           Alcotest.test_case "docker config mount and env args" `Quick
             test_docker_config_mount_and_env_args;
-          Alcotest.test_case "docker gitconfig mount skipped when missing" `Quick
-            test_docker_gitconfig_mount_args_skips_when_missing;
-          Alcotest.test_case "docker gitconfig mount present when host file exists" `Quick
-            test_docker_gitconfig_mount_args_includes_when_present;
           Alcotest.test_case "docker run classifies timeout as daemon pressure" `Quick
             test_docker_run_looks_daemon_pressure_classifies_timeout;
           Alcotest.test_case "docker run classifies daemon unavailable as pressure" `Quick

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1077,6 +1077,51 @@ let test_docker_config_mount_and_env_args () =
        ~base_path:base
        ~container_root)
 
+let test_docker_gitconfig_mount_args_skips_when_missing () =
+  with_env "HOME" "/nonexistent/missing_home_for_gitconfig_test" @@ fun () ->
+  Alcotest.(check (list string))
+    "missing gitconfig yields no mount args"
+    []
+    (Keeper_sandbox_runtime.docker_gitconfig_mount_args ())
+
+let test_docker_gitconfig_mount_args_includes_when_present () =
+  let home = temp_dir () in
+  let gitconfig = Filename.concat home ".gitconfig" in
+  write_file gitconfig "[user]\nname = MASC Test\n";
+  Fun.protect ~finally:(fun () -> cleanup_dir home) @@ fun () ->
+  with_env "HOME" home @@ fun () ->
+  let args = Keeper_sandbox_runtime.docker_gitconfig_mount_args () in
+  Alcotest.(check bool) "args contain -v flag" true (List.mem "-v" args);
+  let expected = home ^ "/.gitconfig:/tmp/.gitconfig:ro" in
+  Alcotest.(check bool)
+    "mount spec points to container gitconfig"
+    true
+    (List.mem expected args)
+
+let test_docker_run_looks_daemon_pressure_classifies_timeout () =
+  Alcotest.(check bool)
+    "WEXITED 124 with timeout output is daemon pressure"
+    true
+    (Keeper_sandbox_runtime.docker_run_looks_daemon_pressure
+       ~status:(Unix.WEXITED 124)
+       ~output:"process error: timeout after 5s")
+
+let test_docker_run_looks_daemon_pressure_classifies_daemon_unavailable () =
+  Alcotest.(check bool)
+    "daemon unavailable output is daemon pressure"
+    true
+    (Keeper_sandbox_runtime.docker_run_looks_daemon_pressure
+       ~status:(Unix.WEXITED 1)
+       ~output:"Cannot connect to the Docker daemon at unix:///var/run/docker.sock")
+
+let test_docker_run_looks_daemon_pressure_not_pressure_on_command_error () =
+  Alcotest.(check bool)
+    "normal command failure is not daemon pressure"
+    false
+    (Keeper_sandbox_runtime.docker_run_looks_daemon_pressure
+       ~status:(Unix.WEXITED 1)
+       ~output:"No such file or directory")
+
 let test_docker_workspace_state_mount_args_expose_safe_subset () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
@@ -2294,6 +2339,16 @@ let run_tests ~clock () =
             test_docker_masc_config_binding_pins_container_runtime_paths;
           Alcotest.test_case "docker config mount and env args" `Quick
             test_docker_config_mount_and_env_args;
+          Alcotest.test_case "docker gitconfig mount skipped when missing" `Quick
+            test_docker_gitconfig_mount_args_skips_when_missing;
+          Alcotest.test_case "docker gitconfig mount present when host file exists" `Quick
+            test_docker_gitconfig_mount_args_includes_when_present;
+          Alcotest.test_case "docker run classifies timeout as daemon pressure" `Quick
+            test_docker_run_looks_daemon_pressure_classifies_timeout;
+          Alcotest.test_case "docker run classifies daemon unavailable as pressure" `Quick
+            test_docker_run_looks_daemon_pressure_classifies_daemon_unavailable;
+          Alcotest.test_case "docker run does not classify command error as pressure" `Quick
+            test_docker_run_looks_daemon_pressure_not_pressure_on_command_error;
           Alcotest.test_case "docker workspace state mount exposes safe subset" `Quick
             test_docker_workspace_state_mount_args_expose_safe_subset;
           Alcotest.test_case "managed label args include ttl" `Quick

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1077,10 +1077,10 @@ let test_docker_config_mount_and_env_args () =
        ~base_path:base
        ~container_root)
 
-let test_docker_run_looks_daemon_pressure_classifies_timeout () =
+let test_docker_run_looks_daemon_pressure_does_not_retry_timeout () =
   Alcotest.(check bool)
-    "WEXITED 124 with timeout output is daemon pressure"
-    true
+    "WEXITED 124 with timeout output is not daemon pressure"
+    false
     (Keeper_sandbox_runtime.docker_run_looks_daemon_pressure
        ~status:(Unix.WEXITED 124)
        ~output:"process error: timeout after 5s")
@@ -2318,8 +2318,8 @@ let run_tests ~clock () =
             test_docker_masc_config_binding_pins_container_runtime_paths;
           Alcotest.test_case "docker config mount and env args" `Quick
             test_docker_config_mount_and_env_args;
-          Alcotest.test_case "docker run classifies timeout as daemon pressure" `Quick
-            test_docker_run_looks_daemon_pressure_classifies_timeout;
+          Alcotest.test_case "docker run timeout is terminal" `Quick
+            test_docker_run_looks_daemon_pressure_does_not_retry_timeout;
           Alcotest.test_case "docker run classifies daemon unavailable as pressure" `Quick
             test_docker_run_looks_daemon_pressure_classifies_daemon_unavailable;
           Alcotest.test_case "docker run does not classify command error as pressure" `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -26,6 +26,15 @@ module Resolution = Masc.Keeper_tool_descriptor_resolution
 module Surface = Masc.Keeper_agent_tool_surface
 module Board = Tool_shard_types
 module Board_tool_registry = Board_tool_registry
+module Keeper_dispatch_ref = Masc.Keeper_dispatch_ref
+module Workspace = Masc.Workspace
+module Task = Masc.Task
+module Keeper_tool_surface = Masc.Keeper_tool_surface
+
+(* Force-link [Keeper_tool_surface] so its module-load registration of
+   keeper tools into [Keeper_dispatch_ref.dispatch] runs before the
+   dispatch gap test. *)
+let () = ignore Masc.Keeper_tool_surface.schemas
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
 
@@ -834,6 +843,102 @@ let test_rfc_0182_clusters_have_descriptor_projection () =
     cluster_projection_table
 ;;
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm path =
+        if Sys.file_exists path
+        then
+          if Sys.is_directory path
+          then begin
+            Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+            Unix.rmdir path
+          end else Unix.unlink path
+      in
+      try rm dir with _ -> ())
+    (fun () -> f dir)
+;;
+
+(* RFC-0267 Phase 2 — [masc_task_set_goal] must have a descriptor that
+   projects from the task schema registry and must actually dispatch
+   through [Task.Tool.dispatch]. The descriptor makes the tool visible
+   to the keeper surface; the dispatch check proves the runtime handler
+   wiring is not stale. *)
+let test_masc_task_set_goal_is_described_and_dispatched () =
+  let descriptor = required_internal_descriptor "masc_task_set_goal" in
+  Alcotest.(check string)
+    "masc_task_set_goal descriptor id"
+    "masc.task.set_goal"
+    descriptor.Descriptor.id;
+  Alcotest.(check string)
+    "masc_task_set_goal runtime handler"
+    "tool_masc_task_dispatch"
+    (Descriptor.runtime_handler_to_string descriptor.runtime_handler);
+  let expected_schema =
+    match
+      List.find_opt
+        (fun (s : Masc_domain.tool_schema) -> String.equal s.name "masc_task_set_goal")
+        Task.Schemas.schemas
+    with
+    | Some schema -> schema.input_schema
+    | None -> Alcotest.fail "missing Task.Schemas schema for masc_task_set_goal"
+  in
+  Alcotest.(check bool)
+    "masc_task_set_goal schema projected from Task.Schemas"
+    true
+    (descriptor.Descriptor.input_schema = expected_schema);
+  with_temp_dir "masc_task_set_goal_dispatch" (fun dir ->
+    let config = Workspace.default_config dir in
+    ignore (Workspace.init config ~agent_name:(Some "test-agent"));
+    let ctx : Task.Tool.context =
+      { config; agent_name = "test-agent"; sw = None }
+    in
+    let args =
+      `Assoc [ "task_id", `String "task-001"; "goal_id", `String "goal-001" ]
+    in
+    match Task.Tool.dispatch ctx ~name:"masc_task_set_goal" ~args with
+    | Some _ -> ()
+    | None -> Alcotest.fail "masc_task_set_goal dispatch returned None")
+;;
+
+(* Dispatch gap integrity: every descriptor backed by the keeper
+   dispatch cluster must be reachable through [Keeper_dispatch_ref.dispatch].
+   This catches the common failure mode where a descriptor is added to
+   [internal_descriptors] but its ctx-free registration in
+   [Keeper_tool_surface] is forgotten. *)
+let test_keeper_dispatch_ref_reaches_every_keeper_descriptor () =
+  with_temp_dir "keeper_dispatch_gap" (fun dir ->
+    let config = Workspace.default_config dir in
+    let agent_name = "test-agent" in
+    let keeper_descriptors =
+      Descriptor.all_descriptors ()
+      |> List.filter (fun d ->
+        match d.Descriptor.runtime_handler with
+        | Descriptor.Tool_masc_keeper_dispatch -> true
+        | _ -> false)
+    in
+    let unreachable =
+      List.filter_map
+        (fun d ->
+           let name = d.Descriptor.internal_name in
+           match
+             !Keeper_dispatch_ref.dispatch ~config ~agent_name ~name ~args:(`Assoc []) ()
+           with
+           | Some _ -> None
+           | None -> Some name)
+        keeper_descriptors
+    in
+    if unreachable <> []
+    then
+      Alcotest.failf
+        "Keeper_dispatch_ref.dispatch returned None for %d keeper descriptor(s): %s"
+        (List.length unreachable)
+        (String.concat ", " unreachable))
+;;
+
 (* RFC-0190 — every entry of [public_mcp_surface_tools] must either have
    a descriptor or be on the [public_mcp_non_descriptor]
    allowlist. New surface additions without a descriptor are rejected. *)
@@ -992,6 +1097,16 @@ let () =
             "keeper/surface_audit project to descriptors"
             `Quick
             test_rfc_0182_clusters_have_descriptor_projection
+        ] )
+    ; ( "dispatch-gap"
+      , [ test_case
+            "masc_task_set_goal is described and dispatched"
+            `Quick
+            test_masc_task_set_goal_is_described_and_dispatched
+        ; test_case
+            "every keeper descriptor is reachable via Keeper_dispatch_ref.dispatch"
+            `Quick
+            test_keeper_dispatch_ref_reaches_every_keeper_descriptor
         ] )
     ; ( "rfc-0190-surface-projection"
       , [ test_case

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -448,6 +448,24 @@ let test_to_string_non_empty_for_every_variant () =
     variants
 ;;
 
+let test_read_repo_access_denial_is_policy_blocked () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "ok", `Bool false
+         ; "error", `String "Keeper rondo is not allowed to access repository masc-mcp"
+         ; "path", `String "/Users/dancer/me/.masc/playground/docker/rondo/repos/masc-mcp/lib/foo.ml"
+         ; ( "deterministic_retry"
+           , `Assoc [ "reason", `String "policy_blocked"; "retry_same_args", `Bool false ] )
+         ])
+  in
+  check_classify_source
+    ~name:"read_repo_access_denial"
+    ~expected_reason:D.Policy_blocked
+    ~expected_source:D.Deterministic_retry_marker
+    raw
+;;
+
 let () =
   Alcotest.run
     "tool_execute_retry_deterministic_close"
@@ -469,6 +487,10 @@ let () =
             "gh_irreversible_blocked"
             `Quick
             test_policy_blocked_gh_irreversible
+        ; Alcotest.test_case
+            "read_repo_access_denial"
+            `Quick
+            test_read_repo_access_denial_is_policy_blocked
         ; Alcotest.test_case
             "completion_contract_violation"
             `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -78,8 +78,8 @@ let cases : case list =
     ; typed = mk_exec "cat" [ "cat"; "README.md" ]
     ; expect_typed = true
     ; rationale =
-        "typed Execute autocorrects a leading duplicate argv[0] by dropping \
-         it before validation and lowering"
+        "typed Execute preserves caller-authored argv; a leading token equal \
+         to executable may be intentional payload"
     }
   ; { name = "unknown_executable"
     ; sample_cmd = "unknown_cmd foo"
@@ -556,23 +556,23 @@ let to_shell_ir_exn input =
       error
 ;;
 
-let test_duplicate_executable_argv0_autocorrected () =
+let test_duplicate_executable_argv0_preserved () =
   let input = mk_exec "git" [ "git"; "status"; "--short" ] in
   Alcotest.(check bool)
-    "validate accepts duplicate argv[0] after autocorrection"
+    "validate accepts caller-authored argv"
     true
     (typed_ok input);
   match Execute_input.to_shell_ir input with
   | Ok (Masc_exec.Shell_ir.Simple simple) ->
     Alcotest.(check (pair string (list string)))
-      "lowered IR drops duplicated argv[0]"
-      ("git", [ "status"; "--short" ])
+      "lowered IR preserves duplicated argv[0]"
+      ("git", [ "git"; "status"; "--short" ])
       (shell_simple_tuple simple)
   | Ok (Masc_exec.Shell_ir.Pipeline _) ->
     Alcotest.fail "single Exec must not lower to Pipeline"
   | Error err ->
     Alcotest.failf
-      "to_shell_ir should autocorrect duplicate argv[0], got %a"
+      "to_shell_ir should preserve duplicate argv[0], got %a"
       Execute_input.pp_validation_error
       err
 ;;
@@ -611,7 +611,7 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
     Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
 ;;
 
-let test_exec_lowering_autocorrects_duplicate_executable_argv () =
+let test_exec_lowering_preserves_duplicate_executable_argv () =
   let input =
     Execute_input.Exec
       { executable = "git"
@@ -626,14 +626,14 @@ let test_exec_lowering_autocorrects_duplicate_executable_argv () =
   match Execute_input.to_shell_ir input with
   | Ok (Masc_exec.Shell_ir.Simple simple) ->
     Alcotest.(check (pair string (list string)))
-      "lowered IR drops duplicated argv[0]"
-      ("git", [ "status" ])
+      "lowered IR preserves caller-authored argv"
+      ("git", [ "git"; "status" ])
       (shell_simple_tuple simple)
   | Ok (Masc_exec.Shell_ir.Pipeline _) ->
     Alcotest.fail "single Exec must not lower to Pipeline"
   | Error error ->
     Alcotest.failf
-      "duplicated argv[0] should be autocorrected, got %a"
+      "duplicated argv[0] should remain caller-authored, got %a"
       Execute_input.pp_validation_error
       error
 ;;
@@ -693,6 +693,38 @@ let test_pipeline_lowering_preserves_single_stage_argv_equal_to_executable () =
   | Error error ->
     Alcotest.failf
       "pipeline with single argv equal to executable should remain valid, got %a"
+      Execute_input.pp_validation_error
+      error
+;;
+
+let test_pipeline_lowering_preserves_duplicate_stage_argv () =
+  let input =
+    Execute_input.Pipeline
+      { stages =
+          [ { executable = "printf"; argv = [ "printf"; "hello" ] }
+          ; { executable = "wc"; argv = [ "wc"; "-c" ] }
+          ]
+      ; cwd = None
+      ; env = []
+      }
+  in
+  match Execute_input.to_shell_ir input with
+  | Ok
+      (Masc_exec.Shell_ir.Pipeline
+        [ Masc_exec.Shell_ir.Simple first; Masc_exec.Shell_ir.Simple second ]) ->
+    Alcotest.(check (pair string (list string)))
+      "first stage preserves caller-authored argv"
+      ("printf", [ "printf"; "hello" ])
+      (shell_simple_tuple first);
+    Alcotest.(check (pair string (list string)))
+      "second stage preserves caller-authored argv"
+      ("wc", [ "wc"; "-c" ])
+      (shell_simple_tuple second)
+  | Ok other ->
+    Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
+  | Error error ->
+    Alcotest.failf
+      "pipeline duplicated argv[0] should remain caller-authored, got %a"
       Execute_input.pp_validation_error
       error
 ;;
@@ -1235,9 +1267,9 @@ let suite =
           `Quick
           test_empty_executable_with_argv_hints_rewrite
       ; Alcotest.test_case
-          "duplicate_executable_argv0_autocorrected"
+          "duplicate_executable_argv0_preserved"
           `Quick
-          test_duplicate_executable_argv0_autocorrected
+          test_duplicate_executable_argv0_preserved
       ; Alcotest.test_case
           "unvalidated_path_preserves_argv_in_error"
           `Quick
@@ -1301,9 +1333,9 @@ let suite =
           `Quick
           test_pipeline_lowers_to_shell_ir_pipeline
       ; Alcotest.test_case
-          "exec_lowering_autocorrects_duplicate_executable_argv"
+          "exec_lowering_preserves_duplicate_executable_argv"
           `Quick
-          test_exec_lowering_autocorrects_duplicate_executable_argv
+          test_exec_lowering_preserves_duplicate_executable_argv
       ; Alcotest.test_case
           "exec_lowering_preserves_single_argv_equal_to_executable"
           `Quick
@@ -1312,6 +1344,10 @@ let suite =
           "pipeline_lowering_preserves_single_stage_argv_equal_to_executable"
           `Quick
           test_pipeline_lowering_preserves_single_stage_argv_equal_to_executable
+      ; Alcotest.test_case
+          "pipeline_lowering_preserves_duplicate_stage_argv"
+          `Quick
+          test_pipeline_lowering_preserves_duplicate_stage_argv
       ; Alcotest.test_case
           "pipeline_lowers_with_injected_docker_sandbox"
           `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -638,6 +638,65 @@ let test_exec_lowering_autocorrects_duplicate_executable_argv () =
       error
 ;;
 
+let test_exec_lowering_preserves_single_argv_equal_to_executable () =
+  let input =
+    Execute_input.Exec
+      { executable = "echo"
+      ; argv = [ "echo" ]
+      ; cwd = None
+      ; env = []
+      ; stdin = Execute_input.Inherit
+      ; stdout = Execute_input.Inherit
+      ; stderr = Execute_input.Inherit
+      }
+  in
+  match Execute_input.to_shell_ir input with
+  | Ok (Masc_exec.Shell_ir.Simple simple) ->
+    Alcotest.(check (pair string (list string)))
+      "single argv equal to executable remains an argument"
+      ("echo", [ "echo" ])
+      (shell_simple_tuple simple)
+  | Ok (Masc_exec.Shell_ir.Pipeline _) ->
+    Alcotest.fail "single Exec must not lower to Pipeline"
+  | Error error ->
+    Alcotest.failf
+      "single argv equal to executable should remain valid, got %a"
+      Execute_input.pp_validation_error
+      error
+;;
+
+let test_pipeline_lowering_preserves_single_stage_argv_equal_to_executable () =
+  let input =
+    Execute_input.Pipeline
+      { stages =
+          [ { executable = "echo"; argv = [ "echo" ] }
+          ; { executable = "wc"; argv = [ "-c" ] }
+          ]
+      ; cwd = None
+      ; env = []
+      }
+  in
+  match Execute_input.to_shell_ir input with
+  | Ok
+      (Masc_exec.Shell_ir.Pipeline
+        [ Masc_exec.Shell_ir.Simple first; Masc_exec.Shell_ir.Simple second ]) ->
+    Alcotest.(check (pair string (list string)))
+      "first stage preserves single argv equal to executable"
+      ("echo", [ "echo" ])
+      (shell_simple_tuple first);
+    Alcotest.(check (pair string (list string)))
+      "second stage unchanged"
+      ("wc", [ "-c" ])
+      (shell_simple_tuple second)
+  | Ok other ->
+    Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
+  | Error error ->
+    Alcotest.failf
+      "pipeline with single argv equal to executable should remain valid, got %a"
+      Execute_input.pp_validation_error
+      error
+;;
+
 let docker_test_sandbox () =
   Masc_exec.Sandbox_target.docker
     ~image:"typed-docker"
@@ -1245,6 +1304,14 @@ let suite =
           "exec_lowering_autocorrects_duplicate_executable_argv"
           `Quick
           test_exec_lowering_autocorrects_duplicate_executable_argv
+      ; Alcotest.test_case
+          "exec_lowering_preserves_single_argv_equal_to_executable"
+          `Quick
+          test_exec_lowering_preserves_single_argv_equal_to_executable
+      ; Alcotest.test_case
+          "pipeline_lowering_preserves_single_stage_argv_equal_to_executable"
+          `Quick
+          test_pipeline_lowering_preserves_single_stage_argv_equal_to_executable
       ; Alcotest.test_case
           "pipeline_lowers_with_injected_docker_sandbox"
           `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -76,10 +76,10 @@ let cases : case list =
   ; { name = "duplicate_executable_argv0"
     ; sample_cmd = "cat cat README.md"
     ; typed = mk_exec "cat" [ "cat"; "README.md" ]
-    ; expect_typed = false
+    ; expect_typed = true
     ; rationale =
-        "typed Execute argv excludes argv[0]; repeating executable would \
-         execute the wrong file list"
+        "typed Execute autocorrects a leading duplicate argv[0] by dropping \
+         it before validation and lowering"
     }
   ; { name = "unknown_executable"
     ; sample_cmd = "unknown_cmd foo"
@@ -217,41 +217,6 @@ let test_empty_executable_with_argv_hints_rewrite () =
       Execute_input.pp_validation_error
       error
   | Ok () -> Alcotest.fail "empty executable should not be accepted"
-;;
-
-let test_duplicate_executable_argv0_rejected () =
-  match
-    Execute_input.validate
-            (mk_exec "cat" [ "cat"; "-n"; "keeper_sandbox.mli" ])
-  with
-  | Error (Execute_input.Executable_repeated_in_argv0 { executable; argv }) ->
-    Alcotest.(check string) "executable" "cat" executable;
-    Alcotest.(check (list string))
-      "argv preserved for rewrite"
-      [ "cat"; "-n"; "keeper_sandbox.mli" ]
-      argv;
-    let msg =
-      Format.asprintf
-        "%a"
-        Execute_input.pp_validation_error
-        (Execute_input.Executable_repeated_in_argv0 { executable; argv })
-    in
-    Alcotest.(check bool)
-      "error points at argv[0]"
-      true
-      (String_util.contains_substring_ci msg "argv[0]");
-    Alcotest.(check bool)
-      "error rewrites without duplicated executable"
-      true
-      (String_util.contains_substring_ci
-         msg
-         "argv=[\"-n\",\"keeper_sandbox.mli\"]")
-  | Error error ->
-    Alcotest.failf
-      "expected Executable_repeated_in_argv0, got %a"
-      Execute_input.pp_validation_error
-      error
-  | Ok () -> Alcotest.fail "duplicated argv[0] should not be accepted"
 ;;
 
 (* Regression: validate-bypass paths (to_shell_ir_unvalidated /
@@ -591,6 +556,27 @@ let to_shell_ir_exn input =
       error
 ;;
 
+let test_duplicate_executable_argv0_autocorrected () =
+  let input = mk_exec "git" [ "git"; "status"; "--short" ] in
+  Alcotest.(check bool)
+    "validate accepts duplicate argv[0] after autocorrection"
+    true
+    (typed_ok input);
+  match Execute_input.to_shell_ir input with
+  | Ok (Masc_exec.Shell_ir.Simple simple) ->
+    Alcotest.(check (pair string (list string)))
+      "lowered IR drops duplicated argv[0]"
+      ("git", [ "status"; "--short" ])
+      (shell_simple_tuple simple)
+  | Ok (Masc_exec.Shell_ir.Pipeline _) ->
+    Alcotest.fail "single Exec must not lower to Pipeline"
+  | Error err ->
+    Alcotest.failf
+      "to_shell_ir should autocorrect duplicate argv[0], got %a"
+      Execute_input.pp_validation_error
+      err
+;;
+
 let test_pipeline_lowers_to_shell_ir_pipeline () =
   let input =
     Execute_input.Pipeline
@@ -625,7 +611,7 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
     Alcotest.failf "expected Shell_ir.Pipeline, got %a" Masc_exec.Shell_ir.pp other
 ;;
 
-let test_exec_lowering_rejects_duplicate_executable_argv () =
+let test_exec_lowering_autocorrects_duplicate_executable_argv () =
   let input =
     Execute_input.Exec
       { executable = "git"
@@ -637,20 +623,19 @@ let test_exec_lowering_rejects_duplicate_executable_argv () =
       ; stderr = Execute_input.Inherit
       }
   in
-  match Execute_input.to_shell_ir  input with
-  | Error
-      (Execute_input.Executable_repeated_in_argv0
-        { executable = "git"; argv = [ "git"; "status" ] }) -> ()
+  match Execute_input.to_shell_ir input with
+  | Ok (Masc_exec.Shell_ir.Simple simple) ->
+    Alcotest.(check (pair string (list string)))
+      "lowered IR drops duplicated argv[0]"
+      ("git", [ "status" ])
+      (shell_simple_tuple simple)
+  | Ok (Masc_exec.Shell_ir.Pipeline _) ->
+    Alcotest.fail "single Exec must not lower to Pipeline"
   | Error error ->
     Alcotest.failf
-      "expected Executable_repeated_in_argv0, got %a"
+      "duplicated argv[0] should be autocorrected, got %a"
       Execute_input.pp_validation_error
       error
-  | Ok ir ->
-    Alcotest.failf
-      "duplicated argv[0] should not produce Shell IR, got %a"
-      Masc_exec.Shell_ir.pp
-      ir
 ;;
 
 let docker_test_sandbox () =
@@ -1191,9 +1176,9 @@ let suite =
           `Quick
           test_empty_executable_with_argv_hints_rewrite
       ; Alcotest.test_case
-          "duplicate_executable_argv0_rejected"
+          "duplicate_executable_argv0_autocorrected"
           `Quick
-          test_duplicate_executable_argv0_rejected
+          test_duplicate_executable_argv0_autocorrected
       ; Alcotest.test_case
           "unvalidated_path_preserves_argv_in_error"
           `Quick
@@ -1257,9 +1242,9 @@ let suite =
           `Quick
           test_pipeline_lowers_to_shell_ir_pipeline
       ; Alcotest.test_case
-          "exec_lowering_rejects_duplicate_executable_argv"
+          "exec_lowering_autocorrects_duplicate_executable_argv"
           `Quick
-          test_exec_lowering_rejects_duplicate_executable_argv
+          test_exec_lowering_autocorrects_duplicate_executable_argv
       ; Alcotest.test_case
           "pipeline_lowers_with_injected_docker_sandbox"
           `Quick

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -500,7 +500,11 @@ let extra_guard_fragments_for_name = function
         "keeper not found";
       ]
   | "masc_keeper_sandbox_start" | "masc_keeper_sandbox_stop" ->
-      [ "sandbox image not found"; "no such container"; "Docker" ]
+      [
+        "keeper sandbox docker image is not configured";
+        "docker_container_start_failed";
+        "no such container";
+      ]
   | "masc_keeper_list" | "masc_keeper_msg_result"
   | "masc_keeper_msg_cancel" | "masc_keeper_msg_queue" | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -500,7 +500,7 @@ let extra_guard_fragments_for_name = function
         "keeper not found";
       ]
   | "masc_keeper_sandbox_start" | "masc_keeper_sandbox_stop" ->
-      [ "descriptor projection: cluster dispatcher did not recognise" ]
+      [ "sandbox image not found"; "no such container"; "Docker" ]
   | "masc_keeper_list" | "masc_keeper_msg_result"
   | "masc_keeper_msg_cancel" | "masc_keeper_msg_queue" | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -316,10 +316,9 @@ let test_local_keeper_rg_invalid_type_surfaces_stderr () =
              (String.lowercase_ascii detail)
              "unrecognized file type"))
 
-(* Validate that malformed ripgrep inputs are rejected before any Docker
-   spawn attempt. When turn_sandbox_factory=None and the Docker image is
-   unconfigured, an unvalidated request would otherwise fail with
-   "docker image is not configured" after trying to prepare the sandbox. *)
+(* Validate that malformed ripgrep --type values are rejected without crossing
+   the execution boundary. Regex/glob validity is owned by the actual rg
+   invocation so Docker keepers do not depend on host rg availability. *)
 let test_docker_keeper_invalid_type_rejects_before_docker_spawn () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground:_ ->
@@ -351,69 +350,6 @@ let test_docker_keeper_invalid_type_rejects_before_docker_spawn () =
       "docker image was not pulled"
       false
       (String_util.contains_substring err "docker image is not configured")
-
-let test_docker_keeper_malformed_regex_rejects_before_docker_spawn () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
-  @@ fun ~base:_ ~config ~meta ~playground:_ ->
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  let raw =
-    Keeper_tool_command_runtime.handle_tool_search_files
-      ~turn_sandbox_factory:None
-      ~exec_cache:None
-      ~config
-      ~meta
-      ~args:
-        (`Assoc
-          [
-            ("op", `String "rg");
-            ("pattern", `String "(");
-            ("path", `String ".");
-          ])
-  in
-  match parse_field raw "error" with
-  | None ->
-    Alcotest.failf "expected error for malformed regex; raw=%s" raw
-  | Some err ->
-    Alcotest.(check bool)
-      "error explains invalid regex"
-      true
-      (String_util.contains_substring err "invalid");
-    Alcotest.(check bool)
-      "docker image was not pulled"
-      false
-      (String_util.contains_substring err "docker image is not configured")
-
-let test_docker_keeper_rust_regex_rejects_before_docker_spawn () =
-  setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
-  @@ fun ~base:_ ~config ~meta ~playground:_ ->
-  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
-  let raw =
-    Keeper_tool_command_runtime.handle_tool_search_files
-      ~turn_sandbox_factory:None
-      ~exec_cache:None
-      ~config
-      ~meta
-      ~args:
-        (`Assoc
-          [
-            ("op", `String "rg");
-            ("pattern", `String "(?=secret)");
-            ("path", `String ".");
-          ])
-  in
-  match parse_field raw "error" with
-  | None ->
-    Alcotest.failf "expected error for non-ripgrep regex; raw=%s" raw
-  | Some err ->
-    Alcotest.(check bool)
-      "error explains invalid ripgrep regex"
-      true
-      (String_util.contains_substring err "invalid ripgrep regex");
-    Alcotest.(check bool)
-      "docker image was not pulled"
-      false
-      (String_util.contains_substring err "docker image is not configured")
-
 let test_docker_keeper_blocks_second_rg_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -625,12 +561,6 @@ let () =
             `Quick test_local_keeper_rg_invalid_type_surfaces_stderr;
           Alcotest.test_case "docker keeper invalid type rejects before docker spawn"
             `Quick test_docker_keeper_invalid_type_rejects_before_docker_spawn;
-          Alcotest.test_case
-            "docker keeper malformed regex rejects before docker spawn"
-            `Quick test_docker_keeper_malformed_regex_rejects_before_docker_spawn;
-          Alcotest.test_case
-            "docker keeper rejects non-ripgrep regex before docker spawn"
-            `Quick test_docker_keeper_rust_regex_rejects_before_docker_spawn;
           Alcotest.test_case "docker keeper blocks second rg outside" `Quick
             test_docker_keeper_blocks_second_rg_outside;
           Alcotest.test_case "docker keeper allows inside playground"

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -383,6 +383,37 @@ let test_docker_keeper_malformed_regex_rejects_before_docker_spawn () =
       false
       (String_util.contains_substring err "docker image is not configured")
 
+let test_docker_keeper_rust_regex_rejects_before_docker_spawn () =
+  setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~base:_ ~config ~meta ~playground:_ ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_search_files
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "rg");
+            ("pattern", `String "(?=secret)");
+            ("path", `String ".");
+          ])
+  in
+  match parse_field raw "error" with
+  | None ->
+    Alcotest.failf "expected error for non-ripgrep regex; raw=%s" raw
+  | Some err ->
+    Alcotest.(check bool)
+      "error explains invalid ripgrep regex"
+      true
+      (String_util.contains_substring err "invalid ripgrep regex");
+    Alcotest.(check bool)
+      "docker image was not pulled"
+      false
+      (String_util.contains_substring err "docker image is not configured")
+
 let test_docker_keeper_blocks_second_rg_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -597,6 +628,9 @@ let () =
           Alcotest.test_case
             "docker keeper malformed regex rejects before docker spawn"
             `Quick test_docker_keeper_malformed_regex_rejects_before_docker_spawn;
+          Alcotest.test_case
+            "docker keeper rejects non-ripgrep regex before docker spawn"
+            `Quick test_docker_keeper_rust_regex_rejects_before_docker_spawn;
           Alcotest.test_case "docker keeper blocks second rg outside" `Quick
             test_docker_keeper_blocks_second_rg_outside;
           Alcotest.test_case "docker keeper allows inside playground"

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -316,6 +316,73 @@ let test_local_keeper_rg_invalid_type_surfaces_stderr () =
              (String.lowercase_ascii detail)
              "unrecognized file type"))
 
+(* Validate that malformed ripgrep inputs are rejected before any Docker
+   spawn attempt. When turn_sandbox_factory=None and the Docker image is
+   unconfigured, an unvalidated request would otherwise fail with
+   "docker image is not configured" after trying to prepare the sandbox. *)
+let test_docker_keeper_invalid_type_rejects_before_docker_spawn () =
+  setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~base:_ ~config ~meta ~playground:_ ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_search_files
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "rg");
+            ("pattern", `String "secret");
+            ("path", `String ".");
+            ("type", `String "ml;cat /etc/passwd");
+          ])
+  in
+  match parse_field raw "error" with
+  | None ->
+    Alcotest.failf "expected error for invalid type; raw=%s" raw
+  | Some err ->
+    Alcotest.(check bool)
+      "error explains invalid type"
+      true
+      (String_util.contains_substring err "invalid");
+    Alcotest.(check bool)
+      "docker image was not pulled"
+      false
+      (String_util.contains_substring err "docker image is not configured")
+
+let test_docker_keeper_malformed_regex_rejects_before_docker_spawn () =
+  setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~base:_ ~config ~meta ~playground:_ ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_search_files
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "rg");
+            ("pattern", `String "(");
+            ("path", `String ".");
+          ])
+  in
+  match parse_field raw "error" with
+  | None ->
+    Alcotest.failf "expected error for malformed regex; raw=%s" raw
+  | Some err ->
+    Alcotest.(check bool)
+      "error explains invalid regex"
+      true
+      (String_util.contains_substring err "invalid");
+    Alcotest.(check bool)
+      "docker image was not pulled"
+      false
+      (String_util.contains_substring err "docker image is not configured")
+
 let test_docker_keeper_blocks_second_rg_outside () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base ~config ~meta ~playground:_ ->
@@ -525,6 +592,11 @@ let () =
           Alcotest.test_case
             "local keeper rg invalid type surfaces stderr to keeper"
             `Quick test_local_keeper_rg_invalid_type_surfaces_stderr;
+          Alcotest.test_case "docker keeper invalid type rejects before docker spawn"
+            `Quick test_docker_keeper_invalid_type_rejects_before_docker_spawn;
+          Alcotest.test_case
+            "docker keeper malformed regex rejects before docker spawn"
+            `Quick test_docker_keeper_malformed_regex_rejects_before_docker_spawn;
           Alcotest.test_case "docker keeper blocks second rg outside" `Quick
             test_docker_keeper_blocks_second_rg_outside;
           Alcotest.test_case "docker keeper allows inside playground"

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -143,6 +143,15 @@ let str_contains s substring =
     in
     loop 0
 
+let json_member keys json =
+  List.fold_left (fun acc key -> Yojson.Safe.Util.member key acc) json keys
+
+let json_string path json =
+  json_member path json |> Yojson.Safe.Util.to_string
+
+let json_bool path json =
+  json_member path json |> Yojson.Safe.Util.to_bool
+
 let str_starts_with ~prefix s =
   let len_s = String.length s in
   let len_prefix = String.length prefix in
@@ -741,9 +750,10 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
   assert (str_contains (Tool_result.message result) "claim");
   (* The output must be a structured workflow rejection so the OAS retry
      ladder treats it as deterministic non-retryable. *)
-  assert (str_contains (Tool_result.message result) "\"failure_class\":\"workflow_rejection\"");
-  assert (str_contains (Tool_result.message result) "\"error_class\":\"deterministic\"");
-  assert (str_contains (Tool_result.message result) "\"recoverable\":false");
+  let rejection_json = Yojson.Safe.from_string (Tool_result.message result) in
+  assert (json_string [ "failure_class" ] rejection_json = "workflow_rejection");
+  assert (json_string [ "error_class" ] rejection_json = "deterministic");
+  assert (not (json_bool [ "recoverable" ] rejection_json));
   let task_entries =
     Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
   in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -739,6 +739,11 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
   assert (str_contains (Tool_result.message result) "todo");
   assert (str_contains (Tool_result.message result) "Valid actions");
   assert (str_contains (Tool_result.message result) "claim");
+  (* The output must be a structured workflow rejection so the OAS retry
+     ladder treats it as deterministic non-retryable. *)
+  assert (str_contains (Tool_result.message result) "\"failure_class\":\"workflow_rejection\"");
+  assert (str_contains (Tool_result.message result) "\"error_class\":\"deterministic\"");
+  assert (str_contains (Tool_result.message result) "\"recoverable\":false");
   let task_entries =
     Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
   in

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -622,6 +622,24 @@ let test_read_recent_lines_skips_malformed_rows () =
       1
       (List.length all_lines))
 
+(* trajectory_summary rows are intentionally written to the same JSONL file at
+   session end; they must not inflate the "malformed JSON or unrecognized
+   shape" skip counter that the dashboard read paths log. *)
+let test_summary_row_not_counted_as_malformed () =
+  let lines =
+    [
+      {|{"ts":1000.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":10,"error":null,"cost_usd":0.0}|}
+    ; {|{"type":"trajectory_summary","keeper_name":"k","trace_id":"t","generation":0,"total_cost_usd":0.0,"total_turns":0,"total_tool_calls":0,"outcome":{"status":"completed"},"task_id":null,"started_at":0.0,"ended_at":0.0}|}
+    ; "{not valid json"
+    ]
+  in
+  let parsed, skipped, total =
+    Trajectory.trajectory_lines_of_jsonl_lines ~trace_id:"t" lines
+  in
+  Alcotest.(check int) "parsed lines (tool call only)" 1 (List.length parsed);
+  Alcotest.(check int) "skipped count counts only malformed" 1 skipped;
+  Alcotest.(check int) "total rows processed" 3 total
+
 let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
   Trajectory.Thinking
     {
@@ -798,6 +816,8 @@ let () =
       Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
       Alcotest.test_case "read_recent_lines/read_all_lines skip malformed rows" `Quick
         test_read_recent_lines_skips_malformed_rows;
+      Alcotest.test_case "summary row not counted as malformed" `Quick
+        test_summary_row_not_counted_as_malformed;
     ]);
     ("keeper_trace", [
       Alcotest.test_case "dedupe_thinking_lines uses structural key" `Quick


### PR DESCRIPTION
## Summary

Fixes a cluster of keeper tool failure patterns observed in `~/.masc/logs/system_log_2026-07-01.jsonl` and `system_log_2026-06-30.jsonl`. The changes either auto-correct deterministic caller mistakes or surface structured error payloads so the LLM/operator can act without retry loops.

## Changes

- **Surface dispatch**: Register `masc_keeper_sandbox_start/stop` in `Keeper_dispatch_ref.dispatch`.
- **In-process runtime**: Preserve `failure_class` in typed tool error JSON.
- **Task transitions**: Return deterministic `workflow_rejection` payload for invalid state transitions.
- **Read repo access**: Return `policy_blocked` structured error when a keeper is denied repository access.
- **Typed Execute**: Auto-correct a leading duplicate `argv[0]` instead of rejecting it.
- **Trajectory**: Stop counting `trajectory_summary` rows as malformed JSON.
- **Docker sandbox**: Add daemon back-pressure/timeout retry and mount host `~/.gitconfig` into containers.
- **Search validation**: Reject invalid ripgrep `--type` values and malformed regexes before spawning Docker.
- **Dashboard telemetry**: Include the actual error body and `failure_class` in `masc_keeper_msg` failure events.
- **Descriptor integrity**: Add `masc_task_set_goal` descriptor and a dispatch-gap test verifying every descriptor is reachable.

## Verification

- `dune build --root . @check` ✅
- Relevant test executables all pass (550+ tests), including:
  - `test_keeper_tool_matrix` (140)
  - `test_tool_task_coverage` (93)
  - `test_keeper_tool_execute_typed_input` (51)
  - `test_trajectory` (39)
  - `test_keeper_sandbox_docker_route` (64)
  - `test_gate_keeper_backend` (97)
  - `test_keeper_tool_descriptor_registry_integrity` (32)

## Notes

- A local HTML progress report is available at `tool-failure-progress-report.html` in the worktree (untracked).
- ~/me root checkout remains on `main`; all work was done in the `fix/tool-failures-2026-07-01` worktree.
