### PR TITLE
feat(ide-sec): read-only method allowlist for LSP proxy, drop overlay write edits

### DIFF
--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -291,21 +291,20 @@ let completion_items ~base_dir ~file_path ~line:_ : Yojson.Safe.t list =
     Used by textDocument/codeAction. *)
 let code_actions ~base_dir ~file_path ~line ~diagnostics:_ : Yojson.Safe.t list =
   let matching = annotations_at_line ~base_dir ~file_path ~line in
+  (* task-1692: the observation plane is read-only, so "Create MASC
+     Annotation" must not return a WorkspaceEdit that inserts text into the
+     source file (the old [edit]/[newText]). Annotations live in the MASC
+     store, not the buffer, so this offers a MASC command (a separate write
+     lane the client routes to the annotation API) instead of an LSP edit. *)
   let create_action =
     `Assoc [
       ("title", `String "Create MASC Annotation");
       ("kind", `String "quickfix.createAnnotation");
-      ("edit", `Assoc [
-        ("changes", `Assoc [
-          ("file://" ^ base_dir ^ "/" ^ file_path, `List [
-            `Assoc [
-              ("range", `Assoc [
-                ("start", `Assoc [("line", `Int line); ("character", `Int 0)]);
-                ("end", `Assoc [("line", `Int line); ("character", `Int 0)]);
-              ]);
-              ("newText", `String "/* [Comment]  */\n");
-            ];
-          ]);
+      ("command", `Assoc [
+        ("title", `String "Create MASC Annotation");
+        ("command", `String "masc.createAnnotation");
+        ("arguments", `List [
+          `Assoc [("file_path", `String file_path); ("line", `Int line)];
         ]);
       ]);
     ]

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -412,6 +412,44 @@ let forward_notification cs lang_id method_ params =
   | Ok proc -> Lsp_message_router.send_notification cs.router proc ~method_ ~params
 ;;
 
+(* Read-only method allowlist for the catch-all forwarder (task-1692). The
+   observation plane must never forward a write-adjacent request — rename,
+   any formatting, executeCommand, applyEdit, willSaveWaitUntil — to the
+   language server. The overlay methods handled explicitly above (hover,
+   codeAction, ...) are all read-only and never reach the catch-all; this
+   closes the "forward any other textDocument request" hole.
+
+   Default-deny by a typed variant, not a string-prefix classifier: only a
+   listed read method forwards, so a new or unrecognized method is rejected
+   rather than silently passed through, and adding a method forces an explicit
+   classification (RFC-0194 / workaround §2 — no substring allowlist). *)
+type method_disposition =
+  | Forward_read_only
+  | Reject_write_adjacent
+
+let classify_forwarded_method = function
+  | "textDocument/signatureHelp"
+  | "textDocument/declaration"
+  | "textDocument/typeDefinition"
+  | "textDocument/implementation"
+  | "textDocument/documentColor"
+  | "textDocument/colorPresentation"
+  | "textDocument/documentLink"
+  | "textDocument/selectionRange"
+  | "textDocument/linkedEditingRange"
+  | "textDocument/moniker"
+  | "textDocument/prepareCallHierarchy"
+  | "textDocument/prepareTypeHierarchy"
+  | "textDocument/semanticTokens/full"
+  | "textDocument/semanticTokens/full/delta"
+  | "textDocument/semanticTokens/range" -> Forward_read_only
+  (* Everything else — textDocument/rename, prepareRename, formatting,
+     rangeFormatting, onTypeFormatting, willSaveWaitUntil,
+     workspace/executeCommand, workspace/applyEdit, and any unrecognized
+     method — is denied. *)
+  | _ -> Reject_write_adjacent
+;;
+
 (** Handle textDocument/codeLens — merge LSP response with MASC overlays. *)
 let handle_codelens cs params id =
   match extract_uri params with
@@ -887,18 +925,35 @@ let dispatch_message cs msg =
             let lang_id = Lsp_process_manager.lang_of_path relative in
             if lang_id <> "unknown" then forward_notification cs lang_id m params
           | None -> ())
-       (* Other requests with textDocument URI → forward to LSP *)
+       (* Other read-only requests with a textDocument URI → forward to LSP.
+          Write-adjacent / unrecognized methods are rejected here (task-1692)
+          rather than forwarded, so the observation plane never mutates the
+          workspace through the language server. *)
        | Some m, Some n ->
-         (match extract_uri params with
-          | Some uri ->
-            let relative =
-              resolve_relative ~base:cs.base_path uri |> Option.value ~default:""
-            in
-            let lang_id = Lsp_process_manager.lang_of_path relative in
-            if lang_id <> "unknown"
-            then forward_request cs lang_id m params n
-            else send_error cs n (-32801) ("No LSP server for: " ^ relative)
-          | None -> send_error cs n Mcp_error_code.(to_wire_code Method_not_found) ("Unhandled method: " ^ m))
+         (match classify_forwarded_method m with
+          | Reject_write_adjacent ->
+            send_error cs n
+              Mcp_error_code.(to_wire_code Invalid_request)
+              ("Read-only LSP proxy: method not permitted: " ^ m)
+          | Forward_read_only ->
+            (match extract_uri params with
+             | None ->
+               send_error cs n
+                 Mcp_error_code.(to_wire_code Method_not_found)
+                 ("Unhandled method: " ^ m)
+             | Some uri ->
+               (* Resolve the URI explicitly: an out-of-workspace or malformed
+                  URI ([None]) is rejected here rather than collapsed to a
+                  path, so the forward is only reached for a resolved
+                  in-workspace file. *)
+               (match resolve_relative ~base:cs.base_path uri with
+                | None ->
+                  send_error cs n (-32801) "Path is outside the workspace"
+                | Some relative ->
+                  let lang_id = Lsp_process_manager.lang_of_path relative in
+                  if lang_id <> "unknown"
+                  then forward_request cs lang_id m params n
+                  else send_error cs n (-32801) ("No LSP server for: " ^ relative))))
        (* Server-initiated notification broadcast *)
        | Some m, None ->
          Eio.Mutex.use_rw ~protect:true cs.spawn_mutex (fun () ->
@@ -1011,4 +1066,11 @@ module For_testing = struct
 
   let lang_status_json = lang_status_json
   let status_snapshot_json = status_snapshot_json
+
+  (* task-1692: read-only method allowlist for the catch-all forwarder. *)
+  type disposition = method_disposition =
+    | Forward_read_only
+    | Reject_write_adjacent
+
+  let classify_forwarded_method = classify_forwarded_method
 end

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -29,4 +29,18 @@ module For_testing : sig
       (the [masc/lspStatus] response/notification payload), languages sorted
       by id for a stable wire order. *)
   val status_snapshot_json : (string * health) list -> Yojson.Safe.t
+
+  (** Disposition of a catch-all forwarded LSP method (task-1692).
+      [Forward_read_only] methods are proxied to the language server;
+      [Reject_write_adjacent] (rename / formatting / executeCommand /
+      applyEdit / unrecognized) are refused so the observation plane stays
+      read-only. *)
+  type disposition =
+    | Forward_read_only
+    | Reject_write_adjacent
+
+  (** [classify_forwarded_method m] is the read-only allowlist decision for a
+      method reaching the catch-all forwarder. Default-deny: only listed read
+      methods forward. *)
+  val classify_forwarded_method : string -> disposition
 end

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -181,6 +181,82 @@ let test_status_snapshot_is_sorted_and_complete () =
   check (list string) "sorted by lang id" [ "ocaml"; "python" ] (List.map lang_of langs)
 ;;
 
+(* --- task-1692: read-only method allowlist + no overlay write edits --- *)
+
+(* Read-only navigation methods that reach the catch-all forwarder are
+   proxied to the language server. *)
+let test_read_methods_forward () =
+  List.iter
+    (fun m ->
+      check
+        bool
+        (m ^ " forwards")
+        true
+        (Lsp.classify_forwarded_method m = Lsp.Forward_read_only))
+    [ "textDocument/signatureHelp"
+    ; "textDocument/typeDefinition"
+    ; "textDocument/implementation"
+    ; "textDocument/declaration"
+    ; "textDocument/semanticTokens/full"
+    ]
+;;
+
+(* Write-adjacent methods — and, by default-deny, any unrecognized method —
+   are refused so the observation plane never mutates the workspace. *)
+let test_write_and_unknown_methods_rejected () =
+  List.iter
+    (fun m ->
+      check
+        bool
+        (m ^ " rejected")
+        true
+        (Lsp.classify_forwarded_method m = Lsp.Reject_write_adjacent))
+    [ "textDocument/rename"
+    ; "textDocument/prepareRename"
+    ; "textDocument/formatting"
+    ; "textDocument/rangeFormatting"
+    ; "textDocument/onTypeFormatting"
+    ; "textDocument/willSaveWaitUntil"
+    ; "workspace/executeCommand"
+    ; "workspace/applyEdit"
+    ; (* default-deny: an unknown method is rejected, not passed through *)
+      "textDocument/totallyMadeUpMethod"
+    ]
+;;
+
+let rec json_contains_key key = function
+  | `Assoc fields ->
+    List.exists (fun (k, v) -> String.equal k key || json_contains_key key v) fields
+  | `List items -> List.exists (json_contains_key key) items
+  | _ -> false
+;;
+
+(* Overlay code actions must not carry a WorkspaceEdit/newText that writes the
+   source buffer; the create affordance is offered through a MASC command
+   instead (a separate write lane). *)
+let test_code_actions_have_no_workspace_edit () =
+  (* code_actions reads the annotation cache, which takes an Eio mutex, so it
+     must run inside an Eio context. A non-existent base yields no annotations
+     but still exercises the create action that used to carry the edit. *)
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let actions =
+      Lsp_overlay_provider.code_actions
+        ~base_dir:"/tmp/x"
+        ~file_path:"a.ml"
+        ~line:0
+        ~diagnostics:[]
+    in
+    let j = `List actions in
+    check bool "no WorkspaceEdit in code actions" false (json_contains_key "edit" j);
+    check bool "no newText in code actions" false (json_contains_key "newText" j);
+    check
+      bool
+      "create action offered via a command lane"
+      true
+      (json_contains_key "command" j))
+;;
+
 let () =
   run
     "server_ide_lsp_proxy"
@@ -203,6 +279,13 @@ let () =
             test_unmapped_lang_has_null_command
         ; test_case "status snapshot is sorted and complete" `Quick
             test_status_snapshot_is_sorted_and_complete
+        ] )
+    ; ( "lsp_read_only_allowlist"
+      , [ test_case "read-only methods forward" `Quick test_read_methods_forward
+        ; test_case "write/unknown methods are rejected" `Quick
+            test_write_and_unknown_methods_rejected
+        ; test_case "overlay code actions carry no write edit" `Quick
+            test_code_actions_have_no_workspace_edit
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (적대검증 확정 — 진짜 침투 경로)

IDE LSP proxy(관람/observation plane)의 read-only split 실제 구멍은 handshake capabilities가 아니라 **dispatch의 catch-all forward**였습니다:

- `dispatch_message`의 `Some m, Some n` 브랜치가 textDocument URI를 가진 **'기타 모든 요청'을 메서드 allowlist 없이** 언어 서버로 그대로 전달 — `textDocument/rename`, `textDocument/formatting`, `workspace/executeCommand`, `workspace/applyEdit` 등 workspace 변조성 요청 포함.
- overlay `code_actions`("Create MASC Annotation")가 소스 파일에 `/* [Comment] */`를 삽입하는 **WorkspaceEdit(newText)를 반환** — 관람 plane 안에 write 표면이 이미 존재. (MASC annotation은 별도 스토어에 저장되므로 소스 삽입은 의미적으로도 틀림.)

## 수정 (#23070 스택)

1. **read-only 메서드 allowlist** (`classify_forwarded_method`, catch-all에 적용):
   - typed variant `method_disposition = Forward_read_only | Reject_write_adjacent`. **default-deny** — 명시된 조회계 메서드(signatureHelp/typeDefinition/implementation/declaration/semanticTokens/documentColor/selectionRange/prepareCallHierarchy 등)만 forward, rename/formatting/executeCommand/applyEdit/willSaveWaitUntil **및 인식 안 되는 메서드는 거부**.
   - **string prefix 분류기가 아니라 typed enum**으로 닫음 — reader가 exhaustive하고 새 메서드는 명시적 분류를 강제(RFC-0194 / 워크어라운드 §2 "문자열 분류기" 회피). 명시 처리되는 overlay 메서드(hover/codeAction 등)는 catch-all에 도달하지 않음.
   - 거부는 typed error(`Invalid_request` + "method not permitted", silent 아님).
   - 부수 강화: forward 경로의 URI 해석을 `Option.value ~default:""` collapse에서 **명시적 match**로 바꿔 out-of-workspace/malformed URI를 명확히 거부(결정성 경계 부채도 제거).

2. **overlay write edit 제거**: `code_actions`의 create action이 WorkspaceEdit/newText 대신 **MASC 명령(`masc.createAnnotation`)**을 반환 — write를 별도 command lane(annotation 스토어)으로 분리, 소스 버퍼 미변조.

## 검증

`test/test_server_ide_lsp_proxy.ml` 확장(신규 3 케이스, 전부 통과):
- (a) read 메서드(signatureHelp/typeDefinition 등) → `Forward_read_only`.
- (b) write 메서드(rename/formatting/executeCommand/applyEdit/willSaveWaitUntil) **및 unknown 메서드** → `Reject_write_adjacent`(default-deny).
- (c) `code_actions`가 `edit`/`newText` 미반환(재귀 JSON 스캔) + create affordance는 command로 유지.
- (d) allowlist가 typed variant(string prefix 아님).

기존 8 테스트(#23070 degraded-status 포함) 회귀 없음(11/11). `@fmt` clean, server lib + test 빌드 green.
**push 전 묶음 게이트 전체 로컬 재현**(tool-keeper/masc-domain/telemetry-coverage/**determinism**/silent-failure/enum-string/masc-oas-boundary/log-severity/hardcoding 등 14개) **0 fails** — determinism 부채는 명시적 URI 처리로 사전 해소.

## RFC gate

변경 파일은 `lib/server/`(LSP proxy/overlay) + `test/`로 RFC-gate subsystem 경로(credential/repo_manager/operator/dashboard credential/hooks/workflow)에 해당하지 않습니다. 성격상 **write 표면 차단**(방어적 read-only 강화)이며 credential/identity 로직 변경 아님.

RFC-WAIVED: 관람 plane의 read-only 경계 강화(write 메서드 allowlist 거부 + overlay write edit 제거). credential/repo_manager subsystem 미변경, 신규 write 경로 없음(오히려 제거).

MASC task: task-1692 (IDE v2 LSP, #23070 스택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
