### PR TITLE
[codex] Preserve soft-forbidden HITL gate

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -397,7 +397,6 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
     in
     let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
     let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
-    let hitl_disabled = Env_config_core.disable_hitl () in
     if hard_forbidden
     then (
       Log.Governance.debug
@@ -408,13 +407,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         (risk_level_to_string risk);
       reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta ())
     else (
-      let auto_approval_forbidden = (not hitl_disabled) && soft_forbidden in
-      if hitl_disabled && soft_forbidden
-      then
-        Log.Governance.warn
-          "[%s] HITL bypass: soft_forbidden tool=%s allowed via disable_hitl"
-          keeper_name
-          tool_name;
+      let auto_approval_forbidden = soft_forbidden in
       let requires_operator_approval = needs_approval || auto_approval_forbidden in
       if trifecta_active
       then

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1761,7 +1761,7 @@ let test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing () =
         initial_pending
         (AQ.pending_count ()))
 
-let test_callback_hitl_disabled_soft_forbidden_auto_approved () =
+let test_callback_hitl_disabled_soft_forbidden_requires_approval () =
   with_env "MASC_DISABLE_HITL" "true" @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1804,21 +1804,21 @@ let test_callback_hitl_disabled_soft_forbidden_auto_approved () =
       in
       yield_until (fun () -> Option.is_some !result);
       Alcotest.(check bool)
-        "soft destructive op does not queue when HITL threshold is disabled"
-        false
+        "soft destructive op still queues when HITL threshold is disabled"
+        true
         queued;
       Alcotest.(check int)
-        "pending count unchanged"
+        "pending count restored after operator resolution"
         initial_pending
         (AQ.pending_count ());
       match !result with
       | Some Agent_sdk.Hooks.Approve -> ()
       | Some Agent_sdk.Hooks.Reject reason ->
-        Alcotest.fail ("expected Approve for HITL-disabled soft match, got reject: " ^ reason)
+        Alcotest.fail ("expected operator-approved soft match, got reject: " ^ reason)
       | Some Agent_sdk.Hooks.Edit _ ->
-        Alcotest.fail "expected Approve for HITL-disabled soft match, got edit"
+        Alcotest.fail "expected operator-approved soft match, got edit"
       | None ->
-        Alcotest.fail "HITL-disabled soft-forbidden callback did not return")
+        Alcotest.fail "HITL-disabled soft-forbidden callback did not return after approval")
 
 let test_read_recent_audit_filters_after_wide_scan () =
   with_temp_masc_base @@ fun base_path ->
@@ -2039,7 +2039,7 @@ let () =
         test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing;
       Alcotest.test_case "HITL enabled hard-forbidden rejects without queuing" `Quick
         test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing;
-      Alcotest.test_case "HITL disabled allows soft forbidden tools" `Quick
-        test_callback_hitl_disabled_soft_forbidden_auto_approved;
+      Alcotest.test_case "HITL disabled still queues soft forbidden tools" `Quick
+        test_callback_hitl_disabled_soft_forbidden_requires_approval;
     ]);
   ]


### PR DESCRIPTION
## Summary
- keeps soft-forbidden tools behind operator approval even when `MASC_DISABLE_HITL=true`
- preserves hard-forbidden immediate rejection precedence
- updates the HITL-disabled regression to queue a soft-forbidden request and resume after operator approval

## Why
The IDE Observation Plane cross-axis audit flagged a HITL bypass: `disable_hitl` could allow soft-forbidden tools that should still require explicit operator approval. This keeps `hard_forbidden > soft_forbidden > disable_hitl` as the effective precedence.

## Validation
- `scripts/dune-local.sh exec ./test/test_hitl_approval.exe` -> `Test Successful in 0.472s. 47 tests run.`
- `git diff --check HEAD~1..HEAD`
- `ocamlformat --check lib/governance_pipeline.ml test/test_hitl_approval.ml`