### PR TITLE
fix(otel): emit write_meta_cycle_failures only on failure, not every success cycle

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -610,16 +610,22 @@ let persist_terminal_turn_meta
              else "keeper_cycle" )
          ]
        ();
+     (* #22043: emit inside the [Error] arm so
+        [write_meta_cycle_failures_total] stays a failure counter. It is
+        summed into the dashboard failure panel (Dashboard.ml), and the
+        sibling emit site (Keeper_unified_turn.ml, site=Turn_failure) only
+        fires on the failure path. Previously this inc sat after the match
+        and fired on every successful persist cycle, inflating the series. *)
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string WriteMetaCycleFailures)
+       ~labels:
+         [ "keeper", original_meta.name
+         ; "site", Keeper_write_meta_cycle_failure_site.(to_label Keeper_cycle)
+         ]
+       ();
      if Keeper_meta_store.is_version_conflict_error msg
      then Log.Keeper.warn "write_meta lost CAS race after retries (keeper cycle): %s" msg
      else Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string WriteMetaCycleFailures)
-    ~labels:
-      [ "keeper", original_meta.name
-      ; "site", Keeper_write_meta_cycle_failure_site.(to_label Keeper_cycle)
-      ]
-    ();
   updated_meta
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -929,6 +929,7 @@
   test_server_timing
   test_server_startup_takeover
   test_keeper_meta_cas_retry
+  test_keeper_write_meta_cycle_failures_counter
   test_judge_diagnostics
   test_board_vote_quarantine
   test_keeper_identity_parse
@@ -1123,6 +1124,7 @@
   test_server_timing
   test_server_startup_takeover
   test_keeper_meta_cas_retry
+  test_keeper_write_meta_cycle_failures_counter
   test_judge_diagnostics
   test_board_vote_quarantine
   test_keeper_identity_parse

--- a/test/test_keeper_write_meta_cycle_failures_counter.ml
+++ b/test/test_keeper_write_meta_cycle_failures_counter.ml
@@ -1,0 +1,100 @@
+(** #22043: [masc_keeper_write_meta_cycle_failures_total] must count write-meta
+    failures only, not every successful persist cycle.
+
+    [Keeper_unified_turn_success.persist_terminal_turn_meta] previously
+    incremented [WriteMetaCycleFailures] after the [write_meta_with_merge]
+    match rather than inside its [Error] arm, so a successful persist (the
+    common case) inflated a [*_failures_total] series that [Dashboard.ml] sums
+    into the operator failure panel.
+
+    This test drives the success path with a writable temp config (write
+    returns [Ok]) and asserts the counter does not move. *)
+
+open Alcotest
+open Masc
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_wmcf_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_meta ~name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok m -> m
+  | Error e -> fail ("meta_of_json failed: " ^ e)
+
+(* Read the exact series+labels production emits at the keeper-cycle site. *)
+let cycle_failures_for ~keeper =
+  Otel_metric_store.metric_value_or_zero
+    Keeper_metrics.(to_string WriteMetaCycleFailures)
+    ~labels:
+      [ ("keeper", keeper)
+      ; ("site", Keeper_write_meta_cycle_failure_site.(to_label Keeper_cycle))
+      ]
+    ()
+
+let test_success_path_does_not_increment_failures () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      ignore (Workspace.init config ~agent_name:(Some "operator"));
+      let name = "success-cycle" in
+      let m0 = make_meta ~name in
+      (* Seed the meta file so the merge write has a base version to advance. *)
+      (match
+         Keeper_meta_store.write_meta_with_merge
+           ~merge:Keeper_meta_merge.caller_wins config m0
+       with
+       | Ok () -> ()
+       | Error e -> fail ("seed write failed: " ^ e));
+      let before = cycle_failures_for ~keeper:name in
+      (* Success path: writable temp config -> write_meta returns Ok. *)
+      let (_ : Keeper_meta_contract.keeper_meta) =
+        Keeper_unified_turn_success.For_testing.persist_terminal_turn_meta_for_outcome
+          ~config
+          ~original_meta:m0
+          ~updated_meta:{ m0 with continuity_summary = "cycle ok" }
+          ~terminal_outcome:Keeper_unified_turn_success.For_testing.Terminal_done
+      in
+      let after = cycle_failures_for ~keeper:name in
+      check (float 0.0001) "WriteMetaCycleFailures unchanged on success cycle"
+        before after)
+
+let () =
+  run "keeper_write_meta_cycle_failures_counter"
+    [ ( "emit_location"
+      , [ test_case "success cycle does not inflate failures counter" `Quick
+            test_success_path_does_not_increment_failures
+        ] )
+    ]


### PR DESCRIPTION
## 목표

`masc_keeper_write_meta_cycle_failures_total`(otel counter `WriteMetaCycleFailures`)이 **실패가 아닌 매 성공 keeper 사이클마다 증가**하던 방출 위치 버그를 고친다. `*_failures_total` 시리즈가 성공으로 도배되어 operator 대시보드 실패 패널에서 실제 write 실패 신호가 묻혔다. Closes #22043.

## 근본 원인 (telemetry 위치 버그, telemetry-as-fix 아님)

`lib/keeper/keeper_unified_turn_success.ml` `persist_terminal_turn_meta`:

```ocaml
(match Keeper_meta_store.write_meta_with_merge ... with
 | Ok () -> ()
 | Error msg -> inc WriteMetaFailures ...; log);   (* WriteMetaFailures는 Error arm 안 — 정상 *)
inc WriteMetaCycleFailures ...                       (* match 밖 — Ok/Error 무관하게 항상 실행 *)
```

`WriteMetaCycleFailures` inc가 match 식이 닫힌 뒤에 있어 `Ok ()`(성공) 경로에서도 실행됐다. 이 함수는 성공 사이클 영속화 함수이므로 write가 성공하는 일반 케이스마다 실패 카운터가 증가.

## 변경

- `WriteMetaCycleFailures` inc를 `| Error msg ->` arm 안으로 이동 (write 실패 시에만 방출).
- sibling 방출부(`keeper_unified_turn.ml`, `site=Turn_failure`)는 이미 실패 경로에서만 방출 — 두 site의 의미가 이제 일치한다.
- **메트릭 이름/라벨 불변** (`masc_keeper_write_meta_cycle_failures_total`, `site=keeper_cycle`) → 대시보드 쿼리/PromQL 파손 없음.

## 검증

- 회귀 테스트 `test/test_keeper_write_meta_cycle_failures_counter.ml`: 성공 경로를 구동하고 counter 델타 == 0 단언.
- **Mutation check**: inc를 다시 match 밖으로 되돌린 pre-fix 형태에서 이 테스트가 FAIL함을 확인 → 진짜 회귀 가드임을 증명.
- 테스트는 production과 동일한 `Otel_metric_store.metric_value_or_zero`로 정확 라벨(`keeper`+`site=keeper_cycle`)을 읽음 (#20708 test-shim split-brain 회피).
- `dune build @check` PASS.

## 경계

- telemetry-as-fix(증상 가시화)가 아니라 **방출 위치 버그 수정** — counter가 실제 실패만 세도록 정확성을 회복한다. 데이터 손실 없음, 신규 counter 없음, string 분류기 없음.
