### PR TITLE
fix(runtime): degrade boot on catalog gaps

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -333,6 +333,37 @@ type missing_catalog_report =
   ; missing_models : missing_catalog_model list
   }
 
+type dropped_runtime_assignment =
+  { keeper_name : string
+  ; runtime_id : string
+  }
+
+type dropped_runtime_route =
+  { route_name : string
+  ; runtime_id : string
+  }
+
+type dropped_runtime_lane =
+  { lane_id : string
+  ; runtime_ids : string list
+  }
+
+type startup_degradation =
+  { report : missing_catalog_report
+  ; configured_default_runtime_id : string
+  ; effective_default_runtime_id : string
+  ; disabled_runtime_ids : string list
+  ; dropped_assignments : dropped_runtime_assignment list
+  ; dropped_routes : dropped_runtime_route list
+  ; dropped_media_failover : string list
+  ; dropped_lane_candidates : dropped_runtime_lane list
+  ; dropped_lanes : dropped_runtime_lane list
+  }
+
+type init_default_outcome =
+  | Initialized
+  | Initialized_degraded of startup_degradation
+
 type strict_init_error =
   | Runtime_config_error of string
   | Missing_catalog_models of missing_catalog_report
@@ -354,6 +385,94 @@ let missing_catalog_report_to_string (report : missing_catalog_report) =
 let strict_init_error_to_string = function
   | Runtime_config_error msg -> msg
   | Missing_catalog_models report -> missing_catalog_report_to_string report
+;;
+
+let startup_degradation_to_string (degradation : startup_degradation) =
+  Printf.sprintf
+    "runtime catalog degraded boot: disabled %d uncatalogued runtime(s); \
+     configured default %S -> effective default %S; operator must add catalog \
+     rows for: %s"
+    (List.length degradation.disabled_runtime_ids)
+    degradation.configured_default_runtime_id
+    degradation.effective_default_runtime_id
+    (String.concat ", "
+       (List.map missing_catalog_model_label degradation.report.missing_models))
+;;
+
+let dropped_assignment_to_yojson (entry : dropped_runtime_assignment) =
+  `Assoc
+    [ "keeper_name", `String entry.keeper_name
+    ; "runtime_id", `String entry.runtime_id
+    ]
+;;
+
+let dropped_route_to_yojson (entry : dropped_runtime_route) =
+  `Assoc [ "route_name", `String entry.route_name; "runtime_id", `String entry.runtime_id ]
+;;
+
+let dropped_lane_to_yojson (entry : dropped_runtime_lane) =
+  `Assoc
+    [ "lane_id", `String entry.lane_id
+    ; "runtime_ids", `List (List.map (fun id -> `String id) entry.runtime_ids)
+    ]
+;;
+
+let missing_catalog_model_to_yojson (entry : missing_catalog_model) =
+  `Assoc
+    [ "runtime_id", `String entry.runtime_id
+    ; "provider_id", `String entry.provider_id
+    ; "provider_label", `String entry.provider_label
+    ; "model_id", `String entry.model_id
+    ]
+;;
+
+let startup_degradation_to_yojson = function
+  | None ->
+    `Assoc
+      [ "schema", `String "masc.runtime_startup_degradation.v1"
+      ; "status", `String "ok"
+      ; "degraded", `Bool false
+      ; "operator_action_required", `Bool false
+      ; "terminal_reason", `String "none"
+      ; "missing_catalog_model_count", `Int 0
+      ; "disabled_runtime_ids", `List []
+      ]
+  | Some degradation ->
+    `Assoc
+      [ "schema", `String "masc.runtime_startup_degradation.v1"
+      ; "status", `String "degraded"
+      ; "degraded", `Bool true
+      ; "operator_action_required", `Bool true
+      ; "terminal_reason", `String "missing_oas_catalog_models"
+      ; "message", `String (startup_degradation_to_string degradation)
+      ; "config_path", `String degradation.report.config_path
+      ; "configured_default_runtime_id"
+        , `String degradation.configured_default_runtime_id
+      ; "effective_default_runtime_id", `String degradation.effective_default_runtime_id
+      ; "missing_catalog_model_count", `Int (List.length degradation.report.missing_models)
+      ; ( "missing_catalog_models"
+        , `List (List.map missing_catalog_model_to_yojson degradation.report.missing_models)
+        )
+      ; ( "disabled_runtime_ids"
+        , `List (List.map (fun id -> `String id) degradation.disabled_runtime_ids)
+        )
+      ; ( "dropped_assignments"
+        , `List (List.map dropped_assignment_to_yojson degradation.dropped_assignments)
+        )
+      ; "dropped_routes", `List (List.map dropped_route_to_yojson degradation.dropped_routes)
+      ; ( "dropped_media_failover"
+        , `List (List.map (fun id -> `String id) degradation.dropped_media_failover)
+        )
+      ; ( "dropped_lane_candidates"
+        , `List (List.map dropped_lane_to_yojson degradation.dropped_lane_candidates)
+        )
+      ; "dropped_lanes", `List (List.map dropped_lane_to_yojson degradation.dropped_lanes)
+      ; ( "next_action"
+        , `String
+            "Add the listed provider/model rows to oas-models.toml or remove \
+             those runtime.toml bindings; uncatalogued runtimes are disabled \
+             for this process." )
+      ]
 ;;
 
 let capabilities_for_runtime (rt : t) =
@@ -401,6 +520,150 @@ let missing_runtime_model_capabilities ~(config_path : string) (runtimes : t lis
   match missing_models with
   | [] -> None
   | first :: rest -> Some { config_path; missing_models = first :: rest }
+;;
+
+let runtime_missing_from_report (report : missing_catalog_report) runtime_id =
+  List.exists
+    (fun (missing : missing_catalog_model) -> String.equal missing.runtime_id runtime_id)
+    report.missing_models
+;;
+
+let degrade_loaded_for_missing_catalog
+    ( (runtimes, configured_default, assignments, librarian_id, structured_judge_id,
+       cross_verifier_id, media_failover, lanes) :
+      t list
+      * t
+      * (string * string) list
+      * string option
+      * string option
+      * string option
+      * string list
+      * Runtime_lane.t list )
+    (report : missing_catalog_report)
+  : ( ( t list
+        * t
+        * (string * string) list
+        * string option
+        * string option
+        * string option
+        * string list
+        * Runtime_lane.t list )
+      * startup_degradation
+    , string )
+    result
+  =
+  let is_missing = runtime_missing_from_report report in
+  let active_runtimes = List.filter (fun (rt : t) -> not (is_missing rt.id)) runtimes in
+  match active_runtimes with
+  | [] ->
+    Error
+      (Printf.sprintf
+         "%s: all configured runtime models are absent from the OAS capability \
+          catalog; cannot degrade without dispatching through provider_default"
+         report.config_path)
+  | effective_default :: _ ->
+    let effective_default =
+      if is_missing configured_default.id then effective_default else configured_default
+    in
+    let disabled_runtime_ids =
+      report.missing_models
+      |> List.map (fun (missing : missing_catalog_model) -> missing.runtime_id)
+      |> List.sort_uniq String.compare
+    in
+    let kept_assignments, dropped_assignments =
+      List.fold_right
+        (fun (keeper_name, runtime_id) (kept, dropped) ->
+           if is_missing runtime_id
+           then kept, { keeper_name; runtime_id } :: dropped
+           else (keeper_name, runtime_id) :: kept, dropped)
+        assignments
+        ([], [])
+    in
+    let drop_route route_name = function
+      | None -> None, None
+      | Some runtime_id when is_missing runtime_id ->
+        None, Some { route_name; runtime_id }
+      | Some _ as value -> value, None
+    in
+    let librarian_id, librarian_drop = drop_route "runtime.librarian" librarian_id in
+    let structured_judge_id, structured_judge_drop =
+      drop_route "runtime.structured_judge" structured_judge_id
+    in
+    let cross_verifier_id, cross_verifier_drop =
+      drop_route "runtime.cross_verifier" cross_verifier_id
+    in
+    let dropped_routes =
+      [ librarian_drop; structured_judge_drop; cross_verifier_drop ]
+      |> List.filter_map Fun.id
+    in
+    let kept_media_failover, dropped_media_failover =
+      List.fold_right
+        (fun runtime_id (kept, dropped) ->
+           if is_missing runtime_id
+           then kept, runtime_id :: dropped
+           else runtime_id :: kept, dropped)
+        media_failover
+        ([], [])
+    in
+    let kept_lanes, dropped_lane_candidates, dropped_lanes =
+      List.fold_right
+        (fun (lane : Runtime_lane.t) (kept, dropped_candidates, dropped_lanes) ->
+           let kept_candidates, dropped_candidates_for_lane =
+             List.fold_right
+               (fun runtime_id (kept_ids, dropped_ids) ->
+                  if is_missing runtime_id
+                  then kept_ids, runtime_id :: dropped_ids
+                  else runtime_id :: kept_ids, dropped_ids)
+               (Runtime_lane.ordered_candidates lane)
+               ([], [])
+           in
+           let dropped_candidates =
+             match dropped_candidates_for_lane with
+             | [] -> dropped_candidates
+             | runtime_ids ->
+               { lane_id = Runtime_lane.id lane; runtime_ids } :: dropped_candidates
+           in
+           match kept_candidates with
+           | [] ->
+             ( kept
+             , dropped_candidates
+             , { lane_id = Runtime_lane.id lane
+               ; runtime_ids = Runtime_lane.ordered_candidates lane
+               }
+               :: dropped_lanes )
+           | _ ->
+             ( Runtime_lane.make
+                 ~id:(Runtime_lane.id lane)
+                 ~strategy:(Runtime_lane.strategy lane)
+                 kept_candidates
+               :: kept
+             , dropped_candidates
+             , dropped_lanes ))
+        lanes
+        ([], [], [])
+    in
+    let degradation =
+      { report
+      ; configured_default_runtime_id = configured_default.id
+      ; effective_default_runtime_id = effective_default.id
+      ; disabled_runtime_ids
+      ; dropped_assignments
+      ; dropped_routes
+      ; dropped_media_failover
+      ; dropped_lane_candidates
+      ; dropped_lanes
+      }
+    in
+    Ok
+      ( ( active_runtimes
+        , effective_default
+        , kept_assignments
+        , librarian_id
+        , structured_judge_id
+        , cross_verifier_id
+        , kept_media_failover
+        , kept_lanes )
+      , degradation )
 ;;
 
 let materialize_config ~(config_path : string) (cfg : config)
@@ -461,7 +724,8 @@ let materialize_config ~(config_path : string) (cfg : config)
   in
   (* The OAS catalog membership gate is intentionally not called here:
      [load_list] stays a routing-validity parser for tests and config probes.
-     Production startup applies the stricter gate via [init_default_strict]. *)
+     Startup callers choose fail-closed [init_default_strict] or server-visible
+     degraded boot [init_default_degraded_report]. *)
   Ok
     ( runtimes
     , rt
@@ -511,6 +775,7 @@ type loaded_state =
   ; media_failover : string list
   ; lanes : Runtime_lane.t list
   ; config_path : string option
+  ; startup_degradation : startup_degradation option
   }
 
 let empty_loaded_state =
@@ -523,6 +788,7 @@ let empty_loaded_state =
   ; media_failover = []
   ; lanes = []
   ; config_path = None
+  ; startup_degradation = None
   }
 
 let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
@@ -530,6 +796,7 @@ let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let set_loaded
+    ?startup_degradation
     ~config_path
     ( runtimes
     , rt
@@ -549,6 +816,7 @@ let set_loaded
     ; media_failover
     ; lanes
     ; config_path = Some config_path
+    ; startup_degradation
     }
 
 let init_default ~config_path =
@@ -556,11 +824,11 @@ let init_default ~config_path =
   set_loaded ~config_path loaded;
   Ok ()
 
-(* Startup entry point: [load_list] (RFC-0206 routing validation) PLUS the OAS
-   capability-catalog gate. Production callers (server boot, fusion run) use this
-   so an operator runtime.toml whose model is absent from the catalog is rejected
-   before boot — the gate that load_list intentionally no longer applies, kept out
-   of load_list so unit tests stay catalog-independent. *)
+(* Fail-closed startup entry point: [load_list] (RFC-0206 routing validation)
+   PLUS the OAS capability-catalog gate. Strict callers use this so an operator
+   runtime.toml whose model is absent from the catalog is rejected before boot —
+   the gate that load_list intentionally no longer applies, kept out of load_list
+   so unit tests stay catalog-independent. *)
 let init_default_strict_report ~config_path =
   match load_list ~config_path with
   | Error msg -> Error (Runtime_config_error msg)
@@ -575,6 +843,21 @@ let init_default_strict ~config_path =
   init_default_strict_report ~config_path
   |> Result.map_error strict_init_error_to_string
 
+let init_default_degraded_report ~config_path =
+  match load_list ~config_path with
+  | Error msg -> Error (Runtime_config_error msg)
+  | Ok ((runtimes, _, _, _, _, _, _, _) as loaded) ->
+    (match missing_runtime_model_capabilities ~config_path runtimes with
+     | None ->
+       set_loaded ~config_path loaded;
+       Ok Initialized
+     | Some report ->
+       (match degrade_loaded_for_missing_catalog loaded report with
+        | Error msg -> Error (Runtime_config_error msg)
+        | Ok (degraded_loaded, degradation) ->
+          set_loaded ~startup_degradation:degradation ~config_path degraded_loaded;
+          Ok (Initialized_degraded degradation)))
+
 let runtime_state () = Atomic.get loaded_state_ref
 
 module For_testing = struct
@@ -587,6 +870,8 @@ end
 let get_default_runtime () = (runtime_state ()).default_runtime
 let get_runtimes () = (runtime_state ()).runtimes
 let get_runtime_ids () = runtime_ids (runtime_state ()).runtimes
+let startup_degradation () = (runtime_state ()).startup_degradation
+let startup_degraded () = Option.is_some (startup_degradation ())
 
 let default_runtime_id_or_fail () =
   match (runtime_state ()).default_runtime with

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -54,11 +54,48 @@ type missing_catalog_report =
   ; missing_models : missing_catalog_model list
   }
 
+type dropped_runtime_assignment =
+  { keeper_name : string
+  ; runtime_id : string
+  }
+
+type dropped_runtime_route =
+  { route_name : string
+  ; runtime_id : string
+  }
+
+type dropped_runtime_lane =
+  { lane_id : string
+  ; runtime_ids : string list
+  }
+
+type startup_degradation =
+  { report : missing_catalog_report
+  ; configured_default_runtime_id : string
+  ; effective_default_runtime_id : string
+  ; disabled_runtime_ids : string list
+  ; dropped_assignments : dropped_runtime_assignment list
+  ; dropped_routes : dropped_runtime_route list
+  ; dropped_media_failover : string list
+  ; dropped_lane_candidates : dropped_runtime_lane list
+  ; dropped_lanes : dropped_runtime_lane list
+  }
+(** Operator-visible startup degradation. Missing-catalog runtime bindings are
+    removed from the active runtime set so requests never dispatch through OAS
+    [provider_default]. The server may continue only when at least one
+    catalog-known runtime remains. *)
+
+type init_default_outcome =
+  | Initialized
+  | Initialized_degraded of startup_degradation
+
 type strict_init_error =
   | Runtime_config_error of string
   | Missing_catalog_models of missing_catalog_report
 
 val strict_init_error_to_string : strict_init_error -> string
+val startup_degradation_to_string : startup_degradation -> string
+val startup_degradation_to_yojson : startup_degradation option -> Yojson.Safe.t
 
 val load_list :
   config_path:string
@@ -95,18 +132,27 @@ val runtime_ids : t list -> string list
 
 val init_default : config_path:string -> (unit, string) result
 (** Parse + RFC-0206 routing validation + populate the singletons. Does NOT apply
-    the OAS capability-catalog gate (use {!init_default_strict} at production
-    startup). Safe for tests with arbitrary-model runtime fixtures. *)
+    the OAS capability-catalog gate (use {!init_default_strict} for fail-closed
+    callers or {!init_default_degraded_report} for server boot). Safe for tests
+    with arbitrary-model runtime fixtures. *)
 
 val init_default_strict : config_path:string -> (unit, string) result
-(** Production startup entry point: {!init_default} PLUS the OAS capability-catalog
-    gate ({!decide_capability_gate}). Rejects ([Error]) a runtime whose model is
-    absent from the catalog before boot. Used by server boot and fusion run. *)
+(** Fail-closed startup entry point: {!init_default} PLUS the OAS
+    capability-catalog gate ({!decide_capability_gate}). Rejects ([Error]) a
+    runtime whose model is absent from the catalog before boot. Used by strict
+    validation callers such as fusion run. *)
 
 val init_default_strict_report :
   config_path:string -> (unit, strict_init_error) result
-(** Typed form of {!init_default_strict}. Server bootstrap uses this to log
-    missing catalog models without string-matching the fatal error message. *)
+(** Typed form of {!init_default_strict}. Useful when callers need missing
+    catalog models without string-matching the fatal error message. *)
+
+val init_default_degraded_report :
+  config_path:string -> (init_default_outcome, strict_init_error) result
+(** Server bootstrap entry point. Applies the strict OAS catalog gate, but when
+    only the catalog-membership gate fails it can remove uncatalogued runtimes
+    from the active runtime set and continue in an operator-visible degraded
+    mode. Routing/parse errors and all-missing runtime sets remain fatal. *)
 
 module For_testing : sig
   type snapshot
@@ -118,6 +164,8 @@ end
 val get_default_runtime : unit -> t option
 val get_runtimes : unit -> t list
 val get_runtime_ids : unit -> string list
+val startup_degradation : unit -> startup_degradation option
+val startup_degraded : unit -> bool
 val runtimes_and_media_failover : unit -> t list * string list
 (** Atomically consistent snapshot of configured runtimes plus
     [\[runtime\].media_failover]. Use when both values drive one routing

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1977,6 +1977,8 @@ let runtime_inventory_json () =
     [ "updated_at", `String (Masc_domain.now_iso ())
     ; "source", `String runtime_inventory_source
     ; "config_path", Json_util.string_opt_to_json (Runtime.config_path ())
+    ; ( "startup_degradation"
+      , Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ()) )
     ; ( "summary"
       , `Assoc
           [ "providers", `Int (runtime_unique_count provider_ids)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -345,6 +345,8 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("uptime", `String (health_uptime_string uptime_secs));
       ("sse_clients", `Int (Sse.client_count ()));
       ("startup", Server_startup_state.to_yojson ());
+      ("runtime_startup_degradation",
+       Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ()));
       ("subsystems", Subsystem_health.to_yojson ());
       ("logs", Log.Ring.summary_json ());
       ("gc", quick_gc_json ());
@@ -420,7 +422,8 @@ let health_status_rank = Health_status.rank_string
 let max_health_status = Health_status.max_string
 
 let full_health_operator_summary ~keeper_fleet_safety
-    ~keeper_identity_drift_json ~reaction_ledger_json ~keeper_config_schema_status
+    ~keeper_identity_drift_json ~reaction_ledger_json ~runtime_startup_degradation_json
+    ~keeper_config_schema_status
     ~keeper_config_schema_blocking ~keeper_config_schema_terminal_reason
     ~keeper_config_operator_action_required ~lazy_task_boot_guard_fires_total =
   let status = ref "ok" in
@@ -455,6 +458,8 @@ let full_health_operator_summary ~keeper_fleet_safety
   note_status "keeper_identity_drift" keeper_identity_drift_json
     (assoc_string_opt "terminal_reason" keeper_identity_drift_json);
   note_status "keeper_reaction_ledger" reaction_ledger_json None;
+  note_status "runtime_startup_degradation" runtime_startup_degradation_json
+    (assoc_string_opt "terminal_reason" runtime_startup_degradation_json);
   status := max_health_status !status keeper_config_schema_status;
   if keeper_config_operator_action_required || keeper_config_schema_blocking
   then
@@ -599,12 +604,16 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     int_of_float
       (Otel_metric_store.metric_total "masc_lazy_task_boot_guard_fired_total")
   in
+  let runtime_startup_degradation_json =
+    Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ())
+  in
   let keeper_config_operator_action_required = keeper_config_schema_blocking in
   let overall_status, operator_action_required, operator_action_reasons =
     full_health_operator_summary
       ~keeper_fleet_safety
       ~keeper_identity_drift_json
       ~reaction_ledger_json
+      ~runtime_startup_degradation_json
       ~keeper_config_schema_status:
         (if keeper_config_schema_blocking then "blocked" else "ok")
       ~keeper_config_schema_blocking
@@ -631,6 +640,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     ("uptime", `String (health_uptime_string uptime_secs));
     ("sse_clients", `Int (Sse.client_count ()));
     ("startup", Server_startup_state.to_yojson ());
+    ("runtime_startup_degradation", runtime_startup_degradation_json);
     ("subsystems", Subsystem_health.to_yojson ());
     (* Server log visibility belongs on the first health probe too.  Keep the
        payload cheap and redacted: only ring counters, latest metadata, and

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -664,18 +664,26 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          create_server_state) and before any runtime name resolution.
 
          fail-fast: a missing config path or a missing/broken [runtime].default
-         is fatal — the server cannot route turns without a default Runtime, so
-         booting into a half-configured state only defers the failure to the
-         first turn (runtime→Runtime vision: no silent fallback). *)
+         is fatal — the server cannot route turns without a default Runtime.
+         The OAS capability-catalog gate may degrade only by removing
+         uncatalogued runtimes from the active routing set; it never dispatches
+         through OAS provider_default. *)
       (match Runtime.config_path () with
        | Some config_path ->
-         (match Runtime.init_default_strict_report ~config_path with
-          | Ok () ->
+         (match Runtime.init_default_degraded_report ~config_path with
+          | Ok Runtime.Initialized ->
             Log.Server.info "Runtime default initialized: %s"
+              (Runtime.get_default_runtime_id ())
+          | Ok (Runtime.Initialized_degraded degradation) ->
+            Log.Server.warn
+              "Runtime default initialized in degraded catalog mode: %s"
+              (Runtime.startup_degradation_to_string degradation);
+            Log.Server.warn
+              "Runtime degraded effective default: %s"
               (Runtime.get_default_runtime_id ())
           | Error err ->
             Log.Server.error
-              "Runtime.init_default_strict failed (fatal, refusing to boot): %s"
+              "Runtime.init_default_degraded failed (fatal, refusing to boot): %s"
               (Runtime.strict_init_error_to_string err);
             exit 1)
        | None ->

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1358,6 +1358,93 @@ let test_runtime_capability_gate_reports_missing_catalog_models () =
                  (Runtime.Missing_catalog_models report))
               "oas-models.toml"))
 
+let test_server_degraded_init_disables_uncatalogued_runtimes () =
+  let catalog =
+    "[[models]]\n\
+     id_prefix = \"good\"\n\
+     base = \"ollama\"\n\
+     max_context_tokens = 1024\n"
+  in
+  let runtime_toml =
+    "[providers.ollama]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.missing]\n\
+     api-name = \"missing-from-oas-catalog\"\n\
+     max-context = 1024\n\
+     \n\
+     [ollama.good]\n\
+     \n\
+     [ollama.missing]\n\
+     \n\
+     [runtime]\n\
+     default = \"ollama.missing\"\n\
+     librarian = \"ollama.missing\"\n\
+     media_failover = [\"ollama.missing\", \"ollama.good\"]\n\
+     \n\
+     [runtime.assignments]\n\
+     keeper_a = \"ollama.missing\"\n\
+     keeper_b = \"ollama.good\"\n\
+     \n\
+     [runtime.lanes.safe]\n\
+     candidates = [\"ollama.missing\", \"ollama.good\"]\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content catalog @@ fun () ->
+       with_temp_runtime_toml runtime_toml @@ fun path ->
+       match Runtime.init_default_degraded_report ~config_path:path with
+       | Error err ->
+         failf
+           "server degraded init should keep a catalog-known runtime alive: %s"
+           (Runtime.strict_init_error_to_string err)
+       | Ok Runtime.Initialized -> fail "expected degraded startup outcome"
+       | Ok (Runtime.Initialized_degraded degradation) ->
+         check string "configured default"
+           "ollama.missing"
+           degradation.configured_default_runtime_id;
+         check string "effective default"
+           "ollama.good"
+           degradation.effective_default_runtime_id;
+         check (list string) "active runtime ids"
+           [ "ollama.good" ]
+           (Runtime.get_runtime_ids ());
+         check (option string) "dropped assignment falls back to default"
+           None
+           (Runtime.runtime_id_for_keeper "keeper_a");
+         check (option string) "catalog-known assignment preserved"
+           (Some "ollama.good")
+           (Runtime.runtime_id_for_keeper "keeper_b");
+         check (option string) "librarian route dropped"
+           None
+           (Runtime.librarian_runtime_id ());
+         check (list string) "media failover keeps known ids only"
+           [ "ollama.good" ]
+           (Runtime.media_failover ());
+         (match Runtime.get_lane_by_id "safe" with
+          | None -> fail "lane should remain with its known candidate"
+          | Some lane ->
+            check (list string) "lane candidates keep known ids only"
+              [ "ollama.good" ]
+              (Runtime_lane.ordered_candidates lane));
+         check bool "runtime records startup degradation" true
+           (Runtime.startup_degraded ());
+         let json =
+           Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ())
+         in
+         let rendered = Yojson.Safe.to_string json in
+         check bool "json is operator-visible degraded" true
+           (String_util.contains_substring rendered "\"status\":\"degraded\"");
+         check bool "json names disabled runtime" true
+           (String_util.contains_substring rendered "ollama.missing"))
+
 let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_fake_runtime_model_catalog @@ fun () ->
   let content =
@@ -1737,6 +1824,9 @@ let () =
           test_case
             "runtime capability gate reports missing catalog models"
             `Quick test_runtime_capability_gate_reports_missing_catalog_models;
+          test_case
+            "server degraded init disables uncatalogued runtimes"
+            `Quick test_server_degraded_init_disables_uncatalogued_runtimes;
           test_case
             "runtime assignment rejects commented disabled binding"
             `Quick test_runtime_assignment_rejects_commented_disabled_binding;


### PR DESCRIPTION
## Summary
- add server-only degraded runtime init for missing OAS catalog rows: disable uncatalogued runtimes, promote a catalog-known default when needed, and drop assignments/role/media/lane references to disabled runtimes
- keep strict init APIs fail-closed for validation/fusion callers so catalog gaps are still caught outside server boot
- expose startup_degradation on /health, /health?full=1, and provider inventory with operator_action_required=true

## Validation
- opam exec -- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli lib/server/server_runtime_bootstrap.ml lib/server/server_routes_http_runtime.ml lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_config_validity.ml
- git diff --check
- local Dune build/test intentionally not run; build authority is CI per operator instruction