### PR TITLE
fix(fusion): restore working deliberation — panel free-text, judge two-tier contract, honest failure observability

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -22,11 +22,12 @@
    than silently collapsing [2] into [1].
 
    It is keeper-independent: it bypasses [Fusion_orchestrator.run] (gate +
-   hourly budget + keeper chat-lane sink) and calls [Fusion_panel.run] and
+   keeper chat-lane sink) and calls [Fusion_panel.run] and
    [Fusion_judge.run] directly. Bypassing the orchestrator avoids the sink
    side effect (which writes a transcript to a keeper chat lane and, for a
    synthetic keeper, can return [Sink_failed] and discard the computed panel
-   and judge results) and the shared hourly budget counter.
+   and judge results). (An hourly budget counter used to be listed here; it
+   was removed in PR #22051 and no invocation rate limit exists.)
 
    The baseline and the self-consistency arm reuse [Fusion_panel.run] so the
    call path is identical to a panel member: the arms differ only in model set
@@ -175,12 +176,13 @@ let run_harness ~sw ~net ~(policy : Fusion_policy.t) ~(preset : Fusion_policy.pr
     prompt;
 
   let run_panel ~max_fibers ~models =
+    let groups = [ { g0 with Fusion_policy.models } ] in
     Masc.Fusion_panel.run
       ~sw
       ~net
       ~max_fibers
-      ~outer_timeout_s:g0.Fusion_policy.timeout_s
-      ~groups:[ { g0 with Fusion_policy.models } ]
+      ~outer_timeout_s:(Fusion_policy.panel_outer_timeout_of ~max_fibers groups)
+      ~groups
       ~prompt
       ()
   in

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -141,19 +141,37 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
     Provider_error
       (prefix ^ Fusion_oas.provider_error_detail ~runtime_id (sdk_error_detail e))
 
+(* 심판 출력 계약은 typed 2-tier다. tier는 OAS capability facts(
+   [validate_output_schema_request])로만 결정하며 provider-name 특례는 없다:
+
+   - Native tier: 모델/엔드포인트가 native structured output을 선언하면 JsonSchema를
+     provider config에 싣는다 (와이어 레벨 강제).
+   - Prompt tier: 선언이 없으면 schema를 싣지 않는다. 계약은 프롬프트가 이미 항상
+     싣고 다니는 [Fusion_judge_parse.expected_json_doc]이 전달하고, 위반은
+     [Fusion_judge_parse.of_string]의 strict 파싱이 [Parse_error]로 fail-loud 한다.
+
+   #22768("native schema or fail before HTTP")은 native 미선언을 빌드 실패로
+   만들었는데, 이는 두 가지 이유로 뒤집는다: (1) capability 사실이 거짓일 수 있음이
+   실측됨(ollama.com cloud는 declared인데 json_schema를 조용히 무시 — 2026-07-02
+   probe), (2) 사실이 참(미지원)일 때 빌드 실패는 해당 preset의 fusion 자체를
+   영구 불능으로 만든다(2026-06-17~06-30 prompt 계약만으로 성공한 run 다수).
+   Prompt tier는 silent downgrade가 아니다 — 결정 시점에 로그로 관측되고, 파싱은
+   여전히 strict다. *)
 let apply_fusion_judge_output_contract provider_cfg =
   let schema = Keeper_structured_output_schema.fusion_judge_output_schema in
   let native_schema_provider_cfg =
     Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
   in
-  (* The tier is decided by OAS capability facts, never by provider-name
-     special cases: native schema or fail before an HTTP request. *)
   match
     Llm_provider.Provider_config.validate_output_schema_request
       native_schema_provider_cfg
   with
   | Ok () -> Ok native_schema_provider_cfg
-  | Error detail -> Error (Printf.sprintf "fusion.judge.output_schema: %s" detail)
+  | Error detail ->
+    Log.Keeper.info
+      "fusion judge output contract: prompt tier (native schema unavailable: %s)"
+      detail;
+    Ok provider_cfg
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가
    서로 다른 [compose_*]로 만든 프롬프트를 넘기는 공유 본체 — 프롬프트 구성만 다르고

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -1,9 +1,12 @@
 (** Fusion — 심판. 패널 답들을 judge 모델에 넘겨 구조화 종합({!Fusion_types.judge_synthesis})을 받는다.
 
-    Judge 실행은 provider-native structured output schema를 요청한다. OAS가 해당
-    provider/model 조합의 native schema를 거부하면 [JsonMode]로 degrade하지 않고
-    build 단계에서 fail-loud한다. 패널 실행도 별도의 `{answer:string}` schema를 요청하고,
-    provider-success malformed output은 typed failure로 격리한다.
+    Judge 출력 계약은 typed 2-tier다 (구현부 [apply_fusion_judge_output_contract]
+    주석 참조): OAS capability facts가 native structured output을 허용하면 JsonSchema를
+    provider config에 싣고(Native tier), 아니면 schema 없이 프롬프트의
+    {!Fusion_judge_parse.expected_json_doc} 지시에 의존한다(Prompt tier — 결정은
+    로그로 관측). 어느 tier든 응답은 {!Fusion_judge_parse.of_string}의 strict 파싱을
+    통과해야 하며 위반은 [Parse_error]로 fail-loud한다. [JsonMode]로의 silent
+    downgrade는 없다.
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §7.2 *)
 

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -31,9 +31,13 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               groups
           in
           let panel =
+            (* 외곽 타임아웃은 fan-out에 실제 쓰는 동시성과 같은 max_fibers로
+               웨이브 직렬화를 반영해야 한다 (panel_outer_timeout_of 주석). *)
             Fusion_panel.run ~sw ~net
               ~max_fibers:policy.Fusion_policy.max_concurrent_panels
-              ~outer_timeout_s:(Fusion_policy.panel_outer_timeout_of groups)
+              ~outer_timeout_s:
+                (Fusion_policy.panel_outer_timeout_of
+                   ~max_fibers:policy.Fusion_policy.max_concurrent_panels groups)
               ~groups:effective_groups ~prompt:req.Fusion_types.prompt ()
           in
           let judge_web_tools =
@@ -386,8 +390,11 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 ~min_answered:preset.Fusion_policy.min_answered panel
             with
             | Some reason ->
-              let reason = Fusion_types.render_skip_reason reason in
-              (Error (Fusion_types.Internal_error reason, Fusion_types.zero_usage), [])
+              (* typed 그대로 propagate — 문자열로 렌더해 [Internal_error]에 압축하면
+                 패널 전멸이 "judge failed"/failure_code=internal_error로 오귀속된다
+                 (2026-07-01 사고: 8 run 전부 이 경로였는데 keeper 표면은 judge
+                 메커니즘 고장으로 보고했다). 렌더는 sink/텍스트 경계에서 한다. *)
+              (Error (Fusion_types.Panels_unavailable reason, Fusion_types.zero_usage), [])
             | None ->
             match topology with
             | Fusion_types.Simple ->

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -11,61 +11,37 @@
    attribution(`Provider '...'` 슬롯)에는 raw [model]만 쓴다 — panelist(예
    "skeptic (claude)")는 실제 provider id가 아니므로 그 슬롯에 새면 provider 집계/로그
    디버깅이 오염된다 (RFC-0278 §2.4, 정체성·routable model 비압축 원칙). *)
+(* 패널 답변 계약 = free text. 패널 답변은 의미상 단일 문자열이므로 {"answer": string}
+   JSON envelope(#22768)는 정보 이득 0에 실패 클래스만 추가했다: envelope 파싱은
+   provider-native schema 강제(response_format json_schema)에 100% 의존했고 프롬프트에는
+   JSON 지시가 전혀 없었는데, ollama.com cloud는 json_schema를 에러 없이 무시한다
+   (2026-07-02 실측: deepseek-v4-pro/kimi-k2.6/devstral-small-2 모두 /v1 response_format과
+   native /api/chat format 양쪽에서 prose 반환). 결과: 모델은 prose를 반환, strict 파서가
+   패널 전멸 — 2026-07-01 사고(8 run 전부 "0 of 3 panels answered",
+   invalid_structured_response 17건). free text에는 이 실패 모드 자체가 없다.
+   thinking 오염 분리는 OAS 소관이며 이미 동작한다(reasoning은 별도 채널,
+   [Fusion_oas.answer_text]는 visible text만 투영 — #22854). *)
 let outcome_of_result ~(panelist : string) ~(model : string)
     (res : (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result)
   : Fusion_types.panel_outcome
   =
   match res with
   | Ok resp ->
-    let raw = String.trim (Fusion_oas.answer_text resp) in
-    if String.length raw = 0 then
+    let answer = String.trim (Fusion_oas.answer_text resp) in
+    if String.length answer = 0 then
       Fusion_types.Failed
         { failed_model = panelist
         ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
         }
-    else (
-      match Yojson.Safe.from_string raw with
-      | exception Yojson.Json_error msg ->
-        Fusion_types.Failed
-          { failed_model = panelist
-          ; reason =
-              Fusion_types.Invalid_structured_response
-                ("panel response is not valid JSON: " ^ msg)
-          }
-      | `Assoc fields ->
-        (match List.assoc_opt "answer" fields with
-         | Some (`String answer) ->
-           let answer = String.trim answer in
-           if String.length answer = 0 then
-             Fusion_types.Failed
-               { failed_model = panelist
-               ; reason =
-                   Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
-               }
-           else
-             Fusion_types.Answered
-               { model = panelist; answer; usage = Fusion_oas.usage_of resp }
-         | Some _ ->
-           Fusion_types.Failed
-             { failed_model = panelist
-             ; reason =
-                 Fusion_types.Invalid_structured_response
-                   "panel response field \"answer\" must be a string"
-             }
-         | None ->
-           Fusion_types.Failed
-             { failed_model = panelist
-             ; reason =
-                 Fusion_types.Invalid_structured_response
-                   "panel response missing required field \"answer\""
-             })
-      | _ ->
-        Fusion_types.Failed
-          { failed_model = panelist
-          ; reason =
-              Fusion_types.Invalid_structured_response
-                "panel response must be a JSON object"
-          })
+    else
+      Fusion_types.Answered
+        { model = panelist; answer; usage = Fusion_oas.usage_of resp }
+  | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _)) ->
+    (* per-agent HTTP 타임아웃을 typed [Timeout]으로. 이전에는 to_string 직렬화로
+       [Provider_error]에 뭉개져, 외곽 붕괴(전 패널 동시 [Timeout])와 개별 HTTP
+       타임아웃을 board 증거에서 구분할 수 없었다. [bridge_failure_of_error]·
+       [Fusion_judge.failure_of_sdk_error]와 대칭. *)
+    Fusion_types.Failed { failed_model = panelist; reason = Fusion_types.Timeout }
   | Error e ->
     Fusion_types.Failed
       { failed_model = panelist
@@ -79,18 +55,6 @@ let bridge_failure_of_error (error : Agent_sdk.Error.sdk_error) : Fusion_types.p
   match error with
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_sdk.Error.to_string error)
-
-let apply_fusion_panel_output_contract provider_cfg =
-  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
-  let native_schema_provider_cfg =
-    Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
-  in
-  match
-    Llm_provider.Provider_config.validate_output_schema_request
-      native_schema_provider_cfg
-  with
-  | Ok () -> Ok native_schema_provider_cfg
-  | Error detail -> Error (Printf.sprintf "fusion.panel.output_schema: %s" detail)
 
 let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
   : Fusion_types.panel_outcome list
@@ -110,7 +74,6 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~max_tool_calls:g.max_tool_calls ~timeout_s:g.timeout_s
-                ~provider_config_transform:apply_fusion_panel_output_contract
                 ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
@@ -155,5 +118,4 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
 
 module For_testing = struct
   let outcome_of_result = outcome_of_result
-  let apply_output_contract = apply_fusion_panel_output_contract
 end

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -16,12 +16,15 @@
       모델들을 에이전트로 빌드한다 (그룹마다 다를 수 있음 = 이종). 모든 그룹의
       에이전트를 하나의 [Async_agent.all]에 union으로 던진다.
     - [web_tools]가 true인 그룹은 web_search/web_fetch 도구를 주입한다.
-    - 패널 에이전트는 [fusion.panel.output_schema] provider-native structured output
-      contract를 요청한다. 응답은 string [answer] 필드를 가진 JSON object여야 하며,
-      free-text/invalid JSON/missing answer는 [Failed]로 격리된다.
+    - 패널 답변 계약은 free text다: 응답의 visible text 전체(trim)가 답변이 된다.
+      빈 텍스트만 [Failed Empty_response]. JSON envelope를 요구하지 않는다 —
+      단일 문자열에 envelope는 정보 이득 0에 provider가 schema를 무시하면 패널이
+      전멸하는 실패 클래스만 추가했다 (2026-07-01 사고, 구현부 주석 참조).
     - [max_tool_calls]: 0이면 무제한, 양수면 에이전트 [max_turns]로 근approximate.
     - [outer_timeout_s]: 전체 fan-out을 감싸는 [Masc_oas_bridge.run_safe] 구조적
-      타임아웃(보통 그룹 timeout 중 max). 타임아웃 시 빌드된 모델은 [Failed Timeout].
+      타임아웃. 웨이브 직렬화를 반영해 [Fusion_policy.panel_outer_timeout_of
+      ~max_fibers]로 산출한 값을 넘겨야 한다. 타임아웃 시 빌드된 모델은
+      [Failed Timeout].
     - 빌드 실패·실행 실패·빈 응답은 [Failed]로 격리되어 다른 패널을 죽이지 않는다.
     - 반환 순서: 빌드 실패분 먼저, 그 다음 실행 결과(그룹순 × 그룹내 모델순). *)
 val run
@@ -40,8 +43,4 @@ module For_testing : sig
     -> model:string
     -> (Agent_sdk.Types.api_response, Agent_sdk.Error.sdk_error) result
     -> Fusion_types.panel_outcome
-
-  val apply_output_contract
-    :  Llm_provider.Provider_config.t
-    -> (Llm_provider.Provider_config.t, string) result
 end

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -323,12 +323,38 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
     (* board post — 패널 답변 전체 + 심판 종합을 쿼리 가능한 구조화 증거(meta_json)로.
        사용자는 대시보드 board에서 상세를 본다. chat lane *서사*를 board로 옮긴 것이
        RFC §8.1 대비 변경점(키퍼 observation 도배 방지). 실패는 [Error]로 orchestrator에. *)
+    (* 실패한 패널의 per-panel 사유 요약. 실패 headline/chat이 이걸 나르지 않으면
+       사유는 meta_json에만 남는데, 키퍼 도구(masc_board_post_get)는 title/body만
+       렌더하므로 키퍼가 원인에 도달할 tool-reachable 경로가 없다 (2026-07-01:
+       "0 of 3 panels answered"만 보고 judge 메커니즘 고장으로 오진, 수 시간 소모). *)
+    let failed_panel_lines =
+      panel
+      |> List.filter_map (fun (o : Fusion_types.panel_outcome) ->
+             match o with
+             | Fusion_types.Answered _ -> None
+             | Fusion_types.Failed { failed_model; reason } ->
+               Some
+                 (Printf.sprintf "- %s: %s" failed_model
+                    (Fusion_oas.panel_failure_text reason)))
+    in
+    let render_failure f =
+      let base =
+        Printf.sprintf "%s: %s"
+          (Fusion_types.judge_failure_tag f)
+          (Fusion_types.judge_failure_text f)
+      in
+      match failed_panel_lines with
+      | [] -> base
+      | lines -> base ^ "\n" ^ String.concat "\n" lines
+    in
     let board_headline =
       match judge with
       | Ok j ->
         Printf.sprintf "Fusion deliberation (run %s): %s" run_id
           (render_decision j.Fusion_types.decision)
-      | Error _ -> Printf.sprintf "Fusion deliberation (run %s): judge failed" run_id
+      | Error f ->
+        Printf.sprintf "Fusion deliberation (run %s) failed — %s" run_id
+          (render_failure f)
     in
     let meta_json =
       Some
@@ -374,39 +400,48 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
        [Fusion] block을 함께 첨부해 대시보드가 결론 카드를 패널/심판 상세로 펼치게 한다.
        block은 content가 아니므로 키퍼 observation(recent_direct_conversation, role/content만
        읽음)을 도배하지 않는다 → librarian은 메인 chat 결론(content)을 fact로 추출하고,
-       사용자만 카드 상세를 본다(강결합 없는 통합). judge 실패 시에는 메인 흐름을
-       오염시키지 않으려 결론을 남기지 않는다(board에는 실패도 증거로 남는다). *)
+       사용자만 카드 상세를 본다(강결합 없는 통합).
+
+       judge 실패도 결론이다: 실패 사유(+ per-panel 사유)를 같은 lane에 남긴다.
+       이전에는 "메인 흐름 비오염"을 이유로 실패 시 아무것도 남기지 않았는데,
+       그 결과 (a) wake 일회성 preview가 유일한 사유 전달 채널이 됐고(비-Running
+       키퍼면 조용히 유실 — keeper_keepalive_signal은 Running만 깨움), (b) 키퍼가
+       실패 원인을 조회할 수 있는 durable 표면이 없어 폴링·오진을 유발했다
+       (2026-07-01 사고). denied/sink_failed/aborted가 이미 같은 메인 lane에
+       남는 것(fusion_tool.append_chat_failure)과도 정합. *)
     let chat_lane_result =
-      match judge with
-      | Ok j ->
-        let content =
+      let content =
+        match judge with
+        | Ok j ->
           Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
             (render_decision j.Fusion_types.decision)
             j.Fusion_types.resolved_answer
-        in
-        let blocks =
-          match board_result with
-          | Ok (post : Board.post) ->
-            Some
-              [ Keeper_chat_blocks.Fusion
-                  { board_post_id = Board.Post_id.to_string post.id; run_id }
-              ]
-          | Error _ -> None
-          (* board 생성 실패 시 카드 링크를 생략하되 결론은 남긴다(키퍼가 인지). *)
-        in
-        (* .mli 계약: chat store append 예외 시 [Error msg]를 반환한다. unit 버전은
-           실패를 삼켜 emit이 Ok를 반환했었다(silent drop). [_result] 변형으로 실패를
-           surface한다. 성공한 경우에만 broadcast한다. *)
-        (match
-           Keeper_chat_store.append_assistant_message_result ~base_dir
-             ~keeper_name:keeper ~content ?blocks ()
-         with
-         | Ok () ->
-           Keeper_chat_broadcast.chat_appended ~keeper_name:keeper
-             ~source:"fusion" ~content ();
-           Ok ()
-         | Error _ as e -> e)
-      | Error _ -> Ok ()
+        | Error f ->
+          Printf.sprintf "Fusion deliberation (run %s) failed — %s" run_id
+            (render_failure f)
+      in
+      let blocks =
+        match board_result with
+        | Ok (post : Board.post) ->
+          Some
+            [ Keeper_chat_blocks.Fusion
+                { board_post_id = Board.Post_id.to_string post.id; run_id }
+            ]
+        | Error _ -> None
+        (* board 생성 실패 시 카드 링크를 생략하되 결론은 남긴다(키퍼가 인지). *)
+      in
+      (* .mli 계약: chat store append 예외 시 [Error msg]를 반환한다. unit 버전은
+         실패를 삼켜 emit이 Ok를 반환했었다(silent drop). [_result] 변형으로 실패를
+         surface한다. 성공한 경우에만 broadcast한다. *)
+      match
+        Keeper_chat_store.append_assistant_message_result ~base_dir
+          ~keeper_name:keeper ~content ?blocks ()
+      with
+      | Ok () ->
+        Keeper_chat_broadcast.chat_appended ~keeper_name:keeper
+          ~source:"fusion" ~content ();
+        Ok ()
+      | Error _ as e -> e
     in
     (* RFC-0266 (개정, board best-effort): completion 여부는 *키퍼가 결론을 받았는가*
        (chat lane)로 판정한다. board post는 증거 카드일 뿐이므로 그 생성 실패는 fatal이
@@ -430,17 +465,26 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
              (Board.show_board_error e);
            ""
        in
-       let ok, resolved_answer =
-         match judge with
-         | Ok j -> true, j.Fusion_types.resolved_answer
-         | Error e ->
-           false, Printf.sprintf "judge failed: %s" (Fusion_types.judge_failure_text e)
-       in
-       (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake 직전 무조건 호출. *)
-       Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
-       broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
-       wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok
-         ~resolved_answer ~board_post_id;
+       (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake 직전 무조건 호출.
+          실패 시 사유/태그를 함께 기록해 masc_fusion_status·SSE가 opaque
+          "failed"가 되지 않게 한다. *)
+       (match judge with
+        | Ok j ->
+          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+            ~ok:true ();
+          broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+          wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
+            ~resolved_answer:j.Fusion_types.resolved_answer ~board_post_id
+        | Error e ->
+          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+            ~failure:(Fusion_types.judge_failure_text e)
+            ~failure_code:(Fusion_types.judge_failure_tag e)
+            ~ok:false ();
+          broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+          wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
+            ~resolved_answer:
+              (Printf.sprintf "fusion run failed — %s" (render_failure e))
+            ~board_post_id);
        Ok ())
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -34,11 +34,16 @@ val judge_meta : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) resu
     identity는 [First]면 panelist_id. 프론트는 배열 shape만으로 위상 구조를 렌더한다. *)
 val judge_node_meta : Fusion_types.judge_outcome -> Yojson.Safe.t
 
-(** judge 결론을 키퍼 메인 chat lane에 남기고 board에 패널/심판 구조화 증거를 post한다.
+(** judge 결론(성공/실패 모두)을 키퍼 메인 chat lane에 남기고 board에 패널/심판
+    구조화 증거를 post한다.
 
-    chat lane: judge가 [Ok]면 "결론 — resolved_answer" 한 줄을 메인 conversation에
-    append하고 [chat_appended]로 대시보드에 알린다(judge 실패면 메인 흐름 비오염을 위해
-    생략). board: [Board_dispatch.create_post]로 meta_json(source/run_id/question/panel
+    chat lane: judge가 [Ok]면 "결론 — resolved_answer" 한 줄, [Error]면 실패 사유
+    (failure_code + 사유 + 실패 패널별 사유)를 메인 conversation에 append하고
+    [chat_appended]로 대시보드에 알린다. 실패를 durable하게 남기는 이유: wake
+    stimulus는 Running 키퍼에게만 배달되는 일회성 채널이라, chat lane이 비어 있으면
+    비-Running 키퍼는 실패 사유에 도달할 tool-reachable 표면이 없다(2026-07-01 사고 —
+    bare "judge failed"만 보고 keeper들이 원인을 추측·폴링). board headline도 같은
+    실패 요약을 나른다. board: [Board_dispatch.create_post]로 meta_json(source/run_id/question/panel
     답변 전체/judge 종합/observed_usage = panel N + judge 1 합산) 증거를 남긴다. [judge_usage]는
     심판이 소비한 토큰(orchestrator가 [Fusion_judge.run]에서 분리해 주입). [judges]는 실제로
     실행된 심판 노드 관측 배열(RFC-0284)로 board meta_json [judges] 키에 panel과 동형으로

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -4,7 +4,7 @@
 let status_json ~ok fields =
   Yojson.Safe.to_string (`Assoc (("ok", `Bool ok) :: fields))
 
-let append_chat_failure ~base_dir ~keeper ~run_id content =
+let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
   (* 실패 알림도 성공 결론(fusion_sink.emit)과 동일하게 키퍼 *메인* conversation에
      남긴다(conversation_id 생략). recent_direct_conversation observation 필터는
      conversation_id를 보지 않고 role/kind만 보므로
@@ -22,7 +22,8 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
      orchestrator-level Cancelled(handle fork match)
      만 막았고 이 내부 append window는 못 막았다. Denied/Sink_failed/aborted 종료 분기가 모두
      이 함수를 경유하므로 같은 누수의 형제 경로다. *)
-  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
+  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+    ~failure:content ~failure_code ~ok:false ();
   (try
      Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
      Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
@@ -107,11 +108,11 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
         with
         | Fusion_orchestrator.Completed _ -> ()
         | Fusion_orchestrator.Denied reason ->
-          append_chat_failure ~base_dir ~keeper ~run_id
+          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"denied"
             (Printf.sprintf "**Fusion run `%s`** _(denied after start: %s)_" run_id
                (Fusion_types.deny_reason_label reason))
         | Fusion_orchestrator.Sink_failed msg ->
-          append_chat_failure ~base_dir ~keeper ~run_id
+          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
             (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
         | exception (Eio.Cancel.Cancelled _ as exn) ->
           (* RFC-0266 §7: 취소도 종료 상태다. register_running(위 line 73)으로 [Running]
@@ -125,11 +126,24 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
              취소/셧다운 캐스케이드를 deadlock시킬 위험이 있으므로 이 경로에선 생략한다 —
              registry가 정확해 다음 HTTP fetch / tab-refresh가 패널을 self-heal한다.
              그 뒤 구조적 취소는 흡수하지 않고 재전파한다 (Eio 규약). *)
-          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
+          Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id
+            ~failure:"cancelled: structural cancellation (shutdown or sibling switch failure)"
+            ~failure_code:"cancelled" ~ok:false ();
           raise exn
         | exception exn ->
-          append_chat_failure ~base_dir ~keeper ~run_id
+          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
             (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id
                (Printexc.to_string exn)));
+      (* [delivery] 필드는 도구 결과의 async 계약을 명시한다: 완료 시 키퍼는
+         [Fusion_completed] wake로 깨워지고 결론/실패 사유가 chat lane에 durable하게
+         남는다. 2026-07-01 관측: 이 계약이 결과 JSON에 없어서 키퍼들이 3-5초 간격
+         masc_fusion_status 폴링으로 턴을 소모했다(8 run에 35 poll + nudge 8회). *)
       status_json ~ok:true
-        [ ("status", `String "fusion_started"); ("run_id", `String run_id) ]
+        [ ("status", `String "fusion_started")
+        ; ("run_id", `String run_id)
+        ; ( "delivery"
+          , `String
+              "async: you will be woken with the result when deliberation \
+               completes; the conclusion (or failure reason) also lands on \
+               your chat lane. No need to poll masc_fusion_status." )
+        ]

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -224,12 +224,29 @@ let staged_judge_groups ~group_size judges =
     in
     loop [] judges
 
-(* 외곽 run_safe 타임아웃 = 그룹 timeout 중 max. 하나의 Async_agent.all은 하나의
-   외곽 타임아웃만 가지므로(RFC-0252-A §4.3), 그룹별 정밀 timeout은 build_agent에
-   반영하고 외곽은 상한으로만 둔다. 단일 그룹(legacy desugar)이면 그 그룹 timeout =
-   오늘의 panel_timeout_s (byte-identity). *)
-let panel_outer_timeout_of (groups : panel_group list) =
-  List.fold_left (fun acc (g : panel_group) -> Float.max acc g.timeout_s) 0.0 groups
+(* 외곽 run_safe 타임아웃. 하나의 Async_agent.all은 하나의 외곽 타임아웃만
+   가지므로(RFC-0252-A §4.3) 그룹별 정밀 timeout은 build_agent에 반영하고 외곽은
+   상한으로만 둔다.
+
+   상한은 fan-out 직렬화를 반영해야 한다: [Async_agent.all ~max_fibers]는 패널
+   총원 N을 [max_fibers]씩 웨이브로 실행하므로, 웨이브 수 = ceil(N / max_fibers)
+   이고 각 웨이브의 상한은 그룹 timeout 중 max다. 이전 구현(max만)은 N >
+   max_fibers일 때 마지막 웨이브가 구조적으로 외곽 데드라인 밖에 놓여, 이미
+   완료된 패널 답변까지 통째로 취소·폐기하고 전 패널을 bare [Timeout]으로
+   보고했다 (2026-07-01 사고의 reason_code=timeout 9건 서명; 라이브 config
+   3패널 × max_concurrent_panels=2 × 120s → 외곽 120s < 필요 240s).
+   [max_fibers <= 0]은 config 검증이 막지만 나눗셈 방어로 1로 clamp한다.
+   단일 웨이브(N <= max_fibers)면 이전과 byte-identical (max of group timeouts). *)
+let panel_outer_timeout_of ~max_fibers (groups : panel_group list) =
+  let max_group_timeout =
+    List.fold_left (fun acc (g : panel_group) -> Float.max acc g.timeout_s) 0.0 groups
+  in
+  let total_panelists =
+    List.fold_left (fun acc (g : panel_group) -> acc + List.length g.models) 0 groups
+  in
+  let max_fibers = max 1 max_fibers in
+  let waves = (total_panelists + max_fibers - 1) / max_fibers in
+  float_of_int (max 1 waves) *. max_group_timeout
 
 (* 심판은 preset당 1개이므로 그룹들에서 web_tools를 derive한다: req 또는 어느 그룹이든
    web_tools면 심판도 web tool. 단일 그룹이면 req || group.web_tools = 오늘의

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -175,8 +175,11 @@ val staged_judge_groups
   -> judge_spec list
   -> (judge_spec list list, staged_judge_group_error) result
 
-(** 외곽 run_safe 타임아웃 = 그룹 timeout 중 max. 단일 그룹이면 그 그룹 timeout. *)
-val panel_outer_timeout_of : panel_group list -> float
+(** 외곽 run_safe 타임아웃 = ceil(패널 총원 / max_fibers) 웨이브 × 그룹 timeout 중 max.
+    [max_fibers]는 패널 fan-out에 실제로 쓰는 동시성(= [max_concurrent_panels])과 같은
+    값을 넘겨야 한다 — 웨이브 직렬화를 무시하면 마지막 웨이브가 외곽 데드라인 밖에
+    놓여 완료된 답변까지 폐기된다. 단일 웨이브(N <= max_fibers)면 그룹 timeout 중 max. *)
+val panel_outer_timeout_of : max_fibers:int -> panel_group list -> float
 
 (** 심판 web_tools를 그룹들에서 derive: [req_web_tools] 또는 어느 그룹이든 web_tools.
     단일 그룹이면 [req_web_tools || group.web_tools] (오늘과 byte-identical). *)

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -15,7 +15,14 @@
 
 type run_status =
   | Running
-  | Completed of { ok : bool }
+  | Completed of {
+      ok : bool;
+      (* ok=false일 때의 사람-가독 사유 + 안정 분류 태그. 2026-07-01 사고에서
+         상태 표면(masc_fusion_status/SSE)이 status="failed"만 나르는 바람에
+         키퍼가 원인을 얻을 tool-reachable 경로가 없었다 (mli 참조). *)
+      failure : string option;
+      failure_code : string option;
+    }
 
 type run = {
   run_id : string;
@@ -28,8 +35,10 @@ type run = {
 type t = run list Atomic.t
 
 (* Recent-history retention for [Completed] runs. [Running] runs are never
-   evicted (active state must stay accurate) and are bounded in practice by the
-   per-hour fusion budget (RFC-0252 §10). This is a log-retention bound, not a
+   evicted (active state must stay accurate). NOTE: 이전 주석은 [Running]이
+   "per-hour fusion budget (RFC-0252 §10)으로 bounded"라고 주장했으나 그 budget은
+   PR #22051에서 제거되어 존재하지 않는다 — 현재 fusion 호출률 제한은 없다(설계
+   미결정, 집계만 한다는 운영 원칙과 정합). This is a log-retention bound, not a
    symptom cap — it stops the table from growing without limit over a long
    server lifetime. *)
 let max_completed_retained = 64
@@ -68,11 +77,13 @@ let register_running (t : t) ~run_id ~keeper ~preset ~started_at =
     prune (run :: without_dup))
 ;;
 
-let mark_completed (t : t) ~run_id ~ok =
+let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
   update t (fun runs ->
     runs
     |> List.map (fun r ->
-         if String.equal r.run_id run_id then { r with status = Completed { ok } } else r)
+         if String.equal r.run_id run_id
+         then { r with status = Completed { ok; failure; failure_code } }
+         else r)
     |> prune)
 ;;
 
@@ -91,21 +102,33 @@ let get (t : t) ~run_id : run option =
    never reconstructs run state from the variant, only reads these labels. *)
 let status_label = function
   | Running -> "running"
-  | Completed { ok = true } -> "completed"
-  | Completed { ok = false } -> "failed"
+  | Completed { ok = true; _ } -> "completed"
+  | Completed { ok = false; _ } -> "failed"
 ;;
 
 (* The single per-run JSON object. The HTTP list endpoint, the SSE delta, and the
    keeper status tool all serialize a run through here so the field set and the
    status label never drift between surfaces. *)
 let run_to_yojson (r : run) : Yojson.Safe.t =
-  `Assoc
+  let base =
     [ ("run_id", `String r.run_id)
     ; ("keeper", `String r.keeper)
     ; ("preset", `String r.preset)
     ; ("started_at", `Float r.started_at)
     ; ("status", `String (status_label r.status))
     ]
+  in
+  (* 실패 사유는 additive 필드로만 싣는다 — 기존 소비자(tool/HTTP/SSE/프론트)의
+     필드 집합은 그대로 유지된다. *)
+  let failure_fields =
+    match r.status with
+    | Running | Completed { ok = true; _ } -> []
+    | Completed { ok = false; failure; failure_code } ->
+      List.filter_map
+        (fun (k, v) -> Option.map (fun s -> (k, `String s)) v)
+        [ ("error", failure); ("failure_code", failure_code) ]
+  in
+  `Assoc (base @ failure_fields)
 ;;
 
 (* Process-wide registry the fusion tool/sink write to (server-lifetime). Tests

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -9,7 +9,17 @@
 
 type run_status =
   | Running
-  | Completed of { ok : bool }
+  | Completed of {
+      ok : bool;
+      failure : string option;
+          (** [ok=false]일 때 사람-가독 실패 사유([Fusion_types.judge_failure_text]
+              또는 denied/sink_failed/aborted 라벨). 2026-07-01 사고에서
+              [masc_fusion_status]가 status="failed"만 반환해 키퍼가 원인을 추측·
+              폴링했다 — 상태 표면이 사유를 함께 나른다. [ok=true]면 [None]. *)
+      failure_code : string option;
+          (** 안정 분류 태그([Fusion_types.judge_failure_tag] 어휘 +
+              denied/sink_failed/aborted/cancelled). [ok=true]면 [None]. *)
+    }
 
 type run = {
   run_id : string;
@@ -29,9 +39,18 @@ val register_running :
   t -> run_id:string -> keeper:string -> preset:string -> started_at:float -> unit
 (** Record a run as [Running]. A repeated [run_id] replaces its prior entry. *)
 
-val mark_completed : t -> run_id:string -> ok:bool -> unit
+val mark_completed
+  :  t
+  -> run_id:string
+  -> ?failure:string
+  -> ?failure_code:string
+  -> ok:bool
+  -> unit
+  -> unit
 (** Transition a run to [Completed]. No-op if [run_id] is unknown. [ok] is the
-    judge/sink outcome (false for denied/sink_failed/aborted). *)
+    judge/sink outcome (false for denied/sink_failed/aborted). [failure]/
+    [failure_code]는 [ok=false]일 때의 사유·분류 태그 — 상태 표면(tool/HTTP/SSE)이
+    사유 없이 "failed"만 보이는 opaque 실패가 되지 않게 함께 기록한다. *)
 
 val list_runs : t -> run list
 (** All tracked runs, newest [started_at] first ([Running] + recently
@@ -47,9 +66,9 @@ val status_label : run_status -> string
     route, and the [fusion_run_status] SSE event so it never drifts. *)
 
 val run_to_yojson : run -> Yojson.Safe.t
-(** Canonical per-run JSON: [{run_id, keeper, preset, started_at, status}]. The
-    single serializer for every fusion-run surface (tool / HTTP list / SSE
-    delta). *)
+(** Canonical per-run JSON: [{run_id, keeper, preset, started_at, status}] +
+    실패 시 additive [error]/[failure_code] 필드. The single serializer for
+    every fusion-run surface (tool / HTTP list / SSE delta). *)
 
 val global : t
 (** Process-wide registry the fusion tool/sink write to (server-lifetime). *)

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -233,6 +233,7 @@ type judge_failure =
   | Build_error of string
   | Parse_error of string
   | Budget_exceeded of string
+  | Panels_unavailable of skip_reason
   | Internal_error of string
 [@@deriving yojson, show, eq]
 
@@ -250,6 +251,7 @@ let judge_failure_text = function
   | Build_error detail -> detail
   | Parse_error detail -> detail
   | Budget_exceeded detail -> detail
+  | Panels_unavailable reason -> render_skip_reason reason
   | Internal_error detail -> detail
 
 let judge_failure_tag = function
@@ -260,6 +262,7 @@ let judge_failure_tag = function
   | Build_error _ -> "build_error"
   | Parse_error _ -> "parse_error"
   | Budget_exceeded _ -> "budget_exceeded"
+  | Panels_unavailable _ -> "panels_unavailable"
   | Internal_error _ -> "internal_error"
 
 type judge_error_node =

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -238,6 +238,12 @@ type judge_failure =
   | Build_error of string  (** Fusion_oas.build_agent 실패 *)
   | Parse_error of string  (** Fusion_judge_parse.of_string 파싱 실패 *)
   | Budget_exceeded of string  (** wave budget 초과로 심판 실행 전 SKIP *)
+  | Panels_unavailable of skip_reason
+      (** 패널 정족수 미달로 심판이 실행조차 되지 않음. 2026-07-01 사고에서 이
+          사유가 [Internal_error] 문자열로 압축돼 모든 keeper-가시 표면이 패널
+          전멸을 "judge failed"로 오귀속했다 — 진단 주체(키퍼)가 judge 메커니즘을
+          의심하게 만든 원인. typed로 분리해 failure_code/헤드라인이 패널 실패를
+          패널 실패로 말하게 한다. *)
   | Internal_error of string  (** all_fail_error fallback / 미분류 *)
 [@@deriving yojson, show, eq]
 

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -272,14 +272,30 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
 let wakeup_keeper ?base_path ?stimulus name =
   Keeper_registry.all ?base_path ()
   |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    if String.equal entry.name name && entry.phase = Keeper_state_machine.Running
-    then begin
-      Option.iter
-        (fun s ->
-          Keeper_registry_event_queue.enqueue ~base_path:entry.base_path name s)
-        stimulus;
-      Keeper_registry.wakeup ~base_path:entry.base_path name
-    end)
+    if String.equal entry.name name
+    then
+      if entry.phase = Keeper_state_machine.Running
+      then begin
+        Option.iter
+          (fun s ->
+            Keeper_registry_event_queue.enqueue ~base_path:entry.base_path name s)
+          stimulus;
+        Keeper_registry.wakeup ~base_path:entry.base_path name
+      end
+      else
+        (* 비-Running 키퍼로의 stimulus는 배달하지 않는다(보수적 기본값 유지 —
+           Paused를 강제 재개하지 않음). 단, 유실을 조용히 두지 않는다: payload가
+           있는 wake가 여기서 떨어지면 발신자(예: fusion sink)는 배달됐다고 믿는데
+           수신자는 아무것도 못 받는다. durable 표면(chat/board)이 사유를 따로
+           나르지 않던 2026-07-01 fusion 사고에서 이 무로그 drop이 두 run의 결과를
+           완전히 증발시켰다(fus-c9a63064/fus-46fce8a8 — 로그에 delivery 라인
+           부재). *)
+        Log.Keeper.info ~keeper_name:name
+          "wakeup_keeper: dropped (keeper not Running, phase=%s) stimulus=%s"
+          (Keeper_state_machine.phase_to_string entry.phase)
+          (match stimulus with
+           | None -> "none"
+           | Some s -> Keeper_event_queue.payload_kind_label s.Keeper_event_queue.payload))
 ;;
 
 (** Wake up all running keepers — used when a broadcast mentions @@all

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -332,11 +332,6 @@ let fusion_judge_output_schema =
     fields
 ;;
 
-let fusion_panel_answer_output_schema =
-  let fields = [ "answer", string_schema ] in
-  object_schema ~required:(List.map fst fields) fields
-;;
-
 let apply_to_provider_config schema (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     response_format = Agent_sdk.Types.JsonSchema schema

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -26,9 +26,6 @@ val governance_judge_output_schema : Yojson.Safe.t
 val fusion_judge_output_schema : Yojson.Safe.t
 (** JSON object the Fusion judge/refine/meta-judge provider must return. *)
 
-val fusion_panel_answer_output_schema : Yojson.Safe.t
-(** JSON object each Fusion panel provider must return. *)
-
 val verification_verdict_output_schema : Yojson.Safe.t
 (** JSON object the verification verdict providers must return. *)
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1446,11 +1446,15 @@ let internal_descriptors : t list =
          the configured preset answers the prompt independently; a judge model \
          synthesises consensus, contradictions, partial coverage, unique \
          insights, and blind spots. Advisory only: this keeper turn continues \
-         immediately and the synthesis arrives asynchronously on this keeper's \
-         chat lane (also visible in the dashboard). Returns a status with a \
-         run_id. Set web_tools=true to let the panel and judge ground their \
-         answers with web_search / web_fetch. Gated by runtime.toml [fusion] \
-         (disabled by default)."
+         immediately; when the deliberation completes you are WOKEN with the \
+         result, and the conclusion (or the failure reason) is appended to \
+         your chat lane (also visible in the dashboard) — do not poll \
+         masc_fusion_status while waiting. Returns a status with a run_id. \
+         Panels answer from their own knowledge only: they cannot see your \
+         files, tasks, or conversation, so phrase the prompt \
+         self-contained. Set web_tools=true to let the panel and judge ground \
+         their answers with web_search / web_fetch. Gated by runtime.toml \
+         [fusion] (disabled by default)."
       ~input_schema:masc_fusion_schema
       (* RFC-0252 §159/§177: 심의 가치는 키퍼(이미 LLM)가 스스로 판단해
          masc_fusion 을 직접 호출하는 것으로 표현된다. 따라서 키퍼가 LLM 도구
@@ -1468,9 +1472,11 @@ let internal_descriptors : t list =
          masc_fusion. With no argument, lists tracked runs (in-progress and \
          recently completed); with a run_id, returns that single run. Each run \
          reports keeper, preset, started_at (unix seconds), and status \
-         (running | completed | failed). Read-only — does not start a \
-         deliberation. In-memory and server-lifetime: runs do not survive a \
-         restart."
+         (running | completed | failed); failed runs also carry error and \
+         failure_code. Prefer waiting for the completion wake over polling \
+         this tool — the result reaches you without it. Read-only — does not \
+         start a deliberation. In-memory and server-lifetime: runs do not \
+         survive a restart."
       ~input_schema:masc_fusion_status_schema
       (* read-only, but visibility=Default so the keeper LLM can poll its own
          fusion runs (sibling to masc_fusion, which is also Default). Without

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1012,7 +1012,7 @@ let g_web4 : Fusion_policy.panel_group =
 let test_judge_args_single_group_identity () =
   let groups = [ g_web4 ] in
   Alcotest.(check (float 0.001)) "outer timeout = sole group timeout" 123.0
-    (Fusion_policy.panel_outer_timeout_of groups);
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2 groups);
   Alcotest.(check bool) "judge web = req||group, req=false, group=true" true
     (Fusion_policy.judge_web_tools_of ~req_web_tools:false groups);
   Alcotest.(check bool) "judge web = req||group, both false" false
@@ -1027,13 +1027,36 @@ let test_judge_args_single_group_identity () =
 let test_judge_args_multi_group () =
   let g_unlimited = { g_web4 with Fusion_policy.models = [ "x" ]; max_tool_calls = 0 } in
   let g_slow = { g_web4 with Fusion_policy.models = [ "y" ]; timeout_s = 200.0 } in
-  Alcotest.(check (float 0.001)) "outer timeout = max over groups" 200.0
-    (Fusion_policy.panel_outer_timeout_of [ g_web4; g_slow ]);
+  Alcotest.(check (float 0.001)) "outer timeout = max over groups (single wave)" 200.0
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2 [ g_web4; g_slow ]);
   Alcotest.(check int) "judge tool budget: 0 (unlimited) absorbs" 0
     (Fusion_policy.judge_tool_budget_of [ g_web4; g_unlimited ]);
   Alcotest.(check int) "judge tool budget: max when none unlimited" 4
     (Fusion_policy.judge_tool_budget_of
        [ { g_web4 with Fusion_policy.models = [ "z" ]; max_tool_calls = 2 }; g_web4 ])
+
+(* --- outer timeout wave math: ceil(총원/max_fibers) 웨이브 × max timeout.
+       2026-07-01 사고 회귀 가드: 라이브 config(3패널, max_concurrent_panels=2,
+       120s)에서 외곽이 120s로 잡혀 마지막 웨이브가 구조적으로 데드라인 밖에
+       놓였고, 완료된 패널 답변까지 폐기됐다(bare timeout 9건 서명). --- *)
+let test_panel_outer_timeout_wave_math () =
+  let g3 = { g_web4 with Fusion_policy.models = [ "a"; "b"; "c" ]; timeout_s = 120.0 } in
+  Alcotest.(check (float 0.001))
+    "3 panelists / max_fibers=2 -> 2 waves x 120s" 240.0
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2 [ g3 ]);
+  Alcotest.(check (float 0.001))
+    "3 panelists / max_fibers=3 -> 1 wave (byte-identity with max)" 120.0
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:3 [ g3 ]);
+  Alcotest.(check (float 0.001))
+    "5 panelists across groups / max_fibers=2 -> 3 waves x max(123,200)" 600.0
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2
+       [ { g_web4 with Fusion_policy.models = [ "a"; "b" ] }
+       ; { g_web4 with Fusion_policy.models = [ "c"; "d"; "e" ]; timeout_s = 200.0 }
+       ]);
+  Alcotest.(check (float 0.001))
+    "max_fibers <= 0 clamps to 1 (defensive; config validation forbids it)" 369.0
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:0
+       [ { g_web4 with Fusion_policy.models = [ "a"; "b"; "c" ] } ])
 
 (* --- judge LLM-facing JSON parse (RFC-0252 §7.2) --- *)
 
@@ -1321,6 +1344,21 @@ let test_judge_skip_reason () =
       "fusion aborted: 1 of 2 panels answered, preset requires at least 2"
       (render_skip_reason reason)
   | None -> Alcotest.fail "expected skip when 1 < min_answered 2"
+
+(* 패널 정족수 미달은 typed [Panels_unavailable]로 propagate된다 — 2026-07-01
+   사고에서 이 사유가 [Internal_error] 문자열로 압축돼 failure_code=internal_error
+   로 오귀속됐던 것의 회귀 가드. tag/text가 패널 실패를 패널 실패로 말해야 한다. *)
+let test_panels_unavailable_failure () =
+  let reason = Quorum_not_met { answered = 0; total = 3; required = 1 } in
+  let failure : judge_failure = Panels_unavailable reason in
+  Alcotest.(check string) "failure_code tag" "panels_unavailable"
+    (judge_failure_tag failure);
+  Alcotest.(check string) "failure text = rendered skip reason"
+    "fusion aborted: 0 of 3 panels answered, preset requires at least 1"
+    (judge_failure_text failure);
+  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure);
+  Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
+    (judge_failure_is_timeout_or_budget failure)
 
 (* min_answered must be in the policy range 1..total panels (inclusive).
    base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
@@ -1678,6 +1716,8 @@ let () =
       , [ Alcotest.test_case "single_group_identity" `Quick
             test_judge_args_single_group_identity
         ; Alcotest.test_case "multi_group" `Quick test_judge_args_multi_group
+        ; Alcotest.test_case "outer_timeout_wave_math" `Quick
+            test_panel_outer_timeout_wave_math
         ] )
     ; ( "adaptive_timeout"
       , [ Alcotest.test_case "disabled" `Quick test_adjust_judge_timeout_disabled
@@ -1717,5 +1757,7 @@ let () =
       , [ Alcotest.test_case "judge_skip_reason" `Quick test_judge_skip_reason
         ; Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered
         ; Alcotest.test_case "min_answered_constants" `Quick test_min_answered_constants
+        ; Alcotest.test_case "panels_unavailable_failure" `Quick
+            test_panels_unavailable_failure
         ] )
     ]

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -10,7 +10,7 @@ let status_running = function
 ;;
 
 let status_completed_ok = function
-  | R.Completed { ok } -> Some ok
+  | R.Completed { ok; _ } -> Some ok
   | R.Running -> None
 ;;
 
@@ -41,13 +41,13 @@ let test_register_then_query () =
 let test_mark_completed () =
   let t = R.create () in
   R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"deep" ~started_at:1.0;
-  R.mark_completed t ~run_id:"r1" ~ok:true;
+  R.mark_completed t ~run_id:"r1" ~ok:true ();
   (match R.get t ~run_id:"r1" with
    | Some run -> check (option bool) "completed ok=true" (Some true) (status_completed_ok run.R.status)
    | None -> fail "run should still be tracked after completion");
   (* a failed completion records ok=false, not a drop *)
   R.register_running t ~run_id:"r2" ~keeper:"k" ~preset:"deep" ~started_at:2.0;
-  R.mark_completed t ~run_id:"r2" ~ok:false;
+  R.mark_completed t ~run_id:"r2" ~ok:false ();
   match R.get t ~run_id:"r2" with
   | Some run -> check (option bool) "completed ok=false" (Some false) (status_completed_ok run.R.status)
   | None -> fail "failed run must remain visible as Completed{ok=false}"
@@ -64,7 +64,7 @@ let test_mark_completed () =
 let simulate_failure_path ~finalize_first t ~run_id =
   R.register_running t ~run_id ~keeper:"k" ~preset:"deep" ~started_at:3.0;
   try
-    if finalize_first then R.mark_completed t ~run_id ~ok:false;
+    if finalize_first then R.mark_completed t ~run_id ~ok:false ();
     raise Exit (* the suspending append re-propagates Cancelled here *)
   with
   | Exit -> ()
@@ -95,7 +95,7 @@ let test_finalize_before_suspend_keeps_completed () =
 
 let test_mark_unknown_is_noop () =
   let t = R.create () in
-  R.mark_completed t ~run_id:"ghost" ~ok:true;
+  R.mark_completed t ~run_id:"ghost" ~ok:true ();
   check int "unknown run_id does not create an entry" 0 (List.length (R.list_runs t))
 ;;
 
@@ -116,7 +116,7 @@ let test_prune_keeps_running_and_recent () =
   for i = 0 to 99 do
     let id = Printf.sprintf "c%d" i in
     R.register_running t ~run_id:id ~keeper:"k" ~preset:"p" ~started_at:(float_of_int i);
-    R.mark_completed t ~run_id:id ~ok:true
+    R.mark_completed t ~run_id:id ~ok:true ()
   done;
   (* the Running run is never evicted *)
   (match R.get t ~run_id:"active" with
@@ -133,8 +133,13 @@ let test_prune_keeps_running_and_recent () =
    keeper tool. "failed" (ok=false) must never collapse into "completed". *)
 let test_status_label () =
   check string "running label" "running" (R.status_label R.Running);
-  check string "completed label" "completed" (R.status_label (R.Completed { ok = true }));
-  check string "failed label" "failed" (R.status_label (R.Completed { ok = false }))
+  check string "completed label" "completed" (R.status_label (R.Completed { ok = true; failure = None; failure_code = None }));
+  check string "failed label" "failed" (R.status_label
+       (R.Completed
+          { ok = false
+          ; failure = Some "judge failed"
+          ; failure_code = Some "parse_error"
+          }))
 ;;
 
 (* Phase 4: run_to_yojson is the one per-run serializer for every fusion-run
@@ -143,7 +148,9 @@ let test_status_label () =
 let test_run_to_yojson_shape () =
   let t = R.create () in
   R.register_running t ~run_id:"r-ser" ~keeper:"kx" ~preset:"deep" ~started_at:42.0;
-  R.mark_completed t ~run_id:"r-ser" ~ok:false;
+  R.mark_completed t ~run_id:"r-ser"
+    ~failure:"fusion aborted: 0 of 3 panels answered, preset requires at least 1"
+    ~failure_code:"panels_unavailable" ~ok:false ();
   match R.get t ~run_id:"r-ser" with
   | None -> fail "run must be present"
   | Some run ->
@@ -154,7 +161,27 @@ let test_run_to_yojson_shape () =
     check string "status label (ok=false -> failed)" "failed" (yojson_str j "status");
     (match yojson_field j "started_at" with
      | Some (`Float f) -> check (float 0.001) "started_at" 42.0 f
-     | _ -> fail "started_at must serialize as a float field")
+     | _ -> fail "started_at must serialize as a float field");
+    (* 실패 사유는 additive 필드로 실린다 — 상태 표면이 opaque "failed"가 되지
+       않게 하는 2026-07-01 사고 회귀 가드. *)
+    check string "error field carries failure reason"
+      "fusion aborted: 0 of 3 panels answered, preset requires at least 1"
+      (yojson_str j "error");
+    check string "failure_code field" "panels_unavailable" (yojson_str j "failure_code")
+;;
+
+(* 성공 run에는 error/failure_code 필드가 없어야 한다(additive-only 계약). *)
+let test_run_to_yojson_success_has_no_failure_fields () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r-ok" ~keeper:"kx" ~preset:"deep" ~started_at:1.0;
+  R.mark_completed t ~run_id:"r-ok" ~ok:true ();
+  match R.get t ~run_id:"r-ok" with
+  | None -> fail "run must be present"
+  | Some run ->
+    let j = R.run_to_yojson run in
+    check bool "no error field on success" true (Option.is_none (yojson_field j "error"));
+    check bool "no failure_code field on success" true
+      (Option.is_none (yojson_field j "failure_code"))
 ;;
 
 let () =
@@ -174,6 +201,8 @@ let () =
     ; ( "rfc-0266-phase4"
       , [ test_case "status_label vocabulary" `Quick test_status_label
         ; test_case "run_to_yojson shape + label" `Quick test_run_to_yojson_shape
+        ; test_case "run_to_yojson success omits failure fields" `Quick
+            test_run_to_yojson_success_has_no_failure_fields
         ] )
     ]
 ;;

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -24,7 +24,6 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   }
 
 let fusion_schema = Keeper_structured_output_schema.fusion_judge_output_schema
-let panel_schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema
 
 let restore_model_catalog previous =
   match previous with
@@ -82,7 +81,11 @@ let test_output_contract_keeps_native_schema_when_supported () =
        | Some schema -> Yojson.Safe.equal fusion_schema schema
        | None -> false)
 
-let test_output_contract_fails_loud_when_schema_is_not_native () =
+(* Prompt tier: native schema 미선언이면 schema를 싣지 않고 base config 그대로
+   통과한다(빌드 실패 아님). 계약은 프롬프트의 expected_json_doc + strict 파싱이
+   나른다. 2026-07-01 사고 이후 #22768의 "native or fail before HTTP"를 뒤집은
+   지점 — 근거는 fusion_judge.ml [apply_fusion_judge_output_contract] 주석. *)
+let test_output_contract_prompt_tier_when_schema_is_not_native () =
   with_repo_oas_model_catalog @@ fun () ->
   let cfg =
     provider_cfg
@@ -91,12 +94,16 @@ let test_output_contract_fails_loud_when_schema_is_not_native () =
       ~base_url:"https://api.deepseek.com"
   in
   match Fusion_judge.For_testing.apply_output_contract cfg with
-  | Ok _ -> fail "expected schema-native fusion judge to fail loud"
-  | Error msg ->
-    check bool "schema validation reason is retained" true
-      (String.length msg > 0)
+  | Error msg -> fail ("prompt tier must not fail the build: " ^ msg)
+  | Ok configured ->
+    check bool "no native schema is attached (prompt tier)" true
+      (match configured.response_format with
+       | Agent_sdk.Types.Off -> true
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+    check bool "output_schema stays empty (prompt tier)" true
+      (Option.is_none configured.output_schema)
 
-let test_output_contract_fails_loud_when_no_output_contract_is_known () =
+let test_output_contract_prompt_tier_when_no_output_contract_is_known () =
   with_empty_oas_model_catalog @@ fun () ->
   let cfg =
     provider_cfg
@@ -105,73 +112,64 @@ let test_output_contract_fails_loud_when_no_output_contract_is_known () =
       ~base_url:"https://api.example.invalid/v1"
   in
   match Fusion_judge.For_testing.apply_output_contract cfg with
-  | Ok _ -> fail "expected unknown provider/model to fail loud"
-  | Error msg ->
-    check bool "schema validation reason is retained" true (String.length msg > 0)
-
-let test_panel_output_contract_keeps_native_schema_when_supported () =
-  let cfg =
-    provider_cfg
-      ~kind:Llm_provider.Provider_config.Anthropic
-      ~model_id:"claude-test"
-      ~base_url:"https://api.anthropic.test"
-  in
-  match Fusion_panel.For_testing.apply_output_contract cfg with
-  | Error msg -> fail ("expected native schema config: " ^ msg)
+  | Error msg -> fail ("prompt tier must not fail the build: " ^ msg)
   | Ok configured ->
-    check bool "response_format uses JsonSchema" true
+    check bool "no native schema is attached (prompt tier)" true
       (match configured.response_format with
-       | Agent_sdk.Types.JsonSchema schema -> Yojson.Safe.equal panel_schema schema
-       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
-    check bool "output_schema mirrors schema" true
-      (match configured.output_schema with
-       | Some schema -> Yojson.Safe.equal panel_schema schema
-       | None -> false)
+       | Agent_sdk.Types.Off -> true
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+    check bool "output_schema stays empty (prompt tier)" true
+      (Option.is_none configured.output_schema)
 
-let test_panel_outcome_parses_structured_answer () =
+(* 패널 계약 = free text (2026-07-01 사고 회귀 가드). prose가 그대로 답변이 된다 —
+   JSON envelope 파싱이 없으므로 "provider가 schema를 무시해 prose를 반환"하는
+   실패 모드 자체가 존재하지 않는다. *)
+let test_panel_outcome_accepts_free_text () =
   match
     Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
       ~model:"provider.model"
-      (Ok (response_with_text {|{"answer":"  hello  "}|}))
+      (Ok (response_with_text "  Eio is production-ready for most new projects.  "))
   with
   | Fusion_types.Answered { model; answer; usage } ->
     check string "panel identity preserved" "panel-a" model;
-    check string "answer is parsed and trimmed" "hello" answer;
+    check string "free text is the answer, trimmed"
+      "Eio is production-ready for most new projects." answer;
     check usage_t "missing provider usage defaults to zero" Fusion_types.zero_usage
       usage
   | Fusion_types.Failed failure ->
-    fail ("expected structured answer, got failure: " ^ Fusion_types.show_panel_error failure)
-
-let test_panel_outcome_rejects_invalid_structured_answer () =
-  match
-    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
-      ~model:"provider.model"
-      (Ok (response_with_text "not-json"))
-  with
-  | Fusion_types.Failed
-      { failed_model = "panel-a"
-      ; reason = Fusion_types.Invalid_structured_response detail
-      } ->
-    check bool "invalid JSON detail is retained" true
-      (String_util.string_contains_substring ~needle:"not valid JSON" detail)
-  | other ->
-    fail
-      ("expected invalid structured response failure, got: "
-       ^ Fusion_types.show_panel_outcome other)
+    fail ("expected free-text answer, got failure: "
+          ^ Fusion_types.show_panel_error failure)
 
 let test_panel_outcome_rejects_empty_answer () =
   match
     Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
       ~model:"provider.model"
-      (Ok (response_with_text {|{"answer":"   "}|}))
+      (Ok (response_with_text "   "))
   with
   | Fusion_types.Failed
       { failed_model = "panel-a"; reason = Fusion_types.Empty_response detail } ->
     check bool "empty response detail is retained" true (String.length detail > 0)
   | other ->
     fail
-      ("expected empty structured answer failure, got: "
+      ("expected empty answer failure, got: "
        ^ Fusion_types.show_panel_outcome other)
+
+(* per-agent HTTP 타임아웃은 typed [Timeout]으로 분류된다 — to_string 직렬화로
+   [Provider_error]에 뭉개지면 외곽 붕괴(전 패널 Timeout)와 개별 타임아웃을 board
+   증거에서 구분할 수 없다. *)
+let test_panel_outcome_types_per_agent_timeout () =
+  let timeout_error =
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.Timeout { message = "120s"; phase = None })
+  in
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model" (Error timeout_error)
+  with
+  | Fusion_types.Failed { failed_model = "panel-a"; reason = Fusion_types.Timeout } ->
+    ()
+  | other ->
+    fail ("expected typed Timeout, got: " ^ Fusion_types.show_panel_outcome other)
 
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
@@ -264,25 +262,20 @@ let () =
             `Quick
             test_output_contract_keeps_native_schema_when_supported
         ; test_case
-            "fails loud when native schema is not available"
+            "prompt tier when native schema is not available"
             `Quick
-            test_output_contract_fails_loud_when_schema_is_not_native
+            test_output_contract_prompt_tier_when_schema_is_not_native
         ; test_case
-            "fails loud when no JSON output contract is known"
+            "prompt tier when no JSON output contract is known"
             `Quick
-            test_output_contract_fails_loud_when_no_output_contract_is_known
-        ; test_case
-            "panel keeps native answer schema when supported"
-            `Quick
-            test_panel_output_contract_keeps_native_schema_when_supported
+            test_output_contract_prompt_tier_when_no_output_contract_is_known
         ] )
     ; ( "panel_outcome"
-      , [ test_case "parses structured answer" `Quick
-            test_panel_outcome_parses_structured_answer
-        ; test_case "rejects invalid structured answer" `Quick
-            test_panel_outcome_rejects_invalid_structured_answer
+      , [ test_case "accepts free text" `Quick test_panel_outcome_accepts_free_text
         ; test_case "rejects empty answer" `Quick
             test_panel_outcome_rejects_empty_answer
+        ; test_case "types per-agent timeout" `Quick
+            test_panel_outcome_types_per_agent_timeout
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success

--- a/test/test_fusion_status_tool.ml
+++ b/test/test_fusion_status_tool.ml
@@ -61,9 +61,10 @@ let seeded () =
   let t = R.create () in
   R.register_running t ~run_id:"r-run" ~keeper:"k1" ~preset:"balanced" ~started_at:300.0;
   R.register_running t ~run_id:"r-done" ~keeper:"k1" ~preset:"deep" ~started_at:100.0;
-  R.mark_completed t ~run_id:"r-done" ~ok:true;
+  R.mark_completed t ~run_id:"r-done" ~ok:true ();
   R.register_running t ~run_id:"r-fail" ~keeper:"k1" ~preset:"deep" ~started_at:200.0;
-  R.mark_completed t ~run_id:"r-fail" ~ok:false;
+  R.mark_completed t ~run_id:"r-fail"
+    ~failure:"judge failed: timeout" ~failure_code:"timeout" ~ok:false ();
   R.register_running
     t
     ~run_id:"r-foreign"

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -282,8 +282,8 @@ let test_emit_board_failure_is_best_effort () =
     (match Fusion_run_registry.get Fusion_run_registry.global ~run_id with
      | Some run ->
        (match run.Fusion_run_registry.status with
-        | Fusion_run_registry.Completed { ok = true } -> ()
-        | Fusion_run_registry.Completed { ok = false } ->
+        | Fusion_run_registry.Completed { ok = true; _ } -> ()
+        | Fusion_run_registry.Completed { ok = false; _ } ->
           fail "fusion run should complete with ok=true"
         | Fusion_run_registry.Running -> fail "fusion run should not remain running")
      | None -> fail "fusion run should remain visible");

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -67,9 +67,17 @@ let expected_structured_dashboard_agent_run_json_judges =
 ;;
 
 let expected_structured_fusion_agent_build_files =
+  List.sort String.compare [ "lib/fusion/fusion_judge.ml" ]
+;;
+
+let expected_freeform_fusion_agent_build_files =
   List.sort
     String.compare
-    [ "lib/fusion/fusion_judge.ml"; "lib/fusion/fusion_panel.ml" ]
+    [ (* 패널 답변 계약은 free text다 (fusion_panel.ml 참조): 단일 문자열에 JSON
+         envelope는 정보 이득 0에, provider가 schema를 무시하면 패널이 전멸하는
+         실패 클래스만 추가했다 (2026-07-01 사고). *)
+      "lib/fusion/fusion_panel.ml"
+    ]
 ;;
 
 let expected_structured_tool_agent_runs =
@@ -120,7 +128,10 @@ let fusion_agent_build_files () =
 ;;
 
 let expected_all_fusion_agent_build_files =
-  expected_structured_fusion_agent_build_files
+  List.sort
+    String.compare
+    (expected_structured_fusion_agent_build_files
+     @ expected_freeform_fusion_agent_build_files)
 ;;
 
 let with_repo_oas_model_catalog f =
@@ -317,7 +328,9 @@ let test_fusion_agent_builds_do_not_degrade_to_json_mode () =
     expected_structured_fusion_agent_build_files
 ;;
 
-let test_repo_fusion_seed_judges_accept_native_schema () =
+(* 2-tier 계약: native schema 미선언 runtime도 prompt tier로 Ok — 계약 적용은
+   total이다. seed 설정의 어떤 judge runtime도 빌드 단계에서 실패하지 않는다. *)
+let test_repo_fusion_seed_judge_contract_is_total () =
   with_repo_oas_model_catalog @@ fun _catalog ->
   let path = Ast_grep.resolve_path "config/runtime.toml" in
   check bool "repo runtime.toml present" true (Sys.file_exists path);
@@ -357,57 +370,11 @@ let test_repo_fusion_seed_judges_accept_native_schema () =
                  | Ok _ -> ()
                  | Error msg ->
                    failf
-                     "fusion preset %s judge runtime %s must accept native schema: %s"
+                     "fusion preset %s judge runtime %s: output contract must be total: %s"
                      preset.Fusion_policy.name
                      runtime_id
                      msg)
               judge_runtime_ids)
-         policy.Fusion_policy.presets)
-;;
-
-let assert_panel_runtime_accepts_native_schema runtimes ~preset runtime_id =
-  let runtime = runtime_by_id_or_fail runtimes runtime_id in
-  match Fusion_panel.For_testing.apply_output_contract runtime.provider_config with
-  | Ok _ -> ()
-  | Error msg ->
-    failf
-      "fusion preset %s panel runtime %s must accept native schema: %s"
-      preset
-      runtime_id
-      msg
-;;
-
-let test_repo_fusion_panel_presets_are_schema_capable () =
-  with_repo_oas_model_catalog @@ fun _catalog ->
-  let path = Ast_grep.resolve_path "config/runtime.toml" in
-  match Runtime.load_list ~config_path:path with
-  | Error msg -> failf "repo runtime.toml should load: %s" msg
-  | Ok
-      ( runtimes
-      , _default
-      , _assignments
-      , _librarian
-      , _structured_judge
-      , _cross
-      , _media ) ->
-    let runtime_cfg = fusion_toml_or_fail path in
-    (match Fusion_config.of_toml runtime_cfg with
-     | Error errs ->
-       failf
-         "repo fusion config should load: %s"
-         (String.concat ", " (List.map Fusion_config.show_config_error errs))
-     | Ok policy ->
-       List.iter
-         (fun validated_preset ->
-            let preset = Fusion_policy.Validated_preset.preset validated_preset in
-            List.iter
-              (fun (group : Fusion_policy.panel_group) ->
-                 List.iter
-                   (assert_panel_runtime_accepts_native_schema
-                      runtimes
-                      ~preset:preset.Fusion_policy.name)
-                   group.Fusion_policy.models)
-              preset.Fusion_policy.panels)
          policy.Fusion_policy.presets)
 ;;
 
@@ -589,13 +556,9 @@ let () =
             `Quick
             test_fusion_agent_builds_do_not_degrade_to_json_mode
         ; test_case
-            "repo Fusion seed judge runtimes accept native schema"
+            "repo Fusion seed judge output contract is total"
             `Quick
-            test_repo_fusion_seed_judges_accept_native_schema
-        ; test_case
-            "repo Fusion panel presets use schema-capable runtimes"
-            `Quick
-            test_repo_fusion_panel_presets_are_schema_capable
+            test_repo_fusion_seed_judge_contract_is_total
         ] )
     ; ( "structured tool Agent.run"
       , [ test_case

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -57,7 +57,6 @@ let all_provider_native_schema_cases =
   ; "operator_judge", Keeper_structured_output_schema.operator_judge_output_schema
   ; "governance_judge", Keeper_structured_output_schema.governance_judge_output_schema
   ; "fusion_judge", Keeper_structured_output_schema.fusion_judge_output_schema
-  ; "fusion_panel", Keeper_structured_output_schema.fusion_panel_answer_output_schema
   ; "verification_verdict", Keeper_structured_output_schema.verification_verdict_output_schema
   ; ( "anti_rationalization_verdict"
     , Keeper_structured_output_schema.anti_rationalization_verdict_output_schema )
@@ -225,23 +224,6 @@ let test_fusion_judge_schema_uses_parser_wire_contract () =
   check bool "fusion schema exposes parser wire fields" true true
 ;;
 
-let test_fusion_panel_schema_uses_answer_contract () =
-  let schema = Keeper_structured_output_schema.fusion_panel_answer_output_schema in
-  check
-    (list string)
-    "fusion panel required fields"
-    [ "answer" ]
-    (required_strings schema);
-  check
-    (option string)
-    "fusion panel answer is string"
-    (Some "string")
-    (match schema |> schema_property "answer" |> schema_member "type" with
-     | Some (`String value) -> Some value
-     | _ -> None);
-  check bool "fusion panel schema is closed" false
-    (allows_additional_properties schema)
-;;
 
 let test_verification_verdict_schema_uses_core_ssot () =
   let schema = Keeper_structured_output_schema.verification_verdict_output_schema in
@@ -323,10 +305,6 @@ let () =
             "fusion judge schema uses parser wire contract"
             `Quick
             test_fusion_judge_schema_uses_parser_wire_contract
-        ; test_case
-            "fusion panel schema uses answer contract"
-            `Quick
-            test_fusion_panel_schema_uses_answer_contract
         ] )
     ; ( "verdict schemas"
       , [ test_case


### PR DESCRIPTION
## 무엇이 깨져 있었나 (실측)

2026-06-30 22:20 KST #22768 머지 이후 **모든 fusion 실행이 실패**했다. 07-01 하루 8/8 run 실패, keeper 가시 표면 전부가 bare `"judge failed"`만 보고해 keeper들이 judge 메커니즘 고장으로 오진하고 수 시간을 소모했다 (board post "[Systemic] Fusion deliberation judge mechanism — 5/5 runs failed").

포렌식 (board_posts.jsonl + system_log 06-25~07-02):

- 실패 run 전부 **judge는 실행조차 안 됨** — `fusion aborted: 0 of 3 panels answered` (failure_code=`internal_error`로 오분류).
- 패널 실패 사유 분포: `invalid_structured_response` 17건 / bare `timeout` 9건 / `provider_error` 6건.
- #22768 이후 성공 run **0건**. 이전(06-17~06-30)에는 prompt 계약만으로 성공 run 다수 (issue_king/verifier/albini/ramarama chat lane 증거).

### 근본 원인 1 — provider가 schema를 조용히 무시 (17건)

2026-07-02 직접 프로브: **ollama.com cloud는 `response_format: json_schema`(OpenAI-compat)와 네이티브 `/api/chat format` 양쪽 모두를 에러 없이 무시**한다. deepseek-v4-pro, kimi-k2.6, devstral-small-2:24b 전부 순수 prose 반환.

- 패널 JSON 계약(`{"answer": string}`)은 와이어(`response_format`)에만 실려 있었고 panel_system_prompt에는 JSON 지시가 전혀 없음 → prose 반환이 보장됨 → strict 파서가 패널 전멸.
- OAS 카탈로그의 `ollama_cloud` base가 `supports_structured_output=true`를 암묵 상속해 빌드타임 검증이 통과 → 거짓 capability 사실. OAS #2440이 이 사실을 교정한다 (본 PR과 독립적으로 정합; 아래 참조).

### 근본 원인 2 — 외곽 타임아웃이 웨이브 직렬화를 무시 (9건)

`panel_outer_timeout_of` = max(그룹 timeout) = 120s인데, 라이브 config는 3패널 × `max_concurrent_panels=2` × 120s → 마지막 웨이브가 구조적으로 데드라인 밖. 외곽 발화 시 **완료된 패널 답변까지 통째로 취소·폐기**되고 전 패널이 bare `Timeout`으로 보고됨.

### 근본 원인 3 — 실패 상세의 전면 유실

- `fusion_sink.ml:331`: board headline이 `Error _`로 typed 사유를 버림.
- chat lane: 실패 시 아무것도 남기지 않음 → 유일한 사유 전달 채널이 일회성 wake stimulus가 됨. `wakeup_keeper`는 비-Running keeper에서 **무로그 drop** (07-01 두 run의 결과가 흔적 없이 증발: fus-c9a63064, fus-46fce8a8).
- registry/`masc_fusion_status`: `ok:bool`만 저장 → opaque `status="failed"`.
- 결과: keeper가 원인에 도달할 tool-reachable 경로가 0개.

## 무엇을 바꿨나

1. **패널 = free text** (`fusion_panel.ml`). 패널 답변은 의미상 단일 문자열 — JSON envelope는 정보 이득 0에 실패 클래스만 추가했다. envelope/스키마/파싱 제거, trimmed visible text가 답변. thinking 분리는 OAS가 이미 수행 (`reasoning` 별도 채널 실측 + #22854). per-agent HTTP 타임아웃을 typed `Timeout`으로 분류 (기존: `Provider_error` 문자열로 압축).
2. **judge = typed 2-tier 계약** (`fusion_judge.ml`). tier는 OAS capability facts(`validate_output_schema_request`)로만 결정: Native tier(schema 첨부) / Prompt tier(schema 미첨부, 프롬프트가 항상 싣는 `expected_json_doc` + strict fail-loud 파싱, 결정 시점 로그). #22768의 "native or fail before HTTP"는 (a) capability 사실이 거짓일 수 있음이 실측됐고 (b) 사실이 참이어도 해당 preset의 fusion을 영구 불능으로 만들기에 뒤집었다. JsonMode silent downgrade는 여전히 없음 (coverage 테스트 유지).
3. **`Panels_unavailable of skip_reason`** judge_failure variant 추가 — 패널 전멸을 패널 전멸로 보고 (`failure_code=panels_unavailable`), `Internal_error` 문자열 압축 제거.
4. **실패 관측성 복원**: board headline에 failure_code+사유+패널별 사유, chat lane에 실패 결론 durable 기록(denied/sink_failed/aborted 선례와 정합), registry `Completed`에 `failure`/`failure_code` 추가 → `masc_fusion_status`·SSE가 사유를 나름, wake drop에 로그.
5. **웨이브 인지 외곽 타임아웃**: `panel_outer_timeout_of ~max_fibers` = ceil(총원/max_fibers) × max timeout. 결정론적 수식, 마진 휴리스틱 없음.
6. **도구 계약 명시**: `masc_fusion` 결과에 `delivery` 필드(비폴링 async 계약), descriptor에 wake 계약 + "패널은 keeper 파일/컨텍스트를 볼 수 없음" 명시 (07-01: 8 run에 status 폴링 35회 + nudge 8회 소모; keeper가 패널에게 로컬 파일 검사를 요청하는 오용 관측).

## OAS/기존 PR과의 관계

- **OAS #2440** (`ollama_cloud` `supports_structured_output=false`): 방향 지지 — 내 프로브 3모델×2엔드포인트가 근거를 보강. 본 PR은 #2440 머지 전(거짓 native tier여도 judge 프롬프트 계약+strict 파싱으로 동작)·후(정직한 prompt tier) 모두 동작한다.
- **MASC #22985**: supersede 권고. "prose에서 첫 JSON 추출"은 순수 prose 응답(실측 다수)에는 JSON이 아예 없어 여전히 실패하고, MASC config에 모델 capability 선언을 두는 것은 OAS 카탈로그와 SSOT 충돌, config-load fail-fast는 라이브 trio에서 fusion을 영구 불능으로 만든다. 리뷰 코멘트로 상세 남김.
- **후속 (별도 PR)**: `runtime_agent.ml` `request_runtime_fields_on_base_config`가 base provider config의 `response_format`/`output_schema`를 요청 config의 `Off`/`None`으로 **무조건 덮어써 native schema가 어떤 소비자에서도 와이어에 도달한 적이 없음**을 hop-by-hop 추적으로 확정 (fusion뿐 아니라 verifier/dashboard judge 전체 영향). 별도 PR로 수정 예정 — blast radius가 다름.

## 검증

- 전 변경 파일 25개 `ocamlc -stop-after parsing` 통과 (repo ocamlformat은 RFC-0010으로 disable 상태).
- dune build/test는 운영 지침대로 CI에서 수행.
- 신규/갱신 테스트: 웨이브 수식 4케이스, `Panels_unavailable` tag/text/predicate, 패널 free-text/빈답변/typed timeout, judge prompt-tier 2케이스(비-native/무카탈로그), registry 실패 필드 직렬화+성공시 필드 부재, status tool 실패 상세.
- 실측 프로브 재현: `curl https://ollama.com/v1/chat/completions -d '{"model":"deepseek-v4-pro",...,"response_format":{"type":"json_schema",...}}'` → prose (2026-07-02, OLLAMA_CLOUD_API_KEY).

RFC-WAIVED: fusion 서브시스템은 CLAUDE.md agent_delegation RFC-필수 목록(credential/repo_manager/operator_control/hooks/workflow 문서) 밖이며, 본 PR은 신규 설계가 아니라 실측 사고(2026-07-01 8/8 실패)의 근본 원인 수정이다. 설계 SSOT는 기존 RFC-0252/0266/0278/0283/0284를 따르고 각 변경점에 RFC 절 참조를 주석으로 남겼다.

MASC task: task-1638

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
