### PR TITLE
fix(ide): match path_of_file_uri result directly (2nd #23070 compile error)

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -476,11 +476,12 @@ let realpath_scoped_relative ~base relative =
 
 let workspace_root_for_initialize ~base_path root_uri =
   let candidate = root_uri |> path_of_file_uri in
+  (* [path_of_file_uri] returns a plain [string], so match on it directly rather
+     than [Option.bind] (which expects a [string option]). *)
   match
-    Option.bind candidate (fun s ->
-      match Fpath.of_string s with
-      | Ok p when Fpath.is_abs p -> Some Fpath.(rem_empty_seg (normalize p))
-      | _ -> None)
+    (match Fpath.of_string candidate with
+     | Ok p when Fpath.is_abs p -> Some (Fpath.rem_empty_seg (Fpath.normalize p))
+     | _ -> None)
   with
   | Some candidate ->
     (match fpath_within ~base:base_path (Fpath.to_string candidate) with


### PR DESCRIPTION
## 요약

#23093 후속. `#23070`이 `lib/server/server_ide_lsp_proxy.ml`에 남긴 **두 번째 타입 에러**를 고칩니다. #23093이 Fpath.base shadowing을 고친 뒤에도 이 에러로 lib/server 빌드가 여전히 깨져 main_eio(서버)가 안 빌드됐습니다.

## 근본 원인

`workspace_root_for_initialize`:
```
let candidate = root_uri |> path_of_file_uri in   (* candidate : string *)
match Option.bind candidate (fun s -> ...) with    (* Option.bind expects string option *)
```
`path_of_file_uri`는 plain `string`을 반환(:499에서 string으로 직접 사용)하는데 `Option.bind`가 option을 기대 →
```
Error: The value candidate has type string but an expression was expected of type 'a option
```

## 변경

`Option.bind` 제거, `Fpath.of_string candidate`를 직접 match. 동작(workspace root 해석) 불변.

## 검증

- `ocamlformat --check` 통과. dune build는 CI 위임.
- origin/main(f7dbc7e53d1, #23093 반영)이 base.

## 비고

#23070은 컴파일 안 되는 채 머지됐고(Fpath + Option.bind 두 lib 에러), #23063/#23062가 위로 미수정 머지 = CI Gate 우회(masc#21757/#22050 계열). 별도 test-only 에러(`Lsp.inbound_dispatch_worker_count`/`Bigstringaf`/`latched_reason`)는 서버 무관, 별건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
