### PR TITLE
[codex] surface runtime parameter policy in dashboard

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -70,6 +70,86 @@ export interface DashboardRuntimeRequestConfig {
   connect_timeout_s?: number | null
 }
 
+export interface DashboardRuntimeProviderBehaviorCapabilities {
+  supports_inline_tools?: boolean
+  requires_per_keeper_bridging_for_bound_actor_tools?: boolean
+  identity_runtime_mcp_header_keys: string[]
+  argv_prompt_preflight?: boolean
+  uses_anthropic_caching?: boolean
+  max_turns_per_attempt?: number | null
+  tolerates_bound_actor_fallback?: boolean
+}
+
+export interface DashboardRuntimeDeclaredProviderSpec {
+  id?: string | null
+  display_name?: string | null
+  protocol?: string | null
+  api_format?: string | null
+  transport?: string | null
+  auth_kind?: string | null
+  is_non_interactive?: boolean
+  has_capabilities?: boolean
+  behavior_capabilities?: DashboardRuntimeProviderBehaviorCapabilities | null
+  custom_header_count?: number | null
+  connect_timeout_s?: number | null
+}
+
+export interface DashboardRuntimeDeclaredModelCapabilities {
+  source?: string | null
+  max_output_tokens?: number | null
+  supports_tool_choice?: boolean
+  supports_extended_thinking?: boolean
+  supports_reasoning_budget?: boolean
+  thinking_control_format?: string | null
+  supports_image_input?: boolean
+  supports_audio_input?: boolean
+  supports_video_input?: boolean
+  supports_multimodal_inputs?: boolean
+  supports_response_format_json?: boolean
+  supports_structured_output?: boolean
+  supports_native_streaming?: boolean
+  supports_caching?: boolean
+  supports_prompt_caching?: boolean
+  prompt_cache_alignment?: number | null
+  supports_top_k?: boolean
+  supports_min_p?: boolean
+  supports_seed?: boolean
+  emits_usage_tokens?: boolean
+  supports_computer_use?: boolean
+}
+
+export interface DashboardRuntimeDeclaredModelSpec {
+  id?: string | null
+  api_name?: string | null
+  tools_support?: boolean
+  max_context?: number | null
+  thinking_support?: boolean
+  preserve_thinking?: boolean | null
+  max_thinking_budget?: number | null
+  streaming?: boolean
+  temperature?: number | null
+  capabilities?: DashboardRuntimeDeclaredModelCapabilities | null
+  match_prefixes: string[]
+}
+
+export interface DashboardRuntimeDeclaredBindingSpec {
+  provider_id?: string | null
+  model_id?: string | null
+  is_default?: boolean
+  max_concurrent?: number | null
+  price_input?: number | null
+  price_output?: number | null
+  keep_alive?: string | null
+  num_ctx?: number | null
+}
+
+export interface DashboardRuntimeDeclaredSpec {
+  source?: string | null
+  provider?: DashboardRuntimeDeclaredProviderSpec | null
+  model?: DashboardRuntimeDeclaredModelSpec | null
+  binding?: DashboardRuntimeDeclaredBindingSpec | null
+}
+
 export interface DashboardRuntimeReasoningStreamingFormat {
   kind?: string | null
   field?: string | null
@@ -148,6 +228,7 @@ export interface DashboardRuntimeProviderSnapshot {
   effective_capabilities?: DashboardRuntimeEffectiveCapabilities | null
   parameter_policy?: DashboardRuntimeParameterPolicy | null
   request_config?: DashboardRuntimeRequestConfig | null
+  declared_spec?: DashboardRuntimeDeclaredSpec | null
   model_count?: number | null
   models: string[]
   source?: string | null
@@ -364,6 +445,109 @@ function decodeRuntimeRequestConfig(raw: unknown): DashboardRuntimeRequestConfig
   }
 }
 
+function decodeRuntimeProviderBehaviorCapabilities(
+  raw: unknown,
+): DashboardRuntimeProviderBehaviorCapabilities | null {
+  if (!isRecord(raw)) return null
+  return {
+    supports_inline_tools: asBoolean(raw.supports_inline_tools),
+    requires_per_keeper_bridging_for_bound_actor_tools:
+      asBoolean(raw.requires_per_keeper_bridging_for_bound_actor_tools),
+    identity_runtime_mcp_header_keys: asStringArray(raw.identity_runtime_mcp_header_keys),
+    argv_prompt_preflight: asBoolean(raw.argv_prompt_preflight),
+    uses_anthropic_caching: asBoolean(raw.uses_anthropic_caching),
+    max_turns_per_attempt: asNumber(raw.max_turns_per_attempt) ?? null,
+    tolerates_bound_actor_fallback: asBoolean(raw.tolerates_bound_actor_fallback),
+  }
+}
+
+function decodeRuntimeDeclaredProviderSpec(raw: unknown): DashboardRuntimeDeclaredProviderSpec | null {
+  if (!isRecord(raw)) return null
+  return {
+    id: asNullableString(raw.id),
+    display_name: asNullableString(raw.display_name),
+    protocol: asNullableString(raw.protocol),
+    api_format: asNullableString(raw.api_format),
+    transport: asNullableString(raw.transport),
+    auth_kind: asNullableString(raw.auth_kind),
+    is_non_interactive: asBoolean(raw.is_non_interactive),
+    has_capabilities: asBoolean(raw.has_capabilities),
+    behavior_capabilities: decodeRuntimeProviderBehaviorCapabilities(raw.behavior_capabilities),
+    custom_header_count: asNumber(raw.custom_header_count) ?? null,
+    connect_timeout_s: asNumber(raw.connect_timeout_s) ?? null,
+  }
+}
+
+function decodeRuntimeDeclaredModelCapabilities(
+  raw: unknown,
+): DashboardRuntimeDeclaredModelCapabilities | null {
+  if (!isRecord(raw)) return null
+  return {
+    source: asNullableString(raw.source),
+    max_output_tokens: asNumber(raw.max_output_tokens) ?? null,
+    supports_tool_choice: asBoolean(raw.supports_tool_choice),
+    supports_extended_thinking: asBoolean(raw.supports_extended_thinking),
+    supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
+    thinking_control_format: asNullableString(raw.thinking_control_format),
+    supports_image_input: asBoolean(raw.supports_image_input),
+    supports_audio_input: asBoolean(raw.supports_audio_input),
+    supports_video_input: asBoolean(raw.supports_video_input),
+    supports_multimodal_inputs: asBoolean(raw.supports_multimodal_inputs),
+    supports_response_format_json: asBoolean(raw.supports_response_format_json),
+    supports_structured_output: asBoolean(raw.supports_structured_output),
+    supports_native_streaming: asBoolean(raw.supports_native_streaming),
+    supports_caching: asBoolean(raw.supports_caching),
+    supports_prompt_caching: asBoolean(raw.supports_prompt_caching),
+    prompt_cache_alignment: asNumber(raw.prompt_cache_alignment) ?? null,
+    supports_top_k: asBoolean(raw.supports_top_k),
+    supports_min_p: asBoolean(raw.supports_min_p),
+    supports_seed: asBoolean(raw.supports_seed),
+    emits_usage_tokens: asBoolean(raw.emits_usage_tokens),
+    supports_computer_use: asBoolean(raw.supports_computer_use),
+  }
+}
+
+function decodeRuntimeDeclaredModelSpec(raw: unknown): DashboardRuntimeDeclaredModelSpec | null {
+  if (!isRecord(raw)) return null
+  return {
+    id: asNullableString(raw.id),
+    api_name: asNullableString(raw.api_name),
+    tools_support: asBoolean(raw.tools_support),
+    max_context: asNumber(raw.max_context) ?? null,
+    thinking_support: asBoolean(raw.thinking_support),
+    preserve_thinking: asBoolean(raw.preserve_thinking) ?? null,
+    max_thinking_budget: asNumber(raw.max_thinking_budget) ?? null,
+    streaming: asBoolean(raw.streaming),
+    temperature: asNumber(raw.temperature) ?? null,
+    capabilities: decodeRuntimeDeclaredModelCapabilities(raw.capabilities),
+    match_prefixes: asStringArray(raw.match_prefixes),
+  }
+}
+
+function decodeRuntimeDeclaredBindingSpec(raw: unknown): DashboardRuntimeDeclaredBindingSpec | null {
+  if (!isRecord(raw)) return null
+  return {
+    provider_id: asNullableString(raw.provider_id),
+    model_id: asNullableString(raw.model_id),
+    is_default: asBoolean(raw.is_default),
+    max_concurrent: asNumber(raw.max_concurrent) ?? null,
+    price_input: asNumber(raw.price_input) ?? null,
+    price_output: asNumber(raw.price_output) ?? null,
+    keep_alive: asNullableString(raw.keep_alive),
+    num_ctx: asNumber(raw.num_ctx) ?? null,
+  }
+}
+
+function decodeRuntimeDeclaredSpec(raw: unknown): DashboardRuntimeDeclaredSpec | null {
+  if (!isRecord(raw)) return null
+  return {
+    source: asNullableString(raw.source),
+    provider: decodeRuntimeDeclaredProviderSpec(raw.provider),
+    model: decodeRuntimeDeclaredModelSpec(raw.model),
+    binding: decodeRuntimeDeclaredBindingSpec(raw.binding),
+  }
+}
+
 function decodeNullableStringArray(raw: unknown): string[] | null {
   return Array.isArray(raw) ? asStringArray(raw) : null
 }
@@ -468,6 +652,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     effective_capabilities: decodeRuntimeEffectiveCapabilities(raw.effective_capabilities),
     parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
     request_config: decodeRuntimeRequestConfig(raw.request_config),
+    declared_spec: decodeRuntimeDeclaredSpec(raw.declared_spec),
     model_count: asNumber(raw.model_count) ?? null,
     models: asStringArray(raw.models),
     source: asNullableString(raw.source),

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -16,6 +16,14 @@ interface DashboardRuntimeProviderDiscovery {
   idle_slots?: number | null
 }
 
+export interface DashboardRuntimeParameterPolicy {
+  reasoning_toggle_wire?: string | null
+  reasoning_replay_policy?: string | null
+  requires_reasoning_replay_on_tool_call?: boolean
+  ignored_sampling_params: string[]
+  always_ignored_sampling_params: string[]
+}
+
 export interface DashboardRuntimeProviderSnapshot {
   provider: string
   runtime_id?: string | null
@@ -43,6 +51,7 @@ export interface DashboardRuntimeProviderSnapshot {
   supports_image_input?: boolean
   supports_reasoning_budget?: boolean
   thinking_control_format?: string | null
+  parameter_policy?: DashboardRuntimeParameterPolicy | null
   model_count?: number | null
   models: string[]
   source?: string | null
@@ -193,6 +202,17 @@ export interface DashboardRuntimeModelMetricsResponse {
   models: DashboardRuntimeModelMetric[]
 }
 
+function decodeRuntimeParameterPolicy(raw: unknown): DashboardRuntimeParameterPolicy | null {
+  if (!isRecord(raw)) return null
+  return {
+    reasoning_toggle_wire: asNullableString(raw.reasoning_toggle_wire),
+    reasoning_replay_policy: asNullableString(raw.reasoning_replay_policy),
+    requires_reasoning_replay_on_tool_call: asBoolean(raw.requires_reasoning_replay_on_tool_call),
+    ignored_sampling_params: asStringArray(raw.ignored_sampling_params),
+    always_ignored_sampling_params: asStringArray(raw.always_ignored_sampling_params),
+  }
+}
+
 function decodeRuntimeProviderDiscovery(raw: unknown): DashboardRuntimeProviderDiscovery | null {
   if (!isRecord(raw)) return null
   return {
@@ -234,6 +254,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     supports_image_input: asBoolean(raw.supports_image_input),
     supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
     thinking_control_format: asNullableString(raw.thinking_control_format),
+    parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
     model_count: asNumber(raw.model_count) ?? null,
     models: asStringArray(raw.models),
     source: asNullableString(raw.source),

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -24,6 +24,52 @@ export interface DashboardRuntimeParameterPolicy {
   always_ignored_sampling_params: string[]
 }
 
+export interface DashboardRuntimeToolChoice {
+  kind?: string | null
+  name?: string | null
+}
+
+export interface DashboardRuntimeResponseFormat {
+  kind?: string | null
+  has_schema?: boolean
+}
+
+export interface DashboardRuntimeRequestConfig {
+  source?: string | null
+  provider_kind?: string | null
+  request_path?: string | null
+  request_path_targets_responses_api?: boolean
+  max_tokens?: number | null
+  max_context?: number | null
+  temperature?: number | null
+  top_p?: number | null
+  top_k?: number | null
+  min_p?: number | null
+  has_system_prompt?: boolean
+  enable_thinking?: boolean | null
+  preserve_thinking?: boolean | null
+  thinking_budget?: number | null
+  clear_thinking?: boolean | null
+  resolved_reasoning_effort?: string | null
+  glm_clear_thinking?: boolean
+  glm_replay_reasoning?: boolean
+  tool_stream?: boolean
+  tool_choice?: DashboardRuntimeToolChoice | null
+  disable_parallel_tool_use?: boolean
+  response_format?: DashboardRuntimeResponseFormat | null
+  has_output_schema?: boolean
+  cache_system_prompt?: boolean
+  supports_tool_choice_override?: boolean | null
+  supports_structured_output_override?: boolean | null
+  has_model_capabilities_override?: boolean
+  keep_alive?: string | null
+  internal_model_rotation_count?: number | null
+  num_ctx?: number | null
+  seed?: number | null
+  has_previous_response_id?: boolean
+  connect_timeout_s?: number | null
+}
+
 export interface DashboardRuntimeReasoningStreamingFormat {
   kind?: string | null
   field?: string | null
@@ -101,6 +147,7 @@ export interface DashboardRuntimeProviderSnapshot {
   thinking_control_format?: string | null
   effective_capabilities?: DashboardRuntimeEffectiveCapabilities | null
   parameter_policy?: DashboardRuntimeParameterPolicy | null
+  request_config?: DashboardRuntimeRequestConfig | null
   model_count?: number | null
   models: string[]
   source?: string | null
@@ -262,6 +309,61 @@ function decodeRuntimeParameterPolicy(raw: unknown): DashboardRuntimeParameterPo
   }
 }
 
+function decodeRuntimeToolChoice(raw: unknown): DashboardRuntimeToolChoice | null {
+  if (!isRecord(raw)) return null
+  return {
+    kind: asNullableString(raw.kind),
+    name: asNullableString(raw.name),
+  }
+}
+
+function decodeRuntimeResponseFormat(raw: unknown): DashboardRuntimeResponseFormat | null {
+  if (!isRecord(raw)) return null
+  return {
+    kind: asNullableString(raw.kind),
+    has_schema: asBoolean(raw.has_schema),
+  }
+}
+
+function decodeRuntimeRequestConfig(raw: unknown): DashboardRuntimeRequestConfig | null {
+  if (!isRecord(raw)) return null
+  return {
+    source: asNullableString(raw.source),
+    provider_kind: asNullableString(raw.provider_kind),
+    request_path: asNullableString(raw.request_path),
+    request_path_targets_responses_api: asBoolean(raw.request_path_targets_responses_api),
+    max_tokens: asNumber(raw.max_tokens) ?? null,
+    max_context: asNumber(raw.max_context) ?? null,
+    temperature: asNumber(raw.temperature) ?? null,
+    top_p: asNumber(raw.top_p) ?? null,
+    top_k: asNumber(raw.top_k) ?? null,
+    min_p: asNumber(raw.min_p) ?? null,
+    has_system_prompt: asBoolean(raw.has_system_prompt),
+    enable_thinking: asBoolean(raw.enable_thinking) ?? null,
+    preserve_thinking: asBoolean(raw.preserve_thinking) ?? null,
+    thinking_budget: asNumber(raw.thinking_budget) ?? null,
+    clear_thinking: asBoolean(raw.clear_thinking) ?? null,
+    resolved_reasoning_effort: asNullableString(raw.resolved_reasoning_effort),
+    glm_clear_thinking: asBoolean(raw.glm_clear_thinking),
+    glm_replay_reasoning: asBoolean(raw.glm_replay_reasoning),
+    tool_stream: asBoolean(raw.tool_stream),
+    tool_choice: decodeRuntimeToolChoice(raw.tool_choice),
+    disable_parallel_tool_use: asBoolean(raw.disable_parallel_tool_use),
+    response_format: decodeRuntimeResponseFormat(raw.response_format),
+    has_output_schema: asBoolean(raw.has_output_schema),
+    cache_system_prompt: asBoolean(raw.cache_system_prompt),
+    supports_tool_choice_override: asBoolean(raw.supports_tool_choice_override) ?? null,
+    supports_structured_output_override: asBoolean(raw.supports_structured_output_override) ?? null,
+    has_model_capabilities_override: asBoolean(raw.has_model_capabilities_override),
+    keep_alive: asNullableString(raw.keep_alive),
+    internal_model_rotation_count: asNumber(raw.internal_model_rotation_count) ?? null,
+    num_ctx: asNumber(raw.num_ctx) ?? null,
+    seed: asNumber(raw.seed) ?? null,
+    has_previous_response_id: asBoolean(raw.has_previous_response_id),
+    connect_timeout_s: asNumber(raw.connect_timeout_s) ?? null,
+  }
+}
+
 function decodeNullableStringArray(raw: unknown): string[] | null {
   return Array.isArray(raw) ? asStringArray(raw) : null
 }
@@ -365,6 +467,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     thinking_control_format: asNullableString(raw.thinking_control_format),
     effective_capabilities: decodeRuntimeEffectiveCapabilities(raw.effective_capabilities),
     parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
+    request_config: decodeRuntimeRequestConfig(raw.request_config),
     model_count: asNumber(raw.model_count) ?? null,
     models: asStringArray(raw.models),
     source: asNullableString(raw.source),

--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -24,6 +24,54 @@ export interface DashboardRuntimeParameterPolicy {
   always_ignored_sampling_params: string[]
 }
 
+export interface DashboardRuntimeReasoningStreamingFormat {
+  kind?: string | null
+  field?: string | null
+}
+
+export interface DashboardRuntimeEffectiveCapabilities {
+  source?: string | null
+  max_context_tokens?: number | null
+  max_output_tokens?: number | null
+  supports_tools?: boolean
+  supports_tool_choice?: boolean
+  supports_required_tool_choice?: boolean
+  supports_named_tool_choice?: boolean
+  supports_parallel_tool_calls?: boolean
+  supports_runtime_mcp_tools?: boolean
+  supports_runtime_tool_events?: boolean
+  assistant_tool_content_format?: string | null
+  supports_reasoning?: boolean
+  supports_extended_thinking?: boolean
+  supports_reasoning_budget?: boolean
+  accepted_reasoning_efforts: string[] | null
+  thinking_control_format?: string | null
+  preserve_thinking_control_format?: string | null
+  reasoning_output_format?: string | null
+  reasoning_streaming_format?: DashboardRuntimeReasoningStreamingFormat | null
+  reasoning_replay_override?: string | null
+  supports_response_format_json?: boolean
+  supports_structured_output?: boolean
+  supports_multimodal_inputs?: boolean
+  supports_image_input?: boolean
+  supports_audio_input?: boolean
+  supports_video_input?: boolean
+  task?: string | null
+  supports_native_streaming?: boolean
+  supports_system_prompt?: boolean
+  supports_caching?: boolean
+  supports_prompt_caching?: boolean
+  prompt_cache_alignment?: number | null
+  supports_top_k?: boolean
+  supports_min_p?: boolean
+  supports_seed?: boolean
+  supports_seed_with_images?: boolean
+  supports_computer_use?: boolean
+  supports_code_execution?: boolean
+  emits_usage_tokens?: boolean
+  supported_models: string[] | null
+}
+
 export interface DashboardRuntimeProviderSnapshot {
   provider: string
   runtime_id?: string | null
@@ -51,6 +99,7 @@ export interface DashboardRuntimeProviderSnapshot {
   supports_image_input?: boolean
   supports_reasoning_budget?: boolean
   thinking_control_format?: string | null
+  effective_capabilities?: DashboardRuntimeEffectiveCapabilities | null
   parameter_policy?: DashboardRuntimeParameterPolicy | null
   model_count?: number | null
   models: string[]
@@ -213,6 +262,66 @@ function decodeRuntimeParameterPolicy(raw: unknown): DashboardRuntimeParameterPo
   }
 }
 
+function decodeNullableStringArray(raw: unknown): string[] | null {
+  return Array.isArray(raw) ? asStringArray(raw) : null
+}
+
+function decodeRuntimeReasoningStreamingFormat(
+  raw: unknown,
+): DashboardRuntimeReasoningStreamingFormat | null {
+  if (!isRecord(raw)) return null
+  return {
+    kind: asNullableString(raw.kind),
+    field: asNullableString(raw.field),
+  }
+}
+
+function decodeRuntimeEffectiveCapabilities(raw: unknown): DashboardRuntimeEffectiveCapabilities | null {
+  if (!isRecord(raw)) return null
+  return {
+    source: asNullableString(raw.source),
+    max_context_tokens: asNumber(raw.max_context_tokens) ?? null,
+    max_output_tokens: asNumber(raw.max_output_tokens) ?? null,
+    supports_tools: asBoolean(raw.supports_tools),
+    supports_tool_choice: asBoolean(raw.supports_tool_choice),
+    supports_required_tool_choice: asBoolean(raw.supports_required_tool_choice),
+    supports_named_tool_choice: asBoolean(raw.supports_named_tool_choice),
+    supports_parallel_tool_calls: asBoolean(raw.supports_parallel_tool_calls),
+    supports_runtime_mcp_tools: asBoolean(raw.supports_runtime_mcp_tools),
+    supports_runtime_tool_events: asBoolean(raw.supports_runtime_tool_events),
+    assistant_tool_content_format: asNullableString(raw.assistant_tool_content_format),
+    supports_reasoning: asBoolean(raw.supports_reasoning),
+    supports_extended_thinking: asBoolean(raw.supports_extended_thinking),
+    supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
+    accepted_reasoning_efforts: decodeNullableStringArray(raw.accepted_reasoning_efforts),
+    thinking_control_format: asNullableString(raw.thinking_control_format),
+    preserve_thinking_control_format: asNullableString(raw.preserve_thinking_control_format),
+    reasoning_output_format: asNullableString(raw.reasoning_output_format),
+    reasoning_streaming_format: decodeRuntimeReasoningStreamingFormat(raw.reasoning_streaming_format),
+    reasoning_replay_override: asNullableString(raw.reasoning_replay_override),
+    supports_response_format_json: asBoolean(raw.supports_response_format_json),
+    supports_structured_output: asBoolean(raw.supports_structured_output),
+    supports_multimodal_inputs: asBoolean(raw.supports_multimodal_inputs),
+    supports_image_input: asBoolean(raw.supports_image_input),
+    supports_audio_input: asBoolean(raw.supports_audio_input),
+    supports_video_input: asBoolean(raw.supports_video_input),
+    task: asNullableString(raw.task),
+    supports_native_streaming: asBoolean(raw.supports_native_streaming),
+    supports_system_prompt: asBoolean(raw.supports_system_prompt),
+    supports_caching: asBoolean(raw.supports_caching),
+    supports_prompt_caching: asBoolean(raw.supports_prompt_caching),
+    prompt_cache_alignment: asNumber(raw.prompt_cache_alignment) ?? null,
+    supports_top_k: asBoolean(raw.supports_top_k),
+    supports_min_p: asBoolean(raw.supports_min_p),
+    supports_seed: asBoolean(raw.supports_seed),
+    supports_seed_with_images: asBoolean(raw.supports_seed_with_images),
+    supports_computer_use: asBoolean(raw.supports_computer_use),
+    supports_code_execution: asBoolean(raw.supports_code_execution),
+    emits_usage_tokens: asBoolean(raw.emits_usage_tokens),
+    supported_models: decodeNullableStringArray(raw.supported_models),
+  }
+}
+
 function decodeRuntimeProviderDiscovery(raw: unknown): DashboardRuntimeProviderDiscovery | null {
   if (!isRecord(raw)) return null
   return {
@@ -254,6 +363,7 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     supports_image_input: asBoolean(raw.supports_image_input),
     supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
     thinking_control_format: asNullableString(raw.thinking_control_format),
+    effective_capabilities: decodeRuntimeEffectiveCapabilities(raw.effective_capabilities),
     parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
     model_count: asNumber(raw.model_count) ?? null,
     models: asStringArray(raw.models),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2430,6 +2430,46 @@ describe('fetchRuntimeProviders', () => {
               ignored_sampling_params: ['temperature', 'top_p'],
               always_ignored_sampling_params: ['temperature'],
             },
+            request_config: {
+              source: 'oas-provider-config',
+              provider_kind: 'openai_compat',
+              request_path: '/chat/completions',
+              request_path_targets_responses_api: false,
+              max_tokens: 65536,
+              max_context: 131072,
+              temperature: null,
+              top_p: null,
+              top_k: null,
+              min_p: null,
+              has_system_prompt: false,
+              enable_thinking: true,
+              preserve_thinking: null,
+              thinking_budget: 32768,
+              clear_thinking: false,
+              resolved_reasoning_effort: 'high',
+              glm_clear_thinking: false,
+              glm_replay_reasoning: true,
+              tool_stream: true,
+              tool_choice: {
+                kind: 'required',
+              },
+              disable_parallel_tool_use: false,
+              response_format: {
+                kind: 'json_schema',
+                has_schema: true,
+              },
+              has_output_schema: true,
+              cache_system_prompt: true,
+              supports_tool_choice_override: true,
+              supports_structured_output_override: null,
+              has_model_capabilities_override: true,
+              keep_alive: '30m',
+              internal_model_rotation_count: null,
+              num_ctx: 131072,
+              seed: 42,
+              has_previous_response_id: false,
+              connect_timeout_s: 120,
+            },
             effective_capabilities: {
               source: 'oas-provider-config-model',
               max_context_tokens: 131072,
@@ -2529,6 +2569,14 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.parameter_policy?.reasoning_replay_policy).toBe('preserve_always')
     expect(result.providers[0]?.parameter_policy?.ignored_sampling_params).toEqual(['temperature', 'top_p'])
     expect(result.providers[0]?.parameter_policy?.always_ignored_sampling_params).toEqual(['temperature'])
+    expect(result.providers[0]?.request_config?.provider_kind).toBe('openai_compat')
+    expect(result.providers[0]?.request_config?.request_path).toBe('/chat/completions')
+    expect(result.providers[0]?.request_config?.max_tokens).toBe(65536)
+    expect(result.providers[0]?.request_config?.thinking_budget).toBe(32768)
+    expect(result.providers[0]?.request_config?.resolved_reasoning_effort).toBe('high')
+    expect(result.providers[0]?.request_config?.tool_choice?.kind).toBe('required')
+    expect(result.providers[0]?.request_config?.response_format?.kind).toBe('json_schema')
+    expect(result.providers[0]?.request_config?.num_ctx).toBe(131072)
     expect(result.providers[0]?.effective_capabilities?.max_output_tokens).toBe(65536)
     expect(result.providers[0]?.effective_capabilities?.supports_parallel_tool_calls).toBe(true)
     expect(result.providers[0]?.effective_capabilities?.accepted_reasoning_efforts).toEqual(['low', 'medium', 'high'])

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2515,6 +2515,75 @@ describe('fetchRuntimeProviders', () => {
               emits_usage_tokens: true,
               supported_models: null,
             },
+            declared_spec: {
+              source: 'runtime.toml',
+              provider: {
+                id: 'runpod_mtp',
+                display_name: 'RunPod',
+                protocol: 'openai-compatible-http',
+                api_format: 'chat-completions',
+                transport: 'http',
+                auth_kind: 'env:RUNPOD_API_KEY',
+                is_non_interactive: false,
+                has_capabilities: true,
+                behavior_capabilities: {
+                  supports_inline_tools: true,
+                  requires_per_keeper_bridging_for_bound_actor_tools: false,
+                  identity_runtime_mcp_header_keys: ['x-masc-keeper'],
+                  argv_prompt_preflight: false,
+                  uses_anthropic_caching: false,
+                  max_turns_per_attempt: 3,
+                  tolerates_bound_actor_fallback: true,
+                },
+                custom_header_count: 2,
+                connect_timeout_s: 120,
+              },
+              model: {
+                id: 'qwen',
+                api_name: 'Qwen/Qwen3-32B',
+                tools_support: true,
+                max_context: 128000,
+                thinking_support: true,
+                preserve_thinking: true,
+                max_thinking_budget: 32768,
+                streaming: true,
+                temperature: 0.65,
+                capabilities: {
+                  source: 'runtime.toml',
+                  max_output_tokens: 65536,
+                  supports_tool_choice: true,
+                  supports_extended_thinking: true,
+                  supports_reasoning_budget: true,
+                  thinking_control_format: 'chat-template-kwargs',
+                  supports_image_input: true,
+                  supports_audio_input: false,
+                  supports_video_input: false,
+                  supports_multimodal_inputs: true,
+                  supports_response_format_json: true,
+                  supports_structured_output: true,
+                  supports_native_streaming: true,
+                  supports_caching: true,
+                  supports_prompt_caching: true,
+                  prompt_cache_alignment: 1024,
+                  supports_top_k: true,
+                  supports_min_p: true,
+                  supports_seed: true,
+                  emits_usage_tokens: true,
+                  supports_computer_use: false,
+                },
+                match_prefixes: ['Qwen/'],
+              },
+              binding: {
+                provider_id: 'runpod_mtp',
+                model_id: 'qwen',
+                is_default: true,
+                max_concurrent: 4,
+                price_input: 0.1,
+                price_output: 0.2,
+                keep_alive: '30m',
+                num_ctx: 131072,
+              },
+            },
             source: 'runtime.toml',
             discovery: {
               healthy: true,
@@ -2582,6 +2651,14 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.effective_capabilities?.accepted_reasoning_efforts).toEqual(['low', 'medium', 'high'])
     expect(result.providers[0]?.effective_capabilities?.reasoning_streaming_format?.field).toBe('reasoning_content')
     expect(result.providers[0]?.effective_capabilities?.supports_top_k).toBe(true)
+    expect(result.providers[0]?.declared_spec?.source).toBe('runtime.toml')
+    expect(result.providers[0]?.declared_spec?.provider?.api_format).toBe('chat-completions')
+    expect(
+      result.providers[0]?.declared_spec?.provider?.behavior_capabilities
+        ?.identity_runtime_mcp_header_keys,
+    ).toEqual(['x-masc-keeper'])
+    expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_structured_output).toBe(true)
+    expect(result.providers[0]?.declared_spec?.binding?.max_concurrent).toBe(4)
     expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_governance?.status).toBe('degraded')

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2423,6 +2423,13 @@ describe('fetchRuntimeProviders', () => {
             model_count: 1,
             models: ['Qwen/Qwen3-32B'],
             temperature: 0.65,
+            parameter_policy: {
+              reasoning_toggle_wire: 'chat_template_kwargs',
+              reasoning_replay_policy: 'preserve_always',
+              requires_reasoning_replay_on_tool_call: false,
+              ignored_sampling_params: ['temperature', 'top_p'],
+              always_ignored_sampling_params: ['temperature'],
+            },
             source: 'runtime.toml',
             discovery: {
               healthy: true,
@@ -2473,6 +2480,10 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.kind).toBe('cloud')
     expect(result.providers[0]?.runtime_kind).toBe('http')
     expect(result.providers[0]?.temperature).toBe(0.65)
+    expect(result.providers[0]?.parameter_policy?.reasoning_toggle_wire).toBe('chat_template_kwargs')
+    expect(result.providers[0]?.parameter_policy?.reasoning_replay_policy).toBe('preserve_always')
+    expect(result.providers[0]?.parameter_policy?.ignored_sampling_params).toEqual(['temperature', 'top_p'])
+    expect(result.providers[0]?.parameter_policy?.always_ignored_sampling_params).toEqual(['temperature'])
     expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_governance?.status).toBe('degraded')

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2430,6 +2430,51 @@ describe('fetchRuntimeProviders', () => {
               ignored_sampling_params: ['temperature', 'top_p'],
               always_ignored_sampling_params: ['temperature'],
             },
+            effective_capabilities: {
+              source: 'oas-provider-config-model',
+              max_context_tokens: 131072,
+              max_output_tokens: 65536,
+              supports_tools: true,
+              supports_tool_choice: true,
+              supports_required_tool_choice: true,
+              supports_named_tool_choice: false,
+              supports_parallel_tool_calls: true,
+              supports_runtime_mcp_tools: false,
+              supports_runtime_tool_events: false,
+              assistant_tool_content_format: 'null',
+              supports_reasoning: true,
+              supports_extended_thinking: true,
+              supports_reasoning_budget: true,
+              accepted_reasoning_efforts: ['low', 'medium', 'high'],
+              thinking_control_format: 'chat-template-kwargs',
+              preserve_thinking_control_format: 'chat-template-kwargs-preserve-thinking',
+              reasoning_output_format: 'split-reasoning-fields',
+              reasoning_streaming_format: {
+                kind: 'delta-reasoning-field',
+                field: 'reasoning_content',
+              },
+              reasoning_replay_override: 'preserve-always',
+              supports_response_format_json: true,
+              supports_structured_output: true,
+              supports_multimodal_inputs: true,
+              supports_image_input: true,
+              supports_audio_input: false,
+              supports_video_input: false,
+              task: null,
+              supports_native_streaming: true,
+              supports_system_prompt: true,
+              supports_caching: true,
+              supports_prompt_caching: true,
+              prompt_cache_alignment: 1024,
+              supports_top_k: true,
+              supports_min_p: true,
+              supports_seed: true,
+              supports_seed_with_images: false,
+              supports_computer_use: false,
+              supports_code_execution: false,
+              emits_usage_tokens: true,
+              supported_models: null,
+            },
             source: 'runtime.toml',
             discovery: {
               healthy: true,
@@ -2484,6 +2529,11 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.parameter_policy?.reasoning_replay_policy).toBe('preserve_always')
     expect(result.providers[0]?.parameter_policy?.ignored_sampling_params).toEqual(['temperature', 'top_p'])
     expect(result.providers[0]?.parameter_policy?.always_ignored_sampling_params).toEqual(['temperature'])
+    expect(result.providers[0]?.effective_capabilities?.max_output_tokens).toBe(65536)
+    expect(result.providers[0]?.effective_capabilities?.supports_parallel_tool_calls).toBe(true)
+    expect(result.providers[0]?.effective_capabilities?.accepted_reasoning_efforts).toEqual(['low', 'medium', 'high'])
+    expect(result.providers[0]?.effective_capabilities?.reasoning_streaming_format?.field).toBe('reasoning_content')
+    expect(result.providers[0]?.effective_capabilities?.supports_top_k).toBe(true)
     expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_governance?.status).toBe('degraded')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -124,6 +124,8 @@ export { fetchDashboardBriefing, fetchDashboardMission, fetchDashboardMissionSes
 export type {
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeParameterPolicy,
+  DashboardRuntimeEffectiveCapabilities,
+  DashboardRuntimeReasoningStreamingFormat,
   DashboardRuntimeAssignment,
   DashboardRuntimeAssignmentGovernance,
   DashboardRuntimeProvidersResponse,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -123,6 +123,12 @@ export { fetchDashboardBriefing, fetchDashboardMission, fetchDashboardMissionSes
 
 export type {
   DashboardRuntimeProviderSnapshot,
+  DashboardRuntimeDeclaredBindingSpec,
+  DashboardRuntimeDeclaredModelCapabilities,
+  DashboardRuntimeDeclaredModelSpec,
+  DashboardRuntimeDeclaredProviderSpec,
+  DashboardRuntimeDeclaredSpec,
+  DashboardRuntimeProviderBehaviorCapabilities,
   DashboardRuntimeParameterPolicy,
   DashboardRuntimeRequestConfig,
   DashboardRuntimeResponseFormat,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -124,6 +124,9 @@ export { fetchDashboardBriefing, fetchDashboardMission, fetchDashboardMissionSes
 export type {
   DashboardRuntimeProviderSnapshot,
   DashboardRuntimeParameterPolicy,
+  DashboardRuntimeRequestConfig,
+  DashboardRuntimeResponseFormat,
+  DashboardRuntimeToolChoice,
   DashboardRuntimeEffectiveCapabilities,
   DashboardRuntimeReasoningStreamingFormat,
   DashboardRuntimeAssignment,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -123,6 +123,7 @@ export { fetchDashboardBriefing, fetchDashboardMission, fetchDashboardMissionSes
 
 export type {
   DashboardRuntimeProviderSnapshot,
+  DashboardRuntimeParameterPolicy,
   DashboardRuntimeAssignment,
   DashboardRuntimeAssignmentGovernance,
   DashboardRuntimeProvidersResponse,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -145,6 +145,53 @@ function runtimeParameterPolicySummary(
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeRequestToolChoiceSummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const choice = entry.request_config?.tool_choice
+  if (!choice?.kind) return null
+  return choice.name ? `${choice.kind}:${choice.name}` : choice.kind
+}
+
+function runtimeRequestFormatSummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const format = entry.request_config?.response_format
+  if (!format?.kind) return null
+  return format.has_schema ? `${format.kind}+schema` : format.kind
+}
+
+function runtimeRequestConfigSummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const request = entry.request_config
+  if (!request) return null
+  const sampling = [
+    typeof request.temperature === 'number' ? `temp ${request.temperature}` : null,
+    typeof request.top_p === 'number' ? `top_p ${request.top_p}` : null,
+    typeof request.top_k === 'number' ? `top_k ${request.top_k}` : null,
+    typeof request.min_p === 'number' ? `min_p ${request.min_p}` : null,
+  ].filter((value): value is string => Boolean(value))
+  const toolChoice = runtimeRequestToolChoiceSummary(entry)
+  const format = runtimeRequestFormatSummary(entry)
+  const parts = [
+    request.provider_kind ? request.provider_kind : null,
+    request.request_path_targets_responses_api ? 'responses-api' : null,
+    typeof request.max_tokens === 'number' ? `out ${request.max_tokens}` : null,
+    typeof request.max_context === 'number' ? `ctx ${request.max_context}` : null,
+    sampling.length > 0 ? sampling.join(',') : null,
+    typeof request.enable_thinking === 'boolean' ? `think ${request.enable_thinking ? 'on' : 'off'}` : null,
+    request.resolved_reasoning_effort ? `effort ${request.resolved_reasoning_effort}` : null,
+    toolChoice ? `tool ${toolChoice}` : null,
+    request.disable_parallel_tool_use ? 'parallel off' : null,
+    format ? `format ${format}` : null,
+    typeof request.seed === 'number' ? `seed ${request.seed}` : null,
+    typeof request.num_ctx === 'number' ? `num_ctx ${request.num_ctx}` : null,
+    request.keep_alive ? `keep ${request.keep_alive}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeEffectiveCapabilitySummary(
   entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
 ): string | null {
@@ -191,6 +238,7 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   const effortAdjustable = effortMode === 'reasoning-effort' || Boolean(entry?.supports_reasoning_budget)
   const effectiveCapabilities = entry ? runtimeEffectiveCapabilitySummary(entry) : null
   const parameterPolicy = entry ? runtimeParameterPolicySummary(entry) : null
+  const requestConfig = entry ? runtimeRequestConfigSummary(entry) : null
 
   return html`
     <div class="ctx-sec">
@@ -235,6 +283,14 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
               <div class="rtc-effort">
                 <span class="rtc-effort-k">params</span>
                 <span class="rtc-eff-na" title=${parameterPolicy}>${parameterPolicy}</span>
+              </div>
+            `
+          : null}
+        ${requestConfig
+          ? html`
+              <div class="rtc-effort">
+                <span class="rtc-effort-k">request</span>
+                <span class="rtc-eff-na" title=${requestConfig}>${requestConfig}</span>
               </div>
             `
           : null}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -129,6 +129,22 @@ function formatCtxK(n: number | null | undefined): string | null {
   return `${Math.round(n / 1000)}k ctx`
 }
 
+function runtimeParameterPolicySummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const policy = entry.parameter_policy
+  if (!policy) return null
+  const ignored = policy.ignored_sampling_params.join(',')
+  const alwaysIgnored = policy.always_ignored_sampling_params.join(',')
+  const parts = [
+    policy.reasoning_toggle_wire ? policy.reasoning_toggle_wire : null,
+    policy.reasoning_replay_policy ? policy.reasoning_replay_policy : null,
+    ignored ? `ignore ${ignored}` : null,
+    alwaysIgnored ? `always ${alwaysIgnored}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   useEffect(() => {
     loadRuntimeCatalog()
@@ -150,6 +166,7 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   const effortMode = entry?.thinking_control_format ?? null
   const effortControlled = effortMode !== null && effortMode !== 'none'
   const effortAdjustable = effortMode === 'reasoning-effort' || Boolean(entry?.supports_reasoning_budget)
+  const parameterPolicy = entry ? runtimeParameterPolicySummary(entry) : null
 
   return html`
     <div class="ctx-sec">
@@ -189,6 +206,14 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
               ? html`<span class="rtc-eff-na" data-effort-mode=${effortMode}>${effortMode} · ${effortAdjustable ? '조정 가능' : '고정'}</span>`
               : html`<span class="rtc-eff-na" data-effort-mode="none">effort 제어 없음</span>`}
         </div>
+        ${parameterPolicy
+          ? html`
+              <div class="rtc-effort">
+                <span class="rtc-effort-k">params</span>
+                <span class="rtc-eff-na" title=${parameterPolicy}>${parameterPolicy}</span>
+              </div>
+            `
+          : null}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -192,6 +192,40 @@ function runtimeRequestConfigSummary(
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeDeclaredSpecSummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const spec = entry.declared_spec
+  if (!spec) return null
+  const caps = spec.model?.capabilities
+  const sampling = [
+    caps?.supports_top_k ? 'top_k' : null,
+    caps?.supports_min_p ? 'min_p' : null,
+    caps?.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const formats = [
+    caps?.supports_response_format_json ? 'json' : null,
+    caps?.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  let thinking: string | null = null
+  if (typeof spec.model?.thinking_support === 'boolean') {
+    thinking = spec.model.thinking_support ? 'think on' : 'think off'
+  }
+  const parts = [
+    spec.provider?.api_format ? spec.provider.api_format : null,
+    typeof spec.model?.max_context === 'number' ? `ctx ${spec.model.max_context}` : null,
+    thinking,
+    caps?.thinking_control_format ? caps.thinking_control_format : null,
+    typeof caps?.max_output_tokens === 'number' ? `out ${caps.max_output_tokens}` : null,
+    formats.length > 0 ? `format ${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    typeof spec.binding?.max_concurrent === 'number' ? `conc ${spec.binding.max_concurrent}` : null,
+    spec.binding?.keep_alive ? `keep ${spec.binding.keep_alive}` : null,
+    typeof spec.binding?.num_ctx === 'number' ? `num_ctx ${spec.binding.num_ctx}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeEffectiveCapabilitySummary(
   entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
 ): string | null {
@@ -239,6 +273,7 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   const effectiveCapabilities = entry ? runtimeEffectiveCapabilitySummary(entry) : null
   const parameterPolicy = entry ? runtimeParameterPolicySummary(entry) : null
   const requestConfig = entry ? runtimeRequestConfigSummary(entry) : null
+  const declaredSpec = entry ? runtimeDeclaredSpecSummary(entry) : null
 
   return html`
     <div class="ctx-sec">
@@ -291,6 +326,14 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
               <div class="rtc-effort">
                 <span class="rtc-effort-k">request</span>
                 <span class="rtc-eff-na" title=${requestConfig}>${requestConfig}</span>
+              </div>
+            `
+          : null}
+        ${declaredSpec
+          ? html`
+              <div class="rtc-effort">
+                <span class="rtc-effort-k">declared</span>
+                <span class="rtc-eff-na" title=${declaredSpec}>${declaredSpec}</span>
               </div>
             `
           : null}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -145,6 +145,29 @@ function runtimeParameterPolicySummary(
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeEffectiveCapabilitySummary(
+  entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
+): string | null {
+  const caps = entry.effective_capabilities
+  if (!caps) return null
+  const sampling = [
+    caps.supports_top_k ? 'top_k' : null,
+    caps.supports_min_p ? 'min_p' : null,
+    caps.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const formats = [
+    caps.supports_response_format_json ? 'json' : null,
+    caps.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const parts = [
+    typeof caps.max_output_tokens === 'number' ? `out ${caps.max_output_tokens}` : null,
+    caps.supports_tool_choice ? `tool_choice${caps.supports_parallel_tool_calls ? '+parallel' : ''}` : null,
+    formats.length > 0 ? `format ${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   useEffect(() => {
     loadRuntimeCatalog()
@@ -166,6 +189,7 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
   const effortMode = entry?.thinking_control_format ?? null
   const effortControlled = effortMode !== null && effortMode !== 'none'
   const effortAdjustable = effortMode === 'reasoning-effort' || Boolean(entry?.supports_reasoning_budget)
+  const effectiveCapabilities = entry ? runtimeEffectiveCapabilitySummary(entry) : null
   const parameterPolicy = entry ? runtimeParameterPolicySummary(entry) : null
 
   return html`
@@ -211,6 +235,14 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
               <div class="rtc-effort">
                 <span class="rtc-effort-k">params</span>
                 <span class="rtc-eff-na" title=${parameterPolicy}>${parameterPolicy}</span>
+              </div>
+            `
+          : null}
+        ${effectiveCapabilities
+          ? html`
+              <div class="rtc-effort">
+                <span class="rtc-effort-k">caps</span>
+                <span class="rtc-eff-na" title=${effectiveCapabilities}>${effectiveCapabilities}</span>
               </div>
             `
           : null}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -172,6 +172,55 @@ function runtimeParameterPolicyText(provider: DashboardRuntimeProviderSnapshot):
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeRequestToolChoiceText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const choice = provider.request_config?.tool_choice
+  if (!choice?.kind) return null
+  return choice.name ? `${choice.kind}:${choice.name}` : choice.kind
+}
+
+function runtimeRequestFormatText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const format = provider.request_config?.response_format
+  if (!format?.kind) return null
+  return format.has_schema ? `${format.kind}+schema` : format.kind
+}
+
+function runtimeRequestConfigText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const request = provider.request_config
+  if (!request) return null
+  const sampling = [
+    typeof request.temperature === 'number' ? `temp ${request.temperature}` : null,
+    typeof request.top_p === 'number' ? `top_p ${request.top_p}` : null,
+    typeof request.top_k === 'number' ? `top_k ${request.top_k}` : null,
+    typeof request.min_p === 'number' ? `min_p ${request.min_p}` : null,
+  ].filter((value): value is string => Boolean(value))
+  const toolChoice = runtimeRequestToolChoiceText(provider)
+  const format = runtimeRequestFormatText(provider)
+  let requestPath: string | null = null
+  if (request.request_path_targets_responses_api) {
+    requestPath = 'responses-api'
+  } else if (request.request_path) {
+    requestPath = `path ${request.request_path}`
+  }
+  const parts = [
+    request.provider_kind ? `kind ${request.provider_kind}` : null,
+    requestPath,
+    typeof request.max_tokens === 'number' ? `out ${formatNumber(request.max_tokens)}` : null,
+    typeof request.max_context === 'number' ? `ctx ${formatNumber(request.max_context)}` : null,
+    sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    typeof request.enable_thinking === 'boolean' ? `think ${request.enable_thinking ? 'on' : 'off'}` : null,
+    typeof request.thinking_budget === 'number' ? `budget ${formatNumber(request.thinking_budget)}` : null,
+    request.resolved_reasoning_effort ? `effort ${request.resolved_reasoning_effort}` : null,
+    toolChoice ? `tool ${toolChoice}` : null,
+    request.disable_parallel_tool_use ? 'parallel off' : null,
+    format ? `format ${format}` : null,
+    typeof request.seed === 'number' ? `seed ${request.seed}` : null,
+    typeof request.num_ctx === 'number' ? `num_ctx ${formatNumber(request.num_ctx)}` : null,
+    request.keep_alive ? `keep ${request.keep_alive}` : null,
+    typeof request.connect_timeout_s === 'number' ? `connect ${request.connect_timeout_s}s` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnapshot): string | null {
   const caps = provider.effective_capabilities
   if (!caps) return null
@@ -578,10 +627,11 @@ export function RuntimeMonitor() {
           : null}
         <div class="flex flex-col gap-3">
           ${(providers?.providers ?? []).length > 0
-            ? providers?.providers.map(provider => {
+              ? providers?.providers.map(provider => {
                 const liveProbe = providerProbes.get(providerRuntimeKey(provider)) ?? null
                 const effectiveCapabilities = runtimeEffectiveCapabilitiesText(provider)
                 const parameterPolicy = runtimeParameterPolicyText(provider)
+                const requestConfig = runtimeRequestConfigText(provider)
                 return html`
                 <article class="v2-monitoring-card p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
@@ -612,6 +662,11 @@ export function RuntimeMonitor() {
                   ${parameterPolicy
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${parameterPolicy}>
                         params · ${parameterPolicy}
+                      </div>`
+                    : null}
+                  ${requestConfig
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${requestConfig}>
+                        request · ${requestConfig}
                       </div>`
                     : null}
                   ${effectiveCapabilities

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -172,6 +172,39 @@ function runtimeParameterPolicyText(provider: DashboardRuntimeProviderSnapshot):
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const caps = provider.effective_capabilities
+  if (!caps) return null
+  const sampling = [
+    caps.supports_top_k ? 'top_k' : null,
+    caps.supports_min_p ? 'min_p' : null,
+    caps.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const modalities = [
+    caps.supports_image_input ? 'image' : null,
+    caps.supports_audio_input ? 'audio' : null,
+    caps.supports_video_input ? 'video' : null,
+  ].filter((value): value is string => Boolean(value))
+  const output = typeof caps.max_output_tokens === 'number'
+    ? `out ${formatNumber(caps.max_output_tokens)}`
+    : null
+  const tools = caps.supports_tool_choice
+    ? `tool_choice${caps.supports_parallel_tool_calls ? '+parallel' : ''}`
+    : null
+  const formats = [
+    caps.supports_response_format_json ? 'json' : null,
+    caps.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const parts = [
+    output,
+    tools,
+    formats.length > 0 ? `format ${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    modalities.length > 0 ? `input ${modalities.join(',')}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function providerProbeKey(probe: DashboardRuntimeProviderProbe): string | null {
   return probe.runtime_id ?? null
 }
@@ -547,6 +580,7 @@ export function RuntimeMonitor() {
           ${(providers?.providers ?? []).length > 0
             ? providers?.providers.map(provider => {
                 const liveProbe = providerProbes.get(providerRuntimeKey(provider)) ?? null
+                const effectiveCapabilities = runtimeEffectiveCapabilitiesText(provider)
                 const parameterPolicy = runtimeParameterPolicyText(provider)
                 return html`
                 <article class="v2-monitoring-card p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
@@ -578,6 +612,11 @@ export function RuntimeMonitor() {
                   ${parameterPolicy
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${parameterPolicy}>
                         params · ${parameterPolicy}
+                      </div>`
+                    : null}
+                  ${effectiveCapabilities
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${effectiveCapabilities}>
+                        caps · ${effectiveCapabilities}
                       </div>`
                     : null}
                   ${liveProbe?.error

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -156,6 +156,22 @@ function runtimeStatusLabel(provider: DashboardRuntimeProviderSnapshot): string 
   return provider.discovery?.healthy === false ? 'degraded' : 'unknown'
 }
 
+function runtimeParameterPolicyText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const policy = provider.parameter_policy
+  if (!policy) return null
+  const parts = [
+    policy.reasoning_toggle_wire ? `wire ${policy.reasoning_toggle_wire}` : null,
+    policy.reasoning_replay_policy ? `replay ${policy.reasoning_replay_policy}` : null,
+    policy.ignored_sampling_params.length > 0
+      ? `ignored ${policy.ignored_sampling_params.join(',')}`
+      : null,
+    policy.always_ignored_sampling_params.length > 0
+      ? `always ignored ${policy.always_ignored_sampling_params.join(',')}`
+      : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function providerProbeKey(probe: DashboardRuntimeProviderProbe): string | null {
   return probe.runtime_id ?? null
 }
@@ -531,6 +547,7 @@ export function RuntimeMonitor() {
           ${(providers?.providers ?? []).length > 0
             ? providers?.providers.map(provider => {
                 const liveProbe = providerProbes.get(providerRuntimeKey(provider)) ?? null
+                const parameterPolicy = runtimeParameterPolicyText(provider)
                 return html`
                 <article class="v2-monitoring-card p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
@@ -556,6 +573,11 @@ export function RuntimeMonitor() {
                   ${liveProbe?.probe_url || provider.endpoint_url
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>
                         probe · ${liveProbe?.probe_url ?? provider.endpoint_url}
+                      </div>`
+                    : null}
+                  ${parameterPolicy
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${parameterPolicy}>
+                        params · ${parameterPolicy}
                       </div>`
                     : null}
                   ${liveProbe?.error

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -221,6 +221,65 @@ function runtimeRequestConfigText(provider: DashboardRuntimeProviderSnapshot): s
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeDeclaredSpecText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const spec = provider.declared_spec
+  if (!spec) return null
+  const declaredCaps = spec.model?.capabilities
+  const declaredSampling = [
+    declaredCaps?.supports_top_k ? 'top_k' : null,
+    declaredCaps?.supports_min_p ? 'min_p' : null,
+    declaredCaps?.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const declaredFormats = [
+    declaredCaps?.supports_response_format_json ? 'json' : null,
+    declaredCaps?.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const declaredInputs = [
+    declaredCaps?.supports_image_input ? 'image' : null,
+    declaredCaps?.supports_audio_input ? 'audio' : null,
+    declaredCaps?.supports_video_input ? 'video' : null,
+  ].filter((value): value is string => Boolean(value))
+  let declaredThinking: string | null = null
+  if (typeof spec.model?.thinking_support === 'boolean') {
+    declaredThinking = spec.model.thinking_support ? 'think on' : 'think off'
+  }
+  const providerParts = [
+    spec.provider?.api_format ? `api ${spec.provider.api_format}` : null,
+    spec.provider?.protocol ? `protocol ${spec.provider.protocol}` : null,
+    spec.provider?.transport ? `transport ${spec.provider.transport}` : null,
+    typeof spec.provider?.custom_header_count === 'number'
+      ? `headers ${spec.provider.custom_header_count}`
+      : null,
+  ].filter((value): value is string => Boolean(value))
+  const modelParts = [
+    spec.model?.api_name ? `model ${spec.model.api_name}` : null,
+    typeof spec.model?.max_context === 'number' ? `ctx ${formatNumber(spec.model.max_context)}` : null,
+    typeof spec.model?.temperature === 'number' ? `temp ${spec.model.temperature}` : null,
+    declaredThinking,
+    typeof spec.model?.max_thinking_budget === 'number'
+      ? `budget ${formatNumber(spec.model.max_thinking_budget)}`
+      : null,
+    declaredCaps?.thinking_control_format ? `wire ${declaredCaps.thinking_control_format}` : null,
+    typeof declaredCaps?.max_output_tokens === 'number'
+      ? `out ${formatNumber(declaredCaps.max_output_tokens)}`
+      : null,
+    declaredFormats.length > 0 ? `format ${declaredFormats.join(',')}` : null,
+    declaredSampling.length > 0 ? `sampling ${declaredSampling.join(',')}` : null,
+    declaredInputs.length > 0 ? `input ${declaredInputs.join(',')}` : null,
+  ].filter((value): value is string => Boolean(value))
+  const bindingParts = [
+    typeof spec.binding?.max_concurrent === 'number' ? `concurrency ${spec.binding.max_concurrent}` : null,
+    spec.binding?.keep_alive ? `keep ${spec.binding.keep_alive}` : null,
+    typeof spec.binding?.num_ctx === 'number' ? `num_ctx ${formatNumber(spec.binding.num_ctx)}` : null,
+  ].filter((value): value is string => Boolean(value))
+  const parts = [
+    providerParts.length > 0 ? providerParts.join(',') : null,
+    modelParts.length > 0 ? modelParts.join(',') : null,
+    bindingParts.length > 0 ? bindingParts.join(',') : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnapshot): string | null {
   const caps = provider.effective_capabilities
   if (!caps) return null
@@ -632,6 +691,7 @@ export function RuntimeMonitor() {
                 const effectiveCapabilities = runtimeEffectiveCapabilitiesText(provider)
                 const parameterPolicy = runtimeParameterPolicyText(provider)
                 const requestConfig = runtimeRequestConfigText(provider)
+                const declaredSpec = runtimeDeclaredSpecText(provider)
                 return html`
                 <article class="v2-monitoring-card p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
@@ -667,6 +727,11 @@ export function RuntimeMonitor() {
                   ${requestConfig
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${requestConfig}>
                         request · ${requestConfig}
+                      </div>`
+                    : null}
+                  ${declaredSpec
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${declaredSpec}>
+                        declared · ${declaredSpec}
                       </div>`
                     : null}
                   ${effectiveCapabilities

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -228,6 +228,31 @@ function runtimeCatalogParameterPolicy(item: DashboardRuntimeProviderSnapshot): 
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnapshot): string | null {
+  const caps = item.effective_capabilities
+  if (!caps) return null
+  const sampling = [
+    caps.supports_top_k ? 'top_k' : null,
+    caps.supports_min_p ? 'min_p' : null,
+    caps.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const output = typeof caps.max_output_tokens === 'number' ? `out:${caps.max_output_tokens}` : null
+  const format = [
+    caps.supports_response_format_json ? 'json' : null,
+    caps.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const toolChoice = caps.supports_tool_choice
+    ? `tool-choice${caps.supports_parallel_tool_calls ? '+parallel' : ''}`
+    : null
+  const parts = [
+    output,
+    toolChoice,
+    format.length > 0 ? `format:${format.join(',')}` : null,
+    sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeCatalogFromDefaults(defaults: RuntimeDefaultsResponse | null): DashboardRuntimeProviderSnapshot[] {
   if (!defaults) return []
   return defaults.runtimes.map((entry: RuntimeEntry) => ({
@@ -263,6 +288,7 @@ function RuntimeCatalogCard({
   const transport = item.endpoint_url ?? item.transport ?? item.kind ?? 'transport 미수집'
   const status = item.available === false ? 'unavailable' : item.status ?? 'configured'
   const isDefault = runtimeId === (defaultRuntimeId ?? '')
+  const effectiveCapabilities = runtimeCatalogEffectiveCapabilities(item)
   const parameterPolicy = runtimeCatalogParameterPolicy(item)
 
   return html`
@@ -289,6 +315,9 @@ function RuntimeCatalogCard({
         <${RuntimeCatalogCapability} label="tools" value=${item.tools_support} />
         <${RuntimeCatalogCapability} label="thinking" value=${item.thinking_support} />
         <${RuntimeCatalogCapability} label="streaming" value=${item.streaming} />
+        ${effectiveCapabilities
+          ? html`<span class="rt-cap tcf mono" title=${effectiveCapabilities}>${effectiveCapabilities}</span>`
+          : null}
         ${parameterPolicy
           ? html`<span class="rt-cap tcf mono" title=${parameterPolicy}>${parameterPolicy}</span>`
           : null}

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -214,6 +214,20 @@ function RuntimeCatalogCapability({ label, value }: { label: string; value: bool
   return html`<span class=${`rt-cap ${isOn ? 'on' : ''}`}>${isOn ? '✓' : '·'} ${label}</span>`
 }
 
+function runtimeCatalogParameterPolicy(item: DashboardRuntimeProviderSnapshot): string | null {
+  const policy = item.parameter_policy
+  if (!policy) return null
+  const ignored = policy.ignored_sampling_params.join(',')
+  const alwaysIgnored = policy.always_ignored_sampling_params.join(',')
+  const parts = [
+    policy.reasoning_toggle_wire ? `wire:${policy.reasoning_toggle_wire}` : null,
+    policy.reasoning_replay_policy ? `replay:${policy.reasoning_replay_policy}` : null,
+    ignored ? `ignore:${ignored}` : null,
+    alwaysIgnored ? `always:${alwaysIgnored}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeCatalogFromDefaults(defaults: RuntimeDefaultsResponse | null): DashboardRuntimeProviderSnapshot[] {
   if (!defaults) return []
   return defaults.runtimes.map((entry: RuntimeEntry) => ({
@@ -249,6 +263,7 @@ function RuntimeCatalogCard({
   const transport = item.endpoint_url ?? item.transport ?? item.kind ?? 'transport 미수집'
   const status = item.available === false ? 'unavailable' : item.status ?? 'configured'
   const isDefault = runtimeId === (defaultRuntimeId ?? '')
+  const parameterPolicy = runtimeCatalogParameterPolicy(item)
 
   return html`
     <div class="set-rt" data-testid="runtime-catalog-card">
@@ -274,6 +289,9 @@ function RuntimeCatalogCard({
         <${RuntimeCatalogCapability} label="tools" value=${item.tools_support} />
         <${RuntimeCatalogCapability} label="thinking" value=${item.thinking_support} />
         <${RuntimeCatalogCapability} label="streaming" value=${item.streaming} />
+        ${parameterPolicy
+          ? html`<span class="rt-cap tcf mono" title=${parameterPolicy}>${parameterPolicy}</span>`
+          : null}
       </div>
       <div class="set-rt-row">
         <span class="sub-k">transport</span>

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -269,6 +269,39 @@ function runtimeCatalogRequestConfig(item: DashboardRuntimeProviderSnapshot): st
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapshot): string | null {
+  const spec = item.declared_spec
+  if (!spec) return null
+  const caps = spec.model?.capabilities
+  const sampling = [
+    caps?.supports_top_k ? 'top_k' : null,
+    caps?.supports_min_p ? 'min_p' : null,
+    caps?.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const formats = [
+    caps?.supports_response_format_json ? 'json' : null,
+    caps?.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  let thinking: string | null = null
+  if (typeof spec.model?.thinking_support === 'boolean') {
+    thinking = spec.model.thinking_support ? 'think:on' : 'think:off'
+  }
+  const parts = [
+    spec.provider?.api_format ? `api:${spec.provider.api_format}` : null,
+    spec.provider?.protocol ? `protocol:${spec.provider.protocol}` : null,
+    typeof spec.model?.max_context === 'number' ? `ctx:${spec.model.max_context}` : null,
+    thinking,
+    caps?.thinking_control_format ? `wire:${caps.thinking_control_format}` : null,
+    typeof caps?.max_output_tokens === 'number' ? `out:${caps.max_output_tokens}` : null,
+    formats.length > 0 ? `format:${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+    typeof spec.binding?.max_concurrent === 'number' ? `concurrency:${spec.binding.max_concurrent}` : null,
+    spec.binding?.keep_alive ? `keep:${spec.binding.keep_alive}` : null,
+    typeof spec.binding?.num_ctx === 'number' ? `num_ctx:${spec.binding.num_ctx}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnapshot): string | null {
   const caps = item.effective_capabilities
   if (!caps) return null
@@ -332,6 +365,7 @@ function RuntimeCatalogCard({
   const effectiveCapabilities = runtimeCatalogEffectiveCapabilities(item)
   const parameterPolicy = runtimeCatalogParameterPolicy(item)
   const requestConfig = runtimeCatalogRequestConfig(item)
+  const declaredSpec = runtimeCatalogDeclaredSpec(item)
 
   return html`
     <div class="set-rt" data-testid="runtime-catalog-card">
@@ -365,6 +399,9 @@ function RuntimeCatalogCard({
           : null}
         ${requestConfig
           ? html`<span class="rt-cap tcf mono" title=${requestConfig}>${requestConfig}</span>`
+          : null}
+        ${declaredSpec
+          ? html`<span class="rt-cap tcf mono" title=${declaredSpec}>declared:${declaredSpec}</span>`
           : null}
       </div>
       <div class="set-rt-row">

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -228,6 +228,47 @@ function runtimeCatalogParameterPolicy(item: DashboardRuntimeProviderSnapshot): 
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeCatalogRequestToolChoice(item: DashboardRuntimeProviderSnapshot): string | null {
+  const choice = item.request_config?.tool_choice
+  if (!choice?.kind) return null
+  return choice.name ? `${choice.kind}:${choice.name}` : choice.kind
+}
+
+function runtimeCatalogRequestFormat(item: DashboardRuntimeProviderSnapshot): string | null {
+  const format = item.request_config?.response_format
+  if (!format?.kind) return null
+  return format.has_schema ? `${format.kind}+schema` : format.kind
+}
+
+function runtimeCatalogRequestConfig(item: DashboardRuntimeProviderSnapshot): string | null {
+  const request = item.request_config
+  if (!request) return null
+  const sampling = [
+    typeof request.temperature === 'number' ? `temp:${request.temperature}` : null,
+    typeof request.top_p === 'number' ? `top_p:${request.top_p}` : null,
+    typeof request.top_k === 'number' ? `top_k:${request.top_k}` : null,
+    typeof request.min_p === 'number' ? `min_p:${request.min_p}` : null,
+  ].filter((value): value is string => Boolean(value))
+  const toolChoice = runtimeCatalogRequestToolChoice(item)
+  const format = runtimeCatalogRequestFormat(item)
+  const parts = [
+    request.provider_kind ? `kind:${request.provider_kind}` : null,
+    request.request_path_targets_responses_api ? 'responses-api' : null,
+    typeof request.max_tokens === 'number' ? `out:${request.max_tokens}` : null,
+    typeof request.max_context === 'number' ? `ctx:${request.max_context}` : null,
+    sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+    typeof request.enable_thinking === 'boolean' ? `think:${request.enable_thinking ? 'on' : 'off'}` : null,
+    request.resolved_reasoning_effort ? `effort:${request.resolved_reasoning_effort}` : null,
+    toolChoice ? `tool:${toolChoice}` : null,
+    request.disable_parallel_tool_use ? 'parallel:off' : null,
+    format ? `format:${format}` : null,
+    typeof request.seed === 'number' ? `seed:${request.seed}` : null,
+    typeof request.num_ctx === 'number' ? `num_ctx:${request.num_ctx}` : null,
+    request.keep_alive ? `keep:${request.keep_alive}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnapshot): string | null {
   const caps = item.effective_capabilities
   if (!caps) return null
@@ -290,6 +331,7 @@ function RuntimeCatalogCard({
   const isDefault = runtimeId === (defaultRuntimeId ?? '')
   const effectiveCapabilities = runtimeCatalogEffectiveCapabilities(item)
   const parameterPolicy = runtimeCatalogParameterPolicy(item)
+  const requestConfig = runtimeCatalogRequestConfig(item)
 
   return html`
     <div class="set-rt" data-testid="runtime-catalog-card">
@@ -320,6 +362,9 @@ function RuntimeCatalogCard({
           : null}
         ${parameterPolicy
           ? html`<span class="rt-cap tcf mono" title=${parameterPolicy}>${parameterPolicy}</span>`
+          : null}
+        ${requestConfig
+          ? html`<span class="rt-cap tcf mono" title=${requestConfig}>${requestConfig}</span>`
           : null}
       </div>
       <div class="set-rt-row">

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1447,6 +1447,30 @@ let thinking_control_format_wire : Runtime_schema.thinking_control_format -> str
   | Runtime_schema.Enable_thinking -> "enable-thinking"
 ;;
 
+let runtime_parameter_policy_json (rt : Runtime.t) =
+  let module RD = Llm_provider.Reasoning_dialect in
+  let dialect = RD.for_provider_config rt.provider_config in
+  let sampling_candidates = RD.sampling_params_ignored_when_thinking dialect in
+  let ignored_sampling_params =
+    List.filter
+      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:None field)
+      sampling_candidates
+  in
+  let always_ignored_sampling_params =
+    List.filter
+      (fun field -> RD.ignores_sampling_param dialect ~enable_thinking:(Some false) field)
+      sampling_candidates
+  in
+  `Assoc
+    [ "reasoning_toggle_wire", `String (RD.toggle_wire_to_string dialect.toggle_wire)
+    ; "reasoning_replay_policy", `String (RD.replay_policy_to_string dialect.replay_policy)
+    ; "requires_reasoning_replay_on_tool_call", `Bool (RD.requires_reasoning_replay_on_tool_call dialect)
+    ; "ignored_sampling_params", Json_util.json_string_list ignored_sampling_params
+    ; ( "always_ignored_sampling_params"
+      , Json_util.json_string_list always_ignored_sampling_params )
+    ]
+;;
+
 let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
   let runtime_kind = runtime_kind_of_transport rt.provider.transport in
   let models = [ rt.model.api_name ] in
@@ -1494,6 +1518,7 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "supports_image_input", `Bool caps.supports_image_input
     ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
     ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
+    ; "parameter_policy", runtime_parameter_policy_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models
     ; "source", `String runtime_inventory_source

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1497,6 +1497,69 @@ let task_json : Llm_provider.Capabilities.task option -> Yojson.Safe.t = functio
   | Some Video_generation -> `String "video-generation"
 ;;
 
+let tool_choice_json : Llm_provider.Types.tool_choice option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some Llm_provider.Types.Auto -> `Assoc [ "kind", `String "auto" ]
+  | Some Llm_provider.Types.Any -> `Assoc [ "kind", `String "required" ]
+  | Some Llm_provider.Types.None_ -> `Assoc [ "kind", `String "none" ]
+  | Some (Llm_provider.Types.Tool name) ->
+    `Assoc [ "kind", `String "tool"; "name", `String name ]
+;;
+
+let response_format_json : Llm_provider.Types.response_format -> Yojson.Safe.t = function
+  | Llm_provider.Types.Off -> `Assoc [ "kind", `String "off"; "has_schema", `Bool false ]
+  | Llm_provider.Types.JsonMode ->
+    `Assoc [ "kind", `String "json_mode"; "has_schema", `Bool false ]
+  | Llm_provider.Types.JsonSchema _ ->
+    `Assoc [ "kind", `String "json_schema"; "has_schema", `Bool true ]
+;;
+
+let runtime_request_config_json (rt : Runtime.t) =
+  let cfg = rt.provider_config in
+  `Assoc
+    [ "source", `String "oas-provider-config"
+    ; "provider_kind", `String (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
+    ; "request_path", `String cfg.request_path
+    ; ( "request_path_targets_responses_api"
+      , `Bool (Llm_provider.Provider_config.request_path_targets_responses_api cfg.request_path)
+      )
+    ; "max_tokens", Json_util.int_opt_to_json cfg.max_tokens
+    ; "max_context", Json_util.int_opt_to_json cfg.max_context
+    ; "temperature", Json_util.float_opt_to_json cfg.temperature
+    ; "top_p", Json_util.float_opt_to_json cfg.top_p
+    ; "top_k", Json_util.int_opt_to_json cfg.top_k
+    ; "min_p", Json_util.float_opt_to_json cfg.min_p
+    ; "has_system_prompt", `Bool (Option.is_some cfg.system_prompt)
+    ; "enable_thinking", Json_util.bool_opt_to_json cfg.enable_thinking
+    ; "preserve_thinking", Json_util.bool_opt_to_json cfg.preserve_thinking
+    ; "thinking_budget", Json_util.int_opt_to_json cfg.thinking_budget
+    ; "clear_thinking", Json_util.bool_opt_to_json cfg.clear_thinking
+    ; ( "resolved_reasoning_effort"
+      , Json_util.string_opt_to_json
+          (Llm_provider.Provider_config.reasoning_effort_request_value
+             ~enable_thinking:cfg.enable_thinking
+             ~thinking_budget:cfg.thinking_budget) )
+    ; "glm_clear_thinking", `Bool (Llm_provider.Provider_config.glm_clear_thinking cfg)
+    ; "glm_replay_reasoning", `Bool (Llm_provider.Provider_config.glm_should_replay_reasoning cfg)
+    ; "tool_stream", `Bool cfg.tool_stream
+    ; "tool_choice", tool_choice_json cfg.tool_choice
+    ; "disable_parallel_tool_use", `Bool cfg.disable_parallel_tool_use
+    ; "response_format", response_format_json cfg.response_format
+    ; "has_output_schema", `Bool (Option.is_some cfg.output_schema)
+    ; "cache_system_prompt", `Bool cfg.cache_system_prompt
+    ; "supports_tool_choice_override", Json_util.bool_opt_to_json cfg.supports_tool_choice_override
+    ; ( "supports_structured_output_override"
+      , Json_util.bool_opt_to_json cfg.supports_structured_output_override )
+    ; "has_model_capabilities_override", `Bool (Option.is_some cfg.model_capabilities_override)
+    ; "keep_alive", Json_util.string_opt_to_json cfg.keep_alive
+    ; "internal_model_rotation_count", Json_util.int_opt_to_json cfg.internal_model_rotation_count
+    ; "num_ctx", Json_util.int_opt_to_json cfg.num_ctx
+    ; "seed", Json_util.int_opt_to_json cfg.seed
+    ; "has_previous_response_id", `Bool (Option.is_some cfg.previous_response_id)
+    ; "connect_timeout_s", Json_util.float_opt_to_json cfg.connect_timeout_s
+    ]
+;;
+
 let effective_capabilities_json (rt : Runtime.t) =
   match Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config with
   | None -> `Null
@@ -1634,6 +1697,7 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
     ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
+    ; "request_config", runtime_request_config_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models
     ; "source", `String runtime_inventory_source

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1560,6 +1560,110 @@ let runtime_request_config_json (rt : Runtime.t) =
     ]
 ;;
 
+let runtime_api_format_wire : Runtime_schema.api_format -> string = function
+  | Runtime_schema.Messages_api -> "messages"
+  | Runtime_schema.Chat_completions_api -> "chat-completions"
+  | Runtime_schema.Ollama_api -> "ollama"
+;;
+
+let runtime_provider_behavior_capabilities_json
+    (capabilities : Runtime_schema.capabilities option) =
+  match capabilities with
+  | None -> `Null
+  | Some caps ->
+    `Assoc
+      [ "supports_inline_tools", `Bool caps.supports_inline_tools
+      ; ( "requires_per_keeper_bridging_for_bound_actor_tools"
+        , `Bool caps.requires_per_keeper_bridging_for_bound_actor_tools )
+      ; ( "identity_runtime_mcp_header_keys"
+        , Json_util.json_string_list caps.identity_runtime_mcp_header_keys )
+      ; "argv_prompt_preflight", `Bool caps.argv_prompt_preflight
+      ; "uses_anthropic_caching", `Bool caps.uses_anthropic_caching
+      ; "max_turns_per_attempt", Json_util.int_opt_to_json caps.max_turns_per_attempt
+      ; "tolerates_bound_actor_fallback", `Bool caps.tolerates_bound_actor_fallback
+      ]
+;;
+
+let runtime_declared_model_capabilities_json
+    (capabilities : Runtime_schema.model_capabilities option) =
+  match capabilities with
+  | None -> `Null
+  | Some caps ->
+    `Assoc
+      [ "source", `String runtime_inventory_source
+      ; "max_output_tokens", Json_util.int_opt_to_json caps.max_output_tokens
+      ; "supports_tool_choice", `Bool caps.supports_tool_choice
+      ; "supports_extended_thinking", `Bool caps.supports_extended_thinking
+      ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
+      ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
+      ; "supports_image_input", `Bool caps.supports_image_input
+      ; "supports_audio_input", `Bool caps.supports_audio_input
+      ; "supports_video_input", `Bool caps.supports_video_input
+      ; "supports_multimodal_inputs", `Bool caps.supports_multimodal_inputs
+      ; "supports_response_format_json", `Bool caps.supports_response_format_json
+      ; "supports_structured_output", `Bool caps.supports_structured_output
+      ; "supports_native_streaming", `Bool caps.supports_native_streaming
+      ; "supports_caching", `Bool caps.supports_caching
+      ; "supports_prompt_caching", `Bool caps.supports_prompt_caching
+      ; "prompt_cache_alignment", Json_util.int_opt_to_json caps.prompt_cache_alignment
+      ; "supports_top_k", `Bool caps.supports_top_k
+      ; "supports_min_p", `Bool caps.supports_min_p
+      ; "supports_seed", `Bool caps.supports_seed
+      ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
+      ; "supports_computer_use", `Bool caps.supports_computer_use
+      ]
+;;
+
+let runtime_declared_spec_json (rt : Runtime.t) =
+  `Assoc
+    [ "source", `String runtime_inventory_source
+    ; ( "provider"
+      , `Assoc
+          [ "id", `String rt.provider.id
+          ; "display_name", `String rt.provider.display_name
+          ; "protocol", `String rt.provider.protocol
+          ; "api_format", `String (runtime_api_format_wire rt.provider.api_format)
+          ; "transport", `String (runtime_transport_string rt.provider.transport)
+          ; "auth_kind", `String (runtime_auth_kind_of_credential rt.provider.credentials)
+          ; "is_non_interactive", `Bool rt.provider.is_non_interactive
+          ; "has_capabilities", `Bool (Option.is_some rt.provider.capabilities)
+          ; ( "behavior_capabilities"
+            , runtime_provider_behavior_capabilities_json rt.provider.capabilities )
+          ; ( "custom_header_count"
+            , `Int
+                (rt.provider.headers
+                 |> Option.map List.length
+                 |> Option.value ~default:0) )
+          ; "connect_timeout_s", Json_util.float_opt_to_json rt.provider.connect_timeout_s
+          ] )
+    ; ( "model"
+      , `Assoc
+          [ "id", `String rt.model.id
+          ; "api_name", `String rt.model.api_name
+          ; "tools_support", `Bool rt.model.tools_support
+          ; "max_context", `Int rt.model.max_context
+          ; "thinking_support", `Bool rt.model.thinking_support
+          ; "preserve_thinking", Json_util.bool_opt_to_json rt.model.preserve_thinking
+          ; "max_thinking_budget", Json_util.int_opt_to_json rt.model.max_thinking_budget
+          ; "streaming", `Bool rt.model.streaming
+          ; "temperature", Json_util.float_opt_to_json rt.model.temperature
+          ; "capabilities", runtime_declared_model_capabilities_json rt.model.capabilities
+          ; "match_prefixes", Json_util.json_string_list rt.model.match_prefixes
+          ] )
+    ; ( "binding"
+      , `Assoc
+          [ "provider_id", `String rt.binding.provider_id
+          ; "model_id", `String rt.binding.model_id
+          ; "is_default", `Bool rt.binding.is_default
+          ; "max_concurrent", Json_util.int_opt_to_json rt.binding.max_concurrent
+          ; "price_input", Json_util.float_opt_to_json rt.binding.price_input
+          ; "price_output", Json_util.float_opt_to_json rt.binding.price_output
+          ; "keep_alive", Json_util.string_opt_to_json rt.binding.keep_alive
+          ; "num_ctx", Json_util.int_opt_to_json rt.binding.num_ctx
+          ] )
+    ]
+;;
+
 let effective_capabilities_json (rt : Runtime.t) =
   match Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config with
   | None -> `Null
@@ -1698,6 +1802,7 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "request_config", runtime_request_config_json rt
+    ; "declared_spec", runtime_declared_spec_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models
     ; "source", `String runtime_inventory_source

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1631,9 +1631,9 @@ let runtime_declared_spec_json (rt : Runtime.t) =
             , runtime_provider_behavior_capabilities_json rt.provider.capabilities )
           ; ( "custom_header_count"
             , `Int
-                (rt.provider.headers
-                 |> Option.map List.length
-                 |> Option.value ~default:0) )
+                (match rt.provider.headers with
+                 | None -> 0
+                 | Some headers -> List.length headers) )
           ; "connect_timeout_s", Json_util.float_opt_to_json rt.provider.connect_timeout_s
           ] )
     ; ( "model"

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1447,6 +1447,120 @@ let thinking_control_format_wire : Runtime_schema.thinking_control_format -> str
   | Runtime_schema.Enable_thinking -> "enable-thinking"
 ;;
 
+let preserve_thinking_control_format_wire
+  : Llm_provider.Capabilities.preserve_thinking_control_format -> string
+  = function
+  | No_preserve_thinking_control -> "none"
+  | Thinking_object_keep_all -> "thinking-object-keep-all"
+  | Chat_template_kwargs_preserve_thinking -> "chat-template-kwargs-preserve-thinking"
+  | Top_level_preserve_thinking -> "top-level-preserve-thinking"
+  | Always_preserved_thinking -> "always-preserved-thinking"
+;;
+
+let assistant_tool_content_format_wire
+  : Llm_provider.Capabilities.assistant_tool_content_format -> string
+  = function
+  | Assistant_tool_content_null -> "null"
+  | Assistant_tool_content_empty_string -> "empty-string"
+;;
+
+let reasoning_output_format_wire : Llm_provider.Capabilities.reasoning_output_format -> string =
+  function
+  | No_reasoning_output_format -> "none"
+  | Split_reasoning_fields -> "split-reasoning-fields"
+;;
+
+let reasoning_streaming_format_json
+  : Llm_provider.Capabilities.reasoning_streaming_format -> Yojson.Safe.t
+  = function
+  | Default_reasoning_streaming -> `Assoc [ "kind", `String "default" ]
+  | No_reasoning_streaming -> `Assoc [ "kind", `String "none" ]
+  | Delta_reasoning_field field ->
+    `Assoc [ "kind", `String "delta-reasoning-field"; "field", `String field ]
+  | Template_reasoning_streaming -> `Assoc [ "kind", `String "template" ]
+;;
+
+let reasoning_replay_override_wire
+  : Llm_provider.Capabilities.reasoning_replay_override -> string
+  = function
+  | Default_reasoning_replay -> "default"
+  | Force_no_replay -> "force-no-replay"
+  | Force_drop_without_tool_preserve_with_tool -> "drop-without-tool-preserve-with-tool"
+  | Force_preserve_always -> "preserve-always"
+;;
+
+let task_json : Llm_provider.Capabilities.task option -> Yojson.Safe.t = function
+  | None -> `Null
+  | Some Transcription -> `String "transcription"
+  | Some Speech -> `String "speech"
+  | Some Image_generation -> `String "image-generation"
+  | Some Video_generation -> `String "video-generation"
+;;
+
+let effective_capabilities_json (rt : Runtime.t) =
+  match Llm_provider.Provider_config.capabilities_for_config_model rt.provider_config with
+  | None -> `Null
+  | Some caps ->
+    let accepted_reasoning_efforts =
+      match caps.accepted_reasoning_efforts with
+      | None -> `Null
+      | Some efforts ->
+        efforts
+        |> List.map Llm_provider.Reasoning_effort.to_string
+        |> Json_util.json_string_list
+    in
+    let supported_models =
+      match caps.supported_models with
+      | None -> `Null
+      | Some models -> Json_util.json_string_list models
+    in
+    `Assoc
+      [ "source", `String "oas-provider-config-model"
+      ; "max_context_tokens", Json_util.int_opt_to_json caps.max_context_tokens
+      ; "max_output_tokens", Json_util.int_opt_to_json caps.max_output_tokens
+      ; "supports_tools", `Bool caps.supports_tools
+      ; "supports_tool_choice", `Bool caps.supports_tool_choice
+      ; "supports_required_tool_choice", `Bool caps.supports_required_tool_choice
+      ; "supports_named_tool_choice", `Bool caps.supports_named_tool_choice
+      ; "supports_parallel_tool_calls", `Bool caps.supports_parallel_tool_calls
+      ; "supports_runtime_mcp_tools", `Bool caps.supports_runtime_mcp_tools
+      ; "supports_runtime_tool_events", `Bool caps.supports_runtime_tool_events
+      ; ( "assistant_tool_content_format"
+        , `String (assistant_tool_content_format_wire caps.assistant_tool_content_format) )
+      ; "supports_reasoning", `Bool caps.supports_reasoning
+      ; "supports_extended_thinking", `Bool caps.supports_extended_thinking
+      ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
+      ; "accepted_reasoning_efforts", accepted_reasoning_efforts
+      ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
+      ; ( "preserve_thinking_control_format"
+        , `String (preserve_thinking_control_format_wire caps.preserve_thinking_control_format)
+        )
+      ; "reasoning_output_format", `String (reasoning_output_format_wire caps.reasoning_output_format)
+      ; "reasoning_streaming_format", reasoning_streaming_format_json caps.reasoning_streaming_format
+      ; "reasoning_replay_override", `String (reasoning_replay_override_wire caps.reasoning_replay_override)
+      ; "supports_response_format_json", `Bool caps.supports_response_format_json
+      ; "supports_structured_output", `Bool caps.supports_structured_output
+      ; "supports_multimodal_inputs", `Bool caps.supports_multimodal_inputs
+      ; "supports_image_input", `Bool caps.supports_image_input
+      ; "supports_audio_input", `Bool caps.supports_audio_input
+      ; "supports_video_input", `Bool caps.supports_video_input
+      ; "task", task_json caps.task
+      ; "supports_native_streaming", `Bool caps.supports_native_streaming
+      ; "supports_system_prompt", `Bool caps.supports_system_prompt
+      ; "supports_caching", `Bool caps.supports_caching
+      ; "supports_prompt_caching", `Bool caps.supports_prompt_caching
+      ; "prompt_cache_alignment", Json_util.int_opt_to_json caps.prompt_cache_alignment
+      ; "supports_top_k", `Bool caps.supports_top_k
+      ; "supports_min_p", `Bool caps.supports_min_p
+      ; "supports_seed", `Bool caps.supports_seed
+      ; "supports_seed_with_images", `Bool caps.supports_seed_with_images
+      ; "supports_computer_use", `Bool caps.supports_computer_use
+      ; "supports_code_execution", `Bool caps.supports_code_execution
+      ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
+      ; "supported_models", supported_models
+      ]
+;;
+
 let runtime_parameter_policy_json (rt : Runtime.t) =
   let module RD = Llm_provider.Reasoning_dialect in
   let dialect = RD.for_provider_config rt.provider_config in
@@ -1518,6 +1632,7 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
     ; "supports_image_input", `Bool caps.supports_image_input
     ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
     ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
+    ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "model_count", `Int (List.length models)
     ; "models", Json_util.json_string_list models

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -918,14 +918,26 @@ let runtime_thinking_model_catalog =
 id_prefix = "openai_compat/qwen36-35b-a3b-mtp"
 base = "openai_chat"
 max_context_tokens = 131072
+max_output_tokens = 65536
 supports_tools = true
 supports_tool_choice = true
+supports_required_tool_choice = true
+supports_parallel_tool_calls = true
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
+accepted_reasoning_efforts = ["low", "medium", "high"]
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_output_format = "split_reasoning_fields"
+reasoning_streaming_format = "delta:reasoning_content"
+supports_response_format_json = true
+supports_structured_output = true
 supports_native_streaming = true
+supports_prompt_caching = true
+supports_top_k = true
+supports_min_p = true
+supports_seed = true
 
 [[models]]
 id_prefix = "openai_compat/reasoning-small-out"
@@ -1037,6 +1049,48 @@ let test_runtime_inventory_surfaces_parameter_policy () =
       "always ignored sampling params empty"
       0
       (policy |> J.member "always_ignored_sampling_params" |> J.to_list |> List.length))
+;;
+
+let test_runtime_inventory_surfaces_effective_capabilities () =
+  with_runtime_thinking (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let thinkdefault =
+      List.find
+        (fun provider ->
+           String.equal
+             "ollama_cloud.thinkdefault"
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let caps = thinkdefault |> J.member "effective_capabilities" in
+    Alcotest.(check string)
+      "effective capability source"
+      "oas-provider-config-model"
+      (caps |> J.member "source" |> J.to_string);
+    Alcotest.(check int)
+      "effective max output"
+      65536
+      (caps |> J.member "max_output_tokens" |> J.to_int);
+    Alcotest.(check bool)
+      "parallel tool calls"
+      true
+      (caps |> J.member "supports_parallel_tool_calls" |> J.to_bool);
+    Alcotest.(check (list string))
+      "accepted reasoning efforts"
+      [ "low"; "medium"; "high" ]
+      (caps
+       |> J.member "accepted_reasoning_efforts"
+       |> J.to_list
+       |> List.map J.to_string);
+    Alcotest.(check string)
+      "reasoning streaming field"
+      "reasoning_content"
+      (caps |> J.member "reasoning_streaming_format" |> J.member "field" |> J.to_string);
+    Alcotest.(check bool)
+      "top_k"
+      true
+      (caps |> J.member "supports_top_k" |> J.to_bool))
 ;;
 
 let test_thinking_unknown_runtime_defers () =
@@ -1486,6 +1540,10 @@ let () =
             "runtime inventory surfaces OAS parameter policy"
             `Quick
             test_runtime_inventory_surfaces_parameter_policy
+        ; Alcotest.test_case
+            "runtime inventory surfaces OAS effective capabilities"
+            `Quick
+            test_runtime_inventory_surfaces_effective_capabilities
         ; Alcotest.test_case
             "unknown runtime id defers (None)"
             `Quick

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1093,6 +1093,63 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
       (caps |> J.member "supports_top_k" |> J.to_bool))
 ;;
 
+let test_runtime_inventory_surfaces_request_config () =
+  with_runtime_thinking (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let thinkdefault =
+      List.find
+        (fun provider ->
+           String.equal
+             "ollama_cloud.thinkdefault"
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let request = thinkdefault |> J.member "request_config" in
+    Alcotest.(check string)
+      "request config source"
+      "oas-provider-config"
+      (request |> J.member "source" |> J.to_string);
+    Alcotest.(check string)
+      "provider kind"
+      "openai_compat"
+      (request |> J.member "provider_kind" |> J.to_string);
+    Alcotest.(check string)
+      "request path"
+      "/chat/completions"
+      (request |> J.member "request_path" |> J.to_string);
+    Alcotest.(check bool)
+      "not responses api"
+      false
+      (request |> J.member "request_path_targets_responses_api" |> J.to_bool);
+    Alcotest.(check int)
+      "request max context"
+      128000
+      (request |> J.member "max_context" |> J.to_int);
+    Alcotest.(check string)
+      "response format kind"
+      "off"
+      (request |> J.member "response_format" |> J.member "kind" |> J.to_string);
+    Alcotest.(check bool)
+      "no output schema body exposed"
+      false
+      (request |> J.member "has_output_schema" |> J.to_bool);
+    Alcotest.(check bool)
+      "no model capabilities override on provider_config"
+      false
+      (request |> J.member "has_model_capabilities_override" |> J.to_bool);
+    (match request with
+     | `Assoc fields ->
+       List.iter
+         (fun secret_key ->
+            Alcotest.(check bool)
+              ("secret key omitted: " ^ secret_key)
+              false
+              (List.mem_assoc secret_key fields))
+         [ "api_key"; "headers"; "system_prompt"; "output_schema"; "previous_response_id" ]
+     | _ -> Alcotest.fail "request_config must be an object"))
+;;
+
 let test_thinking_unknown_runtime_defers () =
   with_runtime_thinking (fun () ->
     let seed = Runtime_inference.for_runtime ~name:"bogus.binding" in
@@ -1544,6 +1601,10 @@ let () =
             "runtime inventory surfaces OAS effective capabilities"
             `Quick
             test_runtime_inventory_surfaces_effective_capabilities
+        ; Alcotest.test_case
+            "runtime inventory surfaces OAS request config"
+            `Quick
+            test_runtime_inventory_surfaces_request_config
         ; Alcotest.test_case
             "unknown runtime id defers (None)"
             `Quick

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1150,6 +1150,95 @@ let test_runtime_inventory_surfaces_request_config () =
      | _ -> Alcotest.fail "request_config must be an object"))
 ;;
 
+let test_runtime_inventory_surfaces_declared_spec () =
+  with_runtime_thinking (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let thinkdefault =
+      List.find
+        (fun provider ->
+           String.equal
+             "ollama_cloud.thinkdefault"
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let spec = thinkdefault |> J.member "declared_spec" in
+    let provider = spec |> J.member "provider" in
+    let model = spec |> J.member "model" in
+    let binding = spec |> J.member "binding" in
+    Alcotest.(check string)
+      "declared spec source"
+      "runtime.toml"
+      (spec |> J.member "source" |> J.to_string);
+    Alcotest.(check string)
+      "provider id"
+      "ollama_cloud"
+      (provider |> J.member "id" |> J.to_string);
+    Alcotest.(check string)
+      "api format"
+      "chat-completions"
+      (provider |> J.member "api_format" |> J.to_string);
+    Alcotest.(check string)
+      "transport"
+      "http"
+      (provider |> J.member "transport" |> J.to_string);
+    Alcotest.(check bool)
+      "provider capabilities absent"
+      false
+      (provider |> J.member "has_capabilities" |> J.to_bool);
+    (match provider |> J.member "behavior_capabilities" with
+     | `Null -> ()
+     | _ -> Alcotest.fail "absent provider capabilities must remain null");
+    Alcotest.(check int)
+      "custom header count"
+      0
+      (provider |> J.member "custom_header_count" |> J.to_int);
+    Alcotest.(check string)
+      "model id"
+      "thinkdefault"
+      (model |> J.member "id" |> J.to_string);
+    Alcotest.(check string)
+      "model api name"
+      "qwen36-35b-a3b-mtp"
+      (model |> J.member "api_name" |> J.to_string);
+    Alcotest.(check int)
+      "declared max context"
+      128000
+      (model |> J.member "max_context" |> J.to_int);
+    Alcotest.(check bool)
+      "declared thinking support"
+      true
+      (model |> J.member "thinking_support" |> J.to_bool);
+    (match model |> J.member "capabilities" with
+     | `Null -> ()
+     | _ -> Alcotest.fail "absent model capabilities must remain null");
+    Alcotest.(check string)
+      "binding provider id"
+      "ollama_cloud"
+      (binding |> J.member "provider_id" |> J.to_string);
+    Alcotest.(check string)
+      "binding model id"
+      "thinkdefault"
+      (binding |> J.member "model_id" |> J.to_string);
+    Alcotest.(check int)
+      "binding max concurrency"
+      1
+      (binding |> J.member "max_concurrent" |> J.to_int);
+    (match binding |> J.member "keep_alive", binding |> J.member "num_ctx" with
+     | `Null, `Null -> ()
+     | _ -> Alcotest.fail "unset binding keep_alive/num_ctx must remain null");
+    (match provider with
+     | `Assoc fields ->
+       List.iter
+         (fun secret_key ->
+            Alcotest.(check bool)
+              ("declared provider secret omitted: " ^ secret_key)
+              false
+              (List.mem_assoc secret_key fields))
+         [ "credentials"; "headers"; "endpoint_url" ]
+     | _ -> Alcotest.fail "declared_spec provider must be an object"))
+;;
+
 let test_thinking_unknown_runtime_defers () =
   with_runtime_thinking (fun () ->
     let seed = Runtime_inference.for_runtime ~name:"bogus.binding" in
@@ -1605,6 +1694,10 @@ let () =
             "runtime inventory surfaces OAS request config"
             `Quick
             test_runtime_inventory_surfaces_request_config
+        ; Alcotest.test_case
+            "runtime inventory surfaces declared spec"
+            `Quick
+            test_runtime_inventory_surfaces_declared_spec
         ; Alcotest.test_case
             "unknown runtime id defers (None)"
             `Quick

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1004,6 +1004,41 @@ let test_thinking_support_false_forces_off () =
       seed.Runtime_inference.thinking_enabled)
 ;;
 
+let test_runtime_inventory_surfaces_parameter_policy () =
+  with_runtime_thinking (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let thinkdefault =
+      List.find
+        (fun provider ->
+           String.equal
+             "ollama_cloud.thinkdefault"
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let policy = thinkdefault |> J.member "parameter_policy" in
+    Alcotest.(check string)
+      "reasoning toggle wire"
+      "chat_template_kwargs"
+      (policy |> J.member "reasoning_toggle_wire" |> J.to_string);
+    Alcotest.(check string)
+      "reasoning replay policy"
+      "no_replay"
+      (policy |> J.member "reasoning_replay_policy" |> J.to_string);
+    Alcotest.(check bool)
+      "no tool replay requirement"
+      false
+      (policy |> J.member "requires_reasoning_replay_on_tool_call" |> J.to_bool);
+    Alcotest.(check int)
+      "ignored sampling params empty"
+      0
+      (policy |> J.member "ignored_sampling_params" |> J.to_list |> List.length);
+    Alcotest.(check int)
+      "always ignored sampling params empty"
+      0
+      (policy |> J.member "always_ignored_sampling_params" |> J.to_list |> List.length))
+;;
+
 let test_thinking_unknown_runtime_defers () =
   with_runtime_thinking (fun () ->
     let seed = Runtime_inference.for_runtime ~name:"bogus.binding" in
@@ -1447,6 +1482,10 @@ let () =
             "thinking-support=false forces thinking off (Some false)"
             `Quick
             test_thinking_support_false_forces_off
+        ; Alcotest.test_case
+            "runtime inventory surfaces OAS parameter policy"
+            `Quick
+            test_runtime_inventory_surfaces_parameter_policy
         ; Alcotest.test_case
             "unknown runtime id defers (None)"
             `Quick


### PR DESCRIPTION
## Summary
- add `parameter_policy` to the runtime inventory JSON using OAS `Llm_provider.Reasoning_dialect` as the policy source
- add `effective_capabilities` to the runtime inventory JSON from OAS `Provider_config.capabilities_for_config_model`
- decode and expose provider/model capability axes in dashboard runtime API types
- show reasoning wire/replay, ignored sampling params, output limit, tool choice, structured/json, sampling, and modality summaries in runtime monitor, settings catalog, and keeper workspace rail
- cover backend inventory output and dashboard decoder behavior with focused tests

## Why
Provider/model prompting behavior is not uniform across GLM, Kimi, OpenAI, Claude, Gemini, Ollama, and compatible endpoints. The dashboard needs to show the actual runtime parameter and capability policy without duplicating provider heuristics in MASC.

## Validation
- `ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_per_keeper_routing.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe`
- `_build/default/test/test_runtime_per_keeper_routing.exe test "per-model thinking gate" --color=never --show-errors`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/api/dashboard-runtime.ts src/api/dashboard.ts src/components/runtime-monitor.ts src/components/settings-surface.ts src/components/keeper-workspace/keeper-workspace-rail.ts`