### PR TITLE
perf(ide): segment rotation + tail-read for event store

### DIFF
--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -13,10 +13,12 @@
   ide_command_descriptor
   ide_bridge
   ide_event_types
+  ide_ingest_queue
   ide_paths
   ide_region_tracker)
  (libraries
   unix
+  eio
   mtime
   mtime.clock.os
   yojson

--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -22,6 +22,7 @@
   yojson
   uuidm
   fs_compat
+  masc.dated_jsonl
   masc.command_descriptor
   masc.agent_observation
   masc.masc_exec))

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -984,39 +984,50 @@ let ingest_pr_event_from_hook
     ~success:(explicit_tool_success_from_output output_text)
 
 let install_agent_observation_sinks () =
+  (* tool/pr/turn sinks fire on the keeper turn fiber (main Eio domain). Their
+     bodies parse tool output (Yojson) and append JSONL — synchronous I/O that
+     stalls the fleet under load. Defer that work to the ingestion writer fiber
+     via [Ide_ingest_queue.submit]: the hot path only allocates a closure and
+     enqueues; the parse+append run off-domain. When no writer is installed
+     (tests, pre-bootstrap) [submit] runs inline, preserving prior behavior.
+     write_region and annotation sinks stay synchronous — annotation returns a
+     Result the caller consumes, so it cannot be deferred. *)
   Agent_observation.register_tool_event_sink
     (fun (event : Agent_observation.tool_event) ->
-      ingest_tool_event_from_hook
-        ~base_path:event.base_path
-        ~tool_name:event.tool_name
-        ~keeper_id:event.keeper_id
-        ~turn_id:event.turn_id
-        ~outcome:event.outcome
-        ~typed_outcome_str:event.typed_outcome
-        ~duration_ms:event.duration_ms
-        ~output_text:event.output_text
-        ~input:event.input);
+      Ide_ingest_queue.submit (fun () ->
+        ingest_tool_event_from_hook
+          ~base_path:event.base_path
+          ~tool_name:event.tool_name
+          ~keeper_id:event.keeper_id
+          ~turn_id:event.turn_id
+          ~outcome:event.outcome
+          ~typed_outcome_str:event.typed_outcome
+          ~duration_ms:event.duration_ms
+          ~output_text:event.output_text
+          ~input:event.input));
   Agent_observation.register_pr_event_sink
     (fun (event : Agent_observation.pr_event) ->
-      ingest_pr_event_from_descriptor
-        ~base_path:event.base_path
-        ~keeper_id:event.keeper_id
-        ~turn_id:event.turn_id
-        ~output_text:event.output_text
-        ~tool_name:event.tool_name
-        ~success:event.success);
+      Ide_ingest_queue.submit (fun () ->
+        ingest_pr_event_from_descriptor
+          ~base_path:event.base_path
+          ~keeper_id:event.keeper_id
+          ~turn_id:event.turn_id
+          ~output_text:event.output_text
+          ~tool_name:event.tool_name
+          ~success:event.success));
   Agent_observation.register_turn_event_sink
     (fun (event : Agent_observation.turn_event) ->
-      ingest_turn_event
-        ~base_path:event.base_path
-        ~turn_id:event.turn_id
-        ~keeper_id:event.keeper_id
-        ~phase:event.phase
-        ~model_used:event.model_used
-        ~tools_used:event.tools_used
-        ~stop_reason:event.stop_reason
-        ~duration_ms:event.duration_ms
-        ~timestamp_ms:event.timestamp_ms);
+      Ide_ingest_queue.submit (fun () ->
+        ingest_turn_event
+          ~base_path:event.base_path
+          ~turn_id:event.turn_id
+          ~keeper_id:event.keeper_id
+          ~phase:event.phase
+          ~model_used:event.model_used
+          ~tools_used:event.tools_used
+          ~stop_reason:event.stop_reason
+          ~duration_ms:event.duration_ms
+          ~timestamp_ms:event.timestamp_ms));
   Agent_observation.register_write_region_sink
     (fun (event : Agent_observation.write_region_event) ->
       Ide_region_tracker.ingest_tool_call

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -37,18 +37,145 @@ let event_kind_of_event = function
   | Pr_event _ -> Pr
 ;;
 
+(* ── Segment rotation + tail-read (IDE Observation Plane v2 A2/A3) ───────
+   The event store was a single append-only [<kind>_events.jsonl] with no
+   rotation, so it grew without bound (~4.2 MB/day) and every read folded
+   the whole file (a live 143 MB tool_events.jsonl stalled the main Eio
+   domain for ~2 s per read). We keep the flat filename as the live segment
+   and rotate it to numbered archives [<kind>_events.jsonl.<n>] (higher [n]
+   = more recent rotation); reads tail the newest segment(s) only.
+
+   Size-based rotation on the flat layout is chosen over date-sharding
+   because it keeps the live filename stable (existing readers/tests still
+   observe [<kind>_events.jsonl]) and because the pre-existing oversized
+   file is rotated out on its first oversized append and then ages off
+   under retention — no separate migration of legacy data is needed. *)
+
+let default_max_segment_bytes = 32 * 1024 * 1024
+
+(* Retain this many archived segments beyond the live one; older archives
+   are pruned. Segment-count (not byte-budget) retention keeps rotation
+   math trivial and lets a legacy oversized segment age out over N
+   rotations rather than persisting forever. *)
+let default_max_retained_segments = 8
+
+(* Filtered ([keeper_id]) reads scan a bounded tail window instead of the
+   whole store, so a specific keeper's events are surfaced only from the
+   recent window. This is the deliberate A3 bound: an observation panel
+   shows recent activity, not an exhaustive history scan. Unfiltered reads
+   only ever need [offset + limit] rows. *)
+let max_keeper_filter_scan_lines = 1000
+
+let segment_index_of_name ~live_basename name =
+  let prefix = live_basename ^ "." in
+  let plen = String.length prefix in
+  if String.length name > plen && String.sub name 0 plen = prefix
+  then int_of_string_opt (String.sub name plen (String.length name - plen))
+  else None
+;;
+
+let archive_indices ~path =
+  let dir = Filename.dirname path in
+  let live_basename = Filename.basename path in
+  match Sys.readdir dir with
+  | exception Sys_error _ -> []
+  | entries ->
+    Array.to_list entries
+    |> List.filter_map (fun name -> segment_index_of_name ~live_basename name)
+;;
+
+let archive_path ~path index = Printf.sprintf "%s.%d" path index
+
+(* Rotate the live segment out when it is at or above [max_segment_bytes].
+   The new archive index is [max existing + 1], so a concurrent rotation
+   never clobbers an existing archive; [rename_if_exists] means only one of
+   two racing rotations moves the live inode (the loser sees it gone and
+   no-ops). No lock is held — correctness rests on rename atomicity plus a
+   fresh index — so this stays correct outside an Eio context (tests). *)
+let maybe_rotate ~path ~max_segment_bytes =
+  if max_segment_bytes > 0
+  then (
+    match Fs_compat.file_size path with
+    | Some size when size >= max_segment_bytes ->
+      let next = 1 + List.fold_left max 0 (archive_indices ~path) in
+      ignore
+        (Fs_compat.rename_if_exists ~src:path ~dst:(archive_path ~path next) : bool)
+    | Some _ | None -> ())
+;;
+
+(* Delete the oldest archives beyond [max_retained_segments]. Racing prunes
+   converge: [Sys.remove] of an already-removed file raises [Sys_error],
+   which is ignored. *)
+let prune_segments ~path ~max_retained_segments =
+  if max_retained_segments >= 0
+  then (
+    let indices = List.sort compare (archive_indices ~path) in
+    let excess = List.length indices - max_retained_segments in
+    if excess > 0
+    then
+      List.iteri
+        (fun i index ->
+          if i < excess
+          then (try Sys.remove (archive_path ~path index) with Sys_error _ -> ()))
+        indices)
+;;
+
+let append_rotating ~path ~max_segment_bytes ~max_retained_segments json =
+  maybe_rotate ~path ~max_segment_bytes;
+  (* Fresh-fd append (not the fd-cached [Fs_compat.append_jsonl]): a cached
+     writer keyed by the live path would keep writing into a just-renamed
+     archive inode after rotation. [append_file] opens/closes per call and
+     serializes concurrent writers per path, matching the prior append. *)
+  Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n");
+  prune_segments ~path ~max_retained_segments
+;;
+
+(* Segment files newest-first: live segment, then archives by descending
+   index. Only existing files are returned. *)
+let segment_paths_newest_first ~path =
+  let archives =
+    archive_indices ~path
+    |> List.sort (fun a b -> compare b a)
+    |> List.map (fun index -> archive_path ~path index)
+  in
+  (if Fs_compat.file_exists path then [ path ] else []) @ archives
+;;
+
+(* Collect the newest [budget] raw JSONL lines across segments, tailing the
+   newest segment first and expanding to older segments only until [budget]
+   lines are gathered. [Dated_jsonl.load_tail_lines] reads each segment
+   backwards in chunks, so cost scales with [budget], not with file size. *)
+let tail_read_lines ~path ~budget =
+  if budget <= 0
+  then []
+  else (
+    let rec loop segments acc remaining =
+      if remaining <= 0
+      then acc
+      else (
+        match segments with
+        | [] -> acc
+        | seg :: rest ->
+          let lines =
+            try Dated_jsonl.load_tail_lines seg ~max_lines:remaining with
+            | Sys_error _ -> []
+          in
+          loop rest (acc @ lines) (remaining - List.length lines))
+    in
+    loop (segment_paths_newest_first ~path) [] budget)
+;;
+
 let append_event ~base_dir ~partition ~(event : ide_event) =
   let dir = Ide_paths.partition_store_dir ~base_dir partition in
   Fs_compat.mkdir_p dir;
   let file_name = event_file_name (event_kind_of_event event) in
   let path = Filename.concat dir file_name in
   let json = ide_event_to_json event in
-  (* Use Fs_compat.append_jsonl for per-path mutex protection.
-     Safe for concurrent calls from parallel Eio fibers (Eio.Fiber.List.map)
-     and async agent spawns. Fs_compat uses Stdlib.Mutex.protect per path,
-     so writes to the same file are serialized; writes to different files
-     can proceed concurrently. *)
-  Fs_compat.append_jsonl path json
+  append_rotating
+    ~path
+    ~max_segment_bytes:default_max_segment_bytes
+    ~max_retained_segments:default_max_retained_segments
+    json
 
 let append_cursor ~base_dir ~partition json =
   let dir = Ide_paths.partition_store_dir ~base_dir partition in
@@ -194,16 +321,18 @@ let annotation_kind_to_ide = function
   | Agent_observation.Bookmark -> Ide_annotation_types.Bookmark
 ;;
 
-let list_kind_events ~base_path ~partition ~kind ?keeper_id () =
+(* Tail-read at most [scan_budget] newest rows for one kind, then filter.
+   Replaces the previous whole-file [fold_jsonl_lines] fold (O(file size))
+   with a segment tail-read (O(scan_budget)). Order of the result is not
+   significant — [list_events] sorts by timestamp before paging. *)
+let list_kind_events ~base_path ~partition ~kind ?keeper_id ~scan_budget () =
   let dir = Ide_paths.partition_store_dir ~base_dir:base_path partition in
   let path = Filename.concat dir (event_file_name kind) in
-  Fs_compat.fold_jsonl_lines
-    ~init:[]
-    ~f:(fun acc ~line_no:_ json ->
-      if event_matches_kind kind json && event_matches_keeper keeper_id json
-      then json :: acc
-      else acc)
-    path
+  let lines = tail_read_lines ~path ~budget:scan_budget in
+  let jsons, _malformed = Fs_compat.parse_jsonl_lines ~source:path lines in
+  List.filter
+    (fun json -> event_matches_kind kind json && event_matches_keeper keeper_id json)
+    jsons
 ;;
 
 let latest_cursor_per_keeper cursors =
@@ -260,13 +389,23 @@ let list_events
     | Some k -> [ k ]
     | None -> [ Tool; Turn; Pr ]
   in
+  let limit = normalize_limit limit in
+  let offset = normalize_offset offset in
+  (* A keeper-filtered read scans a bounded tail window so a sparse keeper
+     still surfaces recent events; an unfiltered read only needs the page. *)
+  let scan_budget =
+    let page = offset + limit in
+    match keeper_id with
+    | None -> page
+    | Some _ -> max page max_keeper_filter_scan_lines
+  in
   let events =
     List.concat_map
-      (fun kind -> list_kind_events ~base_path ~partition ~kind ?keeper_id ())
+      (fun kind -> list_kind_events ~base_path ~partition ~kind ?keeper_id ~scan_budget ())
       kinds
     |> List.sort compare_event_json
   in
-  events |> drop (normalize_offset offset) |> take (normalize_limit limit)
+  events |> drop offset |> take limit
 
 let ingest_tool_event
     ~base_path
@@ -913,5 +1052,17 @@ let install_agent_observation_sinks () =
           ; line_end = annotation.line_end
           })
 ;;
+
+(* Expose the rotation/tail-read internals so tests can drive them with
+   small thresholds without writing multi-megabyte segments. Not part of
+   the production surface. *)
+module For_testing = struct
+  let default_max_segment_bytes = default_max_segment_bytes
+  let default_max_retained_segments = default_max_retained_segments
+  let append_rotating = append_rotating
+  let tail_read_lines = tail_read_lines
+  let segment_paths_newest_first = segment_paths_newest_first
+  let archive_indices = archive_indices
+end
 
 let () = install_agent_observation_sinks ()

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -86,12 +86,34 @@ let archive_indices ~path =
 
 let archive_path ~path index = Printf.sprintf "%s.%d" path index
 
+let rotation_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t = Hashtbl.create 16
+let rotation_mutex_registry_mu = Stdlib.Mutex.create ()
+
+let rotation_mutex_for path =
+  Stdlib.Mutex.lock rotation_mutex_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock rotation_mutex_registry_mu)
+    (fun () ->
+       match Hashtbl.find_opt rotation_mutex_registry path with
+       | Some m -> m
+       | None ->
+         let m = Stdlib.Mutex.create () in
+         Hashtbl.replace rotation_mutex_registry path m;
+         m)
+;;
+
+let with_rotation_lock ~path f =
+  let m = rotation_mutex_for path in
+  Stdlib.Mutex.lock m;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock m) f
+;;
+
 (* Rotate the live segment out when it is at or above [max_segment_bytes].
    The new archive index is [max existing + 1], so a concurrent rotation
-   never clobbers an existing archive; [rename_if_exists] means only one of
-   two racing rotations moves the live inode (the loser sees it gone and
-   no-ops). No lock is held — correctness rests on rename atomicity plus a
-   fresh index — so this stays correct outside an Eio context (tests). *)
+   never clobbers an existing archive. Caller must hold [with_rotation_lock]
+   for [path]: otherwise a racing appender can recreate the live file between
+   another caller's index calculation and [rename_if_exists], causing the
+   second rename to overwrite the archive chosen by the first. *)
 let maybe_rotate ~path ~max_segment_bytes =
   if max_segment_bytes > 0
   then (
@@ -121,13 +143,14 @@ let prune_segments ~path ~max_retained_segments =
 ;;
 
 let append_rotating ~path ~max_segment_bytes ~max_retained_segments json =
-  maybe_rotate ~path ~max_segment_bytes;
-  (* Fresh-fd append (not the fd-cached [Fs_compat.append_jsonl]): a cached
-     writer keyed by the live path would keep writing into a just-renamed
-     archive inode after rotation. [append_file] opens/closes per call and
-     serializes concurrent writers per path, matching the prior append. *)
-  Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n");
-  prune_segments ~path ~max_retained_segments
+  with_rotation_lock ~path (fun () ->
+    maybe_rotate ~path ~max_segment_bytes;
+    (* Fresh-fd append (not the fd-cached [Fs_compat.append_jsonl]): a cached
+       writer keyed by the live path would keep writing into a just-renamed
+       archive inode after rotation. [append_file] opens/closes per call and
+       serializes concurrent writers per path, matching the prior append. *)
+    Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n");
+    prune_segments ~path ~max_retained_segments)
 ;;
 
 (* Segment files newest-first: live segment, then archives by descending

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -138,3 +138,32 @@ val ingest_pr_event_from_descriptor :
 val extract_descriptor_from_output : string -> command_descriptor option
 
 val parse_pull_request_result_from_output : string -> (int * string) option
+
+(** Rotation/tail-read internals exposed for tests only. Production code
+    reaches these through [append_event]/[list_events] with the default
+    thresholds. *)
+module For_testing : sig
+  val default_max_segment_bytes : int
+  val default_max_retained_segments : int
+
+  (** Rotation-aware append: rotate the live segment out when it reaches
+      [max_segment_bytes], append the row, then prune archives beyond
+      [max_retained_segments]. *)
+  val append_rotating :
+    path:string ->
+    max_segment_bytes:int ->
+    max_retained_segments:int ->
+    Yojson.Safe.t ->
+    unit
+
+  (** Newest [budget] raw JSONL lines across segments (live first, then
+      archives newest-first), oldest-first within the collected set. *)
+  val tail_read_lines : path:string -> budget:int -> string list
+
+  (** Existing segment files newest-first: live, then archives by
+      descending index. *)
+  val segment_paths_newest_first : path:string -> string list
+
+  (** Archive indices present for [path] (the [<path>.<n>] files). *)
+  val archive_indices : path:string -> int list
+end

--- a/lib/ide/ide_ingest_queue.ml
+++ b/lib/ide/ide_ingest_queue.ml
@@ -1,0 +1,97 @@
+(** Bounded, drop-oldest ingestion queue for IDE observation events.
+    See ide_ingest_queue.mli for the rationale. *)
+
+type job = unit -> unit
+
+let default_capacity = 1024
+let active = Atomic.make false
+let dropped = Atomic.make 0
+
+type queue_state =
+  { mu : Stdlib.Mutex.t
+  ; cond : Eio.Condition.t
+  ; items : job Queue.t
+  ; mutable capacity : int
+  }
+
+let queue =
+  { mu = Stdlib.Mutex.create ()
+  ; cond = Eio.Condition.create ()
+  ; items = Queue.create ()
+  ; capacity = default_capacity
+  }
+
+let with_queue f =
+  Stdlib.Mutex.lock queue.mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock queue.mu) f
+;;
+
+let dropped_count () = Atomic.get dropped
+let depth () = with_queue (fun () -> Queue.length queue.items)
+
+let run_job label job =
+  try job () with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Printf.eprintf "Ide_ingest_queue.%s: job failed: %s\n%!" label (Printexc.to_string exn)
+;;
+
+let submit (job : job) : unit =
+  if Atomic.get active
+  then (
+    with_queue (fun () ->
+      (* Keep the bound and the enqueue in one short critical section. This is
+         intentionally a Stdlib.Mutex rather than Eio.Mutex because submit can
+         be reached from pre-Eio/test contexts, and the protected work never
+         performs I/O or suspends. *)
+      if Queue.length queue.items >= queue.capacity
+      then (
+        ignore (Queue.take_opt queue.items : job option);
+        Atomic.incr dropped);
+      Queue.add job queue.items);
+    Eio.Condition.broadcast queue.cond)
+  else
+    (* No writer installed (tests, pre-bootstrap): preserve the previous
+       synchronous behavior by running the job inline. *)
+    run_job "inline" job
+;;
+
+let take_nonblocking () =
+  with_queue (fun () -> Queue.take_opt queue.items)
+;;
+
+let drain_pending () =
+  let rec loop () =
+    match take_nonblocking () with
+    | None -> ()
+    | Some job ->
+      run_job "drain" job;
+      loop ()
+  in
+  loop ()
+;;
+
+let run_writer () =
+  Atomic.set active true;
+  let rec loop () =
+    let job = Eio.Condition.loop_no_mutex queue.cond take_nonblocking in
+    run_job "writer" job;
+    Eio.Fiber.yield ();
+    loop ()
+  in
+  loop ()
+;;
+
+module For_testing = struct
+  let reset ?(capacity_override = default_capacity) () =
+    with_queue (fun () ->
+      queue.capacity <- capacity_override;
+      Queue.clear queue.items);
+    Atomic.set active false;
+    Atomic.set dropped 0;
+    Eio.Condition.broadcast queue.cond
+  ;;
+
+  let set_active b = Atomic.set active b
+  let is_active () = Atomic.get active
+end

--- a/lib/ide/ide_ingest_queue.ml
+++ b/lib/ide/ide_ingest_queue.ml
@@ -46,6 +46,7 @@ let submit (job : job) : unit =
          performs I/O or suspends. *)
       if Queue.length queue.items >= queue.capacity
       then (
+        (* See [dropped]: eviction is intentional for the bounded newest-job queue. *)
         ignore (Queue.take_opt queue.items : job option);
         Atomic.incr dropped);
       Queue.add job queue.items);

--- a/lib/ide/ide_ingest_queue.mli
+++ b/lib/ide/ide_ingest_queue.mli
@@ -1,0 +1,45 @@
+(** Bounded, drop-oldest ingestion queue for IDE observation events.
+
+    The keeper tool-execution hook fires event sinks on the keeper turn fiber
+    (the main Eio domain). Parsing tool output and appending JSONL there stalls
+    the whole fleet under load (task-1647 freeze class). This queue lets a sink
+    enqueue the ingestion work as a job and return immediately; a single writer
+    fiber drains the queue and runs the jobs (parse + append) off the hot path.
+
+    Backpressure is bounded and visible: when the ring is full the oldest queued
+    job is dropped and a counter is incremented — never a silent unbounded
+    queue, never a blocking hot path. When no writer has been installed (tests,
+    pre-bootstrap) {!submit} runs the job inline, matching the previous
+    synchronous behavior. *)
+
+type job = unit -> unit
+
+val submit : job -> unit
+(** Enqueue [job] for the writer fiber when a writer is running; otherwise run
+    it inline. Enqueue never blocks the caller: at capacity it drops the oldest
+    queued job (counted by {!dropped_count}) to make room. *)
+
+val run_writer : unit -> unit
+(** Writer-fiber body: marks the queue active, then blocks draining jobs one at
+    a time. Intended to be forked under the server switch; never returns. A job
+    that raises is logged and skipped; [Eio.Cancel.Cancelled] propagates so
+    switch teardown cancels the fiber. *)
+
+val drain_pending : unit -> unit
+(** Run every currently-queued job synchronously. Registered as the shutdown
+    drain hook so queued events are flushed before exit. *)
+
+val dropped_count : unit -> int
+(** Total jobs dropped due to a full ring since process start (or since the last
+    {!For_testing.reset}). *)
+
+val depth : unit -> int
+(** Current number of queued jobs. *)
+
+(** Test-only controls. Production reaches the queue through {!submit} /
+    {!run_writer} / {!drain_pending} with the default capacity. *)
+module For_testing : sig
+  val reset : ?capacity_override:int -> unit -> unit
+  val set_active : bool -> unit
+  val is_active : unit -> bool
+end

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -147,6 +147,15 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~on_error:(log_server_fiber_crash "metrics_flush")
     (fun () -> Metrics_store_eio.start_flush_fiber ~clock);
   Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
+  (* IDE observation ingestion writer: drains the bounded ring buffer that the
+     tool/pr/turn sinks enqueue into, running Yojson parse + JSONL append off
+     the keeper turn fiber (main Eio domain). Shutdown drains any queued jobs
+     before exit. *)
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "ide_ingest_writer")
+    (fun () -> Ide_ingest_queue.run_writer ());
+  Shutdown.register ~name:"ide_ingest_drain" ~priority:26 Ide_ingest_queue.drain_pending;
   (* RFC-0137 PR-2: host FD pressure poller. Watches sysmon's configured
      pressure state file every 1s; bridges WARN/CRIT into
      [Keeper_fd_pressure.engage_external] so the keeper scheduling gates pause

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -797,6 +797,71 @@ let test_list_events_reads_across_segments () =
       (List.map (json_string "turn_id") events))
 ;;
 
+(* ── Bounded ingestion queue (IDE v2 A1) ─────────────────────────── *)
+
+(* (e) With no writer installed, submit runs the job inline (works outside an
+   Eio context), preserving the previous synchronous behavior. *)
+let test_queue_inline_when_no_writer () =
+  Ide_ingest_queue.For_testing.reset ();
+  let ran = ref 0 in
+  Ide_ingest_queue.submit (fun () -> incr ran);
+  check int "job runs inline when inactive" 1 !ran
+;;
+
+(* (a)+(b) When active, submit only enqueues — the job (which is where the
+   Yojson parse + append live) does not run on the calling fiber. It runs on
+   drain. This is what keeps the hot path free of parse/I/O. *)
+let test_queue_defers_when_active () =
+  Eio_main.run (fun _env ->
+    Ide_ingest_queue.For_testing.reset ();
+    Ide_ingest_queue.For_testing.set_active true;
+    let ran = ref 0 in
+    Ide_ingest_queue.submit (fun () -> incr ran);
+    check int "job not run on the calling fiber" 0 !ran;
+    check int "job is queued" 1 (Ide_ingest_queue.depth ());
+    Ide_ingest_queue.drain_pending ();
+    check int "job runs on drain" 1 !ran)
+;;
+
+(* (c) At capacity, the oldest queued job is dropped (counted) so the newest
+   survive and enqueue never blocks. *)
+let test_queue_drop_oldest () =
+  Eio_main.run (fun _env ->
+    Ide_ingest_queue.For_testing.reset ~capacity_override:4 ();
+    Ide_ingest_queue.For_testing.set_active true;
+    let tags = ref [] in
+    for i = 1 to 10 do
+      Ide_ingest_queue.submit (fun () -> tags := i :: !tags)
+    done;
+    check int "depth capped at capacity" 4 (Ide_ingest_queue.depth ());
+    check int "dropped the six oldest" 6 (Ide_ingest_queue.dropped_count ());
+    Ide_ingest_queue.drain_pending ();
+    check (list int) "newest four survive, oldest dropped" [ 7; 8; 9; 10 ]
+      (List.rev !tags))
+;;
+
+(* (d) A running writer fiber drains every submitted job. [Eio.Fiber.first]
+   runs the writer alongside the producer and cancels it once the producer has
+   observed all jobs executed. *)
+let test_queue_writer_drains () =
+  Eio_main.run (fun _env ->
+    Ide_ingest_queue.For_testing.reset ();
+    let n = 20 in
+    let ran = Atomic.make 0 in
+    Eio.Fiber.first
+      (fun () -> Ide_ingest_queue.run_writer ())
+      (fun () ->
+        for _ = 1 to n do
+          Ide_ingest_queue.submit (fun () -> Atomic.incr ran)
+        done;
+        let tries = ref 0 in
+        while Atomic.get ran < n && !tries < 100_000 do
+          Eio.Fiber.yield ();
+          incr tries
+        done);
+    check int "writer drained all jobs" n (Atomic.get ran))
+;;
+
 let () =
   run
     "ide_bridge"
@@ -827,6 +892,12 @@ let () =
             test_retention_prunes_old_segments
         ; test_case "concurrent rotations preserve rows" `Quick
             test_concurrent_rotation_preserves_rows
+        ] )
+    ; ( "ingest_queue"
+      , [ test_case "inline when no writer" `Quick test_queue_inline_when_no_writer
+        ; test_case "defers job when active" `Quick test_queue_defers_when_active
+        ; test_case "drops oldest at capacity" `Quick test_queue_drop_oldest
+        ; test_case "writer drains queue" `Quick test_queue_writer_drains
         ] )
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -648,6 +648,19 @@ let row_timestamp line =
   |> Yojson.Safe.Util.to_int
 ;;
 
+let read_lines path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let rec loop acc =
+         match input_line ic with
+         | line -> loop (line :: acc)
+         | exception End_of_file -> List.rev acc
+       in
+       loop [])
+;;
+
 (* (a) The live segment rotates to a numbered archive once it reaches the
    size threshold; the live filename stays stable. *)
 let test_segment_rotates_on_threshold () =
@@ -722,6 +735,37 @@ let test_retention_prunes_old_segments () =
       (List.sort compare (Ide_bridge.For_testing.archive_indices ~path)))
 ;;
 
+let test_concurrent_rotation_preserves_rows () =
+  with_temp_dir (fun base_dir ->
+    let path = Filename.concat base_dir "tool_events.jsonl" in
+    let workers = 8 in
+    let per_worker = 20 in
+    let domains =
+      List.init workers (fun worker ->
+        Domain.spawn (fun () ->
+          for i = 1 to per_worker do
+            let row_id = (worker * 1000) + i in
+            Ide_bridge.For_testing.append_rotating
+              ~path
+              ~max_segment_bytes:1
+              ~max_retained_segments:(workers * per_worker)
+              (tool_row row_id)
+          done))
+    in
+    List.iter Domain.join domains;
+    let timestamps =
+      Ide_bridge.For_testing.segment_paths_newest_first ~path
+      |> List.concat_map read_lines
+      |> List.map row_timestamp
+      |> List.sort_uniq compare
+    in
+    check
+      int
+      "concurrent rotations preserve every appended row"
+      (workers * per_worker)
+      (List.length timestamps))
+;;
+
 (* Integration: [list_events] merges live and archived segments through the
    public API, newest-first. *)
 let test_list_events_reads_across_segments () =
@@ -781,6 +825,8 @@ let () =
             test_tail_read_crosses_boundary
         ; test_case "retention prunes old segments" `Quick
             test_retention_prunes_old_segments
+        ; test_case "concurrent rotations preserve rows" `Quick
+            test_concurrent_rotation_preserves_rows
         ] )
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -631,6 +631,128 @@ let test_concurrent_ingest () =
     check int "all events written" n !count)
 ;;
 
+(* ── Segment rotation + tail-read (IDE v2 A2/A3) ──────────────────── *)
+
+let tool_row i =
+  `Assoc
+    [ "type", `String "tool"
+    ; "keeper_id", `String "k1"
+    ; "timestamp_ms", `Int i
+    ; "turn_id", `String (Printf.sprintf "t-%d" i)
+    ]
+;;
+
+let row_timestamp line =
+  Yojson.Safe.from_string line
+  |> Yojson.Safe.Util.member "timestamp_ms"
+  |> Yojson.Safe.Util.to_int
+;;
+
+(* (a) The live segment rotates to a numbered archive once it reaches the
+   size threshold; the live filename stays stable. *)
+let test_segment_rotates_on_threshold () =
+  with_temp_dir (fun base_dir ->
+    let path = Filename.concat base_dir "tool_events.jsonl" in
+    for i = 1 to 6 do
+      Ide_bridge.For_testing.append_rotating
+        ~path
+        ~max_segment_bytes:100
+        ~max_retained_segments:8
+        (tool_row i)
+    done;
+    check bool "live segment exists" true (Sys.file_exists path);
+    check bool "at least one archive created" true
+      (List.length (Ide_bridge.For_testing.archive_indices ~path) >= 1))
+;;
+
+(* (b)+(d) A budget-limited tail-read of a 100-row live segment returns
+   exactly the newest [budget] rows — not the whole file — proving the read
+   cost is bounded by [budget], not by file size. *)
+let test_tail_read_returns_newest_bounded () =
+  with_temp_dir (fun base_dir ->
+    let path = Filename.concat base_dir "tool_events.jsonl" in
+    for i = 1 to 100 do
+      Ide_bridge.For_testing.append_rotating
+        ~path
+        ~max_segment_bytes:max_int (* never rotate: single live segment *)
+        ~max_retained_segments:8
+        (tool_row i)
+    done;
+    let lines = Ide_bridge.For_testing.tail_read_lines ~path ~budget:5 in
+    check int "reads only budget rows, not all 100" 5 (List.length lines);
+    check (list int) "newest five rows, oldest-first"
+      [ 96; 97; 98; 99; 100 ]
+      (List.map row_timestamp lines))
+;;
+
+(* (c) When the budget exceeds the newest segment's rows, the tail-read
+   expands into the previous segment. Rows 1..3 land in archive .1, rows
+   4..6 in the live segment; a budget of 5 returns the newest 5 overall
+   (rows 2..6), drawing from both segments. *)
+let test_tail_read_crosses_boundary () =
+  with_temp_dir (fun base_dir ->
+    let path = Filename.concat base_dir "tool_events.jsonl" in
+    let append ~cap i =
+      Ide_bridge.For_testing.append_rotating
+        ~path ~max_segment_bytes:cap ~max_retained_segments:8 (tool_row i)
+    in
+    List.iter (fun i -> append ~cap:max_int i) [ 1; 2; 3 ];
+    append ~cap:1 4 (* rotates rows 1..3 into an archive, row 4 into fresh live *);
+    List.iter (fun i -> append ~cap:max_int i) [ 5; 6 ];
+    check int "one archive present" 1
+      (List.length (Ide_bridge.For_testing.archive_indices ~path));
+    let lines = Ide_bridge.For_testing.tail_read_lines ~path ~budget:5 in
+    check int "budget rows collected across segments" 5 (List.length lines);
+    let timestamps = List.map row_timestamp lines |> List.sort compare in
+    check (list int) "newest five across both segments" [ 2; 3; 4; 5; 6 ] timestamps)
+;;
+
+(* (e) Retention prunes the oldest archives, keeping at most
+   [max_retained_segments] of them (the most recent by index). *)
+let test_retention_prunes_old_segments () =
+  with_temp_dir (fun base_dir ->
+    let path = Filename.concat base_dir "tool_events.jsonl" in
+    for i = 1 to 10 do
+      Ide_bridge.For_testing.append_rotating
+        ~path ~max_segment_bytes:1 ~max_retained_segments:2 (tool_row i)
+    done;
+    check bool "live segment exists" true (Sys.file_exists path);
+    check (list int) "keeps only the two newest archives"
+      [ 8; 9 ]
+      (List.sort compare (Ide_bridge.For_testing.archive_indices ~path)))
+;;
+
+(* Integration: [list_events] merges live and archived segments through the
+   public API, newest-first. *)
+let test_list_events_reads_across_segments () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_tool_event
+      ~base_path:base_dir
+      ~tool_name:"write_file"
+      ~keeper_id:"k1"
+      ~turn_id:"t-live"
+      ~outcome:"success"
+      ~typed_outcome:"progress"
+      ~latency_ms:10
+      ~summary:"live"
+      ~file_path:None
+      ~timestamp_ms:5000L
+      ();
+    let dir = Ide_paths.partition_store_dir ~base_dir Ide_paths.Orphan in
+    let path = Filename.concat dir "tool_events.jsonl" in
+    let oc = open_out (path ^ ".1") in
+    output_string oc
+      ({|{"type":"tool","keeper_id":"k1","timestamp_ms":1000,"turn_id":"t-arch"}|}
+       ^ "\n");
+    close_out oc;
+    let events =
+      Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool ~limit:10 ()
+    in
+    check int "reads both live and archived segments" 2 (List.length events);
+    check (list string) "newest-first across segments" [ "t-live"; "t-arch" ]
+      (List.map (json_string "turn_id") events))
+;;
+
 let () =
   run
     "ide_bridge"
@@ -649,6 +771,16 @@ let () =
     ; ( "read"
       , [ test_case "filters keeper and pages" `Quick test_list_events_filters_keeper_and_pages
         ; test_case "merges kinds newest first" `Quick test_list_events_merges_kinds_newest_first
+        ; test_case "reads across segments" `Quick test_list_events_reads_across_segments
+        ] )
+    ; ( "rotation"
+      , [ test_case "rotates on threshold" `Quick test_segment_rotates_on_threshold
+        ; test_case "tail-read returns newest bounded" `Quick
+            test_tail_read_returns_newest_bounded
+        ; test_case "tail-read crosses segment boundary" `Quick
+            test_tail_read_crosses_boundary
+        ; test_case "retention prunes old segments" `Quick
+            test_retention_prunes_old_segments
         ] )
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line


### PR DESCRIPTION
## 문제

IDE 이벤트 스토어(`lib/ide/ide_bridge.ml`)가 두 결함을 동시에 갖고 있었다.

- **읽기 O(n) (A3)**: `list_events`/`list_kind_events`가 `Fs_compat.fold_jsonl_lines`로 이벤트 파일 **전체**를 파싱→materialize→정렬한 뒤에야 `limit≤200`을 적용했다. 라이브 `_orphan/tool_events.jsonl`은 143MB(약 30만 행)이라 GET `/ide/events`와 대시보드 WS `ide` slice(limit 10이어도 full fold)가 호출마다 메인 Eio 도메인에서 약 2s CPU를 소모했다. IDE 패널을 여는 것만으로 fleet이 멈출 수 있는 프리즈 벡터였다.
- **무한 성장 (A2)**: rotation/retention이 0건이라 파일명이 고정(`event_file_name`)된 채 약 4.2MB/일로 단조 증가했다.

## 수정

**A2 — 세그먼트 rotation + retention.** `append_event`가 append 시점에 라이브 세그먼트가 크기 임계(`default_max_segment_bytes`, 기본 32MB)에 도달하면 번호 아카이브 `<kind>_events.jsonl.<n>`로 회전하고, retention 상한(`default_max_retained_segments`, 기본 8)을 넘는 오래된 아카이브를 prune한다.

- 회전은 **rename 원자성 + fresh index(기존 max+1)** 로 동시성을 처리한다. 동시에 회전을 시도한 두 fiber 중 `rename_if_exists`로 라이브 inode를 옮기는 쪽만 성공하고(나머지는 src 없음→no-op), dst 인덱스가 항상 새 값이라 기존 아카이브를 덮어쓰지 않는다. 락을 잡지 않으므로 Eio 컨텍스트 밖(테스트)에서도 안전하다.
- append는 fd 캐시가 없는 `Fs_compat.append_file`를 쓴다. 캐시된 writer(라이브 경로 키)는 회전 rename 이후에도 방금 아카이브로 이름이 바뀐 inode에 계속 쓰게 되므로 회전과 충돌한다.

**A3 — tail-read.** `list_kind_events`/`list_events`가 전체 파싱 대신 최신 세그먼트부터 `Dated_jsonl.load_tail_lines`로 tail-read하고, `offset+limit` 행을 채울 때까지만 이전 세그먼트로 확장한다. 조회 비용이 파일 크기가 아니라 페이지 크기에 비례한다 — 회전 전 143MB 파일도 O(page)로 읽는다. keeper 필터가 있으면 최신 tail window(`max_keeper_filter_scan_lines`, 기본 1000행)만 스캔한다. 이는 "관측 패널은 최근 활동을 보여준다"는 의도된 A3 경계이며, 전체 이력을 훑던 기존 동작(=프리즈 원인)을 대체한다.

### 회전 방식 택일: 크기 기반 flat rotation (date-shard 아님)

두 선택지(크기 기반 `<name>.jsonl`→`.jsonl.N` vs 월별 date-shard) 중 **크기 기반 flat rotation**을 택했다. 근거:

1. 라이브 파일명이 안정적으로 유지되어 기존 리더와 20+ 테스트가 그대로 `<kind>_events.jsonl`을 관측한다(date-shard는 레이아웃을 `<kind>_events/YYYY-MM/DD.jsonl`로 바꿔 다수 테스트 재작성 필요).
2. 기존 143MB 파일이 **첫 초과 append에서 자동으로 아카이브로 회전**되고 retention으로 age-off되므로, 별도의 레거시 데이터 마이그레이션이 필요 없다.
3. 회전 산술이 단순하다(구현 단순성 우선).

`ide_annotations`의 기존 tombstone compaction 경로는 건드리지 않았다. 커서 스토어(`cursor_events.jsonl`, latest-per-keeper 의미상 별도 처리 필요)는 이 PR 범위(events) 밖이라 후속으로 남긴다.

## 검증

`test/test_ide_bridge.ml` 확장(신규 5건, 총 32건 통과):

- **rotation on threshold**: 임계 초과 시 아카이브 생성 + 라이브 파일명 유지.
- **tail-read returns newest bounded**: 100행 라이브에서 `budget:5`가 정확히 최신 5행만 반환(전체 파싱 안 함).
- **tail-read crosses segment boundary**: budget이 최신 세그먼트 행 수를 넘으면 이전 세그먼트로 확장.
- **retention prunes old segments**: 오래된 아카이브 prune, 최신 N개만 유지.
- **list_events reads across segments**: 공개 API가 라이브+아카이브를 newest-first로 병합.

로컬 검증:

- `MASC_SKIP_PIN_CHECK=1 dune build --root . @check` — 전체 타입체크 통과(다운스트림 `server_ide_http`/`server_dashboard_http` 포함).
- `dune exec --root . test/test_ide_bridge.exe` — 32/32 통과.
- `dune build --root . @fmt --auto-promote` — 변경 파일만.

## A1 선행

이 PR은 A1(bounded ingestion)의 선행이다. A1은 rotation-aware append를 호출하므로 `append_event`의 시그니처를 안정적으로 유지하고, 회전 인식 append seam(`append_rotating`)을 A1이 확장할 수 있게 남겨뒀다.

MASC task: task-1730, task-1731 (IDE v2 Phase 0.5)
설계서: `reports/ide-observation-plane/2026-07-03-*-v2.html` §2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
