### PR TITLE
ci: extend build test job timeout budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,7 +571,11 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Keep the job budget above the sum of cold dune build time and the
+    # quick-suite step timeout. On 2026-07-04, PRs #23060/#23121 built
+    # successfully but cancelled during quick suite after ~42-43m builds,
+    # so a 60m job cap left less time than the suite's own 25m bound.
+    timeout-minutes: 90
     needs: [pr-live-gate, changes]
     # Main-push safety-net (mirrors `dashboard` job below). Non-PR events
     # (branch push to main/develop, workflow_dispatch) always run Build and Test


### PR DESCRIPTION
## Summary
- Raise Build and Test job timeout from 60m to 90m.
- Keep the quick-suite step timeout unchanged at 25m.

## Evidence
- #23060 rerun 28693222192 attempt 2: Build succeeded, quick suite was cancelled, downstream operator/SSE/transport/contract harnesses passed, and CI Gate failed from BUILD_RESULT=cancelled.
- #23121 run 28693671533: same shape after a 42-43m cold build left less than the quick-suite budget before the 60m job cap.

## Validation
- python3 yaml.safe_load(.github/workflows/ci.yml)
- git diff --check
- Local Dune build/test intentionally not run; GitHub CI is the build authority for this task.