### PR TITLE
fix(keeper): auto-resume read-only no-progress pauses

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -315,6 +315,12 @@ let is_recoverable_no_progress_accept_rejection
     true
   | Some _ | None -> false
 
+let is_read_only_no_progress_accept_rejection
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match accept_rejection_degraded_retry_reason err with
+  | Some Read_only_no_progress -> true
+  | Some _ | None -> false
+
 type degraded_retry =
   { next_runtime : string
   ; fallback_reason : degraded_retry_reason

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -114,6 +114,11 @@ type degraded_retry_reason =
 
 val degraded_retry_reason_to_string : degraded_retry_reason -> string
 
+val is_read_only_no_progress_accept_rejection : Agent_sdk.Error.sdk_error -> bool
+(** [true] for typed accept rejections whose only progress was read-only tool
+    observation. These can remain terminal for direct retry while still using a
+    bounded auto-resume pause policy after repeated failures. *)
+
 val normalized_runtime_id : catalog_names:string list -> string -> string
 (** Normalize a runtime name for rotation matching.
     All runtime names are plain provider:model strings. *)

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -82,6 +82,9 @@ let record_failure_and_maybe_escalate
     && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
+  let read_only_no_progress_auto_paused =
+    completion_contract_auto_paused && EC.is_read_only_no_progress_accept_rejection err
+  in
   let idle_detected_auto_paused =
     is_idle_detected_error err
     && count >= turn_fail_streak_threshold
@@ -115,7 +118,8 @@ let record_failure_and_maybe_escalate
         else updated_meta
       in
       let resume_policy =
-        if completion_contract_auto_paused || idle_detected_auto_paused
+        if idle_detected_auto_paused
+           || (completion_contract_auto_paused && not read_only_no_progress_auto_paused)
         then Keeper_supervisor_pause_policy.Manual_resume_required
         else Keeper_supervisor_pause_policy.Auto_resume_with_backoff
       in
@@ -144,14 +148,25 @@ let record_failure_and_maybe_escalate
         else
           if completion_contract_auto_paused
           then
-            Log.Keeper.warn
-              "%s: auto-paused after %d completion contract no-progress failures \
-               (pause_threshold=%d, crash_threshold=%d, task_release=policy_checked); \
-               operator must inspect provider/model reasoning output before resuming"
-              meta.name
-              count
-              turn_fail_streak_threshold
-              threshold
+            if read_only_no_progress_auto_paused
+            then
+              Log.Keeper.warn
+                "%s: auto-paused with backoff after %d read-only no-progress \
+                 failures (pause_threshold=%d, crash_threshold=%d, \
+                 task_release=policy_checked)"
+                meta.name
+                count
+                turn_fail_streak_threshold
+                threshold
+            else
+              Log.Keeper.warn
+                "%s: auto-paused after %d completion contract no-progress failures \
+                 (pause_threshold=%d, crash_threshold=%d, task_release=policy_checked); \
+                 operator must inspect provider/model reasoning output before resuming"
+                meta.name
+                count
+                turn_fail_streak_threshold
+                threshold
           else
             Log.Keeper.warn
               "%s: auto-paused after %d idle-detected loop failures \

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -326,6 +326,20 @@ let make_meta name =
   | Ok meta -> meta
   | Error err -> fail ("parse base: " ^ err)
 
+let accept_no_progress_error ?last_tool_effect ?any_mutating_tool
+      ?(tool_effects_seen = []) () =
+  Masc.Keeper_turn_driver.sdk_error_of_masc_internal_error
+    (Masc.Keeper_turn_driver.Accept_rejected
+       { scope = "runtime.test"
+       ; model = Some "runtime"
+       ; reason_kind = Some Masc.Keeper_turn_driver.Accept_no_usable_progress
+       ; response_shape = Some Masc.Keeper_turn_driver.Accept_response_thinking_only
+       ; last_tool_effect
+       ; any_mutating_tool
+       ; tool_effects_seen
+       ; reason = "shape=thinking_only"
+       })
+
 let task_id_of_created_task (created : Masc.Workspace.add_task_success) =
   match Keeper_id.Task_id.of_string created.task_id with
   | Ok task_id -> task_id
@@ -1154,6 +1168,93 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
        | None -> fail "expected idle-detected blocker")
        | None -> fail "expected registered keeper")
 
+let test_read_only_no_progress_pause_uses_backoff_auto_resume () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_runtime_config (runtime_toml_with_pause_threshold 2) @@ fun () ->
+  let base_path = temp_dir "masc-read-only-no-progress-pause-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "read-only-no-progress-paused" in
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let err =
+         accept_no_progress_error
+           ~last_tool_effect:Masc.Keeper_turn_driver.Tool_effect_read_only
+           ~any_mutating_tool:false
+           ~tool_effects_seen:[ Masc.Keeper_turn_driver.Tool_effect_read_only ]
+           ()
+       in
+       for _ = 1 to 2 do
+         Masc.Keeper_unified_turn_failure.record_failure_and_maybe_escalate
+           ~config
+           ~meta
+           ~updated_meta:meta
+           ~is_auto_recoverable:false
+           ~err
+           ~error_text:(Agent_sdk.Error.to_string err)
+       done;
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         let paused_meta = entry.Masc.Keeper_registry.meta in
+         check bool "registry meta paused" true paused_meta.paused;
+         check bool
+           "read-only no-progress pause has auto-resume backoff"
+           true
+           (Option.is_some paused_meta.auto_resume_after_sec);
+         (match paused_meta.runtime.last_blocker with
+          | Some { Keeper_meta_contract.klass = Completion_contract_violation; _ } -> ()
+          | Some _ -> fail "expected Completion_contract_violation blocker"
+          | None -> fail "expected completion-contract blocker")
+       | None -> fail "expected registered keeper")
+
+let test_mutating_no_progress_pause_stays_manual_resume () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_runtime_config (runtime_toml_with_pause_threshold 2) @@ fun () ->
+  let base_path = temp_dir "masc-mutating-no-progress-pause-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "mutating-no-progress-paused" in
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let err =
+         accept_no_progress_error
+           ~last_tool_effect:Masc.Keeper_turn_driver.Tool_effect_mutating
+           ~any_mutating_tool:true
+           ~tool_effects_seen:[ Masc.Keeper_turn_driver.Tool_effect_mutating ]
+           ()
+       in
+       for _ = 1 to 2 do
+         Masc.Keeper_unified_turn_failure.record_failure_and_maybe_escalate
+           ~config
+           ~meta
+           ~updated_meta:meta
+           ~is_auto_recoverable:false
+           ~err
+           ~error_text:(Agent_sdk.Error.to_string err)
+       done;
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         let paused_meta = entry.Masc.Keeper_registry.meta in
+         check bool "registry meta paused" true paused_meta.paused;
+         check
+           (option (float 0.001))
+           "mutating no-progress pause remains manual"
+           None
+           paused_meta.auto_resume_after_sec
+       | None -> fail "expected registered keeper")
+
 let test_runtime_pause_threshold_override_controls_idle_auto_pause () =
   Eio_main.run
   @@ fun env ->
@@ -1302,6 +1403,12 @@ let () =
             test_direct_success_persist_failure_keeps_no_progress_pause;
           test_case "direct success leaves unrelated pause intact" `Quick
             test_direct_success_leaves_unrelated_pause_intact;
+          test_case
+            "read-only no-progress pause uses auto-resume backoff"
+            `Quick
+            test_read_only_no_progress_pause_uses_backoff_auto_resume;
+          test_case "mutating no-progress pause stays manual resume" `Quick
+            test_mutating_no_progress_pause_stays_manual_resume;
         ] );
       ( "completion_contract pause",
         [


### PR DESCRIPTION
## Summary
- add a typed `is_read_only_no_progress_accept_rejection` classifier for accept rejections whose only progress was read-only observation
- keep mutating completion-contract no-progress pauses on manual resume, but give read-only no-progress pauses the existing auto-resume backoff policy
- add regression coverage for both read-only and mutating no-progress pause behavior

## Why
Live keeper health showed a durable pause with `completion_contract_violation` after an `accept_rejected` / `no_usable_progress` error where `last_tool_effect=read_only` and `any_mutating_tool=false`. The broader RCA is that the runtime already treats this typed read-only/no-progress shape as a recoverable provider/runtime signal for candidate handling, but the repeated-failure pause path collapsed it into the same `Manual_resume_required` bucket as mutating no-progress.

That makes multi-keeper wait/poll patterns sticky: a keeper that only observed state and produced no visible progress can require manual resume instead of backing off and retrying.

## Validation
- `opam exec -- ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_unified_turn_failure.ml test/test_keeper_auto_pause_blocker_persist_12683.ml`
- `python3 scripts/check_test_coverage.py`
- `git diff --check`

Dune build/test left to CI per operator instruction.