### PR TITLE
fix(runtime): fail closed on degraded default gaps

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -565,10 +565,16 @@ let degrade_loaded_for_missing_catalog
          "%s: all configured runtime models are absent from the OAS capability \
           catalog; cannot degrade without dispatching through provider_default"
          report.config_path)
-  | effective_default :: _ ->
-    let effective_default =
-      if is_missing configured_default.id then effective_default else configured_default
-    in
+  | _ when is_missing configured_default.id ->
+    Error
+      (Printf.sprintf
+         "%s: [runtime].default = %S is absent from the OAS capability catalog; \
+          cannot degrade without silently routing unassigned keepers to a \
+          different default runtime"
+         report.config_path
+         configured_default.id)
+  | _ ->
+    let effective_default = configured_default in
     let disabled_runtime_ids =
       report.missing_models
       |> List.map (fun (missing : missing_catalog_model) -> missing.runtime_id)

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -150,9 +150,11 @@ val init_default_strict_report :
 val init_default_degraded_report :
   config_path:string -> (init_default_outcome, strict_init_error) result
 (** Server bootstrap entry point. Applies the strict OAS catalog gate, but when
-    only the catalog-membership gate fails it can remove uncatalogued runtimes
-    from the active runtime set and continue in an operator-visible degraded
-    mode. Routing/parse errors and all-missing runtime sets remain fatal. *)
+    only non-default catalog-membership routes fail it can remove uncatalogued
+    runtimes from the active runtime set and continue in an operator-visible
+    degraded mode. Routing/parse errors, all-missing runtime sets, and an
+    uncatalogued [\[runtime\].default] remain fatal because server boot must not
+    invent a replacement default runtime. *)
 
 module For_testing : sig
   type snapshot

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1388,7 +1388,7 @@ let test_server_degraded_init_disables_uncatalogued_runtimes () =
      [ollama.missing]\n\
      \n\
      [runtime]\n\
-     default = \"ollama.missing\"\n\
+     default = \"ollama.good\"\n\
      librarian = \"ollama.missing\"\n\
      media_failover = [\"ollama.missing\", \"ollama.good\"]\n\
      \n\
@@ -1413,7 +1413,7 @@ let test_server_degraded_init_disables_uncatalogued_runtimes () =
        | Ok Runtime.Initialized -> fail "expected degraded startup outcome"
        | Ok (Runtime.Initialized_degraded degradation) ->
          check string "configured default"
-           "ollama.missing"
+           "ollama.good"
            degradation.configured_default_runtime_id;
          check string "effective default"
            "ollama.good"
@@ -1449,6 +1449,56 @@ let test_server_degraded_init_disables_uncatalogued_runtimes () =
            (String_util.contains_substring rendered "\"status\":\"degraded\"");
          check bool "json names disabled runtime" true
            (String_util.contains_substring rendered "ollama.missing"))
+
+let test_server_degraded_init_rejects_uncatalogued_default () =
+  let catalog =
+    "[[models]]\n\
+     id_prefix = \"good\"\n\
+     base = \"ollama\"\n\
+     max_context_tokens = 1024\n"
+  in
+  let runtime_toml =
+    "[providers.ollama]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.missing]\n\
+     api-name = \"missing-from-oas-catalog\"\n\
+     max-context = 1024\n\
+     \n\
+     [ollama.good]\n\
+     \n\
+     [ollama.missing]\n\
+     \n\
+     [runtime]\n\
+     default = \"ollama.missing\"\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content catalog @@ fun () ->
+       with_temp_runtime_toml runtime_toml @@ fun path ->
+       match Runtime.init_default_degraded_report ~config_path:path with
+       | Ok Runtime.Initialized -> fail "expected missing default catalog row"
+       | Ok (Runtime.Initialized_degraded _) ->
+         fail "missing configured default must not pick another effective default"
+       | Error (Runtime.Missing_catalog_models report) ->
+         failf
+           "expected default-specific config error, got missing catalog report: %s"
+           (Runtime.strict_init_error_to_string
+              (Runtime.Missing_catalog_models report))
+       | Error (Runtime.Runtime_config_error msg) ->
+         check bool "error names runtime default" true
+           (String_util.contains_substring msg "[runtime].default");
+         check bool "error names missing default runtime" true
+           (String_util.contains_substring msg "ollama.missing");
+         check bool "error rejects alternate default routing" true
+           (String_util.contains_substring msg "different default runtime"))
 
 let test_runtime_toml_max_concurrent_flows_to_candidate () =
   with_fake_runtime_model_catalog @@ fun () ->
@@ -1832,6 +1882,9 @@ let () =
           test_case
             "server degraded init disables uncatalogued runtimes"
             `Quick test_server_degraded_init_disables_uncatalogued_runtimes;
+          test_case
+            "server degraded init rejects uncatalogued default"
+            `Quick test_server_degraded_init_rejects_uncatalogued_default;
           test_case
             "runtime assignment rejects commented disabled binding"
             `Quick test_runtime_assignment_rejects_commented_disabled_binding;


### PR DESCRIPTION
## Summary

- fail closed when degraded runtime boot finds `[runtime].default` absent from the OAS capability catalog
- keep degraded boot for non-default catalog gaps by disabling those assignments/routes while preserving the configured default
- add focused regression coverage for both allowed non-default degradation and rejected default degradation

## Why

Post-merge review of #23192 found that `degrade_loaded_for_missing_catalog` selected the first remaining catalog-known runtime as the new effective default when the configured default was uncatalogued. That is deterministic, but it still invents a replacement default and routes unassigned keepers through a runtime the operator did not choose. This violates the existing runtime default invariant and the no-silent-fallback review rule.

## Validation

- `opam exec -- ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli test/test_runtime_config_validity.ml`
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlc -stop-after parsing lib/runtime/runtime.ml`
- `opam exec -- ocamlc -stop-after parsing lib/runtime/runtime.mli`
- `opam exec -- ocamlc -stop-after parsing test/test_runtime_config_validity.ml`

No local Dune build/test run; CI remains the build authority.

