### PR TITLE
fix: main 빌드 복구 — dune build . 실패 2건 (ide_bridge exit_semantics + dashboard test Masc qualify)

### DIFF
--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -722,7 +722,12 @@ let ingest_cursor_event
     ?focus_mode
     ~source
     ()
+    : (unit, string) result
   =
+  (* The explicit return annotation pins the branches to [result]: this file
+     [open Ide_event_types], whose [exit_semantics] also has an [Error of
+     string] constructor, so a bare [Error msg] arm would otherwise infer
+     [exit_semantics] and reject the sibling [Ok ()]. *)
   (* DEFER (task-1733): this is the human-IDE direct path (server_ide_http.ml
      POST /api/v1/ide/cursors). [partition] is accepted so the caller CAN scope
      the write, but the server call site does not yet resolve one from the


### PR DESCRIPTION
## 🔴 main 빌드 복구 (hotfix) — `dune build .` 실패 2건

현재 main에서 `dune build .`가 **두 독립 근본원인**으로 실패합니다. 둘 다 여기서 고쳐 한 번 머지로 main을 green으로 만듭니다.

---

### 1. `lib/ide/ide_bridge.ml:761` (lib 빌드) — 원인: #23196

```
This variant expression is expected to have type exit_semantics;
there is no constructor Ok within type exit_semantics
```

- `ide_bridge.ml:4`의 `open Ide_event_types` → `exit_semantics`의 `Error of string` 생성자가 `Stdlib.Result.Error`를 **shadow**.
- #23196이 `ingest_cursor_event`에 result 타입 focus-mode 처리를 추가하면서, outer match 첫 arm `| Error msg -> Error msg`가 `exit_semantics.Error`로 추론 → match 전체가 `exit_semantics`로 고정 → `Ok ()`가 실패(`exit_semantics`엔 `Ok` 없음).
- **수정**: `.mli`가 이미 선언한 `(unit, string) result`를 `.ml` 함수 반환 타입으로 명시 → bare `Ok`/`Error`가 `result`로 해석.

### 2. `test/test_dashboard_http_core.ml:737` (test 빌드) — 원인: #23211

```
Unbound module Client_registry_eio
```

- 이 파일은 `open Masc`가 없고 `Masc.X` qualified alias만 사용.
- `Client_registry_eio`는 **wrapped `masc`** lib 소속 → bare 참조 불가(`Masc.` 필요). (`Server_dashboard_http`/`Ide_paths`는 **unwrapped `masc.server`** lib이라 bare OK.)
- #23211이 새 테스트에 bare `Client_registry_eio.reset_for_testing`를 추가.
- **수정**: 파일 관습대로 `Masc.Client_registry_eio`로 qualify(737/739). `open Masc` 추가는 unwrapped `masc.server` 모듈과 충돌 위험이라 배제.

---

### 검증
- `dune build .`(전체 lib + 전체 test) 컴파일 성공 — 남은 컴파일 에러 0 확인
- `test_ide_bridge` 42/42, `test_dashboard_http_core` 46/46 통과

### 참고 (프로세스 갭)
두 에러 모두 **테스트 빌드가 아닌 lib/바이너리 빌드만 하는 CI**를 통과해 main에 들어온 것으로 보입니다(#23196·#23211). 별도 이슈로 기록 권장 — CI에 `dune build .` 또는 `@check` 게이트 추가.

**빠른 머지 요망** — 머지 전까지 main `dune build .` red.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
