### PR TITLE
fix(runtime): resolve messages-http provider kind via OAS registry

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -197,34 +197,45 @@ let provider_kind_of_cli_provider (provider : Runtime_schema.provider)
        provider.protocol)
 ;;
 
+let registry_provider_kind = function
+  | Some entry -> Some entry.Llm_provider.Provider_registry.defaults.kind
+  | None -> None
+;;
+
+let messages_api_compatible_provider_kind = function
+  | Llm_provider.Provider_config.Anthropic | Llm_provider.Provider_config.Kimi -> true
+  | Llm_provider.Provider_config.OpenAI_compat
+  | Llm_provider.Provider_config.Ollama
+  | Llm_provider.Provider_config.Gemini
+  | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.DashScope -> false
+;;
+
 let provider_kind_for_http_provider ?registry_entry (provider : Runtime_schema.provider)
     : (Llm_provider.Provider_config.provider_kind, string) result =
   match provider.api_format with
   | Ollama_api -> Ok Llm_provider.Provider_config.Ollama
   | Chat_completions_api ->
+    (* Chat-completions keeps the historical OpenAI-compatible fallback when
+       registry metadata is absent. Messages API deliberately fails closed
+       below because there is no safe Anthropic-style default. *)
     Ok
-      (match registry_entry with
-       | Some entry ->
-         let kind = entry.Llm_provider.Provider_registry.defaults.kind in
-         if kind = Llm_provider.Provider_config.Ollama
-         then Llm_provider.Provider_config.OpenAI_compat
-         else kind
+      (match registry_provider_kind registry_entry with
+       | Some Llm_provider.Provider_config.Ollama ->
+         Llm_provider.Provider_config.OpenAI_compat
+       | Some kind -> kind
        | None -> Llm_provider.Provider_config.OpenAI_compat)
   | Messages_api ->
-    (match registry_entry with
-     | Some entry ->
-       let kind = entry.Llm_provider.Provider_registry.defaults.kind in
-       if kind = Llm_provider.Provider_config.OpenAI_compat
-          || kind = Llm_provider.Provider_config.Ollama
-       then
-         Error
-           (Printf.sprintf
-              "provider %S uses protocol %s, but registry kind %s is not \
-               messages-compatible"
-              provider.id
-              provider.protocol
-              (Llm_provider.Provider_config.string_of_provider_kind kind))
-       else Ok kind
+    (match registry_provider_kind registry_entry with
+     | Some kind when messages_api_compatible_provider_kind kind -> Ok kind
+     | Some kind ->
+       Error
+         (Printf.sprintf
+            "provider %S uses protocol %s, but registry kind %s is not \
+             messages-compatible"
+            provider.id
+            provider.protocol
+            (Llm_provider.Provider_config.string_of_provider_kind kind))
      | None ->
        Error
          (Printf.sprintf

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -220,7 +220,7 @@ ramarama = "kimi.kimi-for-coding"
 [providers.kimi]
 display-name = "Kimi Code Plan"
 protocol = "messages-http"
-endpoint = "https://api.kimi.com/coding"
+endpoint = "https://example.invalid/kimi"
 
 [providers.kimi.credentials]
 type = "inline"

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -209,6 +209,33 @@ max-concurrent = 1
   |}
 ;;
 
+let runtime_config_messages_http =
+  {|
+[runtime]
+default = "kimi.kimi-for-coding"
+
+[runtime.assignments]
+ramarama = "kimi.kimi-for-coding"
+
+[providers.kimi]
+display-name = "Kimi Code Plan"
+protocol = "messages-http"
+endpoint = "https://api.kimi.com/coding"
+
+[providers.kimi.credentials]
+type = "inline"
+value = "test-kimi-key"
+
+[models.kimi-for-coding]
+api-name = "kimi-for-coding"
+max-context = 256000
+tools-support = true
+streaming = true
+
+[kimi.kimi-for-coding]
+|}
+;;
+
 let runtime_structured_judge_model_catalog =
   {|
 [[models]]
@@ -257,6 +284,29 @@ let with_runtime_file f =
 
 let with_runtime_initialized f =
   with_runtime_file (fun _path -> f ())
+;;
+
+let test_messages_http_runtime_loads_and_assignment_resolves () =
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content runtime_route_model_catalog @@ fun () ->
+       with_temp_dir "runtime-messages-http" @@ fun dir ->
+       let path = Filename.concat dir "runtime.toml" in
+       write_file path runtime_config_messages_http;
+       match Runtime.init_default ~config_path:path with
+       | Error msg ->
+         Alcotest.failf "messages-http runtime init_default failed: %s" msg
+       | Ok () ->
+         Alcotest.(check string)
+           "ramarama assignment resolves to kimi.kimi-for-coding"
+           "kimi.kimi-for-coding"
+           (KMC.runtime_id_of_meta (make_meta "ramarama"));
+         Alcotest.(check bool)
+           "messages-http runtime is materialized"
+           true
+           (List.mem "kimi.kimi-for-coding" (Runtime.get_runtime_ids ())))
 ;;
 
 (* ---- the per-keeper selection actually reaches the dispatcher ---- *)
@@ -1206,6 +1256,10 @@ let () =
             "runtime_id API arg is not rejected as a removed keeper arg"
             `Quick
             test_runtime_id_tool_arg_is_not_removed_keeper_arg
+        ; Alcotest.test_case
+            "messages-http provider loads and keeper assignment resolves"
+            `Quick
+            test_messages_http_runtime_loads_and_assignment_resolves
         ] )
     ; ( "driver lookup"
       , [ Alcotest.test_case

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -366,6 +366,52 @@ let test_runtime_adapter_materializes_kimi_messages_http () =
             (Llm_provider.Provider_config.string_of_provider_kind other)))
   | bindings -> failf "expected one Kimi binding, got %d" (List.length bindings)
 
+let unregistered_messages_http_toml =
+  {|
+[runtime]
+default = "local.model"
+
+[providers.local]
+display-name = "Local Messages API"
+protocol = "messages-http"
+endpoint = "https://example.invalid/messages"
+
+[models.model]
+api-name = "model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[local.model]
+|}
+
+let test_runtime_adapter_rejects_unregistered_messages_http () =
+  match Runtime_toml.parse_string unregistered_messages_http_toml with
+  | Error errors ->
+    failf
+      "expected unregistered messages-http runtime TOML to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.bindings with
+     | [ binding ] ->
+       (match Runtime_adapter.binding_to_provider_config cfg binding with
+        | Ok provider_cfg ->
+          failf
+            "unregistered messages-http provider must fail closed, got kind %s"
+            (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
+        | Error msg ->
+          check
+            string
+            "adapter reports unmapped provider kind"
+            "local.model: binding resolution failed (provider transport/kind unmapped)"
+            msg)
+     | bindings -> failf "expected one local binding, got %d" (List.length bindings))
+
 let deepseek_runtime_toml =
   {|
 [runtime]
@@ -1227,6 +1273,10 @@ let () =
             "runtime adapter materializes Kimi messages-http provider"
             `Quick
             test_runtime_adapter_materializes_kimi_messages_http
+        ; test_case
+            "runtime adapter rejects unregistered messages-http provider"
+            `Quick
+            test_runtime_adapter_rejects_unregistered_messages_http
         ; test_case
             "runtime TOML accepts DeepSeek reasoning effort"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -316,7 +316,7 @@ default = "kimi.kimi-for-coding"
 [providers.kimi]
 display-name = "Kimi Code Plan"
 protocol = "messages-http"
-endpoint = "https://api.kimi.com/coding"
+endpoint = "https://example.invalid/kimi"
 
 [providers.kimi.credentials]
 type = "inline"
@@ -351,7 +351,7 @@ let test_runtime_adapter_materializes_kimi_messages_http () =
     (match Runtime_adapter.binding_to_provider_config cfg binding with
      | Error msg -> failf "unexpected Kimi messages-http adapter error: %s" msg
      | Ok provider_cfg ->
-       check string "base url" "https://api.kimi.com/coding" provider_cfg.base_url;
+       check string "base url" "https://example.invalid/kimi" provider_cfg.base_url;
        check string "request path" "/v1/messages" provider_cfg.request_path;
        check
          string
@@ -404,12 +404,7 @@ let test_runtime_adapter_rejects_unregistered_messages_http () =
           failf
             "unregistered messages-http provider must fail closed, got kind %s"
             (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
-        | Error msg ->
-          check
-            string
-            "adapter reports unmapped provider kind"
-            "local.model: binding resolution failed (provider transport/kind unmapped)"
-            msg)
+        | Error _ -> ())
      | bindings -> failf "expected one local binding, got %d" (List.length bindings))
 
 let deepseek_runtime_toml =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -308,6 +308,64 @@ max-concurrent = 2
         | None -> fail "expected provider capabilities")
      | _ -> fail "expected one provider")
 
+let kimi_runtime_toml =
+  {|
+[runtime]
+default = "kimi.kimi-for-coding"
+
+[providers.kimi]
+display-name = "Kimi Code Plan"
+protocol = "messages-http"
+endpoint = "https://api.kimi.com/coding"
+
+[providers.kimi.credentials]
+type = "inline"
+value = "test-kimi-key"
+
+[models.kimi-for-coding]
+api-name = "kimi-for-coding"
+max-context = 256000
+tools-support = true
+streaming = true
+
+[kimi.kimi-for-coding]
+|}
+
+let kimi_runtime_config_or_fail () =
+  match Runtime_toml.parse_string kimi_runtime_toml with
+  | Ok cfg -> cfg
+  | Error errors ->
+    failf
+      "expected Kimi runtime TOML to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+
+let test_runtime_adapter_materializes_kimi_messages_http () =
+  let cfg = kimi_runtime_config_or_fail () in
+  match cfg.bindings with
+  | [ binding ] ->
+    (match Runtime_adapter.binding_to_provider_config cfg binding with
+     | Error msg -> failf "unexpected Kimi messages-http adapter error: %s" msg
+     | Ok provider_cfg ->
+       check string "base url" "https://api.kimi.com/coding" provider_cfg.base_url;
+       check string "request path" "/v1/messages" provider_cfg.request_path;
+       check
+         string
+         "api key"
+         "test-kimi-key"
+         (Llm_provider.Secret.header_value provider_cfg.api_key);
+       (match provider_cfg.kind with
+        | Llm_provider.Provider_config.Kimi -> ()
+        | other ->
+          failf
+            "expected Kimi provider kind, got %s"
+            (Llm_provider.Provider_config.string_of_provider_kind other)))
+  | bindings -> failf "expected one Kimi binding, got %d" (List.length bindings)
+
 let deepseek_runtime_toml =
   {|
 [runtime]
@@ -1165,6 +1223,10 @@ let () =
             "runtime TOML reads uses-messages-caching capability"
             `Quick
             test_runtime_toml_accepts_messages_caching_capability
+        ; test_case
+            "runtime adapter materializes Kimi messages-http provider"
+            `Quick
+            test_runtime_adapter_materializes_kimi_messages_http
         ; test_case
             "runtime TOML accepts DeepSeek reasoning effort"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -385,6 +385,25 @@ streaming = true
 [local.model]
 |}
 
+let incompatible_messages_http_toml =
+  {|
+[runtime]
+default = "openai.model"
+
+[providers.openai]
+display-name = "OpenAI over wrong protocol"
+protocol = "messages-http"
+endpoint = "https://api.openai.example/v1/messages"
+
+[models.model]
+api-name = "model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[openai.model]
+|}
+
 let test_runtime_adapter_rejects_unregistered_messages_http () =
   match Runtime_toml.parse_string unregistered_messages_http_toml with
   | Error errors ->
@@ -406,6 +425,38 @@ let test_runtime_adapter_rejects_unregistered_messages_http () =
             (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
         | Error _ -> ())
      | bindings -> failf "expected one local binding, got %d" (List.length bindings))
+
+let test_runtime_adapter_rejects_incompatible_messages_http_kind () =
+  match Runtime_toml.parse_string incompatible_messages_http_toml with
+  | Error errors ->
+    failf
+      "expected incompatible messages-http runtime TOML to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.bindings with
+     | [ binding ] ->
+       (match Runtime_adapter.binding_to_provider_config cfg binding with
+        | Ok provider_cfg ->
+          failf
+            "incompatible messages-http provider must fail closed, got kind %s"
+            (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
+        | Error msg ->
+          check
+            bool
+            "error names messages compatibility policy"
+            true
+            (String_util.contains_substring msg "messages-compatible");
+          check
+            bool
+            "error names provider"
+            true
+            (String_util.contains_substring msg "openai"))
+     | bindings -> failf "expected one OpenAI binding, got %d" (List.length bindings))
 
 let deepseek_runtime_toml =
   {|
@@ -1272,6 +1323,10 @@ let () =
             "runtime adapter rejects unregistered messages-http provider"
             `Quick
             test_runtime_adapter_rejects_unregistered_messages_http
+        ; test_case
+            "runtime adapter rejects incompatible messages-http registry kind"
+            `Quick
+            test_runtime_adapter_rejects_incompatible_messages_http_kind
         ; test_case
             "runtime TOML accepts DeepSeek reasoning effort"
             `Quick


### PR DESCRIPTION
Closes the boot gap where `protocol = "messages-http"` providers were silently dropped, causing keeper runtime assignments to fail validation.