### PR TITLE
fix(config): Memory OS env knob SSOT — typed descriptors, resolve phantom LIBRARIAN_MAX_TOKENS no-op

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,7 +16,7 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 360 unique knobs across 9 modules.
 
-**Typed getter classification**: 45/216 tagged (`operator`: 45, `algorithm`: 0, `unclassified`: 171).
+**Typed getter classification**: 46/217 tagged (`operator`: 46, `algorithm`: 0, `unclassified`: 171).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -85,17 +85,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (86 knobs; typed classification 23/74)
+## Env_config_keeper (87 knobs; typed classification 24/75)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 517 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 841 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 876 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 877 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 878 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 879 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 882 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 545 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 869 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 904 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 905 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 906 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 907 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 910 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 703 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 755 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 731 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 783 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,59 +122,60 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 775 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 347 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 373 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 363 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 383 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 353 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 803 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 375 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 401 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 391 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 411 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 381 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 736 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 470 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 459 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 481 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 795 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 803 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 522 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 596 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 785 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 570 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 830 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 577 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 611 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 618 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 537 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 321 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 331 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 310 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 242 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 254 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 298 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 266 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 286 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 276 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 230 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 764 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 498 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 487 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 509 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 823 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 831 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 550 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 624 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 813 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 598 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 858 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 605 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 639 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 646 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 565 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 349 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 359 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 338 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 258 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 270 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 326 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 282 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 304 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 314 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 292 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 246 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 664 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 813 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 500 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 509 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 588 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 547 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 692 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 841 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 528 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 537 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 616 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 575 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 819 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 712 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 650 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 554 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 420 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 430 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 410 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 531 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 900 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 914 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 847 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 740 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 678 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 582 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 448 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 458 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 438 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 559 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 928 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 942 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -335,14 +336,14 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_SANDBOX_TMPFS_SIZE` | typed:string | unclassified | unclassified | 30 |  |
 | `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 190 |  |
 
-## Env_config_snapshot (83 knobs; typed classification 0/0)
+## Env_config_snapshot (82 knobs; typed classification 0/0)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 689 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 693 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 695 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 692 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 696 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 698 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 228 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 318 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 320 |  |
@@ -351,8 +352,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 282 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 336 |  |
 | `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 338 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 643 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 645 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 646 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 648 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 322 |  |
 | `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 219 |  |
 | `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 218 |  |
@@ -365,8 +366,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 393 |  |
 | `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 395 |  |
 | `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 397 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 797 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 647 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 800 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 650 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
 | `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 211 |  |
 | `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 221 |  |
@@ -379,7 +380,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 170 |  |
 | `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 166 |  |
 | `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 548 |  |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | string_literal | n/a | n/a | 606 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 195 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 191 |  |
 | `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 189 |  |
@@ -396,26 +396,26 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 175 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 174 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 222 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 773 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 809 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 649 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 776 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 812 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 652 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 471 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 819 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 731 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 733 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 735 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 737 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 799 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 753 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 822 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 734 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 736 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 738 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 740 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 802 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 756 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 158 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 54 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 51 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 789 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 791 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 792 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 794 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 160 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 851 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 853 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 855 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 854 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 856 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 858 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 116 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -202,6 +202,22 @@ module KeeperMemoryOs = struct
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
 
+  (* Env-key SSOT: the config-introspection registry
+     (env_config_snapshot.ml memory_entries) and the tests reference these
+     constants instead of re-spelling the literals, so a knob rename breaks
+     compilation instead of silently drifting into a phantom registry entry. *)
+  let recall_env_key = "MASC_KEEPER_MEMORY_OS_RECALL"
+  let librarian_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+  let librarian_cadence_turns_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+  let librarian_max_messages_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+  let librarian_timeout_sec_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+  let librarian_max_tokens_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
+  let librarian_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+  let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+  let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
+  let consolidation_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+  let consolidation_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+
   let optional_string_default value = Option.value value ~default:""
   ;;
 
@@ -227,7 +243,7 @@ module KeeperMemoryOs = struct
   let recall_enabled () =
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
-      "MASC_KEEPER_MEMORY_OS_RECALL"
+      recall_env_key
       ~default:recall_enabled_default
   ;;
 
@@ -239,7 +255,7 @@ module KeeperMemoryOs = struct
   let librarian_enabled () =
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+      librarian_env_key
       ~default:librarian_enabled_default
   ;;
 
@@ -251,7 +267,7 @@ module KeeperMemoryOs = struct
     max
       1
       (get_int_logged
-         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+         librarian_cadence_turns_env_key
          ~default:librarian_cadence_turns_default)
   ;;
 
@@ -263,7 +279,7 @@ module KeeperMemoryOs = struct
     max
       1
       (get_int_logged
-         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+         librarian_max_messages_env_key
          ~default:librarian_max_messages_default)
   ;;
 
@@ -273,8 +289,20 @@ module KeeperMemoryOs = struct
       @ops_class operator *)
   let librarian_timeout_sec () =
     get_float_positive_logged
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+      librarian_timeout_sec_env_key
       ~default:librarian_timeout_sec_default
+  ;;
+
+  (** Output token cap for librarian extraction, applied as min with the
+      provider max_tokens. Default: 4096, floored to 1.
+      @category Runtime
+      @ops_class operator *)
+  let librarian_max_tokens () =
+    max
+      1
+      (get_int_logged
+         librarian_max_tokens_env_key
+         ~default:librarian_max_tokens_default)
   ;;
 
   (** Optional runtime id override for librarian extraction.
@@ -283,7 +311,7 @@ module KeeperMemoryOs = struct
   let librarian_runtime_id () =
     get_string
       ~default:(optional_string_default librarian_runtime_id_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+      librarian_runtime_id_env_key
     |> nonempty_string
   ;;
 
@@ -295,7 +323,7 @@ module KeeperMemoryOs = struct
     max
       0
       (get_int_logged
-         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+         librarian_global_slot_env_key
          ~default:librarian_global_slot_default)
   ;;
 
@@ -307,7 +335,7 @@ module KeeperMemoryOs = struct
   let gc_enabled () =
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
-      "MASC_KEEPER_MEMORY_OS_GC"
+      gc_env_key
       ~default:gc_enabled_default
   ;;
 
@@ -318,7 +346,7 @@ module KeeperMemoryOs = struct
   let consolidation_enabled () =
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
-      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+      consolidation_env_key
       ~default:consolidation_enabled_default
   ;;
 
@@ -328,7 +356,7 @@ module KeeperMemoryOs = struct
   let consolidation_runtime_id () =
     get_string
       ~default:(optional_string_default consolidation_runtime_id_default)
-      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+      consolidation_runtime_id_env_key
     |> nonempty_string
   ;;
 end

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -83,6 +83,22 @@ end
 (** {1 Keeper Memory OS} *)
 
 module KeeperMemoryOs : sig
+  (** Env-var names (SSOT). The config-introspection registry and tests must
+      reference these constants rather than re-spelling the literals, so a
+      knob rename breaks compilation instead of silently drifting. *)
+
+  val recall_env_key : string
+  val librarian_env_key : string
+  val librarian_cadence_turns_env_key : string
+  val librarian_max_messages_env_key : string
+  val librarian_timeout_sec_env_key : string
+  val librarian_max_tokens_env_key : string
+  val librarian_runtime_id_env_key : string
+  val librarian_global_slot_env_key : string
+  val gc_env_key : string
+  val consolidation_env_key : string
+  val consolidation_runtime_id_env_key : string
+
   val recall_enabled_default : bool
   val librarian_enabled_default : bool
   val librarian_cadence_turns_default : int
@@ -104,6 +120,11 @@ module KeeperMemoryOs : sig
   val librarian_cadence_turns : unit -> int
   val librarian_max_messages : unit -> int
   val librarian_timeout_sec : unit -> float
+
+  val librarian_max_tokens : unit -> int
+  (** Output token cap for librarian extraction, applied as min with the
+      provider max_tokens. Default: 4096, floored to 1. *)
+
   val librarian_runtime_id : unit -> string option
   val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -578,55 +578,58 @@ let optional_default_to_display = function
   | Some value -> value
 ;;
 
+(* Env-var names come from Env_config_keeper.KeeperMemoryOs (the reader
+   module), never from re-spelled literals: a registry entry whose env var
+   nothing reads is a silent no-op reported as source=env. *)
 let memory_entries =
   [
     entry
       ~default:(string_of_bool Memory_os_defaults.recall_enabled_default)
-      "MASC_KEEPER_MEMORY_OS_RECALL"
+      Memory_os_defaults.recall_env_key
       "Memory OS recall prompt injection enabled; invalid values fail closed";
     entry
       ~default:(string_of_bool Memory_os_defaults.librarian_enabled_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+      Memory_os_defaults.librarian_env_key
       "Memory OS post-turn librarian extraction enabled; invalid values fail closed";
     entry
       ~default:(string_of_int Memory_os_defaults.librarian_cadence_turns_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+      Memory_os_defaults.librarian_cadence_turns_env_key
       "Turns between librarian extraction attempts per keeper (floor 1)";
     entry
       ~default:(string_of_int Memory_os_defaults.librarian_max_messages_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+      Memory_os_defaults.librarian_max_messages_env_key
       "Recent-message window for librarian extraction (floor 1)";
     entry
       ~default:
         (Memory_os_defaults.float_default_to_display Memory_os_defaults.librarian_timeout_sec_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+      Memory_os_defaults.librarian_timeout_sec_env_key
       "Provider timeout for librarian extraction in seconds";
     entry
       ~default:(string_of_int Memory_os_defaults.librarian_max_tokens_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
-      "Output token cap for librarian extraction (applied as min with provider max_tokens)";
+      Memory_os_defaults.librarian_max_tokens_env_key
+      "Output token cap for librarian extraction (applied as min with provider max_tokens, floor 1)";
     entry
       ~default:
         (optional_default_to_display Memory_os_defaults.librarian_runtime_id_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+      Memory_os_defaults.librarian_runtime_id_env_key
       "Optional runtime id override for librarian extraction; (none) displays the empty default";
     entry
       ~default:(string_of_int Memory_os_defaults.librarian_global_slot_default)
-      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+      Memory_os_defaults.librarian_global_slot_env_key
       "Fleet-wide concurrency gate for librarian provider calls; 0 disables";
     entry
       ~default:(string_of_bool Memory_os_defaults.gc_enabled_default)
-      "MASC_KEEPER_MEMORY_OS_GC"
+      Memory_os_defaults.gc_env_key
       "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";
     entry
       ~default:(string_of_bool Memory_os_defaults.consolidation_enabled_default)
-      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+      Memory_os_defaults.consolidation_env_key
       "Per-keeper Memory OS consolidation maintenance fiber kill switch; invalid values fail closed";
     entry
       ~default:
         (optional_default_to_display
            Memory_os_defaults.consolidation_runtime_id_default)
-      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+      Memory_os_defaults.consolidation_runtime_id_env_key
       "Optional runtime id override for Memory OS consolidation; (none) displays the empty default";
   ]
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -253,12 +253,12 @@ let select_recent_messages ~max_messages messages =
 ;;
 
 let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
-  let librarian_max_tokens = librarian_max_tokens () in
+  let configured_librarian_max_tokens = librarian_max_tokens () in
   let max_tokens =
     match provider_cfg.max_tokens with
-    | Some n when n > 0 -> Some (min n librarian_max_tokens)
-    | Some _ -> Some librarian_max_tokens
-    | None -> Some librarian_max_tokens
+    | Some n when n > 0 -> Some (min n configured_librarian_max_tokens)
+    | Some _ -> Some configured_librarian_max_tokens
+    | None -> Some configured_librarian_max_tokens
   in
   { provider_cfg with
     max_tokens

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -1,13 +1,14 @@
 (** Runtime adapter for Memory OS librarian extraction. *)
 
 (* Cap on the librarian extraction output, applied as
-   [min provider_cfg.max_tokens librarian_max_tokens] at the complete call
+   [min provider_cfg.max_tokens (librarian_max_tokens ())] at the complete call
    (see [extract] below). The previous fixed cap of 1024 truncated episode
    JSON mid-object whenever the summary plus facts exceeded ~1024 output
    tokens, surfacing as "invalid_json: Unexpected end of input" every turn.
    4096 covers realistic episode payloads while staying well under the
-   JSON-capable model context budget; tunable via Env_config.KeeperMemoryOs. *)
-let librarian_max_tokens = Env_config.KeeperMemoryOs.librarian_max_tokens_default
+   JSON-capable model context budget; tunable via
+   [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS] (floor 1). *)
+let librarian_max_tokens () = Env_config.KeeperMemoryOs.librarian_max_tokens ()
 
 (* Memory extraction runs against a JSON-capable model with a long context
    window and is not constrained by the generic inference API budget (30s).
@@ -252,6 +253,7 @@ let select_recent_messages ~max_messages messages =
 ;;
 
 let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
+  let librarian_max_tokens = librarian_max_tokens () in
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some (min n librarian_max_tokens)

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -114,6 +114,10 @@ val messages_for_librarian
 val provider_for_librarian
   :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
+(** Provider config specialized for episode extraction. Caps [max_tokens] at
+    the librarian output budget (default 4096, overridable with
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS], floor 1) and requests the
+    structured episode output schema. *)
 
 val librarian_max_parse_retries : int
 (** Additional provider attempts after an initial unparseable response before

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -740,15 +740,15 @@ let test_librarian_defaults_missing_optional_lists () =
 
 let test_librarian_runtime_override_env () =
   Fun.protect
-    ~finally:(fun () -> Unix.putenv "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" "")
+    ~finally:(fun () -> Unix.putenv Env_config.KeeperMemoryOs.librarian_runtime_id_env_key "")
     (fun () ->
-       Unix.putenv "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID" "";
+       Unix.putenv Env_config.KeeperMemoryOs.librarian_runtime_id_env_key "";
        Alcotest.(check string)
          "empty override falls back"
          "keeper-runtime"
          (Librarian_runtime.runtime_id_for_librarian ~runtime_id:"keeper-runtime");
        Unix.putenv
-         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+         Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
          " runpod_mtp.qwen36-35b-a3b-mtp ";
        Alcotest.(check string)
          "override trims"
@@ -816,32 +816,32 @@ let with_captured_console_lines f =
 ;;
 
 let test_memory_os_bool_env_accepts_enabled_disabled () =
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "disabled" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.recall_env_key "disabled" (fun () ->
     Alcotest.(check bool)
       "disabled disables recall"
       false
       (Env_config.KeeperMemoryOs.recall_enabled ()));
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" " TRUE " (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.recall_env_key " TRUE " (fun () ->
     Alcotest.(check bool)
       "bool parser trims and lowercases true tokens"
       true
       (Env_config.KeeperMemoryOs.recall_enabled ()));
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.recall_env_key "" (fun () ->
     Alcotest.(check bool)
       "blank bool token is treated as unset"
       true
       (Env_config.KeeperMemoryOs.recall_enabled ()));
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN" "disabled" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.librarian_env_key "disabled" (fun () ->
     Alcotest.(check bool)
       "disabled disables librarian"
       false
       (Env_config.KeeperMemoryOs.librarian_enabled ()));
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_GC" "enabled" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.gc_env_key "enabled" (fun () ->
     Alcotest.(check bool)
       "enabled enables GC"
       true
       (Env_config.KeeperMemoryOs.gc_enabled ()));
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATION" "enabled" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.consolidation_env_key "enabled" (fun () ->
     Alcotest.(check bool)
       "enabled enables consolidation"
       true
@@ -856,52 +856,52 @@ let test_memory_os_env_invalid_values_fail_closed_or_default () =
       (List.exists (contains substring) !lines)
   in
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "maybe" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.recall_env_key "maybe" (fun () ->
       Alcotest.(check bool)
         "invalid default-on recall fail-closes to false"
         false
         (Env_config.KeeperMemoryOs.recall_enabled ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_RECALL";
+    check_log_contains lines Env_config.KeeperMemoryOs.recall_env_key;
     check_log_contains lines "fail-closed false");
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN" "maybe" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.librarian_env_key "maybe" (fun () ->
       Alcotest.(check bool)
         "invalid default-on librarian fail-closes to false"
         false
         (Env_config.KeeperMemoryOs.librarian_enabled ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_LIBRARIAN";
+    check_log_contains lines Env_config.KeeperMemoryOs.librarian_env_key;
     check_log_contains lines "fail-closed false");
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_GC" "maybe" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.gc_env_key "maybe" (fun () ->
       Alcotest.(check bool)
         "invalid GC flag fail-closes"
         false
         (Env_config.KeeperMemoryOs.gc_enabled ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_GC";
+    check_log_contains lines Env_config.KeeperMemoryOs.gc_env_key;
     check_log_contains lines "fail-closed false");
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_CONSOLIDATION" "maybe" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.consolidation_env_key "maybe" (fun () ->
       Alcotest.(check bool)
         "invalid consolidation flag fail-closes"
         false
         (Env_config.KeeperMemoryOs.consolidation_enabled ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_CONSOLIDATION";
+    check_log_contains lines Env_config.KeeperMemoryOs.consolidation_env_key;
     check_log_contains lines "fail-closed false");
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES" "bogus" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.librarian_max_messages_env_key "bogus" (fun () ->
       Alcotest.(check int)
         "invalid max messages falls back"
         24
         (Env_config.KeeperMemoryOs.librarian_max_messages ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES";
+    check_log_contains lines Env_config.KeeperMemoryOs.librarian_max_messages_env_key;
     check_log_contains lines "using default");
   with_captured_console_lines (fun lines ->
-    with_memory_os_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" "nan" (fun () ->
+    with_memory_os_env Env_config.KeeperMemoryOs.librarian_timeout_sec_env_key "nan" (fun () ->
       Alcotest.(check (float 0.001))
         "invalid timeout falls back"
         600.0
         (Env_config.KeeperMemoryOs.librarian_timeout_sec ()));
-    check_log_contains lines "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC";
+    check_log_contains lines Env_config.KeeperMemoryOs.librarian_timeout_sec_env_key;
     check_log_contains lines "using default")
 ;;
 
@@ -946,34 +946,94 @@ let find_config_env env entries =
   | None -> Alcotest.failf "config entry %s missing" env
 ;;
 
+(* Introspection-parity SSOT rows: one row per Memory OS knob pairing the
+   exported env-key constant with a thunk exercising its compiled reader. A
+   snapshot registry entry cannot be added to this list without a reader
+   existing (the phantom MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS
+   regression: registered + tested, zero readers, so setting it was a silent
+   no-op reported as source=env). *)
+let memory_os_knob_readers : (string * (unit -> unit)) list =
+  [ ( Env_config.KeeperMemoryOs.recall_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.recall_enabled () : bool) )
+  ; ( Env_config.KeeperMemoryOs.librarian_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_enabled () : bool) )
+  ; ( Env_config.KeeperMemoryOs.librarian_cadence_turns_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_cadence_turns () : int) )
+  ; ( Env_config.KeeperMemoryOs.librarian_max_messages_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_max_messages () : int) )
+  ; ( Env_config.KeeperMemoryOs.librarian_timeout_sec_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_timeout_sec () : float) )
+  ; ( Env_config.KeeperMemoryOs.librarian_max_tokens_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_max_tokens () : int) )
+  ; ( Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
+    , fun () ->
+        ignore (Env_config.KeeperMemoryOs.librarian_runtime_id () : string option) )
+  ; ( Env_config.KeeperMemoryOs.librarian_global_slot_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_global_slot () : int) )
+  ; ( Env_config.KeeperMemoryOs.gc_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.gc_enabled () : bool) )
+  ; ( Env_config.KeeperMemoryOs.consolidation_env_key
+    , fun () -> ignore (Env_config.KeeperMemoryOs.consolidation_enabled () : bool) )
+  ; ( Env_config.KeeperMemoryOs.consolidation_runtime_id_env_key
+    , fun () ->
+        ignore (Env_config.KeeperMemoryOs.consolidation_runtime_id () : string option)
+    )
+  ]
+;;
+
+let memory_os_env_namespace = "MASC_KEEPER_MEMORY_OS_"
+
+let test_memory_os_snapshot_registry_parity () =
+  let reader_names = List.map fst memory_os_knob_readers in
+  (* Guard the namespace literal against renames: every reader key must live
+     under it, otherwise the registry->reader sweep below goes vacuous. *)
+  List.iter
+    (fun name ->
+       Alcotest.(check bool)
+         (name ^ " under Memory OS namespace")
+         true
+         (String.starts_with ~prefix:memory_os_env_namespace name))
+    reader_names;
+  let entries = storage_config_entries () in
+  let names = List.map (string_field "config entry" "env") entries in
+  (* Reader -> registry: every knob with a compiled reader is surfaced. *)
+  List.iter
+    (fun (env_key, exercise_reader) ->
+       exercise_reader ();
+       Alcotest.(check bool)
+         (env_key ^ " registered in snapshot")
+         true
+         (List.mem env_key names))
+    memory_os_knob_readers;
+  (* Registry -> reader: no Memory OS entry without a compiled reader. *)
+  List.iter
+    (fun name ->
+       if String.starts_with ~prefix:memory_os_env_namespace name
+       then
+         Alcotest.(check bool)
+           (name ^ " has a compiled reader")
+           true
+           (List.mem name reader_names))
+    names
+;;
+
 let test_memory_os_config_snapshot_surfaces_effective_envs () =
-  let timeout_env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
+  let timeout_env = Env_config.KeeperMemoryOs.librarian_timeout_sec_env_key in
   let timeout_default =
     Env_config.KeeperMemoryOs.float_default_to_display
       Env_config.KeeperMemoryOs.librarian_timeout_sec_default
   in
-  with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "" (fun () ->
+  with_memory_os_env Env_config.KeeperMemoryOs.recall_env_key "" (fun () ->
     with_memory_os_env timeout_env "123.5" (fun () ->
       let entries = storage_config_entries () in
       let names = List.map (string_field "config entry" "env") entries in
       List.iter
-        (fun expected ->
+        (fun (expected, _) ->
            Alcotest.(check bool)
              (expected ^ " surfaced")
              true
              (List.mem expected names))
-        [ "MASC_KEEPER_MEMORY_OS_RECALL"
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
-        ; timeout_env
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
-        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
-        ; "MASC_KEEPER_MEMORY_OS_GC"
-        ; "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
-        ; "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
-        ];
+        memory_os_knob_readers;
       let timeout = find_config_env timeout_env entries in
       Alcotest.(check string)
         "timeout snapshot source"
@@ -987,7 +1047,7 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
         "timeout snapshot default"
         timeout_default
         (string_field "timeout entry" "default" timeout);
-      let recall = find_config_env "MASC_KEEPER_MEMORY_OS_RECALL" entries in
+      let recall = find_config_env Env_config.KeeperMemoryOs.recall_env_key entries in
       Alcotest.(check string)
         "blank recall env falls back to default source"
         "default"
@@ -1021,7 +1081,7 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
 ;;
 
 let test_librarian_timeout_override_env () =
-  let env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
+  let env = Env_config.KeeperMemoryOs.librarian_timeout_sec_env_key in
   Fun.protect
     ~finally:(fun () -> Unix.putenv env "")
     (fun () ->
@@ -1041,6 +1101,41 @@ let test_librarian_timeout_override_env () =
          "invalid timeout override falls back"
          default
          (Librarian_runtime.default_timeout_sec ()))
+;;
+
+let test_librarian_max_tokens_override_env () =
+  let env = Env_config.KeeperMemoryOs.librarian_max_tokens_env_key in
+  let default = Env_config.KeeperMemoryOs.librarian_max_tokens_default in
+  (* Exercise the cap through [provider_for_librarian] (the consuming site):
+     before the knob was wired to a reader, setting the env var was a silent
+     no-op while the config snapshot reported source=env. *)
+  let effective_cap () =
+    (Librarian_runtime.provider_for_librarian (test_provider_cfg ()))
+      .Llm_provider.Provider_config.max_tokens
+  in
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv env "")
+    (fun () ->
+       Unix.putenv env "";
+       Alcotest.(check (option int))
+         "empty max tokens override falls back"
+         (Some default)
+         (effective_cap ());
+       Unix.putenv env "512";
+       Alcotest.(check (option int))
+         "max tokens override caps the librarian provider config"
+         (Some 512)
+         (effective_cap ());
+       Unix.putenv env "0";
+       Alcotest.(check int)
+         "non-positive max tokens override floors at 1"
+         1
+         (Env_config.KeeperMemoryOs.librarian_max_tokens ());
+       Unix.putenv env "bogus";
+       Alcotest.(check (option int))
+         "invalid max tokens override falls back"
+         (Some default)
+         (effective_cap ()))
 ;;
 
 let test_librarian_preserves_admission_memory_text () =
@@ -2256,7 +2351,7 @@ let test_recall_context_empty_without_memory () =
    keeper_run_tools_hooks. Env reads are live (Env_config_core uses
    Unix.getenv), so putenv steers the flag per test. *)
 let with_recall_env value f =
-  let var = "MASC_KEEPER_MEMORY_OS_RECALL" in
+  let var = Env_config.KeeperMemoryOs.recall_env_key in
   let old = Sys.getenv_opt var in
   Unix.putenv var value;
   Fun.protect ~finally:(fun () -> restore_env var old) f
@@ -3816,7 +3911,7 @@ let test_recall_waits_for_shared_fact_lock () =
             | None -> Alcotest.fail "expected recall block")))))
 ;;
 let test_librarian_provider_slot_gate_caps_at_capacity () =
-  with_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" "1" (fun () ->
+  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
     with_eio (fun ~sw ~net:_ ~clock ->
       (* Capacity 1: while one entrant holds the slot, a concurrent entrant drops
          ([None]) after [provider_slot_wait_sec] instead of blocking — the #21230
@@ -3851,7 +3946,7 @@ let test_librarian_provider_slot_gate_caps_at_capacity () =
 ;;
 
 let test_librarian_provider_slot_gate_disabled_at_zero () =
-  with_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" "0" (fun () ->
+  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "0" (fun () ->
     with_eio (fun ~sw ~net:_ ~clock ->
       (* Capacity 0 disables the gate: a held slot does not cap a concurrent
          entrant — both run ([Some]). *)
@@ -3885,7 +3980,7 @@ let test_librarian_provider_slot_gate_disabled_at_zero () =
 ;;
 
 let test_librarian_provider_slot_gate_is_per_keeper () =
-  with_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" "1" (fun () ->
+  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
     with_eio (fun ~sw ~net:_ ~clock ->
       (* Capacity 1 is per keeper: a slot held by keeper-a must not block
          keeper-b. This is the P0-4 isolation contract. *)
@@ -5302,9 +5397,17 @@ let () =
             `Quick
             test_memory_os_config_snapshot_surfaces_effective_envs
         ; Alcotest.test_case
+            "memory os snapshot registry parity with compiled readers"
+            `Quick
+            test_memory_os_snapshot_registry_parity
+        ; Alcotest.test_case
             "librarian timeout override env"
             `Quick
             test_librarian_timeout_override_env
+        ; Alcotest.test_case
+            "librarian max tokens override env"
+            `Quick
+            test_librarian_max_tokens_override_env
         ; Alcotest.test_case
             "librarian preserves admission memory text"
             `Quick


### PR DESCRIPTION
## 문제

원 보고서: 03-resilience-48h-spec / masc-memory-env-knobs-duplicated (adversarial triage problem-13, P2).

Memory OS env knob 이름이 세 곳에 독립 리터럴로 3중 복제되어 있었다.

1. `lib/config/env_config_keeper.ml` `KeeperMemoryOs` getter (동작 reader)
2. `lib/config/env_config_snapshot.ml` `memory_entries` (config introspection registry)
3. `test/test_keeper_memory_os.ml` 기대값 리스트

이 복제는 이미 phantom knob 하나를 실체화했다. `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS`는 snapshot registry와 테스트에는 등록되어 있으나 reader가 0개다. 운영자가 이 변수를 설정하면 snapshot은 `source=env`로 보고하지만 실제 동작은 아무것도 바뀌지 않는 silent no-op이며, `keeper_librarian_runtime.ml`의 주석은 "tunable via Env_config.KeeperMemoryOs"라고 사실과 다르게 기술하고 있었다 (PR #22508에서 도입).

## 적대적 검증 근거

base `4f4cde04a48`에서 재검증 완료.

- `lib/config/env_config_keeper.ml:230,242,254,266,276,286,298,310,321,331` — getter가 env 이름을 리터럴로 직접 사용. `env_config_keeper.mli`에는 `*_env_key` 상수 export 0건.
- `lib/config/env_config_snapshot.ml:585-629` — `memory_entries`가 동일한 10개 이름을 독립 리터럴로 재기술. 같은 파일의 다른 카테고리(`env_config_snapshot.ml:12-19`)는 `Env_config_core.http_port_env_key` 등 상수 참조 관습을 이미 사용 중 — Memory OS에만 미적용.
- phantom knob: `lib/config/env_config_snapshot.ml:604-607` + `test/test_keeper_memory_os.ml:970`에 `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` 등록, reader는 repo 전체에서 0건 (`rg "LIBRARIAN_MAX_TOKENS"` 결과: snapshot 1곳 + test 1곳뿐).
- `lib/keeper/keeper_librarian_runtime.ml:10` — `let librarian_max_tokens = Env_config.KeeperMemoryOs.librarian_max_tokens_default` (컴파일 타임 상수 바인딩) + env 튜너블이라는 거짓 주석.
- `test/test_keeper_memory_os.ml:966-976` — 이름 리터럴 3번째 사본.

env-name drift로 인한 silent no-op은 이 workspace에서 반복 관측된 agent-PR 안티패턴이다 (open PR #22974가 동일 계열 노출 사례).

## 근본 수정

정의 지점(reader 모듈)을 이름의 SSOT로 만든다.

1. `Env_config_keeper.KeeperMemoryOs`에 knob당 `*_env_key : string` 상수 11개를 export하고, getter가 이 상수를 사용하도록 변경. `.mli` 동기화.
2. `env_config_snapshot.ml` `memory_entries`가 리터럴 대신 `Memory_os_defaults.*_env_key` 상수를 참조 — 이름 rename 시 silent drift 대신 컴파일 에러.
3. phantom knob을 root에서 해소: `librarian_max_tokens` getter를 실제로 배선 (`get_int_logged`, floor 1 — sibling knob과 동일 계약)하고 `Keeper_librarian_runtime.provider_for_librarian`이 호출 시점마다 읽도록 변경 (KeeperMemoryOs 모듈 계약: 함수 reader, 모듈 로드 상수 금지). 거짓 주석을 실제 동작으로 교정.
4. 테스트의 이름 리터럴 사본을 전부 상수 참조로 교체.

workaround 시그니처 self-check: telemetry-as-fix 아님(실제 reader 배선), string 분류기 추가 아님(closed 상수로 리터럴 제거), N-of-M 아님(3사본 전부 + knob 11개 전부 단일 PR에서 통합), catch-all 추가 없음.

## 테스트

`test/test_keeper_memory_os.ml`에 추가:

- `test_memory_os_snapshot_registry_parity` (introspection-parity): knob마다 (env_key 상수, reader 실행 thunk) 쌍을 컴파일 타임에 강제하는 `memory_os_knob_readers` 리스트를 두고 양방향 검증 — (a) reader가 있는 모든 knob은 snapshot에 노출, (b) snapshot의 Memory OS namespace 항목은 전부 compiled reader 보유. namespace 리터럴 자체도 reader key 전수와 대조해 vacuous화 방지. pre-fix 코드에서는 `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS`에 reader가 없어 (b)가 실패한다.
- `test_librarian_max_tokens_override_env`: env 설정이 소비 지점(`provider_for_librarian`)까지 실제로 반영되는지 검증 — `512` override 시 provider max_tokens cap이 512 (pre-fix에서는 4096으로 실패), `0`은 floor 1, invalid는 default 4096 fallback.
- 기존 `test_memory_os_config_snapshot_surfaces_effective_envs`의 리터럴 기대값 리스트를 SSOT 상수 기반 parity 리스트로 교체.

## 검증

로컬 dune 미실행 — 이 repo는 CI가 빌드/테스트 authority이며 worktree에서의 dune@fmt는 dune 파일을 오염시킨다. 변경 파일 6개는 `ocamlc -stop-after parsing`으로 구문 검증 완료 (scratch 사본). `.ocamlformat`은 repo-wide `disable = true` 상태라 포맷 적용은 pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
