### PR TITLE
fix(bin): register Process_eio clock in fusion_run so stream idle timeout can arm

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -369,6 +369,7 @@
   masc.fusion_core
   masc.runtime
   masc.config_dir_resolver
+  masc.masc_process
   masc_core
   unix
   yojson

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -383,6 +383,15 @@ let () =
   Eio_main.run @@ fun env ->
   Mirage_crypto_rng_unix.use_default ();
   Time_compat.set_clock (Eio.Stdenv.clock env);
+  (* Register the ambient Eio clock the agent runtime resolves via
+     [Process_eio.get_clock]. Without this, any runtime config that sets
+     [stream_idle_timeout_s] fails closed at agent build time ("no clock
+     resolvable ... refusing to run with a silently disarmed stream idle
+     timeout") and every panel/judge call aborts before the first request. *)
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.fs env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
   (* Capture the Eio handles the OAS/fusion call path reads via


### PR DESCRIPTION
## 문제

`fusion_run.exe`(라이브 fusion 심의 CLI 하네스)가 `Process_eio.init`을 호출하지 않고 시작한다. agent 런타임은 runtime config에 `stream_idle_timeout_s`가 설정되면 `Process_eio.get_clock`으로 ambient clock을 해석하는데, init이 없으면 fail-closed 가드가 발동한다:

```
Invalid config 'stream_idle_timeout_s': runtime_agent: stream_idle_timeout_s configured (120.0s)
but no clock resolvable (Process_eio.get_clock: init not called);
refusing to run with a silently disarmed stream idle timeout
```

`~/.masc/config/runtime.toml`이 fusion trio에 `stream_idle_timeout_s=120`을 선언하므로 **panel/judge 전 agent 빌드가 시작 전에 전멸** — baseline/self-consistency/self-moa/fusion 4경로 모두 "no answer". 2026-07-02 masc#23003 복구 라이브 검증 중 실측.

가드 자체는 올바르다(조용히 무장해제된 idle timeout으로 실행 거부). 결함은 CLI가 서버 부트스트랩(`lib/server/server_runtime_bootstrap.ml:289`)과 달리 init을 누락한 것.

## 수정

`bin/masc_worker_run.ml:45-49`와 동일 관용구: `Time_compat.set_clock` 직후 `Process_eio.init ~cwd_default:(fs env) ~proc_mgr:(process_mgr env) ~clock:(clock env)`. `bin/dune`의 fusion_run 스탠자에 `masc.masc_process` 추가.

## 검증

- `ocamlc -stop-after parsing` 통과. dune build/test는 CI.
- 로컬 재현: 수정 전 위 fail-closed 메시지로 즉사 → 수정 후 라이브 trio 심의 실행 (결과는 코멘트로 첨부 예정).

MASC task: task-1640 (fusion 라이브 검증 경로 차단 해제)

관련: masc#23003 (fusion 복구 본체), masc#23004 (runtime schema 병합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
