### PR TITLE
[codex] Reject invalid IDE cursor focus modes

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -266,9 +266,13 @@ let cursor_matches_file file_path json =
      | None -> false)
 ;;
 
-let valid_focus_mode = function
-  | "reading" | "editing" | "reviewing" | "planning" -> true
-  | _ -> false
+let cursor_focus_mode_of_string = function
+  | ("reading" | "editing" | "reviewing" | "planning") as mode -> Some mode
+  | _ -> None
+;;
+
+let valid_focus_mode mode =
+  Option.is_some (cursor_focus_mode_of_string mode)
 ;;
 
 let cursor_is_valid json =
@@ -729,13 +733,15 @@ let ingest_cursor_event
   let column = Option.value column ~default:0 in
   let focus_mode =
     match focus_mode with
-    | None -> Some "editing"
-    | Some mode when valid_focus_mode mode -> Some mode
-    | Some _ -> None
+    | None -> Ok "editing"
+    | Some mode ->
+      (match cursor_focus_mode_of_string mode with
+       | Some mode -> Ok mode
+       | None -> Error "Invalid focus_mode")
   in
   match focus_mode with
-  | None -> ()
-  | Some focus_mode ->
+  | Error msg -> Error msg
+  | Ok focus_mode ->
     let timestamp_ms = now_ms () in
     let json =
       cursor_event_json
@@ -750,11 +756,11 @@ let ingest_cursor_event
         ~turn_id:""
         ()
     in
-    (try append_cursor ~base_dir:base_path ~partition json
+    (try
+       append_cursor ~base_dir:base_path ~partition json;
+       Ok ()
      with exn ->
-       Printf.eprintf
-         "Ide_bridge.ingest_cursor_event error: %s\n%!"
-         (Printexc.to_string exn))
+       Error (Printf.sprintf "Failed to persist cursor event: %s" (Printexc.to_string exn)))
 ;;
 ;;
 

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -760,7 +760,10 @@ let ingest_cursor_event
        append_cursor ~base_dir:base_path ~partition json;
        Ok ()
      with exn ->
-       Error (Printf.sprintf "Failed to persist cursor event: %s" (Printexc.to_string exn)))
+       Printf.eprintf
+         "Ide_bridge.ingest_cursor_event error: %s\n%!"
+         (Printexc.to_string exn);
+       Error "Failed to persist cursor event")
 ;;
 ;;
 

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -31,6 +31,10 @@ val list_cursors :
   unit ->
   Yojson.Safe.t list
 
+val cursor_focus_mode_of_string : string -> string option
+(** Return the canonical cursor focus mode when [mode] is part of the IDE
+    cursor contract. *)
+
 (** Ingest a cursor event from an external source (e.g. editor or LSP).
     Unlike [ingest_cursor_event_from_hook], this does not require a tool hook
     context and uses the provided [source] label as the tool_name field. *)
@@ -45,7 +49,7 @@ val ingest_cursor_event :
   ?focus_mode:string ->
   source:string ->
   unit ->
-  unit
+  (unit, string) result
 (** Return latest valid cursor records, newest first. Cursor records are
     produced from tool hooks only when the hook input contains a non-empty
     file path and a positive line number. *)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -134,6 +134,18 @@ let json_int_field key = function
   | _ -> None
 ;;
 
+let cursor_focus_mode_field = function
+  | `Assoc fields ->
+    (match List.assoc_opt "focus_mode" fields with
+     | None -> Ok None
+     | Some (`String mode) ->
+       (match Ide_bridge.cursor_focus_mode_of_string mode with
+        | Some mode -> Ok (Some mode)
+        | None -> Error "focus_mode must be one of reading, editing, reviewing, planning")
+     | Some _ -> Error "focus_mode must be a string")
+  | _ -> Ok None
+;;
+
 let log_keeper_id_not_accepted ~operation ~auth_identity ~requested =
   Log.Server.warn
     "IDE annotation %s rejected client-supplied keeper_id: requested_keeper_id=%S \
@@ -757,51 +769,69 @@ let add_routes router =
              let find_int key = json_int_field key json in
              (match find_string "file_path", find_int "line" with
               | Some file_path, Some line when line >= 1 ->
-               let column = find_int "column" in
-               let source =
-                 match find_string "source" with
-                 | Some source -> source
-                 | None ->
-                   (* DET-OK: absent source preserves legacy cursor telemetry. *)
-                   "editor"
-               in
-               let requested_keeper_id = find_string "keeper_id" in
-               (match
-                  bind_mutation_keeper_id ~auth_identity ~requested:requested_keeper_id
-                with
-                | Error msg ->
-                  Option.iter
-                    (fun requested ->
-                       log_keeper_id_not_accepted
-                         ~operation:"cursor"
-                         ~auth_identity
-                         ~requested)
-                    requested_keeper_id;
-                  Http.Response.json_value
-                    ~status:`Forbidden
-                    ~request
-                    (json_error msg)
-                    reqd
-                | Ok keeper_id ->
-                  Ide_bridge.ingest_cursor_event
-                    ~base_path:base
-                    ~keeper_id
-                    ~file_path
-                    ~line
-                    ?column
-                    ~source
-                    ();
-                  Http.Response.json_value
-                    ~status:`Created
-                    ~request
-                    (json_ok (`Assoc [ "ok", `Bool true ]))
-                    reqd)
+                let column = find_int "column" in
+                let source =
+                  match find_string "source" with
+                  | Some source -> source
+                  | None ->
+                    (* DET-OK: absent source preserves legacy cursor telemetry. *)
+                    "editor"
+                in
+                (match cursor_focus_mode_field json with
+                 | Error msg ->
+                   Http.Response.json_value
+                     ~status:`Bad_request
+                     ~request
+                     (json_error msg)
+                     reqd
+                 | Ok focus_mode ->
+                   let requested_keeper_id = find_string "keeper_id" in
+                   (match
+                      bind_mutation_keeper_id ~auth_identity ~requested:requested_keeper_id
+                    with
+                    | Error msg ->
+                      Option.iter
+                        (fun requested ->
+                           log_keeper_id_not_accepted
+                             ~operation:"cursor"
+                             ~auth_identity
+                             ~requested)
+                        requested_keeper_id;
+                      Http.Response.json_value
+                        ~status:`Forbidden
+                        ~request
+                        (json_error msg)
+                        reqd
+                    | Ok keeper_id ->
+                      (match
+                         Ide_bridge.ingest_cursor_event
+                           ~base_path:base
+                           ~keeper_id
+                           ~file_path
+                           ~line
+                           ?column
+                           ?focus_mode
+                           ~source
+                           ()
+                       with
+                       | Ok () ->
+                         Http.Response.json_value
+                           ~status:`Created
+                           ~request
+                           (json_ok (`Assoc [ "ok", `Bool true ]))
+                           reqd
+                       | Error msg ->
+                         Http.Response.json_value
+                           ~status:`Internal_server_error
+                           ~request
+                           (json_error msg)
+                           reqd)))
               | _ ->
-               Http.Response.json_value
-                 ~status:`Bad_request
-                 ~request
-                 (json_error "Missing required fields: file_path, line (>=1)")
-                 reqd)))
+                Http.Response.json_value
+                  ~status:`Bad_request
+                  ~request
+                  (json_error "Missing required fields: file_path, line (>=1)")
+                  reqd)))
       request
       reqd)
   |> Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -770,14 +770,22 @@ let add_routes router =
              (match find_string "file_path", find_int "line" with
               | Some file_path, Some line when line >= 1 ->
                 let column = find_int "column" in
-                let source =
-                  match find_string "source" with
-                  | Some source -> source
-                  | None ->
-                    (* DET-OK: absent source preserves legacy cursor telemetry. *)
-                    "editor"
-                in
-                (match cursor_focus_mode_field json with
+                (match column with
+                 | Some value when value < 0 ->
+                   Http.Response.json_value
+                     ~status:`Bad_request
+                     ~request
+                     (json_error "column must be >= 0")
+                     reqd
+                 | _ ->
+                   let source =
+                     match find_string "source" with
+                     | Some source -> source
+                     | None ->
+                       (* DET-OK: absent source preserves legacy cursor telemetry. *)
+                       "editor"
+                   in
+                   (match cursor_focus_mode_field json with
                  | Error msg ->
                    Http.Response.json_value
                      ~status:`Bad_request
@@ -825,7 +833,7 @@ let add_routes router =
                            ~status:`Internal_server_error
                            ~request
                            (json_error msg)
-                           reqd)))
+                           reqd))))
               | _ ->
                 Http.Response.json_value
                   ~status:`Bad_request

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -238,6 +238,45 @@ let test_post_cursors_rejects_client_keeper_id () =
     check_status "POST cursor with keeper_id returns 403" 403 response)
 ;;
 
+let test_post_cursors_rejects_invalid_focus_mode () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "alice" in
+    let body = {|{"file_path":"lib/a.ml","line":1,"focus_mode":"hovering"}|} in
+    let request = http_request ~meth:`POST ~path:"/api/v1/ide/cursors" ~body ~token:(Some token) () in
+    let response = dispatch router request in
+    check_status "POST cursor with invalid focus_mode returns 400" 400 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    check
+      string
+      "invalid focus_mode error"
+      "focus_mode must be one of reading, editing, reviewing, planning"
+      (json_string_member "invalid focus_mode response" "error" json))
+;;
+
+let test_post_cursors_persists_valid_focus_mode () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "alice" in
+    let body = {|{"file_path":"lib/a.ml","line":7,"focus_mode":"reviewing"}|} in
+    let post_request =
+      http_request ~meth:`POST ~path:"/api/v1/ide/cursors" ~body ~token:(Some token) ()
+    in
+    let post_response = dispatch router post_request in
+    check_status "POST cursor with valid focus_mode returns 201" 201 post_response;
+    let get_request = http_request ~meth:`GET ~path:"/api/v1/ide/cursors" () in
+    let get_response = dispatch router get_request in
+    check_status "GET cursors after POST succeeds" 200 get_response;
+    let json = get_response |> response_body |> Yojson.Safe.from_string in
+    let data = Json.member "data" json in
+    match json_list_member "cursor snapshot" "cursors" data with
+    | cursor :: _ ->
+      check
+        string
+        "persisted focus_mode"
+        "reviewing"
+        (json_string_member "cursor" "focus_mode" cursor)
+    | [] -> fail "expected persisted cursor")
+;;
+
 let test_post_annotations_requires_auth () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let body = {|{"file_path":"lib/a.ml","line_start":1,"line_end":2,"content":"note"}|} in
@@ -367,6 +406,10 @@ let () =
             test_post_annotations_rejects_client_keeper_id
         ; test_case "POST cursor rejects client keeper_id" `Quick
             test_post_cursors_rejects_client_keeper_id
+        ; test_case "POST cursor rejects invalid focus_mode" `Quick
+            test_post_cursors_rejects_invalid_focus_mode
+        ; test_case "POST cursor persists valid focus_mode" `Quick
+            test_post_cursors_persists_valid_focus_mode
         ; test_case "POST annotation requires auth" `Quick
             test_post_annotations_requires_auth
         ; test_case "DELETE annotation requires auth" `Quick

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -253,6 +253,23 @@ let test_post_cursors_rejects_invalid_focus_mode () =
       (json_string_member "invalid focus_mode response" "error" json))
 ;;
 
+let test_post_cursors_rejects_negative_column () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "alice" in
+    let body = {|{"file_path":"lib/a.ml","line":7,"column":-1}|} in
+    let request =
+      http_request ~meth:`POST ~path:"/api/v1/ide/cursors" ~body ~token:(Some token) ()
+    in
+    let response = dispatch router request in
+    check_status "POST cursor with negative column returns 400" 400 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    check
+      string
+      "negative column error"
+      "column must be >= 0"
+      (json_string_member "negative column response" "error" json))
+;;
+
 let test_post_cursors_persists_valid_focus_mode () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "alice" in
@@ -408,6 +425,8 @@ let () =
             test_post_cursors_rejects_client_keeper_id
         ; test_case "POST cursor rejects invalid focus_mode" `Quick
             test_post_cursors_rejects_invalid_focus_mode
+        ; test_case "POST cursor rejects negative column" `Quick
+            test_post_cursors_rejects_negative_column
         ; test_case "POST cursor persists valid focus_mode" `Quick
             test_post_cursors_persists_valid_focus_mode
         ; test_case "POST annotation requires auth" `Quick


### PR DESCRIPTION
## Summary
- rejects invalid `focus_mode` values on `POST /api/v1/ide/cursors` with a 400 instead of silently succeeding
- exposes the cursor focus-mode contract from `Ide_bridge` so HTTP parsing uses the same allowed values as cursor storage
- returns a 500 if direct cursor persistence fails, rather than reporting a successful write
- adds focused HTTP tests for invalid and valid cursor focus modes

## Why
The IDE Observation Plane remaining-goals report flagged direct cursor ingestion as a P0 silent-failure path. Before this change, a bad `focus_mode` could be accepted by the HTTP route and then dropped in the bridge without a visible API failure.

## Validation
- `git diff --check HEAD~1..HEAD`
- `ocamlformat --check lib/ide/ide_bridge.ml lib/ide/ide_bridge.mli lib/server/server_ide_http.ml test/test_server_ide_http.ml`

Local focused Dune test was not run because another parallel slice held `/tmp/me-dune-local.lock`; per operator direction, Dune build/test authority is CI and I did not wait on CI.