### PR TITLE
fix(keeper): redact model_id from memory-summary Otel label and keeper warn logs

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -171,7 +171,12 @@ OAS  ──does not know──→ MASC
   Provider-error and OAS-run-timeout metric counters follow the same
   projection rule: they retain error kind, runtime, capacity scope, and timeout
   source, but the historical `provider` label value is the neutral `runtime`
-  lane rather than a concrete provider/model identity.
+  lane rather than a concrete provider/model identity. The keeper
+  memory-summary outcome counter (`masc_keeper_memory_llm_summary_outcomes_total`)
+  and its warn logs follow the same rule: they keep the historical `provider`
+  label key and the `runtime_id`/`outcome` evidence, but the `provider` value is
+  the neutral `runtime` lane and the warn logs name the runtime rather than the
+  model id.
   The typed `Provider_error` contract itself is also runtime-lane scoped:
   variants no longer store provider/model identifiers, and legacy JSON keys
   such as `provider`, `affected`, and `model_name` emit neutral `runtime`
@@ -202,6 +207,15 @@ OAS  ──does not know──→ MASC
   `Runtime_oas_runner`, provider-attempt FSM APIs, or config/preflight helpers
   from `Runtime_error_classify`; provider/model-shaped helpers stay behind
   lower-level OAS boundary modules instead of the keeper facade.
+  Documented boundary-allow exception: `keeper_runtime_attempt.ml`
+  `enrich_sdk_error` (`openai_compat_not_found_detail`) intentionally
+  interpolates `model_id`, `base_url`, `request_path`, and the composed
+  `endpoint` into the OpenAI-compatible 404/invalid-request error message it
+  appends. This is a diagnostic-only leak: it exists so an operator can see the
+  exact misconfigured endpoint that a neutral runtime lane would hide, the
+  values come from the masc-owned `runtime.toml` provider binding, and they are
+  surfaced only on the error message path — never in metric labels or product
+  telemetry. It is retained deliberately rather than redacted.
   The stricter OAS-owned provider/model migration is tracked in
   <https://github.com/jeong-sik/masc/issues/15028>.
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -730,9 +730,8 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
            if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
            then
              Log.Keeper.warn ~keeper_name:keeper_id
-               "memory os librarian skipped runtime=%s provider=%s: provider does not support direct completion"
+               "memory os librarian skipped runtime=%s: provider does not support direct completion"
                runtime_id
-               provider_cfg.Llm_provider.Provider_config.model_id
            else (
              let clock = Eio_context.get_clock_opt () in
              let timeout_sec =

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -24,7 +24,8 @@ let () =
       "Total [summarize_with_provider] attempts classified by label \
        [outcome] (ok_summary | timed_out | http_error | empty_response | \
        invalid_structured_response). \
-       Labels: [outcome], [provider] (model_id), [runtime_id]."
+       Labels: [outcome], [provider] (neutral runtime lane — concrete \
+       model_id is OAS-owned and redacted per RFC-0132 PR-2), [runtime_id]."
     ();
   Otel_metric_store.register_counter
     ~name:Keeper_metrics.(to_string MemoryLlmSummaryChainExhausted)
@@ -35,6 +36,13 @@ let () =
        means consolidation is silently skipping the LLM summary."
     ()
 ;;
+
+(* RFC-0132 PR-2: memory-summary outcome metric label + warn logs are an
+   external boundary; redact concrete provider/model identity via SSOT.
+   Runtime identity stays in-boundary through the separate [runtime_id]
+   label and warn-log argument. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 type complete_fn =
   sw:Eio.Switch.t ->
@@ -156,11 +164,6 @@ let summary_text_of_response response =
   | Error _ -> None
 ;;
 
-module For_testing = struct
-  let summary_text_of_response = summary_text_of_response
-  let summary_text_result_of_response = summary_text_result_of_response
-end
-
 let with_timeout ?clock ~timeout_sec f =
   match clock with
   | None -> Some (f ())
@@ -170,16 +173,21 @@ let with_timeout ?clock ~timeout_sec f =
 
 let record_summary_outcome
     ~(runtime_id : string)
-    ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(outcome : Keeper_memory_llm_summary_outcome.t) =
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string MemoryLlmSummaryOutcomes)
     ~labels:
       [ ("outcome", Keeper_memory_llm_summary_outcome.to_label outcome)
-      ; ("provider", provider_cfg.Llm_provider.Provider_config.model_id)
+      ; ("provider", runtime_lane_label)
       ; ("runtime_id", runtime_id)
       ]
     ()
+
+module For_testing = struct
+  let summary_text_of_response = summary_text_of_response
+  let summary_text_result_of_response = summary_text_result_of_response
+  let record_summary_outcome = record_summary_outcome
+end
 
 let summarize_with_provider
     ?(complete : complete_fn = default_complete)
@@ -201,8 +209,8 @@ let summarize_with_provider
     with
     | None ->
         Log.Keeper.warn
-          "memory LLM summary timed out trace_id=%s provider=%s timeout_sec=%.1f"
-          trace_id provider_cfg.model_id timeout_sec;
+          "memory LLM summary timed out trace_id=%s runtime=%s timeout_sec=%.1f"
+          trace_id runtime_id timeout_sec;
         None, Keeper_memory_llm_summary_outcome.Timed_out
     | Some (Ok response) ->
         (match summary_text_result_of_response response with
@@ -210,22 +218,22 @@ let summarize_with_provider
              Some summary, Keeper_memory_llm_summary_outcome.Ok_summary
          | Error Empty_summary_response ->
              Log.Keeper.warn
-               "memory LLM summary empty trace_id=%s provider=%s"
-               trace_id provider_cfg.model_id;
+               "memory LLM summary empty trace_id=%s runtime=%s"
+               trace_id runtime_id;
              None, Keeper_memory_llm_summary_outcome.Empty_response
          | Error (Invalid_structured_response detail) ->
              Log.Keeper.warn
                "memory LLM summary invalid structured response trace_id=%s \
-                provider=%s detail=%s"
-               trace_id provider_cfg.model_id detail;
+                runtime=%s detail=%s"
+               trace_id runtime_id detail;
              None, Keeper_memory_llm_summary_outcome.Invalid_structured_response)
     | Some (Error err) ->
         Log.Keeper.warn
-          "memory LLM summary failed trace_id=%s provider=%s: %s"
-          trace_id provider_cfg.model_id (Provider_http_error.to_message err);
+          "memory LLM summary failed trace_id=%s runtime=%s: %s"
+          trace_id runtime_id (Provider_http_error.to_message err);
         None, Keeper_memory_llm_summary_outcome.Http_error
   in
-  record_summary_outcome ~runtime_id ~provider_cfg ~outcome;
+  record_summary_outcome ~runtime_id ~outcome;
   result
 
 let summarize_with_providers

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -31,6 +31,14 @@ module For_testing : sig
 
   val summary_text_result_of_response :
     Agent_sdk.Types.api_response -> (string, summary_parse_error) result
+
+  (** Emits the [masc_keeper_memory_llm_summary_outcomes_total] counter.
+      Exposed for the label-redaction regression test; the [provider]
+      label value is the neutral runtime lane, never the model id. *)
+  val record_summary_outcome :
+    runtime_id:string ->
+    outcome:Keeper_memory_llm_summary_outcome.t ->
+    unit
 end
 
 val make :

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -195,6 +195,14 @@ let enrich_sdk_error ~runtime_id ~(provider_cfg : Llm_provider.Provider_config.t
     then Printf.sprintf "%s: %s" hint_marker detail
     else Printf.sprintf "%s (%s: %s)" message hint_marker detail
   in
+  (* RFC-0132 PR-2 boundary-allow exception: this detail intentionally names
+     model_id/base_url/request_path/endpoint. It exists to pinpoint a
+     misconfigured OpenAI-compatible endpoint when the provider returns
+     404/invalid-request, where the neutral runtime lane would hide the exact
+     misconfiguration an operator must fix. The values originate from the
+     masc-owned runtime.toml provider binding, and the string is surfaced only
+     on the error path, not in metric labels or product telemetry. Documented
+     as an exception in docs/OAS-MASC-BOUNDARY.md Open Structural Gaps. *)
   let openai_compat_not_found_detail () =
     Printf.sprintf
       "runtime_id=%s model=%s base_url=%s request_path=%s endpoint=%s"

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -117,9 +117,8 @@ let vision_runtime_candidates () : (string * Runtime.t) list =
          then Some (rt.Runtime.id, rt)
          else (
            Log.Keeper.warn
-             "vision runtime skipped runtime=%s provider=%s: provider does not support native structured output"
-             rt.Runtime.id
-             rt.Runtime.provider_config.Llm_provider.Provider_config.model_id;
+             "vision runtime skipped runtime=%s: provider does not support native structured output"
+             rt.Runtime.id;
            None)
        else None)
 

--- a/test/dune
+++ b/test/dune
@@ -159,6 +159,7 @@
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
   test_keeper_tool_duration_buckets
+  test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
@@ -492,6 +493,7 @@
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
   test_keeper_tool_duration_buckets
+  test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter

--- a/test/test_keeper_memory_summary_label_redaction.ml
+++ b/test/test_keeper_memory_summary_label_redaction.ml
@@ -1,0 +1,60 @@
+(* RFC-0132 PR-2 regression: the keeper memory-summary outcome counter must
+   emit the neutral runtime lane in its [provider] label, never the concrete
+   model id. Runtime identity is preserved by the separate [runtime_id] label. *)
+
+module Summary = Masc.Keeper_memory_llm_summary
+module Metrics = Masc.Otel_metric_store
+module Outcome = Keeper_memory_llm_summary_outcome
+
+let metric = Keeper_metrics.(to_string MemoryLlmSummaryOutcomes)
+let runtime_lane = Masc.Keeper_hooks_oas.runtime_lane_label
+let runtime_id = "test-runtime-memory-summary-label"
+let raw_model_id = "vendor/concrete-model-must-not-leak"
+let outcome = Outcome.Ok_summary
+
+(* Label order matches the emission order in [record_summary_outcome]. *)
+let redacted_labels =
+  [ "outcome", Outcome.to_label outcome
+  ; "provider", runtime_lane
+  ; "runtime_id", runtime_id
+  ]
+
+let leaked_labels =
+  [ "outcome", Outcome.to_label outcome
+  ; "provider", raw_model_id
+  ; "runtime_id", runtime_id
+  ]
+
+let test_runtime_lane_value_is_neutral () =
+  Alcotest.(check string)
+    "runtime lane label is the neutral constant"
+    "runtime"
+    runtime_lane
+
+let test_provider_label_redacted_to_runtime_lane () =
+  let before_redacted = Metrics.metric_value_or_zero metric ~labels:redacted_labels () in
+  let before_leaked = Metrics.metric_value_or_zero metric ~labels:leaked_labels () in
+  Summary.For_testing.record_summary_outcome ~runtime_id ~outcome;
+  Alcotest.(check (float 0.0001))
+    "provider=runtime labelset increments by 1"
+    (before_redacted +. 1.0)
+    (Metrics.metric_value_or_zero metric ~labels:redacted_labels ());
+  Alcotest.(check (float 0.0001))
+    "raw model_id labelset never materializes"
+    before_leaked
+    (Metrics.metric_value_or_zero metric ~labels:leaked_labels ())
+
+let () =
+  Alcotest.run
+    "keeper_memory_summary_label_redaction"
+    [ ( "otel-label"
+      , [ Alcotest.test_case
+            "runtime lane value is neutral"
+            `Quick
+            test_runtime_lane_value_is_neutral
+        ; Alcotest.test_case
+            "provider label redacted to runtime lane"
+            `Quick
+            test_provider_label_redacted_to_runtime_lane
+        ] )
+    ]


### PR DESCRIPTION
## 문제

`docs/OAS-MASC-BOUNDARY.md` 규칙: MASC는 keeper runtime product에 구체 provider/model 식별자를 노출하지 않는다 (redaction SSOT = `lib/types_boundary/boundary_redaction.ml`, 컨벤션 = RFC-0132 PR-2). `lib/keeper/`에 위반 4곳이 남아 있었습니다:

1. `keeper_memory_llm_summary.ml:179` — Otel counter `masc_keeper_memory_llm_summary_outcomes_total`의 `provider` label에 `provider_cfg.model_id` 원값 방출
2. 같은 파일 warn log 4곳 — `provider=%s`로 model_id 출력
3. `keeper_vision_tool.ml:119-122` — warn log에 model_id (runtime=%s는 이미 별도 출력)
4. `keeper_librarian_runtime.ml:732-735` — warn log에 model_id (runtime=%s는 이미 별도 출력)

## 수정

- **Otel label**: Open Structural Gaps 선례를 따라 label **key `provider`는 유지**(dashboard 호환), value만 neutral `runtime` lane으로 교체 (`Boundary_redaction.runtime_model_label`). runtime 식별은 기존 `runtime_id` label이 계속 담당하므로 in-boundary 정보 손실 없음. metric help string도 갱신.
- **타입 레벨 차단**: `record_summary_outcome`에서 `~provider_cfg` 파라미터 자체를 제거 — 이 함수는 이제 model_id에 접근할 수 없습니다.
- **warn logs**: memory summary 4곳은 `provider=%s`(model_id) → `runtime=%s`(runtime_id). vision/librarian 2곳은 `provider=%s` 세그먼트 삭제 — 로그에 이미 runtime id + skip 사유가 있어 추가 정보가 없음.
- **`enrich_sdk_error`는 문서화된 진단 예외로 유지**: `openai_compat_not_found_detail`은 404/invalid-request 시 잘못 설정된 endpoint를 특정하기 위한 진단이며, 값 출처가 masc 소유 runtime.toml binding이고 에러 메시지 경로에만 실립니다. 코드 주석 + boundary doc Open Structural Gaps에 boundary-allow 항목으로 명시 (silent 예외 → 문서화된 예외).

## 테스트

`test/test_keeper_memory_summary_label_redaction.ml` (신규, `test_keeper_tool_duration_buckets.ml` 패턴):
- lane 상수가 `"runtime"`인지 assert
- `For_testing.record_summary_outcome` 호출 후 `provider=runtime` labelset +1, 원 model_id labelset은 불변 (leak 회귀 가드)
- `record_summary_outcome`을 For_testing에 노출 (mli 문서 주석 포함)

## 검증

편집 파일 전부 `ocamlformat --check` PASS. dune build/test는 CI 위임 (repo 정책).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
