### PR TITLE
fix(test): sync test/mli drift left by #23058 and #23070

### DIFF
--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -12,6 +12,7 @@ module For_testing : sig
   val resolve_relative : base:string -> string -> string option
   val workspace_root_for_initialize : base_path:string -> string -> string
   val initialize_result_json : unit -> Yojson.Safe.t
+  val inbound_dispatch_worker_count : int
 
   (** Per-language LSP health (task-1691). [Overlay_only] carries the last
       error that forced the language into overlay-only mode. *)

--- a/test/dune
+++ b/test/dune
@@ -715,7 +715,7 @@
   test_keeper_behavior_trace
   test_keeper_wire_capture
   test_board_rest_routes)
- (libraries masc_test_deps multimodal))
+ (libraries masc_test_deps multimodal bigstringaf))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.
 

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -972,6 +972,7 @@ let make_test_meta ?(last_blocker = None) () =
   ; continuity_summary = ""
   ; active_goal_ids = []
   ; paused = false
+  ; latched_reason = None
   ; auto_resume_after_sec = None
   ; autoboot_enabled = false
   ; current_task_id = None

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -612,7 +612,7 @@ let test_response_empty_includes_content_length_zero () =
       String.concat
         ""
         (List.map
-           (fun iov -> Bigstringaf.substring iov.buf ~off:iov.off ~len:iov.len)
+           (fun iov -> Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len)
            iovecs)
     | `Yield | `Close _ -> ""
   in

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -691,7 +691,7 @@ let test_direct_success_clears_no_progress_pause () =
            paused = true
          ; latched_reason =
              Some
-               (Masc.Keeper_latched_reason.No_progress_loop
+               (Keeper_latched_reason.No_progress_loop
                   { consecutive_idle_cycles = 3
                   ; detector_kind = `Consecutive_no_progress
                   })


### PR DESCRIPTION
## 요약

`dune build .`(test 그래프)를 막던 5개 컴파일 에러를 고칩니다. #23058(latched_reason 배선) / #23070(LSP inbound dispatch)이 lib를 바꾸면서 대응 test/interface를 동기화하지 않아 발생한 drift입니다.

## 변경 (전부 test/interface 동기화, lib 로직 무변경)

| 파일 | 에러 | fix |
|---|---|---|
| test_keeper_auto_pause_blocker_persist_12683 | `Masc.Keeper_latched_reason` unbound | `Keeper_latched_reason`(keeper_runtime lib 직접) |
| test_governance_pipeline | record `latched_reason` 필드 누락 | `; latched_reason = None` 추가(#23058 신규 필드) |
| server_ide_lsp_proxy.mli | `Lsp.inbound_dispatch_worker_count` unbound | For_testing sig에 `val` 노출(.ml엔 이미 있음) |
| test_http_server_eio | `iov.buf` record field unbound | Faraday iovec 필드는 `buffer` |
| test/dune | `Bigstringaf` module unbound | test_server_ide_http stanza에 `bigstringaf` 추가 |

## 검증

- `ocamlformat --check` 통과. dune build/test는 CI 위임.
- 서버(main_eio)는 이 test들을 의존하지 않아 이 PR 없이도 빌드됨 — 본 PR은 `dune build .` green 회복용.

## 비고

#23058/#23070이 test를 동기화 안 한 채 머지된 것은 CI Gate가 lib만 보고 `dune runtest`를 강제 안 했거나 admin-merge 우회(masc#21757/#22050) 정황.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
