### PR TITLE
Decode runtime discovery model names

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -626,7 +626,7 @@ function decodeRuntimeProviderDiscovery(raw: unknown): DashboardRuntimeProviderD
   if (!isRecord(raw)) return null
   return {
     healthy: asBoolean(raw.healthy),
-    discovered_model: null,
+    discovered_model: asNullableString(raw.discovered_model),
     ctx_size: asNumber(raw.ctx_size) ?? null,
     total_slots: asNumber(raw.total_slots) ?? null,
     busy_slots: asNumber(raw.busy_slots) ?? null,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2594,6 +2594,7 @@ describe('fetchRuntimeProviders', () => {
             source: 'runtime.toml',
             discovery: {
               healthy: true,
+              discovered_model: 'Qwen/Qwen3-32B',
               ctx_size: 200000,
             },
           },
@@ -2672,6 +2673,7 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_code_execution).toBe(true)
     expect(result.providers[0]?.declared_spec?.binding?.max_concurrent).toBe(4)
     expect(result.providers[1]?.temperature).toBeNull()
+    expect(result.providers[0]?.discovery?.discovered_model).toBe('Qwen/Qwen3-32B')
     expect(result.providers[0]?.discovery?.ctx_size).toBe(200000)
     expect(result.assignment_governance?.status).toBe('degraded')
     expect(result.assignment_governance?.assignment_count).toBe(2)


### PR DESCRIPTION
## Summary
- decode runtime provider discovery.discovered_model instead of dropping it
- add API regression coverage so provider discovery model names reach dashboard consumers

## Validation
- pnpm --dir dashboard install --frozen-lockfile
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec eslint src/api/dashboard-runtime.ts src/api/dashboard.test.ts (warning only: dashboard.test.ts ignored by repo eslint config)
- git diff --check origin/main...HEAD