### PR TITLE
fix(governance): reject hard-forbidden OAS callback requests in all HITL modes

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -486,8 +486,14 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         let risk_level = queue_risk_level risk in
         let base_path = (config : Workspace.config).base_path in
         let always_approve =
-          Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
-          |> Option.value ~default:false
+          match meta with
+          | Some (m : Keeper_meta_contract.keeper_meta) ->
+            (match m.always_approve with
+             | Some enabled -> enabled
+             | None -> false)
+          | None ->
+            (* No keeper meta means no persisted operator always-approve policy. *)
+            false
         in
         let rule_match =
           (* Hard forbidden returned early; only soft forbidden may be

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -304,6 +304,82 @@ let auto_approval_soft_forbidden ~tool_name ~input =
   destructive_tool_or_op ~tool_name ~input
 ;;
 
+let queue_risk_level = function
+  | Low -> Keeper_approval_queue.Low
+  | Medium -> Keeper_approval_queue.Medium
+  | High -> Keeper_approval_queue.High
+  | Critical -> Keeper_approval_queue.Critical
+;;
+
+(* Human-readable reason attached to a hard-forbidden rejection.
+   Reports every wall that fired — Critical risk, an active runtime
+   blocker, or both — so operators see the complete disposition in the
+   audit trail rather than only the highest-precedence one. *)
+let forbidden_reject_reason ~risk ~runtime_blocked =
+  match risk = Critical, runtime_blocked with
+  | true, true ->
+    "critical risk tool and runtime contract both block auto-approval"
+  | true, false -> "critical risk tool cannot be auto-approved"
+  | false, true -> "runtime contract blocks auto-approval"
+  | false, false ->
+    (* [auto_approval_hard_forbidden] is [risk = Critical || runtime_blocked],
+       so this branch is unreachable when the predicate is true. Kept total
+       to avoid a silent misreport if the invariant ever breaks. *)
+    "auto-approval forbidden by runtime governance"
+;;
+
+(* Reject a hard-forbidden request outright, auditing the decision as a
+   terminal event. Called before any HITL queue path so the request can
+   never be approved by an operator or a remembered rule. *)
+let reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta () =
+  let risk_level = queue_risk_level risk in
+  let base_path = (config : Workspace.config).base_path in
+  let runtime_blocked = runtime_auto_approval_blocked meta in
+  let reason = forbidden_reject_reason ~risk ~runtime_blocked in
+  let turn_id =
+    Option.map
+      (fun (m : Keeper_meta_contract.keeper_meta) -> m.runtime.usage.total_turns + 1)
+      meta
+  in
+  let task_id = Option.bind meta Keeper_runtime_contract.current_task_id_opt in
+  let goal_id = Option.bind meta Keeper_runtime_contract.primary_goal_id_opt in
+  let goal_ids =
+    match meta with
+    | Some (m : Keeper_meta_contract.keeper_meta) -> m.active_goal_ids
+    | None -> []
+  in
+  let runtime_contract =
+    Option.map (Keeper_runtime_contract.runtime_contract_json ~config) meta
+  in
+  let sandbox_target =
+    Option.map
+      (fun keeper_meta -> Keeper_runtime_contract.backend_of_meta keeper_meta)
+      meta
+  in
+  let selected_model = selected_model_of_meta meta in
+  let decision = Agent_sdk.Hooks.Reject reason in
+  Keeper_approval_queue.audit_approval_event
+    ~base_path
+    ~event_type:Keeper_approval_queue.approval_audit_hard_forbidden_event
+    ~id:(Printf.sprintf "hard_forbidden_%s_%s" keeper_name tool_name)
+    ~keeper_name
+    ~tool_name
+    ~risk_level
+    ?turn_id
+    ?task_id
+    ?goal_id
+    ~goal_ids
+    ?sandbox_target
+    ?runtime_contract
+    ?selected_model
+    ~disposition:"Blocked"
+    ~disposition_reason:"hard_forbidden"
+    ~auto_approved:false
+    ~decision:(Keeper_approval_queue.Approval_resolved decision)
+    ();
+  decision
+;;
+
 let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock ()
   : Agent_sdk.Hooks.approval_callback
   =
@@ -333,79 +409,89 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
     let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
     let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
     let hitl_disabled = Env_config_core.disable_hitl () in
-    let auto_approval_forbidden = hard_forbidden || (not hitl_disabled && soft_forbidden) in
-    if hitl_disabled && soft_forbidden then
-      Log.Governance.warn "[%s] HITL bypass: soft_forbidden tool=%s allowed via disable_hitl"
-        keeper_name tool_name;
-    let requires_operator_approval = needs_approval || auto_approval_forbidden in
-    if trifecta_active
-    then
+    if hard_forbidden
+    then (
       Log.Governance.debug
-        "[%s] trifecta_active tool=%s base=%s effective=%s needs_approval=%b \
-         requires_operator_approval=%b"
-        keeper_name
-        tool_name
-        (risk_level_to_string base_risk)
-        (risk_level_to_string risk)
-        needs_approval
-        requires_operator_approval;
-    if trifecta_active && risk_level_to_int risk > risk_level_to_int base_risk
-    then
-      Log.Governance.warn
-        "[%s] trifecta escalated tool=%s base=%s effective=%s"
+        "[%s] hard_forbidden tool=%s base=%s effective=%s: rejecting outright"
         keeper_name
         tool_name
         (risk_level_to_string base_risk)
         (risk_level_to_string risk);
-    if requires_operator_approval
-    then (
-      let turn_id =
-        Option.map
-          (fun (meta : Keeper_meta_contract.keeper_meta) -> meta.runtime.usage.total_turns + 1)
-          meta
-      in
-      let task_id =
-        Option.bind meta (fun keeper_meta ->
-          Keeper_runtime_contract.current_task_id_opt keeper_meta)
-      in
-      let goal_id =
-        Option.bind meta (fun keeper_meta ->
-          Keeper_runtime_contract.primary_goal_id_opt keeper_meta)
-      in
-      let goal_ids =
-        Option.map
-          (fun (keeper_meta : Keeper_meta_contract.keeper_meta) -> keeper_meta.active_goal_ids)
-          meta
-      in
-      let runtime_contract =
-        Option.map
-          (fun keeper_meta ->
-             Keeper_runtime_contract.runtime_contract_json ~config keeper_meta)
-          meta
-      in
-      let sandbox_profile, backend, sandbox_target =
-        match meta with
-        | Some keeper_meta ->
-          let backend = Keeper_runtime_contract.backend_of_meta keeper_meta in
-          ( Some (Keeper_types_profile.sandbox_profile_to_string keeper_meta.sandbox_profile)
-          , Some backend
-          , Some backend )
-        | None -> None, None, None
-      in
-      let selected_model = selected_model_of_meta meta in
-      let risk_level = queue_risk_level risk in
-      let base_path = (config : Workspace.config).base_path in
-      let always_approve =
-        Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
-        |> Option.value ~default:false
-      in
-      let rule_match =
-        (* Hard forbidden cannot be overridden by routine allow-rules.
-           Soft forbidden is HITL-dependent and *is* permitted to be
-           overridden by a narrowly-scoped remembered rule. *)
-        if hard_forbidden
-        then None
-        else
+      reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta ())
+    else (
+      let auto_approval_forbidden = (not hitl_disabled) && soft_forbidden in
+      if hitl_disabled && soft_forbidden
+      then
+        Log.Governance.warn
+          "[%s] HITL bypass: soft_forbidden tool=%s allowed via disable_hitl"
+          keeper_name
+          tool_name;
+      let requires_operator_approval = needs_approval || auto_approval_forbidden in
+      if trifecta_active
+      then
+        Log.Governance.debug
+          "[%s] trifecta_active tool=%s base=%s effective=%s needs_approval=%b \
+           requires_operator_approval=%b"
+          keeper_name
+          tool_name
+          (risk_level_to_string base_risk)
+          (risk_level_to_string risk)
+          needs_approval
+          requires_operator_approval;
+      if trifecta_active && risk_level_to_int risk > risk_level_to_int base_risk
+      then
+        Log.Governance.warn
+          "[%s] trifecta escalated tool=%s base=%s effective=%s"
+          keeper_name
+          tool_name
+          (risk_level_to_string base_risk)
+          (risk_level_to_string risk);
+      if requires_operator_approval
+      then (
+        let turn_id =
+          Option.map
+            (fun (meta : Keeper_meta_contract.keeper_meta) ->
+               meta.runtime.usage.total_turns + 1)
+            meta
+        in
+        let task_id =
+          Option.bind meta (fun keeper_meta ->
+            Keeper_runtime_contract.current_task_id_opt keeper_meta)
+        in
+        let goal_id =
+          Option.bind meta (fun keeper_meta ->
+            Keeper_runtime_contract.primary_goal_id_opt keeper_meta)
+        in
+        let goal_ids =
+          match meta with
+          | Some (keeper_meta : Keeper_meta_contract.keeper_meta) -> keeper_meta.active_goal_ids
+          | None -> []
+        in
+        let runtime_contract =
+          Option.map
+            (fun keeper_meta ->
+               Keeper_runtime_contract.runtime_contract_json ~config keeper_meta)
+            meta
+        in
+        let sandbox_profile, backend, sandbox_target =
+          match meta with
+          | Some keeper_meta ->
+            let backend = Keeper_runtime_contract.backend_of_meta keeper_meta in
+            ( Some (Keeper_types_profile.sandbox_profile_to_string keeper_meta.sandbox_profile)
+            , Some backend
+            , Some backend )
+          | None -> None, None, None
+        in
+        let selected_model = selected_model_of_meta meta in
+        let risk_level = queue_risk_level risk in
+        let base_path = (config : Workspace.config).base_path in
+        let always_approve =
+          Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
+          |> Option.value ~default:false
+        in
+        let rule_match =
+          (* Hard forbidden returned early; only soft forbidden may be
+             overridden by a narrowly-scoped remembered rule. *)
           Keeper_approval_queue.find_matching_rule
             ~base_path
             ~keeper_name
@@ -416,70 +502,70 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
             ?backend
             ?runtime_contract
             ()
-      in
-      if (not auto_approval_forbidden) && always_approve
-      then (
-        Keeper_approval_queue.audit_approval_event
-          ~base_path
-          ~event_type:"auto_approved_always"
-          ~id:(Printf.sprintf "auto_always_%s_%s" keeper_name tool_name)
-          ~keeper_name
-          ~tool_name
-          ~risk_level
-          ?turn_id
-          ?task_id
-          ?goal_id
-          ~goal_ids:(Option.value ~default:[] goal_ids)
-          ?sandbox_target
-          ?runtime_contract
-          ?selected_model
-          ~disposition:"Pass"
-          ~disposition_reason:"always_approve_enabled"
-          ~auto_approved:true
-          ();
-        Agent_sdk.Hooks.Approve)
-      else (
-        match rule_match with
-           | Some matched ->
-             Keeper_approval_queue.audit_approval_event
-               ~base_path
-               ~event_type:"auto_approved_rule_match"
-               ~id:(Printf.sprintf "auto_%s_%s" keeper_name matched.rule_id)
-               ~keeper_name
-               ~tool_name
-               ~risk_level
-               ?turn_id
-               ?task_id
-               ?goal_id
-               ~goal_ids:(Option.value ~default:[] goal_ids)
-               ?sandbox_target
-               ?runtime_contract
-               ?selected_model
-               ~disposition:"Pass"
-               ~disposition_reason:"healthy"
-               ~rule_match:matched
-               ~auto_approved:true
-               ();
-             Agent_sdk.Hooks.Approve
-           | None ->
-             Keeper_approval_queue.submit_and_await
-               ~keeper_name
-               ~tool_name
-               ~input
-               ~base_path
-               ?turn_id
-               ?task_id
-               ?goal_id
-               ?goal_ids
-               ?sandbox_target
-               ?sandbox_profile
-               ?backend
-               ?runtime_contract
-               ?selected_model
-               ~disposition:"Blocked"
-               ~disposition_reason:"waiting_approval"
-               ~risk_level
-               ?clock
-               ()))
-    else Agent_sdk.Hooks.Approve
+        in
+        if (not auto_approval_forbidden) && always_approve
+        then (
+          Keeper_approval_queue.audit_approval_event
+            ~base_path
+            ~event_type:"auto_approved_always"
+            ~id:(Printf.sprintf "auto_always_%s_%s" keeper_name tool_name)
+            ~keeper_name
+            ~tool_name
+            ~risk_level
+            ?turn_id
+            ?task_id
+            ?goal_id
+            ~goal_ids
+            ?sandbox_target
+            ?runtime_contract
+            ?selected_model
+            ~disposition:"Pass"
+            ~disposition_reason:"always_approve_enabled"
+            ~auto_approved:true
+            ();
+          Agent_sdk.Hooks.Approve)
+        else (
+          match rule_match with
+             | Some matched ->
+               Keeper_approval_queue.audit_approval_event
+                 ~base_path
+                 ~event_type:"auto_approved_rule_match"
+                 ~id:(Printf.sprintf "auto_%s_%s" keeper_name matched.rule_id)
+                 ~keeper_name
+                 ~tool_name
+                 ~risk_level
+                 ?turn_id
+                 ?task_id
+                 ?goal_id
+                 ~goal_ids
+                 ?sandbox_target
+                 ?runtime_contract
+                 ?selected_model
+                 ~disposition:"Pass"
+                 ~disposition_reason:"healthy"
+                 ~rule_match:matched
+                 ~auto_approved:true
+                 ();
+               Agent_sdk.Hooks.Approve
+             | None ->
+               Keeper_approval_queue.submit_and_await
+                 ~keeper_name
+                 ~tool_name
+                 ~input
+                 ~base_path
+                 ?turn_id
+                 ?task_id
+                 ?goal_id
+                 ~goal_ids
+                 ?sandbox_target
+                 ?sandbox_profile
+                 ?backend
+                 ?runtime_contract
+                 ?selected_model
+                 ~disposition:"Blocked"
+                 ~disposition_reason:"waiting_approval"
+                 ~risk_level
+                 ?clock
+                 ()))
+      else Agent_sdk.Hooks.Approve)
 ;;

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -322,10 +322,8 @@ let forbidden_reject_reason ~risk ~runtime_blocked =
   | true, false -> "critical risk tool cannot be auto-approved"
   | false, true -> "runtime contract blocks auto-approval"
   | false, false ->
-    (* [auto_approval_hard_forbidden] is [risk = Critical || runtime_blocked],
-       so this branch is unreachable when the predicate is true. Kept total
-       to avoid a silent misreport if the invariant ever breaks. *)
-    "auto-approval forbidden by runtime governance"
+    invalid_arg
+      "forbidden_reject_reason: expected Critical risk or runtime auto-approval blocker"
 ;;
 
 (* Reject a hard-forbidden request outright, auditing the decision as a
@@ -361,7 +359,7 @@ let reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta () 
   Keeper_approval_queue.audit_approval_event
     ~base_path
     ~event_type:Keeper_approval_queue.approval_audit_hard_forbidden_event
-    ~id:(Printf.sprintf "hard_forbidden_%s_%s" keeper_name tool_name)
+    ~id:(Keeper_approval_queue.generate_id ())
     ~keeper_name
     ~tool_name
     ~risk_level

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -81,6 +81,7 @@ let read_recent_audit_raw store limit =
 
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
+let approval_audit_hard_forbidden_event = "hard_forbidden"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
 
@@ -338,10 +339,19 @@ let resolved_approval_decision_kind json =
     Option.bind (Safe_ops.json_string_opt "decision" json) legacy_decision_kind_of_string
 ;;
 
+let resolved_history_event json =
+  match Safe_ops.json_string_opt "event" json with
+  | Some event ->
+    String.equal event approval_audit_resolved_event
+    || String.equal event approval_audit_hard_forbidden_event
+  | None -> false
+;;
+
 let resolved_approval_json_of_audit_event json =
   let resolved_at = Safe_ops.json_float_opt "ts" json in
   `Assoc
     [ "id", `String (Safe_ops.json_string ~default:"" "id" json)
+    ; "event", `String (Safe_ops.json_string ~default:"" "event" json)
     ; "keeper_name", `String (Safe_ops.json_string ~default:"" "keeper" json)
     ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
     ; "risk_level", `String (Safe_ops.json_string ~default:"" "risk" json)
@@ -375,9 +385,7 @@ let list_recent_resolved_json ~base_path ?(n = recent_resolved_history_limit) ()
     | Some store ->
       try
         read_recent_audit_raw store (resolved_audit_scan_window n)
-        |> List.filter (fun json ->
-             String.equal approval_audit_resolved_event
-               (Safe_ops.json_string ~default:"" "event" json))
+        |> List.filter resolved_history_event
         |> List.rev
         |> List.filteri (fun idx _ -> idx < n)
         |> List.map resolved_approval_json_of_audit_event

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -187,6 +187,10 @@ val approval_audit_pending_event : string
 val approval_audit_resolved_event : string
 (** Event tag persisted when an approval is resolved. *)
 
+val approval_audit_hard_forbidden_event : string
+(** Event tag persisted when governance rejects a hard-forbidden approval
+    (Critical risk or an active runtime blocker) without queuing it. *)
+
 val recent_resolved_history_limit : int
 (** Default dashboard history length for resolved HITL approvals. *)
 

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -191,6 +191,9 @@ val approval_audit_hard_forbidden_event : string
 (** Event tag persisted when governance rejects a hard-forbidden approval
     (Critical risk or an active runtime blocker) without queuing it. *)
 
+val generate_id : unit -> string
+(** Generate a unique approval/audit id. *)
+
 val recent_resolved_history_limit : int
 (** Default dashboard history length for resolved HITL approvals. *)
 

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -582,6 +582,9 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       match latest_event_kind with
       | Some "auto_approved_always" -> "always_flag"
       | Some "auto_approved_rule_match" -> "always_rule"
+      | Some event
+        when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
+        "hard_forbidden"
       | Some "resolved" -> "resolved"
       | Some "expired" | Some "approval_timeout" -> "expired"
       | Some "cancelled" -> "cancelled"

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -86,6 +86,8 @@ let severity_of_approval_event event decision =
   match event with
   | "pending" -> "warn"
   | "expired" | "approval_timeout" | "cancelled" -> "bad"
+  | event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
+    "bad"
   | "resolved" -> (
       match decision with
       | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -66,6 +66,11 @@ let rec yield_until ?(attempts = 50) predicate =
     Eio.Fiber.yield ();
     yield_until ~attempts:(attempts - 1) predicate)
 
+let approval_decision_is_reject = function
+  | Agent_sdk.Hooks.Reject _ -> true
+  | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ -> false
+;;
+
 let pending_id_for_keeper ~keeper_name =
   match AQ.list_pending_json () with
   | `List entries ->
@@ -1193,54 +1198,45 @@ let test_callback_approves_low_risk () =
     Alcotest.fail ("expected Approve for low-risk tool, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
-let test_callback_production_tool_edit_file_requires_approval () =
+let test_callback_production_tool_edit_file_rejects_hard_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let initial_pending = AQ.pending_count () in
-  let result = ref None in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let config = (Mcp_server.workspace_config state) in
-  Eio.Fiber.fork ~sw (fun () ->
-    let cb =
-      GP.to_oas_approval_callback
-        ~config ~governance_level:"production" ~keeper_name:"test" () in
-    let decision =
-      cb
-        ~tool_name:"tool_edit_file"
-        ~input:(`Assoc [
-          ("path", `String "lib/example.ml");
-          ("content", `String "let x = 1\n");
-        ])
-    in
-    result := Some decision
-  );
-  yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-  Alcotest.(check int) "one pending approval"
-    (initial_pending + 1) (AQ.pending_count ());
-  let pending_json = AQ.list_pending_json () in
-  let id =
-    match pending_json with
-    | `List (`Assoc kvs :: _) ->
-      (match List.assoc_opt "id" kvs with
-       | Some (`String id) -> id
-       | _ -> Alcotest.fail "missing approval id")
-    | _ -> Alcotest.fail "expected pending approval entry"
-  in
-  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
-   | Ok () -> ()
-   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-  yield_until (fun () -> Option.is_some !result);
-  match !result with
-  | Some Agent_sdk.Hooks.Approve -> ()
-  | Some _ -> Alcotest.fail "expected Approve after operator resolution"
-  | None -> Alcotest.fail "keeper write callback did not suspend for approval")
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = (Mcp_server.workspace_config state) in
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name:"test" ()
+          in
+          cb
+            ~tool_name:"tool_edit_file"
+            ~input:(`Assoc [
+              ("path", `String "lib/example.ml");
+              ("content", `String "let x = 1\n");
+            ]))
+      in
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "tool_edit_file is hard-forbidden and rejects outright"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden tool never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
 let test_callback_production_claimed_worktree_write_auto_approved () =
   with_test_config @@ fun config ->
@@ -1291,54 +1287,44 @@ let test_callback_production_claimed_worktree_write_auto_approved () =
       ("expected Approve for claimed sandbox worktree write, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
-let test_callback_production_worktree_prepare_requires_approval () =
+let test_callback_production_tool_execute_rejects_hard_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let initial_pending = AQ.pending_count () in
-  let result = ref None in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let config = (Mcp_server.workspace_config state) in
-      Eio.Fiber.fork ~sw (fun () ->
-        let cb =
-          GP.to_oas_approval_callback
-            ~config ~governance_level:"production" ~keeper_name:"test" ()
-        in
-        let decision =
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name:"test" ()
+          in
           cb
             ~tool_name:"tool_execute"
             ~input:
               (`Assoc
-                [ ("task_id", `String "task-187"); ("repo_name", `String "masc") ])
-        in
-        result := Some decision);
-      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-      Alcotest.(check int)
-        "worktree preparation requires approval"
-        (initial_pending + 1)
-        (AQ.pending_count ());
-      let id =
-        match AQ.list_pending_json () with
-        | `List (`Assoc kvs :: _) ->
-          (match List.assoc_opt "id" kvs with
-           | Some (`String id) -> id
-           | _ -> Alcotest.fail "missing approval id")
-        | _ -> Alcotest.fail "expected pending approval entry"
+                [ ("task_id", `String "task-187"); ("repo_name", `String "masc") ]))
       in
-      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
-       | Ok () -> ()
-       | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-      yield_until (fun () -> Option.is_some !result);
-      match !result with
-      | Some Agent_sdk.Hooks.Approve -> ()
-      | Some _ -> Alcotest.fail "expected Approve after operator resolution"
-      | None -> Alcotest.fail "worktree preparation callback did not suspend for approval")
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "tool_execute is hard-forbidden and rejects outright"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden tool never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
 let test_callback_paranoid_medium_risk_uses_remembered_policy () =
   with_eio_base_path @@ fun base_path ->
@@ -1455,7 +1441,7 @@ let test_callback_always_approve_bypasses_threshold () =
     Alcotest.fail ("expected Approve with always_approve, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
-let test_callback_typed_last_blocker_overrides_always_approve () =
+let test_callback_typed_last_blocker_rejects_hard_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
@@ -1463,7 +1449,6 @@ let test_callback_typed_last_blocker_overrides_always_approve () =
   Eio.Switch.run @@ fun sw ->
   let keeper_name = "typed-blocked-keeper" in
   let initial_pending = AQ.pending_count () in
-  let result = ref None in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -1493,39 +1478,29 @@ let test_callback_typed_last_blocker_overrides_always_approve () =
           runtime = { base.runtime with last_blocker = Some blocker };
         }
       in
-      Eio.Fiber.fork ~sw (fun () ->
-        let cb =
-          GP.to_oas_approval_callback
-            ~config ~governance_level:"production" ~keeper_name ~meta ()
-        in
-        let decision =
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name ~meta ()
+          in
           cb
             ~tool_name:"masc_create_task"
-            ~input:(`Assoc [ ("title", `String "test") ])
-        in
-        result := Some decision);
-      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-      Alcotest.(check int)
-        "typed last_blocker prevents always_approve bypass"
-        (initial_pending + 1)
-        (AQ.pending_count ());
-      let id =
-        match pending_id_for_keeper ~keeper_name with
-        | Some id -> id
-        | None -> Alcotest.fail "expected pending approval for runtime blocker"
+            ~input:(`Assoc [ ("title", `String "test") ]))
       in
-      (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "blocked") with
-       | Ok () -> ()
-       | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-      yield_until (fun () -> Option.is_some !result);
-      match !result with
-      | Some (Agent_sdk.Hooks.Reject "blocked") -> ()
-      | Some Agent_sdk.Hooks.Approve ->
-        Alcotest.fail "typed last_blocker must not auto-approve"
-      | Some (Agent_sdk.Hooks.Reject reason) ->
-        Alcotest.fail ("unexpected reject reason: " ^ reason)
-      | Some (Agent_sdk.Hooks.Edit _) -> Alcotest.fail "unexpected edit"
-      | None -> Alcotest.fail "runtime blocker callback did not suspend")
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "typed last_blocker makes request hard-forbidden and rejects outright"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden request never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
 let test_callback_transient_last_blocker_allows_always_approve () =
   with_test_config @@ fun config ->
@@ -1597,14 +1572,13 @@ let test_runtime_trust_classifies_always_approve_flag () =
         "auto_approved_always"
         (approval |> member "latest_event_kind" |> to_string))
 
-let test_callback_always_approve_respects_forbidden () =
+let test_callback_always_approve_respects_hard_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let initial_pending = AQ.pending_count () in
-  let result = ref None in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -1621,88 +1595,132 @@ let test_callback_always_approve_respects_forbidden () =
             ("always_approve", `Bool true);
           ])
       in
-      Eio.Fiber.fork ~sw (fun () ->
-        let cb =
-          GP.to_oas_approval_callback
-            ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
-        in
-        let decision =
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name:"test-keeper" ~meta ()
+          in
           cb ~tool_name:"tool_edit_file"
-            ~input:(`Assoc [("path", `String "/dangerous")])
-        in
-        result := Some decision
-      );
-      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-      Alcotest.(check int) "destructive tool still requires approval"
-        (initial_pending + 1) (AQ.pending_count ());
-      let pending_json = AQ.list_pending_json () in
-      let id =
-        match pending_json with
-        | `List (`Assoc kvs :: _) ->
-          (match List.assoc_opt "id" kvs with
-           | Some (`String id) -> id
-           | _ -> Alcotest.fail "missing approval id")
-        | _ -> Alcotest.fail "expected pending approval entry"
+            ~input:(`Assoc [("path", `String "/dangerous")]))
       in
-      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
-       | Ok () -> ()
-       | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-      yield_until (fun () -> Option.is_some !result);
-      match !result with
-      | Some Agent_sdk.Hooks.Approve -> ()
-      | Some _ -> Alcotest.fail "expected Approve after operator resolution"
-      | None -> Alcotest.fail "destructive tool callback did not suspend for approval")
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "always_approve does not bypass hard-forbidden"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden tool never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
-let test_callback_hitl_disabled_forbidden_requires_approval () =
-  with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
+(* Hard-forbidden requests must be rejected outright in all HITL modes.
+   Queuing them would let an operator or remembered rule approve a request
+   that the safety wall already decided cannot run. *)
+let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
+  with_env Env_config_core.disable_hitl_env_key "true" @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
-  let keeper_name = "hitl-disabled-forbidden-keeper" in
+  let keeper_name = "hitl-disabled-hard-forbidden-keeper" in
   let initial_pending = AQ.pending_count () in
-  let result = ref None in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let config = Mcp_server.workspace_config state in
-      Eio.Fiber.fork ~sw (fun () ->
-        let cb =
-          GP.to_oas_approval_callback
-            ~config ~governance_level:"production" ~keeper_name ()
-        in
-        let decision =
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name ()
+          in
           cb
             ~tool_name:"tool_edit_file"
-            ~input:(`Assoc [ ("path", `String "/dangerous") ])
-        in
-        result := Some decision);
-      yield_until (fun () -> AQ.pending_count () = initial_pending + 1);
-      Alcotest.(check int)
-        "forbidden tool still requires approval when HITL threshold is disabled"
-        (initial_pending + 1)
-        (AQ.pending_count ());
-      let id =
-        match pending_id_for_keeper ~keeper_name with
-        | Some id -> id
-        | None -> Alcotest.fail "expected pending approval for HITL-disabled forbidden tool"
+            ~input:(`Assoc [ ("path", `String "/dangerous") ]))
       in
-      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
-       | Ok () -> ()
-       | Error err ->
-         Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-      yield_until (fun () -> Option.is_some !result);
-      match !result with
-      | Some Agent_sdk.Hooks.Approve -> ()
-      | Some Agent_sdk.Hooks.Reject reason ->
-        Alcotest.fail ("expected Approve after operator resolution, got reject: " ^ reason)
-      | Some Agent_sdk.Hooks.Edit _ ->
-        Alcotest.fail "expected Approve after operator resolution, got edit"
-      | None ->
-        Alcotest.fail "HITL-disabled forbidden callback did not suspend for approval")
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "hard-forbidden tool rejects immediately when HITL is disabled"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden rejection never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ());
+      yield_until (fun () ->
+        match
+          find_audit_event
+            ~base_path
+            ~keeper_name
+            ~event_type:AQ.approval_audit_hard_forbidden_event
+        with
+        | Some _ -> true
+        | None -> false);
+      match
+        find_audit_event
+          ~base_path
+          ~keeper_name
+          ~event_type:AQ.approval_audit_hard_forbidden_event
+      with
+      | Some json ->
+        Alcotest.(check string)
+          "audit disposition"
+          "Blocked"
+          (Yojson.Safe.Util.(json |> member "disposition" |> to_string));
+        Alcotest.(check string)
+          "audit disposition_reason"
+          "hard_forbidden"
+          (Yojson.Safe.Util.(json |> member "disposition_reason" |> to_string))
+      | None -> Alcotest.fail "expected hard_forbidden audit event")
+
+let test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing () =
+  with_env Env_config_core.disable_hitl_env_key "" @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  let keeper_name = "hitl-enabled-hard-forbidden-keeper" in
+  let initial_pending = AQ.pending_count () in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = Mcp_server.workspace_config state in
+      let decision_promise =
+        Eio.Fiber.fork_promise ~sw (fun () ->
+          let cb =
+            GP.to_oas_approval_callback
+              ~config ~governance_level:"production" ~keeper_name ()
+          in
+          cb ~tool_name:"masc_delete_workspace" ~input:`Null)
+      in
+      let decision =
+        match Eio.Promise.await decision_promise with
+        | Ok decision -> decision
+        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+      in
+      Alcotest.(check bool)
+        "hard-forbidden Critical tool rejects immediately when HITL is enabled"
+        true
+        (approval_decision_is_reject decision);
+      Alcotest.(check int)
+        "hard-forbidden Critical tool never enters the approval queue"
+        initial_pending
+        (AQ.pending_count ()))
 
 let test_callback_hitl_disabled_soft_forbidden_auto_approved () =
   with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
@@ -1956,28 +1974,30 @@ let () =
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;
-      Alcotest.test_case "production keeper write requires approval" `Quick
-        test_callback_production_tool_edit_file_requires_approval;
+      Alcotest.test_case "production keeper write rejects hard-forbidden" `Quick
+        test_callback_production_tool_edit_file_rejects_hard_forbidden;
       Alcotest.test_case "production claimed worktree write auto-approved" `Quick
         test_callback_production_claimed_worktree_write_auto_approved;
-      Alcotest.test_case "production worktree preparation requires approval" `Quick
-        test_callback_production_worktree_prepare_requires_approval;
+      Alcotest.test_case "production tool execute rejects hard-forbidden" `Quick
+        test_callback_production_tool_execute_rejects_hard_forbidden;
       Alcotest.test_case "paranoid medium risk uses remembered policy" `Quick
         test_callback_paranoid_medium_risk_uses_remembered_policy;
       Alcotest.test_case "remembered rule overrides soft forbidden" `Quick
         test_callback_remembered_rule_overrides_soft_forbidden;
       Alcotest.test_case "always_approve bypasses threshold" `Quick
         test_callback_always_approve_bypasses_threshold;
-      Alcotest.test_case "typed last_blocker overrides always_approve" `Quick
-        test_callback_typed_last_blocker_overrides_always_approve;
+      Alcotest.test_case "typed last_blocker rejects hard-forbidden" `Quick
+        test_callback_typed_last_blocker_rejects_hard_forbidden;
       Alcotest.test_case "transient last_blocker allows always_approve" `Quick
         test_callback_transient_last_blocker_allows_always_approve;
       Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
         test_runtime_trust_classifies_always_approve_flag;
-      Alcotest.test_case "always_approve respects forbidden" `Quick
-        test_callback_always_approve_respects_forbidden;
-      Alcotest.test_case "HITL disabled still gates forbidden tools" `Quick
-        test_callback_hitl_disabled_forbidden_requires_approval;
+      Alcotest.test_case "always_approve respects hard forbidden" `Quick
+        test_callback_always_approve_respects_hard_forbidden;
+      Alcotest.test_case "HITL disabled hard-forbidden rejects without queuing" `Quick
+        test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing;
+      Alcotest.test_case "HITL enabled hard-forbidden rejects without queuing" `Quick
+        test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing;
       Alcotest.test_case "HITL disabled allows soft forbidden tools" `Quick
         test_callback_hitl_disabled_soft_forbidden_auto_approved;
     ]);


### PR DESCRIPTION
## Problem

The OAS approval callback (`Governance_pipeline.to_oas_approval_callback`) was a second, inconsistent source of truth for hard-forbidden requests: it queued Critical-risk / runtime-blocked tool calls when HITL was enabled, while `Keeper_guards.governance_approval_guard` already overrides those unconditionally. This meant the callback could be invoked directly (or future guard changes could leave it exposed) to queue and later approve requests that the safety wall had already decided cannot run.

## Change

- Reject hard-forbidden requests outright in the callback, before any HITL queue path, regardless of HITL state.
- Add `approval_audit_hard_forbidden_event` and include it in resolved history so these terminal decisions are observable.
- Update `Keeper_runtime_trust_snapshot` / `Keeper_runtime_trust_timeline` to surface `hard_forbidden`.
- Update callback tests to expect outright rejection instead of queuing.

## Verification

- `scripts/dune-local.sh build test/test_hitl_approval.exe test/test_governance_pipeline.exe`
- `test/test_hitl_approval.exe test` — 46 tests pass
- `test/test_governance_pipeline.exe test` — 99 tests pass
- `scripts/dune-local.sh build @fmt` — clean

Depends on the CI-breakage fixes in #23081 (branch currently includes those commits for a green build).
