### PR TITLE
fix(runtime): expose model temperature in schema interface

### DIFF
--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -114,6 +114,7 @@ type model_spec =
   ; preserve_thinking : bool option
   ; max_thinking_budget : int option
   ; streaming : bool
+  ; temperature : float option
   ; capabilities : model_capabilities option
   ; match_prefixes : string list
   }


### PR DESCRIPTION
## Summary
- Add the missing `temperature : float option` field to `Runtime_schema.model_spec` in `runtime_schema.mli`.
- Repairs the #23105 main break where `runtime_schema.ml` and tests expose the field but the public interface does not.

## Evidence
- Merged #23105 CI failed in Health/Build/Test/Lint/Canary with `runtime_schema.ml` not matching `runtime_schema.mli` and `Unbound record field ...temperature`.
- This follow-up is intentionally one line against `origin/main`.

## Validation
- `ocamlformat --check lib/runtime/runtime_schema.mli`
- `ocamlc -stop-after parsing lib/runtime/runtime_schema.mli`
- `git diff --check`

Local Dune build/test was not run per CI-authority workflow.