### PR TITLE
[codex] Surface runtime lane spec in agent strip

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.test.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.test.ts
@@ -127,6 +127,22 @@ describe('AgentRuntimeStrip', () => {
     expect(container.textContent).toContain('claude-4')
   })
 
+  it('does not load runtime catalog when no runtime evidence exists', () => {
+    mockFindKeeper.mockReturnValue({
+      pipeline_stage: null,
+      context_ratio: null,
+      generation: null,
+    })
+    mockKeeperDisplayModel.mockReturnValue(null)
+    mockKeeperDisplayRuntime.mockReturnValue(null)
+    mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
+    const container = document.createElement('div')
+    render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
+    expect(mockLoadRuntimeCatalog).not.toHaveBeenCalled()
+    expect(mockFindRuntimeCatalogEntry).not.toHaveBeenCalled()
+    expect(mockRuntimeCatalogSnapshotFacts).not.toHaveBeenCalled()
+  })
+
   it('renders runtime lane when present', () => {
     mockFindKeeper.mockReturnValue({
       pipeline_stage: null,

--- a/dashboard/src/components/agent-monitor/runtime-strip.test.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.test.ts
@@ -6,8 +6,13 @@ import { AgentRuntimeStrip } from './runtime-strip'
 
 const mockFindKeeper = vi.hoisted(() => vi.fn())
 const mockKeeperDisplayModel = vi.hoisted(() => vi.fn())
+const mockKeeperDisplayRuntime = vi.hoisted(() => vi.fn())
 const mockKeeperActivityDisplay = vi.hoisted(() => vi.fn())
 const mockFormatDuration = vi.hoisted(() => vi.fn((s: number) => `${s}s`))
+const mockFindRuntimeCatalogEntry = vi.hoisted(() => vi.fn())
+const mockLoadRuntimeCatalog = vi.hoisted(() => vi.fn())
+const mockRuntimeCatalogState = vi.hoisted(() => ({ value: { status: 'idle' } }))
+const mockRuntimeCatalogSnapshotFacts = vi.hoisted(() => vi.fn())
 
 vi.mock('../../lib/keeper-utils', () => ({
   findKeeper: (...args: Parameters<typeof mockFindKeeper>) => mockFindKeeper(...args),
@@ -15,7 +20,20 @@ vi.mock('../../lib/keeper-utils', () => ({
 
 vi.mock('../../lib/keeper-runtime-display', () => ({
   keeperDisplayModel: (...args: Parameters<typeof mockKeeperDisplayModel>) => mockKeeperDisplayModel(...args),
+  keeperDisplayRuntime: (...args: Parameters<typeof mockKeeperDisplayRuntime>) => mockKeeperDisplayRuntime(...args),
   keeperActivityDisplay: (...args: Parameters<typeof mockKeeperActivityDisplay>) => mockKeeperActivityDisplay(...args),
+}))
+
+vi.mock('../../lib/runtime-catalog-resource', () => ({
+  findRuntimeCatalogEntry: (...args: Parameters<typeof mockFindRuntimeCatalogEntry>) =>
+    mockFindRuntimeCatalogEntry(...args),
+  loadRuntimeCatalog: mockLoadRuntimeCatalog,
+  runtimeCatalogState: mockRuntimeCatalogState,
+}))
+
+vi.mock('../../lib/runtime-provider-summary', () => ({
+  runtimeCatalogSnapshotFacts: (...args: Parameters<typeof mockRuntimeCatalogSnapshotFacts>) =>
+    mockRuntimeCatalogSnapshotFacts(...args),
 }))
 
 vi.mock('../../lib/format-time', () => ({
@@ -31,8 +49,14 @@ describe('AgentRuntimeStrip', () => {
   beforeEach(() => {
     mockFindKeeper.mockReset()
     mockKeeperDisplayModel.mockReset()
+    mockKeeperDisplayRuntime.mockReset()
     mockKeeperActivityDisplay.mockReset()
     mockFormatDuration.mockReset()
+    mockFindRuntimeCatalogEntry.mockReset()
+    mockLoadRuntimeCatalog.mockReset()
+    mockRuntimeCatalogSnapshotFacts.mockReset()
+    mockKeeperDisplayRuntime.mockReturnValue(null)
+    mockRuntimeCatalogState.value = { status: 'idle' }
     mockFormatDuration.mockImplementation((s: number) => `${s}s`)
   })
 
@@ -101,6 +125,76 @@ describe('AgentRuntimeStrip', () => {
     render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
     expect(container.textContent).toContain('Model')
     expect(container.textContent).toContain('claude-4')
+  })
+
+  it('renders runtime lane when present', () => {
+    mockFindKeeper.mockReturnValue({
+      pipeline_stage: null,
+      context_ratio: null,
+      generation: null,
+    })
+    mockKeeperDisplayModel.mockReturnValue(null)
+    mockKeeperDisplayRuntime.mockReturnValue({ label: 'Runtime', value: 'oas.primary' })
+    mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
+    const container = document.createElement('div')
+    render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
+    expect(mockLoadRuntimeCatalog).toHaveBeenCalled()
+    expect(container.textContent).toContain('Runtime')
+    expect(container.textContent).toContain('oas.primary')
+  })
+
+  it('renders runtime catalog facts when a catalog entry is loaded', () => {
+    const entry = { runtime_id: 'oas.primary' }
+    mockFindKeeper.mockReturnValue({
+      pipeline_stage: null,
+      context_ratio: null,
+      generation: null,
+    })
+    mockRuntimeCatalogState.value = { status: 'loaded', data: [entry] }
+    mockKeeperDisplayModel.mockReturnValue(null)
+    mockKeeperDisplayRuntime.mockReturnValue({ label: 'Runtime', value: 'oas.primary' })
+    mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
+    mockFindRuntimeCatalogEntry.mockReturnValue(entry)
+    mockRuntimeCatalogSnapshotFacts.mockReturnValue('caps:declared · format:json,schema')
+    const container = document.createElement('div')
+    render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
+    expect(mockFindRuntimeCatalogEntry).toHaveBeenCalledWith([entry], 'oas.primary')
+    expect(container.textContent).toContain('SPEC')
+    expect(container.textContent).toContain('caps:declared · format:json,schema')
+  })
+
+  it('renders explicit spec status when the catalog load failed', () => {
+    mockFindKeeper.mockReturnValue({
+      pipeline_stage: null,
+      context_ratio: null,
+      generation: null,
+    })
+    mockRuntimeCatalogState.value = { status: 'error', message: 'fetch failed' }
+    mockKeeperDisplayModel.mockReturnValue(null)
+    mockKeeperDisplayRuntime.mockReturnValue({ label: 'Runtime', value: 'oas.primary' })
+    mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
+    const container = document.createElement('div')
+    render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
+    expect(container.textContent).toContain('SPEC')
+    expect(container.textContent).toContain('catalog unavailable')
+    expect(container.querySelector('[title="fetch failed"]')).not.toBeNull()
+  })
+
+  it('renders explicit spec status when the runtime is absent from the loaded catalog', () => {
+    mockFindKeeper.mockReturnValue({
+      pipeline_stage: null,
+      context_ratio: null,
+      generation: null,
+    })
+    mockRuntimeCatalogState.value = { status: 'loaded', data: [] }
+    mockKeeperDisplayModel.mockReturnValue(null)
+    mockKeeperDisplayRuntime.mockReturnValue({ label: 'Runtime', value: 'oas.primary' })
+    mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
+    mockFindRuntimeCatalogEntry.mockReturnValue(null)
+    const container = document.createElement('div')
+    render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
+    expect(container.textContent).toContain('SPEC')
+    expect(container.textContent).toContain('catalog entry missing')
   })
 
   it('renders activity when ageSeconds present', () => {

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -40,16 +40,18 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const model = keeperDisplayModel(keeper)
   const runtime = keeperDisplayRuntime(keeper)
   const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
-  loadRuntimeCatalog()
-  const catalogState = runtimeCatalogState.value
-  const catalog = catalogState.status === 'loaded' ? catalogState.data : []
+  if (runtime) loadRuntimeCatalog()
+  const catalogState = runtime ? runtimeCatalogState.value : null
+  const catalog = catalogState?.status === 'loaded' ? catalogState.data : []
   const runtimeEntry = runtime ? findRuntimeCatalogEntry(catalog, runtime.value) : null
   const runtimeFacts = runtimeEntry ? runtimeCatalogSnapshotFacts(runtimeEntry) : null
-  const runtimeSpecState = runtimeFacts
-    ?? (runtime && catalogState.status === 'error' ? 'catalog unavailable' : null)
-    ?? (runtime && catalogState.status === 'loaded' && runtimeEntry === null ? 'catalog entry missing' : null)
+  const runtimeSpecState = runtime
+    ? runtimeFacts
+      ?? (catalogState?.status === 'error' ? 'catalog unavailable' : null)
+      ?? (catalogState?.status === 'loaded' && runtimeEntry === null ? 'catalog entry missing' : null)
+    : null
   const runtimeSpecTitle = runtimeFacts
-    ?? (catalogState.status === 'error' ? catalogState.message : runtimeSpecState)
+    ?? (catalogState?.status === 'error' ? catalogState.message : runtimeSpecState)
 
   return html`
     <div class="v2-monitoring-detail agent-runtime-strip">

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -6,7 +6,17 @@ import { html } from 'htm/preact'
 import { PipelineStageBadge } from '../keeper-pipeline-stage'
 import { findKeeper } from '../../lib/keeper-utils'
 import { formatDuration } from '../../lib/format-time'
-import { keeperActivityDisplay, keeperDisplayModel } from '../../lib/keeper-runtime-display'
+import {
+  keeperActivityDisplay,
+  keeperDisplayModel,
+  keeperDisplayRuntime,
+} from '../../lib/keeper-runtime-display'
+import {
+  findRuntimeCatalogEntry,
+  loadRuntimeCatalog,
+  runtimeCatalogState,
+} from '../../lib/runtime-catalog-resource'
+import { runtimeCatalogSnapshotFacts } from '../../lib/runtime-provider-summary'
 
 function ctxBarClass(ratio: number | null | undefined): string {
   if (ratio == null) return ''
@@ -28,7 +38,18 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper.generation
   const model = keeperDisplayModel(keeper)
+  const runtime = keeperDisplayRuntime(keeper)
   const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  loadRuntimeCatalog()
+  const catalogState = runtimeCatalogState.value
+  const catalog = catalogState.status === 'loaded' ? catalogState.data : []
+  const runtimeEntry = runtime ? findRuntimeCatalogEntry(catalog, runtime.value) : null
+  const runtimeFacts = runtimeEntry ? runtimeCatalogSnapshotFacts(runtimeEntry) : null
+  const runtimeSpecState = runtimeFacts
+    ?? (runtime && catalogState.status === 'error' ? 'catalog unavailable' : null)
+    ?? (runtime && catalogState.status === 'loaded' && runtimeEntry === null ? 'catalog entry missing' : null)
+  const runtimeSpecTitle = runtimeFacts
+    ?? (catalogState.status === 'error' ? catalogState.message : runtimeSpecState)
 
   return html`
     <div class="v2-monitoring-detail agent-runtime-strip">
@@ -53,6 +74,20 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
         <div class="flex items-center gap-1.5 text-sm">
           <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">GEN</span>
           <span class="text-sm text-[var(--color-fg-primary)] tabular-nums">${generation}</span>
+        </div>
+      ` : null}
+
+      ${runtime ? html`
+        <div class="flex items-center gap-1.5 text-sm min-w-0">
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">${runtime.label}</span>
+          <span class="text-sm text-[var(--color-fg-primary)] font-mono truncate max-w-50" title=${runtime.value}>${runtime.value}</span>
+        </div>
+      ` : null}
+
+      ${runtimeSpecState ? html`
+        <div class="flex items-center gap-1.5 text-sm min-w-0">
+          <span class="text-3xs text-[var(--color-fg-muted)] uppercase tracking-wider">SPEC</span>
+          <span class="text-3xs text-[var(--color-fg-secondary)] font-mono truncate max-w-80" title=${runtimeSpecTitle}>${runtimeSpecState}</span>
         </div>
       ` : null}
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -99,9 +99,11 @@ describe('keeperModelLabel', () => {
 })
 
 describe('keeperRuntimeLabel', () => {
-  it('prefers runtime_canonical then selected_runtime_canonical', () => {
-    expect(keeperRuntimeLabel(mk({ runtime_canonical: 'oas·seoul-1' }))).toBe('oas·seoul-1')
+  it('uses the shared runtime display priority', () => {
+    expect(keeperRuntimeLabel(mk({ runtime_canonical: ' oas.seoul-1 ' }))).toBe('oas.seoul-1')
     expect(keeperRuntimeLabel(mk({ selected_runtime_canonical: 'local·docker' }))).toBe('local·docker')
+    expect(keeperRuntimeLabel(mk({ runtime_id: 'keeper_unified' }))).toBe('keeper_unified')
+    expect(keeperRuntimeLabel(mk({ runtime_ref: { group: 'tier', item: 'resilient_breaker' } }))).toBe('tier.resilient_breaker')
     expect(keeperRuntimeLabel(mk({}))).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -5,7 +5,10 @@
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
 import { kSlot, kSigil } from '../keeper-badge'
-import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
+import {
+  keeperDisplayRuntime,
+  keeperDisplayStatus,
+} from '../../lib/keeper-runtime-display'
 import { isKeeperOffline, isKeeperPaused } from '../../lib/keeper-predicates'
 import {
   PHASE_LABEL_KO,
@@ -164,5 +167,5 @@ export function keeperModelLabel(keeper: Keeper): string | null {
 
 /** Current runtime label for the header/rail. */
 export function keeperRuntimeLabel(keeper: Keeper): string | null {
-  return keeper.runtime_canonical ?? keeper.selected_runtime_canonical ?? null
+  return keeperDisplayRuntime(keeper)?.value ?? null
 }

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -4,6 +4,7 @@ import type { Keeper, KeeperRuntimeBlockerClass } from '../types'
 import {
   keeperActivityDisplay,
   keeperDisplayModel,
+  keeperDisplayRuntime,
   keeperDisplayStatus,
   keeperPauseDisplay,
   keeperRuntimeBlockerHint,
@@ -186,6 +187,53 @@ describe('keeperDisplayModel', () => {
           { model_used: 'openai:gpt-5.4' },
           { model_used: 'anthropic:claude-sonnet' },
         ],
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('keeperDisplayRuntime', () => {
+  it('prefers runtime_canonical then selected_runtime_canonical', () => {
+    expect(
+      keeperDisplayRuntime({
+        runtime_canonical: 'oas.primary',
+        selected_runtime_canonical: 'oas.secondary',
+        runtime_id: 'legacy.runtime',
+      }),
+    ).toEqual({ label: 'Runtime', value: 'oas.primary' })
+    expect(
+      keeperDisplayRuntime({
+        selected_runtime_canonical: 'oas.secondary',
+        runtime_id: 'legacy.runtime',
+      }),
+    ).toEqual({ label: 'Runtime', value: 'oas.secondary' })
+  })
+
+  it('falls back to runtime_id', () => {
+    expect(keeperDisplayRuntime({ runtime_id: 'keeper_unified' })).toEqual({
+      label: 'Runtime',
+      value: 'keeper_unified',
+    })
+  })
+
+  it('falls back to runtime_ref group and item', () => {
+    expect(
+      keeperDisplayRuntime({ runtime_ref: { group: 'tier', item: 'resilient_breaker' } }),
+    ).toEqual({ label: 'Runtime', value: 'tier.resilient_breaker' })
+    expect(keeperDisplayRuntime({ runtime_ref: { group: 'tier', item: null } })).toEqual({
+      label: 'Runtime',
+      value: 'tier',
+    })
+  })
+
+  it('returns null for missing or blank runtime evidence', () => {
+    expect(keeperDisplayRuntime(null)).toBeNull()
+    expect(
+      keeperDisplayRuntime({
+        runtime_canonical: ' ',
+        selected_runtime_canonical: '',
+        runtime_id: ' ',
+        runtime_ref: { group: ' ', item: 'ignored' },
       }),
     ).toBeNull()
   })

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -34,6 +34,11 @@ interface KeeperModelDisplay {
   value: string
 }
 
+interface KeeperRuntimeDisplay {
+  label: string
+  value: string
+}
+
 export interface KeeperPauseDisplay {
   reason: string
   nextAction: string | null
@@ -50,6 +55,13 @@ type KeeperModelDisplaySource = {
   model?: string | null
   primary_model?: string | null
   metrics_series?: Array<{ model_used?: string | null } | null> | null
+}
+
+type KeeperRuntimeDisplaySource = {
+  runtime_id?: string | null
+  runtime_ref?: { group?: string | null; item?: string | null } | null
+  runtime_canonical?: string | null
+  selected_runtime_canonical?: string | null
 }
 
 type KeeperActivityDisplaySource = {
@@ -94,6 +106,24 @@ export function keeperDisplayModel(
   _source: KeeperModelDisplaySource | null | undefined,
 ): KeeperModelDisplay | null {
   return null
+}
+
+export function keeperDisplayRuntime(
+  source: KeeperRuntimeDisplaySource | null | undefined,
+): KeeperRuntimeDisplay | null {
+  const canonical = firstNonEmptyString(
+    source?.runtime_canonical,
+    source?.selected_runtime_canonical,
+  )
+  if (canonical) return { label: 'Runtime', value: canonical }
+
+  const runtimeId = trimmed(source?.runtime_id)
+  if (runtimeId) return { label: 'Runtime', value: runtimeId }
+
+  const group = trimmed(source?.runtime_ref?.group)
+  if (!group) return null
+  const item = trimmed(source?.runtime_ref?.item)
+  return { label: 'Runtime', value: item ? `${group}.${item}` : group }
 }
 
 function timestampCandidate(


### PR DESCRIPTION
## Summary

- Add a shared keeper runtime display helper that preserves runtime lane evidence while keeping model/provider identity redacted.
- Surface the keeper runtime lane and catalog-derived typed snapshot facts in `AgentRuntimeStrip`.
- Render explicit compact SPEC states when the runtime catalog fails to load or the runtime is absent from a loaded catalog.
- Route the workspace runtime label through the same helper so strip/header/rail priority does not diverge.

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-runtime-display.test.ts src/components/agent-monitor/runtime-strip.test.ts src/components/keeper-workspace/keeper-workspace-shared.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`

## Notes

This keeps `keeperDisplayModel()` redacted by design. The dashboard strip only shows runtime lane identity plus typed catalog capability facts already exposed by the runtime inventory.