### PR TITLE
fix(gc): never archive non-terminal tasks; restore orphaned verification obligations

### DIFF
--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -255,7 +255,25 @@ let gc config ?(days=7) () =
   in
   results := zombie_str :: !results;
 
-  (* 2. Archive stale tasks (older than N days, not completed) *)
+  (* 2. Archive terminal tasks (Done/Cancelled) older than N days, and
+        self-heal any non-terminal task a prior buggy GC pass stranded in the
+        archive.
+
+        Only terminal states are archive-eligible.  masc_transition and the
+        dashboard verification resolve path read the *live* backlog only, so
+        archiving a non-terminal task strands it: an AwaitingVerification
+        obligation can no longer be approved/rejected and a Claimed/InProgress
+        task can no longer be released, with no unarchive path.  RFC-0220
+        requires an AwaitingVerification obligation to stay claimable by a
+        verifier.  Live incident: task-1537 (submitted 2026-06-29) was orphaned
+        into tasks-archive.json for days because the old [not is_done]
+        predicate archived every non-[Done] task, including
+        AwaitingVerification.
+
+        Archive-eligibility is decided by [task_status_is_terminal] — an
+        exhaustive match over [task_status] with no [_] catch-all, so adding a
+        new status forces a compile-time decision there rather than silently
+        defaulting to "archive". *)
   let cutoff_time =
     let now = Time_compat.now () in
     now -. (float_of_int days *. 24. *. 60. *. 60.)
@@ -266,27 +284,69 @@ let gc config ?(days=7) () =
   let stale_count = ref 0 in
   let archived_tasks = ref [] in
   let kept_tasks = List.filter (fun task ->
-    let is_done = Masc_domain.task_status_is_done task.task_status in
+    let is_terminal = Masc_domain.task_status_is_terminal task.task_status in
     let is_old = task.created_at < cutoff_iso in
-    if is_old && not is_done then begin
+    if is_old && is_terminal then begin
       incr stale_count;
       archived_tasks := task :: !archived_tasks;
-      false  (* Remove stale task *)
+      false  (* Archive: terminal and older than the cutoff. *)
     end else
-      true   (* Keep task *)
+      true   (* Keep: recent, or non-terminal at any age. *)
   ) backlog.tasks in
 
-  if !stale_count > 0 then begin
-    append_archive_tasks config (List.rev !archived_tasks);
+  (* Self-healing restore: recover non-terminal obligations a prior pass
+     mis-archived.  Restore only ids not already live so a crash between the
+     backlog write and the archive drop below cannot duplicate a task. *)
+  let orphaned = read_orphaned_nonterminal_tasks config in
+  let live_ids = List.map (fun (t : task) -> t.id) kept_tasks in
+  let restored =
+    List.filter (fun (t : task) -> not (List.mem t.id live_ids)) orphaned
+  in
+  let restore_count = List.length restored in
+
+  (* Backlog first: on a crash before the archive is rewritten below, the
+     restored task survives in both stores and the next GC pass dedups it. *)
+  if !stale_count > 0 || restore_count > 0 then begin
     let new_backlog = {
-      tasks = kept_tasks;
+      tasks = kept_tasks @ restored;
       last_updated = now_iso ();
       version = backlog.version + 1;
     } in
-    write_backlog config new_backlog;
-    results := Printf.sprintf "Archived %d stale task(s) (older than %d days)" !stale_count days :: !results
-  end else
-    results := Printf.sprintf "No stale tasks (threshold: %d days)" days :: !results;
+    write_backlog config new_backlog
+  end;
+  if !stale_count > 0 then append_archive_tasks config (List.rev !archived_tasks);
+  (* Drop every orphaned non-terminal entry from the archive, including any that
+     was already live (a pure duplicate). *)
+  if orphaned <> [] then
+    drop_archive_tasks config ~ids:(List.map (fun (t : task) -> t.id) orphaned);
+  List.iter (fun (t : task) ->
+    let status = Masc_domain.task_status_to_string t.task_status in
+    log_event config (`Assoc [
+      ("type", `String "task_restored_from_archive");
+      ("task_id", `String t.id);
+      ("status", `String status);
+      ("ts", `String (now_iso ()));
+    ]);
+    (Atomic.get Workspace_hooks.activity_emit_fn)
+      config
+      ~actor:Workspace_hooks.{ kind = "system"; id = "keeper-gc" }
+      ~subject:Workspace_hooks.{ kind = "task"; id = t.id }
+      ~kind:"task.restored_from_archive"
+      ~payload:(`Assoc [ ("status", `String status) ])
+      ~tags:[ "gc"; "self_heal"; "rfc-0220" ]
+      ()
+  ) restored;
+  (if !stale_count > 0 then
+     results :=
+       Printf.sprintf "Archived %d terminal task(s) (older than %d days)" !stale_count days
+       :: !results
+   else
+     results :=
+       Printf.sprintf "No terminal tasks to archive (threshold: %d days)" days :: !results);
+  if restore_count > 0 then
+    results :=
+      Printf.sprintf "Restored %d non-terminal task(s) from archive" restore_count
+      :: !results;
 
   (* 3. Cleanup old messages - but preserve messages referencing open tasks *)
   let messages_path = messages_dir config in

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -303,12 +303,13 @@ let gc config ?(days=7) () =
     List.filter (fun (t : task) -> not (List.mem t.id live_ids)) orphaned
   in
   let restore_count = List.length restored in
+  let live_tasks_after_gc = kept_tasks @ restored in
 
   (* Backlog first: on a crash before the archive is rewritten below, the
      restored task survives in both stores and the next GC pass dedups it. *)
   if !stale_count > 0 || restore_count > 0 then begin
     let new_backlog = {
-      tasks = kept_tasks @ restored;
+      tasks = live_tasks_after_gc;
       last_updated = now_iso ();
       version = backlog.version + 1;
     } in
@@ -358,7 +359,7 @@ let gc config ?(days=7) () =
     List.filter_map (fun task ->
       if Masc_domain.task_status_is_terminal task.task_status then None
       else Some task.id
-    ) backlog.tasks
+    ) live_tasks_after_gc
   in
 
   (* Substring check against any open task ID.

--- a/lib/workspace/workspace_gc.mli
+++ b/lib/workspace/workspace_gc.mli
@@ -41,12 +41,18 @@ val cleanup_zombies :
 (** Run the full workspace garbage-collection pass:
     {ol
     {- {!cleanup_zombies} (default thresholds)}
-    {- archive backlog tasks older than [days] days that are not
-       already in a terminal state (default [days = 7], clamped to
-       at least 1)}}
+    {- archive backlog tasks in a terminal state ([Done]/[Cancelled]) older
+       than [days] days (default [days = 7], clamped to at least 1).
+       Non-terminal tasks — including [AwaitingVerification] obligations — are
+       never archived (RFC-0220: an obligation must stay claimable by a
+       verifier)}
+    {- self-heal: restore any non-terminal task a prior buggy pass stranded in
+       [tasks-archive.json] back into the live backlog}}
 
-    Stale tasks are appended to [tasks-archive.json] via
-    {!Workspace_task_id.append_archive_tasks} and the backlog is rewritten
-    with [version + 1].  Returns a multi-line summary string. *)
+    Archived tasks are appended to [tasks-archive.json] via
+    {!Workspace_task_id.append_archive_tasks}; restored tasks are removed from
+    it via {!Workspace_task_id.drop_archive_tasks}.  The backlog is rewritten
+    with [version + 1] when anything changes.  Returns a multi-line summary
+    string. *)
 val gc :
   Workspace_utils_backend_setup.config -> ?days:int -> unit -> string

--- a/lib/workspace/workspace_task_id.ml
+++ b/lib/workspace/workspace_task_id.ml
@@ -12,25 +12,29 @@ let task_id_to_int id =
   else if String.sub id 0 prefix_len <> prefix then None
   else int_of_string_opt (String.sub id prefix_len (String.length id - prefix_len))
 
-let read_archive_task_ids config =
-  if not (Sys.file_exists (archive_path config)) then []
-  else
-    let json = read_json config (archive_path config) in
-    let tasks =
-      match json with
-      | `List tasks -> tasks
-      | `Assoc _ -> begin
-          match Json_util.assoc_member_opt "tasks" json with
-          | Some (`List tasks) -> tasks
-          | _ -> []
-        end
+(** Extract the raw task-entry JSON list from a parsed archive document,
+    tolerating both the bare-[`List] legacy shape and the current
+    [{"tasks": [...]}] envelope.  Single source for the archive
+    readers/writers so the shape cannot drift between them. *)
+let archive_entries_of_json = function
+  | `List tasks -> tasks
+  | `Assoc _ as json -> begin
+      match Json_util.assoc_member_opt "tasks" json with
+      | Some (`List tasks) -> tasks
       | _ -> []
-    in
-    List.filter_map (fun task ->
-      match Json_util.get_string task "id" with
-      | Some id -> task_id_to_int id
-      | None -> None
-    ) tasks
+    end
+  | _ -> []
+
+let read_archive_entries config =
+  if not (Sys.file_exists (archive_path config)) then []
+  else archive_entries_of_json (read_json config (archive_path config))
+
+let read_archive_task_ids config =
+  List.filter_map (fun task ->
+    match Json_util.get_string task "id" with
+    | Some id -> task_id_to_int id
+    | None -> None
+  ) (read_archive_entries config)
 
 (** Append tasks to archive file (tasks-archive.json).
 
@@ -42,16 +46,7 @@ let append_archive_tasks config (tasks : task list) =
     let arch_path = archive_path config in
     with_file_lock config arch_path (fun () ->
       let existing = read_json config arch_path in
-      let existing_tasks =
-        match existing with
-        | `List items -> items
-        | `Assoc _ -> begin
-            match Json_util.assoc_member_opt "tasks" existing with
-            | Some (`List items) -> items
-            | _ -> []
-          end
-        | _ -> []
-      in
+      let existing_tasks = archive_entries_of_json existing in
       let new_tasks = List.map task_to_yojson tasks in
       let seen = Hashtbl.create 64 in
       let dedup = List.filter (fun json ->
@@ -64,6 +59,42 @@ let append_archive_tasks config (tasks : task list) =
       in
       let archive_json = `Assoc [
         ("tasks", `List dedup);
+        ("last_updated", `String (now_iso ()));
+      ] in
+      write_json config arch_path archive_json)
+
+(** RFC-0220 self-healing: read the archive and return every task whose status
+    is non-terminal.  A non-terminal task in the archive is an obligation a
+    prior buggy GC pass stranded (masc_transition and dashboard verification
+    read only the live backlog); the GC restore path splices these back into
+    the backlog.  Read-only — the caller rewrites the live backlog first, then
+    calls {!drop_archive_tasks}, so a crash between the two leaves the task in
+    both stores (recovered by dedup on the next pass) rather than losing it.
+    Entries that fail to parse are skipped here and preserved by
+    {!drop_archive_tasks}. *)
+let read_orphaned_nonterminal_tasks config : task list =
+  List.filter_map (fun entry ->
+    match task_of_yojson entry with
+    | Ok task when not (task_status_is_terminal task.task_status) -> Some task
+    | Ok _ | Error _ -> None
+  ) (read_archive_entries config)
+
+(** Remove archive entries whose task id is in [ids], under the archive lock.
+    Entries without an [id] field are preserved — an unreadable archive line is
+    never silently dropped.  No-op on []. *)
+let drop_archive_tasks config ~ids =
+  if ids = [] then ()
+  else
+    let arch_path = archive_path config in
+    with_file_lock config arch_path (fun () ->
+      let entries = archive_entries_of_json (read_json config arch_path) in
+      let kept = List.filter (fun entry ->
+        match Json_util.get_string entry "id" with
+        | Some id -> not (List.mem id ids)
+        | None -> true
+      ) entries in
+      let archive_json = `Assoc [
+        ("tasks", `List kept);
         ("last_updated", `String (now_iso ()));
       ] in
       write_json config arch_path archive_json)

--- a/lib/workspace/workspace_task_id.mli
+++ b/lib/workspace/workspace_task_id.mli
@@ -23,6 +23,20 @@ val read_archive_task_ids : Workspace_utils_backend_setup.config -> int list
 val append_archive_tasks :
   Workspace_utils_backend_setup.config -> task list -> unit
 
+(** Non-terminal tasks currently sitting in [tasks-archive.json] — obligations a
+    buggy GC pass stranded (RFC-0220: an [AwaitingVerification] obligation must
+    stay claimable by a verifier).  Read-only; pair with {!drop_archive_tasks}
+    after the live backlog has been rewritten so a crash between the two cannot
+    lose the task.  Unparseable entries are skipped. *)
+val read_orphaned_nonterminal_tasks :
+  Workspace_utils_backend_setup.config -> task list
+
+(** Remove archive entries whose task id is in [ids], under the archive lock.
+    Entries without an [id] field are preserved (an unreadable line is never
+    silently dropped).  No-op on []. *)
+val drop_archive_tasks :
+  Workspace_utils_backend_setup.config -> ids:string list -> unit
+
 (** Next task number = [max(existing backlog ids, archive ids) + 1].
     Returns [1] when both backlog and archive are empty. *)
 val next_task_number :

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1910,6 +1910,42 @@ let gc_backlog_has config task_id =
     (Workspace.read_backlog config).tasks
 ;;
 
+let gc_message_path_with_content config content =
+  let messages_dir = Workspace.messages_dir config in
+  let matching_paths =
+    Sys.readdir messages_dir
+    |> Array.to_list
+    |> List.filter_map (fun name ->
+      let path = Filename.concat messages_dir name in
+      match Workspace.read_json config path with
+      | `Assoc fields ->
+        (match List.assoc_opt "content" fields with
+         | Some (`String actual) when String.equal actual content -> Some path
+         | _ -> None)
+      | _ -> None)
+  in
+  match matching_paths with
+  | [ path ] -> path
+  | paths ->
+    Alcotest.failf
+      "expected one message with content %S, got %d"
+      content
+      (List.length paths)
+;;
+
+let gc_backdate_message config ~content =
+  let path = gc_message_path_with_content config content in
+  let json = Workspace.read_json config path in
+  let updated =
+    match json with
+    | `Assoc fields ->
+      `Assoc (("timestamp", `String gc_ancient_ts) :: List.remove_assoc "timestamp" fields)
+    | _ -> Alcotest.fail "expected message object"
+  in
+  Workspace.write_json config path updated;
+  path
+;;
+
 (* RFC-0220: an old AwaitingVerification obligation must survive GC in the live
    backlog — masc_transition and dashboard verification read the live backlog
    only, so archiving strands its approve/reject path (task-1537 incident). *)
@@ -1971,6 +2007,43 @@ let test_gc_restores_orphaned_nonterminal_from_archive () =
       "restored obligation removed from archive"
       false
       (List.mem 901 (Workspace.read_archive_task_ids config)))
+;;
+
+(* The same GC pass that restores an archive-only non-terminal task must use the
+   restored live task set when pruning old messages.  Otherwise the restored
+   task survives but its old task-reference message is deleted immediately. *)
+let test_gc_restored_task_preserves_old_messages_same_pass () =
+  with_test_env (fun config ->
+    let orphan =
+      gc_make_task
+        ~id:"task-904"
+        ~created_at:gc_ancient_ts
+        ~status:
+          (Masc_domain.AwaitingVerification
+             { assignee = "claude"
+             ; submitted_at = gc_ancient_ts
+             ; verification_id = "verif-904"
+             ; phase = Masc_domain.Awaiting_verifier
+             })
+    in
+    Workspace.append_archive_tasks config [ orphan ];
+    let content = "verification context for task-904" in
+    let _ =
+      Workspace.broadcast
+        config
+        ~from_agent:"claude"
+        ~content
+    in
+    let message_path = gc_backdate_message config ~content in
+    let _ = Workspace.gc config ~days:1 () in
+    Alcotest.(check bool)
+      "orphaned obligation restored to live backlog"
+      true
+      (gc_backlog_has config "task-904");
+    Alcotest.(check bool)
+      "old message referencing restored task preserved"
+      true
+      (Sys.file_exists message_path))
 ;;
 
 (* Regression guard: terminal (Done/Cancelled) tasks past the cutoff are still
@@ -2288,6 +2361,10 @@ let () =
             "restores orphaned non-terminal from archive"
             `Quick
             test_gc_restores_orphaned_nonterminal_from_archive
+        ; Alcotest.test_case
+            "restored task preserves old messages same pass"
+            `Quick
+            test_gc_restored_task_preserves_old_messages_same_pass
         ; Alcotest.test_case
             "archives terminal tasks"
             `Quick

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1884,6 +1884,130 @@ let test_gc_with_tasks () =
     Alcotest.(check bool) "gc with recent task" true (String.length result > 0))
 ;;
 
+(* Well before any [days]-based cutoff so [is_old] is true for these tasks. *)
+let gc_ancient_ts = "2020-01-01T00:00:00Z"
+
+let gc_make_task ~id ~created_at ~status : Masc_domain.task =
+  { id
+  ; title = "GC " ^ id
+  ; description = ""
+  ; task_status = status
+  ; priority = 1
+  ; files = []
+  ; created_at
+  ; created_by = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+let gc_backlog_has config task_id =
+  List.exists
+    (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+    (Workspace.read_backlog config).tasks
+;;
+
+(* RFC-0220: an old AwaitingVerification obligation must survive GC in the live
+   backlog — masc_transition and dashboard verification read the live backlog
+   only, so archiving strands its approve/reject path (task-1537 incident). *)
+let test_gc_preserves_awaiting_verification () =
+  with_test_env (fun config ->
+    let task =
+      gc_make_task
+        ~id:"task-900"
+        ~created_at:gc_ancient_ts
+        ~status:
+          (Masc_domain.AwaitingVerification
+             { assignee = "claude"
+             ; submitted_at = gc_ancient_ts
+             ; verification_id = "verif-900"
+             ; phase = Masc_domain.Awaiting_verifier
+             })
+    in
+    write_tasks config [ task ];
+    let _ = Workspace.gc config ~days:1 () in
+    Alcotest.(check bool)
+      "awaiting_verification obligation kept in live backlog"
+      true
+      (gc_backlog_has config "task-900");
+    Alcotest.(check bool)
+      "awaiting_verification obligation not archived"
+      false
+      (List.mem 900 (Workspace.read_archive_task_ids config)))
+;;
+
+(* Self-healing: a non-terminal task stranded in the archive (the pre-fix
+   symptom) is pulled back into the live backlog on the next GC pass. *)
+let test_gc_restores_orphaned_nonterminal_from_archive () =
+  with_test_env (fun config ->
+    let orphan =
+      gc_make_task
+        ~id:"task-901"
+        ~created_at:gc_ancient_ts
+        ~status:
+          (Masc_domain.AwaitingVerification
+             { assignee = "claude"
+             ; submitted_at = gc_ancient_ts
+             ; verification_id = "verif-901"
+             ; phase = Masc_domain.Awaiting_verifier
+             })
+    in
+    (* Simulate the orphaning a buggy GC pass produced: obligation lives in the
+       archive only, absent from the backlog. *)
+    Workspace.append_archive_tasks config [ orphan ];
+    Alcotest.(check bool)
+      "precondition: orphan not yet in backlog"
+      false
+      (gc_backlog_has config "task-901");
+    let _ = Workspace.gc config ~days:1 () in
+    Alcotest.(check bool)
+      "orphaned obligation restored to live backlog"
+      true
+      (gc_backlog_has config "task-901");
+    Alcotest.(check bool)
+      "restored obligation removed from archive"
+      false
+      (List.mem 901 (Workspace.read_archive_task_ids config)))
+;;
+
+(* Regression guard: terminal (Done/Cancelled) tasks past the cutoff are still
+   archived, so the fix does not disable GC's intended behaviour. *)
+let test_gc_archives_terminal_tasks () =
+  with_test_env (fun config ->
+    let done_task =
+      gc_make_task
+        ~id:"task-902"
+        ~created_at:gc_ancient_ts
+        ~status:
+          (Masc_domain.Done
+             { assignee = "claude"; completed_at = gc_ancient_ts; notes = None })
+    in
+    let cancelled_task =
+      gc_make_task
+        ~id:"task-903"
+        ~created_at:gc_ancient_ts
+        ~status:
+          (Masc_domain.Cancelled
+             { cancelled_by = "claude"; cancelled_at = gc_ancient_ts; reason = None })
+    in
+    write_tasks config [ done_task; cancelled_task ];
+    let _ = Workspace.gc config ~days:1 () in
+    Alcotest.(check bool)
+      "done task removed from live backlog"
+      false
+      (gc_backlog_has config "task-902");
+    Alcotest.(check bool)
+      "cancelled task removed from live backlog"
+      false
+      (gc_backlog_has config "task-903");
+    let archive_ids = Workspace.read_archive_task_ids config in
+    Alcotest.(check bool) "done task archived" true (List.mem 902 archive_ids);
+    Alcotest.(check bool) "cancelled task archived" true (List.mem 903 archive_ids))
+;;
+
 (* ============================================================ *)
 (* Task ID Parsing Tests                                         *)
 (* ============================================================ *)
@@ -2156,6 +2280,18 @@ let () =
       ( "gc"
       , [ Alcotest.test_case "no cleanup" `Quick test_gc_no_cleanup_needed
         ; Alcotest.test_case "with tasks" `Quick test_gc_with_tasks
+        ; Alcotest.test_case
+            "preserves awaiting_verification"
+            `Quick
+            test_gc_preserves_awaiting_verification
+        ; Alcotest.test_case
+            "restores orphaned non-terminal from archive"
+            `Quick
+            test_gc_restores_orphaned_nonterminal_from_archive
+        ; Alcotest.test_case
+            "archives terminal tasks"
+            `Quick
+            test_gc_archives_terminal_tasks
         ] )
     ; (* === Task ID Parsing === *)
       ( "task_id"


### PR DESCRIPTION
## 문제

`lib/workspace/workspace_gc.ml`의 `gc`가 stale-task 아카이브 단계에서 `is_old && not is_done` 술어를 사용했다. `task_status_is_done`은 `Done`만 true이므로, 이 술어는 cutoff보다 오래된 **비종결(non-terminal)** task — `AwaitingVerification` / `Claimed` / `InProgress` / `Todo` — 를 전부 live backlog에서 `tasks-archive.json`으로 옮겼다.

`masc_transition`과 dashboard verification resolve 경로는 **live backlog만** 읽는다. 따라서 아카이브된 `AwaitingVerification` 의무는:
- approve/reject가 영구히 불가능(NotFound)하고,
- unarchive 경로가 없어 복구 불가능하다.

이는 RFC-0220 불변식 위반이다: *"AwaitingVerification 의무는 verifier가 claim 가능해야 한다"*. 

**라이브 사고**: `task-1537`(2026-06-29 제출)이 검증 대기 상태로 `tasks-archive.json`에 고아화되어 수일째 approve/reject 불가 상태로 방치됨.

## 수정

1. **아카이브 대상을 종결 상태로 한정**: 술어를 `task_status_is_terminal`(= `Done`/`Cancelled`)로 교체. 이 helper는 `task_status`에 대한 exhaustive match(`_ ->` catch-all 없음)이므로, 새 status variant 추가 시 `types_core.ml`에서 컴파일 에러로 "아카이브 대상 여부"를 강제 결정하게 된다(AI 코드 생성 anti-pattern #4 방어). 비종결 task는 나이에 관계없이 보존.

2. **Self-healing 복원**: 매 gc 패스마다 archive에서 비종결 task를 발견하면 live backlog로 복원한다(`task-1537`이 다음 gc에서 자동 복구). crash-safety를 위해 **backlog write → archive drop** 순서로 처리하여, 두 write 사이 크래시 시 task가 양쪽에 존재(다음 패스가 dedup)할 뿐 유실되지 않는다. 복원마다 activity event(`task.restored_from_archive`)를 기록한다. 파싱 불가한 archive 항목은 절대 drop하지 않는다.

3. **archive I/O primitive 정리**: `read_orphaned_nonterminal_tasks` / `drop_archive_tasks`를 `workspace_task_id.ml`에 추가하고, 3곳에 중복돼 있던 archive envelope 추출 로직을 `archive_entries_of_json` 단일 helper로 SSOT화.

## 검증

- `MASC_SKIP_PIN_CHECK=1 bash scripts/dune-local.sh build --root . @check` → EXIT 0
- `test/test_workspace_coverage.ml` focused runtest → **77 tests, Test Successful**. GC 그룹 신규 3종 포함:
  - `preserves awaiting_verification`: is_old인 `AwaitingVerification`가 GC 생존 + 미아카이브
  - `restores orphaned non-terminal from archive`: archive의 비종결 task가 live backlog로 복원 + archive에서 제거
  - `archives terminal tasks`: `Done`/`Cancelled`는 기존대로 아카이브
- `ocamlformat --check` (5개 파일) → EXIT 0

## 변경 파일

- `lib/workspace/workspace_gc.ml` / `.mli` — 아카이브 술어 교체 + self-healing 복원
- `lib/workspace/workspace_task_id.ml` / `.mli` — archive read/drop primitive + SSOT 추출
- `test/test_workspace_coverage.ml` — GC 테스트 3종

---

MASC task: task-1664 (audit Wave B1, CONFIRMED P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
