### PR TITLE
fix(hitl): keep summary worker on root switch

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -735,6 +735,15 @@ let update_pending_entry ~id f =
     | Some entry -> SMap.add id (f entry) map)
 ;;
 
+let record_summary_failure ~id ~reason ~retryable =
+  let now = Time_compat.now () in
+  update_pending_entry ~id (fun e ->
+    { e with summary_status = Summary_failed { reason; retryable } });
+  match get_pending_entry ~id with
+  | Some updated -> record_summary_updated ~now updated
+  | None -> ()
+;;
+
 let provider_config_for_summary ~keeper_name =
   let runtime_id =
     match Runtime.runtime_id_for_keeper keeper_name with
@@ -764,17 +773,32 @@ let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =
       | None -> ()
     in
     let on_failure ~reason ~retryable =
-      update_pending_entry ~id:entry.id (fun e ->
-        { e with summary_status = Summary_failed { reason; retryable } });
-      match get_pending_entry ~id:entry.id with
-      | Some updated -> record_summary_updated ~now updated
-      | None -> ()
+      record_summary_failure ~id:entry.id ~reason ~retryable
     in
     match provider_config_for_summary ~keeper_name:entry.keeper_name with
     | None ->
       on_failure ~reason:"HITL summary: no runtime provider config available" ~retryable:false
     | Some config ->
       Hitl_summary_worker.spawn ~sw ~entry ~provider_config:config ~on_summary ~on_failure ()
+;;
+
+let spawn_hitl_summary_worker_on_root_switch ~(entry : pending_approval) =
+  (* HITL summaries are queued background enrichment, not turn-scoped work.
+     Fork on the server root switch so the worker can finish after the keeper
+     turn that created the approval has unwound. *)
+  match entry.risk_level with
+  | Low -> ()
+  | Medium | High | Critical ->
+    (match Eio_context.get_root_switch_opt () with
+     | Some sw -> spawn_hitl_summary_worker ~sw ~entry
+     | None ->
+       let reason = "HITL summary: server root switch unavailable" in
+       Log.Keeper.warn
+         "HITL summary worker not spawned approval_id=%s keeper=%s reason=%s"
+         entry.id
+         entry.keeper_name
+         reason;
+       record_summary_failure ~id:entry.id ~reason ~retryable:false)
 ;;
 
 (* Wake the keeper that was waiting on this approval. A keeper that enqueued an
@@ -1022,11 +1046,7 @@ let submit_and_await
   in
   atomic_update pending (fun map -> SMap.add id entry map);
   record_pending entry;
-  let () =
-    match Eio_context.get_switch_opt () with
-    | Some sw -> spawn_hitl_summary_worker ~sw ~entry
-    | None -> ()
-  in
+  spawn_hitl_summary_worker_on_root_switch ~entry;
   let timeout_decision reason =
     let decision = Agent_sdk.Hooks.Reject reason in
     match Eio.Promise.peek promise with
@@ -1203,11 +1223,7 @@ let submit_pending
       if Atomic.compare_and_set pending map updated
       then (
         record_pending entry;
-        let () =
-          match Eio_context.get_switch_opt () with
-          | Some sw -> spawn_hitl_summary_worker ~sw ~entry
-          | None -> ()
-        in
+        spawn_hitl_summary_worker_on_root_switch ~entry;
         id)
       else submit ()
   in

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -373,9 +373,52 @@ let test_summary_survives_include_input_paths () =
          (summary_status_status detail_entry);
        (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
         | Ok () -> ()
-        | Error err ->
+       | Error err ->
           Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
        yield_until (fun () -> Option.is_some !result))
+;;
+
+let test_summary_worker_missing_root_switch_is_explicit_failure () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run
+       @@ fun turn_sw ->
+       let keeper_name = "summary-root-switch-missing-test" in
+       let id =
+         Eio_context.with_turn_switch turn_sw (fun () ->
+           AQ.submit_pending
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_reconcile"
+             ~input:(`Assoc [ "kind", `String "medium_gate" ])
+             ~risk_level:AQ.Medium
+             ~base_path
+             ~on_resolution:(fun _decision -> ())
+             ())
+       in
+       let entry =
+         match AQ.get_pending_entry ~id with
+         | Some entry -> entry
+         | None -> Alcotest.fail "pending entry missing"
+       in
+       (match entry.summary_status with
+        | AQ.Summary_failed { reason; retryable } ->
+          Alcotest.(check string)
+            "missing root switch is explicit"
+            "HITL summary: server root switch unavailable"
+            reason;
+          Alcotest.(check bool) "not retryable without a root switch" false retryable
+        | other ->
+          Alcotest.failf
+            "expected Summary_failed, got %s"
+            (Yojson.Safe.to_string (AQ.summary_status_to_yojson other)));
+       match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+       | Ok () -> ()
+       | Error err ->
+         Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err))
 ;;
 
 let test_pending_phase_conversions () =
@@ -429,6 +472,10 @@ let () =
             "context summary survives include_input:true JSON paths"
             `Quick
             test_summary_survives_include_input_paths
+        ; Alcotest.test_case
+            "missing root switch marks summary failed"
+            `Quick
+            test_summary_worker_missing_root_switch_is_explicit_failure
         ] )
     ; ( "conversions"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- fork HITL context-summary enrichment from the server root switch, not the turn-local switch
- mark Medium+ summaries as explicit failed status when the root switch is unavailable instead of silently dropping enrichment
- add a regression test for the missing-root-switch failure surface

## Verification
- git diff --check
- opam exec -- ocamlformat --check lib/keeper/keeper_approval_queue.ml test/test_keeper_approval_queue.ml

Local dune build intentionally not run; CI is the build authority for this repo.