### PR TITLE
[codex] Redact keeper model labels in roster surfaces

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -1216,7 +1216,7 @@ describe('AgentRoster live-only cards', () => {
     expect(presence.textContent).toContain('대기 중')
   })
 
-  it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {
+  it('uses heartbeat and shared runtime labels for cards when action/model fallbacks disagree', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-24T18:00:00Z'))
     agents.value = [
@@ -1232,6 +1232,7 @@ describe('AgentRoster live-only cards', () => {
         name: 'sangsu',
         agent_name: 'keeper-sangsu-agent',
         status: 'active',
+        runtime_canonical: 'oas.primary',
         active_model: 'claude-code:auto',
         model: 'claude',
         last_heartbeat: '2026-04-24T17:54:00Z',
@@ -1251,9 +1252,8 @@ describe('AgentRoster live-only cards', () => {
     expect(text).toContain('sangsu')
     expect(text).toContain('하트비트')
     expect(text).toContain('6분 전')
-    // Full model id is surfaced verbatim — the `claude-` prefix is no longer
-    // truncated so multi-provider model names stay distinguishable (audit P1-5).
-    expect(text).toContain('claude-code:auto')
+    expect(text).toContain('oas.primary')
+    expect(text).not.toContain('claude-code:auto')
     expect(text).not.toContain('마지막 행동 이후')
     expect(text).not.toContain('최근 모델claude')
   })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -57,6 +57,7 @@ import {
 } from '../runtime-counts'
 import {
   keeperActivityDisplay,
+  keeperDisplayRuntime,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
   keeperWorkPreview,
@@ -319,7 +320,7 @@ const FLEET_CTX_HOT_PCT = 85
 
 type FleetVital = { k: string; v: string }
 
-// Build the aside `런타임` vitals grid from real keeper runtime fields only.
+// Build the aside `런타임` vitals grid from shared keeper runtime display only.
 // Fields with no live source (e.g. tps) are omitted rather than fabricated —
 // the audit (P1-6) flags `tps` as having no roster-model source.
 function fleetRuntimeVitals(
@@ -329,14 +330,8 @@ function fleetRuntimeVitals(
   if (!keeper) return []
   const vitals: FleetVital[] = []
 
-  // Full model id, no prefix truncation: in a multi-provider fleet a stripped
-  // `claude-` prefix collides with other providers' model names (audit P1-5).
-  const model = (keeper.active_model ?? keeper.model ?? keeper.last_model_used ?? '')
-    .trim()
-  if (model) vitals.push({ k: 'model', v: model })
-
-  const runtime = (keeper.runtime_canonical ?? keeper.selected_runtime_canonical ?? '').trim()
-  if (runtime) vitals.push({ k: 'runtime', v: runtime })
+  const runtime = keeperDisplayRuntime(keeper)
+  if (runtime) vitals.push({ k: 'runtime', v: runtime.value })
 
   if (typeof keeper.keeper_age_s === 'number' && Number.isFinite(keeper.keeper_age_s)) {
     vitals.push({ k: 'uptime', v: formatDuration(keeper.keeper_age_s) })
@@ -550,7 +545,6 @@ function keeperRuntimeAgentProjection(source: Keeper): RosterAgent | null {
     capabilities: linkedAgent?.capabilities,
     emoji: source.emoji,
     koreanName: source.koreanName,
-    model: source.model,
     traits: source.traits,
     activityLevel: source.activityLevel,
     primaryValue: source.primaryValue,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -120,7 +120,8 @@ describe('KeeperWorkspaceRail', () => {
     // low-signal in the detail view; the 런타임 section keeps its vitals.
     expect(container.textContent).not.toContain('처리량')
     expect(container.textContent).toContain('런타임')
-    expect(container.textContent).toContain('sonnet-4.6')
+    expect(container.textContent).not.toContain('sonnet-4.6')
+    expect(container.querySelector('.rtc-model')?.textContent).toContain('—')
     expect(container.textContent).toContain('oas·seoul-1')
   })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -427,11 +427,17 @@ describe('KeeperWorkspaceRoster', () => {
     expect(handle?.getAttribute('title')).toBe('/workspace/keepers/keeper-miso')
   })
 
-  it('falls back to the scope proxy when a keeper has no sandbox_target', () => {
-    keepers.value = [mk({ name: 'nobase', status: 'running', model: 'anthropic/claude-x' })]
+  it('falls back to the runtime scope proxy when a keeper has no sandbox_target', () => {
+    keepers.value = [mk({
+      name: 'nobase',
+      status: 'running',
+      runtime_canonical: 'oas.primary',
+      model: 'anthropic/claude-x',
+    })]
     render(html`<${KeeperWorkspaceRoster} activeName="nobase" />`, host)
     const handle = host.querySelector('.kw-kp-handle') as HTMLElement
-    expect(handle?.textContent).toBe('anthropic/claude-x')
+    expect(handle?.textContent).toBe('oas.primary')
+    expect(handle?.textContent).not.toBe('anthropic/claude-x')
   })
 
   it('matches a search query against the basepath', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -22,7 +22,7 @@ import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-actions'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { formatRelativeSec } from '../../lib/format-time'
-import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import { keeperActivityDisplay, keeperDisplayRuntime } from '../../lib/keeper-runtime-display'
 import type { KeeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import { sortByRecency } from '../../lib/keeper-recency'
@@ -178,9 +178,9 @@ function compareKeepers(a: Keeper, b: Keeper, sort: 'name' | 'att'): number {
 }
 
 /** ns proxy: keepers have no namespace field; the skill path is the closest
- *  real scope signal, with the model as fallback. */
+ *  real scope signal, with runtime identity as fallback. */
 function keeperScope(keeper: Keeper): string | null {
-  return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
+  return keeper.skill_primary ?? keeperDisplayRuntime(keeper)?.value ?? null
 }
 
 /** The keeper's sandbox location — the design's roster identity sub-line
@@ -189,7 +189,7 @@ function keeperScope(keeper: Keeper): string | null {
  *  profile it is the worktree root path, for `docker` the container target.
  *  Unlike the alert strip, this deliberately does NOT fall back to
  *  `sandbox_profile`: a bare 'local'/'docker' literal is not a useful roster
- *  identity, so RosterRow falls through to the scope proxy (skill/model) instead. */
+ *  identity, so RosterRow falls through to the scope proxy (skill/runtime) instead. */
 function keeperBasepath(keeper: Keeper): string {
   return keeper.sandbox_target?.trim() ?? ''
 }
@@ -229,7 +229,7 @@ function keeperRecentTool(keeper: Keeper): { label: string; title: string } | nu
 
 function matchesQuery(keeper: Keeper, q: string): boolean {
   if (!q) return true
-  const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''} ${keeperBasepath(keeper)}`.toLowerCase()
+  const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeperBasepath(keeper)}`.toLowerCase()
   return hay.includes(q.toLowerCase())
 }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -90,10 +90,10 @@ describe('statePillTone', () => {
 })
 
 describe('keeperModelLabel', () => {
-  it('prefers active_model_label, then active_model, then model', () => {
-    expect(keeperModelLabel(mk({ active_model_label: 'A', active_model: 'B', model: 'C' }))).toBe('A')
-    expect(keeperModelLabel(mk({ active_model: 'B', model: 'C' }))).toBe('B')
-    expect(keeperModelLabel(mk({ model: 'C' }))).toBe('C')
+  it('does not expose raw keeper model fields', () => {
+    expect(keeperModelLabel(mk({ active_model_label: 'A', active_model: 'B', model: 'C' }))).toBeNull()
+    expect(keeperModelLabel(mk({ active_model: 'B', model: 'C' }))).toBeNull()
+    expect(keeperModelLabel(mk({ model: 'C' }))).toBeNull()
     expect(keeperModelLabel(mk({}))).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import type { VNode } from 'preact'
 import { kSlot, kSigil } from '../keeper-badge'
 import {
+  keeperDisplayModel,
   keeperDisplayRuntime,
   keeperDisplayStatus,
 } from '../../lib/keeper-runtime-display'
@@ -159,10 +160,9 @@ export function statePillTone(tone: FleetTone): 'run' | 'warn' | 'bad' | 'busy' 
   return 'off'
 }
 
-/** Current model label, reading the populated fields directly
- *  (keeperDisplayModel is a stub that returns null upstream). */
+/** Current model label, intentionally routed through the redaction boundary. */
 export function keeperModelLabel(keeper: Keeper): string | null {
-  return keeper.active_model_label ?? keeper.active_model ?? keeper.model ?? null
+  return keeperDisplayModel(keeper)?.value ?? null
 }
 
 /** Current runtime label for the header/rail. */

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -16,7 +16,7 @@ import {
   computeOverviewStats,
   computeOverviewDigest,
   buildOverviewTelemetrySnapshot,
-  keeperModelLabel,
+  keeperRuntimeLabel,
   OVERVIEW_TELEMETRY_BAR_COUNT,
   OVERVIEW_TELEMETRY_EVENTS_PER_BUCKET,
   OVERVIEW_TELEMETRY_EVENT_SAMPLE_LIMIT,
@@ -642,21 +642,25 @@ describe('computeOverviewStats', () => {
   })
 })
 
-describe('keeperModelLabel', () => {
-  it('prefers explicit model labels before runtime fallback is needed', () => {
-    expect(keeperModelLabel(makeKeeper({
+describe('keeperRuntimeLabel', () => {
+  it('uses the shared runtime display priority', () => {
+    expect(keeperRuntimeLabel(makeKeeper({
+      runtime_canonical: 'oas.primary',
+      selected_runtime_canonical: 'oas.secondary',
+      runtime_id: 'legacy.runtime',
+    }))).toBe('oas.primary')
+  })
+
+  it('does not expose raw keeper model fields as runtime labels', () => {
+    expect(keeperRuntimeLabel(makeKeeper({
       active_model_label: 'deepseek-v4-flash',
       active_model: 'claude-sonnet-4',
       model: 'fallback',
-    }))).toBe('deepseek-v4-flash')
+    }))).toBe('')
   })
 
-  it('normalizes claude-prefixed model names', () => {
-    expect(keeperModelLabel(makeKeeper({ active_model: 'claude-sonnet-4' }))).toBe('sonnet-4')
-  })
-
-  it('returns an empty string when no model field is present', () => {
-    expect(keeperModelLabel(makeKeeper({}))).toBe('')
+  it('returns an empty string when no runtime field is present', () => {
+    expect(keeperRuntimeLabel(makeKeeper({}))).toBe('')
   })
 })
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -13,7 +13,7 @@
 //   - KPI strip       — running / attention / context pressure / avg ctx / tasks / traces
 //   - Attention queue — keepers flagged for operator attention with reason + action
 //   - Telemetry bars  — deterministic 28-bar trace histogram
-//   - Keeper fleet    — full keeper grid with status, model, context meter
+//   - Keeper fleet    — full keeper grid with status, runtime, context meter
 
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
@@ -27,7 +27,7 @@ import type {
   DashboardMissionSessionCard,
 } from '../../types/dashboard-mission'
 import { useNowSecondsTicker } from '../../lib/now-signal'
-import { keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
+import { keeperDisplayRuntime, keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
 import { isKeeperPaused } from '../../lib/keeper-predicates'
 import { attentionReasonLabel, nextHumanActionLabel } from '../../lib/keeper-attention-labels'
 import { isAgentOffline } from '../../lib/agent-status'
@@ -148,14 +148,8 @@ function keeperTraceCount(keeper: Keeper): number {
   return keeper.total_turns ?? keeper.turn_count ?? keeper.autonomous_turn_count ?? 0
 }
 
-export function keeperModelLabel(keeper: Keeper): string {
-  const model = keeper.active_model_label
-    ?? keeper.active_model
-    ?? keeper.model
-    ?? keeper.primary_model
-    ?? keeper.last_model_used
-    ?? ''
-  return model.replace(/^claude-/, '')
+export function keeperRuntimeLabel(keeper: Keeper): string {
+  return keeperDisplayRuntime(keeper)?.value ?? ''
 }
 
 export function computeOverviewStats(keeperList: readonly Keeper[], taskList: readonly Task[]): OverviewStats {


### PR DESCRIPTION
## What changed

- Routes overview and keeper workspace runtime labels through `keeperDisplayRuntime`.
- Stops roster and rail surfaces from falling back to raw keeper `active_model` / `model` snapshot fields.
- Keeps typed runtime catalog `model_api_name` display intact when the catalog has an entry; otherwise the model cell renders as missing instead of inventing a model label from keeper state.

## Why

Follow-up to #23188. The prior slice added the shared runtime/capability display path; this PR removes older direct model fallbacks from adjacent dashboard roster surfaces so provider/model identity is exposed only through the intended display/catalog boundary.

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/overview/overview.test.ts src/components/agent-roster.test.ts src/components/keeper-workspace/keeper-workspace-shared.test.ts src/components/keeper-workspace/keeper-workspace-roster.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
