### PR TITLE
feat(keeper): since-last-seen catch-up digest — server endpoint + dashboard card

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -27,6 +27,7 @@ import type {
   FleetCompositeSnapshot,
 } from './schemas/keeper-composite'
 import type { KeeperChatHistoryMessage } from './schemas/keeper-chat-history'
+import type { KeeperCatchupDigest } from './schemas/keeper-catchup-digest'
 import type {
   KeeperTransition,
   KeeperTransitionsResponse,
@@ -671,6 +672,32 @@ export async function fetchKeeperChatHistory(
   return data
     .map(safeParseKeeperChatHistoryMessage)
     .filter((m): m is KeeperChatHistoryMessage => m !== null)
+}
+
+// Since-last-seen catch-up digest for one keeper. `sinceUnix` is the operator's
+// per-keeper last-seen cursor (unix seconds). The whole payload is decoded and
+// thrown on drift (unlike chat history's tolerant per-row drop) so a malformed
+// digest can never render a wrong count. Same raw-fetch + jsonHeaders()
+// convention as fetchKeeperChatHistory; the valibot schema is imported lazily
+// to keep it out of the initial bundle.
+export async function fetchKeeperCatchupDigest(
+  keeperName: string,
+  sinceUnix: number,
+): Promise<KeeperCatchupDigest> {
+  const resp = await fetch(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/digest?since_unix=${encodeURIComponent(String(sinceUnix))}`,
+    { headers: jsonHeaders() },
+  )
+  if (!resp.ok) {
+    throw new Error(`fetchKeeperCatchupDigest: HTTP ${resp.status} ${resp.statusText}`)
+  }
+  const data: unknown = await resp.json()
+  const { parseKeeperCatchupDigest } = await import('./schemas/keeper-catchup-digest')
+  const digest = parseKeeperCatchupDigest(data)
+  if (!digest) {
+    throw new Error('fetchKeeperCatchupDigest: invalid digest payload')
+  }
+  return digest
 }
 
 // --- Keeper observability API ---

--- a/dashboard/src/api/schemas/keeper-catchup-digest.ts
+++ b/dashboard/src/api/schemas/keeper-catchup-digest.ts
@@ -1,0 +1,94 @@
+/**
+ * Keeper catch-up digest schema — schema-at-boundary for
+ * `GET /api/v1/keepers/:name/digest?since_unix=<float>`.
+ *
+ * Wire contract SSOT: docs/design/keeper-catchup-digest.md §"Wire contract (v1)".
+ * The server assembles the digest deterministically (no LLM, no heuristics) by
+ * scanning existing durable stores with a since-cursor. Every timestamp is a
+ * unix-seconds float; `read_errors` surfaces per-source read failures instead
+ * of dropping them silently (fail-visible).
+ *
+ * Unlike the tolerant per-row chat-history schema, this is a single object
+ * decoded whole: `parseKeeperCatchupDigest` returns null on any shape drift and
+ * the fetch layer throws, so a malformed digest never renders a wrong count.
+ */
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  safeParse,
+  string,
+  type InferOutput,
+} from 'valibot'
+
+const KeeperCatchupDigestChatSchema = object({
+  new_messages: number(),
+  // Null / absent when new_messages is 0 (no first row to anchor).
+  first_new_ts: optional(nullable(number())),
+  transport_failures: number(),
+})
+
+const KeeperCatchupDigestTurnsSchema = object({
+  completed: number(),
+  failed: number(),
+  crashes: number(),
+})
+
+const KeeperCatchupDigestTaskItemSchema = object({
+  task_id: string(),
+  transition: string(),
+  ts: number(),
+})
+
+const KeeperCatchupDigestTasksSchema = object({
+  claimed: number(),
+  done: number(),
+  released: number(),
+  cancelled: number(),
+  // Capped to digest_items_cap (newest-first); the count fields above are the
+  // uncapped totals.
+  items: array(KeeperCatchupDigestTaskItemSchema),
+})
+
+const KeeperCatchupDigestBoardSchema = object({
+  posted: number(),
+  commented: number(),
+  voted: number(),
+})
+
+const KeeperCatchupDigestLifecycleItemSchema = object({
+  kind: string(),
+  ts: number(),
+})
+
+const KeeperCatchupDigestLifecycleSchema = object({
+  paused_now: boolean(),
+  pause_events: number(),
+  resume_events: number(),
+  items: array(KeeperCatchupDigestLifecycleItemSchema),
+})
+
+export const KeeperCatchupDigestSchema = object({
+  keeper: string(),
+  since_unix: number(),
+  generated_at_unix: number(),
+  chat: KeeperCatchupDigestChatSchema,
+  turns: KeeperCatchupDigestTurnsSchema,
+  tasks: KeeperCatchupDigestTasksSchema,
+  board: KeeperCatchupDigestBoardSchema,
+  lifecycle: KeeperCatchupDigestLifecycleSchema,
+  read_errors: array(string()),
+})
+
+export type KeeperCatchupDigest = InferOutput<typeof KeeperCatchupDigestSchema>
+export type KeeperCatchupDigestTaskItem = InferOutput<typeof KeeperCatchupDigestTaskItemSchema>
+export type KeeperCatchupDigestLifecycleItem = InferOutput<typeof KeeperCatchupDigestLifecycleItemSchema>
+
+export function parseKeeperCatchupDigest(data: unknown): KeeperCatchupDigest | null {
+  const result = safeParse(KeeperCatchupDigestSchema, data)
+  return result.success ? result.output : null
+}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -7,6 +7,7 @@ import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'pr
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
 import { linkifyHtmlReferences } from './chat-linkify'
+import { UNREAD_DIVIDER_LABEL, unreadDividerAnchorKey } from './unread-divider'
 import { showToast } from '../common/toast'
 import { copyToClipboard } from '../common/copyable-code'
 import { ExternalLink, Mic, Square } from 'lucide-preact'
@@ -2945,6 +2946,24 @@ function buildChatRenderUnits(
   return units
 }
 
+function unitTimestamp(unit: ChatRenderUnit): string | null {
+  const ts = unit.kind === 'entry'
+    ? unit.entry.timestamp
+    : unit.entries[0]?.timestamp ?? (unit.kind === 'turnBundle' ? unit.entry.timestamp : null)
+  return ts ?? null
+}
+
+function unitTimestampMs(unit: ChatRenderUnit): number | null {
+  const ts = unitTimestamp(unit)
+  if (!ts) return null
+  const ms = Date.parse(ts)
+  return Number.isFinite(ms) ? ms : null
+}
+
+function unitKey(unit: ChatRenderUnit): string {
+  return unit.kind === 'entry' ? unit.entry.id : unit.id
+}
+
 function renderChatTranscriptBody(opts: {
   entries: KeeperConversationEntry[]
   showDayDividers: boolean
@@ -2954,10 +2973,17 @@ function renderChatTranscriptBody(opts: {
   showSourceBadge: boolean
   toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
+  // Since-last-seen cursor (unix seconds) for the unread divider; null on every
+  // non-keeper chat surface so those transcripts render unchanged.
+  unreadAfterTs: number | null
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, unreadAfterTs, action } = opts
   const units = buildChatRenderUnits(entries, groupToolCalls)
+  const unreadAnchorKey = unreadDividerAnchorKey(
+    units.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
+    unreadAfterTs,
+  )
   const out: VNode[] = []
   // Track the last NON-NULL calendar day rather than only the immediately
   // previous entry, so a null-timestamp entry (live placeholder, checkpoint) in
@@ -2965,16 +2991,18 @@ function renderChatTranscriptBody(opts: {
   // second divider for a day already shown above.
   let lastDayKey: string | null = null
   for (const unit of units) {
-    const ts =
-      unit.kind === 'entry'
-        ? unit.entry.timestamp
-        : unit.entries[0]?.timestamp ?? (unit.kind === 'turnBundle' ? unit.entry.timestamp : null)
+    const ts = unitTimestamp(unit)
     if (showDayDividers) {
       const dk = dayKey(ts)
       if (dk && dk !== lastDayKey) {
         out.push(html`<div class="kw-daydiv" key=${`day:${dk}`}>${dayDividerLabel(ts)}</div>`)
         lastDayKey = dk
       }
+    }
+    // Placed after any day divider so the unread line sits closest to the first
+    // unread message.
+    if (unreadAnchorKey !== null && unitKey(unit) === unreadAnchorKey) {
+      out.push(html`<div class="kw-daydiv kw-unreaddiv" key="unread-divider">${UNREAD_DIVIDER_LABEL}</div>`)
     }
     if (unit.kind === 'toolGroup') {
       out.push(html`<${ToolTraceCard} key=${unit.id} tools=${unit.entries} />`)
@@ -3027,6 +3055,8 @@ export function ChatTranscript({
   showSourceBadge = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
+  unreadAfterTs = null,
+  onSeenBottom,
   action,
 }: {
   entries: KeeperConversationEntry[]
@@ -3043,11 +3073,22 @@ export function ChatTranscript({
   showSourceBadge?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
+  // Since-last-seen cursor (unix seconds) driving the unread divider. Null on
+  // non-keeper surfaces -> no divider.
+  unreadAfterTs?: number | null
+  // Called when the operator has demonstrably caught up (scrolled/pinned to the
+  // bottom, or a new row arrived while pinned, or the tab regained visibility
+  // while pinned). The keeper panel uses it to advance the last-seen cursor.
+  onSeenBottom?: () => void
   action?: ChatTranscriptAction
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const pinnedRef = useRef(true)
   const [unread, setUnread] = useState(false)
+  // Latest onSeenBottom captured in a ref so the scroll/effect callbacks always
+  // fire the current closure without listing it as an effect dependency.
+  const onSeenBottomRef = useRef(onSeenBottom)
+  onSeenBottomRef.current = onSeenBottom
   const lastSignature = useMemo(
     () => entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}:${entry.streamState ?? ''}:${traceStepsSignature(entry)}`).join('|'),
     [entries],
@@ -3074,6 +3115,7 @@ export function ChatTranscript({
     el.scrollTop = el.scrollHeight
     pinnedRef.current = true
     setUnread(false)
+    onSeenBottomRef.current?.()
   }
 
   const handleScroll = () => {
@@ -3082,7 +3124,10 @@ export function ChatTranscript({
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight
     const pinned = distance <= STICK_TO_BOTTOM_THRESHOLD_PX
     pinnedRef.current = pinned
-    if (pinned) setUnread(false)
+    if (pinned) {
+      setUnread(false)
+      onSeenBottomRef.current?.()
+    }
   }
 
   useLayoutEffect(() => {
@@ -3092,10 +3137,26 @@ export function ChatTranscript({
       const snap = () => { el.scrollTop = el.scrollHeight }
       snap()
       requestAnimationFrame(snap)
+      // Bottom-pinned with new content arriving means the operator is watching
+      // it live — advance the cursor so the divider/card do not resurrect it.
+      onSeenBottomRef.current?.()
     } else {
       setUnread(true)
     }
   }, [lastSignature, toolOutputSignature])
+
+  // Advance the cursor when the tab regains visibility while pinned to bottom:
+  // background rows that streamed in are treated as seen only once the operator
+  // could actually see them. Pattern mirrors lib/auto-refresh.ts visibilitychange.
+  useEffect(() => {
+    const onVisible = () => {
+      if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
+      if (!pinnedRef.current) return
+      onSeenBottomRef.current?.()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => { document.removeEventListener('visibilitychange', onVisible) }
+  }, [])
 
   const isPrimary = size === 'primary'
   const heightClass = isPrimary
@@ -3133,6 +3194,7 @@ export function ChatTranscript({
               showSourceBadge,
               toolOutputsCoveredSinceMs,
               toolOutputsCoveredThroughMs,
+              unreadAfterTs,
               action,
             })}
       </div>

--- a/dashboard/src/components/chat/unread-divider.test.ts
+++ b/dashboard/src/components/chat/unread-divider.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import type { KeeperConversationEntry } from '../../types'
+import {
+  entryTimestampMs,
+  unreadDividerAnchorEntryId,
+  unreadDividerAnchorKey,
+} from './unread-divider'
+
+// Minimal entry factory — only id/timestamp matter for divider placement.
+function entry(id: string, timestamp: string | null): KeeperConversationEntry {
+  return {
+    id,
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: id,
+    text: id,
+    timestamp,
+    delivery: 'history',
+  } as KeeperConversationEntry
+}
+
+// Fixed cutoff of 1000s; entries below are "read", above are "unread".
+const CURSOR = 1000
+function iso(unix: number): string {
+  return new Date(unix * 1000).toISOString()
+}
+
+describe('unreadDividerAnchorKey', () => {
+  it('returns null when there is no cursor (non-keeper surfaces)', () => {
+    expect(unreadDividerAnchorKey([{ key: 'a', tsMs: 2000_000 }], null)).toBeNull()
+  })
+
+  it('anchors before the first unread item when a read item precedes it', () => {
+    const anchor = unreadDividerAnchorKey(
+      [
+        { key: 'read', tsMs: 900 * 1000 },
+        { key: 'first-unread', tsMs: 1100 * 1000 },
+        { key: 'later-unread', tsMs: 1200 * 1000 },
+      ],
+      CURSOR,
+    )
+    expect(anchor).toBe('first-unread')
+  })
+
+  it('skips null-ts items (live placeholders / checkpoints)', () => {
+    const anchor = unreadDividerAnchorKey(
+      [
+        { key: 'read', tsMs: 900 * 1000 },
+        { key: 'placeholder', tsMs: null },
+        { key: 'first-unread', tsMs: 1100 * 1000 },
+      ],
+      CURSOR,
+    )
+    expect(anchor).toBe('first-unread')
+  })
+
+  it('returns null when the boundary was trimmed (first non-null item already unread)', () => {
+    const anchor = unreadDividerAnchorKey(
+      [
+        { key: 'placeholder', tsMs: null },
+        { key: 'oldest-visible', tsMs: 1100 * 1000 },
+        { key: 'newer', tsMs: 1200 * 1000 },
+      ],
+      CURSOR,
+    )
+    expect(anchor).toBeNull()
+  })
+
+  it('returns null when every item is already read', () => {
+    const anchor = unreadDividerAnchorKey(
+      [
+        { key: 'a', tsMs: 800 * 1000 },
+        { key: 'b', tsMs: 900 * 1000 },
+      ],
+      CURSOR,
+    )
+    expect(anchor).toBeNull()
+  })
+})
+
+describe('unreadDividerAnchorEntryId', () => {
+  it('finds the first unread entry id in the normal case', () => {
+    const entries = [
+      entry('read', iso(900)),
+      entry('unread', iso(1100)),
+    ]
+    expect(unreadDividerAnchorEntryId(entries, CURSOR)).toBe('unread')
+  })
+
+  it('yields no divider when the anchor was trimmed by the 200-row cap', () => {
+    // The operator last saw ts=1000, but the oldest surviving row is 1100 —
+    // every visible row is unread, so the read/unread boundary is above the
+    // window and no divider should render.
+    const entries = [
+      entry('oldest-visible', iso(1100)),
+      entry('newer', iso(1200)),
+    ]
+    expect(unreadDividerAnchorEntryId(entries, CURSOR)).toBeNull()
+  })
+
+  it('skips null-timestamp entries defensively', () => {
+    const entries = [
+      entry('read', iso(900)),
+      entry('live-placeholder', null),
+      entry('unread', iso(1100)),
+    ]
+    expect(unreadDividerAnchorEntryId(entries, CURSOR)).toBe('unread')
+  })
+})
+
+describe('entryTimestampMs', () => {
+  it('parses ISO timestamps and returns null for missing/invalid ones', () => {
+    expect(entryTimestampMs({ timestamp: iso(1234) })).toBe(1234 * 1000)
+    expect(entryTimestampMs({ timestamp: null })).toBeNull()
+    expect(entryTimestampMs({ timestamp: 'garbage' })).toBeNull()
+  })
+})

--- a/dashboard/src/components/chat/unread-divider.ts
+++ b/dashboard/src/components/chat/unread-divider.ts
@@ -1,0 +1,47 @@
+import type { KeeperConversationEntry } from '../../types'
+
+export const UNREAD_DIVIDER_LABEL = '여기까지 읽음'
+
+// ISO timestamp -> ms, or null for rows with no observable position (live
+// placeholders / checkpoints). Kept standalone so the divider logic is unit
+// testable without pulling in the full chat primitive layer.
+export function entryTimestampMs(entry: Pick<KeeperConversationEntry, 'timestamp'>): number | null {
+  if (!entry.timestamp) return null
+  const ms = Date.parse(entry.timestamp)
+  return Number.isFinite(ms) ? ms : null
+}
+
+// Resolve the render key BEFORE which the "read up to here" divider should sit.
+// - null unreadAfterTs (non-keeper surfaces) -> no divider.
+// - null-ts items (placeholders/checkpoints) are skipped, never anchor.
+// - The first item newer than the cursor anchors the divider, but only if a read
+//   (<= cursor) item was seen first. If the very first non-null item is already
+//   unread, the read/unread boundary was trimmed by the 200-row cap: no divider
+//   (the digest card carries the true counts instead).
+export function unreadDividerAnchorKey(
+  items: readonly { key: string; tsMs: number | null }[],
+  unreadAfterTs: number | null,
+): string | null {
+  if (unreadAfterTs === null) return null
+  const cutoffMs = unreadAfterTs * 1000
+  let seenReadItem = false
+  for (const item of items) {
+    if (item.tsMs === null) continue
+    if (item.tsMs > cutoffMs) return seenReadItem ? item.key : null
+    seenReadItem = true
+  }
+  return null
+}
+
+// Entry-level convenience: the anchor entry id, computed before render grouping.
+// The render loop groups tool rows into units but a unit's representative ts is
+// its first entry's ts, so the entry-level and unit-level anchors coincide.
+export function unreadDividerAnchorEntryId(
+  entries: readonly KeeperConversationEntry[],
+  unreadAfterTs: number | null,
+): string | null {
+  return unreadDividerAnchorKey(
+    entries.map(entry => ({ key: entry.id, tsMs: entryTimestampMs(entry) })),
+    unreadAfterTs,
+  )
+}

--- a/dashboard/src/components/keeper-catchup-digest-card.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.ts
@@ -1,0 +1,115 @@
+import { html } from 'htm/preact'
+import type { KeeperCatchupDigest } from '../api/schemas/keeper-catchup-digest'
+import { KEEPER_DIGEST_MIN_ACTIVITY } from '../config/constants'
+
+// Total count of new activity across every category since the operator's
+// last-seen cursor. Drives the "is there anything worth showing" gate.
+export function keeperCatchupDigestActivityCount(digest: KeeperCatchupDigest): number {
+  const { chat, turns, tasks, board, lifecycle } = digest
+  return (
+    chat.new_messages +
+    chat.transport_failures +
+    turns.completed +
+    turns.failed +
+    turns.crashes +
+    tasks.claimed +
+    tasks.done +
+    tasks.released +
+    tasks.cancelled +
+    board.posted +
+    board.commented +
+    board.voted +
+    lifecycle.pause_events +
+    lifecycle.resume_events
+  )
+}
+
+// The card renders only when there is genuine new activity, OR when a source
+// read failed (read_errors is fail-visible — the operator must know the counts
+// may be incomplete even if everything else is zero).
+export function shouldShowKeeperCatchupDigest(
+  digest: KeeperCatchupDigest | null | undefined,
+): digest is KeeperCatchupDigest {
+  if (!digest) return false
+  return (
+    keeperCatchupDigestActivityCount(digest) >= KEEPER_DIGEST_MIN_ACTIVITY ||
+    digest.read_errors.length > 0
+  )
+}
+
+interface DigestChip {
+  key: string
+  text: string
+  tone: 'default' | 'warn'
+}
+
+const CHIP_BASE =
+  'inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-2xs tabular-nums'
+const CHIP_DEFAULT =
+  'border-[var(--color-border-default)] bg-[var(--color-bg-page)] text-[var(--color-fg-secondary)]'
+const CHIP_WARN = 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
+
+function digestChips(digest: KeeperCatchupDigest): DigestChip[] {
+  const { chat, turns, tasks, board, lifecycle } = digest
+  const chips: DigestChip[] = []
+  if (chat.new_messages > 0) chips.push({ key: 'messages', text: `메시지 ${chat.new_messages}`, tone: 'default' })
+  if (turns.completed > 0) chips.push({ key: 'turns', text: `턴 ${turns.completed}회`, tone: 'default' })
+  const taskTotal = tasks.claimed + tasks.done + tasks.released + tasks.cancelled
+  if (taskTotal > 0) chips.push({ key: 'tasks', text: `태스크 ${taskTotal}`, tone: 'default' })
+  const boardTotal = board.posted + board.commented + board.voted
+  if (boardTotal > 0) chips.push({ key: 'board', text: `보드 ${boardTotal}`, tone: 'default' })
+  const lifecycleTotal = lifecycle.pause_events + lifecycle.resume_events
+  if (lifecycleTotal > 0) chips.push({ key: 'lifecycle', text: `일시정지/재개 ${lifecycleTotal}`, tone: 'default' })
+  // Warn-toned chips for failure signals; kept distinct from the neutral counts.
+  if (turns.failed > 0) chips.push({ key: 'turns-failed', text: `턴 실패 ${turns.failed}`, tone: 'warn' })
+  if (turns.crashes > 0) chips.push({ key: 'turns-crashes', text: `크래시 ${turns.crashes}`, tone: 'warn' })
+  if (chat.transport_failures > 0) chips.push({ key: 'transport', text: `전송 실패 ${chat.transport_failures}`, tone: 'warn' })
+  return chips
+}
+
+// Since-last-seen digest card. Rendered OUTSIDE the transcript scroller (above
+// the ChatTranscript call sites) so injecting it never perturbs the scroller's
+// autoscroll signature. Anchors on digest.since_unix — the frozen baseline the
+// server echoed — independent of the live cursor.
+export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDigest }) {
+  const chips = digestChips(digest)
+  return html`
+    <div
+      data-keeper-catchup-digest
+      class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 v2-monitoring-panel"
+    >
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <span class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-muted)]">그 사이 활동</span>
+          ${digest.chat.new_messages > 0
+            ? html`<span class="text-2xs text-[var(--color-fg-secondary)]">이후 ${digest.chat.new_messages}개 메시지</span>`
+            : null}
+        </div>
+        ${digest.lifecycle.paused_now
+          ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-2xs font-medium text-[var(--warn-bright)]">일시정지됨</span>`
+          : null}
+      </div>
+      ${chips.length > 0
+        ? html`
+            <div class="mt-2 flex flex-wrap items-center gap-1.5">
+              ${chips.map(chip => html`
+                <span
+                  key=${chip.key}
+                  class=${`${CHIP_BASE} ${chip.tone === 'warn' ? CHIP_WARN : CHIP_DEFAULT}`}
+                >
+                  ${chip.text}
+                </span>
+              `)}
+            </div>
+          `
+        : null}
+      ${digest.read_errors.length > 0
+        ? html`
+            <div class="mt-2 rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-2xs leading-relaxed text-[var(--warn-bright)]">
+              읽기 오류 (일부 카운트가 누락됐을 수 있습니다): ${digest.read_errors.join(', ')}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -37,6 +37,17 @@ import {
 } from '../keeper-state'
 import { isDefaultVisibleConversationEntry } from '../keeper-state'
 import {
+  getKeeperLastSeen,
+  advanceKeeperLastSeen,
+  newestConversationEntryUnix,
+} from '../keeper-last-seen'
+import { refreshKeeperCatchupDigest } from '../keeper-digest-actions'
+import { keeperCatchupDigests } from '../keeper-digest-signals'
+import {
+  KeeperCatchupDigestCard,
+  shouldShowKeeperCatchupDigest,
+} from './keeper-catchup-digest-card'
+import {
   enqueueInput,
   clearInputQueue,
   getQueuedMessages,
@@ -515,7 +526,20 @@ export function KeeperConversationPanel({
   // (.masc/keeper_chat/<name>.jsonl) on mount so the conversation
   // survives full page reloads. Once-per-keeper inside the action.
   useEffect(() => {
-    void hydrateKeeperChatHistory(keeperName)
+    // Capture the last-seen cursor BEFORE anything advances it, and fetch the
+    // since-last-seen digest against that frozen baseline. The card and the
+    // unread divider anchor on the server's echoed since_unix, not the live
+    // cursor, so the advance below does not move them mid-visit.
+    const baseline = getKeeperLastSeen(keeperName)
+    if (baseline !== null) void refreshKeeperCatchupDigest(keeperName, baseline)
+    void (async () => {
+      await hydrateKeeperChatHistory(keeperName)
+      // The server transcript is now merged: mark the newest merged entry as
+      // seen so the NEXT visit's baseline is current. First-ever visits (no
+      // prior cursor) also land here, seeding the cursor without a card.
+      const newest = newestConversationEntryUnix(keeperThreads.value[keeperName] ?? [])
+      if (newest !== null) advanceKeeperLastSeen(keeperName, newest)
+    })()
     void resumePendingKeeperChatRequests(keeperName)
   }, [keeperName])
 
@@ -555,6 +579,24 @@ export function KeeperConversationPanel({
     () => filterConversationEntries(visibleThreadWithQueue, searchQuery),
     [visibleThreadWithQueue, searchQuery],
   )
+  // Since-last-seen digest (fetched once on mount against the frozen baseline).
+  // Reading the signal here subscribes the panel so the card appears when the
+  // fetch resolves. Card + divider anchor on digest.since_unix, not the cursor.
+  const catchupDigest = keeperCatchupDigests.value[keeperName] ?? null
+  const digestCard = shouldShowKeeperCatchupDigest(catchupDigest)
+    ? html`<${KeeperCatchupDigestCard} digest=${catchupDigest} />`
+    : null
+  const unreadAfterTs = catchupDigest?.since_unix ?? null
+  const newestEntryTsUnix = useMemo(
+    () => newestConversationEntryUnix(transcriptEntries),
+    [transcriptEntries],
+  )
+  // Advance the cursor to the newest visible entry once the operator has caught
+  // up (ChatTranscript calls this when pinned to bottom / tab visible). Monotonic
+  // and localStorage-guarded, so repeated pinned calls are cheap.
+  const markTranscriptSeen = () => {
+    if (newestEntryTsUnix !== null) advanceKeeperLastSeen(keeperName, newestEntryTsUnix)
+  }
   // Stable action object so the memoized ChatMessageBubble's shallow prop
   // compare can skip unchanged messages — an inline `{ ...onClick }` literal
   // would be a new reference each render and defeat the memo.
@@ -729,6 +771,8 @@ export function KeeperConversationPanel({
             `
           : null}
 
+        ${digestCard ? html`<div class="mx-10 mt-3">${digestCard}</div>` : null}
+
         <div class="kw-thread v2-monitoring-panel">
           <div class="kw-thread-inner v2-monitoring-panel">
             <${ChatTranscript}
@@ -742,6 +786,8 @@ export function KeeperConversationPanel({
               showSourceBadge=${true}
               toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+              unreadAfterTs=${unreadAfterTs}
+              onSeenBottom=${markTranscriptSeen}
               action=${inspectAction}
             />
           </div>
@@ -865,6 +911,8 @@ export function KeeperConversationPanel({
             `
           : null}
 
+        ${digestCard ? html`<div class="shrink-0">${digestCard}</div>` : null}
+
         <${ChatTranscript}
           entries=${transcriptEntries}
           emptyText=${transcriptEmptyText}
@@ -874,6 +922,8 @@ export function KeeperConversationPanel({
           groupToolCalls=${true}
           toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+          unreadAfterTs=${unreadAfterTs}
+          onSeenBottom=${markTranscriptSeen}
           action=${inspectAction}
         />
 
@@ -981,6 +1031,7 @@ export function KeeperConversationPanel({
                 </div>
               `
             : null}
+          ${digestCard ? html`<div class="mb-4">${digestCard}</div>` : null}
           <${ChatTranscript}
             entries=${transcriptEntries}
             emptyText=${transcriptEmptyText}
@@ -990,6 +1041,8 @@ export function KeeperConversationPanel({
             groupToolCalls=${true}
             toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+            unreadAfterTs=${unreadAfterTs}
+            onSeenBottom=${markTranscriptSeen}
             action=${inspectAction}
           />
         </div>

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -81,6 +81,13 @@ export const KEEPER_STREAM_IDLE_TIMEOUT_MS = 120_000
 export const KEEPER_STREAM_IDLE_POLL_MS = 5_000
 export const STREAMING_THINKING_PREVIEW_CHARS = 6_000
 
+// --- Keeper catch-up digest ---
+// Minimum count of aggregate new activity (messages + turns + tasks + board +
+// lifecycle events + transport failures) required before the since-last-seen
+// digest card is rendered. Below this the card is noise; the transcript and the
+// unread divider still carry the detail. read_errors override this (fail-visible).
+export const KEEPER_DIGEST_MIN_ACTIVITY = 1
+
 // --- Buffer & cache sizes (Vite env overridable) ---
 // Defaults balance memory/render cost against available history. Users who
 // want deeper replay (e.g. OAS telemetry) can raise the ceiling at build

--- a/dashboard/src/keeper-digest-actions.test.ts
+++ b/dashboard/src/keeper-digest-actions.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fetchKeeperCatchupDigest } = vi.hoisted(() => ({ fetchKeeperCatchupDigest: vi.fn() }))
+vi.mock('./api/keeper', () => ({ fetchKeeperCatchupDigest }))
+
+import { refreshKeeperCatchupDigest, _resetKeeperDigestForTests } from './keeper-digest-actions'
+import {
+  keeperCatchupDigests,
+  keeperDigestError,
+  keeperDigestLoading,
+} from './keeper-digest-signals'
+import type { KeeperCatchupDigest } from './api/schemas/keeper-catchup-digest'
+
+function makeDigest(sinceUnix: number): KeeperCatchupDigest {
+  return {
+    keeper: 'garnet',
+    since_unix: sinceUnix,
+    generated_at_unix: sinceUnix + 100,
+    chat: { new_messages: 3, first_new_ts: sinceUnix + 1, transport_failures: 0 },
+    turns: { completed: 5, failed: 0, crashes: 0 },
+    tasks: { claimed: 0, done: 1, released: 0, cancelled: 0, items: [] },
+    board: { posted: 0, commented: 0, voted: 0 },
+    lifecycle: { paused_now: false, pause_events: 0, resume_events: 0, items: [] },
+    read_errors: [],
+  }
+}
+
+describe('refreshKeeperCatchupDigest', () => {
+  beforeEach(() => {
+    _resetKeeperDigestForTests()
+    fetchKeeperCatchupDigest.mockReset()
+  })
+
+  afterEach(() => {
+    _resetKeeperDigestForTests()
+  })
+
+  it('stores the fetched digest on the per-keeper signal', async () => {
+    fetchKeeperCatchupDigest.mockResolvedValue(makeDigest(1000))
+
+    await refreshKeeperCatchupDigest('garnet', 1000)
+
+    expect(fetchKeeperCatchupDigest).toHaveBeenCalledTimes(1)
+    expect(fetchKeeperCatchupDigest).toHaveBeenCalledWith('garnet', 1000)
+    expect(keeperCatchupDigests.value.garnet?.since_unix).toBe(1000)
+    expect(keeperDigestLoading.value.garnet).toBe(false)
+    expect(keeperDigestError.value.garnet ?? null).toBeNull()
+  })
+
+  it('dedups two concurrent refreshes into a single fetch', async () => {
+    let resolveFetch: (digest: KeeperCatchupDigest) => void = () => {}
+    fetchKeeperCatchupDigest.mockImplementation(
+      () => new Promise<KeeperCatchupDigest>((resolve) => { resolveFetch = resolve }),
+    )
+
+    const first = refreshKeeperCatchupDigest('garnet', 1000)
+    const second = refreshKeeperCatchupDigest('garnet', 1000)
+    resolveFetch(makeDigest(1000))
+    await Promise.all([first, second])
+
+    expect(fetchKeeperCatchupDigest).toHaveBeenCalledTimes(1)
+    expect(keeperCatchupDigests.value.garnet?.since_unix).toBe(1000)
+  })
+
+  it('surfaces fetch errors on keeperDigestError without throwing', async () => {
+    fetchKeeperCatchupDigest.mockRejectedValue(new Error('boom'))
+
+    await expect(refreshKeeperCatchupDigest('garnet', 1000)).resolves.toBeUndefined()
+
+    expect(keeperDigestError.value.garnet).toContain('boom')
+    expect(keeperDigestLoading.value.garnet).toBe(false)
+    expect(keeperCatchupDigests.value.garnet ?? null).toBeNull()
+  })
+
+  it('ignores blank keeper names and non-finite since values', async () => {
+    await refreshKeeperCatchupDigest('   ', 1000)
+    await refreshKeeperCatchupDigest('garnet', Number.NaN)
+    expect(fetchKeeperCatchupDigest).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/keeper-digest-actions.test.ts
+++ b/dashboard/src/keeper-digest-actions.test.ts
@@ -62,6 +62,28 @@ describe('refreshKeeperCatchupDigest', () => {
     expect(keeperCatchupDigests.value.garnet?.since_unix).toBe(1000)
   })
 
+  it('does not let an older in-flight baseline overwrite a newer one', async () => {
+    const resolvers = new Map<number, (digest: KeeperCatchupDigest) => void>()
+    fetchKeeperCatchupDigest.mockImplementation(
+      (_keeper: string, sinceUnix: number) => new Promise<KeeperCatchupDigest>((resolve) => {
+        resolvers.set(sinceUnix, resolve)
+      }),
+    )
+
+    const older = refreshKeeperCatchupDigest('garnet', 1000)
+    const newer = refreshKeeperCatchupDigest('garnet', 2000)
+    resolvers.get(2000)?.(makeDigest(2000))
+    await newer
+    resolvers.get(1000)?.(makeDigest(1000))
+    await older
+
+    expect(fetchKeeperCatchupDigest).toHaveBeenCalledTimes(2)
+    expect(fetchKeeperCatchupDigest).toHaveBeenNthCalledWith(1, 'garnet', 1000)
+    expect(fetchKeeperCatchupDigest).toHaveBeenNthCalledWith(2, 'garnet', 2000)
+    expect(keeperCatchupDigests.value.garnet?.since_unix).toBe(2000)
+    expect(keeperDigestLoading.value.garnet).toBe(false)
+  })
+
   it('surfaces fetch errors on keeperDigestError without throwing', async () => {
     fetchKeeperCatchupDigest.mockRejectedValue(new Error('boom'))
 

--- a/dashboard/src/keeper-digest-actions.ts
+++ b/dashboard/src/keeper-digest-actions.ts
@@ -5,11 +5,17 @@ import {
   keeperDigestLoading,
 } from './keeper-digest-signals'
 
-// Per-keeper inflight dedup: concurrent refreshes for the same keeper share a
-// single fetch (mirrors the operator digest stack's *RefreshInflight guard in
-// operator-actions.ts). Keyed by keeper name so different keepers still fetch
-// in parallel.
-const inflight = new Map<string, Promise<void>>()
+interface InflightDigestRefresh {
+  requestId: number
+  sinceUnix: number
+  promise: Promise<void>
+}
+
+// Per-keeper+baseline inflight dedup. The digest is anchored to the captured
+// sinceUnix cursor, so a later refresh for the same keeper with a newer cursor
+// must not reuse or be overwritten by an older in-flight response.
+const inflight = new Map<string, InflightDigestRefresh>()
+let nextRequestId = 0
 
 function setRecord<T>(
   target: typeof keeperCatchupDigests | typeof keeperDigestLoading | typeof keeperDigestError,
@@ -30,28 +36,36 @@ export async function refreshKeeperCatchupDigest(
   const name = keeperName.trim()
   if (!name || !Number.isFinite(sinceUnix)) return
   const existing = inflight.get(name)
-  if (existing) return existing
+  if (existing && existing.sinceUnix === sinceUnix) return existing.promise
 
+  const requestId = ++nextRequestId
   setRecord(keeperDigestLoading, name, true)
   setRecord(keeperDigestError, name, null)
   const run = (async () => {
     try {
       const digest = await fetchKeeperCatchupDigest(name, sinceUnix)
-      setRecord(keeperCatchupDigests, name, digest)
+      if (inflight.get(name)?.requestId === requestId) {
+        setRecord(keeperCatchupDigests, name, digest)
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : `${name} digest 로드 실패`
-      setRecord(keeperDigestError, name, message)
+      if (inflight.get(name)?.requestId === requestId) {
+        setRecord(keeperDigestError, name, message)
+      }
     } finally {
-      setRecord(keeperDigestLoading, name, false)
-      inflight.delete(name)
+      if (inflight.get(name)?.requestId === requestId) {
+        setRecord(keeperDigestLoading, name, false)
+        inflight.delete(name)
+      }
     }
   })()
-  inflight.set(name, run)
+  inflight.set(name, { requestId, sinceUnix, promise: run })
   return run
 }
 
 export function _resetKeeperDigestForTests(): void {
   inflight.clear()
+  nextRequestId = 0
   keeperCatchupDigests.value = {}
   keeperDigestLoading.value = {}
   keeperDigestError.value = {}

--- a/dashboard/src/keeper-digest-actions.ts
+++ b/dashboard/src/keeper-digest-actions.ts
@@ -1,0 +1,58 @@
+import { fetchKeeperCatchupDigest } from './api/keeper'
+import {
+  keeperCatchupDigests,
+  keeperDigestError,
+  keeperDigestLoading,
+} from './keeper-digest-signals'
+
+// Per-keeper inflight dedup: concurrent refreshes for the same keeper share a
+// single fetch (mirrors the operator digest stack's *RefreshInflight guard in
+// operator-actions.ts). Keyed by keeper name so different keepers still fetch
+// in parallel.
+const inflight = new Map<string, Promise<void>>()
+
+function setRecord<T>(
+  target: typeof keeperCatchupDigests | typeof keeperDigestLoading | typeof keeperDigestError,
+  key: string,
+  value: T,
+): void {
+  target.value = { ...target.value, [key]: value } as typeof target.value
+}
+
+// Fetch the since-last-seen digest for one keeper and publish it to the signal.
+// `sinceUnix` is the operator's last-seen cursor captured at panel mount. Errors
+// are surfaced on keeperDigestError (never thrown) so a digest failure cannot
+// break panel mount; the transcript still renders.
+export async function refreshKeeperCatchupDigest(
+  keeperName: string,
+  sinceUnix: number,
+): Promise<void> {
+  const name = keeperName.trim()
+  if (!name || !Number.isFinite(sinceUnix)) return
+  const existing = inflight.get(name)
+  if (existing) return existing
+
+  setRecord(keeperDigestLoading, name, true)
+  setRecord(keeperDigestError, name, null)
+  const run = (async () => {
+    try {
+      const digest = await fetchKeeperCatchupDigest(name, sinceUnix)
+      setRecord(keeperCatchupDigests, name, digest)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `${name} digest 로드 실패`
+      setRecord(keeperDigestError, name, message)
+    } finally {
+      setRecord(keeperDigestLoading, name, false)
+      inflight.delete(name)
+    }
+  })()
+  inflight.set(name, run)
+  return run
+}
+
+export function _resetKeeperDigestForTests(): void {
+  inflight.clear()
+  keeperCatchupDigests.value = {}
+  keeperDigestLoading.value = {}
+  keeperDigestError.value = {}
+}

--- a/dashboard/src/keeper-digest-signals.ts
+++ b/dashboard/src/keeper-digest-signals.ts
@@ -1,0 +1,12 @@
+import { signal } from '@preact/signals'
+import type { KeeperCatchupDigest } from './api/schemas/keeper-catchup-digest'
+
+// Per-keeper since-last-seen digest state. Flat Record signals keyed by keeper
+// name, mirroring the keeperThreads / keeperHydrating shape in keeper-state.ts.
+// The digest is fetched once per panel mount with the baseline cursor captured
+// at that moment; the value's `since_unix` echo is the frozen anchor the card
+// and the unread divider render against (so a later cursor advance does not move
+// them mid-visit).
+export const keeperCatchupDigests = signal<Record<string, KeeperCatchupDigest | null>>({})
+export const keeperDigestLoading = signal<Record<string, boolean>>({})
+export const keeperDigestError = signal<Record<string, string | null>>({})

--- a/dashboard/src/keeper-last-seen.test.ts
+++ b/dashboard/src/keeper-last-seen.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  _clearKeeperLastSeenForTests,
+  advanceKeeperLastSeen,
+  conversationEntryUnix,
+  getKeeperLastSeen,
+  hydrateKeeperLastSeen,
+  keeperLastSeen,
+  newestConversationEntryUnix,
+} from './keeper-last-seen'
+
+const STORAGE_KEY = 'masc_keeper_chat_last_seen_v1'
+
+describe('keeper last-seen cursor', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    _clearKeeperLastSeenForTests()
+  })
+
+  afterEach(() => {
+    _clearKeeperLastSeenForTests()
+    window.localStorage.clear()
+  })
+
+  it('advances monotonically and persists to localStorage', () => {
+    advanceKeeperLastSeen('garnet', 1000)
+    expect(getKeeperLastSeen('garnet')).toBe(1000)
+
+    // A backward advance is a no-op — the operator cannot "un-see" a message.
+    advanceKeeperLastSeen('garnet', 500)
+    expect(getKeeperLastSeen('garnet')).toBe(1000)
+
+    // A forward advance moves the cursor and rewrites storage.
+    advanceKeeperLastSeen('garnet', 2000)
+    expect(getKeeperLastSeen('garnet')).toBe(2000)
+
+    const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '{}') as Record<string, number>
+    expect(persisted).toEqual({ garnet: 2000 })
+  })
+
+  it('ignores non-finite / non-positive advances', () => {
+    advanceKeeperLastSeen('echo', Number.NaN)
+    advanceKeeperLastSeen('echo', Number.POSITIVE_INFINITY)
+    advanceKeeperLastSeen('echo', 0)
+    advanceKeeperLastSeen('echo', -5)
+    expect(getKeeperLastSeen('echo')).toBeNull()
+  })
+
+  it('hydrates from localStorage and drops malformed values on read', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      garnet: 1234.5,
+      zero_cursor: 0,
+      negative_cursor: -5,
+      stringy_cursor: 'nope',
+      nullish_cursor: null,
+    }))
+
+    const hydrated = hydrateKeeperLastSeen()
+    expect(hydrated).toEqual({ garnet: 1234.5 })
+    expect(keeperLastSeen.value).toEqual({ garnet: 1234.5 })
+    expect(getKeeperLastSeen('garnet')).toBe(1234.5)
+    expect(getKeeperLastSeen('zero_cursor')).toBeNull()
+    expect(getKeeperLastSeen('stringy_cursor')).toBeNull()
+  })
+
+  it('clears the signal and storage for tests', () => {
+    advanceKeeperLastSeen('garnet', 1000)
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+    _clearKeeperLastSeenForTests()
+    expect(keeperLastSeen.value).toEqual({})
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('converts entry ISO timestamps to unix seconds and finds the newest', () => {
+    expect(conversationEntryUnix({ timestamp: '2026-07-02T00:00:00.000Z' })).toBe(
+      Date.parse('2026-07-02T00:00:00.000Z') / 1000,
+    )
+    expect(conversationEntryUnix({ timestamp: null })).toBeNull()
+    expect(conversationEntryUnix({ timestamp: 'not-a-date' })).toBeNull()
+
+    const newest = newestConversationEntryUnix([
+      { timestamp: '2026-07-01T00:00:00.000Z' },
+      { timestamp: null },
+      { timestamp: '2026-07-03T00:00:00.000Z' },
+      { timestamp: '2026-07-02T00:00:00.000Z' },
+    ])
+    expect(newest).toBe(Date.parse('2026-07-03T00:00:00.000Z') / 1000)
+    expect(newestConversationEntryUnix([{ timestamp: null }])).toBeNull()
+    expect(newestConversationEntryUnix([])).toBeNull()
+  })
+})

--- a/dashboard/src/keeper-last-seen.ts
+++ b/dashboard/src/keeper-last-seen.ts
@@ -1,0 +1,132 @@
+import { signal } from '@preact/signals'
+import type { KeeperConversationEntry } from './types'
+
+// Per-keeper "last-seen" cursor. The stored value is the newest chat entry
+// `ts` (unix seconds) the operator has actually observed in that keeper's
+// transcript — NOT wall-clock time. Anchoring on the entry ts (rather than
+// Date.now()) keeps the cursor immune to client/server clock skew and makes
+// the since-last-seen digest deterministic: the server echoes the same
+// since_unix it was queried with.
+//
+// Storage/normalize conventions are cloned from keeper-chat-pending.ts
+// (try/catch storage() wrapper, normalize-on-read dropping malformed values,
+// a _clear...ForTests reset). The reactive signal is the render source of
+// truth; localStorage is the durability layer.
+
+const STORAGE_KEY = 'masc_keeper_chat_last_seen_v1'
+
+function storage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// Drop any entry whose value is not a finite, positive unix timestamp. A
+// non-finite or non-positive cursor cannot describe a real observed entry, so
+// treating it as "unseen" is safer than persisting garbage.
+function normalizeLastSeen(raw: unknown): Record<string, number> {
+  if (!isRecord(raw)) return {}
+  const out: Record<string, number> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    const name = key.trim()
+    if (!name) continue
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      out[name] = value
+    }
+  }
+  return out
+}
+
+function readAll(): Record<string, number> {
+  const store = storage()
+  if (!store) return {}
+  try {
+    const raw = store.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    return normalizeLastSeen(JSON.parse(raw) as unknown)
+  } catch {
+    return {}
+  }
+}
+
+function writeAll(record: Record<string, number>): void {
+  const store = storage()
+  if (!store) return
+  try {
+    if (Object.keys(record).length === 0) {
+      store.removeItem(STORAGE_KEY)
+    } else {
+      store.setItem(STORAGE_KEY, JSON.stringify(record))
+    }
+  } catch {
+    // Best-effort persistence only; the in-memory signal remains authoritative
+    // for this session even if localStorage is unavailable (private mode, quota).
+  }
+}
+
+export const keeperLastSeen = signal<Record<string, number>>({})
+
+// Re-read the persisted cursor map into the signal, normalizing away malformed
+// values. Called once at module load; exposed so a cross-tab/storage event (or a
+// test) can re-hydrate the in-memory signal from localStorage on demand.
+export function hydrateKeeperLastSeen(): Record<string, number> {
+  const record = readAll()
+  keeperLastSeen.value = record
+  return record
+}
+
+hydrateKeeperLastSeen()
+
+export function getKeeperLastSeen(keeperName: string): number | null {
+  const name = keeperName.trim()
+  if (!name) return null
+  const value = keeperLastSeen.value[name]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+// Monotonic forward-only advance: the operator cannot "un-see" a message, so a
+// cursor never moves backwards. Writes to localStorage only when it actually
+// advances, so pinned-transcript churn does not thrash storage.
+export function advanceKeeperLastSeen(keeperName: string, entryUnixTs: number): void {
+  const name = keeperName.trim()
+  if (!name || !Number.isFinite(entryUnixTs) || entryUnixTs <= 0) return
+  const current = keeperLastSeen.value[name]
+  if (typeof current === 'number' && current >= entryUnixTs) return
+  const next = { ...keeperLastSeen.value, [name]: entryUnixTs }
+  keeperLastSeen.value = next
+  writeAll(next)
+}
+
+// Convert a rendered conversation entry's ISO timestamp to the unix-seconds unit
+// the cursor stores. Null-timestamp rows (live placeholders, checkpoints) have
+// no observable position and return null.
+export function conversationEntryUnix(
+  entry: Pick<KeeperConversationEntry, 'timestamp'>,
+): number | null {
+  if (!entry.timestamp) return null
+  const ms = Date.parse(entry.timestamp)
+  return Number.isFinite(ms) ? ms / 1000 : null
+}
+
+export function newestConversationEntryUnix(
+  entries: readonly Pick<KeeperConversationEntry, 'timestamp'>[],
+): number | null {
+  let newest: number | null = null
+  for (const entry of entries) {
+    const unix = conversationEntryUnix(entry)
+    if (unix === null) continue
+    if (newest === null || unix > newest) newest = unix
+  }
+  return newest
+}
+
+export function _clearKeeperLastSeenForTests(): void {
+  keeperLastSeen.value = {}
+  writeAll({})
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1611,6 +1611,18 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   content: ""; flex: 1; height: 1px; background: var(--color-border-divider);
 }
 
+/* Since-last-seen "read up to here" divider. Same hairline layout as the day
+ * divider but accent-toned and normal-case so the unread boundary reads as a
+ * status marker rather than a date. Emitted by ChatTranscript when unreadAfterTs
+ * is set (keeper surfaces only). */
+.kw-unreaddiv {
+  text-transform: none; letter-spacing: 0.04em;
+  color: var(--color-accent-fg);
+}
+.kw-unreaddiv::before, .kw-unreaddiv::after {
+  background: var(--color-accent-fg-dim);
+}
+
 /* ════ C2 — message source badge ════════════════════════════════════
  * Distinguishes non-obvious message provenance (world-state / internal /
  * tool / system) from a plain user/assistant turn. Mirrors the standalone

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -36,7 +36,7 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
 
 - 모든 timestamp는 unix seconds float로 정규화한다 (소스는 ISO/unix 혼재 — digest 계층에서 통일).
 - `items` 배열은 상수 cap (`digest_items_cap`, 최신순)로 제한하고, 카운트 필드는 cap과 무관한 전체 수를 담는다.
-- `read_errors`: 소스 저장소별 읽기 실패를 문자열 목록으로 노출한다 (silent skip 금지, fail-visible).
+- `read_errors`: 소스 저장소별 읽기 실패와 bounded scan 조기 중단을 문자열 목록으로 노출한다 (silent skip 금지, fail-visible).
 
 ## Source mapping (전부 기존 저장소)
 
@@ -82,7 +82,7 @@ keeper identity 매칭은 `Tool_agent_timeline.identity_matches`의 3-형태 규
 
 - **lifecycle는 durable JSONL을 직접 읽는다.** `Keeper_transition_audit`의 노출된 read API(`recent_transitions`)는 in-memory ring(50, 재시작 시 유실)만 읽고 "keeper X의 since 이후" 질의를 하지 못한다. digest의 핵심 전제가 재시작 straddle이므로 durable `.masc/transition-audit` dated store를 직접 파싱한다(`{keeper, record:{event_type, wall_clock_at_decision}}`). 즉 lifecycle는 그 모듈의 함수가 아니라 on-disk 포맷에 결합한다.
 - **fail-visible read는 라이브러리를 우회한다.** `Dated_jsonl.read_range`는 malformed 행을 조용히 건너뛰므로, "read 실패는 silent skip 금지" 계약을 지키려고 day-file(`YYYY-MM/DD.jsonl`, since→now 창)을 직접 열어 줄 단위로 파싱하고 파싱 실패를 `read_errors`에 노출한다(`turn-records`/`audit`/`activity-events`/`transition-audit`). 파일 부재는 0(무활동), 실패 아님.
-- **chat 파싱 실패는 digest read_errors에 오지 않는다.** chat은 `Keeper_chat_store.load_page`(tail에서 backward paging, `chat_page_cap`로 상한)로 읽고, 그 스토어가 자체 read-drop 메트릭으로 파싱 실패를 소유한다.
+- **chat 파싱 실패는 digest read_errors에 오지 않는다.** chat은 `Keeper_chat_store.load_page`(tail에서 backward paging, `chat_page_cap`로 상한)로 읽고, 그 스토어가 자체 read-drop 메트릭으로 파싱 실패를 소유한다. 단, page cap에 도달했는데 아직 since 커서에 닿지 못한 경우는 digest count가 하한값이므로 `read_errors`에 노출한다.
 - **crash는 count-limited.** `Keeper_crash_persistence.recent_crashes`(SSOT reader) 최신 `crash_scan_max=500`행을 읽고 `ts > since` 필터. crash는 희소하므로 이 상한을 넘으면 하한값.
 - **task transition은 typed로 분류.** 문자열 매칭 대신 `Audit_log.entry_of_json_r` + typed `action` 변형으로 claim/done/release/cancel/start를 구분(워크어라운드 시그니처 2 회피). 비-task action은 catch-all 없이 전부 열거.
 - **경로는 default-cluster 가정.** keeper-local/워크스페이스 스토어 경로를 `base_path`에서 `Common.*_of_base`로 유도한다(`<base_path>/.masc/...`). 비-default `MASC_CLUSTER_NAME`이 keeper 데이터를 재배치하면 이 v1은 default 경로를 읽는다.

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -75,3 +75,16 @@ keeper identity 매칭은 `Tool_agent_timeline.identity_matches`의 3-형태 규
 
 - H2 게이트웨이(`MASC_USE_H2`)가 라우트를 수동 미러링하므로 신규 경로의 이중 등록 필요 여부를 확인한다.
 - 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(30d) 프루닝 대상 — since가 보존 창보다 오래되면 카운트는 하한값이며, 응답의 `since_unix` 에코가 그 사실 판정을 클라이언트에 위임한다.
+
+## 구현 노트 (server v1)
+
+`lib/keeper_catchup_digest.ml` + `.mli`, 라우트는 `handle_keeper_get_subroutes`의 `ends_with "/digest"` arm. 아래는 소스 매핑을 실제 코드로 옮기며 확정한 사항이다.
+
+- **lifecycle는 durable JSONL을 직접 읽는다.** `Keeper_transition_audit`의 노출된 read API(`recent_transitions`)는 in-memory ring(50, 재시작 시 유실)만 읽고 "keeper X의 since 이후" 질의를 하지 못한다. digest의 핵심 전제가 재시작 straddle이므로 durable `.masc/transition-audit` dated store를 직접 파싱한다(`{keeper, record:{event_type, wall_clock_at_decision}}`). 즉 lifecycle는 그 모듈의 함수가 아니라 on-disk 포맷에 결합한다.
+- **fail-visible read는 라이브러리를 우회한다.** `Dated_jsonl.read_range`는 malformed 행을 조용히 건너뛰므로, "read 실패는 silent skip 금지" 계약을 지키려고 day-file(`YYYY-MM/DD.jsonl`, since→now 창)을 직접 열어 줄 단위로 파싱하고 파싱 실패를 `read_errors`에 노출한다(`turn-records`/`audit`/`activity-events`/`transition-audit`). 파일 부재는 0(무활동), 실패 아님.
+- **chat 파싱 실패는 digest read_errors에 오지 않는다.** chat은 `Keeper_chat_store.load_page`(tail에서 backward paging, `chat_page_cap`로 상한)로 읽고, 그 스토어가 자체 read-drop 메트릭으로 파싱 실패를 소유한다.
+- **crash는 count-limited.** `Keeper_crash_persistence.recent_crashes`(SSOT reader) 최신 `crash_scan_max=500`행을 읽고 `ts > since` 필터. crash는 희소하므로 이 상한을 넘으면 하한값.
+- **task transition은 typed로 분류.** 문자열 매칭 대신 `Audit_log.entry_of_json_r` + typed `action` 변형으로 claim/done/release/cancel/start를 구분(워크어라운드 시그니처 2 회피). 비-task action은 catch-all 없이 전부 열거.
+- **경로는 default-cluster 가정.** keeper-local/워크스페이스 스토어 경로를 `base_path`에서 `Common.*_of_base`로 유도한다(`<base_path>/.masc/...`). 비-default `MASC_CLUSTER_NAME`이 keeper 데이터를 재배치하면 이 v1은 default 경로를 읽는다.
+- **H2 미러링 없음.** `server_h2_gateway.ml`은 `/api/v1/keepers/` 프리픽스를 미러링하지 않는다(command-plane/board/특정 dashboard 라우트만). 따라서 형제 `/chat/history`와 동일하게 `/digest`는 H1 전용이다. 전체 keeper 체인이 H1 전용인데 신규 suffix만 H2에 등록하는 건 불일치라 추가하지 않았다.
+- **동기 읽기.** digest는 chat-open 시점(저빈도, 운영자 유발)에 HTTP 도메인에서 동기로 스캔한다. 매우 긴 부재+바쁜 keeper의 activity-events 스캔은 후속으로 domain-pool offload 여지(연구 권고).

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -1,0 +1,77 @@
+# Keeper Catch-up Digest (since-last-seen)
+
+운영자가 자리를 비운 사이 특정 keeper에게 무슨 일이 있었는지를, keeper 채팅 진입 시점에 결정론적으로 집계해 보여준다. LLM 요약 없음, 휴리스틱 없음 — 기존 durable 저장소의 since-필터 집계만 수행한다.
+
+발단: 2026-07-02 garnet 재시작-유실 리뷰 중, "지난 방문 이후" catch-up 수단이 1급 기능으로 부재함을 확인 (backlog task-1641).
+
+## Wire contract (v1)
+
+```
+GET /api/v1/keepers/:name/digest?since_unix=<float>
+```
+
+- `since_unix` (required, unix seconds float): 운영자의 per-keeper last-seen 커서. 누락/비수치이면 400.
+- 응답 (`Content-Type: application/json`, 기존 keeper GET subroute 체인과 동일한 public-read 게이트):
+
+```json
+{
+  "keeper": "garnet",
+  "since_unix": 1782976498.87,
+  "generated_at_unix": 1783003000.1,
+  "chat": { "new_messages": 12, "first_new_ts": 1782976500.2, "transport_failures": 2 },
+  "turns": { "completed": 34, "failed": 3, "crashes": 1 },
+  "tasks": {
+    "claimed": 2, "done": 1, "released": 1, "cancelled": 0,
+    "items": [ { "task_id": "task-1635", "transition": "done", "ts": 1782980000.0 } ]
+  },
+  "board": { "posted": 3, "commented": 11, "voted": 4 },
+  "lifecycle": {
+    "paused_now": true,
+    "pause_events": 1, "resume_events": 0,
+    "items": [ { "kind": "operator_pause", "ts": 1782990000.0 } ]
+  },
+  "read_errors": []
+}
+```
+
+- 모든 timestamp는 unix seconds float로 정규화한다 (소스는 ISO/unix 혼재 — digest 계층에서 통일).
+- `items` 배열은 상수 cap (`digest_items_cap`, 최신순)로 제한하고, 카운트 필드는 cap과 무관한 전체 수를 담는다.
+- `read_errors`: 소스 저장소별 읽기 실패를 문자열 목록으로 노출한다 (silent skip 금지, fail-visible).
+
+## Source mapping (전부 기존 저장소)
+
+| 카테고리 | 소스 | 필터 |
+|---|---|---|
+| chat | `Keeper_chat_store` (`.masc/keeper_chat/<name>.jsonl`, ts append-ordered) | `ts > since`; `Row_kind.Transport_failure`는 별도 카운트 |
+| turns.completed | keeper-local `turn-records/YYYY-MM/DD.jsonl` (day-partitioned) | day 파일 >= since 날짜만 open 후 `ts > since` |
+| turns.failed | activity-events `keeper.turn_failed` (actor/keeper_name match) | `ts_ms > since*1000` |
+| turns.crashes | keeper-local `crash-events/YYYY-MM/DD.jsonl` | `ts > since` |
+| tasks | `.masc/audit/YYYY-MM/DD.jsonl` (`event_family:"task_transition"`, agent_id) | `timestamp > since` + keeper identity |
+| board | activity-events `board.posted/commented/voted` (actor = author) | `ts_ms > since*1000` + identity |
+| lifecycle | `Keeper_transition_audit` durable store (`.masc/transition-audit`, Operator_pause/Operator_resume) + 현재 meta.paused | `ts > since` |
+
+keeper identity 매칭은 `Tool_agent_timeline.identity_matches`의 3-형태 규칙(name / `keeper-<name>-agent` / `keeper:<name>`)을 재사용한다.
+
+## v1에서 뺀 것 (근거와 함께)
+
+- **tool-call 카테고리**: keeper 내부 tool call의 typed per-keeper 로그가 디스크에 없다 (activity-events `tool.called`는 external_mcp 전용; runtime-manifests의 `links.tool_call_log_path`는 전부 null). metrics heartbeat의 `continuity_state.progress` 문자열("Used: ...")을 파싱하는 안은 워크어라운드 시그니처 2(string 분류기)라 기각. 근본 해결 = tool_call_log_path 배선 후 v2에서 추가.
+- **LLM 한 줄 요약**: 선택 기능으로도 v1 제외. 결정론 집계가 먼저 자리 잡아야 한다.
+- **global feed 기반 turn 카운트**: activity-events `keeper.turn_completed`는 dashboard-chat 주도 턴에서 emission 갭이 실측됨 (garnet 07-02: turn-records엔 턴 존재, feed엔 1건). turn 카운트는 keeper-local 저장소가 진실.
+
+## Dashboard (v1)
+
+- **last-seen 커서**: `localStorage` 키 `masc_keeper_chat_last_seen_v1`, per-keeper `Record<string, number>` (값 = 그 keeper 채팅에서 관측한 최신 entry ts — 벽시계가 아니라 entry ts라 clock skew 무관). `keeper-chat-pending.ts`의 storage wrapper 패턴을 복제 (try/catch, normalize-on-read, `_clear...ForTests`).
+- **갱신 시점**: (a) KeeperConversationPanel mount/keeper 전환, (b) ChatTranscript가 bottom-pinned 상태로 스크롤/도착, (c) `visibilitychange`로 다시 보일 때 pinned면.
+- **digest 카드**: 커서가 존재하고 fetch 결과에 신규 활동이 있으면 transcript 스크롤러 **바깥**, ChatTranscript 호출부 바로 위에 카드 렌더 (autoscroll effect 불간섭). 카드에는 카테고리별 카운트 + "이후 N개 메시지" + paused 상태.
+- **unread divider**: transcript 내부에 `kw-daydiv` 패턴을 복제한 divider를 첫 unread entry 앞에 렌더. anchor entry가 200-cap으로 잘려나간 경우 "가장 오래된 표시 행 위 + 카드가 실제 카운트 담당"으로 폴백. null timestamp entry (live placeholder/checkpoint) 방어.
+- **fetch 스택**: 기존 operator digest 스택 패턴 복제 — `fetchKeeperCatchupDigest` (api/keeper.ts) + per-keeper signal + inflight-dedup.
+
+## 테스트
+
+- OCaml: digest 빌더 단위 테스트 — 임시 base_dir에 fixture JSONL을 쓰고 since 경계/카테고리별 집계/read_errors fail-visible/identity 3-형태 매칭을 assert.
+- TS(vitest): last-seen 모듈 (hydrate/persist/clear), digest fetch+signal, divider 위치 계산 (null-ts/cap-trim 케이스).
+
+## 유의
+
+- H2 게이트웨이(`MASC_USE_H2`)가 라우트를 수동 미러링하므로 신규 경로의 이중 등록 필요 여부를 확인한다.
+- 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(30d) 프루닝 대상 — since가 보존 창보다 오래되면 카운트는 하한값이며, 응답의 `since_unix` 에코가 그 사실 판정을 클라이언트에 위임한다.

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -1,0 +1,520 @@
+(** Keeper_catchup_digest — see the .mli for the contract and design SSOT. *)
+
+(* ── Named constants ─────────────────────────────────────────────── *)
+
+let digest_items_cap = 20
+
+(* Upper bound on the [read_errors] list so a corrupt store cannot fan the
+   payload out without limit; the digest reports at most this many failures. *)
+let read_errors_cap = 50
+
+(* Retention SSOT is MASC_JSONL_RETENTION_DAYS (default 30d); look-back is
+   clamped to this window plus slack so a far-past cursor cannot fan the
+   day-file scan out unboundedly. Beyond it the counts are a lower bound and
+   the echoed [since_unix] lets the client detect it. *)
+let max_scan_days = 40
+
+(* Termination guard for the backward chat paging loop: each page walks at
+   most one [Keeper_chat_store] window older, so this bounds the walk. *)
+let chat_page_cap = 200
+
+(* Newest crash events scanned before the [ts > since] filter; crashes are
+   rare, so this is a generous ceiling rather than a since-scan. *)
+let crash_scan_max = 500
+
+(* Workspace-level dated-JSONL store directory names. Each store is owned by
+   another module that spells this same literal internally but exposes no
+   constant; naming them here keeps the digest's reads off bare literals and
+   records the owner so a rename is a grep away. *)
+let audit_dirname = "audit" (* Audit_log store *)
+let activity_events_dirname = "activity-events" (* Activity_graph store *)
+let transition_audit_dirname = "transition-audit" (* Keeper_transition_audit durable store *)
+
+(* keeper.* activity-event kinds are still raw strings pending the #8455
+   Event_kind migration; the board.* kinds below come from the typed
+   Event_kind.Board SSOT. *)
+let keeper_turn_failed_kind = "keeper.turn_failed"
+
+(* Operator pause/resume [event_type] labels as serialised by
+   Keeper_state_machine_json.event_to_json ([obj "operator_pause"] /
+   [obj "operator_resume"]) and surfaced flat as a transition record's
+   ["event_type"] field. *)
+let operator_pause_event = "operator_pause"
+let operator_resume_event = "operator_resume"
+
+(* ── Types (mirror the .mli) ─────────────────────────────────────── *)
+
+type task_item =
+  { task_id : string
+  ; transition : string
+  ; ts : float
+  }
+
+type lifecycle_item =
+  { kind : string
+  ; ts : float
+  }
+
+type chat =
+  { new_messages : int
+  ; first_new_ts : float option
+  ; transport_failures : int
+  }
+
+type turns =
+  { completed : int
+  ; failed : int
+  ; crashes : int
+  }
+
+type tasks =
+  { claimed : int
+  ; done_ : int
+  ; released : int
+  ; cancelled : int
+  ; items : task_item list
+  }
+
+type board =
+  { posted : int
+  ; commented : int
+  ; voted : int
+  }
+
+type lifecycle =
+  { paused_now : bool
+  ; pause_events : int
+  ; resume_events : int
+  ; items : lifecycle_item list
+  }
+
+type t =
+  { keeper : string
+  ; since_unix : float
+  ; generated_at_unix : float
+  ; chat : chat
+  ; turns : turns
+  ; tasks : tasks
+  ; board : board
+  ; lifecycle : lifecycle
+  ; read_errors : string list
+  }
+
+(* ── Small helpers ───────────────────────────────────────────────── *)
+
+let take n xs =
+  let rec go i = function
+    | [] -> []
+    | x :: tl -> if i >= n then [] else x :: go (i + 1) tl
+  in
+  go 0 xs
+;;
+
+(* [ts]-carrying items, newest first, capped at {!digest_items_cap}. *)
+let cap_task_items items =
+  items
+  |> List.sort (fun (a : task_item) (b : task_item) -> Float.compare b.ts a.ts)
+  |> take digest_items_cap
+;;
+
+let cap_lifecycle_items items =
+  items
+  |> List.sort (fun (a : lifecycle_item) (b : lifecycle_item) ->
+    Float.compare b.ts a.ts)
+  |> take digest_items_cap
+;;
+
+(* A JSON number field read as a float, accepting both [`Int] and [`Float]
+   so mixed ISO/unix stores whose stamps are integral still resolve. *)
+let json_num_field name json =
+  match Safe_ops.json_member_opt name json with
+  | Some (`Float f) -> Some f
+  | Some (`Int i) -> Some (float_of_int i)
+  | _ -> None
+;;
+
+(* ── Fail-visible day-partitioned reader ─────────────────────────── *)
+
+(* A parse or IO failure is appended to [errs] (fail-visible), never
+   silently dropped. The list is bounded by {!read_errors_cap}. *)
+let bounded_add errs msg = if List.length !errs < read_errors_cap then errs := msg :: !errs
+
+let read_jsonl_file ~errs ~label ~path ~f =
+  match In_channel.with_open_bin path In_channel.input_all with
+  | exception Sys_error detail ->
+    bounded_add errs (Printf.sprintf "%s: %s: %s" label path detail)
+  | contents ->
+    let lineno = ref 0 in
+    String.split_on_char '\n' contents
+    |> List.iter (fun line ->
+      incr lineno;
+      let trimmed = String.trim line in
+      if trimmed <> ""
+      then (
+        (* Parse under its own guard so a bad line is a visible read error,
+           while an exception raised by [f] itself is not misattributed. *)
+        let parsed =
+          try Some (Yojson.Safe.from_string trimmed) with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | _ -> None
+        in
+        match parsed with
+        | Some json -> f json
+        | None ->
+          bounded_add
+            errs
+            (Printf.sprintf "%s: %s:%d unparseable JSON line" label path !lineno)))
+;;
+
+(* Iterate day-partitioned files [dir/YYYY-MM/DD.jsonl] whose UTC day is in
+   [[since_unix, now_unix]] (look-back clamped to {!max_scan_days}). A missing
+   day-file is zero activity, not an error. Day indexing off [ts /. 86400] is
+   month/year-boundary safe because 86400 divides UTC days exactly and the
+   epoch is UTC midnight. *)
+let fold_day_partitioned ~errs ~label ~dir ~since_unix ~now_unix ~f =
+  let day_seconds = 86400. in
+  let start_unix =
+    Float.max since_unix (now_unix -. (float_of_int max_scan_days *. day_seconds))
+  in
+  let day_index ts = int_of_float (Float.floor (ts /. day_seconds)) in
+  let path_of_day d =
+    let ts = (float_of_int d *. day_seconds) +. 1. in
+    let tm = Unix.gmtime ts in
+    Filename.concat
+      dir
+      (Printf.sprintf
+         "%04d-%02d/%02d.jsonl"
+         (tm.Unix.tm_year + 1900)
+         (tm.Unix.tm_mon + 1)
+         tm.Unix.tm_mday)
+  in
+  let start_day = day_index start_unix in
+  let end_day = day_index now_unix in
+  for d = start_day to end_day do
+    let path = path_of_day d in
+    if Sys.file_exists path then read_jsonl_file ~errs ~label ~path ~f
+  done
+;;
+
+(* ── Chat (single per-keeper append-ordered file) ────────────────── *)
+
+let payload_identity_match ~identity_of payload =
+  List.exists
+    (fun key ->
+      match Safe_ops.json_string_opt key payload with
+      | Some s -> identity_of s
+      | None -> false)
+    [ "keeper_name"; "agent_name"; "name" ]
+;;
+
+(* Page [Keeper_chat_store] backward from the tail, counting rows strictly
+   after [since]. Utterances (user/assistant) are [new_messages];
+   [Transport_failure] rows are counted separately; tool rows are ignored.
+   The store's own parser owns chat read-drop accounting, so chat parse
+   failures do not enter [read_errors]. Rows are de-duped by their stable
+   [id] across page overlaps. *)
+let read_chat ~base_dir ~keeper_name ~since =
+  let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
+  let new_messages = ref 0 in
+  let transport = ref 0 in
+  let first_new = ref None in
+  let note_first ts =
+    first_new
+      := Some (match !first_new with Some f -> Float.min f ts | None -> ts)
+  in
+  let process ({ ts; id; kind; role; _ } : Keeper_chat_store.chat_message) =
+    match ts with
+    | Some ts when ts > since && not (Hashtbl.mem seen id) ->
+      Hashtbl.add seen id ();
+      (match kind with
+       | Keeper_chat_store.Row_kind.Transport_failure -> incr transport
+       | Keeper_chat_store.Row_kind.Utterance ->
+         (match role with
+          | Keeper_chat_store.Role.User | Keeper_chat_store.Role.Assistant ->
+            incr new_messages;
+            note_first ts
+          | Keeper_chat_store.Role.Tool -> ()))
+    | Some _ | None -> ()
+  in
+  let rec loop before iters =
+    if iters >= chat_page_cap
+    then ()
+    else (
+      let { Keeper_chat_store.messages; has_more } =
+        Keeper_chat_store.load_page ~base_dir ~keeper_name ?before ()
+      in
+      List.iter process messages;
+      let oldest =
+        List.fold_left
+          (fun acc ({ ts; _ } : Keeper_chat_store.chat_message) ->
+            match ts with
+            | Some t -> Some (match acc with Some a -> Float.min a t | None -> t)
+            | None -> acc)
+          None
+          messages
+      in
+      match oldest with
+      | Some o when o > since && has_more -> loop (Some o) (iters + 1)
+      | Some _ | None -> ())
+  in
+  loop None 0;
+  { new_messages = !new_messages
+  ; first_new_ts = !first_new
+  ; transport_failures = !transport
+  }
+;;
+
+(* ── Aggregation ─────────────────────────────────────────────────── *)
+
+let build ~base_path ~keeper_name ~since_unix ~now_unix =
+  let errs = ref [] in
+  let identity_of candidate =
+    Tool_agent_timeline.identity_matches ~agent_name:keeper_name candidate
+  in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_local store =
+    Filename.concat
+      (Filename.concat keepers_dir keeper_name)
+      (Common.keeper_runtime_store_dirname store)
+  in
+  (* chat *)
+  let chat = read_chat ~base_dir:base_path ~keeper_name ~since:since_unix in
+  (* turns.completed — keeper-local turn-records *)
+  let completed = ref 0 in
+  fold_day_partitioned
+    ~errs
+    ~label:"turn-records"
+    ~dir:(keeper_local Common.Keeper_turn_records)
+    ~since_unix
+    ~now_unix
+    ~f:(fun json ->
+      match json_num_field "ts" json with
+      | Some ts when ts > since_unix -> incr completed
+      | _ -> ());
+  (* turns.crashes — Keeper_crash_persistence exposes the crash-events reader,
+     so use it rather than re-spelling that store's path. *)
+  let crashes = ref 0 in
+  Keeper_crash_persistence.recent_crashes
+    ~keepers_dir
+    ~name:keeper_name
+    ~max_entries:crash_scan_max
+  |> List.iter (fun json ->
+    match json_num_field "ts" json with
+    | Some ts when ts > since_unix -> incr crashes
+    | _ -> ());
+  (* turns.failed + board — one pass over activity-events *)
+  let failed = ref 0 in
+  let posted = ref 0 in
+  let commented = ref 0 in
+  let voted = ref 0 in
+  let since_ms = since_unix *. 1000. in
+  fold_day_partitioned
+    ~errs
+    ~label:"activity-events"
+    ~dir:(Filename.concat masc_dir activity_events_dirname)
+    ~since_unix
+    ~now_unix
+    ~f:(fun json ->
+      match Activity_graph.event_of_yojson json with
+      | None -> ()
+      | Some ({ kind; ts_ms; actor; payload; _ } : Activity_graph.event) ->
+        let actor_match =
+          match actor with
+          | Some ({ id; _ } : Activity_graph.entity_ref) -> identity_of id
+          | None -> false
+        in
+        if float_of_int ts_ms > since_ms
+           && (actor_match || payload_identity_match ~identity_of payload)
+        then
+          if String.equal kind keeper_turn_failed_kind
+          then incr failed
+          else if String.equal kind Event_kind.Board.(to_string Posted)
+          then incr posted
+          else if String.equal kind Event_kind.Board.(to_string Commented)
+          then incr commented
+          else if String.equal kind Event_kind.Board.(to_string Voted)
+          then incr voted);
+  (* tasks — Audit_log owns the .masc/audit schema; parse each row through its
+     typed decoder so the transition class comes from the [action] variant,
+     not a local string classifier. *)
+  let claimed = ref 0 in
+  let done_ = ref 0 in
+  let released = ref 0 in
+  let cancelled = ref 0 in
+  let task_items = ref [] in
+  fold_day_partitioned
+    ~errs
+    ~label:"audit"
+    ~dir:(Filename.concat masc_dir audit_dirname)
+    ~since_unix
+    ~now_unix
+    ~f:(fun json ->
+      match Audit_log.entry_of_json_r json with
+      | Error _ ->
+        (* Valid JSON that is not an audit entry (e.g. a foreign row); the
+           true parse-failure path is handled inside [read_jsonl_file]. *)
+        ()
+      | Ok ({ timestamp; agent_id; action; details; _ } : Audit_log.audit_entry)
+        ->
+        if timestamp > since_unix && identity_of agent_id
+        then (
+          let task_id =
+            Option.value ~default:"" (Safe_ops.json_string_opt "task_id" details)
+          in
+          let record transition =
+            task_items := { task_id; transition; ts = timestamp } :: !task_items
+          in
+          match action with
+          | Audit_log.ClaimTask ->
+            incr claimed;
+            record "claim"
+          | Audit_log.DoneTask ->
+            incr done_;
+            record "done"
+          | Audit_log.ReleaseTask ->
+            incr released;
+            record "release"
+          | Audit_log.CancelTask ->
+            incr cancelled;
+            record "cancel"
+          | Audit_log.StartTask -> record "start"
+          (* Non-task audit actions are not task transitions. Enumerated (no
+             catch-all) so a new task-relevant action fails compile here. *)
+          | Audit_log.Broadcast
+          | Audit_log.Suspend
+          | Audit_log.ToolCall _
+          | Audit_log.AuthSuccess
+          | Audit_log.AuthFailure
+          | Audit_log.CircuitOpen
+          | Audit_log.CircuitClose
+          | Audit_log.SearchRefinement
+          | Audit_log.GovernanceDecision _
+          | Audit_log.RuntimeConfigWrite
+          | Audit_log.Custom _
+          | Audit_log.Unknown _ -> ()));
+  (* lifecycle — durable transition-audit operator_pause/operator_resume +
+     current paused state from meta. The durable store survives a keeper
+     restart, which the in-memory ring (the recent_transitions API) does not,
+     and restart-straddling is the digest's whole premise. *)
+  let pause_events = ref 0 in
+  let resume_events = ref 0 in
+  let life_items = ref [] in
+  fold_day_partitioned
+    ~errs
+    ~label:"transition-audit"
+    ~dir:(Filename.concat masc_dir transition_audit_dirname)
+    ~since_unix
+    ~now_unix
+    ~f:(fun json ->
+      match
+        Safe_ops.json_string_opt "keeper" json, Safe_ops.json_member_opt "record" json
+      with
+      | Some k, Some record when identity_of k ->
+        (match
+           Safe_ops.json_string_opt "event_type" record
+         , json_num_field "wall_clock_at_decision" record
+         with
+         | Some event_type, Some ts when ts > since_unix ->
+           if String.equal event_type operator_pause_event
+           then (
+             incr pause_events;
+             life_items := { kind = event_type; ts } :: !life_items)
+           else if String.equal event_type operator_resume_event
+           then (
+             incr resume_events;
+             life_items := { kind = event_type; ts } :: !life_items)
+         | _ -> ())
+      | _ -> ());
+  let paused_now =
+    let meta_path = Filename.concat keepers_dir (keeper_name ^ ".json") in
+    match Keeper_meta_store.read_meta_file_path meta_path with
+    | Ok (Some m) -> m.Keeper_meta_contract.paused
+    | Ok None -> false
+    | Error e ->
+      bounded_add errs (Printf.sprintf "keeper-meta: %s: %s" meta_path e);
+      false
+  in
+  { keeper = keeper_name
+  ; since_unix
+  ; generated_at_unix = now_unix
+  ; chat
+  ; turns = { completed = !completed; failed = !failed; crashes = !crashes }
+  ; tasks =
+      { claimed = !claimed
+      ; done_ = !done_
+      ; released = !released
+      ; cancelled = !cancelled
+      ; items = cap_task_items !task_items
+      }
+  ; board = { posted = !posted; commented = !commented; voted = !voted }
+  ; lifecycle =
+      { paused_now
+      ; pause_events = !pause_events
+      ; resume_events = !resume_events
+      ; items = cap_lifecycle_items !life_items
+      }
+  ; read_errors = List.rev !errs
+  }
+;;
+
+(* ── Wire encoding ───────────────────────────────────────────────── *)
+
+let float_opt_to_json = function
+  | Some f -> `Float f
+  | None -> `Null
+;;
+
+let task_item_to_json (i : task_item) =
+  `Assoc
+    [ "task_id", `String i.task_id
+    ; "transition", `String i.transition
+    ; "ts", `Float i.ts
+    ]
+;;
+
+let lifecycle_item_to_json (i : lifecycle_item) =
+  `Assoc [ "kind", `String i.kind; "ts", `Float i.ts ]
+;;
+
+let to_json (t : t) : Yojson.Safe.t =
+  `Assoc
+    [ "keeper", `String t.keeper
+    ; "since_unix", `Float t.since_unix
+    ; "generated_at_unix", `Float t.generated_at_unix
+    ; ( "chat"
+      , `Assoc
+          [ "new_messages", `Int t.chat.new_messages
+          ; "first_new_ts", float_opt_to_json t.chat.first_new_ts
+          ; "transport_failures", `Int t.chat.transport_failures
+          ] )
+    ; ( "turns"
+      , `Assoc
+          [ "completed", `Int t.turns.completed
+          ; "failed", `Int t.turns.failed
+          ; "crashes", `Int t.turns.crashes
+          ] )
+    ; ( "tasks"
+      , `Assoc
+          [ "claimed", `Int t.tasks.claimed
+          ; "done", `Int t.tasks.done_
+          ; "released", `Int t.tasks.released
+          ; "cancelled", `Int t.tasks.cancelled
+          ; "items", `List (List.map task_item_to_json t.tasks.items)
+          ] )
+    ; ( "board"
+      , `Assoc
+          [ "posted", `Int t.board.posted
+          ; "commented", `Int t.board.commented
+          ; "voted", `Int t.board.voted
+          ] )
+    ; ( "lifecycle"
+      , `Assoc
+          [ "paused_now", `Bool t.lifecycle.paused_now
+          ; "pause_events", `Int t.lifecycle.pause_events
+          ; "resume_events", `Int t.lifecycle.resume_events
+          ; "items", `List (List.map lifecycle_item_to_json t.lifecycle.items)
+          ] )
+    ; "read_errors", `List (List.map (fun s -> `String s) t.read_errors)
+    ]
+;;

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -226,7 +226,7 @@ let payload_identity_match ~identity_of payload =
    The store's own parser owns chat read-drop accounting, so chat parse
    failures do not enter [read_errors]. Rows are de-duped by their stable
    [id] across page overlaps. *)
-let read_chat ~base_dir ~keeper_name ~since =
+let read_chat ~base_dir ~keeper_name ~since ~errs =
   let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
   let new_messages = ref 0 in
   let transport = ref 0 in
@@ -251,7 +251,10 @@ let read_chat ~base_dir ~keeper_name ~since =
   in
   let rec loop before iters =
     if iters >= chat_page_cap
-    then ()
+    then
+      bounded_add
+        errs
+        "keeper-chat: page cap reached before since_unix; chat counts are lower bounds"
     else (
       let { Keeper_chat_store.messages; has_more } =
         Keeper_chat_store.load_page ~base_dir ~keeper_name ?before ()
@@ -292,7 +295,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       (Common.keeper_runtime_store_dirname store)
   in
   (* chat *)
-  let chat = read_chat ~base_dir:base_path ~keeper_name ~since:since_unix in
+  let chat = read_chat ~base_dir:base_path ~keeper_name ~since:since_unix ~errs in
   (* turns.completed — keeper-local turn-records *)
   let completed = ref 0 in
   fold_day_partitioned

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -139,6 +139,19 @@ let json_num_field name json =
    silently dropped. The list is bounded by {!read_errors_cap}. *)
 let bounded_add errs msg = if List.length !errs < read_errors_cap then errs := msg :: !errs
 
+let task_id_of_audit_details ~errs details =
+  match Safe_ops.json_string_opt "task_id" details with
+  | None ->
+    bounded_add errs "audit: task transition missing task_id";
+    None
+  | Some raw ->
+    (match Validation.Task_id.validate raw with
+     | Ok task_id -> Some (Validation.Task_id.to_string task_id)
+     | Error reason ->
+       bounded_add errs (Printf.sprintf "audit: invalid task_id: %s" reason);
+       None)
+;;
+
 let read_jsonl_file ~errs ~label ~path ~f =
   match In_channel.with_open_bin path In_channel.input_all with
   | exception Sys_error detail ->
@@ -359,11 +372,11 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
         ->
         if timestamp > since_unix && identity_of agent_id
         then (
-          let task_id =
-            Option.value ~default:"" (Safe_ops.json_string_opt "task_id" details)
-          in
           let record transition =
-            task_items := { task_id; transition; ts = timestamp } :: !task_items
+            match task_id_of_audit_details ~errs details with
+            | Some task_id ->
+              task_items := { task_id; transition; ts = timestamp } :: !task_items
+            | None -> ()
           in
           match action with
           | Audit_log.ClaimTask ->

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -104,5 +104,5 @@ val build :
 
     Look-back is clamped to the JSONL retention window; beyond it the counts
     are a lower bound and the echoed [since_unix] lets the client detect it.
-    Failures append to [read_errors]; a missing store is zero, not a
-    failure. *)
+    Failures and bounded scans that stop before [since_unix] append to
+    [read_errors]; a missing store is zero, not a failure. *)

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -1,0 +1,108 @@
+(** Keeper_catchup_digest — deterministic "since last seen" activity digest.
+
+    Aggregates what happened to one keeper since an operator's per-keeper
+    last-seen cursor, reading only existing durable stores with a
+    [ts > since] filter. No LLM summarisation and no heuristics — the digest
+    is pure since-windowed counts over the chat / turn / task / board /
+    lifecycle stores. Design SSOT: [docs/design/keeper-catchup-digest.md].
+
+    Fail-visible reads: every store-read failure that is not a missing
+    directory (a missing store is zero activity, not an error) surfaces in
+    [read_errors] rather than being silently dropped. [items] arrays are
+    capped at {!digest_items_cap}, newest-first; the count fields are the
+    full counts, independent of the cap. All timestamps in the output are
+    unix seconds — the sources mix ISO and unix stamps and the digest
+    normalises to unix. *)
+
+val digest_items_cap : int
+(** Upper bound on each [items] array ([tasks], [lifecycle]). The sibling
+    count fields stay full counts, independent of this cap. *)
+
+type task_item =
+  { task_id : string
+  ; transition : string
+  ; ts : float
+  }
+
+type lifecycle_item =
+  { kind : string
+  ; ts : float
+  }
+
+type chat =
+  { new_messages : int
+  ; first_new_ts : float option
+  ; transport_failures : int
+  }
+
+type turns =
+  { completed : int
+  ; failed : int
+  ; crashes : int
+  }
+
+type tasks =
+  { claimed : int
+  ; done_ : int
+  ; released : int
+  ; cancelled : int
+  ; items : task_item list
+  }
+
+type board =
+  { posted : int
+  ; commented : int
+  ; voted : int
+  }
+
+type lifecycle =
+  { paused_now : bool
+  ; pause_events : int
+  ; resume_events : int
+  ; items : lifecycle_item list
+  }
+
+type t =
+  { keeper : string
+  ; since_unix : float
+  ; generated_at_unix : float
+  ; chat : chat
+  ; turns : turns
+  ; tasks : tasks
+  ; board : board
+  ; lifecycle : lifecycle
+  ; read_errors : string list
+  }
+
+val to_json : t -> Yojson.Safe.t
+(** Wire encoding matching the design contract v1.  [chat.first_new_ts]
+    renders as [null] when there is no new message. *)
+
+val build :
+  base_path:string ->
+  keeper_name:string ->
+  since_unix:float ->
+  now_unix:float ->
+  t
+(** [build ~base_path ~keeper_name ~since_unix ~now_unix] aggregates the
+    since-windowed digest for [keeper_name] from the stores rooted under
+    [base_path] (default-cluster layout: [<base_path>/.masc/...]).
+
+    Sources (all filtered to activity strictly after [since_unix]):
+    - [chat]: [Keeper_chat_store] paged backward from the tail; utterances
+      count as [new_messages], [Row_kind.Transport_failure] rows as
+      [transport_failures].
+    - [turns.completed]: keeper-local [turn-records] day-files.
+    - [turns.failed]: activity-events [keeper.turn_failed] for the keeper.
+    - [turns.crashes]: [Keeper_crash_persistence] recent crash events.
+    - [tasks]: [Audit_log] task-transition entries whose [agent_id] resolves
+      to the keeper via {!Tool_agent_timeline.identity_matches}.
+    - [board]: activity-events [board.posted]/[board.commented]/[board.voted]
+      whose actor resolves to the keeper.
+    - [lifecycle]: durable transition-audit [operator_pause]/[operator_resume]
+      records, plus [paused_now] from the keeper meta.
+
+    Look-back is clamped to the JSONL retention window; beyond it the counts
+    are a lower bound and the echoed [since_unix] lets the client detect it.
+    Failures append to [read_errors]; a missing store is zero, not a
+    failure. *)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1030,6 +1030,9 @@ let handle_keeper_get_subroutes state req request reqd =
     if name = "" then
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
         (error_json "missing keeper name")
+    else if not (Keeper_config.validate_name name) then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json (Printf.sprintf "invalid keeper name: %s" name))
     else
       match Server_utils.query_param req "since_unix" with
       | None ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1022,7 +1022,34 @@ let handle_keeper_get_subroutes state req request reqd =
     let slen = String.length suffix in
     String.trim (String.sub req_path plen (tlen - plen - slen))
   in
-  if ends_with "/chat/history" then
+  if ends_with "/digest" then (
+    (* Keeper catch-up digest (since-last-seen). Inherits the enclosing
+       prefix_get "/api/v1/keepers/" + with_public_read gating, same as the
+       sibling arms below; no separate router wiring. *)
+    let name = extract_name "/digest" in
+    if name = "" then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json "missing keeper name")
+    else
+      match Server_utils.query_param req "since_unix" with
+      | None ->
+        Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+          (error_json "missing required query param: since_unix")
+      | Some raw ->
+        (match float_of_string_opt (String.trim raw) with
+         | None ->
+           Server_auth.respond_json_value_with_cors ~status:`Bad_request request
+             reqd
+             (error_json "since_unix must be a unix-seconds float")
+         | Some since_unix ->
+           let config = Mcp_server.workspace_config state in
+           let digest =
+             Keeper_catchup_digest.build ~base_path:config.base_path
+               ~keeper_name:name ~since_unix ~now_unix:(Time_compat.now ())
+           in
+           Server_auth.respond_json_value_with_cors ~status:`OK request reqd
+             (Keeper_catchup_digest.to_json digest)))
+  else if ends_with "/chat/history" then
     let name = extract_name "/chat/history" in
     if name = "" then
       Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd

--- a/test/dune
+++ b/test/dune
@@ -160,6 +160,7 @@
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
   test_keeper_tool_duration_buckets
+  test_keeper_catchup_digest
   test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter
@@ -496,6 +497,7 @@
   test_keeper_hooks_oas_log_shape
   test_keeper_idle_metric
   test_keeper_tool_duration_buckets
+  test_keeper_catchup_digest
   test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
   test_keeper_compaction_outcome_counter

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -1,0 +1,351 @@
+(* Unit tests for Masc.Keeper_catchup_digest.build over fixture stores on a
+   temporary base_dir. Covers: since-boundary exclusivity, per-category
+   counts, keeper-identity 3-form matching, fail-visible read_errors on a
+   corrupt line, items cap, missing-store-as-zero, and to_json shape. *)
+
+module D = Masc.Keeper_catchup_digest
+
+let keeper = "garnet"
+
+(* Chosen so the whole [since .. now] window sits mid-UTC-day: no fixture row
+   lands on a midnight boundary that could split a day-file unexpectedly. *)
+let now_unix = 1783000000.
+let day = 86400.
+let since_unix = now_unix -. (2. *. day)
+
+(* ── filesystem helpers ──────────────────────────────────────────── *)
+
+let rec mkdir_p dir =
+  if not (Sys.file_exists dir)
+  then (
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+let append_line path line =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path in
+  output_string oc (line ^ "\n");
+  close_out oc
+;;
+
+let write_file path contents =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+;;
+
+(* Day-partitioned path for a timestamp, mirroring the reader in the module
+   under test (UTC YYYY-MM/DD.jsonl). *)
+let day_file ~dir ts =
+  let tm = Unix.gmtime ts in
+  Filename.concat
+    dir
+    (Printf.sprintf
+       "%04d-%02d/%02d.jsonl"
+       (tm.Unix.tm_year + 1900)
+       (tm.Unix.tm_mon + 1)
+       tm.Unix.tm_mday)
+;;
+
+let str_contains ~needle haystack =
+  let nl = String.length needle
+  and hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
+  nl = 0 || go 0
+;;
+
+(* ── store paths (mirror Common.*_from_base_path) ────────────────── *)
+
+let masc base = Filename.concat base ".masc"
+let keepers base = Filename.concat (masc base) "keepers"
+let keeper_local base store = Filename.concat (Filename.concat (keepers base) keeper) store
+let turn_dir base = keeper_local base "turn-records"
+let crash_dir base = keeper_local base "crash-events"
+let audit_dir base = Filename.concat (masc base) "audit"
+let activity_dir base = Filename.concat (masc base) "activity-events"
+let transition_dir base = Filename.concat (masc base) "transition-audit"
+let chat_file base = Filename.concat (Filename.concat (masc base) "keeper_chat") (keeper ^ ".jsonl")
+let meta_file base = Filename.concat (keepers base) (keeper ^ ".json")
+
+(* ── fixture row builders ────────────────────────────────────────── *)
+
+let json_line j = Yojson.Safe.to_string j
+
+let chat_row ?id ?kind ~role ~ts () =
+  let base = [ "role", `String role; "content", `String "x"; "ts", `Float ts ] in
+  let base = match id with Some i -> ("id", `String i) :: base | None -> base in
+  let base = match kind with Some k -> ("kind", `String k) :: base | None -> base in
+  json_line (`Assoc base)
+;;
+
+let audit_row ~ts ~agent_id ~action ~transition ~task_id =
+  json_line
+    (`Assoc
+        [ "timestamp", `Float ts
+        ; "agent_id", `String agent_id
+        ; "action", `String action
+        ; "workspace_id", `String "default"
+        ; ( "details"
+          , `Assoc
+              [ "event_family", `String "task_transition"
+              ; "transition", `String transition
+              ; "task_id", `String task_id
+              ; "agent_id", `String agent_id
+              ; "from_status", `String "todo"
+              ; "to_status", `String "claimed"
+              ; "forced", `Bool false
+              ] )
+        ; "outcome", `Assoc [ "status", `String "success" ]
+        ])
+;;
+
+let activity_row ~seq ~ts ~kind ~actor_id =
+  json_line
+    (`Assoc
+        [ "seq", `Int seq
+        ; "ts_ms", `Int (int_of_float (ts *. 1000.))
+        ; "ts_iso", `String "2026-07-02T00:00:00Z"
+        ; "workspace_id", `String "default"
+        ; "kind", `String kind
+        ; "actor", `Assoc [ "kind", `String "agent"; "id", `String actor_id ]
+        ; "subject", `Null
+        ; "payload", `Assoc []
+        ; "tags", `List []
+        ])
+;;
+
+let transition_row ~keeper_name ~event_type ~ts =
+  json_line
+    (`Assoc
+        [ "keeper", `String keeper_name
+        ; ( "record"
+          , `Assoc
+              [ "event_type", `String event_type
+              ; "wall_clock_at_decision", `Float ts
+              ] )
+        ])
+;;
+
+let crash_row ~ts = json_line (`Assoc [ "ts", `Float ts; "reason", `String "boom"; "restart_count", `Int 1 ])
+
+(* ── rich fixture used by the primary assertions ─────────────────── *)
+
+let write_rich_fixture base =
+  (* chat: one legacy row before since (excluded), two utterances after,
+     one transport-failure after. *)
+  let cf = chat_file base in
+  append_line cf (chat_row ~role:"user" ~ts:(since_unix -. 10.) ());
+  append_line cf (chat_row ~id:"m1" ~role:"user" ~ts:(since_unix +. 10.) ());
+  append_line cf (chat_row ~id:"m2" ~role:"assistant" ~ts:(since_unix +. 11.) ());
+  append_line
+    cf
+    (chat_row ~id:"m3" ~role:"assistant" ~kind:"transport_failure" ~ts:(since_unix +. 12.) ());
+  (* turn-records across two day-files straddling since; day-file B carries a
+     deliberately corrupt line that must surface in read_errors. *)
+  let td = turn_dir base in
+  append_line (day_file ~dir:td (since_unix -. 100.)) (json_line (`Assoc [ "ts", `Float (since_unix -. 100.) ]));
+  append_line (day_file ~dir:td since_unix) (json_line (`Assoc [ "ts", `Float since_unix ]));
+  append_line (day_file ~dir:td (since_unix +. 100.)) (json_line (`Assoc [ "ts", `Float (since_unix +. 100.) ]));
+  append_line (day_file ~dir:td (since_unix +. day)) (json_line (`Assoc [ "ts", `Float (since_unix +. day) ]));
+  append_line (day_file ~dir:td (since_unix +. day)) "{ this is not valid json";
+  (* crash-events *)
+  let cd = crash_dir base in
+  append_line (day_file ~dir:cd (since_unix +. 500.)) (crash_row ~ts:(since_unix +. 500.));
+  append_line (day_file ~dir:cd (since_unix -. 500.)) (crash_row ~ts:(since_unix -. 500.));
+  (* audit task transitions — keeper identity in all three persisted forms,
+     plus a foreign agent and a pre-since row that must be excluded. *)
+  let ad = audit_dir base in
+  let af ts = day_file ~dir:ad ts in
+  append_line (af (since_unix +. 200.)) (audit_row ~ts:(since_unix +. 200.) ~agent_id:keeper ~action:"claim_task" ~transition:"claim" ~task_id:"task-1");
+  append_line (af (since_unix +. 300.)) (audit_row ~ts:(since_unix +. 300.) ~agent_id:("keeper-" ^ keeper ^ "-agent") ~action:"done_task" ~transition:"done" ~task_id:"task-2");
+  append_line (af (since_unix +. 400.)) (audit_row ~ts:(since_unix +. 400.) ~agent_id:("keeper:" ^ keeper) ~action:"release_task" ~transition:"release" ~task_id:"task-3");
+  append_line (af (since_unix +. 500.)) (audit_row ~ts:(since_unix +. 500.) ~agent_id:"other" ~action:"claim_task" ~transition:"claim" ~task_id:"task-4");
+  append_line (af (since_unix -. 200.)) (audit_row ~ts:(since_unix -. 200.) ~agent_id:keeper ~action:"claim_task" ~transition:"claim" ~task_id:"task-5");
+  (* activity-events board.* + keeper.turn_failed for the keeper; a foreign
+     board row and a pre-since board row that must be excluded. *)
+  let acd = activity_dir base in
+  let acf ts = day_file ~dir:acd ts in
+  append_line (acf (since_unix +. 600.)) (activity_row ~seq:1 ~ts:(since_unix +. 600.) ~kind:"board.posted" ~actor_id:("keeper-" ^ keeper ^ "-agent"));
+  append_line (acf (since_unix +. 700.)) (activity_row ~seq:2 ~ts:(since_unix +. 700.) ~kind:"board.commented" ~actor_id:keeper);
+  append_line (acf (since_unix +. 800.)) (activity_row ~seq:3 ~ts:(since_unix +. 800.) ~kind:"board.voted" ~actor_id:keeper);
+  append_line (acf (since_unix +. 900.)) (activity_row ~seq:4 ~ts:(since_unix +. 900.) ~kind:"keeper.turn_failed" ~actor_id:keeper);
+  append_line (acf (since_unix +. 950.)) (activity_row ~seq:5 ~ts:(since_unix +. 950.) ~kind:"board.posted" ~actor_id:"other");
+  append_line (acf (since_unix -. 100.)) (activity_row ~seq:6 ~ts:(since_unix -. 100.) ~kind:"board.posted" ~actor_id:keeper);
+  (* transition-audit operator pause/resume for the keeper; pre-since and
+     foreign-keeper rows excluded. *)
+  let ttd = transition_dir base in
+  let ttf ts = day_file ~dir:ttd ts in
+  append_line (ttf (since_unix +. 1000.)) (transition_row ~keeper_name:keeper ~event_type:"operator_pause" ~ts:(since_unix +. 1000.));
+  append_line (ttf (since_unix +. 1100.)) (transition_row ~keeper_name:keeper ~event_type:"operator_resume" ~ts:(since_unix +. 1100.));
+  append_line (ttf (since_unix -. 100.)) (transition_row ~keeper_name:keeper ~event_type:"operator_pause" ~ts:(since_unix -. 100.));
+  append_line (ttf (since_unix +. 1200.)) (transition_row ~keeper_name:"other" ~event_type:"operator_pause" ~ts:(since_unix +. 1200.));
+  (* meta with paused = true *)
+  write_file
+    (meta_file base)
+    (json_line
+       (`Assoc
+           [ "name", `String keeper
+           ; "agent_name", `String keeper
+           ; "trace_id", `String "digest-test"
+           ; "tool_access", `List []
+           ; "paused", `Bool true
+           ]))
+;;
+
+let with_workspace f =
+  let base = Masc_test_deps.setup_test_workspace () in
+  Fun.protect ~finally:(fun () -> Masc_test_deps.cleanup_test_workspace base) (fun () -> f base)
+;;
+
+(* ── tests ───────────────────────────────────────────────────────── *)
+
+let test_counts_and_boundary () =
+  with_workspace (fun base ->
+    write_rich_fixture base;
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    let { D.chat = { new_messages; first_new_ts; transport_failures }
+        ; turns = { completed; failed; crashes }
+        ; tasks = { claimed; done_; released; cancelled; items = task_items }
+        ; board = { posted; commented; voted }
+        ; lifecycle = { paused_now; pause_events; resume_events; items = life_items }
+        ; read_errors
+        ; keeper = keeper_out
+        ; since_unix = since_out
+        ; generated_at_unix
+        }
+      =
+      digest
+    in
+    Alcotest.(check string) "keeper echoed" keeper keeper_out;
+    Alcotest.(check (float 0.0001)) "since echoed" since_unix since_out;
+    Alcotest.(check (float 0.0001)) "now echoed" now_unix generated_at_unix;
+    (* chat *)
+    Alcotest.(check int) "new_messages (2 utterances after since)" 2 new_messages;
+    Alcotest.(check int) "transport_failures" 1 transport_failures;
+    Alcotest.(check (option (float 0.0001)))
+      "first_new_ts is the earliest new utterance"
+      (Some (since_unix +. 10.))
+      first_new_ts;
+    (* turns: completed excludes ts == since and ts < since *)
+    Alcotest.(check int) "turns.completed" 2 completed;
+    Alcotest.(check int) "turns.failed" 1 failed;
+    Alcotest.(check int) "turns.crashes" 1 crashes;
+    (* tasks: identity 3-form all matched (claim/done/release each = 1) *)
+    Alcotest.(check int) "tasks.claimed (short-form id)" 1 claimed;
+    Alcotest.(check int) "tasks.done (full agent-id form)" 1 done_;
+    Alcotest.(check int) "tasks.released (keeper: prefix form)" 1 released;
+    Alcotest.(check int) "tasks.cancelled" 0 cancelled;
+    Alcotest.(check int) "task items (foreign + pre-since excluded)" 3 (List.length task_items);
+    (* board *)
+    Alcotest.(check int) "board.posted" 1 posted;
+    Alcotest.(check int) "board.commented" 1 commented;
+    Alcotest.(check int) "board.voted" 1 voted;
+    (* lifecycle *)
+    Alcotest.(check bool) "paused_now" true paused_now;
+    Alcotest.(check int) "pause_events" 1 pause_events;
+    Alcotest.(check int) "resume_events" 1 resume_events;
+    Alcotest.(check int) "lifecycle items" 2 (List.length life_items);
+    (* fail-visible read error from the corrupt turn-records line *)
+    Alcotest.(check bool) "read_errors non-empty" true (read_errors <> []);
+    Alcotest.(check bool)
+      "corrupt turn-records line surfaced"
+      true
+      (List.exists
+         (fun s -> str_contains ~needle:"turn-records" s && str_contains ~needle:"unparseable" s)
+         read_errors))
+;;
+
+let test_missing_stores_are_zero () =
+  with_workspace (fun base ->
+    (* No fixtures written at all: every category is zero and, crucially, no
+       read_errors (a missing directory is not a failure). *)
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    let { D.chat = { new_messages; transport_failures; _ }
+        ; turns = { completed; failed; crashes }
+        ; tasks = { claimed; done_; released; cancelled; items }
+        ; board = { posted; commented; voted }
+        ; lifecycle = { paused_now; pause_events; resume_events; items = life_items }
+        ; read_errors
+        ; _
+        }
+      =
+      digest
+    in
+    Alcotest.(check int) "chat zero" 0 (new_messages + transport_failures);
+    Alcotest.(check int) "turns zero" 0 (completed + failed + crashes);
+    Alcotest.(check int) "tasks zero" 0 (claimed + done_ + released + cancelled);
+    Alcotest.(check int) "task items empty" 0 (List.length items);
+    Alcotest.(check int) "board zero" 0 (posted + commented + voted);
+    Alcotest.(check bool) "not paused when no meta" false paused_now;
+    Alcotest.(check int) "lifecycle zero" 0 (pause_events + resume_events);
+    Alcotest.(check int) "lifecycle items empty" 0 (List.length life_items);
+    Alcotest.(check bool) "no read_errors for missing stores" true (read_errors = []))
+;;
+
+let test_items_cap () =
+  with_workspace (fun base ->
+    let ad = audit_dir base in
+    let total = D.digest_items_cap + 5 in
+    for i = 1 to total do
+      let ts = since_unix +. float_of_int i in
+      append_line
+        (day_file ~dir:ad ts)
+        (audit_row ~ts ~agent_id:keeper ~action:"claim_task" ~transition:"claim"
+           ~task_id:(Printf.sprintf "task-%d" i))
+    done;
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    let { D.tasks = { claimed; items; _ }; _ } = digest in
+    Alcotest.(check int) "count is full, independent of cap" total claimed;
+    Alcotest.(check int) "items capped at digest_items_cap" D.digest_items_cap (List.length items);
+    (* newest-first: the first item is the most recent transition *)
+    match items with
+    | first :: _ ->
+      Alcotest.(check (float 0.0001))
+        "items newest-first"
+        (since_unix +. float_of_int total)
+        first.D.ts
+    | [] -> Alcotest.fail "expected capped items")
+;;
+
+let test_to_json_shape () =
+  with_workspace (fun base ->
+    write_rich_fixture base;
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    (* round-trip through a string to prove it serialises, then assert the
+       required top-level keys are present. *)
+    let round_tripped = Yojson.Safe.from_string (Yojson.Safe.to_string (D.to_json digest)) in
+    match round_tripped with
+    | `Assoc fields ->
+      List.iter
+        (fun key ->
+          Alcotest.(check bool)
+            (Printf.sprintf "top-level key %s present" key)
+            true
+            (List.mem_assoc key fields))
+        [ "keeper"
+        ; "since_unix"
+        ; "generated_at_unix"
+        ; "chat"
+        ; "turns"
+        ; "tasks"
+        ; "board"
+        ; "lifecycle"
+        ; "read_errors"
+        ]
+    | _ -> Alcotest.fail "to_json must be a JSON object")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_catchup_digest"
+    [ ( "build"
+      , [ Alcotest.test_case "counts + since boundary + identity + read_errors" `Quick test_counts_and_boundary
+        ; Alcotest.test_case "missing stores are zero, not errors" `Quick test_missing_stores_are_zero
+        ; Alcotest.test_case "items cap with full counts" `Quick test_items_cap
+        ; Alcotest.test_case "to_json shape round-trips" `Quick test_to_json_shape
+        ] )
+    ]
+;;

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -102,6 +102,26 @@ let audit_row ~ts ~agent_id ~action ~transition ~task_id =
         ])
 ;;
 
+let audit_row_without_task_id ~ts ~agent_id ~action ~transition =
+  json_line
+    (`Assoc
+       [ "timestamp", `Float ts
+       ; "agent_id", `String agent_id
+       ; "action", `String action
+       ; "workspace_id", `String "default"
+       ; ( "details"
+         , `Assoc
+             [ "event_family", `String "task_transition"
+             ; "transition", `String transition
+             ; "agent_id", `String agent_id
+             ; "from_status", `String "todo"
+             ; "to_status", `String "claimed"
+             ; "forced", `Bool false
+             ] )
+       ; "outcome", `Assoc [ "status", `String "success" ]
+       ])
+;;
+
 let activity_row ~seq ~ts ~kind ~actor_id =
   json_line
     (`Assoc
@@ -310,6 +330,41 @@ let test_items_cap () =
     | [] -> Alcotest.fail "expected capped items")
 ;;
 
+let test_task_items_are_sound_partial () =
+  with_workspace (fun base ->
+    let ad = audit_dir base in
+    let ts_missing = since_unix +. 200. in
+    let ts_invalid = since_unix +. 300. in
+    append_line
+      (day_file ~dir:ad ts_missing)
+      (audit_row_without_task_id
+         ~ts:ts_missing
+         ~agent_id:keeper
+         ~action:"claim_task"
+         ~transition:"claim");
+    append_line
+      (day_file ~dir:ad ts_invalid)
+      (audit_row
+         ~ts:ts_invalid
+         ~agent_id:keeper
+         ~action:"done_task"
+         ~transition:"done"
+         ~task_id:"../bad");
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    let { D.tasks = { claimed; done_; items; _ }; read_errors; _ } = digest in
+    Alcotest.(check int) "missing-id task action still counted" 1 claimed;
+    Alcotest.(check int) "invalid-id task action still counted" 1 done_;
+    Alcotest.(check int) "invalid task ids do not create items" 0 (List.length items);
+    Alcotest.(check bool)
+      "missing task_id is fail-visible"
+      true
+      (List.exists (str_contains ~needle:"missing task_id") read_errors);
+    Alcotest.(check bool)
+      "invalid task_id is fail-visible"
+      true
+      (List.exists (str_contains ~needle:"invalid task_id") read_errors))
+;;
+
 let test_to_json_shape () =
   with_workspace (fun base ->
     write_rich_fixture base;
@@ -345,6 +400,7 @@ let () =
       , [ Alcotest.test_case "counts + since boundary + identity + read_errors" `Quick test_counts_and_boundary
         ; Alcotest.test_case "missing stores are zero, not errors" `Quick test_missing_stores_are_zero
         ; Alcotest.test_case "items cap with full counts" `Quick test_items_cap
+        ; Alcotest.test_case "task items are sound-partial" `Quick test_task_items_are_sound_partial
         ; Alcotest.test_case "to_json shape round-trips" `Quick test_to_json_shape
         ] )
     ]

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -330,6 +330,29 @@ let test_items_cap () =
     | [] -> Alcotest.fail "expected capped items")
 ;;
 
+let test_chat_page_cap_is_fail_visible () =
+  with_workspace (fun base ->
+    let total = 20_001 in
+    let cf = chat_file base in
+    for i = 1 to total do
+      append_line
+        cf
+        (chat_row
+           ~id:(Printf.sprintf "chat-%05d" i)
+           ~role:"user"
+           ~ts:(since_unix +. float_of_int i)
+           ())
+    done;
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
+    let { D.chat = { new_messages; _ }; read_errors; _ } = digest in
+    Alcotest.(check bool) "chat count is a lower bound" true
+      (new_messages > 0 && new_messages < total);
+    Alcotest.(check bool)
+      "chat page cap is fail-visible"
+      true
+      (List.exists (str_contains ~needle:"keeper-chat: page cap reached") read_errors))
+;;
+
 let test_task_items_are_sound_partial () =
   with_workspace (fun base ->
     let ad = audit_dir base in
@@ -400,6 +423,7 @@ let () =
       , [ Alcotest.test_case "counts + since boundary + identity + read_errors" `Quick test_counts_and_boundary
         ; Alcotest.test_case "missing stores are zero, not errors" `Quick test_missing_stores_are_zero
         ; Alcotest.test_case "items cap with full counts" `Quick test_items_cap
+        ; Alcotest.test_case "chat page cap is fail-visible" `Quick test_chat_page_cap_is_fail_visible
         ; Alcotest.test_case "task items are sound-partial" `Quick test_task_items_are_sound_partial
         ; Alcotest.test_case "to_json shape round-trips" `Quick test_to_json_shape
         ] )


### PR DESCRIPTION
## 문제

운영자가 자리를 비운 뒤 keeper 채팅에 돌아오면 "그 사이 무슨 일이 있었는지"를 볼 1급 수단이 없습니다. 현재는 전체 이력(200) 스크롤, 턴 상세, progress.md, timeline 도구를 수동으로 이어 붙여야 합니다. 발단: 2026-07-02 garnet 재시작-유실 리뷰 (backlog task-1641 → 재개설 task-1643).

## 설계

`docs/design/keeper-catchup-digest.md` (이 PR에 포함) — wire contract SSOT + 소스 매핑 + v1 제외사항.

- **결정론 집계만**: LLM 요약 없음, 휴리스틱 없음. 기존 durable 저장소를 since-커서로 스캔.
- **`GET /api/v1/keepers/:name/digest?since_unix=<float>`** → chat / turns / tasks / board / lifecycle 5카테고리 카운트 + capped items + `read_errors`(fail-visible).
- **v1 제외**: tool-call 카테고리 (typed per-keeper 로그 부재; heartbeat 문자열 파싱은 워크어라운드 시그니처 2라 기각 — 근본 해결은 `tool_call_log_path` 배선 후 v2), LLM 요약, global feed 기반 turn 카운트 (dashboard-chat 주도 턴의 feed emission 갭 실측).

## 서버 (`lib/keeper_catchup_digest.ml` + route arm)

- turn 카운트는 keeper-local `turn-records` day-파일 (global feed 아님 — 갭 실측 근거).
- lifecycle(Operator_pause/Resume)은 durable `.masc/transition-audit` dated JSONL 직접 파싱 — 노출된 read API는 in-memory ring(50)뿐이라 재시작 straddle 질의 불가.
- fail-visible: `Dated_jsonl.read_range`가 malformed 행을 조용히 건너뛰므로 day-파일을 직접 열어 파싱 실패를 `read_errors`로 노출. 파일 부재 = 0 (무활동), 실패 아님.
- task transition은 `Audit_log.entry_of_json_r` typed action 변형으로 분류 (문자열 매칭 없음, catch-all 없음).
- keeper identity는 `Tool_agent_timeline.identity_matches` 3-형태 규칙 재사용 (mli export 추가).
- H2 게이트웨이는 `/api/v1/keepers/` 프리픽스를 미러링하지 않아 형제 라우트와 동일하게 H1 전용 (불일치 방지 위해 신규 등록 안 함).

## 대시보드

- last-seen 커서: `masc_keeper_chat_last_seen_v1` localStorage, 값 = 관측한 최신 entry ts (벽시계 아님 — clock skew 무관). `keeper-chat-pending.ts` wrapper 패턴 복제.
- 커서 갱신: 패널 mount/keeper 전환 + bottom-pinned 수신 + `visibilitychange`.
- digest 카드: transcript 스크롤러 밖 (autoscroll 불간섭), 0 카테고리 생략, paused/transport_failures/read_errors 표시.
- unread divider: `kw-daydiv` 패턴 복제, opt-in prop으로 비-keeper 채팅 표면 무영향, null-ts entry 방어, 200-cap trim 시 카드가 실제 카운트 담당.
- fetch 스택: operator digest 패턴 복제 (typed valibot 스키마 — shape drift 시 null→throw, 잘못된 카운트 렌더 차단; inflight dedup).

## 검증

- dashboard: `vitest run` 전체 612 files / 8222 tests PASS (신규 18 포함), `npm run typecheck` PASS.
- OCaml: `ocamlformat --check` PASS (4파일). dune build/test는 CI 위임 (repo 정책). 신규 `test/test_keeper_catchup_digest.ml` — since 경계, identity 3-형태, read_errors fail-visible(고의 corrupt 행), items cap, JSON round-trip.

task: masc task-1643 (task-1641 faithless-done 재개설)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
