### PR TITLE
[codex] Surface runtime request paths in summaries

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -387,7 +387,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('params')
     expect(container.textContent).toContain('chat_template_kwargs · preserve_always')
     expect(container.textContent).toContain('request')
-    expect(container.textContent).toContain('openai_compat · out 65536 · ctx 131072')
+    expect(container.textContent).toContain('openai_compat · path /chat/completions · out 65536 · ctx 131072')
     expect(container.textContent).toContain('tool required')
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -176,9 +176,14 @@ function runtimeRequestConfigSummary(
   ].filter((value): value is string => Boolean(value))
   const toolChoice = runtimeRequestToolChoiceSummary(entry)
   const format = runtimeRequestFormatSummary(entry)
+  const requestPath = request.request_path_targets_responses_api
+    ? 'responses-api'
+    : request.request_path
+      ? `path ${request.request_path}`
+      : null
   const parts = [
     request.provider_kind ? request.provider_kind : null,
-    request.request_path_targets_responses_api ? 'responses-api' : null,
+    requestPath,
     typeof request.max_tokens === 'number' ? `out ${request.max_tokens}` : null,
     typeof request.max_context === 'number' ? `ctx ${request.max_context}` : null,
     sampling.length > 0 ? sampling.join(',') : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -968,6 +968,7 @@ describe('SettingsSurface', () => {
         expect.stringContaining('Provider B'),
       ])
       expect(cards[0]?.textContent).toContain('wire:chat-template-kwargs')
+      expect(cards[0]?.textContent).toContain('path:/chat/completions')
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -252,9 +252,14 @@ function runtimeCatalogRequestConfig(item: DashboardRuntimeProviderSnapshot): st
   ].filter((value): value is string => Boolean(value))
   const toolChoice = runtimeCatalogRequestToolChoice(item)
   const format = runtimeCatalogRequestFormat(item)
+  const requestPath = request.request_path_targets_responses_api
+    ? 'responses-api'
+    : request.request_path
+      ? `path:${request.request_path}`
+      : null
   const parts = [
     request.provider_kind ? `kind:${request.provider_kind}` : null,
-    request.request_path_targets_responses_api ? 'responses-api' : null,
+    requestPath,
     typeof request.max_tokens === 'number' ? `out:${request.max_tokens}` : null,
     typeof request.max_context === 'number' ? `ctx:${request.max_context}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,


### PR DESCRIPTION
## Summary
- surface typed runtime `request_config.request_path` values in settings runtime catalog request summaries
- surface the same request path in the keeper workspace rail runtime request summary
- preserve the existing `responses-api` marker when `request_path_targets_responses_api` is true

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/settings-surface.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts` (settings-surface.test.ts ignored by repo config warning only)
- `git diff --check origin/main...HEAD`