### PR TITLE
feat(keeper): expose per-source catch-up digest coverage and dashboard warnings

### DIFF
--- a/dashboard/src/api/schemas/keeper-catchup-digest.ts
+++ b/dashboard/src/api/schemas/keeper-catchup-digest.ts
@@ -20,6 +20,7 @@ import {
   number,
   object,
   optional,
+  picklist,
   safeParse,
   string,
   type InferOutput,
@@ -72,9 +73,16 @@ const KeeperCatchupDigestLifecycleSchema = object({
   items: array(KeeperCatchupDigestLifecycleItemSchema),
 })
 
+const KeeperCatchupDigestCoverageCauseSchema = picklist([
+  'chat_page_cap',
+  'chat_retention_window',
+  'jsonl_retention_window',
+  'crash_scan_cap',
+])
+
 const KeeperCatchupDigestSourceCoverageSchema = object({
   lower_bound: boolean(),
-  reason: optional(nullable(string())),
+  causes: optional(array(KeeperCatchupDigestCoverageCauseSchema)),
 })
 
 const KeeperCatchupDigestCoverageSchema = object({
@@ -99,6 +107,7 @@ export const KeeperCatchupDigestSchema = object({
 })
 
 export type KeeperCatchupDigest = InferOutput<typeof KeeperCatchupDigestSchema>
+export type KeeperCatchupDigestCoverageCause = InferOutput<typeof KeeperCatchupDigestCoverageCauseSchema>
 export type KeeperCatchupDigestTaskItem = InferOutput<typeof KeeperCatchupDigestTaskItemSchema>
 export type KeeperCatchupDigestLifecycleItem = InferOutput<typeof KeeperCatchupDigestLifecycleItemSchema>
 

--- a/dashboard/src/api/schemas/keeper-catchup-digest.ts
+++ b/dashboard/src/api/schemas/keeper-catchup-digest.ts
@@ -72,6 +72,19 @@ const KeeperCatchupDigestLifecycleSchema = object({
   items: array(KeeperCatchupDigestLifecycleItemSchema),
 })
 
+const KeeperCatchupDigestSourceCoverageSchema = object({
+  lower_bound: boolean(),
+  reason: optional(nullable(string())),
+})
+
+const KeeperCatchupDigestCoverageSchema = object({
+  chat: KeeperCatchupDigestSourceCoverageSchema,
+  turns: KeeperCatchupDigestSourceCoverageSchema,
+  tasks: KeeperCatchupDigestSourceCoverageSchema,
+  board: KeeperCatchupDigestSourceCoverageSchema,
+  lifecycle: KeeperCatchupDigestSourceCoverageSchema,
+})
+
 export const KeeperCatchupDigestSchema = object({
   keeper: string(),
   since_unix: number(),
@@ -81,6 +94,7 @@ export const KeeperCatchupDigestSchema = object({
   tasks: KeeperCatchupDigestTasksSchema,
   board: KeeperCatchupDigestBoardSchema,
   lifecycle: KeeperCatchupDigestLifecycleSchema,
+  coverage: KeeperCatchupDigestCoverageSchema,
   read_errors: array(string()),
 })
 

--- a/dashboard/src/components/keeper-catchup-digest-card.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.ts
@@ -1,5 +1,8 @@
 import { html } from 'htm/preact'
-import type { KeeperCatchupDigest } from '../api/schemas/keeper-catchup-digest'
+import type {
+  KeeperCatchupDigest,
+  KeeperCatchupDigestCoverageCause,
+} from '../api/schemas/keeper-catchup-digest'
 import { KEEPER_DIGEST_MIN_ACTIVITY } from '../config/constants'
 
 // Total count of new activity across every category since the operator's
@@ -30,22 +33,30 @@ function coverageHasLowerBound(
   return Object.values(coverage).some(source => source.lower_bound)
 }
 
+const COVERAGE_CAUSE_LABELS: Record<KeeperCatchupDigestCoverageCause, string> = {
+  chat_page_cap: '채팅 페이지 상한에 도달',
+  chat_retention_window: '채팅 보존 기간 밖',
+  jsonl_retention_window: '보존 기간 밖',
+  crash_scan_cap: '크래시 이벤트 상한에 도달',
+}
+
 function coverageWarnings(digest: KeeperCatchupDigest): string[] {
-  const warnings: string[] = []
-  const push = (
-    label: string,
-    source: { lower_bound: boolean; reason?: string | null },
-  ) => {
-    if (source.lower_bound) {
-      warnings.push(`${label}: ${source.reason ?? '일부 누락 가능'}`)
-    }
-  }
-  push('채팅', digest.coverage.chat)
-  push('턴', digest.coverage.turns)
-  push('태스크', digest.coverage.tasks)
-  push('보드', digest.coverage.board)
-  push('일시정지/재개', digest.coverage.lifecycle)
-  return warnings
+  const sources: ReadonlyArray<readonly [
+    string,
+    KeeperCatchupDigest['coverage']['chat'],
+  ]> = [
+    ['채팅', digest.coverage.chat],
+    ['턴', digest.coverage.turns],
+    ['태스크', digest.coverage.tasks],
+    ['보드', digest.coverage.board],
+    ['일시정지/재개', digest.coverage.lifecycle],
+  ]
+  return sources
+    .filter(([, source]) => source.lower_bound)
+    .map(([label, source]) => {
+      const causeLabels = (source.causes ?? []).map(cause => COVERAGE_CAUSE_LABELS[cause])
+      return `${label}: ${causeLabels.length > 0 ? causeLabels.join(', ') : '일부 누락 가능'}`
+    })
 }
 
 // The card renders when there is genuine new activity, when a source read
@@ -97,6 +108,7 @@ function digestChips(digest: KeeperCatchupDigest): DigestChip[] {
 // server echoed — independent of the live cursor.
 export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDigest }) {
   const chips = digestChips(digest)
+  const coverageWarningItems = coverageWarnings(digest)
   return html`
     <div
       data-keeper-catchup-digest
@@ -134,10 +146,10 @@ export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDiges
             </div>
           `
         : null}
-      ${coverageWarnings(digest).length > 0
+      ${coverageWarningItems.length > 0
         ? html`
             <div class="mt-2 rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-2xs leading-relaxed text-[var(--warn-bright)]">
-              일부 저장소가 생략되어 카운트가 하한값일 수 있습니다: ${coverageWarnings(digest).join('; ')}
+              일부 저장소가 생략되어 카운트가 하한값일 수 있습니다: ${coverageWarningItems.join('; ')}
             </div>
           `
         : null}

--- a/dashboard/src/components/keeper-catchup-digest-card.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.ts
@@ -24,16 +24,40 @@ export function keeperCatchupDigestActivityCount(digest: KeeperCatchupDigest): n
   )
 }
 
-// The card renders only when there is genuine new activity, OR when a source
-// read failed (read_errors is fail-visible — the operator must know the counts
-// may be incomplete even if everything else is zero).
+function coverageHasLowerBound(
+  coverage: KeeperCatchupDigest['coverage'],
+): boolean {
+  return Object.values(coverage).some(source => source.lower_bound)
+}
+
+function coverageWarnings(digest: KeeperCatchupDigest): string[] {
+  const warnings: string[] = []
+  const push = (
+    label: string,
+    source: { lower_bound: boolean; reason?: string | null },
+  ) => {
+    if (source.lower_bound) {
+      warnings.push(`${label}: ${source.reason ?? '일부 누락 가능'}`)
+    }
+  }
+  push('채팅', digest.coverage.chat)
+  push('턴', digest.coverage.turns)
+  push('태스크', digest.coverage.tasks)
+  push('보드', digest.coverage.board)
+  push('일시정지/재개', digest.coverage.lifecycle)
+  return warnings
+}
+
+// The card renders when there is genuine new activity, when a source read
+// failed, or when a source count is a lower bound (fail-visible truncation).
 export function shouldShowKeeperCatchupDigest(
   digest: KeeperCatchupDigest | null | undefined,
 ): digest is KeeperCatchupDigest {
   if (!digest) return false
   return (
     keeperCatchupDigestActivityCount(digest) >= KEEPER_DIGEST_MIN_ACTIVITY ||
-    digest.read_errors.length > 0
+    digest.read_errors.length > 0 ||
+    coverageHasLowerBound(digest.coverage)
   )
 }
 
@@ -107,6 +131,13 @@ export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDiges
         ? html`
             <div class="mt-2 rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-2xs leading-relaxed text-[var(--warn-bright)]">
               읽기 오류 (일부 카운트가 누락됐을 수 있습니다): ${digest.read_errors.join(', ')}
+            </div>
+          `
+        : null}
+      ${coverageWarnings(digest).length > 0
+        ? html`
+            <div class="mt-2 rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-1 text-2xs leading-relaxed text-[var(--warn-bright)]">
+              일부 저장소가 생략되어 카운트가 하한값일 수 있습니다: ${coverageWarnings(digest).join('; ')}
             </div>
           `
         : null}

--- a/dashboard/src/keeper-digest-actions.test.ts
+++ b/dashboard/src/keeper-digest-actions.test.ts
@@ -21,6 +21,13 @@ function makeDigest(sinceUnix: number): KeeperCatchupDigest {
     tasks: { claimed: 0, done: 1, released: 0, cancelled: 0, items: [] },
     board: { posted: 0, commented: 0, voted: 0 },
     lifecycle: { paused_now: false, pause_events: 0, resume_events: 0, items: [] },
+    coverage: {
+      chat: { lower_bound: false, reason: null },
+      turns: { lower_bound: false, reason: null },
+      tasks: { lower_bound: false, reason: null },
+      board: { lower_bound: false, reason: null },
+      lifecycle: { lower_bound: false, reason: null },
+    },
     read_errors: [],
   }
 }

--- a/dashboard/src/keeper-digest-actions.test.ts
+++ b/dashboard/src/keeper-digest-actions.test.ts
@@ -22,11 +22,11 @@ function makeDigest(sinceUnix: number): KeeperCatchupDigest {
     board: { posted: 0, commented: 0, voted: 0 },
     lifecycle: { paused_now: false, pause_events: 0, resume_events: 0, items: [] },
     coverage: {
-      chat: { lower_bound: false, reason: null },
-      turns: { lower_bound: false, reason: null },
-      tasks: { lower_bound: false, reason: null },
-      board: { lower_bound: false, reason: null },
-      lifecycle: { lower_bound: false, reason: null },
+      chat: { lower_bound: false, causes: [] },
+      turns: { lower_bound: false, causes: [] },
+      tasks: { lower_bound: false, causes: [] },
+      board: { lower_bound: false, causes: [] },
+      lifecycle: { lower_bound: false, causes: [] },
     },
     read_errors: [],
   }

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -31,11 +31,11 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
     "items": [ { "kind": "operator_pause", "ts": 1782990000.0 } ]
   },
   "coverage": {
-    "chat": { "lower_bound": false, "reason": null },
-    "turns": { "lower_bound": false, "reason": null },
-    "tasks": { "lower_bound": false, "reason": null },
-    "board": { "lower_bound": false, "reason": null },
-    "lifecycle": { "lower_bound": false, "reason": null }
+    "chat": { "lower_bound": false, "causes": [] },
+    "turns": { "lower_bound": false, "causes": [] },
+    "tasks": { "lower_bound": false, "causes": [] },
+    "board": { "lower_bound": false, "causes": [] },
+    "lifecycle": { "lower_bound": false, "causes": [] }
   },
   "read_errors": []
 }
@@ -43,7 +43,7 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
 
 - 모든 timestamp는 unix seconds float로 정규화한다 (소스는 ISO/unix 혼재 — digest 계층에서 통일).
 - `items` 배열은 상수 cap (`digest_items_cap`, 최신순)로 제한하고, 카운트 필드는 cap과 무관한 전체 수를 담는다.
-- `coverage`: 소스별로 카운트가 하한값(lower bound)인지 명시한다. `lower_bound=true`이면 `reason`에 왜 그 소스를 모두 스캔하지 못했는지(예: page cap, scan window clamp, crash scan cap)를 담는다. 클라이언트는 이 필드로 잘린 집계를 경고 UI에 노출한다.
+- `coverage`: 소스별로 카운트가 하한값(lower bound)인지 명시한다. `lower_bound=true`이면 `causes`에 왜 그 소스를 모두 스캔하지 못했는지 machine tag를 담는다: `chat_page_cap`, `chat_retention_window`, `jsonl_retention_window`, `crash_scan_cap`. 클라이언트는 이 tag를 로컬라이즈해서 경고 UI에 노출한다.
 - `read_errors`: 소스 저장소별 읽기/파싱 실패를 문자열 목록으로 노출한다 (silent skip 금지, fail-visible). bounded scan 조기 중단은 주로 `coverage`가 담당하며, chat page cap 같은 운영자가 바로 알아야 할 경우에는 `read_errors`에도 중복 노출될 수 있다.
 
 ## Source mapping (전부 기존 저장소)
@@ -82,7 +82,7 @@ keeper identity 매칭은 `Tool_agent_timeline.identity_matches`의 3-형태 규
 ## 유의
 
 - H2 게이트웨이(`MASC_USE_H2`)가 라우트를 수동 미러링하므로 신규 경로의 이중 등록 필요 여부를 확인한다.
-- 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(30d) 프루닝 대상 — since가 보존 창보다 오래되면 카운트는 하한값이며, `coverage` 필드가 소스별로 그 사실을 명시한다.
+- 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(기본 30d) 보존 창 기준으로 집계한다 — since가 보존 창보다 오래되면 카운트는 하한값이며, `coverage` 필드가 소스별로 그 사실을 명시한다.
 
 ## 구현 노트 (server v1)
 

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -30,13 +30,21 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
     "pause_events": 1, "resume_events": 0,
     "items": [ { "kind": "operator_pause", "ts": 1782990000.0 } ]
   },
+  "coverage": {
+    "chat": { "lower_bound": false, "reason": null },
+    "turns": { "lower_bound": false, "reason": null },
+    "tasks": { "lower_bound": false, "reason": null },
+    "board": { "lower_bound": false, "reason": null },
+    "lifecycle": { "lower_bound": false, "reason": null }
+  },
   "read_errors": []
 }
 ```
 
 - 모든 timestamp는 unix seconds float로 정규화한다 (소스는 ISO/unix 혼재 — digest 계층에서 통일).
 - `items` 배열은 상수 cap (`digest_items_cap`, 최신순)로 제한하고, 카운트 필드는 cap과 무관한 전체 수를 담는다.
-- `read_errors`: 소스 저장소별 읽기 실패와 bounded scan 조기 중단을 문자열 목록으로 노출한다 (silent skip 금지, fail-visible).
+- `coverage`: 소스별로 카운트가 하한값(lower bound)인지 명시한다. `lower_bound=true`이면 `reason`에 왜 그 소스를 모두 스캔하지 못했는지(예: page cap, scan window clamp, crash scan cap)를 담는다. 클라이언트는 이 필드로 잘린 집계를 경고 UI에 노출한다.
+- `read_errors`: 소스 저장소별 읽기/파싱 실패를 문자열 목록으로 노출한다 (silent skip 금지, fail-visible). bounded scan 조기 중단은 주로 `coverage`가 담당하며, chat page cap 같은 운영자가 바로 알아야 할 경우에는 `read_errors`에도 중복 노출될 수 있다.
 
 ## Source mapping (전부 기존 저장소)
 
@@ -74,7 +82,7 @@ keeper identity 매칭은 `Tool_agent_timeline.identity_matches`의 3-형태 규
 ## 유의
 
 - H2 게이트웨이(`MASC_USE_H2`)가 라우트를 수동 미러링하므로 신규 경로의 이중 등록 필요 여부를 확인한다.
-- 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(30d) 프루닝 대상 — since가 보존 창보다 오래되면 카운트는 하한값이며, 응답의 `since_unix` 에코가 그 사실 판정을 클라이언트에 위임한다.
+- 모든 저장소는 `MASC_JSONL_RETENTION_DAYS`(30d) 프루닝 대상 — since가 보존 창보다 오래되면 카운트는 하한값이며, `coverage` 필드가 소스별로 그 사실을 명시한다.
 
 ## 구현 노트 (server v1)
 

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -265,13 +265,17 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
           | Keeper_chat_store.Role.Tool -> ()))
     | Some _ | None -> ()
   in
-  let rec loop before iters =
-    if iters >= chat_page_cap
+  let mark_truncated () =
+    if not !truncated
     then (
       truncated := true;
       bounded_add
         errs
         "keeper-chat: page cap reached before since_unix; chat counts are lower bounds")
+  in
+  let rec loop before iters =
+    if iters >= chat_page_cap
+    then mark_truncated ()
     else (
       let { Keeper_chat_store.messages; has_more } =
         Keeper_chat_store.load_page ~base_dir ~keeper_name ?before ()
@@ -287,6 +291,7 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
           messages
       in
       match oldest with
+      | Some o when o > since && iters + 1 >= chat_page_cap -> mark_truncated ()
       | Some o when o > since && has_more -> loop (Some o) (iters + 1)
       | Some _ | None -> ())
   in
@@ -485,9 +490,15 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       false
   in
   let coverage =
-    let day_reason = Some "scan window clamped to 40 days" in
-    let chat_reason = Some "chat page cap reached before since_unix" in
-    let crash_reason = Some "crash scan capped at 500 events" in
+    let day_reason =
+      Some (Printf.sprintf "scan window clamped to %d days" max_scan_days)
+    in
+    let chat_reason =
+      Some (Printf.sprintf "chat page cap (%d pages) reached before since_unix" chat_page_cap)
+    in
+    let crash_reason =
+      Some (Printf.sprintf "crash scan capped at %d events" crash_scan_max)
+    in
     { chat =
         { lower_bound = chat_truncated
         ; reason = if chat_truncated then chat_reason else None
@@ -496,7 +507,12 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
         { lower_bound = turns_day_truncated || crash_truncated
         ; reason =
             (match turns_day_truncated, crash_truncated with
-             | true, true -> Some "turn scan window clamped and crash scan capped"
+             | true, true ->
+               Some
+                 (Printf.sprintf
+                    "turn scan window clamped to %d days and crash scan capped at %d events"
+                    max_scan_days
+                    crash_scan_max)
              | true, false -> day_reason
              | false, true -> crash_reason
              | false, false -> None)

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -88,6 +88,19 @@ type lifecycle =
   ; items : lifecycle_item list
   }
 
+type source_coverage =
+  { lower_bound : bool
+  ; reason : string option
+  }
+
+type coverage =
+  { chat : source_coverage
+  ; turns : source_coverage
+  ; tasks : source_coverage
+  ; board : source_coverage
+  ; lifecycle : source_coverage
+  }
+
 type t =
   { keeper : string
   ; since_unix : float
@@ -97,6 +110,7 @@ type t =
   ; tasks : tasks
   ; board : board
   ; lifecycle : lifecycle
+  ; coverage : coverage
   ; read_errors : string list
   }
 
@@ -186,7 +200,7 @@ let read_jsonl_file ~errs ~label ~path ~f =
    epoch is UTC midnight. *)
 let fold_day_partitioned ~errs ~label ~dir ~since_unix ~now_unix ~f =
   let day_seconds = 86400. in
-  let start_unix =
+  let clamped_since =
     Float.max since_unix (now_unix -. (float_of_int max_scan_days *. day_seconds))
   in
   let day_index ts = int_of_float (Float.floor (ts /. day_seconds)) in
@@ -201,12 +215,13 @@ let fold_day_partitioned ~errs ~label ~dir ~since_unix ~now_unix ~f =
          (tm.Unix.tm_mon + 1)
          tm.Unix.tm_mday)
   in
-  let start_day = day_index start_unix in
+  let start_day = day_index clamped_since in
   let end_day = day_index now_unix in
   for d = start_day to end_day do
     let path = path_of_day d in
     if Sys.file_exists path then read_jsonl_file ~errs ~label ~path ~f
-  done
+  done;
+  clamped_since > since_unix
 ;;
 
 (* ── Chat (single per-keeper append-ordered file) ────────────────── *)
@@ -231,6 +246,7 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
   let new_messages = ref 0 in
   let transport = ref 0 in
   let first_new = ref None in
+  let truncated = ref false in
   let note_first ts =
     first_new
       := Some (match !first_new with Some f -> Float.min f ts | None -> ts)
@@ -251,10 +267,11 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
   in
   let rec loop before iters =
     if iters >= chat_page_cap
-    then
+    then (
+      truncated := true;
       bounded_add
         errs
-        "keeper-chat: page cap reached before since_unix; chat counts are lower bounds"
+        "keeper-chat: page cap reached before since_unix; chat counts are lower bounds")
     else (
       let { Keeper_chat_store.messages; has_more } =
         Keeper_chat_store.load_page ~base_dir ~keeper_name ?before ()
@@ -274,10 +291,11 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
       | Some _ | None -> ())
   in
   loop None 0;
-  { new_messages = !new_messages
-  ; first_new_ts = !first_new
-  ; transport_failures = !transport
-  }
+  ( { new_messages = !new_messages
+    ; first_new_ts = !first_new
+    ; transport_failures = !transport
+    }
+  , !truncated )
 ;;
 
 (* ── Aggregation ─────────────────────────────────────────────────── *)
@@ -295,62 +313,73 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       (Common.keeper_runtime_store_dirname store)
   in
   (* chat *)
-  let chat = read_chat ~base_dir:base_path ~keeper_name ~since:since_unix ~errs in
+  let chat, chat_truncated =
+    read_chat ~base_dir:base_path ~keeper_name ~since:since_unix ~errs
+  in
   (* turns.completed — keeper-local turn-records *)
   let completed = ref 0 in
-  fold_day_partitioned
-    ~errs
-    ~label:"turn-records"
-    ~dir:(keeper_local Common.Keeper_turn_records)
-    ~since_unix
-    ~now_unix
-    ~f:(fun json ->
-      match json_num_field "ts" json with
-      | Some ts when ts > since_unix -> incr completed
-      | _ -> ());
+  let turns_day_truncated =
+    fold_day_partitioned
+      ~errs
+      ~label:"turn-records"
+      ~dir:(keeper_local Common.Keeper_turn_records)
+      ~since_unix
+      ~now_unix
+      ~f:(fun json ->
+        match json_num_field "ts" json with
+        | Some ts when ts > since_unix -> incr completed
+        | _ -> ())
+  in
   (* turns.crashes — Keeper_crash_persistence exposes the crash-events reader,
      so use it rather than re-spelling that store's path. *)
   let crashes = ref 0 in
-  Keeper_crash_persistence.recent_crashes
-    ~keepers_dir
-    ~name:keeper_name
-    ~max_entries:crash_scan_max
-  |> List.iter (fun json ->
-    match json_num_field "ts" json with
-    | Some ts when ts > since_unix -> incr crashes
-    | _ -> ());
+  let crash_entries =
+    Keeper_crash_persistence.recent_crashes
+      ~keepers_dir
+      ~name:keeper_name
+      ~max_entries:crash_scan_max
+  in
+  let crash_truncated = List.length crash_entries >= crash_scan_max in
+  List.iter
+    (fun json ->
+      match json_num_field "ts" json with
+      | Some ts when ts > since_unix -> incr crashes
+      | _ -> ())
+    crash_entries;
   (* turns.failed + board — one pass over activity-events *)
   let failed = ref 0 in
   let posted = ref 0 in
   let commented = ref 0 in
   let voted = ref 0 in
   let since_ms = since_unix *. 1000. in
-  fold_day_partitioned
-    ~errs
-    ~label:"activity-events"
-    ~dir:(Filename.concat masc_dir activity_events_dirname)
-    ~since_unix
-    ~now_unix
-    ~f:(fun json ->
-      match Activity_graph.event_of_yojson json with
-      | None -> ()
-      | Some ({ kind; ts_ms; actor; payload; _ } : Activity_graph.event) ->
-        let actor_match =
-          match actor with
-          | Some ({ id; _ } : Activity_graph.entity_ref) -> identity_of id
-          | None -> false
-        in
-        if float_of_int ts_ms > since_ms
-           && (actor_match || payload_identity_match ~identity_of payload)
-        then
-          if String.equal kind keeper_turn_failed_kind
-          then incr failed
-          else if String.equal kind Event_kind.Board.(to_string Posted)
-          then incr posted
-          else if String.equal kind Event_kind.Board.(to_string Commented)
-          then incr commented
-          else if String.equal kind Event_kind.Board.(to_string Voted)
-          then incr voted);
+  let activity_truncated =
+    fold_day_partitioned
+      ~errs
+      ~label:"activity-events"
+      ~dir:(Filename.concat masc_dir activity_events_dirname)
+      ~since_unix
+      ~now_unix
+      ~f:(fun json ->
+        match Activity_graph.event_of_yojson json with
+        | None -> ()
+        | Some ({ kind; ts_ms; actor; payload; _ } : Activity_graph.event) ->
+          let actor_match =
+            match actor with
+            | Some ({ id; _ } : Activity_graph.entity_ref) -> identity_of id
+            | None -> false
+          in
+          if float_of_int ts_ms > since_ms
+             && (actor_match || payload_identity_match ~identity_of payload)
+          then
+            if String.equal kind keeper_turn_failed_kind
+            then incr failed
+            else if String.equal kind Event_kind.Board.(to_string Posted)
+            then incr posted
+            else if String.equal kind Event_kind.Board.(to_string Commented)
+            then incr commented
+            else if String.equal kind Event_kind.Board.(to_string Voted)
+            then incr voted)
+  in
   (* tasks — Audit_log owns the .masc/audit schema; parse each row through its
      typed decoder so the transition class comes from the [action] variant,
      not a local string classifier. *)
@@ -359,56 +388,58 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
   let released = ref 0 in
   let cancelled = ref 0 in
   let task_items = ref [] in
-  fold_day_partitioned
-    ~errs
-    ~label:"audit"
-    ~dir:(Filename.concat masc_dir audit_dirname)
-    ~since_unix
-    ~now_unix
-    ~f:(fun json ->
-      match Audit_log.entry_of_json_r json with
-      | Error _ ->
-        (* Valid JSON that is not an audit entry (e.g. a foreign row); the
-           true parse-failure path is handled inside [read_jsonl_file]. *)
-        ()
-      | Ok ({ timestamp; agent_id; action; details; _ } : Audit_log.audit_entry)
-        ->
-        if timestamp > since_unix && identity_of agent_id
-        then (
-          let record transition =
-            match task_id_of_audit_details ~errs details with
-            | Some task_id ->
-              task_items := { task_id; transition; ts = timestamp } :: !task_items
-            | None -> ()
-          in
-          match action with
-          | Audit_log.ClaimTask ->
-            incr claimed;
-            record "claim"
-          | Audit_log.DoneTask ->
-            incr done_;
-            record "done"
-          | Audit_log.ReleaseTask ->
-            incr released;
-            record "release"
-          | Audit_log.CancelTask ->
-            incr cancelled;
-            record "cancel"
-          | Audit_log.StartTask -> record "start"
-          (* Non-task audit actions are not task transitions. Enumerated (no
-             catch-all) so a new task-relevant action fails compile here. *)
-          | Audit_log.Broadcast
-          | Audit_log.Suspend
-          | Audit_log.ToolCall _
-          | Audit_log.AuthSuccess
-          | Audit_log.AuthFailure
-          | Audit_log.CircuitOpen
-          | Audit_log.CircuitClose
-          | Audit_log.SearchRefinement
-          | Audit_log.GovernanceDecision _
-          | Audit_log.RuntimeConfigWrite
-          | Audit_log.Custom _
-          | Audit_log.Unknown _ -> ()));
+  let audit_truncated =
+    fold_day_partitioned
+      ~errs
+      ~label:"audit"
+      ~dir:(Filename.concat masc_dir audit_dirname)
+      ~since_unix
+      ~now_unix
+      ~f:(fun json ->
+        match Audit_log.entry_of_json_r json with
+        | Error _ ->
+          (* Valid JSON that is not an audit entry (e.g. a foreign row); the
+             true parse-failure path is handled inside [read_jsonl_file]. *)
+          ()
+        | Ok ({ timestamp; agent_id; action; details; _ } : Audit_log.audit_entry)
+          ->
+          if timestamp > since_unix && identity_of agent_id
+          then (
+            let record transition =
+              match task_id_of_audit_details ~errs details with
+              | Some task_id ->
+                task_items := { task_id; transition; ts = timestamp } :: !task_items
+              | None -> ()
+            in
+            match action with
+            | Audit_log.ClaimTask ->
+              incr claimed;
+              record "claim"
+            | Audit_log.DoneTask ->
+              incr done_;
+              record "done"
+            | Audit_log.ReleaseTask ->
+              incr released;
+              record "release"
+            | Audit_log.CancelTask ->
+              incr cancelled;
+              record "cancel"
+            | Audit_log.StartTask -> record "start"
+            (* Non-task audit actions are not task transitions. Enumerated (no
+               catch-all) so a new task-relevant action fails compile here. *)
+            | Audit_log.Broadcast
+            | Audit_log.Suspend
+            | Audit_log.ToolCall _
+            | Audit_log.AuthSuccess
+            | Audit_log.AuthFailure
+            | Audit_log.CircuitOpen
+            | Audit_log.CircuitClose
+            | Audit_log.SearchRefinement
+            | Audit_log.GovernanceDecision _
+            | Audit_log.RuntimeConfigWrite
+            | Audit_log.Custom _
+            | Audit_log.Unknown _ -> ()))
+  in
   (* lifecycle — durable transition-audit operator_pause/operator_resume +
      current paused state from meta. The durable store survives a keeper
      restart, which the in-memory ring (the recent_transitions API) does not,
@@ -416,32 +447,34 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
   let pause_events = ref 0 in
   let resume_events = ref 0 in
   let life_items = ref [] in
-  fold_day_partitioned
-    ~errs
-    ~label:"transition-audit"
-    ~dir:(Filename.concat masc_dir transition_audit_dirname)
-    ~since_unix
-    ~now_unix
-    ~f:(fun json ->
-      match
-        Safe_ops.json_string_opt "keeper" json, Safe_ops.json_member_opt "record" json
-      with
-      | Some k, Some record when identity_of k ->
-        (match
-           Safe_ops.json_string_opt "event_type" record
-         , json_num_field "wall_clock_at_decision" record
-         with
-         | Some event_type, Some ts when ts > since_unix ->
-           if String.equal event_type operator_pause_event
-           then (
-             incr pause_events;
-             life_items := { kind = event_type; ts } :: !life_items)
-           else if String.equal event_type operator_resume_event
-           then (
-             incr resume_events;
-             life_items := { kind = event_type; ts } :: !life_items)
-         | _ -> ())
-      | _ -> ());
+  let transition_truncated =
+    fold_day_partitioned
+      ~errs
+      ~label:"transition-audit"
+      ~dir:(Filename.concat masc_dir transition_audit_dirname)
+      ~since_unix
+      ~now_unix
+      ~f:(fun json ->
+        match
+          Safe_ops.json_string_opt "keeper" json, Safe_ops.json_member_opt "record" json
+        with
+        | Some k, Some record when identity_of k ->
+          (match
+             Safe_ops.json_string_opt "event_type" record
+           , json_num_field "wall_clock_at_decision" record
+           with
+           | Some event_type, Some ts when ts > since_unix ->
+             if String.equal event_type operator_pause_event
+             then (
+               incr pause_events;
+               life_items := { kind = event_type; ts } :: !life_items)
+             else if String.equal event_type operator_resume_event
+             then (
+               incr resume_events;
+               life_items := { kind = event_type; ts } :: !life_items)
+           | _ -> ())
+        | _ -> ())
+  in
   let paused_now =
     let meta_path = Filename.concat keepers_dir (keeper_name ^ ".json") in
     match Keeper_meta_store.read_meta_file_path meta_path with
@@ -450,6 +483,37 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
     | Error e ->
       bounded_add errs (Printf.sprintf "keeper-meta: %s: %s" meta_path e);
       false
+  in
+  let coverage =
+    let day_reason = Some "scan window clamped to 40 days" in
+    let chat_reason = Some "chat page cap reached before since_unix" in
+    let crash_reason = Some "crash scan capped at 500 events" in
+    { chat =
+        { lower_bound = chat_truncated
+        ; reason = if chat_truncated then chat_reason else None
+        }
+    ; turns =
+        { lower_bound = turns_day_truncated || crash_truncated
+        ; reason =
+            (match turns_day_truncated, crash_truncated with
+             | true, true -> Some "turn scan window clamped and crash scan capped"
+             | true, false -> day_reason
+             | false, true -> crash_reason
+             | false, false -> None)
+        }
+    ; tasks =
+        { lower_bound = audit_truncated
+        ; reason = if audit_truncated then day_reason else None
+        }
+    ; board =
+        { lower_bound = activity_truncated
+        ; reason = if activity_truncated then day_reason else None
+        }
+    ; lifecycle =
+        { lower_bound = transition_truncated
+        ; reason = if transition_truncated then day_reason else None
+        }
+    }
   in
   { keeper = keeper_name
   ; since_unix
@@ -470,6 +534,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ; resume_events = !resume_events
       ; items = cap_lifecycle_items !life_items
       }
+  ; coverage
   ; read_errors = List.rev !errs
   }
 ;;
@@ -491,6 +556,23 @@ let task_item_to_json (i : task_item) =
 
 let lifecycle_item_to_json (i : lifecycle_item) =
   `Assoc [ "kind", `String i.kind; "ts", `Float i.ts ]
+;;
+
+let source_coverage_to_json (c : source_coverage) : Yojson.Safe.t =
+  `Assoc
+    [ "lower_bound", `Bool c.lower_bound
+    ; "reason", (match c.reason with Some r -> `String r | None -> `Null)
+    ]
+;;
+
+let coverage_to_json (c : coverage) : Yojson.Safe.t =
+  `Assoc
+    [ "chat", source_coverage_to_json c.chat
+    ; "turns", source_coverage_to_json c.turns
+    ; "tasks", source_coverage_to_json c.tasks
+    ; "board", source_coverage_to_json c.board
+    ; "lifecycle", source_coverage_to_json c.lifecycle
+    ]
 ;;
 
 let to_json (t : t) : Yojson.Safe.t =
@@ -531,6 +613,7 @@ let to_json (t : t) : Yojson.Safe.t =
           ; "resume_events", `Int t.lifecycle.resume_events
           ; "items", `List (List.map lifecycle_item_to_json t.lifecycle.items)
           ] )
+    ; "coverage", coverage_to_json t.coverage
     ; "read_errors", `List (List.map (fun s -> `String s) t.read_errors)
     ]
 ;;

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -8,11 +8,21 @@ let digest_items_cap = 20
    payload out without limit; the digest reports at most this many failures. *)
 let read_errors_cap = 50
 
-(* Retention SSOT is MASC_JSONL_RETENTION_DAYS (default 30d); look-back is
-   clamped to this window plus slack so a far-past cursor cannot fan the
-   day-file scan out unboundedly. Beyond it the counts are a lower bound and
-   the echoed [since_unix] lets the client detect it. *)
-let max_scan_days = 40
+let jsonl_retention_env = "MASC_JSONL_RETENTION_DAYS"
+let default_jsonl_retention_days = 30
+
+(* Retention SSOT is MASC_JSONL_RETENTION_DAYS, read the same way as startup
+   and periodic pruning. The digest still uses the default when pruning is
+   disabled with a non-positive value; otherwise an old cursor could trigger
+   an unbounded synchronous scan from a dashboard read. *)
+let jsonl_retention_scan_days () =
+  let days =
+    Safe_ops.get_env_int_logged
+      jsonl_retention_env
+      ~default:default_jsonl_retention_days
+  in
+  if days > 0 then days else default_jsonl_retention_days
+;;
 
 (* Termination guard for the backward chat paging loop: each page walks at
    most one [Keeper_chat_store] window older, so this bounds the walk. *)
@@ -88,9 +98,15 @@ type lifecycle =
   ; items : lifecycle_item list
   }
 
+type truncation_cause =
+  | Chat_page_cap
+  | Chat_retention_window
+  | Jsonl_retention_window
+  | Crash_scan_cap
+
 type source_coverage =
   { lower_bound : bool
-  ; reason : string option
+  ; causes : truncation_cause list
   }
 
 type coverage =
@@ -194,14 +210,14 @@ let read_jsonl_file ~errs ~label ~path ~f =
 ;;
 
 (* Iterate day-partitioned files [dir/YYYY-MM/DD.jsonl] whose UTC day is in
-   [[since_unix, now_unix]] (look-back clamped to {!max_scan_days}). A missing
+   [[since_unix, now_unix]] (look-back clamped to [scan_days]). A missing
    day-file is zero activity, not an error. Day indexing off [ts /. 86400] is
    month/year-boundary safe because 86400 divides UTC days exactly and the
    epoch is UTC midnight. *)
-let fold_day_partitioned ~errs ~label ~dir ~since_unix ~now_unix ~f =
+let fold_day_partitioned ~errs ~label ~dir ~since_unix ~now_unix ~scan_days ~f =
   let day_seconds = 86400. in
   let clamped_since =
-    Float.max since_unix (now_unix -. (float_of_int max_scan_days *. day_seconds))
+    Float.max since_unix (now_unix -. (float_of_int scan_days *. day_seconds))
   in
   let day_index ts = int_of_float (Float.floor (ts /. day_seconds)) in
   let path_of_day d =
@@ -307,6 +323,8 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
 
 let build ~base_path ~keeper_name ~since_unix ~now_unix =
   let errs = ref [] in
+  let scan_days = jsonl_retention_scan_days () in
+  let retention_start = now_unix -. (float_of_int scan_days *. Masc_time_constants.day) in
   let identity_of candidate =
     Tool_agent_timeline.identity_matches ~agent_name:keeper_name candidate
   in
@@ -321,6 +339,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
   let chat, chat_truncated =
     read_chat ~base_dir:base_path ~keeper_name ~since:since_unix ~errs
   in
+  let chat_retention_truncated = since_unix < retention_start in
   (* turns.completed — keeper-local turn-records *)
   let completed = ref 0 in
   let turns_day_truncated =
@@ -330,6 +349,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ~dir:(keeper_local Common.Keeper_turn_records)
       ~since_unix
       ~now_unix
+      ~scan_days
       ~f:(fun json ->
         match json_num_field "ts" json with
         | Some ts when ts > since_unix -> incr completed
@@ -364,6 +384,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ~dir:(Filename.concat masc_dir activity_events_dirname)
       ~since_unix
       ~now_unix
+      ~scan_days
       ~f:(fun json ->
         match Activity_graph.event_of_yojson json with
         | None -> ()
@@ -400,6 +421,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ~dir:(Filename.concat masc_dir audit_dirname)
       ~since_unix
       ~now_unix
+      ~scan_days
       ~f:(fun json ->
         match Audit_log.entry_of_json_r json with
         | Error _ ->
@@ -459,6 +481,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ~dir:(Filename.concat masc_dir transition_audit_dirname)
       ~since_unix
       ~now_unix
+      ~scan_days
       ~f:(fun json ->
         match
           Safe_ops.json_string_opt "keeper" json, Safe_ops.json_member_opt "record" json
@@ -490,45 +513,21 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       false
   in
   let coverage =
-    let day_reason =
-      Some (Printf.sprintf "scan window clamped to %d days" max_scan_days)
-    in
-    let chat_reason =
-      Some (Printf.sprintf "chat page cap (%d pages) reached before since_unix" chat_page_cap)
-    in
-    let crash_reason =
-      Some (Printf.sprintf "crash scan capped at %d events" crash_scan_max)
-    in
+    let source causes = { lower_bound = causes <> []; causes } in
     { chat =
-        { lower_bound = chat_truncated
-        ; reason = if chat_truncated then chat_reason else None
-        }
+        source
+          ((if chat_truncated then [ Chat_page_cap ] else [])
+           @ if chat_retention_truncated then [ Chat_retention_window ] else [])
     ; turns =
-        { lower_bound = turns_day_truncated || crash_truncated
-        ; reason =
-            (match turns_day_truncated, crash_truncated with
-             | true, true ->
-               Some
-                 (Printf.sprintf
-                    "turn scan window clamped to %d days and crash scan capped at %d events"
-                    max_scan_days
-                    crash_scan_max)
-             | true, false -> day_reason
-             | false, true -> crash_reason
-             | false, false -> None)
-        }
+        source
+          ((if turns_day_truncated then [ Jsonl_retention_window ] else [])
+           @ if crash_truncated then [ Crash_scan_cap ] else [])
     ; tasks =
-        { lower_bound = audit_truncated
-        ; reason = if audit_truncated then day_reason else None
-        }
+        source (if audit_truncated then [ Jsonl_retention_window ] else [])
     ; board =
-        { lower_bound = activity_truncated
-        ; reason = if activity_truncated then day_reason else None
-        }
+        source (if activity_truncated then [ Jsonl_retention_window ] else [])
     ; lifecycle =
-        { lower_bound = transition_truncated
-        ; reason = if transition_truncated then day_reason else None
-        }
+        source (if transition_truncated then [ Jsonl_retention_window ] else [])
     }
   in
   { keeper = keeper_name
@@ -574,10 +573,17 @@ let lifecycle_item_to_json (i : lifecycle_item) =
   `Assoc [ "kind", `String i.kind; "ts", `Float i.ts ]
 ;;
 
+let truncation_cause_to_wire = function
+  | Chat_page_cap -> "chat_page_cap"
+  | Chat_retention_window -> "chat_retention_window"
+  | Jsonl_retention_window -> "jsonl_retention_window"
+  | Crash_scan_cap -> "crash_scan_cap"
+;;
+
 let source_coverage_to_json (c : source_coverage) : Yojson.Safe.t =
   `Assoc
     [ "lower_bound", `Bool c.lower_bound
-    ; "reason", (match c.reason with Some r -> `String r | None -> `Null)
+    ; "causes", `List (List.map (fun c -> `String (truncation_cause_to_wire c)) c.causes)
     ]
 ;;
 

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -62,6 +62,23 @@ type lifecycle =
   ; items : lifecycle_item list
   }
 
+type source_coverage =
+  { lower_bound : bool
+  ; reason : string option
+  }
+
+(** Per-source coverage flags. A [lower_bound = true] means the corresponding
+    count may be incomplete because scanning stopped before the requested
+    [since_unix] (e.g. page cap or look-back window clamp). [reason] is present
+    when the count is a lower bound and absent otherwise. *)
+type coverage =
+  { chat : source_coverage
+  ; turns : source_coverage
+  ; tasks : source_coverage
+  ; board : source_coverage
+  ; lifecycle : source_coverage
+  }
+
 type t =
   { keeper : string
   ; since_unix : float
@@ -71,6 +88,7 @@ type t =
   ; tasks : tasks
   ; board : board
   ; lifecycle : lifecycle
+  ; coverage : coverage
   ; read_errors : string list
   }
 
@@ -103,6 +121,7 @@ val build :
       records, plus [paused_now] from the keeper meta.
 
     Look-back is clamped to the JSONL retention window; beyond it the counts
-    are a lower bound and the echoed [since_unix] lets the client detect it.
-    Failures and bounded scans that stop before [since_unix] append to
-    [read_errors]; a missing store is zero, not a failure. *)
+    are a lower bound. The [coverage] field exposes per-source lower-bound
+    flags and reasons so the client can render truncation warnings without
+    inferring them from [since_unix]. Failures append to [read_errors]; a
+    missing store is zero, not a failure. *)

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -62,15 +62,22 @@ type lifecycle =
   ; items : lifecycle_item list
   }
 
+type truncation_cause =
+  | Chat_page_cap
+  | Chat_retention_window
+  | Jsonl_retention_window
+  | Crash_scan_cap
+
 type source_coverage =
   { lower_bound : bool
-  ; reason : string option
+  ; causes : truncation_cause list
   }
 
 (** Per-source coverage flags. A [lower_bound = true] means the corresponding
     count may be incomplete because scanning stopped before the requested
-    [since_unix] (e.g. page cap or look-back window clamp). [reason] is present
-    when the count is a lower bound and absent otherwise. *)
+    [since_unix] (e.g. page cap, retention window clamp, crash scan cap).
+    [causes] is a closed set of machine tags for the client to render without
+    parsing backend prose. *)
 type coverage =
   { chat : source_coverage
   ; turns : source_coverage
@@ -120,8 +127,9 @@ val build :
     - [lifecycle]: durable transition-audit [operator_pause]/[operator_resume]
       records, plus [paused_now] from the keeper meta.
 
-    Look-back is clamped to the JSONL retention window; beyond it the counts
-    are a lower bound. The [coverage] field exposes per-source lower-bound
-    flags and reasons so the client can render truncation warnings without
-    inferring them from [since_unix]. Failures append to [read_errors]; a
-    missing store is zero, not a failure. *)
+    Look-back is clamped to [MASC_JSONL_RETENTION_DAYS] (default 30d), matching
+    the JSONL pruning policy; beyond it the counts are a lower bound. The
+    [coverage] field exposes per-source lower-bound flags and machine-tagged
+    causes so the client can render truncation warnings without inferring them
+    from [since_unix]. Failures append to [read_errors]; a missing store is
+    zero, not a failure. *)

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -231,6 +231,7 @@ let test_counts_and_boundary () =
         ; tasks = { claimed; done_; released; cancelled; items = task_items }
         ; board = { posted; commented; voted }
         ; lifecycle = { paused_now; pause_events; resume_events; items = life_items }
+        ; coverage
         ; read_errors
         ; keeper = keeper_out
         ; since_unix = since_out
@@ -239,6 +240,11 @@ let test_counts_and_boundary () =
       =
       digest
     in
+    Alcotest.(check bool) "coverage.chat lower_bound false" false coverage.D.chat.lower_bound;
+    Alcotest.(check bool) "coverage.turns lower_bound false" false coverage.D.turns.lower_bound;
+    Alcotest.(check bool) "coverage.tasks lower_bound false" false coverage.D.tasks.lower_bound;
+    Alcotest.(check bool) "coverage.board lower_bound false" false coverage.D.board.lower_bound;
+    Alcotest.(check bool) "coverage.lifecycle lower_bound false" false coverage.D.lifecycle.lower_bound;
     Alcotest.(check string) "keeper echoed" keeper keeper_out;
     Alcotest.(check (float 0.0001)) "since echoed" since_unix since_out;
     Alcotest.(check (float 0.0001)) "now echoed" now_unix generated_at_unix;
@@ -344,13 +350,37 @@ let test_chat_page_cap_is_fail_visible () =
            ())
     done;
     let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
-    let { D.chat = { new_messages; _ }; read_errors; _ } = digest in
+    let { D.chat = { new_messages; _ }; coverage; read_errors; _ } = digest in
     Alcotest.(check bool) "chat count is a lower bound" true
       (new_messages > 0 && new_messages < total);
     Alcotest.(check bool)
-      "chat page cap is fail-visible"
+      "chat page cap is fail-visible in read_errors"
       true
-      (List.exists (str_contains ~needle:"keeper-chat: page cap reached") read_errors))
+      (List.exists (str_contains ~needle:"keeper-chat: page cap reached") read_errors);
+    Alcotest.(check bool)
+      "coverage.chat lower_bound true"
+      true
+      coverage.D.chat.lower_bound;
+    Alcotest.(check bool)
+      "coverage.chat reason present"
+      true
+      (Option.is_some coverage.D.chat.reason))
+;;
+
+let test_scan_window_clamp_is_coverage_visible () =
+  with_workspace (fun base ->
+    (* since_unix is beyond max_scan_days, so every day-partitioned source is
+       clamped even though the stores are missing (missing = zero activity). The
+       coverage flags, not read_errors, carry the truncation signal. *)
+    let since_old = now_unix -. (50. *. day) in
+    let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix:since_old ~now_unix in
+    let { D.coverage; read_errors; _ } = digest in
+    Alcotest.(check bool) "coverage.turns lower_bound true" true coverage.D.turns.lower_bound;
+    Alcotest.(check bool) "coverage.tasks lower_bound true" true coverage.D.tasks.lower_bound;
+    Alcotest.(check bool) "coverage.board lower_bound true" true coverage.D.board.lower_bound;
+    Alcotest.(check bool) "coverage.lifecycle lower_bound true" true coverage.D.lifecycle.lower_bound;
+    Alcotest.(check bool) "chat not scanned, lower_bound false" false coverage.D.chat.lower_bound;
+    Alcotest.(check bool) "no read_errors for missing stores" true (read_errors = []))
 ;;
 
 let test_task_items_are_sound_partial () =
@@ -411,6 +441,7 @@ let test_to_json_shape () =
         ; "tasks"
         ; "board"
         ; "lifecycle"
+        ; "coverage"
         ; "read_errors"
         ]
     | _ -> Alcotest.fail "to_json must be a JSON object")
@@ -424,6 +455,7 @@ let () =
         ; Alcotest.test_case "missing stores are zero, not errors" `Quick test_missing_stores_are_zero
         ; Alcotest.test_case "items cap with full counts" `Quick test_items_cap
         ; Alcotest.test_case "chat page cap is fail-visible" `Quick test_chat_page_cap_is_fail_visible
+        ; Alcotest.test_case "scan window clamp is coverage-visible" `Quick test_scan_window_clamp_is_coverage_visible
         ; Alcotest.test_case "task items are sound-partial" `Quick test_task_items_are_sound_partial
         ; Alcotest.test_case "to_json shape round-trips" `Quick test_to_json_shape
         ] )

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -57,6 +57,8 @@ let str_contains ~needle haystack =
   nl = 0 || go 0
 ;;
 
+let has_cause cause coverage = List.exists (( = ) cause) coverage.D.causes
+
 (* ── store paths (mirror Common.*_from_base_path) ────────────────── *)
 
 let masc base = Filename.concat base ".masc"
@@ -366,14 +368,14 @@ let test_chat_page_cap_is_fail_visible () =
       true
       coverage.D.chat.lower_bound;
     Alcotest.(check bool)
-      "coverage.chat reason present"
+      "coverage.chat page-cap cause present"
       true
-      (Option.is_some coverage.D.chat.reason))
+      (has_cause D.Chat_page_cap coverage.D.chat))
 ;;
 
 let test_scan_window_clamp_is_coverage_visible () =
   with_workspace (fun base ->
-    (* since_unix is beyond max_scan_days, so every day-partitioned source is
+    (* since_unix is beyond the retention scan window, so every source is
        clamped even though the stores are missing (missing = zero activity). The
        coverage flags, not read_errors, carry the truncation signal. *)
     let since_old = now_unix -. (50. *. day) in
@@ -383,7 +385,15 @@ let test_scan_window_clamp_is_coverage_visible () =
     Alcotest.(check bool) "coverage.tasks lower_bound true" true coverage.D.tasks.lower_bound;
     Alcotest.(check bool) "coverage.board lower_bound true" true coverage.D.board.lower_bound;
     Alcotest.(check bool) "coverage.lifecycle lower_bound true" true coverage.D.lifecycle.lower_bound;
-    Alcotest.(check bool) "chat not scanned, lower_bound false" false coverage.D.chat.lower_bound;
+    Alcotest.(check bool) "coverage.chat lower_bound true" true coverage.D.chat.lower_bound;
+    Alcotest.(check bool)
+      "coverage.chat carries retention-window cause"
+      true
+      (has_cause D.Chat_retention_window coverage.D.chat);
+    Alcotest.(check bool)
+      "coverage.turns carries retention-window cause"
+      true
+      (has_cause D.Jsonl_retention_window coverage.D.turns);
     Alcotest.(check bool) "no read_errors for missing stores" true (read_errors = []))
 ;;
 
@@ -448,6 +458,17 @@ let test_to_json_shape () =
         ; "coverage"
         ; "read_errors"
         ]
+      ;
+      (match List.assoc_opt "coverage" fields with
+       | Some (`Assoc coverage_fields) ->
+         (match List.assoc_opt "chat" coverage_fields with
+          | Some (`Assoc chat_fields) ->
+            Alcotest.(check bool)
+              "coverage.chat causes present"
+              true
+              (List.mem_assoc "causes" chat_fields)
+          | _ -> Alcotest.fail "coverage.chat must be an object")
+       | _ -> Alcotest.fail "coverage must be an object")
     | _ -> Alcotest.fail "to_json must be a JSON object")
 ;;
 

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -74,8 +74,8 @@ let meta_file base = Filename.concat (keepers base) (keeper ^ ".json")
 
 let json_line j = Yojson.Safe.to_string j
 
-let chat_row ?id ?kind ~role ~ts () =
-  let base = [ "role", `String role; "content", `String "x"; "ts", `Float ts ] in
+let chat_row ?id ?kind ?(content = "x") ~role ~ts () =
+  let base = [ "role", `String role; "content", `String content; "ts", `Float ts ] in
   let base = match id with Some i -> ("id", `String i) :: base | None -> base in
   let base = match kind with Some k -> ("kind", `String k) :: base | None -> base in
   json_line (`Assoc base)
@@ -339,6 +339,9 @@ let test_items_cap () =
 let test_chat_page_cap_is_fail_visible () =
   with_workspace (fun base ->
     let total = 20_001 in
+    (* Pad each row so the chat file exceeds the store's tail-read window;
+       otherwise a small file may return has_more=false before the page cap. *)
+    let padding = String.make 400 'x' in
     let cf = chat_file base in
     for i = 1 to total do
       append_line
@@ -346,6 +349,7 @@ let test_chat_page_cap_is_fail_visible () =
         (chat_row
            ~id:(Printf.sprintf "chat-%05d" i)
            ~role:"user"
+           ~content:padding
            ~ts:(since_unix +. float_of_int i)
            ())
     done;


### PR DESCRIPTION
Follow-up to #23013 review: makes bounded-scan truncation fail-visible per source.\n\n- Wire: add `coverage` object to digest JSON (chat/turns/tasks/board/lifecycle lower_bound + reason).\n- Dashboard: update schema, render truncation warnings, show card on lower-bound coverage.\n- Tests: coverage assertions for normal, chat-page-cap, and scan-window-clamp cases.\n- Docs: update wire contract in keeper-catchup-digest.md.\n\nThe original #23013 endpoint already validates keeper names with `Keeper_config.validate_name`; this change addresses the remaining per-source coverage visibility request.