### PR TITLE
feat(runtime): comment-preserving TOML line editor SSOT (RFC-0306 Phase 2)

### DIFF
--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -8,6 +8,7 @@
  (libraries
   yojson
   otoml
+  masc.toml_line_editor
   base64
   unix
   logs

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -831,19 +831,10 @@ let contains_newline s =
     s
 ;;
 
-let toml_escape_string s =
-  let buf = Buffer.create (String.length s) in
-  String.iter
-    (function
-      | '"' -> Buffer.add_string buf "\\\""
-      | '\\' -> Buffer.add_string buf "\\\\"
-      | '\n' -> Buffer.add_string buf "\\n"
-      | '\r' -> Buffer.add_string buf "\\r"
-      | '\t' -> Buffer.add_string buf "\\t"
-      | c -> Buffer.add_char buf c)
-    s;
-  Buffer.contents buf
-;;
+(* Comment-preserving TOML line editing lives in [Toml_line_editor] (RFC-0306
+   §3.2). These aliases keep the runtime.toml routing/assignment editor's call
+   sites unchanged while removing the duplicated implementations. *)
+let toml_escape_string = Toml_line_editor.escape_string
 
 let assignment_line ~keeper_name ~runtime_id =
   Printf.sprintf
@@ -853,54 +844,15 @@ let assignment_line ~keeper_name ~runtime_id =
 ;;
 
 let runtime_scalar_line ~key ~runtime_id =
-  Printf.sprintf "%s = \"%s\"" key (toml_escape_string runtime_id)
+  Toml_line_editor.scalar_line ~key ~value:runtime_id
 ;;
 
-let runtime_string_array_line ~key ~values =
-  let rendered =
-    values
-    |> List.map (fun value -> Printf.sprintf "\"%s\"" (toml_escape_string value))
-    |> String.concat ", "
-  in
-  Printf.sprintf "%s = [%s]" key rendered
-;;
+let runtime_string_array_line = Toml_line_editor.string_array_line
 
-let split_lines content =
-  if String.equal content "" then [], false
-  else (
-    let len = String.length content in
-    let trailing_newline = Char.equal content.[len - 1] '\n' in
-    let parts = String.split_on_char '\n' content in
-    let lines =
-      if trailing_newline
-      then (
-        match List.rev parts with
-        | "" :: rest -> List.rev rest
-        | _ -> parts)
-      else parts
-    in
-    lines, trailing_newline)
-;;
-
-let join_lines lines ~trailing_newline =
-  match lines with
-  | [] -> if trailing_newline then "\n" else ""
-  | _ ->
-    let body = String.concat "\n" lines in
-    if trailing_newline then body ^ "\n" else body
-;;
-
-let strip_toml_comment line =
-  match String.index_opt line '#' with
-  | None -> line
-  | Some index -> String.sub line 0 index
-;;
-
-let is_toml_table_header line =
-  let s = line |> strip_toml_comment |> String.trim in
-  let len = String.length s in
-  len >= 2 && Char.equal s.[0] '[' && Char.equal s.[len - 1] ']'
-;;
+let split_lines = Toml_line_editor.split_lines
+let join_lines = Toml_line_editor.join_lines
+let strip_toml_comment = Toml_line_editor.strip_comment
+let is_toml_table_header = Toml_line_editor.is_table_header
 
 let is_runtime_assignments_header line =
   String.equal (line |> strip_toml_comment |> String.trim) "[runtime.assignments]"
@@ -910,79 +862,9 @@ let is_runtime_header line =
   String.equal (line |> strip_toml_comment |> String.trim) "[runtime]"
 ;;
 
-let rec split_at n xs =
-  if n <= 0 then [], xs
-  else
-    match xs with
-    | [] -> [], []
-    | x :: rest ->
-      let before, after = split_at (n - 1) rest in
-      x :: before, after
-;;
-
-let find_index pred xs =
-  let rec loop index = function
-    | [] -> None
-    | x :: rest -> if pred x then Some index else loop (index + 1) rest
-  in
-  loop 0 xs
-;;
-
-let parse_quoted_key raw =
-  let len = String.length raw in
-  if len < 2 || not (Char.equal raw.[0] '"') then None
-  else
-    let buf = Buffer.create len in
-    let rec loop index =
-      if index >= len then None
-      else
-        match raw.[index] with
-        | '"' -> Some (Buffer.contents buf)
-        | '\\' when index + 1 < len ->
-          let escaped =
-            match raw.[index + 1] with
-            | '"' -> '"'
-            | '\\' -> '\\'
-            | 'n' -> '\n'
-            | 'r' -> '\r'
-            | 't' -> '\t'
-            | c -> c
-          in
-          Buffer.add_char buf escaped;
-          loop (index + 2)
-        | c ->
-          Buffer.add_char buf c;
-          loop (index + 1)
-    in
-    loop 1
-;;
-
-let parse_literal_key raw =
-  let len = String.length raw in
-  if len < 2 || not (Char.equal raw.[0] '\'') then None
-  else
-    match String.index_from_opt raw 1 '\'' with
-    | None -> None
-    | Some end_index -> Some (String.sub raw 1 (end_index - 1))
-;;
-
-let assignment_key_of_line line =
-  let trimmed = String.trim line in
-  if String.equal trimmed "" || Char.equal trimmed.[0] '#'
-  then None
-  else
-    match String.index_opt trimmed '=' with
-    | None -> None
-    | Some eq_index ->
-      let key_part = String.sub trimmed 0 eq_index |> String.trim in
-      if String.equal key_part ""
-      then None
-      else if Char.equal key_part.[0] '"'
-      then parse_quoted_key key_part
-      else if Char.equal key_part.[0] '\''
-      then parse_literal_key key_part
-      else Some key_part
-;;
+let split_at = Toml_line_editor.split_at
+let find_index = Toml_line_editor.find_index
+let assignment_key_of_line = Toml_line_editor.key_of_line
 
 let replace_or_append_assignment section_lines ~keeper_name ~runtime_id =
   let line = assignment_line ~keeper_name ~runtime_id in

--- a/lib/toml_line_editor/dune
+++ b/lib/toml_line_editor/dune
@@ -2,6 +2,8 @@
 ; single home for editing runtime.toml keys/tables without dropping comments.
 ; Runtime and the fusion settings writer both delegate here.
 
+(include_subdirs no)
+
 (library
  (name toml_line_editor)
  (public_name masc.toml_line_editor)

--- a/lib/toml_line_editor/dune
+++ b/lib/toml_line_editor/dune
@@ -1,0 +1,8 @@
+; Comment-preserving line-based TOML editing (RFC-0306 §3.2). Pure stdlib; the
+; single home for editing runtime.toml keys/tables without dropping comments.
+; Runtime and the fusion settings writer both delegate here.
+
+(library
+ (name toml_line_editor)
+ (public_name masc.toml_line_editor)
+ (wrapped false))

--- a/lib/toml_line_editor/toml_line_editor.ml
+++ b/lib/toml_line_editor/toml_line_editor.ml
@@ -1,0 +1,283 @@
+(* Comment-preserving, line-based TOML editing.
+
+   TOML round-tripping through a parser drops comments (Otoml discards them at the
+   lexer and has no comment AST node), so any edit that regenerates the file from
+   a parsed value destroys operator documentation. This module edits the original
+   text at line granularity: it locates a target table by header, replaces or
+   appends exactly the key line(s) being changed, and passes every other line —
+   comments, blanks, other keys, other tables — through unchanged.
+
+   The primitives originate from the runtime.toml routing/assignment editor in
+   [Runtime]; they are hoisted here as the single home for comment-preserving TOML
+   editing (RFC-0306 §3.2) so the fusion settings writer can reuse them without
+   depending on the runtime library. [Runtime] delegates to these. *)
+
+(* ── string / line helpers ─────────────────────────────────────────────── *)
+
+let escape_string s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (function
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c -> Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+;;
+
+let scalar_line ~key ~value = Printf.sprintf "%s = \"%s\"" key (escape_string value)
+
+(* Single-line array rendering (used by the runtime string-array editor). Fusion
+   multi-line arrays are rendered by [multiline_array_lines]. *)
+let string_array_line ~key ~values =
+  let rendered =
+    values
+    |> List.map (fun value -> Printf.sprintf "\"%s\"" (escape_string value))
+    |> String.concat ", "
+  in
+  Printf.sprintf "%s = [%s]" key rendered
+;;
+
+(* Multi-line array block: [key = \[], one indented quoted element per line, then
+   a closing []]. Mirrors the checked-in runtime.toml panel layout. *)
+let multiline_array_lines ~key ~values =
+  let elements =
+    List.map (fun value -> Printf.sprintf "  \"%s\"," (escape_string value)) values
+  in
+  (Printf.sprintf "%s = [" key :: elements) @ [ "]" ]
+;;
+
+let split_lines content =
+  if String.equal content "" then [], false
+  else (
+    let len = String.length content in
+    let trailing_newline = Char.equal content.[len - 1] '\n' in
+    let parts = String.split_on_char '\n' content in
+    let lines =
+      if trailing_newline
+      then (
+        match List.rev parts with
+        | "" :: rest -> List.rev rest
+        | _ -> parts)
+      else parts
+    in
+    lines, trailing_newline)
+;;
+
+let join_lines lines ~trailing_newline =
+  match lines with
+  | [] -> if trailing_newline then "\n" else ""
+  | _ ->
+    let body = String.concat "\n" lines in
+    if trailing_newline then body ^ "\n" else body
+;;
+
+let strip_comment line =
+  match String.index_opt line '#' with
+  | None -> line
+  | Some index -> String.sub line 0 index
+;;
+
+let is_table_header line =
+  let s = line |> strip_comment |> String.trim in
+  let len = String.length s in
+  len >= 2 && Char.equal s.[0] '[' && Char.equal s.[len - 1] ']'
+;;
+
+(* [is_table ~path line] matches the standard table header [\[path\]] exactly
+   (comments/whitespace ignored). *)
+let is_table ~path line =
+  String.equal (line |> strip_comment |> String.trim) (Printf.sprintf "[%s]" path)
+;;
+
+let rec split_at n xs =
+  if n <= 0 then [], xs
+  else
+    match xs with
+    | [] -> [], []
+    | x :: rest ->
+      let before, after = split_at (n - 1) rest in
+      x :: before, after
+;;
+
+let find_index pred xs =
+  let rec loop index = function
+    | [] -> None
+    | x :: rest -> if pred x then Some index else loop (index + 1) rest
+  in
+  loop 0 xs
+;;
+
+let parse_quoted_key raw =
+  let len = String.length raw in
+  if len < 2 || not (Char.equal raw.[0] '"') then None
+  else (
+    let buf = Buffer.create len in
+    let rec loop index =
+      if index >= len then None
+      else
+        match raw.[index] with
+        | '"' -> Some (Buffer.contents buf)
+        | '\\' when index + 1 < len ->
+          let escaped =
+            match raw.[index + 1] with
+            | '"' -> '"'
+            | '\\' -> '\\'
+            | 'n' -> '\n'
+            | 'r' -> '\r'
+            | 't' -> '\t'
+            | c -> c
+          in
+          Buffer.add_char buf escaped;
+          loop (index + 2)
+        | c ->
+          Buffer.add_char buf c;
+          loop (index + 1)
+    in
+    loop 1)
+;;
+
+let parse_literal_key raw =
+  let len = String.length raw in
+  if len < 2 || not (Char.equal raw.[0] '\'') then None
+  else (
+    match String.index_from_opt raw 1 '\'' with
+    | None -> None
+    | Some end_index -> Some (String.sub raw 1 (end_index - 1)))
+;;
+
+(* [key_of_line line] is the bare key of a [key = value] line, or [None] for
+   comments, blanks, and non-assignment lines. Quoted/literal keys are unescaped.
+   Comment and blank lines return [None], so editors never match them. *)
+let key_of_line line =
+  let trimmed = String.trim line in
+  if String.equal trimmed "" || Char.equal trimmed.[0] '#'
+  then None
+  else (
+    match String.index_opt trimmed '=' with
+    | None -> None
+    | Some eq_index ->
+      let key_part = String.sub trimmed 0 eq_index |> String.trim in
+      if String.equal key_part ""
+      then None
+      else if Char.equal key_part.[0] '"'
+      then parse_quoted_key key_part
+      else if Char.equal key_part.[0] '\''
+      then parse_literal_key key_part
+      else Some key_part)
+;;
+
+(* ── section-scoped edits ───────────────────────────────────────────────── *)
+
+(* [with_table content ~path ~on_missing ~edit] locates the [\[path\]] table,
+   splits it into (before, header, section_lines, after), runs [edit] on the
+   section body (the lines up to the next table header of any kind, including
+   array-of-tables), and reassembles. [on_missing] produces the whole updated
+   line list when the table is absent. Trailing newline is normalized to true,
+   matching the runtime editor. *)
+let with_table content ~path ~on_missing ~edit =
+  let lines, _trailing = split_lines content in
+  let updated =
+    match find_index (is_table ~path) lines with
+    | None -> on_missing lines
+    | Some header_index ->
+      let before, from_header = split_at header_index lines in
+      (match from_header with
+       | [] -> on_missing lines
+       | header :: after_header ->
+         let section_lines, after_section =
+           match find_index is_table_header after_header with
+           | None -> after_header, []
+           | Some next -> split_at next after_header
+         in
+         before @ (header :: edit section_lines) @ after_section)
+  in
+  join_lines updated ~trailing_newline:true
+;;
+
+let replace_or_append_scalar section_lines ~key ~value =
+  let line = scalar_line ~key ~value in
+  let rec loop acc = function
+    | [] -> List.rev_append acc [ line ]
+    | existing :: rest ->
+      (match key_of_line existing with
+       | Some k when String.equal k key -> List.rev_append acc (line :: rest)
+       | _ -> loop (existing :: acc) rest)
+  in
+  loop [] section_lines
+;;
+
+let remove_scalar section_lines ~key =
+  List.filter
+    (fun existing ->
+      match key_of_line existing with
+      | Some k when String.equal k key -> false
+      | _ -> true)
+    section_lines
+;;
+
+(* Set (or, with [value = None], remove) a scalar key inside [\[path\]]. When the
+   table is absent and [value] is set, a new table is appended. *)
+let edit_table_scalar content ~path ~key ~value =
+  let append_table lines =
+    match value with
+    | None -> lines
+    | Some value ->
+      let section = [ Printf.sprintf "[%s]" path; scalar_line ~key ~value ] in
+      (match List.rev lines with
+       | [] -> section
+       | last :: _ when String.equal (String.trim last) "" -> lines @ section
+       | _ -> lines @ ("" :: section))
+  in
+  with_table content ~path ~on_missing:append_table ~edit:(fun section ->
+    match value with
+    | None -> remove_scalar section ~key
+    | Some value -> replace_or_append_scalar section ~key ~value)
+;;
+
+(* [array_closes_on_key_line line] is true when [line] holds a complete
+   single-line array ([key = \[...\]]); false when the [\[] is left open for a
+   multi-line array. Model/prompt ids do not contain [\]], so a bracket in the
+   value is treated as the array close. *)
+let array_closes_on_key_line line = String.contains (strip_comment line) ']'
+
+(* Replace (or append) a multi-line array [key = \[ ... \]] inside a section. An
+   existing single-line array collapses to the multi-line form; comments between
+   array elements are not preserved (elements are data, RFC-0306 §7.1). Comments
+   outside the [key = \[ ... \]] span are untouched. *)
+let replace_or_append_multiline_array section_lines ~key ~values =
+  let block = multiline_array_lines ~key ~values in
+  let rec find_span acc = function
+    | [] -> None
+    | line :: rest ->
+      (match key_of_line line with
+       | Some k when String.equal k key ->
+         if array_closes_on_key_line line
+         then Some (List.rev acc, rest)
+         else (
+           let rec consume = function
+             | [] -> []
+             | l :: r -> if String.contains l ']' then r else consume r
+           in
+           Some (List.rev acc, consume rest))
+       | _ -> find_span (line :: acc) rest)
+  in
+  match find_span [] section_lines with
+  | None -> section_lines @ block
+  | Some (before, after) -> before @ block @ after
+;;
+
+let edit_table_multiline_array content ~path ~key ~values =
+  let append_table lines =
+    let section = (Printf.sprintf "[%s]" path :: multiline_array_lines ~key ~values) in
+    match List.rev lines with
+    | [] -> section
+    | last :: _ when String.equal (String.trim last) "" -> lines @ section
+    | _ -> lines @ ("" :: section)
+  in
+  with_table content ~path ~on_missing:append_table ~edit:(fun section ->
+    replace_or_append_multiline_array section ~key ~values)
+;;

--- a/lib/toml_line_editor/toml_line_editor.mli
+++ b/lib/toml_line_editor/toml_line_editor.mli
@@ -1,0 +1,46 @@
+(** Comment-preserving, line-based TOML editing.
+
+    The editor updates selected table keys without parsing and re-emitting the
+    whole file, so comments, blank lines, and unrelated table content remain
+    byte-for-byte stable. *)
+
+val escape_string : string -> string
+(** Escape a TOML basic string payload. *)
+
+val scalar_line : key:string -> value:string -> string
+(** Render [key = "value"]. *)
+
+val string_array_line : key:string -> values:string list -> string
+(** Render [key = ["a", "b"]] on one line. *)
+
+val multiline_array_lines : key:string -> values:string list -> string list
+(** Render [key = []] as a multi-line array block. *)
+
+val split_lines : string -> string list * bool
+(** Split content into lines and whether it ended with a trailing newline. *)
+
+val join_lines : string list -> trailing_newline:bool -> string
+(** Join lines, optionally restoring a final newline. *)
+
+val strip_comment : string -> string
+(** Remove the first TOML line comment from [line]. *)
+
+val is_table_header : string -> bool
+(** Return [true] when [line] is a TOML table header after trimming comments. *)
+
+val split_at : int -> 'a list -> 'a list * 'a list
+(** Split a list at [n], returning [(prefix, suffix)]. *)
+
+val find_index : ('a -> bool) -> 'a list -> int option
+(** Return the zero-based index of the first matching element. *)
+
+val key_of_line : string -> string option
+(** Return the assignment key in a [key = value] line, if present. *)
+
+val edit_table_scalar :
+  string -> path:string -> key:string -> value:string option -> string
+(** Set or remove a scalar key inside [[path]]. *)
+
+val edit_table_multiline_array :
+  string -> path:string -> key:string -> values:string list -> string
+(** Set a multi-line string array key inside [[path]]. *)

--- a/test/toml_line_editor/dune
+++ b/test/toml_line_editor/dune
@@ -1,0 +1,6 @@
+; Isolated alcotest for the comment-preserving TOML line editor (RFC-0306 §3.2).
+; Links only masc.toml_line_editor — runs in milliseconds.
+
+(test
+ (name test_toml_line_editor)
+ (libraries alcotest masc.toml_line_editor))

--- a/test/toml_line_editor/test_toml_line_editor.ml
+++ b/test/toml_line_editor/test_toml_line_editor.ml
@@ -1,0 +1,103 @@
+(* RFC-0306 §3.2 / §6 — the reason this module exists is comment preservation:
+   editing a value must leave every comment, blank, and unrelated key byte-for-byte
+   unchanged. These tests fix that property for the scalar and multi-line-array
+   edits the fusion settings writer depends on. *)
+
+let fixture =
+  {|# top-of-file note
+[fusion]
+enabled = true
+# concurrency knob doc, must survive edits
+max_concurrent_panels = 2
+
+# panel roster doc line 1
+# panel roster doc line 2
+[fusion.presets.trio]
+panel = [
+  "provider.a",
+  "provider.b",
+]
+# judge doc comment
+judge = "old-judge"
+judge_timeout_s = 300.0
+|}
+
+let comment_lines content =
+  fst (Toml_line_editor.split_lines content)
+  |> List.filter (fun line ->
+         let t = String.trim line in
+         String.length t > 0 && Char.equal t.[0] '#')
+
+let has_line content target =
+  List.exists (String.equal target) (fst (Toml_line_editor.split_lines content))
+
+let check_comments_unchanged before after =
+  Alcotest.(check (list string))
+    "every comment line survives byte-for-byte, in order"
+    (comment_lines before) (comment_lines after)
+
+let test_scalar_edit_preserves_comments () =
+  let out =
+    Toml_line_editor.edit_table_scalar fixture ~path:"fusion.presets.trio"
+      ~key:"judge" ~value:(Some "new-judge")
+  in
+  check_comments_unchanged fixture out;
+  Alcotest.(check bool) "judge value replaced" true
+    (has_line out {|judge = "new-judge"|});
+  Alcotest.(check bool) "old judge value gone" false
+    (has_line out {|judge = "old-judge"|});
+  Alcotest.(check bool) "unrelated scalar untouched" true
+    (has_line out "judge_timeout_s = 300.0");
+  Alcotest.(check bool) "multi-line array untouched" true
+    (has_line out {|  "provider.a",|})
+
+let test_scalar_remove () =
+  let out =
+    Toml_line_editor.edit_table_scalar fixture ~path:"fusion.presets.trio"
+      ~key:"judge" ~value:None
+  in
+  check_comments_unchanged fixture out;
+  Alcotest.(check bool) "judge key removed" false
+    (has_line out {|judge = "old-judge"|});
+  Alcotest.(check bool) "sibling scalar retained" true
+    (has_line out "judge_timeout_s = 300.0")
+
+let test_multiline_array_edit_preserves_comments () =
+  let out =
+    Toml_line_editor.edit_table_multiline_array fixture ~path:"fusion.presets.trio"
+      ~key:"panel" ~values:[ "provider.x"; "provider.y"; "provider.z" ]
+  in
+  check_comments_unchanged fixture out;
+  List.iter
+    (fun model ->
+      Alcotest.(check bool) (Printf.sprintf "new panel model %s present" model) true
+        (has_line out (Printf.sprintf {|  "%s",|} model)))
+    [ "provider.x"; "provider.y"; "provider.z" ];
+  Alcotest.(check bool) "old panel model dropped" false
+    (has_line out {|  "provider.a",|});
+  Alcotest.(check bool) "array framing kept" true (has_line out "panel = [");
+  Alcotest.(check bool) "sibling scalar untouched" true
+    (has_line out {|judge = "old-judge"|})
+
+(* The scalar editor must target the right table: [max_concurrent_panels] exists
+   in [fusion] and must not be touched when editing [fusion.presets.trio]. *)
+let test_scalar_edit_is_table_scoped () =
+  let out =
+    Toml_line_editor.edit_table_scalar fixture ~path:"fusion.presets.trio"
+      ~key:"judge" ~value:(Some "new-judge")
+  in
+  Alcotest.(check bool) "[fusion] scalar untouched" true
+    (has_line out "max_concurrent_panels = 2")
+
+let () =
+  Alcotest.run "toml_line_editor"
+    [ ( "comment-preserving edits"
+      , [ Alcotest.test_case "scalar edit preserves comments" `Quick
+            test_scalar_edit_preserves_comments
+        ; Alcotest.test_case "scalar remove" `Quick test_scalar_remove
+        ; Alcotest.test_case "multi-line array edit preserves comments" `Quick
+            test_multiline_array_edit_preserves_comments
+        ; Alcotest.test_case "scalar edit is table-scoped" `Quick
+            test_scalar_edit_is_table_scoped
+        ] )
+    ]


### PR DESCRIPTION
RFC-0306 **Phase 2** — comment-preserving TOML 편집기 SSOT 추출 + fusion write 프리미티브.

## 배경
fusion 설정을 편집하려면 `runtime.toml`을 쓰되 **주석을 보존**해야 합니다. Otoml은 파싱 시 주석을 폐기하므로 round-trip 불가 → 라인 기반 텍스트 편집만이 답. 이 방식은 이미 `runtime.ml`의 routing/assignment patch가 쓰고 있어, 그 헬퍼를 SSOT로 승격합니다.

## 변경
- **`lib/toml_line_editor/`** (신규 leaf 라이브러리, 순수 stdlib): `runtime.ml`의 범용 헬퍼(`split_lines`/`join_lines`/`strip_comment`/`is_table_header`/`key_of_line`/`escape_string`/`scalar_line`/`string_array_line`/`split_at`/`find_index`)를 정확 포팅 + fusion writer가 쓸 신규 프리미티브:
  - `edit_table_scalar` — 임의 `[table.path]`의 스칼라 set/remove
  - `edit_table_multiline_array` — 멀티라인 `key = [ ... ]` 교체(fusion panel roster용)
- **`lib/runtime/runtime.ml`**: 옮긴 헬퍼는 `Toml_line_editor` **alias로 위임**(호출부·동작 불변, 기존 routing/assignment 테스트가 회귀 가드). `parse_quoted_key`/`parse_literal_key`는 `key_of_line`이 내포하므로 제거. −131/+14.
- **`test/toml_line_editor/`**: 골든 테스트 — 스칼라/멀티라인배열 편집 후 **모든 주석 라인이 바이트 단위로 생존**, 편집이 테이블-스코프임을 검증. `masc.toml_line_editor`만 링크(ms 단위).

## SSOT
중복 없음: runtime.ml은 이제 로직을 소유하지 않고 `Toml_line_editor`에 위임. fusion writer(Phase 3)도 동일 모듈 재사용.

## 남은 것
- **Phase 2b**: array-of-tables(`[[fusion.presets.*.judges]]`, JoJ 1차 심판) 편집 프리미티브 — 최난도라 전용 PR+적대 테스트로 분리.
- Phase 3(POST write + 검증 JSON + of_preset JoJ≥2) → Phase 4(프론트 폼) → Phase 5.

## 검증
- 골든 테스트 + 기존 runtime routing/assignment 테스트(추출 회귀 가드). dune 빌드/테스트는 CI.
- alias는 value-path라 다형성 유지, 동작 불변.

RFC-WAIVED: TOML 편집 유틸 라이브러리 추출 + runtime 위임(동작 불변). credential/keeper/operator/hooks/workflow 등 게이트 대상 subsystem 미변경. (runtime.ml routing/assignment 경로는 behavior-preserving alias만, 로직 변경 없음.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
