### PR TITLE
ci: add OCaml 5.5 build canary

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -48,6 +48,9 @@ runs:
           5.4|5.4.x)
             compiler_pkg="ocaml-base-compiler.5.4.1"
             ;;
+          5.5|5.5.x)
+            compiler_pkg="ocaml-base-compiler.5.5.0"
+            ;;
           [0-9]*.[0-9]*.[0-9]*)
             compiler_pkg="ocaml-base-compiler.${OCAML_COMPILER_INPUT}"
             ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,6 +914,41 @@ jobs:
             echo "::notice::main_eio.exe not found, skipping config-diagnostic"
           fi
 
+  ocaml-55-canary:
+    name: OCaml 5.5 Build Canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: true
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.build == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup OCaml 5.5 toolchain
+        uses: ./.github/actions/setup-ocaml-toolchain
+        with:
+          ocaml-compiler: '5.5.0'
+          cache-prefix: ocaml55-canary
+
+      - name: Pin external OCaml dependencies
+        uses: ./.github/actions/pin-ocaml-deps
+        with:
+          pin-flags: --with-bisect
+
+      - name: Install system and OCaml dependencies
+        uses: ./.github/actions/install-ocaml-deps
+        with:
+          install-flags: --with-test
+          install-timeout-minutes: "30"
+          os-packages: jq ripgrep
+
+      - name: Build install target
+        env:
+          DUNE_JOBS: 1
+        run: opam exec -- dune build --root . @install
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/lib/keeper/keeper_tool_affinity.ml
+++ b/lib/keeper/keeper_tool_affinity.ml
@@ -20,11 +20,11 @@ let default_lookback_days = 7
 let min_success_rate = 0.3
 let recency_lambda = 0.01
 
-(* Empty/whitespace-only env values count as unset: OCaml stdlib has no
-   portable [Unix.unsetenv] before 4.12, and the codebase convention is
-   [Unix.putenv name ""] to clear a var. Without the trim guard,
-   [Some ""] would be distinguishable from [None] at the reader level
-   even though the intent is identical. *)
+(* Empty/whitespace-only env values count as unset: OCaml 5.5 adds
+   [Unix.unsetenv], but the supported 5.4 floor does not expose it, and the
+   codebase convention is [Unix.putenv name ""] to clear a var. Without the trim
+   guard, [Some ""] would be distinguishable from [None] at the reader level even
+   though the intent is identical. *)
 let clamped_env_int ?(getenv = Sys.getenv_opt) ~name ~min_val ~max_val ~default () =
   match getenv name with
   | Some s when String.trim s <> "" ->

--- a/test/test_board_vote_quarantine.ml
+++ b/test/test_board_vote_quarantine.ml
@@ -17,12 +17,12 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
-(* [Unix.unsetenv] is not available portably, so the default-unset case
-   is exercised by the matching [quarantine_enabled] branch below via
-   the "empty string treated as disabled" rule. The code path for the
-   [None] arm of [Sys.getenv_opt] is trivially [true] and not tested
-   directly here — [test_quarantine_explicit_*] pins the non-default
-   paths. *)
+(* OCaml 5.5 adds [Unix.unsetenv], but this repo still supports the 5.4
+   floor. The default-unset case is exercised by the matching
+   [quarantine_enabled] branch below via the "empty string treated as disabled"
+   rule. The code path for the [None] arm of [Sys.getenv_opt] is trivially
+   [true] and not tested directly here — [test_quarantine_explicit_*] pins the
+   non-default paths. *)
 let test_quarantine_empty_treated_as_disabled () =
   with_env "MASC_BOARD_VOTE_QUARANTINE" "" (fun () ->
     check bool "empty string disables (explicit operator opt-out)"

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -5,8 +5,9 @@ module U = Yojson.Safe.Util
 
 let with_env name value f =
   let previous = Sys.getenv_opt name in
-  (* OCaml stdlib lacks Unix.unsetenv; this test only exercises config paths
-     that route through Env_config_core.trim_opt, where "" behaves like unset. *)
+  (* On the current supported 5.4 floor there is no Unix.unsetenv; this test
+     only exercises config paths that route through Env_config_core.trim_opt,
+     where "" behaves like unset. *)
   (match value with
    | Some v -> Unix.putenv name v
    | None -> Unix.putenv name "");

--- a/test/test_env_config_sandbox.ml
+++ b/test/test_env_config_sandbox.ml
@@ -54,13 +54,13 @@ let sandbox_env_names =
   ; "MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC"
   ]
 
-(* String-typed env vars whose default is non-empty.  OCaml 5.4 stdlib
-   has no [Unix.unsetenv], so [Unix.putenv NAME ""] is the closest we
-   can do — but [Env_config_core.get_string ~default] returns the
-   literal "" rather than the default in that case.  Workaround: set
-   each string env to its default literal so [get_string] yields the
-   expected value.  Drift between this table and the .ml will surface
-   in the cross-module consistency test below. *)
+(* String-typed env vars whose default is non-empty. OCaml 5.5 adds
+   [Unix.unsetenv], but the supported 5.4 floor has no equivalent, so
+   [Unix.putenv NAME ""] is the closest we can do — but
+   [Env_config_core.get_string ~default] returns the literal "" rather than the
+   default in that case. Workaround: set each string env to its default literal
+   so [get_string] yields the expected value. Drift between this table and the
+   .ml will surface in the cross-module consistency test below. *)
 let string_env_defaults =
   [ "MASC_KEEPER_SANDBOX_MEMORY", "2g"
   ; "MASC_KEEPER_SANDBOX_TMPFS_SIZE", "256m"

--- a/test/test_keeper_compact_audit.ml
+++ b/test/test_keeper_compact_audit.ml
@@ -288,9 +288,9 @@ module KCARO = Keeper_compact_audit_retention_outcome
 
 let env_var = "MASC_COMPACTION_AUDIT_RETENTION_DAYS"
 
-(* OCaml's Unix module lacks portable unsetenv in older stdlib; we test
-   the "unset" path by skipping when the env var leaks in from CI and
-   otherwise pre-asserting None. *)
+(* OCaml 5.5 adds Unix.unsetenv, but the supported 5.4 floor lacks it. We test
+   the "unset" path by skipping when the env var leaks in from CI and otherwise
+   pre-asserting None. *)
 let with_env_unset f =
   match Sys.getenv_opt env_var with
   | Some _ ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -835,9 +835,9 @@ let write_file path content =
 let restore_env name = function
   | Some value -> Unix.putenv name value
   | None ->
-      (* This OCaml Unix module does not expose [unsetenv]. Config_dir_resolver
-         normalizes empty env values to [None], so this restores the effective
-         resolver state for these tests. *)
+      (* OCaml 5.5 adds [Unix.unsetenv], but the supported 5.4 floor used here
+         does not expose it. Config_dir_resolver normalizes empty env values to
+         [None], so this restores the effective resolver state for these tests. *)
       Unix.putenv name ""
 
 let with_personas_dir f =

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -47,10 +47,10 @@ let make_config_root root =
   write_file (Filename.concat config "runtime.toml") "";
   config
 
-(* OCaml stdlib lacks Unix.unsetenv; putenv name "" is only an
-   approximation. Code that treats [""] as missing is fine, but
-   Sys.getenv_opt (or Option.is_some checks on it) still sees the
-   variable as present, so tests must not assume true unset semantics. *)
+(* OCaml 5.5 adds Unix.unsetenv, but the supported 5.4 floor lacks it; putenv
+   name "" is only an approximation. Code that treats [""] as missing is fine,
+   but Sys.getenv_opt (or Option.is_some checks on it) still sees the variable
+   as present, so tests must not assume true unset semantics. *)
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with

--- a/test/test_workspace_bind_fail_closed.ml
+++ b/test/test_workspace_bind_fail_closed.ml
@@ -47,9 +47,9 @@ let with_temp_dir prefix f =
 let restore_env name = function
   | Some value -> Unix.putenv name value
   | None ->
-      (* This OCaml Unix module does not expose [unsetenv]. Config_dir_resolver
-         normalizes empty env values to [None], so this restores the effective
-         resolver state for these tests. *)
+      (* OCaml 5.5 adds [Unix.unsetenv], but the supported 5.4 floor used here
+         does not expose it. Config_dir_resolver normalizes empty env values to
+         [None], so this restores the effective resolver state for these tests. *)
       Unix.putenv name ""
 
 let with_empty_personas_dir f =


### PR DESCRIPTION
## Summary
- add a non-blocking OCaml 5.5 build canary to the main CI workflow
- keep the existing required OCaml 5.4.1 Build and Test job unchanged
- teach the shared setup action to resolve the 5.5/5.5.x aliases to ocaml-base-compiler.5.5.0

## Evidence
- [근거] GitHub official OCaml release page: OCaml 5.5.0 released June 19, 2026; checked 2026-07-03 KST; confidence High.
- [근거] opam package page: ocaml-base-compiler 5.5.0 is latest and published June 19, 2026; checked 2026-07-03 KST; confidence High.
- [근거] local repo inventory: MASC still has required/default 5.4.1 surfaces, so this PR intentionally adds a canary instead of changing production/default compiler pins; checked from current main; confidence High.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/actions/setup-ocaml-toolchain/action.yml")'
- git diff --check
- actionlint -ignore 'SC2129' .github/workflows/ci.yml

## Notes
The canary runs dependency install with test deps and then builds @install under OCaml 5.5.0. It is continue-on-error so it reports ecosystem/compiler readiness without weakening or replacing the required 5.4.1 Build and Test lane.