### PR TITLE
fix(ide-sec): annotation 쓰기 직렬화 + fd-cache 무효화 + version CAS (task-1738 B4)

### DIFF
--- a/lib/fs_compat/fd_cache.ml
+++ b/lib/fs_compat/fd_cache.ml
@@ -58,6 +58,15 @@ let get_writer path =
   Stdlib.Mutex.protect mu (fun () -> get_or_open_locked path)
 ;;
 
+let invalidate path =
+  Stdlib.Mutex.protect mu (fun () ->
+    match Hashtbl.find_opt cached path with
+    | Some w ->
+      close_silently w;
+      Hashtbl.remove cached path
+    | None -> ())
+;;
+
 let close_all () =
   Stdlib.Mutex.protect mu (fun () ->
     Hashtbl.iter (fun _ w -> close_silently w) cached;

--- a/lib/fs_compat/fd_cache.mli
+++ b/lib/fs_compat/fd_cache.mli
@@ -23,6 +23,15 @@
     [output_string]/[flush] on the returned channel. *)
 val get_writer : string -> out_channel
 
+(** [invalidate path] flushes, closes, and drops the cached writer for
+    [path] when present (a no-op otherwise). Call it after the inode at
+    [path] is replaced (e.g. an atomic-rename save) so a later
+    [get_writer] reopens the new file rather than appending to the
+    orphaned pre-replacement inode. The caller must ensure no concurrent
+    append is in flight on [path] (the cached channel is closed), which
+    the JSONL store guarantees by holding its per-partition write lock. *)
+val invalidate : string -> unit
+
 (** Flush and close every cached writer. Safe to call concurrently
     with active appends; a subsequent [get_writer] re-opens fresh.
     Registered at [Stdlib.at_exit]. *)

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -652,6 +652,7 @@ let fold_jsonl_lines ~init ~f path =
      ([fd_cache_mu]) so two appends to *different* paths never
      contend on a global fd-cache lock. *)
 let close_all_cached_writers () = Fd_cache.close_all ()
+let invalidate_cached_writer path = Fd_cache.invalidate path
 let reset_fd_cache_for_testing () = Fd_cache.reset_for_testing ()
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -200,6 +200,14 @@ val append_jsonl_batch : string -> Yojson.Safe.t list -> unit
     RFC-0162 §3.4. *)
 val close_all_cached_writers : unit -> unit
 
+(** [invalidate_cached_writer path] drops the cached [append_jsonl]
+    writer for [path] (a no-op if none is cached). Call it after
+    replacing the inode at [path] with [save_file_atomic]: the cached
+    [O_APPEND] channel still points at the pre-rename inode, so without
+    this a later [append_jsonl] would write to the orphaned file. The
+    caller must hold off concurrent appends on [path] while doing so. *)
+val invalidate_cached_writer : string -> unit
+
 (** Drop and close every cached writer. Test-only — production
     relies on process-lifetime persistence and [at_exit] drain. *)
 val reset_fd_cache_for_testing : unit -> unit

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -21,6 +21,46 @@ let annotations_file ~base_dir =
   annotations_file_for ~base_dir Ide_paths.Orphan
 ;;
 
+(* task-1738: per-partition write serialization.
+
+   Individual appends are atomic, but [compact]'s read-all + atomic-rename
+   rewrite ([write_all_partition]) can drop an append that lands between
+   the read and the rename. Every writer of a partition takes the
+   partition's mutex so a rewrite never overlaps an append.
+
+   [Stdlib.Mutex], not [Eio.Mutex]: this storage layer is deliberately
+   Eio-free (it reaches the filesystem only through [Fs_compat], which
+   isolates Eio) and its callers include unit tests that run outside any
+   Eio scheduler. [Eio.Mutex] performs a cancellation-context effect even
+   on the uncontended path and raises [Effect.Unhandled] outside an Eio
+   run, so it is not usable here. This mirrors [Fs_compat]'s own
+   [append_path_mutex_registry], which serializes appends with a
+   [Stdlib.Mutex] in the same Eio-capable-but-Eio-free layer. The
+   registry is guarded by its own [Stdlib.Mutex]; its critical section is
+   a pure in-memory [Hashtbl] lookup. *)
+let write_mutex_registry : (string, Stdlib.Mutex.t) Hashtbl.t = Hashtbl.create 16
+let write_mutex_registry_mu = Stdlib.Mutex.create ()
+
+let write_mutex_for ~base_dir partition =
+  let key = annotations_file_for ~base_dir partition in
+  Stdlib.Mutex.lock write_mutex_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock write_mutex_registry_mu)
+    (fun () ->
+       match Hashtbl.find_opt write_mutex_registry key with
+       | Some m -> m
+       | None ->
+         let m = Stdlib.Mutex.create () in
+         Hashtbl.replace write_mutex_registry key m;
+         m)
+;;
+
+let with_partition_write_lock ~base_dir partition f =
+  let m = write_mutex_for ~base_dir partition in
+  Stdlib.Mutex.lock m;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock m) f
+;;
+
 (* RFC-0128 §4.2: [_orphan/] and [by-url/<slug>/] live one or two
    levels deeper than the flat store. Recursive mkdir avoids
    ENOENT when the parent chain has never been created. *)
@@ -113,7 +153,14 @@ let write_all_partition ~base_dir partition annotations =
   let lines = List.map Yojson.Safe.to_string jsons in
   let content = String.concat "" (List.map (fun line -> line ^ "\n") lines) in
   match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
+  | Ok () ->
+    (* task-1738: the atomic save renamed a fresh inode over [path], so
+       [append_jsonl]'s cached O_APPEND channel now points at the
+       orphaned pre-rename inode. Drop it here — under the partition
+       write lock, so no append is in flight — and the next [create]
+       reopens the compacted file. Without this, every append after the
+       first compaction is written to the orphaned inode and lost. *)
+    Fs_compat.invalidate_cached_writer path
   | Error msg -> raise (Sys_error msg)
 ;;
 
@@ -176,9 +223,10 @@ let create
       ; updated_at_ms = ts
       }
     in
-    Fs_compat.append_jsonl
-      (annotations_file_for ~base_dir partition)
-      (annotation_to_json annotation);
+    with_partition_write_lock ~base_dir partition (fun () ->
+      Fs_compat.append_jsonl
+        (annotations_file_for ~base_dir partition)
+        (annotation_to_json annotation));
     Ok annotation)
 ;;
 
@@ -220,31 +268,56 @@ let list ~base_dir ?(partition = Ide_paths.Orphan) ~filter () =
   List.sort (fun a b -> Int64.compare b.created_at_ms a.created_at_ms) by_task
 ;;
 
-let compact ~base_dir ?(partition = Ide_paths.Orphan) () =
+(* Compaction body without locking; the caller must already hold the
+   partition write lock (e.g. [delete] compacting inline). *)
+let compact_unlocked ~base_dir partition =
   let all = load_all_partition ~base_dir partition in
   write_all_partition ~base_dir partition all
 ;;
 
-let delete ~base_dir ?(partition = Ide_paths.Orphan) ~id ~keeper_id () =
+let compact ~base_dir ?(partition = Ide_paths.Orphan) () =
+  with_partition_write_lock ~base_dir partition (fun () ->
+    compact_unlocked ~base_dir partition)
+;;
+
+let delete ~base_dir ?(partition = Ide_paths.Orphan) ~id ~keeper_id ?expected_version () =
   ensure_store ~base_dir ~partition ();
-  let all = load_all_partition ~base_dir partition in
-  match List.find_opt (fun a -> a.id = id && a.keeper_id = keeper_id) all with
-  | None -> Error "annotation not found or keeper mismatch"
-  | Some _ ->
-    let ts = now_ms () in
-    Fs_compat.append_jsonl
-      (annotations_file_for ~base_dir partition)
-      (tombstone_json id keeper_id ts);
-    let tombstone_count =
-      Fs_compat.fold_jsonl_lines
-        ~init:0
-        ~f:(fun acc ~line_no:_ j -> if is_tombstone j then acc + 1 else acc)
-        (annotations_file_for ~base_dir partition)
-    in
-    let total = List.length all + tombstone_count in
-    if
-      total > 0
-      && float_of_int tombstone_count /. float_of_int total >= compact_threshold
-    then compact ~base_dir ~partition ();
-    Ok ()
+  (* The read (existence + ownership + version check) and the write
+     (tombstone append + optional compaction) run under one partition lock
+     so a concurrent writer cannot slip between the check and the write. *)
+  with_partition_write_lock ~base_dir partition (fun () ->
+    let all = load_all_partition ~base_dir partition in
+    match List.find_opt (fun a -> a.id = id && a.keeper_id = keeper_id) all with
+    | None -> Error "annotation not found or keeper mismatch"
+    | Some found ->
+      (* task-1738: optimistic-concurrency CAS. [updated_at_ms] is the
+         opaque version token (already exposed in [annotation_to_json]);
+         a caller that read the annotation earlier passes it back as
+         [expected_version], and a mismatch means the annotation changed
+         under it, so the delete is refused. Absent [expected_version]
+         preserves the pre-CAS contract (delete by id alone). *)
+      (match expected_version with
+       | Some v when not (Int64.equal found.updated_at_ms v) ->
+         Error
+           (Printf.sprintf
+              "version mismatch: expected %Ld, found %Ld"
+              v
+              found.updated_at_ms)
+       | _ ->
+         let ts = now_ms () in
+         Fs_compat.append_jsonl
+           (annotations_file_for ~base_dir partition)
+           (tombstone_json id keeper_id ts);
+         let tombstone_count =
+           Fs_compat.fold_jsonl_lines
+             ~init:0
+             ~f:(fun acc ~line_no:_ j -> if is_tombstone j then acc + 1 else acc)
+             (annotations_file_for ~base_dir partition)
+         in
+         let total = List.length all + tombstone_count in
+         if
+           total > 0
+           && float_of_int tombstone_count /. float_of_int total >= compact_threshold
+         then compact_unlocked ~base_dir partition;
+         Ok ()))
 ;;

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -60,12 +60,23 @@ val delete
   -> ?partition:Ide_paths.partition
   -> id:string
   -> keeper_id:string
+  -> ?expected_version:int64
   -> unit
   -> (unit, string) result
 (** Soft-delete: append a tombstone record. Only the original
     [keeper_id] may delete its own annotation. The [?partition] must
     match the one the annotation was created under. Default
-    [partition] is {!Ide_paths.Orphan}. *)
+    [partition] is {!Ide_paths.Orphan}.
+
+    task-1738: the existence/ownership check and the tombstone write run
+    under a per-partition write lock, so a concurrent [create]/[delete]
+    on the same partition cannot be lost to an interleaved compaction.
+
+    [?expected_version] enables optimistic concurrency: pass the
+    annotation's [updated_at_ms] (its version token, exposed in
+    {!Ide_annotation_types.annotation_to_json}) and the delete is refused
+    with a ["version mismatch"] error when the stored value differs.
+    Omitting it keeps the legacy delete-by-id contract. *)
 
 val compact : base_dir:string -> ?partition:Ide_paths.partition -> unit -> unit
 (** Rewrite the annotation file excluding tombstones. Called

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -869,6 +869,109 @@ let test_compact_drops_tombstoned () =
       (List.exists (fun (a : Types.annotation) -> a.id = victim.id) listed))
 ;;
 
+(* task-1738: per-partition write serialization + version CAS. *)
+
+let make_cas_annotation base_dir =
+  Result.get_ok
+    (Store.create
+       ~base_dir
+       ~keeper_id:"alice"
+       ~file_path:"lib/a.ml"
+       ~line_start:1
+       ~line_end:1
+       ~kind:Types.Comment
+       ~content:"cas note"
+       ())
+;;
+
+(* Real parallelism (Domain, not systhreads) maximises the chance of a
+   compaction rewrite overlapping an append. Without per-partition write
+   serialization, [compact]'s read-all + atomic-rename drops appends that
+   land between the read and the rename, so the final count would be
+   below the number created. With the lock the count is exact. *)
+let test_concurrent_create_compact_no_loss () =
+  with_temp_dir (fun base_dir ->
+    Store.ensure_store ~base_dir ();
+    let n_writers = 4 in
+    let per_writer = 25 in
+    let writers =
+      List.init n_writers (fun w ->
+        Domain.spawn (fun () ->
+          for i = 0 to per_writer - 1 do
+            match
+              Store.create
+                ~base_dir
+                ~keeper_id:"alice"
+                ~file_path:"lib/a.ml"
+                ~line_start:1
+                ~line_end:1
+                ~kind:Types.Comment
+                ~content:(Printf.sprintf "w%d-%d" w i)
+                ()
+            with
+            | Ok _ -> ()
+            | Error msg -> failf "create failed: %s" msg
+          done))
+    in
+    let compactor =
+      Domain.spawn (fun () ->
+        for _ = 1 to 50 do
+          Store.compact ~base_dir ()
+        done)
+    in
+    List.iter Domain.join writers;
+    Domain.join compactor;
+    let listed = Store.list ~base_dir ~filter:(make_filter ()) () in
+    check
+      int
+      "no annotation lost to concurrent compaction"
+      (n_writers * per_writer)
+      (List.length listed))
+;;
+
+let test_cas_rejects_version_mismatch () =
+  with_temp_dir (fun base_dir ->
+    let created = make_cas_annotation base_dir in
+    let wrong_version = Int64.add created.updated_at_ms 1L in
+    (match
+       Store.delete
+         ~base_dir
+         ~id:created.id
+         ~keeper_id:"alice"
+         ~expected_version:wrong_version
+         ()
+     with
+     | Ok () -> fail "stale expected_version must be rejected"
+     | Error _ -> ());
+    (* The annotation is untouched after a rejected CAS delete. *)
+    let still_there =
+      List.exists
+        (fun (a : Types.annotation) -> a.id = created.id)
+        (Store.list ~base_dir ~filter:(make_filter ()) ())
+    in
+    check bool "annotation survives rejected CAS delete" true still_there;
+    (* The correct version deletes. *)
+    match
+      Store.delete
+        ~base_dir
+        ~id:created.id
+        ~keeper_id:"alice"
+        ~expected_version:created.updated_at_ms
+        ()
+    with
+    | Ok () -> ()
+    | Error msg -> failf "matching expected_version must delete: %s" msg)
+;;
+
+let test_cas_absent_version_is_legacy () =
+  with_temp_dir (fun base_dir ->
+    let created = make_cas_annotation base_dir in
+    (* No expected_version → legacy delete-by-id contract. *)
+    match Store.delete ~base_dir ~id:created.id ~keeper_id:"alice" () with
+    | Ok () -> ()
+    | Error msg -> failf "legacy delete without version must succeed: %s" msg)
+;;
+
 let () =
   run
     "ide_annotations"
@@ -950,6 +1053,20 @@ let () =
             "compaction drops tombstoned annotation"
             `Quick
             test_compact_drops_tombstoned
+        ] )
+    ; ( "write lock + CAS (task-1738)"
+      , [ test_case
+            "concurrent create + compaction loses nothing"
+            `Slow
+            test_concurrent_create_compact_no_loss
+        ; test_case
+            "CAS rejects stale expected_version, accepts current"
+            `Quick
+            test_cas_rejects_version_mismatch
+        ; test_case
+            "absent expected_version keeps legacy delete"
+            `Quick
+            test_cas_absent_version_is_legacy
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

`Ide_annotations`의 annotation 쓰기에 직렬화/버전 검사가 없어 동시 쓰기 시 데이터가 유실될 수 있었습니다.

적대검증 + 재현 테스트로 확인한 **실제 손실 메커니즘**은 단순 read-write 경합이 아니었습니다:

- `append_jsonl`은 `Fs_compat`의 경로별 **캐시된 `O_APPEND` out_channel**(`Fd_cache`)에 씁니다.
- `compact`의 `save_file_atomic`은 temp를 새 inode로 만들어 `annotations.jsonl`에 **rename**합니다.
- rename 이후에도 캐시된 append fd는 **rename 전의 고아 inode**를 계속 가리키므로, 첫 compaction 이후의 모든 append가 그 고아 inode로 기록되어 `path`(compact된 inode)에서 사라집니다.
- 재현: `Domain` 4개 × 25 create + compaction 동시 실행 시, 수정 전에는 100개 중 **1개만** 잔존.

부차적으로 HTTP/스토어에 optimistic-concurrency 수단이 없어 여러 클라이언트의 동시 mutation이 last-writer로 조용히 덮일 수 있었습니다.

## 수정

축 B4(task-1738). #23065(tombstone read) 위에 스택.

1. **per-partition 쓰기 직렬화** (`ide_annotations.ml`): partition별 `Stdlib.Mutex`로 `create`의 append와 `delete`/`compact`의 rewrite를 직렬화. compaction의 read-rename 윈도우에 append가 끼어들지 못합니다. `Stdlib.Mutex`인 이유: 이 storage layer는 `Fs_compat`으로만 파일에 닿는 Eio-free 계층이고 unit test가 Eio 스케줄러 밖에서 돌기 때문입니다(`Eio.Mutex`는 uncontended 경로에서도 cancellation-context effect를 수행해 `Effect.Unhandled`로 실패 — 실측 확인). `Fs_compat`의 `append_path_mutex_registry`와 동일한 패턴.
2. **캐시 fd 무효화 — 근본 수정** (`fs_compat`/`fd_cache`): `Fd_cache.invalidate path`를 추가하고, `write_all_partition`이 atomic save 성공 후(partition lock 하) 호출합니다. rename으로 교체된 inode에 대한 stale append fd를 드롭해 다음 `create`가 새 inode를 reopen하도록 합니다. lock을 잡은 상태에서만 무효화하므로 close-during-write 경합이 없습니다(그래서 전역 `save_file_atomic`이 아니라 스토어 write 경로에서 호출).
3. **version CAS** (`delete ?expected_version:int64`): annotation의 `updated_at_ms`(이미 `annotation_to_json`에 노출된 opaque version token)를 CAS 토큰으로 사용. 값 불일치 시 tombstone을 쓰지 않고 `"version mismatch"` 에러로 거부. `expected_version` 생략 시 기존 delete-by-id 계약 유지(하위호환). 존재/소유권/버전 확인과 tombstone 쓰기가 한 partition lock 안에서 실행되어 TOCTOU가 없습니다.

## 검증

`test/test_ide_annotations.ml`에 그룹 `write lock + CAS (task-1738)` 3개 추가 (전체 27 tests green):

- **(a) 동시 create + compaction 손실 0**: `Domain` 4×25 create + 50 compaction 병렬 → `list` count == 100. 수정 전에는 1(위 재현). 근본 수정의 회귀 가드.
- **(b) CAS**: stale `expected_version` → 거부(annotation 잔존 확인) / 일치 `expected_version` → 삭제.
- **(c) legacy**: `expected_version` 생략 → 기존 delete 성공.
- **(d) 회귀**: 기존 24 tests(create/list/tombstone/compact/overlay) green.

로컬 검증:
- `dune build @check` (전체 repo) green
- `dune exec test/test_ide_annotations.exe` → 27 tests, Test Successful
- `dune exec test/test_fs_compat_fd_cache.exe` → 4 green, `test_fs_compat_append_jsonl_atomicity.exe` → 2 green (fd_cache 변경 회귀 없음)
- `dune build @fmt --auto-promote` 적용

## 스코프

HTTP DELETE 라우트의 `expected_version` 노출은 이 PR에서 제외했습니다. 해당 핸들러는 B3(#23063)가 재작성 중이고, 적절한 409 상태 반환은 delete의 typed 에러가 필요한데 그건 문자열 분류기 안티패턴 회피를 위해 B3 위에서 한 번에 하는 것이 맞습니다. CAS 능력은 스토어 계층에서 완결되고 테스트됩니다.

MASC task: task-1738 (IDE v2 축B4, #23065 스택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
