### PR TITLE
[keeper] prompt-tier fallback when provider lacks json_schema (librarian/verifier/governance)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -662,16 +662,15 @@ let prompt_for_facts facts_json =
 
 let apply_governance_judge_output_schema provider_cfg =
   let schema = Keeper_structured_output_schema.governance_judge_output_schema in
-  let provider_cfg =
+  let native_cfg =
     Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
   in
-  match Llm_provider.Provider_config.validate_output_schema_request provider_cfg with
-  | Ok () -> Ok provider_cfg
-  | Error detail ->
-      Error
-        (Agent_sdk.Error.Config
-           (Agent_sdk.Error.InvalidConfig
-              { field = "dashboard.governance_judge.output_schema"; detail }))
+  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
+  | Ok () -> Ok native_cfg
+  | Error _ ->
+      (* Schema unavailable (GLM, MiMo, ollama cloud): prompt-tier fallback so the
+         governance judge still runs. Mirrors fusion_judge's fallback. *)
+      Ok provider_cfg
 
 let compute_judgments
     ~(masc_tools : Masc_domain.tool_schema list)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -260,18 +260,33 @@ let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
     | Some _ -> Some configured_librarian_max_tokens
     | None -> Some configured_librarian_max_tokens
   in
-  { provider_cfg with
-    max_tokens
-  ; temperature = Some 0.0
-  ; tool_choice = None
-  ; disable_parallel_tool_use = true
-  ; enable_thinking = Some false
-  ; preserve_thinking = Some false
-  ; thinking_budget = None
-  ; clear_thinking = Some true
-  }
-    |> Keeper_structured_output_schema.apply_to_provider_config
-         Keeper_structured_output_schema.librarian_episode_output_schema
+  let tuned_cfg =
+    { provider_cfg with
+      max_tokens
+    ; temperature = Some 0.0
+    ; tool_choice = None
+    ; disable_parallel_tool_use = true
+    ; enable_thinking = Some false
+    ; preserve_thinking = Some false
+    ; thinking_budget = None
+    ; clear_thinking = Some true
+    }
+  in
+  (* Native json_schema when the provider declares it; otherwise fall back to the
+     schema-free tuned config so json_object / free-text providers (GLM, MiMo,
+     ollama cloud) can still serve the librarian. The schema gate is NOT the
+     silent-failure safety net — the parse-retry loop below plus WARN on
+     permanent failure is. Mirrors fusion_judge's prompt-tier fallback. *)
+  let native_cfg =
+    Keeper_structured_output_schema.apply_to_provider_config
+      Keeper_structured_output_schema.librarian_episode_output_schema tuned_cfg
+  in
+  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
+  | Ok () -> native_cfg
+  (* Schema unavailable (GLM, MiMo, ollama cloud): prompt-tier fallback. The
+     parse-retry loop below + WARN on permanent failure is the silent-failure
+     safety net — the schema gate is not. Mirrors fusion_judge's fallback. *)
+  | Error _ -> tuned_cfg
 ;;
 
 let message role text =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -62,16 +62,16 @@ If you cannot call the tool, return only the same JSON object with fields
 
 let apply_report_verdict_output_schema provider_cfg =
   let schema = Keeper_structured_output_schema.verification_verdict_output_schema in
-  let provider_cfg =
+  let native_cfg =
     Keeper_structured_output_schema.apply_to_provider_config schema provider_cfg
   in
-  match Llm_provider.Provider_config.validate_output_schema_request provider_cfg with
-  | Ok () -> Ok provider_cfg
-  | Error detail ->
-    Error
-      (Agent_sdk.Error.Config
-         (Agent_sdk.Error.InvalidConfig
-            { field = "verification.report_verdict.output_schema"; detail }))
+  match Llm_provider.Provider_config.validate_output_schema_request native_cfg with
+  | Ok () -> Ok native_cfg
+  | Error _ ->
+    (* Schema unavailable (GLM, MiMo, ollama cloud): prompt-tier fallback so the
+       verifier still runs; the caller parses the response as free-text/JSON.
+       Mirrors fusion_judge's fallback. *)
+    Ok provider_cfg
 ;;
 
 let parse_verdict_from_response_text text =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1567,7 +1567,7 @@ let test_librarian_runtime_appends_episode_bundle () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
-let test_librarian_runtime_rejects_invalid_schema_provider_before_call () =
+let test_librarian_runtime_falls_back_when_schema_unavailable () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
@@ -1593,20 +1593,15 @@ let test_librarian_runtime_rejects_invalid_schema_provider_before_call () =
             ~generation:1
             inp
         with
-        | Ok _ -> Alcotest.fail "expected invalid schema provider to fail closed"
-        | Error (Librarian_runtime.Provider_config_rejected msg) ->
+        | Ok _ ->
           Alcotest.(check bool)
-            "fake complete was not called"
-            false
-            !called;
-          Alcotest.(check bool)
-            "rejection cites native structured output"
+            "complete called on the prompt-tier fallback path"
             true
-            (contains "native structured output" msg)
+            !called
         | Error err ->
           Alcotest.fail
             (Printf.sprintf
-               "expected provider config rejection, got %s"
+               "expected prompt-tier fallback to succeed, got %s"
                (Librarian_runtime.extraction_error_to_string err)))))
 ;;
 
@@ -5781,9 +5776,9 @@ let () =
             `Quick
             test_librarian_runtime_appends_episode_bundle
         ; Alcotest.test_case
-            "librarian runtime rejects invalid schema provider before call"
+            "librarian runtime falls back when schema unavailable"
             `Quick
-            test_librarian_runtime_rejects_invalid_schema_provider_before_call
+            test_librarian_runtime_falls_back_when_schema_unavailable
         ; Alcotest.test_case
             "librarian runtime requires clock for provider call"
             `Quick


### PR DESCRIPTION
## Summary

Seven structured-output call sites hard-rejected providers that don't support native `json_schema` (GLM, MiMo, ollama cloud) via `Config InvalidConfig` / `Provider_config_rejected` / `Transport_failed`. With the runtime routed to such a provider (e.g. `librarian = "glm-coding.glm-5-turbo"`), episode extraction, verification, and judgment silently broke. `fusion_judge` already had the correct prompt-tier fallback; this applies the same pattern everywhere a hard reject existed.

## Call sites

- `keeper_librarian_runtime` — `provider_for_librarian` validates `native_cfg`, falls back to `tuned_cfg` on `Error`.
- `verifier_oas` — `apply_report_verdict_output_schema` returns `Ok` with the schema-free cfg (was `Config InvalidConfig`).
- `dashboard_governance_judge` — same pattern.
- `workspace_metric_hooks` — `apply_review_verdict_output_schema` (anti_rationalization), same.
- `dashboard_operator_judge` — same.
- `keeper_adversarial_review` — same.
- `keeper_memory_os_consolidation_runtime` — `provider_for_consolidation`, same.
- **unchanged**: `keeper_vision_tool` and `keeper_memory_llm_summary` already use a `*_schema_supported` **pre-check** (not a hard reject), so they already degrade gracefully.
- test: flip "rejects invalid schema before call" → "falls back when schema unavailable" (complete called, `Ok`).

## Why

The schema gate is not the silent-failure safety net — the parse-retry loop (`keeper_librarian`) plus WARN on permanent failure is. This removes the hard gates so `json_object` providers can serve these lanes; it does not remove the safety net. `validate_output_schema_request` itself is the runtime probe, so no provider-capability matrix / hardcoding is introduced (Instructor-style; same approach Hermes/OpenClaw take by not keeping a capability matrix).

`RFC-WAIVED: lib/keeper, lib/verifier_oas, lib/dashboard, lib/workspace changes are structured-output fallback only; no credential/identity/auth/operator-control surface.`

Tuning-value env-config follow-up tracked in #23153 (kept separate per surgical-changes).

## Validation

- `scripts/dune-local.sh build lib/ test/test_keeper_memory_os.exe`
- `./_build/default/test/test_keeper_memory_os.exe test "librarian runtime"` → 6/6 pass
- `opam exec -- ocamlformat --check` (clean)
