### PR TITLE
fix(keeper): bound async keeper message workers

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -51,6 +51,12 @@ exception Worker_timeout of float
 let counter = Atomic.make 0
 let max_age_sec = Masc_time_constants.hour
 
+let effective_timeout_sec ?timeout_sec () =
+  match timeout_sec with
+  | Some timeout_sec -> timeout_sec
+  | None -> Keeper_runtime_resolved.turn_timeout_sec ()
+;;
+
 let request_dir ~base_path =
   Filename.concat (Common.masc_dir_from_base_path ~base_path) "keeper_msg_requests"
 ;;
@@ -424,15 +430,18 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
   persist_entry entry;
   Eio.Fiber.fork_daemon ~sw (fun () ->
     set_status_protected ~preserve_terminal:true request_id Running;
+    let worker_timeout_sec = effective_timeout_sec ?timeout_sec () in
     let run_worker_with_timeout () =
-      match clock, timeout_sec with
-      | Some clock, Some timeout_sec ->
-        (try Eio.Time.with_timeout_exn clock timeout_sec f with
+      match clock with
+      | Some clock ->
+        (try Eio.Time.with_timeout_exn clock worker_timeout_sec f with
          | Eio.Time.Timeout ->
-           let status = timeout_done_status ~request_id ~keeper_name ~timeout_sec in
+           let status =
+             timeout_done_status ~request_id ~keeper_name ~timeout_sec:worker_timeout_sec
+           in
            set_status_protected ~preserve_terminal:true request_id status;
-           raise (Worker_timeout timeout_sec))
-      | None, _ | _, None -> f ()
+           raise (Worker_timeout worker_timeout_sec))
+      | None -> f ()
     in
     let result =
       try
@@ -589,4 +598,6 @@ module For_testing = struct
   let active_switch_count () =
     Eio.Mutex.use_ro mu (fun () -> Hashtbl.length active_switches)
   ;;
+
+  let effective_timeout_sec = effective_timeout_sec
 end

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -48,12 +48,13 @@ type load_result =
 
 (** [submit ?clock ?timeout_sec ~sw ~f ~keeper_name] forks a background daemon fiber on
     [sw] that runs [f] and stores the result. Returns the fresh
-    [request_id] synchronously. When both [clock] and [timeout_sec] are
-    provided, the worker records a terminal timeout error if [f] does not
-    return before the deadline. Cancellation of [sw] interrupts the worker
-    and records a terminal [Cancelled] state before stopping, so pollers do
-    not observe an indefinite [Running] request. [Lost] is reserved for
-    persisted non-terminal requests recovered without a live worker. *)
+    [request_id] synchronously. When [clock] is provided, the worker records a
+    terminal timeout error if [f] does not return before the deadline:
+    [timeout_sec] when explicitly supplied, otherwise the runtime-resolved
+    keeper turn timeout. Cancellation of [sw] interrupts the worker and records
+    a terminal [Cancelled] state before stopping, so pollers do not observe an
+    indefinite [Running] request. [Lost] is reserved for persisted non-terminal
+    requests recovered without a live worker. *)
 val submit
   :  ?clock:_ Eio.Time.clock
   -> ?timeout_sec:float
@@ -97,4 +98,5 @@ module For_testing : sig
   val load_record : base_path:string -> request_id:string -> load_result
   val gc_stale_disk : base_path:string -> int
   val active_switch_count : unit -> int
+  val effective_timeout_sec : ?timeout_sec:float -> unit -> float
 end

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -299,7 +299,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("timeout_sec", `Assoc [
           ("type", `String "number");
-          ("description", `String "Optional: overall timeout (sec) for this async keeper message request and its runtime turn");
+          ("description", `String "Optional override: overall timeout (sec) for this async keeper message request and its runtime turn. Defaults to the runtime-resolved keeper turn timeout.");
         ]);
         ("direct_reply", `Assoc [
           ("type", `String "boolean");

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -405,6 +405,18 @@ let test_keeper_msg_async_timeout_is_terminal_error () =
     Alcotest.fail "expected timeout request to remain pollable"
 ;;
 
+let test_keeper_msg_async_default_timeout_uses_turn_timeout () =
+  let expected = Keeper_runtime_resolved.turn_timeout_sec () in
+  Alcotest.(check (float 0.0001))
+    "default async worker timeout"
+    expected
+    (Keeper_msg_async.For_testing.effective_timeout_sec ());
+  Alcotest.(check (float 0.0001))
+    "explicit async worker timeout wins"
+    42.0
+    (Keeper_msg_async.For_testing.effective_timeout_sec ~timeout_sec:42.0 ())
+;;
+
 let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
   with_eio_env
   @@ fun env ->
@@ -690,6 +702,10 @@ let () =
             "timeout is terminal error"
             `Quick
             test_keeper_msg_async_timeout_is_terminal_error
+        ; test_case
+            "default timeout follows keeper turn timeout"
+            `Quick
+            test_keeper_msg_async_default_timeout_uses_turn_timeout
         ; test_case
             "gc removes stale terminal disk record"
             `Quick


### PR DESCRIPTION
## Summary
- give async `masc_keeper_msg` workers a finite default deadline using `Keeper_runtime_resolved.turn_timeout_sec ()` when no `timeout_sec` override is supplied
- keep explicit `timeout_sec` overrides winning over the default
- update the tool schema/interface docs and add regression coverage for effective timeout selection

## Why
Multiple keepers can hold their own per-keeper turn slots while polling async messages to each other. Before this change, an async worker submitted without `timeout_sec` could wait behind a busy keeper admission slot indefinitely and remain `Running`, which makes cross-keeper waiting patterns look stuck.

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_msg_async.ml lib/keeper/keeper_msg_async.mli lib/keeper/keeper_schema.ml test/test_keeper_mutex_coverage.ml`
- `python3 scripts/check_test_coverage.py`
- `git diff --check`
- `rg -n "None, _ \\| _, None -> f \\(\\)|with_timeout_exn clock timeout_sec f|Optional: overall timeout" lib/keeper/keeper_msg_async.ml lib/keeper/keeper_schema.ml` returned no matches

Dune build/test left to CI per operator instruction.