### PR TITLE
fix(ide): qualify Fpath calls in fpath_within to avoid Fpath.base shadowing

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -437,8 +437,11 @@ let path_of_file_uri uri =
 let fpath_within ~base path =
   match Fpath.of_string base, Fpath.of_string path with
   | Ok base, Ok path when Fpath.is_abs base && Fpath.is_abs path ->
-    let base = Fpath.(rem_empty_seg (normalize base)) in
-    let path = Fpath.(rem_empty_seg (normalize path)) in
+    (* Qualify explicitly instead of [Fpath.(...)]: inside the local open the
+       identifier [base] resolves to [Fpath.base] (t -> t) and shadows the local
+       [base] value, which fails to type-check under fpath 0.7.3. *)
+    let base = Fpath.rem_empty_seg (Fpath.normalize base) in
+    let path = Fpath.rem_empty_seg (Fpath.normalize path) in
     (match Fpath.relativize ~root:base path with
      | Some rel ->
        if List.exists (String.equal "..") (Fpath.segs rel) then None else Some rel


### PR DESCRIPTION
## 요약

`lib/server/server_ide_lsp_proxy.ml`의 `fpath_within`이 `Fpath.(rem_empty_seg (normalize base))`를 써서 main 컴파일이 깨지고 `main_eio`(서버) 빌드가 막히던 문제를 고칩니다.

## 근본 원인

`Fpath.(...)` local open 안에서 식별자 `base`가 로컬 `base` 값(패턴 바인딩)이 아니라 **`Fpath.base` (t -> t)** 로 resolve되어 shadowing → 타입 에러:
```
Error: The value base has type t -> t but an expression was expected of type t
```
lock이 `fpath = "0.7.3"`(base 함수 보유)이라 이 버전에서 컴파일 불가. #23070(feat(ide) LSP)이 이 코드를 도입했고, 이후 #23063/#23062가 위로 머지되며 미수정 상태로 origin/main에 잔존.

## 변경

`Fpath.(...)` local open 제거, 명시 qualify:
```
let base = Fpath.rem_empty_seg (Fpath.normalize base) in
let path = Fpath.rem_empty_seg (Fpath.normalize path) in
```
`base`/`path` 로컬 값을 사용하며 어느 fpath 버전에서도 안전. `fpath_within`의 경로 traversal 방어(`%2F..%2F` 거부) 동작 불변.

## 검증

- `ocamlformat --check` 통과. 동일 shadowing 패턴 전수 스캔 결과 다른 사이트 없음(:482는 `p`라 미충돌).
- dune build는 CI 위임. 이 fix로 `dune build bin/main_eio.exe`가 lib 에러 없이 통과해야 함.

## 비고

이 파일이 컴파일 안 되는 채 3개 PR(#23070/#23063/#23062)이 연속 머지된 것은 CI Gate 우회(admin-merge of red) 정황 — masc#21757/#22050 계열. 별도 test-only 컴파일 에러(`Keeper_latched_reason`/`latched_reason`/`Bigstringaf`/`Lsp.inbound_dispatch_worker_count`)도 관측되나 서버 빌드와 무관해 이 PR 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
