### PR TITLE
fix(runtime): expose model temperature in schema interface

### DIFF
--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -114,6 +114,13 @@ type model_spec =
   ; preserve_thinking : bool option
   ; max_thinking_budget : int option
   ; streaming : bool
+  ; temperature : float option
+    (** [temperature] — per-model sampling temperature for keeper turns. [None]
+        keeps the caller fallback ([MASC_KEEPER_UNIFIED_TEMP], then the OAS
+        [agent_default] profile). [Some t] overrides it for every turn on this
+        model. Required for models that reject the default value. Resolved via
+        {!Runtime.temperature_of_runtime_id} →
+        {!Runtime_inference.resolve_temperature}. *)
   ; capabilities : model_capabilities option
   ; match_prefixes : string list
   }


### PR DESCRIPTION
## Summary
- Expose `model_spec.temperature` in `Runtime_schema.mli` to match the implementation type in `runtime_schema.ml`.
- Fixes the merged #23105 CI type error where `Runtime.temperature_of_runtime_id` could not read `rt.model.temperature` through the public schema interface.

## Validation
- `opam exec -- ocamlformat --check lib/runtime/runtime_schema.mli`
- `opam exec -- ocamlc -stop-after parsing lib/runtime/runtime_schema.mli lib/runtime/runtime.ml`
- `git diff --check -- lib/runtime/runtime_schema.mli`
- conflict-marker scan: clean

No local Dune run; CI is the build/type authority for this hotfix.