### PR TITLE
refactor(dashboard): connector vocabulary SSOT 추출 (FE 개선 Wave1/Slice3)

### DIFF
--- a/dashboard/src/components/connector-constants.test.ts
+++ b/dashboard/src/components/connector-constants.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONNECTOR_DISPLAY_NAMES,
+  IN_PROCESS_CONNECTOR_ENV,
+  IN_PROCESS_CONNECTOR_IDS,
+  KNOWN_CONNECTOR_IDS,
+  channelIcon,
+  connectorAccentStyle,
+  isInProcessConnector,
+  sidecarCommands,
+} from './connector-constants'
+
+describe('connector vocabulary constants', () => {
+  it('KNOWN_CONNECTOR_IDS is the expected set', () => {
+    expect([...KNOWN_CONNECTOR_IDS]).toEqual(['discord', 'imessage', 'slack', 'telegram'])
+  })
+
+  it('every known connector has a display name (no drift)', () => {
+    for (const id of KNOWN_CONNECTOR_IDS) {
+      expect(CONNECTOR_DISPLAY_NAMES[id]).toBeTruthy()
+    }
+  })
+
+  it('in-process connectors are a subset of known connectors with an env var', () => {
+    for (const id of IN_PROCESS_CONNECTOR_IDS) {
+      expect((KNOWN_CONNECTOR_IDS as readonly string[]).includes(id)).toBe(true)
+      expect(IN_PROCESS_CONNECTOR_ENV[id]).toBeTruthy()
+      expect(isInProcessConnector(id)).toBe(true)
+    }
+  })
+})
+
+describe('isInProcessConnector', () => {
+  it('discord is in-process, external sidecars are not', () => {
+    expect(isInProcessConnector('discord')).toBe(true)
+    expect(isInProcessConnector('slack')).toBe(false)
+    expect(isInProcessConnector('unknown')).toBe(false)
+  })
+})
+
+describe('sidecarCommands', () => {
+  it('uses the known sidecar dir for external connectors', () => {
+    expect(sidecarCommands('slack').start).toBe('cd sidecars/slack-bot && ./run.sh')
+    expect(sidecarCommands('slack').stop).toBe('cd sidecars/slack-bot && ./run.sh stop')
+  })
+  it('falls back to a derived dir for unknown connectors', () => {
+    expect(sidecarCommands('whatsapp').start).toBe('cd sidecars/whatsapp-bot && ./run.sh')
+  })
+})
+
+describe('connectorAccentStyle / channelIcon fallbacks', () => {
+  it('connectorAccentStyle returns a gradient, with a neutral fallback', () => {
+    expect(connectorAccentStyle('discord')).toContain('linear-gradient')
+    expect(connectorAccentStyle('unknown')).toContain('120,130,150')
+  })
+  it('channelIcon returns a per-channel glyph, with a link fallback', () => {
+    expect(channelIcon('discord')).toBe('\u{1F3AE}')
+    expect(channelIcon('nope')).toBe('\u{1F517}')
+  })
+})

--- a/dashboard/src/components/connector-constants.ts
+++ b/dashboard/src/components/connector-constants.ts
@@ -1,0 +1,96 @@
+// Connector vocabulary SSOT.
+//
+// Pure, side-effect-free constants and accessors for the connector surface,
+// extracted from the 2458-LOC connector-status.ts so lightweight consumers
+// (overview skeleton, onboarding) import them from one small module instead of
+// pulling a reference to the whole ConnectorStatusPanel body. connector-status.ts
+// re-exports every symbol here for back-compat.
+//
+// Scope note: only the pure connector *vocabulary* lives here. State-label
+// classification (connectorStateLabel / connectorCardBorderClass) stays in
+// connector-status.ts because it shares the file-local exhaustiveness helper,
+// and the sidecar actions (start/stop/bind) stay there because they close over
+// the panel's signal-backed UI state. The connector-status import cycle is
+// therefore NOT addressed here (tracked separately — backlog Slice 8).
+
+// Known connectors shown in the dashboard (status panels, accent colours,
+// channel icons). Includes external sidecars and the in-process Discord gateway.
+// Source of truth: the sidecars under /sidecars/, the in-process gateway under
+// lib/server/server_discord_in_process_gateway.{ml,mli}, and config/navigation.ts.
+export const KNOWN_CONNECTOR_IDS = ['discord', 'imessage', 'slack', 'telegram'] as const
+export type KnownConnectorId = (typeof KNOWN_CONNECTOR_IDS)[number]
+
+// Subset of {@link KNOWN_CONNECTOR_IDS} that run inside the server process. For
+// these the sidecar Start/Stop/tail affordances are suppressed (no sidecar
+// process — the operator sets an env var and restarts). RFC-0203 §Phase 3.
+export const IN_PROCESS_CONNECTOR_IDS = ['discord'] as const
+export type InProcessConnectorId = (typeof IN_PROCESS_CONNECTOR_IDS)[number]
+
+export function isInProcessConnector(connectorId: string): boolean {
+  return (IN_PROCESS_CONNECTOR_IDS as readonly string[]).includes(connectorId)
+}
+
+// The env var the operator must set to activate an in-process connector.
+export const IN_PROCESS_CONNECTOR_ENV: Record<InProcessConnectorId, string> = {
+  discord: 'DISCORD_BOT_TOKEN',
+}
+
+export const CONNECTOR_DISPLAY_NAMES: Record<KnownConnectorId, string> = {
+  discord: 'Discord',
+  imessage: 'iMessage',
+  slack: 'Slack',
+  telegram: 'Telegram',
+}
+
+export interface SidecarCommands {
+  start: string
+  tail: string
+  status: string
+  stop: string
+}
+
+// Sidecar directories — only for connectors that run as external sidecar
+// processes. Discord is intentionally absent (RFC-0203 §Phase 3).
+const SIDECAR_DIRS: Record<string, string> = {
+  imessage: 'sidecars/imessage-bot',
+  slack: 'sidecars/slack-bot',
+  telegram: 'sidecars/telegram-bot',
+}
+
+export function sidecarCommands(connectorId: string): SidecarCommands {
+  const dir = SIDECAR_DIRS[connectorId] ?? `sidecars/${connectorId}-bot`
+  return {
+    start: `cd ${dir} && ./run.sh`,
+    tail: `cd ${dir} && ./run.sh tail`,
+    status: `cd ${dir} && ./run.sh status`,
+    stop: `cd ${dir} && ./run.sh stop`,
+  }
+}
+
+// Brand accent RGB triplets per connector, biased toward dark-theme legibility.
+const CONNECTOR_ACCENT_RGB: Record<string, string> = {
+  discord: '88,101,242', // blurple
+  imessage: '48,209,88', // iOS Messages bubble green
+  slack: '236,178,46', // brand yellow (most distinctive vs telegram cyan)
+  telegram: '34,158,217', // brand cyan
+}
+
+export function connectorAccentStyle(connectorId: string): string {
+  const rgb = CONNECTOR_ACCENT_RGB[connectorId] ?? '120,130,150'
+  return `background:linear-gradient(135deg,rgba(${rgb},0.16),rgba(${rgb},0.04))`
+}
+
+const CHANNEL_ICONS: Record<string, string> = {
+  discord: '\u{1F3AE}',
+  imessage: '\u{1F4F1}',
+  telegram: '\u{2708}',
+  slack: '\u{1F4AC}',
+  signal: '\u{1F512}',
+  webchat: '\u{1F310}',
+  api: '\u{26A1}',
+  internal: '\u{2699}',
+}
+
+export function channelIcon(ch: string): string {
+  return CHANNEL_ICONS[ch] ?? '\u{1F517}'
+}

--- a/dashboard/src/components/connector-onboarding.test.ts
+++ b/dashboard/src/components/connector-onboarding.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { ConnectorOnboardingGrid, onboardingStartLabel } from './connector-onboarding'
 import { resetSetupGuideExpansionState } from './setup-guide-card'
-import { sidecarCommands } from './connector-status'
+import { sidecarCommands } from './connector-constants'
 import { _testResetBulkInflight } from './connector-overview-strip'
 
 describe('ConnectorOnboardingGrid', () => {

--- a/dashboard/src/components/connector-onboarding.ts
+++ b/dashboard/src/components/connector-onboarding.ts
@@ -12,12 +12,12 @@ import {
   channelIcon,
   connectorAccentStyle,
   sidecarCommands,
-  startSidecar,
   isInProcessConnector,
   CONNECTOR_DISPLAY_NAMES,
   KNOWN_CONNECTOR_IDS,
   type KnownConnectorId,
-} from './connector-status'
+} from './connector-constants'
+import { startSidecar } from './connector-status'
 import { ConnectorBulkActions } from './connector-overview-strip'
 import { SurfaceCard } from './common/card'
 

--- a/dashboard/src/components/connector-overview-skeleton.test.ts
+++ b/dashboard/src/components/connector-overview-skeleton.test.ts
@@ -7,7 +7,7 @@ import {
   overviewSkeletonGridClasses,
   overviewSkeletonTileCount,
 } from './connector-overview-skeleton'
-import { KNOWN_CONNECTOR_IDS } from './connector-status'
+import { KNOWN_CONNECTOR_IDS } from './connector-constants'
 
 describe('overview skeleton (pure helpers)', () => {
   it('tile count matches KNOWN_CONNECTOR_IDS (no drift if a 5th bridge is added)', () => {

--- a/dashboard/src/components/connector-overview-skeleton.ts
+++ b/dashboard/src/components/connector-overview-skeleton.ts
@@ -15,7 +15,7 @@
 // swapped".
 
 import { html } from 'htm/preact'
-import { KNOWN_CONNECTOR_IDS } from './connector-status'
+import { KNOWN_CONNECTOR_IDS } from './connector-constants'
 import { SkeletonCircle } from './common/skeleton'
 import { SurfaceCard } from './common/card'
 

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -21,6 +21,29 @@ import {
   type GateKeeperInfo,
   type GateStatusData,
 } from '../api/gate'
+import {
+  KNOWN_CONNECTOR_IDS,
+  IN_PROCESS_CONNECTOR_ENV,
+  isInProcessConnector,
+  CONNECTOR_DISPLAY_NAMES,
+  sidecarCommands,
+  connectorAccentStyle,
+  channelIcon,
+  type KnownConnectorId,
+  type InProcessConnectorId,
+} from './connector-constants'
+// Back-compat re-export: connector vocabulary now lives in ./connector-constants.
+export {
+  KNOWN_CONNECTOR_IDS,
+  IN_PROCESS_CONNECTOR_IDS,
+  IN_PROCESS_CONNECTOR_ENV,
+  isInProcessConnector,
+  CONNECTOR_DISPLAY_NAMES,
+  sidecarCommands,
+  connectorAccentStyle,
+  channelIcon,
+} from './connector-constants'
+export type { KnownConnectorId, InProcessConnectorId, SidecarCommands } from './connector-constants'
 import { formatTimeAgoEn } from '../lib/format-time'
 import { ErrorState } from './common/feedback-state'
 import { ConnectorOverviewSkeleton } from './connector-overview-skeleton'
@@ -75,49 +98,9 @@ function activeConnectorFilter(): string | null {
 // no sidecar process, no lifecycle command panel — see
 // {@link IN_PROCESS_CONNECTOR_IDS}.
 // Source of truth: docs/CONNECTOR-CONFIG-SCHEMA.md.
-interface SidecarCommands {
-  start: string
-  tail: string
-  status: string
-  stop: string
-}
-
-// Known connectors that appear in the dashboard (status panels, accent
-// colours, channel icons). Includes both external sidecars and the
-// in-process Discord gateway — the operator still wants to see Discord's
-// status row even though there's no sidecar process to start.
-//
-// Source of truth: the three remaining sidecars under /sidecars/, the
-// in-process gateway under lib/server/server_discord_in_process_gateway.{ml,mli},
-// and config/navigation.ts.
-export const KNOWN_CONNECTOR_IDS = ['discord', 'imessage', 'slack', 'telegram'] as const
-export type KnownConnectorId = (typeof KNOWN_CONNECTOR_IDS)[number]
-
-// Subset of {@link KNOWN_CONNECTOR_IDS} that run inside the server
-// process. For these, the "사이드카 미시작 / Start / Stop / tail
-// run.sh" lifecycle affordances are suppressed because there is no
-// sidecar process — the operator boots them by setting an env var and
-// restarting the server. RFC-0203 §Phase 3.
-export const IN_PROCESS_CONNECTOR_IDS = ['discord'] as const
-export type InProcessConnectorId = (typeof IN_PROCESS_CONNECTOR_IDS)[number]
-
-export function isInProcessConnector(connectorId: string): boolean {
-  return (IN_PROCESS_CONNECTOR_IDS as readonly string[]).includes(connectorId)
-}
-
-// The env var the operator must set to activate an in-process connector.
-// One per IN_PROCESS_CONNECTOR_IDS entry. Used by the status panel hint
-// shown in place of the "Start sidecar" affordance.
-export const IN_PROCESS_CONNECTOR_ENV: Record<InProcessConnectorId, string> = {
-  discord: 'DISCORD_BOT_TOKEN',
-}
-
-export const CONNECTOR_DISPLAY_NAMES: Record<KnownConnectorId, string> = {
-  discord: 'Discord',
-  imessage: 'iMessage',
-  slack: 'Slack',
-  telegram: 'Telegram',
-}
+// Connector vocabulary (KNOWN_CONNECTOR_IDS, display names, sidecar commands,
+// accent styles, channel icons) lives in ./connector-constants and is imported
+// at the top of this file; re-exported there for back-compat.
 
 const CONNECTOR_STATE_LABELS = ['offline', 'stale', 'connected', 'disconnected'] as const
 export type ConnectorStateLabel = (typeof CONNECTOR_STATE_LABELS)[number]
@@ -128,41 +111,6 @@ function isConnectorStateLabel(value: string | undefined): value is ConnectorSta
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled connector state label: ${String(value)}`)
-}
-
-// Sidecar directories — only for connectors that actually run as
-// external sidecar processes. Discord is intentionally absent
-// (RFC-0203 §Phase 3 deleted sidecars/discord-bot/).
-const SIDECAR_DIRS: Record<string, string> = {
-  imessage: 'sidecars/imessage-bot',
-  slack: 'sidecars/slack-bot',
-  telegram: 'sidecars/telegram-bot',
-}
-
-export function sidecarCommands(connectorId: string): SidecarCommands {
-  const dir = SIDECAR_DIRS[connectorId] ?? `sidecars/${connectorId}-bot`
-  return {
-    start: `cd ${dir} && ./run.sh`,
-    tail: `cd ${dir} && ./run.sh tail`,
-    status: `cd ${dir} && ./run.sh status`,
-    stop: `cd ${dir} && ./run.sh stop`,
-  }
-}
-
-// Brand accent RGB triplets per connector. Used as a subtle 135deg gradient
-// behind the panel header so an operator scanning many connectors can tell
-// them apart without reading the title. Values picked from each platform's
-// official brand palette, biased toward dark-theme legibility.
-const CONNECTOR_ACCENT_RGB: Record<string, string> = {
-  discord: '88,101,242',   // blurple
-  imessage: '48,209,88',   // iOS Messages bubble green
-  slack: '236,178,46',     // brand yellow (most distinctive vs telegram cyan)
-  telegram: '34,158,217',  // brand cyan
-}
-
-export function connectorAccentStyle(connectorId: string): string {
-  const rgb = CONNECTOR_ACCENT_RGB[connectorId] ?? '120,130,150'
-  return `background:linear-gradient(135deg,rgba(${rgb},0.16),rgba(${rgb},0.04))`
 }
 
 interface ConnectorUiState {
@@ -291,21 +239,6 @@ async function refresh() {
 
     return next
   })
-}
-
-const CHANNEL_ICONS: Record<string, string> = {
-  discord: '\u{1F3AE}',
-  imessage: '\u{1F4F1}',
-  telegram: '\u{2708}',
-  slack: '\u{1F4AC}',
-  signal: '\u{1F512}',
-  webchat: '\u{1F310}',
-  api: '\u{26A1}',
-  internal: '\u{2699}',
-}
-
-export function channelIcon(ch: string): string {
-  return CHANNEL_ICONS[ch] ?? '\u{1F517}'
 }
 
 const timeAgo = formatTimeAgoEn

--- a/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
+++ b/docs/design/dashboard-fe-improvement-backlog-2026-07-04.md
@@ -21,7 +21,7 @@ Bank the low-risk, compiler-checkable, behavior-preserving wins first (typed-uni
 |---|-------|------|------|--------|---------------------|--------|
 | 1 | Shared typed delivery classifier (`lib/keeper-delivery.ts`) | ssot | low | S | yes | **DONE** (this branch) |
 | 2 | Total parsers for 4 store-normalizer unions | ssot | low | M | yes | **DONE** (this branch) |
-| 3 | Connector constants/helpers extraction (`connector-constants.ts`) | ssot | low | M | yes | Wave 1 |
+| 3 | Connector vocabulary extraction (`connector-constants.ts`) | ssot | low | M | yes | **DONE** (this branch — SSOT only; cycle NOT broken, see note) |
 | 4 | Transcript off-screen cost (`content-visibility` first, windowing = RFC) | perf | med | M | no | Wave 2 (measure-gated) |
 | 5 | Decompose `chat/primitives.ts` along concern boundaries | refactor | med | L | yes | Wave 3 (after 1) |
 | 6 | `fsm-hub` prop→state derivation (store-prev-during-render) | refactor | med | S | no (naive fix regresses) | Wave 3 |
@@ -35,7 +35,7 @@ Bank the low-risk, compiler-checkable, behavior-preserving wins first (typed-uni
 **Wave 1 — low-risk SSOT + safe extractions (behavior-preserving, `tsc`+vitest green, no user-visible change):**
 - Slice 1 (delivery classifier) — **done**
 - Slice 2 (store-normalizer total parsers) — needs a completeness check (`type _Covered = Exclude<T, typeof VALUES[number]> extends never ? true : never`); preserve each callsite's exact normalization (taskStatus trims+lowercases; executionTone lowercases only; signalTruth/evidenceSource case-sensitive). Severity SSOT is `types/dashboard-execution.ts` `DashboardExecutionTone`, not `core.ts`. Helper is `assertExhaustive`.
-- Slice 3 (connector constants) — SSOT-only; the bundle-shrink claim is deferred to Wave-2 measurement. Moving constants alone does **not** break the `connector-status ↔ connector-overview-strip` cycle (strip still imports `startSidecar`/`stopSidecar`; quick-bind imports `bindConnector`) — add a separate `connector-actions.ts` to cut the cycle, or drop the cycle claim.
+- Slice 3 (connector vocabulary) — **DONE, SSOT-only.** Extracted the pure vocabulary (KNOWN_CONNECTOR_IDS, display names, sidecar commands, accent style, channel icon) to `connector-constants.ts` (a leaf — imports nothing from connector-status, so no new cycle); connector-status re-exports for back-compat; skeleton/onboarding repointed. **Cycle NOT broken and NOT claimed:** the sidecar actions (start/stop/bind) close over connector-status's signal-backed UI state (`patchConnectorUiState`/`refresh`), so they cannot move to a `connector-actions.ts` without dragging that state — verified by reading the action bodies. Breaking the cycle needs the UI-state store extraction (Slice 8/RFC). State-label helpers (`connectorStateLabel`/`connectorCardBorderClass`) also stayed (share the file-local exhaustiveness helper). Bundle-shrink claim deferred to Wave-2 `BUNDLE_REPORT=1` measurement. Gates: tsc 0, eslint 0, vitest (4 connector suites +42, panel 37) green.
 
 **Wave 2 — performance, measurement-gated:**
 - Slice 4: measure first (`performance-monitor` LoAF + a memo render counter) on a synthetic 500+ entry streaming transcript; ship the cheap `content-visibility:auto` row wrapper (mirrors `virtual-list.ts:242-259`) *before* any windowing; gate on real transcript-length distribution.


### PR DESCRIPTION
## 목표

대시보드 FE 개선 이니셔티브 **Wave 1 / Slice 3**. 2458-LOC `connector-status.ts`에서 **순수 connector vocabulary**를 leaf 모듈 `connector-constants.ts`로 추출(SSOT). (Slice 1·2는 #23120으로 이미 머지됨.)

## 변경 (behavior-preserving, SSOT only)

- **신규 `connector-constants.ts`** (leaf — connector-status를 import하지 않음 → 새 cycle 없음): `KNOWN_CONNECTOR_IDS`, `IN_PROCESS_CONNECTOR_IDS`/`ENV`, `isInProcessConnector`, `CONNECTOR_DISPLAY_NAMES`, `SidecarCommands`/`sidecarCommands`, `connectorAccentStyle`, `channelIcon`.
- `connector-status.ts`: 이동 정의 삭제 → connector-constants에서 import(내부 사용) + **re-export(back-compat)**. `assertNever`(7회 사용)와 state-label 헬퍼(`connectorStateLabel`/`connectorCardBorderClass`)는 잔류(file-local 헬퍼 공유).
- `connector-overview-skeleton`(초기 라우트)·`connector-onboarding`을 leaf 모듈로 repoint.
- 신규 `connector-constants.test.ts`: vocabulary 완성도 + helper fallback 검증.

## 정직한 범위 (cycle·bundle 미주장)

- **import cycle은 끊지 않았고 주장하지 않음**: 액션(start/stop/bind)이 connector-status의 signal 상태(`patchConnectorUiState`/`refresh`)를 클로저로 참조 — 본문 확인 결과 상태를 함께 끌지 않고는 이동 불가. cycle 제거는 UI-state store 추출(백로그 Slice 8/RFC) 필요.
- 번들 효과는 `BUNDLE_REPORT=1` before/after 측정 전까지 주장하지 않음.

## 검증 (로컬 게이트, CI 재확인)

- `tsc --noEmit` 0 · `eslint src` 0
- vitest: connector 4 스위트 +42, **connector-status 패널 37 unchanged**(behavior 보존)

RFC-WAIVED: 순수 프론트엔드 SSOT 추출, credential/identity/operator/sandbox/hooks/workflow 경계 미접촉.
