### PR TITLE
[codex] Subscribe cursor stream by repository

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -49,6 +49,21 @@ import { resetIdeDataWorkspaceStoreForTest } from './ide-workspace-singleton'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { EMPTY_LSP_STATUS_SNAPSHOT, lspStatusSnapshot } from './ide-lsp-client'
 
+class MockEventSource {
+  static instances: MockEventSource[] = []
+
+  readonly url: string
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+}
+
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
     .find(candidate => candidate.textContent === text)
@@ -137,6 +152,8 @@ describe('IdeShell', () => {
 
   beforeEach(() => {
     container = document.createElement('div')
+    MockEventSource.instances = []
+    vi.stubGlobal('EventSource', MockEventSource)
     clearLocalStorage()
     vi.stubGlobal('fetch', vi.fn(dashboardFetchMock))
   })
@@ -944,6 +961,25 @@ describe('IdeShell', () => {
       surface: 'Keeper',
       label: 'str_replace',
       keeper_id: 'sangsu',
+    })
+  })
+
+  it('subscribes to the cursor stream with active repository scope', async () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    await waitFor(() => {
+      const scoped = MockEventSource.instances.some(instance => {
+        const url = new URL(instance.url)
+        return url.pathname === '/api/v1/ide/cursors/stream'
+          && url.searchParams.get('repo_id') === 'masc'
+      })
+      expect(scoped).toBe(true)
     })
   })
 

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -33,6 +33,7 @@ import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeMemoryPanel } from './ide-memory-panel'
 import { routeLinksForContext } from './ide-context-lens'
 import {
+  connectKeeperCursorStream,
   cursorOverlaySignal,
   getKeeperColor,
   type KeeperCursor,
@@ -44,6 +45,7 @@ import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
 import { connected } from '../../sse'
 import { dashboardBearerToken } from '../../api/core'
+import { DEFAULT_MASC_ORIGIN } from '../../config/constants'
 import { devTokenBootstrapStatus } from '../../api/dev-token'
 import { dashboardWsOnlyEnabled } from '../../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../../dashboard-ws-state'
@@ -322,6 +324,10 @@ function dashboardRuntimeConnected(): boolean {
     return dashboardWsConnected.value || dashboardWsSseFallbackActive.value
   }
   return connected.value
+}
+
+function dashboardOrigin(): string {
+  return typeof window === 'undefined' ? DEFAULT_MASC_ORIGIN : window.location.origin
 }
 
 /**
@@ -961,6 +967,17 @@ export function IdeShell() {
     dashboardConnected: dashboardRuntimeConnected(),
     lspStatus,
   })
+
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return
+    return connectKeeperCursorStream(
+      dashboardOrigin(),
+      overlay => {
+        cursorOverlaySignal.value = overlay
+      },
+      { repoId: activeRepositoryId },
+    )
+  }, [activeRepositoryId])
 
   useEffect(() => {
     const next = viewFromRoute(route.value.params.view)

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   connectKeeperCursorStream,
   getKeeperColor,
+  keeperCursorStreamUrl,
   normalizeKeeperCursorSnapshot,
 } from './keeper-cursor-overlay'
 
@@ -102,6 +103,11 @@ describe('getKeeperColor', () => {
     expect(instances[0]?.url).toBe('http://localhost:8935/api/v1/ide/cursors/stream')
     cleanup()
     expect(instances[0]?.close).toHaveBeenCalled()
+  })
+
+  it('builds repository-scoped cursor stream URLs', () => {
+    expect(keeperCursorStreamUrl('http://localhost:8935', { repoId: 'masc' }))
+      .toBe('http://localhost:8935/api/v1/ide/cursors/stream?repo_id=masc')
   })
 
   it('cancels cursor stream reconnect timers during cleanup', () => {

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -403,11 +403,25 @@ export function normalizeKeeperCursorSnapshot(snapshot: unknown): KeeperCursorOv
   }
 }
 
+export interface KeeperCursorStreamOptions {
+  readonly repoId?: string | null
+}
+
+export function keeperCursorStreamUrl(
+  baseUrl: string,
+  opts: KeeperCursorStreamOptions = {},
+): string {
+  const url = new URL('/api/v1/ide/cursors/stream', baseUrl)
+  if (opts.repoId) url.searchParams.set('repo_id', opts.repoId)
+  return url.toString()
+}
+
 export function connectKeeperCursorStream(
   baseUrl: string,
   onUpdate: (overlay: KeeperCursorOverlay) => void,
+  opts: KeeperCursorStreamOptions = {},
 ): () => void {
-  const transport = createSseTransport(`${baseUrl}/api/v1/ide/cursors/stream`)
+  const transport = createSseTransport(keeperCursorStreamUrl(baseUrl, opts))
   const unsubscribe = transport.subscribe((event) => {
     if (event.type === 'message') {
       onUpdate(normalizeKeeperCursorSnapshot(event.data))


### PR DESCRIPTION
## Summary
- wire the IDE shell to the dedicated cursor SSE stream instead of relying only on pre-seeded cursor state
- add `repo_id` to cursor stream URLs when an active repository is selected
- keep the backend stream contract unchanged; it already resolves partition from the request URI

## Stacking
- Base branch: `codex/ide-activity-repo-scope-20260704` (#23214)
- This keeps the `ide-shell.ts` changes in one stack: #23210 -> #23214 -> this PR.

## Validation
- git diff --check
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/components/ide/keeper-cursor-overlay.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty

Dune/CI was not run or waited on per instruction.