### PR TITLE
feat(dashboard): surface reality notices

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -272,6 +272,8 @@ describe('ConnectorStatusPanel', () => {
     expect(fetchGateConnectors).toHaveBeenCalled()
     expect(fetchGateKeepers).toHaveBeenCalled()
     expect(text).toContain('커넥터')
+    expect(text).toContain('혼합 연결')
+    expect(text).toContain('Discord는 서버 내장 gateway')
     expect(text).toContain('connected')
     expect(text).toContain('Discord')
     expect(text).toContain('sangsu')

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -28,6 +28,7 @@ import { lastEvent } from '../sse'
 import { KpiStripIsland, type KpiStripIslandData } from './kpi-strip-island'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
+import { StatusChip } from './common/status-chip'
 import { showToast } from './common/toast'
 import { CopyableCode } from './common/copyable-code'
 import { SetupGuideCard } from './setup-guide-card'
@@ -1669,6 +1670,10 @@ function ConnectorsSurfaceHeader({
         <div class="cn-surf-sub surf-sub">
           외부 게이트 ${connectorCount}개 · <b>${activeCount} active</b> ·
           <span class="mono">GET /api/v1/gate/connectors</span>
+        </div>
+        <div class="mt-2 flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]" data-testid="connector-reality-notice">
+          <${StatusChip} tone="info" uppercase=${false}>혼합 연결<//>
+          <span>Discord는 서버 내장 gateway, iMessage/Slack/Telegram은 sidecar 관측 기반입니다.</span>
         </div>
       </div>
       <div class="cn-surf-actions" style=${{ display: 'flex', gap: 8 }}>

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -126,6 +126,10 @@ describe('FusionSurface', () => {
     render(html`<${FusionSurface} />`, container)
 
     expect(container.querySelector('[data-testid="fusion-surface"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="fusion-reality-notice"]')?.textContent)
+      .toContain('부분 지원')
+    expect(container.querySelector('[data-testid="fusion-reality-notice"]')?.textContent)
+      .toContain('fail-closed')
     expect(container.textContent).toContain('fus-1')
     expect(container.textContent).toContain('Which deploy path should we take?')
     expect(container.textContent).toContain('gpt-5')

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -16,6 +16,7 @@ import { RichContent } from '../common/rich-content'
 import { AgentAvatar } from '../overview/agent-avatar'
 import { FusionRunsPanel } from './fusion-runs-panel'
 import { asRecord, asString, asStringArray } from '../common/normalize'
+import { StatusChip } from '../common/status-chip'
 import { fusionDecisionSpec, type FusionDecisionSpec } from '../v2/fusion-constants'
 import {
   firstString,
@@ -919,6 +920,10 @@ export function FusionSurface() {
           <p class="surf-sub ov-sub">
             masc_fusion 패널 심의 · 심판 종합 · 보드 sink 증거.
           </p>
+          <div class="mt-2 flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]" data-testid="fusion-reality-notice">
+            <${StatusChip} tone="warn" uppercase=${false}>부분 지원<//>
+            <span>보드 sink와 registry 관측을 표시합니다. live JoJ는 judges 패널 구성이 없으면 fail-closed 상태로 남습니다.</span>
+          </div>
         </div>
         <button
           type="button"

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -146,6 +146,8 @@ describe('IdeShell', () => {
     expect(container.querySelector('.v2-ide-surface')).not.toBeNull()
     expect(container.querySelectorAll('.v2-ide-panel').length).toBeGreaterThanOrEqual(3)
     expect(container.querySelector('.v2-ide-toolbar')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ide-readiness-notice"]')?.textContent)
+      .toBe('experimental')
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -978,6 +978,11 @@ export function IdeShell() {
           data-testid="ide-statusbar"
         >
           <span class="ide-plane-statusbar-title">MASC IDE</span>
+          <span
+            class="chip sm is-warn"
+            data-testid="ide-readiness-notice"
+            title="IDE shell is observational; LSP, overlay, and shell flows are not a verified execution boundary."
+          >experimental</span>
           <span>·</span>
           <span
             class="chip sm is-brass"

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -111,6 +111,10 @@ describe('ScheduleSurface', () => {
 
     expect(mocks.loadTools).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[data-testid="schedule-surface"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="schedule-reality-notice"]')?.textContent)
+      .toContain('관측 전용')
+    expect(container.querySelector('[data-testid="schedule-reality-notice"]')?.textContent)
+      .toContain('keeper turn을 자동 구동하지 않습니다')
     expect(container.textContent).toContain('예약 자동화')
     expect(container.textContent).toContain('예약 자동화 projection 없음')
   })

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -9,6 +9,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import type { DashboardScheduledAutomation } from '../../api'
 import { ErrorState, LoadingState } from '../common/feedback-state'
+import { StatusChip } from '../common/status-chip'
 import { ScheduledAutomationPanel, normalizedScheduleStatus } from '../tools/scheduled-automation-panel'
 import {
   loadTools,
@@ -62,6 +63,10 @@ export function ScheduleSurface() {
             <p class="ov-sub">
               keeper가 예약한 미래 작업 · operator가 due 전 승인 · <span class="mono">lib/schedule</span>
             </p>
+            <div class="mt-2 flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]" data-testid="schedule-reality-notice">
+              <${StatusChip} tone="warn" uppercase=${false}>관측 전용<//>
+              <span>schedule runner projection을 읽어 표시하며, 이 화면에서 keeper turn을 자동 구동하지 않습니다.</span>
+            </div>
           </div>
         </header>
 

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -862,6 +862,10 @@ describe('SettingsSurface', () => {
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('Librarian')
+      expect(container.querySelector('[data-testid="runtime-media-failover-reality"]')?.textContent)
+        .toContain('수동 reroute')
+      expect(container.querySelector('[data-testid="runtime-media-failover-reality"]')?.textContent)
+        .toContain('provider 실패 자동 전환이 아니라')
       expect((container.querySelector('[data-testid="runtime-routing-structured-judge"]') as HTMLSelectElement | null)?.value)
         .toBe('rt-c')
       expect(container.querySelector('[data-testid="runtime-routing-cross-verifier"]')).not.toBeNull()

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -32,6 +32,7 @@ import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
 import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
+import { StatusChip } from './common/status-chip'
 import { logDisplayKind } from './log-classification'
 import { tweaksDensity, type Density } from './tweaks-panel'
 import type { ComponentChildren } from 'preact'
@@ -402,6 +403,10 @@ function RuntimeMediaFailoverEditor({
                 >×</button>
               </span>
             `)}
+        </div>
+        <div class="set-hint flex flex-wrap items-center gap-2" data-testid="runtime-media-failover-reality">
+          <${StatusChip} tone="warn" uppercase=${false}>수동 reroute<//>
+          <span>provider 실패 자동 전환이 아니라 <span class="mono">runtime.toml</span>의 media lane 후보 목록입니다.</span>
         </div>
         <div class="set-runtime-media-actions">
           <select


### PR DESCRIPTION
## Summary
- add visible reality notices for Schedule, Fusion, Connectors, Code IDE, and runtime media_failover
- align dashboard surfaces with the v2 (28) design cleanup item: partial or unsupported surfaces should not look fully operational
- add focused render assertions so the notices do not silently regress

## Design source
- /Users/dancer/Downloads/v2 (28)/keeper-v2/notes/grounding.md
- /Users/dancer/Downloads/v2 (28)/keeper-v2/notes/cleanup-plan.md section B

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/schedule/schedule-surface.test.ts src/components/fusion/fusion-surface.test.ts src/components/connector-status.test.ts src/components/settings-surface.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src/components/schedule/schedule-surface.ts src/components/fusion/fusion-surface.ts src/components/connector-status.ts src/components/settings-surface.ts src/components/ide/ide-shell.ts src/components/schedule/schedule-surface.test.ts src/components/fusion/fusion-surface.test.ts src/components/connector-status.test.ts src/components/settings-surface.test.ts src/components/ide/ide-shell.test.ts
- git diff --check

Note: local Dune build intentionally not run; CI is the build authority for Dune.