### PR TITLE
Surface declared model capability fields in runtime dashboard

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -98,6 +98,9 @@ export interface DashboardRuntimeDeclaredModelCapabilities {
   source?: string | null
   max_output_tokens?: number | null
   supports_tool_choice?: boolean
+  supports_required_tool_choice?: boolean
+  supports_named_tool_choice?: boolean
+  supports_parallel_tool_calls?: boolean
   supports_extended_thinking?: boolean
   supports_reasoning_budget?: boolean
   thinking_control_format?: string | null
@@ -108,14 +111,17 @@ export interface DashboardRuntimeDeclaredModelCapabilities {
   supports_response_format_json?: boolean
   supports_structured_output?: boolean
   supports_native_streaming?: boolean
+  supports_system_prompt?: boolean
   supports_caching?: boolean
   supports_prompt_caching?: boolean
   prompt_cache_alignment?: number | null
   supports_top_k?: boolean
   supports_min_p?: boolean
   supports_seed?: boolean
+  supports_seed_with_images?: boolean
   emits_usage_tokens?: boolean
   supports_computer_use?: boolean
+  supports_code_execution?: boolean
 }
 
 export interface DashboardRuntimeDeclaredModelSpec {
@@ -487,6 +493,9 @@ function decodeRuntimeDeclaredModelCapabilities(
     source: asNullableString(raw.source),
     max_output_tokens: asNumber(raw.max_output_tokens) ?? null,
     supports_tool_choice: asBoolean(raw.supports_tool_choice),
+    supports_required_tool_choice: asBoolean(raw.supports_required_tool_choice),
+    supports_named_tool_choice: asBoolean(raw.supports_named_tool_choice),
+    supports_parallel_tool_calls: asBoolean(raw.supports_parallel_tool_calls),
     supports_extended_thinking: asBoolean(raw.supports_extended_thinking),
     supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
     thinking_control_format: asNullableString(raw.thinking_control_format),
@@ -497,14 +506,17 @@ function decodeRuntimeDeclaredModelCapabilities(
     supports_response_format_json: asBoolean(raw.supports_response_format_json),
     supports_structured_output: asBoolean(raw.supports_structured_output),
     supports_native_streaming: asBoolean(raw.supports_native_streaming),
+    supports_system_prompt: asBoolean(raw.supports_system_prompt),
     supports_caching: asBoolean(raw.supports_caching),
     supports_prompt_caching: asBoolean(raw.supports_prompt_caching),
     prompt_cache_alignment: asNumber(raw.prompt_cache_alignment) ?? null,
     supports_top_k: asBoolean(raw.supports_top_k),
     supports_min_p: asBoolean(raw.supports_min_p),
     supports_seed: asBoolean(raw.supports_seed),
+    supports_seed_with_images: asBoolean(raw.supports_seed_with_images),
     emits_usage_tokens: asBoolean(raw.emits_usage_tokens),
     supports_computer_use: asBoolean(raw.supports_computer_use),
+    supports_code_execution: asBoolean(raw.supports_code_execution),
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2553,6 +2553,9 @@ describe('fetchRuntimeProviders', () => {
                   source: 'runtime.toml',
                   max_output_tokens: 65536,
                   supports_tool_choice: true,
+                  supports_required_tool_choice: true,
+                  supports_named_tool_choice: true,
+                  supports_parallel_tool_calls: true,
                   supports_extended_thinking: true,
                   supports_reasoning_budget: true,
                   thinking_control_format: 'chat-template-kwargs',
@@ -2563,14 +2566,17 @@ describe('fetchRuntimeProviders', () => {
                   supports_response_format_json: true,
                   supports_structured_output: true,
                   supports_native_streaming: true,
+                  supports_system_prompt: true,
                   supports_caching: true,
                   supports_prompt_caching: true,
                   prompt_cache_alignment: 1024,
                   supports_top_k: true,
                   supports_min_p: true,
                   supports_seed: true,
+                  supports_seed_with_images: true,
                   emits_usage_tokens: true,
                   supports_computer_use: false,
+                  supports_code_execution: true,
                 },
                 match_prefixes: ['Qwen/'],
               },
@@ -2660,6 +2666,10 @@ describe('fetchRuntimeProviders', () => {
         ?.identity_runtime_mcp_header_keys,
     ).toEqual(['x-masc-keeper'])
     expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_structured_output).toBe(true)
+    expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_parallel_tool_calls).toBe(true)
+    expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_system_prompt).toBe(true)
+    expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_seed_with_images).toBe(true)
+    expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_code_execution).toBe(true)
     expect(result.providers[0]?.declared_spec?.binding?.max_concurrent).toBe(4)
     expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -314,6 +314,9 @@ describe('KeeperWorkspaceRail', () => {
                 source: 'runtime.toml',
                 max_output_tokens: 65536,
                 supports_tool_choice: true,
+                supports_required_tool_choice: true,
+                supports_named_tool_choice: true,
+                supports_parallel_tool_calls: true,
                 supports_extended_thinking: true,
                 supports_reasoning_budget: true,
                 thinking_control_format: 'reasoning-effort',
@@ -324,14 +327,17 @@ describe('KeeperWorkspaceRail', () => {
                 supports_response_format_json: true,
                 supports_structured_output: true,
                 supports_native_streaming: true,
+                supports_system_prompt: true,
                 supports_caching: true,
                 supports_prompt_caching: true,
                 prompt_cache_alignment: 1024,
                 supports_top_k: true,
                 supports_min_p: true,
                 supports_seed: true,
+                supports_seed_with_images: true,
                 emits_usage_tokens: true,
                 supports_computer_use: false,
+                supports_code_execution: true,
               },
               match_prefixes: ['minimax'],
             },
@@ -375,6 +381,9 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge')
+    expect(container.textContent).toContain(
+      'controls tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
+    )
     expect(container.textContent).toContain('modality visual-first')
     // the "no source" stub is replaced once the catalog reports capabilities
     expect(container.textContent).not.toContain('조정 정보 미수신')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -251,13 +251,19 @@ function runtimeDeclaredSpecSummary(
     : []
   const controls = [
     caps?.supports_tool_choice ? 'tool-choice' : null,
+    caps?.supports_required_tool_choice ? 'required' : null,
+    caps?.supports_named_tool_choice ? 'named' : null,
+    caps?.supports_parallel_tool_calls ? 'parallel' : null,
     caps?.supports_native_streaming ? 'native-stream' : null,
+    caps?.supports_system_prompt ? 'system-prompt' : null,
     caps?.supports_caching ? 'cache' : null,
     caps?.supports_prompt_caching
       ? `prompt-cache${typeof caps.prompt_cache_alignment === 'number' ? `@${caps.prompt_cache_alignment}` : ''}`
       : null,
+    caps?.supports_seed_with_images ? 'seed+images' : null,
     caps?.emits_usage_tokens ? 'usage' : null,
     caps?.supports_computer_use ? 'computer-use' : null,
+    caps?.supports_code_execution ? 'code-exec' : null,
   ].filter((value): value is string => Boolean(value))
   let thinking: string | null = null
   if (typeof spec.model?.thinking_support === 'boolean') {

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -180,6 +180,9 @@ describe('RuntimeMonitor', () => {
                 source: 'runtime.toml',
                 max_output_tokens: 65536,
                 supports_tool_choice: true,
+                supports_required_tool_choice: true,
+                supports_named_tool_choice: true,
+                supports_parallel_tool_calls: true,
                 supports_extended_thinking: true,
                 supports_reasoning_budget: true,
                 thinking_control_format: 'chat-template-kwargs',
@@ -190,14 +193,17 @@ describe('RuntimeMonitor', () => {
                 supports_response_format_json: true,
                 supports_structured_output: true,
                 supports_native_streaming: true,
+                supports_system_prompt: true,
                 supports_caching: true,
                 supports_prompt_caching: true,
                 prompt_cache_alignment: 1024,
                 supports_top_k: true,
                 supports_min_p: true,
                 supports_seed: true,
+                supports_seed_with_images: true,
                 emits_usage_tokens: true,
                 supports_computer_use: true,
+                supports_code_execution: true,
               },
               match_prefixes: ['Qwen/'],
             },
@@ -330,7 +336,9 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('declared · api chat-completions')
     expect(container.textContent).toContain('auth env:RUNPOD_API_KEY')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge,argv-preflight,anthropic-cache')
-    expect(container.textContent).toContain('controls tool-choice,native-stream,cache,prompt-cache@1024,usage,computer-use')
+    expect(container.textContent).toContain(
+      'controls tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,computer-use,code-exec',
+    )
     expect(container.textContent).toContain('price-in 0.1')
     expect(container.textContent).toContain('effective · out 65,536')
     expect(container.textContent).toContain('runtime-mcp-tools')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -313,13 +313,19 @@ function runtimeDeclaredModelControlText(provider: DashboardRuntimeProviderSnaps
   if (!caps) return null
   return textList([
     flagText(caps.supports_tool_choice, 'tool-choice'),
+    flagText(caps.supports_required_tool_choice, 'required'),
+    flagText(caps.supports_named_tool_choice, 'named'),
+    flagText(caps.supports_parallel_tool_calls, 'parallel'),
     flagText(caps.supports_native_streaming, 'native-stream'),
+    flagText(caps.supports_system_prompt, 'system-prompt'),
     flagText(caps.supports_caching, 'cache'),
     caps.supports_prompt_caching
       ? `prompt-cache${typeof caps.prompt_cache_alignment === 'number' ? `@${caps.prompt_cache_alignment}` : ''}`
       : flagText(caps.supports_prompt_caching, 'prompt-cache'),
+    flagText(caps.supports_seed_with_images, 'seed+images'),
     flagText(caps.emits_usage_tokens, 'usage'),
     flagText(caps.supports_computer_use, 'computer-use'),
+    flagText(caps.supports_code_execution, 'code-exec'),
   ])
 }
 
@@ -581,13 +587,19 @@ function runtimeDeclaredSpecText(provider: DashboardRuntimeProviderSnapshot): st
     : []
   const declaredModelControls = [
     declaredCaps?.supports_tool_choice ? 'tool-choice' : null,
+    declaredCaps?.supports_required_tool_choice ? 'required' : null,
+    declaredCaps?.supports_named_tool_choice ? 'named' : null,
+    declaredCaps?.supports_parallel_tool_calls ? 'parallel' : null,
     declaredCaps?.supports_native_streaming ? 'native-stream' : null,
+    declaredCaps?.supports_system_prompt ? 'system-prompt' : null,
     declaredCaps?.supports_caching ? 'cache' : null,
     declaredCaps?.supports_prompt_caching
       ? `prompt-cache${typeof declaredCaps.prompt_cache_alignment === 'number' ? `@${declaredCaps.prompt_cache_alignment}` : ''}`
       : null,
+    declaredCaps?.supports_seed_with_images ? 'seed+images' : null,
     declaredCaps?.emits_usage_tokens ? 'usage' : null,
     declaredCaps?.supports_computer_use ? 'computer-use' : null,
+    declaredCaps?.supports_code_execution ? 'code-exec' : null,
   ].filter((value): value is string => Boolean(value))
   let declaredThinking: string | null = null
   if (typeof spec.model?.thinking_support === 'boolean') {

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -891,6 +891,9 @@ describe('SettingsSurface', () => {
                 source: 'runtime.toml',
                 max_output_tokens: 4096,
                 supports_tool_choice: true,
+                supports_required_tool_choice: true,
+                supports_named_tool_choice: true,
+                supports_parallel_tool_calls: true,
                 supports_extended_thinking: true,
                 supports_reasoning_budget: true,
                 thinking_control_format: 'chat-template-kwargs',
@@ -901,14 +904,17 @@ describe('SettingsSurface', () => {
                 supports_response_format_json: true,
                 supports_structured_output: true,
                 supports_native_streaming: true,
+                supports_system_prompt: true,
                 supports_caching: true,
                 supports_prompt_caching: true,
                 prompt_cache_alignment: 1024,
                 supports_top_k: true,
                 supports_min_p: true,
                 supports_seed: true,
+                supports_seed_with_images: true,
                 emits_usage_tokens: true,
                 supports_computer_use: false,
+                supports_code_execution: true,
               },
               match_prefixes: ['m1'],
             },
@@ -956,6 +962,9 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
+      expect(cards[0]?.textContent).toContain(
+        'controls:tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
+      )
       expect(cards[0]?.textContent).toContain('behavior:inline-tools,keeper-bridge')
       expect(container.querySelector('[data-testid="runtime-catalog-default"]')?.textContent).toBe('default')
       expect(

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -325,13 +325,19 @@ function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapshot): str
     : []
   const controls = [
     caps?.supports_tool_choice ? 'tool-choice' : null,
+    caps?.supports_required_tool_choice ? 'required' : null,
+    caps?.supports_named_tool_choice ? 'named' : null,
+    caps?.supports_parallel_tool_calls ? 'parallel' : null,
     caps?.supports_native_streaming ? 'native-stream' : null,
+    caps?.supports_system_prompt ? 'system-prompt' : null,
     caps?.supports_caching ? 'cache' : null,
     caps?.supports_prompt_caching
       ? `prompt-cache${typeof caps.prompt_cache_alignment === 'number' ? `@${caps.prompt_cache_alignment}` : ''}`
       : null,
+    caps?.supports_seed_with_images ? 'seed+images' : null,
     caps?.emits_usage_tokens ? 'usage' : null,
     caps?.supports_computer_use ? 'computer-use' : null,
+    caps?.supports_code_execution ? 'code-exec' : null,
   ].filter((value): value is string => Boolean(value))
   let thinking: string | null = null
   if (typeof spec.model?.thinking_support === 'boolean') {

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -96,6 +96,9 @@ type thinking_control_format =
 type model_capabilities =
   { max_output_tokens : int option
   ; supports_tool_choice : bool
+  ; supports_required_tool_choice : bool
+  ; supports_named_tool_choice : bool
+  ; supports_parallel_tool_calls : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
@@ -106,20 +109,26 @@ type model_capabilities =
   ; supports_response_format_json : bool
   ; supports_structured_output : bool
   ; supports_native_streaming : bool
+  ; supports_system_prompt : bool
   ; supports_caching : bool
   ; supports_prompt_caching : bool
   ; prompt_cache_alignment : int option
   ; supports_top_k : bool
   ; supports_min_p : bool
   ; supports_seed : bool
+  ; supports_seed_with_images : bool
   ; emits_usage_tokens : bool
   ; supports_computer_use : bool
+  ; supports_code_execution : bool
   }
 [@@deriving show, eq]
 
 let model_capabilities_default =
   { max_output_tokens = None
   ; supports_tool_choice = false
+  ; supports_required_tool_choice = false
+  ; supports_named_tool_choice = false
+  ; supports_parallel_tool_calls = false
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false
   ; thinking_control_format = No_thinking_control
@@ -130,15 +139,18 @@ let model_capabilities_default =
   ; supports_response_format_json = false
   ; supports_structured_output = false
   ; supports_native_streaming = false
+  ; supports_system_prompt = false
   ; supports_caching = false
   ; supports_prompt_caching = false
   ; prompt_cache_alignment = None
   ; supports_top_k = false
   ; supports_min_p = false
   ; supports_seed = false
+  ; supports_seed_with_images = false
   ; (* stricter default: most providers report usage; CLI wrappers opt out *)
     emits_usage_tokens = true
   ; supports_computer_use = false
+  ; supports_code_execution = false
   }
 ;;
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -79,6 +79,9 @@ type thinking_control_format =
 type model_capabilities =
   { max_output_tokens : int option
   ; supports_tool_choice : bool
+  ; supports_required_tool_choice : bool
+  ; supports_named_tool_choice : bool
+  ; supports_parallel_tool_calls : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
   ; thinking_control_format : thinking_control_format
@@ -89,14 +92,17 @@ type model_capabilities =
   ; supports_response_format_json : bool
   ; supports_structured_output : bool
   ; supports_native_streaming : bool
+  ; supports_system_prompt : bool
   ; supports_caching : bool
   ; supports_prompt_caching : bool
   ; prompt_cache_alignment : int option
   ; supports_top_k : bool
   ; supports_min_p : bool
   ; supports_seed : bool
+  ; supports_seed_with_images : bool
   ; emits_usage_tokens : bool
   ; supports_computer_use : bool
+  ; supports_code_execution : bool
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -440,6 +440,9 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
     (fun thinking_control_format ->
       { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
       ; supports_tool_choice = b "supports-tool-choice"
+      ; supports_required_tool_choice = b "supports-required-tool-choice"
+      ; supports_named_tool_choice = b "supports-named-tool-choice"
+      ; supports_parallel_tool_calls = b "supports-parallel-tool-calls"
       ; supports_extended_thinking = b "supports-extended-thinking"
       ; supports_reasoning_budget = b "supports-reasoning-budget"
       ; thinking_control_format
@@ -450,14 +453,17 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       ; supports_response_format_json = b "supports-response-format-json"
       ; supports_structured_output = b "supports-structured-output"
       ; supports_native_streaming = b "supports-native-streaming"
+      ; supports_system_prompt = b "supports-system-prompt"
       ; supports_caching = b "supports-caching"
       ; supports_prompt_caching = b "supports-prompt-caching"
       ; prompt_cache_alignment = positive_int_opt_field "prompt-cache-alignment"
       ; supports_top_k = b "supports-top-k"
       ; supports_min_p = b "supports-min-p"
       ; supports_seed = b "supports-seed"
+      ; supports_seed_with_images = b "supports-seed-with-images"
       ; emits_usage_tokens = b_default_true "emits-usage-tokens"
       ; supports_computer_use = b "supports-computer-use"
+      ; supports_code_execution = b "supports-code-execution"
       })
     thinking_control_format_result
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1598,6 +1598,9 @@ let runtime_declared_model_capabilities_json
       [ "source", `String runtime_inventory_source
       ; "max_output_tokens", Json_util.int_opt_to_json caps.max_output_tokens
       ; "supports_tool_choice", `Bool caps.supports_tool_choice
+      ; "supports_required_tool_choice", `Bool caps.supports_required_tool_choice
+      ; "supports_named_tool_choice", `Bool caps.supports_named_tool_choice
+      ; "supports_parallel_tool_calls", `Bool caps.supports_parallel_tool_calls
       ; "supports_extended_thinking", `Bool caps.supports_extended_thinking
       ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
       ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
@@ -1608,14 +1611,17 @@ let runtime_declared_model_capabilities_json
       ; "supports_response_format_json", `Bool caps.supports_response_format_json
       ; "supports_structured_output", `Bool caps.supports_structured_output
       ; "supports_native_streaming", `Bool caps.supports_native_streaming
+      ; "supports_system_prompt", `Bool caps.supports_system_prompt
       ; "supports_caching", `Bool caps.supports_caching
       ; "supports_prompt_caching", `Bool caps.supports_prompt_caching
       ; "prompt_cache_alignment", Json_util.int_opt_to_json caps.prompt_cache_alignment
       ; "supports_top_k", `Bool caps.supports_top_k
       ; "supports_min_p", `Bool caps.supports_min_p
       ; "supports_seed", `Bool caps.supports_seed
+      ; "supports_seed_with_images", `Bool caps.supports_seed_with_images
       ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
       ; "supports_computer_use", `Bool caps.supports_computer_use
+      ; "supports_code_execution", `Bool caps.supports_code_execution
       ]
 ;;
 

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -180,8 +180,16 @@ tools-support = true
 streaming = true
 
 [models.gpt.capabilities]
+supports-tool-choice = true
+supports-required-tool-choice = true
+supports-named-tool-choice = true
+supports-parallel-tool-calls = true
 supports-response-format-json = true
 supports-structured-output = true
+supports-system-prompt = true
+supports-seed = true
+supports-seed-with-images = true
+supports-code-execution = true
 
 [runpod_mtp.qwen]
 is-default = true
@@ -221,8 +229,16 @@ tools-support = true
 streaming = true
 
 [models.gpt.capabilities]
+supports-tool-choice = true
+supports-required-tool-choice = true
+supports-named-tool-choice = true
+supports-parallel-tool-calls = true
 supports-response-format-json = true
 supports-structured-output = true
+supports-system-prompt = true
+supports-seed = true
+supports-seed-with-images = true
+supports-code-execution = true
 
 [runpod_mtp.qwen]
 is-default = true
@@ -427,6 +443,57 @@ let test_runtime_inventory_surfaces_assignment_governance () =
       (match gpt |> J.member "temperature" with
        | `Null -> true
        | _ -> false))
+;;
+
+let test_runtime_inventory_surfaces_declared_model_capabilities () =
+  with_runtime_initialized (fun () ->
+    let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
+    let providers = json |> J.member "providers" |> J.to_list in
+    let gpt =
+      List.find
+        (fun provider ->
+           String.equal
+             "openai.gpt"
+             (provider |> J.member "runtime_id" |> J.to_string))
+        providers
+    in
+    let caps =
+      gpt
+      |> J.member "declared_spec"
+      |> J.member "model"
+      |> J.member "capabilities"
+    in
+    (match caps with
+     | `Assoc _ -> ()
+     | _ -> Alcotest.fail "declared model capabilities must be an object");
+    Alcotest.(check string)
+      "declared capability source"
+      "runtime.toml"
+      (caps |> J.member "source" |> J.to_string);
+    Alcotest.(check bool)
+      "declared required tool choice"
+      true
+      (caps |> J.member "supports_required_tool_choice" |> J.to_bool);
+    Alcotest.(check bool)
+      "declared named tool choice"
+      true
+      (caps |> J.member "supports_named_tool_choice" |> J.to_bool);
+    Alcotest.(check bool)
+      "declared parallel tool calls"
+      true
+      (caps |> J.member "supports_parallel_tool_calls" |> J.to_bool);
+    Alcotest.(check bool)
+      "declared system prompt"
+      true
+      (caps |> J.member "supports_system_prompt" |> J.to_bool);
+    Alcotest.(check bool)
+      "declared seed with images"
+      true
+      (caps |> J.member "supports_seed_with_images" |> J.to_bool);
+    Alcotest.(check bool)
+      "declared code execution"
+      true
+      (caps |> J.member "supports_code_execution" |> J.to_bool))
 ;;
 
 let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
@@ -1283,15 +1350,14 @@ let fallback_sentinel () = 8192
 
 let test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback () =
   with_runtime_thinking (fun () ->
-    (* qwen36-35b-a3b-mtp declares no explicit [max_output_tokens], so its
-       capability inherits the provider base ceiling (16384). The reasoning path
-       defers to that OAS-owned ceiling — NOT the flat keeper fallback (8192).
-       Raising this runtime to the 32768 operational bound is a catalog change
-       (declare a higher max_output_tokens), per the OAS-owns-the-value split. *)
+    (* qwen36-35b-a3b-mtp declares [max_output_tokens = 65536] in the OAS
+       fixture catalog. The reasoning path defers to that OAS-owned ceiling,
+       bounded by the 32768 operational cap — NOT the flat keeper fallback
+       (8192). *)
     Alcotest.(check int)
-      "reasoning runtime defers to its OAS capability ceiling (16384 base), \
-       above the 8192 keeper fallback"
-      16384
+      "reasoning runtime defers to its OAS capability ceiling, clamped by the \
+       operational bound above the 8192 keeper fallback"
+      32768
       (Runtime_inference.resolve_max_tokens
          ~runtime_id:"ollama_cloud.thinkdefault"
          ~fallback:fallback_sentinel))
@@ -1364,8 +1430,8 @@ let test_max_output_tokens_accessor_projects_catalog () =
       (Some 200000)
       (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.bigout");
     Alcotest.(check (option int))
-      "catalog row without max_output_tokens inherits the provider base ceiling"
-      (Some 16384)
+      "catalog row projects its declared max_output_tokens"
+      (Some 65536)
       (Runtime.max_output_tokens_of_runtime_id "ollama_cloud.thinkdefault");
     Alcotest.(check (option int))
       "reasoning runtime whose model is absent from the catalog projects None"
@@ -1703,6 +1769,10 @@ let () =
             "runtime inventory surfaces declared spec"
             `Quick
             test_runtime_inventory_surfaces_declared_spec
+        ; Alcotest.test_case
+            "runtime inventory surfaces declared model capabilities"
+            `Quick
+            test_runtime_inventory_surfaces_declared_model_capabilities
         ; Alcotest.test_case
             "unknown runtime id defers (None)"
             `Quick


### PR DESCRIPTION
## Summary
- extend runtime.toml declared model capabilities for tool-choice variants, system prompts, seed-with-images, and code execution
- surface the new declared capability fields through runtime inventory JSON and dashboard decoders
- show the declared capability controls in runtime monitor, settings catalog, and keeper workspace rail
- update runtime capability tests and align stale max_output_tokens expectations with the fixture catalog

## Validation
- scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe test/test_runtime_config_validity.exe
- _build/default/test/test_runtime_per_keeper_routing.exe
- _build/default/test/test_runtime_config_validity.exe
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts
