### PR TITLE
fix(governance): reject HITL approval-resolve with missing decision (RFC-0305)

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -315,26 +315,29 @@ let dashboard_governance_approval_resolve_http_json ~base_path ~(args : Yojson.S
     let remember_rule =
       Safe_ops.json_bool_opt "remember_rule" args |> Option.value ~default:false
     in
-    let decision_name =
-      Safe_ops.json_string_opt "decision" args
-      |> Option.value ~default:"approve"
-      |> String.trim
-      |> String.lowercase_ascii
-    in
+    (* RFC-0305: a missing [decision] field must not default to approve — this
+       resolves a pending HITL approval, so an omitted/malformed decision is a
+       bad request, not a silent grant. Mirrors the [id]-required check above. *)
+    (* Carry the canonical name alongside the decision so the success response
+       echoes what was applied without re-matching [approval_decision] (whose
+       [Edit] arm is never produced here). *)
     let decision =
-      match decision_name with
-      | "approve" -> Ok Agent_sdk.Hooks.Approve
-      | "reject" ->
-        let reason =
-          Safe_ops.json_string_opt "reason" args
-          |> Option.value ~default:"dashboard rejected approval"
-        in
-        Ok (Agent_sdk.Hooks.Reject reason)
-      | _ -> Error (Bad_request "decision must be 'approve' or 'reject'")
+      match Safe_ops.json_string_opt "decision" args with
+      | None -> Error (Bad_request "decision is required")
+      | Some raw ->
+        (match raw |> String.trim |> String.lowercase_ascii with
+         | "approve" -> Ok (Agent_sdk.Hooks.Approve, "approve")
+         | "reject" ->
+           let reason =
+             Safe_ops.json_string_opt "reason" args
+             |> Option.value ~default:"dashboard rejected approval"
+           in
+           Ok (Agent_sdk.Hooks.Reject reason, "reject")
+         | _ -> Error (Bad_request "decision must be 'approve' or 'reject'"))
     in
     (match decision with
      | Error _ as err -> err
-     | Ok decision ->
+     | Ok (decision, decision_name) ->
        (match
           Keeper_approval_queue.resolve_with_policy
             ~id

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -301,6 +301,44 @@ type approval_resolve_http_error =
   | Bad_request of string
   | Gone of Keeper_approval_queue.resolve_error
 
+let approval_resolve_decision_field = "decision"
+let approval_resolve_reason_field = "reason"
+let approval_resolve_approve_name = "approve"
+let approval_resolve_reject_name = "reject"
+let approval_resolve_decision_required_message = "decision is required"
+let approval_resolve_decision_invalid_message = "decision must be 'approve' or 'reject'"
+let approval_resolve_default_reject_reason = "dashboard rejected approval"
+
+type approval_resolve_decision =
+  | Approval_resolve_approve
+  | Approval_resolve_reject of string
+
+let approval_resolve_decision_name = function
+  | Approval_resolve_approve -> approval_resolve_approve_name
+  | Approval_resolve_reject _ -> approval_resolve_reject_name
+;;
+
+let approval_resolve_decision_to_hook = function
+  | Approval_resolve_approve -> Agent_sdk.Hooks.Approve
+  | Approval_resolve_reject reason -> Agent_sdk.Hooks.Reject reason
+;;
+
+let approval_resolve_decision_of_json args =
+  match Safe_ops.json_string_opt approval_resolve_decision_field args with
+  | None -> Error (Bad_request approval_resolve_decision_required_message)
+  | Some raw ->
+    (match raw |> String.trim |> String.lowercase_ascii with
+     | name when String.equal name approval_resolve_approve_name ->
+       Ok Approval_resolve_approve
+     | name when String.equal name approval_resolve_reject_name ->
+       let reason =
+         Safe_ops.json_string_opt approval_resolve_reason_field args
+         |> Option.value ~default:approval_resolve_default_reject_reason
+       in
+       Ok (Approval_resolve_reject reason)
+     | _ -> Error (Bad_request approval_resolve_decision_invalid_message))
+;;
+
 let approval_resolve_http_error_to_string = function
   | Bad_request msg -> msg
   | Gone err -> Keeper_approval_queue.resolve_error_to_string err
@@ -321,23 +359,11 @@ let dashboard_governance_approval_resolve_http_json ~base_path ~(args : Yojson.S
     (* Carry the canonical name alongside the decision so the success response
        echoes what was applied without re-matching [approval_decision] (whose
        [Edit] arm is never produced here). *)
-    let decision =
-      match Safe_ops.json_string_opt "decision" args with
-      | None -> Error (Bad_request "decision is required")
-      | Some raw ->
-        (match raw |> String.trim |> String.lowercase_ascii with
-         | "approve" -> Ok (Agent_sdk.Hooks.Approve, "approve")
-         | "reject" ->
-           let reason =
-             Safe_ops.json_string_opt "reason" args
-             |> Option.value ~default:"dashboard rejected approval"
-           in
-           Ok (Agent_sdk.Hooks.Reject reason, "reject")
-         | _ -> Error (Bad_request "decision must be 'approve' or 'reject'"))
-    in
-    (match decision with
+    (match approval_resolve_decision_of_json args with
      | Error _ as err -> err
-     | Ok (decision, decision_name) ->
+     | Ok decision ->
+       let decision_name = approval_resolve_decision_name decision in
+       let decision = approval_resolve_decision_to_hook decision in
        (match
           Keeper_approval_queue.resolve_with_policy
             ~id

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -45,6 +45,8 @@ type approval_resolve_http_error =
 val approval_resolve_http_error_to_string :
   approval_resolve_http_error -> string
 
+val approval_resolve_decision_required_message : string
+
 (** {1 Board / memory / governance HTTP entries} *)
 
 val dashboard_board_json :

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1165,9 +1165,10 @@ let test_approval_resolve_missing_decision_is_rejected () =
            ~base_path:workspace_base ~args
        with
        | Error (SDH.Bad_request msg) ->
-         Alcotest.(check bool)
-           "missing decision surfaces a decision-required bad request" true
-           (Astring.String.is_infix ~affix:"decision" msg)
+         Alcotest.(check string)
+           "missing decision surfaces exact bad request"
+           SDH.approval_resolve_decision_required_message
+           msg
        | Error (SDH.Gone _) ->
          Alcotest.fail "expected Bad_request, got Gone"
        | Ok _ ->

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1139,6 +1139,44 @@ let test_dashboard_resolve_and_delete_rules_use_workspace_base_path () =
       Alcotest.(check int) "env fallback still empty" 0
         (List.length (AQ.list_rules ~base_path:env_base ())))
 
+(* RFC-0305 (fail-closed default): a resolve request that omits the [decision]
+   field must be rejected as a bad request, NOT silently defaulted to approve.
+   Pre-fix this returned [Ok Approve] and granted the pending action. *)
+let test_approval_resolve_missing_decision_is_rejected () =
+  let workspace_base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir workspace_base)
+    (fun () ->
+      let resolved = ref None in
+      let id =
+        AQ.submit_pending
+          ~keeper_name:"failclosed-keeper"
+          ~tool_name:"masc_transition"
+          ~input:(`Assoc [ ("action", `String "claim") ])
+          ~risk_level:AQ.Medium
+          ~base_path:workspace_base
+          ~on_resolution:(fun d -> resolved := Some d)
+          ()
+      in
+      (* [decision] intentionally omitted. *)
+      let args = `Assoc [ ("id", `String id) ] in
+      (match
+         SDH.dashboard_governance_approval_resolve_http_json
+           ~base_path:workspace_base ~args
+       with
+       | Error (SDH.Bad_request msg) ->
+         Alcotest.(check bool)
+           "missing decision surfaces a decision-required bad request" true
+           (Astring.String.is_infix ~affix:"decision" msg)
+       | Error (SDH.Gone _) ->
+         Alcotest.fail "expected Bad_request, got Gone"
+       | Ok _ ->
+         Alcotest.fail
+           "missing decision must NOT resolve the approval (fail-closed, RFC-0305)");
+      (* The pending approval must remain unresolved. *)
+      Alcotest.(check bool) "pending approval not resolved" true
+        (!resolved = None))
+
 let test_submit_pending_audit_uses_workspace_base_path () =
   let env_base = temp_dir () in
   let workspace_base = temp_dir () in
@@ -1961,6 +1999,8 @@ let () =
         test_runtime_contract_policy_uses_workspace_base_path;
       Alcotest.test_case "dashboard approve-always rules use workspace base_path" `Quick
         test_dashboard_resolve_and_delete_rules_use_workspace_base_path;
+      Alcotest.test_case "resolve without decision is rejected (RFC-0305 fail-closed)" `Quick
+        test_approval_resolve_missing_decision_is_rejected;
       Alcotest.test_case "submit_pending audit uses workspace base_path" `Quick
         test_submit_pending_audit_uses_workspace_base_path;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick


### PR DESCRIPTION
## 목표

HITL approval-resolve 엔드포인트가 `decision` 필드 누락 시 **자동 승인**하던 fail-open을 닫는다. RFC-0305 site I.

관련 RFC: RFC-0305 (safety and governance gates fail closed by default, PR #23091).

## 근본 원인

`server_dashboard_http.ml` `dashboard_governance_approval_resolve_http_json`:

```ocaml
let decision_name =
  Safe_ops.json_string_opt "decision" args
  |> Option.value ~default:"approve"   (* ← 누락 → approve *)
```

이 핸들러는 pending HITL approval을 resolve한다. `decision` 필드를 빠뜨린 요청(operator 오조작, 프론트 버그, 위조 요청)이 **조용히 승인**된다. 안전 결정(승인)이 입력 누락 시 default가 되는 fail-open.

## 변경

- `decision` 누락 → `Error (Bad_request "decision is required")`. 바로 위 `id`-required 체크와 동일 패턴.
- canonical name을 decision 생성 시점에 함께 바인딩(`(decision, name)` 튜플)해 성공 응답이 적용된 결정을 echo. `approval_decision`의 `Edit` arm은 이 경로에서 생성 안 되므로 non-exhaustive match 회피.
- 동작 불변(정상 클라이언트는 항상 approve/reject 전송). 누락은 버그/조작이므로 reject가 안전하고 정상 UX 무영향.

## 검증

- 회귀 테스트 `test_approval_resolve_missing_decision_is_rejected`(`test_hitl_approval.ml`): decision 없이 resolve → `Bad_request` + approval 미해결 단언.
- **Mutation-verified**: fix를 pre-fix 형태(`default:"approve"`)로 되돌리면 이 테스트가 FAIL(로그에 `HITL_APPROVAL_RESOLVED decision=approve` 확인) → 진짜 회귀 가드.
- `dune build @check` + `test_hitl_approval.exe` 47 tests green.

## 경계

fail-open을 **닫는** 변경(telemetry-as-fix/permissive-default의 반대). credential 미변경. RFC-0305의 blast-radius 최소 site(입력 오류 fail-closed, fleet-stall 위험 無).
