### PR TITLE
Surface runtime modality priority

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -182,6 +182,7 @@ export interface DashboardRuntimeEffectiveCapabilities {
   supports_image_input?: boolean
   supports_audio_input?: boolean
   supports_video_input?: boolean
+  modality_priority?: string | null
   task?: string | null
   supports_native_streaming?: boolean
   supports_system_prompt?: boolean
@@ -591,6 +592,7 @@ function decodeRuntimeEffectiveCapabilities(raw: unknown): DashboardRuntimeEffec
     supports_image_input: asBoolean(raw.supports_image_input),
     supports_audio_input: asBoolean(raw.supports_audio_input),
     supports_video_input: asBoolean(raw.supports_video_input),
+    modality_priority: asNullableString(raw.modality_priority),
     task: asNullableString(raw.task),
     supports_native_streaming: asBoolean(raw.supports_native_streaming),
     supports_system_prompt: asBoolean(raw.supports_system_prompt),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2500,6 +2500,7 @@ describe('fetchRuntimeProviders', () => {
               supports_image_input: true,
               supports_audio_input: false,
               supports_video_input: false,
+              modality_priority: 'visual-first',
               task: null,
               supports_native_streaming: true,
               supports_system_prompt: true,
@@ -2650,6 +2651,7 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.effective_capabilities?.supports_parallel_tool_calls).toBe(true)
     expect(result.providers[0]?.effective_capabilities?.accepted_reasoning_efforts).toEqual(['low', 'medium', 'high'])
     expect(result.providers[0]?.effective_capabilities?.reasoning_streaming_format?.field).toBe('reasoning_content')
+    expect(result.providers[0]?.effective_capabilities?.modality_priority).toBe('visual-first')
     expect(result.providers[0]?.effective_capabilities?.supports_top_k).toBe(true)
     expect(result.providers[0]?.declared_spec?.source).toBe('runtime.toml')
     expect(result.providers[0]?.declared_spec?.provider?.api_format).toBe('chat-completions')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -204,6 +204,35 @@ describe('KeeperWorkspaceRail', () => {
             has_previous_response_id: true,
             connect_timeout_s: 120,
           },
+          effective_capabilities: {
+            source: 'oas-provider-config-model',
+            max_output_tokens: 65536,
+            supports_tool_choice: true,
+            supports_parallel_tool_calls: true,
+            supports_runtime_mcp_tools: true,
+            supports_runtime_tool_events: true,
+            supports_response_format_json: true,
+            supports_structured_output: true,
+            supports_reasoning: true,
+            reasoning_output_format: 'split-reasoning-fields',
+            reasoning_streaming_format: {
+              kind: 'delta-reasoning-field',
+              field: 'reasoning_content',
+            },
+            reasoning_replay_override: 'preserve-always',
+            supports_system_prompt: true,
+            supports_caching: true,
+            supports_prompt_caching: true,
+            prompt_cache_alignment: 1024,
+            supports_top_k: true,
+            supports_min_p: true,
+            supports_seed: true,
+            supports_seed_with_images: true,
+            supports_code_execution: true,
+            emits_usage_tokens: true,
+            modality_priority: 'visual-first',
+            supported_models: ['minimax-m3'],
+          },
           declared_spec: {
             source: 'runtime.toml',
             provider: {
@@ -302,6 +331,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge')
+    expect(container.textContent).toContain('modality visual-first')
     // the "no source" stub is replaced once the catalog reports capabilities
     expect(container.textContent).not.toContain('조정 정보 미수신')
   })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -314,6 +314,7 @@ function runtimeEffectiveCapabilitySummary(
     caps.supports_runtime_tool_events ? 'runtime-tool-events' : null,
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -127,6 +127,7 @@ describe('RuntimeMonitor', () => {
             supports_image_input: true,
             supports_audio_input: true,
             supports_video_input: false,
+            modality_priority: 'visual-first',
             task: null,
             supports_native_streaming: true,
             supports_system_prompt: true,
@@ -334,6 +335,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('effective · out 65,536')
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
+    expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('seed+images')
     expect(container.textContent).toContain('code-exec')
   })
@@ -369,6 +371,8 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('chat-template-kwargs')
     expect(container.textContent).toContain('effective · preserve wire')
     expect(container.textContent).toContain('chat-template-kwargs-preserve-thinking')
+    expect(container.textContent).toContain('effective · modality priority')
+    expect(container.textContent).toContain('visual-first')
     expect(container.textContent).toContain('effective · tool content')
     expect(container.textContent).toContain('null')
   })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -369,6 +369,7 @@ function runtimeEffectiveInputText(provider: DashboardRuntimeProviderSnapshot): 
     flagText(caps.supports_image_input, 'image'),
     flagText(caps.supports_audio_input, 'audio'),
     flagText(caps.supports_video_input, 'video'),
+    caps.modality_priority ? `modality ${caps.modality_priority}` : null,
   ])
 }
 
@@ -535,6 +536,7 @@ function runtimeParameterDetailRows(
     detailRow('effective', 'reasoning replay', caps?.reasoning_replay_override),
     detailRow('effective', 'format', effectiveFormat),
     detailRow('effective', 'inputs', runtimeEffectiveInputText(provider)),
+    detailRow('effective', 'modality priority', caps?.modality_priority),
     detailRow('effective', 'task', caps?.task),
     detailRow('effective', 'controls', runtimeEffectiveControlText(provider)),
     detailRow('effective', 'sampling', effectiveSampling),
@@ -675,6 +677,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     modalities.length > 0 ? `input ${modalities.join(',')}` : null,
+    caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -824,6 +824,36 @@ describe('SettingsSurface', () => {
             has_previous_response_id: true,
             connect_timeout_s: 120,
           },
+          effective_capabilities: {
+            source: 'oas-provider-config-model',
+            max_output_tokens: 4096,
+            supports_tool_choice: true,
+            supports_parallel_tool_calls: true,
+            supports_runtime_mcp_tools: true,
+            supports_runtime_tool_events: true,
+            supports_response_format_json: true,
+            supports_structured_output: true,
+            supports_reasoning: true,
+            accepted_reasoning_efforts: null,
+            reasoning_output_format: 'split-reasoning-fields',
+            reasoning_streaming_format: {
+              kind: 'delta-reasoning-field',
+              field: 'reasoning_content',
+            },
+            reasoning_replay_override: 'preserve-always',
+            supports_system_prompt: true,
+            supports_caching: true,
+            supports_prompt_caching: true,
+            prompt_cache_alignment: 1024,
+            supports_top_k: true,
+            supports_min_p: true,
+            supports_seed: true,
+            supports_seed_with_images: true,
+            supports_code_execution: true,
+            emits_usage_tokens: true,
+            modality_priority: 'visual-first',
+            supported_models: ['m1'],
+          },
           declared_spec: {
             source: 'runtime.toml',
             provider: {
@@ -924,6 +954,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('wire:chat-template-kwargs')
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
+      expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
       expect(cards[0]?.textContent).toContain('behavior:inline-tools,keeper-bridge')
       expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -391,6 +391,9 @@ function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnaps
     item.effective_capabilities?.supports_runtime_tool_events ? 'runtime-tool-events' : null,
     format.length > 0 ? `format:${format.join(',')}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+    item.effective_capabilities?.modality_priority
+      ? `modality:${item.effective_capabilities.modality_priority}`
+      : null,
     item.effective_capabilities?.supports_reasoning ? 'reasoning' : null,
     item.effective_capabilities?.reasoning_output_format
       ? `reasoning-out:${item.effective_capabilities.reasoning_output_format}`

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1497,6 +1497,11 @@ let task_json : Llm_provider.Capabilities.task option -> Yojson.Safe.t = functio
   | Some Video_generation -> `String "video-generation"
 ;;
 
+let modality_priority_wire : Llm_provider.Modality.priority -> string = function
+  | Preserve_input_order -> "preserve-input-order"
+  | Visual_first -> "visual-first"
+;;
+
 let tool_choice_json : Llm_provider.Types.tool_choice option -> Yojson.Safe.t = function
   | None -> `Null
   | Some Llm_provider.Types.Auto -> `Assoc [ "kind", `String "auto" ]
@@ -1711,6 +1716,7 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "supports_image_input", `Bool caps.supports_image_input
       ; "supports_audio_input", `Bool caps.supports_audio_input
       ; "supports_video_input", `Bool caps.supports_video_input
+      ; "modality_priority", `String (modality_priority_wire caps.modality_priority)
       ; "task", task_json caps.task
       ; "supports_native_streaming", `Bool caps.supports_native_streaming
       ; "supports_system_prompt", `Bool caps.supports_system_prompt

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1090,7 +1090,14 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
     Alcotest.(check bool)
       "top_k"
       true
-      (caps |> J.member "supports_top_k" |> J.to_bool))
+      (caps |> J.member "supports_top_k" |> J.to_bool);
+    let modality_priority = caps |> J.member "modality_priority" |> J.to_string in
+    Alcotest.(check bool)
+      "effective modality priority wire enum"
+      true
+      (List.exists
+         (String.equal modality_priority)
+         [ "preserve-input-order"; "visual-first" ]))
 ;;
 
 let test_runtime_inventory_surfaces_request_config () =

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -933,6 +933,7 @@ reasoning_output_format = "split_reasoning_fields"
 reasoning_streaming_format = "delta:reasoning_content"
 supports_response_format_json = true
 supports_structured_output = true
+modality_priority = "visual_first"
 supports_native_streaming = true
 supports_prompt_caching = true
 supports_top_k = true
@@ -1091,13 +1092,10 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
       "top_k"
       true
       (caps |> J.member "supports_top_k" |> J.to_bool);
-    let modality_priority = caps |> J.member "modality_priority" |> J.to_string in
-    Alcotest.(check bool)
-      "effective modality priority wire enum"
-      true
-      (List.exists
-         (String.equal modality_priority)
-         [ "preserve-input-order"; "visual-first" ]))
+    Alcotest.(check string)
+      "effective modality priority"
+      "visual-first"
+      (caps |> J.member "modality_priority" |> J.to_string))
 ;;
 
 let test_runtime_inventory_surfaces_request_config () =


### PR DESCRIPTION
## Summary
- expose OAS effective `modality_priority` on the runtime dashboard provider JSON
- decode and render the field in runtime monitor, settings runtime catalog, and keeper workspace rail
- cover API decoding, UI readouts, and the runtime inventory effective-capability contract

## Validation
- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1`
- `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe`
- `./_build/default/test/test_runtime_per_keeper_routing.exe test 'per-model thinking gate' 5 --show-errors`\n- `git diff --check`\n\nNote: local lint on touched dashboard files reported 0 errors; three `*.test.ts` files are ignored by the current ESLint config and emitted warnings only.