### PR TITLE
fix(fusion): classify provider-level timeouts as typed Timeout in panel and judge outcomes

### DIFF
--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -126,9 +126,13 @@ let sdk_error_detail (e : Agent_sdk.Error.sdk_error) : string =
   | Agent_sdk.Error.Orchestration _ | Agent_sdk.Error.Internal _ ->
     Agent_sdk.Error.to_string e
 
-(* [Agent_sdk.Error.sdk_error]를 typed {!judge_failure}로 변환한다. [Api (Retry.Timeout _)]
-   를 잡아 [Timeout]으로 propagate하고, 그 외는 [Provider_error]에 사람-가독 detail을
-   보존한다. Non-timeout detail은 표시용이며 재분류에 쓰지 않는다; provider 오류는
+(* [Agent_sdk.Error.sdk_error]를 typed {!judge_failure}로 변환한다. 두 타임아웃 variant를
+   모두 [Timeout]으로 propagate한다: 외곽 실행 래퍼 [Api (Retry.Timeout _)]와
+   provider-level [Provider (Llm_provider.Error.Timeout _)](비스트리밍 sync 경로의
+   connect_timeout이 본문 전체를 바운드해 발생, detail "timeout phase=http_operation").
+   후자는 [Fusion_panel.outcome_of_result]와 대칭으로, 이전에는 [_] catch-all에서
+   [Provider_error]로 오귀속됐다. 그 외는 [Provider_error]에 사람-가독 detail을 보존한다.
+   Non-timeout detail은 표시용이며 재분류에 쓰지 않는다; provider 오류는
    [Llm_provider.Error.to_string] 경로로 렌더해 provider/status/retry/phase metadata를
    유지한다. 이 match가 "to_string 직렬화 → substring 역분류" round-trip 안티패턴의 근본
    해소다: timeout 분류가 컴파일 타입에 묶인다. [prefix]는 호출 context(run 실패 vs
@@ -136,7 +140,8 @@ let sdk_error_detail (e : Agent_sdk.Error.sdk_error) : string =
 let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
     Fusion_types.judge_failure =
   match e with
-  | Agent_sdk.Error.Api (Agent_sdk.Error.Retry.Timeout _) -> Timeout
+  | Agent_sdk.Error.Api (Agent_sdk.Error.Retry.Timeout _)
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> Timeout
   | _ ->
     Provider_error
       (prefix ^ Fusion_oas.provider_error_detail ~runtime_id (sdk_error_detail e))
@@ -251,4 +256,5 @@ let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~
 
 module For_testing = struct
   let apply_output_contract = apply_fusion_judge_output_contract
+  let failure_of_sdk_error = failure_of_sdk_error
 end

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -120,4 +120,10 @@ module For_testing : sig
   val apply_output_contract
     :  Llm_provider.Provider_config.t
     -> (Llm_provider.Provider_config.t, string) result
+
+  val failure_of_sdk_error
+    :  runtime_id:string
+    -> prefix:string
+    -> Agent_sdk.Error.sdk_error
+    -> Fusion_types.judge_failure
 end

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -42,6 +42,15 @@ let outcome_of_result ~(panelist : string) ~(model : string)
        타임아웃을 board 증거에서 구분할 수 없었다. [bridge_failure_of_error]·
        [Fusion_judge.failure_of_sdk_error]와 대칭. *)
     Fusion_types.Failed { failed_model = panelist; reason = Fusion_types.Timeout }
+  | Error (Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)) ->
+    (* provider-level 타임아웃. 비스트리밍 sync 경로의 connect_timeout(기본 60s)이
+       응답 본문 전체를 바운드해 발생하며 detail은 "timeout phase=http_operation"으로
+       렌더된다. [Api (Retry.Timeout _)] 외곽 래퍼와 다른 variant라 위 arm이 잡지
+       못하고, 이전에는 [Error e] catch-all에서 [Provider_error]로 오귀속됐다 — 개별
+       provider 타임아웃이 provider 실패(연결 거부/5xx 등)와 board 증거에서 구분되지
+       않았다. 타임아웃은 타임아웃으로 분류한다 (CLAUDE.md §Unknown→Permissive/
+       catch-all 회피). *)
+    Fusion_types.Failed { failed_model = panelist; reason = Fusion_types.Timeout }
   | Error e ->
     Fusion_types.Failed
       { failed_model = panelist
@@ -53,7 +62,8 @@ let outcome_of_result ~(panelist : string) ~(model : string)
 
 let bridge_failure_of_error (error : Agent_sdk.Error.sdk_error) : Fusion_types.panel_failure =
   match error with
-  | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> Fusion_types.Timeout
+  | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _)
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> Fusion_types.Timeout
   | _ -> Fusion_types.Bridge_error (Agent_sdk.Error.to_string error)
 
 let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -171,6 +171,64 @@ let test_panel_outcome_types_per_agent_timeout () =
   | other ->
     fail ("expected typed Timeout, got: " ^ Fusion_types.show_panel_outcome other)
 
+(* provider-level 타임아웃도 typed [Timeout]으로 분류된다. connect_timeout(비스트리밍 sync
+   경로가 본문 전체를 바운드, detail "timeout phase=http_operation")은
+   [Provider (Llm_provider.Error.Timeout _)] variant로 나오는데, [Api (Retry.Timeout _)]
+   외곽 래퍼와 다른 arm이라 이전엔 [Provider_error] catch-all로 오귀속됐다. reason_code가
+   board/대시보드에 "timeout"으로 나가는지 함께 핀한다. *)
+let test_panel_outcome_types_provider_timeout () =
+  let timeout_error =
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "ollama"
+         ; timeout_phase = None
+         ; detail = "timeout phase=http_operation"
+         })
+  in
+  match
+    Fusion_panel.For_testing.outcome_of_result ~panelist:"panel-a"
+      ~model:"provider.model" (Error timeout_error)
+  with
+  | Fusion_types.Failed
+      { failed_model = "panel-a"; reason = Fusion_types.Timeout as reason } ->
+    check string "reason_code surfaces as timeout" "timeout"
+      (Fusion_oas.panel_failure_code reason)
+  | other ->
+    fail ("expected typed Timeout, got: " ^ Fusion_types.show_panel_outcome other)
+
+(* 심판 분류기도 두 타임아웃 variant([Api (Retry.Timeout _)] 외곽 래퍼 +
+   [Provider (Llm_provider.Error.Timeout _)] provider-level)를 [Timeout]으로 매핑하고,
+   비-타임아웃 provider 오류는 [Provider_error]로 보존한다 —
+   [Fusion_panel.outcome_of_result]와 대칭. 과분류(모든 provider 오류를 Timeout으로)를
+   막기 위해 5xx가 provider_error로 남는지도 핀한다. *)
+let test_judge_failure_classifies_timeouts () =
+  let classify e =
+    Fusion_judge.For_testing.failure_of_sdk_error ~runtime_id:"provider.model"
+      ~prefix:"judge run failed: " e
+  in
+  let api_timeout =
+    Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout { message = "120s"; phase = None })
+  in
+  let provider_timeout =
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.Timeout
+         { provider = "ollama"
+         ; timeout_phase = None
+         ; detail = "timeout phase=http_operation"
+         })
+  in
+  let provider_5xx =
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.ServerError
+         { provider = "ollama"; code = 503; transient = true; detail = "unavailable" })
+  in
+  check string "outer Api timeout -> timeout tag" "timeout"
+    (Fusion_types.judge_failure_tag (classify api_timeout));
+  check string "provider-level timeout -> timeout tag" "timeout"
+    (Fusion_types.judge_failure_tag (classify provider_timeout));
+  check string "non-timeout provider error stays provider_error" "provider_error"
+    (Fusion_types.judge_failure_tag (classify provider_5xx))
+
 let test_attach_usage_on_success () =
   match Fusion_judge.attach_usage (Ok sample_synthesis) sample_usage with
   | Ok (_synthesis, usage) ->
@@ -276,6 +334,12 @@ let () =
             test_panel_outcome_rejects_empty_answer
         ; test_case "types per-agent timeout" `Quick
             test_panel_outcome_types_per_agent_timeout
+        ; test_case "types provider-level timeout" `Quick
+            test_panel_outcome_types_provider_timeout
+        ] )
+    ; ( "judge_failure_classification"
+      , [ test_case "maps both timeout variants, keeps provider errors" `Quick
+            test_judge_failure_classifies_timeouts
         ] )
     ; ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success


### PR DESCRIPTION
## 문제 (task-1640 fusion 감사, 적대검증 CONFIRMED — 07-02 실측 8/8 오귀속)

provider-level timeout(`Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)`)이 typed 분류 arm 부재로 catch-all에서 `Provider_error`로 오귀속됐다. 비스트리밍 sync 경로에서는 connect_timeout kind 기본값(60s)이 **본문 생성 전체**를 바운드하므로("timeout phase=http_operation") 이 클래스가 fusion 실패의 최빈값인데(07-02: 15패널 중 timeout 8), board 증거에서 connection refused/5xx와 구분이 불가능했다.

외곽 실행 래퍼용 `Api (Retry.Timeout _)` arm은 #23003이 이미 추가 — 이번 건은 그와 **별개 variant**다.

## 수정

대칭 분류기 3곳에 provider-timeout arm 추가 (소스에서 typed 분류 — substring 역분류 아님):
- `Fusion_panel.outcome_of_result` (per-agent)
- `Fusion_panel.bridge_failure_of_error` (fan-out 전체)
- `Fusion_judge.failure_of_sdk_error` (judge run/refine)

## 행동 변화 (의도됨, 커밋 본문 상세)

provider timeout이 `Timeout`으로 분류되면서 `judge_failure_is_timeout_or_budget`이 참이 되어 **JoJ adaptive/fallback 경로(fusion_orchestrator_judge_wave.ml:97-101,188-201)가 per-request provider timeout에서 처음 발동**한다. 라이브 trio(Simple topology)는 fallback wave가 없어 무영향. 비-timeout provider 오류(5xx)는 여전히 `Provider_error` — 테스트로 핀.

## 검증

- 신규 단위 테스트: Provider Timeout → typed `Timeout`(panel, reason_code="timeout") / judge 분류기에서 양 timeout variant → `Timeout`, 5xx ServerError → `Provider_error` 유지
- 로컬 `dune-local.sh build @test/runtest-test_fusion_judge_usage` **green** (base가 #22950 pin 정합)

관련: T0(라이브 config connect-timeout-s=180 적용됨), 후속 PR-T2(패널별 격리), PR-S1(대시보드 실패 사유 렌더 — 이 PR 없이는 timeout이 provider_error로 표시됨)

MASC task: task-1640

Co-Authored-By: MASC Agent (impl-t1-timeout subagent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
