### PR TITLE
[codex] Tighten HITL summary schema contract

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -291,15 +291,19 @@ let parse_suggested_option json =
       (match risk_level_of_string s with
        | Some lvl -> Some lvl
        | None ->
-         Log.Keeper.warn
-           "HITL summary parsed unknown estimated_risk_delta=%s; treating as null"
-           s;
-         None)
+         raise
+           (Failure
+              (Printf.sprintf
+                 "estimated_risk_delta %S is not %s"
+                 s
+                 allowed_risk_level_values_label)))
     | other ->
-      Log.Keeper.warn
-        "HITL summary estimated_risk_delta has unexpected JSON type: %s; treating as null"
-        (Yojson.Safe.to_string other);
-      None
+      raise
+        (Failure
+           (Printf.sprintf
+              "estimated_risk_delta must be null or %s, got %s"
+              allowed_risk_level_values_label
+              (Yojson.Safe.to_string other)))
   in
   { label; rationale; estimated_risk_delta }
 ;;

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -259,10 +259,7 @@ let hitl_context_summary_schema =
     object_schema ~required:(List.map fst suggested_option_fields) suggested_option_fields
   in
   let fields =
-    [ "summary_version", integer_schema
-    ; "generated_at", number_schema
-    ; "model_run_id", string_schema
-    ; "context_summary", string_schema
+    [ "context_summary", string_schema
     ; "key_questions", string_array_schema
     ; "suggested_options", array_schema suggested_option_schema
     ; "risk_rationale", nullable_string_schema

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -10,6 +10,7 @@ open Alcotest
 
 module Q = Keeper_approval_queue_rules_types
 module H = Masc.Hitl_summary_worker
+module Schema = Masc.Keeper_structured_output_schema
 module Workspace = Masc.Workspace
 module Goal_store = Goal_store
 module Keeper_chat_store = Masc.Keeper_chat_store
@@ -153,6 +154,65 @@ let test_parse_summary_failure () =
   match H.For_testing.summary_of_response ~generated_at:1234567890.0 response with
   | Ok _ -> fail "expected summary_of_response to return Error"
   | Error reason -> check bool "error reason non-empty" true (String.length reason > 0)
+;;
+
+let test_parse_summary_rejects_unknown_risk_delta () =
+  let malformed =
+    `Assoc
+      [ "context_summary", `String "A tool request is pending."
+      ; "key_questions", `List [ `String "Is this safe?" ]
+      ; ( "suggested_options"
+        , `List
+            [ `Assoc
+                [ "label", `String "approve"
+                ; "rationale", `String "looks safe"
+                ; "estimated_risk_delta", `String "not-a-risk"
+                ]
+            ] )
+      ; "risk_rationale", `Null
+      ; "uncertainty", `Float 0.25
+      ]
+  in
+  let response : Agent_sdk.Types.api_response =
+    { id = "run-test"
+    ; model = "test-model"
+    ; stop_reason = Agent_sdk.Types.EndTurn
+    ; content = [ Agent_sdk.Types.Text (Yojson.Safe.to_string malformed) ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match H.For_testing.summary_of_response ~generated_at:1234567890.0 response with
+  | Ok _ -> fail "expected unknown risk delta to fail parsing"
+  | Error reason ->
+    check bool "error names estimated_risk_delta" true
+      (Astring.String.is_infix ~affix:"estimated_risk_delta" reason)
+;;
+
+let test_hitl_summary_schema_excludes_server_owned_fields () =
+  let schema = Schema.hitl_context_summary_schema in
+  let open Yojson.Safe.Util in
+  let required =
+    schema
+    |> member "required"
+    |> convert_each to_string
+    |> List.sort String.compare
+  in
+  check (list string) "required model-owned fields"
+    [ "context_summary"
+    ; "key_questions"
+    ; "risk_rationale"
+    ; "suggested_options"
+    ; "uncertainty"
+    ]
+    required;
+  let properties = schema |> member "properties" in
+  check yojson_t "summary_version is server-owned" `Null
+    (member "summary_version" properties);
+  check yojson_t "generated_at is server-owned" `Null
+    (member "generated_at" properties);
+  check yojson_t "model_run_id is server-owned" `Null
+    (member "model_run_id" properties)
 ;;
 
 (* ── spawn / bundle tests ───────────────────────── *)
@@ -299,6 +359,10 @@ let () =
     ; ( "parse_summary"
       , [ test_case "success" `Quick test_parse_summary_success
         ; test_case "failure" `Quick test_parse_summary_failure
+        ; test_case "unknown risk delta fails" `Quick
+            test_parse_summary_rejects_unknown_risk_delta
+        ; test_case "schema excludes server-owned fields" `Quick
+            test_hitl_summary_schema_excludes_server_owned_fields
         ] )
     ; ( "worker"
       , [ test_case "spawn with no provider config calls on_failure" `Quick

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -535,7 +535,7 @@ let test_repo_oas_model_catalog_modality_priorities_resolve () =
     List.filter
       (fun (entry : Llm_provider.Model_catalog.model_entry) ->
          Option.is_some entry.modality_priority)
-      catalog
+      (Llm_provider.Model_catalog.model_entries catalog)
   in
   check bool "repo OAS catalog has modality priority rows" true (rows <> []);
   List.iter


### PR DESCRIPTION
## Summary

- remove server-owned HITL summary metadata from the LLM structured-output schema
- fail HITL summary parsing when `estimated_risk_delta` violates the catalog enum instead of degrading it to `null`
- update the runtime config test to use the OAS `Model_catalog.model_entries` accessor for the opaque catalog type

## Why

The HITL worker already stamps `summary_version`, `generated_at`, and `model_run_id` from server-side state. Requiring the model to emit those fields widened the structured-output contract past the parser contract and made the LLM a second source of truth for server metadata.

Unknown risk deltas were previously logged and dropped to `None`, which could make an invalid provider response look like "no risk delta" in the operator surface. This now fails the summary parse and surfaces through the existing `Summary_failed` path.

## Validation

- `ocamlformat --check lib/keeper/keeper_structured_output_schema.ml lib/keeper/hitl_summary_worker.ml test/test_hitl_summary_worker.ml test/test_runtime_config_validity.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_hitl_summary_worker.exe test/test_runtime_config_validity.exe`
- `./_build/default/test/test_hitl_summary_worker.exe`
- `scripts/check-oas-pin.sh --local-only`

## Notes

The broad root `scripts/dune-local.sh build .` was stopped after it exposed local disk pressure (`No space left on device`) during unrelated full-test linking. The focused targets above compile in this branch.
