### PR TITLE
fix(ide): share tool input path attribution

### DIFF
--- a/lib/attribution/tool_input_path.ml
+++ b/lib/attribution/tool_input_path.ml
@@ -1,0 +1,18 @@
+let non_empty_string_member name input =
+  match Yojson.Safe.Util.member name input with
+  | `String raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+  | _ -> None
+;;
+
+let tool_input_file_path input =
+  let rec first = function
+    | [] -> None
+    | name :: rest ->
+      (match non_empty_string_member name input with
+       | Some _ as path -> path
+       | None -> first rest)
+  in
+  first [ "path"; "file_path" ]
+;;

--- a/lib/attribution/tool_input_path.mli
+++ b/lib/attribution/tool_input_path.mli
@@ -1,0 +1,6 @@
+val tool_input_file_path : Yojson.Safe.t -> string option
+(** Extract the edited file path from a tool input payload.
+
+    Key priority is shared across IDE tool events, IDE cursor attribution, and
+    keeper observation attribution. Caller-specific base-path or cwd fallback
+    remains outside this helper. *)

--- a/lib/ide/dune
+++ b/lib/ide/dune
@@ -25,6 +25,7 @@
   uuidm
   fs_compat
   masc.dated_jsonl
+  masc.attribution
   masc.masc_process
   masc.command_descriptor
   masc.agent_observation

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -600,15 +600,7 @@ let extract_descriptor_from_output (output_text : string) : Ide_event_types.comm
   with _ -> None
 
 let cursor_file_path_of_input input =
-  let non_empty = function
-    | Some s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-    | None -> None
-  in
-  match non_empty (string_field "file_path" input) with
-  | Some _ as path -> path
-  | None -> non_empty (string_field "path" input)
+  Tool_input_path.tool_input_file_path input
 ;;
 
 let cursor_line_of_input input =
@@ -781,14 +773,7 @@ let ingest_tool_event_from_hook
     ~output_text
     ~(input : Yojson.Safe.t)
   =
-  let file_path =
-    match Yojson.Safe.Util.member "path" input with
-    | `String p -> Some p
-    | _ ->
-      match Yojson.Safe.Util.member "file_path" input with
-      | `String p -> Some p
-      | _ -> None
-  in
+  let file_path = Tool_input_path.tool_input_file_path input in
   let summary =
     if String.length output_text > 200 then String.sub output_text 0 200
     else output_text

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -76,12 +76,7 @@ let non_empty_string_member name input =
 ;;
 
 let observation_file_path_from_tool_input ~base_path input =
-  let path =
-    match non_empty_string_member "path" input with
-    | Some p -> Some p
-    | None -> non_empty_string_member "file_path" input
-  in
-  match path with
+  match Tool_input_path.tool_input_file_path input with
   | None -> base_path
   | Some p when Filename.is_relative p && not (sandbox_rooted_relative_path p) ->
     (match non_empty_string_member "cwd" input with

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -380,6 +380,82 @@ let test_hook_extracts_file_path_from_file_path_key () =
     check string "file_path" "src/main.ml" (Yojson.Safe.Util.to_string fp))
 ;;
 
+let test_hook_and_cursor_share_path_priority () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc
+        [ "path", `String "lib/from-path.ml"
+        ; "file_path", `String "lib/from-file-path.ml"
+        ; "line", `Int 9
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~tool_name:"fs_edit"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-9"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:50.0
+      ~output_text:"edited"
+      ~input;
+    let events = Ide_bridge.list_events ~base_path:base_dir () in
+    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
+    match events, cursors with
+    | event :: _, [ cursor ] ->
+      check
+        string
+        "tool event path priority"
+        "lib/from-path.ml"
+        (json_string "file_path" event);
+      check
+        string
+        "cursor path priority"
+        "lib/from-path.ml"
+        (json_string "file_path" cursor)
+    | _ -> fail "expected one tool event and one cursor")
+;;
+
+let test_hook_and_cursor_share_blank_path_fallback () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc
+        [ "path", `String " "
+        ; "file_path", `String "lib/from-file-path.ml"
+        ; "line", `Int 9
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~tool_name:"fs_edit"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-9"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:50.0
+      ~output_text:"edited"
+      ~input;
+    let events = Ide_bridge.list_events ~base_path:base_dir () in
+    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
+    match events, cursors with
+    | event :: _, [ cursor ] ->
+      check
+        string
+        "tool event blank path fallback"
+        "lib/from-file-path.ml"
+        (json_string "file_path" event);
+      check
+        string
+        "cursor blank path fallback"
+        "lib/from-file-path.ml"
+        (json_string "file_path" cursor)
+    | _ -> fail "expected one tool event and one cursor")
+;;
+
 let test_hook_no_file_path () =
   with_temp_dir (fun base_dir ->
     let input = `Assoc [ "command", `String "ls" ] in
@@ -1054,6 +1130,14 @@ let () =
     ; ( "hook_extract"
       , [ test_case "file_path from path key" `Quick test_hook_extracts_file_path_from_path_key
         ; test_case "file_path from file_path key" `Quick test_hook_extracts_file_path_from_file_path_key
+        ; test_case
+            "tool event and cursor share path priority"
+            `Quick
+            test_hook_and_cursor_share_path_priority
+        ; test_case
+            "tool event and cursor share blank path fallback"
+            `Quick
+            test_hook_and_cursor_share_blank_path_fallback
         ; test_case "no file_path (execute)" `Quick test_hook_no_file_path
         ; test_case "summary truncation" `Quick test_hook_summary_truncation
         ; test_case "typed_outcome mapping" `Quick test_hook_typed_outcome_mapping

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -85,6 +85,17 @@ let test_blank_path_falls_back_to_file_path () =
        ])
 ;;
 
+let test_path_priority_matches_ide_helper () =
+  check
+    string
+    "path wins"
+    "repos/masc/lib/from-path.ml"
+    (observed_path
+       [ "path", `String "repos/masc/lib/from-path.ml"
+       ; "file_path", `String "repos/masc/lib/from-file-path.ml"
+       ])
+;;
+
 let test_missing_path_falls_back_to_base_path () =
   check string "base fallback" "/tmp/masc-base" (observed_path [])
 ;;
@@ -128,6 +139,8 @@ let () =
         ; test_case "absolute path ignores cwd" `Quick test_absolute_path_ignores_cwd
         ; test_case "blank path falls back to file_path" `Quick
             test_blank_path_falls_back_to_file_path
+        ; test_case "path priority matches IDE helper" `Quick
+            test_path_priority_matches_ide_helper
         ; test_case "missing path falls back to base_path" `Quick
             test_missing_path_falls_back_to_base_path
         ] )


### PR DESCRIPTION
## Summary
- add a shared attribution helper for tool input path extraction
- route IDE cursor attribution, IDE tool-event ingestion, and keeper observation attribution through the same helper
- add regression coverage for path/file_path priority and blank path fallback parity

Closes #23161

## Validation
- git diff --check origin/main...HEAD
- opam exec -- ocamlformat --check lib/attribution/tool_input_path.ml lib/attribution/tool_input_path.mli lib/ide/ide_bridge.ml lib/keeper/keeper_run_tools_hooks.ml test/test_ide_bridge.ml
- dune build/test intentionally left to CI per operator instruction