### PR TITLE
fix(test): qualify workspace config in tool hook test

### DIFF
--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -94,7 +94,7 @@ let test_partition_resolution_uses_project_root_for_masc_base_path () =
     (match Repo_store.save_all ~base_path [ sample_repo ] with
      | Ok () -> ()
      | Error msg -> fail ("repo save failed: " ^ msg));
-    let config = Workspace.default_config (Filename.concat base_path ".masc") in
+    let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
     let partition, rel_path =
       Masc.Keeper_run_tools_hooks.observation_partition_for_tool_input
         ~config


### PR DESCRIPTION
## Summary
- qualify the tool hook regression test with Masc.Workspace.default_config
- keep the fix scoped to the compile error reported from test/test_keeper_run_tools_hooks.ml

## Verification
- opam exec -- ocamlformat --check test/test_keeper_run_tools_hooks.ml
- opam exec -- ocamlc -stop-after parsing test/test_keeper_run_tools_hooks.ml
- git diff --check

Full dune build is left to CI per workflow.