### PR TITLE
fix(server): add missing REST bridge for masc_board_comment_vote

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -90,6 +90,24 @@ let json_ensure_meta_string_field name value = function
   | _non_object ->
       Error "json_ensure_meta_string_field: expected JSON object"
 
+let board_tool_agent_name_from_request request =
+  let hdr name =
+    Option.bind
+      (Httpun.Headers.get request.Httpun.Request.headers name)
+      (fun value ->
+        let trimmed = String.trim value in
+        if String.equal trimmed "" then None else Some trimmed)
+  in
+  match hdr "x-gate-agent" with
+  | Some value -> value
+  | None -> (
+      match hdr "x-masc-agent" with
+      | Some value -> value
+      | None ->
+          (* NDT-OK: same-origin dashboard tool calls may omit agent headers;
+             the sibling board REST bridges already use this dashboard actor fallback. *)
+          "dashboard")
+
 let governance_surface_for_param_key param_key =
   Governance_registry.surfaces
   |> List.find_opt (fun (surface : Governance_registry.surface) ->
@@ -644,7 +662,7 @@ let add_routes ~sw ~clock router =
   |> Http.Router.post "/api/v1/tools/masc_board_comment_vote" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_board_comment_vote"
          (fun _state _req reqd ->
-         let agent_name = (let hdr k = Option.bind (Httpun.Headers.get request.Httpun.Request.headers k) (fun s -> if s = "" then None else Some s) in match hdr "x-gate-agent" with Some _ as v -> v | None -> hdr "x-masc-agent") |> Option.value ~default:"dashboard" in
+         let agent_name = board_tool_agent_name_from_request request in
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let ( let* ) r f =

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -638,6 +638,44 @@ let add_routes ~sw ~clock router =
                   ])
          )
        ) request reqd)
+
+  (* Comment vote — mirrors masc_board_vote. Server re-derives [voter] from the
+     agent header so the client cannot forge the voting identity. *)
+  |> Http.Router.post "/api/v1/tools/masc_board_comment_vote" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_board_comment_vote"
+         (fun _state _req reqd ->
+         let agent_name = (let hdr k = Option.bind (Httpun.Headers.get request.Httpun.Request.headers k) (fun s -> if s = "" then None else Some s) in match hdr "x-gate-agent" with Some _ as v -> v | None -> hdr "x-masc-agent") |> Option.value ~default:"dashboard" in
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let ( let* ) r f =
+               match r with
+               | Ok v -> f v
+               | Error msg ->
+                   respond_json_value_with_cors ~status:`Bad_request request reqd
+                     (`Assoc
+                        [ ("ok", `Bool false); ("message", `String msg) ])
+             in
+             let* args =
+               try Ok (Yojson.Safe.from_string body_str)
+               with Yojson.Json_error msg -> Error ("Invalid JSON: " ^ msg)
+             in
+             let voter = board_actor_author_for_write agent_name in
+             let* args = json_upsert_string_field "voter" voter args in
+             let result = Board_tool.handle_tool "masc_board_comment_vote" args in
+             let ok = Tool_result.is_success result in
+             let msg = Tool_result.message result in
+             let status = if ok then `OK else `Bad_request in
+             respond_json_value_with_cors ~status request reqd
+               (`Assoc [ ("ok", `Bool ok); ("message", `String msg) ])
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+             respond_json_value_with_cors ~status:`Bad_request request reqd
+               (`Assoc
+                  [
+                    ("ok", `Bool false);
+                    ("message", `String (Printexc.to_string exn));
+                  ])
+         )
+       ) request reqd)
   |> Http.Router.get "/api/v1/karma" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
          let karma_list = Board_dispatch.get_all_karma () in

--- a/test/dune
+++ b/test/dune
@@ -359,7 +359,8 @@
   test_event_log
   test_relation_materializer
   test_keeper_behavior_trace
-  test_keeper_wire_capture)
+  test_keeper_wire_capture
+  test_board_rest_routes)
  (modules
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
@@ -700,7 +701,8 @@
   test_event_log
   test_relation_materializer
   test_keeper_behavior_trace
-  test_keeper_wire_capture)
+  test_keeper_wire_capture
+  test_board_rest_routes)
  (libraries masc_test_deps multimodal))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -1,0 +1,100 @@
+(** Regression guard for the dashboard board REST bridge (task-1647).
+
+    The dashboard board API client (dashboard/src/api/board.ts) posts to
+    [/api/v1/tools/masc_board_*] endpoints. Each MCP board tool the dashboard
+    calls needs a matching REST route registered by
+    {!Server_routes_http_routes_activity.add_routes}; a missing route makes the
+    corresponding dashboard button return 404.
+
+    [masc_board_comment_vote] existed as an MCP tool and was called by the
+    comment up/down buttons, but had no REST route — every comment vote
+    returned 404. This test builds the real router and asserts that every
+    board tool the dashboard depends on resolves to a POST route.
+
+    All [/api/v1/tools/*] routes are registered by this one module, so
+    enumerating its [add_routes] output is exhaustive for this route family.
+    The expected set mirrors the [/api/v1/tools/*] literals in
+    dashboard/src/api/board.ts; adding a dashboard board endpoint requires both
+    a new route and an entry here, so drift fails the build. *)
+
+open Alcotest
+
+module Http = Masc.Http_server_eio
+
+(* /api/v1/tools/* endpoints called by dashboard/src/api/board.ts.
+   Kept in sync with that file — see module doc. *)
+let dashboard_board_tool_routes =
+  [ "/api/v1/tools/masc_board_vote"
+  ; "/api/v1/tools/masc_board_post"
+  ; "/api/v1/tools/masc_board_comment"
+  ; "/api/v1/tools/masc_board_comment_vote"
+  ]
+
+(* [add_routes] only registers closures — no fiber is spawned — so the
+   [Eio_main.run] just supplies the switch + clock the handlers capture. *)
+let with_router f =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let clock = Eio.Stdenv.clock env in
+      let router =
+        Server_routes_http_routes_activity.add_routes
+          ~sw
+          ~clock
+          (Http.Router.create ())
+      in
+      f router))
+
+(* Every dashboard-consumed board tool must resolve to a Plain POST route. *)
+let test_dashboard_board_routes_registered () =
+  with_router (fun router ->
+    List.iter
+      (fun path ->
+        let request = Httpun.Request.create `POST path in
+        match Http.Router.resolve router request with
+        | `Matched route -> (
+          match route.Http.Router.handler with
+          | Http.Router.Plain _ -> ()
+          | Http.Router.Ws _ ->
+            fail (Printf.sprintf "%s must be a Plain POST route, not Ws" path))
+        | `Method_not_allowed ->
+          fail (Printf.sprintf "%s exists but rejects POST" path)
+        | `Not_found ->
+          fail
+            (Printf.sprintf
+               "%s is not registered — dashboard call would 404"
+               path))
+      dashboard_board_tool_routes)
+
+(* The registered /api/v1/tools/* set must equal the dashboard-consumed set:
+   no orphan server route, no dashboard endpoint left unregistered. *)
+let test_no_tools_route_drift () =
+  with_router (fun router ->
+    let registered =
+      Http.Router.routes router
+      |> List.filter_map (fun (r : Http.Router.route) ->
+             if String.starts_with ~prefix:"/api/v1/tools/" r.Http.Router.path
+             then Some r.Http.Router.path
+             else None)
+      |> List.sort_uniq String.compare
+    in
+    let expected = List.sort_uniq String.compare dashboard_board_tool_routes in
+    check
+      (list string)
+      "registered /api/v1/tools/* routes match dashboard-consumed set"
+      expected
+      registered)
+
+let () =
+  run
+    "board_rest_routes"
+    [ ( "dashboard bridge"
+      , [ test_case
+            "dashboard board tool routes registered"
+            `Quick
+            test_dashboard_board_routes_registered
+        ; test_case
+            "no /api/v1/tools/* route drift"
+            `Quick
+            test_no_tools_route_drift
+        ] )
+    ]


### PR DESCRIPTION
## 문제 (감사 CONFIRMED, P1)

대시보드 게시물 상세 화면의 댓글 up/down 버튼이 항상 404를 반환합니다.

- `dashboard/src/api/board.ts`의 `voteComment()`가 `POST /api/v1/tools/masc_board_comment_vote`를 호출합니다.
- MCP tool `masc_board_comment_vote`(`Board_tool.handle_tool` → `Board_tool_handlers.handle_comment_vote`)와 스키마(`board_tool_schemas.ml`)는 이미 완비돼 있습니다.
- 그러나 서버(lib+bin 전체)에 이 **REST 브릿지 라우트가 등록돼 있지 않았습니다.** 형제 라우트(`masc_board_vote` / `masc_board_post` / `masc_board_comment`)만 `server_routes_http_routes_activity.ml`에 존재했습니다.
- 순수 배선 결함입니다. tool 계층은 정상, REST↔MCP 브릿지 한 곳만 누락.

## 수정

`lib/server/server_routes_http_routes_activity.ml`에 `POST /api/v1/tools/masc_board_comment_vote` 라우트를 `masc_board_vote`와 **동형**으로 추가했습니다.

- `with_tool_auth ~tool_name:"masc_board_comment_vote"` (same-origin / allowlisted dev browser 허용, 형제와 동일)
- `voter`를 클라이언트 payload가 아니라 `board_actor_author_for_write agent_name`으로 **서버측에서 재주입** (`x-gate-agent`/`x-masc-agent` 헤더 기반). 투표자 신원을 클라이언트가 위조하지 못하게 하는 형제 라우트의 신뢰 모델을 그대로 따릅니다.
- 성공 시 `` `OK ``(투표는 리소스 생성이 아니므로 `masc_board_vote`와 동일하게 200), 실패 시 `` `Bad_request ``.
- dashboard payload(`comment_id`/`direction`/`vote`/`voter`)는 스키마(`comment_id` 필수, `voter`, `direction`)와 일치하며, `vote`는 핸들러가 읽지 않는 무해한 alias입니다.

## 회귀 방지 테스트

신규 `test/test_board_rest_routes.ml` (Alcotest, `masc_test_deps`):

**어느 방식을 택했는가 / 근거** — 팀리드가 제시한 옵션 1(대시보드 TS 소스를 런타임에 파싱해 대조)이 아니라, **라우터 레벨 introspection 교차검증**을 택했습니다. 이유:

1. 이 repo에는 dune 테스트에서 repo 소스 파일을 런타임에 읽는 확립된 패턴이 없습니다(유일한 `test_board_api_e2e`는 `MASC_E2E_TESTS=true` gated + 바이너리 spawn 방식이라 일반 CI 미실행).
2. dune 샌드박스에서 `board.ts`를 읽으려면 dep 배선이 필요하고, **단일 파일만 스캔하면 다른 파일의 tools 호출을 놓쳐 false-pass**가 됩니다 — 오히려 약한 가드.
3. `Http.Router`가 `routes : t -> route list`를 노출하므로, 실제 라우터를 `add_routes`로 만들어 등록된 라우트를 **런타임에 결정론적으로 열거**할 수 있습니다. 모든 `/api/v1/tools/*` 라우트가 이 한 모듈에서만 등록되므로 이 패밀리에 대해 exhaustive합니다.

테스트 2건:
- `dashboard board tool routes registered`: 대시보드가 소비하는 4개 board tool 경로(`masc_board_vote`/`post`/`comment`/`comment_vote`)가 전부 `Plain POST`로 resolve되는지 확인.
- `no /api/v1/tools/* route drift`: 실제 라우터에서 열거한 `/api/v1/tools/*` 등록 집합이 대시보드 소비 집합과 **정확히 일치**하는지(orphan 라우트도, 미등록 엔드포인트도 없음) 확인. 이 수정 이전 상태(comment_vote 미등록)에서는 registered=3 vs expected=4로 **결정론적으로 실패**합니다 = 실제 버그를 잡는 가드.

기대 집합은 `dashboard/src/api/board.ts`의 `/api/v1/tools/*` 리터럴을 미러링하며, 대시보드 board 엔드포인트 추가 시 라우트와 이 목록을 함께 갱신하지 않으면 빌드가 실패하도록 문서화했습니다.

## 검증

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --root . test/test_board_rest_routes.exe` → exit 0 (라우트 편집 + 신규 테스트 컴파일)
- `./_build/default/test/test_board_rest_routes.exe` → 2 tests, all `[OK]`
- `dune build --root . @fmt --auto-promote` → exit 0, 변경 없음 (repo `.ocamlformat`는 RFC-0010에 따라 `disable = true`이므로 포맷 no-op)

## 참고

- main 상속 CI red(4건)는 이 PR과 무관하며 `#23012` 머지 전까지 무죄입니다.
- RFC 게이트 비대상: 변경은 board 투표 REST 라우트 + 테스트로 credential / identity / operator control / keeper sandbox / dashboard credential component / hooks / workflow 문서 어디에도 해당하지 않습니다.

MASC task: task-1647 (audit P1 — 댓글 투표 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
