### PR TITLE
feat(dashboard): surface fusion failure reasons — run error/failure_code, panel reason_code, judge timing, staged JoJ labels

### DIFF
--- a/dashboard/src/api/dashboard-fusion.ts
+++ b/dashboard/src/api/dashboard-fusion.ts
@@ -20,6 +20,12 @@ export interface FusionRunRecord {
   preset: string
   startedAt: number // unix seconds
   status: FusionRunStatusLabel
+  // Failure attribution, present only on `failed` rows. The backend emits both
+  // as additive fields (Fusion_run_registry.run_to_yojson): `error` is the human
+  // failure text, `failure_code` the closed machine tag (timeout / provider_error
+  // / …). Absent on running/completed rows.
+  error?: string
+  failureCode?: string
 }
 
 export interface DashboardFusionRunsResponse {
@@ -45,6 +51,8 @@ export function parseFusionRunsResponse(raw: unknown): DashboardFusionRunsRespon
       preset: asString(row.preset) ?? '',
       startedAt: asNumber(row.started_at) ?? 0,
       status: asFusionRunStatus(row.status),
+      error: asString(row.error),
+      failureCode: asString(row.failure_code),
     }))
     .filter(run => run.runId.length > 0)
   return {

--- a/dashboard/src/components/board/fusion-evidence.test.ts
+++ b/dashboard/src/components/board/fusion-evidence.test.ts
@@ -103,3 +103,50 @@ describe('FusionBoardEvidence judge topology strip (RFC-0284 PR 2)', () => {
     expect(container.querySelector('[data-testid="fusion-board-evidence"]')).toBeNull()
   })
 })
+
+describe('FusionBoardEvidence failure attribution', () => {
+  it('surfaces failure_code and elapsed timing on a failed judge node', () => {
+    render(
+      h(FusionBoardEvidence, {
+        post: fusionPost([
+          {
+            role: 'meta',
+            identity: 'o1',
+            status: 'failed',
+            error: 'judge timed out',
+            failure_code: 'timeout',
+            elapsed_s: 30.2,
+            timed_out: true,
+          },
+        ]),
+      }),
+    )
+    const failedRow = screen.getByTestId('fusion-board-judges').querySelector('[data-failed="true"]')
+    expect(failedRow?.querySelector('[data-fusion-judge-code]')?.textContent).toBe('timeout')
+    expect(failedRow?.textContent).toContain('30.2s')
+  })
+
+  it('renders the panel reason_code chip on a failed panel', () => {
+    const post = {
+      meta: {
+        source: 'fusion',
+        run_id: 'fus-1',
+        question: 'q?',
+        panel: [
+          { model: 'gpt-5', status: 'answered', answer: 'panel answer' },
+          {
+            model: 'claude',
+            status: 'failed',
+            reason_code: 'provider_error',
+            reason_detail: 'quota exceeded',
+          },
+        ],
+        judge: { status: 'synthesized', synthesis: '최종 종합' },
+      },
+    } as Parameters<typeof FusionBoardEvidence>[0]['post']
+    render(h(FusionBoardEvidence, { post }))
+    const codes = screen.getAllByText('provider_error', { selector: '[data-fusion-panel-code]' })
+    expect(codes).toHaveLength(1)
+    expect(codes[0]?.getAttribute('title')).toBe('quota exceeded')
+  })
+})

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -13,6 +13,7 @@ import {
   judgeRoleLabel,
   judgeNodeTokenLabel,
   judgeNodeIdentity,
+  judgeNodeElapsedLabel,
 } from '../fusion/fusion-judge-format'
 
 function formatTokens(value: number | null | undefined): string | null {
@@ -44,6 +45,9 @@ function PanelCard({ panel }: { panel: FusionPanelEntry }) {
       <div class="mb-2 flex flex-wrap items-center gap-2">
         <span class="min-w-0 break-all font-mono text-2xs text-[var(--color-fg-secondary)]">${panel.model}</span>
         <span class=${`inline-flex rounded-[var(--r-0)] border px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wide ${statusClass(panel.status)}`}>${panel.status}</span>
+        ${panel.reasonCode
+          ? html`<span class="inline-flex rounded-[var(--r-0)] border border-[var(--bad-30)] bg-[var(--bad-15)] px-1.5 py-0.5 font-mono text-3xs text-[var(--bad-light)]" title=${panel.reason ?? panel.reasonCode} data-fusion-panel-code>${panel.reasonCode}</span>`
+          : null}
         ${tokenLabel ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">${tokenLabel}</span>` : null}
       </div>
       ${panel.answer
@@ -89,6 +93,12 @@ function JudgeNodeRow({ node }: { node: FusionJudgeNode }) {
       ${identity
         ? html`<span class="min-w-0 flex-1 break-all font-mono text-2xs text-[var(--color-fg-muted)]" title=${identity}>${identity}</span>`
         : html`<span class="flex-1"></span>`}
+      ${node.failed && node.failureCode
+        ? html`<span class="inline-flex rounded-[var(--r-0)] border border-[var(--bad-30)] bg-[var(--bad-15)] px-1.5 py-0.5 font-mono text-3xs text-[var(--bad-light)]" title=${node.error ?? node.failureCode} data-fusion-judge-code>${node.failureCode}</span>`
+        : null}
+      ${node.failed && judgeNodeElapsedLabel(node)
+        ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]" title=${node.timedOut ? '타임아웃 초과' : '경과 시간'}>${judgeNodeElapsedLabel(node)}</span>`
+        : null}
       <span class="font-mono text-2xs text-[var(--color-fg-muted)]">${judgeNodeTokenLabel(node)}</span>
       ${node.failed
         ? html`<span class="text-2xs font-semibold text-[var(--bad-light)]" title=${node.error ?? 'failed'}>✗ 실패</span>`

--- a/dashboard/src/components/fusion/fusion-judge-format.test.ts
+++ b/dashboard/src/components/fusion/fusion-judge-format.test.ts
@@ -4,6 +4,7 @@ import {
   judgeRoleLabel,
   judgeNodeTokenLabel,
   judgeNodeIdentity,
+  judgeNodeElapsedLabel,
 } from './fusion-judge-format'
 import type { FusionJudgeNode } from '../../lib/fusion-meta'
 
@@ -21,14 +22,27 @@ describe('judgeShapeLabel', () => {
 })
 
 describe('judgeRoleLabel', () => {
-  it('maps the known closed backend roles', () => {
+  it('maps every role of the closed six-role backend enum', () => {
     expect(judgeRoleLabel('first')).toBe('1차')
     expect(judgeRoleLabel('meta')).toBe('메타')
     expect(judgeRoleLabel('refine')).toBe('재검토')
     expect(judgeRoleLabel('single')).toBe('단일')
+    // staged JoJ reducers — previously fell through to the raw latin role string
+    expect(judgeRoleLabel('stage_meta')).toBe('단계 심판')
+    expect(judgeRoleLabel('final_meta')).toBe('최종 심판')
   })
   it('falls through to the raw string for an unanticipated role', () => {
     expect(judgeRoleLabel('arbiter')).toBe('arbiter')
+  })
+})
+
+describe('judgeNodeElapsedLabel', () => {
+  it('returns null when the node carries no timing', () => {
+    expect(judgeNodeElapsedLabel(node({}))).toBeNull()
+  })
+  it('formats the elapsed seconds to one decimal', () => {
+    expect(judgeNodeElapsedLabel(node({ failed: true, elapsedS: 4.12 }))).toBe('4.1s')
+    expect(judgeNodeElapsedLabel(node({ failed: true, elapsedS: 0 }))).toBe('0.0s')
   })
 })
 

--- a/dashboard/src/components/fusion/fusion-judge-format.ts
+++ b/dashboard/src/components/fusion/fusion-judge-format.ts
@@ -19,9 +19,11 @@ export function judgeShapeLabel(shape: FusionJudgeShape): string {
   return JUDGE_SHAPE_LABEL[shape]
 }
 
-// Korean badge for a backend judge role. Unknown roles fall through to the raw
-// string so a new backend role still renders (the enum is closed on the backend,
-// so this is defensive rather than expected).
+// Korean badge for a backend judge role. Covers the closed six-role enum
+// (fusion_types.ml judge_role: Single | Refine_pass | First | Meta | Stage_meta |
+// Final_meta); the staged-JoJ reducers (`stage_meta` / `final_meta`) share the
+// "심판" wording of the others. Unknown roles fall through to the raw string so a
+// new backend role still renders (defensive rather than expected).
 export function judgeRoleLabel(role: string): string {
   switch (role) {
     case 'first':
@@ -32,9 +34,20 @@ export function judgeRoleLabel(role: string): string {
       return '재검토'
     case 'single':
       return '단일'
+    case 'stage_meta':
+      return '단계 심판'
+    case 'final_meta':
+      return '최종 심판'
     default:
       return role
   }
+}
+
+// Elapsed wall-clock of a failed judge node (`Ns`, one decimal), or null when the
+// node carries no timing (successful nodes, or older payloads). Shared by both
+// render surfaces so a slow failure reads the same way in each.
+export function judgeNodeElapsedLabel(node: FusionJudgeNode): string | null {
+  return node.elapsedS != null ? `${node.elapsedS.toFixed(1)}s` : null
 }
 
 // Per-node combined token figure (`Nk tok` / `N tok`), em-dash when no usage.

--- a/dashboard/src/components/fusion/fusion-runs-panel.test.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.test.ts
@@ -48,6 +48,32 @@ describe('parseFusionRunsResponse', () => {
     expect(parsed.count).toBe(0)
     expect(parsed.generatedAt).toBeNull()
   })
+
+  it('carries the additive error / failure_code fields on a failed row', () => {
+    const parsed = parseFusionRunsResponse({
+      runs: [
+        {
+          run_id: 'r-fail',
+          keeper: 'k',
+          preset: 'deep',
+          started_at: 1,
+          status: 'failed',
+          error: 'judge timed out after 30s',
+          failure_code: 'timeout',
+        },
+        { run_id: 'r-run', keeper: 'k', preset: 'p', started_at: 2, status: 'running' },
+      ],
+    })
+    expect(parsed.runs[0]).toMatchObject({
+      runId: 'r-fail',
+      status: 'failed',
+      error: 'judge timed out after 30s',
+      failureCode: 'timeout',
+    })
+    // running rows carry no failure attribution
+    expect(parsed.runs[1]?.error).toBeUndefined()
+    expect(parsed.runs[1]?.failureCode).toBeUndefined()
+  })
 })
 
 describe('fusion run status helpers', () => {
@@ -149,5 +175,32 @@ describe('FusionRunsPanel', () => {
     ]
     render(html`<${FusionRunsPanel} />`, container)
     expect(container.querySelector('.fus-runs-live')).toBeNull()
+  })
+
+  it('surfaces the failure code and error on a failed run card', () => {
+    fusionRuns.value = [
+      {
+        runId: 'r-fail',
+        keeper: 'k3',
+        preset: 'deep',
+        startedAt: 200,
+        status: 'failed',
+        error: 'judge timed out after 30s',
+        failureCode: 'timeout',
+      },
+    ]
+    render(html`<${FusionRunsPanel} />`, container)
+    const reason = container.querySelector('[data-testid="fusion-run-reason"]')
+    expect(reason).not.toBeNull()
+    expect(reason?.querySelector('.fus-runs-code')?.textContent).toBe('timeout')
+    expect(reason?.textContent).toContain('judge timed out after 30s')
+  })
+
+  it('omits the reason line for a completed run', () => {
+    fusionRuns.value = [
+      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
+    ]
+    render(html`<${FusionRunsPanel} />`, container)
+    expect(container.querySelector('[data-testid="fusion-run-reason"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/fusion/fusion-runs-panel.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.ts
@@ -100,6 +100,14 @@ function FusionRunStatusCard({ run }: { run: FusionRunRecord }) {
           <${TimeAgo} timestamp=${run.startedAt} />
         </span>
       </div>
+      ${run.status === 'failed' && (run.failureCode || run.error)
+        ? html`<div class="fus-runs-reason" data-testid="fusion-run-reason">
+            ${run.failureCode
+              ? html`<span class="fus-runs-code mono" title=${run.error ?? run.failureCode}>${run.failureCode}</span>`
+              : null}
+            ${run.error ? html`<span class="fus-runs-reason-text" title=${run.error}>${run.error}</span>` : null}
+          </div>`
+        : null}
       <${FusionRunPipeline} status=${run.status} />
     </li>
   `

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -705,6 +705,40 @@ describe('FusionSurface', () => {
     expect(cards[1]?.classList.contains('failed')).toBe(true)
   })
 
+  it('renders the panel reason_code as a category chip on a failed panel card', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-reason-code',
+        title: 'Fusion deliberation (run fus-reason-code): mixed',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-reason-code',
+          question: 'Reason code?',
+          panel: [
+            { model: 'gpt-5', status: 'answered', answer: 'ok' },
+            {
+              model: 'claude',
+              status: 'failed',
+              reason_code: 'provider_error',
+              reason_detail: 'quota exceeded',
+            },
+          ],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'done' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const failedCard = container.querySelector('.fus-panel-card.failed')
+    const code = failedCard?.querySelector('.fus-pcode')
+    expect(code?.textContent).toBe('provider_error')
+    // the human detail still shows in the state chip; the answered card has no code
+    expect(failedCard?.textContent).toContain('quota exceeded')
+    const answeredCard = container.querySelector('.fus-panel-card.answered')
+    expect(answeredCard?.querySelector('.fus-pcode')).toBeNull()
+  })
+
   it('renders generation parameters when present in board meta', () => {
     fusionBoardPosts.value = [
       boardPost({
@@ -918,5 +952,47 @@ describe('FusionJudgesStrip', () => {
   it('renders nothing for a board post that predates the judges array', () => {
     render(html`<${FusionJudgesStrip} nodes=${[]} />`, container)
     expect(container.querySelector('[data-testid="fusion-judges"]')).toBeNull()
+  })
+
+  it('surfaces failure_code and elapsed timing on a failed node, marking a timeout', () => {
+    const failing: FusionJudgeNode[] = [
+      {
+        role: 'meta',
+        identity: 'o1',
+        failed: true,
+        error: 'judge timed out',
+        failureCode: 'timeout',
+        elapsedS: 30.2,
+        timedOut: true,
+        inputTokens: 800,
+        outputTokens: 0,
+      },
+    ]
+    render(html`<${FusionJudgesStrip} nodes=${failing} />`, container)
+    const row = container.querySelector('[data-failed="true"]')
+    expect(row?.querySelector('.fus-jn-code')?.textContent).toBe('timeout')
+    const time = row?.querySelector('.fus-jn-time')
+    expect(time?.textContent).toBe('30.2s')
+    // timed_out is consumed, not just the code — the elapsed chip is marked
+    expect(time?.classList.contains('timeout')).toBe(true)
+  })
+
+  it('shows elapsed without the timeout mark for a non-timeout failure', () => {
+    const failing: FusionJudgeNode[] = [
+      {
+        role: 'single',
+        identity: 'single',
+        failed: true,
+        error: 'could not parse structured output',
+        failureCode: 'parse_error',
+        elapsedS: 2.4,
+        timedOut: false,
+      },
+    ]
+    render(html`<${FusionJudgesStrip} nodes=${failing} />`, container)
+    const time = container.querySelector('[data-failed="true"] .fus-jn-time')
+    expect(time?.textContent).toBe('2.4s')
+    expect(time?.classList.contains('timeout')).toBe(false)
+    expect(container.querySelector('.fus-jn-code')?.textContent).toBe('parse_error')
   })
 })

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -34,6 +34,7 @@ import {
   judgeRoleLabel,
   judgeNodeTokenLabel,
   judgeNodeIdentity,
+  judgeNodeElapsedLabel,
 } from './fusion-judge-format'
 
 type FusionRunStatus = 'complete' | 'failed' | 'running'
@@ -476,6 +477,15 @@ export function FusionJudgesStrip({ nodes }: { nodes: readonly FusionJudgeNode[]
               <span class="fus-jn-id mono" title=${judgeNodeIdentity(node) ?? ''}>
                 ${judgeNodeIdentity(node) ?? ''}
               </span>
+              ${node.failed && node.failureCode
+                ? html`<span class="fus-jn-code mono" title=${node.error ?? node.failureCode}>${node.failureCode}</span>`
+                : null}
+              ${node.failed && judgeNodeElapsedLabel(node)
+                ? html`<span
+                    class=${`fus-jn-time ${node.timedOut ? 'timeout' : ''}`}
+                    title=${node.timedOut ? '타임아웃 초과' : '경과 시간'}
+                  >${judgeNodeElapsedLabel(node)}</span>`
+                : null}
               <span class="fus-jn-tok">${judgeNodeTokenLabel(node)}</span>
               ${node.failed
                 ? html`<span class="fus-jn-status deny" title=${node.error ?? 'failed'}>✗ 실패</span>`
@@ -666,6 +676,9 @@ function FusionPanelCard({ entry }: { entry: FusionPanelEntry }) {
     <article class=${`fus-pcard fus-panel-card ${failed ? 'failed' : 'answered'}`}>
       <div class="fus-pcard-h">
         <span class="fus-pmodel mono">${entry.model}</span>
+        ${failed && entry.reasonCode
+          ? html`<span class="fus-pcode mono" title=${entry.reason ?? entry.reasonCode}>${entry.reasonCode}</span>`
+          : null}
         ${failed
           ? html`<span class="fus-pstate fail">${entry.reason ?? entry.status}</span>`
           : tokenLabel

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -266,11 +266,31 @@ describe('normalizeFusionJudgeNodes', () => {
       { role: 'first', identity: 'gemini', status: 'failed', error: 'timeout', input_tokens: 5, output_tokens: 0 },
       { role: 'meta', identity: 'o1', input_tokens: 2000, output_tokens: 418 },
     ])
-    expect(nodes).toEqual([
-      { role: 'first', identity: 'gpt-4o', failed: false, error: undefined, inputTokens: 100, outputTokens: 10 },
-      { role: 'first', identity: 'gemini', failed: true, error: 'timeout', inputTokens: 5, outputTokens: 0 },
-      { role: 'meta', identity: 'o1', failed: false, error: undefined, inputTokens: 2000, outputTokens: 418 },
-    ])
+    expect(nodes).toHaveLength(3)
+    expect(nodes[0]).toMatchObject({
+      role: 'first',
+      identity: 'gpt-4o',
+      failed: false,
+      error: undefined,
+      inputTokens: 100,
+      outputTokens: 10,
+    })
+    expect(nodes[1]).toMatchObject({
+      role: 'first',
+      identity: 'gemini',
+      failed: true,
+      error: 'timeout',
+      inputTokens: 5,
+      outputTokens: 0,
+    })
+    expect(nodes[2]).toMatchObject({
+      role: 'meta',
+      identity: 'o1',
+      failed: false,
+      error: undefined,
+      inputTokens: 2000,
+      outputTokens: 418,
+    })
   })
 
   it('drops non-record elements and defaults a missing role/identity', () => {
@@ -304,6 +324,39 @@ describe('normalizeFusionJudgeNodes', () => {
       { role: 'first', identity: 'lit', decision: 'insufficient — missing: data', synthesis: '**Decision**: insufficient' },
     ])
     expect(node.summary).toBe('**Decision**: insufficient')
+  })
+
+  it('extracts failure_code / elapsed_s / timed_out from a Judge_failed node', () => {
+    const [node] = normalizeFusionJudgeNodes([
+      {
+        role: 'meta',
+        identity: 'o1',
+        status: 'failed',
+        error: 'judge budget exceeded',
+        failure_code: 'budget_exceeded',
+        elapsed_s: 12.5,
+        timed_out: true,
+        input_tokens: 800,
+        output_tokens: 0,
+      },
+    ])
+    expect(node).toMatchObject({
+      role: 'meta',
+      failed: true,
+      error: 'judge budget exceeded',
+      failureCode: 'budget_exceeded',
+      elapsedS: 12.5,
+      timedOut: true,
+    })
+  })
+
+  it('leaves failure attribution undefined on a successful node', () => {
+    const [node] = normalizeFusionJudgeNodes([
+      { role: 'first', identity: 'gpt-4o', input_tokens: 100, output_tokens: 10 },
+    ])
+    expect(node.failureCode).toBeUndefined()
+    expect(node.elapsedS).toBeUndefined()
+    expect(node.timedOut).toBeUndefined()
   })
 })
 

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -4,7 +4,7 @@
 // is the single source of truth for that normalization.
 
 import { isRecord } from './type-guards'
-import { asRecord, asString } from './json-coerce'
+import { asRecord, asString, asBoolean } from './json-coerce'
 
 function decodeOcamlStringLiteral(value: string): string {
   return value
@@ -178,11 +178,9 @@ export function normalizeFusionJudge(value: unknown): FusionJudgeView | null {
 // One judge execution node from `fusion_sink.ml judge_node_meta`. `role` is the
 // closed backend enum (single | refine | first | meta) but kept as a string so
 // an unanticipated role degrades to a raw badge instead of being dropped.
-// `decision`/`summary` are the per-node verdict + resolved answer that a
-// Synthesized node carries (judge_node_meta → judge_synthesis_fields:
-// decision/resolved_answer); a Judge_failed node carries neither, so both stay
-// undefined there. They power the judge-of-judges 1차 심판 cards; the compact
-// topology strip ignores them and reads only the array shape.
+// Successful Synthesized nodes carry per-node decision/summary, while failed
+// nodes carry failure attribution. The compact topology strip still reads only
+// the observed array shape.
 export type FusionJudgeNode = {
   role: string
   identity: string
@@ -190,6 +188,9 @@ export type FusionJudgeNode = {
   error?: string | null
   decision?: string | null
   summary?: string | null
+  failureCode?: string | null
+  elapsedS?: number | null
+  timedOut?: boolean
   inputTokens?: number | null
   outputTokens?: number | null
 }
@@ -223,6 +224,9 @@ export function normalizeFusionJudgeNodes(value: unknown): FusionJudgeNode[] {
         summary: failed
           ? undefined
           : firstString(node, ['resolved_answer', 'resolvedAnswer', 'synthesis']) ?? undefined,
+        failureCode: failed ? firstString(node, ['failure_code']) ?? undefined : undefined,
+        elapsedS: failed ? firstNumber(node, ['elapsed_s', 'elapsedS']) ?? undefined : undefined,
+        timedOut: failed ? asBoolean(node.timed_out) : undefined,
         inputTokens: firstNumber(node, ['input_tokens', 'inputTokens']) ?? undefined,
         outputTokens: firstNumber(node, ['output_tokens', 'outputTokens']) ?? undefined,
       },

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -894,6 +894,34 @@ button.fus-reconcile-row:hover {
   flex: 0 0 auto;
 }
 
+/* Failure attribution on a failed registry card: machine code chip + human
+   detail. Only rendered for `failed` runs (fusion-runs-panel FusionRunStatusCard). */
+.v2-fusion-surface .fus-runs-reason {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: var(--fs-11);
+}
+
+.v2-fusion-surface .fus-runs-code {
+  flex: 0 0 auto;
+  border: 1px solid var(--bad-30);
+  border-radius: var(--r-0);
+  background: var(--bad-10);
+  color: var(--bad-light);
+  font-size: var(--fs-10);
+  padding: 1px 6px;
+}
+
+.v2-fusion-surface .fus-runs-reason-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fus-muted);
+}
+
 .v2-fusion-surface .fus-runs-pipe {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/dashboard/src/styles/keeper-v2/fusion.css
+++ b/dashboard/src/styles/keeper-v2/fusion.css
@@ -114,6 +114,9 @@
 .fus-conf .mono { font-size: 9.5px; color: var(--text-dim); }
 .fus-ptok { font-size: 9.5px; color: var(--text-dim); }
 .fus-pcard-h .fus-conf + .fus-ptok { margin-left: 0; }
+/* Panel failure category chip (reason_code). Sits next to the model id; the
+   human reason detail stays in the .fus-pstate/.fus-pans body. */
+.fus-pcode { font-size: 9.5px; padding: 1px 6px; border-radius: var(--radius-xs); font-family: var(--font-mono); color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); white-space: nowrap; }
 
 .fus-pans { font-size: var(--fs-12); color: var(--text-mid); line-height: 1.55; cursor: pointer; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden; position: relative; }
 .fus-pans.open { -webkit-line-clamp: unset; }
@@ -173,6 +176,11 @@
 .fus-judge-node.failed .fus-jn-role { border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); color: var(--status-bad); }
 .fus-jn-id { color: var(--text-mid); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1 1 auto; min-width: 0; }
 .fus-jn-tok { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; }
+/* Failed judge-node attribution: failure_code category chip + elapsed wall-clock.
+   Only rendered on failed nodes; .timeout marks a node that hit the budget. */
+.fus-jn-code { font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 6px; border-radius: var(--radius-xs); color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); white-space: nowrap; }
+.fus-jn-time { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; }
+.fus-jn-time.timeout { color: var(--status-bad); }
 .fus-jn-status { font-size: var(--fs-11); white-space: nowrap; }
 .fus-jn-status.done { color: var(--status-ok); }
 .fus-jn-status.deny { color: var(--status-bad); }


### PR DESCRIPTION
## 문제 (task-1640 fusion×JoJ 감사 — "실패 관측성 UI 소비 20%")

서버는 fusion 실패 사유를 3계층으로 전부 emit하는데 프론트가 전부 버린다:

1. registry failed 런의 `error`/`failure_code`(#23003, `fusion_run_registry.ml:123-131`) → `FusionRunRecord`/parse가 drop → 라이브 패널 카드가 bare "failed" 칩만. 운영자가 본 "timeout phase=http_operation"이 대시보드에서 불가시.
2. panel `reason_code`(timeout/dns_failure 등, `fusion_sink.ml:145-155`) → `fusion-meta.ts:142`에서 normalize까지 되고 렌더 소비자 0.
3. judge 노드 `failure_code`/`elapsed_s`/`timed_out`(`fusion_sink.ml:206,246-256`) → normalizer 미소비.
4. `stage_meta`/`final_meta` judge role — 서버는 6종 emit, 라벨 맵은 4종만 → staged JoJ 노드가 raw 문자열 배지 fallback.

## 수정 (프론트-only, 서버 무변경)

- `FusionRunRecord`에 `error`/`failureCode` + failed 카드 사유 칩(툴팁에 error 전문)
- 패널 카드(fusion-surface + board fusion-evidence) `reasonCode` 배지
- judge 노드 `elapsed_s`/`timed_out`/`failureCode` 표시
- `stage_meta`("단계 심판")/`final_meta`("최종 심판") 라벨 추가 — 기존 fusion-judge-format 어휘와 일관

## 검증

- vitest 3파일 **73/73 passed** + `tsc --noEmit` 통과 (worktree에서 직접 실행)
- 신규 테스트: failed run 사유 렌더 / reasonCode 배지 / 6종 role 라벨

관련: #23014(typed timeout 분류 — 이 PR과 순서 결합: 분류 전엔 timeout이 provider_error로 표시됨), #22972(registry WAL — 머지 시 재시작 후에도 사유 생존)

MASC task: task-1640 (PR-S1)

Co-Authored-By: MASC Agent (impl-s1-ui subagent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
