### PR TITLE
feat(ide): route observation records through resolve_partition_for_write (task-1716)

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -1,36 +1,3 @@
-type tool_event =
-  { base_path : string
-  ; tool_name : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; outcome : string
-  ; typed_outcome : string
-  ; duration_ms : float
-  ; output_text : string
-  ; input : Yojson.Safe.t
-  }
-
-type pr_event =
-  { base_path : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; output_text : string
-  ; tool_name : string
-  ; success : bool
-  }
-
-type turn_event =
-  { base_path : string
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-
 type codebase_partition =
   | By_url of string
       (** canonical URL 정상 resolved: host_path slug. *)
@@ -49,6 +16,43 @@ type codebase_partition =
           carries no [partition] field at all (tool/turn/pr_event,
           annotation_request). Structural ceiling, NOT a soft fallback.
           v2 §7 "(3) default 미갱신". *)
+
+type tool_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; duration_ms : float
+  ; output_text : string
+  ; input : Yojson.Safe.t
+  }
+
+type pr_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; keeper_id : string
+  ; turn_id : string
+  ; output_text : string
+  ; tool_name : string
+  ; success : bool
+  }
+
+type turn_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
 
 (* RFC-0128 §4.1 neutral codebase slug derivation.
 
@@ -188,6 +192,7 @@ let annotation_kind_of_string = function
 
 type annotation_request =
   { base_path : string
+  ; partition : codebase_partition
   ; keeper_id : string
   ; file_path : string
   ; line_start : int

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -4,39 +4,6 @@
     storage module. Consumers register process-local sinks that translate
     these neutral records into their own persistence or streaming surfaces. *)
 
-type tool_event =
-  { base_path : string
-  ; tool_name : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; outcome : string
-  ; typed_outcome : string
-  ; duration_ms : float
-  ; output_text : string
-  ; input : Yojson.Safe.t
-  }
-
-type pr_event =
-  { base_path : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; output_text : string
-  ; tool_name : string
-  ; success : bool
-  }
-
-type turn_event =
-  { base_path : string
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-
 type codebase_partition =
   | By_url of string
       (** canonical URL 정상 resolved: host_path slug. *)
@@ -54,6 +21,42 @@ type codebase_partition =
       (** No [canonical_url]/[repo_id] supplied, or record has no [partition]
           field (tool/turn/pr_event). Structural ceiling, NOT a soft fallback.
           v2 §7 "(3) default 미갱신". *)
+
+type tool_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; duration_ms : float
+  ; output_text : string
+  ; input : Yojson.Safe.t
+  }
+
+type pr_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; keeper_id : string
+  ; turn_id : string
+  ; output_text : string
+  ; tool_name : string
+  ; success : bool
+  }
+
+type turn_event =
+  { base_path : string
+  ; partition : codebase_partition
+  ; turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
 
 val canonical_url_of_remote : string -> string option
 (** [canonical_url_of_remote remote] normalises a git remote string into a
@@ -79,6 +82,7 @@ val annotation_kind_of_string : string -> annotation_kind option
 
 type annotation_request =
   { base_path : string
+  ; partition : codebase_partition
   ; keeper_id : string
   ; file_path : string
   ; line_start : int

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -1038,6 +1038,7 @@ let install_agent_observation_sinks () =
         event.tool_call_json);
   Agent_observation.register_annotation_sink
     (fun ({ base_path
+           ; partition
            ; keeper_id
            ; file_path
            ; line_start
@@ -1059,6 +1060,7 @@ let install_agent_observation_sinks () =
       match
         Ide_annotations.create
           ~base_dir:base_path
+          ~partition
           ~keeper_id
           ~file_path
           ~line_start

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -225,8 +225,13 @@ let run_turn
   (* Section 1: Setup — sanitize input, build context, compose prompt. *)
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
+  let partition, _ =
+    Keeper_tool_filesystem_runtime.resolve_partition_for_write
+      ~base_dir:config.base_path ~kind:"turn_event" ~file_path:config.base_path
+  in
   Agent_observation.emit_turn_event
     { base_path = config.base_path
+    ; partition
     ; turn_id =
         (match meta.current_task_id with
          | Some t -> Keeper_id.Task_id.to_string t
@@ -253,8 +258,13 @@ let run_turn
   let emit_observation_turn_end ~phase ~stop_reason () =
     let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
     let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
+    let partition, _ =
+      Keeper_tool_filesystem_runtime.resolve_partition_for_write
+        ~base_dir:config.base_path ~kind:"turn_event" ~file_path:config.base_path
+    in
     Agent_observation.emit_turn_event
       { base_path = config.base_path
+      ; partition
       ; turn_id
       ; keeper_id = meta.name
       ; phase

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -190,8 +190,13 @@ let assemble_hooks
              | Some t -> Keeper_id.Task_id.to_string t
              | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
            in
+           let partition, _ =
+             Keeper_tool_filesystem_runtime.resolve_partition_for_write
+               ~base_dir:config.base_path ~kind:"tool_event" ~file_path:config.base_path
+           in
            Agent_observation.emit_tool_event
              { base_path = config.base_path
+             ; partition
              ; tool_name
              ; keeper_id = acc.meta.name
              ; turn_id
@@ -203,6 +208,7 @@ let assemble_hooks
              };
            Agent_observation.emit_pr_event
              { base_path = config.base_path
+             ; partition
              ; keeper_id = acc.meta.name
              ; turn_id
              ; output_text

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -47,9 +47,14 @@ let handle_ide_annotate
       | Some k -> k
       | None -> Agent_observation.Comment
     in
+    let partition, _ =
+      Keeper_tool_filesystem_runtime.resolve_partition_for_write
+        ~base_dir:base_dir ~kind:"annotation" ~file_path
+    in
     match
       Agent_observation.emit_annotation_request
         { base_path = base_dir
+        ; partition
         ; keeper_id = keeper_name
         ; file_path
         ; line_start

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -30,6 +30,7 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
     install_fresh_ide_sink ();
     Agent_observation.emit_tool_event
       { base_path = base_dir
+      ; partition = Agent_observation.Legacy_default
       ; tool_name = "keeper_ide_annotate"
       ; keeper_id = "keeper-alpha"
       ; turn_id = "turn-9"
@@ -56,6 +57,7 @@ let test_turn_observation_reaches_ide_storage () =
     install_fresh_ide_sink ();
     Agent_observation.emit_turn_event
       { base_path = base_dir
+      ; partition = Agent_observation.Legacy_default
       ; turn_id = "turn-10"
       ; keeper_id = "keeper-beta"
       ; phase = "completed"
@@ -77,6 +79,7 @@ let test_pr_observation_reaches_ide_storage () =
     install_fresh_ide_sink ();
     Agent_observation.emit_pr_event
       { base_path = base_dir
+      ; partition = Agent_observation.Legacy_default
       ; keeper_id = "keeper-gamma"
       ; turn_id = "turn-11"
       ; output_text =
@@ -135,6 +138,7 @@ let test_annotation_request_reaches_ide_storage () =
     let result =
       Agent_observation.emit_annotation_request
         { base_path = base_dir
+        ; partition = Agent_observation.Legacy_default
         ; keeper_id = "keeper-epsilon"
         ; file_path = "lib/annotated.ml"
         ; line_start = 7


### PR DESCRIPTION
## task-1716: Observation metadata partition routing

Refs task-1716 (IDE Observation Plane v2 §7 Observation Metadata). **Stacks on #23110** (base = `fix/ide-partition-typed-reasons`).

## 문제
`codebase_partition`이 `write_region_event`에만 있고, `tool_event`/`pr_event`/`turn_event`/`annotation_request` record에는 partition 필드 자체가 없었습니다. 결과적으로 모든 keeper producer가 `default_partition = Legacy_default` 하드코딩 → 관측 전부 `_orphan/`에 쌓임. partition 시스템이 **반만 동작**: regions는 `by-url/<slug>/`에, annotations/events/cursors는 `_orphan/`에. 같은 codebase의 regions와 annotations가 disjoint partition → `?repo_id=X` read가 regions만 반환(annotations 안 보임).

## 해결
- `tool_event`/`pr_event`/`turn_event`/`annotation_request`에 `partition : codebase_partition`을 **required 필드**로 추가(option으로 두면 default가 곧 이 버그 재생산).
- producer(3 keeper 파일)가 `resolve_partition_for_write`로 partition을 채움:
  - annotation_request → 실제 `file_path` 기반
  - tool/pr/turn event → `config.base_path` 기반(이 record들은 file_path를 안 가짐)
- `ide_bridge` annotation_sink가 `Ide_annotations.create ~partition:request.partition`으로 라우팅.

## 범위 / follow-up (별도 sub-PR)
- **ingest_tool/turn/pr_event**는 여전 `default_partition`: `[event]` 값이 `ide_event` **variant**(record 아님)라 `event.partition` 불가. variant record 4개에 partition 추가 + match 추출이 필요해 큰 변경 → 분리.
- **ingest_cursor_event**도 scalar-arg 기반(별도).
- `default_partition`은 cursor가 아직 써서 유지.
- **read-path IdeOrphanReads counter**(task-1715 TODO 승계).
- **LSP overlay partition-blindness**(`lsp_overlay_provider`).

## 의존성
**Depends-on #23110**(task-1715 partition 5-variant). 이 PR은 `fix/ide-partition-typed-reasons` 위에 stack → #23110 머지 시 자연 승계.

## 검증
- `dune build --root .` green (partial-match warning 0).
- `test_agent_observation_bridge` / `test_ide_annotations` / `test_ide_bridge` green.

---
RFC-WAIVED: lib/agent_observation + lib/ide + lib/keeper. RFC-gated subsystem 미접촉.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
