### PR TITLE
[codex] Surface runtime request origin summaries

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -387,7 +387,10 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('params')
     expect(container.textContent).toContain('chat_template_kwargs · preserve_always')
     expect(container.textContent).toContain('request')
-    expect(container.textContent).toContain('openai_compat · path /chat/completions · out 65536 · ctx 131072')
+    expect(container.textContent).toContain(
+      'openai_compat · source oas-provider-config · path /chat/completions · out 65536 · ctx 131072',
+    )
+    expect(container.textContent).toContain('system prompt')
     expect(container.textContent).toContain('tool required')
     expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('chat-completions · openai-compatible-http')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -183,10 +183,12 @@ function runtimeRequestConfigSummary(
       : null
   const parts = [
     request.provider_kind ? request.provider_kind : null,
+    request.source ? `source ${request.source}` : null,
     requestPath,
     typeof request.max_tokens === 'number' ? `out ${request.max_tokens}` : null,
     typeof request.max_context === 'number' ? `ctx ${request.max_context}` : null,
     sampling.length > 0 ? sampling.join(',') : null,
+    request.has_system_prompt ? 'system prompt' : null,
     typeof request.enable_thinking === 'boolean' ? `think ${request.enable_thinking ? 'on' : 'off'}` : null,
     typeof request.preserve_thinking === 'boolean' ? `preserve ${request.preserve_thinking ? 'on' : 'off'}` : null,
     typeof request.clear_thinking === 'boolean' ? `clear ${request.clear_thinking ? 'on' : 'off'}` : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -327,7 +327,10 @@ describe('RuntimeMonitor', () => {
     )
 
     expect(container.textContent).toContain('params · wire chat_template_kwargs')
-    expect(container.textContent).toContain('request · kind openai_compat')
+    expect(container.textContent).toContain(
+      'request · kind openai_compat · source oas-provider-config · path /chat/completions',
+    )
+    expect(container.textContent).toContain('system prompt')
     expect(container.textContent).toContain('preserve off')
     expect(container.textContent).toContain('glm replay')
     expect(container.textContent).toContain('tool stream on')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -259,10 +259,12 @@ function runtimeRequestConfigText(provider: DashboardRuntimeProviderSnapshot): s
   }
   const parts = [
     request.provider_kind ? `kind ${request.provider_kind}` : null,
+    request.source ? `source ${request.source}` : null,
     requestPath,
     typeof request.max_tokens === 'number' ? `out ${formatNumber(request.max_tokens)}` : null,
     typeof request.max_context === 'number' ? `ctx ${formatNumber(request.max_context)}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    request.has_system_prompt ? 'system prompt' : null,
     typeof request.enable_thinking === 'boolean' ? `think ${request.enable_thinking ? 'on' : 'off'}` : null,
     typeof request.preserve_thinking === 'boolean' ? `preserve ${request.preserve_thinking ? 'on' : 'off'}` : null,
     typeof request.clear_thinking === 'boolean' ? `clear ${request.clear_thinking ? 'on' : 'off'}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -968,7 +968,9 @@ describe('SettingsSurface', () => {
         expect.stringContaining('Provider B'),
       ])
       expect(cards[0]?.textContent).toContain('wire:chat-template-kwargs')
+      expect(cards[0]?.textContent).toContain('source:oas-provider-config')
       expect(cards[0]?.textContent).toContain('path:/chat/completions')
+      expect(cards[0]?.textContent).toContain('system-prompt')
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -259,10 +259,12 @@ function runtimeCatalogRequestConfig(item: DashboardRuntimeProviderSnapshot): st
       : null
   const parts = [
     request.provider_kind ? `kind:${request.provider_kind}` : null,
+    request.source ? `source:${request.source}` : null,
     requestPath,
     typeof request.max_tokens === 'number' ? `out:${request.max_tokens}` : null,
     typeof request.max_context === 'number' ? `ctx:${request.max_context}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+    request.has_system_prompt ? 'system-prompt' : null,
     typeof request.enable_thinking === 'boolean' ? `think:${request.enable_thinking ? 'on' : 'off'}` : null,
     typeof request.preserve_thinking === 'boolean' ? `preserve:${request.preserve_thinking ? 'on' : 'off'}` : null,
     typeof request.clear_thinking === 'boolean' ? `clear:${request.clear_thinking ? 'on' : 'off'}` : null,


### PR DESCRIPTION
## Summary
- expose typed runtime request provenance (`request_config.source`) in runtime request summaries
- expose actual system prompt presence in settings, keeper rail, and runtime monitor compact summaries
- keep the existing typed request path/parameter rendering intact without provider-specific branching

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/runtime-monitor.ts src/components/runtime-monitor.test.ts src/components/settings-surface.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts` (runtime-monitor.test.ts and settings-surface.test.ts ignored by repo config warning only)
- `git diff --check`