### PR TITLE
feat(dashboard): surface per-model temperature in runtime inventory JSON

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -35,6 +35,9 @@ export interface DashboardRuntimeProviderSnapshot {
   tools_support?: boolean
   thinking_support?: boolean
   streaming?: boolean
+  /** Per-model sampling temperature override ([models.<id>].temperature);
+   *  null when unset (runtime keeps the fleet fallback). */
+  temperature?: number | null
   capabilities_declared?: boolean
   supports_multimodal_inputs?: boolean
   supports_image_input?: boolean
@@ -225,6 +228,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     tools_support: asBoolean(raw.tools_support),
     thinking_support: asBoolean(raw.thinking_support),
     streaming: asBoolean(raw.streaming),
+    temperature: asNumber(raw.temperature) ?? null,
     capabilities_declared: asBoolean(raw.capabilities_declared),
     supports_multimodal_inputs: asBoolean(raw.supports_multimodal_inputs),
     supports_image_input: asBoolean(raw.supports_image_input),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2422,11 +2422,17 @@ describe('fetchRuntimeProviders', () => {
             available: true,
             model_count: 1,
             models: ['Qwen/Qwen3-32B'],
+            temperature: 0.65,
             source: 'runtime.toml',
             discovery: {
               healthy: true,
               ctx_size: 200000,
             },
+          },
+          {
+            provider: 'openai.gpt',
+            runtime_id: 'openai.gpt',
+            temperature: null,
           },
         ],
         assignment_governance: {
@@ -2466,6 +2472,8 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.model_api_name).toBe('Qwen/Qwen3-32B')
     expect(result.providers[0]?.kind).toBe('cloud')
     expect(result.providers[0]?.runtime_kind).toBe('http')
+    expect(result.providers[0]?.temperature).toBe(0.65)
+    expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_governance?.status).toBe('degraded')
     expect(result.assignment_governance?.assignment_count).toBe(2)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1479,6 +1479,13 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "tools_support", `Bool rt.model.tools_support
     ; "thinking_support", `Bool rt.model.thinking_support
     ; "streaming", `Bool rt.model.streaming
+      (* Per-model sampling temperature override ([models.<id>].temperature).
+         [`Null] when unset (the runtime keeps the fleet fallback). Read-only
+         projection for the dashboard runtime capability card. *)
+    ; ( "temperature"
+      , match rt.model.temperature with
+        | Some t -> `Float t
+        | None -> `Null )
       (* Additive capability projection for the per-keeper runtime capability
          card (dashboard keeper-workspace-rail rtc-card): multimodal input +
          effort adjustability read-only. *)

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -145,6 +145,7 @@ endpoint = "https://api.openai.example/v1"
 [models.qwen]
 api-name = "qwen"
 max-context = 128000
+temperature = 0.65
 tools-support = true
 streaming = true
 
@@ -351,6 +352,17 @@ let test_runtime_inventory_surfaces_assignment_governance () =
   with_runtime_initialized (fun () ->
     let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
     let governance = J.member "assignment_governance" json in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let provider_by_runtime_id runtime_id =
+      List.find
+        (fun provider ->
+           String.equal
+             runtime_id
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let qwen = provider_by_runtime_id "runpod_mtp.qwen" in
+    let gpt = provider_by_runtime_id "openai.gpt" in
     Alcotest.(check string)
       "schema"
       "masc.runtime_assignment_governance.v1"
@@ -380,7 +392,17 @@ let test_runtime_inventory_surfaces_assignment_governance () =
       true
       (string_contains
          (Yojson.Safe.to_string governance)
-         "single_runtime_assignment_pin"))
+         "single_runtime_assignment_pin");
+    Alcotest.(check (float 0.0001))
+      "model temperature override"
+      0.65
+      (qwen |> J.member "temperature" |> J.to_float);
+    Alcotest.(check bool)
+      "absent model temperature is null"
+      true
+      (match gpt |> J.member "temperature" with
+       | `Null -> true
+       | _ -> false))
 ;;
 
 let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =


### PR DESCRIPTION
## 요약

`#23105`/`#23107`로 per-model `[models.<id>].temperature`가 스키마 필드가 됐으므로, 대시보드 runtime capability 카드가 이 값을 표시할 수 있게 노출합니다.

## 변경

| 파일 | 변경 |
|------|------|
| `lib/server/server_dashboard_http_runtime_info.ml` | `runtime_inventory_entry_json`에 `temperature` 키 추가 (`Float t`, 미설정 시 `Null` — runtime이 fleet fallback 유지) |
| `dashboard/src/api/dashboard-runtime.ts` | `DashboardRuntimeProviderSnapshot.temperature?: number \| null` + 디코더 `asNumber(raw.temperature) ?? null` |

## 경계 / 근거

- **read-only projection**: 표시만 추가, 동작 변화 0.
- `.mli` 불변: `runtime_inventory_entry_json`은 내부 헬퍼(`.mli`는 aggregate `runtime_inventory_json`만 export).
- shape 테스트 무영향: `test_runtime_inventory_surfaces_assignment_governance`는 `assignment_governance` 멤버만 assert(키 집합 아님).
- effort는 이 PR 범위 밖 — send-path가 agent_sdk 변경을 요구해 별도 판단 필요(config 절반만 노출하면 no-op 필드가 됨).

## 검증

- `ocamlformat --check` (janestreet 0.29.0): exit 0.
- 로컬 dune build/test 미실행(CI가 build authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)