### PR TITLE
feat(dashboard): Settings fusion 프리셋 구성 read-only 표시

### DIFF
--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -179,4 +179,54 @@ describe('FusionSettingsPanel', () => {
     await vi.waitFor(() => expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('정수'))
     expect(saveMock).not.toHaveBeenCalled()
   })
+
+  it('renders the read-only preset composition parsed from the loaded config', async () => {
+    fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE }))
+    await mount()
+
+    expect(q('[data-testid="fusion-preset-view"]')).not.toBeNull()
+    const models = Array.from(container.querySelectorAll('[data-testid="fusion-preset-panel-model"]')).map(m => m.textContent)
+    expect(models).toEqual(['a', 'b', 'c'])
+    expect(q('[data-testid="fusion-preset-judge"]')?.textContent).toBe('j')
+    // SAMPLE's trio declares no timeouts/max_tool_calls → shown as '—', never fabricated.
+    const timing = q('[data-testid="fusion-preset-timing"]')?.textContent ?? ''
+    expect(timing).toContain('panel_timeout —')
+    expect(timing).toContain('judge_timeout —')
+    expect(timing).toContain('max_tool_calls_per_panel —')
+    expect(timing).toContain('(0 = 무제한)')
+  })
+
+  it('omits the preset card when the default preset has no backing section', async () => {
+    // enabled=false keeps the editor valid even though default_preset is unknown;
+    // the read-only card is data-driven, so it must not appear.
+    const noSection = `[fusion]
+enabled = false
+default_preset = "ghost"
+max_concurrent_panels = 2
+`
+    fetchMock.mockResolvedValue(cfg({ source_text: noSection }))
+    await mount()
+
+    expect(q('[data-testid="fusion-settings-editor"]')).not.toBeNull()
+    expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
+  })
+
+  it('omits the preset card when the preset declares no panel models', async () => {
+    // A preset with only min_answered has no composition to display; the card is
+    // gated on panel models so the live writer stays lane-free for such configs.
+    const noPanel = `[fusion]
+enabled = true
+default_preset = "trio"
+max_concurrent_panels = 2
+
+[fusion.presets.trio]
+min_answered = 2
+`
+    fetchMock.mockResolvedValue(cfg({ source_text: noPanel }))
+    await mount()
+
+    expect(q('[data-testid="fusion-settings-editor"]')).not.toBeNull()
+    expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
+    expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
+  })
 })

--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -229,4 +229,55 @@ min_answered = 2
     expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
   })
+
+  it('shows a fail-visible note (not a partial panel) for grouped presets', async () => {
+    const grouped = `[fusion]
+enabled = true
+default_preset = "mixed"
+max_concurrent_panels = 2
+
+[fusion.presets.mixed]
+judge = "j"
+[[fusion.presets.mixed.panels]]
+panel = ["fast1", "fast2"]
+[[fusion.presets.mixed.panels]]
+panel = ["careful1"]
+`
+    fetchMock.mockResolvedValue(cfg({ source_text: grouped }))
+    await mount()
+
+    expect(q('[data-testid="fusion-settings-editor"]')).not.toBeNull()
+    // Grouped note shown; the flat lane card is NOT rendered.
+    expect(q('[data-testid="fusion-preset-grouped"]')?.textContent).toContain('2개 그룹')
+    expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
+    expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
+    // Must never leak the first group's model as the preset panel (the P1 bug).
+    expect(container.textContent).not.toContain('fast1')
+  })
+
+  it('renders a flat-panel preset with a judge-of-judges note when first-pass judges exist', async () => {
+    const quorumLike = `[fusion]
+enabled = true
+default_preset = "quorum"
+max_concurrent_panels = 2
+
+[fusion.presets.quorum]
+panel = ["p1", "p2"]
+judge = "meta_model"
+[[fusion.presets.quorum.judges]]
+model = "evidence_model"
+[[fusion.presets.quorum.judges]]
+model = "coverage_model"
+`
+    fetchMock.mockResolvedValue(cfg({ source_text: quorumLike }))
+    await mount()
+
+    // Flat panels are shown normally.
+    expect(q('[data-testid="fusion-preset-view"]')).not.toBeNull()
+    const models = Array.from(container.querySelectorAll('[data-testid="fusion-preset-panel-model"]')).map(m => m.textContent)
+    expect(models).toEqual(['p1', 'p2'])
+    expect(q('[data-testid="fusion-preset-judge"]')?.textContent).toBe('meta_model')
+    // The judge lane honestly notes the first-pass judges rather than implying one.
+    expect(q('[data-testid="fusion-preset-judge-lane-h"]')?.textContent).toContain('1차 심판 2')
+  })
 })

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -221,7 +221,11 @@ export function FusionSettingsPanel() {
   // preset with no panel has no composition worth displaying. The editor scalars
   // above stay writable.
   const presetView = readFusionPresetView(source, draft.defaultPreset)
-  const showPresetView = presetView !== null && presetView.panel.length > 0
+  // Flat preset with panel models → full read-only card. Grouped preset
+  // ([[...panels]] array-of-tables) → fail-visible note (a single flat card
+  // cannot represent N groups without silently dropping some).
+  const showPresetView = presetView !== null && !presetView.grouped && presetView.panel.length > 0
+  const showGroupedNote = presetView !== null && presetView.grouped
   const timeoutLabel = (value: number | null): string => (value === null ? '—' : `${value}s`)
 
   return html`
@@ -251,6 +255,14 @@ export function FusionSettingsPanel() {
         ${state === 'saved' && html`<span class="set-ok" data-testid="fusion-settings-saved">${savedMessage}</span>`}
         ${state === 'error' && html`<span class="set-err" data-testid="fusion-settings-error">${error}</span>`}
       </div>
+      ${showGroupedNote && presetView
+        ? html`
+            <div class="set-sub-h">${presetView.preset} 프리셋</div>
+            <div class="set-hint" data-testid="fusion-preset-grouped">
+              그룹형 패널 구성 · ${presetView.groupCount}개 그룹 (<span class="mono">[[fusion.presets.${presetView.preset}.panels]]</span>) · 미리보기 미지원
+            </div>
+          `
+        : null}
       ${showPresetView && presetView
         ? html`
             <div class="set-sub-h">${presetView.preset} 프리셋</div>
@@ -260,7 +272,7 @@ export function FusionSettingsPanel() {
                 ${presetView.panel.map(id => html`<div key=${id} class="set-fus-model mono" data-testid="fusion-preset-panel-model">${id}</div>`)}
               </div>
               <div class="set-fus-lane">
-                <div class="set-fus-lane-h">judge</div>
+                <div class="set-fus-lane-h" data-testid="fusion-preset-judge-lane-h">judge${presetView.judgeGroupCount > 0 ? ` · 메타 (1차 심판 ${presetView.judgeGroupCount} · judge-of-judges)` : ''}</div>
                 ${presetView.judge
                   ? html`<div class="set-fus-model judge mono" data-testid="fusion-preset-judge">${presetView.judge}</div>`
                   : html`<div class="set-fus-model judge mono" data-testid="fusion-preset-judge">미지정</div>`}

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -20,6 +20,7 @@ import {
   type FusionSettings,
   type FusionSettingsParseIssue,
 } from '../lib/fusion-settings'
+import { readFusionPresetView } from '../lib/fusion-preset-view'
 import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
 
 type EditorState = 'loading' | 'idle' | 'saving' | 'saved' | 'error'
@@ -213,6 +214,16 @@ export function FusionSettingsPanel() {
   const str = (e: Event) => (e.target as HTMLInputElement).value
   const checked = (e: Event) => (e.target as HTMLInputElement).checked
 
+  // Read-only view of the active preset's composition (panel models · judge ·
+  // timeouts · max_tool_calls), parsed from the same runtime.toml source the
+  // editor already loaded. Shown only when the default_preset resolves to a real
+  // [fusion.presets.<preset>] table that actually declares panel models — a
+  // preset with no panel has no composition worth displaying. The editor scalars
+  // above stay writable.
+  const presetView = readFusionPresetView(source, draft.defaultPreset)
+  const showPresetView = presetView !== null && presetView.panel.length > 0
+  const timeoutLabel = (value: number | null): string => (value === null ? '—' : `${value}s`)
+
   return html`
     <div class="set-fusion-editor" data-testid="fusion-settings-editor">
       <label class="set-line">
@@ -240,6 +251,26 @@ export function FusionSettingsPanel() {
         ${state === 'saved' && html`<span class="set-ok" data-testid="fusion-settings-saved">${savedMessage}</span>`}
         ${state === 'error' && html`<span class="set-err" data-testid="fusion-settings-error">${error}</span>`}
       </div>
+      ${showPresetView && presetView
+        ? html`
+            <div class="set-sub-h">${presetView.preset} 프리셋</div>
+            <div class="set-fus-preset" data-testid="fusion-preset-view">
+              <div class="set-fus-lane">
+                <div class="set-fus-lane-h">panel · ${presetView.panel.length}</div>
+                ${presetView.panel.map(id => html`<div key=${id} class="set-fus-model mono" data-testid="fusion-preset-panel-model">${id}</div>`)}
+              </div>
+              <div class="set-fus-lane">
+                <div class="set-fus-lane-h">judge</div>
+                ${presetView.judge
+                  ? html`<div class="set-fus-model judge mono" data-testid="fusion-preset-judge">${presetView.judge}</div>`
+                  : html`<div class="set-fus-model judge mono" data-testid="fusion-preset-judge">미지정</div>`}
+              </div>
+            </div>
+            <div class="set-mcp-detail mono" data-testid="fusion-preset-timing" style=${{ marginTop: 10 }}>
+              panel_timeout ${timeoutLabel(presetView.panelTimeoutS)} · judge_timeout ${timeoutLabel(presetView.judgeTimeoutS)} · max_tool_calls_per_panel ${presetView.maxToolCallsPerPanel ?? '—'} (0 = 무제한)
+            </div>
+          `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/lib/fusion-preset-view.test.ts
+++ b/dashboard/src/lib/fusion-preset-view.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { readFusionPresetView } from './fusion-preset-view'
+
+// Mirrors the real runtime.toml shape: a multi-line panel array, a scalar judge,
+// multi-line prompt strings between judge and the timeout scalars, then the
+// numeric scalars — so the reader must find scalars that follow triple-quoted
+// values, and a sibling preset must not bleed into the requested one.
+const MULTILINE = `[fusion]
+enabled = true
+default_preset = "trio"
+
+[fusion.presets.trio]
+panel = [
+  "ollama_cloud.devstral-2-123b",
+  "ollama_cloud.devstral-small-2-24b",
+  "ollama_cloud.ministral-3-14b",
+]
+judge = "ollama_cloud.devstral-2-123b"
+panel_system_prompt = """
+You are an expert panelist. Answer directly.
+"""
+panel_timeout_s = 300.0
+judge_timeout_s = 250.0
+max_tool_calls_per_panel = 0
+
+[fusion.presets.quorum]
+panel = ["lens_a", "lens_b"]
+judge = "meta"
+`
+
+describe('readFusionPresetView', () => {
+  it('returns null for an empty preset name', () => {
+    expect(readFusionPresetView(MULTILINE, '')).toBeNull()
+    expect(readFusionPresetView(MULTILINE, '   ')).toBeNull()
+  })
+
+  it('returns null when the preset section is absent', () => {
+    expect(readFusionPresetView(MULTILINE, 'nonexistent')).toBeNull()
+  })
+
+  it('parses a multi-line panel array plus scalar judge/timeouts/max_tool_calls', () => {
+    const view = readFusionPresetView(MULTILINE, 'trio')
+    expect(view).not.toBeNull()
+    expect(view!.preset).toBe('trio')
+    expect(view!.panel).toEqual([
+      'ollama_cloud.devstral-2-123b',
+      'ollama_cloud.devstral-small-2-24b',
+      'ollama_cloud.ministral-3-14b',
+    ])
+    expect(view!.judge).toBe('ollama_cloud.devstral-2-123b')
+    // Scalars are found even though a multi-line prompt string precedes them.
+    expect(view!.panelTimeoutS).toBe(300)
+    expect(view!.judgeTimeoutS).toBe(250)
+    expect(view!.maxToolCallsPerPanel).toBe(0)
+  })
+
+  it('scopes to the requested preset and does not inherit a sibling preset', () => {
+    const view = readFusionPresetView(MULTILINE, 'quorum')
+    expect(view!.panel).toEqual(['lens_a', 'lens_b'])
+    expect(view!.judge).toBe('meta')
+    // quorum declares no timeouts → null, not the trio values.
+    expect(view!.panelTimeoutS).toBeNull()
+    expect(view!.judgeTimeoutS).toBeNull()
+    expect(view!.maxToolCallsPerPanel).toBeNull()
+  })
+
+  it('handles a single-line panel array', () => {
+    const src = '[fusion.presets.solo]\npanel = ["only-model"]\njudge = "j"\n'
+    const view = readFusionPresetView(src, 'solo')
+    expect(view!.panel).toEqual(['only-model'])
+    expect(view!.judge).toBe('j')
+  })
+
+  it('returns an empty panel and null scalars when keys are absent', () => {
+    const src = '[fusion.presets.bare]\n# no keys declared\n'
+    const view = readFusionPresetView(src, 'bare')
+    expect(view).not.toBeNull()
+    expect(view!.panel).toEqual([])
+    expect(view!.judge).toBeNull()
+    expect(view!.panelTimeoutS).toBeNull()
+    expect(view!.maxToolCallsPerPanel).toBeNull()
+  })
+})

--- a/dashboard/src/lib/fusion-preset-view.test.ts
+++ b/dashboard/src/lib/fusion-preset-view.test.ts
@@ -80,4 +80,99 @@ describe('readFusionPresetView', () => {
     expect(view!.panelTimeoutS).toBeNull()
     expect(view!.maxToolCallsPerPanel).toBeNull()
   })
+
+  it('flags a flat preset as not grouped', () => {
+    const view = readFusionPresetView(MULTILINE, 'trio')
+    expect(view!.grouped).toBe(false)
+    expect(view!.groupCount).toBe(0)
+  })
+})
+
+// Array-of-tables grammar (fusion_config.ml parse_preset). Shape mirrors
+// test/fusion_core/test_fusion.ml `multi_group_toml`: a preset table with a flat
+// judge plus two [[fusion.presets.NAME.panels]] groups (2 + 1 models).
+const MULTI_GROUP = `
+[fusion]
+enabled = true
+default_preset = "mixed"
+[fusion.presets.mixed]
+judge = "j"
+judge_system_prompt = "synthesize"
+[[fusion.presets.mixed.panels]]
+panel = ["fast1", "fast2"]
+panel_system_prompt = "quick"
+web_tools = false
+max_tool_calls_per_panel = 0
+[[fusion.presets.mixed.panels]]
+panel = ["careful1"]
+panel_system_prompt = "deliberate"
+web_tools = true
+max_tool_calls_per_panel = 4
+panel_timeout_s = 180.0
+`
+
+describe('readFusionPresetView — grouped panels', () => {
+  it('reports a grouped preset instead of parsing one group as the whole preset', () => {
+    const view = readFusionPresetView(MULTI_GROUP, 'mixed')
+    expect(view).not.toBeNull()
+    expect(view!.grouped).toBe(true)
+    expect(view!.groupCount).toBe(2)
+    // Must NOT surface the first group's panel (["fast1","fast2"]) as the preset
+    // panel — the silent-partial regression this guards against.
+    expect(view!.panel).toEqual([])
+    expect(view!.judge).toBeNull()
+    expect(view!.panelTimeoutS).toBeNull()
+  })
+
+  it('treats a conflicting grouped+flat preset as grouped (never trusts the flat panel)', () => {
+    const conflicting = `[fusion.presets.mixed]
+panel = ["flat_a", "flat_b"]
+judge = "j"
+[[fusion.presets.mixed.panels]]
+panel = ["group_a"]
+`
+    const view = readFusionPresetView(conflicting, 'mixed')
+    expect(view!.grouped).toBe(true)
+    expect(view!.groupCount).toBe(1)
+    expect(view!.panel).toEqual([])
+  })
+
+  it('does not mistake a sibling preset\'s panel groups for the requested flat preset', () => {
+    // `trio` is flat; a separate grouped `mixed` preset in the same document must
+    // not make `trio` look grouped, nor bleed its groups into trio.
+    const mixedSource = `${MULTILINE}${MULTI_GROUP}`
+    const trio = readFusionPresetView(mixedSource, 'trio')
+    expect(trio!.grouped).toBe(false)
+    expect(trio!.panel).toEqual([
+      'ollama_cloud.devstral-2-123b',
+      'ollama_cloud.devstral-small-2-24b',
+      'ollama_cloud.ministral-3-14b',
+    ])
+    const mixed = readFusionPresetView(mixedSource, 'mixed')
+    expect(mixed!.grouped).toBe(true)
+    expect(mixed!.groupCount).toBe(2)
+  })
+
+  it('keeps a flat-panel preset flat but counts its first-pass judge tables (JoJ)', () => {
+    // Mirrors the real `quorum`: flat panel + flat meta judge + two
+    // [[...judges]] first-pass judge tables. Panels stay flat (correctly shown);
+    // judgeGroupCount surfaces the meta/first-pass split honestly.
+    const quorumLike = `[fusion.presets.quorum]
+panel = ["p1", "p2"]
+judge = "meta_model"
+[[fusion.presets.quorum.judges]]
+model = "evidence_model"
+label = "evidence"
+[[fusion.presets.quorum.judges]]
+model = "coverage_model"
+label = "coverage"
+`
+    const view = readFusionPresetView(quorumLike, 'quorum')
+    expect(view!.grouped).toBe(false)
+    expect(view!.panel).toEqual(['p1', 'p2'])
+    // The flat meta judge is shown; group tables use `model=` so they never bleed
+    // into the `judge` scalar.
+    expect(view!.judge).toBe('meta_model')
+    expect(view!.judgeGroupCount).toBe(2)
+  })
 })

--- a/dashboard/src/lib/fusion-preset-view.ts
+++ b/dashboard/src/lib/fusion-preset-view.ts
@@ -16,6 +16,15 @@ import { getRuntimeTomlKey } from './runtime-toml-config'
 
 export interface FusionPresetView {
   readonly preset: string
+  // Grouped presets ([[fusion.presets.NAME.panels]] array-of-tables) cannot be
+  // represented by a single flat panel array; `grouped` flags them so the UI
+  // shows a "preview unsupported" note instead of one group's models. When
+  // grouped is true the flat fields below are empty/null (not parsed).
+  readonly grouped: boolean
+  readonly groupCount: number
+  // Number of [[...judges]] first-pass judge tables (judge-of-judges). >0 means
+  // `judge` is the meta judge and there are additional first-pass judges.
+  readonly judgeGroupCount: number
   readonly panel: readonly string[]
   readonly judge: string | null
   readonly panelTimeoutS: number | null
@@ -37,11 +46,15 @@ function escapeForRegExp(value: string): string {
 }
 
 // Body lines of a `[section]`: everything between its header and the next
-// section header (or EOF). Used only to locate the multi-line `panel` array.
+// header (or EOF). Used only to locate a flat, single-group `panel` array.
+// The boundary matches both single `[section]` and array-of-tables `[[a.b]]`
+// headers, so a grouped preset's child `[[...panels]]` tables do NOT bleed into
+// the parent preset body (which previously let the first group's panel be read
+// as the whole preset — silent partial).
 function sectionBodyLines(sourceText: string, sectionName: string): string[] | null {
   const lines = sourceText.split('\n')
   const headerRe = new RegExp(`^\\s*\\[${escapeForRegExp(sectionName)}\\]\\s*(?:#.*)?$`)
-  const anyHeaderRe = /^\s*\[[^\]]+\]\s*(?:#.*)?$/
+  const anyHeaderRe = /^\s*\[\[?[^\]]+\]\]?\s*(?:#.*)?$/
   let start = -1
   for (let index = 0; index < lines.length; index += 1) {
     if (headerRe.test(lines[index] ?? '')) {
@@ -57,6 +70,28 @@ function sectionBodyLines(sourceText: string, sectionName: string): string[] | n
     body.push(line)
   }
   return body
+}
+
+// Count `[[<section>.panels]]` array-of-tables headers — the grouped-panels
+// grammar (fusion_config.ml parse_preset). >0 means the preset defines panel
+// groups rather than a single flat `panel = [...]`.
+function countGroupedPanelTables(sourceText: string, sectionName: string): number {
+  return countArrayOfTables(sourceText, sectionName, 'panels')
+}
+
+// Count `[[<section>.judges]]` first-pass judge tables (RFC-0283 judge-of-judges).
+// A flat preset can still carry these alongside a flat meta `judge`; the count
+// lets the UI honestly note the first-pass judges rather than imply a single one.
+function countGroupedJudgeTables(sourceText: string, sectionName: string): number {
+  return countArrayOfTables(sourceText, sectionName, 'judges')
+}
+
+function countArrayOfTables(sourceText: string, sectionName: string, child: string): number {
+  const headerRe = new RegExp(
+    `^\\s*\\[\\[${escapeForRegExp(sectionName)}\\.${child}\\]\\]\\s*(?:#.*)?$`,
+    'gm',
+  )
+  return (sourceText.match(headerRe) ?? []).length
 }
 
 // Strip a surrounding TOML basic/literal quote. Preset panel/judge ids are plain
@@ -122,10 +157,35 @@ export function readFusionPresetView(sourceText: string, preset: string): Fusion
   const trimmed = preset.trim()
   if (trimmed === '') return null
   const section = presetSection(trimmed)
+
+  // Grouped grammar first: if the preset declares [[...panels]] tables, do not
+  // parse a single flat panel (a partial group would misrepresent the preset).
+  // Report the grouped shape so the UI can show a "preview unsupported" note.
+  // This also covers the backend's Conflicting_panel_grammar case (both grouped
+  // and flat present) — treated as grouped so the flat panel is never trusted.
+  const judgeGroupCount = countGroupedJudgeTables(sourceText, section)
+  const groupCount = countGroupedPanelTables(sourceText, section)
+  if (groupCount > 0) {
+    return {
+      preset: trimmed,
+      grouped: true,
+      groupCount,
+      judgeGroupCount,
+      panel: [],
+      judge: null,
+      panelTimeoutS: null,
+      judgeTimeoutS: null,
+      maxToolCallsPerPanel: null,
+    }
+  }
+
   const body = sectionBodyLines(sourceText, section)
   if (body === null) return null
   return {
     preset: trimmed,
+    grouped: false,
+    groupCount: 0,
+    judgeGroupCount,
     panel: parseStringArray(body, 'panel'),
     judge: parseScalarString(sourceText, section, KEY_JUDGE),
     panelTimeoutS: parseScalarNumber(sourceText, section, KEY_PANEL_TIMEOUT_S),

--- a/dashboard/src/lib/fusion-preset-view.ts
+++ b/dashboard/src/lib/fusion-preset-view.ts
@@ -1,0 +1,135 @@
+// Read-only view of a [fusion.presets.<preset>] table for the Settings fusion
+// section (keeper-v2 settings.jsx: trio preset lanes + timeout/max_tool_calls).
+//
+// This is a display-only reader — it never writes back, so it deliberately does
+// NOT live in fusion-settings.ts (whose line-surgical write path forbids
+// multi-line values). The preset `panel` value is a possibly multi-line TOML
+// array, which the scalar getRuntimeTomlKey helper cannot read; scalar keys
+// (judge / timeouts / max_tool_calls_per_panel) reuse getRuntimeTomlKey so the
+// section-scoping stays consistent with the rest of the runtime.toml tooling.
+//
+// The source text is the live runtime.toml already fetched by
+// FusionSettingsPanel (fetchRuntimeTomlConfig().source_text); no new endpoint or
+// projection is introduced. Absent/malformed values become null/empty rather
+// than fabricated defaults, so the UI can show "표시할 구성 없음" honestly.
+import { getRuntimeTomlKey } from './runtime-toml-config'
+
+export interface FusionPresetView {
+  readonly preset: string
+  readonly panel: readonly string[]
+  readonly judge: string | null
+  readonly panelTimeoutS: number | null
+  readonly judgeTimeoutS: number | null
+  readonly maxToolCallsPerPanel: number | null
+}
+
+const KEY_JUDGE = 'judge'
+const KEY_PANEL_TIMEOUT_S = 'panel_timeout_s'
+const KEY_JUDGE_TIMEOUT_S = 'judge_timeout_s'
+const KEY_MAX_TOOL_CALLS = 'max_tool_calls_per_panel'
+
+function presetSection(preset: string): string {
+  return `fusion.presets.${preset}`
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Body lines of a `[section]`: everything between its header and the next
+// section header (or EOF). Used only to locate the multi-line `panel` array.
+function sectionBodyLines(sourceText: string, sectionName: string): string[] | null {
+  const lines = sourceText.split('\n')
+  const headerRe = new RegExp(`^\\s*\\[${escapeForRegExp(sectionName)}\\]\\s*(?:#.*)?$`)
+  const anyHeaderRe = /^\s*\[[^\]]+\]\s*(?:#.*)?$/
+  let start = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    if (headerRe.test(lines[index] ?? '')) {
+      start = index
+      break
+    }
+  }
+  if (start === -1) return null
+  const body: string[] = []
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (anyHeaderRe.test(line)) break
+    body.push(line)
+  }
+  return body
+}
+
+// Strip a surrounding TOML basic/literal quote. Preset panel/judge ids are plain
+// identifiers (no escapes), so a quote strip is sufficient; unquoted tokens are
+// returned as-is after trimming.
+function dequote(token: string): string {
+  const trimmed = token.trim()
+  if (trimmed.length >= 2) {
+    const first = trimmed[0]
+    const last = trimmed[trimmed.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1)
+    }
+  }
+  return trimmed
+}
+
+// Parse a `key = [ "a", "b" ]` string array that may span multiple lines.
+function parseStringArray(bodyLines: string[], key: string): string[] {
+  const openRe = new RegExp(`^\\s*${escapeForRegExp(key)}\\s*=\\s*\\[`)
+  let openIndex = -1
+  for (let index = 0; index < bodyLines.length; index += 1) {
+    if (openRe.test(bodyLines[index] ?? '')) {
+      openIndex = index
+      break
+    }
+  }
+  if (openIndex === -1) return []
+
+  let collected = ''
+  for (let index = openIndex; index < bodyLines.length; index += 1) {
+    const line = bodyLines[index] ?? ''
+    collected += `${line}\n`
+    if (line.includes(']')) break
+  }
+  const openBracket = collected.indexOf('[')
+  const closeBracket = collected.lastIndexOf(']')
+  if (openBracket === -1 || closeBracket === -1 || closeBracket < openBracket) return []
+  const inner = collected.slice(openBracket + 1, closeBracket)
+  const tokens = inner.match(/"(?:[^"\\]|\\.)*"|'[^']*'/g) ?? []
+  return tokens.map(dequote).filter(value => value !== '')
+}
+
+function parseScalarString(sourceText: string, section: string, key: string): string | null {
+  const raw = getRuntimeTomlKey(sourceText, section, key)
+  if (raw === undefined) return null
+  const value = dequote(raw)
+  return value === '' ? null : value
+}
+
+function parseScalarNumber(sourceText: string, section: string, key: string): number | null {
+  const raw = getRuntimeTomlKey(sourceText, section, key)
+  if (raw === undefined) return null
+  const value = Number(raw.trim())
+  return Number.isFinite(value) ? value : null
+}
+
+/**
+ * Read the read-only view of `[fusion.presets.<preset>]` from runtime.toml text.
+ * Returns null when the preset name is empty or the section is absent.
+ */
+export function readFusionPresetView(sourceText: string, preset: string): FusionPresetView | null {
+  const trimmed = preset.trim()
+  if (trimmed === '') return null
+  const section = presetSection(trimmed)
+  const body = sectionBodyLines(sourceText, section)
+  if (body === null) return null
+  return {
+    preset: trimmed,
+    panel: parseStringArray(body, 'panel'),
+    judge: parseScalarString(sourceText, section, KEY_JUDGE),
+    panelTimeoutS: parseScalarNumber(sourceText, section, KEY_PANEL_TIMEOUT_S),
+    judgeTimeoutS: parseScalarNumber(sourceText, section, KEY_JUDGE_TIMEOUT_S),
+    maxToolCallsPerPanel: parseScalarNumber(sourceText, section, KEY_MAX_TOOL_CALLS),
+  }
+}


### PR DESCRIPTION
## 개요

Settings › fusion 섹션에 활성 프리셋 구성(panel 모델 목록 · judge · panel/judge timeout · max_tool_calls_per_panel)을 **읽기 전용**으로 표시합니다. 판정 findings의 "fusion: 프리셋 구성 read-only 표시" [M] 항목.

## 판정 충돌 재검증 (최우선)

- 다른 에이전트의 백엔드 검증: `fusion_policy` 레코드(`lib/fusion_core/fusion_policy.ml`)는 어떤 HTTP endpoint에도 structured projection이 없음 — **사실**.
- 그러나 오디트의 backing은 structured projection이 아니라 **이미 클라이언트가 fetch하는 raw `runtime.toml` 원문**입니다. `FusionSettingsPanel`이 `fetchRuntimeTomlConfig()`로 `source_text`를 로드해 state로 보관 중(`fusion-settings-panel.ts:115`). preset 구성은 그 원문의 `[fusion.presets.<preset>]` 섹션에 존재합니다.
- **실증**: 실제 `config/runtime.toml`을 파서로 파싱해 확인 — `[fusion.presets.trio]`가 panel 3모델 · judge · `panel_timeout_s=300` · `judge_timeout_s=300` · `max_tool_calls_per_panel=0`으로 정확히 파싱됨(멀티라인 프롬프트 뒤에 오는 스칼라까지 정상 발견).
- **결론**: 두 판정은 서로 다른 데이터 경로(structured JSON vs raw TOML)를 본 것으로 충돌이 아님. 표시 전용이므로 **OCaml/projection 발명 불필요** — 원문 파싱만으로 backed.

## 구현

- 신규 순수 파서 `lib/fusion-preset-view.ts`(`readFusionPresetView`): raw `runtime.toml`에서 `[fusion.presets.<preset>]`의 panel 배열(멀티라인)·judge·timeout·max_tool_calls를 파싱. 스칼라는 기존 `getRuntimeTomlKey`(섹션 스코핑 일관성) 재사용, 멀티라인 `panel` 배열은 섹션 body 스코프 파서로 처리. 부재/오류 값은 fabricate 없이 `null`/빈 배열.
  - write-path인 `fusion-settings.ts`(멀티라인 값 out-of-scope 명시)를 오염시키지 않도록 read-only 전용 별도 파일로 분리.
- `fusion-settings-panel.ts`: 로드된 `source`에서 `readFusionPresetView(source, default_preset)`로 파생해, **panel 모델이 1개 이상일 때만** read-only 카드(디자인 `settings.jsx:376-387`의 `.set-fus-preset` lanes + `.set-mcp-detail` timing)를 렌더. 편집 스칼라(enabled/default_preset/max_concurrent_panels/min_answered)는 그대로 writable.

## 함정 대응

- `settings-surface.test.ts:1059`가 live-backed writer일 때 `.set-fus-lane` 개수를 0으로 잠급니다(read-only preview 마커). preset 카드를 **panel 모델 존재 시에만** 렌더하도록 게이트해, 그 테스트의 config(trio가 `min_answered`만 있고 panel 없음)에선 카드가 안 뜨고(=lane 0 유지) 실제 config(panel 있음)에선 뜹니다. 리드의 파일(`settings-surface.ts`/`.test`, #23041)은 미접촉. 이 게이트는 UX상으로도 옳음(구성이 없는 preset의 빈 카드 노이즈 제거).

## CSS

- `.set-fus-preset`/`.set-fus-lane`/`.set-fus-lane-h`/`.set-fus-model`/`.set-sub-h`/`.set-mcp-detail`는 전부 이미 vendored(`settings-surface.css` + `keeper-v2/surfaces.css`). **CSS 변경 없음.**

## 검증

- `pnpm exec tsc --noEmit --pretty false`: **0 errors**
- `pnpm lint`: clean
- `pnpm exec vitest run` (전체): 609/610 files pass. 유일한 실패 `keeper-detail.test.ts`("monitoring error boundary")는 **pre-existing flaky** — 격리 실행 2/2 pass(각 22 tests), fusion을 import하지 않아 본 변경과 인과 관계 없음(병렬 스위트 타이밍 flake).
- 신규/갱신 테스트: `fusion-preset-view.test.ts`(멀티라인 배열·스칼라·형제 preset 스코핑·단일라인·부재키 6건), `fusion-settings-panel.test.ts`(카드 렌더 + panel 없음 게이트 3건). 기존 `settings-surface.test.ts` fusion writer 테스트 green 유지.
- 실제 `config/runtime.toml` 파싱을 별도 임시 테스트로 실증 후 제거.

## 범위 밖 (제외)

- 프리셋 편집/생성, `web_tools` 전역 토글(별도 defer 항목), `fusion_policy` structured projection 추가는 범위 밖. 이 PR은 read-only 표시만.

task: masc task-1669 하위 슬라이스

🤖 Generated with [Claude Code](https://claude.com/claude-code)
