### PR TITLE
fix(keeper): autonomous idle loop yields turn slot to parked chat requests

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -244,6 +244,8 @@ let outcome_of_stop (sr : Runtime_agent.stop_reason) : Trajectory.trajectory_out
     let t = match tool_name with Some s -> s | None -> "none" in
     Trajectory.Gated
       (Printf.sprintf "mutation_boundary:turns=%d,tool=%s" turns_used t)
+  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+    Trajectory.Gated (Printf.sprintf "yielded_to_chat_waiting:turns=%d" turns_used)
 ;;
 
 let build_eval_run (scenario : EH.scenario) ~run_index

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -218,6 +218,7 @@ let run_turn
       ?shared_context
       ?event_bus
       ?trace_link
+      ?yield_to_chat_waiting
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
   =
@@ -585,6 +586,32 @@ let run_turn
                   ?max_tokens:requested_max_tokens
                   ()
               in
+              (* Autonomous chat-yield: when the caller supplies
+                 [yield_to_chat_waiting], evaluate it at each OAS agent-loop turn
+                 boundary (the [check_loop_guard] point, beside [max_idle_turns],
+                 before the next model dispatch — never mid tool execution). A
+                 [true] result stops the loop; [runtime_agent] converts that stop
+                 into a graceful [Ok] result *only* when [exit_condition_result]
+                 is also present, so both are wired together — otherwise the SDK
+                 [ExitConditionMet] surfaces as an error and the yield would be
+                 recorded as a turn failure/blocker. The rendered stop reason is
+                 [Yielded_to_chat_waiting], whose disposition is a
+                 [Continuation_checkpoint] (like [MutationBoundaryReached]):
+                 "stopped early, checkpoint saved, resume next cycle". *)
+              let chat_yield_exit_condition, chat_yield_exit_condition_result =
+                match yield_to_chat_waiting with
+                | None -> None, None
+                | Some pred ->
+                  ( Some (fun (_turn : int) -> pred ())
+                  , Some
+                      (fun (turn : int) ->
+                        ( Runtime_agent.Yielded_to_chat_waiting { turns_used = turn }
+                        , Some
+                            (Printf.sprintf
+                               "[yielded turn slot at turn %d to a waiting chat \
+                                request; keeper resumes on the next cycle]"
+                               turn) )) )
+              in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* The keeper turn deadline must own the OAS Agent.run switch.
                    Stream/body idle budgets catch liveness gaps; this hard
@@ -646,8 +673,13 @@ let run_turn
                          ?clock:(Eio_context.get_clock_opt ())
                          ())
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-                      (* exit_condition removed with mutation_boundary — OAS runs to
-             natural completion (model end_turn). *)
+                      (* Mutation-boundary is native to OAS now; [exit_condition]
+                         is re-wired here solely for the autonomous chat-yield
+                         (see [chat_yield_exit_condition] above). Both are [None]
+                         on the chat lane, so a chat turn runs to natural
+                         completion (model end_turn) unchanged. *)
+                    ?exit_condition:chat_yield_exit_condition
+                    ?exit_condition_result:chat_yield_exit_condition_result
                     ?oas_checkpoint:resume_oas_checkpoint
                     ?event_bus
                     ?trace_link

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -155,5 +155,14 @@ val run_turn
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?trace_link:string * string
+  -> ?yield_to_chat_waiting:(unit -> bool)
+       (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
+          (the same guard point as [max_idle_turns], before the next model
+          dispatch — never mid tool execution). When it returns [true] the run
+          stops gracefully at that boundary, releasing the turn slot so a
+          dashboard/connector chat request parked behind this turn admits via
+          direct handoff before its shorter budget expires. Only the
+          heartbeat-scheduled path passes it; a chat turn must not yield to a
+          later-queued chat. *)
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -41,7 +41,10 @@ let progress_keeper_tool_names_for_contract
 
 let visible_response_text_present ~stop_reason ~response_text_present =
   match stop_reason with
-  | Runtime_agent.TurnBudgetExhausted _ -> false
+  (* A yield renders only a synthetic status marker, not a deliverable — like
+     a budget stop it does not count as a visible reply for the contract. *)
+  | Runtime_agent.TurnBudgetExhausted _ | Runtime_agent.Yielded_to_chat_waiting _ ->
+    false
   | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ ->
     response_text_present
 ;;
@@ -51,7 +54,12 @@ let budget_exhausted_contract_status ~stop_reason status =
   | ( Runtime_agent.TurnBudgetExhausted _
     , Keeper_execution_receipt.Contract_satisfied_execution ) ->
     Keeper_execution_receipt.Contract_needs_execution_progress
-  | (Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _), _
+  (* A chat-yield is not a budget exhaustion: pass the status through unchanged,
+     as for [Completed]/[MutationBoundaryReached]. *)
+  | ( ( Runtime_agent.Completed
+      | Runtime_agent.MutationBoundaryReached _
+      | Runtime_agent.Yielded_to_chat_waiting _ )
+    , _ )
   | Runtime_agent.TurnBudgetExhausted _, _ ->
     status
 ;;

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -62,7 +62,12 @@ let replay_suffix_prune_reason
 
 let stop_reason_requests_resume_merge = function
   | Runtime_agent.TurnBudgetExhausted _ -> true
-  | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+  (* A yield stops at a clean turn boundary (no partial in-flight work to merge),
+     like [MutationBoundaryReached]; the OAS checkpoint already holds the
+     completed turns and the keeper resumes on the next cycle. *)
+  | Runtime_agent.Completed
+  | Runtime_agent.MutationBoundaryReached _
+  | Runtime_agent.Yielded_to_chat_waiting _ -> false
 ;;
 
 let should_resume_merge

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -13,11 +13,14 @@ let stop_reason_label = function
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
      | None -> "mutation_boundary")
+  | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
 ;;
 
 let stop_reason_is_turn_budget_exhausted = function
   | Runtime_agent.TurnBudgetExhausted _ -> true
-  | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+  | Runtime_agent.Completed
+  | Runtime_agent.MutationBoundaryReached _
+  | Runtime_agent.Yielded_to_chat_waiting _ -> false
 ;;
 
 let direct_assistant_source = "direct_assistant"

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -331,6 +331,8 @@ let stop_reason_to_string = function
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary:%s:%d" tool turns_used
      | None -> Printf.sprintf "mutation_boundary:%d" turns_used)
+  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+    Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
 ;;
 
 let enrich_contract_violation_reason (receipt : t) : string =

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -82,9 +82,18 @@ let run_locked slot ~lane f =
     raise exn
 ;;
 
+let waiting_count slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting)
+
 let run_if_free ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  if Eio.Mutex.try_lock slot.turn_mu
+  (* Yield to a parked chat before touching the lock. [waiting > 0] implies
+     the slot is held (a waiter only parks because a turn is in flight), so
+     [try_lock] would fail here anyway; the explicit check keeps the
+     autonomous lane from competing for a slot a dashboard/connector message
+     is already queued on and documents the intent at the entry point. *)
+  if waiting_count slot > 0
+  then `Busy (peek_info slot)
+  else if Eio.Mutex.try_lock slot.turn_mu
   then run_locked slot ~lane:Autonomous f
   else `Busy (peek_info slot)
 ;;
@@ -121,6 +130,13 @@ let in_flight ~base_path ~keeper_name =
   match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with
   | None -> None
   | Some slot -> peek_info slot
+;;
+
+let chat_waiting ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with
+  | None -> false (* no slot yet ⇒ no turn ran ⇒ no chat can be waiting *)
+  | Some slot -> waiting_count slot > 0
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -46,7 +46,26 @@ val run_if_free
     a busy slot skips the cycle and the next heartbeat retries naturally.
     [`Busy None] means the slot is held but the holder has not yet published
     its info (admission in progress on another fiber). Exceptions from [f]
-    (including [Eio.Cancel.Cancelled]) release the slot and re-raise. *)
+    (including [Eio.Cancel.Cancelled]) release the slot and re-raise.
+
+    Also returns [`Busy] without attempting the lock when a chat request is
+    already parked on this slot ([chat_waiting] is true). Eio.Mutex hands a
+    released slot directly to the next parked waiter, so a new autonomous
+    cycle would not overtake a queued chat regardless; this pre-check makes
+    the yield explicit and keeps a heartbeat-scheduled cycle from competing
+    for a slot a dashboard/connector message is already waiting on. *)
+
+val chat_waiting : base_path:string -> keeper_name:string -> bool
+(** [true] when at least one chat request is parked on this keeper's slot
+    (waiting in [run_serialized] for an in-flight turn to release). Read
+    under the slot's state mutex; [false] for an unknown keeper (no slot,
+    hence no waiters). The autonomous lane feeds this into the OAS agent
+    loop's exit condition: an idle-filler turn that observes a parked chat
+    stops at the next turn boundary so the slot releases and the chat admits
+    via direct handoff, instead of the chat starving behind the autonomous
+    turn's longer budget. Only counts *parked* waiters, never an already
+    admitted (in-flight) turn — an admitted chat holds the slot and is no
+    longer waiting. *)
 
 val run_serialized
   :  base_path:string

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -34,12 +34,14 @@ let of_stop_reason = function
   | Runtime_agent.Completed -> Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_chat_waiting _ -> Continuation_checkpoint
 
 let of_result_surface ~response_text = function
   | Runtime_agent.Completed ->
       if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_chat_waiting _ -> Continuation_checkpoint
 
 let of_reply_payload payload =
   match payload with

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -293,6 +293,8 @@ let append_decision_record
                            Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
                        | None ->
                            Printf.sprintf "mutation_boundary(%d)" turns_used)
+                  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+                      Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
                 in
               let inference_fields =
                 match r.inference_telemetry with

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -189,6 +189,18 @@ let run (ctx : ctx)
                  ?shared_context
                  ?event_bus
                  ?trace_link:(trace_link ())
+                   (* This module is the autonomous lane's turn runner
+                      ([Keeper_unified_turn.run_keeper_cycle] → here, only ever
+                      reached via [Keeper_turn_admission.run_if_free]); the chat
+                      lane runs [run_keeper_msg_turn_admitted] on a separate
+                      path. So passing the yield hook here is inherently
+                      lane-gated: an idle-filler turn stops at the next boundary
+                      when a dashboard/connector chat is parked, but a chat turn
+                      never yields to a later-queued chat. *)
+                 ~yield_to_chat_waiting:(fun () ->
+                   Keeper_turn_admission.chat_waiting
+                     ~base_path:config.base_path
+                     ~keeper_name:meta.name)
                  ()))
     in
     result, turn_state

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -56,7 +56,9 @@ let budget_exhausted_no_progress_threshold_override
   let budget_exhausted =
     match stop_reason with
     | Runtime_agent.TurnBudgetExhausted _ -> true
-    | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+    | Runtime_agent.Completed
+    | Runtime_agent.MutationBoundaryReached _
+    | Runtime_agent.Yielded_to_chat_waiting _ -> false
   in
   if
     budget_exhausted
@@ -222,7 +224,9 @@ let completion_contract_terminal_failure_reason_code result =
      | Runtime_agent.TurnBudgetExhausted _ ->
        completion_contract_attention_reason_code
          result.Keeper_agent_run.completion_contract_result
-     | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> None)
+     | Runtime_agent.Completed
+     | Runtime_agent.MutationBoundaryReached _
+     | Runtime_agent.Yielded_to_chat_waiting _ -> None)
   | Some _ -> None
   | None ->
     Some
@@ -237,7 +241,8 @@ let terminal_outcome_of_result result =
     (match result.Keeper_agent_run.stop_reason with
      | Runtime_agent.Completed -> Terminal_done
      | Runtime_agent.TurnBudgetExhausted _
-     | Runtime_agent.MutationBoundaryReached _ ->
+     | Runtime_agent.MutationBoundaryReached _
+     | Runtime_agent.Yielded_to_chat_waiting _ ->
        Terminal_checkpoint)
 ;;
 
@@ -438,6 +443,8 @@ let emit_usage_metrics_and_log
       (match tool_name with
        | Some tool -> Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
        | None -> Printf.sprintf "mutation_boundary(%d)" turns_used)
+    | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+      Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
   in
   let outcome_label =
     match terminal_outcome with
@@ -447,6 +454,7 @@ let emit_usage_metrics_and_log
       (match result.stop_reason with
        | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
        | Runtime_agent.MutationBoundaryReached _ -> "mutation_boundary"
+       | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
        | Runtime_agent.Completed -> "success")
   in
   Otel_metric_store.inc_counter
@@ -564,7 +572,9 @@ let terminal_reason_of_outcome result = function
          ~source:"runtime_stop_reason"
          (Keeper_turn_disposition.Turn_budget_exhausted
             { detail = None; used = turns_used; limit })
-     | Runtime_agent.MutationBoundaryReached _ | Runtime_agent.Completed ->
+     | Runtime_agent.MutationBoundaryReached _
+     | Runtime_agent.Yielded_to_chat_waiting _
+     | Runtime_agent.Completed ->
        Keeper_turn_terminal.success ())
   | Terminal_failed_completion_contract _ ->
     Keeper_turn_terminal.of_disposition
@@ -676,6 +686,15 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
       (match tool_name with
        | Some tool -> tool
        | None -> "committed tool");
+    reset_failure_state ()
+  | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
+    (* A clean, intentional yield to a parked chat, not a degraded outcome:
+       clear turn-failure state and record health success, like a completed
+       turn. The keeper resumes its own work on the next cycle. *)
+    Log.Keeper.info ~keeper_name:updated_meta.name
+      "yielded turn slot to a waiting chat request after %d turn(s), checkpoint \
+       saved — will resume next cycle"
+      turns_used;
     reset_failure_state ()
   | Runtime_agent.Completed -> reset_failure_state ()
 ;;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -31,6 +31,7 @@ type stop_reason =
   | Completed
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
+  | Yielded_to_chat_waiting of { turns_used : int }
 
 type config =
   Runtime_agent_context.config = {
@@ -925,6 +926,8 @@ let dashboard_status_of_stop_reason = function
   | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Error { transient = false }
   | MutationBoundaryReached _ ->
       Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
+  | Yielded_to_chat_waiting _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
 
 let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
     ~status (response : Agent_sdk.Types.api_response) =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -33,6 +33,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
       turns_used : int;
       tool_name : string option;
     }
+  | Yielded_to_chat_waiting of { turns_used : int }
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path; [TurnBudgetExhausted] means the per-call
     turn budget checkpoint was reached. It is not a completed
@@ -40,7 +41,11 @@ type stop_reason = Runtime_agent_context.stop_reason =
     durable-progress evidence before deciding whether to continue from
     the persisted checkpoint. [MutationBoundaryReached] fires when the
     keeper hit a mutation tool while in read-only mode (the [tool_name]
-    surfaces which tool triggered the gate). *)
+    surfaces which tool triggered the gate). [Yielded_to_chat_waiting]
+    fires when an autonomous-lane run stopped at a turn boundary to hand
+    the keeper's turn slot to a parked dashboard/connector chat request;
+    like [MutationBoundaryReached] it is a continuation checkpoint, not a
+    completed deliverable, and the keeper resumes on the next cycle. *)
 
 (** {1 Config} *)
 

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -17,6 +17,12 @@ type stop_reason =
       { turns_used : int
       ; tool_name : string option
       }
+  | Yielded_to_chat_waiting of { turns_used : int }
+    (* The autonomous lane's OAS run stopped at a turn boundary because a
+       dashboard/connector chat request was parked on the keeper's turn slot.
+       Progress is checkpointed and the keeper resumes on the next cycle — the
+       same disposition as [MutationBoundaryReached], but a distinct reason so
+       receipts do not conflate an on-demand yield with a budget/mutation stop. *)
 
 type config =
   { name : string

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -23,6 +23,7 @@ type stop_reason =
       turns_used : int;
       tool_name : string option;
     }
+  | Yielded_to_chat_waiting of { turns_used : int }
 
 (** {1 Per-worker config} *)
 

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -219,6 +219,99 @@ let test_cancelled_waiter_leaves_queue () =
     Eio.Promise.resolve set_release ())
 ;;
 
+let test_autonomous_yields_to_parked_chat () =
+  reset ();
+  Printf.printf "Test 8: autonomous lane yields to a parked chat request\n%!";
+  (* No slot has been created, so nothing can be waiting. *)
+  check
+    "chat_waiting is false before any turn"
+    (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    let parked_ran = ref false in
+    (* Holder: an in-flight chat turn occupying the slot. *)
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "holder chat admitted on a free slot" false);
+    Eio.Promise.await started;
+    (* Parked waiter: a second chat request queued behind the holder. [fork]
+       runs it to its first suspension — the [Eio.Mutex.lock] park — so by the
+       time [fork] returns the waiter is counted in [waiting]. *)
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          parked_ran := true)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "parked chat is not rejected below the cap" false);
+    check
+      "chat_waiting reports the parked chat"
+      (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name);
+    (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+     | `Busy _ -> check "run_if_free yields (Busy) while a chat is parked" true
+     | `Ran () -> check "run_if_free must not admit while a chat is parked" false);
+    check
+      "parked chat has not run while the holder is in flight"
+      (not !parked_ran);
+    Eio.Promise.resolve set_release ());
+  (* The switch exits only after the parked chat drained; nothing waits now. *)
+  check
+    "chat_waiting is false after the queue drains"
+    (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name))
+;;
+
+let test_idle_loop_yields_to_parked_chat () =
+  reset ();
+  Printf.printf
+    "Test 9: an idle autonomous loop exits on a parked chat so the chat admits\n%!";
+  let autonomous_exited_via_yield = ref false in
+  let chat_ran = ref false in
+  Eio.Switch.run (fun sw ->
+    let autonomous_admitted, set_autonomous_admitted = Eio.Promise.create () in
+    (* Autonomous holder: a bounded idle loop modelling the OAS agent loop's
+       per-turn-boundary exit check. Each iteration yields (a turn boundary)
+       and inspects [chat_waiting]; a parked chat ends the loop early, the
+       admission slot releases, and the chat admits by direct handoff. This
+       harnesses the admission-level contract; the SDK-level [exit_condition]
+       wiring in [Keeper_agent_run] drives the real loop the same way. *)
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->
+          Eio.Promise.resolve set_autonomous_admitted ();
+          let rec idle_turns n =
+            if n <= 0
+            then () (* idle budget spent without a chat: ordinary loop end *)
+            else if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
+            then autonomous_exited_via_yield := true (* graceful early exit *)
+            else (
+              Eio.Fiber.yield ();
+              idle_turns (n - 1))
+          in
+          idle_turns 1000)
+      with
+      | `Ran () -> ()
+      | `Busy _ -> check "autonomous lane admits on a free slot" false);
+    Eio.Promise.await autonomous_admitted;
+    (* Chat parks behind the in-flight autonomous turn. *)
+    Eio.Fiber.fork ~sw (fun () ->
+      match
+        Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+          chat_ran := true)
+      with
+      | `Ran () -> ()
+      | `Rejected _ -> check "parked chat is not rejected below the cap" false));
+  check
+    "idle loop exited early because a chat was waiting"
+    !autonomous_exited_via_yield;
+  check "parked chat admitted after the autonomous turn yielded" !chat_ran
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -228,6 +321,8 @@ let () =
   test_waiting_cap_rejects ();
   test_exception_releases_slot ();
   test_cancelled_waiter_leaves_queue ();
+  test_autonomous_yields_to_parked_chat ();
+  test_idle_loop_yields_to_parked_chat ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## 문제 (라이브 재현 + 코드 확정, task-1640)

대시보드/커넥터 챗 요청이 autonomous idle 사이클에 밀려 300s 타임아웃으로 굶는다.

**라이브 재현 (2026-07-02 10:09Z)**: 재시작 직후 무부하 서버에서 dashboard 챗 요청(`kmsg_analyst_4_*`)이 큐 진입 후 **300초 동안 어떤 턴에도 편입되지 못하고** `keeper_msg_timeout`으로 종결 — 같은 구간 keeper는 idle/proactive 턴 3개를 소화 (메시지는 어떤 프롬프트에도 실리지 않았음 — LLM 무죄).

**기계적 원인**: 챗은 `Keeper_turn_admission.run_serialized`에서 `slot.turn_mu` 파킹(최대 300s, `keeper_msg_timeout_sec_max`), autonomous는 `run_if_free`(try_lock)로 슬롯을 잡은 뒤 `run_turn ~max_idle_turns`(기본 10) 전체를 `run_locked` 아래에서 돌린다 — **벽시계 예산 600s(turn_timeout_sec)로 연속 점유**. Eio.Mutex는 direct FIFO handoff라 새치기 문제가 아니라 **점유 시간 문제**: 600 > 300이므로 겹치면 챗이 구조적으로 항상 먼저 죽는다. 커넥터 큐 경로(`keeper_chat_consumer.ml:73-77` in_flight 스킵)도 동일 root.

## 수정 (typed — 기존 `slot.waiting` 카운터 재사용, cap/cooldown/string match 없음)

1. **핵심**: `Keeper_turn_admission.chat_waiting` 노출 → autonomous idle 루프의 exit_condition으로 주입 (`Keeper_unified_turn_execution.run` — `run_if_free` 레인 전용 호출부라 구조적으로 lane-gated; chat 레인 `run_keeper_msg_turn_admitted`는 hook 미전달). OAS `check_loop_guard`가 exit_condition을 **턴 경계에서만** 평가하므로 in-flight tool 실행/응답 생성은 중단되지 않는다. idle 필러 조기 종료(정상 반환) → `run_locked`가 turn_mu 해제 → 파킹된 챗이 direct handoff로 즉시 admit. 챗 대기 상한: 600s 예산 전체 → 내부 idle 1턴.
2. **보강**: `run_if_free`가 try_lock 전 `waiting > 0`이면 `Busy` — 신규 autonomous 사이클이 파킹된 챗에 양보 (기존 Busy skip과 동형).
3. **전용 stop_reason**: `Runtime_agent.Yielded_to_chat_waiting of { turns_used : int }` 신설 — 컴파일러 exhaustive match가 강제한 11개 분류 사이트를 의미별 처리. 특히 **health는 `reset_failure_state()`(healthy)**: 의도적 협조 yield를 실패로 세면 failure policy가 keeper를 오탐 pause/kill한다. outcome은 `Continuation_checkpoint`(checkpoint + 다음 사이클 resume, 기존 behavior).

**Reactive lane 포함 (의도)**: 챗은 300s 데드라인의 직접 상호작용, 하트비트 구동 작업은 더 긴 예산 + checkpoint resume 가능 → 슬롯을 챗에 넘기는 것이 올바른 우선순위.

## 검증

- `dune-local.sh build --root . @check` **green** (lib+bin+test 0 errors)
- `test_keeper_turn_admission.exe` **Tests 1–9 전부 통과**: 신규 Test 8(파킹-챗에 run_if_free 양보), Test 9(idle 루프 조기 종료 → 파킹 챗 admit, fiber 스케줄링 순서 실행 검증), 기존 7개 무손상
- 참고: 로컬 opam 스위치가 다른 에이전트에 의해 repin된 상태라 `MASC_SKIP_PIN_CHECK=1`로 빌드 — 이 변경은 masc 자체 stop_reason 타입(agent_sdk 독립)이며 CI가 SSOT pin으로 최종 검증

관련: 선행 조사(스카우트 보고 — 인과 체인 file:line 전수), masc#23009(챗 공백 대시보드 측), keeper_turn.ml:676 주석의 동일 계열 선행 사례(Issue #2610)

MASC task: task-1640

Co-Authored-By: MASC Agent (impl-chat-preempt subagent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
