### PR TITLE
fix(test): repair main build — schema callee sync + memory_os clock

### DIFF
--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -432,13 +432,19 @@ let test_structured_tool_agent_runs_use_tool_schema_output () =
 let test_structured_tool_agent_runs_request_provider_native_output () =
   List.iter
     (fun rel ->
+       (* module마다 provider-native schema를 직접 적용(apply_to_provider_config)하거나
+          공유 prompt-tier 헬퍼(apply_schema_or_prompt_tier)로 위임한다. 둘 중 하나면
+          schema 적용 의도를 만족한다. 각 module의 callee는 아래 두 count의 합으로 잡는다. *)
        check
          int
          (rel ^ " applies provider-native structured-output schema")
          1
          (Ast_grep.count_calls
             ~module_path:rel
-            ~callee:"Keeper_structured_output_schema.apply_to_provider_config");
+            ~callee:"Keeper_structured_output_schema.apply_to_provider_config"
+          + Ast_grep.count_calls
+            ~module_path:rel
+            ~callee:"Keeper_structured_output_schema.apply_schema_or_prompt_tier");
        check
          int
          (rel ^ " wires provider_config_transform")

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -103,6 +103,7 @@ let test_accumulate_consolidate_recall () =
             ~complete:(fake_complete plan)
             ~sw
             ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
             ~provider_cfg:(provider_cfg ())
             ~now
             ();


### PR DESCRIPTION
## Summary

Fixes the main build breakage (Build and Test fail since `e4b99ac0` / #23157 merge). Two test-only failures from the #23157/batch2 schema-fail-open refactor not updating tests.

## Root cause

1. **test_keeper_structured_output_coverage:435** — batch2 migrated `keeper_adversarial_review` and `verifier_oas` to the shared `apply_schema_or_prompt_tier` helper, but the test still asserts each module calls `apply_to_provider_config` directly. Count = 0 on migrated modules → fail. `workspace_metric_hooks` was intentionally NOT migrated (anti_rationalization safety-gate, fail-closed per RFC-0305 #23091).

2. **test_server_bootstrap_maintenance_memory_os:111** — `run_memory_os_consolidation_tick ?clock` gained a clock guard that refuses the provider call when clock is None, but `test_accumulate_consolidate_recall` did not pass `~clock` → "consolidation provider clock unavailable; refusing provider call" → consolidate did not run → store size 5 (expected 4).

## Fix (test-only, no production change)

1. Count `apply_to_provider_config` OR `apply_schema_or_prompt_tier` per module. A module satisfies "applies provider-native structured-output schema" via either callee. Keeps `workspace_metric_hooks` fail-closed (RFC-0305) while letting migrated modules pass.
2. Thread `~clock:(Eio.Stdenv.clock env)` to the tick in `test_accumulate_consolidate_recall`.

## Why not migrate workspace_metric_hooks too

`workspace_metric_hooks` is the anti_rationalization safety-gate. RFC-0305 (PR #23091 Draft) wants it fail-closed by default. Migrating it to the fail-open helper here would pre-empt that RFC decision. The callee-agnostic test fix resolves the build break without taking that design call.

## Validation

- `opam exec -- ocamlformat --check` — clean
- diff: 8 insertions, 1 deletion (2 test files)
- Local dune build deferred to CI (masc worktree `--root`/pin caveat); CI is build authority.

Refs: #23157, batch2 helper migration, RFC-0305 #23091.
