### PR TITLE
fix: restore tool registry CI baseline

### DIFF
--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -351,7 +351,7 @@ let operator_tool_name name = operator_remote_tool_name (Operator_remote_name.Op
 let surface_audit_tool_name = operator_remote_tool_name Operator_remote_name.Surface_audit
 
 (* ================================================================ *)
-(* Tool_spec registration                                           *)
+(* Catalog metadata registration                                    *)
 (* ================================================================ *)
 
 let tool_spec_read_only =
@@ -365,27 +365,30 @@ let tool_spec_read_only =
 let tool_spec_hidden = [ "masc_operator_judgment_write"; surface_audit_tool_name ]
 let tool_spec_hidden_destructive = [ operator_tool_name Operator_name.Operator_action ]
 
+let register_catalog_metadata_only (s : tool_schema) =
+  let is_read_only = List.mem s.name tool_spec_read_only in
+  let is_destructive = List.mem s.name tool_spec_hidden_destructive in
+  let is_hidden = List.mem s.name tool_spec_hidden || is_destructive in
+  let existing = Tool_catalog.metadata s.name in
+  Tool_catalog.register_metadata s.name
+    { Tool_catalog.visibility = (if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
+    ; lifecycle = Tool_catalog.Active
+    ; implementation_status = Tool_catalog.Real
+    ; canonical_name = None
+    ; replacement = None
+    ; reason = existing.reason
+    ; allow_direct_call_when_hidden = is_hidden
+    ; readonly = Some is_read_only
+    ; mcp_context_required = Some false
+    ; destructive = Some is_destructive
+    ; idempotent = Some is_read_only
+    ; effect_domain = None
+    ; requires_actor_binding = existing.requires_actor_binding
+    }
+;;
+
 let () =
-  List.iter
-    (fun (s : tool_schema) ->
-      let is_destructive = List.mem s.name tool_spec_hidden_destructive in
-      let is_hidden = List.mem s.name tool_spec_hidden || is_destructive in
-      let existing = Tool_catalog.metadata s.name in
-      Tool_spec.register
-        (Tool_spec.create
-           ~name:s.name
-           ~description:s.description
-           ~module_tag:Tool_dispatch.Mod_operator
-           ~input_schema:s.input_schema
-           ~handler_binding:Tag_dispatch
-           ~is_read_only:(List.mem s.name tool_spec_read_only)
-           ~is_idempotent:(List.mem s.name tool_spec_read_only)
-           ~visibility:(if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
-           ~is_destructive
-           ~allow_direct_call_when_hidden:is_hidden
-           ?reason:existing.reason
-           ()))
-    schemas
+  List.iter register_catalog_metadata_only schemas
 
 let () =
   Tool_operator.register_operator_tools ~dispatch ~schemas ~remote_schemas;

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -66,6 +66,22 @@ let keeper_task_tool_names =
 
 let is_keeper_task_tool_name name = List.mem name keeper_task_tool_names
 
+(** Local operator front-door names are served through the operator remote
+    profile / HTTP transport, not the generic Tool_dispatch registry. Keep
+    catalog metadata elsewhere, but do not mint generic dispatch tokens for
+    these retired local surfaces. *)
+let retired_local_operator_tool_names =
+  [ "masc_operator_snapshot"
+  ; "masc_operator_digest"
+  ; "masc_operator_action"
+  ; "masc_operator_confirm"
+  ; "masc_operator_judgment_write"
+  ; "masc_surface_audit"
+  ]
+
+let is_retired_local_operator_tool name =
+  List.mem name retired_local_operator_tool_names
+
 (** Workspace state tools are handled by [Tool_workspace.dispatch] and share
     [Mod_state] even when the module-load [Tool_spec] side effect has not run
     yet. The schema facade is the owned source for this dispatch cluster. *)
@@ -118,7 +134,7 @@ let tag_of_name name : TD.module_tag option =
 (** Register a tag + schema only if the name is not already in the tag
     registry. Existing [Tool_spec] registrations are preserved. *)
 let register_name_if_missing name tag =
-  if Option.is_none (TD.lookup_tag name)
+  if (not (is_retired_local_operator_tool name)) && Option.is_none (TD.lookup_tag name)
   then TD.register_module_tag ~schemas:[ schema_for_name name ] ~tag
 
 (** 1. Register every LLM-visible schema from [Config.raw_all_tool_schemas]
@@ -165,7 +181,8 @@ let register_all () =
 let visible_schemas_missing_tags () =
   Config.visible_tool_schemas ()
   |> List.filter (fun (s : Masc_domain.tool_schema) ->
-       Option.is_none (TD.lookup_tag s.name))
+       (not (is_retired_local_operator_tool s.name))
+       && Option.is_none (TD.lookup_tag s.name))
   |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
 
 (** Startup invariant: every LLM-visible schema has a dispatch tag.

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1004,6 +1004,7 @@ let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
   (* Before set_masc_schemas, injected_masc_tool_names () returns [].
      Descriptor public names should NOT appear in effective_core_tools
      when their internal_name is absent from the universe. *)
+  Registry.set_masc_schemas [];
   let effective = Registry.effective_core_tools () in
   let descriptor_publics = Descriptor.public_names () in
   List.iter
@@ -1032,7 +1033,8 @@ let test_effective_core_tools_with_full_universe_matches_discovery () =
   Alcotest.(check (list string))
     "effective_core_tools with full universe matches core_discovery_tools"
     (List.sort String.compare discovery)
-    (List.sort String.compare effective)
+    (List.sort String.compare effective);
+  Registry.set_masc_schemas []
 ;;
 
 let () =

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -202,10 +202,17 @@ let test_message_json_roundtrip () =
 ;;
 
 let test_dispatch_structured () =
+  let tool_schema =
+    { Masc_domain.name = "__test_tool"
+    ; description = "test structured dispatch tool"
+    ; input_schema =
+        `Assoc [ "type", `String "object"; "properties", `Assoc []; "required", `List [] ]
+    }
+  in
   (* Register a test handler *)
   Tool_dispatch.register ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
     Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
-  Tool_dispatch.register_name_tag ~tool_name:"__test_tool" ~tag:Mod_misc;
+  Tool_dispatch.register_module_tag ~schemas:[ tool_schema ] ~tag:Mod_misc;
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with
     | Ok t -> t

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -84,9 +84,16 @@ let test_token_name_readable () =
 
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
+  let tool_schema =
+    { Masc_domain.name = tool
+    ; description = "test token registered tool"
+    ; input_schema =
+        `Assoc [ "type", `String "object"; "properties", `Assoc []; "required", `List [] ]
+    }
+  in
   Tool_dispatch.register ~tool_name:tool
     ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
-  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
+  Tool_dispatch.register_module_tag ~schemas:[ tool_schema ] ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
   | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
@@ -98,9 +105,16 @@ let test_mint_token_unregistered () =
 
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
+  let tool_schema =
+    { Masc_domain.name = tool
+    ; description = "test token dispatch tool"
+    ; input_schema =
+        `Assoc [ "type", `String "object"; "properties", `Assoc []; "required", `List [] ]
+    }
+  in
   Tool_dispatch.register ~tool_name:tool
     ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
-  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
+  Tool_dispatch.register_module_tag ~schemas:[ tool_schema ] ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## Summary
- keep retired local operator front-door names out of the generic Tool_dispatch tag/schema registry while preserving catalog metadata and operator-remote export
- exclude that same retired set from unified visible-tag coverage so masc_surface_audit does not re-enter via descriptor raw schema projection
- update synthetic dispatch/token tests to register input schemas under the strict pre-dispatch validation gate
- reset keeper tool schema universe state inside descriptor registry tests to remove order-dependent leakage

## Verification
- opam exec -- ocamlformat --check lib/unified_tool_registry.ml lib/operator/operator_tool.ml test/test_keeper_tool_descriptor_registry_integrity.ml test/test_tool_result.ml test/test_tool_token.ml
- git diff --check
- bash scripts/ocaml-structure-ratchet.sh
- no local Dune build/test run; GitHub CI remains build authority

[근거] GitHub Build and Test failures on #22970 job 84757181770 and #23007 job 84758206526 showed the same current-main tool registry failures: schema-less __test_tool/__test_token_dispatch rejection, leaked retired operator tools, and schema-universe leakage. Checked 2026-07-02 KST. Confidence: High for source root cause, Medium until CI completes.