### PR TITLE
[codex] Surface degraded LSP status

### DIFF
--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clearLspDiagnosticSnapshot,
+  EMPTY_LSP_STATUS_SNAPSHOT,
   LspConnection,
   lspDiagnosticSnapshot,
+  lspStatusSnapshot,
+  parseLspStatusSnapshot,
   resolveLspDiagnosticFilePath,
 } from './ide-lsp-client'
 import {
@@ -66,6 +69,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   lspDiagnosticSnapshot.value = new Map()
+  lspStatusSnapshot.value = EMPTY_LSP_STATUS_SNAPSHOT
   mockSockets.length = 0
 })
 
@@ -141,6 +145,71 @@ describe('clearLspDiagnosticSnapshot', () => {
 })
 
 describe('LspConnection', () => {
+  it('publishes typed masc/lspStatus notifications', () => {
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'masc/lspStatus',
+      params: {
+        langs: [{
+          lang: 'ocaml',
+          connected: false,
+          overlay_only: true,
+          command: 'ocamllsp',
+          last_error: 'ocamllsp unavailable',
+        }],
+      },
+    })
+
+    expect(lspStatusSnapshot.value).toEqual({
+      langs: [{
+        lang: 'ocaml',
+        connected: false,
+        overlay_only: true,
+        command: 'ocamllsp',
+        last_error: 'ocamllsp unavailable',
+      }],
+    })
+    conn.dispose()
+  })
+
+  it('rejects malformed masc/lspStatus payloads without mutating the snapshot', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    lspStatusSnapshot.value = {
+      langs: [{
+        lang: 'ocaml',
+        connected: true,
+        overlay_only: false,
+        command: 'ocamllsp',
+        last_error: null,
+      }],
+    }
+
+    expect(parseLspStatusSnapshot({ langs: [{ lang: 'ocaml', connected: true }] }))
+      .toBeNull()
+
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'masc/lspStatus',
+      params: { langs: [{ lang: 'ocaml', connected: true }] },
+    })
+
+    expect(warn).toHaveBeenCalledWith('[LSP] invalid masc/lspStatus payload')
+    expect(lspStatusSnapshot.value.langs).toHaveLength(1)
+    expect(lspStatusSnapshot.value.langs[0]?.connected).toBe(true)
+    conn.dispose()
+  })
+
   it('settles pending requests when the socket closes', async () => {
     installWebSocketMock()
     const conn = new LspConnection(() => {}, () => {})

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -72,6 +72,21 @@ export interface LspDiagnosticAnchor {
 
 export const lspDiagnosticSnapshot = signal<ReadonlyMap<string, ReadonlyArray<LspDiagnosticAnchor>>>(new Map())
 
+export interface LspLanguageStatus {
+  readonly lang: string
+  readonly connected: boolean
+  readonly overlay_only: boolean
+  readonly command: string | null
+  readonly last_error: string | null
+}
+
+export interface LspStatusSnapshot {
+  readonly langs: ReadonlyArray<LspLanguageStatus>
+}
+
+export const EMPTY_LSP_STATUS_SNAPSHOT: LspStatusSnapshot = { langs: [] }
+export const lspStatusSnapshot = signal<LspStatusSnapshot>(EMPTY_LSP_STATUS_SNAPSHOT)
+
 const LSP_TERMINAL_CLOSE_CODES = new Set([1008, 4401, 4403])
 
 export interface SelectedAnnotation {
@@ -451,6 +466,8 @@ export class LspConnection {
         diagByLine.set(line, existing)
       }
       this.onDiagnostics(params.uri, diagByLine)
+    } else if (msg.method === 'masc/lspStatus') {
+      publishLspStatusSnapshot(msg.params)
     }
   }
 
@@ -703,6 +720,54 @@ function indexByLine<T>(items: ReadonlyArray<T>, getLine: (item: T) => number): 
     map.set(line, existing)
   }
   return map
+}
+
+export function parseLspStatusSnapshot(value: unknown): LspStatusSnapshot | null {
+  if (!isRecord(value)) return null
+  const langs = value.langs
+  if (!Array.isArray(langs)) return null
+
+  const parsed: LspLanguageStatus[] = []
+  for (const lang of langs) {
+    const status = parseLspLanguageStatus(lang)
+    if (status === null) return null
+    parsed.push(status)
+  }
+  return { langs: parsed }
+}
+
+function parseLspLanguageStatus(value: unknown): LspLanguageStatus | null {
+  if (!isRecord(value)) return null
+  const { lang, connected, overlay_only, command, last_error } = value
+  if (typeof lang !== 'string') return null
+  if (typeof connected !== 'boolean') return null
+  if (typeof overlay_only !== 'boolean') return null
+  if (!isStringOrNull(command)) return null
+  if (!isStringOrNull(last_error)) return null
+  return {
+    lang,
+    connected,
+    overlay_only,
+    command,
+    last_error,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return typeof value === 'string' || value === null
+}
+
+function publishLspStatusSnapshot(value: unknown): void {
+  const parsed = parseLspStatusSnapshot(value)
+  if (parsed === null) {
+    console.warn('[LSP] invalid masc/lspStatus payload')
+    return
+  }
+  lspStatusSnapshot.value = parsed
 }
 
 function publishLspDiagnosticSnapshot(

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -47,6 +47,7 @@ import { clearTraces, pushTrace } from './keeper-trace-store'
 import { activeIdeFile, ideContextFocus } from './ide-state'
 import { resetIdeDataWorkspaceStoreForTest } from './ide-workspace-singleton'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import { EMPTY_LSP_STATUS_SNAPSHOT, lspStatusSnapshot } from './ide-lsp-client'
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
@@ -152,6 +153,7 @@ describe('IdeShell', () => {
     activeIdeFile.value = 'package.json'
     ideContextFocus.value = null
     cursorOverlaySignal.value = { cursors: new Map(), heatmap: new Map(), collisions: [], active_file: null }
+    lspStatusSnapshot.value = EMPTY_LSP_STATUS_SNAPSHOT
     clearTraces()
     clearLocalStorage()
   })
@@ -515,6 +517,43 @@ describe('IdeShell', () => {
     })
     expect(chip.textContent).toBe('IDE fetch degraded diff')
     expect(chip.getAttribute('title')).toContain('diff endpoint unavailable')
+  })
+
+  it('surfaces overlay-only LSP languages in the IDE statusbar', async () => {
+    lspStatusSnapshot.value = {
+      langs: [
+        {
+          lang: 'ocaml',
+          connected: false,
+          overlay_only: true,
+          command: 'ocamllsp',
+          last_error: 'ocamllsp unavailable',
+        },
+        {
+          lang: 'typescript',
+          connected: true,
+          overlay_only: false,
+          command: 'typescript-language-server',
+          last_error: null,
+        },
+      ],
+    }
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', file: 'lib/runtime.ml' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const chip = await waitFor(() => {
+      const found = container.querySelector('[data-testid="ide-statusbar-chip-lsp-status"]')
+      expect(found).not.toBeNull()
+      return found!
+    })
+    expect(chip.textContent).toBe('LSP overlay-only 1')
+    expect(chip.getAttribute('title')).toContain('ocaml: ocamllsp unavailable')
+    expect(chip.getAttribute('title')).not.toContain('typescript')
   })
 
   it('focuses active keeper breadcrumb chips into routeable code and keeper context', async () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -38,6 +38,7 @@ import {
   type KeeperCursor,
   type KeeperCursorOverlay,
 } from './keeper-cursor-overlay'
+import { lspStatusSnapshot, type LspStatusSnapshot } from './ide-lsp-client'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -154,6 +155,7 @@ interface IdeStatusbarInput {
   readonly workspaceBasePath?: string | null
   readonly workspaceIssues?: ReadonlyArray<WorkspaceFetchIssue>
   readonly dashboardConnected?: boolean
+  readonly lspStatus?: LspStatusSnapshot
 }
 
 function viewFromRoute(raw: string | null | undefined): ViewTab {
@@ -430,6 +432,15 @@ function workspaceIssueTitle(issues: ReadonlyArray<WorkspaceFetchIssue>): string
     .join('\n')
 }
 
+function lspOverlayOnlyStatus(status: LspStatusSnapshot | undefined): ReadonlyArray<string> {
+  return (status?.langs ?? [])
+    .filter(lang => lang.overlay_only)
+    .map(lang => {
+      const error = lang.last_error?.trim()
+      return error ? `${lang.lang}: ${error}` : lang.lang
+    })
+}
+
 function addStatusbarChip(
   chips: IdeStatusbarChip[],
   id: string,
@@ -458,6 +469,7 @@ export function deriveIdeStatusbarModel({
   workspaceBasePath = null,
   workspaceIssues = [],
   dashboardConnected = false,
+  lspStatus,
 }: IdeStatusbarInput): IdeStatusbarModel {
   const chips: IdeStatusbarChip[] = []
   const viewLabel = STATUSBAR_VIEW_LABELS[activeView]
@@ -479,6 +491,14 @@ export function deriveIdeStatusbarModel({
     issueLabels.length > 0 ? `IDE fetch degraded ${issueLabels.join('/')}` : undefined,
     'warn',
     workspaceIssueTitle(workspaceIssues),
+  )
+  const lspOverlayOnly = lspOverlayOnlyStatus(lspStatus)
+  addStatusbarChip(
+    chips,
+    'lsp-status',
+    lspOverlayOnly.length > 0 ? `LSP overlay-only ${lspOverlayOnly.length}` : undefined,
+    'warn',
+    lspOverlayOnly.join('\n'),
   )
   if (terminalOpen) addStatusbarChip(chips, 'terminal', 'terminal', 'info', 'Execute output drawer open')
   if (findOpen) addStatusbarChip(chips, 'find', 'find', 'ghost', 'Current-file find panel open')
@@ -912,6 +932,7 @@ export function IdeShell() {
 
   const activeFocus = focusFromRoute(route.value.params.focus)
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
+  const lspStatus = useSignalValue(lspStatusSnapshot)
   const reviewFocusActive = activeFocus === 'review' && activeView === 'unified'
   const activeLayers = layersFromRoute(route.value.params.layers, reviewFocusActive ? activeFocus : null)
   const terminalOpen =
@@ -938,6 +959,7 @@ export function IdeShell() {
     workspaceBasePath,
     workspaceIssues,
     dashboardConnected: dashboardRuntimeConnected(),
+    lspStatus,
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- parse typed `masc/lspStatus` WebSocket notifications into a frontend signal
- surface overlay-only LSP languages in the IDE statusbar instead of hiding degraded state
- reject malformed status payloads without mutating the last valid snapshot

## Validation
- git diff --check
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/components/ide/ide-lsp-client.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty

Dune/CI was not run or waited on per instruction.