### PR TITLE
feat(dashboard): keeper-v2 Fleet/Logs/Dock 디자인 델타 6건

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
@@ -1249,8 +1251,173 @@ describe('AgentRoster live-only cards', () => {
     expect(text).toContain('sangsu')
     expect(text).toContain('하트비트')
     expect(text).toContain('6분 전')
-    expect(text).not.toContain('claude-code:auto')
+    // Full model id is surfaced verbatim — the `claude-` prefix is no longer
+    // truncated so multi-provider model names stay distinguishable (audit P1-5).
+    expect(text).toContain('claude-code:auto')
     expect(text).not.toContain('마지막 행동 이후')
     expect(text).not.toContain('최근 모델claude')
+  })
+
+  it('lists live recommended-action attention reasons in the selected keeper aside', async () => {
+    agents.value = [makeAgent({ name: 'keeper-sangsu-agent', status: 'active' })]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+      } as Keeper,
+    ]
+    fleetCompositeSnapshot.value = {
+      generated_at: 1,
+      count: 1,
+      snapshots: [
+        makeCompositeSnapshot({
+          keeper: 'sangsu',
+          runtime_attention: {
+            state: 'blocked',
+            needs_attention: true,
+            blocked: true,
+            reason: 'runtime candidates exhausted',
+            raw_phase: null,
+            is_live: true,
+            source: 'runtime',
+          },
+          recommended_actions: [
+            {
+              action_type: 'keeper_recover',
+              target_type: 'keeper',
+              target_id: 'sangsu',
+              severity: 'bad',
+              reason: 'Resolve keeper tool-route contract blocker: runtime candidates exhausted',
+            },
+            {
+              action_type: 'keeper_probe',
+              target_type: 'keeper',
+              target_id: 'sangsu',
+              severity: 'warn',
+              reason: 'Inspect keeper tool-route contract blocker: runtime candidates exhausted',
+            },
+            {
+              action_type: 'operator_ping',
+              target_type: 'operator',
+              target_id: null,
+              severity: 'warn',
+              reason: 'operator-only action must not leak into the keeper aside',
+            },
+          ],
+        }),
+      ],
+    }
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const attn = container.querySelector('.fl-attn-list') as HTMLElement
+    expect(attn).not.toBeNull()
+    const items = attn.querySelectorAll('.fl-attn-item')
+    // operator-targeted action is excluded — only keeper-targeted reasons render
+    expect(items.length).toBe(2)
+    expect(container.textContent).toContain('주의 · 2')
+    expect(attn.textContent).toContain('Resolve keeper tool-route contract blocker')
+    expect(attn.textContent).toContain('Inspect keeper tool-route contract blocker')
+    expect(attn.textContent).not.toContain('operator-only action must not leak')
+    // sev dot coding follows the recommended-action severity: recover→bad, probe→warn
+    const sevs = Array.from(items).map(item => item.getAttribute('data-sev'))
+    expect(sevs).toEqual(['bad', 'warn'])
+  })
+
+  it('omits the aside attention list when no live recommended actions target the keeper', async () => {
+    agents.value = [makeAgent({ name: 'keeper-sangsu-agent', status: 'active' })]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+      } as Keeper,
+    ]
+    fleetCompositeSnapshot.value = {
+      generated_at: 1,
+      count: 1,
+      snapshots: [makeCompositeSnapshot({ keeper: 'sangsu', recommended_actions: [] })],
+    }
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    expect(container.querySelector('.fl-attn-list')).toBeNull()
+    expect(container.textContent).not.toContain('주의 · ')
+  })
+
+  it('surfaces the honest worktree-isolation badge for local-sandbox keepers', async () => {
+    agents.value = [makeAgent({ name: 'keeper-sangsu-agent', status: 'active' })]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        keeper_id: 'sangsu-uuid-77',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+        sandbox_profile: 'local',
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const row = container.querySelector('[data-testid="keeper-operations-row"]') as HTMLElement
+    const badge = row.querySelector('.fl-sandbox') as HTMLElement
+    expect(badge).not.toBeNull()
+    expect(row.textContent).toContain('worktree 격리')
+    // honest label: git worktree isolation is not an OS security boundary
+    expect(badge.getAttribute('title')).toContain('OS sandbox 없음')
+    // the runtime alias / keeper id no longer occupies the row ns slot
+    expect((row.querySelector('.fl-ns') as HTMLElement).textContent).not.toContain('sangsu-uuid-77')
+  })
+
+  it('keeps the keeper id namespace line when no local sandbox profile is present', async () => {
+    agents.value = [makeAgent({ name: 'keeper-sangsu-agent', status: 'active' })]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        keeper_id: 'sangsu-uuid-77',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+        sandbox_profile: null,
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const row = container.querySelector('[data-testid="keeper-operations-row"]') as HTMLElement
+    expect(row.querySelector('.fl-sandbox')).toBeNull()
+    expect(row.querySelector('.fl-ns')?.textContent).toContain('sangsu-uuid-77')
+  })
+
+  it('vendors the fleet responsive column-shedding and attention-list styles', () => {
+    const css = readFileSync(resolve(__dirname, '../styles/keeper-v2/fleet.css'), 'utf8')
+    expect(css).toContain('@media (max-width: 1320px) and (min-width: 1101px)')
+    expect(css).toContain('@media (max-width: 720px)')
+    expect(css).toContain('.fl-attn-list')
+    expect(css).toContain('.fl-attn-item[data-sev="bad"]')
   })
 })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -333,9 +333,10 @@ function fleetRuntimeVitals(
   if (!keeper) return []
   const vitals: FleetVital[] = []
 
+  // Full model id, no prefix truncation: in a multi-provider fleet a stripped
+  // `claude-` prefix collides with other providers' model names (audit P1-5).
   const model = (keeper.active_model ?? keeper.model ?? keeper.last_model_used ?? '')
     .trim()
-    .replace('claude-', '')
   if (model) vitals.push({ k: 'model', v: model })
 
   const runtime = (keeper.runtime_canonical ?? keeper.selected_runtime_canonical ?? '').trim()
@@ -361,6 +362,30 @@ function fleetRuntimeVitals(
   if (contextDetail) vitals.push({ k: 'context', v: contextDetail })
 
   return vitals
+}
+
+type FleetAttentionItem = { sev: 'warn' | 'bad'; text: string }
+
+// Collapse the operator-severity wire string (operator_digest_types emits
+// "critical" | "bad" | "warn") to the two-level dot the aside attention list
+// paints. Unknown/critical fold to the nearest defined tone rather than
+// inventing a third dot color.
+function fleetAttentionSev(severity: string): 'warn' | 'bad' {
+  return severity === 'bad' || severity === 'critical' ? 'bad' : 'warn'
+}
+
+// Selected-keeper attention reasons, read from the same live composite that
+// drives the row's attention band. Each keeper-targeted `recommended_actions`
+// entry (backend-gated on `runtime_attention.needs_attention`) contributes one
+// reason — no fixture text, so an item exists only when the backend actually
+// recommends an action for this keeper.
+function fleetAttentionItems(
+  composite: KeeperCompositeSnapshot | null,
+): FleetAttentionItem[] {
+  if (!composite) return []
+  return composite.recommended_actions
+    .filter(action => action.target_type === 'keeper')
+    .map(action => ({ sev: fleetAttentionSev(action.severity), text: action.reason }))
 }
 
 function registerKeeperLookup<T extends Pick<Keeper, 'keeper_id' | 'name' | 'agent_name'>>(
@@ -1010,6 +1035,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       compositeSnapshotForKeeper(keeperRuntime, compositeByKeeperKey)
     const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime, compositeForMonitoring) : null
     const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
+    const attentionItems = fleetAttentionItems(compositeForMonitoring)
     const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime, compositeForMonitoring) : null
     const isKeeper = keeperRuntime != null
     // Shared precedence (incl. last_proactive_preview); fall back to the agent
@@ -1088,6 +1114,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       fsmStageKey,
       fsmStageText,
       monitoringEvidence,
+      attentionItems,
       detailLabel,
       openDetail,
     }
@@ -1201,7 +1228,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div class="mt-0.5 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-secondary)]">
               <${AgentPresence} status=${row.presenceDisplay.status} detail=${row.presenceDisplay.detail} size="sm" />
             </div>
-            ${namespaceLine ? html`<div class="fl-ns">${namespaceLine}</div>` : null}
+            ${row.keeperRuntime?.sandbox_profile === 'local'
+              ? html`<div class="fl-ns"><span class="fl-sandbox" title="git worktree 격리 · localhost-trust (OS sandbox 없음)">⬡</span> worktree 격리</div>`
+              : namespaceLine ? html`<div class="fl-ns">${namespaceLine}</div>` : null}
           </div>
         </div>
 
@@ -1439,6 +1468,17 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                       : null}
                   </div>
                   <p class="m-0 mt-1 text-xs leading-relaxed text-[var(--color-fg-primary)]">${selectedBlockerDisplay?.detail}</p>
+                </div>
+              </div>
+            ` : null}
+
+            ${selectedRow.attentionItems.length > 0 ? html`
+              <div class="fl-as-sec">
+                <h4>주의 · ${selectedRow.attentionItems.length}</h4>
+                <div class="fl-attn-list">
+                  ${selectedRow.attentionItems.map(item => html`
+                    <div class="fl-attn-item" data-sev=${item.sev}><span class="fl-attn-dot"></span>${item.text}</div>
+                  `)}
                 </div>
               </div>
             ` : null}

--- a/dashboard/src/components/copilot-dock.test.ts
+++ b/dashboard/src/components/copilot-dock.test.ts
@@ -362,4 +362,34 @@ describe('CopilotDock', () => {
 
     expect(dock.state.value.keeperId).not.toBe('masc-improver')
   })
+
+  it('drops the runtime namespace from the keeper picker sub and conversation hint', async () => {
+    keepers.value = [
+      { name: 'masc-improver', keeper_id: 'masc-improver', koreanName: 'MASC Improver', status: 'running', phase: 'Running', runtime_id: 'fleet', needs_attention: false, total_turns: 0, context_ratio: 0.2 },
+      { name: 'nick0cave', keeper_id: 'nick0cave', koreanName: 'nick0cave', status: 'running', phase: 'Running', runtime_id: 'ops', needs_attention: false, total_turns: 0, context_ratio: 0.3 },
+    ] as unknown as typeof keepers.value
+    const dock = renderDock()
+    dock.open()
+    await waitFor(() => expect(container.querySelector('[data-testid="copilot-dock-picker"]')).not.toBeNull())
+
+    // conversation hint no longer trails the runtime alias ("· <ns>")
+    const hint = container.querySelector('.dock-idrow-hint') as HTMLElement
+    expect(hint.textContent).toContain('와 대화 중')
+    expect(hint.textContent).not.toContain('·')
+    expect(hint.textContent).not.toContain('fleet')
+    expect(hint.textContent).not.toContain('ops')
+
+    // picker rows show the phase only, not "phase · ns"
+    const picker = container.querySelector('[data-testid="copilot-dock-picker"]') as HTMLButtonElement
+    picker.click()
+    await waitFor(() => expect(container.querySelector('.dock-menu')).not.toBeNull())
+    const subs = Array.from(container.querySelectorAll('.dock-menu-row .sub')).map(s => s.textContent ?? '')
+    expect(subs.length).toBeGreaterThan(0)
+    subs.forEach(s => {
+      expect(s).toContain('Running')
+      expect(s).not.toContain('·')
+      expect(s).not.toContain('fleet')
+      expect(s).not.toContain('ops')
+    })
+  })
 })

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -508,7 +508,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
                       <${KeeperBadge} id=${k.id} name=${k.kr} variant="sigil" size="lg" beat=${statusLooksRunning(k.status)} />
                       <div class="minfo">
                         <div class="nm">${k.kr} <span class="h">${k.id}</span></div>
-                        <div class="sub"><${StatusDot} status=${k.status} />${k.phase} · ${k.ns}</div>
+                        <div class="sub"><${StatusDot} status=${k.status} />${k.phase}</div>
                       </div>
                     </button>
                   `)}
@@ -516,7 +516,7 @@ export function CopilotDock({ dock }: { dock: CopilotDockApi }) {
               `
             : null}
         </div>
-        <span class="dock-idrow-hint">와 대화 중 · <span class="mono">${keeper.ns}</span></span>
+        <span class="dock-idrow-hint">와 대화 중</span>
       </div>
 
       <div class="dock-coview" data-testid="copilot-dock-coview">

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { h } from 'preact'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -625,5 +627,16 @@ describe('LogViewer kind column', () => {
     expect(kindCell).not.toBeNull()
     expect(kindCell!.getAttribute('data-kind')).toBe('tool')
     expect(kindCell!.textContent).toBe('TOOL')
+  })
+})
+
+describe('logs vendored stylesheet', () => {
+  it('vendors the phone stacked-card layout for the log stream (@640px)', () => {
+    // Rows carry both `v2-logs-*` and the vendored `lg-*` classes, so the
+    // `lg-*`-scoped media block reshapes the real stream, not a dead selector.
+    const css = readFileSync(resolve(__dirname, '../styles/keeper-v2/logs.css'), 'utf8')
+    expect(css).toContain('@media (max-width: 640px)')
+    expect(css).toContain('grid-template-areas')
+    expect(css).toContain('.lg-colhd { display: none; }')
   })
 })

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -239,7 +239,37 @@
 .fl-tick .v.ok { color: var(--status-ok); }
 .fl-tick .v.warn { color: var(--status-warn); }
 
+/* selected-runtime attention list — canonical ATTENTION (sev-coded) */
+.fl-attn-list { display: flex; flex-direction: column; gap: 7px; }
+.fl-attn-item {
+  display: flex; align-items: flex-start; gap: 8px;
+  font-size: 11.5px; line-height: 1.45; color: var(--text-mid); text-wrap: pretty;
+}
+.fl-attn-dot { flex: none; width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; background: var(--text-dim); }
+.fl-attn-item[data-sev="warn"] .fl-attn-dot { background: var(--status-warn); }
+.fl-attn-item[data-sev="bad"]  .fl-attn-dot { background: var(--status-bad); }
+.fl-attn-item[data-sev="bad"] { color: var(--text-bright); }
+
+/* ── responsive: progressively shed columns instead of letting strings collide ── */
+/* mid width — aside still present, but main is tight: drop 최근 도구 first */
+@media (max-width: 1320px) and (min-width: 1101px) {
+  .fl-shell { --fl-cols: minmax(168px, 1.3fr) 168px 132px 120px; }
+  .fl-rhead span:nth-child(4), .fl-row .fl-tool { display: none; }
+}
+
 @media (max-width: 1100px) {
   .fl-body { grid-template-columns: 1fr; }
   .fl-aside { display: none; }
+}
+
+/* narrow — collapse the row to identity · state · action; ctx/tool move out of the way */
+@media (max-width: 720px) {
+  .fl-shell { --fl-cols: minmax(0, 1fr) 150px 96px; --fl-gap: 10px; }
+  .fl-rhead span:nth-child(3), .fl-rhead span:nth-child(4) { display: none; }
+  .fl-row .fl-ctx, .fl-row .fl-tool { display: none; }
+  .fl-top { height: auto; flex-wrap: wrap; padding: 12px 16px; gap: 10px 14px; }
+  .fl-spacer { display: none; }
+  .fl-health { width: 100%; order: 3; }
+  .fl-rhead, .fl-row, .fl-group { padding-left: 16px; padding-right: 16px; }
+  .fl-foot { gap: 14px; overflow-x: auto; }
 }

--- a/dashboard/src/styles/keeper-v2/logs.css
+++ b/dashboard/src/styles/keeper-v2/logs.css
@@ -116,3 +116,27 @@
 }
 .lg-jump:hover { background: color-mix(in oklab, var(--volt) 12%, transparent); border-color: var(--volt); }
 .lg-empty { padding: 48px; text-align: center; color: var(--text-dim); font-size: var(--fs-13); }
+
+/* ── phones: the 5-col grid (≈426px min) overflows — switch to a stacked card ── */
+@media (max-width: 640px) {
+  .lg-head { flex-wrap: wrap; gap: 12px 18px; padding: 16px 16px 12px; }
+  .lg-stats { margin-left: 0; flex-wrap: wrap; }
+  .lg-stat { min-width: 0; flex: 1 1 auto; }
+  .lg-toolbar { flex-wrap: wrap; gap: 8px; padding: 0 16px 12px; }
+  .lg-tb-spacer { display: none; }
+  .lg-colhd { display: none; }
+
+  .lg-line {
+    grid-template-columns: auto auto 1fr auto;
+    grid-template-areas:
+      "time kind who caret"
+      "msg  msg  msg msg";
+    gap: 6px 10px; padding: 11px 16px; align-items: center;
+  }
+  .lg-time  { grid-area: time; }
+  .lg-kind  { grid-area: kind; }
+  .lg-who   { grid-area: who; justify-self: end; max-width: 46vw; }
+  .lg-caret { grid-area: caret; }
+  .lg-msg   { grid-area: msg; white-space: normal; }
+  .lg-detail { padding: 4px 16px 16px; }
+}


### PR DESCRIPTION
## 요약

keeper-v2 v2(28) Fleet 모니터 / Logs / Copilot Dock 오디트에서 `recommendation=="implement"`로 판정된 6건을 구현했습니다. 전부 live 소스에 연결했으며 fixture 데이터 이식은 없습니다. `dashboard/docs/V2-RESKIN-PROGRESS.md`에 기록된 중복 상단 헤더 함정(monitoring은 SurfaceLead가 타이틀 렌더)을 피하기 위해 `fl-top` 브랜드 헤더는 재도입하지 않았습니다.

`task: masc task-1669 하위 슬라이스`

## 구현 항목 (6/6)

1. **Fleet aside 주의(attention) 목록 — `fl-attn-list`**
   - 선택된 keeper의 live composite `recommended_actions`에서 `주의 · N` 목록을 파생합니다. `target_type === 'keeper'` 항목만 렌더하고(operator-대상 액션 제외), sev는 `operator_digest_types` 와이어 severity(`bad`/`critical`→bad, 그 외→warn)로 코딩합니다.
   - 근거: `lib/server/server_dashboard_http_composite_recommendations.ml`(사유별 추천 액션, `runtime_attention.needs_attention` 게이트) → `keeper-composite` 스키마 `recommended_actions`. 백엔드가 액션을 추천할 때만 항목이 생기므로 canonical 소스와 drift가 없습니다.

2. **Fleet 반응형 컬럼 shedding (@1320px / @720px)** — CSS-only, `fleet.css` 해당 블록 verbatim vendored. 기존 `@1100px` 블록 사이에 배치했습니다. `--fl-cols`/`fl-rhead`/`fl-tool`/`fl-ctx`가 실제 렌더되어 컬럼이 단계적으로 제거됩니다.

3. **Logs 모바일 스택 카드 (@640px)** — CSS-only, `logs.css` `@640` 블록 verbatim vendored. Logs 행은 `v2-logs-* lg-*` 이중 클래스라 `.lg-*`-스코프 블록이 실제 스트림을 재배치합니다(dead selector 아님).

4. **Fleet 행 `fl-sandbox` 'worktree 격리' 배지** — `sandbox_profile === 'local'`일 때만 `⬡ worktree 격리` 배지(title: `git worktree 격리 · localhost-trust (OS sandbox 없음)`)를 표시하고, 그 외에는 기존 keeper-id namespace line을 유지합니다.
   - 근거: `keeper.sandbox_profile`(core 타입 `'local' | 'docker' | null`). `local`에만 배지를 다는 이유는 `docker` 프로파일에 "OS sandbox 없음" 라벨을 붙이면 부정확하기 때문입니다.

5. **모델 ID 전체 표기** — aside 런타임 vitals에서 `.replace('claude-','')` 한 줄 제거. 멀티 프로바이더 환경에서 prefix 절단이 다른 프로바이더 모델명과의 구분을 깨는 문제를 해소합니다. (`logs.ts`는 이미 절단 없음.)

6. **Dock keeper picker·hint에서 ns 표기 제거** — picker sub(`phase · ns`→`phase`)와 대화 hint(`와 대화 중 · <ns>`→`와 대화 중`) 두 곳에서 runtime alias 노출을 제거했습니다. co-view의 ns 라벨 필드는 유지했습니다.

## 제외 항목 (audit 판정 준수)

| 항목 | 판정 | 사유 |
|------|------|------|
| Logs mock 도구명 위생 (keeper_voice_listen 등) | skip | dashboard logs는 실제 이벤트에서 파생 — 가짜 도구명이 애초에 없음 (mock 전용 정리) |
| 알림 엔진 notify wiring (alarm.jsx) | defer | notify 라우팅 writer 서버 API 부재. localStorage 알림 설정은 repo 정책(`settings-surface.ts` notify-routing-readonly)이 명시 금지. 16초 데모 루프는 이식 금지 대상 |
| Toast + undo (toast.jsx) | skip | 이미 dashboard `common/toast.ts`가 원본(디자인 주석도 dashboard를 원본으로 명시) |
| dock.css 66줄 델타 | skip | 전량 `var(--fs-*)` 토큰 ↔ raw px 차이 — dashboard가 앞섬, 역포팅 금지 |

## 설계 판단

- **sandbox 배지 fallback**: 디자인은 배지-또는-없음이지만, 비-local keeper에 대해 keeper-id를 잃지 않도록 namespace line fallback을 유지했습니다(정보 회귀 방지). keeper-id는 선택 시 aside에도 표시됩니다.
- **주의 목록 배치**: phase/gloss → stateNote blocker 박스 → `주의 · N` 목록 → 컨텍스트 압박 순서로, attention 관련 섹션을 상단에 묶었습니다.
- **토큰화**: 신규 블록은 verbatim 추가했습니다. `.fl-attn-item`의 `font-size: 11.5px`는 vendored 파일이 비표준 크기를 raw px로 두는 기존 컨벤션(`.fl-noact`, `.fl-tick`)과 일치합니다.

## 검증

- `pnpm exec tsc --noEmit` — 통과
- `pnpm lint` (eslint) — 통과
- `pnpm exec vitest run agent-roster.test.ts logs.test.ts copilot-dock.test.ts` — **3 파일 / 79 테스트 전부 통과**
  - 신규: attention 목록 positive(sev 코딩 + operator-대상 제외 + `주의 · 2`)/negative, sandbox 배지 local/fallback, 반응형 CSS 존재, dock ns 제거
  - 갱신: `uses heartbeat and full keeper model` — 절단 동작을 강제하던 `not.toContain('claude-code:auto')`를 전체 ID 표기 `toContain('claude-code:auto')`로 교체(약화 아님, 신규 동작 강화)

## 미검증 / 한계

- 반응형/모바일 카드는 CSS-only라 vitest DOM(jsdom/happy-dom)에서 미디어쿼리를 적용하지 못해, CSS 파일 내 블록 존재 assert 수준으로 검증했습니다(실제 뷰포트 렌더는 브라우저 확인 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
