### PR TITLE
[codex] Surface ignored sampling capabilities

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -199,6 +199,7 @@ export interface DashboardRuntimeEffectiveCapabilities {
   supports_min_p?: boolean
   supports_seed?: boolean
   supports_seed_with_images?: boolean
+  ignored_sampling_parameters: string[]
   supports_computer_use?: boolean
   supports_code_execution?: boolean
   emits_usage_tokens?: boolean
@@ -637,6 +638,7 @@ function decodeRuntimeEffectiveCapabilities(raw: unknown): DashboardRuntimeEffec
     supports_min_p: asBoolean(raw.supports_min_p),
     supports_seed: asBoolean(raw.supports_seed),
     supports_seed_with_images: asBoolean(raw.supports_seed_with_images),
+    ignored_sampling_parameters: asStringArray(raw.ignored_sampling_parameters),
     supports_computer_use: asBoolean(raw.supports_computer_use),
     supports_code_execution: asBoolean(raw.supports_code_execution),
     emits_usage_tokens: asBoolean(raw.emits_usage_tokens),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2533,7 +2533,7 @@ describe('fetchRuntimeProviders', () => {
               supports_min_p: true,
               supports_seed: true,
               supports_seed_with_images: false,
-              ignored_sampling_parameters: ['temperature', 'top_p'],
+              ignored_sampling_parameters: ['temperature', 'top_p', 'presence_penalty', 'frequency_penalty'],
               supports_computer_use: false,
               supports_code_execution: false,
               emits_usage_tokens: true,
@@ -2703,7 +2703,12 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.effective_capabilities?.reasoning_streaming_format?.field).toBe('reasoning_content')
     expect(result.providers[0]?.effective_capabilities?.modality_priority).toBe('visual-first')
     expect(result.providers[0]?.effective_capabilities?.supports_top_k).toBe(true)
-    expect(result.providers[0]?.effective_capabilities?.ignored_sampling_parameters).toEqual(['temperature', 'top_p'])
+    expect(result.providers[0]?.effective_capabilities?.ignored_sampling_parameters).toEqual([
+      'temperature',
+      'top_p',
+      'presence_penalty',
+      'frequency_penalty',
+    ])
     expect(result.providers[0]?.declared_spec?.source).toBe('runtime.toml')
     expect(result.providers[0]?.declared_spec?.provider?.api_format).toBe('chat-completions')
     expect(

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2533,6 +2533,7 @@ describe('fetchRuntimeProviders', () => {
               supports_min_p: true,
               supports_seed: true,
               supports_seed_with_images: false,
+              ignored_sampling_parameters: ['temperature', 'top_p'],
               supports_computer_use: false,
               supports_code_execution: false,
               emits_usage_tokens: true,
@@ -2702,6 +2703,7 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.effective_capabilities?.reasoning_streaming_format?.field).toBe('reasoning_content')
     expect(result.providers[0]?.effective_capabilities?.modality_priority).toBe('visual-first')
     expect(result.providers[0]?.effective_capabilities?.supports_top_k).toBe(true)
+    expect(result.providers[0]?.effective_capabilities?.ignored_sampling_parameters).toEqual(['temperature', 'top_p'])
     expect(result.providers[0]?.declared_spec?.source).toBe('runtime.toml')
     expect(result.providers[0]?.declared_spec?.provider?.api_format).toBe('chat-completions')
     expect(

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -285,7 +285,7 @@ describe('KeeperWorkspaceRail', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
-            ignored_sampling_parameters: ['temperature', 'top_p'],
+            ignored_sampling_parameters: ['temperature', 'top_p', 'presence_penalty', 'frequency_penalty'],
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
@@ -407,7 +407,7 @@ describe('KeeperWorkspaceRail', () => {
       'controls tool-choice,required,named,parallel,extended-thinking,reasoning-budget,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
     )
     expect(container.textContent).toContain('ctx 131072 · out 65536 · tools · tool_choice+required+named+parallel')
-    expect(container.textContent).toContain('ignored temperature,top_p')
+    expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('extended thinking')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -285,6 +285,7 @@ describe('KeeperWorkspaceRail', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
+            ignored_sampling_parameters: ['temperature', 'top_p'],
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
@@ -406,6 +407,7 @@ describe('KeeperWorkspaceRail', () => {
       'controls tool-choice,required,named,parallel,extended-thinking,reasoning-budget,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
     )
     expect(container.textContent).toContain('ctx 131072 · out 65536 · tools · tool_choice+required+named+parallel')
+    expect(container.textContent).toContain('ignored temperature,top_p')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('extended thinking')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -323,6 +323,7 @@ function runtimeEffectiveCapabilitySummary(
     caps.supports_min_p ? 'min_p' : null,
     caps.supports_seed ? 'seed' : null,
   ].filter((value): value is string => Boolean(value))
+  const ignoredSampling = caps.ignored_sampling_parameters.join(',')
   const formats = [
     caps.supports_response_format_json ? 'json' : null,
     caps.supports_structured_output ? 'schema' : null,
@@ -342,6 +343,7 @@ function runtimeEffectiveCapabilitySummary(
     caps.supports_runtime_tool_events ? 'runtime-tool-events' : null,
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    ignoredSampling ? `ignored ${ignoredSampling}` : null,
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -167,6 +167,7 @@ describe('RuntimeMonitor', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
+            ignored_sampling_parameters: ['temperature', 'top_p'],
             supports_computer_use: true,
             supports_code_execution: true,
             emits_usage_tokens: true,
@@ -391,6 +392,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
+    expect(container.textContent).toContain('ignored temperature,top_p')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('preserve chat-template-kwargs-preserve-thinking')
@@ -477,5 +479,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('transcription')
     expect(container.textContent).toContain('effective · controls')
     expect(container.textContent).toContain('native-stream,system-prompt,cache')
+    expect(container.textContent).toContain('effective · ignored sampling')
+    expect(container.textContent).toContain('temperature,top_p')
   })
 })

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -167,7 +167,7 @@ describe('RuntimeMonitor', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
-            ignored_sampling_parameters: ['temperature', 'top_p'],
+            ignored_sampling_parameters: ['temperature', 'top_p', 'presence_penalty', 'frequency_penalty'],
             supports_computer_use: true,
             supports_code_execution: true,
             emits_usage_tokens: true,
@@ -392,7 +392,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
-    expect(container.textContent).toContain('ignored temperature,top_p')
+    expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('preserve chat-template-kwargs-preserve-thinking')
@@ -480,6 +480,6 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('effective · controls')
     expect(container.textContent).toContain('native-stream,system-prompt,cache')
     expect(container.textContent).toContain('effective · ignored sampling')
-    expect(container.textContent).toContain('temperature,top_p')
+    expect(container.textContent).toContain('temperature,top_p,presence_penalty,frequency_penalty')
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -519,6 +519,9 @@ function runtimeParameterDetailRows(
         flagText(caps.supports_seed, 'seed'),
       ])
     : null
+  const effectiveIgnoredSampling = caps
+    ? stringArrayText(caps.ignored_sampling_parameters)
+    : null
   const declaredFormat = declaredCaps
     ? textList([
         flagText(declaredCaps.supports_response_format_json, 'json'),
@@ -634,6 +637,7 @@ function runtimeParameterDetailRows(
     detailRow('effective', 'task', caps?.task),
     detailRow('effective', 'controls', runtimeEffectiveControlText(provider)),
     detailRow('effective', 'sampling', effectiveSampling),
+    detailRow('effective', 'ignored sampling', effectiveIgnoredSampling),
     detailRow('effective', 'supported models', stringArrayText(caps?.supported_models)),
   ].filter((row): row is RuntimeParameterDetailRow => row !== null)
 }
@@ -756,6 +760,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     caps.supports_min_p ? 'min_p' : null,
     caps.supports_seed ? 'seed' : null,
   ].filter((value): value is string => Boolean(value))
+  const ignoredSampling = caps.ignored_sampling_parameters.join(',')
   const modalities = [
     caps.supports_image_input ? 'image' : null,
     caps.supports_audio_input ? 'audio' : null,
@@ -787,6 +792,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     caps.supports_runtime_tool_events ? 'runtime-tool-events' : null,
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
+    ignoredSampling ? `ignored ${ignoredSampling}` : null,
     modalities.length > 0 ? `input ${modalities.join(',')}` : null,
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -933,6 +933,7 @@ describe('SettingsSurface', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
+            ignored_sampling_parameters: ['temperature', 'top_p'],
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
@@ -1071,6 +1072,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')
+      expect(cards[0]?.textContent).toContain('ignored:temperature,top_p')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('tool-content:empty-string')
       expect(cards[0]?.textContent).toContain('extended-thinking')

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -933,7 +933,7 @@ describe('SettingsSurface', () => {
             supports_min_p: true,
             supports_seed: true,
             supports_seed_with_images: true,
-            ignored_sampling_parameters: ['temperature', 'top_p'],
+            ignored_sampling_parameters: ['temperature', 'top_p', 'presence_penalty', 'frequency_penalty'],
             supports_code_execution: true,
             emits_usage_tokens: true,
             modality_priority: 'visual-first',
@@ -1072,7 +1072,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')
-      expect(cards[0]?.textContent).toContain('ignored:temperature,top_p')
+      expect(cards[0]?.textContent).toContain('ignored:temperature,top_p,presence_penalty,frequency_penalty')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('tool-content:empty-string')
       expect(cards[0]?.textContent).toContain('extended-thinking')

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -247,6 +247,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     caps.supports_min_p ? 'min_p' : null,
     caps.supports_seed ? 'seed' : null,
   ])
+  const ignoredSampling = caps.ignored_sampling_parameters.join(',')
   const context = typeof caps.max_context_tokens === 'number' ? `ctx:${caps.max_context_tokens}` : null
   const output = typeof caps.max_output_tokens === 'number' ? `out:${caps.max_output_tokens}` : null
   const format = nonEmptyParts([
@@ -269,6 +270,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     caps.supports_runtime_tool_events ? 'runtime-tool-events' : null,
     format.length > 0 ? `format:${format.join(',')}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
+    ignoredSampling ? `ignored:${ignoredSampling}` : null,
     caps.modality_priority ? `modality:${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content:${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1733,6 +1733,10 @@ let effective_capabilities_json (rt : Runtime.t) =
       ; "supports_min_p", `Bool caps.supports_min_p
       ; "supports_seed", `Bool caps.supports_seed
       ; "supports_seed_with_images", `Bool caps.supports_seed_with_images
+      ; ( "ignored_sampling_parameters"
+        , caps.ignored_sampling_parameters
+          |> List.map Llm_provider.Capabilities.sampling_parameter_to_string
+          |> Json_util.json_string_list )
       ; "supports_computer_use", `Bool caps.supports_computer_use
       ; "supports_code_execution", `Bool caps.supports_code_execution
       ; "emits_usage_tokens", `Bool caps.emits_usage_tokens

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1095,6 +1095,7 @@ supports_prompt_caching = true
 supports_top_k = true
 supports_min_p = true
 supports_seed = true
+ignored_sampling_parameters = ["temperature", "top_p"]
 
 [[models]]
 id_prefix = "openai_compat/reasoning-small-out"
@@ -1248,6 +1249,13 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
       "top_k"
       true
       (caps |> J.member "supports_top_k" |> J.to_bool);
+    Alcotest.(check (list string))
+      "ignored sampling parameters"
+      [ "temperature"; "top_p" ]
+      (caps
+       |> J.member "ignored_sampling_parameters"
+       |> J.to_list
+       |> List.map J.to_string);
     Alcotest.(check string)
       "effective modality priority"
       "visual-first"

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1078,7 +1078,9 @@ max_output_tokens = 65536
 supports_tools = true
 supports_tool_choice = true
 supports_required_tool_choice = true
+supports_named_tool_choice = true
 supports_parallel_tool_calls = true
+assistant_tool_content_format = "empty_string"
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
@@ -1087,15 +1089,23 @@ thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
 reasoning_output_format = "split_reasoning_fields"
 reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "preserve_always"
 supports_response_format_json = true
 supports_structured_output = true
 modality_priority = "visual_first"
+task = "transcription"
+supports_audio_input = true
+supports_video_input = true
 supports_native_streaming = true
+supports_system_prompt = true
+supports_caching = true
 supports_prompt_caching = true
 supports_top_k = true
 supports_min_p = true
 supports_seed = true
-ignored_sampling_parameters = ["temperature", "top_p"]
+ignored_sampling_parameters = ["temperature", "top_p", "presence_penalty", "frequency_penalty"]
+supports_computer_use = true
+supports_code_execution = true
 
 [[models]]
 id_prefix = "openai_compat/reasoning-small-out"
@@ -1234,6 +1244,14 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
       "parallel tool calls"
       true
       (caps |> J.member "supports_parallel_tool_calls" |> J.to_bool);
+    Alcotest.(check bool)
+      "named tool choice"
+      true
+      (caps |> J.member "supports_named_tool_choice" |> J.to_bool);
+    Alcotest.(check string)
+      "assistant tool content format"
+      "empty-string"
+      (caps |> J.member "assistant_tool_content_format" |> J.to_string);
     Alcotest.(check (list string))
       "accepted reasoning efforts"
       [ "low"; "medium"; "high" ]
@@ -1245,17 +1263,49 @@ let test_runtime_inventory_surfaces_effective_capabilities () =
       "reasoning streaming field"
       "reasoning_content"
       (caps |> J.member "reasoning_streaming_format" |> J.member "field" |> J.to_string);
+    Alcotest.(check string)
+      "reasoning replay override"
+      "preserve-always"
+      (caps |> J.member "reasoning_replay_override" |> J.to_string);
+    Alcotest.(check string)
+      "task"
+      "transcription"
+      (caps |> J.member "task" |> J.to_string);
+    Alcotest.(check bool)
+      "audio input"
+      true
+      (caps |> J.member "supports_audio_input" |> J.to_bool);
+    Alcotest.(check bool)
+      "video input"
+      true
+      (caps |> J.member "supports_video_input" |> J.to_bool);
+    Alcotest.(check bool)
+      "system prompt"
+      true
+      (caps |> J.member "supports_system_prompt" |> J.to_bool);
+    Alcotest.(check bool)
+      "caching"
+      true
+      (caps |> J.member "supports_caching" |> J.to_bool);
     Alcotest.(check bool)
       "top_k"
       true
       (caps |> J.member "supports_top_k" |> J.to_bool);
     Alcotest.(check (list string))
       "ignored sampling parameters"
-      [ "temperature"; "top_p" ]
+      [ "temperature"; "top_p"; "presence_penalty"; "frequency_penalty" ]
       (caps
        |> J.member "ignored_sampling_parameters"
        |> J.to_list
        |> List.map J.to_string);
+    Alcotest.(check bool)
+      "computer use"
+      true
+      (caps |> J.member "supports_computer_use" |> J.to_bool);
+    Alcotest.(check bool)
+      "code execution"
+      true
+      (caps |> J.member "supports_code_execution" |> J.to_bool);
     Alcotest.(check string)
       "effective modality priority"
       "visual-first"


### PR DESCRIPTION
## Summary
- expose OAS effective capability `ignored_sampling_parameters` in runtime inventory
- decode and surface ignored sampling parameters in runtime monitor, settings catalog, and keeper workspace runtime rail
- add backend/frontend regressions for temperature/top_p ignored sampling visibility

## Validation
- `opam exec -- ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_per_keeper_routing.ml`
- `git diff --check`
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1` (4 files / 143 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `opam exec -- ocamlc -stop-after parsing lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_per_keeper_routing.ml`

## Notes
- Focused Dune wrapper build was attempted, but `/tmp/me-dune-local.lock` was held by another repo-local wrapper process. I stopped only my waiting process and left the lock holder untouched. Full Dune remains CI authority.