### PR TITLE
fix(fusion): reject implicit panel free-text fallback

### DIFF
--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -25,12 +25,13 @@ let outcome_of_result ~(panelist : string) ~(model : string)
         }
     else (
       match Yojson.Safe.from_string raw with
-      | exception Yojson.Json_error msg ->
-        Fusion_types.Failed
-          { failed_model = panelist
-          ; reason =
-              Fusion_types.Invalid_structured_response
-                ("panel response is not valid JSON: " ^ msg)
+      | exception Yojson.Json_error _msg ->
+        (* Free-text fallback: ollama_cloud trio panels may return unstructured text.
+           The judge wraps panel answers in XML tags, so raw text is acceptable. *)
+        Fusion_types.Answered
+          { model = panelist
+          ; answer = raw
+          ; usage = Fusion_oas.usage_of resp
           }
       | `Assoc fields ->
         (match List.assoc_opt "answer" fields with

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -25,13 +25,12 @@ let outcome_of_result ~(panelist : string) ~(model : string)
         }
     else (
       match Yojson.Safe.from_string raw with
-      | exception Yojson.Json_error _msg ->
-        (* Free-text fallback: ollama_cloud trio panels may return unstructured text.
-           The judge wraps panel answers in XML tags, so raw text is acceptable. *)
-        Fusion_types.Answered
-          { model = panelist
-          ; answer = raw
-          ; usage = Fusion_oas.usage_of resp
+      | exception Yojson.Json_error msg ->
+        Fusion_types.Failed
+          { failed_model = panelist
+          ; reason =
+              Fusion_types.Invalid_structured_response
+                ("panel response is not valid JSON: " ^ msg)
           }
       | `Assoc fields ->
         (match List.assoc_opt "answer" fields with

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -159,6 +159,40 @@ let test_panel_outcome_rejects_invalid_structured_answer () =
       ("expected invalid structured response failure, got: "
        ^ Fusion_types.show_panel_outcome other)
 
+let test_panel_outcome_rejects_free_text_without_contract () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text "plain panel answer"))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "free text is not an implicit success" true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
+    fail
+      ("expected free text to fail without an explicit contract, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
+let test_panel_outcome_rejects_malformed_structured_answer () =
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model"
+      (Ok (response_with_text {|{"answer":|}))
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"
+      ; reason = Fusion_types.Invalid_structured_response detail
+      } ->
+    check bool "malformed JSON detail is retained" true
+      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
+  | other ->
+    fail
+      ("expected malformed structured response failure, got: "
+       ^ Fusion_types.show_panel_outcome other)
+
 let test_panel_outcome_rejects_empty_answer () =
   match
     Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
@@ -281,6 +315,10 @@ let () =
             test_panel_outcome_parses_structured_answer
         ; test_case "rejects invalid structured answer" `Quick
             test_panel_outcome_rejects_invalid_structured_answer
+        ; test_case "rejects free text without contract" `Quick
+            test_panel_outcome_rejects_free_text_without_contract
+        ; test_case "rejects malformed structured answer" `Quick
+            test_panel_outcome_rejects_malformed_structured_answer
         ; test_case "rejects empty answer" `Quick
             test_panel_outcome_rejects_empty_answer
         ] )


### PR DESCRIPTION
## Summary

This PR keeps the Fusion panel boundary strict when the panel runtime does not return the requested `fusion.panel.output_schema`.

- reject raw free text as `Invalid_structured_response` unless a future typed/configured free-text mode explicitly allows it
- reject malformed JSON-looking structured output instead of counting it as a successful panel answer
- add focused regressions for raw free text and malformed `{"answer":` payloads

## Why

The earlier attempt to treat `Yojson.Json_error` as `Answered { answer = raw; usage }` hid provider/schema drift as a valid panel answer. That conflicts with the existing `fusion.panel.output_schema` contract and makes failure observability unreliable.

This version intentionally keeps the strict schema boundary. If Fusion needs degraded free-text panel mode later, it should be introduced as an explicit typed/configured mode with sink metadata, failure semantics, and tests.

## Validation

- `opam exec -- ocamlformat --check lib/fusion/fusion_panel.ml test/test_fusion_judge_usage.ml`
- `git diff --check`
- conflict/stub/silent-success marker scan

No local Dune build was run; CI is the build authority.
