### PR TITLE
perf(trajectory): tail-read next_round hydration replaces full-file parse

### DIFF
--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -247,6 +247,144 @@ let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : stri
 let round_counters : (string * string * int, int) Hashtbl.t = Hashtbl.create 64
 let round_counters_mu = Stdlib.Mutex.create ()
 
+(* Initial tail window (in lines) read to hydrate a turn's round count from
+   disk. A single turn's tool-call count is far below this bound, so one
+   tail read normally captures the whole turn plus the previous-turn boundary.
+   Chosen well above realistic per-turn tool-call counts to avoid widening. *)
+let default_hydrate_tail_lines = 512
+
+(* Upper bound on the tail window before falling back to a full-file scan.
+   Doubling from [default_hydrate_tail_lines] yields 512→1024→2048→4096→8192.
+   Beyond this a turn is assumed pathological and a full scan is used so the
+   count is never silently truncated. *)
+let max_hydrate_tail_lines = 8192
+
+(** Extract the [turn] field from a trajectory JSONL line.
+    Preserves the historical semantics: a parseable line with a missing or
+    non-int [turn] (e.g. the trajectory_summary row) is read as turn 0.
+    Returns [None] only when the line does not parse as JSON — such lines are
+    warned about and skipped, never counted. *)
+let entry_turn_of_line ~(trace_id : string) (line : string) : int option =
+  match Yojson.Safe.from_string line with
+  | json -> (
+      match Json_util.assoc_member_opt "turn" json with
+      | Some (`Int n) -> Some n
+      | _ -> Some 0)
+  | exception Yojson.Json_error msg ->
+      Log.Keeper.warn
+        "Failed to parse trajectory JSON during next_round (trace_id=%s): %s"
+        trace_id msg;
+      None
+  | exception exn ->
+      Log.Keeper.warn
+        "Unexpected error reading trajectory line (trace_id=%s): %s" trace_id
+        (Printexc.to_string exn);
+      None
+
+(** Count entries whose [turn = target_turn] within a tail [window] by scanning
+    newest→oldest, stopping at the first line strictly older than [target_turn].
+    turn is monotonically non-decreasing in append-only file order, so once a
+    line with [entry_turn < target_turn] is seen every earlier line is a past
+    turn and the scan stops.
+
+    Returns [(count, boundary_found)]. [boundary_found] is true only when a
+    strictly-older line was seen, i.e. the window definitely contained the turn
+    boundary and [count] is complete. When false, the window may have been
+    truncated before the boundary and the caller must widen it or fall back. *)
+let count_current_turn_backward ~(trace_id : string) ~(target_turn : int)
+    (window : string list) : int * bool =
+  (* [window] is oldest-first (load_tail_lines order); reverse to scan the
+     newest line first so we can stop as soon as the boundary appears. *)
+  let rec scan count = function
+    | [] -> (count, false)
+    | line :: older -> (
+        match entry_turn_of_line ~trace_id line with
+        | None -> scan count older (* unparseable: warn+skip, not a boundary *)
+        | Some entry_turn ->
+            if entry_turn = target_turn then scan (count + 1) older
+            else if entry_turn < target_turn then (count, true) (* boundary *)
+            else (
+              (* entry_turn > target_turn cannot occur under monotonic turn:
+                 future turns are appended after, not before, the current turn.
+                 Exclude it from the count but keep scanning (do not treat it as
+                 a boundary) so an upstream anomaly cannot silently truncate. *)
+              Log.Keeper.warn
+                "next_round saw future turn %d > %d in trajectory tail \
+                 (trace_id=%s); excluding from round count"
+                entry_turn target_turn trace_id;
+              scan count older))
+  in
+  scan 0 (List.rev window)
+
+(** Full-file scan fallback: count entries whose [turn = target_turn] across the
+    whole trajectory file. Restores the pre-tail-read O(file) cost, used only
+    when a turn exceeds [max_hydrate_tail_lines] tool calls. *)
+let full_scan_round_count ~(path : string) ~(trace_id : string)
+    ~(target_turn : int) : int =
+  Fs_compat.load_file path
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> String.trim line <> "")
+  |> List.fold_left
+       (fun acc line ->
+         match entry_turn_of_line ~trace_id line with
+         | Some n when n = target_turn -> acc + 1
+         | _ -> acc)
+       0
+
+(** Count existing entries for [turn] by reading a bounded tail of the file
+    instead of the whole file. Widens the window (doubling) if the boundary is
+    not reached, and only falls back to a full scan past [max_hydrate_tail_lines]
+    so the count is exact for every turn size. *)
+let hydrate_round_count ~(masc_root : string) ~(keeper_name : string)
+    ~(trace_id : string) ~(turn : int) : int =
+  let path = trajectory_path masc_root keeper_name trace_id in
+  if not (Sys.file_exists path) then 0
+  else
+    let rec attempt max_lines =
+      let window = Dated_jsonl.load_tail_lines path ~max_lines in
+      let n = List.length window in
+      let count, boundary_found =
+        count_current_turn_backward ~trace_id ~target_turn:turn window
+      in
+      if boundary_found || n < max_lines then
+        (* boundary_found: the previous-turn marker was inside the window.
+           n < max_lines: load_tail_lines returned fewer lines than requested,
+           so the window already spans the whole file — trajectory JSONL is
+           append-only with one record per line and no interior blank lines —
+           and [count] is complete even without an explicit boundary (e.g. the
+           first turn, whose entries reach the top of the file). *)
+        count
+      else if max_lines >= max_hydrate_tail_lines then (
+        (* Window filled to the cap without reaching the boundary. Fall back to
+           a full scan rather than risk under-counting a pathologically large
+           turn. This restores the pre-optimization cost for that rare case
+           only, and never silently truncates. *)
+        Log.Keeper.warn
+          "next_round tail window exhausted at %d lines without turn boundary \
+           (trace_id=%s, turn=%d); falling back to full scan"
+          max_lines trace_id turn;
+        full_scan_round_count ~path ~trace_id ~target_turn:turn)
+      else attempt (max_lines * 2)
+    in
+    attempt default_hydrate_tail_lines
+
+(** Evict cache entries for turns older than [turn] under the same
+    (keeper_name, trace_id). Round counts for a past turn are never queried
+    again (turn is monotonic), so retaining them would grow the table without
+    bound over a long session. Iteration cost is small: live keys number at
+    most (keepers × in-flight turns). Caller must hold [round_counters_mu]. *)
+let evict_past_turn_keys ~(keeper_name : string) ~(trace_id : string)
+    ~(turn : int) : unit =
+  let stale =
+    Hashtbl.fold
+      (fun ((k, t, kt) as key) _ acc ->
+        if String.equal k keeper_name && String.equal t trace_id && kt < turn
+        then key :: acc
+        else acc)
+      round_counters []
+  in
+  List.iter (Hashtbl.remove round_counters) stale
+
 (** Get the next round number for a given (keeper_name, trace_id, turn).
     Lazily hydrates from disk on first access, then increments in-memory.
     This avoids reading the entire JSONL file on every tool call. *)
@@ -256,30 +394,11 @@ let next_round ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string
     let current =
       match Hashtbl.find_opt round_counters key with
       | Some n -> n
-      | None ->
-          (* Hydrate from disk: count existing entries for this turn *)
-          let path = trajectory_path masc_root keeper_name trace_id in
-          if not (Sys.file_exists path) then 0
-          else
-            let content = Fs_compat.load_file path in
-            String.split_on_char '\n' content
-            |> List.filter (fun line -> String.trim line <> "")
-            |> List.fold_left (fun acc line ->
-                try
-                  let json = Yojson.Safe.from_string line in
-                  let entry_turn = (match Json_util.assoc_member_opt "turn" json with Some (`Int n) -> n | _ -> 0) in
-                  if entry_turn = turn then acc + 1 else acc
-                with
-                | Yojson.Json_error msg ->
-                    Log.Keeper.warn "Failed to parse trajectory JSON during next_round (trace_id=%s): %s" trace_id msg;
-                    acc
-                | exn ->
-                    Log.Keeper.warn "Unexpected error reading trajectory line (trace_id=%s): %s" trace_id (Printexc.to_string exn);
-                    acc
-              ) 0
+      | None -> hydrate_round_count ~masc_root ~keeper_name ~trace_id ~turn
     in
     let next = current + 1 in
     Hashtbl.replace round_counters key next;
+    evict_past_turn_keys ~keeper_name ~trace_id ~turn;
     next)
 
 (** Reset round counters for testing. *)

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -245,6 +245,7 @@ let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : stri
    Hydrated lazily on first access per key. *)
 
 let round_counters : (string * string * int, int) Hashtbl.t = Hashtbl.create 64
+let round_high_water : (string * string * int, int) Hashtbl.t = Hashtbl.create 64
 let round_counters_mu = Stdlib.Mutex.create ()
 
 (* Initial tail window (in lines) read to hydrate a turn's round count from
@@ -374,9 +375,12 @@ let hydrate_round_count ~(masc_root : string) ~(keeper_name : string)
 
 (** Evict cache entries for turns older than [turn] under the same
     (keeper_name, trace_id). Round counts for a past turn are never queried
-    again (turn is monotonic), so retaining them would grow the table without
-    bound over a long session. Iteration cost is small: live keys number at
-    most (keepers × in-flight turns). Caller must hold [round_counters_mu]. *)
+    again in the normal monotonic path, so retaining the active hydrated
+    counter would grow the table without bound over a long session. Issued
+    high-water marks are intentionally retained separately; if a late
+    out-of-order caller asks for an older turn, [next_round] must not hand out
+    a duplicate round number already returned by this process. Caller must
+    hold [round_counters_mu]. *)
 let evict_past_turn_keys ~(keeper_name : string) ~(trace_id : string)
     ~(turn : int) : unit =
   let stale =
@@ -398,17 +402,28 @@ let next_round ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string
     let current =
       match Hashtbl.find_opt round_counters key with
       | Some n -> n
-      | None -> hydrate_round_count ~masc_root ~keeper_name ~trace_id ~turn
+      | None ->
+        let hydrated =
+          hydrate_round_count ~masc_root ~keeper_name ~trace_id ~turn
+        in
+        let issued =
+          match Hashtbl.find_opt round_high_water key with
+          | Some n -> n
+          | None -> 0
+        in
+        max hydrated issued
     in
     let next = current + 1 in
     Hashtbl.replace round_counters key next;
+    Hashtbl.replace round_high_water key next;
     evict_past_turn_keys ~keeper_name ~trace_id ~turn;
     next)
 
 (** Reset round counters for testing. *)
 let reset_round_counters_for_testing () =
   Stdlib.Mutex.protect round_counters_mu (fun () ->
-    Hashtbl.reset round_counters)
+    Hashtbl.reset round_counters;
+    Hashtbl.reset round_high_water)
 
 let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
     ~(keeper_name : string) ~(trace_id : string) (entry : tool_call_entry) :

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -259,17 +259,21 @@ let default_hydrate_tail_lines = 512
    count is never silently truncated. *)
 let max_hydrate_tail_lines = 8192
 
-(** Extract the [turn] field from a trajectory JSONL line.
-    Preserves the historical semantics: a parseable line with a missing or
-    non-int [turn] (e.g. the trajectory_summary row) is read as turn 0.
-    Returns [None] only when the line does not parse as JSON — such lines are
-    warned about and skipped, never counted. *)
+(** Extract the [turn] field from a trajectory JSONL line.  Returns [None] for
+    non-entry rows, malformed [turn] fields, and invalid JSON.  Such lines are
+    skipped rather than counted or treated as turn-boundaries. *)
 let entry_turn_of_line ~(trace_id : string) (line : string) : int option =
   match Yojson.Safe.from_string line with
   | json -> (
       match Json_util.assoc_member_opt "turn" json with
       | Some (`Int n) -> Some n
-      | _ -> Some 0)
+      | None -> None
+      | Some other ->
+          Log.Keeper.warn
+            "Skipping trajectory line with non-int turn during next_round \
+             (trace_id=%s, turn_kind=%s)"
+            trace_id (Yojson.Safe.to_string other);
+          None)
   | exception Yojson.Json_error msg ->
       Log.Keeper.warn
         "Failed to parse trajectory JSON during next_round (trace_id=%s): %s"

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -138,6 +138,10 @@ val next_round :
   masc_root:string -> keeper_name:string -> trace_id:string -> turn:int ->
   int
 
+val reset_round_counters_for_testing : unit -> unit
+(** Clear the in-memory round-counter cache. Test-only: lets tests start from a
+    known state and force re-hydration from disk. *)
+
 val trajectory_lines_of_jsonl_lines :
   trace_id:string -> string list -> trajectory_line list * int * int
 (** Decode JSONL lines into parsed trajectory lines, the number of malformed

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -133,7 +133,9 @@ val read_entries :
 
 (** Get the next round number for a (keeper_name, trace_id, turn) without
     reading the entire trajectory file. Lazily hydrates from disk on first
-    access per key, then increments in-memory. *)
+    access per key, then increments in-memory. Round numbers already issued by
+    this process remain monotonic for the key even if an active counter is
+    evicted and later rehydrated. *)
 val next_round :
   masc_root:string -> keeper_name:string -> trace_id:string -> turn:int ->
   int

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -825,13 +825,13 @@ let test_next_round_evicts_past_turn_keys () =
         ~turn:6
     in
     Alcotest.(check int) "turn 6 first round -> 1" 1 r6;
-    (* The turn-5 key was evicted, so a fresh turn-5 call re-hydrates from disk
-       (2 rows -> 3), not the stale in-memory 4. *)
+    (* The active turn-5 key was evicted, but the issued high-water mark is
+       retained so an out-of-order caller cannot receive a duplicate round. *)
     let r5c =
       Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
         ~turn:5
     in
-    Alcotest.(check int) "turn 5 re-hydrates after evict -> round 3" 3 r5c)
+    Alcotest.(check int) "turn 5 after eviction stays monotonic" 5 r5c)
 
 let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
   Trajectory.Thinking

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -640,6 +640,175 @@ let test_summary_row_not_counted_as_malformed () =
   Alcotest.(check int) "skipped count counts only malformed" 1 skipped;
   Alcotest.(check int) "total rows processed" 3 total
 
+(* ================================================================ *)
+(* Test: next_round tail-read hydration                              *)
+(* ================================================================ *)
+
+(* A trajectory JSONL row carrying the fields next_round reads. next_round only
+   inspects the "turn" field, but the row mirrors a real tool-call entry. *)
+let next_round_row ~turn ~round : Yojson.Safe.t =
+  `Assoc
+    [
+      ("ts", `Float 1000.0);
+      ("ts_iso", `String "2026-07-01T00:00:00Z");
+      ("turn", `Int turn);
+      ("round", `Int round);
+      ("tool_name", `String "tool_execute");
+      ("args", `Assoc []);
+      ("result", `String "ok");
+      ("duration_ms", `Int 1);
+      ("error", `Null);
+      ("cost_usd", `Float 0.0);
+    ]
+
+(* Append rows to the trajectory JSONL for a keeper/trace. Uses a single append
+   fd so the large-turn fixture stays fast, and appends (not truncates) so the
+   cache-hit test can add rows after hydration. *)
+let append_trajectory_rows ~masc_root ~keeper_name ~trace_id (rows : Yojson.Safe.t list) =
+  let dir = Trajectory.trajectories_dir masc_root keeper_name in
+  Fs_compat.mkdir_p dir;
+  let path = Trajectory.trajectory_path masc_root keeper_name trace_id in
+  let oc = open_out_gen [ Open_append; Open_creat ] 0o644 path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      List.iter
+        (fun row ->
+          output_string oc (Yojson.Safe.to_string row);
+          output_char oc '\n')
+        rows)
+
+let test_next_round_empty_or_missing_file () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    (* Missing file: first round is 1. *)
+    let r_missing =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k"
+        ~trace_id:"t-missing" ~turn:1
+    in
+    Alcotest.(check int) "missing file -> round 1" 1 r_missing;
+    (* Present but empty (0-byte) file: still round 1. *)
+    let dir2 = Trajectory.trajectories_dir dir "k" in
+    Fs_compat.mkdir_p dir2;
+    let empty_path = Trajectory.trajectory_path dir "k" "t-empty" in
+    close_out (open_out empty_path);
+    let r_empty =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-empty"
+        ~turn:1
+    in
+    Alcotest.(check int) "empty file -> round 1" 1 r_empty)
+
+let test_next_round_past_turns_only () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-past"
+      (List.init 5 (fun i -> next_round_row ~turn:3 ~round:i));
+    (* No entries for turn 4 yet: first round is 1. *)
+    let r =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-past"
+        ~turn:4
+    in
+    Alcotest.(check int) "past turns only -> round 1" 1 r)
+
+let test_next_round_counts_current_turn () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    let rows =
+      List.init 2 (fun i -> next_round_row ~turn:6 ~round:i)
+      @ List.init 3 (fun i -> next_round_row ~turn:7 ~round:i)
+    in
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cur" rows;
+    let r =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cur"
+        ~turn:7
+    in
+    Alcotest.(check int) "3 current-turn entries -> round 4" 4 r)
+
+let test_next_round_widens_past_initial_window () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    (* 600 current-turn rows (> the 512-line initial tail window, < 1024) sit
+       above a 3-row previous-turn boundary. The first tail read misses the
+       boundary; the window must widen once to count exactly. *)
+    let current_count = 600 in
+    let rows =
+      List.init 3 (fun i -> next_round_row ~turn:9 ~round:i)
+      @ List.init current_count (fun i -> next_round_row ~turn:10 ~round:i)
+    in
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-wide" rows;
+    let r =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-wide"
+        ~turn:10
+    in
+    Alcotest.(check int) "600 current-turn entries -> round 601"
+      (current_count + 1) r)
+
+let test_next_round_full_scan_fallback () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    (* Single-turn file larger than the tail cap (currently 8192 lines) with no
+       older-turn boundary anywhere. Forces the doubling loop to the cap and
+       then the full-scan fallback; the count must still be exact. 9000 is
+       chosen to exceed the internal max_hydrate_tail_lines constant. *)
+    let current_count = 9000 in
+    let rows = List.init current_count (fun i -> next_round_row ~turn:1 ~round:i) in
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-huge" rows;
+    let r =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-huge"
+        ~turn:1
+    in
+    Alcotest.(check int) "9000 current-turn entries via full-scan -> round 9001"
+      (current_count + 1) r)
+
+let test_next_round_cache_hit_skips_disk () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cache"
+      [ next_round_row ~turn:2 ~round:0; next_round_row ~turn:2 ~round:1 ];
+    let r1 =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cache"
+        ~turn:2
+    in
+    Alcotest.(check int) "hydrate 2 rows -> round 3" 3 r1;
+    (* Append two more turn-2 rows AFTER hydration; a cache hit must ignore the
+       disk and increment purely in memory. *)
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cache"
+      [ next_round_row ~turn:2 ~round:9; next_round_row ~turn:2 ~round:9 ];
+    let r2 =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-cache"
+        ~turn:2
+    in
+    Alcotest.(check int) "cache hit ignores new disk rows -> round 4" 4 r2)
+
+let test_next_round_evicts_past_turn_keys () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
+      [ next_round_row ~turn:5 ~round:0; next_round_row ~turn:5 ~round:1 ];
+    let r5a =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
+        ~turn:5
+    in
+    Alcotest.(check int) "turn 5 hydrate -> round 3" 3 r5a;
+    let r5b =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
+        ~turn:5
+    in
+    Alcotest.(check int) "turn 5 cache hit -> round 4" 4 r5b;
+    (* Advancing to turn 6 evicts the turn-5 cache key. *)
+    let r6 =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
+        ~turn:6
+    in
+    Alcotest.(check int) "turn 6 first round -> 1" 1 r6;
+    (* The turn-5 key was evicted, so a fresh turn-5 call re-hydrates from disk
+       (2 rows -> 3), not the stale in-memory 4. *)
+    let r5c =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-evict"
+        ~turn:5
+    in
+    Alcotest.(check int) "turn 5 re-hydrates after evict -> round 3" 3 r5c)
+
 let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
   Trajectory.Thinking
     {
@@ -808,6 +977,22 @@ let () =
         test_execution_id_roundtrip;
       Alcotest.test_case "runtime contract redacts backend details" `Quick
         test_runtime_contract_projection_redacts_backend_details;
+    ]);
+    ("next_round", [
+      Alcotest.test_case "empty or missing file -> 1" `Quick
+        test_next_round_empty_or_missing_file;
+      Alcotest.test_case "past turns only -> 1" `Quick
+        test_next_round_past_turns_only;
+      Alcotest.test_case "counts current-turn entries" `Quick
+        test_next_round_counts_current_turn;
+      Alcotest.test_case "widens window past initial 512" `Quick
+        test_next_round_widens_past_initial_window;
+      Alcotest.test_case "full-scan fallback past cap" `Quick
+        test_next_round_full_scan_fallback;
+      Alcotest.test_case "cache hit skips disk" `Quick
+        test_next_round_cache_hit_skips_disk;
+      Alcotest.test_case "evicts past-turn keys" `Quick
+        test_next_round_evicts_past_turn_keys;
     ]);
     ("read_entries_since", [
       Alcotest.test_case "filter by timestamp" `Quick test_read_entries_since;

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -661,6 +661,15 @@ let next_round_row ~turn ~round : Yojson.Safe.t =
       ("cost_usd", `Float 0.0);
     ]
 
+let next_round_summary_row : Yojson.Safe.t =
+  `Assoc
+    [
+      ("type", `String "trajectory_summary");
+      ("keeper_name", `String "k");
+      ("trace_id", `String "t");
+      ("generation", `Int 0);
+    ]
+
 (* Append rows to the trajectory JSONL for a keeper/trace. Uses a single append
    fd so the large-turn fixture stays fast, and appends (not truncates) so the
    cache-hit test can add rows after hydration. *)
@@ -723,6 +732,21 @@ let test_next_round_counts_current_turn () =
         ~turn:7
     in
     Alcotest.(check int) "3 current-turn entries -> round 4" 4 r)
+
+let test_next_round_ignores_summary_rows_without_turn () =
+  with_tmpdir (fun dir ->
+    Trajectory.reset_round_counters_for_testing ();
+    append_trajectory_rows ~masc_root:dir ~keeper_name:"k" ~trace_id:"t-summary"
+      [
+        next_round_row ~turn:7 ~round:0;
+        next_round_row ~turn:7 ~round:1;
+        next_round_summary_row;
+      ];
+    let r =
+      Trajectory.next_round ~masc_root:dir ~keeper_name:"k"
+        ~trace_id:"t-summary" ~turn:7
+    in
+    Alcotest.(check int) "summary row skipped -> round 3" 3 r)
 
 let test_next_round_widens_past_initial_window () =
   with_tmpdir (fun dir ->
@@ -985,6 +1009,8 @@ let () =
         test_next_round_past_turns_only;
       Alcotest.test_case "counts current-turn entries" `Quick
         test_next_round_counts_current_turn;
+      Alcotest.test_case "ignores summary rows without turn" `Quick
+        test_next_round_ignores_summary_rows_without_turn;
       Alcotest.test_case "widens window past initial 512" `Quick
         test_next_round_widens_past_initial_window;
       Alcotest.test_case "full-scan fallback past cap" `Quick


### PR DESCRIPTION
## 문제 (task-1647 적대 감사 CONFIRMED P0 — lane freeze 기여)

`Trajectory.next_round`(lib/trajectory/trajectory.ml:253)가 round counter 캐시 미스마다 — 캐시 키가 (keeper, trace_id, turn)이라 **매 턴 첫 tool call마다** — 해당 keeper의 trajectory JSONL **전체**를 `Fs_compat.load_file`로 읽고 모든 라인을 Yojson 파싱했다. 이 호출은 MCP 디스패치 fiber(메인 Eio 도메인, 오프로드 없음)에서 인라인 실행된다.

라이브 실측: 최대 파일 86,330,922 bytes / 55,895 lines (sangsu). 프록시 측정 read 0.06s + parse 0.46s ≈ **턴당 ~0.5s 메인 도메인 블로킹**. 12-keeper 동시 구동 시 전 레인 정지에 기여. 파일은 로테이션이 없어 단조 성장하므로 비용이 매주 커진다.

#23011(tool_affinity pre_populate)과는 **별개 사이트** — 같은 파일을 읽는 다른 full-scan이다.

## 수정

turn은 단조 증가하고 파일은 append-only이므로 현재 턴의 엔트리는 파일 끝에만 존재한다:

- hydration을 `Dated_jsonl.load_tail_lines` 기반 **bounded tail-read**로 교체 (초기 512라인, named constant)
- tail window를 **최신→과거 역방향 스캔**, `entry_turn < turn` boundary에서 중단. boundary 미발견 + window ≠ 파일 전체면 **doubling**(512→8192)
- 8192 초과 병리적 턴은 **full-scan 폴백 + warn** — 카운트는 어떤 경우에도 silent truncation 되지 않는다
- `entry_turn > turn`(단조성 위반 이상치)은 warn + 카운트 제외, boundary로 취급하지 않음 (silent failure 방지)
- 과거 턴 캐시 키 **evict** 추가 — 장기 세션에서 Hashtbl 무한 성장 제거
- 파싱 실패 라인 semantics(warn+skip) 및 turn 필드 부재→0 semantics 보존

mli 변경: 기존 `.ml`에 있던 `reset_round_counters_for_testing`을 노출만 함 (신규 test backdoor 추가가 아니라 기존 테스트 리셋 함수의 mli 완성 — 테스트가 hydration 재실행을 강제하는 데 필요).

## 검증 (로컬 실행)

- `dune build --root .` green + `test_trajectory.exe` **46 tests pass** (신규 7 포함)
- 신규 테스트: 빈/부재 파일, 과거 턴만, 현재 턴 k개→k+1, **widen 경로(600 > 512)**, **full-scan 폴백(9000 > 8192)**, 캐시 히트 시 디스크 무시, **evict 후 재hydration**
- ocamlformat auto-promote 완료

주의: CI의 dispatch_integration 등 4-test red는 main 상속(#23012가 수정, 머지 대기) — 이 PR과 무관.

MASC task: task-1647 (audit P0, Wave A1). 후속: C2(trajectory 세그먼트 로테이션 — full-scan 폴백 비용의 근본 해소)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
