### PR TITLE
refactor(dashboard): FE 개선 Wave 1 — typed SSOT 정리 (delivery + store-normalizer unions)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -18,6 +18,7 @@ const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost, formatMsCompact } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
+import { isFailedDelivery } from '../../lib/keeper-delivery'
 import { memo } from 'preact/compat'
 import { readKeeperDraft, writeKeeperDraft } from '../../keeper-chat-store'
 import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, ChatIssueBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatSuggestionsBlock, ChatTableBlock, ChatTraceStep, ChatTraceToolStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
@@ -226,7 +227,7 @@ function liveMessageLabel(entry: KeeperConversationEntry): string | null {
 }
 
 function bubbleTone(entry: KeeperConversationEntry): string {
-  if (entry.delivery === 'error' || entry.delivery === 'timeout' || entry.delivery === 'interrupted') return 'error'
+  if (isFailedDelivery(entry.delivery)) return 'error'
   if (entry.role === 'user') return 'user'
   if (entry.role === 'assistant') return 'assistant'
   if (entry.role === 'tool') return 'tool'
@@ -1985,8 +1986,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
   const isFailureMessage =
-    (entry.delivery === 'error' || entry.delivery === 'timeout' || entry.delivery === 'interrupted')
-    && !!entry.error?.trim()
+    isFailedDelivery(entry.delivery) && !!entry.error?.trim()
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
   const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -3,6 +3,7 @@ import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
+import { isInFlightDelivery } from '../lib/keeper-delivery'
 import { relativeTime, NO_TIME_INFO } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import type {
@@ -231,7 +232,7 @@ function isActiveAssistantEntry(entry: KeeperConversationEntry): boolean {
   return (
     entry.role === 'assistant'
     && entry.source === 'direct_assistant'
-    && (entry.delivery === 'sending' || entry.delivery === 'streaming' || entry.delivery === 'queued')
+    && isInFlightDelivery(entry.delivery)
   )
 }
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1,6 +1,7 @@
 import { signal } from '@preact/signals'
 import { formatKeeperVisibleReply } from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
+import { isInFlightDelivery } from './lib/keeper-delivery'
 import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
 import type {
@@ -1127,10 +1128,6 @@ function sameConversationEntry(
   if (left.id === right.id) return true
   if (left.role === 'tool' || right.role === 'tool') return false
   return left.role === right.role && left.text === right.text
-}
-
-function isInFlightDelivery(delivery: KeeperConversationDelivery): boolean {
-  return delivery === 'sending' || delivery === 'streaming' || delivery === 'queued'
 }
 
 // Entries with no parseable timestamp (live placeholders, still-streaming

--- a/dashboard/src/lib/core-parsers.test.ts
+++ b/dashboard/src/lib/core-parsers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EVIDENCE_SOURCE_VALUES,
+  EXECUTION_TONE_VALUES,
+  SIGNAL_TRUTH_VALUES,
+  TASK_STATUS_VALUES,
+  parseEvidenceSource,
+  parseExecutionTone,
+  parseSignalTruth,
+  parseTaskStatus,
+} from './core-parsers'
+
+describe('parseTaskStatus (trim + lowercase + inprogress alias)', () => {
+  it('accepts every canonical value', () => {
+    for (const v of TASK_STATUS_VALUES) expect(parseTaskStatus(v)).toBe(v)
+  })
+  it('trims and lowercases', () => {
+    expect(parseTaskStatus('  DONE ')).toBe('done')
+    expect(parseTaskStatus('In_Progress')).toBe('in_progress')
+  })
+  it('maps the legacy inprogress alias', () => {
+    expect(parseTaskStatus('inprogress')).toBe('in_progress')
+    expect(parseTaskStatus('InProgress')).toBe('in_progress')
+  })
+  it('returns undefined for unknown / non-string', () => {
+    expect(parseTaskStatus('bogus')).toBeUndefined()
+    expect(parseTaskStatus(42)).toBeUndefined()
+    expect(parseTaskStatus(undefined)).toBeUndefined()
+  })
+})
+
+describe('parseExecutionTone (lowercase, NO trim)', () => {
+  it('accepts every canonical value', () => {
+    for (const v of EXECUTION_TONE_VALUES) expect(parseExecutionTone(v)).toBe(v)
+  })
+  it('lowercases', () => {
+    expect(parseExecutionTone('OK')).toBe('ok')
+  })
+  it('does NOT trim (preserves original callsite behavior)', () => {
+    expect(parseExecutionTone(' ok ')).toBeUndefined()
+  })
+  it('returns undefined for unknown', () => {
+    expect(parseExecutionTone('info')).toBeUndefined()
+    expect(parseExecutionTone(null)).toBeUndefined()
+  })
+})
+
+describe('parseSignalTruth (case-sensitive)', () => {
+  it('accepts every canonical value', () => {
+    for (const v of SIGNAL_TRUTH_VALUES) expect(parseSignalTruth(v)).toBe(v)
+  })
+  it('is case-sensitive', () => {
+    expect(parseSignalTruth('LIVE')).toBeUndefined()
+  })
+  it('returns undefined for undefined / unknown', () => {
+    expect(parseSignalTruth(undefined)).toBeUndefined()
+    expect(parseSignalTruth('archived')).toBeUndefined()
+  })
+})
+
+describe('parseEvidenceSource (case-sensitive)', () => {
+  it('accepts every canonical value', () => {
+    for (const v of EVIDENCE_SOURCE_VALUES) expect(parseEvidenceSource(v)).toBe(v)
+  })
+  it('is case-sensitive', () => {
+    expect(parseEvidenceSource('MESSAGE')).toBeUndefined()
+  })
+  it('returns undefined for undefined / unknown', () => {
+    expect(parseEvidenceSource(undefined)).toBeUndefined()
+    expect(parseEvidenceSource('session')).toBeUndefined()
+  })
+})

--- a/dashboard/src/lib/core-parsers.ts
+++ b/dashboard/src/lib/core-parsers.ts
@@ -1,0 +1,103 @@
+// Total parsers for closed dashboard unions — SSOT membership co-located with
+// each type, replacing the inline `=== 'a' || === 'b'` OR-chains in
+// store-normalizers.ts. Each `<NAME>_VALUES` is `as const satisfies
+// ReadonlyArray<T>` (every element is a valid member) AND is guarded by a
+// compile-time completeness check (every member is present), so adding a
+// variant to the underlying type breaks the build here instead of being
+// silently rejected by a hand-written OR-chain. Mirrors the lib/agent-status.ts
+// precedent and closes the completeness gap that precedent left open.
+
+import type { Task, ExecutionSignalTruth, EvidenceSourceCore } from '../types/core'
+import type { DashboardExecutionQueueItem } from '../types/dashboard-execution'
+
+type TaskStatus = NonNullable<Task['status']>
+type ExecutionTone = NonNullable<DashboardExecutionQueueItem['severity']>
+
+/** Compile-time completeness guard. When a union gains a member that is absent
+ *  from its VALUES array, `Exclude` yields that member (a non-`never` type),
+ *  which violates the `extends never` bound and fails to compile at the
+ *  `type _…Complete = …` line below. */
+type NoMissingVariant<Missing extends never> = Missing
+
+// ── Task.status ──────────────────────────────────────────────
+export const TASK_STATUS_VALUES = [
+  'todo',
+  'in_progress',
+  'claimed',
+  'awaiting_verification',
+  'done',
+  'cancelled',
+] as const satisfies ReadonlyArray<TaskStatus>
+export type _TaskStatusComplete = NoMissingVariant<
+  Exclude<TaskStatus, (typeof TASK_STATUS_VALUES)[number]>
+>
+const TASK_STATUS_SET: ReadonlySet<string> = new Set(TASK_STATUS_VALUES)
+
+/** Task.status total parser: trims + lowercases, maps the legacy `inprogress`
+ *  alias to `in_progress`, and returns undefined for unknown tokens. */
+export function parseTaskStatus(value: unknown): TaskStatus | undefined {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  if (TASK_STATUS_SET.has(raw)) return raw as TaskStatus
+  if (raw === 'inprogress') return 'in_progress'
+  return undefined
+}
+
+// ── DashboardExecutionQueueItem.severity (execution tone) ─────
+export const EXECUTION_TONE_VALUES = [
+  'ok',
+  'warn',
+  'bad',
+] as const satisfies ReadonlyArray<ExecutionTone>
+export type _ExecutionToneComplete = NoMissingVariant<
+  Exclude<ExecutionTone, (typeof EXECUTION_TONE_VALUES)[number]>
+>
+const EXECUTION_TONE_SET: ReadonlySet<string> = new Set(EXECUTION_TONE_VALUES)
+
+/** Execution-tone total parser: lowercases (no trim, matching the original
+ *  callsite), returns undefined for unknown tokens. */
+export function parseExecutionTone(value: unknown): ExecutionTone | undefined {
+  const raw = typeof value === 'string' ? value.toLowerCase() : ''
+  return EXECUTION_TONE_SET.has(raw) ? (raw as ExecutionTone) : undefined
+}
+
+// ── ExecutionSignalTruth ─────────────────────────────────────
+export const SIGNAL_TRUTH_VALUES = [
+  'live',
+  'stale',
+  'absent',
+] as const satisfies ReadonlyArray<ExecutionSignalTruth>
+export type _SignalTruthComplete = NoMissingVariant<
+  Exclude<ExecutionSignalTruth, (typeof SIGNAL_TRUTH_VALUES)[number]>
+>
+const SIGNAL_TRUTH_SET: ReadonlySet<string> = new Set(SIGNAL_TRUTH_VALUES)
+
+/** ExecutionSignalTruth parser over an already-coerced string (the callsite
+ *  applies `asString`). Case-sensitive, matching the original OR-chain. */
+export function parseSignalTruth(
+  raw: string | undefined,
+): ExecutionSignalTruth | undefined {
+  return raw != null && SIGNAL_TRUTH_SET.has(raw)
+    ? (raw as ExecutionSignalTruth)
+    : undefined
+}
+
+// ── EvidenceSourceCore ───────────────────────────────────────
+export const EVIDENCE_SOURCE_VALUES = [
+  'message',
+  'presence',
+  'none',
+] as const satisfies ReadonlyArray<EvidenceSourceCore>
+export type _EvidenceSourceComplete = NoMissingVariant<
+  Exclude<EvidenceSourceCore, (typeof EVIDENCE_SOURCE_VALUES)[number]>
+>
+const EVIDENCE_SOURCE_SET: ReadonlySet<string> = new Set(EVIDENCE_SOURCE_VALUES)
+
+/** EvidenceSourceCore parser over an already-coerced string (the callsite
+ *  applies `asString`). Case-sensitive, matching the original OR-chain. */
+export function parseEvidenceSource(
+  raw: string | undefined,
+): EvidenceSourceCore | undefined {
+  return raw != null && EVIDENCE_SOURCE_SET.has(raw)
+    ? (raw as EvidenceSourceCore)
+    : undefined
+}

--- a/dashboard/src/lib/keeper-delivery.test.ts
+++ b/dashboard/src/lib/keeper-delivery.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { KeeperConversationDelivery } from '../types/core'
+import {
+  FAILED_DELIVERY,
+  IN_FLIGHT_DELIVERY,
+  isFailedDelivery,
+  isInFlightDelivery,
+} from './keeper-delivery'
+
+// Exhaustive expected classification for every delivery variant, declared as a
+// Record keyed by the closed union. Adding a new variant to
+// KeeperConversationDelivery fails to compile here until it is classified —
+// the compile-time drift guard the replaced OR-chains lacked.
+const EXPECTED: Record<KeeperConversationDelivery, 'in-flight' | 'failed' | 'other'> = {
+  history: 'other',
+  queued: 'in-flight',
+  sending: 'in-flight',
+  streaming: 'in-flight',
+  delivered: 'other',
+  no_reply: 'other',
+  timeout: 'failed',
+  cancelled: 'other',
+  error: 'failed',
+  interrupted: 'failed',
+}
+
+describe('keeper-delivery classifiers', () => {
+  const all = Object.keys(EXPECTED) as KeeperConversationDelivery[]
+
+  it('covers all 10 delivery variants', () => {
+    expect(all).toHaveLength(10)
+  })
+
+  it('classifies every variant into exactly one bucket', () => {
+    for (const d of all) {
+      const inFlight = isInFlightDelivery(d)
+      const failed = isFailedDelivery(d)
+      // in-flight and failed are mutually exclusive
+      expect(inFlight && failed).toBe(false)
+      const bucket = inFlight ? 'in-flight' : failed ? 'failed' : 'other'
+      expect(bucket).toBe(EXPECTED[d])
+    }
+  })
+
+  it('IN_FLIGHT_DELIVERY and FAILED_DELIVERY are disjoint sets', () => {
+    const failed = new Set<string>(FAILED_DELIVERY)
+    expect(IN_FLIGHT_DELIVERY.filter((d) => failed.has(d))).toEqual([])
+  })
+
+  it('preserves the original in-flight membership {queued, sending, streaming}', () => {
+    expect([...IN_FLIGHT_DELIVERY].sort()).toEqual(['queued', 'sending', 'streaming'])
+  })
+
+  it('preserves the original failed membership {error, timeout, interrupted}', () => {
+    expect([...FAILED_DELIVERY].sort()).toEqual(['error', 'interrupted', 'timeout'])
+  })
+})

--- a/dashboard/src/lib/keeper-delivery.ts
+++ b/dashboard/src/lib/keeper-delivery.ts
@@ -1,0 +1,41 @@
+// Keeper conversation-delivery vocabulary SSOT.
+//
+// Typed closed-sum classifiers for `KeeperConversationDelivery`. The member
+// arrays are declared `as const satisfies ReadonlyArray<KeeperConversationDelivery>`
+// so a new delivery variant added to the type in `types/core.ts` forces this
+// module (and its drift test) to be revisited, instead of being silently
+// missed by the ad-hoc `=== 'x' || === 'y'` OR-chains this replaces
+// (previously duplicated across keeper-state.ts, keeper-shared.ts, and
+// chat/primitives.ts). Mirrors the `lib/agent-status.ts` precedent.
+
+import type { KeeperConversationDelivery } from '../types/core'
+
+/** Deliveries representing an in-flight (not-yet-terminal) turn: the request
+ *  is queued, being sent, or actively streaming. */
+export const IN_FLIGHT_DELIVERY = [
+  'queued',
+  'sending',
+  'streaming',
+] as const satisfies ReadonlyArray<KeeperConversationDelivery>
+
+/** Deliveries representing a failed terminal outcome. */
+export const FAILED_DELIVERY = [
+  'error',
+  'timeout',
+  'interrupted',
+] as const satisfies ReadonlyArray<KeeperConversationDelivery>
+
+const IN_FLIGHT_SET: ReadonlySet<KeeperConversationDelivery> = new Set(IN_FLIGHT_DELIVERY)
+const FAILED_SET: ReadonlySet<KeeperConversationDelivery> = new Set(FAILED_DELIVERY)
+
+/** True when the turn is in flight (queued / sending / streaming). */
+export function isInFlightDelivery(delivery: KeeperConversationDelivery): boolean {
+  return IN_FLIGHT_SET.has(delivery)
+}
+
+/** True when the turn ended in a failed terminal state (error / timeout /
+ *  interrupted). Callers that additionally require a non-empty error string
+ *  must keep that conjunct at the callsite. */
+export function isFailedDelivery(delivery: KeeperConversationDelivery): boolean {
+  return FAILED_SET.has(delivery)
+}

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,4 +1,10 @@
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
+import {
+  parseTaskStatus,
+  parseExecutionTone,
+  parseSignalTruth,
+  parseEvidenceSource,
+} from './lib/core-parsers'
 import { normalizeKeeperTrust } from './keeper-store-normalize'
 import { normalizeStopCause } from './lib/stop-cause'
 import { parseAgentStatus } from './lib/agent-status'
@@ -47,19 +53,7 @@ export function normalizeAgentStatus(value: unknown): Agent['status'] {
 }
 
 export function normalizeTaskStatus(value: unknown): Task['status'] {
-  const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
-  if (
-    raw === 'todo'
-    || raw === 'in_progress'
-    || raw === 'claimed'
-    || raw === 'awaiting_verification'
-    || raw === 'done'
-    || raw === 'cancelled'
-  ) {
-    return raw
-  }
-  if (raw === 'inprogress') return 'in_progress'
-  return undefined
+  return parseTaskStatus(value)
 }
 
 export function normalizeAgent(raw: unknown): Agent | null {
@@ -159,9 +153,7 @@ export function normalizeMessage(raw: unknown): Message | null {
 }
 
 export function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['severity'] {
-  const raw = typeof value === 'string' ? value.toLowerCase() : ''
-  if (raw === 'ok' || raw === 'warn' || raw === 'bad') return raw
-  return undefined
+  return parseExecutionTone(value)
 }
 
 export function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
@@ -290,16 +282,8 @@ export function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExe
   if (!name || !note || !focus || (state !== 'working' && state !== 'watching' && state !== 'quiet' && state !== 'offline')) {
     return null
   }
-  const signalTruthRaw = asString(raw.signal_truth)
-  const signalTruth =
-    signalTruthRaw === 'live' || signalTruthRaw === 'stale' || signalTruthRaw === 'absent'
-      ? signalTruthRaw
-      : undefined
-  const evidenceSourceRaw = asString(raw.evidence_source)
-  const evidenceSource =
-    evidenceSourceRaw === 'message' || evidenceSourceRaw === 'presence' || evidenceSourceRaw === 'none'
-      ? evidenceSourceRaw
-      : undefined
+  const signalTruth = parseSignalTruth(asString(raw.signal_truth))
+  const evidenceSource = parseEvidenceSource(asString(raw.evidence_source))
   return {
     name,
     agent_name: asString(raw.agent_name),

--- a/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
+++ b/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
@@ -1,0 +1,62 @@
+# Dashboard Frontend-Improvement — Sequenced Execution Backlog
+
+Status: Active · Created 2026-07-04 · Owner vincent
+Scope: `dashboard/` (Preact + `@preact/signals` + `htm`). **Framework change is out of scope** — improve within the current stack (see the framework adversarial review: keep Preact, consolidate stacks).
+
+## Baseline (measured, worktree `feat/dashboard-fe-improvement` @ main `fb59401289`)
+
+- 1,265 `.ts/.tsx` files, ~302K LOC. **153 files > 500 LOC, 78 > 800, 32 > 1200** (300-line guideline).
+- Gates (must stay green through every slice): `tsc --noEmit` = **0 errors**; `eslint src` = **0 errors**; vitest suites green.
+- Perf harness present: `src/lib/performance-monitor.ts` (LoAF `blockingDuration`), `src/utils/performance-metrics.ts`, `src/utils/fps-adaptive.ts`; bundle report via `BUNDLE_REPORT=1 pnpm build` (rollup-plugin-visualizer).
+
+Backlog produced by a mapped + **adversarially-verified** analysis (3 finders → per-slice verify → synthesis). Verification dropped/downgraded overstated claims; corrections are folded in below.
+
+## 1. Strategy
+
+Bank the low-risk, compiler-checkable, behavior-preserving wins first (typed-union SSOT), because they also *carve down* the giant files the expensive refactors must later move. Do performance work **only behind measurement** (measure → cheap mitigation → windowing only if justified). Anything that changes user-visible behavior or that verification downgraded to marginal becomes an RFC, not an opportunistic PR. Keep `main` green; enter the risky refactors on a smaller, better-typed codebase.
+
+## 2. Ranked backlog
+
+| # | Slice | Axis | Risk | Effort | Behavior-preserving | Status |
+|---|-------|------|------|--------|---------------------|--------|
+| 1 | Shared typed delivery classifier (`lib/keeper-delivery.ts`) | ssot | low | S | yes | **DONE** (this branch) |
+| 2 | Total parsers for 4 store-normalizer unions | ssot | low | M | yes | Wave 1 — next |
+| 3 | Connector constants/helpers extraction (`connector-constants.ts`) | ssot | low | M | yes | Wave 1 |
+| 4 | Transcript off-screen cost (`content-visibility` first, windowing = RFC) | perf | med | M | no | Wave 2 (measure-gated) |
+| 5 | Decompose `chat/primitives.ts` along concern boundaries | refactor | med | L | yes | Wave 3 (after 1) |
+| 6 | `fsm-hub` prop→state derivation (store-prev-during-render) | refactor | med | S | no (naive fix regresses) | Wave 3 |
+| 7 | Unify 6 "running keeper" status sets | ssot | med | M | **no** | **RFC** |
+| 8 | Connector-status fine-grained signal decomposition | perf | high | L | yes | **RFC** / fold into 5 |
+| 9 | IDE reference-kind alias SSOT | ssot | med | M | yes | Optional/last (dup ≈ 6 tokens) |
+| 10 | Content-derived keys for ChatBlock list | refactor | low | S | questionable | **DROP** (mechanism refuted) |
+
+## 3. Waves
+
+**Wave 1 — low-risk SSOT + safe extractions (behavior-preserving, `tsc`+vitest green, no user-visible change):**
+- Slice 1 (delivery classifier) — **done**
+- Slice 2 (store-normalizer total parsers) — needs a completeness check (`type _Covered = Exclude<T, typeof VALUES[number]> extends never ? true : never`); preserve each callsite's exact normalization (taskStatus trims+lowercases; executionTone lowercases only; signalTruth/evidenceSource case-sensitive). Severity SSOT is `types/dashboard-execution.ts` `DashboardExecutionTone`, not `core.ts`. Helper is `assertExhaustive`.
+- Slice 3 (connector constants) — SSOT-only; the bundle-shrink claim is deferred to Wave-2 measurement. Moving constants alone does **not** break the `connector-status ↔ connector-overview-strip` cycle (strip still imports `startSidecar`/`stopSidecar`; quick-bind imports `bindConnector`) — add a separate `connector-actions.ts` to cut the cycle, or drop the cycle claim.
+
+**Wave 2 — performance, measurement-gated:**
+- Slice 4: measure first (`performance-monitor` LoAF + a memo render counter) on a synthetic 500+ entry streaming transcript; ship the cheap `content-visibility:auto` row wrapper (mirrors `virtual-list.ts:242-259`) *before* any windowing; gate on real transcript-length distribution.
+- Slice 3 bundle claim: `BUNDLE_REPORT=1 pnpm build` before/after; if Rollup already tree-shakes the panel, record SSOT-only with no bundle assertion.
+
+**Wave 3 — deep refactors (after Wave 1):**
+- Slice 5: depends on Slice 1 (done) + media-union typing; boundaries follow import cohesion, verify no new cycles (`madge`), `primitives.test.ts` must stay green unchanged.
+- Slice 6: only via store-prev-prop-during-render; the `?? fallback` regresses tab/keyboard/dead-keeper selection in the main monitoring panel.
+
+## 4. RFC / drop callouts
+
+- **Slice 7 → RFC.** The 6 callsites do not answer the same question: `overview.ts:646` reads session status; `runtime-counts.ts:92` reads runtime tokens where `idle`=running is deliberate; `unified-status.ts:53` + `keeper-detail-lifecycle.ts:20` document `'working'` as an intentionally-outside-SSOT UI `PulseState`. Needs a written predicate taxonomy (`isKeeperRunning` vs `isKeeperPresent`) + per-callsite before/after membership snapshot.
+- **Slice 8 → RFC / fold into Slice 5.** Children (`ConnectorGateCard`, `BindingRow`, `GateStatusStrip`, `ConnectorsGateGrid`) already exist; the work is pushing `connectorStatusResource.state.value` reads down. Justify with a measured per-subcomponent render counter first.
+- **Slice 4 true windowing → RFC.** Only the `content-visibility` step is a direct PR. Windowing must preserve scroll-pin-to-bottom during streaming, unread-divider anchoring, and folding heterogeneous non-bubble units into a flat measured `items[]`.
+- **Slice 10 → DROP.** List component type is constant (`ChatBlock`), so index keys update-in-place for append-only streams; highlight/mermaid effects are value-dep-guarded. Content keys would add tail remounts (net regression). Discriminant is `block.t`, not `block.type`.
+
+## 5. Slice 1 — completed record
+
+One compiler-checked home for `KeeperConversationDelivery` (10 variants) classification.
+
+- New `src/lib/keeper-delivery.ts`: `IN_FLIGHT_DELIVERY {queued,sending,streaming}` + `FAILED_DELIVERY {error,timeout,interrupted}` as `const satisfies ReadonlyArray<KeeperConversationDelivery>`, Set-backed `isInFlightDelivery` / `isFailedDelivery` (mirrors `lib/agent-status.ts`).
+- Migrated 4 callsites: `keeper-state.ts:1132` (moved the private fn), `keeper-shared.ts:234` (kept the `role==='assistant' && source==='direct_assistant'` guard), `chat/primitives.ts:229` (`bubbleTone`), `chat/primitives.ts:1988` (kept the `&& !!entry.error?.trim()` conjunct). `keeper-stream.ts` untouched (evidence-only; the original "3×" claim was wrong — 2×).
+- New `keeper-delivery.test.ts`: `Record<KeeperConversationDelivery, ...>` forces compile-time exhaustive coverage; runtime asserts the 10 variants partition into exactly one of {in-flight, failed, other} and the two sets are disjoint.
+- Gates: `tsc --noEmit` 0 errors · `eslint src` 0 errors · vitest 172 pass (keeper-delivery, keeper-state, primitives). Behavior-preserving.

--- a/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
+++ b/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
@@ -20,7 +20,7 @@ Bank the low-risk, compiler-checkable, behavior-preserving wins first (typed-uni
 | # | Slice | Axis | Risk | Effort | Behavior-preserving | Status |
 |---|-------|------|------|--------|---------------------|--------|
 | 1 | Shared typed delivery classifier (`lib/keeper-delivery.ts`) | ssot | low | S | yes | **DONE** (this branch) |
-| 2 | Total parsers for 4 store-normalizer unions | ssot | low | M | yes | Wave 1 — next |
+| 2 | Total parsers for 4 store-normalizer unions | ssot | low | M | yes | **DONE** (this branch) |
 | 3 | Connector constants/helpers extraction (`connector-constants.ts`) | ssot | low | M | yes | Wave 1 |
 | 4 | Transcript off-screen cost (`content-visibility` first, windowing = RFC) | perf | med | M | no | Wave 2 (measure-gated) |
 | 5 | Decompose `chat/primitives.ts` along concern boundaries | refactor | med | L | yes | Wave 3 (after 1) |


### PR DESCRIPTION
## 목표

대시보드 프론트엔드 대개선 이니셔티브 **Wave 1 / Slice 1**. `KeeperConversationDelivery`(10 variant closed union) 분류를 흩어진 문자열 OR-chain에서 **컴파일러 검증되는 단일 SSOT 모듈**로 이식합니다. 프레임워크 교체 없이 진행하는 리팩토링/SSOT 트랙의 첫 슬라이스입니다.

## 문제

`sending||streaming||queued`(in-flight)와 `error||timeout||interrupted`(failed) 분류가 타입과 분리된 채 4곳에 하드코딩 → 새 delivery variant 추가 시 어느 callsite도 컴파일 에러 없이 조용히 누락. (SSOT 위반 + 문자열 분류기 안티패턴)

## 변경 (behavior-preserving)

- **신규 `dashboard/src/lib/keeper-delivery.ts`**: `IN_FLIGHT_DELIVERY {queued,sending,streaming}` / `FAILED_DELIVERY {error,timeout,interrupted}`를 `as const satisfies ReadonlyArray<KeeperConversationDelivery>`로 선언, Set 기반 `isInFlightDelivery`/`isFailedDelivery`. 기존 `lib/agent-status.ts` 선례 미러.
- **4 callsite 이식**: `keeper-state.ts:1132`(private fn 이동), `keeper-shared.ts:234`(`role==='assistant' && source==='direct_assistant'` 가드 보존), `chat/primitives.ts:229`(`bubbleTone`), `chat/primitives.ts:1988`(`&& !!entry.error?.trim()` 보존). `keeper-stream.ts`는 건드리지 않음(참조용, 원 분석의 "3×"는 오판—실제 2×).
- **신규 `keeper-delivery.test.ts`**: `Record<KeeperConversationDelivery, ...>`로 **컴파일 타임 exhaustive 커버리지 강제** + 런타임에 10 variant가 {in-flight, failed, other} 중 정확히 하나로 분할되고 두 집합이 disjoint임을 검증.
- **신규 설계 문서** `docs/design/dashboard-fe-improvement-backlog-2026-07-04.md`: 적대 검증된 시퀀싱 백로그(이후 Wave 슬라이스의 SSOT).

## 검증 (로컬 게이트)

- `tsc --noEmit` — **0 errors** (베이스라인 유지)
- `eslint src` — **0 errors**
- `vitest run` (keeper-delivery, keeper-state, primitives) — **172 pass**
- 이식 앵커에 잔여 inline OR-chain **0**

## 반경

순수 로직 이식. render/bundle 메트릭 영향 없음. credential/operator/hooks/workflow 서브시스템 미접촉 → RFC 불필요.

RFC-WAIVED: 순수 프론트엔드 SSOT 리팩토링, credential/identity/operator/sandbox/hooks/workflow 경계 미접촉.
