### PR TITLE
fix(keeper): inject fresh wall-clock time at turn start, not last tool-call time

### DIFF
--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -11,7 +11,7 @@ type config = {
 }
 
 let default_config () : config =
-  { start_time = Unix.gettimeofday () }
+  { start_time = Time_compat.now () }
 
 let iso8601_of_float ts = Masc_domain.iso8601_of_unix_seconds ts
 
@@ -20,6 +20,7 @@ let iso8601_of_float ts = Masc_domain.iso8601_of_unix_seconds ts
 (* ================================================================ *)
 
 let key_wall_time = "session:wall_time"
+let key_session_start = "session:session_start"
 let key_elapsed_seconds = "session:elapsed_seconds"
 let key_tool_call_count = "session:tool_call_count"
 let key_last_tool_name = "session:last_tool_name"
@@ -40,7 +41,7 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
   let success_count = Atomic.make 0 in
   let error_count = Atomic.make 0 in
   fun ~tool_name ~input:_ ~output ->
-    let now = Unix.gettimeofday () in
+    let now = Time_compat.now () in
     let is_ok = match output with Ok _ -> true | Error _ -> false in
     let _ = Atomic.fetch_and_add call_count 1 in
     if is_ok then ignore (Atomic.fetch_and_add success_count 1)
@@ -50,6 +51,10 @@ let make ~(config : config) () : Agent_sdk.Hooks.context_injector =
     Some Agent_sdk.Hooks.{
       context_updates = [
         (key_wall_time, `String (Masc_domain.iso8601_of_unix_seconds now));
+        (* Session anchor: lets [render_temporal_summary] recompute a
+           fresh elapsed at turn start instead of freezing it at the
+           last tool call. Constant across a session (= injector start). *)
+        (key_session_start, `Float config.start_time);
         (key_elapsed_seconds, `Float elapsed);
         (key_tool_call_count, `Int (Atomic.get call_count));
         (key_last_tool_name, `String tool_name);
@@ -80,12 +85,26 @@ let get_int ctx key =
   | Some (`Int i) -> Some i
   | _ -> None
 
-let render_temporal_summary (ctx : Agent_sdk.Context.t) : string option =
-  match get_string ctx key_wall_time with
+let render_temporal_summary ?now (ctx : Agent_sdk.Context.t) : string option =
+  (* [key_wall_time] presence is the "at least one tool has executed"
+     sentinel (turn 0 renders no block). We do NOT display its stored
+     value: it is the last tool-call timestamp and goes stale across
+     idle turns, which is exactly the bug this renderer must avoid. *)
+  match Agent_sdk.Context.get ctx key_wall_time with
   | None -> None
-  | Some wall_time ->
+  | Some _ ->
+    let now = match now with Some n -> n | None -> Time_compat.now () in
+    (* [time=] is recomputed at render (= turn start), so a keeper waking
+       after an idle gap sees the current wall clock, not a past tool time. *)
+    let wall_time = iso8601_of_float now in
     let elapsed =
-      get_float ctx key_elapsed_seconds |> Option.value ~default:0.0 in
+      match get_float ctx key_session_start with
+      | Some session_start -> now -. session_start
+      | None ->
+        (* Backward compat: contexts written before [key_session_start]
+           existed fall back to the stored (possibly stale) elapsed. *)
+        get_float ctx key_elapsed_seconds |> Option.value ~default:0.0
+    in
     let tool_count =
       get_int ctx key_tool_call_count |> Option.value ~default:0 in
     let last_tool =

--- a/lib/masc_context_injector.ml
+++ b/lib/masc_context_injector.ml
@@ -85,6 +85,29 @@ let get_int ctx key =
   | Some (`Int i) -> Some i
   | _ -> None
 
+let legacy_elapsed_seconds ctx =
+  match get_float ctx key_elapsed_seconds with
+  | Some elapsed -> Some elapsed
+  | None ->
+    Log.Keeper.warn
+      "Temporal summary skipped: missing %s and legacy %s"
+      key_session_start key_elapsed_seconds;
+    None
+
+let tool_summary_fields ctx =
+  match
+    ( get_int ctx key_tool_call_count,
+      get_string ctx key_last_tool_name,
+      get_string ctx key_last_tool_outcome )
+  with
+  | Some tool_count, Some last_tool, Some outcome ->
+    Some (tool_count, last_tool, outcome)
+  | _ ->
+    Log.Keeper.warn
+      "Temporal summary skipped: missing tool summary keys (%s/%s/%s)"
+      key_tool_call_count key_last_tool_name key_last_tool_outcome;
+    None
+
 let render_temporal_summary ?now (ctx : Agent_sdk.Context.t) : string option =
   (* [key_wall_time] presence is the "at least one tool has executed"
      sentinel (turn 0 renders no block). We do NOT display its stored
@@ -99,18 +122,15 @@ let render_temporal_summary ?now (ctx : Agent_sdk.Context.t) : string option =
     let wall_time = iso8601_of_float now in
     let elapsed =
       match get_float ctx key_session_start with
-      | Some session_start -> now -. session_start
+      | Some session_start -> Some (now -. session_start)
       | None ->
         (* Backward compat: contexts written before [key_session_start]
            existed fall back to the stored (possibly stale) elapsed. *)
-        get_float ctx key_elapsed_seconds |> Option.value ~default:0.0
+        legacy_elapsed_seconds ctx
     in
-    let tool_count =
-      get_int ctx key_tool_call_count |> Option.value ~default:0 in
-    let last_tool =
-      get_string ctx key_last_tool_name |> Option.value ~default:"none" in
-    let outcome =
-      get_string ctx key_last_tool_outcome |> Option.value ~default:"unknown" in
-    Some (Printf.sprintf
-      "[Temporal] time=%s elapsed=%.0fs tools=%d last=%s(%s)"
-      wall_time elapsed tool_count last_tool outcome)
+    match elapsed, tool_summary_fields ctx with
+    | Some elapsed, Some (tool_count, last_tool, outcome) ->
+      Some (Printf.sprintf
+        "[Temporal] time=%s elapsed=%.0fs tools=%d last=%s(%s)"
+        wall_time elapsed tool_count last_tool outcome)
+    | _ -> None

--- a/lib/masc_context_injector.mli
+++ b/lib/masc_context_injector.mli
@@ -36,8 +36,19 @@ val make : config:config -> unit -> Agent_sdk.Hooks.context_injector
     Thread-safe: uses {!Atomic} counters internally.
     Returns [Some injection] for every tool call (never [None]). *)
 
-val render_temporal_summary : Agent_sdk.Context.t -> string option
-(** Read temporal keys from [Context.t] and render a one-line summary.
+val render_temporal_summary : ?now:float -> Agent_sdk.Context.t -> string option
+(** Render a one-line temporal summary from [Context.t].
+
+    [time=] and [elapsed=] are recomputed from [now] (defaulting to
+    {!Time_compat.now}) at render time — i.e. turn start — rather than
+    read from the stored [key_wall_time]/[key_elapsed_seconds], which
+    reflect the last tool call and go stale across idle turns. A keeper
+    waking after an idle gap therefore sees the current wall clock, not a
+    past tool-call timestamp. [elapsed] is [now - key_session_start]
+    (seconds since the injector/session started).
+
+    [now] is a Unix timestamp in seconds; pass it to inject a fixed clock
+    in tests.
 
     Returns [None] when no tool has executed yet (turn 0).
     Format: [[Temporal] time=<ISO8601> elapsed=<N>s tools=<N> last=<name>(<outcome>)] *)
@@ -53,6 +64,7 @@ val iso8601_of_float : float -> string
     [AppendInstruction.FromContext] wiring. *)
 
 val key_wall_time : string
+val key_session_start : string
 val key_elapsed_seconds : string
 val key_tool_call_count : string
 val key_last_tool_name : string

--- a/lib/masc_context_injector.mli
+++ b/lib/masc_context_injector.mli
@@ -44,8 +44,10 @@ val render_temporal_summary : ?now:float -> Agent_sdk.Context.t -> string option
     read from the stored [key_wall_time]/[key_elapsed_seconds], which
     reflect the last tool call and go stale across idle turns. A keeper
     waking after an idle gap therefore sees the current wall clock, not a
-    past tool-call timestamp. [elapsed] is [now - key_session_start]
-    (seconds since the injector/session started).
+    past tool-call timestamp. For current contexts, [elapsed] is
+    [now - key_session_start] (seconds since the injector/session
+    started). Legacy contexts written before [key_session_start] render
+    only when a stored [key_elapsed_seconds] value is available.
 
     [now] is a Unix timestamp in seconds; pass it to inject a fixed clock
     in tests.

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -79,6 +79,7 @@ let test_context_updates_overwrite_bounded_keys () =
   let expected_keys =
     [
       MCI.key_wall_time;
+      MCI.key_session_start;
       MCI.key_elapsed_seconds;
       MCI.key_tool_call_count;
       MCI.key_last_tool_name;
@@ -147,6 +148,59 @@ let test_render_temporal_summary_populated () =
       (Astring.String.is_infix ~affix:"elapsed=42s" summary)
   | None -> fail "expected Some summary"
 
+(* Regression: turn N+1 must render the *fresh* current time, not the
+   last tool call's timestamp frozen in [key_wall_time]/[key_elapsed_seconds]
+   from turn N (the idle-wake bug). Uses a fixed [~now] far in the future
+   relative to the stored (stale) values. *)
+let test_render_uses_fresh_now_not_stale () =
+  let ctx = Agent_sdk.Context.create_sync () in
+  let stale_now = 1_700_000_000.0 in
+  (* 2023-11-14T22:13:20Z *)
+  let session_start = stale_now -. 100.0 in
+  Agent_sdk.Context.set ctx
+    MCI.key_wall_time (`String (MCI.iso8601_of_float stale_now));
+  Agent_sdk.Context.set ctx
+    MCI.key_session_start (`Float session_start);
+  Agent_sdk.Context.set ctx
+    MCI.key_elapsed_seconds (`Float 100.0);
+  Agent_sdk.Context.set ctx
+    MCI.key_tool_call_count (`Int 2);
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_name (`String "bash");
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_outcome (`String "ok");
+  let fresh_now = 1_800_000_000.0 in
+  (* 2027-01-15T08:00:00Z — 100_000_000s after the stale snapshot *)
+  match MCI.render_temporal_summary ~now:fresh_now ctx with
+  | Some summary ->
+    let fresh_iso = MCI.iso8601_of_float fresh_now in
+    let stale_iso = MCI.iso8601_of_float stale_now in
+    check bool "time= is the fresh render-time clock" true
+      (Astring.String.is_infix ~affix:("time=" ^ fresh_iso) summary);
+    check bool "time= is NOT the stale stored wall_time" false
+      (Astring.String.is_infix ~affix:stale_iso summary);
+    (* elapsed = fresh_now - session_start = 100_000_000 + 100 *)
+    check bool "elapsed recomputed against session_start at render time" true
+      (Astring.String.is_infix ~affix:"elapsed=100000100s" summary)
+  | None -> fail "expected Some summary"
+
+(* When [key_session_start] is absent (context written before the key
+   existed), elapsed falls back to the stored value; time= is still fresh. *)
+let test_render_elapsed_fallback_without_session_start () =
+  let ctx = Agent_sdk.Context.create_sync () in
+  Agent_sdk.Context.set ctx
+    MCI.key_wall_time (`String "2023-11-14T22:13:20Z");
+  Agent_sdk.Context.set ctx
+    MCI.key_elapsed_seconds (`Float 55.0);
+  match MCI.render_temporal_summary ~now:1_800_000_000.0 ctx with
+  | Some summary ->
+    check bool "time= is fresh" true
+      (Astring.String.is_infix
+         ~affix:("time=" ^ MCI.iso8601_of_float 1_800_000_000.0) summary);
+    check bool "elapsed falls back to stored value" true
+      (Astring.String.is_infix ~affix:"elapsed=55s" summary)
+  | None -> fail "expected Some summary"
+
 (* ── ISO 8601 formatting ────────────────────────────── *)
 
 let test_iso8601_format () =
@@ -180,6 +234,10 @@ let () =
         test_render_temporal_summary_empty;
       test_case "populated context" `Quick
         test_render_temporal_summary_populated;
+      test_case "fresh now, not stale wall_time" `Quick
+        test_render_uses_fresh_now_not_stale;
+      test_case "elapsed fallback without session_start" `Quick
+        test_render_elapsed_fallback_without_session_start;
     ];
     "iso8601", [
       test_case "format" `Quick test_iso8601_format;

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -192,6 +192,12 @@ let test_render_elapsed_fallback_without_session_start () =
     MCI.key_wall_time (`String "2023-11-14T22:13:20Z");
   Agent_sdk.Context.set ctx
     MCI.key_elapsed_seconds (`Float 55.0);
+  Agent_sdk.Context.set ctx
+    MCI.key_tool_call_count (`Int 1);
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_name (`String "legacy_tool");
+  Agent_sdk.Context.set ctx
+    MCI.key_last_tool_outcome (`String "ok");
   match MCI.render_temporal_summary ~now:1_800_000_000.0 ctx with
   | Some summary ->
     check bool "time= is fresh" true
@@ -200,6 +206,13 @@ let test_render_elapsed_fallback_without_session_start () =
     check bool "elapsed falls back to stored value" true
       (Astring.String.is_infix ~affix:"elapsed=55s" summary)
   | None -> fail "expected Some summary"
+
+let test_render_omits_malformed_elapsed_context () =
+  let ctx = Agent_sdk.Context.create_sync () in
+  Agent_sdk.Context.set ctx
+    MCI.key_wall_time (`String "2023-11-14T22:13:20Z");
+  check (option string) "missing elapsed anchor omits summary"
+    None (MCI.render_temporal_summary ~now:1_800_000_000.0 ctx)
 
 (* ── ISO 8601 formatting ────────────────────────────── *)
 
@@ -238,6 +251,8 @@ let () =
         test_render_uses_fresh_now_not_stale;
       test_case "elapsed fallback without session_start" `Quick
         test_render_elapsed_fallback_without_session_start;
+      test_case "malformed elapsed context omitted" `Quick
+        test_render_omits_malformed_elapsed_context;
     ];
     "iso8601", [
       test_case "format" `Quick test_iso8601_format;


### PR DESCRIPTION
## 문제 (audit CONFIRMED, P1 — keeper 시간 인지)

keeper 턴 입력에 주입되는 `[Temporal] time=<ISO> elapsed=<N>s ...` 블록의 `time=`이 **stale**하다.

- 이 블록은 `Masc_context_injector.render_temporal_summary`가 `shared_context`의 `key_wall_time`을 읽어 만든다.
- 그런데 `key_wall_time`은 context_injector 클로저가 **tool 호출이 끝난 뒤에만** 기록한다.
- `shared_context`는 heartbeat loop 생애 전체를 관통하므로, 턴 N+1의 첫 model call에는 **턴 N의 마지막 tool 호출 시각**이 `time=`으로 제시된다.

### 재현 시나리오 (idle-wake)

keeper가 idle 600s+ 후 깨어나면, 턴 시작 시 주입되는 `time=`은 수십 분 전(마지막 tool 시각)이다. keeper 입장에서 "지금 몇 시인지"가 과거로 라벨링되므로 "이따 해야지" 같은 **시간 기반 판단이 구조적으로 불가능**하다. `elapsed=`도 이전 턴의 마지막 tool 시점에 얼어붙은 잔존값이었다 (`마지막_tool_시각 - start_time`).

## 수정

`render_temporal_summary`가 **render 시점(= 턴 시작)에** 두 필드를 재계산한다.

- `time=`: 저장된 stale `key_wall_time` 대신 fresh `Time_compat.now ()`로 계산. 결과적으로 idle 후 깨어나도 항상 현재 wall clock을 본다.
- `elapsed=`: 새 세션 앵커 `key_session_start`(injector가 `config.start_time`을 기록)를 기준으로 `now - session_start`를 재계산. "세션 시작 기준 경과"라는 의미를 유지하되 render 시점 기준으로 정직하게 갱신한다.
- `render_temporal_summary`에 optional `?now:float` 추가 → 결정론적 테스트에서 고정 clock 주입 가능. 3개 read 사이트(`keeper_run_prompt`, `keeper_run_tools_hooks`, `worker_oas`)는 인자 없이 호출하므로 자동으로 fresh 값을 받는다 (call-site 변경 0).
- `key_session_start`가 없는(구버전) 컨텍스트는 저장된 `key_elapsed_seconds`로 fallback.
- clock 일관성을 위해 이 모듈의 `Unix.gettimeofday ()` 3곳을 `Time_compat.now ()`로 통일 (session_start와 render now가 동일 Unix epoch clock). MASC의 Time_compat 경유 관례를 따른다.

### 계약

> 턴 시작 시점의 신선한 현재 시각이 항상 주입된다.

turn 0(첫 tool 실행 전)은 기존과 동일하게 `[Temporal]` 블록이 없다 — `key_wall_time` presence를 "tool이 최소 1회 실행됨" sentinel로 유지. idle-wake 버그는 턴 N+1(N≥1)에서 발생하므로 이 fix가 정확히 그 경로를 덮는다.

## 검증

- `test/test_masc_context_injector.ml` 신규 테스트 2건 추가:
  - `fresh now, not stale wall_time`: stale한 저장값(2023) 위에 미래 `~now`(2027)를 주입 → `time=`이 fresh now이고 stale ISO를 포함하지 않으며, `elapsed`가 `now - session_start`로 재계산됨을 검증.
  - `elapsed fallback without session_start`: session_start 부재 시 저장값 fallback + `time=` fresh 검증.
- 전체 테스트 10/10 통과 (`./_build/default/test/test_masc_context_injector.exe`).
- `MASC_SKIP_PIN_CHECK=1 dune build --root . @check` exit 0 (3개 read 사이트 포함 프로젝트 전역 typecheck 통과).
- `@fmt --auto-promote` 통과.

## 범위 밖 / 참고

- 저장 키 `key_wall_time`/`key_elapsed_seconds`의 유일한 소비자는 `render_temporal_summary`이며(전역 grep 확인), 다른 경로에 영향 없음.
- CI에서 main 상속 red 4건은 #23012 머지 전 상태로, 이 PR과 무관하다.

MASC task: task-1647 (audit P1 — 시간 인지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
