### PR TITLE
[codex] Record keeper assigned tools after selection

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -34,6 +34,8 @@ type ctx =
       current_tool_choice:Agent_sdk.Types.tool_choice option ->
       decay_discovered:bool -> unit ->
       string list * turn_lane
+  ; record_tool_assignment :
+      turn:int -> tool_list:string list -> lane:turn_lane -> unit
   ; config : Workspace.config
   ; keeper_tools_cleanup : unit -> unit
   ; manifest_keeper_turn_id : int option
@@ -120,6 +122,7 @@ let assemble_hooks
   let acc = ctx.acc in
   let agent_name = ctx.agent_name in
   let compute_tool_surface = ctx.compute_tool_surface in
+  let record_tool_assignment = ctx.record_tool_assignment in
   let config = ctx.config in
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
   let manifest_keeper_turn_id = ctx.manifest_keeper_turn_id in
@@ -457,6 +460,7 @@ let assemble_hooks
                   relax_strict_tool_choice_for_keeper current_params.tool_choice
                 in
                 let lane = computed_turn_lane in
+                record_tool_assignment ~turn ~tool_list:schema_filter ~lane;
                 Keeper_run_tools_hook_accumulator.record_requested_tool_names
                   acc
                   schema_filter;

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -297,6 +297,7 @@ let prepare_agent_setup
     List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) keeper_tools
   in
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
+  let tool_access_lookup = Keeper_tool_policy.tool_access_lookup_of_meta meta in
   let policy_allowed_tool_names =
     Keeper_tool_dispatch_runtime.keeper_allowed_tool_names meta
   in
@@ -341,6 +342,26 @@ let prepare_agent_setup
     Keeper_tool_policy.StringSet.union
       base
       (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
+  in
+  let policy_allowed_tool_list =
+    Keeper_tool_policy.StringSet.elements policy_allowed_tool_set
+  in
+  let record_tool_assignment ~turn ~tool_list ~lane =
+    let (_assignment_id : Tool_assignment_telemetry.assignment_id) =
+      Tool_assignment_telemetry.emit_assigned
+        ~agent_id:meta.agent_name
+        ~profile:"keeper"
+        ~tool_list
+        ~allow_set:policy_allowed_tool_list
+        ~deny_set:(Keeper_tool_policy.StringSet.elements tool_access_lookup.deny_set)
+        ~reason:
+          (Printf.sprintf
+             "keeper before_turn tool surface turn=%d lane=%s"
+             turn
+             (Keeper_agent_tool_surface.turn_lane_to_string lane))
+        ()
+    in
+    ()
   in
   let allowed_public_name_for_internal internal_name =
     Keeper_tool_descriptor_resolution.public_names_for_internal internal_name
@@ -608,6 +629,7 @@ let prepare_agent_setup
     ; agent_name
     ; all_tool_names
     ; compute_tool_surface
+    ; record_tool_assignment
     ; config
     ; keeper_tools_cleanup
     ; manifest_keeper_turn_id

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -62,36 +62,6 @@ let make_tool_bundle
     |> List.map Keeper_tool_descriptor.internal_names
     |> List.concat
   in
-  let alias_public_names_in_surface =
-    model_visible_descriptors
-    |> List.concat_map (fun descriptor ->
-      if
-        List.exists
-          (fun internal_name -> List.mem internal_name universe_names)
-          (Keeper_tool_descriptor.internal_names descriptor)
-      then Keeper_tool_descriptor.public_names_of_descriptor descriptor
-      else [])
-  in
-  let assembled_surface_names =
-    List.filter (fun n -> not (List.mem n aliased_internal_names)) universe_names
-    @ alias_public_names_in_surface
-  in
-  (* Record tool assignment telemetry for causal tracing.
-     assignment_id links Assigned -> Called -> Completed events.
-     [tool_list] matches the actual LLM-visible surface (internal names
-     minus aliased counterparts, plus public alias names), so downstream
-     Assigned/Called/Completed pairing has no missing entries. *)
-  let (_assignment_id : Tool_assignment_telemetry.assignment_id) =
-    let lookup = Keeper_tool_policy.tool_access_lookup_of_meta meta in
-    Tool_assignment_telemetry.emit_assigned
-      ~agent_id:meta.agent_name
-      ~profile:"keeper"
-      ~tool_list:assembled_surface_names
-      ~allow_set:(Keeper_tool_policy.StringSet.elements lookup.allow_set)
-      ~deny_set:(Keeper_tool_policy.StringSet.elements lookup.deny_set)
-      ~reason:"keeper tool bundle assembly"
-      ()
-  in
   let failure_counts = create_failure_counts () in
   (* Pass A: internal tools that have no public alias.  Aliased internals
      are registered only via Pass B under their public name so the LLM

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -263,6 +263,55 @@ let test_missing_current_task_reconciled_before_transition_hint () =
             check bool "reconciled hint asks for claim/list" true
               (string_contains description "No task currently assigned")))
 
+let test_tool_bundle_does_not_emit_full_universe_assignment () =
+  ignore (init_registry ());
+  Tool_assignment_telemetry.reset_for_testing ();
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_assignment_bundle_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir dir with _ -> ())
+    (fun () ->
+      let config = Workspace.default_config dir in
+      let meta = make_meta ~name:"test-assignment-bundle" () in
+      let ctx_snapshot =
+        Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+          ~max_tokens:4000
+      in
+      let bundle =
+        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+      in
+      Fun.protect
+        ~finally:bundle.cleanup
+        (fun () ->
+          check
+            (option string)
+            "bundle assembly must not claim an LLM-visible assignment"
+            None
+            (Tool_assignment_telemetry.find_latest_assignment_id
+               ~agent_id:meta.agent_name)))
+
+let test_tool_assignment_telemetry_is_before_turn_scoped () =
+  check bool "bundle source does not emit assignment" true
+    (file_not_contains_pattern
+       "lib/keeper/keeper_tools_oas_bundle.ml"
+       "Tool_assignment_telemetry.emit_assigned");
+  check bool "legacy bundle reason removed" true
+    (file_not_contains_pattern
+       "lib/keeper/keeper_tools_oas_bundle.ml"
+       "keeper tool bundle assembly");
+  check bool "before-turn hook records computed schema filter" true
+    (file_contains_pattern
+       "lib/keeper/keeper_run_tools_hooks.ml"
+       "record_tool_assignment ~turn ~tool_list:schema_filter ~lane");
+  check bool "setup owns assignment telemetry emission" true
+    (file_contains_pattern
+       "lib/keeper/keeper_run_tools_setup.ml"
+       "Tool_assignment_telemetry.emit_assigned")
+
 (* ── Test 2: Atomic agent JSON writes ─────────────────────────── *)
 
 let test_atomic_write_not_empty () =
@@ -387,6 +436,10 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
+          test_case "bundle assembly does not emit assignment" `Quick
+            test_tool_bundle_does_not_emit_full_universe_assignment;
+          test_case "assignment telemetry is before-turn scoped" `Quick
+            test_tool_assignment_telemetry_is_before_turn_scoped;
         ] );
       ( "atomic_agent_json",
         [


### PR DESCRIPTION
## Summary
- move keeper tool assignment telemetry from bundle assembly to the before-turn surface selection boundary
- keep the executable full tool universe for BM25/discovery, but only mark `Assigned` after the actual `schema_filter` AllowList is computed
- add regression coverage that bundle assembly no longer claims an LLM-visible assignment

## Validation
- `scripts/dune-local.sh build test/test_warn_root_causes.exe`
- `./_build/default/test/test_warn_root_causes.exe`

## Notes
- Addresses the Discovery/tool-search audit gap where observability could report the full executable universe as the actual LLM-visible tool surface.