### PR TITLE
[codex] Assert typed IDE orphan partitions

### DIFF
--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -376,21 +376,23 @@ let raise_fs_edit_error ?fields message =
 ;;
 
 (* RFC-0128 §4.5 — resolve an absolute or base-relative file_path to
-   a partition + repo-relative path. Three outcomes:
+   a partition + repo-relative path. Four outcomes:
 
    1. [Repo_store.find_repo_by_path_prefix] hits AND the repo's [url]
       normalises via [Agent_observation.canonical_url_of_remote] → [By_url slug]
       bucket + the repo-relative [rel_path].
    2. [Repo_store.find_repo_by_path_prefix] hits but the URL is blank or
-      unparseable → [Orphan] + original path. Counter labelled
+      unparseable → [No_canonical_url] + original path. Counter labelled
       [reason=blank_url] or [reason=url_unparseable].
-   3. No registered repo contains this path → [Orphan] + original path.
+   3. A sandbox playground [repo_id] is not present in the repository store →
+      [Unmatched] + original path. Counter labelled
+      [reason=sandbox_unregistered_repo].
+   4. No registered repo contains this path → [Base_unresolved] + original path.
       Counter labelled [reason=unregistered_repo].
 
    The keeper write path is fire-and-forget; this resolver also never
-   raises — failures during [load_all] degrade to [Orphan] silently
-   with the [reason=unregistered_repo] label so the operator can see
-   how often it happens. *)
+   raises — unresolved paths degrade to typed non-[By_url] partitions with
+   metric labels so the operator can see how often each reason appears. *)
 let resolve_partition_for_write ~base_dir ~kind ~file_path =
   let abs =
     if Filename.is_relative file_path

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -16,9 +16,18 @@ val resolve_partition_for_write
       repository whose [url] normalises via
       {!Agent_observation.canonical_url_of_remote}. [rel_path] is the path
       relative to that repository's [local_path].
-    - [(Orphan, original_path)] otherwise. Increments
-      [masc_ide_orphan_writes_total] with the failure reason label
-      ([unregistered_repo] / [blank_url] / [url_unparseable]).
+    - [(No_canonical_url, original_path)] when a matched repository has a blank
+      or malformed [url].
+    - [(Base_unresolved, original_path)] when no registered repository contains
+      the path.
+    - [(Unmatched, original_path)] when a sandbox playground [repo_id] cannot
+      be found in the repository store.
+
+      The three non-[By_url] variants all write under the shared
+      [.masc-ide/_orphan/] directory, but keep the typed reason in memory and
+      in emitted observation records. Increments [masc_ide_orphan_writes_total]
+      with the concrete failure reason label ([unregistered_repo] /
+      [blank_url] / [url_unparseable] / sandbox variants).
 
     [kind] selects the metric label ([annotation] or [region]). *)
 

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -54,6 +54,14 @@ let touch path =
   close_out oc
 ;;
 
+let partition_to_string = function
+  | Ide_paths.By_url slug -> "By_url " ^ slug
+  | Ide_paths.No_canonical_url -> "No_canonical_url"
+  | Ide_paths.Unmatched -> "Unmatched"
+  | Ide_paths.Base_unresolved -> "Base_unresolved"
+  | Ide_paths.Legacy_default -> "Legacy_default"
+;;
+
 let test_sandbox_write_joins_with_worktree_read () =
   with_temp_base_dir (fun base_dir ->
     (* 1. Build two clones of the same upstream. *)
@@ -131,7 +139,7 @@ let test_sandbox_write_joins_with_worktree_read () =
     check string "worktree rel_path stripped" "lib/foo.ml" worktree_rel)
 ;;
 
-let test_unregistered_path_lands_in_orphan () =
+let test_unregistered_path_lands_in_base_unresolved () =
   with_temp_base_dir (fun base_dir ->
     let elsewhere = Filename.concat base_dir "elsewhere/foo.ml" in
     let partition, original =
@@ -141,12 +149,15 @@ let test_unregistered_path_lands_in_orphan () =
         ~file_path:elsewhere
     in
     (match partition with
-     | Ide_paths.Legacy_default -> ()
-     | _ -> fail "expected Orphan for unregistered path");
+     | Ide_paths.Base_unresolved -> ()
+     | got ->
+       failf
+         "expected Base_unresolved for unregistered path, got %s"
+         (partition_to_string got));
     check string "rel_path passes through unchanged" elsewhere original)
 ;;
 
-let test_blank_url_lands_in_orphan () =
+let test_blank_url_lands_in_no_canonical_url () =
   with_temp_base_dir (fun base_dir ->
     let local = Filename.concat base_dir "blank/repo" in
     mkdir_p local;
@@ -176,8 +187,11 @@ let test_blank_url_lands_in_orphan () =
         ~file_path:file
     in
     match partition with
-    | Ide_paths.Legacy_default -> ()
-    | _ -> fail "expected Orphan for blank-URL repo")
+    | Ide_paths.No_canonical_url -> ()
+    | got ->
+      failf
+        "expected No_canonical_url for blank-URL repo, got %s"
+        (partition_to_string got))
 ;;
 
 (* RFC-0128 PR-6 — sandbox playground path resolution. Keeper writes
@@ -299,13 +313,13 @@ let () =
             `Quick
             test_sandbox_write_joins_with_worktree_read
         ; test_case
-            "unregistered path → Orphan"
+            "unregistered path → Base_unresolved"
             `Quick
-            test_unregistered_path_lands_in_orphan
+            test_unregistered_path_lands_in_base_unresolved
         ; test_case
-            "blank URL → Orphan"
+            "blank URL → No_canonical_url"
             `Quick
-            test_blank_url_lands_in_orphan
+            test_blank_url_lands_in_no_canonical_url
         ; test_case
             "sandbox playground path joins with working-tree (PR-6)"
             `Quick


### PR DESCRIPTION
## Summary
- update IDE canonical URL join tests to assert typed non-By_url partition reasons
- document the resolver contract as No_canonical_url/Base_unresolved/Unmatched while preserving shared _orphan storage

## Validation
- git diff --check
- ocamlformat --check test/test_ide_canonical_url_join.ml lib/keeper/keeper_tool_filesystem_runtime.ml lib/keeper/keeper_tool_filesystem_runtime.mli

Dune/local build intentionally not run; CI is the build authority for this stack.