### PR TITLE
Surface declared runtime transport

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -383,6 +383,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('tool required')
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')
+    expect(container.textContent).toContain('transport http')
     expect(container.textContent).toContain('headers 1')
     expect(container.textContent).toContain('temp 0.65')
     expect(container.textContent).toContain('budget 32768')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -272,6 +272,7 @@ function runtimeDeclaredSpecSummary(
   const parts = [
     spec.provider?.api_format ? spec.provider.api_format : null,
     spec.provider?.protocol ? spec.provider.protocol : null,
+    spec.provider?.transport ? `transport ${spec.provider.transport}` : null,
     spec.provider?.auth_kind ? `auth ${spec.provider.auth_kind}` : null,
     spec.provider?.is_non_interactive ? 'non-interactive' : null,
     typeof spec.provider?.custom_header_count === 'number' ? `headers ${spec.provider.custom_header_count}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -968,6 +968,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('preserve:always-preserved')
       expect(cards[0]?.textContent).toContain('task:transcription')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
+      expect(cards[0]?.textContent).toContain('transport:http')
       expect(cards[0]?.textContent).toContain('headers:1')
       expect(cards[0]?.textContent).toContain('temp:0.65')
       expect(cards[0]?.textContent).toContain('budget:8192')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -346,6 +346,7 @@ function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapshot): str
   const parts = [
     spec.provider?.api_format ? `api:${spec.provider.api_format}` : null,
     spec.provider?.protocol ? `protocol:${spec.provider.protocol}` : null,
+    spec.provider?.transport ? `transport:${spec.provider.transport}` : null,
     spec.provider?.auth_kind ? `auth:${spec.provider.auth_kind}` : null,
     spec.provider?.is_non_interactive ? 'non-interactive' : null,
     typeof spec.provider?.custom_header_count === 'number' ? `headers:${spec.provider.custom_header_count}` : null,


### PR DESCRIPTION
## Summary
- Surface the declared provider transport in runtime compact summaries for Settings and Keeper Workspace rail.
- Add focused assertions so existing runtime catalog fixtures prove transport is visible alongside protocol/api format.

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec eslint src/components/settings-surface.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts
- git diff --check

Note: ESLint reports the existing config warning that settings-surface.test.ts is outside the matching configuration; there were 0 errors.