### PR TITLE
fix(governance): make front-door decide hard-forbidden gate unconditional

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -117,7 +117,7 @@ let decide ~governance_level ~tool_name ~input =
   let risk = assess_risk ~tool_name ~input in
   let trace_id = generate_trace_id () in
   let action =
-    if Env_config_core.disable_hitl () && auto_approval_hard_forbidden ~risk None then
+    if auto_approval_hard_forbidden ~risk None then
       `Require_confirm
         (Printf.sprintf
            "Governance (%s): %s risk tool %S requires confirmation: auto-approval is \

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -61,14 +61,15 @@ val decide :
   input:Yojson.Safe.t ->
   governance_decision
 (** Evaluate a tool call against governance policy and return a decision.
-    - development: allow all while HITL is enabled, audit High+Critical
+    - development: allow Low/Medium/High while HITL is enabled, audit High+Critical,
+      but always confirm Critical hard-forbidden calls
     - production: confirm Critical, audit Medium+
     - enterprise: confirm High+Critical, audit all
     - paranoid: confirm Medium+High+Critical, audit all
 
-    Critical hard-forbidden calls still require confirmation when HITL
-    thresholds are disabled, so disabling HITL cannot silently auto-approve
-    destructive operations. *)
+    Critical hard-forbidden calls always require confirmation, regardless of
+    whether HITL thresholds are disabled, so disabling HITL cannot silently
+    auto-approve destructive operations. *)
 
 val make_pre_hook :
   config:Workspace.config ->

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -512,13 +512,15 @@ let test_risk_payload_beats_low_override () =
 
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
-let test_development_allows_all () =
+let test_development_confirms_critical () =
+  (* Hard-forbidden gate is unconditional: even development must confirm
+     Critical-risk tools rather than allowing silent auto-approval. *)
   let d = Gp.decide ~governance_level:"development"
     ~tool_name:"masc_delete_workspace" ~input:`Null in
   (match d.action with
-   | `Allow -> ()
-   | `Require_confirm _ -> Alcotest.fail "development should allow critical"
-   | `Deny _ -> Alcotest.fail "development should allow critical");
+   | `Require_confirm _ -> ()
+   | `Allow -> Alcotest.fail "development should require confirm for critical"
+   | `Deny _ -> Alcotest.fail "development should require confirm, not deny");
   Alcotest.(check string) "risk" "critical" (Gp.risk_level_to_string d.risk)
 
 let test_development_allows_low () =
@@ -645,7 +647,9 @@ let test_trace_ids_unique () =
 let setup () =
   Tool_dispatch.clear_hooks ()
 
-let test_hook_development_allows () =
+let test_hook_development_blocks_critical () =
+  (* The front-door pre_hook uses decide without keeper meta, but the
+     unconditional hard-forbidden gate still blocks Critical risk. *)
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
@@ -657,8 +661,11 @@ let test_hook_development_allows () =
   let hook = Gp.make_pre_hook ~config ~governance_level:"development" in
   let result = hook ~name:"__gov_test_delete" ~args:`Null in
   (match result with
-   | Tool_dispatch.Pass -> ()
-   | _ -> Alcotest.fail "development should allow critical");
+   | Tool_dispatch.Reject r ->
+       Alcotest.(check bool) "blocked" false (Tool_result.is_success r);
+       let status = Yojson.Safe.Util.((Tool_result.data r) |> member "status" |> to_string) in
+       Alcotest.(check string) "awaiting_approval" "awaiting_approval" status
+   | _ -> Alcotest.fail "development should block critical tool");
   cleanup_tmpdir tmpdir
 
 let test_hook_production_blocks_critical () =
@@ -1078,8 +1085,8 @@ let () =
         test_tool_capabilities_unknown;
     ];
     "governance_levels", [
-      Alcotest.test_case "development allows all" `Quick
-        test_development_allows_all;
+      Alcotest.test_case "development confirms critical" `Quick
+        test_development_confirms_critical;
       Alcotest.test_case "development allows low" `Quick
         test_development_allows_low;
       Alcotest.test_case "production allows low" `Quick
@@ -1122,8 +1129,8 @@ let () =
       Alcotest.test_case "unique per call" `Quick test_trace_ids_unique;
     ];
     "pre_hook_integration", [
-      Alcotest.test_case "development allows delete" `Quick
-        test_hook_development_allows;
+      Alcotest.test_case "development blocks critical" `Quick
+        test_hook_development_blocks_critical;
       Alcotest.test_case "production blocks critical" `Quick
         test_hook_production_blocks_critical;
       Alcotest.test_case "production allows low" `Quick


### PR DESCRIPTION
## Summary
The hard-forbidden check in `Governance_pipeline.decide` was gated on `Env_config_core.disable_hitl ()`, so Critical-risk tools could be silently auto-approved in development when HITL was enabled. This change removes the HITL-disable condition so the hard-forbidden gate is evaluated unconditionally.

## Changes
- `lib/governance_pipeline.ml`: `decide` now always requires confirmation for hard-forbidden calls (Critical risk).
- `lib/governance_pipeline.mli`: update docstring to reflect unconditional behavior.
- `test/test_governance_pipeline.ml`: rename and flip development-critical tests so they fail before the fix and pass after.

## Verification
- `scripts/dune-local.sh build test/test_governance_pipeline.exe` ✅
- `./_build/default/test/test_governance_pipeline.exe` ✅ (99 tests)
- `scripts/dune-local.sh build @check` ✅

## Scope
Narrow: front-door `decide` only. Runtime blocker handling is intentionally left unchanged per current scope.