### PR TITLE
[codex] clean up fleet board controls

### DIFF
--- a/dashboard/docs/consolidation/route-inventory.md
+++ b/dashboard/docs/consolidation/route-inventory.md
@@ -93,7 +93,7 @@ led to the current route table.
 | overview.ts:712 | command/inspector | | |
 | lab-inspector.ts:27,34,41 | monitoring/agents, command/intervene, workspace/board | | |
 | memory.ts:392, memory-post-detail.ts:218 | workspace/board | | |
-| agents-unified.ts:17 | monitoring/agents | view | activeView deep-link narrowing |
+| agents-unified.ts:21 | monitoring/agents | view | activeView deep-link narrowing |
 | agent-detail-state.ts:133 | monitoring/agents | | back navigation |
 | agent-profile.ts:320,362 | monitoring/agents | agent (line 362) | |
 | board-utils.ts:24 | monitoring/agents | agent | |

--- a/dashboard/docs/consolidation/route-inventory.md
+++ b/dashboard/docs/consolidation/route-inventory.md
@@ -93,7 +93,7 @@ led to the current route table.
 | overview.ts:712 | command/inspector | | |
 | lab-inspector.ts:27,34,41 | monitoring/agents, command/intervene, workspace/board | | |
 | memory.ts:392, memory-post-detail.ts:218 | workspace/board | | |
-| agents-unified.ts:79 | monitoring/agents | view | FilterChips onChange |
+| agents-unified.ts:17 | monitoring/agents | view | activeView deep-link narrowing |
 | agent-detail-state.ts:133 | monitoring/agents | | back navigation |
 | agent-profile.ts:320,362 | monitoring/agents | agent (line 362) | |
 | board-utils.ts:24 | monitoring/agents | agent | |

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -130,7 +130,7 @@ describe('cockpit entrypoint registry', () => {
     })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-cognition' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'agents', view: 'keeper' },
+      params: { section: 'agents', view: 'keepers' },
     })
     expect(cockpitTargetForParams({ mode: 'IDE', tab: 'source' })).toEqual({
       tab: 'code',

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -152,7 +152,7 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   {
     mode: 'cognition',
     aliases: ['keeper-cognition'],
-    target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper' } },
+    target: { tab: 'monitoring', params: { section: 'agents', view: 'keepers' } },
     coverage: 'covered',
   },
   {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1095,7 +1095,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         onKeyDown=${handleRowKey}
         class="fl-row v2-monitoring-roster-row ${selected ? 'sel' : ''} ${ringFocusClasses({ tone: 'accent-fg', width: 2 })}"
       >
-        <div class="fl-id">
+        <div class="fl-id" aria-label=${`Keeper ${row.displayName}`}>
           <span class="shrink-0">
             <${AgentAvatar}
               name=${row.agent.name}
@@ -1120,7 +1120,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           </div>
         </div>
 
-        <div class="fl-state">
+        <div class="fl-state" aria-label=${`운영판정 · 차단 · 단계 ${chipLabel} ${glossText} ${row.bandActionHint}`}>
           <span class="fl-chip" data-tone=${tone} title=${row.band.description}>
             <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:currentColor" aria-hidden="true"></span>
             ${chipLabel}
@@ -1132,7 +1132,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             : null}
         </div>
 
-        <div class="fl-ctx">
+        <div class="fl-ctx" aria-label=${`컨텍스트 ${ctxPct != null ? `${ctxPct}%` : '없음'}`}>
           ${ctxPct != null
             ? html`
                 <div class="fl-ctx-bar"><span class=${ctxHot ? 'hot' : ''} style="width:${ctxPct}%"></span></div>
@@ -1141,9 +1141,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             : html`<span class="fl-ctx-val zero" data-stub="no context_ratio">—</span>`}
         </div>
 
-        <div class="fl-tool ${row.recentTools.length || (row.toolCallCount ?? 0) > 0 ? '' : 'none'}" title=${latestTool}>${latestTool}</div>
+        <div
+          class="fl-tool ${row.recentTools.length || (row.toolCallCount ?? 0) > 0 ? '' : 'none'}"
+          title=${latestTool}
+          aria-label=${`최근 도구 ${latestTool}`}
+        >${latestTool}</div>
 
-        <div class="fl-actcell" onClick=${(e: Event) => e.stopPropagation()}>
+        <div class="fl-actcell" aria-label="액션" onClick=${(e: Event) => e.stopPropagation()}>
           ${row.keeperRuntime
             ? html`<${KeeperActionButtons}
                 keeper=${row.keeperRuntime}

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -16,15 +16,12 @@ import {
   shellCounts,
   shellRuntimeResolution,
 } from '../store'
-import { FilterChips } from './common/filter-chips'
-import { TextInput } from './common/input'
 import { EmptyState } from './common/feedback-state'
 import { ringFocusClasses } from './common/ring'
 import { RouteLink } from './common/route-link'
 import { TimeAgo } from './common/time-ago'
 import {
   keeperIdentityKeys,
-  keeperIdentitySearchTerms,
   keeperPrincipalKey,
   keeperPrimaryName,
 } from './common/keeper-identity'
@@ -78,7 +75,7 @@ import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { compositeSnapshotForKeeper } from '../lib/keeper-composite-lookup'
 import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
 
-type StatusFilter = 'all' | RuntimeBand
+type RuntimeCountKey = 'all' | RuntimeBand
 
 type RosterStateNote = { label: string; text: string; kind?: string }
 type RosterPresenceDisplay = { status: string | null; detail: string | null }
@@ -492,55 +489,6 @@ function expectedCountForKeeperFilter(
   return useDetailRows ? expectedRuntimeDetailRows(counts) : counts.configured.totalRuntimes
 }
 
-const FILTER_META: Record<StatusFilter, { label: string; description: string }> = {
-  all: {
-    label: '전체 상세',
-    description: '모든 키퍼와 에이전트를 표시합니다.',
-  },
-  active: { label: runtimeBandMeta('active').label, description: runtimeBandMeta('active').description },
-  attention: { label: runtimeBandMeta('attention').label, description: runtimeBandMeta('attention').description },
-  paused: { label: runtimeBandMeta('paused').label, description: runtimeBandMeta('paused').description },
-  offline: { label: runtimeBandMeta('offline').label, description: runtimeBandMeta('offline').description },
-  // RFC-0295: `transient` joins the filter facets so the operator can drill
-  // into mid-compaction / mid-handoff keepers without losing the busy rail.
-  transient: { label: runtimeBandMeta('transient').label, description: runtimeBandMeta('transient').description },
-}
-
-const STATUS_CHIP_KEYS = [
-  'all',
-  'attention',
-  'transient',
-  'active',
-  'paused',
-  'offline',
-] as const satisfies readonly StatusFilter[]
-
-/**
- * Pure filter for agent roster rows.
- *
- * Case-insensitive substring match on `row.name`, `row.current_task`, and
- * `row.koreanName` so operators can locate an agent/keeper by display name,
- * current task text, or the Korean alias shown on the card.
- *
- * Empty/whitespace query returns the input reference unchanged (no new
- * array allocation, preserves referential equality for memoisation).
- *
- * Input is never mutated; `Agent` is treated as readonly.
- */
-function filterAgentRoster(
-  rows: readonly Agent[],
-  query: string,
-): readonly Agent[] {
-  const needle = query.trim().toLowerCase()
-  if (needle === '') return rows
-  return rows.filter(row => {
-    if (row.name.toLowerCase().includes(needle)) return true
-    if (row.current_task && row.current_task.toLowerCase().includes(needle)) return true
-    if (row.koreanName && row.koreanName.toLowerCase().includes(needle)) return true
-    return false
-  })
-}
-
 function uniqueToolNames(...groups: Array<string[] | null | undefined>): string[] {
   const seen = new Set<string>()
   const names: string[] = []
@@ -679,9 +627,9 @@ function countAgentsByStatus(
   agentList: Agent[],
   keeperList: Keeper[],
   compositeByKeeperKey: ReadonlyMap<string, KeeperCompositeSnapshot> | null = null,
-): Record<StatusFilter, number> {
+): Record<RuntimeCountKey, number> {
   const keeperLookup = buildKeeperRuntimeLookup(keeperList)
-  const counts: Record<StatusFilter, number> = {
+  const counts: Record<RuntimeCountKey, number> = {
     all: agentList.length,
     active: 0,
     attention: 0,
@@ -778,8 +726,6 @@ export function countRuntimeKinds(
 }
 
 export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFilterMode } = {}) {
-  const [filter, setFilter] = useState<StatusFilter>('all')
-  const [search, setSearch] = useState('')
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
 
   const agentList = agents.value
@@ -812,7 +758,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
     const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup)
-    // Count via the same `band` SSOT that the rail paint and filter chip
+    // Count via the same `band` SSOT that the rail paint and health pills
     // use. RFC-0295 §5.3 + iter-6 reconciliation: `Draining` phase
     // contributes to `pausedCount` because `keeperBand()` routes it to
     // the `paused` band. The duplicated count block in `countRuntimeKinds`
@@ -885,47 +831,14 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     ),
     [scopedAgents, keeperRuntimeLookup, runtimeKeeperList, compositeByKeeperKey],
   )
-  const normalizedSearch = search.trim().toLowerCase()
-  const searchTermsByAgent = useMemo(
-    () => new Map(
-      scopedAgents.map(agent => {
-        const keeper =
-          keeperRuntimeLookup.get(agent.name)
-          ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
-          ?? findKeeperRuntime(agent.name, runtimeKeeperList)
-        return [
-          agent.name,
-          keeperIdentitySearchTerms(
-            keeper?.name ?? null,
-            keeper?.agent_name ?? agent.name,
-          ).map(term => term.toLowerCase()),
-        ] as const
-      }),
-    ),
-    [scopedAgents, keeperRuntimeLookup, runtimeKeeperList],
-  )
-  const filtered = useMemo(() => scopedAgents
-    .filter((a: Agent) => {
-      if (filter !== 'all' && bandByAgent.get(a.name)?.key !== filter) return false
-      if (normalizedSearch) {
-        const terms = searchTermsByAgent.get(a.name) ?? [a.name.toLowerCase()]
-        const identityMatch = terms.some(term => term.includes(normalizedSearch))
-        if (!identityMatch) {
-          // Fall back to the pure roster filter (current_task / koreanName).
-          const fieldMatch = filterAgentRoster([a], search).length === 1
-          if (!fieldMatch) return false
-        }
-      }
-      return true
-    })
+  const filtered = useMemo(() => scopedAgents.slice()
     .sort((a: Agent, b: Agent) => {
       // RFC-0295: transient sits between active and paused on the sort
       // axis — the prototype groups "what is currently moving" above the
       // healthy steady-state rows so the operator's first scan reads as
       // "attention → transient → active → paused → offline" instead of
       // burying a mid-compaction keeper under the active rows.
-      const order: Record<StatusFilter, number> = {
-        all: 0,
+      const order: Record<RuntimeBand, number> = {
         attention: 0,
         transient: 1,
         active: 2,
@@ -937,7 +850,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       if (aOrder !== bOrder) return aOrder - bOrder
       return a.name.localeCompare(b.name)
     }),
-    [scopedAgents, filter, bandByAgent, normalizedSearch, searchTermsByAgent, search],
+    [scopedAgents, bandByAgent],
   )
 
   const counts = countAgentsByStatus(scopedAgents, runtimeKeeperList, compositeByKeeperKey)
@@ -960,12 +873,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ? `항목 ${filtered.length}개 표시 중`
             : `항목 ${filtered.length} / ${scopedAgents.length}개 표시 중`
         )
-  const statusChips = STATUS_CHIP_KEYS.map(key => ({
-    key,
-    label: FILTER_META[key].label,
-    count: executionLoaded.value || scopedAgents.length > 0 ? counts[key] : null,
-    title: FILTER_META[key].description,
-  }))
   const liveKeepers = runtimeCounts.live.keepers
   const livePausedKeepers = runtimeCounts.live.pausedKeepers
   const liveOfflineKeepers = runtimeCounts.live.offlineKeepers
@@ -1123,9 +1030,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const transientRows = rosterRows.filter(row => row.band.key === 'transient')
   const steadyRows = rosterRows.filter(row => row.band.key !== 'attention' && row.band.key !== 'transient')
 
-  // Health pills (fl-hpill) read from the same band counts the status filter
-  // chips already compute. No title here — the shell's SurfaceLead owns the
-  // "Keeper Fleet" header for this surface (dashboard-shell SURFACE_OWN_LEAD).
+  // Health pills (fl-hpill) read from the same band counts as the rows. No title
+  // here — the shell's SurfaceLead owns the "Keeper Fleet" header for this
+  // surface (dashboard-shell SURFACE_OWN_LEAD).
   const healthRun = counts.active
   const healthTransient = counts.transient
   const healthPaused = counts.paused
@@ -1265,48 +1172,20 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     <div class="v2-monitoring-surface fl-shell agent-page">
       <section class="monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="runtime surface directory">
         <div class="flex flex-col gap-5">
-          <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
-            <div class="flex min-w-0 flex-col gap-2.5">
-              <div class="fl-health">
-                <span class="fl-hpill ok">실행 rows <b>${healthRun}</b></span>
+          <div class="flex min-w-0 flex-col gap-2.5">
+            <div class="fl-health">
+              <span class="fl-hpill ok">실행 rows <b>${healthRun}</b></span>
                 ${healthTransient > 0 ? html`<span class="fl-hpill busy">전이 rows <b>${healthTransient}</b></span>` : null}
-                <span class="fl-hpill warn">일시정지 rows <b>${healthPaused}</b></span>
-                <span class="fl-hpill">오프라인 rows <b>${healthOffline}</b></span>
-                ${healthAttention > 0 ? html`<span class="fl-hpill bad">주의 <b>${healthAttention}</b></span>` : null}
-              </div>
-              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
-                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">workspace agents ≠ keeper fibers</span>
-                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">configured keeper ≠ running fiber</span>
-                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">task owner ≠ live agent</span>
-              </div>
-              <span class="inline-flex w-fit items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
+              <span class="fl-hpill warn">일시정지 rows <b>${healthPaused}</b></span>
+              <span class="fl-hpill">오프라인 rows <b>${healthOffline}</b></span>
+              ${healthAttention > 0 ? html`<span class="fl-hpill bad">주의 <b>${healthAttention}</b></span>` : null}
             </div>
-
-            <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-muted)] uppercase">
-              <span>이름 / 작업</span>
-              <${TextInput}
-                class="rounded-[var(--r-1)] bg-[var(--color-bg-surface)] px-4 py-3 text-base text-[var(--color-fg-primary)] shadow-[inset_0_1px_0_var(--color-border-default)] focus:border-[var(--color-accent-fg)] focus:shadow-[0_0_0_2px_var(--color-accent-soft)]"
-                name="agent_search"
-                ariaLabel="runtime row 이름 · task owner 검색"
-                autoComplete="off"
-                placeholder="이름 · task owner로 찾기"
-                value=${search}
-                onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
-              />
-            </label>
-          </div>
-
-          <div class="monitor-muted-panel v2-monitoring-panel p-3.5 md:p-4">
-            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div class="text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-secondary)] uppercase">상세 상태</div>
-              <${FilterChips}
-                chips=${statusChips}
-                value=${filter}
-                onChange=${(key: StatusFilter) => setFilter(key)}
-                size="md"
-                tone="accent"
-              />
+            <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+              <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">workspace agents ≠ keeper fibers</span>
+              <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">configured keeper ≠ running fiber</span>
+              <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">task owner ≠ live agent</span>
             </div>
+            <span class="inline-flex w-fit items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
           </div>
 
           ${showExecutionFallbackState
@@ -1336,7 +1215,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             rows + attention/steady group dividers. The shell's SurfaceLead
             owns the "Keeper Fleet" title for this surface, so this body
             renders NO top-level page header (avoids the prior duplicate-header
-            regression). Live wiring (selection, filters, actions, presence) is
+            regression). Live wiring (selection, actions, presence) is
             unchanged — only the markup/class tree is reskinned.
 
             Column header labels keep 운영판정 / 차단 · 단계 / 액션 so existing
@@ -1362,9 +1241,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ${rosterRows.length === 0 ? html`
               <div class="px-6 py-10">
                 <${EmptyState}
-                  message=${normalizedSearch && scopedAgents.length > 0
-                      ? `필터 결과 없음 (${scopedAgents.length} items)`
-                    : showExecutionFallbackState && expectedScopedCount > 0
+                  message=${showExecutionFallbackState && expectedScopedCount > 0
                       ? `${fallbackStateTitle}: ${scopeLabel}가 있지만, 현재 조건에 맞는 항목은 아직 없습니다.`
                       : '조건에 맞는 runtime row가 없습니다.'}
                   compact

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -75,8 +75,6 @@ import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { compositeSnapshotForKeeper } from '../lib/keeper-composite-lookup'
 import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
 
-type RuntimeCountKey = 'all' | RuntimeBand
-
 type RosterStateNote = { label: string; text: string; kind?: string }
 type RosterPresenceDisplay = { status: string | null; detail: string | null }
 
@@ -627,10 +625,9 @@ function countAgentsByStatus(
   agentList: Agent[],
   keeperList: Keeper[],
   compositeByKeeperKey: ReadonlyMap<string, KeeperCompositeSnapshot> | null = null,
-): Record<RuntimeCountKey, number> {
+): Record<RuntimeBand, number> {
   const keeperLookup = buildKeeperRuntimeLookup(keeperList)
-  const counts: Record<RuntimeCountKey, number> = {
-    all: agentList.length,
+  const counts: Record<RuntimeBand, number> = {
     active: 0,
     attention: 0,
     paused: 0,
@@ -863,16 +860,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   })
   const resultCountLabel =
     expectedScopedCount > scopedAgents.length
-      ? (
-          filtered.length === scopedAgents.length
-            ? `항목 ${filtered.length}개 표시 · 예상 ${expectedScopedCount}개`
-            : `항목 ${filtered.length} / ${scopedAgents.length}개 표시 · 예상 ${expectedScopedCount}개`
-        )
-      : (
-          filtered.length === scopedAgents.length
-            ? `항목 ${filtered.length}개 표시 중`
-            : `항목 ${filtered.length} / ${scopedAgents.length}개 표시 중`
-        )
+      ? `항목 ${filtered.length}개 표시 · 예상 ${expectedScopedCount}개`
+      : `항목 ${filtered.length}개 표시 중`
   const liveKeepers = runtimeCounts.live.keepers
   const livePausedKeepers = runtimeCounts.live.pausedKeepers
   const liveOfflineKeepers = runtimeCounts.live.offlineKeepers

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
-import { h, type ComponentChildren } from 'preact'
+import { h } from 'preact'
 import { render } from 'preact'
-import { act } from 'preact/test-utils'
 import type { RouteState } from '../types'
 
 const mockRoute = await vi.hoisted(async () => {
@@ -9,23 +8,11 @@ const mockRoute = await vi.hoisted(async () => {
   return signal<RouteState>({ tab: 'monitoring', params: {}, postId: null })
 })
 
-type FilterChip = { key: string; label: ComponentChildren }
-type FilterChipWithCount = FilterChip & { count?: ComponentChildren }
-
 vi.mock('./keeper-detail-page', () => ({
   KeeperDetailPage: () => h('div', { 'data-testid': 'keeper-detail-page' }, 'KeeperDetailPage'),
 }))
 vi.mock('./agent-profile', () => ({
   AgentProfile: ({ name }: { name: string }) => h('div', { 'data-testid': 'agent-profile', 'data-name': name }, 'AgentProfile'),
-}))
-vi.mock('./keeper-spawn/keeper-spawn-panel', () => ({
-  KeeperSpawnPanel: () => h('div', { 'data-testid': 'keeper-spawn-panel' }, 'KeeperSpawnPanel'),
-}))
-vi.mock('./keeper-token-stats', () => ({
-  KeeperTokenStats: () => h('div', { 'data-testid': 'keeper-token-stats' }, 'KeeperTokenStats'),
-}))
-vi.mock('./keeper-multi-select', () => ({
-  KeeperMultiSelect: ({ hint }: { hint?: string }) => h('div', { 'data-testid': 'keeper-multi-select', 'data-hint': hint }, 'KeeperMultiSelect'),
 }))
 vi.mock('./fsm-hub', () => ({
   FsmHub: ({ selectedName }: { selectedName?: string }) => h('div', { 'data-testid': 'fsm-hub', 'data-selected': selectedName }, 'FsmHub'),
@@ -36,49 +23,12 @@ vi.mock('./fleet-fsm-matrix', () => ({
 vi.mock('./composite-fsm-flowchart', () => ({
   CompositeFsmFlowchart: () => h('div', { 'data-testid': 'composite-fsm-flowchart' }, 'CompositeFsmFlowchart'),
 }))
-vi.mock('./common/filter-chips', () => ({
-  FilterChips: ({ chips, value, onChange }: {
-    chips: FilterChipWithCount[]
-    value: string
-    onChange: (key: string) => void
-  }) =>
-    h('div', { 'data-testid': 'filter-chips', 'data-value': value },
-      chips.map((chip) => h('button', { key: chip.key, onClick: () => onChange(chip.key) }, [
-        chip.label,
-        chip.count != null ? h('span', { 'data-testid': `chip-count-${chip.key}` }, chip.count) : null,
-      ]))
-    ),
-}))
 vi.mock('./agent-roster', () => ({
   AgentRoster: ({ keeperFilter }: { keeperFilter: string }) => h('div', { 'data-testid': 'agent-roster', 'data-filter': keeperFilter }, 'AgentRoster'),
-  countRuntimeKinds: vi.fn(() => ({ agents: 0, keepers: 0, pausedKeepers: 0, transientKeepers: 0, offlineKeepers: 0, keeperRows: 0, totalRuntimes: 0 })),
 }))
 
 vi.mock('../router', () => ({
   route: mockRoute,
-  navigate: vi.fn((tab: RouteState['tab'], params?: Record<string, string>) => {
-    mockRoute.value = { tab, params: params ?? {}, postId: null }
-  }),
-}))
-
-vi.mock('../store', () => ({
-  agents: { value: [] },
-  keepers: { value: [] },
-  executionLoaded: { value: false },
-  shellCounts: { value: null },
-  shellRuntimeResolution: { value: null },
-}))
-vi.mock('../namespace-truth-store', () => ({
-  namespaceTruth: { value: null },
-}))
-vi.mock('../runtime-counts', () => ({
-  formatKeeperRosterCount: vi.fn(() => 'keeper 행 16 / keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16'),
-  formatRuntimeRosterCount: vi.fn(() => 'runtime 행 20 / keeper 실행 fiber 4 / workspace agents 4 / 일시정지 keeper 12 / configured keeper 16'),
-  resolveRuntimeCounts: vi.fn(() => ({
-    live: { agents: 4, keepers: 4, pausedKeepers: 12, transientKeepers: 0, offlineKeepers: 0, keeperRows: 16, tasks: 0, totalRuntimes: 8, available: true },
-    configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' },
-    source: 'execution',
-  })),
 }))
 
 import { AgentsUnified } from './agents-unified'
@@ -118,35 +68,26 @@ describe('AgentsUnified', () => {
     const roster = container.querySelector('[data-testid="agent-roster"]')
     expect(roster).not.toBeNull()
     expect(roster!.getAttribute('data-filter')).toBe('all')
-    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="chip-count-all"]')?.textContent)
-      .toBe('runtime 행 20 / keeper 실행 fiber 4 / workspace agents 4 / 일시정지 keeper 12 / configured keeper 16')
-    expect(container.querySelector('[data-testid="chip-count-keepers"]')?.textContent)
-      .toBe('keeper 행 16 / keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16')
-    expect(container.querySelector('[data-testid="chip-count-agents"]')?.textContent)
-      .toBe('workspace agents 4')
+    expect(container.querySelector('[data-testid="filter-chips"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-multi-select"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
   })
 
-  it('switches to agents view via filter chips', async () => {
-    render(h(AgentsUnified, null), container)
-    const btn = Array.from(container.querySelectorAll('button')).find(
-      b => b.textContent?.includes('Workspace Agents'),
-    )
-    expect(btn).not.toBeUndefined()
-    await act(async () => {
-      btn!.click()
-    })
+  it('honors agents view deep link without showing the old top switcher', async () => {
+    mockRoute.value = { tab: 'monitoring', params: { view: 'agents' }, postId: null }
     render(h(AgentsUnified, null), container)
     const roster = container.querySelector('[data-testid="agent-roster"]')
     expect(roster!.getAttribute('data-filter')).toBe('agent-only')
+    expect(container.querySelector('[data-testid="filter-chips"]')).toBeNull()
   })
 
-  it('renders keepers view with multi-select and token stats', () => {
+  it('renders keepers view as a narrowed roster without multi-select stats', () => {
     mockRoute.value = { tab: 'monitoring', params: { view: 'keepers' }, postId: null }
     render(h(AgentsUnified, null), container)
-    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="keeper-multi-select"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="keeper-token-stats"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-multi-select"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
     const roster = container.querySelector('[data-testid="agent-roster"]')
     expect(roster!.getAttribute('data-filter')).toBe('keeper-only')
   })

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -3,24 +3,11 @@
 // keeper runtime fibers, configured keepers, and task owners into one count.
 
 import { html } from 'htm/preact'
-import { useMemo, useState } from 'preact/hooks'
-import { computed } from '@preact/signals'
-import { FilterChips } from './common/filter-chips'
-import { navigate, route } from '../router'
-import { agents, keepers, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
-import { AgentRoster, countRuntimeKinds } from './agent-roster'
+import { useState } from 'preact/hooks'
+import { route } from '../router'
+import { AgentRoster } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
-import { namespaceTruth } from '../namespace-truth-store'
-import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
-import {
-  formatKeeperRosterCount,
-  formatRuntimeRosterCount,
-  resolveRuntimeCounts,
-} from '../runtime-counts'
-import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
-import { KeeperTokenStats } from './keeper-token-stats'
-import { KeeperMultiSelect } from './keeper-multi-select'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
 import { CompositeFsmFlowchart } from './composite-fsm-flowchart'
@@ -29,43 +16,17 @@ type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
 const VALID_VIEWS: AgentsView[] = ['all', 'agents', 'keepers', 'fsm']
 
-// Derive active view from route params. Single source of truth — no
-// useEffect sync needed. Falls back to 'all' when view param is absent.
-const activeView = computed<AgentsView>(() => {
+// Derive active view from route params. Fleet no longer exposes this as a
+// top-of-page switcher, but existing deep links still narrow the roster.
+function activeView(): AgentsView {
   const v = route.value.params.view
   return v && (VALID_VIEWS as string[]).includes(v) ? v as AgentsView : 'all'
-})
-
-const CHIPS: { id: AgentsView; label: string; description: string }[] = [
-  { id: 'all', label: 'Runtime Ops', description: 'workspace agents와 keeper runtime 행을 함께 보되 count surface는 분리합니다.' },
-  { id: 'agents', label: 'Workspace Agents', description: '/api/v1/agents workspace presence만 봅니다. keeper fiber나 task owner가 아닙니다.' },
-  { id: 'keepers', label: 'Keeper Runtime', description: 'keeper 실행 fiber, runtime detail row, configured keeper inventory를 봅니다.' },
-  { id: 'fsm', label: 'Keeper FSM', description: '키퍼 composite FSM lifecycle 상태를 봅니다.' },
-]
+}
 
 export function AgentsUnified() {
   const keeperParam = route.value.params.keeper as string | undefined
   const agentParam = route.value.params.agent as string | undefined
-  const currentView = activeView.value
-
-  // countRuntimeKinds is an O(N) scan over agents+keepers. Memoized so an
-  // execution_snapshot that only touches unrelated signals (or a re-render from
-  // activeView/namespaceTruth/shellCounts) skips the rescan when agents/keepers
-  // themselves are unchanged.
-  //
-  // Must run before any conditional return: when the route has a keeper/agent
-  // param this component renders a detail page, but navigating back to the
-  // fleet view re-enters this branch. Keeping the hook sequence stable prevents
-  // Preact hook-order failures during detail-to-list navigation.
-  // RFC-0295: pass the same fleet-wide composite snapshot map AgentRoster
-  // uses (and reads from `fleetCompositeSnapshot`) so countRuntimeKinds and
-  // the per-row band derivation agree on transient/attention membership.
-  const fleetSnapshot = fleetCompositeSnapshot.value
-  const compositeByKeeperKey = useMemo(() => buildCompositeByKeeperKey(fleetSnapshot), [fleetSnapshot])
-  const liveRuntimeCounts = useMemo(
-    () => countRuntimeKinds(agents.value, keepers.value, compositeByKeeperKey),
-    [agents.value, keepers.value, compositeByKeeperKey],
-  )
+  const currentView = activeView()
 
   if (keeperParam) {
     return html`<${KeeperDetailPage} />`
@@ -76,65 +37,15 @@ export function AgentsUnified() {
     return html`<${AgentProfile} name=${agentParam} />`
   }
 
-  const runtimeCounts = resolveRuntimeCounts({
-    executionLoaded: executionLoaded.value,
-    agentsCount: liveRuntimeCounts.agents,
-    keepersCount: liveRuntimeCounts.keepers,
-    pausedKeepersCount: liveRuntimeCounts.pausedKeepers,
-    transientKeepersCount: liveRuntimeCounts.transientKeepers,
-    offlineKeepersCount: liveRuntimeCounts.offlineKeepers,
-    keeperRowsCount: liveRuntimeCounts.keeperRows,
-    namespaceTruthCounts: namespaceTruth.value?.root.counts,
-    namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
-    shellCounts: shellCounts.value,
-    shellConfiguredKeepers: shellCounts.value?.configured_keepers,
-    runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
-    runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
-  })
-  function chipCount(id: AgentsView): number | string | null {
-    if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)
-    if (id === 'agents') return `workspace agents ${runtimeCounts.live.agents}`
-    if (id === 'keepers') return formatKeeperRosterCount(runtimeCounts)
-    return null
-  }
-  const viewChips = CHIPS.map(chip => ({
-    key: chip.id,
-    label: chip.label,
-    count: chipCount(chip.id),
-    title: chip.description,
-  }))
-
   return html`
     <div class="v2-monitoring-surface flex flex-col gap-4">
-      <${FilterChips}
-        chips=${viewChips}
-        value=${currentView}
-        onChange=${(key: AgentsView) => {
-          navigate('monitoring', key === 'all' ? { section: 'agents' } : { section: 'agents', view: key })
-        }}
-        size="md"
-        tone="accent"
-        class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_var(--color-border-default)]"
-      />
-
       ${currentView === 'fsm'
         ? html`<${FleetAndFsmHubPanel} />`
-        : html`
-          ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
-
-          ${currentView === 'keepers' ? html`
-            <${KeeperMultiSelect}
-              hint="필터를 적용하면 아래 토큰 집계가 선택한 keeper 만 합산합니다. 비어 있으면 전체 합산입니다."
-            />
-            <${KeeperTokenStats} />
-          ` : null}
-
-          <${AgentRoster}
+        : html`<${AgentRoster}
             keeperFilter=${currentView === 'keepers' ? 'keeper-only'
               : currentView === 'agents' ? 'agent-only'
               : 'all'}
-          />
-        `}
+          />`}
     </div>
   `
 }

--- a/dashboard/src/components/common/keeper-identity.test.ts
+++ b/dashboard/src/components/common/keeper-identity.test.ts
@@ -5,7 +5,6 @@ import {
   canonicalKeeperNameFromAgentName,
   keeperIdentityKeys,
   keeperPrincipalKey,
-  keeperIdentitySearchTerms,
   keeperPrimaryName,
   runtimeAgentName,
 } from './keeper-identity'
@@ -17,13 +16,6 @@ describe('keeper identity helpers', () => {
 
   it('keeps runtime name as secondary identity when it differs', () => {
     expect(runtimeAgentName('sangsu', 'keeper-sangsu-agent')).toBe('keeper-sangsu-agent')
-  })
-
-  it('returns both keeper and runtime names for search matching', () => {
-    expect(keeperIdentitySearchTerms('sangsu', 'keeper-sangsu-agent')).toEqual([
-      'sangsu',
-      'keeper-sangsu-agent',
-    ])
   })
 
   it('canonicalizes generated keeper-owned sub-op aliases to the stable keeper name', () => {

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -149,15 +149,6 @@ export function keeperIdentityKeys(
   return Array.from(new Set(values.filter((value): value is string => Boolean(value))))
 }
 
-export function keeperIdentitySearchTerms(
-  keeperName: string | null | undefined,
-  agentName: string | null | undefined,
-): string[] {
-  const primary = keeperPrimaryName(keeperName, agentName)
-  const runtime = runtimeAgentName(keeperName, agentName)
-  return [primary, runtime].filter((value): value is string => Boolean(value))
-}
-
 export function keeperIdentityHint(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,

--- a/dashboard/src/components/keeper-multi-select.ts
+++ b/dashboard/src/components/keeper-multi-select.ts
@@ -1,17 +1,8 @@
 // MASC Dashboard — I0-B · Cross-zone keeper filter (chip multi-select)
 //
-// Phase 2 spec (`design-system/preview/cb-group-i.jsx:KeeperMultiSelect`)
-// renders a horizontal chip group for selecting a keeper subset that
-// downstream zones (token stats, board, telemetry, etc.) honor as a
-// filter. The cross-cutting nature is the point — this is the IDE
-// backbone's filter affordance.
-//
-// State lives in `selectedKeeperFilter` (store.ts) so other zones can
-// read it without prop-drilling. Empty set = "all keepers" (default
-// unconstrained view).
-//
-// Mount: any zone that benefits from a per-keeper scope. First
-// use-site: cross-keeper TokenStats panel (#11532).
+// Design-system-only atom retained for `design-system/preview/cb-group-i.jsx`.
+// Not mounted in production routes after the fleet-board control cleanup.
+// Mount intentionally deferred; current consumer is the design-system preview.
 
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -264,11 +264,15 @@
 
 /* narrow — collapse the row to identity · state · action; ctx/tool move out of the way */
 @media (max-width: 720px) {
-  .fl-shell { --fl-cols: minmax(0, 1fr); --fl-gap: 8px; }
+  .fl-shell {
+    --fl-cols: minmax(0, 1fr);
+    --fl-gap: var(--space-2);
+    --fl-mobile-row-indent: calc(var(--space-5) + var(--space-4));
+  }
   .fl-rhead { display: none; }
   .fl-row { align-items: start; }
   .fl-row .fl-ctx, .fl-row .fl-tool { display: none; }
-  .fl-row .fl-state, .fl-row .fl-actcell { margin-left: 40px; }
+  .fl-row .fl-state, .fl-row .fl-actcell { margin-left: var(--fl-mobile-row-indent); }
   .fl-row .fl-actcell { justify-content: flex-start; flex-wrap: wrap; }
   .fl-top { height: auto; flex-wrap: wrap; padding: 12px 16px; gap: 10px 14px; }
   .fl-spacer { display: none; }

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -264,12 +264,15 @@
 
 /* narrow — collapse the row to identity · state · action; ctx/tool move out of the way */
 @media (max-width: 720px) {
-  .fl-shell { --fl-cols: minmax(0, 1fr) 150px 96px; --fl-gap: 10px; }
-  .fl-rhead span:nth-child(3), .fl-rhead span:nth-child(4) { display: none; }
+  .fl-shell { --fl-cols: minmax(0, 1fr); --fl-gap: 8px; }
+  .fl-rhead { display: none; }
+  .fl-row { align-items: start; }
   .fl-row .fl-ctx, .fl-row .fl-tool { display: none; }
+  .fl-row .fl-state, .fl-row .fl-actcell { margin-left: 40px; }
+  .fl-row .fl-actcell { justify-content: flex-start; flex-wrap: wrap; }
   .fl-top { height: auto; flex-wrap: wrap; padding: 12px 16px; gap: 10px 14px; }
   .fl-spacer { display: none; }
   .fl-health { width: 100%; order: 3; }
-  .fl-rhead, .fl-row, .fl-group { padding-left: 16px; padding-right: 16px; }
+  .fl-row, .fl-group { padding-left: 16px; padding-right: 16px; }
   .fl-foot { gap: 14px; overflow-x: auto; }
 }

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -269,7 +269,17 @@
     --fl-gap: var(--space-2);
     --fl-mobile-row-indent: calc(var(--space-5) + var(--space-4));
   }
-  .fl-rhead { display: none; }
+  .fl-rhead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   .fl-row { align-items: start; }
   .fl-row .fl-ctx, .fl-row .fl-tool { display: none; }
   .fl-row .fl-state, .fl-row .fl-actcell { margin-left: var(--fl-mobile-row-indent); }

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -983,7 +983,6 @@ let make_test_meta ?(last_blocker = None) () =
   ; keeper_id = None
   ; oas_env = []
   ; meta_version = 0
-  ; latched_reason = None
   }
 
 let test_decide_runtime_blocker_requires_confirm () =


### PR DESCRIPTION
## Summary
- Remove the Fleet board top view switcher and unused runtime/spawn/multi-select control surfaces from the default Keeper Fleet view.
- Keep existing `view=agents`, `view=keepers`, and `view=fsm` deep links working without exposing the old switcher on the page.
- Remove the roster search/status filter row and tighten the narrow mobile roster layout so it stacks instead of colliding.

## Impact
The Fleet board now follows the v2 reference more closely: health/meta at the top, runtime rows in the main list, and selected detail on the side. Operators lose the noisy top menu and filters that were not part of the intended first-screen flow, while direct deep links still preserve narrowed views.

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts src/components/agents-unified.test.ts src/components/agent-roster.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run lint`
- `pnpm run build`
- Playwright desktop/mobile render check with fixture data for the Fleet board