### PR TITLE
[codex] Surface runtime discovery details

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -223,6 +223,7 @@ describe('RuntimeMonitor', () => {
           note: null,
           discovery: {
             healthy: true,
+            discovered_model: 'Qwen/Qwen3-32B',
             ctx_size: 200000,
             total_slots: 4,
             busy_slots: 1,
@@ -354,6 +355,8 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('task transcription · native-stream')
     expect(container.textContent).toContain('seed+images')
     expect(container.textContent).toContain('code-exec')
+    expect(container.textContent).toContain('discovered · Qwen/Qwen3-32B')
+    expect(container.textContent).toContain('idle · 3')
   })
 
   it('renders parameter facts as structured request declared and effective rows', async () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -1181,8 +1181,12 @@ export function RuntimeMonitor() {
                   ${provider.discovery
                     ? html`<div class="grid grid-cols-2 gap-3 text-xs text-[var(--color-fg-secondary)] pt-2 border-t border-[var(--color-border-default)]/50">
                         <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
+                        <div class="min-w-0 truncate" title=${provider.discovery.discovered_model ?? MISSING_DATA_DASH}>
+                          discovered · ${provider.discovery.discovered_model ?? MISSING_DATA_DASH}
+                        </div>
                         <div>ctx · ${formatNumber(provider.discovery.ctx_size)}</div>
                         <div>slots · ${formatNumber(provider.discovery.busy_slots)}/${formatNumber(provider.discovery.total_slots)}</div>
+                        <div>idle · ${formatNumber(provider.discovery.idle_slots)}</div>
                       </div>`
                     : null}
                 </article>


### PR DESCRIPTION
## Summary

- Surface typed provider discovery `discovered_model` on runtime monitor cards.
- Surface typed discovery `idle_slots` next to busy/total slots.
- Extend the runtime monitor fixture/assertions so the UI keeps exposing these discovery facts.

## Why

Provider discovery already carries more runtime facts than the dashboard showed. This keeps the runtime monitor aligned with the snapshot contract without adding provider-specific matching or inferred model rules.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-monitor.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/runtime-monitor.ts src/components/runtime-monitor.test.ts` (test file ignored by repo config warning only)
- `git diff --check`