### PR TITLE
feat(dashboard): fusion config typed read 엔드포인트 (RFC-0306 Phase 1)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -995,11 +995,10 @@ max_concurrent_panels = 2
 max_concurrent_judges = 3
 staged_judge_group_size = 3
 
-# 패널 프리셋. Panel execution requests provider-native structured output, so
-# checked-in defaults must use runtimes that declare supports-structured-output.
-# Add new model families here only after their runtime seed declares that
-# capability; otherwise the panel deterministically fails before the provider
-# request.
+# 패널 프리셋. 패널 답변은 free text다. 2026-07-01 사고(ollama.com cloud가 json_schema를
+# 조용히 무시 → 패널 전멸) 이후 패널의 provider-native structured output 요구는 제거됐다
+# (fusion_panel.ml). 따라서 패널 런타임은 supports-structured-output 선언이 필요 없다 —
+# structured output 요구는 아래 judge에만 남는다.
 # 프롬프트는 행동을 정의하므로 코드 default가 아니라 여기서 받는다 (누락 시 로드
 # 단계에서 fail-fast). 튜닝은 재컴파일 없이 이 값만 바꾸면 된다.
 [fusion.presets.trio]

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -284,7 +284,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 36 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 876 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
+| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 884 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
 | `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 807 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
 | `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 795 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
 | `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 823 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
@@ -311,7 +311,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 503 |  |
 | `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 499 |  |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 491 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 868 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of materializing them in... |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 868 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
 | `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 858 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 265 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 261 | WebSocket server port. Default: 8937. |

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -1,0 +1,78 @@
+(* Fusion config -> JSON projection for the dashboard read endpoint.
+
+   RFC-0306 §3.1. The dashboard fusion settings editor needs the full active
+   [Fusion_policy.t] as structured JSON to populate its form (panel roster, meta
+   judge, JoJ first-round judges, timeouts). No serializer existed: the config
+   types derive only [show]/[eq], and the only consumer flattens errors to a
+   string ([fusion_config_loader.ml]). This is a read-only projection; it does
+   not round-trip back to TOML (the write path is line-based, RFC-0306 §3.2). *)
+
+let opt_int : int option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some n -> `Int n
+
+let opt_float : float option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some f -> `Float f
+
+let opt_string : string option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some s -> `String s
+
+let panel_group_to_yojson (g : Fusion_policy.panel_group) : Yojson.Safe.t =
+  `Assoc
+    [ ( "models"
+      , `List (List.map (fun m -> `String m) g.Fusion_policy.models) )
+    ; ("label", `String g.Fusion_policy.label)
+    ; ("system_prompt", `String g.Fusion_policy.system_prompt)
+    ; ("web_tools", `Bool g.Fusion_policy.web_tools)
+    ; ("max_tool_calls", `Int g.Fusion_policy.max_tool_calls)
+    ; ("max_output_tokens", opt_int g.Fusion_policy.max_output_tokens)
+    ; ("timeout_s", `Float g.Fusion_policy.timeout_s)
+    ]
+
+(* Judge fields are prefixed [j*] in the record; the JSON drops the prefix so the
+   panel/judge shapes read symmetrically on the client. *)
+let judge_spec_to_yojson (j : Fusion_policy.judge_spec) : Yojson.Safe.t =
+  `Assoc
+    [ ("model", `String j.Fusion_policy.jmodel)
+    ; ("label", `String j.Fusion_policy.jlabel)
+    ; ("system_prompt", `String j.Fusion_policy.jsystem_prompt)
+    ; ("web_tools", `Bool j.Fusion_policy.jweb_tools)
+    ; ("max_tool_calls", `Int j.Fusion_policy.jmax_tool_calls)
+    ; ("max_output_tokens", opt_int j.Fusion_policy.jmax_output_tokens)
+    ; ("timeout_s", `Float j.Fusion_policy.jtimeout_s)
+    ; ("max_timeout_s", opt_float j.Fusion_policy.jmax_timeout_s)
+    ]
+
+let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
+  `Assoc
+    [ ("name", `String p.Fusion_policy.name)
+    ; ("panels", `List (List.map panel_group_to_yojson p.Fusion_policy.panels))
+    ; ("judge", `String p.Fusion_policy.judge)
+    ; ("judge_system_prompt", `String p.Fusion_policy.judge_system_prompt)
+    ; ("judge_timeout_s", `Float p.Fusion_policy.judge_timeout_s)
+    ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
+    ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
+    ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
+    ; ("min_answered", `Int p.Fusion_policy.min_answered)
+    ; ("judge_wave_budget_s", `Float p.Fusion_policy.judge_wave_budget_s)
+    ; ( "adaptive_timeout_factor"
+      , `Float p.Fusion_policy.adaptive_timeout_factor )
+    ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)
+    ]
+
+let to_yojson (c : Fusion_policy.t) : Yojson.Safe.t =
+  `Assoc
+    [ ("enabled", `Bool c.Fusion_policy.enabled)
+    ; ("default_preset", `String c.Fusion_policy.default_preset)
+    ; ("max_concurrent_panels", `Int c.Fusion_policy.max_concurrent_panels)
+    ; ("max_concurrent_judges", `Int c.Fusion_policy.max_concurrent_judges)
+    ; ("staged_judge_group_size", `Int c.Fusion_policy.staged_judge_group_size)
+    ; ( "presets"
+      , `List
+          (List.map
+             (fun (vp : Fusion_policy.Validated_preset.t) ->
+               preset_to_yojson (vp :> Fusion_policy.preset))
+             c.Fusion_policy.presets) )
+    ]

--- a/lib/fusion_core/fusion_config_json.mli
+++ b/lib/fusion_core/fusion_config_json.mli
@@ -1,0 +1,12 @@
+(* Fusion config -> JSON projection for the dashboard read endpoint (RFC-0306 §3.1).
+   Read-only; does not round-trip back to TOML. *)
+
+(** [to_yojson c] is the structured JSON projection of the active fusion config:
+    [enabled], [default_preset], the concurrency knobs, and every validated
+    preset (panel roster, meta judge, JoJ first-round judges, timeouts). Judge
+    record fields lose their [j] prefix in the output so panel and judge shapes
+    read symmetrically. *)
+val to_yojson : Fusion_policy.t -> Yojson.Safe.t
+
+(** [preset_to_yojson p] projects a single preset; exposed for tests. *)
+val preset_to_yojson : Fusion_policy.preset -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -542,6 +542,26 @@ let add_routes ~sw ~clock router =
                ~status:(runtime_config_path_error_status msg)
                ~request:req reqd msg)
          request reqd)
+  (* RFC-0306 §3.1 — typed read of the active fusion config for the settings
+     editor. [Fusion_config_loader.load] returns [Ok disabled] when runtime.toml
+     or its [fusion] section is absent, and [Error] only when an existing section
+     fails to parse/validate (a broken on-disk config), which surfaces as 500. *)
+  |> Http.Router.get "/api/v1/runtime/config/fusion" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _agent_name req reqd ->
+           let base_path = (Mcp_server.workspace_config state).base_path in
+           match Fusion_config_loader.load ~base_path with
+           | Ok config ->
+             Http.Response.json_value ~compress:true ~request:req
+               (`Assoc
+                 [ ("generated_at", `String (Masc_domain.now_iso ()))
+                 ; ("config", Fusion_config_json.to_yojson config)
+                 ])
+               reqd
+           | Error msg ->
+             respond_dashboard_error ~status:`Internal_server_error
+               ~request:req reqd msg)
+         request reqd)
   |> Http.Router.post "/api/v1/runtime/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state agent_name req reqd ->

--- a/test/fusion_core/dune
+++ b/test/fusion_core/dune
@@ -3,5 +3,6 @@
 ; main masc library — runs in seconds.
 
 (tests
- (names test_fusion test_fusion_harness test_fusion_run_registry)
- (libraries alcotest otoml masc.fusion_core))
+ (names test_fusion test_fusion_harness test_fusion_run_registry
+   test_fusion_config_json)
+ (libraries alcotest otoml yojson masc.fusion_core))

--- a/test/fusion_core/test_fusion_config_json.ml
+++ b/test/fusion_core/test_fusion_config_json.ml
@@ -1,0 +1,75 @@
+(* RFC-0306 §3.1 — Fusion_config_json.to_yojson projects the active fusion config
+   for the dashboard settings editor. This fixes the JSON shape end-to-end through
+   of_toml, covering the JoJ [[...judges]] array-of-tables path that the read
+   endpoint must surface (the field the current read-only UI cannot show). *)
+
+let parse s = Otoml.Parser.from_string s
+
+(* Mirrors config/runtime.toml [fusion.presets.quorum] structure with placeholder
+   model ids; judges >= 2 so the JoJ array-of-tables projection is exercised. *)
+let joj_preset_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "quorum"
+[fusion.presets.quorum]
+panel = ["pa", "pb", "pc"]
+judge = "meta-reducer"
+panel_system_prompt = "answer independently"
+judge_system_prompt = "reconcile the first-judge syntheses"
+meta_timeout_s = 120.0
+
+[[fusion.presets.quorum.judges]]
+model = "judge-evidence"
+label = "evidence"
+system_prompt = "judge through an evidence lens"
+
+[[fusion.presets.quorum.judges]]
+model = "judge-coverage"
+label = "coverage"
+system_prompt = "judge through a coverage lens"
+|}
+
+let test_to_yojson_projects_joj_preset () =
+  match Fusion_config.of_toml (parse joj_preset_toml) with
+  | Error es ->
+    Alcotest.failf "fixture must parse+validate, got: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+  | Ok config ->
+    let json = Fusion_config_json.to_yojson config in
+    let open Yojson.Safe.Util in
+    Alcotest.(check bool) "enabled" true (json |> member "enabled" |> to_bool);
+    Alcotest.(check string) "default_preset" "quorum"
+      (json |> member "default_preset" |> to_string);
+    let presets = json |> member "presets" |> to_list in
+    Alcotest.(check int) "one preset" 1 (List.length presets);
+    let p = List.hd presets in
+    Alcotest.(check string) "preset name" "quorum"
+      (p |> member "name" |> to_string);
+    Alcotest.(check string) "meta judge" "meta-reducer"
+      (p |> member "judge" |> to_string);
+    let judges = p |> member "judges" |> to_list in
+    Alcotest.(check int) "two JoJ first-round judges serialized" 2
+      (List.length judges);
+    Alcotest.(check (list string))
+      "judge models projected with the j-prefix dropped (jmodel -> model)"
+      [ "judge-evidence"; "judge-coverage" ]
+      (List.map (fun j -> j |> member "model" |> to_string) judges);
+    Alcotest.(check (list string)) "judge lenses projected (jlabel -> label)"
+      [ "evidence"; "coverage" ]
+      (List.map (fun j -> j |> member "label" |> to_string) judges);
+    let panel_models =
+      p |> member "panels" |> to_list
+      |> List.concat_map (fun g ->
+             g |> member "models" |> to_list |> List.map to_string)
+    in
+    Alcotest.(check (list string)) "panel roster flattened in order"
+      [ "pa"; "pb"; "pc" ] panel_models
+
+let () =
+  Alcotest.run "fusion_config_json"
+    [ ( "to_yojson"
+      , [ Alcotest.test_case "projects JoJ preset" `Quick
+            test_to_yojson_projects_joj_preset
+        ] )
+    ]


### PR DESCRIPTION
RFC-0306 **Phase 1** — fusion 설정 편집기용 typed read 경로.

## 목적
fusion 설정 편집기가 폼을 채우려면 활성 fusion config를 **구조화 JSON**으로 받아야 합니다. 현재는 직렬화기가 없어 read-only 뷰가 panel roster / meta judge / JoJ 1차 심판 / timeout을 못 보여줍니다.

## 변경
- `lib/fusion_core/fusion_config_json.ml/.mli`: `Fusion_policy.t` / `preset` / `panel_group` / `judge_spec`를 Yojson으로 손수 투영. judge 필드는 `j` 프리픽스를 떼어 panel/judge 모양을 대칭으로 노출. read-only(TOML 역방향 없음 — write는 Phase 2 라인 편집).
- `GET /api/v1/runtime/config/fusion` 라우트: `Fusion_config_loader.load` 재사용(섹션 부재→`Ok disabled`, 기존 파일 파싱 실패만 `Error`→500). raw 엔드포인트와 동일하게 `CanAdmin` 게이트.
- `config/runtime.toml`: trio panel의 stale 주석 정정. 2026-07-01 사고 이후 panel은 free text이며(`fusion_panel.ml`), supports-structured-output 요구는 judge에만 남습니다.
- `test/fusion_core/test_fusion_config_json.ml`: `of_toml` end-to-end로 JSON 모양 고정 — **JoJ `[[...judges]]` array-of-tables 투영**을 커버(현재 read-only UI가 못 보여주는 필드).

## 검증
- 신규 alcotest(`test_fusion_config_json`)가 `masc.fusion_core`만 링크해 격리 실행. dune 빌드/테스트는 CI에서 수행.
- 경계: 새 `masc → oas` 참조 없음. read 경로는 기존 loader 재사용.

## 남은 것
- Phase 2(comment-preserving TOML 편집기 일반화 + array-of-tables) → Phase 3(POST write + 검증 JSON + of_preset JoJ≥2) → Phase 4(프론트 폼) → Phase 5(supports_structured_output 노출).

RFC-WAIVED: dashboard read 엔드포인트 + fusion_core 직렬화 + config 주석 정정. credential/keeper/operator/hooks/workflow 등 게이트 대상 subsystem 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
