### PR TITLE
docs(release): 0.19.55 version-truth 정합 (CHANGELOG/ROADMAP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+## [0.19.55] - 2026-07-03
+
 ### Changed
+- Bump OAS agent_sdk pin to v0.208.14 (#23054) and bump masc version to
+  0.19.55, following the v0.208.13 pin (#22950) that carried the 0.208.13
+  release line.
 - Bump OAS agent_sdk pin to v0.208.12 (`2f3d6846`), carrying the
   default-unbounded agent turn budget release so MASC keeper/OAS runs no longer
   inherit the older finite default turn cap.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 # masc Roadmap
 
-> Current package version: v0.19.54
-> Latest changelog entry: v0.19.54 (2026-06-29)
+> Current package version: v0.19.55
+> Latest changelog entry: v0.19.55 (2026-07-03)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
-> Updated: 2026-06-29
+> Updated: 2026-07-03
 
 This roadmap is the 6-8 week operating view for `masc`. It is a planning document, not a release promise.
 For the product scope and GitHub planning model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,10 +9,10 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.54
-> Latest changelog entry: v0.19.54 (2026-06-29)
+> Current package version: v0.19.55
+> Latest changelog entry: v0.19.55 (2026-07-03)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
-> Updated: 2026-06-29
+> Updated: 2026-07-03
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only workspace collaboration hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -10,8 +10,8 @@ code_refs:
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-06-29
-> Snapshot baseline: `dune-project` version `0.19.54`
+> Last Updated: 2026-07-03
+> Snapshot baseline: `dune-project` version `0.19.55`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 Keeper/MCP client가 동일 workspace에서 작업할 때 필요한 조율과 관찰성을 제공한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper turn, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 


### PR DESCRIPTION
## 문제

#23054가 dune-project만 0.19.55로 bump하고 CHANGELOG 릴리즈 절과 ROADMAP 버전 라인을 갱신하지 않아, **모든 PR의 Meta Guards(version truth check)가 실패**하고 있습니다 (`dune-project (0.19.55) != ROADMAP current package version (0.19.54)`). 브랜치 갱신으로는 해소되지 않는 main-side drift입니다.

## 수정

- CHANGELOG: Unreleased 항목들을 `## [0.19.55] - 2026-07-03`로 승격하고 트리거였던 v0.208.13(#22950)/v0.208.14(#23054) pin bump 항목 추가.
- ROADMAP: Current package version/Latest changelog entry → v0.19.55, Updated → 2026-07-03. (Latest published GitHub release는 실제 릴리즈 전이라 v0.19.51 유지.)

## 검증

`bash scripts/check-version-truth.sh` → `Version truth OK: package=0.19.55 changelog_entry=0.19.55 published_release=0.19.51`

**이 PR이 머지되어야 현재 열린 PR들의 Meta Guards가 뚫립니다** — 우선 머지 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)