### PR TITLE
fix(eval-gate): fail closed on unparseable destructive-tool args (RFC-0305 C/C')

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -250,7 +250,13 @@ let detect_destructive (policy : Destructive_ops_policy.t) (command : string)
 
     First rejection wins — remaining checks are skipped. *)
 
-let extract_all_strings_from_json (json_str : string) : string =
+(* RFC-0305: return [None] on unparseable JSON rather than [""].  The caller
+   scans the result for destructive patterns; collapsing a parse failure to an
+   empty string let a malformed args payload skip the destructive check
+   (no match on ""), which is fail-open for a bash-capable tool.  A malformed
+   args_json on a destructive tool is already abnormal, so the caller rejects
+   it fail-closed. *)
+let extract_all_strings_from_json (json_str : string) : string option =
   try
     let rec go = function
       | `String s -> s
@@ -258,8 +264,8 @@ let extract_all_strings_from_json (json_str : string) : string =
       | `Assoc fields -> String.concat " " (List.map (fun (_, v) -> go v) fields)
       | _ -> ""
     in
-    go (Yojson.Safe.from_string json_str)
-  with Yojson.Json_error _ -> ""
+    Some (go (Yojson.Safe.from_string json_str))
+  with Yojson.Json_error _ -> None
 
 let pre_check
     ~(config : gate_config)
@@ -321,14 +327,20 @@ let pre_check
               (* 6. Destructive pattern check (bash tools only) *)
               if config.destructive_check_enabled
                  && Tool_capability.has Tool_capability.Destructive tool_name then
-                let cmd_str = extract_all_strings_from_json args_json
-                in
-                begin match detect_destructive destructive_ops_policy cmd_str with
-                | Some (pattern, desc) ->
-                    Trajectory.Reject (Printf.sprintf
-                      "destructive pattern in %s: '%s' (%s)" tool_name pattern desc)
-                | None -> Trajectory.Pass
-                end
+                (match extract_all_strings_from_json args_json with
+                 | None ->
+                     (* RFC-0305: unparseable args on a destructive tool cannot
+                        be screened — fail closed rather than scan "". *)
+                     Trajectory.Reject (Printf.sprintf
+                       "unparseable args for destructive tool '%s' (fail-closed)"
+                       tool_name)
+                 | Some cmd_str ->
+                     begin match detect_destructive destructive_ops_policy cmd_str with
+                     | Some (pattern, desc) ->
+                         Trajectory.Reject (Printf.sprintf
+                           "destructive pattern in %s: '%s' (%s)" tool_name pattern desc)
+                     | None -> Trajectory.Pass
+                     end)
               else
                 Trajectory.Pass
           end
@@ -336,23 +348,20 @@ let pre_check
         (* No trajectory accumulator — skip entropy and turn-limit checks *)
         if config.destructive_check_enabled
            && Tool_capability.has Tool_capability.Destructive tool_name then
-          let cmd_str =
-            try
-              let rec extract_strings = function
-                | `String s -> s
-                | `List lst -> String.concat " " (List.map extract_strings lst)
-                | `Assoc fields -> String.concat " " (List.map (fun (_, v) -> extract_strings v) fields)
-                | _ -> ""
-              in
-              extract_strings (Yojson.Safe.from_string args_json)
-            with Yojson.Json_error _ -> ""
-          in
-          begin match detect_destructive destructive_ops_policy cmd_str with
-          | Some (pattern, desc) ->
-              Trajectory.Reject (Printf.sprintf
-                "destructive pattern in %s: '%s' (%s)" tool_name pattern desc)
-          | None -> Trajectory.Pass
-          end
+          (* Reuse [extract_all_strings_from_json] (was a duplicated inline
+             extractor); RFC-0305: [None] on unparseable args → fail closed. *)
+          (match extract_all_strings_from_json args_json with
+           | None ->
+               Trajectory.Reject (Printf.sprintf
+                 "unparseable args for destructive tool '%s' (fail-closed)"
+                 tool_name)
+           | Some cmd_str ->
+               begin match detect_destructive destructive_ops_policy cmd_str with
+               | Some (pattern, desc) ->
+                   Trajectory.Reject (Printf.sprintf
+                     "destructive pattern in %s: '%s' (%s)" tool_name pattern desc)
+               | None -> Trajectory.Pass
+               end)
         else
           Trajectory.Pass
   end

--- a/lib/eval_gate.mli
+++ b/lib/eval_gate.mli
@@ -69,6 +69,12 @@ val detect_evasion : string -> (string * string) option
     Thin wrapper over {!detect_evasion_typed} that drops the typed
     kind — preserved for callers that consume the string-tuple shape. *)
 
+val extract_all_strings_from_json : string -> string option
+(** Concatenate every string leaf of a JSON args payload for destructive-pattern
+    scanning. [None] when [json_str] is unparseable — RFC-0305: the caller must
+    fail closed rather than scan an empty string, which would let a malformed
+    args payload skip the destructive check. *)
+
 (** {1 Pre-execution gate} *)
 
 val pre_check :

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -55,6 +55,27 @@ let test_detect_case_insensitive () =
   | None -> Alcotest.fail "Should detect RM -RF (case insensitive)"
 
 (* ================================================================ *)
+(* Test: extract_all_strings_from_json — RFC-0305 fail-closed parse  *)
+(* ================================================================ *)
+
+let test_extract_valid_json_returns_strings () =
+  match Eval_gate.extract_all_strings_from_json {|{"cmd": "rm -rf /tmp/x"}|} with
+  | Some s ->
+      Alcotest.(check bool) "valid json yields the string leaves" true
+        (let r = String.lowercase_ascii s in
+         try ignore (Str.search_forward (Str.regexp_string "rm -rf") r 0); true
+         with Not_found -> false)
+  | None -> Alcotest.fail "valid json must parse to Some"
+
+let test_extract_malformed_json_is_none () =
+  (* RFC-0305: unparseable args must surface as [None] (fail-closed at the
+     caller), NOT collapse to "" which would skip the destructive scan. *)
+  match Eval_gate.extract_all_strings_from_json {|{"cmd": "rm -rf /" |} with
+  | None -> ()
+  | Some s ->
+      Alcotest.failf "malformed json must be None, got Some %S (fail-open)" s
+
+(* ================================================================ *)
 (* Test: pre_check — deny list                                       *)
 (* ================================================================ *)
 
@@ -411,6 +432,10 @@ let () =
       Alcotest.test_case "safe command" `Quick test_detect_safe_command;
       Alcotest.test_case "detect drop table" `Quick test_detect_drop_table;
       Alcotest.test_case "case insensitive" `Quick test_detect_case_insensitive;
+      Alcotest.test_case "extract valid json → Some" `Quick
+        test_extract_valid_json_returns_strings;
+      Alcotest.test_case "extract malformed json → None (RFC-0305 fail-closed)" `Quick
+        test_extract_malformed_json_is_none;
     ]);
     ("pre_check", [
       Alcotest.test_case "deny list" `Quick test_pre_deny_list;


### PR DESCRIPTION
## 목표

RFC-0305 사이트 C/C': destructive-command 스캔이 malformed JSON args를 `""`로 삼켜 destructive 검사를 우회하던 fail-open을 닫는다.

관련 RFC: RFC-0305 (safety gates fail closed by default, #23091 머지). site I는 #23092 머지.

## 근본 원인

`eval_gate.ml` `pre_check`의 destructive 스캔(bash-capable 도구):
```ocaml
let cmd_str = extract_all_strings_from_json args_json in  (* Json_error -> "" *)
match detect_destructive policy cmd_str with
| Some ... -> Reject
| None -> Pass   (* "" -> no match -> Pass *)
```
malformed args_json이 destructive 도구에 오면 `""` → 스캔 우회 → Pass. destructive 명령이 malformed JSON에 숨어 검사를 건너뛴다. 두 곳(공유 함수 + inline 중복)에 동일 패턴.

## 변경

- `extract_all_strings_from_json`: `string` → `string option` 반환 (`Json_error` → `None`).
- 두 호출부: `None` → `Reject "unparseable args for destructive tool (fail-closed)"`.
- inline 중복 extractor(348)를 공유 함수 호출로 교체 (중복 제거 + fail-closed).

## site D는 fail-open 아님 (재검토, 미변경)

RFC 조사가 site D(`detect_evasion_typed`의 `Safe_ops.protect ~default:false`)를 fail-open으로 나열했으나, 재검토 결과 **아니다**: per-pattern regex 실행 에러는 `List.find_map`을 통해 **그 패턴만 skip**하지 전체 스캔을 우회하지 않는다. 다른 패턴들은 계속 검사된다. 미변경.

## 검증

- 회귀 테스트(`test_eval_gate.ml`): `extract_all_strings_from_json` malformed→None, valid→Some.
- **Mutation-verified**: malformed를 `Some ""`(fail-open)로 되돌리면 테스트 FAIL.
- `dune build @check` + `test_eval_gate.exe` 28 tests green.

## 경계

fail-open을 닫는 변경. 모듈 docstring이 이미 "any single rejection blocks execution — prevents a failure in one layer from being masked"를 명시 — 이 fix가 그 계약을 이행. (site B와 대조: 거기선 docstring이 admit을 정당화했으나, 여기선 reject를 정당화.)
