### PR TITLE
fix(keeper): wire capture trace_id correlation for OAS session linkage

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -736,17 +736,6 @@ let run_turn
                       with
                       | Error e -> Error e
                       | Ok response_text ->
-                        (* Phase O observability (iter-2): capture the
-                           normalized response after Keeper_tool_response
-                           canonicalization so the wire record matches the text
-                           that is replayed into the next turn's history. The
-                           capture is best-effort and gated by
-                           MASC_KEEPER_WIRE_CAPTURE. *)
-                        Keeper_wire_capture.capture_response
-                          ~masc_root:(Workspace.masc_root_dir config)
-                          ~keeper_name:meta.name
-                          ~turn_id:manifest_keeper_turn_id
-                          ~response_text;
                         Keeper_agent_run_finalize_response.finalize
                           ~config ~meta ~generation ~manifest_keeper_turn_id
                           ~trace_id ~session ~append_manifest ~model
@@ -764,6 +753,19 @@ let run_turn
                           ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
                           ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
                           ~raw_response_text:response_text
+                          ~capture_replay_response:
+                            (fun ~response_text ->
+                              (* Phase O observability: capture the exact
+                                 assistant text persisted for next-turn replay,
+                                 after response finalization has applied
+                                 suppression and internal-markup stripping. The
+                                 capture is best-effort and gated by
+                                 MASC_KEEPER_WIRE_CAPTURE. *)
+                              Keeper_wire_capture.capture_response
+                                ~masc_root:(Workspace.masc_root_dir config)
+                                ~keeper_name:meta.name
+                                ~turn_id:manifest_keeper_turn_id
+                                ~response_text)
                           ())))
                in
        let receipt_result =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -670,15 +670,6 @@ let run_turn
           Agent.run. Post-run episode creation requires an explicit
           flush_incremental call since AfterTurn already fired. *)
                  let text = Agent_sdk.Types.text_of_content result.response.content in
-                 (* Phase O observability (iter-2): pair this turn's response
-                    with the request captured pre-run under the same turn_id, so
-                    the feedback loop (turn N output -> turn N+1 replayed history)
-                    is directly analyzable. No-op unless MASC_KEEPER_WIRE_CAPTURE. *)
-                 Keeper_wire_capture.capture_response
-                   ~masc_root:(Workspace.masc_root_dir config)
-                   ~keeper_name:meta.name
-                   ~turn_id:manifest_keeper_turn_id
-                   ~response_text:text;
                  (* RFC-0132 PR-2: receipt model surface = external boundary; redact via SSOT. *)
                  let model =
                    Boundary_redaction.to_string
@@ -745,6 +736,17 @@ let run_turn
                       with
                       | Error e -> Error e
                       | Ok response_text ->
+                        (* Phase O observability (iter-2): capture the
+                           normalized response after Keeper_tool_response
+                           canonicalization so the wire record matches the text
+                           that is replayed into the next turn's history. The
+                           capture is best-effort and gated by
+                           MASC_KEEPER_WIRE_CAPTURE. *)
+                        Keeper_wire_capture.capture_response
+                          ~masc_root:(Workspace.masc_root_dir config)
+                          ~keeper_name:meta.name
+                          ~turn_id:manifest_keeper_turn_id
+                          ~response_text;
                         Keeper_agent_run_finalize_response.finalize
                           ~config ~meta ~generation ~manifest_keeper_turn_id
                           ~trace_id ~session ~append_manifest ~model

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -765,7 +765,9 @@ let run_turn
                                 ~masc_root:(Workspace.masc_root_dir config)
                                 ~keeper_name:meta.name
                                 ~turn_id:manifest_keeper_turn_id
-                                ~response_text)
+                                ~trace_id:meta.runtime.trace_id
+                                ~response_text
+                                ())
                           ())))
                in
        let receipt_result =

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -79,6 +79,12 @@ let should_resume_merge
     || stop_reason_requests_resume_merge stop_reason
 ;;
 
+let replay_response_text_for_capture ~suppress_visible_response ~response_text =
+  if suppress_visible_response || String.trim response_text = ""
+  then None
+  else Some response_text
+;;
+
 let rec messages_prefix_equal expected actual =
   match expected, actual with
   | [], _ -> true
@@ -227,6 +233,7 @@ module For_testing = struct
 
   let checkpoint_for_replay_persistence = checkpoint_for_replay_persistence
   let should_resume_merge = should_resume_merge
+  let replay_response_text_for_capture = replay_response_text_for_capture
 end
 
 let finalize
@@ -256,6 +263,7 @@ let finalize
     ~pre_dispatch_compaction_before_tokens
     ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
+    ~capture_replay_response
     () =
   let budget_exhausted =
     Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted
@@ -330,25 +338,30 @@ let finalize
     ()
   in
   receipt_response_text_present_ref := raw_response_text_present;
+  let replay_response_text =
+    replay_response_text_for_capture ~suppress_visible_response ~response_text
+  in
   let assistant_msg =
-    if suppress_visible_response || String.trim response_text = ""
-    then None
-    else
-      Some
-        (Agent_sdk.Types.make_message
+    Option.map
+      (fun replay_response_text ->
+         Agent_sdk.Types.make_message
            ~role:Agent_sdk.Types.Assistant
            ~metadata:
              [ ( Keeper_memory_policy.replay_metadata_key
                , Keeper_memory_policy.replay_metadata_of_snapshot
                    state_snapshot )
              ]
-           [ Agent_sdk.Types.Text response_text ])
+           [ Agent_sdk.Types.Text replay_response_text ])
+      replay_response_text
   in
-  Option.iter
-    (Keeper_context_runtime.persist_message
+  (match replay_response_text, assistant_msg with
+   | Some response_text, Some assistant_msg ->
+     Keeper_context_runtime.persist_message
        ~source:history_assistant_source
-       session)
-    assistant_msg;
+       session
+       assistant_msg;
+     capture_replay_response ~response_text
+   | _ -> ());
   let saved_checkpoint_result =
     match result.checkpoint with
     | Some checkpoint ->

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -523,11 +523,13 @@ let assemble_hooks
                        ~masc_root:(Workspace.masc_root_dir config)
                        ~keeper_name:meta.name
                        ~turn_id
+                       ~trace_id:meta.runtime.trace_id
                        ~sdk_turn:turn
                        ~system_prompt:turn_system_prompt
                        ~extra_system_context:ctx
                        ~user_message
-                       ~history_messages:messages)
+                       ~history_messages:messages
+                       ())
                   manifest_keeper_turn_id;
                 Eio.Fiber.yield ();
                 Agent_sdk.Hooks.AdjustParams

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -44,7 +44,7 @@ let json_string_opt = function
   | None -> `Null
 
 let capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
-    ~extra_system_context ~user_message ~history_messages =
+    ~extra_system_context ~user_message ~history_messages ?trace_id () =
   if not (enabled ()) then ()
   else
     best_effort ~masc_root (fun () ->
@@ -63,6 +63,10 @@ let capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
           ; ("kind", `String "request")
           ; ("keeper", `String keeper_name)
           ; ("turn_id", `Int turn_id)
+          ; ( "trace_id"
+            , match trace_id with
+              | Some t -> `String (Keeper_id.Trace_id.to_string t)
+              | None -> `Null )
           ; ("sdk_turn", `Int sdk_turn)
           ; ("system_prompt", `String (redact system_prompt))
           ; ("extra_system_context", json_string_opt extra_system_context)
@@ -75,7 +79,7 @@ let capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
       in
       write_payload ~masc_root payload)
 
-let capture_response ~masc_root ~keeper_name ~turn_id ~response_text =
+let capture_response ~masc_root ~keeper_name ~turn_id ~response_text ?trace_id () =
   if not (enabled ()) then ()
   else
     best_effort ~masc_root (fun () ->
@@ -85,6 +89,10 @@ let capture_response ~masc_root ~keeper_name ~turn_id ~response_text =
           ; ("kind", `String "response")
           ; ("keeper", `String keeper_name)
           ; ("turn_id", `Int turn_id)
+          ; ( "trace_id"
+            , match trace_id with
+              | Some t -> `String (Keeper_id.Trace_id.to_string t)
+              | None -> `Null )
           ; ("response_text", `String (redact response_text))
           ]
       in

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -38,21 +38,29 @@ val capture_request :
   extra_system_context:string option ->
   user_message:string ->
   history_messages:Agent_sdk.Types.message list ->
+  ?trace_id:Keeper_id.Trace_id.t ->
+  unit ->
   unit
 (** [capture_request ~masc_root ~keeper_name ~turn_id ~sdk_turn ~system_prompt
-    ~extra_system_context ~user_message ~history_messages] appends one redacted
-    request record ([kind:"request"]). No-op unless {!enabled}. [turn_id] is the
-    1-based keeper turn index; [sdk_turn] disambiguates multiple OAS/provider
-    calls inside that keeper turn. [masc_root] must already be the effective
-    cluster-aware MASC root. *)
+    ~extra_system_context ~user_message ~history_messages ~trace_id ()] appends
+    one redacted request record ([kind:"request"]). No-op unless {!enabled}.
+    [turn_id] is the 1-based keeper turn index; [sdk_turn] disambiguates
+    multiple OAS/provider calls inside that keeper turn. [trace_id] is the
+    keeper runtime trace id passed to OAS as [session_id] for raw-trace
+    correlation. [masc_root] must already be the effective cluster-aware MASC
+    root. *)
 
 val capture_response :
   masc_root:string ->
   keeper_name:string ->
   turn_id:int ->
   response_text:string ->
+  ?trace_id:Keeper_id.Trace_id.t ->
+  unit ->
   unit
-(** [capture_response ~masc_root ~keeper_name ~turn_id ~response_text] appends
-    one redacted response record ([kind:"response"]) paired with the request of
-    the same [turn_id]. This closes the loop for analysis: turn N's response is
-    turn N+1's replayed history input. No-op unless {!enabled}. *)
+(** [capture_response ~masc_root ~keeper_name ~turn_id ~response_text ~trace_id
+    ()] appends one redacted response record ([kind:"response"]) paired with
+    the request of the same [turn_id]. [trace_id] is the keeper runtime trace id
+    passed to OAS as [session_id] for raw-trace correlation. This closes the
+    loop for analysis: turn N's response is turn N+1's replayed history input.
+    No-op unless {!enabled}. *)

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -1086,6 +1086,61 @@ let test_internal_passive_only_finalizer_still_drops_raw_response_text () =
     ""
     finalized.response_text
 
+let test_replay_capture_uses_visible_finalized_response_text () =
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"sangsu"
+      ~goal:"Maintain direct conversation"
+      ~actual_keeper_tool_names:[]
+      ~completion_contract_result:Receipt.Contract_satisfied_completion
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:"SKILL: routing metadata\nVisible reply"
+      ()
+  in
+  Alcotest.(check string)
+    "internal reply markup stripped before capture decision"
+    "Visible reply"
+    finalized.response_text;
+  Alcotest.(check (option string))
+    "visible finalized response is captured"
+    (Some "Visible reply")
+    (Finalize.replay_response_text_for_capture
+       ~suppress_visible_response:false
+       ~response_text:finalized.response_text)
+
+let test_replay_capture_omits_suppressed_response_text () =
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"sangsu"
+      ~goal:"Maintain direct conversation"
+      ~actual_keeper_tool_names:["keeper_context_status"]
+      ~completion_contract_result:Receipt.Contract_passive_only
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:"No actionable signal. Waiting."
+      ~suppress_response_text:true
+      ()
+  in
+  Alcotest.(check string)
+    "suppressed response text is finalized empty"
+    ""
+    finalized.response_text;
+  Alcotest.(check (option string))
+    "suppressed response is not captured"
+    None
+    (Finalize.replay_response_text_for_capture
+       ~suppress_visible_response:true
+       ~response_text:finalized.response_text)
+
+let test_replay_capture_omits_blank_response_text () =
+  Alcotest.(check (option string))
+    "blank replay response is not captured"
+    None
+    (Finalize.replay_response_text_for_capture
+       ~suppress_visible_response:false
+       ~response_text:"   ")
+
 (* ── Continuity NEXT parsing / text round-trip ───────────────────────
    Regression coverage for the parser/renderer asymmetry that let a single
    [STATE] "NEXT:" line populate both next_summary and next_items and then
@@ -1266,6 +1321,18 @@ let () =
             "internal passive-only finalizer still drops raw response text"
             `Quick
             test_internal_passive_only_finalizer_still_drops_raw_response_text;
+          Alcotest.test_case
+            "replay capture uses visible finalized response text"
+            `Quick
+            test_replay_capture_uses_visible_finalized_response_text;
+          Alcotest.test_case
+            "replay capture omits suppressed response text"
+            `Quick
+            test_replay_capture_omits_suppressed_response_text;
+          Alcotest.test_case
+            "replay capture omits blank response text"
+            `Quick
+            test_replay_capture_omits_blank_response_text;
         ] );
       ( "continuity_next",
         [

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -126,7 +126,7 @@ let disabled_is_noop () =
     let base = Filename.temp_dir "wirecap_off" "" in
     Wire.capture_request ~masc_root:base ~keeper_name:"sangsu" ~turn_id:1
       ~sdk_turn:0 ~system_prompt:"sys" ~extra_system_context:None
-      ~user_message:"u" ~history_messages:[];
+      ~user_message:"u" ~history_messages:[] ();
     Alcotest.(check (list string))
       "no jsonl written when disabled" [] (find_jsonl base))
 
@@ -143,7 +143,7 @@ let enabled_writes_redacted () =
       ~sdk_turn:3
       ~system_prompt:("token " ^ fake_github_token ^ " end")
       ~extra_system_context:(Some "dynamic context")
-      ~user_message:"hello world" ~history_messages:history;
+      ~user_message:"hello world" ~history_messages:history ();
     let files = find_jsonl base in
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
@@ -168,20 +168,33 @@ let enabled_writes_redacted () =
     Alcotest.(check bool) "replayed history text recorded" true
       (contains ~needle:"좋아, 연구 시작한다" content);
     Alcotest.(check bool) "request kind recorded" true
-      (contains ~needle:"\"kind\":\"request\"" content))
+      (contains ~needle:"\"kind\":\"request\"" content);
+    Alcotest.(check bool) "missing trace_id is null" true
+      (contains ~needle:"\"trace_id\":null" content))
+
+let request_trace_id_emitted () =
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_req_trace" "" in
+    let trace_id = Keeper_id.For_testing.unsafe_trace_id_of_string "trace-req-abc" in
+    Wire.capture_request ~masc_root:base ~keeper_name:"sangsu" ~turn_id:1
+      ~trace_id ~sdk_turn:0 ~system_prompt:"sys" ~extra_system_context:None
+      ~user_message:"hello" ~history_messages:[] ();
+    let content = read_file (List.hd (find_jsonl base)) in
+    Alcotest.(check bool) "request trace_id string recorded" true
+      (contains ~needle:"\"trace_id\":\"trace-req-abc\"" content))
 
 let request_capture_failure_is_best_effort () =
   with_flag "1" (fun () ->
     let root_file = Filename.temp_file "wirecap_root_file" "" in
     Wire.capture_request ~masc_root:root_file ~keeper_name:"sangsu" ~turn_id:1
       ~sdk_turn:0 ~system_prompt:"sys" ~extra_system_context:None
-      ~user_message:"hello" ~history_messages:[])
+      ~user_message:"hello" ~history_messages:[] ())
 
 let response_disabled_is_noop () =
   with_flag "" (fun () ->
     let base = Filename.temp_dir "wirecap_resp_off" "" in
     Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:1
-      ~response_text:"anything";
+      ~response_text:"anything" ();
     Alcotest.(check (list string))
       "no jsonl written when disabled" [] (find_jsonl base))
 
@@ -189,7 +202,7 @@ let response_capture_writes_redacted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_resp_on" "" in
     Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:9
-      ~response_text:("out " ^ fake_github_token ^ " done");
+      ~response_text:("out " ^ fake_github_token ^ " done") ();
     let files = find_jsonl base in
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
@@ -198,7 +211,19 @@ let response_capture_writes_redacted () =
     Alcotest.(check bool) "raw github token is redacted" false
       (contains ~needle:fake_github_token content);
     Alcotest.(check bool) "turn_id recorded" true
-      (contains ~needle:"\"turn_id\":9" content))
+      (contains ~needle:"\"turn_id\":9" content);
+    Alcotest.(check bool) "missing trace_id is null" true
+      (contains ~needle:"\"trace_id\":null" content))
+
+let response_trace_id_emitted () =
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_resp_trace" "" in
+    let trace_id = Keeper_id.For_testing.unsafe_trace_id_of_string "trace-resp-xyz" in
+    Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:2
+      ~trace_id ~response_text:"ok" ();
+    let content = read_file (List.hd (find_jsonl base)) in
+    Alcotest.(check bool) "response trace_id string recorded" true
+      (contains ~needle:"\"trace_id\":\"trace-resp-xyz\"" content))
 
 let capture_prunes_old_files () =
   with_flag "1" (fun () ->
@@ -212,7 +237,7 @@ let capture_prunes_old_files () =
         let old_file = Filename.concat old_month "01.jsonl" in
         write_file old_file (String.make 1024 'x');
         Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:10
-          ~response_text:"bounded";
+          ~response_text:"bounded" ();
         Alcotest.(check bool) "old capture file pruned" false
           (Sys.file_exists old_file);
         Alcotest.(check int) "only current capture remains" 1
@@ -223,12 +248,12 @@ let capture_skips_when_current_file_cap_would_be_exceeded () =
     with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "512" (fun () ->
       let base = Filename.temp_dir "wirecap_cap" "" in
       Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:11
-        ~response_text:"small";
+        ~response_text:"small" ();
       let files = find_jsonl base in
       Alcotest.(check int) "small record written" 1 (List.length files);
       let before = read_file (List.hd files) in
       Wire.capture_response ~masc_root:base ~keeper_name:"sangsu" ~turn_id:12
-        ~response_text:(String.make 4096 'x');
+        ~response_text:(String.make 4096 'x') ();
       let after = read_file (List.hd files) in
       Alcotest.(check string)
         "oversized record skipped without mutating current day file"
@@ -255,7 +280,8 @@ let response_capture_matches_replayed_history_text () =
       ~masc_root:base
       ~keeper_name:"history_keeper"
       ~turn_id:5
-      ~response_text:history_text;
+      ~response_text:history_text
+      ();
     let files = find_jsonl base in
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
@@ -328,6 +354,8 @@ let () =
             enabled_writes_redacted;
           Alcotest.test_case "write failure is best effort" `Quick
             request_capture_failure_is_best_effort;
+          Alcotest.test_case "trace_id is emitted when provided" `Quick
+            request_trace_id_emitted;
         ] );
       ( "capture_response",
         [
@@ -339,6 +367,8 @@ let () =
             capture_prunes_old_files;
           Alcotest.test_case "current file cap skips oversized record" `Quick
             capture_skips_when_current_file_cap_would_be_exceeded;
+          Alcotest.test_case "trace_id is emitted when provided" `Quick
+            response_trace_id_emitted;
           Alcotest.test_case "captured response matches replayed history text"
             `Quick response_capture_matches_replayed_history_text;
         ] );

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -56,7 +56,16 @@ let rec find_jsonl dir =
   else []
 
 (* Regression guard: verify in [Keeper_agent_run.run_turn] that the response
-   capture happens after normalization and uses the normalized identifier. *)
+   capture happens after normalization and uses the normalized identifier.
+
+   Dune test actions run in a sandbox, so we locate the source tree via
+   [DUNE_SOURCEROOT] (set by Dune for all actions). *)
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None ->
+    Alcotest.fail "DUNE_SOURCEROOT is not set; cannot locate source file"
+
 let first_line_of path needle =
   let ic = open_in path in
   Fun.protect
@@ -243,7 +252,7 @@ let response_capture_matches_replayed_history_text () =
       (contains ~needle:raw_response content))
 
 let capture_response_uses_normalized_text_in_run_turn () =
-  let path = "lib/keeper/keeper_agent_run.ml" in
+  let path = Filename.concat (repo_root ()) "lib/keeper/keeper_agent_run.ml" in
   let capture_line =
     match first_line_of path "Keeper_wire_capture.capture_response" with
     | Some n -> n

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -80,6 +80,23 @@ let first_line_of path needle =
        loop 1)
 ;;
 
+let last_line_of path needle =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () ->
+       let rec loop line_num last_seen =
+         match input_line ic with
+         | line ->
+           let last_seen =
+             if contains ~needle line then Some line_num else last_seen
+           in
+           loop (line_num + 1) last_seen
+         | exception End_of_file -> last_seen
+       in
+       loop 1 None)
+;;
+
 (* Built at runtime so no literal secret appears in the source (the pre-commit
    secret scanner rejects literal [ghp_...] tokens). Secret_redactor detects the
    [ghp_] prefix regardless. *)
@@ -251,15 +268,15 @@ let response_capture_matches_replayed_history_text () =
       false
       (contains ~needle:raw_response content))
 
-let capture_response_uses_normalized_text_in_run_turn () =
-  let path = Filename.concat (repo_root ()) "lib/keeper/keeper_agent_run.ml" in
+let capture_response_uses_finalized_replay_text () =
+  let run_path = Filename.concat (repo_root ()) "lib/keeper/keeper_agent_run.ml" in
   let capture_line =
-    match first_line_of path "Keeper_wire_capture.capture_response" with
+    match first_line_of run_path "Keeper_wire_capture.capture_response" with
     | Some n -> n
     | None -> Alcotest.fail "Keeper_wire_capture.capture_response call not found"
   in
   let normalize_line =
-    match first_line_of path "normalize_response_text_for_finalization" with
+    match first_line_of run_path "normalize_response_text_for_finalization" with
     | Some n -> n
     | None ->
       Alcotest.fail "normalize_response_text_for_finalization call not found"
@@ -268,17 +285,33 @@ let capture_response_uses_normalized_text_in_run_turn () =
     "capture_response occurs after normalize_response_text_for_finalization"
     true
     (capture_line > normalize_line);
-  let normalized_binding_line =
-    match first_line_of path "~response_text;" with
+  let finalizer_line =
+    match first_line_of run_path "Keeper_agent_run_finalize_response.finalize" with
     | Some n -> n
-    | None ->
-      Alcotest.fail
-        "capture_response should pass the normalized response_text binding"
+    | None -> Alcotest.fail "Keeper_agent_run_finalize_response.finalize call not found"
   in
   Alcotest.(check bool)
-    "capture_response uses the normalized response_text binding"
+    "capture_response is delegated through finalize callback"
     true
-    (normalized_binding_line > normalize_line)
+    (capture_line > finalizer_line);
+  let finalize_path =
+    Filename.concat (repo_root ())
+      "lib/keeper/keeper_agent_run_finalize_response.ml"
+  in
+  let replay_decision_line =
+    match last_line_of finalize_path "replay_response_text_for_capture" with
+    | Some n -> n
+    | None -> Alcotest.fail "replay_response_text_for_capture use not found"
+  in
+  let capture_callback_line =
+    match last_line_of finalize_path "capture_replay_response ~response_text" with
+    | Some n -> n
+    | None -> Alcotest.fail "capture_replay_response invocation not found"
+  in
+  Alcotest.(check bool)
+    "capture callback runs after replay-visible response decision"
+    true
+    (capture_callback_line > replay_decision_line)
 
 let () =
   Alcotest.run "keeper_wire_capture"
@@ -312,6 +345,6 @@ let () =
       ( "run_turn_ordering",
         [
           Alcotest.test_case "capture_response uses normalized response text"
-            `Quick capture_response_uses_normalized_text_in_run_turn;
+            `Quick capture_response_uses_finalized_replay_text;
         ] );
     ]

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -55,6 +55,22 @@ let rec find_jsonl dir =
   else if Filename.check_suffix dir ".jsonl" then [ dir ]
   else []
 
+(* Regression guard: verify in [Keeper_agent_run.run_turn] that the response
+   capture happens after normalization and uses the normalized identifier. *)
+let first_line_of path needle =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () ->
+       let rec loop line_num =
+         match input_line ic with
+         | line ->
+           if contains ~needle line then Some line_num else loop (line_num + 1)
+         | exception End_of_file -> None
+       in
+       loop 1)
+;;
+
 (* Built at runtime so no literal secret appears in the source (the pre-commit
    secret scanner rejects literal [ghp_...] tokens). Secret_redactor detects the
    [ghp_] prefix regardless. *)
@@ -193,6 +209,68 @@ let capture_skips_when_current_file_cap_would_be_exceeded () =
         before
         after))
 
+let response_capture_matches_replayed_history_text () =
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_history_match" "" in
+    let raw_response = "   " in
+    let tool_names = [ "keeper_web_fetch"; "keeper_file_read" ] in
+    let history_text =
+      match
+        Keeper_tool_response.normalize_response_text
+          ~text:raw_response
+          ~tool_names
+          ()
+      with
+      | Ok t -> t
+      | Error _ ->
+        Alcotest.fail "normalization should synthesize text when tools are present"
+    in
+    Wire.capture_response
+      ~masc_root:base
+      ~keeper_name:"history_keeper"
+      ~turn_id:5
+      ~response_text:history_text;
+    let files = find_jsonl base in
+    Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
+    let content = read_file (List.hd files) in
+    Alcotest.(check bool)
+      "synthetic replayed history text is captured"
+      true
+      (contains ~needle:history_text content);
+    Alcotest.(check bool)
+      "raw whitespace response is not captured as the replayed text"
+      false
+      (contains ~needle:raw_response content))
+
+let capture_response_uses_normalized_text_in_run_turn () =
+  let path = "lib/keeper/keeper_agent_run.ml" in
+  let capture_line =
+    match first_line_of path "Keeper_wire_capture.capture_response" with
+    | Some n -> n
+    | None -> Alcotest.fail "Keeper_wire_capture.capture_response call not found"
+  in
+  let normalize_line =
+    match first_line_of path "normalize_response_text_for_finalization" with
+    | Some n -> n
+    | None ->
+      Alcotest.fail "normalize_response_text_for_finalization call not found"
+  in
+  Alcotest.(check bool)
+    "capture_response occurs after normalize_response_text_for_finalization"
+    true
+    (capture_line > normalize_line);
+  let normalized_binding_line =
+    match first_line_of path "~response_text;" with
+    | Some n -> n
+    | None ->
+      Alcotest.fail
+        "capture_response should pass the normalized response_text binding"
+  in
+  Alcotest.(check bool)
+    "capture_response uses the normalized response_text binding"
+    true
+    (normalized_binding_line > normalize_line)
+
 let () =
   Alcotest.run "keeper_wire_capture"
     [
@@ -219,5 +297,12 @@ let () =
             capture_prunes_old_files;
           Alcotest.test_case "current file cap skips oversized record" `Quick
             capture_skips_when_current_file_cap_would_be_exceeded;
+          Alcotest.test_case "captured response matches replayed history text"
+            `Quick response_capture_matches_replayed_history_text;
+        ] );
+      ( "run_turn_ordering",
+        [
+          Alcotest.test_case "capture_response uses normalized response text"
+            `Quick capture_response_uses_normalized_text_in_run_turn;
         ] );
     ]


### PR DESCRIPTION
Adversarial-review follow-up for raw-trace correlation.

- Threads the keeper runtime [trace_id] into [Keeper_wire_capture.capture_request] and [capture_response].
- Emits [trace_id] in redacted request/response JSONL records (null when absent).
- Updates call sites in [keeper_agent_run] and [keeper_run_tools_hooks].
- Adds regression tests verifying trace_id emission and null fallback.

Closes nothing — standalone observability correlation PR.