### PR TITLE
[codex] Scope IDE activity events by repository

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -311,6 +311,33 @@ describe('IdeActivityPanel', () => {
     })
   })
 
+  it('scopes IDE bridge activity events to the active repository', async () => {
+    const ideEventUrls: string[] = []
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        ideEventUrls.push(url)
+        return new Response(JSON.stringify({ ok: true, data: { events: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', repoId: 'masc' }), container)
+
+    await waitFor(() => expect(ideEventUrls).toHaveLength(1))
+    const url = new URL(ideEventUrls[0]!, 'http://localhost')
+    expect(url.pathname).toBe('/api/v1/ide/events')
+    expect(url.searchParams.get('repo_id')).toBe('masc')
+    expect(url.searchParams.get('limit')).toBe('50')
+  })
+
   it('shows linked context coverage for mixed activity events', async () => {
     vi.stubGlobal('fetch', vi.fn(async () =>
       new Response(JSON.stringify({

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -154,6 +154,7 @@ export interface IdeRunProgressGoal {
 
 export interface IdeActivityPanelProps {
   readonly activeFile?: string | null
+  readonly repoId?: string | null
   readonly annotations?: ReadonlyArray<IdeAnnotation>
   readonly diffRows?: ReadonlyArray<UnifiedDiffRow>
   readonly pollMs?: number
@@ -196,9 +197,9 @@ function mapApiEvent(event: ApiActivityEvent, workspaceId: string): RunActivityE
   }
 }
 
-async function fetchActivityEvents(): Promise<ActivityFetchResult> {
+async function fetchActivityEvents(repoId?: string | null): Promise<ActivityFetchResult> {
   const graph = await fetchActivityGraphEvents()
-  const bridgeEvents = await fetchIdeBridgeRunActivityEvents(graph.workspaceId)
+  const bridgeEvents = await fetchIdeBridgeRunActivityEvents(graph.workspaceId, repoId)
   return {
     ...graph,
     events: mergeRunActivityEvents(graph.events, bridgeEvents),
@@ -222,9 +223,10 @@ async function fetchActivityGraphEvents(): Promise<ActivityFetchResult> {
 
 async function fetchIdeBridgeRunActivityEvents(
   workspaceId: string,
+  repoId?: string | null,
 ): Promise<ReadonlyArray<RunActivityEvent>> {
   try {
-    const events = await fetchIdeEvents({ limit: 50 })
+    const events = await fetchIdeEvents({ limit: 50, repoId })
     return events.map((event, index) => mapIdeBridgeEvent(event, workspaceId, index))
   } catch {
     return EMPTY_ACTIVITY
@@ -422,6 +424,7 @@ function normalizedPollMs(value: number | undefined): number | null {
 export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   const {
     activeFile: rawActiveFile = '',
+    repoId = null,
     annotations = EMPTY_ANNOTATIONS,
     diffRows = EMPTY_DIFF_ROWS,
     pollMs = 0,
@@ -446,7 +449,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
         lastAttemptMs: attemptMs,
         tone: prev.lastOkMs === null && prev.failedCount === 0 ? 'loading' : prev.tone,
       }))
-      const { events, workspaceId, ok } = await fetchActivityEvents()
+      const { events, workspaceId, ok } = await fetchActivityEvents(repoId)
       if (cancelled) return
       if (ok) {
         store.reset(workspaceId)
@@ -472,7 +475,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
       cancelled = true
       if (timer !== null) clearTimeout(timer)
     }
-  }, [store, refreshMs])
+  }, [store, refreshMs, repoId])
 
   useStoreSubscription(store.subscribe)
   useSignalValue(globalPresenceSnapshot)

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1207,6 +1207,7 @@ export function IdeShell() {
                   <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
                     <${IdeActivityPanel}
                       activeFile=${activeFilePath}
+                      repoId=${activeRepositoryId}
                       annotations=${annotations}
                       diffRows=${diffRows}
                       pollMs=${IDE_ACTIVITY_POLL_MS}


### PR DESCRIPTION
## Summary
- pass the active repository id from the IDE shell into the activity rail
- scope only the IDE bridge event read path (`/api/v1/ide/events`) by `repo_id`, while keeping the general activity graph feed unchanged
- add a focused query contract test for the bridge events request

## Stacking
- Base branch: `codex/lsp-statusbar-degraded-20260704` (#23210)
- This avoids touching the same `ide-shell.ts` hunk independently on `main`.

## Validation
- git diff --check
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/components/ide/ide-activity-panel.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty

Dune/CI was not run or waited on per instruction.