### PR TITLE
Surface runtime snapshot capability mirrors

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -228,12 +228,32 @@ export interface DashboardRuntimeProviderSnapshot {
    *  null when unset (runtime keeps the fleet fallback). */
   temperature?: number | null
   capabilities_declared?: boolean
+  max_output_tokens?: number | null
+  supports_tool_choice?: boolean
+  supports_required_tool_choice?: boolean
+  supports_named_tool_choice?: boolean
+  supports_parallel_tool_calls?: boolean
+  supports_extended_thinking?: boolean
   supports_multimodal_inputs?: boolean
   supports_image_input?: boolean
   supports_audio_input?: boolean
   supports_video_input?: boolean
   supports_reasoning_budget?: boolean
   thinking_control_format?: string | null
+  supports_response_format_json?: boolean
+  supports_structured_output?: boolean
+  supports_native_streaming?: boolean
+  supports_system_prompt?: boolean
+  supports_caching?: boolean
+  supports_prompt_caching?: boolean
+  prompt_cache_alignment?: number | null
+  supports_top_k?: boolean
+  supports_min_p?: boolean
+  supports_seed?: boolean
+  supports_seed_with_images?: boolean
+  emits_usage_tokens?: boolean
+  supports_computer_use?: boolean
+  supports_code_execution?: boolean
   effective_capabilities?: DashboardRuntimeEffectiveCapabilities | null
   parameter_policy?: DashboardRuntimeParameterPolicy | null
   request_config?: DashboardRuntimeRequestConfig | null
@@ -661,12 +681,32 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     streaming: asBoolean(raw.streaming),
     temperature: asNumber(raw.temperature) ?? null,
     capabilities_declared: asBoolean(raw.capabilities_declared),
+    max_output_tokens: asNumber(raw.max_output_tokens) ?? null,
+    supports_tool_choice: asBoolean(raw.supports_tool_choice),
+    supports_required_tool_choice: asBoolean(raw.supports_required_tool_choice),
+    supports_named_tool_choice: asBoolean(raw.supports_named_tool_choice),
+    supports_parallel_tool_calls: asBoolean(raw.supports_parallel_tool_calls),
+    supports_extended_thinking: asBoolean(raw.supports_extended_thinking),
     supports_multimodal_inputs: asBoolean(raw.supports_multimodal_inputs),
     supports_image_input: asBoolean(raw.supports_image_input),
     supports_audio_input: asBoolean(raw.supports_audio_input),
     supports_video_input: asBoolean(raw.supports_video_input),
     supports_reasoning_budget: asBoolean(raw.supports_reasoning_budget),
     thinking_control_format: asNullableString(raw.thinking_control_format),
+    supports_response_format_json: asBoolean(raw.supports_response_format_json),
+    supports_structured_output: asBoolean(raw.supports_structured_output),
+    supports_native_streaming: asBoolean(raw.supports_native_streaming),
+    supports_system_prompt: asBoolean(raw.supports_system_prompt),
+    supports_caching: asBoolean(raw.supports_caching),
+    supports_prompt_caching: asBoolean(raw.supports_prompt_caching),
+    prompt_cache_alignment: asNumber(raw.prompt_cache_alignment) ?? null,
+    supports_top_k: asBoolean(raw.supports_top_k),
+    supports_min_p: asBoolean(raw.supports_min_p),
+    supports_seed: asBoolean(raw.supports_seed),
+    supports_seed_with_images: asBoolean(raw.supports_seed_with_images),
+    emits_usage_tokens: asBoolean(raw.emits_usage_tokens),
+    supports_computer_use: asBoolean(raw.supports_computer_use),
+    supports_code_execution: asBoolean(raw.supports_code_execution),
     effective_capabilities: decodeRuntimeEffectiveCapabilities(raw.effective_capabilities),
     parameter_policy: decodeRuntimeParameterPolicy(raw.parameter_policy),
     request_config: decodeRuntimeRequestConfig(raw.request_config),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2423,6 +2423,26 @@ describe('fetchRuntimeProviders', () => {
             model_count: 1,
             models: ['Qwen/Qwen3-32B'],
             temperature: 0.65,
+            max_output_tokens: 65536,
+            supports_tool_choice: true,
+            supports_required_tool_choice: true,
+            supports_named_tool_choice: true,
+            supports_parallel_tool_calls: true,
+            supports_extended_thinking: true,
+            supports_response_format_json: true,
+            supports_structured_output: true,
+            supports_native_streaming: true,
+            supports_system_prompt: true,
+            supports_caching: true,
+            supports_prompt_caching: true,
+            prompt_cache_alignment: 1024,
+            supports_top_k: true,
+            supports_min_p: true,
+            supports_seed: true,
+            supports_seed_with_images: true,
+            emits_usage_tokens: true,
+            supports_computer_use: false,
+            supports_code_execution: true,
             supports_audio_input: true,
             supports_video_input: false,
             parameter_policy: {
@@ -2644,6 +2664,24 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.kind).toBe('cloud')
     expect(result.providers[0]?.runtime_kind).toBe('http')
     expect(result.providers[0]?.temperature).toBe(0.65)
+    expect(result.providers[0]?.max_output_tokens).toBe(65536)
+    expect(result.providers[0]?.supports_tool_choice).toBe(true)
+    expect(result.providers[0]?.supports_required_tool_choice).toBe(true)
+    expect(result.providers[0]?.supports_named_tool_choice).toBe(true)
+    expect(result.providers[0]?.supports_parallel_tool_calls).toBe(true)
+    expect(result.providers[0]?.supports_extended_thinking).toBe(true)
+    expect(result.providers[0]?.supports_response_format_json).toBe(true)
+    expect(result.providers[0]?.supports_structured_output).toBe(true)
+    expect(result.providers[0]?.supports_native_streaming).toBe(true)
+    expect(result.providers[0]?.supports_system_prompt).toBe(true)
+    expect(result.providers[0]?.supports_prompt_caching).toBe(true)
+    expect(result.providers[0]?.prompt_cache_alignment).toBe(1024)
+    expect(result.providers[0]?.supports_top_k).toBe(true)
+    expect(result.providers[0]?.supports_min_p).toBe(true)
+    expect(result.providers[0]?.supports_seed).toBe(true)
+    expect(result.providers[0]?.supports_seed_with_images).toBe(true)
+    expect(result.providers[0]?.emits_usage_tokens).toBe(true)
+    expect(result.providers[0]?.supports_code_execution).toBe(true)
     expect(result.providers[0]?.supports_audio_input).toBe(true)
     expect(result.providers[0]?.supports_video_input).toBe(false)
     expect(result.providers[0]?.parameter_policy?.reasoning_toggle_wire).toBe('chat_template_kwargs')

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -56,12 +56,32 @@ describe('RuntimeMonitor', () => {
           streaming: true,
           temperature: 0.7,
           capabilities_declared: true,
+          max_output_tokens: 65536,
+          supports_tool_choice: true,
+          supports_required_tool_choice: true,
+          supports_named_tool_choice: true,
+          supports_parallel_tool_calls: true,
+          supports_extended_thinking: true,
           supports_multimodal_inputs: true,
           supports_image_input: true,
           supports_audio_input: true,
           supports_video_input: false,
           supports_reasoning_budget: true,
           thinking_control_format: 'reasoning-effort',
+          supports_response_format_json: true,
+          supports_structured_output: true,
+          supports_native_streaming: true,
+          supports_system_prompt: true,
+          supports_caching: true,
+          supports_prompt_caching: true,
+          prompt_cache_alignment: 1024,
+          supports_top_k: true,
+          supports_min_p: true,
+          supports_seed: true,
+          supports_seed_with_images: true,
+          emits_usage_tokens: true,
+          supports_computer_use: true,
+          supports_code_execution: true,
           model_count: 1,
           models: ['Qwen/Qwen3-32B'],
           parameter_policy: {
@@ -352,9 +372,14 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('protocol openai-http')
     expect(container.textContent).toContain('model-temp 0.7')
     expect(container.textContent).toContain('caps declared')
+    expect(container.textContent).toContain('format json,schema')
+    expect(container.textContent).toContain('sampling top_k,min_p,seed')
     expect(container.textContent).toContain('tools on,thinking on,streaming on')
     expect(container.textContent).toContain('multimodal on,image on,audio on,video off,reasoning-budget on')
     expect(container.textContent).toContain('thinking-control reasoning-effort')
+    expect(container.textContent).toContain(
+      'controls tool-choice,required,named,parallel,extended-thinking,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,computer-use,code-exec',
+    )
     expect(container.textContent).toContain('note verified by runtime discovery')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge,argv-preflight,anthropic-cache')
     expect(container.textContent).toContain(

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -322,17 +322,50 @@ function runtimeProviderAuthText(
   return provider.auth_kind ?? MISSING_DATA_DASH
 }
 
+function runtimeSnapshotPromptCache(provider: DashboardRuntimeProviderSnapshot): string | null {
+  if (provider.supports_prompt_caching !== true) return null
+  return `prompt-cache${typeof provider.prompt_cache_alignment === 'number' ? `@${provider.prompt_cache_alignment}` : ''}`
+}
+
 function runtimeSnapshotFactsText(provider: DashboardRuntimeProviderSnapshot): string | null {
   const modelCount = runtimeSnapshotModelCount(provider)
   const note = provider.note?.trim()
+  const formats = [
+    provider.supports_response_format_json ? 'json' : null,
+    provider.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const sampling = [
+    provider.supports_top_k ? 'top_k' : null,
+    provider.supports_min_p ? 'min_p' : null,
+    provider.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const controls = [
+    provider.supports_tool_choice ? 'tool-choice' : null,
+    provider.supports_required_tool_choice ? 'required' : null,
+    provider.supports_named_tool_choice ? 'named' : null,
+    provider.supports_parallel_tool_calls ? 'parallel' : null,
+    provider.supports_extended_thinking ? 'extended-thinking' : null,
+    provider.supports_native_streaming ? 'native-stream' : null,
+    provider.supports_system_prompt ? 'system-prompt' : null,
+    provider.supports_caching ? 'cache' : null,
+    runtimeSnapshotPromptCache(provider),
+    provider.supports_seed_with_images ? 'seed+images' : null,
+    provider.emits_usage_tokens ? 'usage' : null,
+    provider.supports_computer_use ? 'computer-use' : null,
+    provider.supports_code_execution ? 'code-exec' : null,
+  ].filter((value): value is string => Boolean(value))
   return textList([
     provider.source ? `source ${provider.source}` : null,
     provider.protocol ? `protocol ${provider.protocol}` : null,
     typeof modelCount === 'number' ? `models ${formatNumber(modelCount)}` : null,
+    typeof provider.max_context === 'number' ? `ctx ${formatNumber(provider.max_context)}` : null,
+    typeof provider.max_output_tokens === 'number' ? `out ${formatNumber(provider.max_output_tokens)}` : null,
     typeof provider.temperature === 'number' ? `model-temp ${provider.temperature}` : null,
     typeof provider.capabilities_declared === 'boolean'
       ? `caps ${provider.capabilities_declared ? 'declared' : 'missing'}`
       : null,
+    formats.length > 0 ? `format ${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     boolStateText(provider.tools_support, 'tools'),
     boolStateText(provider.thinking_support, 'thinking'),
     boolStateText(provider.streaming, 'streaming'),
@@ -342,6 +375,7 @@ function runtimeSnapshotFactsText(provider: DashboardRuntimeProviderSnapshot): s
     boolStateText(provider.supports_video_input, 'video'),
     boolStateText(provider.supports_reasoning_budget, 'reasoning-budget'),
     provider.thinking_control_format ? `thinking-control ${provider.thinking_control_format}` : null,
+    controls.length > 0 ? `controls ${controls.join(',')}` : null,
     note ? `note ${note}` : null,
   ])
 }

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -832,11 +832,31 @@ describe('SettingsSurface', () => {
           models: ['m1', 'm1-fallback'],
           temperature: 0.7,
           capabilities_declared: true,
+          max_output_tokens: 4096,
+          supports_tool_choice: true,
+          supports_required_tool_choice: true,
+          supports_named_tool_choice: true,
+          supports_parallel_tool_calls: true,
+          supports_extended_thinking: true,
           supports_multimodal_inputs: true,
           supports_image_input: true,
           supports_audio_input: true,
           supports_video_input: false,
           supports_reasoning_budget: true,
+          supports_response_format_json: true,
+          supports_structured_output: true,
+          supports_native_streaming: true,
+          supports_system_prompt: true,
+          supports_caching: true,
+          supports_prompt_caching: true,
+          prompt_cache_alignment: 1024,
+          supports_top_k: true,
+          supports_min_p: true,
+          supports_seed: true,
+          supports_seed_with_images: true,
+          emits_usage_tokens: true,
+          supports_computer_use: true,
+          supports_code_execution: true,
           note: 'verified by runtime discovery',
           parameter_policy: {
             reasoning_toggle_wire: 'chat-template-kwargs',
@@ -1026,10 +1046,17 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('wire:chat-template-kwargs')
       expect(cards[0]?.textContent).toContain('snapshot:source:runtime.toml')
       expect(cards[0]?.textContent).toContain('models:2')
+      expect(cards[0]?.textContent).toContain('ctx:128000')
+      expect(cards[0]?.textContent).toContain('out:4096')
       expect(cards[0]?.textContent).toContain('model-temp:0.7')
       expect(cards[0]?.textContent).toContain('caps:declared')
+      expect(cards[0]?.textContent).toContain('format:json,schema')
+      expect(cards[0]?.textContent).toContain('sampling:top_k,min_p,seed')
       expect(cards[0]?.textContent).toContain('audio:on')
       expect(cards[0]?.textContent).toContain('video:off')
+      expect(cards[0]?.textContent).toContain(
+        'controls:tool-choice,required,named,parallel,extended-thinking,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,computer-use,code-exec',
+      )
       expect(cards[0]?.textContent).toContain('note:verified by runtime discovery')
       expect(cards[0]?.textContent).toContain('source:oas-provider-config')
       expect(cards[0]?.textContent).toContain('path:/chat/completions')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -214,6 +214,11 @@ function RuntimeCatalogCapability({ label, value }: { label: string; value: bool
   return html`<span class=${`rt-cap ${isOn ? 'on' : ''}`}>${isOn ? '✓' : '·'} ${label}</span>`
 }
 
+function runtimeSnapshotPromptCache(item: DashboardRuntimeProviderSnapshot): string | null {
+  if (item.supports_prompt_caching !== true) return null
+  return `prompt-cache${typeof item.prompt_cache_alignment === 'number' ? `@${item.prompt_cache_alignment}` : ''}`
+}
+
 function runtimeCatalogSnapshotFacts(item: DashboardRuntimeProviderSnapshot): string | null {
   const modelCount = typeof item.model_count === 'number'
     ? item.model_count
@@ -221,13 +226,41 @@ function runtimeCatalogSnapshotFacts(item: DashboardRuntimeProviderSnapshot): st
       ? item.models.length
       : null
   const note = item.note?.trim()
+  const formats = [
+    item.supports_response_format_json ? 'json' : null,
+    item.supports_structured_output ? 'schema' : null,
+  ].filter((value): value is string => Boolean(value))
+  const sampling = [
+    item.supports_top_k ? 'top_k' : null,
+    item.supports_min_p ? 'min_p' : null,
+    item.supports_seed ? 'seed' : null,
+  ].filter((value): value is string => Boolean(value))
+  const controls = [
+    item.supports_tool_choice ? 'tool-choice' : null,
+    item.supports_required_tool_choice ? 'required' : null,
+    item.supports_named_tool_choice ? 'named' : null,
+    item.supports_parallel_tool_calls ? 'parallel' : null,
+    item.supports_extended_thinking ? 'extended-thinking' : null,
+    item.supports_native_streaming ? 'native-stream' : null,
+    item.supports_system_prompt ? 'system-prompt' : null,
+    item.supports_caching ? 'cache' : null,
+    runtimeSnapshotPromptCache(item),
+    item.supports_seed_with_images ? 'seed+images' : null,
+    item.emits_usage_tokens ? 'usage' : null,
+    item.supports_computer_use ? 'computer-use' : null,
+    item.supports_code_execution ? 'code-exec' : null,
+  ].filter((value): value is string => Boolean(value))
   const parts = [
     item.source ? `source:${item.source}` : null,
     typeof modelCount === 'number' ? `models:${modelCount}` : null,
+    typeof item.max_context === 'number' ? `ctx:${item.max_context}` : null,
+    typeof item.max_output_tokens === 'number' ? `out:${item.max_output_tokens}` : null,
     typeof item.temperature === 'number' ? `model-temp:${item.temperature}` : null,
     typeof item.capabilities_declared === 'boolean'
       ? `caps:${item.capabilities_declared ? 'declared' : 'missing'}`
       : null,
+    formats.length > 0 ? `format:${formats.join(',')}` : null,
+    sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
     typeof item.supports_multimodal_inputs === 'boolean'
       ? `multimodal:${item.supports_multimodal_inputs ? 'on' : 'off'}`
       : null,
@@ -237,6 +270,7 @@ function runtimeCatalogSnapshotFacts(item: DashboardRuntimeProviderSnapshot): st
     typeof item.supports_reasoning_budget === 'boolean'
       ? `reasoning-budget:${item.supports_reasoning_budget ? 'on' : 'off'}`
       : null,
+    controls.length > 0 ? `controls:${controls.join(',')}` : null,
     note ? `note:${note}` : null,
   ].filter((value): value is string => Boolean(value))
   return parts.length > 0 ? parts.join(' · ') : null

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1808,16 +1808,37 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
       , match rt.model.temperature with
         | Some t -> `Float t
         | None -> `Null )
-      (* Additive capability projection for the per-keeper runtime capability
-         card (dashboard keeper-workspace-rail rtc-card): multimodal input +
-         effort adjustability read-only. *)
+      (* Additive capability projection for dashboard runtime snapshot cards.
+         These mirrors are declared model capabilities from runtime.toml only;
+         [capabilities_declared=false] below keeps the all-false fallback from
+         being mistaken for provider/model inference. *)
     ; "capabilities_declared", `Bool capabilities_declared
+    ; "max_output_tokens", Json_util.int_opt_to_json caps.max_output_tokens
+    ; "supports_tool_choice", `Bool caps.supports_tool_choice
+    ; "supports_required_tool_choice", `Bool caps.supports_required_tool_choice
+    ; "supports_named_tool_choice", `Bool caps.supports_named_tool_choice
+    ; "supports_parallel_tool_calls", `Bool caps.supports_parallel_tool_calls
+    ; "supports_extended_thinking", `Bool caps.supports_extended_thinking
     ; "supports_multimodal_inputs", `Bool caps.supports_multimodal_inputs
     ; "supports_image_input", `Bool caps.supports_image_input
     ; "supports_audio_input", `Bool caps.supports_audio_input
     ; "supports_video_input", `Bool caps.supports_video_input
     ; "supports_reasoning_budget", `Bool caps.supports_reasoning_budget
     ; "thinking_control_format", `String (thinking_control_format_wire caps.thinking_control_format)
+    ; "supports_response_format_json", `Bool caps.supports_response_format_json
+    ; "supports_structured_output", `Bool caps.supports_structured_output
+    ; "supports_native_streaming", `Bool caps.supports_native_streaming
+    ; "supports_system_prompt", `Bool caps.supports_system_prompt
+    ; "supports_caching", `Bool caps.supports_caching
+    ; "supports_prompt_caching", `Bool caps.supports_prompt_caching
+    ; "prompt_cache_alignment", Json_util.int_opt_to_json caps.prompt_cache_alignment
+    ; "supports_top_k", `Bool caps.supports_top_k
+    ; "supports_min_p", `Bool caps.supports_min_p
+    ; "supports_seed", `Bool caps.supports_seed
+    ; "supports_seed_with_images", `Bool caps.supports_seed_with_images
+    ; "emits_usage_tokens", `Bool caps.emits_usage_tokens
+    ; "supports_computer_use", `Bool caps.supports_computer_use
+    ; "supports_code_execution", `Bool caps.supports_code_execution
     ; "effective_capabilities", effective_capabilities_json rt
     ; "parameter_policy", runtime_parameter_policy_json rt
     ; "request_config", runtime_request_config_json rt

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -180,6 +180,7 @@ tools-support = true
 streaming = true
 
 [models.gpt.capabilities]
+max-output-tokens = 32000
 supports-tool-choice = true
 supports-required-tool-choice = true
 supports-named-tool-choice = true
@@ -188,9 +189,15 @@ supports-response-format-json = true
 supports-structured-output = true
 supports-audio-input = true
 supports-video-input = true
+supports-native-streaming = true
 supports-system-prompt = true
+supports-prompt-caching = true
+prompt-cache-alignment = 1024
+supports-top-k = true
+supports-min-p = true
 supports-seed = true
 supports-seed-with-images = true
+emits-usage-tokens = true
 supports-code-execution = true
 
 [runpod_mtp.qwen]
@@ -488,6 +495,70 @@ let test_runtime_inventory_surfaces_declared_model_capabilities () =
       "top-level video input"
       true
       (gpt |> J.member "supports_video_input" |> J.to_bool);
+    Alcotest.(check int)
+      "top-level max output tokens"
+      32000
+      (gpt |> J.member "max_output_tokens" |> J.to_int);
+    Alcotest.(check bool)
+      "top-level required tool choice"
+      true
+      (gpt |> J.member "supports_required_tool_choice" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level named tool choice"
+      true
+      (gpt |> J.member "supports_named_tool_choice" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level parallel tool calls"
+      true
+      (gpt |> J.member "supports_parallel_tool_calls" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level response format json"
+      true
+      (gpt |> J.member "supports_response_format_json" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level structured output"
+      true
+      (gpt |> J.member "supports_structured_output" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level native streaming"
+      true
+      (gpt |> J.member "supports_native_streaming" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level system prompt"
+      true
+      (gpt |> J.member "supports_system_prompt" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level prompt caching"
+      true
+      (gpt |> J.member "supports_prompt_caching" |> J.to_bool);
+    Alcotest.(check int)
+      "top-level prompt cache alignment"
+      1024
+      (gpt |> J.member "prompt_cache_alignment" |> J.to_int);
+    Alcotest.(check bool)
+      "top-level top_k"
+      true
+      (gpt |> J.member "supports_top_k" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level min_p"
+      true
+      (gpt |> J.member "supports_min_p" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level seed"
+      true
+      (gpt |> J.member "supports_seed" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level seed with images"
+      true
+      (gpt |> J.member "supports_seed_with_images" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level usage tokens"
+      true
+      (gpt |> J.member "emits_usage_tokens" |> J.to_bool);
+    Alcotest.(check bool)
+      "top-level code execution"
+      true
+      (gpt |> J.member "supports_code_execution" |> J.to_bool);
     Alcotest.(check bool)
       "declared audio input"
       true


### PR DESCRIPTION
## Summary

- Mirror declared runtime model capability fields into the top-level provider snapshot projection.
- Decode those fields in the dashboard runtime API client.
- Surface snapshot-level format, sampling, control, cache, and tool capability facts in Runtime Monitor and Settings runtime catalog cards.

## Notes

The new top-level fields are read-only mirrors of `Runtime_schema.model_capabilities`. They do not infer behavior from provider/model names; absent capability blocks still surface through `capabilities_declared=false` and the existing all-false projection.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/settings-surface.test.ts src/components/runtime-monitor.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec eslint src/api/dashboard-runtime.ts src/api/dashboard.test.ts src/components/settings-surface.ts src/components/settings-surface.test.ts src/components/runtime-monitor.ts src/components/runtime-monitor.test.ts` (test files are ignored by repo eslint config; touched source files passed)
- `git diff --check`
- `ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_per_keeper_routing.ml`

Not completed locally: `scripts/dune-local.sh build test/test_runtime_per_keeper_routing.exe` was queued behind the machine-wide `/tmp/me-dune-local.lock` while other worktree builds were running, then stopped to avoid leaving a long-running waiting session. Dune build/test remains CI authority for this PR.