### PR TITLE
feat(ide): keeper 패널 live-turn을 composite snapshot SSOT로 (task-1740 C3)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -75,6 +75,7 @@ import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
 import { FL_TONE_LABEL, type FleetTone } from '../lib/fleet-tone'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import { compositeSnapshotForKeeper } from '../lib/keeper-composite-lookup'
 import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
 
 type StatusFilter = 'all' | RuntimeBand
@@ -702,17 +703,6 @@ function countAgentsByStatus(
   }
 
   return counts
-}
-
-function compositeSnapshotForKeeper(
-  keeper: Keeper | null | undefined,
-  compositeByKeeperKey: ReadonlyMap<string, KeeperCompositeSnapshot> | null,
-): KeeperCompositeSnapshot | null {
-  if (!keeper || !compositeByKeeperKey) return null
-  return compositeByKeeperKey.get(keeper.name)
-    ?? (typeof keeper.keeper_id === 'string'
-      ? compositeByKeeperKey.get(keeper.keeper_id) ?? null
-      : null)
 }
 
 export function countRuntimeKinds(

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -3,7 +3,12 @@ import { h, render } from 'preact'
 import { fireEvent } from '@testing-library/preact'
 import { IdeKeeperWorkPanel, keeperWorkSummary } from './ide-keeper-work-panel'
 import { goals, keepers, tasks } from '../../store'
+import { fleetCompositeSnapshot } from '../../composite-signals'
 import type { Goal, Keeper, Task } from '../../types'
+import type {
+  FleetCompositeSnapshot,
+  KeeperCompositeSnapshot,
+} from '../../api/schemas/keeper-composite'
 
 describe('IdeKeeperWorkPanel', () => {
   let container: HTMLDivElement
@@ -17,6 +22,7 @@ describe('IdeKeeperWorkPanel', () => {
     goals.value = []
     keepers.value = []
     tasks.value = []
+    fleetCompositeSnapshot.value = null
     window.location.hash = ''
   })
 
@@ -32,6 +38,45 @@ describe('IdeKeeperWorkPanel', () => {
     expect(container.textContent).toContain('tool_route_recoverable_failure')
     expect(container.textContent).toContain('inspect_provider_tool_contract')
     expect(container.textContent).toContain('masc_claim_next')
+  })
+
+  it('renders live-turn fields from the composite snapshot SSOT', () => {
+    keepers.value = [keeperFixture()]
+    fleetCompositeSnapshot.value = fleetFixture([
+      compositeFixture({
+        keeper: 'sangsu',
+        live_turn: {
+          turn_id: 7,
+          started_at: 1,
+          last_progress_at: 2,
+          last_progress_kind: 'tool',
+          selected_model: 'claude-live-model',
+          active_tool_count: 3,
+        },
+        last_skip: { ts: 9, reasons: ['idle_budget'] },
+        livelock: { turn_id: 7, attempts: 2, first_started_at: 1 },
+        board_cursor: { ts: 5, post_id: 'post-42' },
+      }),
+    ])
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    // The store Keeper type carries none of these fields, so their
+    // presence proves the panel sources the live-turn state from the
+    // composite snapshot rather than re-deriving it from the store.
+    expect(container.textContent).toContain('claude-live-model')
+    expect(container.textContent).toContain('idle_budget')
+    expect(container.textContent).toContain('post-42')
+  })
+
+  it('omits the live-turn strip when no composite snapshot resolves', () => {
+    keepers.value = [keeperFixture()]
+    fleetCompositeSnapshot.value = null
+
+    render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
+
+    expect(container.querySelector('[aria-label="Keeper live turn"]')).toBeNull()
+    expect(container.textContent).not.toContain('claude-live-model')
   })
 
   it('matches keeper-agent task assignees to the canonical keeper name', () => {
@@ -196,6 +241,39 @@ function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
     throw new Error(`missing button: ${text}`)
   }
   return button
+}
+
+function compositeFixture(
+  overrides: Partial<KeeperCompositeSnapshot> = {},
+): KeeperCompositeSnapshot {
+  return {
+    correlation_id: 'corr-sangsu',
+    run_id: 'run-1',
+    ts: 1_000_000,
+    phase: 'running',
+    turn_phase: 'executing',
+    decision: { stage: 'undecided' },
+    runtime: { state: 'active' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_runtime_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+      phase_derivation_agreement: true,
+    },
+    fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
+    is_live: true,
+    last_outcome: null,
+    recommended_actions: [],
+    ...overrides,
+  }
+}
+
+function fleetFixture(snapshots: KeeperCompositeSnapshot[]): FleetCompositeSnapshot {
+  return { generated_at: 1_000_000, count: snapshots.length, snapshots }
 }
 
 function keeperFixture(): Keeper {

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -21,6 +21,9 @@ import {
   type IdeContextRouteLink,
 } from './ide-context-lens'
 import { cursorOverlaySignal, getKeeperColor, type KeeperCursor } from './keeper-cursor-overlay'
+import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../../composite-signals'
+import { compositeSnapshotForKeeper } from '../../lib/keeper-composite-lookup'
+import type { KeeperCompositeSnapshot } from '../../api/schemas/keeper-composite'
 
 interface IdeKeeperWorkPanelProps {
   readonly keeperName: string
@@ -76,6 +79,17 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
 
   const cursor = resolveKeeperCursor(keeperName, overlay.cursors)
 
+  // task-1740 C3: the live-turn fields (model / in-flight tools / last
+  // skip / livelock / board cursor) are read from the composite snapshot
+  // SSOT (`/api/v1/keepers/:name/composite` via `fleetCompositeSnapshot`),
+  // not re-derived from the global keepers/tasks store. `.value` access
+  // auto-subscribes this component to composite freshness, mirroring the
+  // `keepers.value` / `tasks.value` reads above.
+  const composite = compositeSnapshotForKeeper(
+    keeper,
+    buildCompositeByKeeperKey(fleetCompositeSnapshot.value),
+  )
+
   return html`
     <section
       class="ide-keeper-work"
@@ -98,6 +112,7 @@ export function IdeKeeperWorkPanel({ keeperName }: IdeKeeperWorkPanelProps) {
           ${WorkMetric('goal', summary.currentGoalId ?? 'none')}
           ${WorkMetric('active', String(summary.activeTaskCount))}
         </div>
+        ${LiveTurnStrip(composite)}
         ${currentTask
           ? html`
             <div class="ide-keeper-work-card v2-ide-card">
@@ -296,6 +311,31 @@ function WorkMetric(label: string, value: string) {
       <span>${label}</span>
       <strong title=${value}>${value}</strong>
     </span>
+  `
+}
+
+// task-1740 C3: render the keeper's live-turn state from the composite
+// snapshot SSOT. Every value below is read from `KeeperCompositeSnapshot`
+// (the drift-guarded schema), never re-derived from the global store.
+// When no snapshot resolves (pinned backend that predates these fields,
+// or fleet composite not yet hydrated) the strip is omitted rather than
+// falling back to a store-derived guess, keeping the source singular.
+function LiveTurnStrip(composite: KeeperCompositeSnapshot | null) {
+  if (!composite) return null
+  const liveTurn = composite.live_turn ?? null
+  const lastSkip = composite.last_skip ?? null
+  const livelock = composite.livelock ?? null
+  const boardCursor = composite.board_cursor ?? null
+  const toolCount = liveTurn?.active_tool_count
+  const firstSkipReason = lastSkip?.reasons[0] ?? null
+  return html`
+    <div class="ide-keeper-work-strip" aria-label="Keeper live turn">
+      ${WorkMetric('model', liveTurn?.selected_model ?? '—')}
+      ${WorkMetric('tools', toolCount != null ? String(toolCount) : '—')}
+      ${WorkMetric('skip', firstSkipReason ?? 'none')}
+      ${WorkMetric('livelock', livelock ? String(livelock.attempts) : 'none')}
+      ${WorkMetric('board', boardCursor?.post_id ?? 'none')}
+    </div>
   `
 }
 

--- a/dashboard/src/lib/keeper-composite-lookup.test.ts
+++ b/dashboard/src/lib/keeper-composite-lookup.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { compositeSnapshotForKeeper } from './keeper-composite-lookup'
+import { buildCompositeByKeeperKey } from '../composite-signals'
+import type { Keeper } from '../types'
+import type {
+  FleetCompositeSnapshot,
+  KeeperCompositeSnapshot,
+} from '../api/schemas/keeper-composite'
+
+function snapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompositeSnapshot {
+  return {
+    correlation_id: 'corr-1',
+    run_id: 'run-1',
+    ts: 1_000_000,
+    phase: 'running',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    runtime: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_runtime_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+      phase_derivation_agreement: true,
+    },
+    fsm_guard_violations: 0,
+    fsm_guard_violation_breakdown: [],
+    is_live: true,
+    last_outcome: null,
+    recommended_actions: [],
+    ...overrides,
+  }
+}
+
+function keeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'sangsu',
+    keeper_id: 'keeper-id-sangsu',
+    agent_name: 'keeper-sangsu-agent',
+    status: 'running',
+    ...overrides,
+  } as Keeper
+}
+
+function fleet(snapshots: KeeperCompositeSnapshot[]): FleetCompositeSnapshot {
+  return { generated_at: 1_000_000, count: snapshots.length, snapshots }
+}
+
+describe('compositeSnapshotForKeeper', () => {
+  it('resolves the snapshot by keeper name', () => {
+    const snap = snapshot({ keeper: 'sangsu', correlation_id: 'corr-sangsu' })
+    const byKey = buildCompositeByKeeperKey(fleet([snap]))
+    expect(compositeSnapshotForKeeper(keeper(), byKey)).toBe(snap)
+  })
+
+  it('falls back to keeper_id when the name key is absent', () => {
+    // Snapshot keyed only by correlation_id equal to the keeper_id.
+    const snap = snapshot({ correlation_id: 'keeper-id-sangsu' })
+    const byKey = buildCompositeByKeeperKey(fleet([snap]))
+    expect(compositeSnapshotForKeeper(keeper(), byKey)).toBe(snap)
+  })
+
+  it('returns null when no key matches the keeper', () => {
+    const snap = snapshot({ keeper: 'someone-else', correlation_id: 'corr-else' })
+    const byKey = buildCompositeByKeeperKey(fleet([snap]))
+    expect(compositeSnapshotForKeeper(keeper(), byKey)).toBeNull()
+  })
+
+  it('returns null for a null keeper or null map', () => {
+    const byKey = buildCompositeByKeeperKey(fleet([snapshot({ keeper: 'sangsu' })]))
+    expect(compositeSnapshotForKeeper(null, byKey)).toBeNull()
+    expect(compositeSnapshotForKeeper(keeper(), null)).toBeNull()
+  })
+})

--- a/dashboard/src/lib/keeper-composite-lookup.ts
+++ b/dashboard/src/lib/keeper-composite-lookup.ts
@@ -1,0 +1,29 @@
+import type { Keeper } from '../types'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+
+/**
+ * Resolve the composite snapshot for a keeper from the fleet-wide
+ * by-key map built by `composite-signals.buildCompositeByKeeperKey`.
+ *
+ * The map is keyed by the backend keeper name and correlation_id
+ * (`keeper_composite_observer.ml` `snapshot_to_json`), while a roster
+ * `Keeper` row carries the registry `name` plus an optional `keeper_id`,
+ * so both keys are tried.
+ *
+ * This is the single source of truth for "which composite snapshot
+ * belongs to this keeper" — shared by the agent roster and the IDE
+ * keeper work panel so the two views cannot drift onto different
+ * resolution rules (task-1740, IDE Observation Plane v2 axis C3).
+ */
+export function compositeSnapshotForKeeper(
+  keeper: Keeper | null | undefined,
+  compositeByKeeperKey: ReadonlyMap<string, KeeperCompositeSnapshot> | null,
+): KeeperCompositeSnapshot | null {
+  if (!keeper || !compositeByKeeperKey) return null
+  return (
+    compositeByKeeperKey.get(keeper.name)
+    ?? (typeof keeper.keeper_id === 'string'
+      ? compositeByKeeperKey.get(keeper.keeper_id) ?? null
+      : null)
+  )
+}


### PR DESCRIPTION
## 문제

`#23018`이 keeper composite observer를 `/api/v1/keepers/:name/composite`로 typed schema 노출하고, dashboard에 drift-guard schema(`keeper-composite.ts`)와 fleet signal SSOT(`composite-signals.ts`)까지 갖췄습니다. 그러나 IDE keeper work panel(`ide-keeper-work-panel.ts`)은 전역 store의 `keepers`/`tasks`를 재가공할 뿐, `dashboard/src/components/ide/` 전체에서 composite 참조가 0건이었습니다.

결과적으로 keeper의 live-turn 상태(모델, 진행 중 tool 수, 마지막 skip, livelock, board cursor)가 IDE 패널에 노출되지 않았고, 노출하려면 전역 store를 또 재가공하는 ad-hoc 이중 소스가 만들어질 위험이 있었습니다(하드코딩-산포 원칙 위반).

## 수정

축 C3(task-1740): IDE keeper 패널의 live-turn 필드를 composite snapshot을 **유일 소스**로 렌더하도록 전환했습니다.

1. **공유 resolver SSOT 추출**: keeper별 composite snapshot을 fleet map에서 찾는 규칙(`get(keeper.name) ?? get(keeper.keeper_id)`)이 `agent-roster.ts`에 로컬로 갇혀 있었습니다. 이를 `dashboard/src/lib/keeper-composite-lookup.ts`의 `compositeSnapshotForKeeper`로 추출하고, `agent-roster.ts`와 IDE 패널이 **동일 resolver를 재사용**하도록 했습니다. 두 소비자가 서로 다른 신원 매칭 규칙으로 drift하는 것을 방지합니다.
2. **composite SSOT 소비**: IDE 패널이 `fleetCompositeSnapshot`(signal) + `buildCompositeByKeeperKey`로 keeper의 snapshot을 얻어, live-turn strip에 `selected_model` / `active_tool_count` / `last_skip` / `livelock` / `board_cursor`를 렌더합니다. `.value` 접근이 컴포넌트를 composite freshness에 auto-subscribe하며, 기존 `keepers.value` 읽기 패턴과 동일합니다.
3. **단일 소스 강제**: composite snapshot이 resolve되지 않으면(pinned backend 또는 fleet 미hydrate) strip을 **생략**합니다. store로 fallback하지 않아 이중 소스가 재생성되지 않습니다.
4. **신규 ad-hoc 타입 0**: drift-guard schema 타입 `KeeperCompositeSnapshot`을 그대로 재사용했습니다. 새 인터페이스를 만들지 않았습니다.

## 검증

- `dashboard/src/lib/keeper-composite-lookup.test.ts`(신규): resolver를 name 매칭 / keeper_id fallback / 미매칭 null / null 입력 4케이스로 검증.
- `dashboard/src/components/ide/ide-keeper-work-panel.test.ts`(확장): (a) composite snapshot을 signal에 주입 후 패널이 `selected_model`/`last_skip`/`board_cursor` 값을 렌더 — store `Keeper` 타입에는 이 필드가 없으므로 값의 존재 자체가 composite 소스임을 증명. (b) composite 부재 시 live-turn strip 미표시.
- 로컬 검증:
  - `pnpm typecheck` (tsc --noEmit) green
  - `pnpm lint` (eslint src) green
  - `pnpm exec vitest run` — 변경 3파일(lookup / IDE 패널 / agent-roster 리팩터) green, 전체 스위트 green

MASC task: task-1740 (IDE v2 축C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
