### PR TITLE
fix(runtime): preserve base structured-output contract in per-request config merge

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -197,6 +197,19 @@ let request_runtime_fields_on_base_config
     ~(base : Llm_provider.Provider_config.t)
     (req_config : Llm_provider.Provider_config.t)
   =
+  let response_format =
+    match req_config.response_format with
+    | Agent_sdk.Types.Off -> base.response_format
+    | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _) as requested ->
+      requested
+  in
+  let output_schema =
+    match req_config.response_format, req_config.output_schema with
+    | Agent_sdk.Types.Off, None -> base.output_schema
+    | _, Some _ as requested -> requested
+    | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _), None ->
+      Llm_provider.Provider_config.output_schema_of_response_format response_format
+  in
   { base with
     max_tokens = req_config.max_tokens;
     temperature = req_config.temperature;
@@ -220,15 +233,8 @@ let request_runtime_fields_on_base_config
        verifier, dashboard judge 등 모든 Keeper_structured_output_schema 소비자의
        native schema가 HTTP body에 실린 적이 없었다 (2026-07-02 hop-by-hop 추적,
        masc#23003 후속). [Off]/[None] = 무의견 → base 유지; 요청이 명시하면 요청 우선. *)
-    response_format =
-      (match req_config.response_format with
-       | Agent_sdk.Types.Off -> base.response_format
-       | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _) as requested ->
-         requested);
-    output_schema =
-      (match req_config.output_schema with
-       | None -> base.output_schema
-       | Some _ as requested -> requested);
+    response_format;
+    output_schema;
     cache_system_prompt = req_config.cache_system_prompt;
     supports_tool_choice_override =
       (match req_config.supports_tool_choice_override with

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -197,18 +197,18 @@ let request_runtime_fields_on_base_config
     ~(base : Llm_provider.Provider_config.t)
     (req_config : Llm_provider.Provider_config.t)
   =
-  let response_format =
-    match req_config.response_format with
-    | Agent_sdk.Types.Off -> base.response_format
-    | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _) as requested ->
-      requested
-  in
-  let output_schema =
+  let response_format, output_schema =
     match req_config.response_format, req_config.output_schema with
-    | Agent_sdk.Types.Off, None -> base.output_schema
-    | _, (Some _ as requested) -> requested
-    | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _), None ->
-      Llm_provider.Provider_config.output_schema_of_response_format response_format
+    | Agent_sdk.Types.Off, None -> base.response_format, base.output_schema
+    | _, Some schema ->
+      let response_format = Agent_sdk.Types.JsonSchema schema in
+      ( response_format
+      , Llm_provider.Provider_config.output_schema_of_response_format response_format )
+    | Agent_sdk.Types.JsonMode, None -> Agent_sdk.Types.JsonMode, None
+    | Agent_sdk.Types.JsonSchema schema, None ->
+      let response_format = Agent_sdk.Types.JsonSchema schema in
+      ( response_format
+      , Llm_provider.Provider_config.output_schema_of_response_format response_format )
   in
   { base with
     max_tokens = req_config.max_tokens;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -206,7 +206,7 @@ let request_runtime_fields_on_base_config
   let output_schema =
     match req_config.response_format, req_config.output_schema with
     | Agent_sdk.Types.Off, None -> base.output_schema
-    | _, Some _ as requested -> requested
+    | _, (Some _ as requested) -> requested
     | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _), None ->
       Llm_provider.Provider_config.output_schema_of_response_format response_format
   in

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -211,8 +211,24 @@ let request_runtime_fields_on_base_config
     tool_stream = req_config.tool_stream;
     tool_choice = req_config.tool_choice;
     disable_parallel_tool_use = req_config.disable_parallel_tool_use;
-    response_format = req_config.response_format;
-    output_schema = req_config.output_schema;
+    (* structured output 계약은 [supports_tool_choice_override]와 같은
+       "요청이 의견을 낼 때만 요청 우선" 병합이다. OAS Agent의 요청 config는
+       [Agent_sdk.Provider.config](라우팅 삼중항)에서 파생되어 schema 필드를
+       구조적으로 운반할 수 없으므로 언제나 [Off]/[None]으로 도착한다 — 이를
+       무조건 복사하면 base(빌드 시 validate까지 통과한 schema-carrying config)의
+       계약이 와이어 직전에 조용히 증발한다. 실제로 #22768 이후 fusion judge/panel,
+       verifier, dashboard judge 등 모든 Keeper_structured_output_schema 소비자의
+       native schema가 HTTP body에 실린 적이 없었다 (2026-07-02 hop-by-hop 추적,
+       masc#23003 후속). [Off]/[None] = 무의견 → base 유지; 요청이 명시하면 요청 우선. *)
+    response_format =
+      (match req_config.response_format with
+       | Agent_sdk.Types.Off -> base.response_format
+       | (Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _) as requested ->
+         requested);
+    output_schema =
+      (match req_config.output_schema with
+       | None -> base.output_schema
+       | Some _ as requested -> requested);
     cache_system_prompt = req_config.cache_system_prompt;
     supports_tool_choice_override =
       (match req_config.supports_tool_choice_override with

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
   test_tool_agent_timeline_name_match
   test_keeper_idle_threshold_contract
   test_provider_tool_support_caps
+  test_runtime_request_config_merge
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_board_activity_cache
@@ -389,6 +390,7 @@
   test_tool_agent_timeline_name_match
   test_keeper_idle_threshold_contract
   test_provider_tool_support_caps
+  test_runtime_request_config_merge
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
   test_board_activity_cache

--- a/test/test_runtime_request_config_merge.ml
+++ b/test/test_runtime_request_config_merge.ml
@@ -20,6 +20,14 @@ let schema : Yojson.Safe.t =
     ; ("required", `List [ `String "answer" ])
     ]
 
+let alternate_schema : Yojson.Safe.t =
+  `Assoc
+    [ ("type", `String "object")
+    ; ( "properties"
+      , `Assoc [ ("verdict", `Assoc [ ("type", `String "string") ]) ] )
+    ; ("required", `List [ `String "verdict" ])
+    ]
+
 let base_with_schema () =
   let cfg =
     Llm_provider.Provider_config.make
@@ -65,7 +73,7 @@ let test_base_schema_survives_opinionless_request () =
   check (option string) "request system_prompt still wins" (Some "req prompt")
     merged.Llm_provider.Provider_config.system_prompt
 
-let test_request_opinion_wins () =
+let test_request_json_mode_clears_base_schema () =
   let req =
     { (request_without_opinion ()) with
       Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonMode
@@ -75,7 +83,26 @@ let test_request_opinion_wins () =
   check bool "explicit request JsonMode overrides base JsonSchema" true
     (match merged.Llm_provider.Provider_config.response_format with
      | Agent_sdk.Types.JsonMode -> true
-     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false)
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
+  check bool "explicit request JsonMode clears base output_schema" true
+    (Option.is_none merged.Llm_provider.Provider_config.output_schema)
+
+let test_request_json_schema_replaces_base_schema () =
+  let req =
+    { (request_without_opinion ()) with
+      Llm_provider.Provider_config.response_format =
+        Agent_sdk.Types.JsonSchema alternate_schema
+    }
+  in
+  let merged = merge ~base:(base_with_schema ()) req in
+  check bool "explicit request JsonSchema overrides base JsonSchema" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonSchema s -> Yojson.Safe.equal s alternate_schema
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonMode -> false);
+  check bool "explicit request JsonSchema replaces base output_schema" true
+    (match merged.Llm_provider.Provider_config.output_schema with
+     | Some s -> Yojson.Safe.equal s alternate_schema
+     | None -> false)
 
 let test_both_opinionless_stays_off () =
   let base =
@@ -98,7 +125,10 @@ let () =
     [ ( "structured output merge"
       , [ test_case "base schema survives opinionless request" `Quick
             test_base_schema_survives_opinionless_request
-        ; test_case "explicit request opinion wins" `Quick test_request_opinion_wins
+        ; test_case "explicit request JsonMode clears base schema" `Quick
+            test_request_json_mode_clears_base_schema
+        ; test_case "explicit request JsonSchema replaces base schema" `Quick
+            test_request_json_schema_replaces_base_schema
         ; test_case "both opinionless stays Off" `Quick
             test_both_opinionless_stays_off
         ] )

--- a/test/test_runtime_request_config_merge.ml
+++ b/test/test_runtime_request_config_merge.ml
@@ -104,6 +104,22 @@ let test_request_json_schema_replaces_base_schema () =
      | Some s -> Yojson.Safe.equal s alternate_schema
      | None -> false)
 
+let test_request_output_schema_normalizes_response_format () =
+  let req =
+    { (request_without_opinion ()) with
+      Llm_provider.Provider_config.output_schema = Some alternate_schema
+    }
+  in
+  let merged = merge ~base:(base_with_schema ()) req in
+  check bool "explicit request output_schema sets JsonSchema response_format" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonSchema s -> Yojson.Safe.equal s alternate_schema
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonMode -> false);
+  check bool "explicit request output_schema replaces base output_schema" true
+    (match merged.Llm_provider.Provider_config.output_schema with
+     | Some s -> Yojson.Safe.equal s alternate_schema
+     | None -> false)
+
 let test_both_opinionless_stays_off () =
   let base =
     Llm_provider.Provider_config.make
@@ -129,6 +145,8 @@ let () =
             test_request_json_mode_clears_base_schema
         ; test_case "explicit request JsonSchema replaces base schema" `Quick
             test_request_json_schema_replaces_base_schema
+        ; test_case "explicit request output_schema normalizes response_format" `Quick
+            test_request_output_schema_normalizes_response_format
         ; test_case "both opinionless stays Off" `Quick
             test_both_opinionless_stays_off
         ] )

--- a/test/test_runtime_request_config_merge.ml
+++ b/test/test_runtime_request_config_merge.ml
@@ -1,0 +1,105 @@
+(* Runtime_agent.request_runtime_fields_on_base_config — structured output 병합 회귀 가드.
+
+   base provider config는 빌드 시 validate까지 통과한 schema-carrying 계약을 나를 수
+   있다 (Keeper_structured_output_schema.apply_to_provider_config). OAS Agent의
+   per-request config는 [Agent_sdk.Provider.config](라우팅 삼중항)에서 파생되어
+   schema 필드를 구조적으로 운반할 수 없으므로 언제나 response_format=Off /
+   output_schema=None으로 도착한다. 이전 병합은 이 무의견 값을 base 위에 무조건
+   복사해 계약을 와이어 직전에 조용히 증발시켰다 — #22768 이후 fusion judge/panel·
+   verifier·dashboard judge의 native schema가 HTTP body에 실린 적이 없었다
+   (2026-07-02 hop-by-hop 추적, masc#23003 후속). 여기서는 "요청이 의견을 낼 때만
+   요청 우선" 병합을 핀한다. *)
+
+open Alcotest
+open Masc
+
+let schema : Yojson.Safe.t =
+  `Assoc
+    [ ("type", `String "object")
+    ; ("properties", `Assoc [ ("answer", `Assoc [ ("type", `String "string") ]) ])
+    ; ("required", `List [ `String "answer" ])
+    ]
+
+let base_with_schema () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+      ()
+  in
+  { cfg with
+    Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonSchema schema
+  ; output_schema = Some schema
+  }
+
+let request_without_opinion () =
+  (* OAS Agent 요청 config의 실제 도착 형태: schema 무의견 + 요청 런타임 필드. *)
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+      ()
+  in
+  { cfg with
+    Llm_provider.Provider_config.max_tokens = Some 777
+  ; system_prompt = Some "req prompt"
+  }
+
+let merge = Runtime_agent.For_testing.request_runtime_fields_on_base_config
+
+let test_base_schema_survives_opinionless_request () =
+  let merged = merge ~base:(base_with_schema ()) (request_without_opinion ()) in
+  check bool "base JsonSchema survives request Off" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonSchema s -> Yojson.Safe.equal s schema
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonMode -> false);
+  check bool "base output_schema survives request None" true
+    (match merged.Llm_provider.Provider_config.output_schema with
+     | Some s -> Yojson.Safe.equal s schema
+     | None -> false);
+  (* 요청 런타임 필드는 여전히 요청이 이긴다 — 병합의 원래 목적 유지. *)
+  check (option int) "request max_tokens still wins" (Some 777)
+    merged.Llm_provider.Provider_config.max_tokens;
+  check (option string) "request system_prompt still wins" (Some "req prompt")
+    merged.Llm_provider.Provider_config.system_prompt
+
+let test_request_opinion_wins () =
+  let req =
+    { (request_without_opinion ()) with
+      Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonMode
+    }
+  in
+  let merged = merge ~base:(base_with_schema ()) req in
+  check bool "explicit request JsonMode overrides base JsonSchema" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonMode -> true
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false)
+
+let test_both_opinionless_stays_off () =
+  let base =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Anthropic
+      ~model_id:"claude-test"
+      ~base_url:"https://api.anthropic.test"
+      ()
+  in
+  let merged = merge ~base (request_without_opinion ()) in
+  check bool "no schema anywhere stays Off" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.Off -> true
+     | Agent_sdk.Types.JsonMode | Agent_sdk.Types.JsonSchema _ -> false);
+  check bool "no output_schema anywhere stays None" true
+    (Option.is_none merged.Llm_provider.Provider_config.output_schema)
+
+let () =
+  run "runtime_request_config_merge"
+    [ ( "structured output merge"
+      , [ test_case "base schema survives opinionless request" `Quick
+            test_base_schema_survives_opinionless_request
+        ; test_case "explicit request opinion wins" `Quick test_request_opinion_wins
+        ; test_case "both opinionless stays Off" `Quick
+            test_both_opinionless_stays_off
+        ] )
+    ]


### PR DESCRIPTION
## 문제 (hop-by-hop 추적으로 확정)

`Runtime_agent`의 per-request 병합(`request_runtime_fields_on_base_config`)이 base provider config의 `response_format`/`output_schema`를 요청 config 값으로 **무조건** 덮어쓴다. 그런데 OAS Agent의 요청 config는 `Agent_sdk.Provider.config`(라우팅 삼중항 `{provider; model_id; api_key_env}`)에서 파생되어 **schema 필드를 구조적으로 운반할 수 없고**, builder는 `with_response_format`을 호출한 적이 없어(`rg` 0건) 언제나 `Off`/`None`으로 도착한다.

결과: **빌드 시 `validate_output_schema_request`까지 통과한 native schema가 HTTP body 직전에 조용히 증발**한다. 영향 소비자 = `Keeper_structured_output_schema.apply_to_provider_config`의 전 호출자:

- fusion judge/panel (#22768이 강제한 계약이 와이어에 실린 적 없음 — masc#23003의 사고 체인 절반)
- `lib/verifier_oas.ml`
- dashboard operator/governance judge
- keeper 구조화 출력 runtime (#22688)

추적 체인 (2026-07-02):
1. `keeper_structured_output_schema.ml:340` — base에 `JsonSchema` + `output_schema` 설정, validate 통과
2. `runtime_agent_context.ml:129` — Agent config의 provider = 라우팅 삼중항 투영 (schema 필드 부재)
3. OAS `pipeline_stage_route.ml` → `provider.ml:721` — 매 턴 요청 config 재구성, `response_format = Off`
4. `runtime_agent.ml:214-215` — `Off`/`None`을 base 위에 복사 → 계약 증발

이 복사는 #15117(2026-05-14, "preserve Ollama HTTP provider config")에서 endpoint 정체성 보존 목적으로 들어왔고, structured output 언급은 커밋 메시지에 없다 — 의도가 아니라 부수 효과다.

## 수정

같은 함수 안의 `supports_tool_choice_override` 병합 관용구를 그대로 따른다: **요청이 의견을 낼 때만 요청 우선**. `Off`/`None` = 무의견 → base 계약 유지. `JsonMode`/`JsonSchema`/`Some schema`를 명시한 요청은 그대로 이긴다. 요청 런타임 필드(max_tokens/system_prompt/sampling/thinking)의 request-wins 의미는 변경 없음.

typed match — 문자열 분류 없음, exhaustive variant match.

## 행동 변화 고지 (의도된 것)

이 수정 후 schema를 첨부한 소비자들의 계약이 **실제로 provider에 도달**한다. 강제형 provider(Anthropic/Gemini/OpenAI 등)에서는 출력이 schema-constrained가 된다 — 이것이 각 소비자가 validate까지 하며 의도했던 동작이다. 비강제 provider(ollama.com cloud)는 무시가 실측 사실이며 OAS #2440이 capability 사실을 교정 중이다.

## 검증

- `ocamlc -stop-after parsing` 통과. dune build/test는 CI에서.
- 신규 테스트 `test/test_runtime_request_config_merge.ml`: base schema가 무의견 요청에서 생존 / 명시 요청 우선 / 양쪽 무의견 시 Off 유지 / 요청 런타임 필드 request-wins 유지.

관련: masc#23003 (fusion 계약 복원), oas#2440 (ollama_cloud capability 교정), masc#22985 코멘트 (capability 전파 관찰의 상위 원인)

RFC-WAIVED: 신규 설계가 아니라 #15117 병합의 의도(endpoint 정체성 보존)를 보존하면서 부수 효과(계약 증발)만 제거하는 실측 사고 근본 수정. 기존 병합 관용구(`supports_tool_choice_override`)를 동일 함수 내에서 따른다.

MASC task: task-1638

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
