### PR TITLE
[codex] Guard connector registry access

### DIFF
--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -25,15 +25,26 @@ module type S = sig
   val connected : unit -> bool
 end
 
+(* Module-level registry: [register] runs during startup while [find]/[all]
+   are also reachable from HTTP handlers and tests. Use Stdlib.Mutex because
+   callers do not always have an Eio context, and keep the critical sections
+   limited to Hashtbl access. *)
 let registry : (string, (module S)) Hashtbl.t = Hashtbl.create 4
+let registry_mu = Stdlib.Mutex.create ()
+
+let with_registry_lock f = Stdlib.Mutex.protect registry_mu f
 
 let register (module C : S) =
-  Hashtbl.replace registry C.connector_id (module C : S)
+  let connector_id = C.connector_id in
+  let connector = (module C : S) in
+  with_registry_lock (fun () -> Hashtbl.replace registry connector_id connector)
 
-let find name = Hashtbl.find_opt registry name
+let find name =
+  with_registry_lock (fun () -> Hashtbl.find_opt registry name)
 
 let all () =
-  Hashtbl.fold (fun _k v acc -> v :: acc) registry []
+  with_registry_lock (fun () ->
+    Hashtbl.fold (fun _k v acc -> v :: acc) registry [])
 
 let connectors_json ?gate_status_json ?(audit_limit = 10) () =
   let connectors = all () in

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -64,13 +64,15 @@ end
 
 val register : (module S) -> unit
 (** Register a connector.  Replaces any existing connector with the
-    same [connector_id].  Call at server startup. *)
+    same [connector_id].  Call at server startup.
+    Registry mutation is serialized internally. *)
 
 val find : string -> (module S) option
-(** [find name] returns the connector registered under [name], if any. *)
+(** [find name] returns the connector registered under [name], if any.
+    Registry lookup is serialized internally. *)
 
 val all : unit -> (module S) list
-(** All registered connectors, in unspecified order. *)
+(** Snapshot of all registered connectors, in unspecified order. *)
 
 val connectors_json : ?gate_status_json:Yojson.Safe.t -> ?audit_limit:int -> unit -> Yojson.Safe.t
 (** Aggregate descriptor for all registered connectors.

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -4,6 +4,41 @@ module Discord_state = Channel_gate_discord_state
 module Discord_names = Channel_gate_discord_names
 module U = Yojson.Safe.Util
 
+module Registry_test_connector_a = struct
+  let connector_id = "registry-test-connector"
+  let display_name = "Registry Test A"
+  let channel = "registry-test"
+  let status_json ?(audit_limit = 10) () = ignore audit_limit; `Assoc []
+  let connector_json ?gate_status_json ?(audit_limit = 10) () =
+    ignore gate_status_json;
+    ignore audit_limit;
+    `Assoc
+      [ "connector_id", `String connector_id
+      ; "display_name", `String display_name
+      ]
+  let bind ~channel_id:_ ~keeper_name:_ ~actor_name:_ =
+    Ok (`Assoc [ "variant", `String "a" ])
+  let unbind ~channel_id:_ ~actor_name:_ =
+    Ok (`Assoc [ "variant", `String "a" ])
+  let bound_channels ~keeper_name:_ = []
+  let connected () = false
+end
+
+module Registry_test_connector_b = struct
+  include Registry_test_connector_a
+
+  let display_name = "Registry Test B"
+  let connector_json ?gate_status_json ?(audit_limit = 10) () =
+    ignore gate_status_json;
+    ignore audit_limit;
+    `Assoc
+      [ "connector_id", `String connector_id
+      ; "display_name", `String display_name
+      ]
+  let bind ~channel_id:_ ~keeper_name:_ ~actor_name:_ =
+    Ok (`Assoc [ "variant", `String "b" ])
+end
+
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with
@@ -205,6 +240,28 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "observed_channel" |> U.member "channel"
        |> U.to_string))
 
+let test_registry_register_replaces_and_all_snapshots () =
+  Channel_gate_connector.register (module Registry_test_connector_a);
+  (match Channel_gate_connector.find Registry_test_connector_a.connector_id with
+   | None -> fail "expected initial registry test connector"
+   | Some (module C : Channel_gate_connector.S) ->
+     check string "initial connector" "Registry Test A" C.display_name);
+  Channel_gate_connector.register (module Registry_test_connector_b);
+  (match Channel_gate_connector.find Registry_test_connector_a.connector_id with
+   | None -> fail "expected replacement registry test connector"
+   | Some (module C : Channel_gate_connector.S) ->
+     check string "replacement connector" "Registry Test B" C.display_name);
+  let registered =
+    Channel_gate_connector.all ()
+    |> List.filter (fun (module C : Channel_gate_connector.S) ->
+      String.equal C.connector_id Registry_test_connector_a.connector_id)
+  in
+  check int "single connector id after replace" 1 (List.length registered);
+  match registered with
+  | [ (module C : Channel_gate_connector.S) ] ->
+    check string "snapshot sees replacement" "Registry Test B" C.display_name
+  | _ -> fail "unexpected registry snapshot"
+
 let test_name_map_round_trip () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
@@ -394,6 +451,8 @@ let () =
             test_unbind_removes_existing_binding;
           test_case "connectors json advertises connector descriptor" `Quick
             test_connectors_json_advertises_gate_connector_descriptor;
+          test_case "registry register replaces and all snapshots" `Quick
+            test_registry_register_replaces_and_all_snapshots;
         ] );
       ( "name_map",
         [


### PR DESCRIPTION
## Summary
- serializes `Channel_gate_connector` registry `register`, `find`, and `all` access with `Stdlib.Mutex`
- keeps critical sections limited to the process-global `Hashtbl` operations
- returns `all ()` as a protected snapshot so connector callbacks still run outside the registry lock
- documents the internal serialization in the interface

## Why
The IDE Observation Plane blast-radius audit identified the connector registry as a cross-axis race risk. OCaml `Hashtbl` access is mutable in-place state, so concurrent readers/writers need explicit synchronization.

## Validation
- `git diff --check HEAD~1..HEAD`
- `ocamlformat --check lib/gate/channel_gate_connector.ml lib/gate/channel_gate_connector.mli`

A parallel agent attempted a focused Dune test, but it was blocked by `/tmp/me-dune-local.lock`. Per operator direction, Dune build/test is left to CI and I did not wait on CI.