### PR TITLE
[codex] Surface runtime catalog snapshot facts

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -828,6 +828,11 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeProviders.mockResolvedValue(makeRuntimeProviders({
       providers: [
         makeRuntimeProvider({
+          model_count: 2,
+          models: ['m1', 'm1-fallback'],
+          temperature: 0.7,
+          capabilities_declared: true,
+          note: 'verified by runtime discovery',
           parameter_policy: {
             reasoning_toggle_wire: 'chat-template-kwargs',
             reasoning_replay_policy: 'preserve-always',
@@ -1014,6 +1019,11 @@ describe('SettingsSurface', () => {
         expect.stringContaining('Provider B'),
       ])
       expect(cards[0]?.textContent).toContain('wire:chat-template-kwargs')
+      expect(cards[0]?.textContent).toContain('snapshot:source:runtime.toml')
+      expect(cards[0]?.textContent).toContain('models:2')
+      expect(cards[0]?.textContent).toContain('model-temp:0.7')
+      expect(cards[0]?.textContent).toContain('caps:declared')
+      expect(cards[0]?.textContent).toContain('note:verified by runtime discovery')
       expect(cards[0]?.textContent).toContain('source:oas-provider-config')
       expect(cards[0]?.textContent).toContain('path:/chat/completions')
       expect(cards[0]?.textContent).toContain('system-prompt')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -214,6 +214,25 @@ function RuntimeCatalogCapability({ label, value }: { label: string; value: bool
   return html`<span class=${`rt-cap ${isOn ? 'on' : ''}`}>${isOn ? '✓' : '·'} ${label}</span>`
 }
 
+function runtimeCatalogSnapshotFacts(item: DashboardRuntimeProviderSnapshot): string | null {
+  const modelCount = typeof item.model_count === 'number'
+    ? item.model_count
+    : item.models.length > 0
+      ? item.models.length
+      : null
+  const note = item.note?.trim()
+  const parts = [
+    item.source ? `source:${item.source}` : null,
+    typeof modelCount === 'number' ? `models:${modelCount}` : null,
+    typeof item.temperature === 'number' ? `model-temp:${item.temperature}` : null,
+    typeof item.capabilities_declared === 'boolean'
+      ? `caps:${item.capabilities_declared ? 'declared' : 'missing'}`
+      : null,
+    note ? `note:${note}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function runtimeCatalogParameterPolicy(item: DashboardRuntimeProviderSnapshot): string | null {
   const policy = item.parameter_policy
   if (!policy) return null
@@ -503,6 +522,7 @@ function RuntimeCatalogCard({
   const parameterPolicy = runtimeCatalogParameterPolicy(item)
   const requestConfig = runtimeCatalogRequestConfig(item)
   const declaredSpec = runtimeCatalogDeclaredSpec(item)
+  const snapshotFacts = runtimeCatalogSnapshotFacts(item)
 
   return html`
     <div class="set-rt" data-testid="runtime-catalog-card">
@@ -528,6 +548,9 @@ function RuntimeCatalogCard({
         <${RuntimeCatalogCapability} label="tools" value=${item.tools_support} />
         <${RuntimeCatalogCapability} label="thinking" value=${item.thinking_support} />
         <${RuntimeCatalogCapability} label="streaming" value=${item.streaming} />
+        ${snapshotFacts
+          ? html`<span class="rt-cap tcf mono" title=${snapshotFacts}>snapshot:${snapshotFacts}</span>`
+          : null}
         ${effectiveCapabilities
           ? html`<span class="rt-cap tcf mono" title=${effectiveCapabilities}>${effectiveCapabilities}</span>`
           : null}


### PR DESCRIPTION
## Summary

- Add a runtime catalog snapshot fact chip on settings runtime cards.
- Surface decoded snapshot provenance and model facts: `source`, `model_count`/`models.length`, per-model `temperature`, `capabilities_declared`, and `note`.
- Extend the settings runtime catalog test fixture/assertions for those typed fields.

## Why

The dashboard already decodes these provider snapshot fields, but settings runtime cards did not expose them. This keeps the operator catalog closer to the runtime snapshot contract without provider-specific matching, heuristics, or new model constants.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/settings-surface.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/settings-surface.ts src/components/settings-surface.test.ts` (test file ignored by repo config warning only)
- `git diff --check`