### PR TITLE
fix(fusion): harden panel JSON parsing and propagate SO capability overrides

### DIFF
--- a/lib/fusion/fusion_config_loader.ml
+++ b/lib/fusion/fusion_config_loader.ml
@@ -13,6 +13,46 @@ let runtime_toml_path ~base_path : string =
     resolution.Config_dir_resolver.config_root.Config_dir_resolver.path
     Config_dir_resolver.runtime_toml_filename
 
+let runtime_id_of_model_in_preset model_id = model_id
+
+let model_declares_structured_output (cfg : Runtime_schema.config) runtime_id :
+  (unit, string) result =
+  match
+    List.find_opt
+      (fun (b : Runtime_schema.binding) -> String.equal (Runtime_schema.binding_key b) runtime_id)
+      cfg.bindings
+  with
+  | None -> Error (Printf.sprintf "runtime %S not found" runtime_id)
+  | Some binding ->
+    (match Runtime_schema.model_of_id cfg binding.Runtime_schema.model_id with
+     | None -> Error (Printf.sprintf "model for runtime %S not found" runtime_id)
+     | Some spec ->
+       (match spec.Runtime_schema.capabilities with
+        | Some caps when caps.Runtime_schema.supports_structured_output -> Ok ()
+        | _ ->
+          Error
+            (Printf.sprintf
+               "runtime %S uses model %S, which does not declare supports-structured-output"
+               runtime_id
+               spec.Runtime_schema.id)))
+
+let validate_preset_structured_output cfg (preset : Fusion_policy.Validated_preset.t) :
+  (unit, string) result =
+  let p = Fusion_policy.Validated_preset.preset preset in
+  let panel_runtime_ids =
+    List.concat_map (fun (g : Fusion_policy.panel_group) -> g.models) p.panels
+  in
+  let judge_runtime_ids = p.judge :: List.map (fun (j : Fusion_policy.judge_spec) -> j.jmodel) p.judges in
+  let runtime_ids = panel_runtime_ids @ judge_runtime_ids in
+  List.fold_left
+    (fun acc id ->
+       match acc with
+       | Error _ -> acc
+       | Ok () ->
+         if String.equal id "" then Ok () else model_declares_structured_output cfg id)
+    (Ok ())
+    runtime_ids
+
 let load ~base_path : (Fusion_policy.t, string) result =
   let path = runtime_toml_path ~base_path in
   if not (Sys.file_exists path) then Ok Fusion_config.disabled
@@ -23,9 +63,31 @@ let load ~base_path : (Fusion_policy.t, string) result =
     | exception Sys_error msg -> Error (Printf.sprintf "runtime.toml read error: %s" msg)
     | toml ->
       (match Fusion_config.of_toml toml with
-       | Ok policy -> Ok policy
        | Error errs ->
          Error
            (Printf.sprintf
               "fusion config invalid: %s"
-              (String.concat "; " (List.map Fusion_config.show_config_error errs))))
+              (String.concat "; " (List.map Fusion_config.show_config_error errs)))
+       | Ok policy ->
+         if not policy.Fusion_policy.enabled
+         then Ok policy
+         else (
+           match Runtime_toml.parse_file path with
+           | Error errs ->
+             Error
+               (Printf.sprintf
+                  "runtime.toml parse error: %s"
+                  (String.concat "; " (List.map Runtime_toml.show_parse_error errs)))
+           | Ok cfg ->
+             let presets = policy.Fusion_policy.presets in
+             (match
+                List.fold_left
+                  (fun acc preset ->
+                     match acc with
+                     | Error _ -> acc
+                     | Ok () -> validate_preset_structured_output cfg preset)
+                  (Ok ())
+                  presets
+              with
+              | Error msg -> Error (Printf.sprintf "fusion preset invalid: %s" msg)
+              | Ok () -> Ok policy)))

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -11,6 +11,76 @@
    attribution(`Provider '...'` 슬롯)에는 raw [model]만 쓴다 — panelist(예
    "skeptic (claude)")는 실제 provider id가 아니므로 그 슬롯에 새면 provider 집계/로그
    디버깅이 오염된다 (RFC-0278 §2.4, 정체성·routable model 비압축 원칙). *)
+
+(* --- Response normalisation: providers that accept json_schema may still wrap
+   the JSON in markdown fences or leading prose. Strip fences and, if necessary,
+   extract the first well-formed JSON object before applying the panel schema.
+   This keeps the contract strict (still requires { "answer": string }) while
+   avoiding false failures for cosmetic wrapping. *)
+
+let fence_marker = "```"
+let fence_marker_len = String.length fence_marker
+
+let strip_fences (s : string) : string =
+  let s = String.trim s in
+  if String.length s >= fence_marker_len
+     && String.equal (String.sub s 0 fence_marker_len) fence_marker
+  then (
+    match String.index_opt s '\n' with
+    | None -> s
+    | Some nl ->
+      let body = String.trim (String.sub s (nl + 1) (String.length s - nl - 1)) in
+      if String.length body >= fence_marker_len
+         && String.equal
+              (String.sub body (String.length body - fence_marker_len) fence_marker_len)
+              fence_marker
+      then String.trim (String.sub body 0 (String.length body - fence_marker_len))
+      else body)
+  else s
+;;
+
+let rec index_of_json_start (s : string) (i : int) : int option =
+  if i >= String.length s then None
+  else if s.[i] = '{' then Some i
+  else index_of_json_start s (i + 1)
+;;
+
+let extract_first_json_object (s : string) : string option =
+  let len = String.length s in
+  let rec scan_from i =
+    match index_of_json_start s i with
+    | None -> None
+    | Some start ->
+      let rec scan_end j =
+        if j > len
+        then None
+        else (
+          let candidate = String.sub s start (j - start) in
+          match Yojson.Safe.from_string candidate with
+          | `Assoc _ -> Some candidate
+          | _ | exception Yojson.Json_error _ -> scan_end (j + 1))
+      in
+      match scan_end (start + 1) with
+      | Some _ as found -> found
+      | None -> scan_from (start + 1)
+  in
+  scan_from 0
+;;
+
+let parse_json_response raw :
+  (Yojson.Safe.t, string) result =
+  let stripped = strip_fences raw in
+  match Yojson.Safe.from_string stripped with
+  | json -> Ok json
+  | exception Yojson.Json_error first_msg ->
+    (match extract_first_json_object stripped with
+     | Some fragment ->
+       (match Yojson.Safe.from_string fragment with
+        | json -> Ok json
+        | exception Yojson.Json_error _ -> Error first_msg)
+     | None -> Error first_msg)
+;;
+
 let outcome_of_result ~(panelist : string) ~(model : string)
     (res : (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result)
   : Fusion_types.panel_outcome
@@ -24,15 +94,13 @@ let outcome_of_result ~(panelist : string) ~(model : string)
         ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
         }
     else (
-      match Yojson.Safe.from_string raw with
-      | exception Yojson.Json_error msg ->
+      match parse_json_response raw with
+      | Error msg ->
         Fusion_types.Failed
           { failed_model = panelist
-          ; reason =
-              Fusion_types.Invalid_structured_response
-                ("panel response is not valid JSON: " ^ msg)
+          ; reason = Fusion_types.Invalid_structured_response ("panel response is not valid JSON: " ^ msg)
           }
-      | `Assoc fields ->
+      | Ok (`Assoc fields) ->
         (match List.assoc_opt "answer" fields with
          | Some (`String answer) ->
            let answer = String.trim answer in
@@ -59,7 +127,7 @@ let outcome_of_result ~(panelist : string) ~(model : string)
                  Fusion_types.Invalid_structured_response
                    "panel response missing required field \"answer\""
              })
-      | _ ->
+      | Ok _ ->
         Fusion_types.Failed
           { failed_model = panelist
           ; reason =

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -13,10 +13,9 @@
    디버깅이 오염된다 (RFC-0278 §2.4, 정체성·routable model 비압축 원칙). *)
 
 (* --- Response normalisation: providers that accept json_schema may still wrap
-   the JSON in markdown fences or leading prose. Strip fences and, if necessary,
-   extract the first well-formed JSON object before applying the panel schema.
-   This keeps the contract strict (still requires { "answer": string }) while
-   avoiding false failures for cosmetic wrapping. *)
+   the JSON in one complete markdown fence. Keep recovery deterministic: exact
+   JSON after trim or one full fence only. Arbitrary prose recovery would weaken
+   the schema boundary by letting an example/debug object win over the answer. *)
 
 let fence_marker = "```"
 let fence_marker_len = String.length fence_marker
@@ -35,36 +34,8 @@ let strip_fences (s : string) : string =
               (String.sub body (String.length body - fence_marker_len) fence_marker_len)
               fence_marker
       then String.trim (String.sub body 0 (String.length body - fence_marker_len))
-      else body)
+      else s)
   else s
-;;
-
-let rec index_of_json_start (s : string) (i : int) : int option =
-  if i >= String.length s then None
-  else if s.[i] = '{' then Some i
-  else index_of_json_start s (i + 1)
-;;
-
-let extract_first_json_object (s : string) : string option =
-  let len = String.length s in
-  let rec scan_from i =
-    match index_of_json_start s i with
-    | None -> None
-    | Some start ->
-      let rec scan_end j =
-        if j > len
-        then None
-        else (
-          let candidate = String.sub s start (j - start) in
-          match Yojson.Safe.from_string candidate with
-          | `Assoc _ -> Some candidate
-          | _ | exception Yojson.Json_error _ -> scan_end (j + 1))
-      in
-      match scan_end (start + 1) with
-      | Some _ as found -> found
-      | None -> scan_from (start + 1)
-  in
-  scan_from 0
 ;;
 
 let parse_json_response raw :
@@ -72,13 +43,7 @@ let parse_json_response raw :
   let stripped = strip_fences raw in
   match Yojson.Safe.from_string stripped with
   | json -> Ok json
-  | exception Yojson.Json_error first_msg ->
-    (match extract_first_json_object stripped with
-     | Some fragment ->
-       (match Yojson.Safe.from_string fragment with
-        | json -> Ok json
-        | exception Yojson.Json_error _ -> Error first_msg)
-     | None -> Error first_msg)
+  | exception Yojson.Json_error msg -> Error msg
 ;;
 
 let outcome_of_result ~(panelist : string) ~(model : string)

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -235,6 +235,48 @@ let max_output_tokens_of_model_spec (spec : Runtime_schema.model_spec) =
   | None -> None
 ;;
 
+(** Project MASC runtime.toml [models.<id>.capabilities] into OAS provider
+    capabilities. Runtime declarations are the SSOT for verified endpoint/model
+    contracts; missing fields keep OAS defaults so the override is partial. *)
+let model_capabilities_override_of_model_spec (spec : Runtime_schema.model_spec)
+  : Llm_provider.Capabilities.capabilities option
+  =
+  match spec.capabilities with
+  | None -> None
+  | Some caps ->
+    let open Llm_provider.Capabilities in
+    let default = default_capabilities in
+    Some
+      { default with
+        max_output_tokens = caps.max_output_tokens
+      ; supports_tool_choice = caps.supports_tool_choice
+      ; supports_extended_thinking = caps.supports_extended_thinking
+      ; supports_reasoning_budget = caps.supports_reasoning_budget
+      ; thinking_control_format = caps.thinking_control_format
+      ; supports_image_input = caps.supports_image_input
+      ; supports_audio_input = caps.supports_audio_input
+      ; supports_video_input = caps.supports_video_input
+      ; supports_multimodal_inputs = caps.supports_multimodal_inputs
+      ; supports_response_format_json = caps.supports_response_format_json
+      ; supports_structured_output = caps.supports_structured_output
+      ; supports_native_streaming = caps.supports_native_streaming
+      ; supports_caching = caps.supports_caching
+      ; supports_prompt_caching = caps.supports_prompt_caching
+      ; prompt_cache_alignment = caps.prompt_cache_alignment
+      ; supports_top_k = caps.supports_top_k
+      ; supports_min_p = caps.supports_min_p
+      ; supports_seed = caps.supports_seed
+      ; emits_usage_tokens = caps.emits_usage_tokens
+      ; supports_computer_use = caps.supports_computer_use
+      }
+;;
+
+let supports_structured_output_override_of_model_spec (spec : Runtime_schema.model_spec) =
+  match spec.capabilities with
+  | Some capabilities -> Some capabilities.supports_structured_output
+  | None -> None
+;;
+
 let effective_max_tokens_for_model spec requested =
   match requested, max_output_tokens_of_model_spec spec with
   | Some configured, Some capability -> Some (min configured capability)
@@ -253,6 +295,10 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
     ~(max_tokens : int option) : Llm_provider.Provider_config.t option =
   let registry_entry = find_registry_entry provider.id in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
+  let model_capabilities_override = model_capabilities_override_of_model_spec spec in
+  let supports_structured_output_override =
+    supports_structured_output_override_of_model_spec spec
+  in
   let max_tokens = effective_max_tokens_for_model spec max_tokens in
   match provider.transport with
   | Http base_url ->
@@ -290,6 +336,8 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~request_path
             ~max_context:spec.max_context
             ?supports_tool_choice_override
+            ?model_capabilities_override
+            ?supports_structured_output_override
             ?max_tokens
             ?keep_alive
             ?num_ctx
@@ -308,6 +356,8 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~headers:(Option.value ~default:[] provider.headers)
             ~max_context:spec.max_context
             ?supports_tool_choice_override
+            ?model_capabilities_override
+            ?supports_structured_output_override
             ?max_tokens
             ?keep_alive
             ?num_ctx

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -235,42 +235,6 @@ let max_output_tokens_of_model_spec (spec : Runtime_schema.model_spec) =
   | None -> None
 ;;
 
-(** Project MASC runtime.toml [models.<id>.capabilities] into OAS provider
-    capabilities. Runtime declarations are the SSOT for verified endpoint/model
-    contracts; missing fields keep OAS defaults so the override is partial. *)
-let model_capabilities_override_of_model_spec (spec : Runtime_schema.model_spec)
-  : Llm_provider.Capabilities.capabilities option
-  =
-  match spec.capabilities with
-  | None -> None
-  | Some caps ->
-    let open Llm_provider.Capabilities in
-    let default = default_capabilities in
-    Some
-      { default with
-        max_output_tokens = caps.max_output_tokens
-      ; supports_tool_choice = caps.supports_tool_choice
-      ; supports_extended_thinking = caps.supports_extended_thinking
-      ; supports_reasoning_budget = caps.supports_reasoning_budget
-      ; thinking_control_format = caps.thinking_control_format
-      ; supports_image_input = caps.supports_image_input
-      ; supports_audio_input = caps.supports_audio_input
-      ; supports_video_input = caps.supports_video_input
-      ; supports_multimodal_inputs = caps.supports_multimodal_inputs
-      ; supports_response_format_json = caps.supports_response_format_json
-      ; supports_structured_output = caps.supports_structured_output
-      ; supports_native_streaming = caps.supports_native_streaming
-      ; supports_caching = caps.supports_caching
-      ; supports_prompt_caching = caps.supports_prompt_caching
-      ; prompt_cache_alignment = caps.prompt_cache_alignment
-      ; supports_top_k = caps.supports_top_k
-      ; supports_min_p = caps.supports_min_p
-      ; supports_seed = caps.supports_seed
-      ; emits_usage_tokens = caps.emits_usage_tokens
-      ; supports_computer_use = caps.supports_computer_use
-      }
-;;
-
 let supports_structured_output_override_of_model_spec (spec : Runtime_schema.model_spec) =
   match spec.capabilities with
   | Some capabilities -> Some capabilities.supports_structured_output
@@ -295,7 +259,6 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
     ~(max_tokens : int option) : Llm_provider.Provider_config.t option =
   let registry_entry = find_registry_entry provider.id in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
-  let model_capabilities_override = model_capabilities_override_of_model_spec spec in
   let supports_structured_output_override =
     supports_structured_output_override_of_model_spec spec
   in
@@ -336,7 +299,6 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~request_path
             ~max_context:spec.max_context
             ?supports_tool_choice_override
-            ?model_capabilities_override
             ?supports_structured_output_override
             ?max_tokens
             ?keep_alive
@@ -356,7 +318,6 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~headers:(Option.value ~default:[] provider.headers)
             ~max_context:spec.max_context
             ?supports_tool_choice_override
-            ?model_capabilities_override
             ?supports_structured_output_override
             ?max_tokens
             ?keep_alive

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -173,6 +173,47 @@ let test_panel_outcome_rejects_empty_answer () =
       ("expected empty structured answer failure, got: "
        ^ Fusion_types.show_panel_outcome other)
 
+let test_panel_outcome_strips_fenced_json () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "```json\n{\"answer\":\"fenced\"}\n```"))
+  with
+  | Fusion_types.Answered { model; answer; _ } ->
+    check string "panel identity preserved" "panel-a" model;
+    check string "fenced JSON answer parsed" "fenced" answer
+  | Fusion_types.Failed failure ->
+    fail ("expected fenced JSON answer, got failure: " ^ Fusion_types.show_panel_error failure)
+
+let test_panel_outcome_extracts_json_from_prose () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "Some prose before {\"answer\":\"embedded\"} more prose"))
+  with
+  | Fusion_types.Answered { model; answer; _ } ->
+    check string "panel identity preserved" "panel-a" model;
+    check string "embedded JSON answer parsed" "embedded" answer
+  | Fusion_types.Failed failure ->
+    fail
+      ("expected embedded JSON answer, got failure: " ^ Fusion_types.show_panel_error failure)
+
+let test_panel_outcome_rejects_json_without_answer_field () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"not_answer":"x"}|}))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "missing answer field detail" true
+      (String_util.string_contains_substring ~needle:"missing required field" detail)
+  | other ->
+    fail
+      ("expected missing answer field failure, got: " ^ Fusion_types.show_panel_outcome other)
+
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
   | Ok (_synthesis, usage) ->
@@ -283,6 +324,11 @@ let () =
             test_panel_outcome_rejects_invalid_structured_answer
         ; test_case "rejects empty answer" `Quick
             test_panel_outcome_rejects_empty_answer
+        ; test_case "strips fenced JSON" `Quick test_panel_outcome_strips_fenced_json
+        ; test_case "extracts JSON from prose" `Quick
+            test_panel_outcome_extracts_json_from_prose
+        ; test_case "rejects JSON without answer field" `Quick
+            test_panel_outcome_rejects_json_without_answer_field
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -185,18 +185,53 @@ let test_panel_outcome_strips_fenced_json () =
   | Fusion_types.Failed failure ->
     fail ("expected fenced JSON answer, got failure: " ^ Fusion_types.show_panel_error failure)
 
-let test_panel_outcome_extracts_json_from_prose () =
+let check_panel_invalid_structured_response ~name raw =
   match
     Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
       ~model:"provider.model"
-      (Ok (response_with_text "Some prose before {\"answer\":\"embedded\"} more prose"))
+      (Ok (response_with_text raw))
   with
-  | Fusion_types.Answered { model; answer; _ } ->
-    check string "panel identity preserved" "panel-a" model;
-    check string "embedded JSON answer parsed" "embedded" answer
-  | Fusion_types.Failed failure ->
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool name true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
     fail
-      ("expected embedded JSON answer, got failure: " ^ Fusion_types.show_panel_error failure)
+      ("expected invalid structured response failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
+let test_panel_outcome_rejects_json_from_prose () =
+  check_panel_invalid_structured_response
+    ~name:"prose-wrapped JSON is rejected"
+    "Some prose before {\"answer\":\"embedded\"} more prose"
+
+let test_panel_outcome_rejects_incomplete_json_fence () =
+  check_panel_invalid_structured_response
+    ~name:"incomplete JSON fence is rejected"
+    "```json\n{\"answer\":\"unterminated fence\"}"
+
+let test_panel_outcome_rejects_example_before_final_json () =
+  check_panel_invalid_structured_response
+    ~name:"example JSON before final JSON is rejected"
+    "example: {\"answer\":\"example\"}\nfinal: {\"answer\":\"real\"}"
+
+let test_panel_outcome_rejects_multiple_json_objects () =
+  check_panel_invalid_structured_response
+    ~name:"multiple JSON objects are rejected"
+    "{\"answer\":\"first\"}\n{\"answer\":\"second\"}"
+
+let test_panel_outcome_rejects_braces_in_prose () =
+  check_panel_invalid_structured_response
+    ~name:"braces in prose are rejected"
+    "The final set is {alpha, beta}; answer follows later."
+
+let test_panel_outcome_rejects_large_malformed_output () =
+  let raw = String.make 8192 '{' ^ "not json" in
+  check_panel_invalid_structured_response
+    ~name:"large malformed output is rejected"
+    raw
 
 let test_panel_outcome_rejects_json_without_answer_field () =
   match
@@ -325,8 +360,18 @@ let () =
         ; test_case "rejects empty answer" `Quick
             test_panel_outcome_rejects_empty_answer
         ; test_case "strips fenced JSON" `Quick test_panel_outcome_strips_fenced_json
-        ; test_case "extracts JSON from prose" `Quick
-            test_panel_outcome_extracts_json_from_prose
+        ; test_case "rejects JSON from prose" `Quick
+            test_panel_outcome_rejects_json_from_prose
+        ; test_case "rejects incomplete JSON fence" `Quick
+            test_panel_outcome_rejects_incomplete_json_fence
+        ; test_case "rejects example before final JSON" `Quick
+            test_panel_outcome_rejects_example_before_final_json
+        ; test_case "rejects multiple JSON objects" `Quick
+            test_panel_outcome_rejects_multiple_json_objects
+        ; test_case "rejects braces in prose" `Quick
+            test_panel_outcome_rejects_braces_in_prose
+        ; test_case "rejects large malformed output" `Quick
+            test_panel_outcome_rejects_large_malformed_output
         ; test_case "rejects JSON without answer field" `Quick
             test_panel_outcome_rejects_json_without_answer_field
         ] )

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -678,6 +678,9 @@ let test_repo_runtime_toml_loads () =
        check (option bool) "MiniMax M3 provider config SO override is Some false"
          (Some false)
          runtime.provider_config.Llm_provider.Provider_config.supports_structured_output_override;
+       check bool "MiniMax M3 keeps OAS capability catalog authoritative" true
+         (Option.is_none
+            runtime.provider_config.Llm_provider.Provider_config.model_capabilities_override);
        (match runtime.model.capabilities with
        | Some caps ->
           check bool "MiniMax M3 response_format json disabled" false
@@ -707,6 +710,9 @@ let test_repo_runtime_toml_loads () =
        check (option bool) "native MiniMax M3 provider config SO override is Some true"
          (Some true)
          runtime.provider_config.Llm_provider.Provider_config.supports_structured_output_override;
+       check bool "native MiniMax M3 keeps OAS capability catalog authoritative" true
+         (Option.is_none
+            runtime.provider_config.Llm_provider.Provider_config.model_capabilities_override);
        (match runtime.model.capabilities with
        | Some caps ->
          check bool "native MiniMax M3 response_format json" true

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -675,6 +675,9 @@ let test_repo_runtime_toml_loads () =
      | Some runtime ->
        check string "MiniMax M3 api name" "minimax-m3" runtime.model.api_name;
        check int "MiniMax M3 context" 524288 runtime.model.max_context;
+       check (option bool) "MiniMax M3 provider config SO override is Some false"
+         (Some false)
+         runtime.provider_config.Llm_provider.Provider_config.supports_structured_output_override;
        (match runtime.model.capabilities with
        | Some caps ->
           check bool "MiniMax M3 response_format json disabled" false
@@ -701,6 +704,9 @@ let test_repo_runtime_toml_loads () =
        check (option (float 0.0)) "native MiniMax M3 connect timeout"
          (Some 600.0)
          runtime.provider_config.connect_timeout_s;
+       check (option bool) "native MiniMax M3 provider config SO override is Some true"
+         (Some true)
+         runtime.provider_config.Llm_provider.Provider_config.supports_structured_output_override;
        (match runtime.model.capabilities with
        | Some caps ->
          check bool "native MiniMax M3 response_format json" true


### PR DESCRIPTION
## Summary
- Forward runtime.toml model capability overrides into OAS Provider_config, making MASC's supports-structured-output declarations authoritative.
- Harden Fusion panel response parsing: strip markdown fences and extract the first JSON object from prose.
- Add fail-fast validation in Fusion_config_loader.load so Fusion presets reject panel/judge runtimes that do not declare structured output support.

## Test Plan
- scripts/dune-local.sh build @check
- scripts/dune-local.sh runtest test/test_fusion_judge_usage.ml test/fusion_core/test_fusion.ml test/test_runtime_config_validity.ml

## Dependencies
- OAS PR: https://github.com/jeong-sik/oas/pull/2440