### PR TITLE
fix(dashboard): coalesce live thinking stream updates

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -32,6 +32,7 @@ import { hasMarkdownRenderCue } from './markdown-cue'
 import type { JSX } from 'preact'
 import { navigate } from '../../router'
 import { normalizeFusionPanelReason } from '../../lib/fusion-meta'
+import { STREAMING_THINKING_PREVIEW_CHARS } from '../../config/constants'
 
 /** Keeper identity used by SigilBadge. */
 export interface SigilBadgeKeeper {
@@ -70,7 +71,6 @@ const TRACE_TOOL_STATUS_UI: Record<TraceToolStatus, { className: 'ok' | 'bad' | 
 }
 
 export const CHAT_SUGGESTIONS_LABEL = '추천 후속 질문'
-const STREAMING_THINKING_PREVIEW_CHARS = 6_000
 
 function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'ok' | 'bad' | 'pending'; title: string } {
   return TRACE_TOOL_STATUS_UI[status ?? 'pending']

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -79,6 +79,7 @@ export const CONTEXT_RATIO_COMPACTING = 0.50 // compacting
 export const KEEPER_HISTORY_TAIL_MESSAGES = 200
 export const KEEPER_STREAM_IDLE_TIMEOUT_MS = 120_000
 export const KEEPER_STREAM_IDLE_POLL_MS = 5_000
+export const STREAMING_THINKING_PREVIEW_CHARS = 6_000
 
 // --- Buffer & cache sizes (Vite env overridable) ---
 // Defaults balance memory/render cost against available history. Users who

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -92,6 +92,7 @@ import {
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from './tool-call-output-store'
+import { _resetKeeperStreamBuffersForTests } from './keeper-stream'
 import type { KeeperChatStreamEvent } from './api'
 import type { KeeperToolReply } from './api/keeper'
 import type { ToolCallEntry } from './api/dashboard'
@@ -101,6 +102,7 @@ beforeEach(() => {
   fetchKeeperToolCalls.mockReset()
   fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
   resetToolCallOutputs()
+  _resetKeeperStreamBuffersForTests()
 })
 
 describe('noteKeeperChatAppended', () => {
@@ -383,6 +385,86 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
     expect(keeperSending.value.echo).toBe(false)
     expect(activeStreamEntryId('echo')).toBeNull()
+  })
+
+  it('keeps another keeper lane available while one keeper is streaming thinking', async () => {
+    let resolveEcho: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage.mockImplementation(async (
+      name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      if (name === 'echo') {
+        for (let i = 0; i < 200; i += 1) {
+          opts.onEvent({
+            type: 'CUSTOM',
+            name: 'KEEPER_THINKING_DELTA',
+            value: { delta: `thought-${i} ` },
+          })
+        }
+        return new Promise<{ terminal: boolean }>(resolve => {
+          resolveEcho = resolve
+        })
+      }
+      opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: `${name} reply` })
+      return { terminal: true }
+    })
+
+    const echoSend = sendKeeperThreadMessage('echo', 'slow thinking turn')
+    await Promise.resolve()
+
+    expect(keeperSending.value.echo).toBe(true)
+    expect(activeStreamEntryId('echo')).not.toBeNull()
+
+    await sendKeeperThreadMessage('rama', 'status?')
+
+    expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
+    expect(streamKeeperMessage.mock.calls.map(call => call[0])).toEqual(['echo', 'rama'])
+    expect(keeperSending.value.echo).toBe(true)
+    expect(keeperSending.value.rama).toBe(false)
+    expect((keeperThreads.value.rama ?? []).map(entry => [entry.role, entry.text, entry.delivery])).toEqual([
+      ['user', 'status?', 'delivered'],
+      ['assistant', 'rama reply', 'delivered'],
+    ])
+
+    resolveEcho({ terminal: true })
+    await echoSend
+
+    expect(keeperSending.value.echo).toBe(false)
+    expect(activeStreamEntryId('echo')).toBeNull()
+  })
+
+  it('flushes pending thinking before finalizing a terminal stream outcome', async () => {
+    vi.useFakeTimers()
+    try {
+      streamKeeperMessage.mockImplementation(async (
+        _name: string,
+        _message: string,
+        opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+      ) => {
+        opts.onEvent({
+          type: 'CUSTOM',
+          name: 'KEEPER_THINKING_DELTA',
+          value: { delta: 'thinking-only terminal outcome' },
+        })
+        return { terminal: true }
+      })
+
+      await sendKeeperThreadMessage('echo', 'thinking only')
+
+      const assistant = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+      expect(assistant?.traceSteps).toEqual([
+        { kind: 'think', text: 'thinking-only terminal outcome', ts: expect.any(String) },
+      ])
+      expect(assistant?.streamState).toBeNull()
+
+      await vi.runOnlyPendingTimersAsync()
+      const afterTimer = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+      expect(afterTimer?.streamState).toBeNull()
+      expect(afterTimer?.traceSteps).toEqual(assistant?.traceSteps)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('keeps queued client action ids guarded while a batched queue send is in flight', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -60,7 +60,12 @@ import {
   setRecordValue,
   setStatusDetail,
 } from './keeper-state'
-import { abortKeeperThreadMessage, applyKeeperStreamEvent, TERMINAL_REQUEST_STATUSES } from './keeper-stream'
+import {
+  abortKeeperThreadMessage,
+  applyKeeperStreamEvent,
+  flushPendingKeeperStreamDeltas,
+  TERMINAL_REQUEST_STATUSES,
+} from './keeper-stream'
 import {
   KEEPER_HISTORY_TAIL_MESSAGES,
 } from './config/constants'
@@ -899,6 +904,7 @@ export async function sendKeeperThreadMessage(
       },
     })
 
+    flushPendingKeeperStreamDeltas(keeperName, assistantId)
     const finalEntry =
       (keeperThreads.value[keeperName] ?? []).find(entry => entry.id === assistantId) ?? null
     const finalText = finalEntry?.text.trim() ?? ''
@@ -974,6 +980,7 @@ export async function sendKeeperThreadMessage(
       releaseActiveStreamRequestId(requestId)
     }
   } catch (err) {
+    flushPendingKeeperStreamDeltas(keeperName, assistantId)
     if (isAbortError(err)) {
       const shouldAttemptServerCancel = Boolean(requestId && liveSendOwnsRequest(requestId))
       const serverCancelAlreadyFinalized = Boolean(

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -863,13 +863,14 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
   }))
 }
 
-export function appendAssistantThinkingDelta(
+function writeAssistantThinkingText(
   name: string,
   entryId: string,
-  delta: string,
+  text: string,
   meta: { oasBlockIndex?: number } = {},
+  mode: 'append' | 'snapshot',
 ): void {
-  if (!delta.trim()) return
+  if (!text.trim()) return
   const oasBlockIndex = meta.oasBlockIndex
   updateThreadEntry(name, entryId, entry => {
     const existing = entry.traceSteps ?? []
@@ -883,13 +884,19 @@ export function appendAssistantThinkingDelta(
     // interleave it with tool entries by occurrence order. When consecutive
     // deltas merge into the same step, the first stamp is preserved: the step
     // began at that time, not when the latest fragment arrived.
+    const nextText =
+      sameThinkingBlock
+        ? mode === 'append'
+          ? `${last.text}${text}`
+          : text
+        : text.trimStart()
     const traceSteps: ChatTraceStep[] =
       sameThinkingBlock
         ? [
             ...existing.slice(0, -1),
             withoutUndefined({
               kind: 'think',
-              text: `${last.text}${delta}`,
+              text: nextText,
               ts: last.ts,
               oasBlockIndex: last.oasBlockIndex,
             }),
@@ -898,7 +905,7 @@ export function appendAssistantThinkingDelta(
             ...existing,
             withoutUndefined({
               kind: 'think',
-              text: delta.trimStart(),
+              text: nextText,
               ts: new Date().toISOString(),
               oasBlockIndex,
             }),
@@ -910,6 +917,24 @@ export function appendAssistantThinkingDelta(
       delivery: 'streaming',
     }
   })
+}
+
+export function appendAssistantThinkingDelta(
+  name: string,
+  entryId: string,
+  delta: string,
+  meta: { oasBlockIndex?: number } = {},
+): void {
+  writeAssistantThinkingText(name, entryId, delta, meta, 'append')
+}
+
+export function setAssistantThinkingSnapshot(
+  name: string,
+  entryId: string,
+  text: string,
+  meta: { oasBlockIndex?: number } = {},
+): void {
+  writeAssistantThinkingText(name, entryId, text, meta, 'snapshot')
 }
 
 function warnMissingToolTrace(

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -14,6 +14,7 @@ import {
   abortKeeperThreadMessage,
   applyKeeperStreamEvent,
 } from './keeper-stream'
+import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
 
 function assistantEntry(): void {
   appendThreadEntry('sangsu', {
@@ -543,6 +544,50 @@ describe('applyKeeperStreamEvent', () => {
       expect(entry?.traceSteps).toEqual([
         { kind: 'think', text: 'checking tool evidence', ts: expect.any(String) },
       ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps live thinking state bounded until a phase boundary commits the full text', async () => {
+    vi.useFakeTimers()
+    try {
+      const hiddenHead = 'hidden-head-marker'
+      const visibleTail = 'visible-tail-marker'
+      assistantEntry()
+
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { delta: `${hiddenHead} ${'x'.repeat(STREAMING_THINKING_PREVIEW_CHARS + 200)} ` },
+      })
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { delta: visibleTail },
+      })
+
+      await vi.advanceTimersByTimeAsync(KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS)
+
+      const liveEntry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+      const liveThinking = liveEntry?.traceSteps?.[0]
+      if (!liveThinking || liveThinking.kind !== 'think') {
+        throw new Error('expected live thinking trace step')
+      }
+      expect(liveThinking.text).toContain(visibleTail)
+      expect(liveThinking.text).not.toContain(hiddenHead)
+      expect(liveThinking.text.length).toBeLessThanOrEqual(STREAMING_THINKING_PREVIEW_CHARS)
+
+      applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START' })
+
+      const committedEntry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+      const committedThinking = committedEntry?.traceSteps?.[0]
+      if (!committedThinking || committedThinking.kind !== 'think') {
+        throw new Error('expected committed thinking trace step')
+      }
+      expect(committedThinking.text).toContain(hiddenHead)
+      expect(committedThinking.text).toContain(visibleTail)
+      expect(committedThinking.text.length).toBeGreaterThan(STREAMING_THINKING_PREVIEW_CHARS)
     } finally {
       vi.useRealTimers()
     }

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   _resetLiveSendRequestOwnersForTests,
   activeStreamRequestId,
@@ -8,6 +8,7 @@ import {
 } from './keeper-state'
 import { keeperThreads } from './keeper-state'
 import {
+  KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS,
   _flushPendingKeeperStreamDeltasForTests,
   _resetKeeperStreamBuffersForTests,
   abortKeeperThreadMessage,
@@ -515,6 +516,36 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.traceSteps).toEqual([
       { kind: 'think', text: 'checking tools', ts: expect.any(String) },
     ])
+  })
+
+  it('coalesces live thinking deltas until the thinking flush interval expires', async () => {
+    vi.useFakeTimers()
+    try {
+      assistantEntry()
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { delta: 'checking ' },
+      })
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { delta: 'tool evidence' },
+      })
+
+      expect(keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')?.traceSteps).toBeUndefined()
+
+      await vi.advanceTimersByTimeAsync(KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS - 1)
+      expect(keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')?.traceSteps).toBeUndefined()
+
+      await vi.advanceTimersByTimeAsync(1)
+      const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+      expect(entry?.traceSteps).toEqual([
+        { kind: 'think', text: 'checking tool evidence', ts: expect.any(String) },
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('flushes pending thinking deltas at TEXT_MESSAGE_START without reverting stream state', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -33,9 +33,10 @@ import { toolEntryIdFromCallId } from './tool-call-output-store'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
+export const KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS = 100
 
 const pendingOasToolBlockIndexes = new Map<string, number>()
-type ScheduledFlushHandle = ReturnType<typeof setTimeout> | number
+type ScheduledFlushHandle = ReturnType<typeof setTimeout>
 interface PendingThinkingBatch {
   text: string
   oasBlockIndex?: number
@@ -43,7 +44,6 @@ interface PendingThinkingBatch {
 interface PendingThinkingState {
   batches: PendingThinkingBatch[]
   flushHandle: ScheduledFlushHandle | null
-  flushViaAnimationFrame: boolean
 }
 
 const pendingThinkingDeltas = new Map<string, PendingThinkingState>()
@@ -52,28 +52,12 @@ function streamEntryKey(keeperName: string, assistantEntryId: string): string {
   return `${keeperName}\u0000${assistantEntryId}`
 }
 
-function scheduleStreamFlush(callback: () => void): {
-  handle: ScheduledFlushHandle
-  viaAnimationFrame: boolean
-} {
-  if (typeof globalThis.requestAnimationFrame === 'function') {
-    return {
-      handle: globalThis.requestAnimationFrame(callback),
-      viaAnimationFrame: true,
-    }
-  }
-  return {
-    handle: setTimeout(callback, 16),
-    viaAnimationFrame: false,
-  }
+function scheduleThinkingFlush(callback: () => void): ScheduledFlushHandle {
+  return setTimeout(callback, KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS)
 }
 
-function cancelStreamFlush(handle: ScheduledFlushHandle, viaAnimationFrame: boolean): void {
-  if (viaAnimationFrame && typeof globalThis.cancelAnimationFrame === 'function') {
-    globalThis.cancelAnimationFrame(handle as number)
-    return
-  }
-  clearTimeout(handle as ReturnType<typeof setTimeout>)
+function cancelStreamFlush(handle: ScheduledFlushHandle): void {
+  clearTimeout(handle)
 }
 
 function sameOasBlockIndex(left: number | undefined, right: number | undefined): boolean {
@@ -86,7 +70,7 @@ function flushPendingThinkingDeltas(keeperName: string, assistantEntryId: string
   if (!pending) return
   pendingThinkingDeltas.delete(key)
   if (pending.flushHandle !== null) {
-    cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+    cancelStreamFlush(pending.flushHandle)
   }
   for (const batch of pending.batches) {
     appendAssistantThinkingDelta(keeperName, assistantEntryId, batch.text, {
@@ -101,7 +85,7 @@ function dropPendingThinkingDeltas(keeperName: string, assistantEntryId: string)
   if (!pending) return
   pendingThinkingDeltas.delete(key)
   if (pending.flushHandle !== null) {
-    cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+    cancelStreamFlush(pending.flushHandle)
   }
 }
 
@@ -124,7 +108,7 @@ function enqueueThinkingDelta(
   const key = streamEntryKey(keeperName, assistantEntryId)
   let pending = pendingThinkingDeltas.get(key)
   if (!pending) {
-    pending = { batches: [], flushHandle: null, flushViaAnimationFrame: false }
+    pending = { batches: [], flushHandle: null }
     pendingThinkingDeltas.set(key, pending)
   }
   const last = pending.batches[pending.batches.length - 1]
@@ -134,21 +118,23 @@ function enqueueThinkingDelta(
     pending.batches.push({ text: delta, oasBlockIndex: meta.oasBlockIndex })
   }
   if (pending.flushHandle !== null) return
-  const scheduled = scheduleStreamFlush(() => {
+  pending.flushHandle = scheduleThinkingFlush(() => {
     flushPendingThinkingDeltas(keeperName, assistantEntryId)
   })
-  pending.flushHandle = scheduled.handle
-  pending.flushViaAnimationFrame = scheduled.viaAnimationFrame
 }
 
 export function _flushPendingKeeperStreamDeltasForTests(): void {
   flushAllPendingThinkingDeltas()
 }
 
+export function flushPendingKeeperStreamDeltas(keeperName: string, assistantEntryId: string): void {
+  flushPendingThinkingDeltas(keeperName, assistantEntryId)
+}
+
 export function _resetKeeperStreamBuffersForTests(): void {
   for (const pending of pendingThinkingDeltas.values()) {
     if (pending.flushHandle !== null) {
-      cancelStreamFlush(pending.flushHandle, pending.flushViaAnimationFrame)
+      cancelStreamFlush(pending.flushHandle)
     }
   }
   pendingThinkingDeltas.clear()

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -8,10 +8,10 @@ import type { KeeperChatStreamEvent } from './api'
 import type { KeeperConversationDetails } from './types'
 import {
   appendAssistantDelta,
-  appendAssistantThinkingDelta,
   appendAssistantToolTraceArgsDelta,
   setAssistantToolTraceArgsSnapshot,
   appendAssistantToolTraceStep,
+  setAssistantThinkingSnapshot,
   setAssistantStreamState,
   updateThreadEntry,
   insertThreadEntryBefore,
@@ -30,6 +30,7 @@ import {
 } from './keeper-state'
 import { isRecord, asNumber, asString } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
+import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
@@ -37,12 +38,10 @@ export const KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS = 100
 
 const pendingOasToolBlockIndexes = new Map<string, number>()
 type ScheduledFlushHandle = ReturnType<typeof setTimeout>
-interface PendingThinkingBatch {
-  text: string
-  oasBlockIndex?: number
-}
 interface PendingThinkingState {
-  batches: PendingThinkingBatch[]
+  chunks: string[]
+  preview: string
+  oasBlockIndex?: number
   flushHandle: ScheduledFlushHandle | null
 }
 
@@ -64,19 +63,39 @@ function sameOasBlockIndex(left: number | undefined, right: number | undefined):
   return left === undefined ? right === undefined : left === right
 }
 
-function flushPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {
+function nextThinkingPreview(current: string, delta: string): string {
+  const next = `${current}${delta}`
+  if (next.length <= STREAMING_THINKING_PREVIEW_CHARS) return next
+  const marker = '...\n'
+  return `${marker}${next.slice(-(STREAMING_THINKING_PREVIEW_CHARS - marker.length))}`
+}
+
+function fullPendingThinkingText(pending: PendingThinkingState): string {
+  return pending.chunks.join('')
+}
+
+function flushPendingThinkingDeltas(
+  keeperName: string,
+  assistantEntryId: string,
+  mode: 'commit' | 'preview' = 'commit',
+): void {
   const key = streamEntryKey(keeperName, assistantEntryId)
   const pending = pendingThinkingDeltas.get(key)
   if (!pending) return
-  pendingThinkingDeltas.delete(key)
   if (pending.flushHandle !== null) {
     cancelStreamFlush(pending.flushHandle)
+    pending.flushHandle = null
   }
-  for (const batch of pending.batches) {
-    appendAssistantThinkingDelta(keeperName, assistantEntryId, batch.text, {
-      oasBlockIndex: batch.oasBlockIndex,
+  if (mode === 'preview') {
+    setAssistantThinkingSnapshot(keeperName, assistantEntryId, pending.preview, {
+      oasBlockIndex: pending.oasBlockIndex,
     })
+    return
   }
+  pendingThinkingDeltas.delete(key)
+  setAssistantThinkingSnapshot(keeperName, assistantEntryId, fullPendingThinkingText(pending), {
+    oasBlockIndex: pending.oasBlockIndex,
+  })
 }
 
 function dropPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {
@@ -107,19 +126,26 @@ function enqueueThinkingDelta(
   if (!delta.trim()) return
   const key = streamEntryKey(keeperName, assistantEntryId)
   let pending = pendingThinkingDeltas.get(key)
-  if (!pending) {
-    pending = { batches: [], flushHandle: null }
-    pendingThinkingDeltas.set(key, pending)
+  if (pending && !sameOasBlockIndex(pending.oasBlockIndex, meta.oasBlockIndex)) {
+    flushPendingThinkingDeltas(keeperName, assistantEntryId)
+    pending = undefined
   }
-  const last = pending.batches[pending.batches.length - 1]
-  if (last && sameOasBlockIndex(last.oasBlockIndex, meta.oasBlockIndex)) {
-    last.text += delta
+  if (!pending) {
+    const text = delta.trimStart()
+    pending = {
+      chunks: [text],
+      preview: text,
+      oasBlockIndex: meta.oasBlockIndex,
+      flushHandle: null,
+    }
+    pendingThinkingDeltas.set(key, pending)
   } else {
-    pending.batches.push({ text: delta, oasBlockIndex: meta.oasBlockIndex })
+    pending.chunks.push(delta)
+    pending.preview = nextThinkingPreview(pending.preview, delta)
   }
   if (pending.flushHandle !== null) return
   pending.flushHandle = scheduleThinkingFlush(() => {
-    flushPendingThinkingDeltas(keeperName, assistantEntryId)
+    flushPendingThinkingDeltas(keeperName, assistantEntryId, 'preview')
   })
 }
 


### PR DESCRIPTION
## Summary
- coalesce live KEEPER_THINKING_DELTA updates on a bounded timer instead of writing chat state every animation frame
- keep text/tool/media/terminal boundary events synchronous by flushing pending thinking before phase transitions
- flush pending thinking before send finalization/error finalization so delayed timers cannot revert a completed assistant entry
- add regressions for thinking-burst coalescing and another keeper lane staying available while one keeper streams thinking

## Verification
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/keeper-stream.test.ts src/keeper-actions.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty
- scripts/dune-local.sh build test/test_keeper_chat_consumer_delivery.exe
- _build/default/test/test_keeper_chat_consumer_delivery.exe

## Notes
- PR #22964 already fixed queued keeper dispatch to fork per keeper.
- PR #22965 already collapses live thinking traces while a turn is still streaming.
- This PR closes the remaining client-side stream pressure path: long thinking delta bursts no longer force per-frame growing-string state writes.