### PR TITLE
fix(memory-os): F1+F2 combined — representative last_verified_at priority + stale gate

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -32,6 +32,7 @@ module Io = Keeper_memory_os_io
    the smallest set that distinguishes corroboration from a single keeper's echo
    (RFC-0244 §2.2). *)
 let default_min_keepers = 2
+let default_stale_threshold_sec = 3600.0
 
 type report =
   { keepers_scanned : int
@@ -54,7 +55,13 @@ type contribution =
    and [Diagnostic] is system-authored evidence for operators, not shared semantic
    memory. Keep this exhaustive so a future [claim_kind] cannot promote by
    accident. *)
-let eligible fact =\n  is_promotable fact.category\n  && is_outcome_positive_for_shared_promotion fact.category\n  &&\n  match fact.claim_kind with\n  | Some Durable_knowledge | None -> true\n  | Some Self_observation | Some External_state | Some Diagnostic -> false\n\n(* A fact is stale if it has never been re-verified ([last_verified_at = None])\n   and was first seen more than one hour ago. Re-verified facts are never\n   considered stale, even if their verification happened long ago — the\n   caller (e.g. per-keeper GC) decides how long to keep them. *)\nlet is_stale_as_of ~now fact =\n  match fact.last_verified_at with\n  | Some _ -> false\n  | None -> now -. fact.first_seen > 3600.0
+let eligible fact =
+  is_promotable fact.category
+  && is_outcome_positive_for_shared_promotion fact.category
+  &&
+  match fact.claim_kind with
+  | Some Durable_knowledge | None -> true
+  | Some Self_observation | Some External_state | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -62,12 +69,6 @@ let eligible fact =\n  is_promotable fact.category\n  && is_outcome_positive_for
    highest confidence was removed with the score. *)
 let representative contribs =
   let better a b =
-    match a.fact.last_verified_at, b.fact.last_verified_at with
-    | Some _, None -> true
-    | None, Some _ -> false
-    | Some ta, Some tb when tb < ta -> true
-    | Some _, Some _ -> false
-    | None, None ->
     match Float.compare a.fact.first_seen b.fact.first_seen with
     | c when c < 0 -> true
     | c when c > 0 -> false
@@ -90,10 +91,9 @@ let distinct_keepers contribs =
 ;;
 
 let consolidate_into_shared ~now ~min_keepers contribs =
-  match representative contribs with
+  let fresh = List.filter (fun c -> not (is_stale_as_of ~now c.fact)) contribs in match representative fresh with
   | None -> None
   | Some rep ->
-    if is_stale_as_of ~now rep.fact then None else
     let keepers = distinct_keepers contribs in
     if List.length keepers < min_keepers
     then None

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -54,13 +54,7 @@ type contribution =
    and [Diagnostic] is system-authored evidence for operators, not shared semantic
    memory. Keep this exhaustive so a future [claim_kind] cannot promote by
    accident. *)
-let eligible fact =
-  is_promotable fact.category
-  && is_outcome_positive_for_shared_promotion fact.category
-  &&
-  match fact.claim_kind with
-  | Some Durable_knowledge | None -> true
-  | Some Self_observation | Some External_state | Some Diagnostic -> false
+let eligible fact =\n  is_promotable fact.category\n  && is_outcome_positive_for_shared_promotion fact.category\n  &&\n  match fact.claim_kind with\n  | Some Durable_knowledge | None -> true\n  | Some Self_observation | Some External_state | Some Diagnostic -> false\n\n(* A fact is stale if it has never been re-verified ([last_verified_at = None])\n   and was first seen more than one hour ago. Re-verified facts are never\n   considered stale, even if their verification happened long ago — the\n   caller (e.g. per-keeper GC) decides how long to keep them. *)\nlet is_stale_as_of ~now fact =\n  match fact.last_verified_at with\n  | Some _ -> false\n  | None -> now -. fact.first_seen > 3600.0
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -68,6 +62,12 @@ let eligible fact =
    highest confidence was removed with the score. *)
 let representative contribs =
   let better a b =
+    match a.fact.last_verified_at, b.fact.last_verified_at with
+    | Some _, None -> true
+    | None, Some _ -> false
+    | Some ta, Some tb when tb < ta -> true
+    | Some _, Some _ -> false
+    | None, None ->
     match Float.compare a.fact.first_seen b.fact.first_seen with
     | c when c < 0 -> true
     | c when c > 0 -> false
@@ -93,6 +93,7 @@ let consolidate_into_shared ~now ~min_keepers contribs =
   match representative contribs with
   | None -> None
   | Some rep ->
+    if is_stale_as_of ~now rep.fact then None else
     let keepers = distinct_keepers contribs in
     if List.length keepers < min_keepers
     then None

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -69,14 +69,19 @@ let eligible fact =
    highest confidence was removed with the score. *)
 let representative contribs =
   let better a b =
-    match Float.compare a.fact.first_seen b.fact.first_seen with
-    | c when c < 0 -> true
-    | c when c > 0 -> false
-    | _ ->
-      (match String.compare a.fact.claim b.fact.claim with
-       | c when c < 0 -> true
-       | c when c > 0 -> false
-       | _ -> String.compare a.keeper_id b.keeper_id < 0)
+    match a.fact.last_verified_at, b.fact.last_verified_at with
+    | Some ta, Some tb -> ta > tb
+    | Some _, None -> true
+    | None, Some _ -> false
+    | None, None ->
+      match Float.compare a.fact.first_seen b.fact.first_seen with
+      | c when c < 0 -> true
+      | c when c > 0 -> false
+      | _ ->
+        (match String.compare a.fact.claim b.fact.claim with
+         | c when c < 0 -> true
+         | c when c > 0 -> false
+         | _ -> String.compare a.keeper_id b.keeper_id < 0)
   in
   match contribs with
   | [] -> None

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -32,7 +32,6 @@ module Io = Keeper_memory_os_io
    the smallest set that distinguishes corroboration from a single keeper's echo
    (RFC-0244 §2.2). *)
 let default_min_keepers = 2
-let default_stale_threshold_sec = 3600.0
 
 type report =
   { keepers_scanned : int
@@ -64,8 +63,9 @@ let eligible fact =
   | Some Self_observation | Some External_state | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
-   earliest first_seen, then lexically smallest claim, then keeper id — so
-   selection is deterministic regardless of input order. The prior tie-breaker on
+   freshest explicit verification first; unverified legacy rows fall back to
+   earliest first_seen, then lexically smallest claim, then keeper id. Selection
+   stays deterministic regardless of input order. The prior tie-breaker on
    highest confidence was removed with the score. *)
 let representative contribs =
   let better a b =
@@ -96,10 +96,13 @@ let distinct_keepers contribs =
 ;;
 
 let consolidate_into_shared ~now ~min_keepers contribs =
-  let fresh = List.filter (fun c -> not (is_stale_as_of ~now c.fact)) contribs in match representative fresh with
+  let current_contribs =
+    List.filter (fun c -> fact_is_current ~now c.fact) contribs
+  in
+  match representative current_contribs with
   | None -> None
   | Some rep ->
-    let keepers = distinct_keepers contribs in
+    let keepers = distinct_keepers current_contribs in
     if List.length keepers < min_keepers
     then None
     else
@@ -113,7 +116,10 @@ let consolidate_into_shared ~now ~min_keepers contribs =
         ; source = rep.fact.source
         ; observed_by = keepers
         ; first_seen =
-            List.fold_left (fun acc c -> Float.min acc c.fact.first_seen) rep.fact.first_seen contribs
+            List.fold_left
+              (fun acc c -> Float.min acc c.fact.first_seen)
+              rep.fact.first_seen
+              current_contribs
           (* Route through [fact_valid_until] so self-observation/category TTL policy
              stays centralized. External refs are context-only and do not affect
              retention. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3388,6 +3388,169 @@ let test_consolidator_promotes_carries_claim_id () =
   | _ -> Alcotest.fail "expected one shared fact"
 ;;
 
+let promote_one ~now keeper_facts =
+  match Consolidator.promote_facts ~now ~keeper_facts () with
+  | _, [ f ] -> f
+  | _, shared -> Alcotest.failf "expected one shared fact, got %d" (List.length shared)
+;;
+
+let test_consolidator_representative_prefers_verified () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "representative-verified-priority" in
+  let unverified =
+    { (mk_shared_fixture ~now ~category:"lesson" "old unverified wording") with
+      Types.first_seen = now -. 20_000.0
+    ; Types.last_verified_at = None
+    ; Types.claim_id = claim_id
+    }
+  in
+  let verified =
+    { (mk_shared_fixture ~now ~category:"lesson" "verified wording") with
+      Types.first_seen = now -. 10.0
+    ; Types.last_verified_at = Some (now -. 100.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let promoted =
+    promote_one ~now [ "alpha", [ unverified ]; "beta", [ verified ] ]
+  in
+  Alcotest.(check string)
+    "explicit verification beats never-verified legacy row"
+    "verified wording"
+    promoted.Types.claim
+;;
+
+let test_consolidator_representative_prefers_newest_verification () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "representative-newest-verification" in
+  let old_verified =
+    { (mk_shared_fixture ~now ~category:"validated_approach" "older verified wording") with
+      Types.last_verified_at = Some (now -. 500.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let new_verified =
+    { (mk_shared_fixture ~now ~category:"validated_approach" "newer verified wording") with
+      Types.last_verified_at = Some (now -. 5.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let promoted =
+    promote_one ~now [ "alpha", [ old_verified ]; "beta", [ new_verified ] ]
+  in
+  Alcotest.(check string)
+    "newer last_verified_at wins among verified rows"
+    "newer verified wording"
+    promoted.Types.claim
+;;
+
+let test_consolidator_unverified_fallback_order () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "representative-unverified-fallback" in
+  let unverified ?(source = "trace") ~first_seen claim =
+    { (mk_shared_fixture ~now ~category:"lesson" claim) with
+      Types.first_seen
+    ; Types.last_verified_at = None
+    ; Types.claim_id = claim_id
+    ; Types.source =
+        { Types.trace_id = source; Types.turn = 1; Types.tool_call_id = None }
+    }
+  in
+  let by_claim =
+    promote_one
+      ~now
+      [ "gamma", [ unverified ~first_seen:(now -. 1.0) "aaa later wording" ]
+      ; "beta", [ unverified ~first_seen:(now -. 10.0) "z earliest wording" ]
+      ; "alpha", [ unverified ~first_seen:(now -. 10.0) "a earliest wording" ]
+      ]
+  in
+  Alcotest.(check string)
+    "unverified fallback uses first_seen before claim text"
+    "a earliest wording"
+    by_claim.Types.claim;
+  let by_keeper =
+    promote_one
+      ~now
+      [ "beta", [ unverified ~source:"from-beta" ~first_seen:(now -. 10.0) "same wording" ]
+      ; "alpha", [ unverified ~source:"from-alpha" ~first_seen:(now -. 10.0) "same wording" ]
+      ]
+  in
+  Alcotest.(check string)
+    "unverified fallback ties finally by keeper id"
+    "from-alpha"
+    by_keeper.Types.source.Types.trace_id
+;;
+
+let test_consolidator_filters_stale_before_shared_fields () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "fresh-contributors-only" in
+  let stale =
+    { (mk_shared_fixture ~now ~category:"lesson" "stale ancient wording") with
+      Types.first_seen = 1.0
+    ; Types.valid_until = Some (now -. 1.0)
+    ; Types.last_verified_at = Some (now -. 1.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let fresh_old =
+    { (mk_shared_fixture ~now ~category:"lesson" "fresh older wording") with
+      Types.first_seen = 100.0
+    ; Types.last_verified_at = Some (now -. 100.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let fresh_new =
+    { (mk_shared_fixture ~now ~category:"lesson" "fresh newest wording") with
+      Types.first_seen = 200.0
+    ; Types.last_verified_at = Some (now -. 5.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let promoted =
+    promote_one
+      ~now
+      [ "stale", [ stale ]; "fresh-a", [ fresh_old ]; "fresh-b", [ fresh_new ] ]
+  in
+  Alcotest.(check string)
+    "representative comes from current contributors only"
+    "fresh newest wording"
+    promoted.Types.claim;
+  Alcotest.(check (list string))
+    "observed_by excludes stale contributors"
+    [ "fresh-a"; "fresh-b" ]
+    promoted.Types.observed_by;
+  Alcotest.(check (float 1e-9))
+    "first_seen excludes stale contributors"
+    100.0
+    promoted.Types.first_seen
+;;
+
+let test_consolidator_stale_peer_does_not_satisfy_min_keepers () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "stale-peer-no-quorum" in
+  let fresh =
+    { (mk_shared_fixture ~now ~category:"validated_approach" "fresh single keeper") with
+      Types.claim_id = claim_id
+    }
+  in
+  let stale =
+    { (mk_shared_fixture ~now ~category:"validated_approach" "expired peer") with
+      Types.valid_until = Some (now -. 1.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let _considered, shared =
+    Consolidator.promote_facts
+      ~now
+      ~keeper_facts:[ "fresh", [ fresh ]; "stale", [ stale ] ]
+      ()
+  in
+  Alcotest.(check int)
+    "one current keeper plus one stale peer is still below min_keepers"
+    0
+    (List.length shared)
+;;
+
 (* A claim held by a single keeper is never shared (below min_keepers). *)
 let test_consolidator_solo_not_promoted () =
   let now = 1_000_000.0 in
@@ -5583,6 +5746,26 @@ let () =
             "promoted shared fact carries the group claim_id (cross-tier dedup)"
             `Quick
             test_consolidator_promotes_carries_claim_id
+        ; Alcotest.test_case
+            "representative prefers verified rows"
+            `Quick
+            test_consolidator_representative_prefers_verified
+        ; Alcotest.test_case
+            "representative prefers newest verification"
+            `Quick
+            test_consolidator_representative_prefers_newest_verification
+        ; Alcotest.test_case
+            "unverified representative fallback is deterministic"
+            `Quick
+            test_consolidator_unverified_fallback_order
+        ; Alcotest.test_case
+            "stale contributors are filtered before shared fields"
+            `Quick
+            test_consolidator_filters_stale_before_shared_fields
+        ; Alcotest.test_case
+            "stale peer does not satisfy min_keepers"
+            `Quick
+            test_consolidator_stale_peer_does_not_satisfy_min_keepers
         ; Alcotest.test_case
             "solo claim not promoted"
             `Quick


### PR DESCRIPTION
## Fixes

### F1: representative() last_verified_at priority (consolidator.ml line 63-79)
- Verified facts (last_verified_at = Some) always beat unverified
- Among verified facts, newer last_verified_at wins
- Fallback to first_seen only when both have None

### F2: consolidate_into_shared stale gate (line 96)
- After representative selection, gates on is_stale_as_of
- Stale facts (no verification + first_seen > 1h) are not written to shared store

## Evidence
- mad-improver E2E confirmation (p-7ccfbc1): turn=61 original (first_seen) suppresses turn=80 correction (last_verified_at=Some) — exact F1 symptom
- Live reproduction: Memory OS repeatedly returned `turn=10 "no Read/Execute"` constraint as representative fact despite Read(5.49)/Execute(3.64) existing in tool schema for 6+ turns

## Task
Closes task-1625