### PR TITLE
[codex] Align IDE annotation mutations with token identity

### DIFF
--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -67,22 +67,24 @@ describe('ide API', () => {
     expect(url).toContain('repo_id=masc')
   })
 
-  it('createIdeAnnotation appends workspace params to mutation URL', async () => {
+  it('createIdeAnnotation relies on token identity and appends workspace params', async () => {
     stubFetch({ ok: true, data: annotation })
 
     await createIdeAnnotation({
       file_path: 'lib/a.ml',
       line_start: 1,
       line_end: 1,
-      keeper_id: 'sangsu',
       kind: 'Comment',
       content: 'Review this line',
     }, { keeper: 'sangsu', repoId: 'masc' })
 
     const url = String(mockFetch.mock.calls[0]![0])
+    const init = mockFetch.mock.calls[0]![1] as RequestInit
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>
     expect(url).toContain('/api/v1/ide/annotations?')
     expect(url).toContain('keeper=sangsu')
     expect(url).toContain('repo_id=masc')
+    expect(body).not.toHaveProperty('keeper_id')
   })
 
   it('fetchIdeRegions appends repo_id param', async () => {
@@ -96,15 +98,15 @@ describe('ide API', () => {
     expect(url).toContain('repo_id=masc')
   })
 
-  it('deleteIdeAnnotation appends repo_id param', async () => {
+  it('deleteIdeAnnotation relies on token identity and appends repo_id param', async () => {
     stubFetch({}, true)
 
-    await deleteIdeAnnotation('ann-1', 'sangsu', { repoId: 'masc' })
+    await deleteIdeAnnotation('ann-1', { repoId: 'masc' })
 
     const url = String(mockFetch.mock.calls[0]![0])
     expect(url).toContain('/api/v1/ide/annotations/ann-1?')
-    expect(url).toContain('keeper_id=sangsu')
     expect(url).toContain('repo_id=masc')
+    expect(url).not.toContain('keeper_id=')
   })
 
   it('fetchIdeEvents appends event filters and parses bridge events', async () => {

--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -67,6 +67,28 @@ describe('ide API', () => {
     expect(url).toContain('repo_id=masc')
   })
 
+  it('fetchIdeAnnotations rejects failed envelopes instead of returning empty', async () => {
+    stubFetch({ ok: false, error: 'repo scope unmatched' })
+
+    await expect(fetchIdeAnnotations()).rejects.toThrow('repo scope unmatched')
+  })
+
+  it('fetchIdeAnnotations rejects malformed rows instead of dropping them', async () => {
+    stubFetch({ ok: true, data: [null] })
+
+    await expect(fetchIdeAnnotations()).rejects.toThrow(
+      'fetchIdeAnnotations returned malformed row at index 0',
+    )
+  })
+
+  it('fetchIdeAnnotations rejects rows with missing required fields', async () => {
+    stubFetch({ ok: true, data: [{ ...annotation, id: '' }] })
+
+    await expect(fetchIdeAnnotations()).rejects.toThrow(
+      'fetchIdeAnnotations returned malformed row at index 0',
+    )
+  })
+
   it('createIdeAnnotation relies on token identity and appends workspace params', async () => {
     stubFetch({ ok: true, data: annotation })
 
@@ -87,6 +109,30 @@ describe('ide API', () => {
     expect(body).not.toHaveProperty('keeper_id')
   })
 
+  it('createIdeAnnotation rejects failed envelopes instead of returning null', async () => {
+    stubFetch({ ok: false, error: 'annotation denied' })
+
+    await expect(createIdeAnnotation({
+      file_path: 'lib/a.ml',
+      line_start: 1,
+      line_end: 1,
+      kind: 'Comment',
+      content: 'Review this line',
+    })).rejects.toThrow('annotation denied')
+  })
+
+  it('createIdeAnnotation rejects malformed annotation rows', async () => {
+    stubFetch({ ok: true, data: { ...annotation, created_at_ms: null } })
+
+    await expect(createIdeAnnotation({
+      file_path: 'lib/a.ml',
+      line_start: 1,
+      line_end: 1,
+      kind: 'Comment',
+      content: 'Review this line',
+    })).rejects.toThrow('createIdeAnnotation returned malformed row')
+  })
+
   it('fetchIdeRegions appends repo_id param', async () => {
     stubFetch({ ok: true, data: [region] })
 
@@ -96,6 +142,22 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/regions?')
     expect(url).toContain('file_path=lib%2Fa.ml')
     expect(url).toContain('repo_id=masc')
+  })
+
+  it('fetchIdeRegions rejects malformed response data', async () => {
+    stubFetch({ ok: true, data: { regions: [] } })
+
+    await expect(fetchIdeRegions('lib/a.ml')).rejects.toThrow(
+      'fetchIdeRegions returned malformed data',
+    )
+  })
+
+  it('fetchIdeRegions rejects malformed region rows instead of coercing defaults', async () => {
+    stubFetch({ ok: true, data: [{ ...region, source: { type: 'legacy' } }] })
+
+    await expect(fetchIdeRegions('lib/a.ml')).rejects.toThrow(
+      'fetchIdeRegions returned malformed row at index 0',
+    )
   })
 
   it('deleteIdeAnnotation relies on token identity and appends repo_id param', async () => {
@@ -151,6 +213,24 @@ describe('ide API', () => {
     })])
   })
 
+  it('fetchIdeEvents rejects malformed event rows instead of dropping them', async () => {
+    stubFetch({
+      ok: true,
+      data: {
+        events: [{
+          type: 'tool',
+          keeper_id: 'sangsu',
+          turn_id: 'turn-1',
+          timestamp_ms: 1717400000000,
+        }],
+      },
+    })
+
+    await expect(fetchIdeEvents()).rejects.toThrow(
+      'fetchIdeEvents returned malformed event at index 0',
+    )
+  })
+
   it('fetchIdeCursors appends cursor filters and parses valid cursor rows', async () => {
     stubFetch({
       ok: true,
@@ -192,5 +272,27 @@ describe('ide API', () => {
       focus_mode: 'editing',
       turn: 7,
     })])
+  })
+
+  it('fetchIdeCursors rejects malformed cursor rows instead of dropping them', async () => {
+    stubFetch({
+      ok: true,
+      data: {
+        runtime_id: 'masc-runtime',
+        connected: true,
+        cursors: [{
+          keeper_id: 'sangsu',
+          file_path: 'lib/a.ml',
+          line: 0,
+          column: 3,
+          focus_mode: 'editing',
+          last_update: 1717400000000,
+        }],
+      },
+    })
+
+    await expect(fetchIdeCursors()).rejects.toThrow(
+      'fetchIdeCursors returned malformed cursor rows',
+    )
   })
 })

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -104,7 +104,6 @@ export interface CreateAnnotationInput {
   readonly file_path: string
   readonly line_start: number
   readonly line_end: number
-  readonly keeper_id: string
   readonly kind: AnnotationKind
   readonly content: string
   readonly goal_id?: string
@@ -164,13 +163,12 @@ export async function createIdeAnnotation(
 
 export async function deleteIdeAnnotation(
   id: string,
-  keeperId: string,
   opts: IdeApiOptions = {},
 ): Promise<boolean> {
   const params = new URLSearchParams()
-  params.set('keeper_id', keeperId)
   appendWorkspaceParams(params, opts)
-  const path = `/api/v1/ide/annotations/${encodeURIComponent(id)}?${params.toString()}`
+  const query = params.size > 0 ? `?${params.toString()}` : ''
+  const path = `/api/v1/ide/annotations/${encodeURIComponent(id)}${query}`
   try {
     const res = await fetchWithTimeout(path, { method: 'DELETE' }, 15_000)
     return res.ok

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -1,7 +1,5 @@
 import { get, post, fetchWithTimeout, type GetOptions } from './core'
 import {
-  parseIdeAnnotations,
-  parseIdeCodeRegions,
   type IdeAnnotation,
   type IdeCodeRegion,
   type AnnotationKind,
@@ -136,6 +134,181 @@ function appendWorkspaceParams(
   if (opts.repoId) params.set('repo_id', opts.repoId)
 }
 
+function ideEnvelopeData(raw: unknown, operation: string): unknown {
+  if (!isRecord(raw)) throw new Error(`${operation} returned a malformed response envelope`)
+  if (raw.ok !== true) {
+    const message = typeof raw.error === 'string' && raw.error.trim() !== ''
+      ? raw.error.trim()
+      : `${operation} failed`
+    throw new Error(message)
+  }
+  return raw.data
+}
+
+function ideEnvelopeRecord(raw: unknown, operation: string): Record<string, unknown> {
+  const data = ideEnvelopeData(raw, operation)
+  if (!isRecord(data)) throw new Error(`${operation} returned malformed data`)
+  return data
+}
+
+function parseStrictRows<T>(
+  operation: string,
+  data: unknown,
+  parse: (value: unknown) => T | null,
+): ReadonlyArray<T> {
+  if (!Array.isArray(data)) throw new Error(`${operation} returned malformed data`)
+  const parsed = data.map(parse)
+  const invalidIndex = parsed.findIndex(item => item === null)
+  if (invalidIndex >= 0) {
+    throw new Error(`${operation} returned malformed row at index ${invalidIndex}`)
+  }
+  return parsed as ReadonlyArray<T>
+}
+
+function parseStrictRow<T>(
+  operation: string,
+  data: unknown,
+  parse: (value: unknown) => T | null,
+): T {
+  const parsed = parse(data)
+  if (parsed === null) throw new Error(`${operation} returned malformed row`)
+  return parsed
+}
+
+function nullableStringField(record: Record<string, unknown>, key: string): string | null | undefined {
+  const value = record[key]
+  if (value === undefined || value === null) return null
+  return typeof value === 'string' ? value : undefined
+}
+
+function integerField(record: Record<string, unknown>, key: string): number | null {
+  const value = numberField(record, key)
+  return value !== null && Number.isInteger(value) ? value : null
+}
+
+function positiveIntegerField(record: Record<string, unknown>, key: string): number | null {
+  const value = integerField(record, key)
+  return value !== null && value > 0 ? value : null
+}
+
+function annotationKindField(record: Record<string, unknown>): AnnotationKind | null {
+  const kind = stringField(record, 'kind')
+  return kind === 'Comment'
+    || kind === 'Decision'
+    || kind === 'Question'
+    || kind === 'Bookmark'
+    ? kind
+    : null
+}
+
+function parseStrictIdeAnnotation(raw: unknown): IdeAnnotation | null {
+  if (!isRecord(raw)) return null
+  const id = stringField(raw, 'id')
+  const filePath = stringField(raw, 'file_path')
+  const lineStart = positiveIntegerField(raw, 'line_start')
+  const lineEnd = positiveIntegerField(raw, 'line_end')
+  const keeperId = stringField(raw, 'keeper_id')
+  const kind = annotationKindField(raw)
+  const content = typeof raw.content === 'string' ? raw.content : null
+  const goalId = nullableStringField(raw, 'goal_id')
+  const taskId = nullableStringField(raw, 'task_id')
+  const boardPostId = nullableStringField(raw, 'board_post_id')
+  const commentId = nullableStringField(raw, 'comment_id')
+  const prId = nullableStringField(raw, 'pr_id')
+  const gitRef = nullableStringField(raw, 'git_ref')
+  const logId = nullableStringField(raw, 'log_id')
+  const sessionId = nullableStringField(raw, 'session_id')
+  const operationId = nullableStringField(raw, 'operation_id')
+  const workerRunId = nullableStringField(raw, 'worker_run_id')
+  const createdAtMs = numberField(raw, 'created_at_ms')
+  const updatedAtMs = numberField(raw, 'updated_at_ms')
+  if (
+    !id
+    || !filePath
+    || lineStart === null
+    || lineEnd === null
+    || lineEnd < lineStart
+    || !keeperId
+    || kind === null
+    || content === null
+    || goalId === undefined
+    || taskId === undefined
+    || boardPostId === undefined
+    || commentId === undefined
+    || prId === undefined
+    || gitRef === undefined
+    || logId === undefined
+    || sessionId === undefined
+    || operationId === undefined
+    || workerRunId === undefined
+    || createdAtMs === null
+    || updatedAtMs === null
+  ) {
+    return null
+  }
+  return {
+    id,
+    file_path: filePath,
+    line_start: lineStart,
+    line_end: lineEnd,
+    keeper_id: keeperId,
+    kind,
+    content,
+    goal_id: goalId,
+    task_id: taskId,
+    board_post_id: boardPostId,
+    comment_id: commentId,
+    pr_id: prId,
+    git_ref: gitRef,
+    log_id: logId,
+    session_id: sessionId,
+    operation_id: operationId,
+    worker_run_id: workerRunId,
+    created_at_ms: createdAtMs,
+    updated_at_ms: updatedAtMs,
+  }
+}
+
+function parseStrictIdeCodeRegion(raw: unknown): IdeCodeRegion | null {
+  if (!isRecord(raw)) return null
+  const source = isRecord(raw.source) ? raw.source : null
+  if (source === null) return null
+  const filePath = stringField(raw, 'file_path')
+  const lineStart = positiveIntegerField(raw, 'line_start')
+  const lineEnd = positiveIntegerField(raw, 'line_end')
+  const keeperId = stringField(raw, 'keeper_id')
+  const sourceType = stringField(source, 'type')
+  const sourceToolName = nullableStringField(source, 'tool_name')
+  const sourceTurn = sourceType === 'tool_call' ? integerField(source, 'turn') : null
+  const sourceNote = sourceType === 'manual' ? nullableStringField(source, 'note') : null
+  const timestampMs = numberField(raw, 'timestamp_ms')
+  if (
+    !filePath
+    || lineStart === null
+    || lineEnd === null
+    || lineEnd < lineStart
+    || !keeperId
+    || (sourceType !== 'tool_call' && sourceType !== 'manual')
+    || sourceToolName === undefined
+    || sourceNote === undefined
+    || (sourceType === 'tool_call' && sourceTurn === null)
+    || timestampMs === null
+  ) {
+    return null
+  }
+  return {
+    file_path: filePath,
+    line_start: lineStart,
+    line_end: lineEnd,
+    keeper_id: keeperId,
+    source_type: sourceType,
+    source_tool_name: sourceToolName,
+    source_turn: sourceTurn,
+    source_note: sourceNote,
+    timestamp_ms: timestampMs,
+  }
+}
+
 export async function fetchIdeAnnotations(
   filter: IdeAnnotationFilter = {},
   opts: IdeApiOptions = {},
@@ -145,8 +318,7 @@ export async function fetchIdeAnnotations(
   appendWorkspaceParams(params, opts)
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const raw = await get<unknown>(`/api/v1/ide/annotations${query}`, opts)
-  if (!isRecord(raw) || raw.ok !== true) return []
-  return parseIdeAnnotations(raw.data)
+  return parseStrictRows('fetchIdeAnnotations', ideEnvelopeData(raw, 'fetchIdeAnnotations'), parseStrictIdeAnnotation)
 }
 
 export async function createIdeAnnotation(
@@ -157,8 +329,7 @@ export async function createIdeAnnotation(
   appendWorkspaceParams(params, opts)
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const raw = await post<unknown>(`/api/v1/ide/annotations${query}`, input)
-  if (!isRecord(raw) || raw.ok !== true) return null
-  return parseIdeAnnotations([raw.data])[0] ?? null
+  return parseStrictRow('createIdeAnnotation', ideEnvelopeData(raw, 'createIdeAnnotation'), parseStrictIdeAnnotation)
 }
 
 export async function deleteIdeAnnotation(
@@ -185,8 +356,7 @@ export async function fetchIdeRegions(
   params.set('file_path', filePath)
   appendWorkspaceParams(params, opts)
   const raw = await get<unknown>(`/api/v1/ide/regions?${params.toString()}`, opts)
-  if (!isRecord(raw) || raw.ok !== true) return []
-  return parseIdeCodeRegions(raw.data)
+  return parseStrictRows('fetchIdeRegions', ideEnvelopeData(raw, 'fetchIdeRegions'), parseStrictIdeCodeRegion)
 }
 
 export async function fetchIdePresence(
@@ -210,8 +380,15 @@ export async function fetchIdeCursors(
   if (opts.offset !== undefined) params.set('offset', String(opts.offset))
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const raw = await get<unknown>(`/api/v1/ide/cursors${query}`, opts)
-  if (!isRecord(raw) || raw.ok !== true) return null
-  return parseIdeCursorSnapshot(raw.data)
+  const data = ideEnvelopeRecord(raw, 'fetchIdeCursors')
+  const snapshot = parseIdeCursorSnapshot(data)
+  if (snapshot === null) throw new Error('fetchIdeCursors returned malformed data')
+  const cursorRows = data.cursors
+  if (!Array.isArray(cursorRows)) throw new Error('fetchIdeCursors returned malformed cursors')
+  if (snapshot.cursors.length !== cursorRows.length) {
+    throw new Error('fetchIdeCursors returned malformed cursor rows')
+  }
+  return snapshot
 }
 
 export async function fetchIdeEvents(
@@ -225,9 +402,15 @@ export async function fetchIdeEvents(
   if (opts.offset !== undefined) params.set('offset', String(opts.offset))
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const raw = await get<unknown>(`/api/v1/ide/events${query}`, opts)
-  if (!isRecord(raw) || raw.ok !== true || !isRecord(raw.data)) return []
-  const events = raw.data.events
-  return Array.isArray(events) ? events.map(parseIdeBridgeEvent).filter(isIdeBridgeEvent) : []
+  const data = ideEnvelopeRecord(raw, 'fetchIdeEvents')
+  const events = data.events
+  if (!Array.isArray(events)) throw new Error('fetchIdeEvents returned malformed events')
+  const parsed = events.map(parseIdeBridgeEvent)
+  const invalidIndex = parsed.findIndex(event => event === null)
+  if (invalidIndex >= 0) {
+    throw new Error(`fetchIdeEvents returned malformed event at index ${invalidIndex}`)
+  }
+  return parsed.filter(isIdeBridgeEvent)
 }
 
 function parseIdeBridgeEvent(raw: unknown): IdeBridgeEvent | null {


### PR DESCRIPTION
## Summary
- remove client-supplied `keeper_id` from IDE annotation create requests
- remove caller-supplied `keeper_id` from annotation delete URLs
- align the dashboard API wrapper with the backend contract: token identity is the only mutation identity authority

## Validation
- git diff --check HEAD~1..HEAD
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/api/ide.test.ts --no-file-parallelism --maxWorkers=1
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty

Dune/CI was not run or waited on per instruction.