### PR TITLE
Surface runtime monitor snapshot facts

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -52,7 +52,14 @@ describe('RuntimeMonitor', () => {
           is_default_runtime: true,
           max_context: 200000,
           tools_support: true,
+          thinking_support: true,
           streaming: true,
+          temperature: 0.7,
+          capabilities_declared: true,
+          supports_multimodal_inputs: true,
+          supports_image_input: true,
+          supports_reasoning_budget: true,
+          thinking_control_format: 'reasoning-effort',
           model_count: 1,
           models: ['Qwen/Qwen3-32B'],
           parameter_policy: {
@@ -220,7 +227,7 @@ describe('RuntimeMonitor', () => {
           },
           source: 'runtime.toml',
           endpoint_url: 'https://example.invalid/v1',
-          note: null,
+          note: 'verified by runtime discovery',
           discovery: {
             healthy: true,
             discovered_model: 'Qwen/Qwen3-32B',
@@ -339,6 +346,14 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('rotation 2')
     expect(container.textContent).toContain('declared · api chat-completions')
     expect(container.textContent).toContain('auth env:RUNPOD_API_KEY')
+    expect(container.textContent).toContain('snapshot · source runtime.toml')
+    expect(container.textContent).toContain('protocol openai-http')
+    expect(container.textContent).toContain('model-temp 0.7')
+    expect(container.textContent).toContain('caps declared')
+    expect(container.textContent).toContain('tools on,thinking on,streaming on')
+    expect(container.textContent).toContain('multimodal on,image on,reasoning-budget on')
+    expect(container.textContent).toContain('thinking-control reasoning-effort')
+    expect(container.textContent).toContain('note verified by runtime discovery')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge,argv-preflight,anthropic-cache')
     expect(container.textContent).toContain(
       'controls tool-choice,required,named,parallel,extended-thinking,reasoning-budget,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,computer-use,code-exec',
@@ -357,6 +372,43 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('code-exec')
     expect(container.textContent).toContain('discovered · Qwen/Qwen3-32B')
     expect(container.textContent).toContain('idle · 3')
+  })
+
+  it('falls back to provider snapshot model count and auth kind when live probe rows are absent', async () => {
+    apiMocks.fetchDashboardRuntimeProbe.mockResolvedValueOnce({
+      generated_at: '2026-06-06T02:47:31Z',
+      refreshed_at_unix: 1780714051,
+      cache_ttl_sec: 30,
+      cache_age_sec: 0,
+      cache_hit: false,
+      probe: {
+        source: 'runtime.toml',
+        status: 'reachable',
+        checked_at: '2026-06-06T02:47:31Z',
+        probe_ok: true,
+        summary: {
+          runtimes: 1,
+          probed: 0,
+          reachable: 0,
+          failed: 0,
+          skipped: 1,
+          default_runtime_id: 'runpod_mtp.qwen',
+        },
+        providers: [],
+        errors: [],
+      },
+    })
+    const { RuntimeMonitor } = await import('./runtime-monitor')
+
+    render(h(RuntimeMonitor, {}), container)
+    await waitFor(
+      () => container.textContent?.includes('runpod_mtp.qwen') ?? false,
+      'runtime snapshot fallback facts',
+    )
+
+    expect(container.textContent).toContain('models · 1')
+    expect(container.textContent).toContain('auth · env:RUNPOD_API_KEY')
+    expect(container.textContent).toContain('snapshot · source runtime.toml')
   })
 
   it('renders parameter facts as structured request declared and effective rows', async () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -223,6 +223,11 @@ function stringArrayText(values: readonly string[] | null | undefined): string |
   return values && values.length > 0 ? values.join(',') : null
 }
 
+function boolStateText(value: boolean | null | undefined, label: string): string | null {
+  if (typeof value !== 'boolean') return null
+  return `${label} ${value ? 'on' : 'off'}`
+}
+
 function detailRow(
   axis: string,
   label: string,
@@ -295,6 +300,48 @@ function runtimeRequestConfigText(provider: DashboardRuntimeProviderSnapshot): s
     typeof request.connect_timeout_s === 'number' ? `connect ${request.connect_timeout_s}s` : null,
   ].filter((value): value is string => Boolean(value))
   return parts.length > 0 ? parts.join(' · ') : null
+}
+
+function runtimeSnapshotModelCount(provider: DashboardRuntimeProviderSnapshot): number | null {
+  if (typeof provider.model_count === 'number') return provider.model_count
+  return provider.models.length > 0 ? provider.models.length : null
+}
+
+function runtimeProviderModelCount(
+  provider: DashboardRuntimeProviderSnapshot,
+  probe: DashboardRuntimeProviderProbe | null | undefined,
+): number | null {
+  return probe?.model_count ?? runtimeSnapshotModelCount(provider)
+}
+
+function runtimeProviderAuthText(
+  provider: DashboardRuntimeProviderSnapshot,
+  probe: DashboardRuntimeProviderProbe | null | undefined,
+): string {
+  if (probe) return runtimeProbeAuthLabel(probe)
+  return provider.auth_kind ?? MISSING_DATA_DASH
+}
+
+function runtimeSnapshotFactsText(provider: DashboardRuntimeProviderSnapshot): string | null {
+  const modelCount = runtimeSnapshotModelCount(provider)
+  const note = provider.note?.trim()
+  return textList([
+    provider.source ? `source ${provider.source}` : null,
+    provider.protocol ? `protocol ${provider.protocol}` : null,
+    typeof modelCount === 'number' ? `models ${formatNumber(modelCount)}` : null,
+    typeof provider.temperature === 'number' ? `model-temp ${provider.temperature}` : null,
+    typeof provider.capabilities_declared === 'boolean'
+      ? `caps ${provider.capabilities_declared ? 'declared' : 'missing'}`
+      : null,
+    boolStateText(provider.tools_support, 'tools'),
+    boolStateText(provider.thinking_support, 'thinking'),
+    boolStateText(provider.streaming, 'streaming'),
+    boolStateText(provider.supports_multimodal_inputs, 'multimodal'),
+    boolStateText(provider.supports_image_input, 'image'),
+    boolStateText(provider.supports_reasoning_budget, 'reasoning-budget'),
+    provider.thinking_control_format ? `thinking-control ${provider.thinking_control_format}` : null,
+    note ? `note ${note}` : null,
+  ])
 }
 
 function runtimeProviderBehaviorText(provider: DashboardRuntimeProviderSnapshot): string | null {
@@ -1113,6 +1160,7 @@ export function RuntimeMonitor() {
                 const requestConfig = runtimeRequestConfigText(provider)
                 const declaredSpec = runtimeDeclaredSpecText(provider)
                 const parameterDetails = runtimeParameterDetailRows(provider)
+                const snapshotFacts = runtimeSnapshotFactsText(provider)
                 return html`
                 <article class="v2-monitoring-card p-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]/40 backdrop-blur-sm flex flex-col gap-2">
                   <div class="flex justify-between gap-3 items-start flex-wrap">
@@ -1132,9 +1180,14 @@ export function RuntimeMonitor() {
                     <div>ctx · ${formatNumber(provider.max_context)}</div>
                     <div>http · ${fmtProbeHttpStatus(liveProbe)}</div>
                     <div>latency · ${fmtProbeLatency(liveProbe)}</div>
-                    <div>models · ${formatNumber(liveProbe?.model_count)}</div>
-                    <div>auth · ${runtimeProbeAuthLabel(liveProbe)}</div>
+                    <div>models · ${formatNumber(runtimeProviderModelCount(provider, liveProbe))}</div>
+                    <div>auth · ${runtimeProviderAuthText(provider, liveProbe)}</div>
                   </div>
+                  ${snapshotFacts
+                    ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${snapshotFacts}>
+                        snapshot · ${snapshotFacts}
+                      </div>`
+                    : null}
                   ${liveProbe?.probe_url || provider.endpoint_url
                     ? html`<div class="truncate text-2xs text-[var(--color-fg-muted)]" title=${liveProbe?.probe_url ?? provider.endpoint_url ?? ''}>
                         probe · ${liveProbe?.probe_url ?? provider.endpoint_url}


### PR DESCRIPTION
## Summary
- surface provider snapshot facts on runtime monitor cards: source, protocol, model count, model temperature, capability declaration state, top-level support flags, thinking control, and note
- fall back to provider snapshot `model_count`/`models.length` and `auth_kind` when live probe rows are absent
- add regression coverage for snapshot fact rendering and live-probe-absent fallback

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/runtime-monitor.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/components/runtime-monitor.ts src/components/runtime-monitor.test.ts` (warning only: test file ignored by repo eslint config)
- `git diff --check origin/main...HEAD`