### PR TITLE
fix(main): repair three CI-breakage sources on main

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -234,6 +234,8 @@ let ensure_task_contract_for_verification ?contract ~title ~description () =
   let required_evidence =
     if base.required_evidence <> []
     then base.required_evidence
+    else if base.verify_gate_evidence <> []
+    then base.verify_gate_evidence
     else default_verification_evidence_refs
   in
   let verify_gate_evidence =


### PR DESCRIPTION
This PR now carries only the remaining verification-contract fix after current main absorbed the other two CI-breakage fixes.

Current live diff:
- `lib/workspace/workspace_task_classify.ml`: when a task contract omits `required_evidence` but provides `verify_gate_evidence`, derive `required_evidence` from `verify_gate_evidence` before falling back to the generic defaults.

Why this remains needed:
- `test_verification_fsm` was failing because contracts that intentionally specified only `verify_gate_evidence = ["output.json"]` got generic defaults injected into `required_artifacts` (`completion_notes`, `reviewable_evidence_ref`).

Already landed on current main, no longer part of this PR diff:
- #23073 removed the duplicate board comment-pagination fixture.
- #23059 fixed catch-up digest page-cap fail-visible behavior.
- #23075 added the verification FSM regression expectation.

Local non-Dune verification on the rebased head:
- `opam exec -- ocamlformat --check lib/workspace/workspace_task_classify.ml`
- `opam exec -- ocamlc -stop-after parsing lib/workspace/workspace_task_classify.ml`
- `git diff --check origin/main...HEAD`

CI is the build authority for the full Dune suite.