### PR TITLE
fix(test): use model catalog entries accessor

### DIFF
--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -535,7 +535,7 @@ let test_repo_oas_model_catalog_modality_priorities_resolve () =
     List.filter
       (fun (entry : Llm_provider.Model_catalog.model_entry) ->
          Option.is_some entry.modality_priority)
-      catalog
+      (Llm_provider.Model_catalog.model_entries catalog)
   in
   check bool "repo OAS catalog has modality priority rows" true (rows <> []);
   List.iter


### PR DESCRIPTION
## Summary
- Fixes the shared Health compile blocker exposed by #23060: `Llm_provider.Model_catalog.t` was passed where a `model_entry list` is expected.
- Uses the official OAS accessor `Llm_provider.Model_catalog.model_entries` instead of assuming the catalog representation.

## Evidence
- CI failure source: #23060 Health job 85132219949, `test/test_runtime_config_validity.ml:538`.
- Local non-Dune checks only, per CI-build-authority policy:
  - `opam exec -- ocamlformat --check test/test_runtime_config_validity.ml`
  - `git diff --check`
  - residual direct-catalog iteration scan

## P0/P1/P2/P3
- P0 improvement: removes a current OCaml type blocker in a shared test without changing production runtime behavior.
- P1 remaining: GitHub CI must prove the full build/test surface.
- P2: intentionally no local `dune build`; CI is the build authority.
- P3 mergeability: draft until required checks are green.
