### PR TITLE
[codex] Surface IDE workspace fetch failures

### DIFF
--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  clearWorkspaceFetchIssue,
+  replaceWorkspaceFetchIssue,
   sameWorkspaceTreeIdentity,
   selectPreferredIdeRepositoryId,
+  workspaceFetchIssueFromError,
   workspaceTreeIdentity,
 } from './ide-data-workspace-store'
 import type { Repository } from '../../api/repositories'
@@ -153,6 +156,63 @@ describe('selectPreferredIdeRepositoryId', () => {
     // After self-healing excludes llama-cpp:
     const excluded = new Set(['llama-cpp'])
     expect(selectPreferredIdeRepositoryId(repositories, null, excluded)).toBe('workspace-a')
+  })
+})
+
+describe('workspace fetch diagnostics', () => {
+  it('materializes failed fetches without stringly fallback coercion', () => {
+    const issue = workspaceFetchIssueFromError('diff', new Error('network down'), {
+      filePath: 'lib/runtime.ml',
+      keeper: 'sangsu',
+      repoId: 'masc',
+      nowMs: 42,
+    })
+
+    expect(issue).toEqual({
+      kind: 'diff',
+      message: 'network down',
+      file_path: 'lib/runtime.ml',
+      keeper: 'sangsu',
+      repo_id: 'masc',
+      observed_at_ms: 42,
+    })
+  })
+
+  it('keeps one issue per fetch scope and clears only that scope', () => {
+    const treeIssue = workspaceFetchIssueFromError('tree', new Error('tree failed'), {
+      repoId: 'masc',
+      nowMs: 1,
+    })!
+    const diffIssue = workspaceFetchIssueFromError('diff', new Error('diff failed'), {
+      filePath: 'lib/runtime.ml',
+      repoId: 'masc',
+      nowMs: 2,
+    })!
+    const newerDiffIssue = workspaceFetchIssueFromError('diff', new Error('diff still failed'), {
+      filePath: 'lib/runtime.ml',
+      repoId: 'masc',
+      nowMs: 3,
+    })!
+
+    const issues = replaceWorkspaceFetchIssue(
+      replaceWorkspaceFetchIssue(
+        replaceWorkspaceFetchIssue([], treeIssue),
+        diffIssue,
+      ),
+      newerDiffIssue,
+    )
+
+    expect(issues).toHaveLength(2)
+    expect(issues.map(issue => issue.message)).toEqual(['tree failed', 'diff still failed'])
+    expect(clearWorkspaceFetchIssue(issues, 'diff', {
+      filePath: 'lib/runtime.ml',
+      repoId: 'masc',
+    })).toEqual([treeIssue])
+  })
+
+  it('does not record navigation aborts as degraded workspace fetches', () => {
+    const abort = new DOMException('Aborted', 'AbortError')
+    expect(workspaceFetchIssueFromError('file', abort)).toBeNull()
   })
 })
 

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   clearWorkspaceFetchIssue,
   replaceWorkspaceFetchIssue,
+  retainCurrentWorkspaceFetchIssues,
   sameWorkspaceTreeIdentity,
   selectPreferredIdeRepositoryId,
   workspaceFetchIssueFromError,
@@ -213,6 +214,31 @@ describe('workspace fetch diagnostics', () => {
   it('does not record navigation aborts as degraded workspace fetches', () => {
     const abort = new DOMException('Aborted', 'AbortError')
     expect(workspaceFetchIssueFromError('file', abort)).toBeNull()
+  })
+
+  it('drops stale workspace-scoped issues when the active repo changes', () => {
+    const repositoryIssue = workspaceFetchIssueFromError('repositories', new Error('repo list down'), {
+      nowMs: 1,
+    })!
+    const oldTreeIssue = workspaceFetchIssueFromError('tree', new Error('old repo tree down'), {
+      repoId: 'old-repo',
+      nowMs: 2,
+    })!
+    const oldFileIssue = workspaceFetchIssueFromError('file', new Error('old repo same file down'), {
+      filePath: 'README.md',
+      repoId: 'old-repo',
+      nowMs: 3,
+    })!
+    const currentDiffIssue = workspaceFetchIssueFromError('diff', new Error('current diff down'), {
+      filePath: 'README.md',
+      repoId: 'current-repo',
+      nowMs: 4,
+    })!
+
+    expect(retainCurrentWorkspaceFetchIssues(
+      [repositoryIssue, oldTreeIssue, oldFileIssue, currentDiffIssue],
+      { filePath: 'README.md', repoId: 'current-repo' },
+    )).toEqual([repositoryIssue, currentDiffIssue])
   })
 })
 

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -186,6 +186,20 @@ export function clearWorkspaceFetchIssue(
   return issues.filter(issue => !sameWorkspaceIssueScope(issue, issueToClear))
 }
 
+export function retainCurrentWorkspaceFetchIssues(
+  issues: ReadonlyArray<WorkspaceFetchIssue>,
+  context: WorkspaceFetchIssueContext,
+): ReadonlyArray<WorkspaceFetchIssue> {
+  const currentFilePath = context.filePath ?? null
+  const currentKeeper = context.keeper ?? null
+  const currentRepoId = context.repoId ?? null
+  return issues.filter(issue => {
+    if (issue.kind === 'repositories') return true
+    if (issue.keeper !== currentKeeper || issue.repo_id !== currentRepoId) return false
+    return issue.file_path === null || issue.file_path === currentFilePath
+  })
+}
+
 function isManagedMirrorRepository(repository: Repository): boolean {
   const localPath = repository.local_path.replace(/\\/g, '/')
   return localPath === `.masc/repos/${repository.id}`
@@ -352,9 +366,11 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
     const keeperParam = keeper || undefined
     const opts = { keeper: keeperParam, repoId, signal, includeDiff: true }
-    workspaceIssuesSignal.value = currentWorkspaceIssues().filter(
-      issue => issue.file_path === null || issue.file_path === filePath,
-    )
+    workspaceIssuesSignal.value = retainCurrentWorkspaceFetchIssues(currentWorkspaceIssues(), {
+      filePath,
+      keeper: keeperParam ?? null,
+      repoId,
+    })
 
     // Load file tree (independent of active file — needed to suggest first file)
     fetchWorkspaceTree(2, opts).then(({ nodes, source, basePath }) => {

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -7,6 +7,7 @@ import {
   fetchRepositoriesList,
   type Repository,
 } from '../../api/repositories'
+import { extractApiError } from '../../api/core'
 import {
   fetchWorkspaceFile,
   fetchWorkspaceChildren,
@@ -35,11 +36,14 @@ import {
   type IdeAnnotation,
 } from '../../api/ide'
 import { registerIdeWorkspaceRefresh } from '../../sse-store'
+import { isAbortError } from '../../lib/async-state'
 
 export interface IdeDataWorkspaceStore {
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
   readonly fileTreeStore: FileTreeStore
+  readonly workspaceIssues: () => ReadonlyArray<WorkspaceFetchIssue>
+  readonly subscribeWorkspaceIssues: (listener: () => void) => () => void
   readonly diffRows: () => ReadonlyArray<UnifiedDiffRow>
   readonly subscribeDiffRows: (listener: () => void) => () => void
   readonly workspaceSource: () => WorkspaceSource
@@ -61,6 +65,34 @@ export interface WorkspaceTreeIdentity {
   readonly source: WorkspaceSource
   readonly basePath: string | null
 }
+
+export type WorkspaceFetchIssueKind =
+  | 'repositories'
+  | 'tree'
+  | 'file'
+  | 'regions'
+  | 'blame'
+  | 'diff'
+  | 'annotations'
+
+export interface WorkspaceFetchIssue {
+  readonly kind: WorkspaceFetchIssueKind
+  readonly message: string
+  readonly file_path: string | null
+  readonly keeper: string | null
+  readonly repo_id: string | null
+  readonly observed_at_ms: number
+}
+
+export interface WorkspaceFetchIssueContext {
+  readonly filePath?: string | null
+  readonly keeper?: string | null
+  readonly repoId?: string | null
+  readonly fallbackMessage?: string
+  readonly nowMs?: number
+}
+
+type WorkspaceFetchIssueScope = Pick<WorkspaceFetchIssueContext, 'filePath' | 'keeper' | 'repoId'>
 
 function firstFilePath(nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>): string | null {
   const firstFile = nodes.find(node => !node.hasChildren)
@@ -99,6 +131,59 @@ export function sameWorkspaceTreeIdentity(
     case 'keeper_unknown':
       return rightSource.kind === 'keeper_unknown' && leftSource.keeper === rightSource.keeper
   }
+}
+
+export function workspaceFetchIssueFromError(
+  kind: WorkspaceFetchIssueKind,
+  error: unknown,
+  context: WorkspaceFetchIssueContext = {},
+): WorkspaceFetchIssue | null {
+  if (isAbortError(error)) return null
+  const summary = extractApiError(error, context.fallbackMessage ?? `${kind} fetch failed`)
+  return {
+    kind,
+    message: summary.message,
+    file_path: context.filePath ?? null,
+    keeper: context.keeper ?? null,
+    repo_id: context.repoId ?? null,
+    observed_at_ms: context.nowMs ?? Date.now(),
+  }
+}
+
+function sameWorkspaceIssueScope(
+  left: WorkspaceFetchIssue,
+  right: WorkspaceFetchIssue,
+): boolean {
+  return left.kind === right.kind
+    && left.file_path === right.file_path
+    && left.keeper === right.keeper
+    && left.repo_id === right.repo_id
+}
+
+export function replaceWorkspaceFetchIssue(
+  issues: ReadonlyArray<WorkspaceFetchIssue>,
+  next: WorkspaceFetchIssue,
+): ReadonlyArray<WorkspaceFetchIssue> {
+  return [
+    ...issues.filter(issue => !sameWorkspaceIssueScope(issue, next)),
+    next,
+  ]
+}
+
+export function clearWorkspaceFetchIssue(
+  issues: ReadonlyArray<WorkspaceFetchIssue>,
+  kind: WorkspaceFetchIssueKind,
+  context: WorkspaceFetchIssueScope = {},
+): ReadonlyArray<WorkspaceFetchIssue> {
+  const issueToClear: WorkspaceFetchIssue = {
+    kind,
+    message: '',
+    file_path: context.filePath ?? null,
+    keeper: context.keeper ?? null,
+    repo_id: context.repoId ?? null,
+    observed_at_ms: 0,
+  }
+  return issues.filter(issue => !sameWorkspaceIssueScope(issue, issueToClear))
 }
 
 function isManagedMirrorRepository(repository: Repository): boolean {
@@ -157,11 +242,34 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   const ownershipStore = createKeeperLineOwnershipStore(activeIdeFile.value)
 
   const diffRowsSignal = signal<ReadonlyArray<UnifiedDiffRow>>([])
+  const workspaceIssuesSignal = signal<ReadonlyArray<WorkspaceFetchIssue>>([])
   const workspaceSourceSignal = signal<WorkspaceSource>({ kind: 'project' })
   const workspaceBasePathSignal = signal<string | null>(null)
   const repositoriesSignal = signal<ReadonlyArray<Repository>>([])
   const activeRepositoryIdSignal = signal<string | null>(null)
   const annotationsSignal = signal<ReadonlyArray<IdeAnnotation>>([])
+  const currentWorkspaceIssues = (): ReadonlyArray<WorkspaceFetchIssue> =>
+    workspaceIssuesSignal.peek()
+  const clearIssue = (
+    kind: WorkspaceFetchIssueKind,
+    context: WorkspaceFetchIssueScope = {},
+  ): void => {
+    workspaceIssuesSignal.value = clearWorkspaceFetchIssue(
+      currentWorkspaceIssues(),
+      kind,
+      context,
+    )
+  }
+  const recordIssue = (
+    kind: WorkspaceFetchIssueKind,
+    error: unknown,
+    context: WorkspaceFetchIssueContext = {},
+  ): void => {
+    const issue = workspaceFetchIssueFromError(kind, error, context)
+    if (issue) {
+      workspaceIssuesSignal.value = replaceWorkspaceFetchIssue(currentWorkspaceIssues(), issue)
+    }
+  }
 
   // Lazy tree: expanding a directory fetches its immediate children on demand.
   // The loader reads the current keeper/repo at call time (not capture time),
@@ -194,9 +302,17 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   }
 
   const refreshRepositories = async (): Promise<ReadonlyArray<Repository>> => {
-    const repositories = await fetchRepositoriesList()
-    applyRepositories(repositories)
-    return repositories
+    try {
+      const repositories = await fetchRepositoriesList()
+      clearIssue('repositories')
+      applyRepositories(repositories)
+      return repositories
+    } catch (error) {
+      recordIssue('repositories', error, {
+        fallbackMessage: 'repository list fetch failed',
+      })
+      throw error
+    }
   }
 
   const scanRepositories = async (): Promise<ReadonlyArray<Repository>> => {
@@ -206,7 +322,10 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   }
 
   refreshRepositories()
-    .catch(() => {
+    .catch(error => {
+      recordIssue('repositories', error, {
+        fallbackMessage: 'repository list fetch failed',
+      })
       repositoriesSignal.value = []
     })
 
@@ -233,10 +352,14 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
     const keeperParam = keeper || undefined
     const opts = { keeper: keeperParam, repoId, signal, includeDiff: true }
+    workspaceIssuesSignal.value = currentWorkspaceIssues().filter(
+      issue => issue.file_path === null || issue.file_path === filePath,
+    )
 
     // Load file tree (independent of active file — needed to suggest first file)
     fetchWorkspaceTree(2, opts).then(({ nodes, source, basePath }) => {
       if (signal.aborted) return
+      clearIssue('tree', { keeper: keeperParam ?? null, repoId })
       // Same source + base path ⇒ live refresh: keep the operator's expansion
       // and any lazily-loaded children. A change ⇒ workspace switch: reset.
       const treeIdentity = workspaceTreeIdentity(source, basePath)
@@ -268,33 +391,75 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       if (nextFile && nextFile !== activeIdeFile.value) {
         activeIdeFile.value = nextFile
       }
-    }).catch(() => {})
+    }).catch(error => {
+      recordIssue('tree', error, {
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'workspace tree fetch failed',
+      })
+    })
 
     // File-scoped fetches require an active file path; skip when none is selected.
     if (filePath === null) {
       diffRowsSignal.value = []
       annotationsSignal.value = []
+      workspaceIssuesSignal.value = currentWorkspaceIssues().filter(issue => issue.file_path === null)
       return
     }
 
     // Load file content
     fetchWorkspaceFile(filePath, opts).then(response => {
       if (signal.aborted) return
-      if (response?.ok && response.content) {
-        documentStore.load({
+      if (response?.ok === true && typeof response.content === 'string') {
+        const loaded = documentStore.load({
           file_path: filePath,
           language: response.language ?? DEFAULT_LANGUAGE_ID,
           content: response.content,
         })
+        if (!loaded) {
+          recordIssue('file', new Error('workspace file response was malformed'), {
+            filePath,
+            keeper: keeperParam ?? null,
+            repoId,
+            fallbackMessage: 'workspace file fetch failed',
+          })
+          return
+        }
+        clearIssue('file', { filePath, keeper: keeperParam ?? null, repoId })
+      } else {
+        recordIssue('file', new Error('workspace file response was not available'), {
+          filePath,
+          keeper: keeperParam ?? null,
+          repoId,
+          fallbackMessage: 'workspace file fetch failed',
+        })
       }
-    }).catch(() => {})
+    }).catch(error => {
+      recordIssue('file', error, {
+        filePath,
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'workspace file fetch failed',
+      })
+    })
 
     // Load regions
-    documentStore.loadRegions(filePath, opts).catch(() => {})
+    documentStore.loadRegions(filePath, opts).then(() => {
+      if (signal.aborted) return
+      clearIssue('regions', { filePath, keeper: keeperParam ?? null, repoId })
+    }).catch(error => {
+      recordIssue('regions', error, {
+        filePath,
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'IDE regions fetch failed',
+      })
+    })
 
     // Load blame → ownership
     fetchGitBlame(filePath, opts).then(blocks => {
       if (signal.aborted) return
+      clearIssue('blame', { filePath, keeper: keeperParam ?? null, repoId })
       for (const block of blocks) {
         ownershipStore.ingest({
           file_path: block.file_path,
@@ -305,19 +470,42 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           kind: block.kind as KeeperEditKind,
         })
       }
-    }).catch(() => {})
+    }).catch(error => {
+      recordIssue('blame', error, {
+        filePath,
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'git blame fetch failed',
+      })
+    })
 
     // Load diff
     fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
       if (signal.aborted) return
+      clearIssue('diff', { filePath, keeper: keeperParam ?? null, repoId })
       diffRowsSignal.value = rows
-    }).catch(() => {})
+    }).catch(error => {
+      recordIssue('diff', error, {
+        filePath,
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'git diff fetch failed',
+      })
+    })
 
     // Load annotations
     fetchIdeAnnotations({ file_path: filePath, goal_id: task?.goal_id ?? undefined, task_id: task?.id ?? undefined }, opts).then(annotations => {
       if (signal.aborted) return
+      clearIssue('annotations', { filePath, keeper: keeperParam ?? null, repoId })
       annotationsSignal.value = annotations
-    }).catch(() => {})
+    }).catch(error => {
+      recordIssue('annotations', error, {
+        filePath,
+        keeper: keeperParam ?? null,
+        repoId,
+        fallbackMessage: 'IDE annotations fetch failed',
+      })
+    })
   }
 
   // Re-run fetches on navigation-signal changes. Reading the signals
@@ -337,6 +525,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     documentStore,
     ownershipStore,
     fileTreeStore,
+    workspaceIssues: () => workspaceIssuesSignal.value,
+    subscribeWorkspaceIssues: (listener: () => void) =>
+      workspaceIssuesSignal.subscribe(listener),
     diffRows: () => diffRowsSignal.value,
     subscribeDiffRows: (listener: () => void) =>
       diffRowsSignal.subscribe(listener),

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -101,9 +101,11 @@ const dashboardFetchHandlers: ReadonlyArray<[
   () => Response,
 ]> = [
   [/\/api\/v1\/workspace\/tree/, () => jsonResponse([])],
-  [/\/api\/v1\/workspace\/file/, () => jsonResponse({ ok: false, content: '' })],
+  [/\/api\/v1\/workspace\/file/, () => jsonResponse({ ok: true, content: '{}', language: 'json' })],
   [/\/api\/v1\/git\/blame/, () => jsonResponse([])],
   [/\/api\/v1\/git\/diff/, () => jsonResponse({ unified: [] })],
+  [/\/api\/v1\/ide\/regions/, () => jsonResponse({ ok: true, data: [] })],
+  [/\/api\/v1\/ide\/annotations/, () => jsonResponse({ ok: true, data: [] })],
   [/\/state-diagram/, () => jsonResponse({
     keeper: 'sangsu',
     current_phase: 'observe',
@@ -116,6 +118,17 @@ function dashboardFetchMock(input: RequestInfo | URL): Promise<Response> {
   const handler = dashboardFetchHandlers.find(([pattern]) => pattern.test(url))
   if (!handler) throw new Error(`Unmocked fetch URL: ${url}`)
   return Promise.resolve(handler[1]())
+}
+
+function dashboardFetchMockWithFailure(
+  pattern: RegExp,
+  error: Error,
+): (input: RequestInfo | URL) => Promise<Response> {
+  return (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input)
+    if (pattern.test(url)) return Promise.reject(error)
+    return dashboardFetchMock(input)
+  }
 }
 
 describe('IdeShell', () => {
@@ -477,6 +490,31 @@ describe('IdeShell', () => {
       'Telemetry turn-42',
       'Keeper sangsu',
     ])
+  })
+
+  it('surfaces workspace fetch failures in the IDE statusbar', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(dashboardFetchMockWithFailure(
+        /\/api\/v1\/git\/diff/,
+        new Error('diff endpoint unavailable'),
+      )),
+    )
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', file: 'lib/runtime.ml' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const chip = await waitFor(() => {
+      const found = container.querySelector('[data-testid="ide-statusbar-chip-workspace-fetch"]')
+      expect(found).not.toBeNull()
+      return found!
+    })
+    expect(chip.textContent).toBe('IDE fetch degraded diff')
+    expect(chip.getAttribute('title')).toContain('diff endpoint unavailable')
   })
 
   it('focuses active keeper breadcrumb chips into routeable code and keeper context', async () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -49,6 +49,7 @@ import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../../dashbo
 import type { Repository } from '../../api/repositories'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import { KeeperBadge } from '../keeper-badge'
+import type { WorkspaceFetchIssue } from './ide-data-workspace-store'
 import {
   parseActive,
   serializeActive,
@@ -57,7 +58,7 @@ import {
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
 type IdeRightRailTab = 'context' | 'activity' | 'cursors'
-type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok'
+type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok' | 'warn'
 type IdeConnectionTone = 'ok' | 'warn'
 
 export interface IdeStatusbarChip {
@@ -151,6 +152,7 @@ interface IdeStatusbarInput {
   readonly activeRepositoryId?: string | null
   readonly workspaceSource?: WorkspaceSource
   readonly workspaceBasePath?: string | null
+  readonly workspaceIssues?: ReadonlyArray<WorkspaceFetchIssue>
   readonly dashboardConnected?: boolean
 }
 
@@ -395,6 +397,39 @@ function statusbarTelemetryLabelFromFocus(focus: IdeContextFocus | null | undefi
   return first ? `Telemetry ${first}` : undefined
 }
 
+function workspaceIssueLabel(issue: WorkspaceFetchIssue): string {
+  switch (issue.kind) {
+    case 'repositories':
+      return 'repos'
+    case 'tree':
+      return 'tree'
+    case 'file':
+      return issue.file_path ? `file ${shortStatusbarPath(issue.file_path)}` : 'file'
+    case 'regions':
+      return 'regions'
+    case 'blame':
+      return 'blame'
+    case 'diff':
+      return 'diff'
+    case 'annotations':
+      return 'annotations'
+  }
+}
+
+function workspaceIssueTitle(issues: ReadonlyArray<WorkspaceFetchIssue>): string {
+  return issues
+    .map(issue => {
+      const scope = [
+        issue.file_path ? `file=${issue.file_path}` : null,
+        issue.repo_id ? `repo=${issue.repo_id}` : null,
+        issue.keeper ? `keeper=${issue.keeper}` : null,
+      ].filter((part): part is string => part !== null)
+      const scoped = scope.length > 0 ? ` (${scope.join(', ')})` : ''
+      return `${workspaceIssueLabel(issue)}${scoped}: ${issue.message}`
+    })
+    .join('\n')
+}
+
 function addStatusbarChip(
   chips: IdeStatusbarChip[],
   id: string,
@@ -421,6 +456,7 @@ export function deriveIdeStatusbarModel({
   activeRepositoryId,
   workspaceSource,
   workspaceBasePath = null,
+  workspaceIssues = [],
   dashboardConnected = false,
 }: IdeStatusbarInput): IdeStatusbarModel {
   const chips: IdeStatusbarChip[] = []
@@ -436,6 +472,14 @@ export function deriveIdeStatusbarModel({
 
   const layerLabel = statusbarLayerLabel(activeLayers)
   addStatusbarChip(chips, 'layers', layerLabel ?? undefined, 'info', layerLabel ? `Active layers: ${layerLabel}` : '')
+  const issueLabels = [...new Set(workspaceIssues.map(workspaceIssueLabel))]
+  addStatusbarChip(
+    chips,
+    'workspace-fetch',
+    issueLabels.length > 0 ? `IDE fetch degraded ${issueLabels.join('/')}` : undefined,
+    'warn',
+    workspaceIssueTitle(workspaceIssues),
+  )
   if (terminalOpen) addStatusbarChip(chips, 'terminal', 'terminal', 'info', 'Execute output drawer open')
   if (findOpen) addStatusbarChip(chips, 'find', 'find', 'ghost', 'Current-file find panel open')
   if (railsCollapsed) addStatusbarChip(chips, 'rails', 'rails hidden', 'ghost', 'IDE side rails hidden')
@@ -773,6 +817,10 @@ export function IdeShell() {
     workspaceStore.workspaceBasePath,
     workspaceStore.subscribeWorkspaceBasePath,
   )
+  const workspaceIssues = useSubscribedValue(
+    workspaceStore.workspaceIssues,
+    workspaceStore.subscribeWorkspaceIssues,
+  )
   const [activeFilePath, setActiveFilePath] = useState(activeIdeFile.value)
 
   useEffect(() => {
@@ -888,6 +936,7 @@ export function IdeShell() {
     activeRepositoryId,
     workspaceSource,
     workspaceBasePath,
+    workspaceIssues,
     dashboardConnected: dashboardRuntimeConnected(),
   })
 


### PR DESCRIPTION
## Summary
- add typed IDE workspace fetch issue state instead of empty catch handlers in the workspace store
- surface degraded workspace fetches in the IDE statusbar without fabricating fallback data
- cover issue replacement/clearing and the statusbar degraded chip in focused dashboard tests

## Validation
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/ide/ide-data-workspace-store.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec eslint src/components/ide/ide-data-workspace-store.ts src/components/ide/ide-shell.ts src/components/ide/ide-data-workspace-store.test.ts src/components/ide/ide-shell.test.ts
- git diff --check