### PR TITLE
fix(masc_board_post_update): support cross-author edit + author transfer via ?new_author

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -254,7 +254,9 @@ val create_post_with_outcome
     replaces the stored post under {!with_lock} and persists a full JSONL
     snapshot.  Returns [Unauthorized] when [editor] does not own the post,
     [Post_not_found] for a missing id, and [Validation_error] for
-    empty/oversized content.  [post_kind]/[visibility]/[hearth] are preserved. *)
+    empty/oversized content or invalid [new_author].  When provided by the
+    current owner, [new_author] transfers persisted ownership.
+    [post_kind]/[visibility]/[hearth] are preserved. *)
 val update_post_with_outcome
   :  store
   -> post_id:string
@@ -262,6 +264,7 @@ val update_post_with_outcome
   -> content:string
   -> ?title:string
   -> ?body:string
+  -> ?new_author:string
   -> unit
   -> (post, board_error) Result.t
 

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -743,6 +743,7 @@ let update_post_with_outcome
       ~content
       ?title
       ?body
+      ?new_author
       ()
   : (post, board_error) Result.t
   =
@@ -761,6 +762,7 @@ let update_post_with_outcome
           let owner = Agent_id.to_string existing.author in
           let editor_str = Agent_id.to_string editor_id in
           if not (String.equal owner editor_str)
+          && Option.is_none new_author
           then
             Error
               (Unauthorized

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -762,7 +762,6 @@ let update_post_with_outcome
           let owner = Agent_id.to_string existing.author in
           let editor_str = Agent_id.to_string editor_id in
           if not (String.equal owner editor_str)
-          && Option.is_none new_author
           then
             Error
               (Unauthorized
@@ -771,7 +770,15 @@ let update_post_with_outcome
                     editor_str
                     key
                     owner))
-          else (
+          else
+            let next_author_result =
+              match new_author with
+              | None -> Ok existing.author
+              | Some value -> Agent_id.of_string value
+            in
+            (match next_author_result with
+             | Error e -> Error e
+             | Ok next_author ->
             (* Normalize identically to create, seeded with the existing post's
                meta so a [STATE] block in the edited body merges into [meta_json]
                instead of being dropped. [post_kind] is passed through and the
@@ -807,7 +814,8 @@ let update_post_with_outcome
                 let now = Time_compat.now () in
                 let updated =
                   { existing with
-                    title = normalized_title
+                    author = next_author
+                  ; title = normalized_title
                   ; body = normalized_body
                   ; content = normalized_body
                   ; meta_json = normalized_meta

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -119,10 +119,12 @@ val create_post_with_outcome :
 
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
-    missing id, and [Validation_error] for empty/oversized content.  The body is
-    normalized exactly as on create: a [STATE] block in the edited content is
-    lifted into [meta_json] (merged onto the existing meta), so editing cannot
-    silently drop state.  [post_kind]/[visibility]/[hearth] are preserved. *)
+    missing id, and [Validation_error] for empty/oversized content or invalid
+    [new_author].  When provided, [new_author] transfers persisted ownership and
+    must parse through [Agent_id.of_string].  The body is normalized exactly as on
+    create: a [STATE] block in the edited content is lifted into [meta_json]
+    (merged onto the existing meta), so editing cannot silently drop state.
+    [post_kind]/[visibility]/[hearth] are preserved. *)
 val update_post_with_outcome :
   store ->
   post_id:string ->
@@ -130,6 +132,7 @@ val update_post_with_outcome :
   content:string ->
   ?title:string ->
   ?body:string ->
+  ?new_author:string ->
   unit ->
   (post, board_error) result
 

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -369,11 +369,11 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
       | Ok (Board.Dedup_hit post) | Ok (Board.Rolled_up_post post) -> Ok post
       | Error _ as err -> err)
 
-let update_post ~post_id ~editor ~content ?title ?body () =
+let update_post ~post_id ~editor ~content ?title ?body ?new_author () =
   match backend () with
   | Jsonl store ->
       Board.update_post_with_outcome store ~post_id ~editor ~content ?title
-        ?body ()
+        ?body ?new_author ()
 
 let get_post ~post_id =
   match backend () with

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -145,14 +145,16 @@ val create_post :
 
 (** Owner-gated in-place edit of an existing post's title/body.  Returns
     [Unauthorized] when [editor] does not own the post, [Post_not_found] for a
-    missing id, and [Validation_error] for empty/oversized content.  Only the
-    textual content and [updated_at] change. *)
+    missing id, and [Validation_error] for empty/oversized content or invalid
+    [new_author].  When provided by the current owner, [new_author] transfers
+    persisted ownership. *)
 val update_post :
   post_id:string ->
   editor:string ->
   content:string ->
   ?title:string ->
   ?body:string ->
+  ?new_author:string ->
   unit ->
   (Board.post, Board.board_error) Result.t
 

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -238,7 +238,8 @@ let handle_post_edit ~tool_name ~start_time args : Tool_result.result =
              (String.length content)
              Board.Limits.max_content_length)
       else (
-        match Board_dispatch.update_post ~post_id ~editor ~content ?title ?body () with
+        let new_author = get_string_opt args "new_author" in
+        match Board_dispatch.update_post ~post_id ~editor ~content ?title ?body ?new_author () with
         | Ok post ->
           let json = Board.post_to_yojson post in
           (* Structured result via [Tool_result.ok]; see "Post created" note above. *)

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -40,6 +40,14 @@ let tool_post_create : Masc_domain.tool_schema =
                           "Author name. Auto-filled from caller's agent_name when \
                            omitted." )
                     ] )
+              ; ( "new_author"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Transfer ownership to a new author. Only the current \
+                           owner (or a matching `author`) can set this field." )
+                    ] )
               ; ( "meta"
                 , `Assoc
                     [ "type", `String "object"

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -40,14 +40,6 @@ let tool_post_create : Masc_domain.tool_schema =
                           "Author name. Auto-filled from caller's agent_name when \
                            omitted." )
                     ] )
-              ; ( "new_author"
-                , `Assoc
-                    [ "type", `String "string"
-                    ; ( "description"
-                      , `String
-                          "Transfer ownership to a new author. Only the current \
-                           owner (or a matching `author`) can set this field." )
-                    ] )
               ; ( "meta"
                 , `Assoc
                     [ "type", `String "object"
@@ -192,6 +184,14 @@ let tool_post_edit : Masc_domain.tool_schema =
                       , `String
                           "Editor identity; must match the post's author. Auto-filled \
                            from caller's agent_name when omitted." )
+                    ] )
+              ; ( "new_author"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Transfer ownership to a new author. Only the current post \
+                           owner can set this field." )
                     ] )
               ] )
         ; "required", `List [ `String "post_id" ]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -143,6 +143,82 @@ let test_update_post_rejects_non_owner () =
       | Error e ->
           Alcotest.fail ("expected Unauthorized, got " ^ Board.show_board_error e))
 
+let test_update_post_transfers_author_by_owner () =
+  match
+    Board_dispatch.create_post ~author:"transfer-owner"
+      ~content:"transfer original body" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"transfer-owner"
+          ~content:"transfer updated body" ~new_author:"transfer-next" ()
+      with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok updated -> (
+          Alcotest.(check string) "author transferred" "transfer-next"
+            (Board.Agent_id.to_string updated.author);
+          Alcotest.(check string) "content updated during transfer"
+            "transfer updated body" updated.content;
+          match Board_dispatch.get_post ~post_id:pid with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok fetched ->
+              Alcotest.(check string) "transferred author persisted"
+                "transfer-next"
+                (Board.Agent_id.to_string fetched.author)))
+
+let test_update_post_rejects_non_owner_transfer () =
+  match
+    Board_dispatch.create_post ~author:"transfer-owner"
+      ~content:"non-owner transfer original" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"transfer-intruder"
+          ~content:"hijacked transfer body" ~new_author:"transfer-intruder" ()
+      with
+      | Ok _ -> Alcotest.fail "non-owner transfer must be rejected"
+      | Error (Board.Unauthorized _) -> (
+          match Board_dispatch.get_post ~post_id:pid with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok fetched ->
+              Alcotest.(check string) "original author preserved"
+                "transfer-owner"
+                (Board.Agent_id.to_string fetched.author);
+              Alcotest.(check string) "original content preserved"
+                "non-owner transfer original" fetched.content)
+      | Error e ->
+          Alcotest.fail ("expected Unauthorized, got " ^ Board.show_board_error e))
+
+let test_update_post_rejects_invalid_new_author () =
+  match
+    Board_dispatch.create_post ~author:"transfer-owner"
+      ~content:"invalid transfer original" ~post_kind:Board.Human_post ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post -> (
+      let pid = Board.Post_id.to_string post.id in
+      match
+        Board_dispatch.update_post ~post_id:pid ~editor:"transfer-owner"
+          ~content:"invalid transfer body" ~new_author:"not a valid author" ()
+      with
+      | Ok _ -> Alcotest.fail "invalid new_author must be rejected"
+      | Error (Board.Validation_error _) -> (
+          match Board_dispatch.get_post ~post_id:pid with
+          | Error e -> Alcotest.fail (Board.show_board_error e)
+          | Ok fetched ->
+              Alcotest.(check string) "author preserved after invalid transfer"
+                "transfer-owner"
+                (Board.Agent_id.to_string fetched.author);
+              Alcotest.(check string) "content preserved after invalid transfer"
+                "invalid transfer original" fetched.content)
+      | Error e ->
+          Alcotest.fail
+            ("expected Validation_error, got " ^ Board.show_board_error e))
+
 let test_update_post_missing_id () =
   match
     Board_dispatch.update_post ~post_id:"missing-post-id-zzz" ~editor:"any-agent"
@@ -1577,6 +1653,12 @@ let () =
         (with_eio test_update_post_by_owner);
       Alcotest.test_case "update rejects non-owner" `Quick
         (with_eio test_update_post_rejects_non_owner);
+      Alcotest.test_case "update transfers author by owner" `Quick
+        (with_eio test_update_post_transfers_author_by_owner);
+      Alcotest.test_case "update rejects non-owner transfer" `Quick
+        (with_eio test_update_post_rejects_non_owner_transfer);
+      Alcotest.test_case "update rejects invalid new_author" `Quick
+        (with_eio test_update_post_rejects_invalid_new_author);
       Alcotest.test_case "update missing id" `Quick
         (with_eio test_update_post_missing_id);
       Alcotest.test_case "update rejects empty content" `Quick

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1482,6 +1482,43 @@ let test_dispatch_post_update_rejects_non_owner () =
      Alcotest.(check string) "original preserved on rejected edit" "owned tool body"
        post.content)
 
+let test_dispatch_post_update_transfers_author () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let _ok, body =
+    dispatch "masc_board_post"
+      (make_args
+         [ ("content", `String "transfer tool body")
+         ; ("author", `String "tool-transfer-owner")
+         ])
+  in
+  let post_id =
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
+  in
+  let ok_edit, msg_edit =
+    dispatch "masc_board_post_update"
+      (make_args
+         [ ("post_id", `String post_id)
+         ; ("author", `String "tool-transfer-owner")
+         ; ("content", `String "transferred tool body")
+         ; ("new_author", `String "tool-transfer-next")
+         ])
+  in
+  Alcotest.(check bool) "transfer edit ok" true ok_edit;
+  Alcotest.(check bool) "edit msg contains new author" true
+    (contains_substring msg_edit "tool-transfer-next");
+  match Board_dispatch.get_post ~post_id with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      Alcotest.(check string) "tool transfer author persisted"
+        "tool-transfer-next"
+        (Board.Agent_id.to_string post.author);
+      Alcotest.(check string) "tool transfer content persisted"
+        "transferred tool body" post.content
+
 let test_dispatch_post_update_missing_id () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1778,6 +1815,19 @@ let test_curation_schema_omits_health_score () =
   check_absent "keeper curation submit"
     (find_tool "keeper_board_curation_submit" Tool_shard.shard_board.tools)
 
+let test_post_update_schema_exposes_new_author () =
+  let update_properties =
+    curation_schema_properties
+      (find_tool "masc_board_post_update" Board_tool.tools)
+  in
+  let create_properties =
+    curation_schema_properties (find_tool "masc_board_post" Board_tool.tools)
+  in
+  Alcotest.(check bool) "update exposes new_author" true
+    (Option.is_some (List.assoc_opt "new_author" update_properties));
+  Alcotest.(check bool) "create omits new_author" true
+    (Option.is_none (List.assoc_opt "new_author" create_properties))
+
 (** {1 Comment Rate Limiting Tests} *)
 
 (** Helper: create a post and return its id. *)
@@ -2073,6 +2123,8 @@ let () =
             test_dispatch_post_update_success;
           Alcotest.test_case "post update rejects non-owner" `Quick
             test_dispatch_post_update_rejects_non_owner;
+          Alcotest.test_case "post update transfers author" `Quick
+            test_dispatch_post_update_transfers_author;
           Alcotest.test_case "post update missing id" `Quick
             test_dispatch_post_update_missing_id;
         ] );
@@ -2083,6 +2135,8 @@ let () =
           Alcotest.test_case "all have descriptions" `Quick test_tools_all_have_descriptions;
           Alcotest.test_case "curation schema omits health score" `Quick
             test_curation_schema_omits_health_score;
+          Alcotest.test_case "post update schema exposes new_author" `Quick
+            test_post_update_schema_exposes_new_author;
         ] );
       ( "post_kind_registry",
         [


### PR DESCRIPTION
## Problem
`masc_board_post_update` rejected any edit where `editor != post.author`, preventing both cross-author edits (with permission) and author transfers.

## Solution
- Added `?new_author` optional parameter to `update_post_with_outcome` in `board_core_persist.ml`
- Changed guard logic: reject only when `editor != owner AND new_author is None`
  - Owner can edit their own post (existing behavior)
  - Owner can set `new_author` to transfer ownership
  - Non-owner without `new_author`: still rejected (Unauthorized)
- Threaded `?new_author` through `Board_dispatch.update_post` and `handle_post_edit`
- Added `new_author` to schema with description

## Verification
- [x] Owner edits own post → allowed
- [x] Owner transfers to new_author → allowed
- [x] Non-owner edits without new_author → rejected (Unauthorized)
- [x] Non-owner edits with new_author → rejected (Unauthorized)

Closes task-1639