### PR TITLE
[codex] fix IDE observation metadata hardening

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -589,18 +589,6 @@ let extract_descriptor_from_output (output_text : string) : Ide_event_types.comm
     | _ -> None
   with _ -> None
 
-let string_contains s needle =
-  let s_len = String.length s in
-  let needle_len = String.length needle in
-  let rec loop i =
-    if needle_len = 0 then true
-    else if i + needle_len > s_len then false
-    else if String.sub s i needle_len = needle then true
-    else loop (i + 1)
-  in
-  loop 0
-;;
-
 let cursor_file_path_of_input input =
   let non_empty = function
     | Some s ->
@@ -619,21 +607,10 @@ let cursor_line_of_input input =
   | None -> int_field "line_start" input
 ;;
 
-let focus_mode_of_tool_input ~tool_name input =
+let focus_mode_of_tool_input input =
   match string_field "focus_mode" input with
-  | Some mode when valid_focus_mode mode -> mode
-  | _ ->
-    let lowered = String.lowercase_ascii tool_name in
-    if string_contains lowered "review"
-    then "reviewing"
-    else if string_contains lowered "read" || string_contains lowered "search"
-    then "reading"
-    else if string_contains lowered "write"
-            || string_contains lowered "edit"
-            || string_contains lowered "patch"
-            || string_contains lowered "annotate"
-    then "editing"
-    else "planning"
+  | Some mode when valid_focus_mode mode -> Some mode
+  | Some _ | None -> None
 ;;
 
 let turn_number_of_id turn_id =
@@ -694,8 +671,8 @@ let ingest_cursor_event_from_hook
     ~timestamp_ms
     ~(input : Yojson.Safe.t)
   =
-  match cursor_file_path_of_input input, cursor_line_of_input input with
-  | Some file_path, Some line when line >= 1 ->
+  match cursor_file_path_of_input input, cursor_line_of_input input, focus_mode_of_tool_input input with
+  | Some file_path, Some line, Some focus_mode when line >= 1 ->
     let column =
       match int_field "column" input with
       | Some n when n >= 0 -> n
@@ -713,7 +690,7 @@ let ingest_cursor_event_from_hook
         ~line
         ~column
         ?selection_end
-        ~focus_mode:(focus_mode_of_tool_input ~tool_name input)
+        ~focus_mode
         ~last_update:timestamp_ms
         ~tool_name
         ?turn:(turn_number_of_id turn_id)
@@ -739,7 +716,7 @@ let ingest_cursor_event
     ()
   =
   let column = Option.value column ~default:0 in
-  let focus_mode = Option.value focus_mode ~default:"edit" in
+  let focus_mode = Option.value focus_mode ~default:"editing" in
   let timestamp_ms = now_ms () in
   let json =
     cursor_event_json
@@ -887,7 +864,7 @@ let ingest_pr_event_from_descriptor
     ~keeper_id
     ~turn_id
     ~output_text
-    ~tool_name
+    ~tool_name:_
     ~success
   =
   (* Gate: only ingest PR events from successful tool executions.
@@ -895,7 +872,7 @@ let ingest_pr_event_from_descriptor
      command_descriptor in their output, which would otherwise produce
      phantom PR #0 events. *)
   if not success then ()
-  else if String.equal (String.lowercase_ascii tool_name) "execute" then
+  else
     match extract_descriptor_from_output output_text with
     | Some (Ide_event_types.Gh_pr_create { title; base = _; draft = _ }) ->
       let pr_number, pull_request_url = match parse_pull_request_result_from_output output_text with
@@ -965,7 +942,7 @@ let ingest_pr_event_from_descriptor
     | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
     | None -> ()
 
-(** Ingest PR creation/update events from Execute tool output.
+(** Ingest PR creation/update events from descriptor-backed tool output.
     This legacy hook entrypoint intentionally delegates to descriptor-backed
     ingestion only; raw stdout URL scanning is not a reliable PR signal. *)
 let ingest_pr_event_from_hook

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -716,26 +716,34 @@ let ingest_cursor_event
     ()
   =
   let column = Option.value column ~default:0 in
-  let focus_mode = Option.value focus_mode ~default:"editing" in
-  let timestamp_ms = now_ms () in
-  let json =
-    cursor_event_json
-      ~keeper_id
-      ~file_path
-      ~line
-      ~column
-      ?selection_end
-      ~focus_mode
-      ~last_update:timestamp_ms
-      ~tool_name:source
-      ~turn_id:""
-      ()
+  let focus_mode =
+    match focus_mode with
+    | None -> Some "editing"
+    | Some mode when valid_focus_mode mode -> Some mode
+    | Some _ -> None
   in
-  (try append_cursor ~base_dir:base_path ~partition:default_partition json
-   with exn ->
-     Printf.eprintf
-       "Ide_bridge.ingest_cursor_event error: %s\n%!"
-       (Printexc.to_string exn))
+  match focus_mode with
+  | None -> ()
+  | Some focus_mode ->
+    let timestamp_ms = now_ms () in
+    let json =
+      cursor_event_json
+        ~keeper_id
+        ~file_path
+        ~line
+        ~column
+        ?selection_end
+        ~focus_mode
+        ~last_update:timestamp_ms
+        ~tool_name:source
+        ~turn_id:""
+        ()
+    in
+    (try append_cursor ~base_dir:base_path ~partition:default_partition json
+     with exn ->
+       Printf.eprintf
+         "Ide_bridge.ingest_cursor_event error: %s\n%!"
+         (Printexc.to_string exn))
 ;;
 ;;
 

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -108,7 +108,7 @@ val ingest_pr_event :
   timestamp_ms:int64 ->
   unit
 
-(** Ingest descriptor-backed PR events from successful Execute tool output.
+(** Ingest descriptor-backed PR events from successful tool output.
     Raw stdout URL scanning is intentionally not a PR signal; only an explicit
     successful wrapper result with a command descriptor may ingest PR events. *)
 val ingest_pr_event_from_hook :

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -37,7 +37,12 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
       ; typed_outcome = "progress"
       ; duration_ms = 12.0
       ; output_text = "annotated"
-      ; input = `Assoc [ "file_path", `String "lib/test.ml"; "line_start", `Int 42 ]
+      ; input =
+          `Assoc
+            [ "file_path", `String "lib/test.ml"
+            ; "line_start", `Int 42
+            ; "focus_mode", `String "editing"
+            ]
       };
     (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool ~limit:1 () with
      | [ event ] ->

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -263,6 +263,7 @@ let test_cursor_from_hook_uses_real_file_and_line () =
         ; "line_start", `Int 12
         ; "line_end", `Int 14
         ; "column", `Int 3
+        ; "focus_mode", `String "editing"
         ]
     in
     Ide_bridge.ingest_tool_event_from_hook
@@ -303,6 +304,25 @@ let test_cursor_from_hook_skips_missing_line () =
       ~output_text:"annotated"
       ~input;
     check int "no cursor without line" 0
+      (List.length (Ide_bridge.list_cursors ~base_path:base_dir ())))
+;;
+
+let test_cursor_from_hook_skips_missing_focus_mode () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc [ "file_path", `String "lib/test.ml"; "line_start", `Int 12 ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~tool_name:"keeper_ide_annotate"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-7"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:10.0
+      ~output_text:"annotated"
+      ~input;
+    check int "no cursor without explicit focus mode" 0
       (List.length (Ide_bridge.list_cursors ~base_path:base_dir ())))
 ;;
 
@@ -502,9 +522,11 @@ let test_pr_event_from_hook_uses_descriptor_confirmed_cli_url () =
       pull_request_url)
 ;;
 
-let test_pr_event_from_hook_ignores_non_execute () =
+let test_pr_event_from_hook_uses_descriptor_for_any_tool_name () =
   with_temp_dir (fun base_dir ->
-    let output = "https://github.com/owner/repo/pull/456" in
+    let output =
+      {|{"ok":true,"output":"{\"number\":456,\"url\":\"https://github.com/owner/repo/pull/456\"}","command_descriptor":{"kind":"gh_pr_create","title":"feat descriptor","base":"main","draft":false}}|}
+    in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
       ~keeper_id:"k1"
@@ -513,7 +535,13 @@ let test_pr_event_from_hook_ignores_non_execute () =
       ~tool_name:"fs_write";
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
     let path = Filename.concat dir "pr_events.jsonl" in
-    check bool "file not created" false (Sys.file_exists path))
+    check bool "file exists" true (Sys.file_exists path);
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic;
+    let json = Yojson.Safe.from_string line in
+    check int "pr_number" 456
+      (Yojson.Safe.Util.member "pr_number" json |> Yojson.Safe.Util.to_int))
 ;;
 
 let test_pr_event_from_hook_ignores_no_url () =
@@ -902,6 +930,10 @@ let () =
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
         ; test_case "from hook skips missing line" `Quick test_cursor_from_hook_skips_missing_line
+        ; test_case
+            "from hook skips missing focus mode"
+            `Quick
+            test_cursor_from_hook_skips_missing_focus_mode
         ] )
     ; ( "hook_extract"
       , [ test_case "file_path from path key" `Quick test_hook_extracts_file_path_from_path_key
@@ -914,7 +946,10 @@ let () =
       , [ test_case "pr event ingest" `Quick test_pr_event_ingest
         ; test_case "from hook uses structured descriptor output" `Quick test_pr_event_from_hook_uses_structured_descriptor_output
         ; test_case "from hook uses descriptor-confirmed CLI URL" `Quick test_pr_event_from_hook_uses_descriptor_confirmed_cli_url
-        ; test_case "from hook ignores non-execute" `Quick test_pr_event_from_hook_ignores_non_execute
+        ; test_case
+            "from hook uses descriptor for any tool name"
+            `Quick
+            test_pr_event_from_hook_uses_descriptor_for_any_tool_name
         ; test_case "from hook ignores no url" `Quick test_pr_event_from_hook_ignores_no_url
         ; test_case "from hook ignores raw url" `Quick test_pr_event_from_hook_ignores_raw_url
         ; test_case "descriptor gated on success" `Quick test_descriptor_gated_on_success


### PR DESCRIPTION
## Summary
- remove tool-name substring inference from IDE cursor focus ingestion
- require hook-produced cursor records to carry an explicit valid `focus_mode`
- allow PR event ingestion from any successful descriptor-backed tool output instead of gating on `tool_name = execute`

## Why
The IDE observation path was still deriving behavior from free-form tool names. That violates the typed/descriptor-backed observation direction and can silently label cursor activity incorrectly. PR ingestion already trusts `command_descriptor`; the extra tool-name gate was redundant string coupling.

## Validation
- `scripts/dune-local.sh build test/test_agent_observation_bridge.exe test/test_ide_bridge.exe test/test_command_descriptor.exe`
- `_build/default/test/test_agent_observation_bridge.exe`
- `_build/default/test/test_ide_bridge.exe`
- `_build/default/test/test_command_descriptor.exe`
- `git diff --check`

Draft PR opened for CI authority per repo workflow.