### PR TITLE
chore(runtime): prefer Kimi K2.7 seed runtime

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -34,7 +34,7 @@ display-name = "Ollama Cloud"
 protocol = "openai-compatible-http"
 endpoint = "https://ollama.com/v1"
 # OAS connect + initial-response-headers wall-clock budget (oas#2163).
-# Ollama Cloud serving reasoning models (kimi-k2.6, minimax-m3) can hold the
+# Ollama Cloud serving reasoning models (kimi-k2.7-code, minimax-m3) can hold the
 # first response header past the 60s OpenAI_compat default (cold-start /
 # admission queueing / long reasoning prefill), surfacing in the Fusion panel
 # as `phase=http_operation: HTTP operation exceeded wall-clock timeout` — which
@@ -242,17 +242,19 @@ supports-multimodal-inputs = true
 
 [ollama_cloud_native.minimax-m3-native-structured]
 
-# Kimi K2.6 (Ollama Cloud) — vision-capable Cloud runtime. The model name is
-# kept separate from Kimi's direct API route; OAS owns provider/model wire
+# Kimi K2.7 Code (Ollama Cloud) — vision-capable Cloud runtime. The model name
+# is kept separate from Kimi's direct API route; OAS owns provider/model wire
 # details and MASC declares only runtime-local concrete model capabilities.
-[models.kimi-k2-6]
-api-name = "kimi-k2.6"
+# Official Kimi docs checked 2026-07-04: kimi-k2.7-code is the latest
+# code-focused thinking model; keep the short Kimi seed on the current model.
+[models.kimi-k2-7-code]
+api-name = "kimi-k2.7-code"
 max-context = 262144
 tools-support = true
 thinking-support = true
 streaming = true
 
-[models.kimi-k2-6.capabilities]
+[models.kimi-k2-7-code.capabilities]
 max-output-tokens = 32768
 supports-tool-choice = false
 supports-extended-thinking = true
@@ -266,7 +268,7 @@ supports-structured-output = false
 supports-image-input = true
 supports-multimodal-inputs = true
 
-[ollama_cloud.kimi-k2-6]
+[ollama_cloud.kimi-k2-7-code]
 
 # Ollama Cloud canonical model seeds
 # Source: https://ollama.com/api/tags + /api/show, checked 2026-06-20 KST.

--- a/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
+++ b/docs/rfc/RFC-0265-capability-driven-proactive-runtime-reroute.md
@@ -70,7 +70,7 @@ The turn died with no answer.
 
 The mismatch is **structural and known before the request is built** — it is not
 a transient error. The inventory *did* contain capable models at that moment
-(`kimi-k2-6` and `minimax-m3` both report `vision` in `/api/show`), but nothing
+(`kimi-k2.7-code` and `minimax-m3` both report `vision` in `/api/show`), but nothing
 routed the image turn to them.
 
 ## 2. Why this is not RFC-0207 Part B
@@ -185,18 +185,18 @@ New optional key in `runtime.toml`:
 # Unset → derive capable runtimes from declared [models.*.capabilities] in
 # declaration order. Each id must resolve to a configured runtime (load error
 # otherwise).
-media_failover = ["ollama_cloud.kimi-k2-6", "ollama_cloud.minimax-m3"]
+media_failover = ["ollama_cloud.kimi-k2-7-code", "ollama_cloud.minimax-m3"]
 ```
 
 ### 4.1 Prerequisite — declare media capabilities accurately (config, not code)
 
 The reroute can only pick a runtime whose `model.capabilities` *declares* the
-modality. Today the vision-capable cloud models are under-declared:
+modality. The vision-capable cloud models must not be under-declared:
 
 - `[models.minimax-m3.capabilities]` declares JSON/structured-output only —
   **no `supports-image-input`** (yet `/api/show` reports `vision`).
-- `[models.kimi-k2-6]` has **no `.capabilities` block** (yet `/api/show` reports
-  `vision`).
+- `[models.kimi-k2-7-code.capabilities]` must retain `supports-image-input` and
+  `supports-multimodal-inputs`.
 
 Until those declarations match `/api/show`, no candidate qualifies and the floor
 (loud reject) fires. This is the same capability-declaration discipline that

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -467,14 +467,17 @@ let test_repo_oas_model_catalog_preserve_axes_resolve () =
         (Llm_provider.Capabilities.(
            caps.reasoning_replay_override = Force_preserve_always))
   in
-  let expect_bare_native_kimi_wire_semantics model_id =
+  let expect_bare_kimi_k27_wire_semantics model_id =
     (match Llm_provider.Model_catalog.lookup catalog model_id with
      | None -> failf "expected repo OAS catalog row for %s" model_id
      | Some entry ->
        check (option string) (model_id ^ " native base") (Some "kimi")
          entry.base_label;
-       check (option string) (model_id ^ " no catalog thinking override") None
+       check (option string) (model_id ^ " no request thinking knob") (Some "none")
          entry.thinking_control_format;
+       check (option string) (model_id ^ " always preserved thinking")
+         (Some "always_preserved")
+         entry.preserve_thinking_control_format;
        check (option string) (model_id ^ " no catalog replay override") None
          entry.reasoning_replay);
     match Llm_provider.Capabilities.for_model_id model_id with
@@ -492,8 +495,8 @@ let test_repo_oas_model_catalog_preserve_axes_resolve () =
   in
   expect_request_side_preserve "runpod_mtp/qwen36-35b-a3b-mtp";
   expect_request_side_preserve "qwen36-35b-a3b-mtp";
-  expect_preserve_always_replay "ollama_cloud/kimi-k2.6";
-  expect_bare_native_kimi_wire_semantics "kimi-k2.6"
+  expect_preserve_always_replay "ollama_cloud/kimi-k2.7-code";
+  expect_bare_kimi_k27_wire_semantics "kimi-k2.7-code"
 
 let test_repo_runtime_bindings_resolve_through_oas_catalog () =
   with_repo_oas_model_catalog @@ fun _catalog ->
@@ -733,23 +736,23 @@ let test_repo_runtime_toml_loads () =
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "ollama_cloud.kimi-k2-6")
+            String.equal runtime.id "ollama_cloud.kimi-k2-7-code")
          runtimes
      with
-     | None -> fail "expected Kimi K2.6 Ollama Cloud runtime in seed"
+     | None -> fail "expected Kimi K2.7 Code Ollama Cloud runtime in seed"
      | Some runtime ->
-       check string "Kimi K2.6 api name" "kimi-k2.6" runtime.model.api_name;
-       check int "Kimi K2.6 context" 262144 runtime.model.max_context;
+       check string "Kimi K2.7 Code api name" "kimi-k2.7-code" runtime.model.api_name;
+       check int "Kimi K2.7 Code context" 262144 runtime.model.max_context;
        (match runtime.model.capabilities with
         | Some caps ->
-          check bool "Kimi K2.6 image input" true caps.supports_image_input;
-          check bool "Kimi K2.6 multimodal input" true
+          check bool "Kimi K2.7 Code image input" true caps.supports_image_input;
+          check bool "Kimi K2.7 Code multimodal input" true
             caps.supports_multimodal_inputs;
-          check bool "Kimi K2.6 reasoning effort" true
+          check bool "Kimi K2.7 Code reasoning effort" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
                Runtime_schema.Reasoning_effort)
-        | None -> fail "expected Kimi K2.6 capabilities"))
+        | None -> fail "expected Kimi K2.7 Code capabilities"))
 
 let test_toml_catalog_resolves_lifecycle_keys () =
   let doc =


### PR DESCRIPTION
## Summary
- Move the short Ollama Cloud Kimi seed runtime from kimi-k2.6 to kimi-k2.7-code.
- Update runtime config validity coverage to assert the K2.7 OAS catalog semantics: no request thinking knob and always-preserved thinking.
- Refresh the RFC-0265 media-failover example to point at the current Kimi seed runtime.

## Evidence
- [근거] Kimi model list: https://platform.kimi.ai/docs/models, checked 2026-07-04 KST, confidence High. It lists kimi-k2.7-code as Kimi's current most capable coding model and keeps K2.6/K2.5 as older models.
- [근거] Kimi thinking docs: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model, checked 2026-07-04 KST, confidence High. It states kimi-k2.7-code is latest, always thinks, and Preserved Thinking is always on.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_runtime_config_validity.exe
- _build/default/test/test_runtime_config_validity.exe