### PR TITLE
fix(keeper): cache Dated_jsonl store for wire capture

### DIFF
--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -9,15 +9,42 @@ let redact = Llm_provider.Secret_redactor.redact_string
    serialise on a per-day file rather than one global blob. *)
 let wire_capture_dir masc_root = Filename.concat masc_root "wire-capture"
 
+(** Cache [Dated_jsonl.t] handles per MASC root so the diagnostic harness does
+    not recreate the store (and re-scan/re-prune) on every request/response
+    capture. The cache is keyed by the effective root path and invalidated when
+    retention or byte-budget configuration changes. *)
+type store_entry =
+  { store : Dated_jsonl.t
+  ; retention_days : int
+  ; max_bytes : int
+  }
+
+let store_cache : (string, store_entry) Hashtbl.t = Hashtbl.create 16
+let store_cache_mu = Stdlib.Mutex.create ()
+
+let store_for ~masc_root =
+  let retention_days = Env_config_keeper.KeeperWireCapture.retention_days () in
+  let max_bytes = Env_config_keeper.KeeperWireCapture.max_bytes () in
+  Stdlib.Mutex.protect store_cache_mu (fun () ->
+    match Hashtbl.find_opt store_cache masc_root with
+    | Some entry
+      when entry.retention_days = retention_days && entry.max_bytes = max_bytes ->
+      entry.store
+    | _ ->
+      let store =
+        Dated_jsonl.create
+          ~base_dir:(wire_capture_dir masc_root)
+          ~retention_days
+          ~max_bytes
+          ()
+      in
+      Hashtbl.replace store_cache masc_root { store; retention_days; max_bytes };
+      store)
+;;
+
 let write_payload ~masc_root (payload : Yojson.Safe.t) =
   let max_bytes = Env_config_keeper.KeeperWireCapture.max_bytes () in
-  let store =
-    Dated_jsonl.create
-      ~base_dir:(wire_capture_dir masc_root)
-      ~retention_days:(Env_config_keeper.KeeperWireCapture.retention_days ())
-      ~max_bytes
-      ()
-  in
+  let store = store_for ~masc_root in
   if
     not
       (Dated_jsonl.append_if_current_file_fits

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -243,6 +243,35 @@ let capture_prunes_old_files () =
         Alcotest.(check int) "only current capture remains" 1
           (List.length (find_jsonl base)))))
 
+let capture_cache_reloads_when_retention_changes () =
+  with_flag "1" (fun () ->
+    with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "4096" (fun () ->
+      let base = Filename.temp_dir "wirecap_cache_retention" "" in
+      let capture_dir = Filename.concat base "wire-capture" in
+      let old_ts = Unix.gettimeofday () -. (2. *. 24. *. 60. *. 60.) in
+      let old_tm = Unix.gmtime old_ts in
+      let old_month_name =
+        Printf.sprintf "%04d-%02d"
+          (old_tm.Unix.tm_year + 1900)
+          (old_tm.Unix.tm_mon + 1)
+      in
+      let old_day_name = Printf.sprintf "%02d.jsonl" old_tm.Unix.tm_mday in
+      let old_month = Filename.concat capture_dir old_month_name in
+      ensure_dir capture_dir;
+      ensure_dir old_month;
+      let old_file = Filename.concat old_month old_day_name in
+      write_file old_file (String.make 1024 'x');
+      with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "30" (fun () ->
+        Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:20
+          ~response_text:"cache warmup" ());
+      Alcotest.(check bool) "old capture retained by warm cache" true
+        (Sys.file_exists old_file);
+      with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "1" (fun () ->
+        Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:21
+          ~response_text:"cache reload" ());
+      Alcotest.(check bool) "old capture pruned after retention change" false
+        (Sys.file_exists old_file)))
+
 let capture_skips_when_current_file_cap_would_be_exceeded () =
   with_flag "1" (fun () ->
     with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "512" (fun () ->
@@ -365,6 +394,8 @@ let () =
             response_capture_writes_redacted;
           Alcotest.test_case "capture store prunes old files" `Quick
             capture_prunes_old_files;
+          Alcotest.test_case "capture store reloads on retention change" `Quick
+            capture_cache_reloads_when_retention_changes;
           Alcotest.test_case "current file cap skips oversized record" `Quick
             capture_skips_when_current_file_cap_would_be_exceeded;
           Alcotest.test_case "trace_id is emitted when provided" `Quick


### PR DESCRIPTION
Adversarial review follow-up for #22966, narrowed after #23046 merged the finalizer-owned response-capture path.

**Problem:** `Keeper_wire_capture.write_payload` created a fresh `Dated_jsonl.t` store on every request/response capture. That caused redundant directory scans and opportunistic pruning on every turn, and discarded the per-store `last_prune_day` state across calls.

**Fix:** Cache the store per MASC root. The cache is invalidated when `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` or `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` changes, so config updates still take effect without a restart.

**Conflict/review resolution:** The older raw SDK response-content capture path was intentionally dropped during the rebase. The branch now preserves the #23046/main contract: response capture remains finalizer-owned and records replay-visible assistant text, not raw provider content.

**Verification (local, narrow):**
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/keeper/keeper_wire_capture.ml test/test_keeper_wire_capture.ml`
- `python3 scripts/check_test_coverage.py`

**CI:** Re-running on head `e299143db4a6cfb4c4cdbaecf2a93783839154ca`.

**Remaining/out-of-scope:** The `Dated_jsonl.append_if_current_file_fits` size check is not atomic across separate MASC processes. Same-process writers are serialized by the per-base-dir mutex registry; cross-process sharing of a wire-capture directory can be addressed separately if it becomes operationally relevant.
