### PR TITLE
fix(dashboard): refresh runtime state after keeper config and runtime.toml edits

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -22,6 +22,7 @@ import { BTN_FILLED_BASE } from './common/button-filled-base'
 import { ExpandableTextarea } from './common/expandable-textarea'
 import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource } from '../lib/async-state'
+import { refreshKeeperRuntimeStatus } from '../store'
 import { SetupGuideCard } from './setup-guide-card'
 import { SectionHeader } from './common/section-header'
 import { StatusDot } from './common/status-dot'
@@ -932,6 +933,10 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     try {
       const updated = await patchKeeperConfig(keeperName, payload)
       applyKeeperConfigUpdate(keeperName, updated)
+      void refreshKeeperRuntimeStatus().catch(err => {
+        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
+        showToast(message, 'warning')
+      })
       showToast('런타임 설정 저장 완료', 'success')
     } catch (err) {
       const msg = err instanceof Error ? err.message : '저장 실패'

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -31,6 +31,7 @@ import {
   loadRuntimeCatalog,
   runtimeCatalogState,
 } from '../lib/runtime-catalog-resource'
+import { refreshKeeperRuntimeStatus } from '../store'
 
 // Pending dropdown selection before save. `null` = no pending change (show the
 // server's current value). Module-level singleton: at most one editor renders at
@@ -218,6 +219,10 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
     try {
       const updated = await patchKeeperConfig(keeperName, { runtime_id: next })
       applyKeeperConfigUpdate(keeperName, updated)
+      void refreshKeeperRuntimeStatus().catch(err => {
+        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
+        showToast(message, 'warning')
+      })
       modelDraft.value = null
       showToast('런타임 저장 완료', 'success')
     } catch (err) {

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -26,6 +26,7 @@ vi.mock('../lib/runtime-config-refresh', () => ({
 }))
 
 import { RuntimeTomlEditor } from './runtime-toml-editor'
+import { keepers } from '../store'
 
 const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
 
@@ -148,6 +149,7 @@ describe('RuntimeTomlEditor', () => {
     setClipboard(realClipboard as unknown as { writeText: (t: string) => Promise<void> } | undefined)
     setConfirm(realConfirm)
     vi.restoreAllMocks()
+    keepers.value = []
   })
 
   it('loads and displays the full runtime.toml source', async () => {
@@ -382,6 +384,58 @@ describe('RuntimeTomlEditor', () => {
     })
     expect(apiMocks.saveRuntimeTomlConfig).not.toHaveBeenCalled()
     expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+  })
+
+  it('updates the assignment select after patching a keeper runtime', async () => {
+    keepers.value = [{ name: 'sangsu', status: 'idle' }]
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-assignments"]')).not.toBeNull()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-assignments"]') as HTMLButtonElement)
+
+    const select = container.querySelector('[aria-label="sangsu 런타임 배정"]') as HTMLSelectElement
+    expect(select.value).toBe('runpod_mtp.qwen')
+
+    fireEvent.change(select, { target: { value: 'openai.gpt' } })
+
+    await waitFor(() => {
+      expect(apiMocks.patchRuntimeAssignment).toHaveBeenCalledWith('sangsu', 'openai.gpt')
+    })
+
+    await waitFor(() => {
+      expect((container.querySelector('[aria-label="sangsu 런타임 배정"]') as HTMLSelectElement).value)
+        .toBe('openai.gpt')
+    })
+    expect(container.querySelector('[data-testid="runtime-assignments-group-pinned"]')?.textContent)
+      .toContain('sangsu')
+    expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('saved')
+  })
+
+  it('notifies onSaved after a successful save so parent surfaces can refresh', async () => {
+    const onSaved = vi.fn()
+    render(html`<${RuntimeTomlEditor} onSaved=${onSaved} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: `${baseConfig.source_text}\n[runtime.assignments]\nsangsu = "runpod_mtp.qwen"\n` } })
+
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalled()
+      expect(onSaved).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('saves from the editor keyboard shortcut', async () => {

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -167,9 +167,13 @@ function stopOverlayContentClick(event: MouseEvent) {
 
 export interface RuntimeTomlEditorProps {
   onClose?: () => void
+  /** Called after a successful backend write (raw save, routing patch, or
+   *  assignment patch). Use this in parent surfaces that also display derived
+   *  runtime state so they can re-fetch and stay in sync with the editor. */
+  onSaved?: () => void
 }
 
-export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
+export function RuntimeTomlEditor({ onClose, onSaved }: RuntimeTomlEditorProps = {}) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const lineGutterRef = useRef<HTMLPreElement | null>(null)
   const [loadState, setLoadState] = useState<LoadState>('loading')
@@ -203,6 +207,8 @@ export function RuntimeTomlEditor({ onClose }: RuntimeTomlEditorProps = {}) {
     } catch (err: unknown) {
       setNotice('적용됨')
       setError(`대시보드 런타임 갱신 실패: ${errorToString(err)}`)
+    } finally {
+      onSaved?.()
     }
   }
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -856,6 +856,14 @@ export function SettingsSurface() {
     await refreshRuntimeConfigConsumers()
   }
 
+  async function handleRuntimeTomlSaved(): Promise<void> {
+    try {
+      await refreshRuntimeSettingsSnapshot()
+    } catch (err) {
+      console.warn('[Settings] runtime settings refresh failed after editor save:', err)
+    }
+  }
+
   async function applyRuntimeRoutingPatch(lane: RuntimeRoutingLane, runtimeId: string | null): Promise<void> {
     if (runtimeRoutingStatus === 'saving') return
     setRuntimeRoutingStatus('saving')
@@ -1195,7 +1203,7 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtimes' && html`
-              <${RuntimeTomlEditor} />
+              <${RuntimeTomlEditor} onSaved=${handleRuntimeTomlSaved} />
             `}
 
             ${sec === 'prompts' && html`


### PR DESCRIPTION
## 문제

- Keeper 상세 패널에서 런타임을 변경한 뒤 대시보드가 갱신되지 않았음.
- Settings > Runtimes 페이지에서 Keeper 배정/라우팅을 변경한 뒤 상단 요약과 runtime catalog 가 갱신되지 않았음.

## 변경 내용

### Keeper 상세 런타임 변경
- `keeper-config-panel.ts` 의 `saveRuntimeConfig` 성공 후 `refreshKeeperRuntimeStatus` 호출.
- `keeper-runtime-model-editor.ts` 의 `applyKeeperConfigUpdate` 성공 후 `refreshKeeperRuntimeStatus` 호출.

### Settings > Runtimes 페이지
- `RuntimeTomlEditor` 에 `onSaved` callback prop 추가. raw save / routing patch / assignment patch 모두 성공 후 호출.
- `SettingsSurface` 에서 `handleRuntimeTomlSaved` 를 연결해 `runtimeDefaults` 와 `runtimeProviders\) 를 재조회.

### 테스트
- `runtime-toml-editor.test.ts` 에 keeper 배정 select 가 patch 후 새 값으로 갱신되는지 검증.
- `onSaved` callback 호출 여부 검증.

## 검증

```bash
cd dashboard
pnpm vitest run src/components/runtime-toml-editor.test.ts src/components/runtime-environment-editor.test.ts src/components/settings-surface.test.ts src/components/keeper-config-panel.test.ts src/components/keeper-runtime-model-editor.test.ts
```

결과: 5 files passed, 136/136 tests passed

```bash
pnpm tsc --noEmit
```

기존 `__debug__/debug-count.test.ts` 의 pre-existing error 외에는 새로운 타입 에러 없음.