### PR TITLE
fix(ide): write-time partition attribution for repo-scoped observation reads

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -432,6 +432,7 @@ let list_events
 
 let ingest_tool_event
     ~base_path
+    ?(partition = default_partition)
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -462,12 +463,13 @@ let ingest_tool_event
       ; timestamp_ms
       }
   in
-  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+  (try append_event ~base_dir:base_path ~partition ~event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_tool_event error: %s\n%!" (Printexc.to_string exn))
 
 let ingest_turn_event
     ~base_path
+    ~partition
     ~turn_id
     ~keeper_id
     ~phase
@@ -477,6 +479,13 @@ let ingest_turn_event
     ~duration_ms
     ~timestamp_ms
   =
+  (* DEFER (task-1733): the turn-event emit (keeper_agent_run.ml) resolves only
+     [config.base_path] because a turn carries no edited file_path, and no
+     keeper->active-repo/canonical_url mapping exists today. So [partition]
+     forwarded here is typically the coarse orphan partition. Forwarding it
+     (instead of hardcoding [default_partition]) removes the silent hardcode and
+     lets a future keeper->repo source flow through unchanged. Real per-turn
+     attribution requires that new source — tracked as task-1733 follow-up. *)
   let event =
     Turn_event
       { turn_id
@@ -489,12 +498,13 @@ let ingest_turn_event
       ; timestamp_ms
       }
   in
-  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+  (try append_event ~base_dir:base_path ~partition ~event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
 
 let ingest_pr_event
     ~base_path
+    ~partition
     ~pr_number
     ~pull_request_url
     ~pr_title
@@ -520,7 +530,7 @@ let ingest_pr_event
       ; timestamp_ms
       }
   in
-  (try append_event ~base_dir:base_path ~partition:default_partition ~event
+  (try append_event ~base_dir:base_path ~partition ~event
    with exn ->
      Printf.eprintf "Ide_bridge.ingest_pr_event error: %s\n%!" (Printexc.to_string exn))
 
@@ -665,6 +675,7 @@ let cursor_event_json
 
 let ingest_cursor_event_from_hook
     ~base_path
+    ~partition
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -697,7 +708,7 @@ let ingest_cursor_event_from_hook
         ~turn_id
         ()
     in
-    (try append_cursor ~base_dir:base_path ~partition:default_partition json
+    (try append_cursor ~base_dir:base_path ~partition json
      with exn ->
        Printf.eprintf
          "Ide_bridge.ingest_cursor_event_from_hook error: %s\n%!"
@@ -706,6 +717,7 @@ let ingest_cursor_event_from_hook
 
 let ingest_cursor_event
     ~base_path
+    ?(partition = default_partition)
     ~keeper_id
     ~file_path
     ~line
@@ -715,6 +727,13 @@ let ingest_cursor_event
     ~source
     ()
   =
+  (* DEFER (task-1733): this is the human-IDE direct path (server_ide_http.ml
+     POST /api/v1/ide/cursors). [partition] is accepted so the caller CAN scope
+     the write, but the server call site does not yet resolve one from the
+     posted file_path (that resolver lives in lib/keeper and server must not
+     depend on it directly). Until the server layer wires a resolver, the
+     default keeps prior behavior. Real attribution here is a task-1733
+     follow-up at the server call site. *)
   let column = Option.value column ~default:0 in
   let focus_mode =
     match focus_mode with
@@ -739,7 +758,7 @@ let ingest_cursor_event
         ~turn_id:""
         ()
     in
-    (try append_cursor ~base_dir:base_path ~partition:default_partition json
+    (try append_cursor ~base_dir:base_path ~partition json
      with exn ->
        Printf.eprintf
          "Ide_bridge.ingest_cursor_event error: %s\n%!"
@@ -752,6 +771,7 @@ let ingest_cursor_event
     Separated for direct testability. *)
 let ingest_tool_event_from_hook
     ~base_path
+    ~partition
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -777,6 +797,7 @@ let ingest_tool_event_from_hook
   let timestamp_ms = now_ms () in
   ingest_tool_event
     ~base_path
+    ~partition
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -788,8 +809,11 @@ let ingest_tool_event_from_hook
     ?command_descriptor
     ~timestamp_ms
     ();
+  (* The hook cursor inherits the tool event's resolved partition: same tool
+     call, same edited file, so the cursor belongs in the same repo scope. *)
   ingest_cursor_event_from_hook
     ~base_path
+    ~partition
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -869,6 +893,7 @@ let explicit_tool_success_from_output output =
     (auth/network/validation errors) must not produce phantom PR events. *)
 let ingest_pr_event_from_descriptor
     ~base_path
+    ~partition
     ~keeper_id
     ~turn_id
     ~output_text
@@ -891,37 +916,37 @@ let ingest_pr_event_from_descriptor
             (descriptor_confirmed_pr_url_from_output output_text)
       in
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url ~pr_title:title
+        ~base_path ~partition ~pr_number ~pull_request_url ~pr_title:title
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_merge { pr_number; squash = _ }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"merged" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_close { pr_number }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"closed" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_comment { pr_number; body = _ }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_edit { pr_number; title = _ }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_pr_review { pr_number }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo:"" ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
@@ -931,19 +956,19 @@ let ingest_pr_event_from_descriptor
         | None -> (0, "")
       in
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url ~pr_title:title
+        ~base_path ~partition ~pr_number ~pull_request_url ~pr_title:title
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_api_pr_merge { repo; pr_number }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"merged" ~repo ~keeper_id ~turn_id
         ~comment_count:0 ~review_status:None
         ~timestamp_ms:(now_ms ())
     | Some (Ide_event_types.Gh_api_pr_comment { repo; pr_number; body = _ }) ->
       ingest_pr_event
-        ~base_path ~pr_number ~pull_request_url:"" ~pr_title:""
+        ~base_path ~partition ~pr_number ~pull_request_url:"" ~pr_title:""
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
         ~timestamp_ms:(now_ms ())
@@ -955,6 +980,7 @@ let ingest_pr_event_from_descriptor
     ingestion only; raw stdout URL scanning is not a reliable PR signal. *)
 let ingest_pr_event_from_hook
     ~base_path
+    ~partition
     ~keeper_id
     ~turn_id
     ~output_text
@@ -962,6 +988,7 @@ let ingest_pr_event_from_hook
   =
   ingest_pr_event_from_descriptor
     ~base_path
+    ~partition
     ~keeper_id
     ~turn_id
     ~output_text
@@ -982,6 +1009,7 @@ let install_agent_observation_sinks () =
       Ide_ingest_queue.submit (fun () ->
         ingest_tool_event_from_hook
           ~base_path:event.base_path
+          ~partition:event.partition
           ~tool_name:event.tool_name
           ~keeper_id:event.keeper_id
           ~turn_id:event.turn_id
@@ -995,6 +1023,7 @@ let install_agent_observation_sinks () =
       Ide_ingest_queue.submit (fun () ->
         ingest_pr_event_from_descriptor
           ~base_path:event.base_path
+          ~partition:event.partition
           ~keeper_id:event.keeper_id
           ~turn_id:event.turn_id
           ~output_text:event.output_text
@@ -1003,8 +1032,11 @@ let install_agent_observation_sinks () =
   Agent_observation.register_turn_event_sink
     (fun (event : Agent_observation.turn_event) ->
       Ide_ingest_queue.submit (fun () ->
+        (* turn: forward event.partition (coarse today — see ingest_turn_event
+           DEFER note; keeper->repo mapping is task-1733 follow-up). *)
         ingest_turn_event
           ~base_path:event.base_path
+          ~partition:event.partition
           ~turn_id:event.turn_id
           ~keeper_id:event.keeper_id
           ~phase:event.phase

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -36,6 +36,7 @@ val list_cursors :
     context and uses the provided [source] label as the tool_name field. *)
 val ingest_cursor_event :
   base_path:string ->
+  ?partition:Ide_paths.partition ->
   keeper_id:string ->
   file_path:string ->
   line:int ->
@@ -55,6 +56,7 @@ val install_agent_observation_sinks : unit -> unit
 
 val ingest_tool_event :
   base_path:string ->
+  ?partition:Ide_paths.partition ->
   tool_name:string ->
   keeper_id:string ->
   turn_id:string ->
@@ -70,6 +72,7 @@ val ingest_tool_event :
 
 val ingest_turn_event :
   base_path:string ->
+  partition:Ide_paths.partition ->
   turn_id:string ->
   keeper_id:string ->
   phase:string ->
@@ -84,6 +87,7 @@ val ingest_turn_event :
     [typed_outcome_str] is pre-computed from [Keeper_tool_outcome.t]. *)
 val ingest_tool_event_from_hook :
   base_path:string ->
+  partition:Ide_paths.partition ->
   tool_name:string ->
   keeper_id:string ->
   turn_id:string ->
@@ -96,6 +100,7 @@ val ingest_tool_event_from_hook :
 
 val ingest_pr_event :
   base_path:string ->
+  partition:Ide_paths.partition ->
   pr_number:int ->
   pull_request_url:string ->
   pr_title:string ->
@@ -113,6 +118,7 @@ val ingest_pr_event :
     successful wrapper result with a command descriptor may ingest PR events. *)
 val ingest_pr_event_from_hook :
   base_path:string ->
+  partition:Ide_paths.partition ->
   keeper_id:string ->
   turn_id:string ->
   output_text:string ->
@@ -127,6 +133,7 @@ val ingest_pr_event_from_hook :
     (auth/network/validation errors) must not produce phantom PR events. *)
 val ingest_pr_event_from_descriptor :
   base_path:string ->
+  partition:Ide_paths.partition ->
   keeper_id:string ->
   turn_id:string ->
   output_text:string ->

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -90,6 +90,15 @@ let observation_file_path_from_tool_input ~base_path input =
   | Some p -> p
 ;;
 
+let observation_partition_for_tool_input ~config ~kind input =
+  let base_dir = Keeper_alerting_path.project_root_of_config config in
+  let file_path = observation_file_path_from_tool_input ~base_path:base_dir input in
+  Keeper_tool_filesystem_runtime.resolve_partition_for_write
+    ~base_dir
+    ~kind
+    ~file_path
+;;
+
 let assemble_hooks
       ~(ctx : ctx)
       ~(session : Keeper_types.session_context)
@@ -226,18 +235,12 @@ let assemble_hooks
            in
            (* task-1733: resolve the partition from the tool's actual edited
               file (input.path / input.file_path, with explicit cwd honoured
-              for relative paths), not [config.base_path]. base_path is the
-              .masc project root, which almost always resolves to the orphan
-              partition; the edited file is what carries the registered-repo
-              attribution. Falls back to base_path only when the tool input
-              names no file (e.g. non-filesystem tools). *)
-           let tool_file_path =
-             observation_file_path_from_tool_input ~base_path:config.base_path input
-           in
+              for relative paths), not from the [.masc] runtime root. *)
            let partition, _ =
-             Keeper_tool_filesystem_runtime.resolve_partition_for_write
-               ~base_dir:config.base_path ~kind:"tool_event"
-               ~file_path:tool_file_path
+             observation_partition_for_tool_input
+               ~config
+               ~kind:"tool_event"
+               input
            in
            Agent_observation.emit_tool_event
              { base_path = config.base_path

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -190,9 +190,30 @@ let assemble_hooks
              | Some t -> Keeper_id.Task_id.to_string t
              | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
            in
+           (* task-1733: resolve the partition from the tool's actual edited
+              file (input.path / input.file_path), not [config.base_path].
+              base_path is the .masc project root, which almost always resolves
+              to the orphan partition; the edited file is what carries the
+              registered-repo attribution. Falls back to base_path only when the
+              tool input names no file (e.g. non-filesystem tools). *)
+           let tool_file_path =
+             let non_empty_string = function
+               | `String p when String.trim p <> "" -> Some p
+               | _ -> None
+             in
+             match non_empty_string (Yojson.Safe.Util.member "path" input) with
+             | Some p -> p
+             | None ->
+               (match
+                  non_empty_string (Yojson.Safe.Util.member "file_path" input)
+                with
+                | Some p -> p
+                | None -> config.base_path)
+           in
            let partition, _ =
              Keeper_tool_filesystem_runtime.resolve_partition_for_write
-               ~base_dir:config.base_path ~kind:"tool_event" ~file_path:config.base_path
+               ~base_dir:config.base_path ~kind:"tool_event"
+               ~file_path:tool_file_path
            in
            Agent_observation.emit_tool_event
              { base_path = config.base_path

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -56,6 +56,40 @@ let relax_strict_tool_choice_for_keeper = function
     Some Agent_sdk.Types.Auto
   | other -> other
 
+let relative_path_has_segment_prefix prefix raw =
+  String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
+;;
+
+let sandbox_rooted_relative_path raw =
+  Filename.is_relative raw
+  && List.exists
+       (fun prefix -> relative_path_has_segment_prefix prefix raw)
+       [ "repos"; "mind"; Common.masc_dirname; "playground" ]
+;;
+
+let non_empty_string_member name input =
+  match Yojson.Safe.Util.member name input with
+  | `String raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some raw
+  | _ -> None
+;;
+
+let observation_file_path_from_tool_input ~base_path input =
+  let path =
+    match non_empty_string_member "path" input with
+    | Some p -> Some p
+    | None -> non_empty_string_member "file_path" input
+  in
+  match path with
+  | None -> base_path
+  | Some p when Filename.is_relative p && not (sandbox_rooted_relative_path p) ->
+    (match non_empty_string_member "cwd" input with
+     | Some cwd -> Filename.concat cwd p
+     | None -> p)
+  | Some p -> p
+;;
+
 let assemble_hooks
       ~(ctx : ctx)
       ~(session : Keeper_types.session_context)
@@ -191,24 +225,14 @@ let assemble_hooks
              | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
            in
            (* task-1733: resolve the partition from the tool's actual edited
-              file (input.path / input.file_path), not [config.base_path].
-              base_path is the .masc project root, which almost always resolves
-              to the orphan partition; the edited file is what carries the
-              registered-repo attribution. Falls back to base_path only when the
-              tool input names no file (e.g. non-filesystem tools). *)
+              file (input.path / input.file_path, with explicit cwd honoured
+              for relative paths), not [config.base_path]. base_path is the
+              .masc project root, which almost always resolves to the orphan
+              partition; the edited file is what carries the registered-repo
+              attribution. Falls back to base_path only when the tool input
+              names no file (e.g. non-filesystem tools). *)
            let tool_file_path =
-             let non_empty_string = function
-               | `String p when String.trim p <> "" -> Some p
-               | _ -> None
-             in
-             match non_empty_string (Yojson.Safe.Util.member "path" input) with
-             | Some p -> p
-             | None ->
-               (match
-                  non_empty_string (Yojson.Safe.Util.member "file_path" input)
-                with
-                | Some p -> p
-                | None -> config.base_path)
+             observation_file_path_from_tool_input ~base_path:config.base_path input
            in
            let partition, _ =
              Keeper_tool_filesystem_runtime.resolve_partition_for_write

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,7 @@
   test_runtime_request_config_merge
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
+  test_keeper_run_tools_hooks
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection
@@ -400,6 +401,7 @@
   test_runtime_request_config_merge
   test_keeper_context_layers
   test_keeper_hooks_oas_introspection
+  test_keeper_run_tools_hooks
   test_board_activity_cache
   test_jsonl_mtime_projection
   test_jsonl_incremental_projection

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -271,6 +271,7 @@ let test_descriptor_to_pr_event () =
     let output = {|{"ok":true,"output":"{\"number\":999,\"url\":\"https://github.com/jeong-sik/masc/pull/999\"}","command_descriptor":{"kind":"gh_pr_create","title":"test PR","base":"main","draft":false}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -294,6 +295,7 @@ let test_descriptor_merge_event () =
     let output = {|{"ok":true,"output":"","command_descriptor":{"kind":"gh_pr_merge","pr_number":456,"squash":true}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -90,6 +90,7 @@ let test_ingest_turn_event () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_turn_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~turn_id:"turn-456"
       ~keeper_id:"keeper-beta"
       ~phase:"completed"
@@ -228,6 +229,7 @@ let test_list_events_merges_kinds_newest_first () =
       ();
     Ide_bridge.ingest_pr_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~pr_number:42
       ~pull_request_url:"https://github.com/owner/repo/pull/42"
       ~pr_title:"feat"
@@ -240,6 +242,7 @@ let test_list_events_merges_kinds_newest_first () =
       ~timestamp_ms:2000L;
     Ide_bridge.ingest_turn_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~turn_id:"t-turn"
       ~keeper_id:"k1"
       ~phase:"completed"
@@ -268,6 +271,7 @@ let test_cursor_from_hook_uses_real_file_and_line () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -295,6 +299,7 @@ let test_cursor_from_hook_skips_missing_line () =
     let input = `Assoc [ "file_path", `String "lib/test.ml" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -314,6 +319,7 @@ let test_cursor_from_hook_skips_missing_focus_mode () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -331,6 +337,7 @@ let test_hook_extracts_file_path_from_path_key () =
     let input = `Assoc [ "path", `String "lib/test.ml"; "content", `String "hello" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"fs_write"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -354,6 +361,7 @@ let test_hook_extracts_file_path_from_file_path_key () =
     let input = `Assoc [ "file_path", `String "src/main.ml" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"fs_edit"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -377,6 +385,7 @@ let test_hook_no_file_path () =
     let input = `Assoc [ "command", `String "ls" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -401,6 +410,7 @@ let test_hook_summary_truncation () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -424,6 +434,7 @@ let test_hook_typed_outcome_mapping () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -446,6 +457,7 @@ let test_pr_event_ingest () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_pr_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~pr_number:19872
       ~pull_request_url:"https://github.com/jeong-sik/masc/pull/19872"
       ~pr_title:"feat(ide): auto-collect tool/turn events"
@@ -476,6 +488,7 @@ let test_pr_event_from_hook_uses_structured_descriptor_output () =
     in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -500,6 +513,7 @@ let test_pr_event_from_hook_uses_descriptor_confirmed_cli_url () =
     in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -529,6 +543,7 @@ let test_pr_event_from_hook_uses_descriptor_for_any_tool_name () =
     in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -549,6 +564,7 @@ let test_pr_event_from_hook_ignores_no_url () =
     let output = "file written successfully\n" in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -563,6 +579,7 @@ let test_pr_event_from_hook_ignores_raw_url () =
     let output = "remote: https://github.com/jeong-sik/masc/pull/123\n" in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:output
@@ -578,6 +595,7 @@ let test_descriptor_gated_on_success () =
     let failed_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}, "error": "authentication failed"}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:failed_output
@@ -595,6 +613,7 @@ let test_legacy_hook_uses_explicit_success_flag () =
     in
     Ide_bridge.ingest_pr_event_from_hook
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:failed_output
@@ -610,6 +629,7 @@ let test_descriptor_ingested_on_success () =
     let success_output = {|{"command_descriptor": {"kind": "gh_pr_create", "title": "feat: test", "base": "main", "draft": true}}|} in
     Ide_bridge.ingest_pr_event_from_descriptor
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"k1"
       ~turn_id:"t1"
       ~output_text:success_output
@@ -890,6 +910,96 @@ let test_queue_writer_drains () =
     check int "writer drained all jobs" n (Atomic.get ran))
 ;;
 
+(* task-1733 regression: a partition threaded through the hook path (as the
+   agent-observation sink now does with [event.partition]) must route the tool
+   event AND its derived cursor into that partition's store — not the orphan
+   [Legacy_default]. This is the exact split that left dashboard by-url reads
+   empty while data piled up in _orphan. *)
+let test_partition_routes_tool_event_and_cursor_by_url () =
+  with_temp_dir (fun base_dir ->
+    let by_url = Ide_paths.By_url "github.com/jeong-sik/wkbl" in
+    let input =
+      `Assoc
+        [ "file_path", `String "lib/test.ml"
+        ; "line", `Int 7
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:by_url
+      ~tool_name:"keeper_ide_annotate"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:5.0
+      ~output_text:"{}"
+      ~input;
+    (* Scoped (by-url) reads see both the tool event and the cursor. *)
+    let by_url_events =
+      Ide_bridge.list_events ~base_path:base_dir ~partition:by_url ()
+    in
+    check bool "by-url partition holds the tool event" true
+      (List.length by_url_events >= 1);
+    let by_url_cursors =
+      Ide_bridge.list_cursors ~base_path:base_dir ~partition:by_url ()
+    in
+    check bool "by-url partition holds the derived cursor" true
+      (List.length by_url_cursors >= 1);
+    (* The orphan partition (what an unscoped read used to fall back to) stays
+       empty for a scoped write — proving the write is no longer hardcoded to
+       Legacy_default. *)
+    let orphan_events =
+      Ide_bridge.list_events ~base_path:base_dir
+        ~partition:Ide_paths.Legacy_default ()
+    in
+    check int "orphan partition has no scoped tool event" 0
+      (List.length orphan_events);
+    let orphan_cursors =
+      Ide_bridge.list_cursors ~base_path:base_dir
+        ~partition:Ide_paths.Legacy_default ()
+    in
+    check int "orphan partition has no scoped cursor" 0
+      (List.length orphan_cursors))
+;;
+
+(* Backward compat: an explicit [Legacy_default] write still lands in the orphan
+   store and is invisible to a by-url read (partitions are isolated). *)
+let test_partition_legacy_default_isolated_from_by_url () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc
+        [ "file_path", `String "lib/test.ml"
+        ; "line", `Int 3
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~tool_name:"keeper_ide_annotate"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:5.0
+      ~output_text:"{}"
+      ~input;
+    let orphan_events =
+      Ide_bridge.list_events ~base_path:base_dir
+        ~partition:Ide_paths.Legacy_default ()
+    in
+    check bool "legacy write lands in orphan" true
+      (List.length orphan_events >= 1);
+    let by_url_events =
+      Ide_bridge.list_events ~base_path:base_dir
+        ~partition:(Ide_paths.By_url "github.com/jeong-sik/wkbl") ()
+    in
+    check int "by-url read does not see the orphan write" 0
+      (List.length by_url_events))
+;;
+
 let () =
   run
     "ide_bridge"
@@ -904,6 +1014,12 @@ let () =
       , [ test_case "tool event" `Quick test_ingest_tool_event
         ; test_case "turn event" `Quick test_ingest_turn_event
         ; test_case "multiple events" `Quick test_ingest_multiple_events
+        ] )
+    ; ( "partition_attribution"
+      , [ test_case "by-url routes tool event + cursor" `Quick
+            test_partition_routes_tool_event_and_cursor_by_url
+        ; test_case "legacy_default isolated from by-url" `Quick
+            test_partition_legacy_default_isolated_from_by_url
         ] )
     ; ( "read"
       , [ test_case "filters keeper and pages" `Quick test_list_events_filters_keeper_and_pages

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -1,4 +1,41 @@
 open Alcotest
+open Repo_manager_types
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "keeper-run-tools-hooks-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Unix.mkdir (Filename.concat dir ".masc") 0o755;
+  Unix.mkdir (Filename.concat (Filename.concat dir ".masc") "config") 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+;;
+
+let sample_repo =
+  { id = "masc"
+  ; name = "masc"
+  ; url = "https://github.com/jeong-sik/masc.git"
+  ; local_path = "repos/masc"
+  ; aliases = []
+  ; default_branch = "main"
+  ; keepers = []
+  ; status = Active
+  ; auto_sync = false
+  ; sync_interval = 300
+  ; created_at = 1L
+  ; updated_at = 1L
+  }
+;;
 
 let observed_path fields =
   Masc.Keeper_run_tools_hooks.observation_file_path_from_tool_input
@@ -52,6 +89,30 @@ let test_missing_path_falls_back_to_base_path () =
   check string "base fallback" "/tmp/masc-base" (observed_path [])
 ;;
 
+let test_partition_resolution_uses_project_root_for_masc_base_path () =
+  with_temp_base_path (fun base_path ->
+    (match Repo_store.save_all ~base_path [ sample_repo ] with
+     | Ok () -> ()
+     | Error msg -> fail ("repo save failed: " ^ msg));
+    let config = Workspace.default_config (Filename.concat base_path ".masc") in
+    let partition, rel_path =
+      Masc.Keeper_run_tools_hooks.observation_partition_for_tool_input
+        ~config
+        ~kind:"tool_event"
+        (`Assoc
+          [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ])
+    in
+    check string "repo-relative path" "lib/foo.ml" rel_path;
+    match partition with
+    | Agent_observation.By_url slug ->
+      check string "slug" "github.com_jeong-sik_masc" slug
+    | Agent_observation.No_canonical_url
+    | Agent_observation.Unmatched
+    | Agent_observation.Base_unresolved
+    | Agent_observation.Legacy_default ->
+      fail "expected By_url partition")
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -69,6 +130,12 @@ let () =
             test_blank_path_falls_back_to_file_path
         ; test_case "missing path falls back to base_path" `Quick
             test_missing_path_falls_back_to_base_path
+        ] )
+    ; ( "observation_partition"
+      , [ test_case
+            "uses project root when config base is .masc"
+            `Quick
+            test_partition_resolution_uses_project_root_for_masc_base_path
         ] )
     ]
 ;;

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -1,0 +1,74 @@
+open Alcotest
+
+let observed_path fields =
+  Masc.Keeper_run_tools_hooks.observation_file_path_from_tool_input
+    ~base_path:"/tmp/masc-base"
+    (`Assoc fields)
+;;
+
+let test_explicit_cwd_scopes_relative_file_path () =
+  check
+    string
+    "cwd/file_path"
+    "repos/masc/lib/foo.ml"
+    (observed_path
+       [ "file_path", `String "lib/foo.ml"; "cwd", `String "repos/masc" ])
+;;
+
+let test_sandbox_rooted_file_path_ignores_cwd () =
+  check
+    string
+    "sandbox-rooted"
+    "repos/masc/lib/foo.ml"
+    (observed_path
+       [ "file_path", `String "repos/masc/lib/foo.ml"
+       ; "cwd", `String "repos/other"
+       ])
+;;
+
+let test_absolute_path_ignores_cwd () =
+  check
+    string
+    "absolute"
+    "/workspace/masc/lib/foo.ml"
+    (observed_path
+       [ "path", `String "/workspace/masc/lib/foo.ml"
+       ; "cwd", `String "repos/other"
+       ])
+;;
+
+let test_blank_path_falls_back_to_file_path () =
+  check
+    string
+    "blank path fallback"
+    "repos/masc/lib/foo.ml"
+    (observed_path
+       [ "path", `String " "
+       ; "file_path", `String "repos/masc/lib/foo.ml"
+       ])
+;;
+
+let test_missing_path_falls_back_to_base_path () =
+  check string "base fallback" "/tmp/masc-base" (observed_path [])
+;;
+
+let () =
+  run
+    "keeper_run_tools_hooks"
+    [ ( "observation_file_path"
+      , [ test_case
+            "explicit cwd scopes relative file_path"
+            `Quick
+            test_explicit_cwd_scopes_relative_file_path
+        ; test_case
+            "sandbox-rooted file_path ignores cwd"
+            `Quick
+            test_sandbox_rooted_file_path_ignores_cwd
+        ; test_case "absolute path ignores cwd" `Quick test_absolute_path_ignores_cwd
+        ; test_case "blank path falls back to file_path" `Quick
+            test_blank_path_falls_back_to_file_path
+        ; test_case "missing path falls back to base_path" `Quick
+            test_missing_path_falls_back_to_base_path
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목적 (task-1733)

IDE observation 대시보드의 **Context/Activity/Cursors 우측 패널이 빈 화면**인 문제를 고친다. 원인은 write/read 파티션 분리다.

## 진단 (실측)

`ide_bridge`의 자동 write가 `default_partition`(_orphan / Legacy_default)를 하드코딩 → 이벤트가 orphan 파티션에 쌓이는데, 대시보드는 **repo 스코프(by-url slug)** 파티션으로 읽는다. 결과:

```
GET .../cursors?canonical_url=...  →  by-url=0    (대시보드가 읽는 곳)
Legacy_default 파티션              →  9 cursors   (실제 데이터가 쌓인 곳)
```

## 변경 (2계층)

- **Layer 2 — `lib/keeper/keeper_run_tools_hooks.ml`**: emit이 `config.base_path`(.masc 루트)가 아니라 **tool input의 실제 `path`/`file_path`**로 파티션을 resolve. 등록된 repo 파일에 write하면 그 repo 파티션이 잡힌다(파일 경로 없으면 base_path fallback).
- **Layer 1 — `lib/ide/ide_bridge.ml` / `.mli`**: sink가 `event.partition`을 쥐고도 ingest에 안 넘기고, ingest엔 partition 파라미터가 없었다. partition threading 추가 — sink가 `event.partition` forward, ingest 6개 함수에 required `~partition`, leaf 2개에 `?partition`(기본 `default_partition`, 호환성).

### DEFER (코드 주석에 근거 명시 — N-of-M 아님, 재료 부재)
- **turn event**: emit이 file_path 없이 base_path만 보유, keeper→active-repo 매핑 인프라 부재 → partition coarse 유지.
- **`ingest_cursor_event`** (human-IDE direct POST): server 레이어 resolver 미배선 → `?partition` optional만 추가, resolve defer.

## 검증

- `scripts/dune-local.sh build @default` → exit 0 (warnings-as-errors).
- `test_ide_bridge.exe` → 40 tests green (신규 `partition_attribution` 회귀 2개 포함: 등록 repo file_path가 tool event + 파생 cursor를 by-url 파티션에 라우팅, orphan은 빈 채 유지 / Legacy_default 격리).
- `test_command_descriptor.exe` → 32 tests green.

RFC-WAIVED: lib/ide / keeper_run_tools_hooks(keeper tool emit)는 credential/identity/operator/sandbox/.claude-hooks/workflow subsystem 미해당. 관측 파티션 라우팅 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
