### PR TITLE
feat(runtime): per-model temperature via runtime.toml [models.<id>].temperature

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -690,6 +690,18 @@ let thinking_support_of_runtime_id (id : string) : bool option =
   | None -> None
 ;;
 
+(* The per-model [temperature] override declared in runtime.toml
+   ([models.<id>.temperature]), or [None] when the runtime is unknown or the
+   model leaves it unset. Projects the runtime.toml [model] record (per-binding
+   config SSOT), mirroring [thinking_support_of_runtime_id]. Consumed by
+   [Runtime_inference.resolve_temperature]: a keeper turn uses this value when
+   set and its caller fallback otherwise. *)
+let temperature_of_runtime_id (id : string) : float option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.model.temperature
+  | None -> None
+;;
+
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* OAS owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -215,6 +215,14 @@ val thinking_support_of_runtime_id : string -> bool option
     {!Runtime_inference.for_runtime} to gate keeper thinking per model from the
     runtime.toml SSOT. *)
 
+val temperature_of_runtime_id : string -> float option
+(** Per-model [temperature] override ([models.<id>.temperature] in runtime.toml)
+    for the model bound to runtime [id], or [None] when the id is not configured
+    or the model leaves it unset.  Consumed by
+    {!Runtime_inference.resolve_temperature}: a keeper turn uses this value when
+    set and its caller fallback ([MASC_KEEPER_UNIFIED_TEMP]) otherwise.  Required
+    for models that reject the default temperature (Kimi K2.7 accepts only 1.0). *)
+
 val preserve_thinking_of_runtime_id : string -> bool option
 (** Explicit [preserve-thinking] for runtime [id]. [None] means unknown runtime,
     uninitialized cache, or no explicit TOML field.

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -1,4 +1,19 @@
-let resolve_temperature ~runtime_id:_ ~fallback = fallback ()
+(* Per-runtime sampling temperature. A model may declare a fixed [temperature]
+   in runtime.toml ([models.<id>.temperature], read via
+   [Runtime.temperature_of_runtime_id]); when set, that value is the request
+   temperature for every turn on the model. Otherwise the caller [fallback]
+   ([Keeper_config.keeper_unified_temperature], i.e. [MASC_KEEPER_UNIFIED_TEMP])
+   stands.
+
+   Completes the previously stubbed per-runtime [resolve_temperature] (the
+   [~runtime_id:_] passthrough), symmetric to [resolve_max_tokens]. Required for
+   a model that rejects the fleet default value: Kimi K2.7 (kimi-for-coding)
+   accepts only temperature = 1.0 and rejects any other at request time
+   ("only 1 is allowed for this model"). *)
+let resolve_temperature ~runtime_id ~fallback =
+  match Runtime.temperature_of_runtime_id runtime_id with
+  | Some temperature -> temperature
+  | None -> fallback ()
 
 (* Upper bound on a reasoning turn's [max_tokens]. A reasoning model spends part
    of one response on thinking before emitting the answer; both share the single

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -155,6 +155,15 @@ type model_spec =
   ; preserve_thinking : bool option
   ; max_thinking_budget : int option
   ; streaming : bool
+  ; temperature : float option
+    (** [temperature] — per-model sampling temperature for keeper turns. [None]
+        keeps the caller fallback ([MASC_KEEPER_UNIFIED_TEMP], then the OAS
+        [agent_default] profile). [Some t] overrides it for every turn on this
+        model. Required for models that reject the default value: e.g. Kimi K2.7
+        (kimi-for-coding) accepts only temperature = 1.0 and rejects any other
+        value at request time ("only 1 is allowed for this model"). Resolved via
+        {!Runtime.temperature_of_runtime_id} → {!Runtime_inference.resolve_temperature},
+        symmetric to the [max-output-tokens]/[max_tokens] path. *)
   ; capabilities : model_capabilities option
   ; match_prefixes : string list
   }

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -462,6 +462,46 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
     thinking_control_format_result
 ;;
 
+(* LLM sampling temperature bounds. OpenAI/Kimi/DeepSeek accept [0.0, 2.0]; a
+   value outside this range is a config error, not something to silently clamp.
+   0.0 (greedy) is valid, so temperature is NOT parsed through the
+   positive-float path. *)
+let temperature_min = 0.0
+let temperature_max = 2.0
+
+(* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)
+   both read as a float so an operator is not tripped by "1 vs 1.0". Absent →
+   [Ok None] (caller keeps its fallback). Wrong type or out of
+   [temperature_min, temperature_max] → parse error: reject at load rather than
+   send an out-of-range value the provider would reject at request time. *)
+let temperature_opt_field ~(path : string) (tbl : Otoml.t)
+  : (float option, parse_error list) result
+  =
+  match Otoml.find_opt tbl Fun.id [ "temperature" ] with
+  | None -> Ok None
+  | Some value ->
+    let as_float =
+      match value with
+      | Otoml.TomlFloat v -> Some v
+      | Otoml.TomlInteger v -> Some (float_of_int v)
+      | _ -> None
+    in
+    (match as_float with
+     | None ->
+       Error (error (path ^ ".temperature") "temperature must be a number (e.g. 1.0)")
+     | Some t when Float.is_finite t && t >= temperature_min && t <= temperature_max ->
+       Ok (Some t)
+     | Some t ->
+       Error
+         (error
+            (path ^ ".temperature")
+            (Printf.sprintf
+               "temperature must be a finite number in [%g, %g]; got %g"
+               temperature_min
+               temperature_max
+               t)))
+;;
+
 let parse_model (id : string) (tbl : Otoml.t)
   : (Runtime_schema.model_spec, parse_error list) result
   =
@@ -518,20 +558,23 @@ let parse_model (id : string) (tbl : Otoml.t)
            Log.Runtime.warn "runtime_toml: %s.match-prefixes — expected string array, ignoring" path;
            [])
     in
-    Result.map
-      (fun capabilities ->
-        { Runtime_schema.id
-        ; api_name
-        ; tools_support
-        ; max_context
-        ; thinking_support
-        ; preserve_thinking
-        ; max_thinking_budget
-        ; streaming
-        ; capabilities
-        ; match_prefixes
-        })
-      capabilities_result)
+    let temperature_result = temperature_opt_field ~path tbl in
+    let ( let* ) = Result.bind in
+    let* capabilities = capabilities_result in
+    let* temperature = temperature_result in
+    Ok
+      { Runtime_schema.id
+      ; api_name
+      ; tools_support
+      ; max_context
+      ; thinking_support
+      ; preserve_thinking
+      ; max_thinking_budget
+      ; streaming
+      ; temperature
+      ; capabilities
+      ; match_prefixes
+      })
 ;;
 
 let parse_models (toml : Otoml.t)

--- a/test/dune
+++ b/test/dune
@@ -2085,6 +2085,8 @@
 
 (include stanzas/test_runtime_pause_threshold_toml.inc)
 
+(include stanzas/test_runtime_model_temperature_toml.inc)
+
 (include stanzas/test_keeper_response_feedback.inc)
 
 (include stanzas/test_mcp_post_sse_e2e.inc)

--- a/test/stanzas/test_runtime_model_temperature_toml.inc
+++ b/test/stanzas/test_runtime_model_temperature_toml.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_model_temperature_toml)
+ (modules test_runtime_model_temperature_toml)
+ (libraries masc_test_deps))

--- a/test/test_runtime_model_temperature_toml.ml
+++ b/test/test_runtime_model_temperature_toml.ml
@@ -1,0 +1,108 @@
+(** Tests for the per-model [temperature] field in the [[models.<id>]] parser
+    ([Runtime_toml.parse_model]).
+
+    Pinned invariants:
+
+    1. [temperature = 1.0] (float) parses to [Some 1.0].
+    2. [temperature = 1] (integer) parses to [Some 1.0] — an operator writing
+       the bare integer is not tripped by "1 vs 1.0".
+    3. [temperature = 0.0] (greedy) is a valid value → [Some 0.0]; temperature
+       is NOT a positive-only field.
+    4. Absent [temperature] → [None]; the caller keeps its fallback
+       ([MASC_KEEPER_UNIFIED_TEMP] / the OAS agent_default profile).
+    5. An out-of-range value (outside [0.0, 2.0]) fails the parse (fail-closed):
+       an invalid temperature is rejected at load rather than sent to the
+       provider, which would reject it at request time.
+    6. A non-number value fails the parse.
+
+    Motivation: Kimi K2.7 (kimi-for-coding) accepts only [temperature = 1.0] and
+    rejects any other value ("only 1 is allowed for this model"). This field lets
+    runtime.toml pin that per model; [Runtime_inference.resolve_temperature]
+    consumes it via [Runtime.temperature_of_runtime_id]. *)
+
+open Alcotest
+
+module Schema = Runtime_schema
+module Toml = Runtime_toml
+
+let parse_string_or_fail s =
+  match Toml.parse_string s with
+  | Ok cfg -> cfg
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (e : Toml.parse_error) ->
+        Printf.sprintf "[%s] %s" e.path e.message)
+      |> String.concat "; "
+    in
+    failf "parse_string failed: %s" rendered
+;;
+
+let parse_string_expect_error label s =
+  match Toml.parse_string s with
+  | Ok _ -> failf "%s: expected parse error, got Ok" label
+  | Error _ -> ()
+;;
+
+let model_temperature cfg id =
+  match List.find_opt (fun (m : Schema.model_spec) -> String.equal m.id id) cfg.Schema.models with
+  | Some m -> m.Schema.temperature
+  | None -> failf "model %S absent from parsed config" id
+;;
+
+(* A minimal valid [[models.<id>]] table needs [max-context]; [temperature] is
+   optional and appended per case. *)
+let model_toml ~temperature_line =
+  Printf.sprintf "[models.m]\nmax-context = 200000\n%s" temperature_line
+;;
+
+let test_float_temperature_parses () =
+  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 1.0\n") in
+  check (option (float 0.0001)) "temperature = 1.0 → Some 1.0" (Some 1.0) (model_temperature cfg "m")
+;;
+
+let test_integer_temperature_parses_as_float () =
+  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 1\n") in
+  check (option (float 0.0001)) "temperature = 1 → Some 1.0" (Some 1.0) (model_temperature cfg "m")
+;;
+
+let test_zero_temperature_is_valid () =
+  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 0.0\n") in
+  check (option (float 0.0001)) "temperature = 0.0 → Some 0.0 (greedy is valid)"
+    (Some 0.0) (model_temperature cfg "m")
+;;
+
+let test_absent_temperature_is_none () =
+  let cfg = parse_string_or_fail (model_toml ~temperature_line:"") in
+  check (option (float 0.0001)) "absent temperature → None" None (model_temperature cfg "m")
+;;
+
+let test_out_of_range_temperature_fails_closed () =
+  parse_string_expect_error "temperature = 5.0 (above 2.0 ceiling)"
+    (model_toml ~temperature_line:"temperature = 5.0\n");
+  parse_string_expect_error "temperature = -1.0 (below 0.0 floor)"
+    (model_toml ~temperature_line:"temperature = -1.0\n")
+;;
+
+let test_non_number_temperature_fails_closed () =
+  parse_string_expect_error "temperature = \"hot\" (not a number)"
+    (model_toml ~temperature_line:"temperature = \"hot\"\n")
+;;
+
+let () =
+  run "runtime_model_temperature_toml"
+    [ ( "valid values"
+      , [ test_case "float temperature parses" `Quick test_float_temperature_parses
+        ; test_case "integer temperature parses as float" `Quick
+            test_integer_temperature_parses_as_float
+        ; test_case "zero temperature is valid (greedy)" `Quick test_zero_temperature_is_valid
+        ; test_case "absent temperature is None" `Quick test_absent_temperature_is_none
+        ] )
+    ; ( "invalid values fail closed"
+      , [ test_case "out-of-range temperature fails parse" `Quick
+            test_out_of_range_temperature_fails_closed
+        ; test_case "non-number temperature fails parse" `Quick
+            test_non_number_temperature_fails_closed
+        ] )
+    ]
+;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -50,6 +50,7 @@ let qwen_model =
   ; preserve_thinking = Some false
   ; max_thinking_budget = None
   ; streaming = true
+  ; temperature = None
   ; capabilities = None
   ; match_prefixes = []
   }


### PR DESCRIPTION
## 문제

keeper turn의 temperature는 `Runtime_inference.resolve_temperature ~runtime_id ~fallback`
한 지점에서 결정되는데, 구현이 `~runtime_id:_ ~fallback = fallback ()` 로 **runtime_id를
무시하는 stub** 이었습니다. 대칭 함수인 `resolve_max_tokens` 는 이미 per-runtime config를
읽어 turn budget을 모델별로 결정합니다.

그 결과 모든 모델이 fleet 공통 fallback(`MASC_KEEPER_UNIFIED_TEMP`, 기본 0.4)을 강제로
씁니다. Kimi K2.7(`kimi-for-coding`)은 **temperature=1.0 이외 값을 request 시점에 거부**
합니다(`invalid temperature: only 1 is allowed for this model`) — 따라서 해당 모델의 모든
turn이 실패했습니다.

## 변경

`resolve_temperature` stub을 `resolve_max_tokens` 와 동일한 방식으로 완성하고, runtime.toml
`[models.<id>]` 에 per-model `temperature` 필드를 추가했습니다. 값이 있으면 그 모델의 turn
temperature로 쓰이고, 없으면 기존 fallback이 그대로 적용됩니다(동작 불변).

| 파일 | 변경 |
|------|------|
| `runtime_schema.ml` | `model_spec` 에 `temperature : float option` |
| `runtime_toml.ml` | `[models.<id>].temperature` 파싱. TOML int/float 모두 허용, `[0.0, 2.0]` 밖이거나 숫자 아님 → **load 시 error (fail-closed)** |
| `runtime.ml` / `.mli` | `temperature_of_runtime_id : string -> float option` |
| `runtime_inference.ml` | `resolve_temperature` 가 위 값을 읽고, 없으면 fallback |
| `test_runtime_model_temperature_toml.ml` (신규) | 파서 round-trip + fail-closed 케이스 |

## 경계 / 근거

- **fail-closed**: 범위 밖 temperature는 load 시 거부. provider가 request 시점에 거부할 값을
  boot 때 잡습니다(anti-pattern: unknown→permissive default 회피).
- **하위호환**: 신규 필드 default `None` → temperature 미선언 모델은 기존 fallback 유지, 동작
  변화 0.
- **경계 구분**: 0.7 fleet default 자체는 OAS `Llm_provider.Constants.Inference_profile.agent_default`
  소유(정책 기본값). 이 PR은 그 default를 바꾸지 않고, per-model override 경로만 뚫습니다. Kimi의
  "temperature=1 필수"는 모델 고유 제약이라 runtime.toml에서 모델별로 고정합니다.
- RFC-0206이 runtime schema를 소유. 신규 필드는 additive·backward-compatible 확장이며 새 routing
  layer가 아닙니다.

## 검증

- `ocamlformat --check` (profile=janestreet 0.29.0): 변경 7개 `.ml/.mli` 전부 exit 0.
- 신규 파서 테스트: float/int/0.0/absent/out-of-range/non-number 6 케이스.
- 로컬 dune build/test는 실행하지 않음(CI가 build authority).

## 후속 (이 PR 범위 밖)

`~/.masc/config/runtime.toml` `[models.kimi-for-coding]` 에 `temperature = 1.0` 을 추가하면
kimi_code 재활성화 시 turn이 통과합니다(개인 config, untracked, PR 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
