### PR TITLE
test(verification): expect deterministic evidence artifact order

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -234,6 +234,9 @@ let ensure_task_contract_for_verification ?contract ~title ~description () =
   let required_evidence =
     if base.required_evidence <> []
     then base.required_evidence
+    (* A verify-only task can require verifier input without widening the
+       completion gate. Keep required_evidence empty in that case; the
+       verifier projection combines verify_gate_evidence separately. *)
     else if base.verify_gate_evidence <> []
     then []
     else default_verification_evidence_refs

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -234,14 +234,14 @@ let ensure_task_contract_for_verification ?contract ~title ~description () =
   let required_evidence =
     if base.required_evidence <> []
     then base.required_evidence
+    else if base.verify_gate_evidence <> []
+    then []
     else default_verification_evidence_refs
   in
   let verify_gate_evidence =
     if base.verify_gate_evidence <> []
     then base.verify_gate_evidence
-    else if base.required_evidence <> []
-    then base.required_evidence
-    else default_verification_evidence_refs
+    else required_evidence
   in
   normalize_task_contract
     { base with completion_contract; required_evidence; verify_gate_evidence }

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -489,7 +489,12 @@ let test_submit_typed_evidence_split_uses_submitted_refs () =
     in
     let raw_required_sources =
       match task.contract with
-      | Some c -> c.verify_gate_evidence @ c.required_evidence
+      | Some c ->
+        Alcotest.(check (list string))
+          "verify-only fixture keeps required_evidence empty"
+          []
+          c.required_evidence;
+        c.verify_gate_evidence @ c.required_evidence
       | None -> Alcotest.fail "fixture task has no contract"
     in
     (* The production projection trims and de-duplicates into deterministic

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -492,12 +492,15 @@ let test_submit_typed_evidence_split_uses_submitted_refs () =
       | Some c -> c.verify_gate_evidence @ c.required_evidence
       | None -> Alcotest.fail "fixture task has no contract"
     in
-    (* Derive the expected value from the raw contract so the test does not
-       merely mirror the production projection function. *)
-    let expected_required_artifacts = raw_required_sources in
+    (* The production projection trims and de-duplicates into deterministic
+       order; this fixture has no blanks/placeholders, so sorting the raw
+       contract sources is enough without mirroring the projection helper. *)
+    let expected_required_artifacts =
+      List.sort_uniq String.compare raw_required_sources
+    in
     Alcotest.(check (list string))
-      "concrete_verification_evidence projection matches raw contract sources"
-      raw_required_sources
+      "concrete_verification_evidence projection matches raw contract artifacts"
+      expected_required_artifacts
       (Task.Completion_review.concrete_verification_evidence task).required_artifacts;
     Alcotest.(check (list string))
       "legacy evidence_refs preserve submitted refs"


### PR DESCRIPTION
Summary:
- Fix the verification-FSM evidence regression after #23073/#23075/#23059 by keeping verifier required_artifacts derived from the task contract's concrete verification evidence.
- Preserve verify-only contracts as verify-only: do not copy verify_gate_evidence into persisted required_evidence, because required_evidence is the deterministic completion-gate SSOT.
- Add a regression assertion that the verify-only fixture keeps required_evidence empty while required_artifacts still resolves to output.json.

Validation:
- opam exec -- ocamlformat --check lib/workspace/workspace_task_classify.ml test/test_verification_fsm.ml
- opam exec -- ocamlc -stop-after parsing lib/workspace/workspace_task_classify.ml
- opam exec -- ocamlc -stop-after parsing test/test_verification_fsm.ml
- git diff --check
- CI Build and Test pending; local full Dune intentionally not run.