### PR TITLE
fix(approval): add 1h auto-escalation for Critical-risk HITL approvals

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -832,7 +832,36 @@ let submit_and_await
          (* Mirror expire_stale's teardown, but preserve any concurrent
             operator decision that wins the promise resolution race. *)
          timeout_decision reason)
-    | Some _, Critical | None, _ -> Eio.Promise.await promise
+    | Some clock, Critical ->
+      (match
+         Eio.Fiber.first
+           (fun () -> `Decision (Eio.Promise.await promise))
+           (fun () ->
+              Eio.Time.sleep clock 3600.0;
+              `Escalated)
+       with
+       | `Decision d -> d
+       | `Escalated ->
+         let reason = "critical approval escalated — operator must decide" in
+         audit_approval_event
+           ~base_path:entry.audit_base_path
+           ~event_type:"approval_escalated"
+           ~id
+           ~keeper_name
+           ~tool_name
+           ~risk_level
+           ?turn_id
+           ?task_id
+           ?goal_id
+           ~goal_ids
+           ~sandbox_target:entry.sandbox_target
+           ?runtime_contract
+           ?selected_model
+           ~decision:(Approval_expired reason)
+           ();
+         (* Escalated — keep waiting for operator, do not reject *)
+         Eio.Promise.await promise)
+    | None, _ -> Eio.Promise.await promise
   in
   Eio_guard.protect await_with_timeout ~finally:(fun () ->
     Safe_ops.protect ~default:() (fun () ->

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -726,6 +726,8 @@ let sort_entries_by_requested_at entries =
 
 let default_noncritical_approval_timeout_s = 600.0
 
+let default_critical_approval_escalation_after_s = 3600.0
+
 (** Submit a tool call for approval and suspend the calling fiber.
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside agent fiber).
@@ -758,6 +760,7 @@ let submit_and_await
       ?disposition_reason
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
+      ?(critical_escalation_after_s = default_critical_approval_escalation_after_s)
       ()
   : Agent_sdk.Hooks.approval_decision
   =
@@ -837,7 +840,7 @@ let submit_and_await
          Eio.Fiber.first
            (fun () -> `Decision (Eio.Promise.await promise))
            (fun () ->
-              Eio.Time.sleep clock 3600.0;
+              Eio.Time.sleep clock critical_escalation_after_s;
               `Escalated)
        with
        | `Decision d -> d

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -96,6 +96,10 @@ let approval_audit_decision_kind_and_reason = function
   | Approval_expired reason -> "reject", non_empty_reason reason
 ;;
 
+let approval_audit_disposition_fields = function
+  | Approval_escalated reason -> "escalated", non_empty_reason reason
+;;
+
 let keeper_audit_metric_label = function
   | Some keeper when String.trim keeper <> "" -> keeper
   | Some _ | None -> "aggregate"
@@ -167,6 +171,7 @@ let audit_approval_event
       ?sandbox_target
       ?runtime_contract
       ?selected_model
+      ?audit_disposition
       ?disposition
       ?disposition_reason
       ?rule_match
@@ -181,6 +186,16 @@ let audit_approval_event
     | Some decision ->
       let kind, reason = approval_audit_decision_kind_and_reason decision in
       approval_audit_decision_to_string decision, Some kind, reason
+  in
+  let disposition, disposition_reason =
+    match audit_disposition with
+    | None -> disposition, disposition_reason
+    | Some audit_disposition ->
+      if Option.is_some disposition || Option.is_some disposition_reason then
+        invalid_arg
+          "audit_approval_event: audit_disposition cannot be combined with raw disposition fields";
+      let disposition, reason = approval_audit_disposition_fields audit_disposition in
+      Some disposition, reason
   in
   match get_audit_store ~base_path () with
   | None -> ()
@@ -860,7 +875,7 @@ let submit_and_await
            ~sandbox_target:entry.sandbox_target
            ?runtime_contract
            ?selected_model
-           ~decision:(Approval_expired reason)
+           ~audit_disposition:(Approval_escalated reason)
            ();
          (* Escalated — keep waiting for operator, do not reject *)
          Eio.Promise.await promise)

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -21,6 +21,9 @@ type approval_audit_decision =
   | Approval_resolved of decision
   | Approval_expired of string
 
+type approval_audit_disposition =
+  | Approval_escalated of string
+
 (** Pending approval entry — the suspended-fiber side of the
     Eio.Promise rendez-vous. *)
 type pending_approval =
@@ -157,6 +160,7 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
+  ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
   ?rule_match:rule_match ->

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -204,6 +204,10 @@ val default_noncritical_approval_timeout_s : float
     not be shorter than this, otherwise a valid HITL wait is misclassified as
     provider idleness. *)
 
+val default_critical_approval_escalation_after_s : float
+(** Default wait before a [Critical] approval emits an escalation audit event
+    while still waiting for a manual operator decision. *)
+
 (** Submit a tool call for approval and suspend the calling fiber.
     Returns the operator's decision when the promise is resolved.
     Called from the OAS approval_callback (inside the agent fiber). *)
@@ -226,6 +230,7 @@ val submit_and_await :
   ?disposition_reason:string ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
+  ?critical_escalation_after_s:float ->
   unit ->
   Agent_sdk.Hooks.approval_decision
 

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -42,6 +42,9 @@ type approval_audit_decision =
   | Approval_resolved of decision
   | Approval_expired of string
 
+type approval_audit_disposition =
+  | Approval_escalated of string
+
 type approval_rule =
   { id : string
   ; keeper_name : string

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -37,6 +37,9 @@ type approval_audit_decision =
   | Approval_resolved of decision
   | Approval_expired of string
 
+type approval_audit_disposition =
+  | Approval_escalated of string
+
 type approval_rule =
   { id : string
   ; keeper_name : string

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -98,6 +98,11 @@ let audit_event_names ~base_path ~keeper_name =
   |> List.map (fun json ->
          Yojson.Safe.Util.(json |> member "event" |> to_string))
 
+let find_audit_event ~base_path ~keeper_name ~event_type =
+  AQ.read_recent_audit ~base_path ~keeper_name ~n:10 ()
+  |> List.find_opt (fun json ->
+         Yojson.Safe.Util.(json |> member "event" |> to_string = event_type))
+
 let test_first_cmd_token_uses_shared_words () =
   Alcotest.(check (option string))
     "quoted command basename preserved"
@@ -523,6 +528,32 @@ let test_submit_and_await_critical_escalates_then_waits () =
     (List.exists
        (String.equal "approval_escalated")
        (audit_event_names ~base_path ~keeper_name));
+  let escalation_event =
+    match find_audit_event ~base_path ~keeper_name ~event_type:"approval_escalated" with
+    | Some json -> json
+    | None -> Alcotest.fail "expected Critical escalation audit row"
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "Critical escalation is not a terminal decision"
+    ""
+    (escalation_event |> member "decision" |> to_string);
+  Alcotest.(check bool)
+    "Critical escalation has no decision kind"
+    true
+    (escalation_event |> member "decision_kind" = `Null);
+  Alcotest.(check bool)
+    "Critical escalation has no decision reason"
+    true
+    (escalation_event |> member "decision_reason" = `Null);
+  Alcotest.(check string)
+    "Critical escalation disposition"
+    "escalated"
+    (escalation_event |> member "disposition" |> to_string);
+  Alcotest.(check string)
+    "Critical escalation disposition reason"
+    "critical approval escalated — operator must decide"
+    (escalation_event |> member "disposition_reason" |> to_string);
   Alcotest.(check bool)
     "Critical escalation does not auto-resolve"
     true

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -485,6 +485,65 @@ let test_submit_and_await_clock_timeout_skips_critical () =
         ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
   | None -> Alcotest.fail "Critical approval did not resume")
 
+let test_submit_and_await_critical_escalates_then_waits () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir () in
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "critical-escalation-test" in
+  let result = ref None in
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name
+        ~tool_name:"keeper_continue_after_partial_commit"
+        ~input:(`Assoc [ ("kind", `String "critical_gate") ])
+        ~risk_level:AQ.Critical
+        ~base_path
+        ~clock
+        ~critical_escalation_after_s:0.01
+        ()
+    in
+    result := Some decision);
+  yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+  Eio.Time.sleep clock 0.03;
+  yield_until (fun () ->
+    List.exists
+      (String.equal "approval_escalated")
+      (audit_event_names ~base_path ~keeper_name));
+  Alcotest.(check bool)
+    "Critical escalation audit recorded"
+    true
+    (List.exists
+       (String.equal "approval_escalated")
+       (audit_event_names ~base_path ~keeper_name));
+  Alcotest.(check bool)
+    "Critical escalation does not auto-resolve"
+    true
+    (Option.is_none !result);
+  let id =
+    match pending_id_for_keeper ~keeper_name with
+    | Some id -> id
+    | None -> Alcotest.fail "Critical approval was removed after escalation"
+  in
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error err ->
+      Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+  yield_until (fun () -> Option.is_some !result);
+  match !result with
+  | Some Agent_sdk.Hooks.Approve -> ()
+  | Some decision ->
+      Alcotest.fail
+        ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
+  | None -> Alcotest.fail "Critical approval did not resume after escalation")
+
 let test_submit_and_await_clock_returns_manual_decision () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -1608,6 +1667,8 @@ let () =
       Alcotest.test_case "expire skips Critical" `Quick test_approval_queue_expire_skips_critical;
       Alcotest.test_case "submit timeout skips Critical" `Quick
         test_submit_and_await_clock_timeout_skips_critical;
+      Alcotest.test_case "Critical escalation waits for manual decision" `Quick
+        test_submit_and_await_critical_escalates_then_waits;
       Alcotest.test_case "submit timeout returns manual winner" `Quick
         test_submit_and_await_clock_returns_manual_decision;
       Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;


### PR DESCRIPTION
## Summary

When a HITL approval is rated **Critical** risk, the operator has 1 hour to decide before the system escalates with an audit event. The approval is **not** auto-rejected on timeout — it stays pending for the operator.

## Changes

`lib/keeper/keeper_approval_queue.ml` — `submit_and_await`:
- `Some clock, Critical` branch now races `Eio.Promise.await` vs 3600s sleep
- On timeout: logs `approval_escalated` audit event + keeps awaiting operator
- Preserves existing `expire_stale` logic for non-Critical cases

## Verification
- CI pending
- Existing approval flow unchanged for `None + any risk` and `Some + non-Critical`