### PR TITLE
fix(keeper_wip_admission): raise repo cap as temporary mitigation

### DIFF
--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -85,7 +85,7 @@ type caps = {
 
 let default_caps =
   { max_global = Some 16
-  ; max_per_repo = Some 6
+  ; max_per_repo = Some 12
   ; max_per_goal = Some 3
   ; max_per_category = Some 4
   }


### PR DESCRIPTION
## Scope

Temporary capacity mitigation only. This PR raises the default per-repo WIP cap so a multi-keeper workspace has more headroom while the existing stale/orphan claim reclamation path does the root cleanup work.

This PR is not the root-cause fix for stale `Claimed` / `InProgress` slots, and should not be described as such.

## Change

Single-line mitigation in `keeper_wip_admission.ml`:

`max_per_repo = Some 6` -> `Some 12`

## Root-Cause Path Already In Base

- #22808 / `4bebf3076a31`: `Workspace.release_stale_claims` releases orphaned `Claimed` / `InProgress` tasks through the typed force-release transition after `audit_orphan_tasks` and task-status TTL checks.
- #22855 / `88566beb4714`: `keeper_task_claim` runs stale-claim release before WIP admission and adds regression coverage: `test_keeper_task_claim_releases_stale_owner_before_wip_admission`.

## Verification

- Current PR diff is limited to `lib/keeper/keeper_wip_admission.ml`.
- Current head checked: `007ba7f4ce536fab8ebb0457389c8a9fcfff91cc`.
- CI is still pending `Build and Test`; this PR is not merge-ready until required checks are green.

Refs task-1648

[근거]
- `gh pr diff 23027 --repo jeong-sik/masc --name-only` at 2026-07-03 KST: High
- `git log -- lib/workspace/workspace_task_schedule.ml lib/keeper/keeper_tool_task_runtime.ml test/test_keeper_wip_admission.ml` at 2026-07-03 KST: High
- `git blame -L 650,712 -- lib/workspace/workspace_task_schedule.ml`, `git blame -L 515,530 -- lib/keeper/keeper_tool_task_runtime.ml`, `git blame -L 276,325 -- test/test_keeper_wip_admission.ml` at 2026-07-03 KST: High
