### PR TITLE
fix(governance): add unconditional hard_forbidden gate in governance_approval_guard

### DIFF
--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -49,6 +49,10 @@ val assess_risk : tool_name:string -> input:Yojson.Safe.t -> risk_level
     - Medium: state-changing reads
     - Low: readonly/status/query surfaces *)
 
+val auto_approval_hard_forbidden :
+  risk:risk_level -> Keeper_meta_contract.keeper_meta option -> bool
+(** True when auto-approval must be blocked regardless of HITL threshold. *)
+
 val decide :
   governance_level:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -929,7 +929,49 @@ let governance_approval_guard
           >= Governance_pipeline.risk_level_to_int threshold
         | None -> false
       in
-      if needs_approval then begin
+      (* task-1627: unconditional hard_forbidden gate — blocks before HITL *)
+      let hard_forbidden =
+        Governance_pipeline.auto_approval_hard_forbidden ~risk !meta_ref
+      in
+      if hard_forbidden then begin
+        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        let source_path = keeper_guards_source_path in
+        let source_line = __LINE__ in
+        report_gate_decision on_gate_decision
+          ~source_path:(Some source_path) ~source_line:(Some source_line)
+          ~stage:"governance_approval" ~decision:Gate_override
+          ~reason_code:"hard_forbidden"
+          ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode"
+          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms;
+        Agent_sdk.Hooks.Override
+          (render_inline_skip_reason_with_source
+             ~source_path ~source_line
+             ~tool_name ~reason_code:"hard_forbidden"
+             ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode")
+      end
+      else (* task-1627: unconditional hard_forbidden gate — blocks before HITL *)
+      let hard_forbidden =
+        Governance_pipeline.auto_approval_hard_forbidden ~risk !meta_ref
+      in
+      if hard_forbidden then begin
+        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        let source_path = keeper_guards_source_path in
+        let source_line = __LINE__ in
+        report_gate_decision on_gate_decision
+          ~source_path:(Some source_path) ~source_line:(Some source_line)
+          ~stage:"governance_approval" ~decision:Gate_override
+          ~reason_code:"hard_forbidden"
+          ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode"
+          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms;
+        Agent_sdk.Hooks.Override
+          (render_inline_skip_reason_with_source
+             ~source_path ~source_line
+             ~tool_name ~reason_code:"hard_forbidden"
+             ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode")
+      end
+      else if needs_approval then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
         let source_path = keeper_guards_source_path in
         let source_line = __LINE__ in

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -950,27 +950,6 @@ let governance_approval_guard
              ~tool_name ~reason_code:"hard_forbidden"
              ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode")
       end
-      else (* task-1627: unconditional hard_forbidden gate — blocks before HITL *)
-      let hard_forbidden =
-        Governance_pipeline.auto_approval_hard_forbidden ~risk !meta_ref
-      in
-      if hard_forbidden then begin
-        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
-        let source_path = keeper_guards_source_path in
-        let source_line = __LINE__ in
-        report_gate_decision on_gate_decision
-          ~source_path:(Some source_path) ~source_line:(Some source_line)
-          ~stage:"governance_approval" ~decision:Gate_override
-          ~reason_code:"hard_forbidden"
-          ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode"
-          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
-          ~stage_latency_ms:latency_ms;
-        Agent_sdk.Hooks.Override
-          (render_inline_skip_reason_with_source
-             ~source_path ~source_line
-             ~tool_name ~reason_code:"hard_forbidden"
-             ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode")
-      end
       else if needs_approval then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
         let source_path = keeper_guards_source_path in

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -931,7 +931,7 @@ let governance_approval_guard
       in
       (* task-1627: unconditional hard_forbidden gate — blocks before HITL *)
       let hard_forbidden =
-        Governance_pipeline.auto_approval_hard_forbidden ~risk !meta_ref
+        Governance_pipeline.auto_approval_hard_forbidden ~risk (Some !meta_ref)
       in
       if hard_forbidden then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -774,8 +774,8 @@ let test_governance_approval_notifies_gate_observer () =
     let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
     let d =
       invoke hook
-        (pre_tool_use_event ~tool_name:"tool_edit_file"
-           ~input:(`Assoc [ ("path", `String "/tmp/file"); ("content", `String "x") ])
+        (pre_tool_use_event ~tool_name:"masc_create_task"
+           ~input:(`Assoc [ ("title", `String "follow up") ])
            ())
     in
     check string "high-risk tool -> ApprovalRequired"
@@ -786,7 +786,7 @@ let test_governance_approval_notifies_gate_observer () =
       check string "decision" "approval_required"
         (KG.gate_decision_to_string event.KG.decision);
       check string "reason_code" "governance_approval" event.KG.reason_code;
-      check string "tool_name" "tool_edit_file" event.KG.tool_name;
+      check string "tool_name" "masc_create_task" event.KG.tool_name;
       check (option string) "source_path"
         (Some "lib/keeper/keeper_guards.ml")
         event.KG.source_path;

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -794,8 +794,39 @@ let test_governance_approval_notifies_gate_observer () =
         (match event.KG.source_line with
          | Some line -> line > 0
          | None -> false)
-    | events ->
+  | events ->
       failf "expected one observer event, got %d" (List.length events)))
+
+let test_governance_approval_hard_forbidden_blocks_without_hitl () =
+  with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let meta_ref = make_meta_ref "test_keeper" in
+    let observed = ref [] in
+    let on_gate_decision event = observed := event :: !observed in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let d =
+      invoke hook
+        (pre_tool_use_event ~tool_name:"masc_force_reset"
+           ~input:(`Assoc [ ("target", `String "workspace") ])
+           ())
+    in
+    check string "critical hard-forbidden tool -> Override"
+      "Override" (decision_kind d);
+    check bool "override carries hard-forbidden reason" true
+      (contains_substring (override_text d) "code=hard_forbidden");
+    match !observed with
+    | [ event ] ->
+      check string "stage" "governance_approval" event.KG.stage;
+      check string "decision" "override"
+        (KG.gate_decision_to_string event.KG.decision);
+      check string "reason_code" "hard_forbidden" event.KG.reason_code;
+      check string "tool_name" "masc_force_reset" event.KG.tool_name;
+      check (option string) "source_path"
+        (Some "lib/keeper/keeper_guards.ml")
+        event.KG.source_path
+    | events ->
+      failf "expected one hard-forbidden observer event, got %d"
+        (List.length events)))
 
 let test_timing_guard_sets_time_and_continues () =
   let tool_start_time = ref 0.0 in
@@ -948,6 +979,8 @@ let () = run "Keeper_guards" [
   "governance_approval_guard", [
     test_case "notifies observer on approval required" `Quick
       test_governance_approval_notifies_gate_observer;
+    test_case "hard-forbidden overrides without HITL" `Quick
+      test_governance_approval_hard_forbidden_blocks_without_hitl;
   ];
   "timing_guard", [
     test_case "sets time and continues" `Quick test_timing_guard_sets_time_and_continues;


### PR DESCRIPTION
## Summary

hard_forbidden checked BEFORE needs_approval in governance_approval_guard, regardless of HITL mode. Uses Governance_pipeline.auto_approval_hard_forbidden.

Prevents Critical-risk ops from being operator-approved when they should be blocked outright.

## Fixes
- task-1627: HITL bypass in keeper_guards.ml needs_approval gate
- task-1628: executor commit 4a0452607 reversed hard_forbidden priority

## How to verify
1. Find governance_approval_guard in lib/keeper/keeper_guards.ml
2. Confirm hard_forbidden binding precedes needs_approval check
3. Confirm Gate_override returned when hard_forbidden=true