### PR TITLE
[codex] Surface effective reasoning effort parameters

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -259,6 +259,9 @@ describe('KeeperWorkspaceRail', () => {
             supports_response_format_json: true,
             supports_structured_output: true,
             supports_reasoning: true,
+            supports_extended_thinking: true,
+            supports_reasoning_budget: true,
+            accepted_reasoning_efforts: ['low', 'medium', 'high'],
             preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
@@ -393,6 +396,9 @@ describe('KeeperWorkspaceRail', () => {
     )
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
+    expect(container.textContent).toContain('extended thinking')
+    expect(container.textContent).toContain('reasoning budget')
+    expect(container.textContent).toContain('effort low,medium,high')
     expect(container.textContent).toContain('preserve always-preserved')
     expect(container.textContent).toContain('task transcription')
     // the "no source" stub is replaced once the catalog reports capabilities

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -328,6 +328,11 @@ function runtimeEffectiveCapabilitySummary(
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
+    caps.supports_extended_thinking ? 'extended thinking' : null,
+    caps.supports_reasoning_budget ? 'reasoning budget' : null,
+    caps.accepted_reasoning_efforts && caps.accepted_reasoning_efforts.length > 0
+      ? `effort ${caps.accepted_reasoning_efforts.join(',')}`
+      : null,
     caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -342,6 +342,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('price-in 0.1')
     expect(container.textContent).toContain('effective · out 65,536')
     expect(container.textContent).toContain('runtime-mcp-tools')
+    expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -692,6 +692,11 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
+    caps.supports_extended_thinking ? 'extended' : null,
+    caps.supports_reasoning_budget ? 'budget' : null,
+    caps.accepted_reasoning_efforts && caps.accepted_reasoning_efforts.length > 0
+      ? `effort ${caps.accepted_reasoning_efforts.join(',')}`
+      : null,
     caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -835,7 +835,9 @@ describe('SettingsSurface', () => {
             supports_response_format_json: true,
             supports_structured_output: true,
             supports_reasoning: true,
-            accepted_reasoning_efforts: null,
+            supports_extended_thinking: true,
+            supports_reasoning_budget: true,
+            accepted_reasoning_efforts: ['low', 'medium', 'high'],
             preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
@@ -965,6 +967,9 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('tool-content:empty-string')
+      expect(cards[0]?.textContent).toContain('extended-thinking')
+      expect(cards[0]?.textContent).toContain('reasoning-budget')
+      expect(cards[0]?.textContent).toContain('effort:low,medium,high')
       expect(cards[0]?.textContent).toContain('preserve:always-preserved')
       expect(cards[0]?.textContent).toContain('task:transcription')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -408,6 +408,12 @@ function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProviderSnaps
       ? `tool-content:${item.effective_capabilities.assistant_tool_content_format}`
       : null,
     item.effective_capabilities?.supports_reasoning ? 'reasoning' : null,
+    item.effective_capabilities?.supports_extended_thinking ? 'extended-thinking' : null,
+    item.effective_capabilities?.supports_reasoning_budget ? 'reasoning-budget' : null,
+    item.effective_capabilities?.accepted_reasoning_efforts
+      && item.effective_capabilities.accepted_reasoning_efforts.length > 0
+      ? `effort:${item.effective_capabilities.accepted_reasoning_efforts.join(',')}`
+      : null,
     item.effective_capabilities?.preserve_thinking_control_format
       ? `preserve:${item.effective_capabilities.preserve_thinking_control_format}`
       : null,


### PR DESCRIPTION
## Summary

- Surface effective `supports_extended_thinking`, `supports_reasoning_budget`, and `accepted_reasoning_efforts` in the settings runtime catalog compact summary.
- Surface the same effective reasoning parameter fields in the keeper workspace rail runtime summary.
- Surface the same fields in the runtime monitor compact effective capability summary; the detailed parameter rows already had this payload.
- Extend dashboard component tests so the newly exposed fields stay wired from the existing runtime snapshot payload.

## Notes

This is dashboard-only wiring. It does not introduce provider-specific constants or new model capability policy; the UI renders the typed effective capability fields already decoded from the runtime snapshot.

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/runtime-monitor.ts src/components/runtime-monitor.test.ts src/components/settings-surface.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `git diff --check`