### PR TITLE
fix(dashboard): restore IDE code-tab scroll (give .v2-surface definite height)

### DIFF
--- a/dashboard/src/styles/app-shell-v2-code-surface-height.test.ts
+++ b/dashboard/src/styles/app-shell-v2-code-surface-height.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
+
+const css = readFileSync(resolve(__dirname, 'app-shell-v2.css'), 'utf-8')
+
+describe('app-shell-v2.css code surface height chain', () => {
+  const codeSurfaceHeightSelectors = [
+    '.v2-app[data-surface="code"] .v2-body',
+    '.v2-app[data-surface="code"] .v2-body > .h-full',
+    '.v2-app[data-surface="code"] .v2-surface',
+    '.v2-app[data-surface="code"] .v2-shell-surface',
+    '.v2-app[data-surface="code"] .ide-v2-surface',
+  ]
+
+  for (const selector of codeSurfaceHeightSelectors) {
+    it(`keeps ${selector} definite for IDE scroll containers`, () => {
+      const declarations = declarationsForSelector(css, selector)
+
+      expect(declarations.height).toBe('100%')
+      expect(declarations['min-height']).toBe('0')
+    })
+  }
+})

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -335,16 +335,16 @@
 
 /* ── v2-surface height: code/IDE tab ───────────────────────────────
    .v2-surface is height:auto by default (only `animation` above sets anything).
-   The code/IDE tab wraps DashboardMain in `h-full overflow-hidden` (app.ts:330),
-   hiding the outer scroll container — the same situation keeper-detail mode is
-   in (see the height:100% patches at keeper-workspace.css:26-32 and :1116-1122).
+   The code/IDE tab wraps DashboardMain in `h-full overflow-hidden`, hiding the
+   outer scroll container. This is the same class of layout as keeper-detail
+   mode, which already owns explicit height patches in keeper-workspace.css.
    Without an explicit height here, every downstream height:100% / flex:1 in the
    IDE chain (.v2-shell-surface -> .ide-v2-surface -> .ide-v2-body 1fr ->
    .ide-v2-rail-scroll) resolves against an indefinite containing block and
    collapses to content height, starving the IDE scroll ports of the definite
-   height that overflow:auto needs to engage. data-surface is emitted at
-   app.ts:290, so the hook already exists in the markup. Mirrors the
-   keeper-detail precedent selector-for-selector. */
+   height that overflow:auto needs to engage. data-surface is emitted by
+   app.ts, so the hook already exists in the markup. Mirrors the keeper-detail
+   precedent selector-for-selector. */
 .v2-app[data-surface="code"] .v2-body,
 .v2-app[data-surface="code"] .v2-body > .h-full,
 .v2-app[data-surface="code"] .v2-surface,

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -333,6 +333,27 @@
   animation: v2-surface-enter 160ms var(--ease) both;
 }
 
+/* ── v2-surface height: code/IDE tab ───────────────────────────────
+   .v2-surface is height:auto by default (only `animation` above sets anything).
+   The code/IDE tab wraps DashboardMain in `h-full overflow-hidden` (app.ts:330),
+   hiding the outer scroll container — the same situation keeper-detail mode is
+   in (see the height:100% patches at keeper-workspace.css:26-32 and :1116-1122).
+   Without an explicit height here, every downstream height:100% / flex:1 in the
+   IDE chain (.v2-shell-surface -> .ide-v2-surface -> .ide-v2-body 1fr ->
+   .ide-v2-rail-scroll) resolves against an indefinite containing block and
+   collapses to content height, starving the IDE scroll ports of the definite
+   height that overflow:auto needs to engage. data-surface is emitted at
+   app.ts:290, so the hook already exists in the markup. Mirrors the
+   keeper-detail precedent selector-for-selector. */
+.v2-app[data-surface="code"] .v2-body,
+.v2-app[data-surface="code"] .v2-body > .h-full,
+.v2-app[data-surface="code"] .v2-surface,
+.v2-app[data-surface="code"] .v2-shell-surface,
+.v2-app[data-surface="code"] .ide-v2-surface {
+  height: 100%;
+  min-height: 0;
+}
+
 /* Respect the v2 motion tweak. */
 .v2-app[data-motion="off"] .v2-surface {
   animation: none;


### PR DESCRIPTION
## Summary

Restores the IDE/code-tab scroll chain by giving the code surface a definite height. The fix scopes the height/min-height rule to the existing `.v2-app[data-surface="code"]` hook and keeps the rest of the dashboard tabs untouched.

## Root Cause

The code tab wraps `DashboardMain` in `h-full overflow-hidden`, which hides the outer scroll container. `.v2-surface` otherwise only owns animation styling, so its height stays auto. That makes the downstream IDE chain (`.v2-shell-surface` -> `.ide-v2-surface` -> `.ide-v2-body` -> `.ide-v2-rail-scroll`) resolve percentage/flex heights against an indefinite containing block, preventing the IDE scroll ports from receiving the definite height required for `overflow:auto`.

Keeper-detail mode already handles this class of layout with explicit surface-height rules. This patch mirrors that precedent for the code surface only.

## Changes

- Add the scoped code-surface height chain in `dashboard/src/styles/app-shell-v2.css`.
- Add a CSS AST/source regression test in `dashboard/src/styles/app-shell-v2-code-surface-height.test.ts` that asserts every selector in the chain keeps `height: 100%` and `min-height: 0`.
- Remove brittle line-number references from the source comment.

## Validation

- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/styles/app-shell-v2-code-surface-height.test.ts`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `python3 scripts/check_test_coverage.py`
- `git diff --check origin/main...HEAD`

## Notes

Happy-dom/jsdom do not compute this layout chain, so the regression guard is a source-level CSS assertion. Browser/manual scroll validation is still useful before marking the draft ready.