### PR TITLE
fix(runtime): resume path must honor base structured-output contract (masc#23004 follow-up)

### DIFF
--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -405,6 +405,15 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; preserve_thinking = config.preserve_thinking
     ; thinking_budget = config.thinking_budget
     ; cache_system_prompt = config.cache_system_prompt
+    ; response_format = config.provider_cfg.response_format
+      (* MASC owns the structured-output contract via [config.provider_cfg].
+         A checkpoint may carry a stale [response_format] from a previous run
+         (e.g., prompt-tier fallback or an older native schema).  If we resumed
+         with [JsonMode] while the current base config carries a native schema,
+         [Runtime_agent.request_runtime_fields_on_base_config] would treat the
+         stale request as an explicit opinion and clear the contract.  Patch the
+         checkpoint so the resume path observes the same contract as a fresh
+         build. *)
     }
   in
   let agent_config : Agent_sdk.Types.agent_config =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1002,6 +1002,61 @@ let test_runtime_agent_context_preserves_unbounded_resume_budget () =
   check int "resume preserves unbounded turn budget" 0
     prepared.agent_config.max_turns
 
+let test_runtime_agent_context_resume_patches_stale_response_format_to_base_contract () =
+  let resume_schema : Yojson.Safe.t =
+    `Assoc
+      [ ("type", `String "object")
+      ; ("properties", `Assoc [ ("answer", `Assoc [("type", `String "string")]) ])
+      ; ("required", `List [ `String "answer" ])
+      ]
+  in
+  let provider_cfg_with_schema =
+    let base = provider_cfg () in
+    { base with
+      Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonSchema resume_schema
+    ; output_schema = Some resume_schema
+    }
+  in
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg:provider_cfg_with_schema
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let checkpoint =
+    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
+    ; session_id = "session"
+    ; agent_name = "oas-runpod_mtp.qwen"
+    ; model = "qwen"
+    ; system_prompt = Some ""
+    ; messages = []
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count = 3
+    ; created_at = 0.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = Some 0.3
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.Off
+    ; thinking_budget = None
+    ; cache_system_prompt = false
+    ; context = Agent_sdk.Context.create_sync ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+  in
+  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
+  check bool "resume patches checkpoint response_format to base JsonSchema" true
+    (match prepared.patched_checkpoint.Agent_sdk.Checkpoint.response_format with
+     | Agent_sdk.Types.JsonSchema s -> Yojson.Safe.equal s resume_schema
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonMode -> false)
+
 let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
   let tool =
     Agent_sdk.Tool.create
@@ -1217,6 +1272,10 @@ let () =
             "runtime agent context preserves unbounded resume budget"
             `Quick
             test_runtime_agent_context_preserves_unbounded_resume_budget
+        ; test_case
+            "runtime agent context resume patches stale response_format to base contract"
+            `Quick
+            test_runtime_agent_context_resume_patches_stale_response_format_to_base_contract
         ; test_case
             "runtime agent context leaves tool_choice unset with tools"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1052,10 +1052,12 @@ let test_runtime_agent_context_resume_patches_stale_response_format_to_base_cont
     }
   in
   let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
+  let expected_response_format =
+    provider_cfg_with_schema.Llm_provider.Provider_config.response_format
+  in
   check bool "resume patches checkpoint response_format to base JsonSchema" true
-    (match prepared.patched_checkpoint.Agent_sdk.Checkpoint.response_format with
-     | Agent_sdk.Types.JsonSchema s -> Yojson.Safe.equal s resume_schema
-     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonMode -> false)
+    (prepared.patched_checkpoint.Agent_sdk.Checkpoint.response_format
+     = expected_response_format)
 
 let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
   let tool =

--- a/test/test_runtime_request_config_merge.ml
+++ b/test/test_runtime_request_config_merge.ml
@@ -136,6 +136,28 @@ let test_both_opinionless_stays_off () =
   check bool "no output_schema anywhere stays None" true
     (Option.is_none merged.Llm_provider.Provider_config.output_schema)
 
+let test_base_json_mode_survives_opinionless_request () =
+  let base =
+    let cfg =
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.Anthropic
+        ~model_id:"claude-test"
+        ~base_url:"https://api.anthropic.test"
+        ()
+    in
+    { cfg with
+      Llm_provider.Provider_config.response_format = Agent_sdk.Types.JsonMode
+    ; output_schema = None
+    }
+  in
+  let merged = merge ~base (request_without_opinion ()) in
+  check bool "base JsonMode survives request Off" true
+    (match merged.Llm_provider.Provider_config.response_format with
+     | Agent_sdk.Types.JsonMode -> true
+     | Agent_sdk.Types.Off | Agent_sdk.Types.JsonSchema _ -> false);
+  check bool "base output_schema None survives request None" true
+    (Option.is_none merged.Llm_provider.Provider_config.output_schema)
+
 (* Mismatched request-side response_format/output_schema pairs must be
    normalized by the merge rather than propagated to the wire.  A request can
    only express a schema opinion through [output_schema] or an explicit
@@ -212,6 +234,8 @@ let () =
             test_request_output_schema_normalizes_response_format
         ; test_case "both opinionless stays Off" `Quick
             test_both_opinionless_stays_off
+        ; test_case "base JsonMode survives opinionless request" `Quick
+            test_base_json_mode_survives_opinionless_request
         ] )
     ; ( "response_format/output_schema mismatch normalization"
       , [ test_case "Off + Some schema" `Quick


### PR DESCRIPTION
Adversarial-review follow-up to #23004.

## Issue
#23004 made "opinionless" per-request configs (`response_format=Off`, `output_schema=None`) preserve the base provider contract instead of erasing it. The same risk exists on the resume path: OAS restores `checkpoint.response_format` verbatim, so a stale checkpoint carrying `JsonMode` or `Off` is treated as an explicit opinion by `request_runtime_fields_on_base_config` and can clear the schema-carrying base config.

## Fix
Patch `prepare_resume` to overwrite `checkpoint.response_format` with `config.provider_cfg.response_format`, aligning resume with fresh builds.

## Tests
- `test_runtime_request_config_merge`: add `base JsonMode survives opinionless request`.
- `test_runtime_provider_auth_headers`: add `runtime agent context resume patches stale response_format to base contract`.

## Verification
- `dune build --root . @check lib/runtime/runtime_agent_context.ml test/test_runtime_request_config_merge.ml test/test_runtime_provider_auth_headers.ml`
- `test/test_runtime_request_config_merge.exe` — 6/6 pass
- `test/test_runtime_provider_auth_headers.exe` — 32/32 pass
- `test/test_mid_turn_resume.exe` — 4/4 pass
- `test/test_keeper_context_isolation.exe` — 7/7 pass
- `test/test_runtime_modality_reroute.exe` — 18/18 pass
