### PR TITLE
fix(ci): free preinstalled disk space before Build and Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,30 @@ jobs:
     #     repair guidance instead of masking the error.
     # See: https://github.com/jeong-sik/masc/issues/2957
     steps:
+      - name: Free disk space
+        # ubuntu-latest starts with roughly 14 GB free but preinstalls the
+        # Android SDK (~9 GB), .NET (~1.6 GB), GHC/Haskell (~1 GB) and the
+        # CodeQL bundle (~5 GB) that this OCaml build never uses. Removing them
+        # reclaims about 15 GB and prevents the recurring "No space left on
+        # device" failures in this job (heavy dune build, _build artifacts and
+        # test runners exceed the default free space; runs 28638901622 /
+        # 28644587505 / 28652695346 all died this way on 2026-07-03). This is a
+        # preventive measure that complements the non-retryable repair guidance
+        # emitted by scripts/ci-run-tests.sh. Alternative considered and
+        # rejected for cost: a paid larger runner.
+        # See: https://github.com/jeong-sik/masc/issues/22954
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"
+          df -h /
+
       - name: Checkout
         uses: actions/checkout@v7
 


### PR DESCRIPTION
## 요약

`Build and Test` job이 ubuntu-latest에서 `No space left on device`로 반복 사망하는 P0(#22954)를 해소합니다.

## 근본 원인

ubuntu-latest는 약 14 GB free로 시작하지만 Android SDK(~9 GB), .NET(~1.6 GB), GHC/Haskell(~1 GB), CodeQL(~5 GB)를 프리인스톨합니다. OCaml 빌드는 이들을 전혀 쓰지 않는데, heavy dune build + `_build` 아티팩트 + 테스트 러너가 기본 여유 공간을 초과합니다. 2026-07-03에만 run `28638901622` / `28644587505` / `28652695346` 3건이 동일 `System.IO.IOException: No space left on device`로 사망했습니다(gh api check-runs annotations 실측).

## 변경

`Build and Test` job의 **첫 스텝**으로 `Free disk space`를 추가해 미사용 툴체인(android/dotnet/ghc/ghcup/CodeQL) 제거 + `docker image prune`으로 약 15 GB를 확보합니다. `df -h`로 확보 전/후를 로그에 남깁니다.

## 트레이드오프

- 대안 A(larger runner): 유료 → 비용 발생으로 기각.
- 대안 B(현행 유지 + repair guidance): 예방이 아닌 사후 안내라 main red 지속 → 기각.
- 선택: 프리인스톨 제거는 additive·가역이며, OCaml CI가 android/dotnet/ghc/CodeQL에 의존하지 않음을 확인(`setup-ocaml-toolchain`은 `ocaml/setup-ocaml@v3.6.0` + `actions/cache`(opam)만 사용). `/opt/hostedtoolcache`는 CodeQL 하위만 제거해 opam 캐시 미영향.

## 검증

- YAML 파싱 통과, 스텝 순서 확인(Free disk space → Checkout, 총 23 steps).
- CI-only 변경이라 dune 로컬 검증 대상 아님. 실증은 이 PR 자체의 `Build and Test` job이 디스크 확보 후 green으로 도는 것.
- 제거 대상 디렉토리를 다른 job이 사용하지 않음 확인(ci.yml에 dotnet/android/ghc/codeql 참조 0건).

RFC-WAIVED: `.github/workflows/ci.yml`의 러너 디스크 provisioning은 credential/identity/operator/sandbox/hooks/workflow-docs 어디에도 해당하지 않으며, gate enforcement 변경이 아니라 리소스 확보다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
