### PR TITLE
fix(keeper): typed docker failure classes (masc#22981)

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -512,7 +512,7 @@ let docker_image_present_with_class ~image ~timeout_sec =
   then
     Error
       { message = "keeper sandbox docker image is not configured"
-      ; failure_class = "image_config_missing"
+      ; failure_class = Image_config_missing
       }
   else (
     let argv = docker_command_argv () @ [ "image"; "inspect"; image ] in
@@ -563,8 +563,8 @@ let ensure_keeper_sandbox_image_present ~image ~timeout_sec =
 
 let docker_image_preflight_error_code (failure : classified_error) =
   match failure.failure_class with
-  | "image_missing" -> "image_not_found"
-  | failure_class -> failure_class
+  | Image_missing -> "image_not_found"
+  | failure_class -> Keeper_sandbox_runtime_classify.docker_failure_class_to_string failure_class
 ;;
 
 let docker_image_preflight_failure_message ~prefix failure =
@@ -788,10 +788,11 @@ let docker_preflight ~timeout_sec () =
       [ docker_runtime_failure_class
       ; image_failure_class
       ; command_failure_class
-      ; (if hardening_ok then None else Some "docker_hardening_error")
-      ; (if missing_commands = [] then None else Some "image_required_command_missing")
+      ; (if hardening_ok then None else Some Docker_hardening_error)
+      ; (if missing_commands = [] then None else Some Image_required_command_missing)
       ]
       |> List.filter_map (fun item -> item)
+      |> List.map Keeper_sandbox_runtime_classify.docker_failure_class_to_string
       |> List.filter (fun s -> s <> "")
       |> Json_util.dedupe_keep_order
     in

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -37,7 +37,7 @@ type cleanup_result =
 
 type classified_error =
   { message : string
-  ; failure_class : string
+  ; failure_class : Keeper_sandbox_runtime_classify.docker_failure_class
   }
 
 type live_container =

--- a/lib/keeper/keeper_sandbox_runtime_classify.ml
+++ b/lib/keeper/keeper_sandbox_runtime_classify.ml
@@ -5,10 +5,41 @@
     parent-local state. All callers are internal to the parent
     (verified via grep across lib/ + test/).
 
-    Note: the [classify_*] functions return string failure-class tokens
-    rather than a typed variant. This is verbatim with the
-    pre-extraction code; a typed conversion is RFC-territory because
-    the strings cross many call sites and the dashboard surface. *)
+    The classifier now returns a typed variant instead of string
+    tokens. String serialization is owned by
+    {!docker_failure_class_to_string} so retry policy and telemetry
+    cannot drift when a new class is added or renamed. *)
+
+type docker_failure_class =
+  | Docker_daemon_timeout
+  | Docker_daemon_unavailable
+  | Docker_runtime_error
+  | Image_inspect_timeout
+  | Image_missing
+  | Image_inspect_error
+  | Image_inventory_timeout
+  | Oci_mount_failure
+  | Image_inventory_error
+  | Docker_info_format_error
+  | Image_config_missing
+  | Docker_hardening_error
+  | Image_required_command_missing
+
+let docker_failure_class_to_string = function
+  | Docker_daemon_timeout -> "docker_daemon_timeout"
+  | Docker_daemon_unavailable -> "docker_daemon_unavailable"
+  | Docker_runtime_error -> "docker_runtime_error"
+  | Image_inspect_timeout -> "image_inspect_timeout"
+  | Image_missing -> "image_missing"
+  | Image_inspect_error -> "image_inspect_error"
+  | Image_inventory_timeout -> "image_inventory_timeout"
+  | Oci_mount_failure -> "oci_mount_failure"
+  | Image_inventory_error -> "image_inventory_error"
+  | Docker_info_format_error -> "docker_info_format_error"
+  | Image_config_missing -> "image_config_missing"
+  | Docker_hardening_error -> "docker_hardening_error"
+  | Image_required_command_missing -> "image_required_command_missing"
+;;
 
 let process_status_is_timeout = function
   | Unix.WEXITED 124 -> true
@@ -47,28 +78,28 @@ let docker_output_looks_oci_mount_failure output =
 
 let classify_docker_runtime_failure ~status ~output =
   if process_status_is_timeout status || output_looks_timeout output
-  then "docker_daemon_timeout"
+  then Docker_daemon_timeout
   else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
-  else "docker_runtime_error"
+  then Docker_daemon_unavailable
+  else Docker_runtime_error
 ;;
 
 let classify_image_inspect_failure ~status ~output =
   if process_status_is_timeout status || output_looks_timeout output
-  then "image_inspect_timeout"
+  then Image_inspect_timeout
   else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
+  then Docker_daemon_unavailable
   else if output_looks_image_missing output
-  then "image_missing"
-  else "image_inspect_error"
+  then Image_missing
+  else Image_inspect_error
 ;;
 
 let classify_image_inventory_failure ~status ~output =
   if process_status_is_timeout status || output_looks_timeout output
-  then "image_inventory_timeout"
+  then Image_inventory_timeout
   else if docker_output_looks_oci_mount_failure output
-  then "oci_mount_failure"
+  then Oci_mount_failure
   else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
-  else "image_inventory_error"
+  then Docker_daemon_unavailable
+  else Image_inventory_error
 ;;

--- a/lib/keeper/keeper_sandbox_runtime_classify.mli
+++ b/lib/keeper/keeper_sandbox_runtime_classify.mli
@@ -1,11 +1,33 @@
 (** Docker output / status classifiers for keeper sandbox runtime. *)
 
+type docker_failure_class =
+  | Docker_daemon_timeout
+  | Docker_daemon_unavailable
+  | Docker_runtime_error
+  | Image_inspect_timeout
+  | Image_missing
+  | Image_inspect_error
+  | Image_inventory_timeout
+  | Oci_mount_failure
+  | Image_inventory_error
+  | Docker_info_format_error
+  | Image_config_missing
+  | Docker_hardening_error
+  | Image_required_command_missing
+
+val docker_failure_class_to_string : docker_failure_class -> string
 val process_status_is_timeout : Unix.process_status -> bool
 val lower_contains : string -> string -> bool
 val output_looks_docker_daemon_unavailable : string -> bool
 val output_looks_image_missing : string -> bool
 val output_looks_timeout : string -> bool
 val docker_output_looks_oci_mount_failure : string -> bool
-val classify_docker_runtime_failure : status:Unix.process_status -> output:string -> string
-val classify_image_inspect_failure : status:Unix.process_status -> output:string -> string
-val classify_image_inventory_failure : status:Unix.process_status -> output:string -> string
+
+val classify_docker_runtime_failure :
+  status:Unix.process_status -> output:string -> docker_failure_class
+
+val classify_image_inspect_failure :
+  status:Unix.process_status -> output:string -> docker_failure_class
+
+val classify_image_inventory_failure :
+  status:Unix.process_status -> output:string -> docker_failure_class

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -60,7 +60,7 @@ let run_docker_argv_with_status ~summary ~timeout_sec argv =
 
 type classified_error =
   { message : string
-  ; failure_class : string
+  ; failure_class : Keeper_sandbox_runtime_classify.docker_failure_class
   }
 
 let process_status_is_timeout = Keeper_sandbox_runtime_classify.process_status_is_timeout
@@ -80,7 +80,7 @@ let classify_image_inventory_failure =
 
 let docker_run_looks_daemon_pressure ~status ~output =
   match classify_docker_runtime_failure ~status ~output with
-  | "docker_daemon_unavailable" -> true
+  | Keeper_sandbox_runtime_classify.Docker_daemon_unavailable -> true
   | _ -> false
 
 let docker_info_security_options_with_class ~timeout_sec =
@@ -115,14 +115,14 @@ let docker_info_security_options_with_class ~timeout_sec =
           { message =
               "docker info returned unexpected SecurityOptions payload while validating \
                sandbox runtime"
-          ; failure_class = "docker_info_format_error"
+          ; failure_class = Docker_info_format_error
           }
     with
     | Yojson.Json_error err ->
       Error
         { message =
             Printf.sprintf "failed to parse docker info SecurityOptions JSON: %s" err
-        ; failure_class = "docker_info_format_error"
+        ; failure_class = Docker_info_format_error
         })
 ;;
 

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -5,7 +5,10 @@ val docker_image_missing_next_action : string
 val run_docker_argv_with_status :
   summary:string ->
   timeout_sec:float -> string list -> Unix.process_status * string
-type classified_error = { message : string; failure_class : string; }
+type classified_error = {
+  message : string;
+  failure_class : Keeper_sandbox_runtime_classify.docker_failure_class;
+}
 val process_status_is_timeout : Unix.process_status -> bool
 val lower_contains : string -> string -> bool
 val output_looks_docker_daemon_unavailable : string -> bool
@@ -13,11 +16,11 @@ val output_looks_image_missing : string -> bool
 val output_looks_timeout : string -> bool
 val docker_output_looks_oci_mount_failure : string -> bool
 val classify_docker_runtime_failure :
-  status:Unix.process_status -> output:string -> string
+  status:Unix.process_status -> output:string -> Keeper_sandbox_runtime_classify.docker_failure_class
 val classify_image_inspect_failure :
-  status:Unix.process_status -> output:string -> string
+  status:Unix.process_status -> output:string -> Keeper_sandbox_runtime_classify.docker_failure_class
 val classify_image_inventory_failure :
-  status:Unix.process_status -> output:string -> string
+  status:Unix.process_status -> output:string -> Keeper_sandbox_runtime_classify.docker_failure_class
 val docker_run_looks_daemon_pressure :
   status:Unix.process_status -> output:string -> bool
 val docker_info_security_options_with_class :

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -17,20 +17,23 @@ let docker_image (meta : keeper_meta) =
   | _ -> Env_config_sandbox.Runtime.docker_image ()
 ;;
 
-let tool_failure_class_of_image_preflight_failure = function
-  | "image_config_missing"
-  | "image_missing" ->
+let tool_failure_class_of_image_preflight_failure failure_class =
+  match failure_class with
+  | Keeper_sandbox_runtime_classify.Image_config_missing
+  | Image_missing ->
     "policy_rejection"
-  | "docker_daemon_unavailable"
-  | "image_inspect_timeout" ->
+  | Docker_daemon_unavailable
+  | Image_inspect_timeout ->
     "transient_error"
   | _ -> "runtime_failure"
 ;;
 
-let image_preflight_failure_fields (failure : Keeper_sandbox_runtime.classified_error)
-  =
+let image_preflight_failure_fields (failure : Keeper_sandbox_runtime.classified_error) =
+  let sandbox_failure_class =
+    Keeper_sandbox_runtime_classify.docker_failure_class_to_string failure.failure_class
+  in
   [ "requested_sandbox", `String "docker"
-  ; "sandbox_failure_class", `String failure.failure_class
+  ; "sandbox_failure_class", `String sandbox_failure_class
   ; ( "failure_class"
     , `String (tool_failure_class_of_image_preflight_failure failure.failure_class) )
   ]

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1101,6 +1101,40 @@ let test_docker_run_looks_daemon_pressure_not_pressure_on_command_error () =
        ~status:(Unix.WEXITED 1)
        ~output:"No such file or directory")
 
+(* The retry predicate must consume the typed classifier result, not a
+   string-token protocol. These tests pin the variant-to-retry mapping so
+   adding or renaming a failure class cannot silently change retry policy. *)
+let test_docker_failure_class_is_typed_and_serializes_stable_string () =
+  let open Masc.Keeper_sandbox_runtime_classify in
+  Alcotest.(check string)
+    "daemon unavailable class serializes to stable string"
+    "docker_daemon_unavailable"
+    (docker_failure_class_to_string Docker_daemon_unavailable);
+  Alcotest.(check string)
+    "timeout class serializes to stable string"
+    "docker_daemon_timeout"
+    (docker_failure_class_to_string Docker_daemon_timeout);
+  Alcotest.(check bool)
+    "classifier maps daemon unavailable output to the typed variant"
+    true
+    (match
+       classify_docker_runtime_failure
+         ~status:(Unix.WEXITED 1)
+         ~output:"Cannot connect to the Docker daemon"
+     with
+     | Docker_daemon_unavailable -> true
+     | _ -> false);
+  Alcotest.(check bool)
+    "classifier maps timeout output to the typed variant"
+    true
+    (match
+       classify_docker_runtime_failure
+         ~status:(Unix.WEXITED 124)
+         ~output:"process error: timeout after 5s"
+     with
+     | Docker_daemon_timeout -> true
+     | _ -> false)
+
 let test_docker_workspace_state_mount_args_expose_safe_subset () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
@@ -2324,6 +2358,8 @@ let run_tests ~clock () =
             test_docker_run_looks_daemon_pressure_classifies_daemon_unavailable;
           Alcotest.test_case "docker run does not classify command error as pressure" `Quick
             test_docker_run_looks_daemon_pressure_not_pressure_on_command_error;
+          Alcotest.test_case "docker failure class is typed and serializes stable string" `Quick
+            test_docker_failure_class_is_typed_and_serializes_stable_string;
           Alcotest.test_case "docker workspace state mount exposes safe subset" `Quick
             test_docker_workspace_state_mount_args_expose_safe_subset;
           Alcotest.test_case "managed label args include ttl" `Quick


### PR DESCRIPTION
Replace string-token docker failure classification with a closed-sum [docker_failure_class] variant in [Keeper_sandbox_runtime_classify].

- Classify functions now return the typed variant.
- [docker_failure_class_to_string] is the single SSOT for serialization to the stable telemetry/dashboard tokens.
- Update consumers: [Keeper_sandbox_runtime_setup.classified_error], [docker_run_looks_daemon_pressure], [Keeper_sandbox_runtime.docker_image_preflight_error_code], preflight failure_classes aggregation, and [Keeper_sandbox_shell_ir_target].
- Add regression tests proving the classifier returns the expected variants and serializes to stable strings.

Verification: scripts/dune-local.sh build lib/masc.a; scripts/dune-local.sh build test/test_keeper_sandbox_read_backend.exe; test_keeper_sandbox_read_backend.exe test docker_preflight 0-5; test_keeper_sandbox_read_backend.exe test container_path_of_host 4-7.