### PR TITLE
fix(governance): HITL 컨텍스트 요약을 대시보드에 전달 (#23112 후속)

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -246,6 +246,86 @@ describe('normalizeKeeperApprovalQueueItem', () => {
     expect(result!.waiting_s).toBe(30)
     expect(result!.input_preview).toBe('ls -la')
   })
+
+  const baseItem = {
+    id: 'q-summary',
+    keeper_name: 'janitor',
+    tool_name: 'shell_exec',
+    risk_level: 'high' as const,
+  }
+
+  it('parses an available summary into the typed union', () => {
+    const result = normalizeKeeperApprovalQueueItem({
+      ...baseItem,
+      summary_status: {
+        status: 'available',
+        summary: {
+          summary_version: 2,
+          generated_at_iso: '2026-07-04T00:00:00Z',
+          model_run_id: 'run-9',
+          context_summary: 'This deletes the production config.',
+          key_questions: ['Is there a backup?'],
+          suggested_options: [
+            { label: 'Reject', rationale: 'irreversible', estimated_risk_delta: 'critical' },
+          ],
+          risk_rationale: 'writes outside sandbox',
+          uncertainty: 0.4,
+        },
+      },
+    })
+    expect(result!.summary_status).toEqual({
+      status: 'available',
+      summary: {
+        summary_version: 2,
+        generated_at_iso: '2026-07-04T00:00:00Z',
+        model_run_id: 'run-9',
+        context_summary: 'This deletes the production config.',
+        key_questions: ['Is there a backup?'],
+        suggested_options: [
+          { label: 'Reject', rationale: 'irreversible', estimated_risk_delta: 'critical' },
+        ],
+        risk_rationale: 'writes outside sandbox',
+        uncertainty: 0.4,
+      },
+    })
+  })
+
+  it('parses bare-string pending / not_requested statuses', () => {
+    expect(
+      normalizeKeeperApprovalQueueItem({ ...baseItem, summary_status: 'pending' })!.summary_status,
+    ).toEqual({ status: 'pending' })
+    expect(
+      normalizeKeeperApprovalQueueItem({ ...baseItem, summary_status: 'not_requested' })!
+        .summary_status,
+    ).toEqual({ status: 'not_requested' })
+  })
+
+  it('parses a failed status with retryable flag', () => {
+    expect(
+      normalizeKeeperApprovalQueueItem({
+        ...baseItem,
+        summary_status: { status: 'failed', reason: 'provider down', retryable: true },
+      })!.summary_status,
+    ).toEqual({ status: 'failed', reason: 'provider down', retryable: true })
+  })
+
+  it('returns null summary_status for absent or malformed shapes (no fabricated state)', () => {
+    expect(normalizeKeeperApprovalQueueItem(baseItem)!.summary_status).toBeNull()
+    expect(
+      normalizeKeeperApprovalQueueItem({ ...baseItem, summary_status: 'garbage' })!.summary_status,
+    ).toBeNull()
+    expect(
+      normalizeKeeperApprovalQueueItem({ ...baseItem, summary_status: { status: 'weird' } })!
+        .summary_status,
+    ).toBeNull()
+    // available with an empty summary body carries no operator value -> null
+    expect(
+      normalizeKeeperApprovalQueueItem({
+        ...baseItem,
+        summary_status: { status: 'available', summary: { context_summary: '  ' } },
+      })!.summary_status,
+    ).toBeNull()
+  })
 })
 
 // ================================================================

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,5 +1,5 @@
 import { currentDashboardActor, get, post, del, put, withRetries, defaultBoardVoter } from './core'
-import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
+import { isRecord, asNullableString, asString, asNumber, asInt, asStringList, asBoolean } from '../components/common/normalize'
 import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { timeBoardRequest } from '../board-metrics'
@@ -12,6 +12,7 @@ import type {
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
   KeeperApprovalQueueItem,
+  HitlContextSummary, HitlSuggestedOption, HitlSummaryStatus,
   GovernanceResolvedAction, GovernanceTimelineEvent,
   SubBoard, SubBoardAccess,
 } from '../types'
@@ -110,6 +111,62 @@ function normalizeBoardKarmaTargetKind(raw: unknown): BoardKarmaLedgerEvent['tar
 // normalizePendingConfirmation re-exported from pending-confirm.ts (SSOT)
 export { normalizePendingConfirmation }
 
+function normalizeHitlSuggestedOption(raw: unknown): HitlSuggestedOption | null {
+  if (!isRecord(raw)) return null
+  const label = asString(raw.label, '').trim()
+  if (!label) return null
+  return {
+    label,
+    rationale: asString(raw.rationale, '').trim(),
+    estimated_risk_delta: asKeeperApprovalRiskLevel(raw.estimated_risk_delta) ?? null,
+  }
+}
+
+function normalizeHitlContextSummary(raw: unknown): HitlContextSummary | null {
+  if (!isRecord(raw)) return null
+  const summaryText = asString(raw.context_summary, '').trim()
+  // A summary with no body carries no operator value; treat it as absent rather
+  // than rendering an empty briefing card.
+  if (!summaryText) return null
+  return {
+    summary_version: asInt(raw.summary_version) ?? 0,
+    generated_at_iso: asNullableString(raw.generated_at_iso),
+    model_run_id: asNullableString(raw.model_run_id),
+    context_summary: summaryText,
+    key_questions: asStringList(raw.key_questions),
+    suggested_options: Array.isArray(raw.suggested_options)
+      ? raw.suggested_options
+          .map(normalizeHitlSuggestedOption)
+          .filter((o): o is HitlSuggestedOption => o !== null)
+      : [],
+    risk_rationale: asNullableString(raw.risk_rationale),
+    uncertainty: asNumber(raw.uncertainty) ?? null,
+  }
+}
+
+/** Parse the backend `summary_status` wire value into the typed union. Returns
+ *  `null` for an absent or contract-violating shape — a malformed status must
+ *  not silently read as `not_requested`, which would hide a wiring fault. */
+function normalizeHitlSummaryStatus(raw: unknown): HitlSummaryStatus | null {
+  if (raw === 'not_requested') return { status: 'not_requested' }
+  if (raw === 'pending') return { status: 'pending' }
+  if (!isRecord(raw)) return null
+  switch (raw.status) {
+    case 'available': {
+      const summary = normalizeHitlContextSummary(raw.summary)
+      return summary ? { status: 'available', summary } : null
+    }
+    case 'failed':
+      return {
+        status: 'failed',
+        reason: asString(raw.reason, '').trim(),
+        retryable: asBoolean(raw.retryable, false),
+      }
+    default:
+      return null
+  }
+}
+
 export function normalizeKeeperApprovalQueueItem(raw: unknown): KeeperApprovalQueueItem | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -154,6 +211,7 @@ export function normalizeKeeperApprovalQueueItem(raw: unknown): KeeperApprovalQu
     rule_match: ruleMatch,
     input: raw.input,
     input_preview: asNullableString(raw.input_preview),
+    summary_status: normalizeHitlSummaryStatus(raw.summary_status),
   }
 }
 

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -135,6 +135,72 @@ describe('ApprovalsSurface', () => {
     expect(container.querySelector('[data-testid="approvals-queue"]')).not.toBeNull()
   }, 20000)
 
+  it('renders the HITL context summary (available) inside the pending card', async () => {
+    const { ApprovalsSurface } = await loadSurface([
+      queueItem({
+        id: 'appr-summary',
+        keeper_name: 'masc-improver',
+        summary_status: {
+          status: 'available',
+          summary: {
+            summary_version: 1,
+            generated_at_iso: '2026-07-04T00:00:00Z',
+            model_run_id: 'run-1',
+            context_summary: 'Deletes the production database — irreversible.',
+            key_questions: ['Is there a verified backup?'],
+            suggested_options: [
+              { label: '거부', rationale: '복구 불가', estimated_risk_delta: 'critical' },
+            ],
+            risk_rationale: 'writes outside the sandbox',
+            uncertainty: 0.6,
+          },
+        },
+      }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const summaryEl = container.querySelector('[data-testid="approval-summary"]')
+    expect(summaryEl).not.toBeNull()
+    expect(summaryEl?.getAttribute('data-summary-state')).toBe('available')
+    expect(container.textContent).toContain('Deletes the production database')
+    expect(container.textContent).toContain('Is there a verified backup?')
+    expect(container.textContent).toContain('복구 불가')
+    // uncertainty rendered as a rounded percentage
+    expect(container.textContent).toContain('60%')
+  }, 20000)
+
+  it('surfaces pending and failed summary states rather than hiding them', async () => {
+    const { ApprovalsSurface } = await loadSurface([
+      queueItem({ id: 'appr-pending', summary_status: { status: 'pending' } }),
+      queueItem({
+        id: 'appr-failed',
+        summary_status: { status: 'failed', reason: 'provider unavailable', retryable: true },
+      }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const states = Array.from(
+      container.querySelectorAll('[data-testid="approval-summary"]'),
+    ).map(el => el.getAttribute('data-summary-state'))
+    expect(states).toContain('pending')
+    expect(states).toContain('failed')
+    expect(container.textContent).toContain('provider unavailable')
+  }, 20000)
+
+  it('renders no summary block when the approval has no summary status', async () => {
+    const { ApprovalsSurface } = await loadSurface([queueItem({ id: 'appr-nosummary' })])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approval-card"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="approval-summary"]')).toBeNull()
+  }, 20000)
+
   it('counts only the bad (critical) visual band in the 비가역·위험 KPI, matching the red card rails', async () => {
     const { ApprovalsSurface } = await loadSurface([
       queueItem({ id: 'c1', risk_level: 'critical' }),

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -14,7 +14,12 @@
 import { html } from 'htm/preact'
 import { Fragment } from 'preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { KeeperApprovalQueueItem, KeeperResolvedApprovalItem } from '../../types'
+import type {
+  KeeperApprovalQueueItem,
+  KeeperResolvedApprovalItem,
+  HitlContextSummary,
+  HitlSummaryStatus,
+} from '../../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
 import { formatDateTimeKo } from '../../lib/format-time'
@@ -157,6 +162,69 @@ function openKeeperWorkspace(name: string): void {
   navigate('monitoring', { section: 'agents', view: 'keepers', keeper: name })
 }
 
+// Render the HITL context-summary worker's operator briefing. `available`
+// carries the LLM-generated summary the operator reads before deciding;
+// `pending`/`failed` are surfaced (not hidden) so a stuck or errored summary is
+// visible rather than silently absent. `not_requested`/`null` render nothing.
+function renderAvailableSummary(summary: HitlContextSummary) {
+  return html`
+    <div class="ap-summary sev-summary" data-testid="approval-summary" data-summary-state="available">
+      <div class="ap-summary-head">
+        <span class="ap-summary-label">🧭 컨텍스트 요약</span>
+        ${typeof summary.uncertainty === 'number'
+          ? html`<span class="ap-summary-uncertainty" title="요약 불확실도">불확실도 ${Math.round(summary.uncertainty * 100)}%</span>`
+          : null}
+      </div>
+      <p class="ap-summary-text">${summary.context_summary}</p>
+      ${summary.key_questions.length
+        ? html`<ul class="ap-summary-questions">
+            ${summary.key_questions.map(q => html`<li>${q}</li>`)}
+          </ul>`
+        : null}
+      ${summary.suggested_options.length
+        ? html`<ul class="ap-summary-options">
+            ${summary.suggested_options.map(
+              opt => html`<li class="ap-summary-option">
+                <span class="ap-summary-option-label">${opt.label}</span>
+                <span class="ap-summary-option-rationale">${opt.rationale}</span>
+                ${opt.estimated_risk_delta
+                  ? html`<span class="ap-summary-option-risk">${keeperApprovalRiskLabel(opt.estimated_risk_delta)}</span>`
+                  : null}
+              </li>`,
+            )}
+          </ul>`
+        : null}
+      ${summary.risk_rationale?.trim()
+        ? html`<p class="ap-summary-rationale">${summary.risk_rationale.trim()}</p>`
+        : null}
+    </div>
+  `
+}
+
+function approvalSummaryBlock(status: HitlSummaryStatus | null | undefined) {
+  if (!status) return null
+  switch (status.status) {
+    case 'not_requested':
+      return null
+    case 'pending':
+      return html`<div class="ap-summary ap-summary-pending" data-testid="approval-summary" data-summary-state="pending">
+        <span class="ap-summary-label">🧭 컨텍스트 요약 생성 중…</span>
+      </div>`
+    case 'failed':
+      return html`<div class="ap-summary ap-summary-failed" data-testid="approval-summary" data-summary-state="failed">
+        <span class="ap-summary-label">컨텍스트 요약 실패${status.retryable ? ' · 재시도 예정' : ''}</span>
+        ${status.reason ? html`<span class="ap-summary-reason">${status.reason}</span>` : null}
+      </div>`
+    case 'available':
+      return renderAvailableSummary(status.summary)
+    default: {
+      // Exhaustive over HitlSummaryStatus — a new backend variant fails typecheck here.
+      const _never: never = status
+      return _never
+    }
+  }
+}
+
 function ApprovalCard({
   item,
   selected,
@@ -198,6 +266,7 @@ function ApprovalCard({
         </div>
         <h3 class="ap-title">${title}</h3>
         ${detailReason ? html`<p class="ap-detail">${detailReason}</p>` : null}
+        ${approvalSummaryBlock(item.summary_status)}
         <div class="ap-req">
           <${AgentAvatar} name=${item.keeper_name} size="sm" />
           <div class="ap-req-body">

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -61,6 +61,28 @@
    cursor:pointer / hover shift, so a non-clickable span is not a false affordance. */
 .ap-req-meta { font-size: var(--fs-10); color: var(--text-dim); }
 
+/* HITL context-summary worker briefing (approvals-surface.ts approvalSummaryBlock).
+   The available card carries the LLM operator briefing; pending/failed states are
+   surfaced rather than hidden so a stuck or errored summary is visible. */
+.ap-summary { margin: 8px 0 4px; padding: 10px 12px; border-radius: var(--radius-sm); border: 1px solid var(--border-soft); background: var(--bg-sunken); display: flex; flex-direction: column; gap: 6px; }
+.ap-summary.sev-summary { border-color: color-mix(in oklab, var(--volt-strong) 30%, var(--border-soft)); background: color-mix(in oklab, var(--volt-strong) 6%, transparent); }
+.ap-summary-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.ap-summary-label { font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.06em; color: var(--volt-strong); font-weight: 600; }
+.ap-summary-uncertainty { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--text-dim); }
+.ap-summary-text { margin: 0; font-size: var(--fs-12); line-height: 1.5; color: var(--text-primary); word-break: break-word; }
+.ap-summary-questions { margin: 0; padding-left: 16px; display: flex; flex-direction: column; gap: 2px; }
+.ap-summary-questions li { font-size: var(--fs-12); color: var(--text-dim); line-height: 1.4; }
+.ap-summary-options { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.ap-summary-option { display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px; font-size: var(--fs-12); }
+.ap-summary-option-label { color: var(--text-bright); font-weight: 600; }
+.ap-summary-option-rationale { color: var(--text-dim); }
+.ap-summary-option-risk { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--text-dim); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); padding: 0 5px; }
+.ap-summary-rationale { margin: 0; font-size: var(--fs-10); color: var(--text-dim); line-height: 1.4; }
+.ap-summary-reason { font-size: var(--fs-12); color: var(--text-dim); word-break: break-word; }
+.ap-summary-pending .ap-summary-label { color: var(--text-dim); }
+.ap-summary-failed { border-color: color-mix(in oklab, var(--status-bad) 35%, var(--border-soft)); background: color-mix(in oklab, var(--status-bad) 7%, transparent); }
+.ap-summary-failed .ap-summary-label { color: var(--status-bad); }
+
 /* Live decision set: disabled (in-flight) state + the "항상 승인" Approve+Always
    action, plus :hover:not(:disabled) guards so a busy button shows no hover. */
 .ap-act:disabled { opacity: 0.5; cursor: default; }

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -212,6 +212,38 @@ export interface PendingConfirmation {
 //   serialized at `:814`. Frontend was untyped `string`.
 export type KeeperApprovalRiskLevel = 'low' | 'medium' | 'high' | 'critical'
 
+/** One operator option proposed by the HITL context-summary worker.
+ *  Mirrors `keeper_approval_queue_rules_types.ml:suggested_option`. */
+export interface HitlSuggestedOption {
+  label: string
+  rationale: string
+  estimated_risk_delta: KeeperApprovalRiskLevel | null
+}
+
+/** LLM-generated operator briefing attached to a pending approval by the HITL
+ *  context-summary worker (`hitl_summary_worker.ml`). Mirrors
+ *  `keeper_approval_queue_rules_types.ml:hitl_context_summary`. */
+export interface HitlContextSummary {
+  summary_version: number
+  generated_at_iso: string | null
+  model_run_id: string | null
+  context_summary: string
+  key_questions: string[]
+  suggested_options: HitlSuggestedOption[]
+  risk_rationale: string | null
+  uncertainty: number | null
+}
+
+/** Discriminated union mirroring the backend `summary_status` variant
+ *  (`keeper_approval_queue_rules_types.ml:summary_status`). `available` carries
+ *  the briefing the operator reads before deciding; `pending`/`failed` are
+ *  in-flight/error states worth surfacing rather than hiding. */
+export type HitlSummaryStatus =
+  | { status: 'not_requested' }
+  | { status: 'pending' }
+  | { status: 'available'; summary: HitlContextSummary }
+  | { status: 'failed'; reason: string; retryable: boolean }
+
 export interface KeeperApprovalQueueItem {
   id: string
   keeper_name: string
@@ -243,6 +275,9 @@ export interface KeeperApprovalQueueItem {
   } | null
   input?: unknown
   input_preview?: string | null
+  /** HITL operator briefing state. `null` when the backend payload omits it or
+   *  the wire shape violates the contract — never coerced into a fake state. */
+  summary_status?: HitlSummaryStatus | null
 }
 
 export interface KeeperResolvedApprovalItem {

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -588,18 +588,25 @@ let pending_entry_json_fields
                ] )
        ]
      else [])
-  @
-  if include_input
-  then
-    [ "input", entry.input; "input_preview", `String (input_preview_of_json entry.input) ]
-  else []
-  @
-  [ "summary_status", summary_status_to_yojson entry.summary_status
-  ; ( "context_summary"
-    , match entry.context_summary with
-      | Some summary -> hitl_context_summary_to_yojson summary
-      | None -> `Null )
-  ]
+  @ (if include_input
+     then
+       [ "input", entry.input
+       ; "input_preview", `String (input_preview_of_json entry.input)
+       ]
+     else [])
+    (* The [include_input] conditional MUST stay parenthesized. Without the
+       parens the trailing [@ summary fields] is parsed as part of the [else]
+       branch ([else ([] @ summary)]), so [include_input = true] silently drops
+       [summary_status]/[context_summary] from the payload. Every dashboard
+       path ([list_pending_dashboard_json], [pending_entry_detail_json],
+       [broadcast_pending]) passes [include_input:true], so the HITL context
+       summary would never reach an operator. *)
+  @ [ "summary_status", summary_status_to_yojson entry.summary_status
+    ; ( "context_summary"
+      , match entry.context_summary with
+        | Some summary -> hitl_context_summary_to_yojson summary
+        | None -> `Null )
+    ]
 ;;
 
 let broadcast_pending entry =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -184,6 +184,143 @@ let test_critical_entry_phase_becomes_escalated_after_timer () =
        | None -> Alcotest.fail "Critical approval did not resume after escalation")
 ;;
 
+(* Regression: the HITL context summary must survive every JSON emission path,
+   including the [include_input:true] dashboard paths. A previous
+   [if include_input then ... else [] @ summary] precedence trap parsed the
+   trailing summary fields into the [else] branch, so [include_input:true]
+   ([list_pending_dashboard_json], [pending_entry_detail_json],
+   [broadcast_pending]) silently dropped the operator-facing summary the HITL
+   worker had computed. *)
+let sample_summary : AQ.hitl_context_summary =
+  { summary_version = 1
+  ; generated_at = 1_700_000_000.0
+  ; model_run_id = "test-model-run"
+  ; context_summary = "HITL-SUMMARY-MARKER"
+  ; key_questions = [ "is this action reversible?" ]
+  ; suggested_options =
+      [ { AQ.label = "approve once"
+        ; rationale = "blast radius is bounded to the sandbox"
+        ; estimated_risk_delta = Some AQ.Low
+        }
+      ]
+  ; risk_rationale = Some "irreversible write outside sandbox"
+  ; uncertainty = 0.25
+  }
+;;
+
+let entry_json_for_keeper ~keeper_name = function
+  | `List entries ->
+    List.find_opt
+      (function
+        | `Assoc kvs ->
+          (match List.assoc_opt "keeper_name" kvs with
+           | Some (`String name) -> String.equal name keeper_name
+           | _ -> false)
+        | _ -> false)
+      entries
+  | _ -> None
+;;
+
+let context_summary_text_opt json =
+  let open Yojson.Safe.Util in
+  match json |> member "context_summary" with
+  | `Null -> None
+  | summary_obj ->
+    (match summary_obj |> member "context_summary" with
+     | `String s -> Some s
+     | _ -> None)
+;;
+
+let summary_status_status json =
+  let open Yojson.Safe.Util in
+  match json |> member "summary_status" with
+  | `Null -> None
+  | `Assoc _ as obj -> obj |> member "status" |> to_string_option
+  | `String s -> Some s
+  | _ -> None
+;;
+
+let test_summary_survives_include_input_paths () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run
+       @@ fun sw ->
+       let keeper_name = "summary-json-emission-test" in
+       let result = ref None in
+       Eio.Fiber.fork ~sw (fun () ->
+         let decision =
+           AQ.submit_and_await
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_reconcile"
+             ~input:(`Assoc [ "kind", `String "critical_gate" ])
+             ~risk_level:AQ.Critical
+             ~base_path
+             ()
+         in
+         result := Some decision);
+       yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+       let id =
+         match pending_id_for_keeper ~keeper_name with
+         | Some id -> id
+         | None -> Alcotest.fail "Critical approval was not queued"
+       in
+       (* Attach a known summary, then read synchronously (no [yield]) so the
+          async summary worker cannot overwrite the entry between write and
+          read under Eio's cooperative scheduler. *)
+       AQ.update_pending_entry ~id (fun e ->
+         { e with
+           context_summary = Some sample_summary
+         ; summary_status = AQ.Summary_available sample_summary
+         });
+       let dashboard_entry =
+         match
+           entry_json_for_keeper ~keeper_name (AQ.list_pending_dashboard_json ())
+         with
+         | Some json -> json
+         | None -> Alcotest.fail "entry missing from list_pending_dashboard_json"
+       in
+       let detail_entry =
+         match AQ.get_pending_json ~id with
+         | Some json -> json
+         | None -> Alcotest.fail "pending detail JSON not found"
+       in
+       let list_entry =
+         match entry_json_for_keeper ~keeper_name (AQ.list_pending_json ()) with
+         | Some json -> json
+         | None -> Alcotest.fail "entry missing from list_pending_json"
+       in
+       let expected = Some "HITL-SUMMARY-MARKER" in
+       Alcotest.(check (option string))
+         "dashboard list (include_input:true) carries context_summary"
+         expected
+         (context_summary_text_opt dashboard_entry);
+       Alcotest.(check (option string))
+         "detail view (include_input:true) carries context_summary"
+         expected
+         (context_summary_text_opt detail_entry);
+       Alcotest.(check (option string))
+         "plain list (include_input:false) carries context_summary"
+         expected
+         (context_summary_text_opt list_entry);
+       Alcotest.(check (option string))
+         "dashboard list exposes summary_status=available"
+         (Some "available")
+         (summary_status_status dashboard_entry);
+       Alcotest.(check (option string))
+         "detail view exposes summary_status=available"
+         (Some "available")
+         (summary_status_status detail_entry);
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       yield_until (fun () -> Option.is_some !result))
+;;
+
 let test_pending_phase_conversions () =
   Alcotest.(check string)
     "Awaiting_operator string"
@@ -223,6 +360,12 @@ let () =
             "Critical entry becomes Escalated after escalation timer"
             `Quick
             test_critical_entry_phase_becomes_escalated_after_timer
+        ] )
+    ; ( "summary"
+      , [ Alcotest.test_case
+            "context summary survives include_input:true JSON paths"
+            `Quick
+            test_summary_survives_include_input_paths
         ] )
     ; ( "conversions"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 목표

HITL context-summary worker(#23112)가 각 Medium/High/Critical 승인 대기 건에 대해 LLM 운영자 브리핑을 생성하지만, 그 요약이 대시보드에 도달하지 않아 계산 후 버려지던 문제를 해결합니다. 운영자가 승인 결정 시 참고할 요약을 실제로 볼 수 있게 배선합니다.

## 근본 원인 — 두 개의 silent 결함

### 1. 백엔드 연산자 우선순위 트랩 (`keeper_approval_queue.ml`)

`pending_entry_json_fields`에서 summary 필드가 괄호 없는 `if include_input then [...] else []` 뒤에 `@`로 이어져, OCaml이 `else ([] @ summary)`로 파싱했습니다. `include_input:true`이면 summary가 else 분기로 흡수되어 **드롭**됩니다.

대시보드로 향하는 3개 방출 경로가 전부 `include_input:true`를 넘깁니다:

| 경로 | include_input | 수정 전 summary |
|------|--------------|----------------|
| `list_pending_dashboard_json` (대시보드 목록 REST) | true | **드롭** |
| `pending_entry_detail_json` (상세 뷰) | true | **드롭** |
| `broadcast_pending` (SSE 실시간 푸시) | true | **드롭** |

즉 운영자는 요약을 절대 받지 못했습니다. `if` 조건을 괄호로 감싸 수정하고, **모든 include_input 경로에서 summary가 살아남는지 검증하는 회귀 테스트**를 추가했습니다. 재발 방지 주석을 코드에 남겼습니다.

### 2. 프론트엔드가 필드를 소비하지 않음 (`approvals-surface.ts`)

`approvals-surface.ts`는 risk/disposition만 렌더링하고 `summary_status`/`context_summary`를 읽지 않았습니다. 백엔드가 필드를 방출해도 화면에 나타나지 않습니다.

- backend variant를 충실히 반영한 typed `HitlSummaryStatus` discriminated union 추가 (`not_requested | pending | available | failed`).
- `normalizeKeeperApprovalQueueItem`에서 파싱 — **malformed/absent → null** (fake state 날조 금지, permissive default 회피).
- pending 카드에 브리핑 렌더링: 요약 본문, 핵심 질문, 제안 옵션, 불확실도. `pending`/`failed` 상태도 숨기지 않고 노출.

## 변경 파일

- `lib/keeper/keeper_approval_queue.ml` — 우선순위 fix + 재발 방지 주석
- `test/test_keeper_approval_queue.ml` — include_input 경로별 summary 생존 회귀 테스트
- `dashboard/src/types/governance.ts` — `HitlContextSummary` / `HitlSummaryStatus` typed union
- `dashboard/src/api/board.ts` — `normalizeHitlSummaryStatus` 파서
- `dashboard/src/components/approvals/approvals-surface.ts` — 브리핑 렌더
- `dashboard/src/styles/approvals-v2.css` — `.ap-summary*` 스타일 (디자인 토큰만 사용)
- `dashboard/src/api/board.test.ts` / `approvals-surface.test.ts` — normalizer + 렌더 테스트

## 로컬 검증

- `dashboard: tsc --noEmit` → exit 0, 0 errors
- `dashboard: eslint src` → exit 0, 0 problems
- `vitest run board.test.ts approvals-surface.test.ts` → 98 passed
- OCaml build/test는 CI에서 확인 (precedence fix는 독립 OCaml 재현으로 논리 검증 완료)

## 미검증 / 후속

- OCaml `Build and Test`는 CI 결과로 확정.
- SSE approval_pending은 `registerGovernanceRefresh`로 재조회를 트리거하므로 라이브 업데이트도 normalizer를 경유해 요약이 흐릅니다.

#23112 후속. 워크어라운드 아님 — telemetry-as-fix가 아니라 실제 데이터 전달 경로(parse precedence + consumer wiring)를 고칩니다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
