### PR TITLE
fix(runtime): block degraded fallback for explicit routes

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -532,6 +532,56 @@ let runtime_missing_from_report (report : missing_catalog_report) runtime_id =
     report.missing_models
 ;;
 
+let dropped_assignment_label (entry : dropped_runtime_assignment) =
+  Printf.sprintf "[runtime.assignments].%s=%S" entry.keeper_name entry.runtime_id
+;;
+
+let dropped_route_label (entry : dropped_runtime_route) =
+  Printf.sprintf "%s=%S" entry.route_name entry.runtime_id
+;;
+
+let dropped_lane_label (prefix : string) (entry : dropped_runtime_lane) =
+  Printf.sprintf
+    "%s.%s=[%s]"
+    prefix
+    entry.lane_id
+    (String.concat ", " (List.map (Printf.sprintf "%S") entry.runtime_ids))
+;;
+
+let missing_reference_error
+    ~(config_path : string)
+    ~(dropped_assignments : dropped_runtime_assignment list)
+    ~(dropped_routes : dropped_runtime_route list)
+    ~(dropped_media_failover : string list)
+    ~(dropped_lane_candidates : dropped_runtime_lane list)
+    ~(dropped_lanes : dropped_runtime_lane list)
+  =
+  let references =
+    List.concat
+      [ List.map dropped_assignment_label dropped_assignments
+      ; List.map dropped_route_label dropped_routes
+      ; (match dropped_media_failover with
+         | [] -> []
+         | runtime_ids ->
+           [ Printf.sprintf
+               "[runtime].media_failover=[%s]"
+               (String.concat ", " (List.map (Printf.sprintf "%S") runtime_ids))
+           ])
+      ; List.map
+          (dropped_lane_label "[runtime.lanes].candidates")
+          dropped_lane_candidates
+      ; List.map (dropped_lane_label "[runtime.lanes].dropped") dropped_lanes
+      ]
+  in
+  Printf.sprintf
+    "%s: cannot use degraded runtime boot because catalog-missing runtime ids \
+     are referenced by routing config: %s. Add catalog rows to oas-models.toml \
+     or remove those routing references; MASC will not erase explicit runtime \
+     intent into default fallback."
+    config_path
+    (String.concat "; " references)
+;;
+
 let degrade_loaded_for_missing_catalog
     ( (runtimes, configured_default, assignments, librarian_id, structured_judge_id,
        cross_verifier_id, media_failover, lanes) :
@@ -558,6 +608,94 @@ let degrade_loaded_for_missing_catalog
   =
   let is_missing = runtime_missing_from_report report in
   let active_runtimes = List.filter (fun (rt : t) -> not (is_missing rt.id)) runtimes in
+  let disabled_runtime_ids =
+    report.missing_models
+    |> List.map (fun (missing : missing_catalog_model) -> missing.runtime_id)
+    |> List.sort_uniq String.compare
+  in
+  let kept_assignments, dropped_assignments =
+    List.fold_right
+      (fun (keeper_name, runtime_id) (kept, dropped) ->
+         if is_missing runtime_id
+         then kept, { keeper_name; runtime_id } :: dropped
+         else (keeper_name, runtime_id) :: kept, dropped)
+      assignments
+      ([], [])
+  in
+  let default_drop =
+    if is_missing configured_default.id
+    then Some { route_name = "[runtime].default"; runtime_id = configured_default.id }
+    else None
+  in
+  let drop_route route_name = function
+    | None -> None, None
+    | Some runtime_id when is_missing runtime_id -> None, Some { route_name; runtime_id }
+    | Some _ as value -> value, None
+  in
+  let librarian_id, librarian_drop = drop_route "[runtime].librarian" librarian_id in
+  let structured_judge_id, structured_judge_drop =
+    drop_route "[runtime].structured_judge" structured_judge_id
+  in
+  let cross_verifier_id, cross_verifier_drop =
+    drop_route "[runtime].cross_verifier" cross_verifier_id
+  in
+  let dropped_routes =
+    [ default_drop; librarian_drop; structured_judge_drop; cross_verifier_drop ]
+    |> List.filter_map Fun.id
+  in
+  let kept_media_failover, dropped_media_failover =
+    List.fold_right
+      (fun runtime_id (kept, dropped) ->
+         if is_missing runtime_id
+         then kept, runtime_id :: dropped
+         else runtime_id :: kept, dropped)
+      media_failover
+      ([], [])
+  in
+  let kept_lanes, dropped_lane_candidates, dropped_lanes =
+    List.fold_right
+      (fun (lane : Runtime_lane.t) (kept, dropped_candidates, dropped_lanes) ->
+         let kept_candidates, dropped_candidates_for_lane =
+           List.fold_right
+             (fun runtime_id (kept_ids, dropped_ids) ->
+                if is_missing runtime_id
+                then kept_ids, runtime_id :: dropped_ids
+                else runtime_id :: kept_ids, dropped_ids)
+             (Runtime_lane.ordered_candidates lane)
+             ([], [])
+         in
+         let dropped_candidates =
+           match dropped_candidates_for_lane with
+           | [] -> dropped_candidates
+           | runtime_ids ->
+             { lane_id = Runtime_lane.id lane; runtime_ids } :: dropped_candidates
+         in
+         match kept_candidates with
+         | [] ->
+           ( kept
+           , dropped_candidates
+           , { lane_id = Runtime_lane.id lane
+             ; runtime_ids = Runtime_lane.ordered_candidates lane
+             }
+             :: dropped_lanes )
+         | _ ->
+           ( Runtime_lane.make
+               ~id:(Runtime_lane.id lane)
+               ~strategy:(Runtime_lane.strategy lane)
+               kept_candidates
+             :: kept
+           , dropped_candidates
+           , dropped_lanes ))
+      lanes
+      ([], [], [])
+  in
+  let has_routing_references =
+    (not (List.is_empty dropped_assignments))
+    || (not (List.is_empty dropped_routes))
+    || (not (List.is_empty dropped_media_failover))
+    || (not (List.is_empty dropped_lane_candidates))
+    || not (List.is_empty dropped_lanes)
+  in
   match active_runtimes with
   | [] ->
     Error
@@ -565,97 +703,20 @@ let degrade_loaded_for_missing_catalog
          "%s: all configured runtime models are absent from the OAS capability \
           catalog; cannot degrade without dispatching through provider_default"
          report.config_path)
-  | _ when is_missing configured_default.id ->
+  | _ when has_routing_references ->
     Error
-      (Printf.sprintf
-         "%s: [runtime].default = %S is absent from the OAS capability catalog; \
-          cannot degrade without silently routing unassigned keepers to a \
-          different default runtime"
-         report.config_path
-         configured_default.id)
+      (missing_reference_error
+         ~config_path:report.config_path
+         ~dropped_assignments
+         ~dropped_routes
+         ~dropped_media_failover
+         ~dropped_lane_candidates
+         ~dropped_lanes)
   | _ ->
-    let effective_default = configured_default in
-    let disabled_runtime_ids =
-      report.missing_models
-      |> List.map (fun (missing : missing_catalog_model) -> missing.runtime_id)
-      |> List.sort_uniq String.compare
-    in
-    let kept_assignments, dropped_assignments =
-      List.fold_right
-        (fun (keeper_name, runtime_id) (kept, dropped) ->
-           if is_missing runtime_id
-           then kept, { keeper_name; runtime_id } :: dropped
-           else (keeper_name, runtime_id) :: kept, dropped)
-        assignments
-        ([], [])
-    in
-    let drop_route route_name = function
-      | None -> None, None
-      | Some runtime_id when is_missing runtime_id ->
-        None, Some { route_name; runtime_id }
-      | Some _ as value -> value, None
-    in
-    let librarian_id, librarian_drop = drop_route "runtime.librarian" librarian_id in
-    let structured_judge_id, structured_judge_drop =
-      drop_route "runtime.structured_judge" structured_judge_id
-    in
-    let cross_verifier_id, cross_verifier_drop =
-      drop_route "runtime.cross_verifier" cross_verifier_id
-    in
-    let dropped_routes =
-      [ librarian_drop; structured_judge_drop; cross_verifier_drop ]
-      |> List.filter_map Fun.id
-    in
-    let kept_media_failover, dropped_media_failover =
-      List.fold_right
-        (fun runtime_id (kept, dropped) ->
-           if is_missing runtime_id
-           then kept, runtime_id :: dropped
-           else runtime_id :: kept, dropped)
-        media_failover
-        ([], [])
-    in
-    let kept_lanes, dropped_lane_candidates, dropped_lanes =
-      List.fold_right
-        (fun (lane : Runtime_lane.t) (kept, dropped_candidates, dropped_lanes) ->
-           let kept_candidates, dropped_candidates_for_lane =
-             List.fold_right
-               (fun runtime_id (kept_ids, dropped_ids) ->
-                  if is_missing runtime_id
-                  then kept_ids, runtime_id :: dropped_ids
-                  else runtime_id :: kept_ids, dropped_ids)
-               (Runtime_lane.ordered_candidates lane)
-               ([], [])
-           in
-           let dropped_candidates =
-             match dropped_candidates_for_lane with
-             | [] -> dropped_candidates
-             | runtime_ids ->
-               { lane_id = Runtime_lane.id lane; runtime_ids } :: dropped_candidates
-           in
-           match kept_candidates with
-           | [] ->
-             ( kept
-             , dropped_candidates
-             , { lane_id = Runtime_lane.id lane
-               ; runtime_ids = Runtime_lane.ordered_candidates lane
-               }
-               :: dropped_lanes )
-           | _ ->
-             ( Runtime_lane.make
-                 ~id:(Runtime_lane.id lane)
-                 ~strategy:(Runtime_lane.strategy lane)
-                 kept_candidates
-               :: kept
-             , dropped_candidates
-             , dropped_lanes ))
-        lanes
-        ([], [], [])
-    in
     let degradation =
       { report
       ; configured_default_runtime_id = configured_default.id
-      ; effective_default_runtime_id = effective_default.id
+      ; effective_default_runtime_id = configured_default.id
       ; disabled_runtime_ids
       ; dropped_assignments
       ; dropped_routes
@@ -666,7 +727,7 @@ let degrade_loaded_for_missing_catalog
     in
     Ok
       ( ( active_runtimes
-        , effective_default
+        , configured_default
         , kept_assignments
         , librarian_id
         , structured_judge_id

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -83,7 +83,8 @@ type startup_degradation =
 (** Operator-visible startup degradation. Missing-catalog runtime bindings are
     removed from the active runtime set so requests never dispatch through OAS
     [provider_default]. The server may continue only when at least one
-    catalog-known runtime remains. *)
+    catalog-known runtime remains and no routing config references a disabled
+    runtime id. *)
 
 type init_default_outcome =
   | Initialized
@@ -150,11 +151,11 @@ val init_default_strict_report :
 val init_default_degraded_report :
   config_path:string -> (init_default_outcome, strict_init_error) result
 (** Server bootstrap entry point. Applies the strict OAS catalog gate, but when
-    only non-default catalog-membership routes fail it can remove uncatalogued
+    only unreferenced catalog-membership rows fail it can remove uncatalogued
     runtimes from the active runtime set and continue in an operator-visible
-    degraded mode. Routing/parse errors, all-missing runtime sets, and an
-    uncatalogued [\[runtime\].default] remain fatal because server boot must not
-    invent a replacement default runtime. *)
+    degraded mode. Routing/parse errors, all-missing runtime sets, and explicit
+    routing references to uncatalogued runtimes remain fatal so configured intent
+    is never erased into default fallback. *)
 
 module For_testing : sig
   type snapshot

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1363,7 +1363,7 @@ let test_runtime_capability_gate_reports_missing_catalog_models () =
                  (Runtime.Missing_catalog_models report))
               "provider_label=openai_compat"))
 
-let test_server_degraded_init_disables_uncatalogued_runtimes () =
+let test_server_degraded_init_rejects_referenced_uncatalogued_runtimes () =
   let catalog =
     "[[models]]\n\
      id_prefix = \"good\"\n\
@@ -1406,9 +1406,66 @@ let test_server_degraded_init_disables_uncatalogued_runtimes () =
        with_model_catalog_content catalog @@ fun () ->
        with_temp_runtime_toml runtime_toml @@ fun path ->
        match Runtime.init_default_degraded_report ~config_path:path with
+       | Ok Runtime.Initialized -> fail "expected referenced missing runtime to fail"
+       | Ok (Runtime.Initialized_degraded _) ->
+         fail "referenced missing runtime must not degrade into fallback routing"
+       | Error (Runtime.Missing_catalog_models report) ->
+         failf
+           "expected routing-reference config error, got missing catalog report: %s"
+           (Runtime.strict_init_error_to_string (Runtime.Missing_catalog_models report))
+       | Error (Runtime.Runtime_config_error msg) ->
+         check bool "diagnostic names default route" true
+           (String_util.contains_substring msg "[runtime].default");
+         check bool "diagnostic names keeper assignment" true
+           (String_util.contains_substring msg "[runtime.assignments].keeper_a");
+         check bool "diagnostic rejects fallback erasure" true
+           (String_util.contains_substring msg "default fallback"))
+
+let test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes () =
+  let catalog =
+    "[[models]]\n\
+     id_prefix = \"good\"\n\
+     base = \"ollama\"\n\
+     max_context_tokens = 1024\n"
+  in
+  let runtime_toml =
+    "[providers.ollama]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.missing]\n\
+     api-name = \"missing-from-oas-catalog\"\n\
+     max-context = 1024\n\
+     \n\
+     [ollama.good]\n\
+     \n\
+     [ollama.missing]\n\
+     \n\
+     [runtime]\n\
+     default = \"ollama.good\"\n\
+     librarian = \"ollama.good\"\n\
+     media_failover = [\"ollama.good\"]\n\
+     \n\
+     [runtime.assignments]\n\
+     keeper_b = \"ollama.good\"\n\
+     \n\
+     [runtime.lanes.safe]\n\
+     candidates = [\"ollama.good\"]\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content catalog @@ fun () ->
+       with_temp_runtime_toml runtime_toml @@ fun path ->
+       match Runtime.init_default_degraded_report ~config_path:path with
        | Error err ->
          failf
-           "server degraded init should keep a catalog-known runtime alive: %s"
+           "server degraded init should disable only unreferenced catalog gaps: %s"
            (Runtime.strict_init_error_to_string err)
        | Ok Runtime.Initialized -> fail "expected degraded startup outcome"
        | Ok (Runtime.Initialized_degraded degradation) ->
@@ -1421,14 +1478,16 @@ let test_server_degraded_init_disables_uncatalogued_runtimes () =
          check (list string) "active runtime ids"
            [ "ollama.good" ]
            (Runtime.get_runtime_ids ());
-         check (option string) "dropped assignment falls back to default"
-           None
-           (Runtime.runtime_id_for_keeper "keeper_a");
+         check (list string) "no dropped assignment"
+           []
+           (List.map
+              (fun (entry : Runtime.dropped_runtime_assignment) -> entry.keeper_name)
+              degradation.dropped_assignments);
          check (option string) "catalog-known assignment preserved"
            (Some "ollama.good")
            (Runtime.runtime_id_for_keeper "keeper_b");
-         check (option string) "librarian route dropped"
-           None
+         check (option string) "librarian route preserved"
+           (Some "ollama.good")
            (Runtime.librarian_runtime_id ());
          check (list string) "media failover keeps known ids only"
            [ "ollama.good" ]
@@ -1880,8 +1939,11 @@ let () =
             "runtime capability gate reports missing catalog models"
             `Quick test_runtime_capability_gate_reports_missing_catalog_models;
           test_case
-            "server degraded init disables uncatalogued runtimes"
-            `Quick test_server_degraded_init_disables_uncatalogued_runtimes;
+            "server degraded init rejects referenced uncatalogued runtimes"
+            `Quick test_server_degraded_init_rejects_referenced_uncatalogued_runtimes;
+          test_case
+            "server degraded init disables unreferenced uncatalogued runtimes"
+            `Quick test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes;
           test_case
             "server degraded init rejects uncatalogued default"
             `Quick test_server_degraded_init_rejects_uncatalogued_default;


### PR DESCRIPTION
## Summary
- Follow-up to #23192: catalog-degraded boot no longer erases explicit runtime routing intent into default fallback.
- Degraded boot can still disable uncatalogued runtime definitions, but only when no default, keeper assignment, special route, media failover, or lane candidate references those disabled runtime ids.
- Split regression coverage into two cases: referenced uncatalogued runtimes are fatal, unreferenced uncatalogued runtime definitions are disabled with operator-visible degradation.

## Validation
- `ocamlformat --check lib/runtime/runtime.ml lib/runtime/runtime.mli test/test_runtime_config_validity.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_runtime_config_validity.exe` was attempted, but another repo-local `scripts/dune-local.sh` process held `/tmp/me-dune-local.lock`; I stopped only my waiting process and left the lock holder untouched.

## Review Notes
- This intentionally favors fail-closed routing over keeping the server alive by silently changing model/runtime intent.
- Full Dune build remains CI authority.