### PR TITLE
fix(governance): hard_forbidden unconditional, soft_forbidden HITL-dependent in to_oas_approval_callback

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -336,7 +336,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
     in
     let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
     let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
-    let auto_approval_forbidden = hard_forbidden || soft_forbidden in
+    let auto_approval_forbidden = hard_forbidden || (not (Env_config_core.disable_hitl ()) && soft_forbidden) in
     let requires_operator_approval = needs_approval || auto_approval_forbidden in
     if trifecta_active
     then

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -122,8 +122,8 @@ val to_oas_approval_callback :
     ([server_dashboard_http.ml]), resuming the fiber.
 
     Tools below the threshold are auto-approved unless auto-approval is
-    explicitly forbidden by critical risk, destructive payload semantics, or
-    runtime safety blockers. Those calls still enter the operator approval
-    queue even when HITL thresholds are otherwise disabled.
+    explicitly forbidden. Critical risk and runtime safety blockers still enter
+    the operator approval queue even when HITL thresholds are otherwise
+    disabled. Soft destructive tool-name/op heuristics are HITL-dependent.
 
     @since 2.262.0 (#5902, #5907) *)

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1458,6 +1458,65 @@ let test_callback_hitl_disabled_forbidden_requires_approval () =
       | None ->
         Alcotest.fail "HITL-disabled forbidden callback did not suspend for approval")
 
+let test_callback_hitl_disabled_soft_forbidden_auto_approved () =
+  with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "hitl-disabled-soft-forbidden-keeper" in
+  let input = `Assoc [ ("op", `String "git") ] in
+  Alcotest.(check string)
+    "soft-only fixture stays below hard-forbidden risk"
+    "low"
+    (GP.assess_risk ~tool_name:"masc_status" ~input |> GP.risk_level_to_string);
+  let initial_pending = AQ.pending_count () in
+  let result = ref None in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = Mcp_server.workspace_config state in
+      Eio.Fiber.fork ~sw (fun () ->
+        let cb =
+          GP.to_oas_approval_callback
+            ~config ~governance_level:"production" ~keeper_name ()
+        in
+        let decision = cb ~tool_name:"masc_status" ~input in
+        result := Some decision);
+      yield_until (fun () ->
+        Option.is_some !result
+        || Option.is_some (pending_id_for_keeper ~keeper_name));
+      let queued =
+        match pending_id_for_keeper ~keeper_name with
+        | Some id ->
+          (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+           | Ok () -> ()
+           | Error err ->
+             Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+          true
+        | None -> false
+      in
+      yield_until (fun () -> Option.is_some !result);
+      Alcotest.(check bool)
+        "soft destructive op does not queue when HITL threshold is disabled"
+        false
+        queued;
+      Alcotest.(check int)
+        "pending count unchanged"
+        initial_pending
+        (AQ.pending_count ());
+      match !result with
+      | Some Agent_sdk.Hooks.Approve -> ()
+      | Some Agent_sdk.Hooks.Reject reason ->
+        Alcotest.fail ("expected Approve for HITL-disabled soft match, got reject: " ^ reason)
+      | Some Agent_sdk.Hooks.Edit _ ->
+        Alcotest.fail "expected Approve for HITL-disabled soft match, got edit"
+      | None ->
+        Alcotest.fail "HITL-disabled soft-forbidden callback did not return")
+
 let test_read_recent_audit_filters_after_wide_scan () =
   with_temp_masc_base @@ fun base_path ->
   let keeper_name = "audit-target-keeper" in
@@ -1665,5 +1724,7 @@ let () =
         test_callback_always_approve_respects_forbidden;
       Alcotest.test_case "HITL disabled still gates forbidden tools" `Quick
         test_callback_hitl_disabled_forbidden_requires_approval;
+      Alcotest.test_case "HITL disabled allows soft forbidden tools" `Quick
+        test_callback_hitl_disabled_soft_forbidden_auto_approved;
     ]);
   ]


### PR DESCRIPTION
## Summary

One-line fix in `to_oas_approval_callback`:

**Before:** `hard_forbidden || soft_forbidden` — disable_hitl() bypassed BOTH
**After:** `hard_forbidden || (not (disable_hitl()) && soft_forbidden)`

hard_forbidden: **unconditional** blocks regardless of HITL mode
soft_forbidden: **HITL-dependent** — only blocks when HITL enabled

## Fixes
- Regression from PR #22978
- task-1627: HITL bypass in governance approval gate

## How to verify
1. See `to_oas_approval_callback` in `lib/governance_pipeline.ml`
2. Confirm `auto_approval_forbidden` = `hard_forbidden || (not (Env_config_core.disable_hitl ()) && soft_forbidden)`