### PR TITLE
fix(test): adapt runtime catalog validity to Model_catalog.t

### DIFF
--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -535,7 +535,7 @@ let test_repo_oas_model_catalog_modality_priorities_resolve () =
     List.filter
       (fun (entry : Llm_provider.Model_catalog.model_entry) ->
          Option.is_some entry.modality_priority)
-      catalog
+      (Llm_provider.Model_catalog.model_entries catalog)
   in
   check bool "repo OAS catalog has modality priority rows" true (rows <> []);
   List.iter


### PR DESCRIPTION
## Summary
- adapt runtime catalog validity test to use Model_catalog.model_entries for the opaque catalog type
- fixes the Health compile failure seen on #23060 merge CI at test_runtime_config_validity.ml:538

## Verification
- git diff --check
- ocamlformat --check test/test_runtime_config_validity.ml
- local dune intentionally not run; CI is the build authority