### PR TITLE
[codex] Guard resilience capability restoration

### DIFF
--- a/lib/resilience/degradation.ml
+++ b/lib/resilience/degradation.ml
@@ -63,9 +63,21 @@ let of_int_opt = function
   | 4 -> Some (Any_level L4)
   | _ -> None
 
-(* ── Authorization (stub) ─────────────────────────────────────── *)
+(* ── Authorization ─────────────────────────────────────────────── *)
 
-let authorize_transition ~from:_ ~to_:_ = Ok ()
+let any_level_to_string (Any_level l) = level_to_string l
+
+let authorize_transition ~from ~to_ =
+  let from_rank = any_to_int from in
+  let to_rank = any_to_int to_ in
+  if to_rank >= from_rank
+  then Ok ()
+  else
+    Error
+      (Printf.sprintf
+         "capability restoration from %s to %s requires explicit policy authorization"
+         (any_level_to_string from)
+         (any_level_to_string to_))
 
 (* ── Strategy adjustment ──────────────────────────────────────── *)
 

--- a/lib/resilience/degradation.mli
+++ b/lib/resilience/degradation.mli
@@ -33,11 +33,12 @@
     the canonical bridges; the integer encoding is the lattice
     ordinal (lower = higher capability).
 
-    {1 Policy lineage (placeholder)}
+    {1 Policy boundary}
 
-    {!authorize_transition} returns [Ok ()] unconditionally in
-    this PR; the real OAS [Policy.evaluate_with_lineage] integration
-    lands in a follow-up tier (A11b) without renaming the function.
+    {!authorize_transition} is the local lattice guard: staying at the same
+    level or moving to a lower-capability degradation level is allowed;
+    capability restoration requires an explicit policy authorizer outside this
+    module.
 
     @stability Evolving
     @since 0.18.10 *)
@@ -89,12 +90,14 @@ val any_to_int : any_level -> int
 val of_int_opt : int -> any_level option
 (** [Some] for [1..4], [None] otherwise. *)
 
-(** {1 Authorization (stub)} *)
+(** {1 Authorization} *)
 
 val authorize_transition :
   from:any_level -> to_:any_level -> (unit, string) result
-(** Stub: returns [Ok ()] for any pair. Tier A11b wires real
-    OAS Policy lineage. *)
+(** Returns [Ok ()] when [to_] is the same level as [from] or a
+    lower-capability degradation level. Returns [Error _] for capability
+    restoration attempts, so callers cannot silently regain capability without
+    a policy decision. *)
 
 (** {1 Strategy adjustment} *)
 

--- a/test/resilience/test_degradation.ml
+++ b/test/resilience/test_degradation.ml
@@ -37,17 +37,23 @@ let test_of_int_opt () =
   assert (D.of_int_opt 0 = None);
   assert (D.of_int_opt (-1) = None)
 
-(* ─── authorize_transition (stub) ─────────────────────────────── *)
+(* ─── authorize_transition ────────────────────────────────────── *)
 
-let test_authorize_transition_stub_always_ok () =
-  let res =
+let test_authorize_transition_allows_same_or_degradation () =
+  assert (
+    D.authorize_transition ~from:(D.Any_level D.L1) ~to_:(D.Any_level D.L1)
+    = Ok ());
+  assert (
     D.authorize_transition ~from:(D.Any_level D.L1) ~to_:(D.Any_level D.L4)
-  in
-  assert (res = Ok ());
-  let res2 =
-    D.authorize_transition ~from:(D.Any_level D.L4) ~to_:(D.Any_level D.L1)
-  in
-  assert (res2 = Ok ())
+    = Ok ());
+  assert (
+    D.authorize_transition ~from:(D.Any_level D.L2) ~to_:(D.Any_level D.L3)
+    = Ok ())
+
+let test_authorize_transition_rejects_restoration_without_policy () =
+  match D.authorize_transition ~from:(D.Any_level D.L4) ~to_:(D.Any_level D.L1) with
+  | Error _ -> ()
+  | Ok () -> assert false
 
 (* ─── apply_level_to_strategy ─────────────────────────────────── *)
 
@@ -153,7 +159,8 @@ let () =
   test_level_to_string ();
   test_to_int ();
   test_of_int_opt ();
-  test_authorize_transition_stub_always_ok ();
+  test_authorize_transition_allows_same_or_degradation ();
+  test_authorize_transition_rejects_restoration_without_policy ();
   test_l1_returns_canonical_for_transient ();
   test_l1_returns_canonical_for_permanent_handoff ();
   test_l2_downgrades_retry_to_fallback ();


### PR DESCRIPTION
## Summary
- replace the permissive `Resilience.Degradation.authorize_transition` placeholder with a local capability-lattice guard
- allow same-level transitions and lower-capability degradation transitions
- return an explicit `Error` for capability restoration attempts that lack a policy authorizer
- update the interface docs and degradation tests

## Validation
- `git diff --check`
- `ocamlformat --check lib/resilience/degradation.ml lib/resilience/degradation.mli test/resilience/test_degradation.ml`
- local Dune build not run; GitHub CI is the build authority for this workspace
