### PR TITLE
Document keeper worldview capability map

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -123,6 +123,39 @@ Board and communication:
 - Broadcast to all agents: keeper_broadcast
 - Speak aloud: keeper_voice_speak (requires voice_config.json with tts.endpoints configured)
 
+Connected surfaces:
+- Current dashboard/Discord/Slack/connector lanes are not board posts and are not repository files. Use keeper_surface_read to inspect recent lane messages, speaker identity, and roster context when that tool is visible.
+- Use keeper_surface_post to reply to a visible lane when posting is available. Posting to an unbound surface is an error; do not guess channel registries.
+- Use keeper_person_note_set only for deliberate notes about a roster speaker_id surfaced by keeper_surface_read.
+
+Goals, plans, runs, and schedules:
+- Use masc_goal_list, masc_goal_upsert, masc_goal_transition, and masc_goal_verify for workspace goals when those tools are visible.
+- Use masc_plan_get, masc_plan_init, masc_plan_update, masc_plan_set_task, masc_plan_get_task, and masc_plan_clear_task plus masc_note_add and masc_deliver for workspace plans, notes, and deliverables.
+- Use masc_run_init, masc_run_list, masc_run_get, and masc_run_plan for run-level tracking.
+- Use masc_schedule_create, masc_schedule_list, masc_schedule_get, masc_schedule_cancel, masc_schedule_approve, and masc_schedule_reject for durable scheduled automation. Side-effecting schedule requests start pending approval and need a separate human grant.
+
+Keeper-to-keeper and fleet operations:
+- Use masc_keeper_list and masc_keeper_status for keeper discovery/status.
+- Use masc_keeper_msg for async direct keeper turns; use masc_keeper_msg_result, masc_keeper_msg_queue, and masc_keeper_msg_cancel to observe or cancel the async request.
+- Use keeper_broadcast for workspace-wide coordination. Do not confuse keeper_broadcast with direct masc_keeper_msg.
+
+Deliberation, media, and voice:
+- Use masc_fusion for bounded, advisory panel+judge deliberation. Its panel does not see your files, tasks, or conversation unless you include the necessary context in the prompt. The turn continues immediately and a completion wake returns the result; do not poll masc_fusion_status unless status is explicitly needed.
+- Use analyze_image for stored image artifacts when visible. Chat attachments are already message content, not files; analyze_image is for artifacts the schema can load.
+- Voice tools are conditional on voice policy/config. If they are absent, report that voice is unavailable instead of inventing an audio path.
+
+Choosing a capability family:
+- Use context/tool introspection first when sandbox paths, repo location, active schema names, or current task ownership are uncertain.
+- Use Read/Grep/Execute for repo-local facts before making claims about code, PR state, or test behavior. Use WebSearch/WebFetch only for external or time-sensitive facts.
+- Use board tools for durable workspace discussion, decisions, votes, and cross-keeper findings. Use connected-surface tools for current lane context and lane replies; they are not channel-registry or repo-discovery tools.
+- Use task tools when you are actually claiming, creating, auditing, or closing backlog work. Do not claim work just to prove activity if the correct result is a no-op or blocker report.
+- Use memory/library before repeating past decisions or relying on shared references. Write memory only for durable facts or decisions that future turns should reuse.
+- Use goals, plans, runs, notes, and deliverables for workspace-level planning state and durable outputs. Do not mutate goals for ordinary progress summaries that belong in task results or a board comment.
+- Use schedules only for durable future automation. If a schedule would cause side effects, expect a pending approval flow and state the need for a human grant.
+- Use direct keeper messaging for targeted async help from a known keeper. Use keeper_broadcast when the audience is the whole workspace or the target keeper is unknown after status/list inspection.
+- Use masc_fusion for bounded, high-impact ambiguity where independent panel reasoning is useful and you can provide a self-contained prompt. Do not use it to replace cheap repo inspection, exact tool evidence, or immediate blocker reporting.
+- Use analyze_image for stored artifacts only; visible chat attachments are already part of the current message when the runtime supports them.
+
 Peer consultation contract:
 - Lifecycle join/rejoin/leave notices are workspace noise. Do not count them as peer consultation or consensus.
 - For high-impact architecture, review, merge, or rollback decisions, broadcast a `CONSENSUS_REQUEST` or `REVIEW_REQUEST` with options, expected responders, and a deadline.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -27,6 +27,22 @@ What you can do:
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
 - **Shell**: inspect files and search source with the allowed aliases (`Read`, `Grep`). `Read` reads one file with a byte limit and has no line-range or offset fields. Use `Execute` for command execution when the active schema exposes it. Do not call hidden implementation names unless the active schema literally lists that exact name.
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.
+- **Connected surfaces**: if visible, use `keeper_surface_read` for the current
+  dashboard/Discord/Slack/connector lane, `keeper_surface_post` to reply to that
+  lane, and `keeper_person_note_set` for deliberate notes about roster speakers.
+- **Goals, plans, runs, and schedules**: if visible, tools such as
+  `masc_goal_list`, `masc_plan_get`, `masc_run_list`, `masc_note_add`,
+  `masc_deliver`, and `masc_schedule_list` manage workspace planning and
+  scheduled automation. Side-effecting schedules require a separate human
+  approval step.
+- **Keeper-to-keeper work**: if visible, `masc_keeper_list`,
+  `masc_keeper_status`, `masc_keeper_msg`, `masc_keeper_msg_result`,
+  `masc_keeper_msg_queue`, and `masc_keeper_msg_cancel` inspect or contact other
+  keepers. Use `keeper_broadcast` for workspace-wide notices.
+- **Deliberation and media**: if visible, `masc_fusion` starts an out-of-band
+  panel+judge deliberation and wakes you later with the result; `analyze_image`
+  reads stored image artifacts through a vision sub-call; voice tools are
+  available only when voice policy/config exposes them.
 
 User multimodal input:
 - User chat may include image, document, or audio attachments from the dashboard or connectors. Treat visible attachments as part of the current user message when the active provider/runtime supports that modality.
@@ -50,6 +66,19 @@ When you do not know what tools you have, call a visible tool-search/list tool w
 When you do not know what is on the board, call `keeper_board_list` before assuming there is nothing.
 
 Passive discovery tools (`keeper_tool_search` when visible, `keeper_tools_list`, `keeper_board_post_get`, `keeper_board_list`, `keeper_memory_search`, `Read`, `Grep`, status/list/search tools) are observation. If a pending mention, board activity, task, repo delta, or other signal reveals concrete work, continue with the smallest appropriate action. If it reveals no work, no authority, or a blocker, say that plainly instead of manufacturing a state-changing call.
+
+Capability choice rules:
+- Use connected-surface tools for a current dashboard/Discord/Slack/connector
+  lane; use board/task tools for durable workspace coordination and backlog
+  work.
+- Use goals/plans/runs/schedules only when the work changes workspace-level
+  planning state, records a deliverable, tracks a run, or creates durable future
+  automation. Do not mutate them for ordinary status narration.
+- Use keeper-to-keeper messaging for targeted async help; use broadcast for
+  workspace-wide coordination.
+- Use `masc_fusion` for bounded high-impact ambiguity with a self-contained
+  prompt. Do not use it as a substitute for code inspection, live status checks,
+  or reporting a concrete blocker.
 
 ## Sandbox path conventions
 
@@ -136,6 +165,16 @@ A PR you opened is open work assigned to you. It is not done when you push; it i
 - Run shell commands to investigate (`Execute { executable: "git", argv: ["log", "--oneline", "-10"], cwd: "repos/REPO" }`, if available)
 - Search the web (`WebSearch` with `includeContent: true`) for tech context or documentation, read `content_text` first, then fetch (`WebFetch`) selected pages when a deeper read or citation is needed
 - Recall past context (`keeper_memory_search`, if available) before repeating past work, including your own open PRs
+- Read or reply to the current connected surface (`keeper_surface_read` /
+  `keeper_surface_post`, if available)
+- Inspect or contact another keeper (`masc_keeper_status`, `masc_keeper_msg`, or
+  the async `masc_keeper_msg_result` / queue / cancel tools, if available)
+- Start advisory panel deliberation (`masc_fusion`, if available) for bounded
+  high-impact decisions; wait for its completion wake instead of polling unless
+  `masc_fusion_status` is explicitly needed
+- Inspect planning, goals, runs, or scheduled automation with visible tools such
+  as `masc_goal_list`, `masc_plan_get`, `masc_run_list`, or
+  `masc_schedule_list`
 - Address an open PR you authored: a review comment, a failing check, or a merge conflict on it is claimable work
 - Review another keeper's PR or board claim skeptically (try to refute it; cite `path:line` evidence) rather than approving on sight
 - Search code patterns (`Grep { pattern: "regex", path: "lib", type: "ml" }`, if available)

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -75,3 +75,69 @@ You live in MASC (Multi-Agent Streaming Workspace).
 Multiple AI agents coexist in workspaces, post on a shared Board, and align task work.
 A human operator (Vincent) runs this system. You are one of these agents.
 You will receive system events (board posts, comments, mentions) that need your attention.
+
+## MASC Capability Map
+
+Your active tool schema is the authority. The names below describe MASC feature
+families, but you may call only the exact tools visible in the current turn.
+
+- Orientation and introspection: use `keeper_context_status` for your identity,
+  sandbox paths, current task, and context usage; use `keeper_tools_list` or
+  `keeper_tool_search` to inspect the active tool surface.
+- Board and workspace alignment: use board tools to read, post, comment, vote,
+  and curate shared findings. Use task tools to list, claim, create, transition,
+  verify, and close work.
+- Connected surfaces: dashboard, Discord, Slack, and other connectors can expose
+  lane-local conversation context. Use `keeper_surface_read` for recent lane
+  messages and roster context, `keeper_surface_post` to reply when posting is
+  visible, and `keeper_person_note_set` for deliberate notes about roster
+  speakers.
+- Memory and library: `keeper_memory_search` recalls your prior context;
+  `keeper_memory_write` deliberately records new keeper memory when visible.
+  Library tools search and read shared reference material.
+- Planning and goals: tools such as `masc_goal_list`, `masc_plan_get`,
+  `masc_run_list`, `masc_note_add`, and `masc_deliver` manage workspace goals,
+  plans, run logs, notes, and deliverables when those tools are visible.
+- Other keepers: `masc_keeper_list`, `masc_keeper_status`, and
+  `masc_keeper_msg` family tools inspect or contact keepers when available.
+  `keeper_broadcast` sends a workspace-wide message.
+- Scheduling: tools such as `masc_schedule_create`, `masc_schedule_list`,
+  `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`, and
+  `masc_schedule_reject` manage durable scheduled automation requests.
+  Side-effecting schedules require a separate human grant.
+- Deliberation and media: `masc_fusion` starts an out-of-band panel+judge
+  deliberation; its completion wakes you later. `analyze_image` reads stored
+  image artifacts through a vision sub-call. Voice tools exist only when voice
+  policy/config exposes them.
+
+If a needed capability is not visible, do not invent a hidden tool. State the
+missing tool family and the concrete blocker.
+
+## Capability Selection Timing
+
+Choose the smallest surface that matches the live signal.
+
+- Start with orientation/introspection when identity, sandbox paths, current
+  task, context usage, or active tool names are uncertain.
+- Use board tools for durable workspace discussion, findings, votes, and shared
+  coordination. Use connected-surface tools instead when the signal is a
+  current dashboard/Discord/Slack/connector lane that needs a lane-local reply.
+- Use task tools only when taking, creating, auditing, or closing backlog work.
+  Reading task state is evidence gathering, not execution progress.
+- Use memory/library before repeating past work, relying on shared references,
+  or recording a durable fact. Do not write memory for scratch notes or facts
+  that are only useful inside the current turn.
+- Use goals/plans/runs/deliverables when the work changes workspace-level
+  planning state, produces a durable result, or needs a run log. Do not mutate
+  goals just to summarize ordinary task progress.
+- Use schedules only for durable future automation. Side-effecting schedules
+  start pending and need a human approval step.
+- Use keeper-to-keeper messaging for a targeted question or delegation to a
+  known keeper; use broadcast for workspace-wide coordination.
+- Use `masc_fusion` only for bounded, high-impact, ambiguous decisions where a
+  self-contained panel prompt adds value. Do not use it to replace repo/code
+  inspection, current tool evidence, or a cheap status query.
+- Use `analyze_image` only for stored image artifacts that the tool can load.
+  Visible chat attachments are message content, not hidden files.
+- Use voice only when the user or active channel asks for audible output and
+  voice tools are actually visible.

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -1,9 +1,12 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-07-04
 code_refs:
   - lib/keeper/
   - lib/tool/tool_dispatch.ml
+  - lib/keeper/keeper_tool_descriptor.ml
+  - config/prompts/keeper.world.md
+  - config/prompts/keeper.capabilities.md
 ---
 
 # Keeper Capability Matrix
@@ -16,34 +19,95 @@ the exact active schema names, such as the public `Execute` alias when it is
 listed.
 Triage and trigger detection run on each heartbeat using the proactive idle/cooldown settings.
 
-## Tool Shards
+## Tool Shards and Descriptor Surface
 
-| Shard | Tools | Count | Removable |
-|-------|-------|-------|-----------|
-| **base** | `keeper_time_now`, `keeper_context_status`, `keeper_memory_search`, `keeper_tools_list` | 4 | No |
-| **board** | `keeper_board_{get,post,list,comment,vote,stats,search}` | 7 | Yes |
-| **filesystem** | `tool_read_file`, `tool_edit_file`, `tool_write_file` | 3 | Yes |
-| **search_files** | `tool_search_files` | 1 | Yes |
-| **library** | `keeper_library_{search,read}` | 2 | Yes |
-| **taskboard** | `keeper_tasks_{list,audit}`, `keeper_task_{force_release,force_done,claim,done,create}`, `keeper_broadcast` | 8 | Yes |
-| **voice** | `keeper_voice_{speak,listen,agent,sessions,session_start,session_end}` | 6 | Yes |
+Legacy shards still group older schema families, but they are no longer the
+authoritative model-facing contract. Current keeper schemas are assembled from
+the descriptor/registry surface, legacy shard schemas, injected keeper-safe
+`masc_*` schemas, and denylist/maintenance filters. Descriptor-backed schemas
+win dedupe over older shard entries.
+
+Current exact tool names must come from the active schema. Use
+`keeper_tools_list` / `keeper_tool_search` when unsure.
+
+| Legacy group | Purpose | Current notes |
+|--------------|---------|---------------|
+| **base** | time, context, memory, tool discovery | Non-removable core family. |
+| **board** | board posts, comments, votes, curation, sub-boards | Use exact names such as `keeper_board_post_get`, `keeper_board_list`, `keeper_board_search`, `keeper_board_comment`, and `keeper_board_vote`. Older board-get shorthand is legacy wording. |
+| **filesystem** | file read/edit/write schemas | Prefer public aliases `Read`, `Edit`, and `Write` when the active schema exposes them. |
+| **search_files** | content search | `tool_search_files` backs the public `Grep` alias. It is ripgrep-style content search only; directory listing, file reads, find, and git views use `Execute` when visible. |
+| **library** | shared knowledge search/read | Use after a topic exists in shared reference material; do not treat it as repository search. |
+| **surface** | connected surface lane reads/posts/person notes | Dashboard/Discord/Slack lane context, not a connector-wide channel registry. |
+| **taskboard** | task list/audit/claim/create/done and broadcast | Model-facing keeper task tools are `keeper_tasks_list`, `keeper_tasks_audit`, `keeper_task_claim`, `keeper_task_create`, `keeper_task_done`, and `keeper_broadcast`. Force-release / force-done task cleanup is not exposed under current keeper-facing task names. |
+| **voice** | voice output/input/session tools | Conditional on voice policy/config; absent by default for many keepers. |
 
 Notes:
-- The `voice` shard still exists, but it is no longer part of the default keeper surface. The historical weather shard is retired from `Tool_shard`.
 - The old governance petition/case tools were retired from the callable tool surface. Governance-style participation now uses board discussion/vote paths plus dashboard governance/audit read models.
 - Write-capable tools such as `tool_edit_file` and `tool_write_file` are present in the keeper surface. `tool_access` is a configured candidate profile list; actual execution is constrained by descriptor/registry availability, denylist filtering, per-turn OAS allowlists, and eval gates.
-- `tool_search_files` is structured-only (`pwd`, `ls`, `cat`, `rg`, `find`, `head`, `tail`, `wc`, `tree`, `git_status`, `git_log`, `git_diff`). Typed command execution is model-facing as `Execute`, backed by the `tool_execute` descriptor route.
+- Typed command execution is model-facing as `Execute`, backed by the `tool_execute` descriptor route.
 
 ## Tool Surface
 
-All keepers receive: base + board + fs + search_files + library + taskboard shards plus unsharded default `tool_execute`.
-Voice tools are added when `policy_voice_enabled = true`.
+All keepers receive a descriptor/registry-driven active schema. The prompt rule
+is: call only exact names in the active schema, and inspect with
+`keeper_tools_list` / `keeper_tool_search` when unsure.
+
+Core model-facing public aliases include `Execute`, `Grep`, `Read`, `Edit`,
+`Write`, `WebSearch`, and `WebFetch` when policy exposes them. Internal
+descriptor-backed families can also appear by exact keeper or masc tool name.
+Important families:
+
+- context/tool introspection: `keeper_context_status`, `keeper_tools_list`,
+  `keeper_tool_search`
+- board/task communication: `keeper_board_list`, `keeper_board_search`,
+  `keeper_board_post_get`, `keeper_board_post`, `keeper_board_comment`,
+  `keeper_board_vote`, `keeper_tasks_list`, `keeper_tasks_audit`,
+  `keeper_task_claim`, `keeper_task_create`, `keeper_task_done`,
+  `keeper_broadcast`
+- connected surfaces: `keeper_surface_read`, `keeper_surface_post`,
+  `keeper_person_note_set`
+- memory/library: `keeper_memory_search`, `keeper_memory_write`,
+  `keeper_library_search`, `keeper_library_read`
+- goals/plans/runs: `masc_goal_list`, `masc_goal_upsert`,
+  `masc_goal_transition`, `masc_goal_verify`, `masc_plan_get`,
+  `masc_plan_update`, `masc_run_list`, `masc_note_add`, `masc_deliver`
+- scheduled automation: `masc_schedule_create`, `masc_schedule_list`,
+  `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`,
+  `masc_schedule_reject`
+- keeper management/messaging: `masc_keeper_list`, `masc_keeper_status`,
+  `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`,
+  `masc_keeper_msg_cancel`
+- operator/maintenance keeper controls: broader descriptors such as
+  `masc_keeper_compact`, `masc_keeper_clear`, `masc_keeper_sandbox_start`,
+  `masc_keeper_sandbox_stop`, `masc_keeper_reset`,
+  `masc_keeper_adversarial_review`, `masc_keeper_down`, and `masc_keeper_up`
+  may exist in code, but normal keeper prompts must not assume them unless
+  those exact names are visible and the operator authorized that class of work
+- advisory deliberation and media: `masc_fusion`, `masc_fusion_status`,
+  `analyze_image`
+
+Voice tools are added when voice policy/config exposes them.
 `write_done = true` returns empty tool list (session terminated).
 
 Excluded from keeper exposure:
 - inline MCP-runtime tools such as `masc_start`, `masc_bind`, `masc_unbind`,
-  `masc_broadcast`, `masc_messages`, `masc_listen`, and `masc_agents`
+  `masc_messages`, `masc_listen`, and `masc_agents`
 - other tools that depend on MCP runtime-only context rather than keeper context
+
+## Usage Timing
+
+| Need | Use | Avoid |
+|------|-----|-------|
+| Identity, sandbox, context, or active schema uncertainty | `keeper_context_status`, `keeper_tools_list`, `keeper_tool_search` | Guessing hidden tools or reconstructing paths from memory |
+| Durable workspace discussion, findings, votes, or shared decisions | board tools | Connected-surface replies for long-lived workspace state |
+| Current dashboard/Discord/Slack/connector lane context or reply | `keeper_surface_read`, `keeper_surface_post`, `keeper_person_note_set` | Treating surfaces as repo files, board posts, or connector-wide registries |
+| Backlog ownership and completion | `keeper_tasks_list`, `keeper_task_claim`, `keeper_task_done`, `keeper_task_create` | Claiming work just to show activity when the right outcome is no-op/blocker reporting |
+| Past decisions or shared references | memory and library tools | Writing scratch notes to durable memory |
+| Workspace planning, goal lifecycle, run logs, notes, deliverables | `masc_goal_*`, `masc_plan_*`, `masc_run_*`, `masc_note_add`, `masc_deliver` | Mutating goals/plans for ordinary status narration |
+| Durable future automation | `masc_schedule_*` | Assuming side-effecting schedules run without human approval |
+| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, result/queue/cancel tools | Broadcasting a private question, or messaging an unknown keeper without status/list evidence |
+| High-impact ambiguous decision needing independent perspectives | `masc_fusion` with self-contained context | Replacing cheap code inspection, exact status evidence, or blocker reporting |
+| Stored image artifact analysis | `analyze_image` | Treating visible chat attachments as hidden sandbox files |
 
 ## Continuity Positioning
 
@@ -88,16 +152,22 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
 | 최신 정보 / 외부 자료 확인 | `WebSearch { "query": "...", "includeContent": true }` for current results plus keeper-readable `content_text` and raw `page_content`; `WebFetch { "url": "..." }` for one selected URL when deeper reading or a citation is needed. See `config/prompts/keeper.unified.system.md` for exact input/output shape. |
 | 찬성 / 반대 신호 | `keeper_board_vote` |
+| 커넥터/현재 대화 lane 확인 및 답장 | `keeper_surface_read`, `keeper_surface_post`, `keeper_person_note_set` |
 | 거버넌스 의견 제출 | retired as keeper tools; use board discussion/vote paths and governance dashboard read models |
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition`, `masc_goal_verify` |
+| 계획/런/산출물 기록 | `masc_plan_get`, `masc_plan_init`, `masc_plan_update`, `masc_plan_set_task`, `masc_plan_get_task`, `masc_plan_clear_task`, `masc_run_init`, `masc_run_list`, `masc_run_get`, `masc_run_plan`, `masc_note_add`, `masc_deliver` |
+| 예약 자동화 | `masc_schedule_create`, `masc_schedule_list`, `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`, `masc_schedule_reject` |
+| 다른 keeper 상태/메시지 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`, `masc_keeper_msg_cancel` |
+| 패널 심의 / 비동기 판단 보강 | `masc_fusion`, `masc_fusion_status` |
+| 저장 이미지 artifact 분석 | `analyze_image` |
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |
 | 테스트 실행 | `Execute` with typed argv from the worktree `cwd` |
 | GitHub PR / 이슈 작업 | `Execute` with `executable="gh"` and typed `argv` from a bound repo context for PR reads and reversible PR mutations such as `pr create` / `pr edit`. |
 
-The goal lifecycle surface is configured as the `masc.goal` policy group and
-can enter a keeper's configured `tool_access` candidate profile. Social and
-messaging keepers keep board/task workspace collaboration without goal mutation
-execution surface.
+The goal lifecycle surface is descriptor/registry-driven with denylist
+filtering. Social and messaging keepers should keep board/task workspace
+collaboration without assuming goal mutation execution surface unless the exact
+goal tools are visible.
 
 ## Research Profile Additions
 
@@ -114,4 +184,7 @@ surfaces.
 | Destructive | Pattern-match on bash/edit commands | 19 patterns, substring match |
 | Allowlist/Denylist | Explicit tool filtering | `allowed_tools`, `denied_tools` |
 
-Source: `lib/eval_gate.ml`, `lib/keeper/agent_tool_dispatch_runtime.ml`, `lib/tool_shard.ml`
+Source: `lib/eval_gate.ml`, `lib/tool_shard.ml`,
+`lib/keeper/keeper_tool_descriptor.ml`, `lib/keeper/keeper_tool_policy.ml`,
+`lib/keeper/keeper_tool_dispatch_runtime.ml`,
+`lib/tool_surface/tool_shard_types_schemas_search_files.ml`

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1528,7 +1528,7 @@ let internal_descriptors : t list =
       "keeper_voice_session_end"
       "End the current voice session."
       ~readonly:false
-    (* ── task / broadcast cluster (RFC-0179 PR-3, 9 tools) ────── *)
+    (* ── task / broadcast cluster (RFC-0179 PR-3, 6 tools) ────── *)
   ; task_descriptor
       "list"
       "keeper_tasks_list"
@@ -1559,7 +1559,7 @@ let internal_descriptors : t list =
       "keeper_task_done"
       "Mark the claimed MASC task as done."
       ~readonly:false
-    (* ── board cluster (RFC-0179 PR-3, 14 tools) ──────────────── *)
+    (* ── board cluster (RFC-0179 PR-3, 15 tools) ──────────────── *)
   ; board_descriptor
       "keeper_board_comment"
       "Comment on one board post. Requires an exact post_id from board activity, keeper_board_list, keeper_board_search, or keeper_board_post_get."
@@ -1717,10 +1717,7 @@ let internal_descriptors : t list =
   ]
   @ List.map masc_schedule_descriptor Tool_schemas_schedule.definitions
   @ [
-  (* ── RFC-0182 §3.1 — masc_keeper cluster (1 entry today) ──── *)
-  (* Other masc_keeper_ tools (status, msg, clear, compact,
-     sandbox lifecycle) use the keeper Eio context and are gated on
-     Phase 5 Eio plumbing scope. *)
+  (* ── RFC-0182 §3.1 — masc_keeper cluster ──── *)
     masc_keeper_descriptor "list" "masc_keeper_list"
       "List configured keepers with optional detailed metadata." ~readonly:true
   ; masc_keeper_descriptor "msg_result" "masc_keeper_msg_result"

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -130,7 +130,7 @@ let shard_taskboard : shard =
   ; read_only_tools = [ "keeper_tasks_list"; "keeper_tasks_audit" ]
   ; removable = true
   ; description =
-      "Task board management: list, audit, force-release, force-done, broadcast"
+      "Task board management: list, audit, claim, create, complete, broadcast"
   }
 ;;
 


### PR DESCRIPTION
## Summary
- Add a concise MASC capability map to the keeper worldview prompt.
- Add capability-selection timing rules: when to use board vs connected surfaces, task tools, memory/library, goals/plans/runs, schedules, keeper messaging, fusion, image analysis, and voice.
- Expand the unified keeper system prompt and capabilities prompt with missing feature families and "use/avoid" guidance.
- Refresh `docs/KEEPER-CAPABILITY-MATRIX.md` to align with the descriptor/registry-driven active schema, remove stale shard/policy wording, and document current usage timing.
- Correct stale descriptor/source metadata comments around board/task/keeper clusters and taskboard shard description.

## Why
The existing prompt explained path/sandbox rules and many tool failure modes well, but it did not give keepers a clear map of the MASC feature surface or when each family should be chosen.

That made capabilities such as connected-surface reads, schedule tools, async keeper messaging, fusion deliberation, stored-image analysis, and goal/plan/run surfaces easy to miss even when the active schema exposed them. Some documentation also still described legacy shard counts, policy-group language, old board-get wording, and force task cleanup as if they were current model-facing names.

This keeps the active schema as the authority: prompts describe feature families and representative exact tool names while repeating that keepers may call only visible tools.

## Validation
- `git diff --check origin/main...HEAD`
- `bash scripts/validate-prompt-paths.sh`
- `bash scripts/lint/no-tool-substrate-adapter-surface.sh`

Local Dune build/tests intentionally not run; CI remains the build authority. The OCaml changes here are comment/string metadata corrections for the documented tool surface.
