### PR TITLE
[codex] Expose IDE snapshot partition metadata

### DIFF
--- a/lib/ide/ide_paths.ml
+++ b/lib/ide/ide_paths.ml
@@ -19,6 +19,19 @@ type partition =
   | Base_unresolved
   | Legacy_default
 
+let partition_kind = function
+  | By_url _ -> "by_url"
+  | No_canonical_url -> "no_canonical_url"
+  | Unmatched -> "unmatched"
+  | Base_unresolved -> "base_unresolved"
+  | Legacy_default -> "legacy_default"
+;;
+
+let partition_is_orphan = function
+  | By_url _ -> false
+  | No_canonical_url | Unmatched | Base_unresolved | Legacy_default -> true
+;;
+
 let partition_store_dir ~base_dir = function
   | By_url slug -> by_url_path ~base_dir ~canonical_url:slug
   (* Layout invariant: all non-By_url partitions share [_orphan/] so disk layout

--- a/lib/ide/ide_paths.mli
+++ b/lib/ide/ide_paths.mli
@@ -51,6 +51,13 @@ type partition =
     here instead of dropping them; the reason distinguishes {v2 §7}
     empty-repo / unmatched-repo_id / base-loss / structural-default. *)
 
+val partition_kind : partition -> string
+(** Stable JSON/debug label for [partition]. *)
+
+val partition_is_orphan : partition -> bool
+(** [partition_is_orphan partition] is [true] when [partition] writes to
+    the shared [_orphan/] store. *)
+
 val partition_store_dir : base_dir:string -> partition -> string
 (** [partition_store_dir ~base_dir partition] returns the directory
     that holds [annotations.jsonl] / [regions.jsonl] for the chosen

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -634,8 +634,8 @@ let dashboard_ide_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
   let regions_count = List.length regions in
   let active_keepers_count = List.length active_keepers in
   `Assoc
-    [ "partition_kind", `String "legacy_default"
-    ; "partition_orphan", `Bool true
+    [ "partition_kind", `String (Ide_paths.partition_kind partition)
+    ; "partition_orphan", `Bool (Ide_paths.partition_is_orphan partition)
     ; "events_count", `Int events_count
     ; "cursors_count", `Int cursors_count
     ; "annotations_count", `Int annotations_count

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -628,24 +628,36 @@ let dashboard_ide_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | _exn -> []
   in
+  let events_count = List.length events in
+  let cursors_count = List.length cursors in
+  let annotations_count = List.length annotations in
+  let regions_count = List.length regions in
+  let active_keepers_count = List.length active_keepers in
   `Assoc
-    [ "events", `Assoc
-        [ "count", `Int (List.length events)
+    [ "partition_kind", `String "legacy_default"
+    ; "partition_orphan", `Bool true
+    ; "events_count", `Int events_count
+    ; "cursors_count", `Int cursors_count
+    ; "annotations_count", `Int annotations_count
+    ; "regions_count", `Int regions_count
+    ; "active_keepers_count", `Int active_keepers_count
+    ; "events", `Assoc
+        [ "count", `Int events_count
         ; "recent", `List events
         ]
     ; "cursors", `Assoc
-        [ "count", `Int (List.length cursors)
+        [ "count", `Int cursors_count
         ; "recent", `List cursors
         ]
     ; "annotations", `Assoc
-        [ "count", `Int (List.length annotations)
+        [ "count", `Int annotations_count
         ]
     ; "regions", `Assoc
-        [ "count", `Int (List.length regions)
+        [ "count", `Int regions_count
         ]
     ; "presence", `Assoc
         [ "active_keepers", `List active_keepers
-        ; "count", `Int (List.length active_keepers)
+        ; "count", `Int active_keepers_count
         ]
     ; "freshness", `Assoc
         [ "snapshot_at", `String (Masc_domain.now_iso ())

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -738,10 +738,11 @@ let test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata () =
     (fun () ->
       Client_registry_eio.reset_for_testing ();
       let json = Server_dashboard_http.dashboard_ide_snapshot_json ~config in
+      let partition = Ide_paths.Legacy_default in
       let open Yojson.Safe.Util in
-      check string "partition kind" "legacy_default"
+      check string "partition kind" (Ide_paths.partition_kind partition)
         (json |> member "partition_kind" |> to_string);
-      check bool "partition is orphan" true
+      check bool "partition is orphan" (Ide_paths.partition_is_orphan partition)
         (json |> member "partition_orphan" |> to_bool);
       check int "events count metadata" 0
         (json |> member "events_count" |> to_int);

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -731,6 +731,33 @@ let test_dashboard_proof_route_registered_in_http_routers () =
   check bool "HTTP/2 dashboard proof route registered" true
     (contains_substring h2 "\"/api/v1/dashboard/proof\"")
 
+let test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  Fun.protect
+    ~finally:Client_registry_eio.reset_for_testing
+    (fun () ->
+      Client_registry_eio.reset_for_testing ();
+      let json = Server_dashboard_http.dashboard_ide_snapshot_json ~config in
+      let open Yojson.Safe.Util in
+      check string "partition kind" "legacy_default"
+        (json |> member "partition_kind" |> to_string);
+      check bool "partition is orphan" true
+        (json |> member "partition_orphan" |> to_bool);
+      check int "events count metadata" 0
+        (json |> member "events_count" |> to_int);
+      check int "cursors count metadata" 0
+        (json |> member "cursors_count" |> to_int);
+      check int "annotations count metadata" 0
+        (json |> member "annotations_count" |> to_int);
+      check int "regions count metadata" 0
+        (json |> member "regions_count" |> to_int);
+      check int "active keepers count metadata" 0
+        (json |> member "active_keepers_count" |> to_int);
+      check int "events nested count remains" 0
+        (json |> member "events" |> member "count" |> to_int);
+      check int "presence nested count remains" 0
+        (json |> member "presence" |> member "count" |> to_int))
+
 let test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   ignore (Lib.Workspace.init config ~agent_name:(Some "dashboard"));
@@ -1532,6 +1559,8 @@ let () =
             test_dashboard_proof_http_json_surfaces_verification_index;
           test_case "proof route registered in HTTP routers" `Quick
             test_dashboard_proof_route_registered_in_http_routers;
+          test_case "IDE snapshot exposes legacy partition metadata" `Quick
+            test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata;
           test_case "bootstrap omits eager goal tree" `Quick
             test_dashboard_bootstrap_omits_eager_goal_tree;
           test_case "planning payload keeps UTF-8 valid after truncation" `Quick

--- a/test/test_ide_paths.ml
+++ b/test/test_ide_paths.ml
@@ -129,6 +129,39 @@ let test_orphan_path () =
     (Paths.orphan_path ~base_dir:"/tmp/base")
 ;;
 
+let check_partition_metadata ~name ~partition ~kind ~is_orphan =
+  check string (name ^ " kind") kind (Paths.partition_kind partition);
+  check bool (name ^ " orphan") is_orphan (Paths.partition_is_orphan partition)
+;;
+
+let test_partition_metadata () =
+  check_partition_metadata
+    ~name:"by_url"
+    ~partition:(Paths.By_url "github.com_jeong-sik_masc")
+    ~kind:"by_url"
+    ~is_orphan:false;
+  check_partition_metadata
+    ~name:"no_canonical_url"
+    ~partition:Paths.No_canonical_url
+    ~kind:"no_canonical_url"
+    ~is_orphan:true;
+  check_partition_metadata
+    ~name:"unmatched"
+    ~partition:Paths.Unmatched
+    ~kind:"unmatched"
+    ~is_orphan:true;
+  check_partition_metadata
+    ~name:"base_unresolved"
+    ~partition:Paths.Base_unresolved
+    ~kind:"base_unresolved"
+    ~is_orphan:true;
+  check_partition_metadata
+    ~name:"legacy_default"
+    ~partition:Paths.Legacy_default
+    ~kind:"legacy_default"
+    ~is_orphan:true
+;;
+
 let () =
   run
     "ide_paths"
@@ -156,5 +189,6 @@ let () =
       , [ test_case "by_url_path" `Quick test_by_url_path
         ; test_case "orphan_path" `Quick test_orphan_path
         ] )
+    ; "partition metadata", [ test_case "kind and orphan flag" `Quick test_partition_metadata ]
     ]
 ;;


### PR DESCRIPTION
## Summary
- add additive IDE snapshot partition metadata for the current Legacy_default/orphan-scoped dashboard snapshot
- expose top-level counts for events, cursors, annotations, regions, and active keepers while preserving existing nested shapes
- add a focused test for the legacy/orphan metadata and empty-fixture counts

## Validation
- git diff --check
- ocamlformat --check lib/server/server_dashboard_http.ml test/test_dashboard_http_core.ml

Dune/CI was not run or waited on per instruction.

## Follow-up
- `server_ide_http.ml` already has local partition reason labels; a later SSOT cleanup should move partition wire labels into a shared helper instead of expanding the hot route file in this PR.