### PR TITLE
fix(ide): restore main lib build — match string result of path_of_file_uri (#23070 follow-up)

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -475,12 +475,14 @@ let realpath_scoped_relative ~base relative =
 ;;
 
 let workspace_root_for_initialize ~base_path root_uri =
+  (* [path_of_file_uri] returns a [string] (not [string option]); the previous
+     [Option.bind candidate] did not type-check and left main uncompilable
+     after #23070. Match the string directly. *)
   let candidate = root_uri |> path_of_file_uri in
   match
-    Option.bind candidate (fun s ->
-      match Fpath.of_string s with
-      | Ok p when Fpath.is_abs p -> Some Fpath.(rem_empty_seg (normalize p))
-      | _ -> None)
+    (match Fpath.of_string candidate with
+     | Ok p when Fpath.is_abs p -> Some (Fpath.rem_empty_seg (Fpath.normalize p))
+     | _ -> None)
   with
   | Some candidate ->
     (match fpath_within ~base:base_path (Fpath.to_string candidate) with


### PR DESCRIPTION
## 목표 (production-blocking: main lib 컴파일 복구)

`origin/main`의 `lib/server/server_ide_lsp_proxy.ml`이 컴파일되지 않아 production 빌드가 막혀 있다. 이 PR이 마지막 컴파일 에러를 고쳐 `dune build lib/`를 복구한다.

## 원인 체인

1. **#23070** (LSP degraded, 761a1af)이 `fpath_within` + `workspace_root_for_initialize`를 **CI 전면 red 상태로 머지**(컴파일 안 됨). 두 개의 타입 에러:
   - `server_ide_lsp_proxy.ml:440` — `Fpath.(rem_empty_seg (normalize base))`의 local open이 지역변수 `base`를 `Fpath.base`(basename, `t -> t`)로 shadow.
   - `server_ide_lsp_proxy.ml:477` — `Option.bind candidate ...`인데 `candidate = path_of_file_uri root_uri`는 **`string`**(not `string option`).
2. **#23093** (f7dbc7e)이 440(Fpath shadowing)을 고쳤다. 하지만 OCaml 컴파일러는 440을 고쳐야 그 아래 477을 드러내므로, #23093 시점엔 477이 안 보였고 **미수정으로 남았다**. main은 여전히 red.
3. **이 PR**이 477을 마저 고친다: `path_of_file_uri`가 string이므로 `Option.bind` 제거, `Fpath.of_string candidate` 직접 매칭.

## 변경

`workspace_root_for_initialize`의 candidate 처리를 string에 맞게 수정 (1파일, +6/-4).

## 검증

- `dune build lib/` → **에러 0** (fresh worktree @ origin/main + 이 fix).
- 순수 컴파일 복구. 런타임 동작은 원 의도대로(절대경로 candidate를 normalize 후 base 내 포함 검사).

## 범위 밖 (별도 추적)

test 5개가 아직 컴파일 실패 — 다른 머지의 API drift이며 이 lib fix와 무관:
`test_server_ide_lsp_proxy`(Lsp.inbound_dispatch_worker_count), `test_keeper_auto_pause_blocker_persist`(Keeper_latched_reason), `test_server_ide_http`(Bigstringaf), `test_http_server_eio`(buf), `test_governance_pipeline`(latched_reason). 이 PR은 production lib 빌드 복구에 집중한다.

## 근본 (별개)

CI 전면 red인 PR(#23070)이 머지된 것이 근본. auto-merge/red-merge 방지는 별도 사안(메모리: #22871 동일 클래스).
