### PR TITLE
fix(timeline): keep newest events when per-source cap exceeded

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -269,15 +269,28 @@ let message_events (config : Workspace.config) ~agent_name ~limit :
                }
          | None -> None)
 
+(* Keep the newest [n] events. [Activity_graph.list_events ~after_seq:0]
+   returns the source's newest window in seq-ascending order (oldest first),
+   so this agent's newest matches sit at the tail; a front-take would discard
+   exactly the recent events the tool contracts to surface (period.to = now)
+   whenever a keeper exceeds the per-source cap. Mirrors [build_timeline]'s
+   tail-keep on the merged list, and preserves the source's ascending order. *)
+let take_last n xs =
+  if n <= 0 then []
+  else
+    let len = List.length xs in
+    if len <= n then xs
+    else
+      let rec skip k = function
+        | [] -> []
+        | _ :: rest when k > 0 -> skip (k - 1) rest
+        | remaining -> remaining
+      in
+      skip (len - n) xs
+
 (* Collect tool call events from Activity Graph *)
 let tool_call_events (config : Workspace.config) ~agent_name ~limit :
     timeline_event list =
-  let rec take n xs =
-    match (n, xs) with
-    | n, _ when n <= 0 -> []
-    | _, [] -> []
-    | n, x :: rest -> x :: take (n - 1) rest
-  in
   (* `list_events` limits globally before we filter by actor, so fetch a
      wider bounded window to reduce the chance that busy-workspace activity from
      other agents crowds out this agent's tool events. *)
@@ -317,16 +330,10 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
                  ("error", Json_util.string_opt_to_json error_str);
                ];
          })
-  |> take limit
+  |> take_last limit
 
 let keeper_cdal_events (config : Workspace.config) ~agent_name ~limit :
     timeline_event list =
-  let rec take n xs =
-    match (n, xs) with
-    | n, _ when n <= 0 -> []
-    | _, [] -> []
-    | n, x :: rest -> x :: take (n - 1) rest
-  in
   let scan_limit =
     let expanded = if limit <= 0 then 0 else limit * 10 in
     min 1000 (max limit expanded)
@@ -345,17 +352,11 @@ let keeper_cdal_events (config : Workspace.config) ~agent_name ~limit :
          event_type = e.kind;
          detail = e.payload;
        })
-  |> take limit
+  |> take_last limit
 
 (* Collect turn-completed events from Activity Graph *)
 let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
     timeline_event list =
-  let rec take n xs =
-    match (n, xs) with
-    | n, _ when n <= 0 -> []
-    | _, [] -> []
-    | n, x :: rest -> x :: take (n - 1) rest
-  in
   let scan_limit =
     let expanded = if limit <= 0 then 0 else limit * 10 in
     min 1000 (max limit expanded)
@@ -436,7 +437,7 @@ let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
                  ("tools_used", `List (List.map (fun s -> `String s) tools_used));
                ] @ optional_fields);
          })
-  |> take limit
+  |> take_last limit
 
 (* Build the full timeline *)
 let build_timeline (config : Workspace.config) ~agent_name ~since_hours ~limit

--- a/test/test_tool_agent_timeline_build.ml
+++ b/test/test_tool_agent_timeline_build.ml
@@ -80,6 +80,86 @@ let test_excludes_other_keeper () =
       check int "no events for the queried handle" 0
         (summary_int json "total_events"))
 
+(* Regression for the per-source take-oldest bug (task-1647): each activity
+   collector ([tool_call_events], [keeper_cdal_events], [turn_completed_events])
+   fetched the source's newest window in seq-ascending order (oldest first) and
+   then front-truncated to the per-source cap. Once a keeper produced more
+   matching events than the cap, the front-take discarded the NEWEST matches —
+   the opposite of the tool contract (period.to = now) and of build_timeline's
+   own tail-keep on the merged list. These tests emit more than the cap and
+   assert the newest event survives while the oldest is dropped. *)
+
+(* Per-source cap pinned in build_timeline (message/tool/cdal/turn = 200). *)
+let source_cap = 200
+let overflow = 60
+
+let marker i = Printf.sprintf "marker-%04d" i
+
+(* Naive substring test — the markers are zero-padded so [marker 1] is never a
+   substring of any other marker in the series. *)
+let contains ~needle haystack =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl = 0 then true
+  else
+    let rec loop i =
+      if i + nl > hl then false
+      else if String.equal (String.sub haystack i nl) needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+(* Emit [source_cap + overflow] events of [kind] for keeper "testkeeper", each
+   tagged via [payload_of] with a per-index marker so the oldest (i = 1) and
+   newest (i = source_cap + overflow) are individually identifiable. *)
+let emit_capacity_series config ~kind ~payload_of =
+  for i = 1 to source_cap + overflow do
+    ignore
+      (Activity_graph.emit config ~kind
+         ~actor:
+           (Activity_graph.entity ~kind:"agent" "keeper-testkeeper-agent")
+         ~payload:(payload_of (marker i))
+         ())
+  done
+
+(* Build with a limit above the per-source cap so the merged-list truncation is
+   a no-op: presence/absence then reflects only the source-collector cap, and is
+   independent of ts-collision ordering in build_timeline's final sort. *)
+let build_all config ~agent_name =
+  Lib.Tool_agent_timeline.build_timeline config ~agent_name ~since_hours:24.0
+    ~limit:1000 ~include_tasks:true ~include_board:false ~include_tool_calls:true
+
+let events_blob json =
+  let open Yojson.Safe.Util in
+  json |> member "events" |> Yojson.Safe.to_string
+
+let newest_marker = marker (source_cap + overflow)
+let oldest_marker = marker 1
+
+let check_keeps_newest ~label config =
+  let blob = events_blob (build_all config ~agent_name:"testkeeper") in
+  check bool (label ^ ": newest event present") true
+    (contains ~needle:newest_marker blob);
+  check bool (label ^ ": oldest event dropped") false
+    (contains ~needle:oldest_marker blob)
+
+let test_tool_call_keeps_newest () =
+  with_config (fun config ->
+      emit_capacity_series config ~kind:"tool.called"
+        ~payload_of:(fun s -> `Assoc [ ("tool_name", `String s) ]);
+      check_keeps_newest ~label:"tool_call" config)
+
+let test_cdal_keeps_newest () =
+  with_config (fun config ->
+      emit_capacity_series config ~kind:"keeper.contract_verdict"
+        ~payload_of:(fun s -> `Assoc [ ("verdict", `String s) ]);
+      check_keeps_newest ~label:"cdal" config)
+
+let test_turn_completed_keeps_newest () =
+  with_config (fun config ->
+      emit_capacity_series config ~kind:"keeper.turn_completed"
+        ~payload_of:(fun s -> `Assoc [ ("model_used", `String s) ]);
+      check_keeps_newest ~label:"turn_completed" config)
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -90,5 +170,12 @@ let () =
           test_case "turn_completed surfaces for short handle" `Quick
             test_surfaces_turn_completed_for_short_handle;
           test_case "other keeper excluded" `Quick test_excludes_other_keeper;
+        ] );
+      ( "per-source-cap-keeps-newest",
+        [
+          test_case "tool_call keeps newest" `Quick test_tool_call_keeps_newest;
+          test_case "cdal keeps newest" `Quick test_cdal_keeps_newest;
+          test_case "turn_completed keeps newest" `Quick
+            test_turn_completed_keeps_newest;
         ] );
     ]


### PR DESCRIPTION
## 문제 (감사 CONFIRMED — take-oldest 역전)

`lib/tool_agent_timeline.ml`의 activity-graph 3개 수집기(`tool_call_events`, `keeper_cdal_events`, `turn_completed_events`)가 각각 로컬 `take limit`(=200)을 리스트 **앞**에서 잘라, 소스 단계에서 **가장 최신 이벤트를 버렸습니다**.

근거를 코드로 확인:

- `Activity_graph.list_events ~after_seq:0`은 `read_all_events`가 `List.sort ... Int.compare a.seq b.seq`로 정렬한 뒤 `List.drop (total - limit)`로 tail을 취하므로, **최신 window를 seq 오름차순(oldest→newest)으로** 반환합니다 (`lib/activity_graph/activity_graph.ml:272`, `:299-303`).
- 수집기는 이 오름차순 리스트를 agent 필터 후 `take limit`(앞에서 자름)으로 잘랐습니다. 따라서 해당 keeper의 매칭 이벤트가 200개를 넘으면 **가장 최신 이벤트가 소스에서 유실**됩니다.
- 이는 도구 계약(`period.to = now`, "Unified timeline")과 정반대이며, 병합 리스트에서 tail-keep(`skip drop`)으로 최신을 유지하는 `build_timeline`(`:472-484`)의 의도와도 불일치합니다. 소비자가 최신만 남기는데 소스가 그 전에 최신을 버려 계약을 정면 위반합니다.

## 수정

- `take_last n xs` 헬퍼 **1개**를 모듈 레벨에 추가하고, 3개 수집기의 로컬 front-take 헬퍼를 제거해 모두 `|> take_last limit`으로 교체했습니다. 같은 변환을 3곳에서 따로 구현하지 않습니다(N-of-M 회피).
- `take_last`는 오름차순 소스 리스트의 **tail(최신) limit개**를 유지하며, `build_timeline`의 기존 tail-keep 관용구(`skip drop`)를 그대로 미러링합니다. 소스가 오름차순으로 방출하고 소비자가 ts로 재정렬하므로 반환 순서(오름차순)를 보존합니다.
- 세 수집기는 `.mli`에 노출되지 않고 `build_timeline` 내부에서만 소비되어 내부 순서 변경이 안전합니다.

## 검증

- 회귀 테스트 3건을 `test/test_tool_agent_timeline_build.ml`에 추가(수집기별 1건). per-source cap(200)을 초과(260건)하도록 이벤트를 방출하고, 결과에 **가장 최신 이벤트가 포함**되고 **가장 오래된 이벤트가 제외**됨을 zero-padded 마커로 검증합니다.
- 음성 대조(negative control): `take_last`를 임시로 front-take(버그)로 되돌려 rebuild한 결과, 신규 3건이 모두 실패하고(기존 identity 테스트 2건은 통과) 테스트가 버그를 판별함을 확인했습니다. 실제 수정에서는 5건 전부 통과.
- `MASC_SKIP_PIN_CHECK=1 dune build --root . @check` = exit 0. `@fmt --auto-promote` = exit 0. focused runtest = 5 tests passed.

## 참고

- CI main 상속 red(`dispatch_integration` 등 4건)은 #23012 머지 전 상태로, 본 변경과 무관합니다.

MASC task: task-1647 (audit P1 — take-oldest 역전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
