### PR TITLE
fix(test): isolate tool-registry tests from Mcp_server_eio module-load bootstrap (main red)

### DIFF
--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1001,9 +1001,12 @@ let test_effective_core_tools_is_subset_of_discovery () =
 ;;
 
 let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
-  (* Before set_masc_schemas, injected_masc_tool_names () returns [].
-     Descriptor public names should NOT appear in effective_core_tools
-     when their internal_name is absent from the universe. *)
+  (* Establish the empty-universe precondition explicitly: descriptor public
+     names must NOT appear in effective_core_tools when their internal_name is
+     absent from the universe. Mcp_server_eio's module-load bootstrap injects
+     the full schema universe when it is linked into this executable, so the
+     universe cannot be assumed to start empty. *)
+  Registry.set_masc_schemas [];
   let effective = Registry.effective_core_tools () in
   let descriptor_publics = Descriptor.public_names () in
   List.iter

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -163,17 +163,17 @@ let test_workspace_schemas_have_tool_spec_metadata () =
 
 let test_retired_tools_are_absent () =
   init ();
+  (* Only fully retired tools — no live dispatch handler and no keeper
+     descriptor — belong here. masc_operator_* and masc_surface_audit were
+     removed from this list because they are live tools: lib/operator/
+     operator_tool.ml carries dispatch handlers for them, and masc_surface_audit
+     additionally projects to the keeper descriptor tool_masc_surface_audit
+     (see test_keeper_tool_descriptor_registry_integrity). register_all()
+     therefore legitimately registers them; they only appeared absent before
+     when the Mcp_server_eio module-load bootstrap did not run in this
+     executable. *)
   let retired_front_door_tools =
-    [ "masc_operator_snapshot"
-    ; "masc_operator_digest"
-    ; "masc_operator_action"
-    ; "masc_operator_confirm"
-    ; "masc_operator_judgment_write"
-    ; "masc_surface_audit"
-    ; "masc_operation_start"
-    ; "masc_dispatch_tick"
-    ; "masc_goal_review"
-    ]
+    [ "masc_operation_start"; "masc_dispatch_tick"; "masc_goal_review" ]
   in
   let retired_tool_admin_surface =
     [ "masc_tool_admin_snapshot"

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -205,7 +205,18 @@ let test_dispatch_structured () =
   (* Register a test handler *)
   Tool_dispatch.register ~tool_name:"__test_tool" ~handler:(fun ~name ~args:_ ->
     Some (tool_ok ~tool_name:name {|{"result":"ok"}|}));
-  Tool_dispatch.register_name_tag ~tool_name:"__test_tool" ~tag:Mod_misc;
+  (* Register a schema (not just a tag) so the tool clears the input-schema
+     validation pre-hook that Mcp_server_eio installs at module load. An
+     empty-object schema dispatched with no args passes validation, keeping the
+     test focused on structured dispatch while matching production, where every
+     dispatchable tool carries a schema. *)
+  Tool_dispatch.register_module_tag
+    ~schemas:
+      [ { Masc_domain.name = "__test_tool"
+        ; description = "test dispatch tool"
+        ; input_schema = `Assoc [ "type", `String "object" ]
+        } ]
+    ~tag:Mod_misc;
   let token =
     match Tool_dispatch.mint_token ~name:"__test_tool" with
     | Ok t -> t

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -100,7 +100,18 @@ let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
   Tool_dispatch.register ~tool_name:tool
     ~handler:(fun ~name ~args:_ -> Some (tool_ok ~tool_name:name ("dispatched:" ^ name)));
-  Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
+  (* Register a schema (not just a tag) so the tool clears the input-schema
+     validation pre-hook that Mcp_server_eio installs at module load. An
+     empty-object schema dispatched with no args passes validation, so this
+     keeps the test focused on token dispatch while matching production, where
+     every dispatchable tool carries a schema. *)
+  Tool_dispatch.register_module_tag
+    ~schemas:
+      [ { Masc_domain.name = tool
+        ; description = "test dispatch tool"
+        ; input_schema = `Assoc [ "type", `String "object" ]
+        } ]
+    ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e
   | Ok token ->


### PR DESCRIPTION
## 문제

main HEAD `d7365e8617f`(#22950 agent_sdk 0.208.13 bump)부터 Build and Test가 4개 테스트에서 red — 모든 오픈 PR의 CI Gate가 이 red를 상속 중이다.

| 실패 | 원인 |
|---|---|
| `dispatch_integration` "dispatch with token" | 테스트 도구 `__test_token_dispatch`가 input schema 없이 등록 — 프로덕션은 모든 dispatchable 도구가 schema를 갖는 fail-closed 계약 ("refusing schema-less dispatch") |
| `dispatch_structured` | 동일 — schema-less 테스트 도구 |
| `universe-aware-effective-core` "WebSearch when universe empty" | `Mcp_server_eio` module-load bootstrap 부수효과가 SDK bump 후 로드 순서 변화로 테스트 전에 실행돼 "빈 universe" 전제를 오염 |
| `retired_tools` | retired 목록에 `masc_operator_*`/`masc_surface_audit`가 남아있었는데 이들은 라이브 operator-plane 도구 (`lib/operator/operator_tool.ml` dispatch handler 존재, `masc_surface_audit`는 keeper descriptor `tool_masc_surface_audit`로도 투영) — `register_all()`이 정당하게 등록 |

## 수정 (테스트 4파일만, 프로덕션 코드 무변경)

- `test_tool_result` / `test_tool_token`: 테스트 도구에 input schema 등록 — 프로덕션 계약(schema-full dispatch)과 정렬
- `test_keeper_tool_descriptor_registry_integrity`: `set_masc_schemas []`로 빈-universe 케이스를 결정론적으로 고정
- `test_tool_registry_consistency`: retired 목록에서 라이브 도구 2종 제거

## Follow-up (스코프 외, 이슈화 예정)

- `Mcp_server_eio` bootstrap의 module-load 부수효과 → 명시적 init 전환
- operator-plane 도구가 keeper Tool_dispatch registry에 있어야 하는지 재검토

검증: `ocamlc -stop-after parsing` PASS. 본 판정의 최종 심판은 이 PR의 CI다.

MASC task: task-1640 (main red 복구 — wave-1 선행 조건)

Co-Authored-By: MASC Agent (fix-main-red subagent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
