### PR TITLE
fix(keeper): remove descriptor discovery assert

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1910,24 +1910,27 @@ let discovery_policy_json policy =
      @ [ "effect_domain", effect_domain_json policy.effect_domain ])
 ;;
 
-let discovery_json d =
+let discovery_fields d =
   let examples_field =
     match d.examples with
     | [] -> []
     | examples -> [ "examples", `List examples ]
   in
-  `Assoc
-    ([ "id", `String d.id
-     ; "public_name", `String d.public_name
-     ; "public_aliases", Json_util.json_string_list d.public_aliases
-     ; "internal_name", `String d.internal_name
-     ; "description", `String d.description
-     ; "executor", `String (executor_to_string d.executor)
-     ; "backend", `String (backend_to_string d.backend)
-     ; "sandbox", `String (sandbox_to_string d.sandbox)
-     ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
-     ; "policy", discovery_policy_json d.policy
-     ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema
-     ]
-     @ examples_field)
+  [ "id", `String d.id
+  ; "public_name", `String d.public_name
+  ; "public_aliases", Json_util.json_string_list d.public_aliases
+  ; "internal_name", `String d.internal_name
+  ; "description", `String d.description
+  ; "executor", `String (executor_to_string d.executor)
+  ; "backend", `String (backend_to_string d.backend)
+  ; "sandbox", `String (sandbox_to_string d.sandbox)
+  ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+  ; "policy", discovery_policy_json d.policy
+  ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema
+  ]
+  @ examples_field
+;;
+
+let discovery_json d =
+  `Assoc (discovery_fields d)
 ;;

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -174,4 +174,7 @@ val route_evidence_json : t -> Yojson.Safe.t
     to the descriptor that owns the runtime route. The policy [effect_domain] is
     [null] when a descriptor has no static effect domain; no fallback sentinel
     string is emitted. *)
+val discovery_fields : t -> (string * Yojson.Safe.t) list
+
+(** Object wrapper for {!discovery_fields}. *)
 val discovery_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -761,18 +761,12 @@ let descriptor_active_names active_name_set descriptor =
 ;;
 
 let descriptor_discovery_json active_name_set descriptor =
-  match Keeper_tool_descriptor.discovery_json descriptor with
-  | `Assoc fields ->
-    `Assoc
-      (fields
-       @ [ ( "active_names"
+  `Assoc
+    (Keeper_tool_descriptor.discovery_fields descriptor
+     @ [ ( "active_names"
          , Json_util.json_string_list
              (descriptor_active_names active_name_set descriptor) )
        ])
-  | _ ->
-    (* [discovery_json] is specified as an object projection; this branch is an
-       internal invariant breach, not user input. *)
-    assert false
 ;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -500,6 +500,17 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     | descriptor :: _ -> descriptor
     | [] -> fail ("missing registered descriptor for " ^ internal_name)
   in
+  let execute_descriptor = descriptor_for_internal "tool_execute" in
+  let execute_fields = KTD.discovery_fields execute_descriptor in
+  check string "discovery_fields internal name" "tool_execute"
+    (match List.assoc_opt "internal_name" execute_fields with
+     | Some (`String internal_name) -> internal_name
+     | _ -> fail "discovery_fields missing internal_name");
+  check bool "discovery_fields leaves active_names to shared runtime" true
+    (Option.is_none (List.assoc_opt "active_names" execute_fields));
+  check string "discovery_json wraps discovery_fields"
+    (Yojson.Safe.to_string (`Assoc execute_fields))
+    (Yojson.Safe.to_string (KTD.discovery_json execute_descriptor));
   let execute = find_descriptor "tool_execute" in
   check string "Execute public alias" "Execute"
     (string_member "public_name" execute);


### PR DESCRIPTION
## Summary

- remove the production `assert false` from keeper tool descriptor discovery wiring
- expose descriptor discovery fields as the object-shaped API and keep `discovery_json` as the wrapper
- keep the existing keeper_tools_list descriptor surface shape while appending `active_names` without a runtime non-object branch
- add regression coverage that `discovery_fields` is the object projection and leaves active runtime state to shared runtime

## Report Item

Starts the `assert false` P0 from `reports/masc-oas-comprehensive-status-2026-07-01.html`: pipeline/control surfaces should not rely on runtime assertions for invariant handling.

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_tool_descriptor.mli lib/keeper/keeper_tool_shared_runtime.ml test/test_keeper_tool_dispatch_runtime.ml`
- `python3 scripts/check_test_coverage.py`
- `git diff --check origin/main..HEAD`
- `rg -n "assert false" lib/keeper/keeper_tool_shared_runtime.ml lib/keeper/keeper_tool_descriptor.ml lib/keeper/keeper_tool_descriptor.mli` returned no matches
- `rg -n "assert false" lib -g "!**/test/**"` now only reports comments/string literals, not executable production assertions

## Not Run

- Local Dune build/test per operator direction; CI is the build authority for this slice.
