### PR TITLE
refactor(keeper-wip): remove per-repo WIP admission cap

### DIFF
--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -50,35 +50,20 @@ let title_category title =
   if stop <= 0 then Other "other" else String.sub normalized 0 stop |> category_of_string
 
 type scope = {
-  repo : string option;
   goal_id : string option;
   category : category;
 }
-
-(* The task model carries no repo attribution (see [Masc_domain.task]); its only
-   repo-ish field is [files], a heuristic path list we deliberately do not parse.
-   A repoless task resolves to [None] and — exactly like a goalless task under the
-   per-goal cap (RFC-0245, see [decide]) — is exempt from the per-repo cap,
-   bounded only by the global/category caps. The per-repo cap stays live for any
-   task that DOES resolve to a repo ([Some]), so the mechanism is preserved for
-   when the task model carries one. Returning a single fallback repo here instead
-   collapsed every fleet task into one [repo:<basename>] bucket, turning
-   [max_per_repo] into a fleet-wide cap tighter than [max_global] — every keeper
-   blocked once 6 tasks were active anywhere in the fleet. *)
-let task_repo (_task : Masc_domain.task) : string option = None
 
 let scope_of_task ?(task_goal_index = Hashtbl.create 0) (task : Masc_domain.task) =
   let goal_id =
     try Some (List.hd (Hashtbl.find task_goal_index task.id)) with Not_found -> None
   in
-  { repo = task_repo task
-  ; goal_id
+  { goal_id
   ; category = title_category task.title
   }
 
 type caps = {
   max_global : int option;
-  max_per_repo : int option;
   max_per_goal : int option;
   max_per_category : int option;
 }
@@ -86,7 +71,6 @@ type caps = {
 (* Historical hardcoded WIP admission caps. Kept as the fallback so an unset
    environment and no override reproduce the exact prior behaviour. *)
 let default_max_global = 16
-let default_max_per_repo = 12
 let default_max_per_goal = 3
 let default_max_per_category = 4
 
@@ -117,10 +101,6 @@ let max_global_rp =
   wip_cap_rp ~key:"keeper.wip.max_global" ~env:"MASC_KEEPER_WIP_MAX_GLOBAL"
     ~default:default_max_global
 
-let max_per_repo_rp =
-  wip_cap_rp ~key:"keeper.wip.max_per_repo" ~env:"MASC_KEEPER_WIP_MAX_PER_REPO"
-    ~default:default_max_per_repo
-
 let max_per_goal_rp =
   wip_cap_rp ~key:"keeper.wip.max_per_goal" ~env:"MASC_KEEPER_WIP_MAX_PER_GOAL"
     ~default:default_max_per_goal
@@ -138,7 +118,6 @@ let cap_of_rp rp =
 
 let default_caps () =
   { max_global = cap_of_rp max_global_rp
-  ; max_per_repo = cap_of_rp max_per_repo_rp
   ; max_per_goal = cap_of_rp max_per_goal_rp
   ; max_per_category = cap_of_rp max_per_category_rp
   }
@@ -166,19 +145,16 @@ let active_items_of_tasks ?task_goal_index tasks =
 
 type reject_reason =
   | Global_cap
-  | Repo_cap
   | Goal_cap
   | Category_cap
 
 let reject_reason_to_string = function
   | Global_cap -> "global_cap"
-  | Repo_cap -> "repo_cap"
   | Goal_cap -> "goal_cap"
   | Category_cap -> "category_cap"
 
 let reject_reason_axis = function
   | Global_cap -> "global"
-  | Repo_cap -> "repo"
   | Goal_cap -> "goal"
   | Category_cap -> "category"
 
@@ -202,12 +178,6 @@ let same_goal a b =
   | None, None -> true
   | _ -> false
 
-let same_repo a b =
-  match a, b with
-  | Some a, Some b -> same_string a b
-  | None, None -> true
-  | _ -> false
-
 let same_category a b =
   String.equal (category_to_string a) (category_to_string b)
 
@@ -215,10 +185,6 @@ let count_matching predicate active =
   active |> List.filter predicate |> List.length
 
 let global_key = "global"
-
-let repo_key = function
-  | Some repo -> Printf.sprintf "repo:%s" (normalize repo)
-  | None -> "repo:<none>"
 
 let goal_key = function
   | Some goal_id -> Printf.sprintf "goal:%s" (normalize goal_id)
@@ -229,8 +195,6 @@ let category_key category =
 
 let active_counts ~scope active =
   [ global_key, List.length active
-  ; ( repo_key scope.repo,
-      count_matching (fun item -> same_repo item.scope.repo scope.repo) active )
   ; ( goal_key scope.goal_id,
       count_matching
         (fun item -> same_goal item.scope.goal_id scope.goal_id)
@@ -251,9 +215,6 @@ let first_rejection checks =
 
 let decide ?(caps = default_caps ()) active ~scope =
   let global_count = List.length active in
-  let repo_count =
-    count_matching (fun item -> same_repo item.scope.repo scope.repo) active
-  in
   let goal_count =
     count_matching
       (fun item -> same_goal item.scope.goal_id scope.goal_id)
@@ -278,21 +239,9 @@ let decide ?(caps = default_caps ()) active ~scope =
         caps.max_per_goal
     | None -> None
   in
-  (* Mirror the per-goal exemption above: a task with no resolved repo
-     ([repo:<none>]) shares no repo scope with any other, so it cannot collide.
-     Applying [max_per_repo] to the [None] bucket lumps every repoless task into
-     one fleet-wide cap — the collapse this module previously suffered. Exempt
-     [None]; the global/category caps still bound repoless WIP. *)
-  let repo_cap_check =
-    match scope.repo with
-    | Some _ ->
-      reject_if_at_cap Repo_cap (repo_key scope.repo) repo_count caps.max_per_repo
-    | None -> None
-  in
   match
     first_rejection
       [ reject_if_at_cap Global_cap global_key global_count caps.max_global
-      ; repo_cap_check
       ; goal_cap_check
       ; reject_if_at_cap Category_cap
           (category_key scope.category)

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -15,7 +15,6 @@ val category_of_string : string -> category
 val title_category : string -> category
 
 type scope = {
-  repo : string option;
   goal_id : string option;
   category : category;
 }
@@ -25,7 +24,6 @@ val scope_of_task :
 
 type caps = {
   max_global : int option;
-  max_per_repo : int option;
   max_per_goal : int option;
   max_per_category : int option;
 }
@@ -34,9 +32,9 @@ val default_caps : unit -> caps
 (** WIP admission caps, resolved at call time from the [keeper.wip.*] runtime
     params (registered via {!Keeper_config_rp_helpers._rp_int}, so they surface in
     runtime.toml and the dashboard knob table rather than being env-only). Each
-    knob's default reads [MASC_KEEPER_WIP_MAX_GLOBAL] / [_MAX_PER_REPO] /
-    [_MAX_PER_GOAL] / [_MAX_PER_CATEGORY]: an unset knob keeps the historical
-    default (16 / 12 / 3 / 4), a positive value overrides, and 0 (or a negative
+    knob's default reads [MASC_KEEPER_WIP_MAX_GLOBAL] / [_MAX_PER_GOAL] /
+    [_MAX_PER_CATEGORY]: an unset knob keeps the historical
+    default (16 / 3 / 4), a positive value overrides, and 0 (or a negative
     value, clamped to 0) disables that axis ([None] = unbounded, deferring to the
     remaining caps). A runtime.toml / dashboard override takes precedence over the
     env default. Read lazily per call. *)
@@ -56,7 +54,6 @@ val active_items_of_tasks :
 
 type reject_reason =
   | Global_cap
-  | Repo_cap
   | Goal_cap
   | Category_cap
 

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -4,14 +4,11 @@ module Admission = Masc.Keeper_wip_admission
 module Task_runtime = Masc.Keeper_tool_task_runtime
 module U = Yojson.Safe.Util
 
-(* Cap-mechanism tests pass a concrete repo string; wrap it as [Some] so the
-   per-repo cap is exercised. [task_repo] resolves real tasks to [None] (no repo
-   attribution in the task model), covered separately below. *)
-let scope ?goal_id ?(category = Admission.Fix) repo =
-  { Admission.repo = Some repo; goal_id; category }
+let scope ?goal_id ?(category = Admission.Fix) () =
+  { Admission.goal_id; category }
 
-let item ?goal_id ?(category = Admission.Fix) repo id =
-  { Admission.id; scope = scope ?goal_id ~category repo }
+let item ?goal_id ?(category = Admission.Fix) id =
+  { Admission.id; scope = scope ?goal_id ~category () }
 
 let task ?(status = Masc_domain.Todo) ?(title = "fix: task") id =
   { Masc_domain.id
@@ -31,14 +28,13 @@ let task ?(status = Masc_domain.Todo) ?(title = "fix: task") id =
 
 let caps =
   { Admission.max_global = Some 10
-  ; max_per_repo = Some 2
   ; max_per_goal = Some 1
   ; max_per_category = Some 3
   }
 
 let test_admits_below_caps () =
-  let active = [ item ~goal_id:"goal-a" "repo-a" "one" ] in
-  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-b" "repo-a") with
+  let active = [ item ~goal_id:"goal-a" "one" ] in
+  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-b" ()) with
   | Admission.Admit { active_count_after_admit } ->
     check int "active after admit" 2 active_count_after_admit
   | Reject rejection ->
@@ -46,24 +42,9 @@ let test_admits_below_caps () =
       (Printf.sprintf "unexpected reject: %s"
          (Admission.reject_reason_to_string rejection.reason))
 
-let test_rejects_repo_cap_before_goal_cap () =
-  let active =
-    [ item ~goal_id:"goal-a" "repo-a" "one"
-    ; item ~goal_id:"goal-b" "repo-a" "two"
-    ]
-  in
-  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-c" "repo-a") with
-  | Admission.Admit _ -> fail "expected repo cap rejection"
-  | Reject rejection ->
-    check string "reason" "repo_cap"
-      (Admission.reject_reason_to_string rejection.reason);
-    check int "current" 2 rejection.current;
-    check int "limit" 2 rejection.limit;
-    check string "scope key" "repo:repo-a" rejection.scope_key
-
 let test_rejects_goal_cap () =
-  let active = [ item ~goal_id:"goal-a" "repo-a" "one" ] in
-  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-a" "repo-b") with
+  let active = [ item ~goal_id:"goal-a" "one" ] in
+  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-a" ()) with
   | Admission.Admit _ -> fail "expected goal cap rejection"
   | Reject rejection ->
     check string "reason" "goal_cap"
@@ -71,16 +52,16 @@ let test_rejects_goal_cap () =
     check string "axis" "goal" (Admission.reject_reason_axis rejection.reason);
     check string "scope key" "goal:goal-a" rejection.scope_key
 
-let test_rejects_category_cap_across_repos () =
+let test_rejects_category_cap () =
   let active =
-    [ item ~goal_id:"goal-a" ~category:Admission.Refactor "repo-a" "one"
-    ; item ~goal_id:"goal-b" ~category:Admission.Refactor "repo-b" "two"
-    ; item ~goal_id:"goal-c" ~category:Admission.Refactor "repo-c" "three"
+    [ item ~goal_id:"goal-a" ~category:Admission.Refactor "one"
+    ; item ~goal_id:"goal-b" ~category:Admission.Refactor "two"
+    ; item ~goal_id:"goal-c" ~category:Admission.Refactor "three"
     ]
   in
   match
     Admission.decide ~caps active
-      ~scope:(scope ~goal_id:"goal-d" ~category:Admission.Refactor "repo-d")
+      ~scope:(scope ~goal_id:"goal-d" ~category:Admission.Refactor ())
   with
   | Admission.Admit _ -> fail "expected category cap rejection"
   | Reject rejection ->
@@ -90,21 +71,21 @@ let test_rejects_category_cap_across_repos () =
 
 let test_active_counts_surface_all_axes () =
   let active =
-    [ item ~goal_id:"goal-a" ~category:Admission.Fix "repo-a" "one"
-    ; item ~goal_id:"goal-b" ~category:Admission.Docs "repo-a" "two"
-    ; item ~goal_id:"goal-a" ~category:Admission.Fix "repo-b" "three"
+    [ item ~goal_id:"goal-a" ~category:Admission.Fix "one"
+    ; item ~goal_id:"goal-b" ~category:Admission.Docs "two"
+    ; item ~goal_id:"goal-a" ~category:Admission.Fix "three"
     ]
   in
-  let counts = Admission.active_counts ~scope:(scope ~goal_id:"goal-a" "repo-a") active in
+  let counts = Admission.active_counts ~scope:(scope ~goal_id:"goal-a" ()) active in
   check (list (pair string int)) "counts"
-    [ "global", 3; "repo:repo-a", 2; "goal:goal-a", 2; "category:fix", 2 ]
+    [ "global", 3; "goal:goal-a", 2; "category:fix", 2 ]
     counts
 
 let test_decision_json_rejects_with_scope_key () =
   let decision =
     Admission.decide
       ~caps:{ caps with max_global = Some 0 }
-      [] ~scope:(scope "repo-a")
+      [] ~scope:(scope ())
   in
   let json = Admission.decision_to_json decision in
   check string "reason" "global_cap"
@@ -114,7 +95,7 @@ let test_decision_json_rejects_with_scope_key () =
   check string "scope key" "global"
     Yojson.Safe.Util.(json |> member "scope_key" |> to_string)
 
-let test_scope_of_task_has_no_repo_uses_goal_and_title_category () =
+let test_scope_of_task_uses_goal_and_title_category () =
   let task_goal_index = Hashtbl.create 1 in
   Hashtbl.replace task_goal_index "task-001" ["goal-a"];
   let scope =
@@ -124,32 +105,8 @@ let test_scope_of_task_has_no_repo_uses_goal_and_title_category () =
          ~title:"refactor(keeper): split claim gate"
          "task-001")
   in
-  (* The task model carries no repo, so the scope resolves to [None] — exempt
-     from the per-repo cap rather than collapsed into a fleet-wide bucket. *)
-  check (option string) "repo" None scope.repo;
   check (option string) "goal" (Some "goal-a") scope.goal_id;
   check string "category" "refactor" (Admission.category_to_string scope.category)
-
-let test_repoless_tasks_exempt_from_repo_cap () =
-  (* Regression guard for the WIP-cap collapse: many repoless ([None]) tasks must
-     NOT share a single fleet-wide repo bucket. With [max_per_repo = Some 2] and
-     three already-active repoless items, a fourth repoless task still admits
-     (only the global cap bounds it). Before the fix, [task_repo] returned a
-     shared fallback string, so this rejected with repo_cap once 2 were active. *)
-  let active =
-    [ { Admission.id = "one"; scope = { Admission.repo = None; goal_id = None; category = Admission.Fix } }
-    ; { Admission.id = "two"; scope = { Admission.repo = None; goal_id = None; category = Admission.Docs } }
-    ; { Admission.id = "three"; scope = { Admission.repo = None; goal_id = None; category = Admission.Chore } }
-    ]
-  in
-  let repoless_scope = { Admission.repo = None; goal_id = None; category = Admission.Ci } in
-  match Admission.decide ~caps active ~scope:repoless_scope with
-  | Admission.Admit { active_count_after_admit } ->
-    check int "active after admit" 4 active_count_after_admit
-  | Reject rejection ->
-    fail
-      (Printf.sprintf "repoless task should be exempt from repo cap, got %s"
-         (Admission.reject_reason_to_string rejection.reason))
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_wip_admission_" "" in
@@ -431,8 +388,8 @@ let test_goalless_task_exempt_from_goal_cap () =
      when the goalless ([None]) bucket is at/over [max_per_goal]. With
      max_per_goal=1 and one goalless active item, the old behavior rejected;
      the exemption must now admit. *)
-  let active = [ item "repo-a" "one" ] in
-  match Admission.decide ~caps active ~scope:(scope "repo-b") with
+  let active = [ item "one" ] in
+  match Admission.decide ~caps active ~scope:(scope ()) with
   | Admission.Admit { active_count_after_admit } ->
     check int "active after admit" 2 active_count_after_admit
   | Reject rejection ->
@@ -441,18 +398,18 @@ let test_goalless_task_exempt_from_goal_cap () =
          (Admission.reject_reason_to_string rejection.reason))
 
 let test_goalless_tasks_never_goal_capped () =
-  (* RFC-0245: many goalless active items, each in a distinct repo/category so
-     only the per-goal cap could fire — it must not, because goalless tasks
-     share no goal scope to collide on. *)
+  (* RFC-0245: many goalless active items, each in a distinct category so only
+     the per-goal cap could fire — it must not, because goalless tasks share no
+     goal scope to collide on. *)
   let active =
-    [ item ~category:Admission.Fix "repo-a" "one"
-    ; item ~category:Admission.Docs "repo-b" "two"
-    ; item ~category:Admission.Refactor "repo-c" "three"
+    [ item ~category:Admission.Fix "one"
+    ; item ~category:Admission.Docs "two"
+    ; item ~category:Admission.Refactor "three"
     ]
   in
   match
     Admission.decide ~caps active
-      ~scope:(scope ~category:Admission.Test "repo-d")
+      ~scope:(scope ~category:Admission.Test ())
   with
   | Admission.Admit _ -> ()
   | Reject rejection ->
@@ -464,11 +421,11 @@ let test_goalless_still_bounded_by_global_cap () =
   (* RFC-0245 non-goal: exempting goalless from the *goal* cap must NOT remove
      the global blast-radius cap. With max_global=1 and one active item, a
      goalless claim is still rejected — by global_cap, not goal_cap. *)
-  let active = [ item "repo-a" "one" ] in
+  let active = [ item "one" ] in
   match
     Admission.decide
       ~caps:{ caps with max_global = Some 1 }
-      active ~scope:(scope "repo-b")
+      active ~scope:(scope ())
   with
   | Admission.Admit _ -> fail "expected global cap rejection for goalless claim"
   | Reject rejection ->
@@ -489,7 +446,6 @@ let with_env name value f =
 
 let wip_env_keys =
   [ "MASC_KEEPER_WIP_MAX_GLOBAL"
-  ; "MASC_KEEPER_WIP_MAX_PER_REPO"
   ; "MASC_KEEPER_WIP_MAX_PER_GOAL"
   ; "MASC_KEEPER_WIP_MAX_PER_CATEGORY"
   ]
@@ -504,7 +460,6 @@ let test_default_caps_unset_uses_historical_defaults () =
   else (
     let c = Admission.default_caps () in
     check (option int) "max_global default" (Some 16) c.Admission.max_global;
-    check (option int) "max_per_repo default" (Some 12) c.max_per_repo;
     check (option int) "max_per_goal default" (Some 3) c.max_per_goal;
     check (option int) "max_per_category default" (Some 4) c.max_per_category)
 
@@ -515,10 +470,10 @@ let test_default_caps_positive_env_override () =
   check (option int) "other axes untouched" (Some 3) c.max_per_goal
 
 let test_default_caps_disable_via_zero_and_negative () =
-  with_env "MASC_KEEPER_WIP_MAX_PER_REPO" "0" @@ fun () ->
+  with_env "MASC_KEEPER_WIP_MAX_GLOBAL" "0" @@ fun () ->
   with_env "MASC_KEEPER_WIP_MAX_PER_GOAL" "-1" @@ fun () ->
   let c = Admission.default_caps () in
-  check (option int) "per_repo disabled by 0" None c.Admission.max_per_repo;
+  check (option int) "global disabled by 0" None c.Admission.max_global;
   check (option int) "per_goal disabled by negative (clamped to 0)" None c.max_per_goal
 
 let test_default_caps_unparseable_keeps_default () =
@@ -543,19 +498,14 @@ let () =
   run "Keeper_wip_admission"
     [ ( "caps"
       , [ test_case "admits below caps" `Quick test_admits_below_caps
-        ; test_case "rejects repo cap before goal cap" `Quick
-            test_rejects_repo_cap_before_goal_cap
         ; test_case "rejects goal cap" `Quick test_rejects_goal_cap
-        ; test_case "rejects category cap across repos" `Quick
-            test_rejects_category_cap_across_repos
+        ; test_case "rejects category cap" `Quick test_rejects_category_cap
         ; test_case "active counts surface all axes" `Quick
             test_active_counts_surface_all_axes
         ; test_case "decision JSON rejects with scope key" `Quick
             test_decision_json_rejects_with_scope_key
-        ; test_case "task scope has no repo, uses goal and title category" `Quick
-            test_scope_of_task_has_no_repo_uses_goal_and_title_category
-        ; test_case "repoless tasks exempt from repo cap" `Quick
-            test_repoless_tasks_exempt_from_repo_cap
+        ; test_case "task scope uses goal and title category" `Quick
+            test_scope_of_task_uses_goal_and_title_category
           ; test_case "keeper_task_claim reports other keepers WIP cap" `Quick
               test_keeper_task_claim_reports_other_keepers_wip_cap
         ; test_case "keeper_task_claim releases stale owners before WIP admission"


### PR DESCRIPTION
## 목적

keeper WIP admission의 **per-repo cap(`Repo_cap`)을 제거**한다. worktree 격리 워크플로에서 존재 이유가 없고, 현재는 아무 것도 reject하지 않는 dead code다.

## 왜 제거하는가

- **worktree 격리가 충돌을 이미 처리한다.** 각 keeper가 별도 worktree/branch에서 작업 → merge conflict는 git/PR 층에서 해소. task-level 1:1 claim이 중복 작업을 막는다. "같은 repo에서 N명 동시 작업"은 충돌이 아니다.
- **fleet 자원 상한은 `max_global`이 이미 담당.** per-repo cap은 그 아래 중복 게이트.
- **이미 dead다.** `task_repo`가 모든 task를 `None`으로 resolve(task 모델에 repo 속성 없음) → `None`은 per-repo cap에서 면제 → cap이 한 건도 reject하지 않음. 과거 fleet-wide collapse(fallback repo 문자열이 모든 task를 `repo:<basename>` 한 버킷으로 뭉쳐 6/6 deadlock) 이후 axis를 제거하는 대신 `task_repo = None`으로 눌러둔 워크어라운드가 잔존했다.

## 변경

- `lib/keeper/keeper_wip_admission.ml` / `.mli`
  - `reject_reason`에서 `Repo_cap` variant 제거
  - `caps.max_per_repo` 필드 + runtime knob(`MASC_KEEPER_WIP_MAX_PER_REPO` / `keeper.wip.max_per_repo`) 제거
  - `scope.repo` 필드 + `task_repo` / `same_repo` / `repo_key` 헬퍼 제거
  - `decide`의 `repo_cap_check` / `repo_count`, `active_counts`의 repo 항목 제거
- `test/test_keeper_wip_admission.ml`
  - repo 전용 테스트 2개(`rejects_repo_cap_before_goal_cap`, `repoless_tasks_exempt_from_repo_cap`) 제거
  - `scope`/`item` 헬퍼에서 repo 인자 제거, 호출부 정리
  - `default_caps` disable 테스트를 global 축으로 이관

남는 상한: `max_global`(16) / `max_per_goal`(3) / `max_per_category`(4).

## 검증

- 로컬: `scripts/dune-local.sh build test/test_keeper_wip_admission.exe` + 테스트 실행 (아래 결과 첨부 예정)
- OCaml exhaustive match: `Repo_cap` 잔여 참조 시 컴파일 실패 → green이 완전 제거 증명
- 소비처 `keeper_tool_task_runtime.ml`은 `scope.repo`를 직접 읽지 않음(rejection.reason/axis만 소비) → blast radius는 이 모듈 + test로 닫힘

## 범위 밖

- **좀비 in_progress task GC** — repo_cap과 별개의 라이브 상태 문제(keeper 사라진 task가 slot 점유). 이 PR로 안 풀리며 별도 운영 조치.
- keen_mappings repo access 게이트 — 별개 트랙.

RFC-WAIVED: keeper_wip_admission은 credential/identity/operator/sandbox/hooks/workflow subsystem 미해당. WIP 동시성 회계 순수 로직 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
