### PR TITLE
[codex] Scope IDE memory panel by repository

### DIFF
--- a/dashboard/src/components/ide/ide-memory-panel.test.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.test.ts
@@ -53,4 +53,17 @@ describe('IdeMemoryPanel', () => {
     expect(container.textContent).toContain('semantic:not configured')
     expect(container.textContent).toContain('retrieval:annotation index')
   })
+
+  it('includes keeper and repository scope when fetching memory', async () => {
+    render(h(IdeMemoryPanel, { keeperName: 'sangsu', repoId: 'masc' }), container)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalled()
+    })
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!
+    expect(String(url)).toContain('/api/v1/ide/memory?')
+    expect(String(url)).toContain('keeper_id=sangsu')
+    expect(String(url)).toContain('repo_id=masc')
+    expect(String(url)).toContain('limit=50')
+  })
 })

--- a/dashboard/src/components/ide/ide-memory-panel.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.ts
@@ -34,6 +34,7 @@ interface MemoryResponse {
 
 interface IdeMemoryPanelProps {
   readonly keeperName?: string | null
+  readonly repoId?: string | null
 }
 
 const KIND_COLORS: Record<string, string> = {
@@ -139,7 +140,7 @@ function buildLensGraph(entries: ReadonlyArray<MemoryEntry>): {
   return { nodes, edges, start: entries[0]!.id }
 }
 
-export function IdeMemoryPanel({ keeperName }: IdeMemoryPanelProps) {
+export function IdeMemoryPanel({ keeperName, repoId }: IdeMemoryPanelProps) {
   const [entries, setEntries] = useState<ReadonlyArray<MemoryEntry>>([])
   const [total, setTotal] = useState(0)
   const [contract, setContract] = useState<MemoryContract | null>(null)
@@ -152,6 +153,7 @@ export function IdeMemoryPanel({ keeperName }: IdeMemoryPanelProps) {
     try {
       const params = new URLSearchParams()
       if (keeperName) params.set('keeper_id', keeperName)
+      if (repoId) params.set('repo_id', repoId)
       params.set('limit', '50')
       const res = await fetch(`/api/v1/ide/memory?${params}`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -164,7 +166,7 @@ export function IdeMemoryPanel({ keeperName }: IdeMemoryPanelProps) {
     } finally {
       setLoading(false)
     }
-  }, [keeperName])
+  }, [keeperName, repoId])
 
   useEffect(() => {
     fetchMemory()

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1172,7 +1172,7 @@ export function IdeShell() {
                   >
                     <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
                     <${IdePersistencePanel} keeperName=${terminalKeeper} />
-                    <${IdeMemoryPanel} keeperName=${terminalKeeper} />
+                    <${IdeMemoryPanel} keeperName=${terminalKeeper} repoId=${activeRepositoryId} />
                   </div>
                   <div
                     class="ide-plane-primary-rail"


### PR DESCRIPTION
## Summary
- threads the active IDE repository id into `IdeMemoryPanel`
- includes `repo_id` when fetching `/api/v1/ide/memory`
- adds a focused panel test that the request carries keeper, repository, and limit scope

## Why
The backend memory endpoint is partition-aware, but the right-rail memory panel only sent `keeper_id`. That meant the UI could keep reading the legacy/default memory partition even while the rest of the IDE shell was repository-scoped.

## Validation
- `git diff --check HEAD~1..HEAD`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/components/ide/ide-memory-panel.test.ts --no-file-parallelism --maxWorkers=1` -> 1 file / 2 tests passed

Per operator direction, Dune build/test is left to CI and I did not wait on CI.