### PR TITLE
fix(governance): classify runtime blockers for auto-approval hard-forbidden gate

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -396,7 +396,10 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         |> Option.value ~default:false
       in
       let rule_match =
-        if auto_approval_forbidden
+        (* Hard forbidden cannot be overridden by routine allow-rules.
+           Soft forbidden is HITL-dependent and *is* permitted to be
+           overridden by a narrowly-scoped remembered rule. *)
+        if hard_forbidden
         then None
         else
           Keeper_approval_queue.find_matching_rule

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -82,7 +82,10 @@ let keeper_confirm_threshold governance_level =
 let runtime_auto_approval_blocked = function
   | None -> false
   | Some (meta : Keeper_meta_contract.keeper_meta) ->
-    Option.is_some meta.runtime.last_blocker
+    match meta.runtime.last_blocker with
+    | None -> false
+    | Some blocker ->
+      Keeper_meta_contract.blocker_class_auto_approval_blocked blocker.klass
 ;;
 
 (** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -288,6 +288,44 @@ let blocker_class_continue_gate = function
   | Sdk_input_required -> false
 ;;
 
+(** [blocker_class_auto_approval_blocked b] is [true] iff the presence of
+    this blocker should prevent auto-approval (including [always_approve]
+    and remembered allow-rules) for the keeper's next tool call.
+
+    Only blockers that signal genuine safety/uncertainty conditions are
+    hard-forbidden.  Transient liveness signals — capacity backpressure,
+    queue timeouts, turn timeouts, SDK budget/idle/input conditions — do
+    NOT block auto-approval, so automated recovery flows are not stalled
+    by a momentary runtime hiccup.
+
+    This classifier is exhaustive so adding a new [blocker_class] variant
+    forces an explicit auto-approval policy decision. *)
+let blocker_class_auto_approval_blocked = function
+  | Ambiguous_post_commit_timeout
+  | Ambiguous_post_commit_failure
+  | Completion_contract_violation
+  | Runtime_exhausted _
+  | Fiber_unresolved
+  | Stale_turn_timeout
+  | Stale_fleet_batch
+  | Turn_livelock_blocked
+  | No_progress_loop
+  | Oas_agent_execution_timeout
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met -> true
+  | Capacity_backpressure
+  | Admission_queue_wait_timeout
+  | Turn_timeout_after_queue_wait
+  | Turn_timeout
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_input_required -> false
+;;
+
 let runtime_exhaustion_reason_to_json reason =
   Keeper_internal_error.runtime_exhaustion_reason_to_json reason
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -190,6 +190,16 @@ val blocker_class_continue_gate : blocker_class -> bool
     other blocker terminates the keeper.  Pinned at the
     contract seam — drift changes keeper recovery semantics. *)
 
+val blocker_class_auto_approval_blocked : blocker_class -> bool
+(** [blocker_class_auto_approval_blocked b] is [true] iff this blocker
+    class should prevent auto-approval of the keeper's next tool call
+    (including [always_approve] and remembered allow-rules).  Only
+    safety/uncertainty classes are hard-forbidden; transient liveness
+    signals such as [Capacity_backpressure], [Turn_timeout], and SDK
+    budget/idle/input conditions are intentionally excluded so
+    automated recovery flows are not stalled.  Exhaustive — adding a
+    variant forces an explicit auto-approval policy decision. *)
+
 val runtime_exhaustion_reason_to_json :
   runtime_exhaustion_reason -> Yojson.Safe.t
 

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -112,6 +112,50 @@ let test_variant_count () =
   check int "blocker_class variant count" expected_variant_count count
 ;;
 
+(* ── Auto-approval blocking classification ─────────────────────── *)
+
+let test_auto_approval_blocked_is_exhaustive () =
+  (* Every variant must be classified without raising.  The function is
+     exhaustive, so a new variant is a compile error until this test and
+     the classifier are updated. *)
+  List.iter
+    (fun variant ->
+       let _blocked = blocker_class_auto_approval_blocked variant in
+       ())
+    all_variants
+;;
+
+let test_auto_approval_blocked_known_cases () =
+  let blocks klass =
+    check bool
+      (Printf.sprintf "%s blocks auto-approval" (blocker_class_to_string klass))
+      true
+      (blocker_class_auto_approval_blocked klass)
+  in
+  let allows klass =
+    check bool
+      (Printf.sprintf "%s allows auto-approval" (blocker_class_to_string klass))
+      false
+      (blocker_class_auto_approval_blocked klass)
+  in
+  (* Safety / uncertainty blockers *)
+  blocks Completion_contract_violation;
+  blocks (Runtime_exhausted No_providers_available);
+  blocks Fiber_unresolved;
+  blocks Stale_turn_timeout;
+  blocks Turn_livelock_blocked;
+  blocks No_progress_loop;
+  blocks Sdk_guardrail_violation;
+  blocks Sdk_tripwire_violation;
+  (* Transient liveness / budget / input signals do not block *)
+  allows Turn_timeout;
+  allows Capacity_backpressure;
+  allows Admission_queue_wait_timeout;
+  allows Sdk_idle_detected;
+  allows Sdk_input_required;
+  allows Sdk_max_turns_exceeded
+;;
+
 (* ── SDK error → blocker_class mapping exhaustiveness ────────────── *)
 
 module SdkE = Agent_sdk.Error
@@ -385,6 +429,11 @@ let () =
         ; test_case "string uniqueness" `Quick test_string_uniqueness
         ; test_case "unknown string returns None" `Quick test_unknown_string
         ; test_case "variant count pin" `Quick test_variant_count
+        ] )
+    ; ( "auto_approval_classification"
+      , [ test_case "exhaustive over all variants" `Quick
+            test_auto_approval_blocked_is_exhaustive
+        ; test_case "known cases" `Quick test_auto_approval_blocked_known_cases
         ] )
     ; ( "sdk_error_mapping"
       , [ test_case "all Agent variants are intentionally classified" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1439,7 +1439,9 @@ let test_callback_typed_last_blocker_overrides_always_approve () =
         in
         let blocker =
           let open Masc.Keeper_meta_contract in
-          blocker_info_of_class ~detail:"previous turn timed out" Turn_timeout
+          blocker_info_of_class
+            ~detail:"completion contract violated"
+            Completion_contract_violation
         in
         { base with
           runtime = { base.runtime with last_blocker = Some blocker };
@@ -1478,6 +1480,44 @@ let test_callback_typed_last_blocker_overrides_always_approve () =
         Alcotest.fail ("unexpected reject reason: " ^ reason)
       | Some (Agent_sdk.Hooks.Edit _) -> Alcotest.fail "unexpected edit"
       | None -> Alcotest.fail "runtime blocker callback did not suspend")
+
+let test_callback_transient_last_blocker_allows_always_approve () =
+  with_test_config @@ fun config ->
+  let keeper_name = "transient-blocked-keeper" in
+  let meta =
+    let base =
+      meta_from_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String ("keeper-" ^ keeper_name ^ "-agent"));
+            ("trace_id", `String "transient-blocked-trace");
+            ("sandbox_profile", `String "docker");
+            ("network_mode", `String "inherit");
+            ("always_approve", `Bool true);
+          ])
+    in
+    let blocker =
+      let open Masc.Keeper_meta_contract in
+      blocker_info_of_class ~detail:"previous turn timed out" Turn_timeout
+    in
+    { base with
+      runtime = { base.runtime with last_blocker = Some blocker };
+    }
+  in
+  let cb =
+    GP.to_oas_approval_callback
+      ~config ~governance_level:"production" ~keeper_name ~meta ()
+  in
+  let decision =
+    cb ~tool_name:"masc_create_task" ~input:(`Assoc [ ("title", `String "test") ])
+  in
+  match decision with
+  | Agent_sdk.Hooks.Approve -> ()
+  | Agent_sdk.Hooks.Reject r ->
+    Alcotest.fail
+      ("transient last_blocker must not block always_approve, got Reject: " ^ r)
+  | Agent_sdk.Hooks.Edit _ -> Alcotest.fail "unexpected edit"
 
 let test_runtime_trust_classifies_always_approve_flag () =
   with_test_config @@ fun config ->
@@ -1882,6 +1922,8 @@ let () =
         test_callback_always_approve_bypasses_threshold;
       Alcotest.test_case "typed last_blocker overrides always_approve" `Quick
         test_callback_typed_last_blocker_overrides_always_approve;
+      Alcotest.test_case "transient last_blocker allows always_approve" `Quick
+        test_callback_transient_last_blocker_allows_always_approve;
       Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
         test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1383,6 +1383,52 @@ let test_callback_paranoid_medium_risk_uses_remembered_policy () =
       | Agent_sdk.Hooks.Edit _ ->
           Alcotest.fail "expected remembered approve, got edit"
 
+let test_callback_remembered_rule_overrides_soft_forbidden () =
+  with_eio_base_path @@ fun base_path ->
+  let keeper_name = "remember-soft-keeper" in
+  let tool_name = "masc_status" in
+  let input = `Assoc [ ("op", `String "git") ] in
+  Alcotest.(check string)
+    "soft-only fixture stays below hard-forbidden risk"
+    "low"
+    (GP.assess_risk ~tool_name ~input |> GP.risk_level_to_string);
+  let id =
+    AQ.submit_pending
+      ~base_path
+      ~keeper_name
+      ~tool_name
+      ~input
+      ~risk_level:AQ.Low
+      ~on_resolution:(fun _ -> ())
+      ()
+  in
+  (match
+     AQ.resolve_with_policy ~base_path ~id
+       ~decision:Agent_sdk.Hooks.Approve ~remember_rule:true ()
+   with
+   | Ok { remembered_rule = Some _ } -> ()
+   | Ok { remembered_rule = None } ->
+     Alcotest.fail "expected soft-forbidden allow-rule to be remembered"
+   | Error err ->
+     Alcotest.fail
+       ("resolve_with_policy failed: " ^ AQ.resolve_error_to_string err));
+  let pending_before = AQ.pending_count () in
+  let config = Masc.Workspace.default_config base_path in
+  let cb =
+    GP.to_oas_approval_callback
+      ~governance_level:"production" ~keeper_name ~config ()
+  in
+  let decision = cb ~tool_name ~input in
+  match decision with
+  | Agent_sdk.Hooks.Approve ->
+    Alcotest.(check int) "remembered rule overrides soft forbidden"
+      pending_before (AQ.pending_count ())
+  | Agent_sdk.Hooks.Reject reason ->
+    Alcotest.fail
+      ("expected remembered rule to override soft forbidden, got reject: " ^ reason)
+  | Agent_sdk.Hooks.Edit _ ->
+    Alcotest.fail "expected remembered approve, got edit"
+
 let test_callback_always_approve_bypasses_threshold () =
   with_test_config @@ fun config ->
   let meta =
@@ -1918,6 +1964,8 @@ let () =
         test_callback_production_worktree_prepare_requires_approval;
       Alcotest.test_case "paranoid medium risk uses remembered policy" `Quick
         test_callback_paranoid_medium_risk_uses_remembered_policy;
+      Alcotest.test_case "remembered rule overrides soft forbidden" `Quick
+        test_callback_remembered_rule_overrides_soft_forbidden;
       Alcotest.test_case "always_approve bypasses threshold" `Quick
         test_callback_always_approve_bypasses_threshold;
       Alcotest.test_case "typed last_blocker overrides always_approve" `Quick

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -828,6 +828,50 @@ let test_governance_approval_hard_forbidden_blocks_without_hitl () =
       failf "expected one hard-forbidden observer event, got %d"
         (List.length events)))
 
+let meta_with_blocker klass meta =
+  let open Masc.Keeper_meta_contract in
+  let blocker = blocker_info_of_class ~detail:"test blocker" klass in
+  { meta with runtime = { meta.runtime with last_blocker = Some blocker } }
+;;
+
+let test_governance_approval_serious_blocker_overrides () =
+  with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let meta_ref = make_meta_ref "test_keeper" in
+    meta_ref := meta_with_blocker Masc.Keeper_meta_contract.Completion_contract_violation !meta_ref;
+    let observed = ref [] in
+    let on_gate_decision event = observed := event :: !observed in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let d =
+      invoke hook
+        (pre_tool_use_event ~tool_name:"masc_create_task"
+           ~input:(`Assoc [ ("title", `String "follow up") ])
+           ())
+    in
+    check string "serious last_blocker -> Override"
+      "Override" (decision_kind d);
+    check bool "override carries hard-forbidden reason" true
+      (contains_substring (override_text d) "code=hard_forbidden")))
+
+let test_governance_approval_transient_blocker_allows () =
+  with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let meta_ref = make_meta_ref "test_keeper" in
+    meta_ref := meta_with_blocker Masc.Keeper_meta_contract.Turn_timeout !meta_ref;
+    let observed = ref [] in
+    let on_gate_decision event = observed := event :: !observed in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let d =
+      invoke hook
+        (pre_tool_use_event ~tool_name:"masc_create_task"
+           ~input:(`Assoc [ ("title", `String "follow up") ])
+           ())
+    in
+    check string "transient last_blocker -> Continue"
+      "Continue" (decision_kind d);
+    check bool "no gate event for transient blocker" true
+      (List.length !observed = 0)))
+
 let test_timing_guard_sets_time_and_continues () =
   let tool_start_time = ref 0.0 in
   let hook = KG.timing_guard ~tool_start_time in
@@ -981,6 +1025,10 @@ let () = run "Keeper_guards" [
       test_governance_approval_notifies_gate_observer;
     test_case "hard-forbidden overrides without HITL" `Quick
       test_governance_approval_hard_forbidden_blocks_without_hitl;
+    test_case "serious last_blocker overrides without HITL" `Quick
+      test_governance_approval_serious_blocker_overrides;
+    test_case "transient last_blocker allows without HITL" `Quick
+      test_governance_approval_transient_blocker_allows;
   ];
   "timing_guard", [
     test_case "sets time and continues" `Quick test_timing_guard_sets_time_and_continues;


### PR DESCRIPTION
## Summary

Adversarial review follow-up for the masc HITL hard-forbidden + 1h auto-escalation quartet (#22999, #22997, #22988, #22995).

### Problem 1 — runtime blocker over-classification (PR #22988)

PR #22988 removed free-form `last_blocker.detail` substring classification from the auto-approval gate and replaced it with `Option.is_some meta.runtime.last_blocker`. This treated **every** runtime blocker as a hard-forbidden safety signal, including transient liveness conditions such as:

- `Capacity_backpressure`
- `Turn_timeout`
- `Sdk_idle_detected`
- SDK budget/turn/input conditions

As noted in the post-merge review on #22988, this stalled automated recovery flows that rely on `always_approve` and remembered allow-rules.

### Fix 1

Introduce `Keeper_meta_contract.blocker_class_auto_approval_blocked` as the single SSOT classifier. Only blocker classes that represent genuine safety/uncertainty conditions block auto-approval; transient liveness signals do not.

`Governance_pipeline.runtime_auto_approval_blocked` now delegates to this classifier instead of checking blocker presence.

### Problem 2 — soft forbidden was not overridable by remembered rules (PR #22999)

The design comment at `lib/governance_pipeline.ml:91-106` states that soft forbidden 'is a narrowly-scoped routine allowlist match [that] is permitted to override.'  However, `to_oas_approval_callback` skipped `find_matching_rule` whenever `auto_approval_forbidden` was true, which includes soft forbidden when HITL is enabled.  Remembered allow-rules therefore could not override soft-forbidden heuristics, contradicting the documented design.

### Fix 2

Gate the rule lookup on `hard_forbidden` only.  Hard forbidden (Critical risk / serious runtime blockers) still cannot be overridden; soft forbidden can be satisfied by a matching remembered rule.

### Safety/uncertainty blockers (hard-forbidden)

- `Ambiguous_post_commit_timeout` / `Ambiguous_post_commit_failure`
- `Completion_contract_violation`
- `Runtime_exhausted _`
- `Fiber_unresolved`
- `Stale_turn_timeout` / `Stale_fleet_batch`
- `Turn_livelock_blocked`
- `No_progress_loop`
- `Oas_agent_execution_timeout`
- `Sdk_guardrail_violation` / `Sdk_tripwire_violation`
- `Sdk_exit_condition_met`

### Transient liveness blockers (NOT hard-forbidden)

- `Capacity_backpressure`
- `Admission_queue_wait_timeout`
- `Turn_timeout_after_queue_wait`
- `Turn_timeout`
- `Sdk_max_turns_exceeded` / `Sdk_token_budget_exceeded` / `Sdk_cost_budget_exceeded`
- `Sdk_unrecognized_stop_reason`
- `Sdk_idle_detected`
- `Sdk_input_required`

### Tests added/strengthened

- `test_blocker_class_exhaustiveness`: exhaustiveness + known-case assertions for the new classifier.
- `test_keeper_guards`: serious blocker → `Override`; transient blocker → `Continue`.
- `test_hitl_approval`:
  - updated the existing typed-blocker test to use `Completion_contract_violation`;
  - added transient-blocker test proving `Turn_timeout` does **not** block `always_approve`;
  - added remembered-rule test proving a rule can override soft forbidden when HITL is enabled.

### Scope / out-of-scope

- The HITL-disabled Critical confirmation behavior is preserved as intended (prevents the "Disabled = Safe" anti-pattern).
- The front-door `Governance_pipeline.decide` path still does not see keeper `last_blocker` because it lacks keeper meta; this is documented as a surface difference.
- PR #22995's 1h escalation via `Fiber.first` diverges from RFC-0304's recommended typed phase + janitor-sweep design (1800s, `Defer`, dashboard badges, SSE type). That is a larger cross-component change and is left for follow-up; this PR focuses on the over-blocking and rule-override gaps.

### Verification

- `dune build --root . @check`
- `dune build --root . @test/runtest-test_governance_pipeline` — 99 tests pass
- `dune build --root . @test/runtest-test_keeper_guards` — 41 tests pass
- `dune build --root . @test/runtest-test_hitl_approval` — 45 tests pass
- `dune build --root . @test/runtest-test_blocker_class_exhaustiveness` — 16 tests pass
- `ocamlformat --check` on touched files