### PR TITLE
fix(test): align tool registry fixtures with dispatch contract

### DIFF
--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1002,11 +1002,15 @@ let test_effective_core_tools_is_subset_of_discovery () =
 
 let with_masc_schemas schemas f =
   let prior = Registry.masc_schemas_snapshot () in
-  Fun.protect
-    ~finally:(fun () -> Registry.set_masc_schemas prior)
-    (fun () ->
-      Registry.set_masc_schemas schemas;
-      f ())
+  Registry.set_masc_schemas schemas;
+  match f () with
+  | result ->
+    Registry.set_masc_schemas prior;
+    result
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Registry.set_masc_schemas prior;
+    Printexc.raise_with_backtrace exn backtrace
 ;;
 
 let test_effective_core_tools_without_universe_has_no_descriptor_publics () =

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1000,23 +1000,32 @@ let test_effective_core_tools_is_subset_of_discovery () =
     effective
 ;;
 
+let with_masc_schemas schemas f =
+  let prior = Registry.masc_schemas_snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Registry.set_masc_schemas prior)
+    (fun () ->
+      Registry.set_masc_schemas schemas;
+      f ())
+;;
+
 let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
   (* Establish the empty-universe precondition explicitly: descriptor public
      names must NOT appear in effective_core_tools when their internal_name is
      absent from the universe. Mcp_server_eio's module-load bootstrap injects
      the full schema universe when it is linked into this executable, so the
      universe cannot be assumed to start empty. *)
-  Registry.set_masc_schemas [];
-  let effective = Registry.effective_core_tools () in
-  let descriptor_publics = Descriptor.public_names () in
-  List.iter
-    (fun name ->
-       if List.mem name effective
-       then
-         Alcotest.failf
-           "effective_core_tools contains descriptor public %S when universe is empty"
-           name)
-    descriptor_publics
+  with_masc_schemas [] (fun () ->
+    let effective = Registry.effective_core_tools () in
+    let descriptor_publics = Descriptor.public_names () in
+    List.iter
+      (fun name ->
+         if List.mem name effective
+         then
+           Alcotest.failf
+             "effective_core_tools contains descriptor public %S when universe is empty"
+             name)
+      descriptor_publics)
 ;;
 
 let test_effective_core_tools_with_full_universe_matches_discovery () =
@@ -1029,13 +1038,13 @@ let test_effective_core_tools_with_full_universe_matches_discovery () =
          })
       (all_descriptors ())
   in
-  Registry.set_masc_schemas all_schemas;
-  let effective = Registry.effective_core_tools () in
-  let discovery = Registry.core_discovery_tools in
-  Alcotest.(check (list string))
-    "effective_core_tools with full universe matches core_discovery_tools"
-    (List.sort String.compare discovery)
-    (List.sort String.compare effective)
+  with_masc_schemas all_schemas (fun () ->
+    let effective = Registry.effective_core_tools () in
+    let discovery = Registry.core_discovery_tools in
+    Alcotest.(check (list string))
+      "effective_core_tools with full universe matches core_discovery_tools"
+      (List.sort String.compare discovery)
+      (List.sort String.compare effective))
 ;;
 
 let () =

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -161,6 +161,28 @@ let test_workspace_schemas_have_tool_spec_metadata () =
     workspace_names
 ;;
 
+let test_operator_remote_tools_are_dispatch_registered () =
+  init ();
+  Operator_tool.remote_tool_names
+  |> List.iter (fun name ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s has schema" name)
+         true
+         (Option.is_some (Tool_dispatch.lookup_schema name));
+       Alcotest.(check bool)
+         (Printf.sprintf "%s mints token" name)
+         true
+         (match Tool_dispatch.mint_token ~name with
+          | Ok _ -> true
+          | Error _ -> false);
+       Alcotest.(check bool)
+         (Printf.sprintf "%s routes to Mod_operator" name)
+         true
+         (match Tool_dispatch.lookup_tag name with
+          | Some Tool_dispatch.Mod_operator -> true
+          | Some _ | None -> false))
+;;
+
 let test_retired_tools_are_absent () =
   init ();
   (* Only fully retired tools — no live dispatch handler and no keeper
@@ -225,6 +247,10 @@ let () =
             test_workspace_schemas_match_dispatch_bindings
         ; test_case "workspace schemas have ToolSpec metadata" `Quick
             test_workspace_schemas_have_tool_spec_metadata
+        ] )
+    ; ( "operator_tools"
+      , [ test_case "operator remote tools are dispatch registered" `Quick
+            test_operator_remote_tools_are_dispatch_registered
         ] )
     ; ( "retired_tools"
       , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -9,6 +9,23 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+let empty_object_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "required", `List []
+    ]
+;;
+
+let test_tool_schema name : Masc_domain.tool_schema =
+  { name; description = "test tool " ^ name; input_schema = empty_object_schema }
+;;
+
+let register_test_tool ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_module_tag ~schemas:[ test_tool_schema tool_name ] ~tag:Mod_misc
+;;
+
 let str_contains haystack needle =
   let hlen = String.length haystack in
   let nlen = String.length needle in
@@ -203,20 +220,9 @@ let test_message_json_roundtrip () =
 
 let test_dispatch_structured () =
   (* Register a test handler *)
-  Tool_dispatch.register ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
-    Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
-  (* Register a schema (not just a tag) so the tool clears the input-schema
-     validation pre-hook that Mcp_server_eio installs at module load. An
-     empty-object schema dispatched with no args passes validation, keeping the
-     test focused on structured dispatch while matching production, where every
-     dispatchable tool carries a schema. *)
-  Tool_dispatch.register_module_tag
-    ~schemas:
-      [ { Masc_domain.name = "__test_tool"
-        ; description = "test dispatch tool"
-        ; input_schema = `Assoc [ "type", `String "object" ]
-        } ]
-    ~tag:Mod_misc;
+  register_test_tool
+    ~tool_name:"__test_tool"
+    ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with
     | Ok t -> t

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -19,6 +19,23 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+let empty_input_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "required", `List []
+    ]
+;;
+
+let test_schema name : Masc_domain.tool_schema =
+  { name; description = "test token tool " ^ name; input_schema = empty_input_schema }
+;;
+
+let register_test_tool ~tool_name ~handler =
+  Tool_dispatch.register ~tool_name ~handler;
+  Tool_dispatch.register_module_tag ~schemas:[ test_schema tool_name ] ~tag:Mod_misc
+;;
+
 (* ================================================================ *)
 (* mint — table variant                                              *)
 (* ================================================================ *)
@@ -84,9 +101,9 @@ let test_token_name_readable () =
 
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
-  Tool_dispatch.register ~tool_name:tool
+  register_test_tool
+    ~tool_name:tool
     ~handler:(fun ~name:_ ~args:_ -> Some (tool_ok "ok"));
-  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
   | Error e -> fail (Printf.sprintf "mint_token failed for registered tool: %s" e)
@@ -98,20 +115,9 @@ let test_mint_token_unregistered () =
 
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
-  Tool_dispatch.register ~tool_name:tool
+  register_test_tool
+    ~tool_name:tool
     ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
-  (* Register a schema (not just a tag) so the tool clears the input-schema
-     validation pre-hook that Mcp_server_eio installs at module load. An
-     empty-object schema dispatched with no args passes validation, so this
-     keeps the test focused on token dispatch while matching production, where
-     every dispatchable tool carries a schema. *)
-  Tool_dispatch.register_module_tag
-    ~schemas:
-      [ { Masc_domain.name = tool
-        ; description = "test dispatch tool"
-        ; input_schema = `Assoc [ "type", `String "object" ]
-        } ]
-    ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## Summary

- Align test-only dispatch fixtures with the fail-closed input-schema contract.
- Isolate the universe-aware `effective_core_tools` tests from process-global schema state.
- Narrow the retired-tool registry assertion to actually retired front-door names; operator tools remain active hidden/privileged surfaces.

## Product impact

- User-visible change: none. This repairs CI coverage around the tool registry and dispatch validation contract.

## Evidence

- `gh api repos/jeong-sik/masc/actions/jobs/84758206526/logs | rg -n -C 16 "retired tools|retired_tools|absent from tag registry|masc_operator_snapshot|schema inventory"` confirmed the registry failure was caused by active operator tools being listed as retired.
- `gh api repos/jeong-sik/masc/actions/jobs/84758206526/logs` confirmed the shared failing set: schema-less test dispatch, universe-aware effective core state leakage, stale retired-tool assertion, and structured dispatch without schema.
- `ocamlformat --check test/test_tool_result.ml test/test_tool_token.ml test/test_keeper_tool_descriptor_registry_integrity.ml test/test_tool_registry_consistency.ml`
- `git diff --check`
- Local Dune build/test intentionally not run; CI is the build authority for this change.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - github_failed_ci_log_review
  - schema_fixture_source_patch
  - ocamlformat_check
  - git_diff_check
```

## GOAL LOOP ACT checklist

- [x] Observe — CI logs showed the four shared failures blocking unrelated PRs.
- [x] Orient — mapped failures to stale/under-specified test fixtures and process-global schema state.
- [x] Decide — repaired tests without weakening production fail-closed validation.
- [x] Act — changed four test files only.
- [x] Verify — ran formatting and whitespace checks; CI remains the build/test authority.
- [x] Loop — no known follow-up beyond CI result and rerunning affected PRs after merge.

## Review evidence

- Self-review focused on preserving fail-closed tool input validation and avoiding unrelated production changes.

## Linked issue

- Closes #
- Relates #22970
- Relates #23007

## Variant addition checklist

- [ ] **OCaml** — N/A: no variants added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union changes.
- [ ] **TLA+ spec** — N/A: no TLA+ domain changes.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema enum changes.
- [ ] **`make check-variants` passes** — N/A: variant surfaces unchanged.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/ci-tool-registry-contract-20260702` → `main` · 1 commit(s) · synced 2026-07-02T15:02:10Z

| sha | subject | date |
|---|---|---|
| `653f66a3d` | fix(test): align tool registry fixtures with dispatch contract | 2026-07-02 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->