### PR TITLE
fix(keeper): make continuity NEXT parsing single-field and text round-trip faithful

### DIFF
--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -187,7 +187,6 @@ val synthesize_state_from_run_result :
   goal:string ->
   tools_used:string list ->
   stop_reason:string -> response_text:string -> keeper_state_snapshot
-val render_state_block : keeper_state_snapshot -> string
 
 (** {1 Bank-specific: candidate selection} *)
 

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -161,7 +161,6 @@ val synthesize_state_from_run_result :
   goal:string ->
   tools_used:string list ->
   stop_reason:string -> response_text:string -> keeper_state_snapshot
-val render_state_block : keeper_state_snapshot -> string
 val with_stdlib_mutex : Mutex.t -> (unit -> 'a) -> 'a
 val memory_bank_locks_mu : Mutex.t
 val memory_bank_locks : (string, Mutex.t) Hashtbl.t

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -285,13 +285,10 @@ let state_snapshot_of_lines (lines : string list) : keeper_state_snapshot option
             (match strip_prefix_ci ~prefix:"Progress:" line with
             | Some v -> { acc with progress = String_util.trim_nonempty v }
             | None ->
-                (match strip_prefix_ci ~prefix:"NEXT:" line with
-                | Some v -> { acc with next_summary = String_util.trim_nonempty v;
-                                       next_items = (match acc.next_items with
-                                                     | [] -> split_state_items v
-                                                     | existing -> existing) }
+                (match strip_prefix_ci ~prefix:"NEXT PLAN:" line with
+                | Some v -> { acc with next_summary = String_util.trim_nonempty v }
                 | None ->
-                (match strip_prefix_ci ~prefix:"Next:" line with
+                (match strip_prefix_ci ~prefix:"NEXT:" line with
                 | Some v -> { acc with next_items = split_state_items v }
                 | None ->
                     (match strip_prefix_ci ~prefix:"Decisions:" line with
@@ -312,6 +309,8 @@ let state_snapshot_of_lines (lines : string list) : keeper_state_snapshot option
   if snapshot.priority = None
      && snapshot.goal = None
      && snapshot.progress = None
+     && snapshot.done_summary = None
+     && snapshot.next_summary = None
      && snapshot.next_items = []
      && snapshot.decisions = []
      && snapshot.open_questions = []
@@ -987,46 +986,3 @@ let synthesize_state_from_run_result
     open_questions = [];
     constraints = [];
   }
-
-(** Render a [keeper_state_snapshot] back into a [\[STATE\]...\[/STATE\]] block. *)
-let render_state_block (snapshot : keeper_state_snapshot) : string =
-  let buf = Buffer.create 256 in
-  Buffer.add_string buf "[STATE]\n";
-  (match snapshot.done_summary with
-   | Some d when String.trim d <> "" ->
-     Printf.bprintf buf "DONE: %s\n" d
-   | Some _ | None ->
-     (match snapshot.progress with
-      | Some p when String.trim p <> "" ->
-        Printf.bprintf buf "DONE: %s\n" p
-      | Some _ | None -> ()));
-  (match snapshot.next_summary with
-   | Some n when String.trim n <> "" ->
-     Printf.bprintf buf "NEXT: %s\n" n
-   | Some _ | None -> ());
-  (match snapshot.goal with
-   | Some g when String.trim g <> "" ->
-     Printf.bprintf buf "Goal: %s\n" g
-   | Some _ | None -> ());
-  (match snapshot.next_items with
-   | [] -> ()
-   | items ->
-     Buffer.add_string buf
-       (Printf.sprintf "Next: %s\n" (String.concat "; " items)));
-  (match snapshot.decisions with
-   | [] -> ()
-   | items ->
-     Buffer.add_string buf
-       (Printf.sprintf "Decisions: %s\n" (String.concat "; " items)));
-  (match snapshot.open_questions with
-   | [] -> ()
-   | items ->
-     Buffer.add_string buf
-       (Printf.sprintf "OpenQuestions: %s\n" (String.concat "; " items)));
-  (match snapshot.constraints with
-   | [] -> ()
-   | items ->
-     Buffer.add_string buf
-       (Printf.sprintf "Constraints: %s\n" (String.concat "; " items)));
-  Buffer.add_string buf "[/STATE]";
-  Buffer.contents buf

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -181,10 +181,8 @@ val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
 
 (** {1 [STATE] block parsing} *)
 
-(** [Some trimmed] when [text] is non-blank, else [None]. *)
-
 val split_state_items : string -> string list
-(** Split a comma- or bullet-delimited [STATE] item list. *)
+(** Split a ';'-delimited [STATE] item list, keeping at most 6 items. *)
 
 val strip_prefix_ci : prefix:string -> string -> string option
 (** Case-insensitive [String.starts_with]: returns the suffix when
@@ -386,6 +384,3 @@ val synthesize_state_from_run_result :
   stop_reason:string -> response_text:string -> keeper_state_snapshot
 (** Build a snapshot from a turn's run result when the assistant did
     not emit a [STATE] block. *)
-
-val render_state_block : keeper_state_snapshot -> string
-(** Render the canonical [STATE]…[/STATE] block from a snapshot. *)

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -858,6 +858,8 @@ let test_text_parse_matches_json_parse () =
      | Some json_snap ->
        Alcotest.(check (option string)) "goal" text_snap.goal json_snap.goal;
        Alcotest.(check (option string)) "done" text_snap.done_summary json_snap.done_summary;
+       Alcotest.(check (option string)) "next_summary" text_snap.next_summary json_snap.next_summary;
+       Alcotest.(check (list string)) "next_items" text_snap.next_items json_snap.next_items;
        Alcotest.(check (list string)) "decisions" text_snap.decisions json_snap.decisions;
        Alcotest.(check (list string)) "open_questions" text_snap.open_questions json_snap.open_questions;
        Alcotest.(check (list string)) "constraints" text_snap.constraints json_snap.constraints)
@@ -1084,6 +1086,73 @@ let test_internal_passive_only_finalizer_still_drops_raw_response_text () =
     ""
     finalized.response_text
 
+(* ── Continuity NEXT parsing / text round-trip ───────────────────────
+   Regression coverage for the parser/renderer asymmetry that let a single
+   [STATE] "NEXT:" line populate both next_summary and next_items and then
+   degenerate next_summary into the joined next_items on every text
+   round-trip. "NEXT PLAN:" now feeds next_summary, "NEXT:" feeds
+   next_items, and the two labels round-trip through the summary text. *)
+
+let parse_state_block body =
+  KMP.parse_state_snapshot_from_reply ("[STATE]\n" ^ body ^ "\n[/STATE]")
+
+let test_next_line_populates_items_only () =
+  match parse_state_block "NEXT: a; b" with
+  | None -> Alcotest.fail "expected Some snapshot for a NEXT: line"
+  | Some s ->
+    Alcotest.(check (list string)) "next_items split on ;" [ "a"; "b" ] s.next_items;
+    Alcotest.(check (option string)) "next_summary untouched" None s.next_summary
+
+let test_next_plan_line_populates_summary_only () =
+  match parse_state_block "NEXT PLAN: do X first" with
+  | None -> Alcotest.fail "expected Some snapshot for a NEXT PLAN: line"
+  | Some s ->
+    Alcotest.(check (option string)) "next_summary set" (Some "do X first") s.next_summary;
+    Alcotest.(check (list string)) "next_items untouched" [] s.next_items
+
+let test_next_case_variants_are_items_only () =
+  List.iter
+    (fun line ->
+      match parse_state_block line with
+      | None -> Alcotest.fail ("expected Some snapshot for " ^ line)
+      | Some s ->
+        Alcotest.(check (list string)) ("next_items for " ^ line) [ "c" ] s.next_items;
+        Alcotest.(check (option string)) ("next_summary None for " ^ line) None s.next_summary)
+    [ "next: c"; "Next: c"; "NEXT: c" ]
+
+let test_summary_text_round_trip_is_faithful () =
+  let original =
+    make_snapshot ~goal:None ~progress:None ~done_summary:None
+      ~next_summary:(Some "prose plan") ~next_items:[ "a"; "b" ] ~decisions:[]
+      ~open_questions:[] ~constraints:[] ()
+  in
+  let text = KMP.keeper_state_snapshot_to_summary_text original in
+  match KMP.state_snapshot_of_summary_text text with
+  | None -> Alcotest.fail "summary-text round-trip returned None"
+  | Some restored ->
+    Alcotest.(check (option string)) "next_summary preserved" original.next_summary
+      restored.next_summary;
+    Alcotest.(check (list string)) "next_items preserved" original.next_items
+      restored.next_items
+
+let test_summary_text_render_parse_render_is_fixed_point () =
+  let original =
+    make_snapshot ~goal:(Some "ship it") ~progress:None ~done_summary:None
+      ~next_summary:(Some "prose plan") ~next_items:[ "a"; "b" ] ~decisions:[]
+      ~open_questions:[] ~constraints:[] ()
+  in
+  let once = KMP.keeper_state_snapshot_to_summary_text original in
+  match KMP.state_snapshot_of_summary_text once with
+  | None -> Alcotest.fail "first parse returned None"
+  | Some reparsed ->
+    let twice = KMP.keeper_state_snapshot_to_summary_text reparsed in
+    Alcotest.(check string) "render -> parse -> render is a fixed point" once twice
+
+let test_next_plan_only_block_yields_snapshot () =
+  match parse_state_block "NEXT PLAN: x" with
+  | None -> Alcotest.fail "a NEXT PLAN:-only block should yield Some snapshot"
+  | Some s -> Alcotest.(check (option string)) "next_summary set" (Some "x") s.next_summary
+
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -1197,5 +1266,32 @@ let () =
             "internal passive-only finalizer still drops raw response text"
             `Quick
             test_internal_passive_only_finalizer_still_drops_raw_response_text;
+        ] );
+      ( "continuity_next",
+        [
+          Alcotest.test_case
+            "NEXT: populates next_items only"
+            `Quick
+            test_next_line_populates_items_only;
+          Alcotest.test_case
+            "NEXT PLAN: populates next_summary only"
+            `Quick
+            test_next_plan_line_populates_summary_only;
+          Alcotest.test_case
+            "next case variants are items only"
+            `Quick
+            test_next_case_variants_are_items_only;
+          Alcotest.test_case
+            "summary text round-trip is faithful"
+            `Quick
+            test_summary_text_round_trip_is_faithful;
+          Alcotest.test_case
+            "render -> parse -> render is a fixed point"
+            `Quick
+            test_summary_text_render_parse_render_is_fixed_point;
+          Alcotest.test_case
+            "NEXT PLAN:-only block yields snapshot"
+            `Quick
+            test_next_plan_only_block_yields_snapshot;
         ] );
     ]


### PR DESCRIPTION
## 문제

`state_snapshot_of_lines`가 `[STATE]` 블록의 `NEXT:` 한 줄을 `next_summary`와 `next_items` **두 필드에 동시에** 채웠고, 바로 뒤의 `Next:` 브랜치는 dead code였습니다 (`strip_prefix_ci`가 양쪽을 lowercase하므로 `NEXT:`와 `Next:`는 동일 predicate — 첫 브랜치가 항상 shadowing).

렌더러(`keeper_state_snapshot_to_summary_text`)는 `Next plan: <summary>` + `Next: <items>` 두 줄을 내보내지만 파서에 `Next plan:` 브랜치가 없어서, 모든 텍스트 라운드트립(progress.md, meta.continuity_summary)이 prose를 잃고 `next_items` join으로 `next_summary`를 재구성했습니다. 한 세대 만에 `next_summary == "item1; item2; item3"`로 퇴화하고, keeper 프롬프트에 매 턴 근사 중복 forward 2줄이 실렸습니다 (반복 생성 되먹임 루프의 결정론적 기여분).

## 설계 결정: 필드 collapse가 아니라 surgical disambiguation

두 필드를 하나로 합치는 안은 기각했습니다:

- JSON 키 `next_summary`/`next_items`는 영속 스키마입니다 (OAS Checkpoint `working_context` envelope v1, `masc.replay` metadata, turn sidecar). `of_json`이 permissive라 필드 제거는 기존 checkpoint에서 silent data loss가 됩니다.
- 대시보드 working-context 패널이 소비하는 외부 계약입니다.
- structured LLM output 스키마에서 prose plan과 concrete items는 의미가 분리된 별개 param입니다.

illegal state는 필드 쌍이 아니라 **파서/렌더러 비대칭**이므로 그쪽을 고쳤습니다.

## 변경

- 파서: `NEXT PLAN:`(ci, 렌더 라벨 `Next plan:` 대칭) → `next_summary`만, `NEXT:` → `next_items`만. dead `Next:` 브랜치 삭제. 이제 각 필드가 렌더 라벨 하나씩을 소유하므로 render→parse→render가 fixed point.
- 텍스트 파스 emptiness gate를 JSON gate와 정렬 (9필드 전부 검사 — 기존엔 `done_summary`/`next_summary`만 있는 블록이 None으로 버려짐).
- `render_state_block` 삭제: call site 0의 dead API이며 출력(`NEXT: <summary>` + `Next: <items>`)의 재파스가 두 필드를 교차 오염시키는 유일한 표면. .ml + 3개 .mli export 제거.
- `split_state_items` doc comment 실제 구현(`;` split, max 6)에 맞게 수정, orphaned doc comment 제거.

## 테스트 (test/test_keeper_state_snapshot_json.ml)

- `NEXT: a; b` → items만 / `NEXT PLAN: x` → summary만 / case variants 3종 동일 동작
- summary-text 라운드트립 faithful (prose + items 원본 보존)
- render→parse→render fixed point (퇴화 회귀 가드)
- `NEXT PLAN:`만 있는 블록이 Some (gate 정렬 검증)
- dual-source(text vs json) 테스트에 next_summary/next_items 동등성 assert 추가 (기존엔 의도적으로 생략돼 있던 갭)

## 검증

편집 파일 ocamlformat --inplace 적용. dune build/test는 CI 위임 (repo 정책).

## 영향

텍스트 소스에서 `NEXT:` prose가 이제 `next_items`로만 들어갑니다 (기존: 양쪽). prose 정보는 items[0]으로 보존되고, structured LLM output 경로(JSON)의 `next_summary`는 영향 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
