### PR TITLE
fix(keeper): HITL 승인 resolve/expire 시 keeper wake (핑 미수신 버그)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -777,6 +777,40 @@ let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =
       Hitl_summary_worker.spawn ~sw ~entry ~provider_config:config ~on_summary ~on_failure ()
 ;;
 
+(* Wake the keeper that was waiting on this approval. A keeper that enqueued an
+   approval and is now skipping cycles via [has_pending_for_keeper -> Skip
+   Approval_pending] (keeper_world_observation) has no in-process fiber blocked
+   on the resolver promise, so resolving the promise does not resume it. The
+   composition root registers a hook that enqueues a [Hitl_resolved] wake
+   stimulus — the same async-completion-wake mechanism [Fusion_completed]
+   (RFC-0266) and [Bg_completed] (RFC-0290) use — so the keeper re-evaluates
+   immediately instead of stalling until an unrelated stimulus, no-progress
+   recovery, or the 30-minute approval janitor.
+
+   Injected as a hook rather than a direct call to break a dependency cycle:
+   this module sits below [Keeper_keepalive_signal], which depends on
+   [Keeper_world_observation], which depends back on this module for
+   [has_pending_for_keeper]. The default is a no-op so unit tests and
+   pre-bootstrap contexts stay wake-free; [Server_bootstrap] installs the real
+   [Keeper_keepalive_signal]-backed wake. *)
+let approval_resolution_wake_hook :
+    (base_path:string -> keeper_name:string -> approval_id:string -> decision:string -> unit)
+    ref =
+  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ())
+
+let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
+
+let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision =
+  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn
+      ~keeper_name
+      "hitl resolution wake failed approval=%s: %s"
+      approval_id
+      (Printexc.to_string exn)
+;;
+
 let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
   Log.Keeper.info
@@ -823,6 +857,11 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
            (Printexc.to_string exn))
        (fun () -> f decision)
    | None -> ());
+  wake_keeper_on_approval_resolution
+    ~base_path
+    ~keeper_name:entry.keeper_name
+    ~approval_id:entry.id
+    ~decision:decision_str;
   try
     Sse.broadcast
       (`Assoc
@@ -1407,6 +1446,15 @@ let expire_stale ~max_wait_s =
          ?disposition_reason:entry.disposition_reason
          ~decision:(Approval_expired reason)
          ();
+       (* Expiry clears the [Approval_pending] skip just like a resolution, so
+          the keeper needs the same wake or it stays stalled until an unrelated
+          stimulus. The keeper's suspended tool call (if any) receives
+          [Reject reason]. *)
+       wake_keeper_on_approval_resolution
+         ~base_path:entry.audit_base_path
+         ~keeper_name:entry.keeper_name
+         ~approval_id:id
+         ~decision:"reject";
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -794,7 +794,11 @@ let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =
    pre-bootstrap contexts stay wake-free; [Server_bootstrap] installs the real
    [Keeper_keepalive_signal]-backed wake. *)
 let approval_resolution_wake_hook :
-    (base_path:string -> keeper_name:string -> approval_id:string -> decision:string -> unit)
+    (base_path:string ->
+     keeper_name:string ->
+     approval_id:string ->
+     decision:Keeper_event_queue.hitl_resolution_decision ->
+     unit)
     ref =
   ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ())
 
@@ -809,6 +813,12 @@ let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~dec
       "hitl resolution wake failed approval=%s: %s"
       approval_id
       (Printexc.to_string exn)
+;;
+
+let hitl_resolution_decision_of_approval_decision = function
+  | Agent_sdk.Hooks.Approve -> Keeper_event_queue.Hitl_approved
+  | Agent_sdk.Hooks.Reject _ -> Keeper_event_queue.Hitl_rejected
+  | Agent_sdk.Hooks.Edit _ -> Keeper_event_queue.Hitl_edited
 ;;
 
 let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
@@ -861,7 +871,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ~base_path
     ~keeper_name:entry.keeper_name
     ~approval_id:entry.id
-    ~decision:decision_str;
+    ~decision:(hitl_resolution_decision_of_approval_decision decision);
   try
     Sse.broadcast
       (`Assoc
@@ -1454,7 +1464,7 @@ let expire_stale ~max_wait_s =
          ~base_path:entry.audit_base_path
          ~keeper_name:entry.keeper_name
          ~approval_id:id
-         ~decision:"reject";
+         ~decision:Keeper_event_queue.Hitl_rejected;
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -309,6 +309,17 @@ val submit_pending :
 
 (** {1 Resolve (operator action)} *)
 
+(** Install the hook that wakes a keeper when one of its pending approvals is
+    resolved or expires. Injected (rather than a direct
+    [Keeper_keepalive_signal] call) to break a dependency cycle: this module
+    sits below [Keeper_keepalive_signal], which depends on
+    [Keeper_world_observation], which depends back here for
+    [has_pending_for_keeper]. The default is a no-op; [Server_bootstrap]
+    installs the [Hitl_resolved]-stimulus wake. *)
+val set_approval_resolution_wake_hook :
+  (base_path:string -> keeper_name:string -> approval_id:string -> decision:string -> unit) ->
+  unit
+
 (** Resolve a pending approval and optionally remember the decision
     as a rule. Returns [Not_found] when [id] is absent or
     [Already_resolved] on concurrent-resolve race. *)

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -317,7 +317,11 @@ val submit_pending :
     [has_pending_for_keeper]. The default is a no-op; [Server_bootstrap]
     installs the [Hitl_resolved]-stimulus wake. *)
 val set_approval_resolution_wake_hook :
-  (base_path:string -> keeper_name:string -> approval_id:string -> decision:string -> unit) ->
+  (base_path:string ->
+   keeper_name:string ->
+   approval_id:string ->
+   decision:Keeper_event_queue.hitl_resolution_decision ->
+   unit) ->
   unit
 
 (** Resolve a pending approval and optionally remember the decision

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -145,7 +145,8 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Fusion_completed _
       | Keeper_event_queue.Bg_completed _
       | Keeper_event_queue.Bootstrap
-      | Keeper_event_queue.No_progress_recovery ->
+      | Keeper_event_queue.No_progress_recovery
+      | Keeper_event_queue.Hitl_resolved _ ->
         None)
     stimuli
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -80,7 +80,12 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
     Some Keeper_world_observation.Connector_attention_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Fusion_completed _
-  | Keeper_event_queue.Bg_completed _ ->
+  | Keeper_event_queue.Bg_completed _
+  | Keeper_event_queue.Hitl_resolved _ ->
+    (* No dedicated turn_reason: like the other async-completion wakes, the
+       stimulus itself forces the keeper to re-run its cycle. Once the resolved
+       approval has left the queue the keeper no longer skips on
+       [Approval_pending] and proceeds on its own state. *)
     None
 ;;
 
@@ -187,6 +192,19 @@ let consume_single_heartbeat_stimulus
       ca.event_id
       meta_after_triage.name;
     pending_events
+  | Keeper_event_queue.Hitl_resolved r ->
+    (* The HITL approval this keeper was skipping on ([Skip Approval_pending])
+       was resolved. The wake is the whole point: the approval has left the
+       queue, so this cycle no longer skips and the keeper resumes on its own
+       state. There is no observation to inject — the decision reached the
+       keeper's suspended tool call (or the reject/expire teardown) through the
+       resolver, not turn input; injecting a pending event would fabricate one. *)
+    Log.Keeper.info
+      "turn entry: hitl resolution delivered approval=%s decision=%s (keeper=%s)"
+      r.approval_id
+      r.decision
+      meta_after_triage.name;
+    []
 ;;
 
 let consume_board_stimulus_batch ~meta_after_triage batch =

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -202,7 +202,7 @@ let consume_single_heartbeat_stimulus
     Log.Keeper.info
       "turn entry: hitl resolution delivered approval=%s decision=%s (keeper=%s)"
       r.approval_id
-      r.decision
+      (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
       meta_after_triage.name;
     []
 ;;

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -169,7 +169,10 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
   | Keeper_event_queue.Connector_attention ca ->
     Printf.sprintf "connector_attention event_id=%s" ca.event_id
   | Keeper_event_queue.Hitl_resolved r ->
-    Printf.sprintf "hitl_resolved approval=%s decision=%s" r.approval_id r.decision
+    Printf.sprintf
+      "hitl_resolved approval=%s decision=%s"
+      r.approval_id
+      (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -11,6 +11,7 @@ type stimulus_kind =
   | Bg_completed  (* RFC-0290: generic background job completion wake *)
   | Connector_attention
       (* RFC-connector-ambient-attention-wake: ambient connector message wake *)
+  | Hitl_resolved  (* HITL approval resolution wake — unblocks Skip Approval_pending *)
 
 type reaction_kind =
   | Turn_started
@@ -30,6 +31,7 @@ let stimulus_kind_to_string = function
   | Fusion_completed -> "fusion_completed"
   | Bg_completed -> "bg_completed"
   | Connector_attention -> "connector_attention"
+  | Hitl_resolved -> "hitl_resolved"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -43,6 +45,7 @@ let stimulus_kind_of_string = function
   | "fusion_completed" -> Some Fusion_completed
   | "bg_completed" -> Some Bg_completed
   | "connector_attention" -> Some Connector_attention
+  | "hitl_resolved" -> Some Hitl_resolved
   | _ -> None
 ;;
 
@@ -88,6 +91,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Fusion_completed _ -> Fusion_completed
   | Keeper_event_queue.Bg_completed _ -> Bg_completed
   | Keeper_event_queue.Connector_attention _ -> Connector_attention
+  | Keeper_event_queue.Hitl_resolved _ -> Hitl_resolved
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -164,6 +168,8 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       (Keeper_event_queue.bg_job_kind_to_string c.bg_kind)
   | Keeper_event_queue.Connector_attention ca ->
     Printf.sprintf "connector_attention event_id=%s" ca.event_id
+  | Keeper_event_queue.Hitl_resolved r ->
+    Printf.sprintf "hitl_resolved approval=%s decision=%s" r.approval_id r.decision
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -177,7 +183,8 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.No_progress_recovery
     | Keeper_event_queue.Fusion_completed _
     | Keeper_event_queue.Bg_completed _
-    | Keeper_event_queue.Connector_attention _ -> None
+    | Keeper_event_queue.Connector_attention _
+    | Keeper_event_queue.Hitl_resolved _ -> None
   in
   `Assoc
     (base_fields
@@ -660,7 +667,7 @@ let summarize_rows ~keeper_name ~limit rows =
           강제한다 (catch-all 금지). *)
        | Some
            ( Board_signal | Bootstrap | No_progress_recovery | Fusion_completed
-           | Bg_completed | Connector_attention )
+           | Bg_completed | Connector_attention | Hitl_resolved )
          -> ())
   in
   let note_payload_parse_error row =
@@ -754,7 +761,7 @@ let summarize_rows ~keeper_name ~limit rows =
         | Some No_progress_recovery -> true
         | Some
             ( Board_signal | Bootstrap | Fusion_completed | Bg_completed
-            | Connector_attention )
+            | Connector_attention | Hitl_resolved )
         | None ->
           false)
       pending_stimulus_ids

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -17,6 +17,7 @@ type stimulus_kind =
   | Fusion_completed  (** RFC-0266: async masc_fusion completion wake *)
   | Bg_completed  (** RFC-0290: generic background job completion wake *)
   | Connector_attention
+  | Hitl_resolved  (** HITL approval resolution wake — unblocks [Skip Approval_pending] *)
       (** RFC-connector-ambient-attention-wake: ambient connector message wake *)
 
 type reaction_kind =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -594,10 +594,12 @@ let pending_board_event_of_stimulus
       (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c)
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.No_progress_recovery
-  | Keeper_event_queue.Connector_attention _ ->
+  | Keeper_event_queue.Connector_attention _
+  | Keeper_event_queue.Hitl_resolved _ ->
     (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
-       fires via the Connector_attention_stimulus trigger; content threading
-       from external_attention is P3. *)
+       fires via the trigger itself; [Hitl_resolved] carries no observation to
+       inject — the keeper resumes on its own state once the approval is gone
+       from the queue. *)
     None
 ;;
 

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -41,6 +41,14 @@ type stimulus_payload =
          recorded as external attention. Carries the [event_id] pointer (not
          content). Dormant — no producer emits it yet (handle_ambient enqueuer
          lands in P3), same staging as [Bg_completed] above. *)
+  | Hitl_resolved of hitl_resolution
+      (* A HITL approval this keeper enqueued — and then skipped cycles on via
+         [has_pending_for_keeper -> Skip Approval_pending] — was resolved. Wakes
+         the keeper so it re-evaluates and proceeds on its next cycle instead of
+         stalling until an unrelated stimulus, no-progress recovery, or the
+         30-minute approval janitor. Mirrors [Fusion_completed]/[Bg_completed]:
+         a HITL decision is an async completion the waiting keeper must be
+         notified of. *)
 
 and fusion_completion = {
   run_id : string;
@@ -63,6 +71,15 @@ and bg_job_kind = Subprocess
       (* RFC-0290: closed sum of background job kinds (v1 = [Subprocess]); a new
          kind forces every match to add an arm rather than defaulting. *)
 
+and hitl_resolution = {
+  approval_id : string;
+  (* the resolved pending-approval id; correlates to the queue entry. *)
+  decision : string;
+  (* resolved decision label ("approve" | "reject" | ...); carried for
+     observability, not for control flow — the keeper re-evaluates from its
+     own state once the approval is gone from the queue. *)
+}
+
 and bg_job_outcome =
   | Bg_ok of string  (* result payload *)
   | Bg_failed of string  (* failure label *)
@@ -79,6 +96,8 @@ let fusion_completion_post_id (fc : fusion_completion) =
 let bg_job_completion_post_id (c : bg_job_completion) =
   if String.equal c.bg_board_post_id "" then "bg-run:" ^ c.bg_run_id
   else c.bg_board_post_id
+
+let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
 
 let bg_job_kind_to_string = function
   | Subprocess -> "subprocess"
@@ -192,11 +211,12 @@ let payload_kind_label = function
   | Fusion_completed _ -> "fusion_completed"
   | Bg_completed _ -> "bg_completed"
   | Connector_attention _ -> "connector_attention"
+  | Hitl_resolved _ -> "hitl_resolved"
 
 let is_board_signal = function
   | Board_signal _ -> true
   | Bootstrap | No_progress_recovery | Fusion_completed _ | Bg_completed _
-  | Connector_attention _ ->
+  | Connector_attention _ | Hitl_resolved _ ->
     false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
@@ -329,6 +349,12 @@ let payload_to_yojson = function
       [ "kind", `String "connector_attention"
       ; "event_id", `String ca.event_id
       ]
+  | Hitl_resolved r ->
+    `Assoc
+      [ "kind", `String "hitl_resolved"
+      ; "approval_id", `String r.approval_id
+      ; "decision", `String r.decision
+      ]
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -366,6 +392,10 @@ let payload_of_yojson json =
   | "connector_attention" ->
     let* event_id = string_field ~context "event_id" fields in
     Ok (Connector_attention { event_id })
+  | "hitl_resolved" ->
+    let* approval_id = string_field ~context "approval_id" fields in
+    let* decision = string_field ~context "decision" fields in
+    Ok (Hitl_resolved { approval_id; decision })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -71,13 +71,18 @@ and bg_job_kind = Subprocess
       (* RFC-0290: closed sum of background job kinds (v1 = [Subprocess]); a new
          kind forces every match to add an arm rather than defaulting. *)
 
+and hitl_resolution_decision =
+  | Hitl_approved
+  | Hitl_rejected
+  | Hitl_edited
+
 and hitl_resolution = {
   approval_id : string;
   (* the resolved pending-approval id; correlates to the queue entry. *)
-  decision : string;
-  (* resolved decision label ("approve" | "reject" | ...); carried for
-     observability, not for control flow — the keeper re-evaluates from its
-     own state once the approval is gone from the queue. *)
+  decision : hitl_resolution_decision;
+  (* resolved decision label carried for observability, not control flow — the
+     keeper re-evaluates from its own state once the approval is gone from the
+     queue. *)
 }
 
 and bg_job_outcome =
@@ -98,6 +103,17 @@ let bg_job_completion_post_id (c : bg_job_completion) =
   else c.bg_board_post_id
 
 let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
+
+let hitl_resolution_decision_to_string = function
+  | Hitl_approved -> "approve"
+  | Hitl_rejected -> "reject"
+  | Hitl_edited -> "edit"
+
+let hitl_resolution_decision_of_string = function
+  | "approve" -> Ok Hitl_approved
+  | "reject" -> Ok Hitl_rejected
+  | "edit" -> Ok Hitl_edited
+  | other -> Error (Printf.sprintf "unknown hitl_resolution decision: %s" other)
 
 let bg_job_kind_to_string = function
   | Subprocess -> "subprocess"
@@ -353,7 +369,7 @@ let payload_to_yojson = function
     `Assoc
       [ "kind", `String "hitl_resolved"
       ; "approval_id", `String r.approval_id
-      ; "decision", `String r.decision
+      ; "decision", `String (hitl_resolution_decision_to_string r.decision)
       ]
 
 let payload_of_yojson json =
@@ -394,7 +410,8 @@ let payload_of_yojson json =
     Ok (Connector_attention { event_id })
   | "hitl_resolved" ->
     let* approval_id = string_field ~context "approval_id" fields in
-    let* decision = string_field ~context "decision" fields in
+    let* decision_s = string_field ~context "decision" fields in
+    let* decision = hitl_resolution_decision_of_string decision_s in
     Ok (Hitl_resolved { approval_id; decision })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -109,9 +109,14 @@ and bg_job_outcome =
   | Bg_ok of string  (** result payload *)
   | Bg_failed of string  (** failure label *)
 
+and hitl_resolution_decision =
+  | Hitl_approved
+  | Hitl_rejected
+  | Hitl_edited
+
 and hitl_resolution = {
   approval_id : string;
-  decision : string;
+  decision : hitl_resolution_decision;
 }
 (** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
     pending-approval queue entry; [decision] is the resolved label
@@ -137,6 +142,9 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 (** Dedup/correlation id for [Hitl_resolved]: ["hitl-approval:<approval_id>"].
     De-dups repeat resolve wakes for the same approval within the dedup
     window. *)
+
+val hitl_resolution_decision_to_string : hitl_resolution_decision -> string
+(** Stable wire/log label for a HITL resolution wake decision. *)
 
 val bg_job_kind_to_string : bg_job_kind -> string
 (** RFC-0290: stable label for a background job kind, for logs and correlation

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -64,6 +64,12 @@ type stimulus_payload =
           content on the turn path and there is no payload duplication.
           Edge-triggered: dequeued once, re-armed only by a new ambient
           message. Dormant until [handle_ambient] enqueues it (P3). *)
+  | Hitl_resolved of hitl_resolution
+      (** A HITL approval this keeper enqueued — and skipped cycles on via
+          [has_pending_for_keeper -> Skip Approval_pending] — was resolved.
+          Wakes the keeper so it re-evaluates immediately instead of stalling
+          until an unrelated stimulus, no-progress recovery, or the 30-minute
+          approval janitor. Mirrors [Fusion_completed]/[Bg_completed]. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -103,6 +109,16 @@ and bg_job_outcome =
   | Bg_ok of string  (** result payload *)
   | Bg_failed of string  (** failure label *)
 
+and hitl_resolution = {
+  approval_id : string;
+  decision : string;
+}
+(** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
+    pending-approval queue entry; [decision] is the resolved label
+    ("approve" | "reject" | ...), carried for observability. The keeper
+    re-evaluates from its own state once the approval leaves the queue, so the
+    decision is not itself control flow. *)
+
 and connector_attention = { event_id : string }
 (** RFC-connector-ambient-attention-wake payload for [Connector_attention]:
     [event_id] is the pointer into [Keeper_external_attention] for the ambient
@@ -116,6 +132,11 @@ val fusion_completion_post_id : fusion_completion -> post_id
 val bg_job_completion_post_id : bg_job_completion -> post_id
 (** RFC-0290 dedup/correlation id for [Bg_completed]. Uses [bg_board_post_id]
     when the producer set it, otherwise falls back to ["bg-run:<run_id>"]. *)
+
+val hitl_resolution_post_id : hitl_resolution -> post_id
+(** Dedup/correlation id for [Hitl_resolved]: ["hitl-approval:<approval_id>"].
+    De-dups repeat resolve wakes for the same approval within the dedup
+    window. *)
 
 val bg_job_kind_to_string : bg_job_kind -> string
 (** RFC-0290: stable label for a background job kind, for logs and correlation

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -505,6 +505,7 @@ let start_keeper_loops
   Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun ~base_path ~keeper_name ~approval_id ~decision ->
        let resolution = Keeper_event_queue.{ approval_id; decision } in
+       let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
        let stimulus : Keeper_event_queue.stimulus =
          { Keeper_event_queue.post_id = Keeper_event_queue.hitl_resolution_post_id resolution
          ; urgency = Keeper_event_queue.Immediate
@@ -516,7 +517,7 @@ let start_keeper_loops
          "hitl resolution wake: keeper=%s approval=%s decision=%s"
          keeper_name
          approval_id
-         decision;
+         decision_label;
        Keeper_keepalive_signal.wakeup_keeper ~base_path ~stimulus keeper_name);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -497,6 +497,27 @@ let start_keeper_loops
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
       ~config:(Mcp_server.workspace_config state)
       signal);
+  (* Wake a keeper when one of its pending HITL approvals resolves/expires.
+     Registered here (composition root) rather than in Keeper_approval_queue to
+     break the Keeper_approval_queue -> Keeper_keepalive_signal ->
+     Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
+     the Fusion_completed/Bg_completed async-completion wakes. *)
+  Keeper_approval_queue.set_approval_resolution_wake_hook
+    (fun ~base_path ~keeper_name ~approval_id ~decision ->
+       let resolution = Keeper_event_queue.{ approval_id; decision } in
+       let stimulus : Keeper_event_queue.stimulus =
+         { Keeper_event_queue.post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+         ; urgency = Keeper_event_queue.Immediate
+         ; arrived_at = Time_compat.now ()
+         ; payload = Keeper_event_queue.Hitl_resolved resolution
+         }
+       in
+       Log.Keeper.info
+         "hitl resolution wake: keeper=%s approval=%s decision=%s"
+         keeper_name
+         approval_id
+         decision;
+       Keeper_keepalive_signal.wakeup_keeper ~base_path ~stimulus keeper_name);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in
     Sse.broadcast

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -112,6 +112,63 @@ let test_fresh_critical_entry_phase_is_awaiting_operator () =
        | None -> Alcotest.fail "Critical approval did not resume after resolve")
 ;;
 
+(* A keeper skipping cycles on [Approval_pending] is not blocked in-process, so
+   resolving must fire the wake hook that enqueues a [Hitl_resolved] stimulus.
+   Without it the keeper only resumes on an unrelated stimulus / no-progress
+   recovery / the 30-minute janitor (the reported "HITL 됐는데 핑을 못 받음"). *)
+let test_resolve_fires_keeper_wake_hook () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_path = temp_dir () in
+  let woke = ref None in
+  AQ.set_approval_resolution_wake_hook (fun ~base_path:_ ~keeper_name ~approval_id ~decision ->
+    woke := Some (keeper_name, approval_id, decision));
+  Fun.protect
+    ~finally:(fun () ->
+      (* Reset to the default no-op so the recording closure does not leak into
+         later tests that share this module-level hook. *)
+      AQ.set_approval_resolution_wake_hook
+        (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ());
+      cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run
+       @@ fun sw ->
+       let keeper_name = "resolve-wake-test" in
+       let result = ref None in
+       Eio.Fiber.fork ~sw (fun () ->
+         let decision =
+           AQ.submit_and_await
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_reconcile"
+             ~input:(`Assoc [ "kind", `String "critical_gate" ])
+             ~risk_level:AQ.Critical
+             ~base_path
+             ()
+         in
+         result := Some decision);
+       yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+       let id =
+         match pending_id_for_keeper ~keeper_name with
+         | Some id -> id
+         | None -> Alcotest.fail "Critical approval was not queued"
+       in
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       (* resolve_entry fires the hook synchronously before returning. *)
+       (match !woke with
+        | Some (kn, aid, decision) ->
+          Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
+          Alcotest.(check string) "wake carries the resolved approval id" id aid;
+          Alcotest.(check bool)
+            "wake carries a non-empty decision label"
+            true
+            (String.length decision > 0)
+        | None -> Alcotest.fail "resolve did not fire the keeper wake hook");
+       yield_until (fun () -> Option.is_some !result))
+;;
+
 let test_critical_entry_phase_becomes_escalated_after_timer () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -360,6 +417,12 @@ let () =
             "Critical entry becomes Escalated after escalation timer"
             `Quick
             test_critical_entry_phase_becomes_escalated_after_timer
+        ] )
+    ; ( "wake"
+      , [ Alcotest.test_case
+            "resolve fires the keeper wake hook"
+            `Quick
+            test_resolve_fires_keeper_wake_hook
         ] )
     ; ( "summary"
       , [ Alcotest.test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -162,9 +162,9 @@ let test_resolve_fires_keeper_wake_hook () =
           Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
           Alcotest.(check string) "wake carries the resolved approval id" id aid;
           Alcotest.(check bool)
-            "wake carries a non-empty decision label"
+            "wake carries the typed decision label"
             true
-            (String.length decision > 0)
+            (decision = Keeper_event_queue.Hitl_approved)
         | None -> Alcotest.fail "resolve did not fire the keeper wake hook");
        yield_until (fun () -> Option.is_some !result))
 ;;

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -119,17 +119,19 @@ let () =
   (match
      stimulus_of_yojson
        (stimulus_to_yojson
-          { post_id = hitl_resolution_post_id { approval_id = "appr-9"; decision = "approve" }
+          { post_id =
+              hitl_resolution_post_id
+                { approval_id = "appr-9"; decision = Hitl_approved }
           ; urgency = Immediate
           ; arrived_at = 4.0
-          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = "approve" }
+          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = Hitl_approved }
           })
    with
    | Ok s ->
      (match s.payload with
       | Hitl_resolved { approval_id; decision } ->
         assert (String.equal approval_id "appr-9");
-        assert (String.equal decision "approve");
+        assert (decision = Hitl_approved);
         assert (String.equal s.post_id "hitl-approval:appr-9")
       | _ -> Alcotest.fail "Hitl_resolved codec round-trip changed payload shape")
    | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -113,6 +113,27 @@ let () =
       | _ -> Alcotest.fail "Bg_completed codec round-trip changed payload shape")
    | Error msg -> Alcotest.fail ("Bg_completed stimulus round-trip failed: " ^ msg));
 
+  (* Hitl_resolved survives the codec round-trip: the wake is persisted for
+     replay when the target keeper is not registered yet, so approval_id and
+     decision must round-trip intact. *)
+  (match
+     stimulus_of_yojson
+       (stimulus_to_yojson
+          { post_id = hitl_resolution_post_id { approval_id = "appr-9"; decision = "approve" }
+          ; urgency = Immediate
+          ; arrived_at = 4.0
+          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = "approve" }
+          })
+   with
+   | Ok s ->
+     (match s.payload with
+      | Hitl_resolved { approval_id; decision } ->
+        assert (String.equal approval_id "appr-9");
+        assert (String.equal decision "approve");
+        assert (String.equal s.post_id "hitl-approval:appr-9")
+      | _ -> Alcotest.fail "Hitl_resolved codec round-trip changed payload shape")
+   | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));
+
   (* --- queue operations preserved --- *)
   let board_stim =
     { post_id = "p1"; urgency = Normal; arrived_at = 0.0; payload = board_payload () }


### PR DESCRIPTION
## 목표

HITL 승인이 결정(resolve)됐는데도 대기 중인 keeper가 핑(wake)을 못 받아 계속 "기다리는 중"에 멈추는 버그를 고칩니다(스크린샷의 `executor` 사례). 사용자 스펙 "HITL은 keeper를 블로킹하지 않고, **결정되면 keeper를 깨우거나** 작업 큐에 넣음"의 "깨우거나" 부분이 미구현이었습니다.

## 근본 원인

keeper가 HITL 승인을 큐잉하고 in-process로 promise를 await하지 **않는** 경우(스크린샷처럼 턴이 끝나고 다음 사이클을 도는 경우), `keeper_world_observation`의 `has_pending_for_keeper -> Skip Approval_pending`으로 **매 사이클을 건너뜁니다**. 승인이 resolve되면 `Keeper_approval_queue.resolve`는:
- resolver promise를 fulfill (await 안 하는 keeper엔 no-op)
- on_resolution 콜백 발화
- SSE broadcast

하지만 **keeper wake stimulus를 전혀 enqueue하지 않습니다.** 그래서 keeper는 무관한 다른 stimulus / no-progress-recovery / 30분 janitor로만 뒤늦게 재개됩니다.

## 수정 — 기존 async-completion wake 패턴(RFC-0266/0290) 재사용

keeper event queue는 이미 `Fusion_completed`(RFC-0266)·`Bg_completed`(RFC-0290)로 비동기 완료를 keeper에게 알립니다. HITL을 같은 메커니즘에 편입:

- `Keeper_event_queue`에 **`Hitl_resolved` stimulus 변형**(payload: approval_id + decision) 추가 + codec round-trip(미등록 keeper용 replay 영속화). closed sum이라 컴파일러가 6개 match 사이트(reaction ledger, heartbeat loop/intake, world observation)를 강제로 지목 → catch-all 없이 전부 처리.
- `resolve_entry`와 `expire_stale`이 wake hook 호출 → `Keeper_keepalive_signal.wakeup_keeper`로 stimulus enqueue.
- **hook은 composition root(`Server_bootstrap`)에서 주입** — `Keeper_approval_queue -> Keeper_keepalive_signal -> Keeper_world_observation -> Keeper_approval_queue` **의존성 순환을 끊기 위함**(경계 존중, 코드베이스 §3 "경계 위반→callback 역전" 원칙). 기본값 no-op(테스트/pre-bootstrap은 wake-free).

**in-process blocking 경로**(`submit_and_await` await/timeout)는 불변: suspended fiber는 promise로 재개되지 stimulus가 아님.

## 검증

- 전체 masc 라이브러리 컴파일 (main_eio.exe)
- **Mutation-verified**: `test_keeper_approval_queue` "resolve fires the keeper wake hook" — resolve_entry에서 wake 호출 제거 시 정확히 실패
- `Hitl_resolved` codec round-trip 테스트
- 인접 회귀: reaction-ledger(19) / fusion-wake(6) / heartbeat-integration(28) / smart-heartbeat(40) 통과
- OCaml build/test는 CI에서 재확인

12파일 +253/-9. RFC-0266/RFC-0290 async-completion-wake 패턴 준수.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
