### PR TITLE
fix(dashboard): unwrap {ok,data} envelope in IDE presence strip (runtime_unknown fix)

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -4,6 +4,7 @@ import {
   presenceContextAnchor,
   presenceContextSummary,
   prLabel,
+  unwrapEnvelope,
   type ApiAgent,
   type ApiStatus,
 } from './ide-presence-strip'
@@ -58,6 +59,34 @@ describe('agentsToPresence', () => {
       expect(snap.entries).toHaveLength(1)
       expect(snap.entries[0]?.workspace_label).toBe('nick0cave')
     }
+  })
+})
+
+describe('unwrapEnvelope', () => {
+  it('unwraps the {ok,data} envelope returned by /api/v1/status', () => {
+    const raw = { ok: true, data: { cluster: 'default', project: 'me' } }
+    expect(unwrapEnvelope<ApiStatus>(raw)).toEqual({ cluster: 'default', project: 'me' })
+  })
+
+  it('returns an already-unwrapped payload unchanged when no data key is present', () => {
+    const raw = { cluster: 'default' }
+    expect(unwrapEnvelope<ApiStatus>(raw)).toEqual({ cluster: 'default' })
+  })
+
+  it('returns undefined for null / non-object input', () => {
+    expect(unwrapEnvelope<ApiStatus>(null)).toBeUndefined()
+  })
+
+  // Regression: the strip read status.cluster off the raw {ok,data} envelope,
+  // so cluster was always undefined -> permanent runtime_unknown even while the
+  // server reported a live cluster. Unwrapping first must yield a live snapshot.
+  it('feeds an enveloped status into agentsToPresence as a live runtime', () => {
+    const envelope = { ok: true, data: { cluster: 'default', project: 'me' } }
+    const status = unwrapEnvelope<ApiStatus>(envelope) ?? {}
+    const agent: ApiAgent = { name: 'nick0cave', status: 'active', current_task: null, model: null }
+    const snap = agentsToPresence([agent], status)
+    expect(snap.kind).toBe('live')
+    if (snap.kind === 'live') expect(snap.runtime_id).toBe('default')
   })
 })
 

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -74,14 +74,32 @@ export function agentsToPresence(
   }
 }
 
+/** The standard MASC API endpoints ([/api/v1/status], [/api/v1/agents]) wrap
+    their payload in an [{ ok, data }] envelope, unlike the dashboard-specific
+    [/api/v1/providers] which returns its payload at the top level. [get()]
+    returns the raw parsed body without unwrapping, so a consumer must pull
+    [.data] out. Reading the envelope's absent top-level fields (e.g.
+    [status.cluster], which actually lives at [status.data.cluster]) is what
+    made this strip render a permanent [disconnected (runtime_unknown)]
+    regardless of the live runtime. Falls back to the raw value when no [data]
+    key is present, so an un-enveloped response still works.
+    @internal — exported for {@link ./ide-presence-strip.test.ts}. */
+export function unwrapEnvelope<T>(raw: unknown): T | undefined {
+  if (raw === null || typeof raw !== 'object') return undefined
+  if ('data' in raw) return (raw as { data: T }).data
+  return raw as T
+}
+
 async function fetchPresence(): Promise<KeeperPresenceSnapshot> {
   try {
-    const [agentsData, statusData] = await Promise.all([
-      get<{ agents: ApiAgent[] }>('/api/v1/agents?limit=20'),
-      get<ApiStatus>('/api/v1/status'),
+    const [agentsRaw, statusRaw] = await Promise.all([
+      get<unknown>('/api/v1/agents?limit=20'),
+      get<unknown>('/api/v1/status'),
     ])
-    const agents: ApiAgent[] = Array.isArray(agentsData.agents) ? agentsData.agents : []
-    return agentsToPresence(agents, statusData)
+    const agentsData = unwrapEnvelope<{ agents?: ApiAgent[] }>(agentsRaw)
+    const statusData = unwrapEnvelope<ApiStatus>(statusRaw)
+    const agents: ApiAgent[] = Array.isArray(agentsData?.agents) ? agentsData.agents : []
+    return agentsToPresence(agents, statusData ?? {})
   } catch {
     return disconnectedSnapshot('fetch_failed')
   }


### PR DESCRIPTION
## 증상

MASC IDE(`dashboard#code?section=ide-shell`) presence가 라이브 runtime이 있어도 **영구적으로 `disconnected (runtime_unknown)`** 로 표시됨.

## 근본 원인

`ide-presence-strip.ts`의 `fetchPresence`가 `status.cluster` / `agentsData.agents`를 **응답 최상위**에서 읽음. 그러나:
- `/api/v1/status`, `/api/v1/agents` = 표준 MASC **`{ok, data:{...}}` envelope** (masc_status는 MCP tool 계약).
- `/api/v1/providers` = payload 최상위 (대시보드 전용, envelope 없음).
- `get()`는 envelope를 언랩하지 않음 (`parseJsonResponse`가 raw `JSON.parse` 반환).

→ `status.cluster`가 항상 `undefined` → `?? ''` → `''` → `agentsToPresence`가 `runtime_unknown` 반환. 서버가 `cluster:"default"`를 정상 반환해도 프론트가 못 봄.

실측: `curl /api/v1/status` → `{"ok":true,"data":{"cluster":"default",...}}`.

## 수정

`unwrapEnvelope()` 추가 — `data` 키가 있으면 언랩, 없으면 raw 그대로(`/api/v1/providers` 호환), null/non-object는 undefined. `fetchPresence`가 언랩 후 읽음. `agentsToPresence`는 불변(언랩된 status를 받으면 원래 정상).

## 검증

- **vitest 18/18 pass** (기존 14 + 신규: `unwrapEnvelope` 3 + envelope→live 회귀 1).
- 회귀 테스트가 버그 시나리오 재현: `{ok,data:{cluster:"default"}}` → 언랩 → `agentsToPresence` → **live** (runtime_id="default").

## 경계

- 프론트 언랩이 근본 수정 — 백엔드 envelope 변경은 MCP/CLI 소비자를 깨므로 부적절. `{ok,data}`는 표준 계약.
- presence-strip이 이 두 엔드포인트의 유일한 소비자 (다른 컴포넌트는 envelope 없는 대시보드 엔드포인트 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)