### PR TITLE
feat(hitl): typed pending_phase lifecycle for keeper approvals

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -512,21 +512,26 @@ let create_entry
 ;;
 
 let update_pending_phase ~id phase =
-  let updated = ref None in
   atomic_update pending (fun map ->
     match SMap.find_opt id map with
     | None -> map
     | Some entry ->
       let entry' = { entry with phase } in
-      updated := Some entry';
       SMap.add id entry' map);
-  match !updated with
+  match SMap.find_opt id (Atomic.get pending) with
+  | Some entry when entry.phase = phase -> Some entry
+  | Some entry ->
+    Log.Keeper.warn
+      "approval_queue: update_pending_phase id=%s phase race current=%s expected=%s"
+      id
+      (pending_phase_to_string entry.phase)
+      (pending_phase_to_string phase);
+    None
   | None ->
     Log.Keeper.warn
       "approval_queue: update_pending_phase id=%s not found"
       id;
     None
-  | Some entry -> Some entry
 ;;
 
 let pending_entry_json_fields

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -409,6 +409,8 @@ module For_testing = struct
   ;;
 
   let first_cmd_token = first_cmd_token
+
+  let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
 end
 
 let action_key_of_input ~tool_name ~(input : Yojson.Safe.t) =
@@ -502,10 +504,29 @@ let create_entry
   ; selected_model
   ; disposition
   ; disposition_reason
+  ; phase = Awaiting_operator
   ; audit_base_path
   ; resolver
   ; on_resolution
   }
+;;
+
+let update_pending_phase ~id phase =
+  let updated = ref None in
+  atomic_update pending (fun map ->
+    match SMap.find_opt id map with
+    | None -> map
+    | Some entry ->
+      let entry' = { entry with phase } in
+      updated := Some entry';
+      SMap.add id entry' map);
+  match !updated with
+  | None ->
+    Log.Keeper.warn
+      "approval_queue: update_pending_phase id=%s not found"
+      id;
+    None
+  | Some entry -> Some entry
 ;;
 
 let pending_entry_json_fields
@@ -520,6 +541,7 @@ let pending_entry_json_fields
   ; "action_key", `String entry.action_key
   ; "sandbox_target", `String entry.sandbox_target
   ; "risk_level", `String (risk_level_to_string entry.risk_level)
+  ; "phase", `String (pending_phase_to_string entry.phase)
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -877,6 +899,9 @@ let submit_and_await
            ?selected_model
            ~audit_disposition:(Approval_escalated reason)
            ();
+         (match update_pending_phase ~id Escalated with
+          | Some escalated_entry -> broadcast_pending escalated_entry
+          | None -> ());
          (* Escalated — keep waiting for operator, do not reject *)
          Eio.Promise.await promise)
     | None, _ -> Eio.Promise.await promise

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -14,6 +14,11 @@ type risk_level =
   | High
   | Critical
 
+(** Lifecycle phase of a pending approval. *)
+type pending_phase =
+  | Awaiting_operator
+  | Escalated
+
 (** [Agent_sdk.Hooks.approval_decision] alias used as the resolver type. *)
 type decision = Agent_sdk.Hooks.approval_decision
 
@@ -47,6 +52,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
+  ; phase : pending_phase
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
@@ -92,6 +98,8 @@ val resolve_error_to_string : resolve_error -> string
 val risk_level_to_string : risk_level -> string
 val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
+val pending_phase_to_string : pending_phase -> string
+val pending_phase_of_string : string -> pending_phase option
 val approval_decision_to_string : decision -> string
 val approval_audit_decision_to_string : approval_audit_decision -> string
 
@@ -198,6 +206,7 @@ val list_recent_resolved_json :
 module For_testing : sig
   val reset_audit_store : unit -> unit
   val first_cmd_token : string -> string option
+  val get_pending_entry : id:string -> pending_approval option
 end
 
 (** {1 Submit & await} *)

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -11,6 +11,10 @@ type risk_level =
   | High
   | Critical
 
+type pending_phase =
+  | Awaiting_operator
+  | Escalated
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -31,6 +35,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
+  ; phase : pending_phase
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
@@ -93,6 +98,17 @@ let risk_level_of_string = function
   | "medium" -> Some Medium
   | "high" -> Some High
   | "critical" -> Some Critical
+  | _ -> None
+;;
+
+let pending_phase_to_string = function
+  | Awaiting_operator -> "awaiting_operator"
+  | Escalated -> "escalated"
+;;
+
+let pending_phase_of_string = function
+  | "awaiting_operator" -> Some Awaiting_operator
+  | "escalated" -> Some Escalated
   | _ -> None
 ;;
 

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -6,6 +6,10 @@ type risk_level =
   | High
   | Critical
 
+type pending_phase =
+  | Awaiting_operator
+  | Escalated
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -26,6 +30,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
+  ; phase : pending_phase
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
@@ -67,6 +72,8 @@ val risk_level_to_string : risk_level -> string
 val allowed_risk_level_values_label : string
 val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
+val pending_phase_to_string : pending_phase -> string
+val pending_phase_of_string : string -> pending_phase option
 val approval_decision_to_string : decision -> string
 
 val approval_audit_decision_to_string : approval_audit_decision -> string

--- a/test/dune
+++ b/test/dune
@@ -2036,6 +2036,8 @@
 
 (include stanzas/test_keeper_approval_queue_rules.inc)
 
+(include stanzas/test_keeper_approval_queue.inc)
+
 (include stanzas/test_keeper_toml_parser.inc)
 
 (include stanzas/test_keeper_toml_loader.inc)

--- a/test/stanzas/test_keeper_approval_queue.inc
+++ b/test/stanzas/test_keeper_approval_queue.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_approval_queue)
+ (modules test_keeper_approval_queue)
+ (libraries alcotest masc masc_test_deps eio_main))

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1,0 +1,220 @@
+(** Tests for the typed pending_phase HITL state machine (RFC-0304).
+
+    Proves:
+    1. Fresh pending approvals start in [Awaiting_operator].
+    2. The phase is included in pending-entry JSON/SSE payloads.
+    3. Critical approvals transition to [Escalated] when the escalation timer
+       fires, and the updated phase is reflected in-memory and in JSON. *)
+
+module AQ = Masc.Keeper_approval_queue
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_approval_queue_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+  in
+  try rm_rf dir with
+  | _ -> ()
+;;
+
+let yield_until ?(attempts = 50) predicate =
+  if predicate () || attempts <= 0
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    yield_until ~attempts:(attempts - 1) predicate)
+;;
+
+let pending_id_for_keeper ~keeper_name =
+  match AQ.list_pending_json () with
+  | `List entries ->
+    List.find_map
+      (function
+        | `Assoc kvs ->
+          (match List.assoc_opt "keeper_name" kvs, List.assoc_opt "id" kvs with
+           | Some (`String name), Some (`String id) when String.equal name keeper_name ->
+             Some id
+           | _ -> None)
+        | _ -> None)
+      entries
+  | _ -> None
+;;
+
+let phase_in_json json =
+  let open Yojson.Safe.Util in
+  json |> member "phase" |> to_string
+;;
+
+let test_fresh_critical_entry_phase_is_awaiting_operator () =
+  Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let keeper_name = "fresh-critical-phase-test" in
+       Eio.Fiber.fork ~sw (fun () ->
+         ignore
+           (AQ.submit_and_await
+              ~keeper_name
+              ~tool_name:"keeper_continue_after_reconcile"
+              ~input:(`Assoc [ ("kind", `String "critical_gate") ])
+              ~risk_level:AQ.Critical
+              ~base_path
+              ()));
+       yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+       let id =
+         match pending_id_for_keeper ~keeper_name with
+         | Some id -> id
+         | None -> Alcotest.fail "Critical approval was not queued"
+       in
+       let entry =
+         match AQ.For_testing.get_pending_entry ~id with
+         | Some entry -> entry
+         | None -> Alcotest.fail "in-memory entry not found"
+       in
+       Alcotest.(check bool)
+         "fresh Critical entry is Awaiting_operator in-memory"
+         true
+         (entry.phase = AQ.Awaiting_operator);
+       let detail =
+         match AQ.get_pending_json ~id with
+         | Some json -> json
+         | None -> Alcotest.fail "pending detail JSON not found"
+       in
+       Alcotest.(check string)
+         "fresh Critical entry is awaiting_operator in JSON"
+         "awaiting_operator"
+         (phase_in_json detail))
+;;
+
+let test_critical_entry_phase_becomes_escalated_after_timer () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir () in
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let keeper_name = "critical-escalated-phase-test" in
+       let result = ref None in
+       Eio.Fiber.fork ~sw (fun () ->
+         let decision =
+           AQ.submit_and_await
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_partial_commit"
+             ~input:(`Assoc [ ("kind", `String "critical_gate") ])
+             ~risk_level:AQ.Critical
+             ~base_path
+             ~clock
+             ~critical_escalation_after_s:0.01
+             ()
+         in
+         result := Some decision);
+       yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+       let id =
+         match pending_id_for_keeper ~keeper_name with
+         | Some id -> id
+         | None -> Alcotest.fail "Critical approval was not queued"
+       in
+       Eio.Time.sleep clock 0.03;
+       yield_until (fun () ->
+         match AQ.For_testing.get_pending_entry ~id with
+         | Some entry -> entry.phase = AQ.Escalated
+         | None -> false);
+       let entry =
+         match AQ.For_testing.get_pending_entry ~id with
+         | Some entry -> entry
+         | None -> Alcotest.fail "in-memory entry missing after escalation"
+       in
+       Alcotest.(check bool)
+         "Critical entry is Escalated in-memory after timer"
+         true
+         (entry.phase = AQ.Escalated);
+       let detail =
+         match AQ.get_pending_json ~id with
+         | Some json -> json
+         | None -> Alcotest.fail "pending detail JSON missing after escalation"
+       in
+       Alcotest.(check string)
+         "Critical entry is escalated in JSON after timer"
+         "escalated"
+         (phase_in_json detail);
+       Alcotest.(check bool)
+         "Critical escalation does not auto-resolve"
+         true
+         (Option.is_none !result);
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       yield_until (fun () -> Option.is_some !result);
+       match !result with
+       | Some Agent_sdk.Hooks.Approve -> ()
+       | Some decision ->
+         Alcotest.fail
+           ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
+       | None -> Alcotest.fail "Critical approval did not resume after escalation")
+;;
+
+let test_pending_phase_conversions () =
+  Alcotest.(check string)
+    "Awaiting_operator string"
+    "awaiting_operator"
+    (AQ.pending_phase_to_string AQ.Awaiting_operator);
+  Alcotest.(check string)
+    "Escalated string"
+    "escalated"
+    (AQ.pending_phase_to_string AQ.Escalated);
+  Alcotest.(check bool)
+    "parse awaiting_operator"
+    true
+    (match AQ.pending_phase_of_string "awaiting_operator" with
+     | Some AQ.Awaiting_operator -> true
+     | _ -> false);
+  Alcotest.(check bool)
+    "parse escalated"
+    true
+    (match AQ.pending_phase_of_string "escalated" with
+     | Some AQ.Escalated -> true
+     | _ -> false);
+  Alcotest.(check bool)
+    "unknown phase returns None"
+    true
+    (Option.is_none (AQ.pending_phase_of_string "unknown"))
+;;
+
+let () =
+  Alcotest.run
+    "Keeper_approval_queue"
+    [ ( "phase"
+      , [ Alcotest.test_case
+            "fresh Critical entry starts in Awaiting_operator"
+            `Quick
+            test_fresh_critical_entry_phase_is_awaiting_operator
+        ; Alcotest.test_case
+            "Critical entry becomes Escalated after escalation timer"
+            `Quick
+            test_critical_entry_phase_becomes_escalated_after_timer
+        ] )
+    ; ( "conversions"
+      , [ Alcotest.test_case
+            "pending_phase string conversions round-trip"
+            `Quick
+            test_pending_phase_conversions
+        ] )
+    ]
+;;

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -27,7 +27,7 @@ let cleanup_dir dir =
   | _ -> ()
 ;;
 
-let yield_until ?(attempts = 50) predicate =
+let rec yield_until ?(attempts = 50) predicate =
   if predicate () || attempts <= 0
   then ()
   else (
@@ -63,15 +63,18 @@ let test_fresh_critical_entry_phase_is_awaiting_operator () =
     (fun () ->
        Eio.Switch.run @@ fun sw ->
        let keeper_name = "fresh-critical-phase-test" in
+       let result = ref None in
        Eio.Fiber.fork ~sw (fun () ->
-         ignore
-           (AQ.submit_and_await
-              ~keeper_name
-              ~tool_name:"keeper_continue_after_reconcile"
-              ~input:(`Assoc [ ("kind", `String "critical_gate") ])
-              ~risk_level:AQ.Critical
-              ~base_path
-              ()));
+         let decision =
+           AQ.submit_and_await
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_reconcile"
+             ~input:(`Assoc [ ("kind", `String "critical_gate") ])
+             ~risk_level:AQ.Critical
+             ~base_path
+             ()
+         in
+         result := Some decision);
        yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
        let id =
          match pending_id_for_keeper ~keeper_name with
@@ -95,7 +98,18 @@ let test_fresh_critical_entry_phase_is_awaiting_operator () =
        Alcotest.(check string)
          "fresh Critical entry is awaiting_operator in JSON"
          "awaiting_operator"
-         (phase_in_json detail))
+         (phase_in_json detail);
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       yield_until (fun () -> Option.is_some !result);
+       match !result with
+       | Some Agent_sdk.Hooks.Approve -> ()
+       | Some decision ->
+         Alcotest.fail
+           ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
+       | None -> Alcotest.fail "Critical approval did not resume after resolve")
 ;;
 
 let test_critical_entry_phase_becomes_escalated_after_timer () =


### PR DESCRIPTION
Adversarial-review follow-up for keeper HITL approval state visibility (RFC-0304).

- Introduces [pending_phase] as a typed variant ([Awaiting_operator] | [Escalated]) in the keeper contract.
- Fresh Critical approvals start in [Awaiting_operator].
- Escalation timer transitions Critical approvals to [Escalated] and broadcasts the updated entry.
- Pending-entry JSON/SSE payloads now include [phase].
- Adds tests covering phase lifecycle and string conversions.

Closes nothing — standalone HITL state-machine PR.