### PR TITLE
fix(test): resolve duplicate latched_reason + Masc.Keeper_metrics drift

### DIFF
--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -983,7 +983,6 @@ let make_test_meta ?(last_blocker = None) () =
   ; keeper_id = None
   ; oas_env = []
   ; meta_version = 0
-  ; latched_reason = None
   }
 
 let test_decide_runtime_blocker_requires_confirm () =

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -12,7 +12,7 @@ module KMP = Masc.Keeper_memory_policy
 module KCC = Masc.Keeper_context_core
 module KRT = Masc.Keeper_agent_run_response_text
 module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
-module Keeper_metrics = Masc.Keeper_metrics
+module Keeper_metrics = Keeper_metrics
 module Metrics = Masc.Otel_metric_store
 module Receipt = Masc.Keeper_execution_receipt
 

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -4,7 +4,7 @@
     one redacted dated jsonl with the expected fields. *)
 
 module Wire = Masc.Keeper_wire_capture
-module Keeper_metrics = Masc.Keeper_metrics
+module Keeper_metrics = Keeper_metrics
 module Metrics = Masc.Otel_metric_store
 
 let flag = "MASC_KEEPER_WIRE_CAPTURE"


### PR DESCRIPTION
## 목표 (main lib+test 빌드 복구)

`origin/main`에 잔존한 3개 test 컴파일 에러를 해소해 `dune build .`를 0 에러로 만든다.

## 원인

- **latched_reason 중복** (`test_governance_pipeline.ml:975,986`): #23099와 #23100이 병렬로 같은 keeper_meta literal에 `latched_reason = None`을 각자 추가 → `record field label latched_reason is defined several times`. 중복(986) 제거.
- **Masc.Keeper_metrics** (`test_keeper_wire_capture.ml:7`, `test_keeper_state_snapshot_json.ml:15`): #23087이 Keeper_metrics를 `lib/keeper_metrics/`(masc.keeper_metrics 서브라이브러리)로 carve-out했으나 이 두 test는 `Masc.Keeper_metrics`(carve 전 경로) 참조 → unbound. masc_test_deps가 bare로 re_export하므로 bare `Keeper_metrics`로 교정.

## 검증

- `dune build .` → **에러 0** (fresh worktree @ origin/main + 이 fix). 단언 불변.

## 근본 (구조적, 개별 fix로 못 막음)

이 세션에서 main breakage를 반복 추격했다: #23070(red-merge)→lib 2지점(#23093/#23097)→#23087(red-merge, Keeper_metrics)→#23099/#23100 병렬 중복(latched 중복)→이 PR. 근본은 **CI 전면 red PR이 머지되는 것**. 개별 복구는 밑빠진 독 — RFC-0270(CI 게이트 집행, `ci.yml` red-merge 통과 차단)이 근본 해결. 별도 사안으로 escalate 권고.
