### PR TITLE
feat(dashboard): refactor HTML snapshot download to a standard compact settings row

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -545,13 +545,12 @@ describe('SettingsSurface', () => {
       await waitFor(() => {
         expect(container.textContent).toContain('HTML 스냅샷 내보내기')
       })
-      expect(container.textContent).toContain('현재 렌더링된 DOM을 HTML로 저장합니다')
-      expect(container.textContent).toContain('실행 상태는 파일에 내장되지 않습니다')
+      expect(container.textContent).toContain('현재 렌더링된 DOM을 HTML 파일로 저장하여 다운로드합니다')
       expect(container.textContent).not.toContain('Standalone HTML')
       expect(container.textContent).not.toContain('모든 리소스')
 
       const button = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
-        .find(candidate => candidate.textContent?.includes('다운로드'))
+        .find(candidate => candidate.textContent?.includes('내보내기'))
       expect(button).toBeTruthy()
 
       await fireEvent.click(button as HTMLButtonElement)

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1458,22 +1458,16 @@ export function SettingsSurface() {
                 </div>
               <//>
 
-              <div class="set-rt-launch" style=${{ marginTop: '16px', border: '1px solid var(--color-border-default)', padding: '16px', borderRadius: '8px', background: 'var(--color-bg-elevated)' }}>
-                <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <div>
-                    <div style=${{ fontWeight: 'bold', fontSize: '14px', color: 'var(--color-fg-primary)' }}>HTML 스냅샷 내보내기</div>
-                    <div class="set-hint" style=${{ marginTop: '4px' }}>현재 렌더링된 DOM을 HTML로 저장합니다. 외부 asset, API 데이터, 실행 상태는 파일에 내장되지 않습니다.</div>
-                  </div>
-                  <button
-                    type="button"
-                    class="cn-act act"
-                    style=${{ background: 'var(--color-brand)', color: 'var(--volt-ink)', fontWeight: '600' }}
-                    onClick=${handleExportHtmlSnapshot}
-                  >
-                    다운로드 ⤓
-                  </button>
-                </div>
-              </div>
+              <${SetRow} label="HTML 스냅샷 내보내기" hint="현재 렌더링된 DOM을 HTML 파일로 저장하여 다운로드합니다.">
+                <button
+                  type="button"
+                  class="cn-act act"
+                  style=${{ background: 'var(--color-brand)', color: 'var(--volt-ink)', fontWeight: '600' }}
+                  onClick=${handleExportHtmlSnapshot}
+                >
+                  내보내기 ⤓
+                </button>
+              <//>
             `}
           </div>
         </div>


### PR DESCRIPTION
Refactors the HTML snapshot export card in Settings -> Display to be a standard, compact SetRow to match the rest of the settings section.