### PR TITLE
fix(test): finish #23070 test drift (resolve_lang sig + httpun IOVec)

### DIFF
--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -14,6 +14,15 @@ module For_testing : sig
   val initialize_result_json : unit -> Yojson.Safe.t
   val inbound_dispatch_worker_count : int
 
+  (** [resolve_lang relative] classifies a workspace-relative path's language
+      (task-1691): [Known_lang lang_id] when a language server is mapped, else
+      [Unknown_lang]. *)
+  type lang =
+    | Known_lang of string
+    | Unknown_lang
+
+  val resolve_lang : string -> lang
+
   (** Per-language LSP health (task-1691). [Overlay_only] carries the last
       error that forced the language into overlay-only mode. *)
   type health =

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -612,7 +612,7 @@ let test_response_empty_includes_content_length_zero () =
       String.concat
         ""
         (List.map
-           (fun iov -> Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len)
+           (fun iov -> Bigstringaf.substring iov.Httpun.IOVec.buffer ~off:iov.off ~len:iov.len)
            iovecs)
     | `Yield | `Close _ -> ""
   in

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -120,7 +120,7 @@ let dispatch router (request, body) =
         (fun iov ->
            Buffer.add_string
              response_buf
-             (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len))
+             (Bigstringaf.substring iov.Httpun.IOVec.buffer ~off:iov.off ~len:iov.len))
         iovecs;
       let written = List.fold_left (fun acc iov -> acc + iov.len) 0 iovecs in
       Httpun.Server_connection.report_write_result conn (`Ok written);


### PR DESCRIPTION
## 요약

#23098이 #23058/#23070 test drift를 대부분 고쳤으나 `dune build .`를 여전히 막는 잔여 2건을 마저 고칩니다.

## 변경 (test/interface 동기화, lib 로직 무변경)

- **server_ide_lsp_proxy.mli**: `For_testing`가 `.ml`에선 `resolve_lang`과 `lang` 타입을 노출하는데 interface엔 없어, test_server_ide_lsp_proxy의 `Lsp.resolve_lang`/`Lsp.Unknown_lang`/`Lsp.Known_lang`이 unbound. test가 참조하는 **모든 `Lsp.*` 심볼(val+생성자)을 sig와 전수 대조**해 일치시킴.
- **test_http_server_eio / test_server_ide_http**: httpun write iovec는 `Bigstringaf.t Httpun.IOVec.t`(=`Faraday.iovec { buffer; off; len }`)인데 두 test 모두 `Httpun.IOVec`을 open하지 않아 bare `buffer` label이 unbound → `iov.Httpun.IOVec.buffer`로 모듈 한정. (#23098이 `iov.buf`→`iov.buffer`로 바꿨으나 label scope 문제로 여전히 unbound였음.)

## 검증

- `ocamlformat --check` 통과. dune build/test는 CI 위임.
- 현재 origin/main(#23098 반영) 기준 clean diff — 충돌 없음.

## 비고

#23058/#23070이 lib/test/mli를 동기화 안 한 채 머지된 drift의 마무리. 컴파일 안 되는 채 여러 PR이 main에 쌓인 건 CI Gate 우회(masc#21757/#22050) 정황.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
