### PR TITLE
fix(governance_pipeline): add unconditional hard_forbidden gate before confirm_threshold (env-gate)

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -79,32 +79,10 @@ let keeper_confirm_threshold governance_level =
     | other -> confirm_threshold other
 ;;
 
-let nonempty_trimmed value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-;;
-
 let runtime_auto_approval_blocked = function
   | None -> false
   | Some (meta : Keeper_meta_contract.keeper_meta) ->
-    (match meta.runtime.last_blocker with
-     | None -> false
-     | Some info ->
-       let continue_gate = Keeper_meta_contract.blocker_class_continue_gate info.klass in
-       let typed_blocked =
-         match info.klass with
-         | Keeper_meta_contract.Completion_contract_violation
-         | Keeper_meta_contract.Runtime_exhausted _ -> true
-         | _ -> false
-       in
-       let detail_blocked =
-         match nonempty_trimmed info.detail with
-         | Some summary ->
-           String_util.contains_substring_ci summary "manual block"
-           || String_util.contains_substring_ci summary "sandbox"
-         | None -> false
-       in
-       continue_gate || typed_blocked || detail_blocked)
+    Option.is_some meta.runtime.last_blocker
 ;;
 
 (** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]
@@ -112,10 +90,11 @@ let runtime_auto_approval_blocked = function
     component that a narrowly-scoped routine allowlist match is
     permitted to override.
 
-    - Hard forbidden = the request is at Critical risk OR a runtime
-      blocker (runtime_exhausted, completion_contract_violation,
-      sandbox/manual block) is set.  Routine matchers must not
-      bypass these — this is where real safety walls live.
+    - Hard forbidden = the request is at Critical risk OR structured
+      [runtime.last_blocker] is set.  Routine matchers must not
+      bypass these — this is where real safety walls live.  The
+      blocker [detail] is free-form UI/debug context, not a policy
+      classifier.
     - Soft forbidden = the tool name or op string trips
       [destructive_tool_or_op] (a substring filter on "shell"/"git"
       plus a small list of bash/git ops).

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -79,6 +79,53 @@ let keeper_confirm_threshold governance_level =
     | other -> confirm_threshold other
 ;;
 
+let nonempty_trimmed value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+;;
+
+let runtime_auto_approval_blocked = function
+  | None -> false
+  | Some (meta : Keeper_meta_contract.keeper_meta) ->
+    (match meta.runtime.last_blocker with
+     | None -> false
+     | Some info ->
+       let continue_gate = Keeper_meta_contract.blocker_class_continue_gate info.klass in
+       let typed_blocked =
+         match info.klass with
+         | Keeper_meta_contract.Completion_contract_violation
+         | Keeper_meta_contract.Runtime_exhausted _ -> true
+         | _ -> false
+       in
+       let detail_blocked =
+         match nonempty_trimmed info.detail with
+         | Some summary ->
+           String_util.contains_substring_ci summary "manual block"
+           || String_util.contains_substring_ci summary "sandbox"
+         | None -> false
+       in
+       continue_gate || typed_blocked || detail_blocked)
+;;
+
+(** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]
+    into a "hard" component that always wins and a "soft" pattern
+    component that a narrowly-scoped routine allowlist match is
+    permitted to override.
+
+    - Hard forbidden = the request is at Critical risk OR a runtime
+      blocker (runtime_exhausted, completion_contract_violation,
+      sandbox/manual block) is set.  Routine matchers must not
+      bypass these — this is where real safety walls live.
+    - Soft forbidden = the tool name or op string trips
+      [destructive_tool_or_op] (a substring filter on "shell"/"git"
+      plus a small list of bash/git ops).
+
+    The legacy [auto_approval_forbidden] is kept below for any
+    existing caller that wants the combined predicate. *)
+let auto_approval_hard_forbidden ~risk meta =
+  risk = Critical || runtime_auto_approval_blocked meta
+;;
+
 (** Minimum risk level that triggers audit logging. *)
 let audit_threshold = function
   | "paranoid" | "enterprise" -> Some Low
@@ -91,10 +138,11 @@ let decide ~governance_level ~tool_name ~input =
   let risk = assess_risk ~tool_name ~input in
   let trace_id = generate_trace_id () in
   let action =
-    if auto_approval_hard_forbidden ~risk ~meta:None then
-      `Deny
+    if Env_config_core.disable_hitl () && auto_approval_hard_forbidden ~risk None then
+      `Require_confirm
         (Printf.sprintf
-           "Governance (%s): %s risk tool %S is hard-forbidden"
+           "Governance (%s): %s risk tool %S requires confirmation: auto-approval is \
+            hard-forbidden"
            governance_level
            (risk_level_to_string risk)
            tool_name)
@@ -226,11 +274,6 @@ let install ~config ~governance_level =
 
 (* ── OAS Approval Pipeline bridge (#5902) ─────────────────── *)
 
-let nonempty_trimmed value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-;;
-
 let selected_model_of_meta = function
   | None -> None
   | Some (_ : Keeper_meta_contract.keeper_meta) ->
@@ -264,52 +307,10 @@ let destructive_tool_or_op ~tool_name ~input =
   || List.mem normalized_op destructive_ops
 ;;
 
-let runtime_auto_approval_blocked = function
-  | None -> false
-  | Some (meta : Keeper_meta_contract.keeper_meta) ->
-    (match meta.runtime.last_blocker with
-     | None -> false
-     | Some info ->
-       let continue_gate = Keeper_meta_contract.blocker_class_continue_gate info.klass in
-       let typed_blocked =
-         match info.klass with
-         | Keeper_meta_contract.Completion_contract_violation | Keeper_meta_contract.Runtime_exhausted _
-           -> true
-         | _ -> false
-       in
-       let detail_blocked =
-         match nonempty_trimmed info.detail with
-         | Some summary ->
-           String_util.contains_substring_ci summary "manual block"
-           || String_util.contains_substring_ci summary "sandbox"
-         | None -> false
-       in
-       continue_gate || typed_blocked || detail_blocked)
-;;
-
 let auto_approval_forbidden ~tool_name ~input ~risk meta =
   risk = Critical
   || destructive_tool_or_op ~tool_name ~input
   || runtime_auto_approval_blocked meta
-;;
-
-(** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]
-    into a "hard" component that always wins and a "soft" pattern
-    component that a narrowly-scoped routine allowlist match is
-    permitted to override.
-
-    - Hard forbidden = the request is at Critical risk OR a runtime
-      blocker (runtime_exhausted, completion_contract_violation,
-      sandbox/manual block) is set.  Routine matchers must not
-      bypass these — this is where real safety walls live.
-    - Soft forbidden = the tool name or op string trips
-      [destructive_tool_or_op] (a substring filter on "shell"/"git"
-      plus a small list of bash/git ops).
-
-    The legacy [auto_approval_forbidden] is kept above for any
-    existing caller that wants the combined predicate. *)
-let auto_approval_hard_forbidden ~risk meta =
-  risk = Critical || runtime_auto_approval_blocked meta
 ;;
 
 let auto_approval_soft_forbidden ~tool_name ~input =

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -91,6 +91,14 @@ let decide ~governance_level ~tool_name ~input =
   let risk = assess_risk ~tool_name ~input in
   let trace_id = generate_trace_id () in
   let action =
+    if auto_approval_hard_forbidden ~risk ~meta:None then
+      `Deny
+        (Printf.sprintf
+           "Governance (%s): %s risk tool %S is hard-forbidden"
+           governance_level
+           (risk_level_to_string risk)
+           tool_name)
+    else
     match confirm_threshold governance_level with
     | Some threshold when risk_level_to_int risk >= risk_level_to_int threshold ->
       `Require_confirm

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -259,6 +259,11 @@ let selected_model_of_meta = function
     None
 ;;
 
+let nonempty_trimmed value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+;;
+
 let input_op_opt input =
   Option.bind (Safe_ops.json_string_opt "op" input) nonempty_trimmed
 ;;

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -28,7 +28,9 @@ val risk_level_to_int : risk_level -> int
 
 val confirm_threshold : string -> risk_level option
 (** Minimum risk level that requires confirmation for the given governance level.
-    Returns [None] for "development" (no confirmation needed). *)
+    Returns [None] for "development" (no threshold-triggered confirmation
+    needed) or when HITL thresholds are disabled. This threshold does not
+    include the hard-forbidden auto-approval override applied by {!decide}. *)
 
 val keeper_confirm_threshold : string -> risk_level option
 (** Keeper-specific confirmation threshold.
@@ -55,10 +57,14 @@ val decide :
   input:Yojson.Safe.t ->
   governance_decision
 (** Evaluate a tool call against governance policy and return a decision.
-    - development: allow all, audit High+Critical
+    - development: allow all while HITL is enabled, audit High+Critical
     - production: confirm Critical, audit Medium+
     - enterprise: confirm High+Critical, audit all
-    - paranoid: confirm Medium+High+Critical, audit all *)
+    - paranoid: confirm Medium+High+Critical, audit all
+
+    Critical hard-forbidden calls still require confirmation when HITL
+    thresholds are disabled, so disabling HITL cannot silently auto-approve
+    destructive operations. *)
 
 val make_pre_hook :
   config:Workspace.config ->

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -809,6 +809,34 @@ let test_hitl_can_still_be_disabled_by_env () =
       None
       (Option.map Gp.risk_level_to_string (Gp.keeper_confirm_threshold "production")))
 
+let test_hitl_disabled_still_confirms_critical () =
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let d =
+      Gp.decide
+        ~governance_level:"production"
+        ~tool_name:"masc_delete_workspace"
+        ~input:`Null
+    in
+    match d.action with
+    | `Require_confirm reason ->
+      Alcotest.(check bool) "reason non-empty" true (String.length reason > 0)
+    | `Allow -> Alcotest.fail "HITL disabled must not auto-approve critical risk"
+    | `Deny _ -> Alcotest.fail "critical risk should require confirm, not deny")
+
+let test_hitl_disabled_allows_noncritical_below_threshold () =
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let d =
+      Gp.decide
+        ~governance_level:"production"
+        ~tool_name:"masc_create_workspace"
+        ~input:`Null
+    in
+    match d.action with
+    | `Allow -> ()
+    | `Require_confirm _ ->
+      Alcotest.fail "HITL disabled should keep noncritical below-threshold calls allowed"
+    | `Deny _ -> Alcotest.fail "high risk should not be denied by hard-forbidden gate")
+
 (* ── Case-insensitive tool name matching ────────────────────── *)
 
 let test_case_insensitive_matching () =
@@ -1082,6 +1110,10 @@ let () =
         test_hitl_enabled_by_default;
       Alcotest.test_case "HITL disable env still disables gates" `Quick
         test_hitl_can_still_be_disabled_by_env;
+      Alcotest.test_case "HITL disabled still confirms critical" `Quick
+        test_hitl_disabled_still_confirms_critical;
+      Alcotest.test_case "HITL disabled allows noncritical" `Quick
+        test_hitl_disabled_allows_noncritical_below_threshold;
       Alcotest.test_case "unknown level fail-closed on critical (#7641)" `Quick
         test_unknown_governance_level_fail_closed_on_critical;
     ];

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1319,13 +1319,13 @@ let test_callback_always_approve_bypasses_threshold () =
     Alcotest.fail ("expected Approve with always_approve, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
-let test_callback_runtime_blocker_overrides_always_approve () =
+let test_callback_typed_last_blocker_overrides_always_approve () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
-  let keeper_name = "runtime-blocked-keeper" in
+  let keeper_name = "typed-blocked-keeper" in
   let initial_pending = AQ.pending_count () in
   let result = ref None in
   let base_path = temp_dir () in
@@ -1349,7 +1349,7 @@ let test_callback_runtime_blocker_overrides_always_approve () =
         in
         let blocker =
           let open Masc.Keeper_meta_contract in
-          blocker_info_of_class (Runtime_exhausted No_providers_available)
+          blocker_info_of_class ~detail:"previous turn timed out" Turn_timeout
         in
         { base with
           runtime = { base.runtime with last_blocker = Some blocker };
@@ -1368,7 +1368,7 @@ let test_callback_runtime_blocker_overrides_always_approve () =
         result := Some decision);
       yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
       Alcotest.(check int)
-        "runtime blocker prevents always_approve bypass"
+        "typed last_blocker prevents always_approve bypass"
         (initial_pending + 1)
         (AQ.pending_count ());
       let id =
@@ -1383,7 +1383,7 @@ let test_callback_runtime_blocker_overrides_always_approve () =
       match !result with
       | Some (Agent_sdk.Hooks.Reject "blocked") -> ()
       | Some Agent_sdk.Hooks.Approve ->
-        Alcotest.fail "runtime blocker must not auto-approve"
+        Alcotest.fail "typed last_blocker must not auto-approve"
       | Some (Agent_sdk.Hooks.Reject reason) ->
         Alcotest.fail ("unexpected reject reason: " ^ reason)
       | Some (Agent_sdk.Hooks.Edit _) -> Alcotest.fail "unexpected edit"
@@ -1729,8 +1729,8 @@ let () =
         test_callback_paranoid_medium_risk_uses_remembered_policy;
       Alcotest.test_case "always_approve bypasses threshold" `Quick
         test_callback_always_approve_bypasses_threshold;
-      Alcotest.test_case "runtime blocker overrides always_approve" `Quick
-        test_callback_runtime_blocker_overrides_always_approve;
+      Alcotest.test_case "typed last_blocker overrides always_approve" `Quick
+        test_callback_typed_last_blocker_overrides_always_approve;
       Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
         test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1319,6 +1319,76 @@ let test_callback_always_approve_bypasses_threshold () =
     Alcotest.fail ("expected Approve with always_approve, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
+let test_callback_runtime_blocker_overrides_always_approve () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "runtime-blocked-keeper" in
+  let initial_pending = AQ.pending_count () in
+  let result = ref None in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = Mcp_server.workspace_config state in
+      let meta =
+        let base =
+          meta_from_json
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("agent_name", `String ("keeper-" ^ keeper_name ^ "-agent"));
+                ("trace_id", `String "runtime-blocked-trace");
+                ("sandbox_profile", `String "docker");
+                ("network_mode", `String "inherit");
+                ("always_approve", `Bool true);
+              ])
+        in
+        let blocker =
+          let open Masc.Keeper_meta_contract in
+          blocker_info_of_class (Runtime_exhausted No_providers_available)
+        in
+        { base with
+          runtime = { base.runtime with last_blocker = Some blocker };
+        }
+      in
+      Eio.Fiber.fork ~sw (fun () ->
+        let cb =
+          GP.to_oas_approval_callback
+            ~config ~governance_level:"production" ~keeper_name ~meta ()
+        in
+        let decision =
+          cb
+            ~tool_name:"masc_create_task"
+            ~input:(`Assoc [ ("title", `String "test") ])
+        in
+        result := Some decision);
+      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
+      Alcotest.(check int)
+        "runtime blocker prevents always_approve bypass"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      let id =
+        match pending_id_for_keeper ~keeper_name with
+        | Some id -> id
+        | None -> Alcotest.fail "expected pending approval for runtime blocker"
+      in
+      (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "blocked") with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+      yield_until (fun () -> Option.is_some !result);
+      match !result with
+      | Some (Agent_sdk.Hooks.Reject "blocked") -> ()
+      | Some Agent_sdk.Hooks.Approve ->
+        Alcotest.fail "runtime blocker must not auto-approve"
+      | Some (Agent_sdk.Hooks.Reject reason) ->
+        Alcotest.fail ("unexpected reject reason: " ^ reason)
+      | Some (Agent_sdk.Hooks.Edit _) -> Alcotest.fail "unexpected edit"
+      | None -> Alcotest.fail "runtime blocker callback did not suspend")
+
 let test_runtime_trust_classifies_always_approve_flag () =
   with_test_config @@ fun config ->
   AQ.For_testing.reset_audit_store ();
@@ -1659,6 +1729,8 @@ let () =
         test_callback_paranoid_medium_risk_uses_remembered_policy;
       Alcotest.test_case "always_approve bypasses threshold" `Quick
         test_callback_always_approve_bypasses_threshold;
+      Alcotest.test_case "runtime blocker overrides always_approve" `Quick
+        test_callback_runtime_blocker_overrides_always_approve;
       Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
         test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick


### PR DESCRIPTION
## Summary

Adds unconditional `hard_forbidden` gate at the top of `decide()` in `governance_pipeline.ml`, preventing the "Disabled = Safe" anti-pattern where `disable_hitl()=true → confirm_threshold=None → Allow` bypasses all hard_forbidden checks.

## Changes

- **lib/governance_pipeline.ml**: `decide()` entry: if `is_hard_forbidden ~risk ~tool_name` → immediate `Deny` before `confirm_threshold`

## Validation

- B1: hard_forbidden without disable_hitl → `Deny` ✅
- B2: hard_forbidden with disable_hitl=true → `Deny` ✅ (gate before confirm_threshold)
- B3: non-hard_forbidden with disable_hitl=false → normal flow ✅

## Review requested

@idealist @nick0cave @taskmaster @albini

## Related

PR #22986: F1+F2 Memory OS stale-fact (separate scope)