### PR TITLE
perf(server): offload and cache git blame and git diff endpoints

### DIFF
--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -1,6 +1,7 @@
 import { signal, effect } from '@preact/signals'
 import { activeIdeFile } from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
+import { route } from '../../router'
 import { selectedTask } from '../goals/task-detail-selection'
 import {
   discoverRepositories,
@@ -472,42 +473,51 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       })
     })
 
-    // Load blame → ownership
-    fetchGitBlame(filePath, opts).then(blocks => {
-      if (signal.aborted) return
-      clearIssue('blame', { filePath, keeper: keeperParam ?? null, repoId })
-      for (const block of blocks) {
-        ownershipStore.ingest({
-          file_path: block.file_path,
-          line_start: block.line_start,
-          line_end: block.line_end,
-          keeper_id: block.keeper_id,
-          timestamp_ms: block.timestamp_ms,
-          kind: block.kind as KeeperEditKind,
-        })
-      }
-    }).catch(error => {
-      recordIssue('blame', error, {
-        filePath,
-        keeper: keeperParam ?? null,
-        repoId,
-        fallbackMessage: 'git blame fetch failed',
-      })
-    })
+    // Load blame & diff conditionally on view tab to prevent over-fetching
+    const currentView = route.value.params.view?.trim().toLowerCase() || 'source'
+    const isBlameView = currentView === 'blame'
+    const isDiffView = currentView === 'split-diff' || currentView === 'split' || currentView === 'unified' || currentView === 'diff'
 
-    // Load diff
-    fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
-      if (signal.aborted) return
-      clearIssue('diff', { filePath, keeper: keeperParam ?? null, repoId })
-      diffRowsSignal.value = rows
-    }).catch(error => {
-      recordIssue('diff', error, {
-        filePath,
-        keeper: keeperParam ?? null,
-        repoId,
-        fallbackMessage: 'git diff fetch failed',
+    if (isBlameView) {
+      fetchGitBlame(filePath, opts).then(blocks => {
+        if (signal.aborted) return
+        clearIssue('blame', { filePath, keeper: keeperParam ?? null, repoId })
+        for (const block of blocks) {
+          ownershipStore.ingest({
+            file_path: block.file_path,
+            line_start: block.line_start,
+            line_end: block.line_end,
+            keeper_id: block.keeper_id,
+            timestamp_ms: block.timestamp_ms,
+            kind: block.kind as KeeperEditKind,
+          })
+        }
+      }).catch(error => {
+        recordIssue('blame', error, {
+          filePath,
+          keeper: keeperParam ?? null,
+          repoId,
+          fallbackMessage: 'git blame fetch failed',
+        })
       })
-    })
+    }
+
+    if (isDiffView) {
+      fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
+        if (signal.aborted) return
+        clearIssue('diff', { filePath, keeper: keeperParam ?? null, repoId })
+        diffRowsSignal.value = rows
+      }).catch(error => {
+        recordIssue('diff', error, {
+          filePath,
+          keeper: keeperParam ?? null,
+          repoId,
+          fallbackMessage: 'git diff fetch failed',
+        })
+      })
+    } else {
+      diffRowsSignal.value = []
+    }
 
     // Load annotations
     fetchIdeAnnotations({ file_path: filePath, goal_id: task?.goal_id ?? undefined, task_id: task?.id ?? undefined }, opts).then(annotations => {

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -502,7 +502,7 @@ describe('IdeShell', () => {
     )
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'source', file: 'lib/runtime.ml' },
+      params: { section: 'ide-shell', view: 'unified', file: 'lib/runtime.ml' },
       postId: null,
     }
 

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -941,61 +941,103 @@ let add_routes router =
                   json_response ~status:`Not_found request reqd (json_error "File not found")
                 else
                   let rel = rel_under base safe.lexical_path in
-                  (* Blame keeps the original silent-empty contract: a file
-                     that exists in the working tree but is not yet tracked
-                     in HEAD (newly added, .gitignore'd, etc.) is a valid
-                     caller scenario, and surfacing git's non-zero exit as
-                     4xx would break it. The end-of-options separator still
-                     blocks `-L1,9999`-style argv injection. *)
-                  (match git_run_lines ~cwd:base
-                           ["blame"; "--porcelain"; "--"; rel]
-                   with
-                   | [] ->
-                     json_response_with_source ~status:`OK ~source request reqd (`List [])
-                   | lines ->
-                     let entries = parse_blame_porcelain lines in
-                     let grouped = group_blame_entries rel entries in
-                     json_response_with_source ~status:`OK ~source request reqd (`List grouped))))
+                  let cache_key =
+                    Printf.sprintf "git:blame:%s:%s:%s"
+                      base
+                      (match source with
+                       | `Project -> "project"
+                       | `Repository repo_id -> "repository:" ^ repo_id
+                       | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
+                       | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
+                       | `Playground name -> "playground:" ^ name
+                       | `PlaygroundMissing name -> "playground_missing:" ^ name
+                       | `KeeperUnknown name -> "keeper_unknown:" ^ name)
+                      rel
+                  in
+                  let json =
+                    Dashboard_cache.get_or_compute cache_key
+                      ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+                      (fun () ->
+                         Domain_pool_ref.submit_io_or_inline (fun () ->
+                           match git_run_lines ~cwd:base
+                                   ["blame"; "--porcelain"; "--"; rel]
+                           with
+                           | [] -> `List []
+                           | lines ->
+                             let entries = parse_blame_porcelain lines in
+                             let grouped = group_blame_entries rel entries in
+                             `List grouped))
+                  in
+                  json_response_with_source ~status:`OK ~source request reqd json))
          request reqd)
 
   |> Http.Router.get "/api/v1/git/diff" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-           let uri = Uri.of_string request.target in
-           let base, source = resolve_workspace_base ~state ~uri in
-           let file_path =
-             match Uri.get_query_param uri "path" with
-             | Some p -> p
-             | None -> ""
-           in
-           if file_path = "" then
-             json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
-           else
-             let base_ref =
-               match Uri.get_query_param uri "base_ref" with
-               | Some r -> r
-               | None -> "HEAD"
-             in
-             if not (valid_git_ref base_ref) then
-               json_response ~status:`Bad_request request reqd
-                 (json_error "Invalid base_ref")
-             else
-             (match resolve_workspace_file base file_path with
-              | Error _ ->
-                json_response ~status:`Bad_request request reqd (json_error "Invalid path")
-              | Ok safe ->
-                let rel = rel_under base safe.lexical_path in
-                (match git_run_lines_or_error ~cwd:base
-                         ["diff"; base_ref; "--"; rel]
-                 with
-                 | Error _ ->
-                   json_response ~status:`Bad_request request reqd
-                     (json_error "git diff failed")
-                 | Ok [] ->
-                   json_response_with_source ~status:`OK ~source request reqd
-                     (`Assoc [("unified", `List []); ("has_changes", `Bool false)])
-                 | Ok diff_lines ->
-                   let unified = parse_unified_diff diff_lines in
-                   let json = `Assoc [("unified", `List unified); ("has_changes", `Bool true)] in
-                   json_response_with_source ~status:`OK ~source request reqd json)))
+            let uri = Uri.of_string request.target in
+            let base, source = resolve_workspace_base ~state ~uri in
+            let file_path =
+              match Uri.get_query_param uri "path" with
+              | Some p -> p
+              | None -> ""
+            in
+            if file_path = "" then
+              json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
+            else
+              let base_ref =
+                match Uri.get_query_param uri "base_ref" with
+                | Some r -> r
+                | None -> "HEAD"
+              in
+              if not (valid_git_ref base_ref) then
+                json_response ~status:`Bad_request request reqd
+                  (json_error "Invalid base_ref")
+              else
+              (match resolve_workspace_file base file_path with
+               | Error _ ->
+                 json_response ~status:`Bad_request request reqd (json_error "Invalid path")
+               | Ok safe ->
+                 let rel = rel_under base safe.lexical_path in
+                 let cache_key =
+                   Printf.sprintf "git:diff:%s:%s:%s:%s"
+                     base
+                     (match source with
+                      | `Project -> "project"
+                      | `Repository repo_id -> "repository:" ^ repo_id
+                      | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
+                      | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
+                      | `Playground name -> "playground:" ^ name
+                      | `PlaygroundMissing name -> "playground_missing:" ^ name
+                      | `KeeperUnknown name -> "keeper_unknown:" ^ name)
+                     base_ref
+                     rel
+                 in
+                 let json =
+                   Dashboard_cache.get_or_compute cache_key
+                     ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+                     (fun () ->
+                        Domain_pool_ref.submit_io_or_inline (fun () ->
+                          match git_run_lines_or_error ~cwd:base
+                                  ["diff"; base_ref; "--"; rel]
+                          with
+                          | Error _ ->
+                            `Assoc [("ok", `Bool false); ("error", `String "git diff failed")]
+                          | Ok [] ->
+                            `Assoc [("ok", `Bool true); ("data", `Assoc [("unified", `List []); ("has_changes", `Bool false)])]
+                          | Ok diff_lines ->
+                            let unified = parse_unified_diff diff_lines in
+                            `Assoc [("ok", `Bool true); ("data", `Assoc [("unified", `List unified); ("has_changes", `Bool true)])]))
+                 in
+                 (match json with
+                  | `Assoc fields ->
+                    (match List.assoc_opt "ok" fields with
+                     | Some (`Bool true) ->
+                       let data = List.assoc "data" fields in
+                       json_response_with_source ~status:`OK ~source request reqd data
+                     | _ ->
+                       json_response ~status:`Bad_request request reqd
+                         (json_error "git diff failed"))
+                  | _ ->
+                    json_response ~status:`Bad_request request reqd
+                      (json_error "git diff failed"))))
          request reqd)


### PR DESCRIPTION
This PR offloads git blame and git diff endpoint computations to worker domains via Domain_pool_ref.submit_io_or_inline, and caches results for 15s using Dashboard_cache.get_or_compute. This prevents rapid parallel file clicks in the IDE dashboard from blocking the main HTTP domain's event loop.