### PR TITLE
fix(oas-catalog): add missing kimi-for-coding model row

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -1001,6 +1001,18 @@ supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
 
+# kimi-for-coding is the Kimi Code *coding plan* alias (api.kimi.com/coding),
+# not the pay-per-token platform API: the key comes from the Kimi Code console,
+# the two credentials are not interchangeable, and the gateway picks the served
+# version (Thinking on = K2.7 Code, off = K2.6). Pricing 0.0 means
+# subscription-included, not free-tier.
+[[models]]
+id_prefix = "kimi-for-coding"
+base = "kimi"
+max_context_tokens = 256000
+input_per_million = 0.0
+output_per_million = 0.0
+
 [[models]]
 id_prefix = "kimi-k2"
 base = "kimi"


### PR DESCRIPTION
## Summary

Adds the missing `kimi-for-coding` row to `oas-models.toml` so `[kimi.kimi-for-coding]` runtime bindings and assignments resolve correctly.

## Root cause

The OAS canonical catalog (`../oas/models.toml`) already defines `id_prefix = "kimi-for-coding"` with `base = "kimi"`, but MASC's subset `oas-models.toml` did not include it. As a result, runtime assignments like `[runtime.assignments].ramarama = "kimi.kimi-for-coding"` were rejected with "not found among 9 runtimes".

## What changed

- Added `[[models]] id_prefix = "kimi-for-coding" base = "kimi"` with 256K context and subscription-included pricing, matching the canonical OAS catalog.

## Test Plan

- [x] `dune build --root . @check`
- [x] `dune build --root . @test/runtest-test_runtime_config_validity` (24 tests pass)
