### PR TITLE
Expose runtime capability summary fields

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -383,6 +383,9 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('tool required')
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')
+    expect(container.textContent).toContain('headers 1')
+    expect(container.textContent).toContain('temp 0.65')
+    expect(container.textContent).toContain('budget 32768')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge')
     expect(container.textContent).toContain(
       'controls tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -255,9 +255,11 @@ describe('KeeperWorkspaceRail', () => {
             supports_parallel_tool_calls: true,
             supports_runtime_mcp_tools: true,
             supports_runtime_tool_events: true,
+            assistant_tool_content_format: 'null',
             supports_response_format_json: true,
             supports_structured_output: true,
             supports_reasoning: true,
+            preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
               kind: 'delta-reasoning-field',
@@ -275,6 +277,7 @@ describe('KeeperWorkspaceRail', () => {
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
+            task: 'transcription',
             supported_models: ['minimax-m3'],
           },
           declared_spec: {
@@ -385,6 +388,9 @@ describe('KeeperWorkspaceRail', () => {
       'controls tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
     )
     expect(container.textContent).toContain('modality visual-first')
+    expect(container.textContent).toContain('tool-content null')
+    expect(container.textContent).toContain('preserve always-preserved')
+    expect(container.textContent).toContain('task transcription')
     // the "no source" stub is replaced once the catalog reports capabilities
     expect(container.textContent).not.toContain('조정 정보 미수신')
   })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -322,10 +322,13 @@ function runtimeEffectiveCapabilitySummary(
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
+    caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
+    caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,
     caps.reasoning_replay_override ? `replay ${caps.reasoning_replay_override}` : null,
+    caps.task ? `task ${caps.task}` : null,
     caps.supports_system_prompt ? 'system-prompt' : null,
     caps.supports_prompt_caching
       ? `prompt-cache${typeof caps.prompt_cache_alignment === 'number' ? `@${caps.prompt_cache_alignment}` : ''}`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -274,15 +274,18 @@ function runtimeDeclaredSpecSummary(
     spec.provider?.protocol ? spec.provider.protocol : null,
     spec.provider?.auth_kind ? `auth ${spec.provider.auth_kind}` : null,
     spec.provider?.is_non_interactive ? 'non-interactive' : null,
+    typeof spec.provider?.custom_header_count === 'number' ? `headers ${spec.provider.custom_header_count}` : null,
     typeof spec.provider?.connect_timeout_s === 'number' ? `connect ${spec.provider.connect_timeout_s}s` : null,
     behaviorParts.length > 0 ? `behavior ${behaviorParts.join(',')}` : null,
     typeof spec.model?.max_context === 'number' ? `ctx ${spec.model.max_context}` : null,
+    typeof spec.model?.temperature === 'number' ? `temp ${spec.model.temperature}` : null,
     typeof spec.model?.tools_support === 'boolean' ? `tools ${spec.model.tools_support ? 'on' : 'off'}` : null,
     typeof spec.model?.streaming === 'boolean' ? `stream ${spec.model.streaming ? 'on' : 'off'}` : null,
     typeof spec.model?.preserve_thinking === 'boolean'
       ? `preserve ${spec.model.preserve_thinking ? 'on' : 'off'}`
       : null,
     thinking,
+    typeof spec.model?.max_thinking_budget === 'number' ? `budget ${spec.model.max_thinking_budget}` : null,
     caps?.thinking_control_format ? caps.thinking_control_format : null,
     typeof caps?.max_output_tokens === 'number' ? `out ${caps.max_output_tokens}` : null,
     formats.length > 0 ? `format ${formats.join(',')}` : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -128,7 +128,7 @@ describe('RuntimeMonitor', () => {
             supports_audio_input: true,
             supports_video_input: false,
             modality_priority: 'visual-first',
-            task: null,
+            task: 'transcription',
             supports_native_streaming: true,
             supports_system_prompt: true,
             supports_caching: true,
@@ -344,6 +344,9 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
     expect(container.textContent).toContain('modality visual-first')
+    expect(container.textContent).toContain('tool-content null')
+    expect(container.textContent).toContain('preserve chat-template-kwargs-preserve-thinking')
+    expect(container.textContent).toContain('task transcription')
     expect(container.textContent).toContain('seed+images')
     expect(container.textContent).toContain('code-exec')
   })
@@ -383,5 +386,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('visual-first')
     expect(container.textContent).toContain('effective · tool content')
     expect(container.textContent).toContain('null')
+    expect(container.textContent).toContain('effective · task')
+    expect(container.textContent).toContain('transcription')
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -690,10 +690,13 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     modalities.length > 0 ? `input ${modalities.join(',')}` : null,
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
+    caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
+    caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,
     caps.reasoning_replay_override ? `replay ${caps.reasoning_replay_override}` : null,
+    caps.task ? `task ${caps.task}` : null,
     caps.supports_system_prompt ? 'system-prompt' : null,
     caps.supports_prompt_caching
       ? `prompt-cache${typeof caps.prompt_cache_alignment === 'number' ? `@${caps.prompt_cache_alignment}` : ''}`

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -831,10 +831,12 @@ describe('SettingsSurface', () => {
             supports_parallel_tool_calls: true,
             supports_runtime_mcp_tools: true,
             supports_runtime_tool_events: true,
+            assistant_tool_content_format: 'empty-string',
             supports_response_format_json: true,
             supports_structured_output: true,
             supports_reasoning: true,
             accepted_reasoning_efforts: null,
+            preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
               kind: 'delta-reasoning-field',
@@ -852,6 +854,7 @@ describe('SettingsSurface', () => {
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
+            task: 'transcription',
             supported_models: ['m1'],
           },
           declared_spec: {
@@ -961,6 +964,9 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
+      expect(cards[0]?.textContent).toContain('tool-content:empty-string')
+      expect(cards[0]?.textContent).toContain('preserve:always-preserved')
+      expect(cards[0]?.textContent).toContain('task:transcription')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
       expect(cards[0]?.textContent).toContain(
         'controls:tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -968,6 +968,9 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('preserve:always-preserved')
       expect(cards[0]?.textContent).toContain('task:transcription')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
+      expect(cards[0]?.textContent).toContain('headers:1')
+      expect(cards[0]?.textContent).toContain('temp:0.65')
+      expect(cards[0]?.textContent).toContain('budget:8192')
       expect(cards[0]?.textContent).toContain(
         'controls:tool-choice,required,named,parallel,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
       )

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -348,15 +348,18 @@ function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapshot): str
     spec.provider?.protocol ? `protocol:${spec.provider.protocol}` : null,
     spec.provider?.auth_kind ? `auth:${spec.provider.auth_kind}` : null,
     spec.provider?.is_non_interactive ? 'non-interactive' : null,
+    typeof spec.provider?.custom_header_count === 'number' ? `headers:${spec.provider.custom_header_count}` : null,
     typeof spec.provider?.connect_timeout_s === 'number' ? `connect:${spec.provider.connect_timeout_s}s` : null,
     behaviorParts.length > 0 ? `behavior:${behaviorParts.join(',')}` : null,
     typeof spec.model?.max_context === 'number' ? `ctx:${spec.model.max_context}` : null,
+    typeof spec.model?.temperature === 'number' ? `temp:${spec.model.temperature}` : null,
     typeof spec.model?.tools_support === 'boolean' ? `tools:${spec.model.tools_support ? 'on' : 'off'}` : null,
     typeof spec.model?.streaming === 'boolean' ? `stream:${spec.model.streaming ? 'on' : 'off'}` : null,
     typeof spec.model?.preserve_thinking === 'boolean'
       ? `preserve:${spec.model.preserve_thinking ? 'on' : 'off'}`
       : null,
     thinking,
+    typeof spec.model?.max_thinking_budget === 'number' ? `budget:${spec.model.max_thinking_budget}` : null,
     caps?.thinking_control_format ? `wire:${caps.thinking_control_format}` : null,
     typeof caps?.max_output_tokens === 'number' ? `out:${caps.max_output_tokens}` : null,
     formats.length > 0 ? `format:${formats.join(',')}` : null,

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -400,7 +400,13 @@ function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnaps
     item.effective_capabilities?.modality_priority
       ? `modality:${item.effective_capabilities.modality_priority}`
       : null,
+    item.effective_capabilities?.assistant_tool_content_format
+      ? `tool-content:${item.effective_capabilities.assistant_tool_content_format}`
+      : null,
     item.effective_capabilities?.supports_reasoning ? 'reasoning' : null,
+    item.effective_capabilities?.preserve_thinking_control_format
+      ? `preserve:${item.effective_capabilities.preserve_thinking_control_format}`
+      : null,
     item.effective_capabilities?.reasoning_output_format
       ? `reasoning-out:${item.effective_capabilities.reasoning_output_format}`
       : null,
@@ -409,6 +415,9 @@ function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnaps
       : null,
     item.effective_capabilities?.reasoning_replay_override
       ? `replay:${item.effective_capabilities.reasoning_replay_override}`
+      : null,
+    item.effective_capabilities?.task
+      ? `task:${item.effective_capabilities.task}`
       : null,
     item.effective_capabilities?.supports_system_prompt ? 'system-prompt' : null,
     item.effective_capabilities?.supports_prompt_caching


### PR DESCRIPTION
## Summary
- surface effective assistant tool-content format, preserve-thinking wire format, and task in runtime compact summaries
- keep dashboard output sourced from existing effective_capabilities fields without adding provider-specific mapping
- cover runtime monitor, settings runtime catalog, and keeper workspace rail fixtures/assertions

## Validation
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts
- pnpm --dir dashboard exec eslint src/components/runtime-monitor.ts src/components/settings-surface.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts

## Notes
- No provider catalog value changes in this slice; latest-model/provider document verification is not required for this dashboard-only wiring change.