### PR TITLE
fix(dashboard): edit fusion preset runtimes

### DIFF
--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -23,6 +23,14 @@ judge = "j"
 min_answered = 1
 `
 
+const SAMPLE_WITH_RUNTIME_OPTIONS = `${SAMPLE}
+[new.x]
+is-default = false
+
+[meta.judge]
+is-default = false
+`
+
 const cfg = (over: { ok?: boolean; source_text?: string; reloaded?: boolean }) => ({
   ok: over.ok ?? true,
   path: null,
@@ -79,6 +87,28 @@ describe('FusionSettingsPanel', () => {
     await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
     const posted = saveMock.mock.calls[0]?.[0] as string
     expect(posted.split('[fusion.presets.trio]')[1]).toContain('min_answered = 2')
+    expect(runtimeRefreshMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('edits the active flat preset panel runtimes and judge runtime', async () => {
+    fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE_WITH_RUNTIME_OPTIONS }))
+    saveMock.mockImplementation(async (sourceText: string) => cfg({ ok: true, reloaded: true, source_text: sourceText }))
+    await mount()
+
+    const add = q('[data-testid="fusion-panel-runtime-add"]') as HTMLSelectElement
+    add.value = 'new.x'
+    await fireEvent.change(add)
+
+    const judge = q('[data-testid="fusion-judge-runtime"]') as HTMLSelectElement
+    judge.value = 'meta.judge'
+    await fireEvent.change(judge)
+
+    ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
+    await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
+    const posted = saveMock.mock.calls[0]?.[0] as string
+    const trio = posted.split('[fusion.presets.trio]')[1] ?? ''
+    expect(trio).toContain('panel = ["a", "b", "c", "new.x"]')
+    expect(trio).toContain('judge = "meta.judge"')
     expect(runtimeRefreshMock).toHaveBeenCalledTimes(1)
   })
 
@@ -227,7 +257,29 @@ min_answered = 2
 
     expect(q('[data-testid="fusion-settings-editor"]')).not.toBeNull()
     expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
+    expect(q('[data-testid="fusion-preset-composition-editor"]')).not.toBeNull()
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
+  })
+
+  it('does not synthesize an empty panel array on unchanged no-panel preset saves', async () => {
+    const noPanel = `[fusion]
+enabled = true
+default_preset = "trio"
+max_concurrent_panels = 2
+
+[fusion.presets.trio]
+min_answered = 2
+`
+    fetchMock.mockResolvedValue(cfg({ source_text: noPanel }))
+    saveMock.mockImplementation(async (sourceText: string) => cfg({ ok: true, reloaded: true, source_text: sourceText }))
+    await mount()
+
+    ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
+    await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
+    const posted = saveMock.mock.calls[0]?.[0] as string
+    const trio = posted.split('[fusion.presets.trio]')[1] ?? ''
+    expect(trio).toContain('min_answered = 2')
+    expect(trio).not.toContain('panel = []')
   })
 
   it('shows a fail-visible note (not a partial panel) for grouped presets', async () => {
@@ -249,6 +301,7 @@ panel = ["careful1"]
     expect(q('[data-testid="fusion-settings-editor"]')).not.toBeNull()
     // Grouped note shown; the flat lane card is NOT rendered.
     expect(q('[data-testid="fusion-preset-grouped"]')?.textContent).toContain('2개 그룹')
+    expect(q('[data-testid="fusion-preset-composition-editor"]')).toBeNull()
     expect(q('[data-testid="fusion-preset-view"]')).toBeNull()
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
     // Must never leak the first group's model as the preset panel (the P1 bug).
@@ -279,5 +332,6 @@ model = "coverage_model"
     expect(q('[data-testid="fusion-preset-judge"]')?.textContent).toBe('meta_model')
     // The judge lane honestly notes the first-pass judges rather than implying one.
     expect(q('[data-testid="fusion-preset-judge-lane-h"]')?.textContent).toContain('1차 심판 2')
+    expect(q('[data-testid="fusion-preset-composition-editor"]')?.textContent).toContain('Judge-of-judges runtime')
   })
 })

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -14,6 +14,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchRuntimeTomlConfig, saveRuntimeTomlConfig } from '../api/dashboard'
 import { errorToString } from '../lib/format-string'
 import {
+  applyFusionPresetComposition,
   applyFusionSettings,
   readFusionPresetMinAnswered,
   readFusionSettingsResult,
@@ -22,6 +23,7 @@ import {
 } from '../lib/fusion-settings'
 import { readFusionPresetView } from '../lib/fusion-preset-view'
 import { refreshRuntimeConfigConsumers } from '../lib/runtime-config-refresh'
+import { parseRuntimeTomlEnvironment } from '../lib/runtime-toml-config'
 
 type EditorState = 'loading' | 'idle' | 'saving' | 'saved' | 'error'
 type FusionSettingsDraft = {
@@ -29,14 +31,20 @@ type FusionSettingsDraft = {
   readonly defaultPreset: string
   readonly maxConcurrentPanels: string
   readonly minAnswered: string
+  readonly panel: readonly string[]
+  readonly judge: string
 }
 
-function draftFromSettings(s: FusionSettings): FusionSettingsDraft {
+function draftFromSettings(sourceText: string, s: FusionSettings): FusionSettingsDraft {
+  const presetView = readFusionPresetView(sourceText, s.defaultPreset)
+  const flatPreset = presetView !== null && !presetView.grouped ? presetView : null
   return {
     enabled: s.enabled,
     defaultPreset: s.defaultPreset,
     maxConcurrentPanels: String(s.maxConcurrentPanels),
     minAnswered: String(s.minAnswered),
+    panel: flatPreset?.panel ?? [],
+    judge: flatPreset?.judge ?? '',
   }
 }
 
@@ -100,6 +108,78 @@ function backendValidationMessage(cfg: { message?: string | null; reason?: strin
   )
 }
 
+function uniqueRuntimeIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const id of ids) {
+    const trimmed = id.trim()
+    if (trimmed === '' || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+  return result
+}
+
+function sameRuntimeIds(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index])
+}
+
+function runtimeOptionsFromSource(sourceText: string, draft: FusionSettingsDraft): string[] {
+  const environment = parseRuntimeTomlEnvironment(sourceText)
+  return uniqueRuntimeIds([
+    ...environment.bindings.map(binding => binding.id),
+    ...draft.panel,
+    draft.judge,
+  ]).sort((a, b) => a.localeCompare(b))
+}
+
+function RuntimePanelEditor({
+  panel,
+  options,
+  onChange,
+}: {
+  panel: readonly string[]
+  options: readonly string[]
+  onChange: (panel: readonly string[]) => void
+}) {
+  const addable = options.filter(option => !panel.includes(option))
+  return html`
+    <div class="set-fusion-runtime-list" data-testid="fusion-panel-runtime-editor">
+      <div class="set-fusion-runtime-chips">
+        ${panel.length === 0
+          ? html`<span class="set-hint" data-testid="fusion-panel-runtime-empty">패널 런타임 없음</span>`
+          : panel.map(runtimeId => html`
+            <span key=${runtimeId} class="set-fusion-runtime-chip mono">
+              ${runtimeId}
+              <button
+                type="button"
+                aria-label=${`${runtimeId} 제거`}
+                data-testid="fusion-panel-runtime-remove"
+                onClick=${() => onChange(panel.filter(id => id !== runtimeId))}
+              >
+                ×
+              </button>
+            </span>
+          `)}
+      </div>
+      <select
+        class="set-fusion-runtime-add mono"
+        data-testid="fusion-panel-runtime-add"
+        value=""
+        disabled=${addable.length === 0}
+        onChange=${(event: Event) => {
+          const value = (event.target as HTMLSelectElement).value
+          if (value) onChange([...panel, value])
+          ;(event.target as HTMLSelectElement).value = ''
+        }}
+      >
+        <option value="">패널 런타임 추가</option>
+        ${addable.map(option => html`<option key=${option} value=${option}>${option}</option>`)}
+      </select>
+    </div>
+  `
+}
+
 export function FusionSettingsPanel() {
   const [source, setSource] = useState<string | null>(null)
   const [draft, setDraft] = useState<FusionSettingsDraft | null>(null)
@@ -124,7 +204,7 @@ export function FusionSettingsPanel() {
           return
         }
         setSource(cfg.source_text)
-        setDraft(draftFromSettings(parsed.settings))
+        setDraft(draftFromSettings(cfg.source_text, parsed.settings))
         setState('idle')
       } catch (err) {
         if (!active) return
@@ -156,7 +236,12 @@ export function FusionSettingsPanel() {
   }
 
   const patchDefaultPreset = (defaultPreset: string) => {
-    const next: { defaultPreset: string; minAnswered?: string } = { defaultPreset }
+    const next: {
+      defaultPreset: string
+      minAnswered?: string
+      panel?: readonly string[]
+      judge?: string
+    } = { defaultPreset }
     if (source !== null) {
       const minAnswered = readFusionPresetMinAnswered(source, defaultPreset)
       if (typeof minAnswered === 'number') {
@@ -164,6 +249,14 @@ export function FusionSettingsPanel() {
       } else {
         setError(parseIssueMessage([minAnswered]))
         setState('error')
+      }
+      const nextPresetView = readFusionPresetView(source, defaultPreset)
+      if (nextPresetView !== null && !nextPresetView.grouped) {
+        next.panel = nextPresetView.panel
+        next.judge = nextPresetView.judge ?? ''
+      } else {
+        next.panel = []
+        next.judge = ''
       }
     }
     patch(next)
@@ -180,7 +273,23 @@ export function FusionSettingsPanel() {
     setState('saving')
     setError('')
     try {
-      const cfg = await saveRuntimeTomlConfig(applyFusionSettings(source, settings))
+      let nextSourceText = applyFusionSettings(source, settings)
+      const activePresetView = readFusionPresetView(source, settings.defaultPreset)
+      if (activePresetView !== null && !activePresetView.grouped) {
+        const panel = uniqueRuntimeIds(draft.panel)
+        const judge = draft.judge.trim()
+        const compositionChanged =
+          !sameRuntimeIds(activePresetView.panel, panel)
+          || (activePresetView.judge ?? '') !== judge
+        if (compositionChanged) {
+          nextSourceText = applyFusionPresetComposition(nextSourceText, {
+            preset: settings.defaultPreset,
+            panel,
+            judge,
+          })
+        }
+      }
+      const cfg = await saveRuntimeTomlConfig(nextSourceText)
       if (!mountedRef.current) return
       if (!cfg.ok) {
         setError(backendValidationMessage(cfg))
@@ -194,7 +303,7 @@ export function FusionSettingsPanel() {
         return
       }
       setSource(cfg.source_text)
-      setDraft(draftFromSettings(parsed.settings))
+      setDraft(draftFromSettings(cfg.source_text, parsed.settings))
       try {
         await refreshRuntimeConfigConsumers()
         setSavedMessage(cfg.reloaded ? '저장됨 (reload 완료)' : '저장됨')
@@ -224,9 +333,12 @@ export function FusionSettingsPanel() {
   // Flat preset with panel models → full read-only card. Grouped preset
   // ([[...panels]] array-of-tables) → fail-visible note (a single flat card
   // cannot represent N groups without silently dropping some).
-  const showPresetView = presetView !== null && !presetView.grouped && presetView.panel.length > 0
+  const showPresetEditor = presetView !== null && !presetView.grouped
+  const showPresetView = showPresetEditor && presetView.panel.length > 0
   const showGroupedNote = presetView !== null && presetView.grouped
+  const runtimeOptions = runtimeOptionsFromSource(source, draft)
   const timeoutLabel = (value: number | null): string => (value === null ? '—' : `${value}s`)
+  const judgeLabel = presetView?.judgeGroupCount ? 'Judge-of-judges runtime' : 'Judge runtime'
 
   return html`
     <div class="set-fusion-editor" data-testid="fusion-settings-editor">
@@ -260,6 +372,33 @@ export function FusionSettingsPanel() {
             <div class="set-sub-h">${presetView.preset} 프리셋</div>
             <div class="set-hint" data-testid="fusion-preset-grouped">
               그룹형 패널 구성 · ${presetView.groupCount}개 그룹 (<span class="mono">[[fusion.presets.${presetView.preset}.panels]]</span>) · 미리보기 미지원
+            </div>
+          `
+        : null}
+      ${showPresetEditor && presetView
+        ? html`
+            <div class="set-sub-h">${presetView.preset} 런타임 구성</div>
+            <div class="set-fusion-composition" data-testid="fusion-preset-composition-editor">
+              <label class="set-line set-line-stack">
+                <span>Panel runtimes</span>
+                <${RuntimePanelEditor}
+                  panel=${draft.panel}
+                  options=${runtimeOptions}
+                  onChange=${(panel: readonly string[]) => patch({ panel })}
+                />
+              </label>
+              <label class="set-line">
+                <span>${judgeLabel}</span>
+                <select
+                  class="set-fusion-runtime-add mono"
+                  data-testid="fusion-judge-runtime"
+                  value=${draft.judge}
+                  onChange=${(event: Event) => patch({ judge: (event.target as HTMLSelectElement).value })}
+                >
+                  <option value="">미지정</option>
+                  ${runtimeOptions.map(option => html`<option key=${option} value=${option}>${option}</option>`)}
+                </select>
+              </label>
             </div>
           `
         : null}

--- a/dashboard/src/lib/fusion-settings.test.ts
+++ b/dashboard/src/lib/fusion-settings.test.ts
@@ -4,6 +4,7 @@ import {
   readFusionSettingsResult,
   readFusionPresetMinAnswered,
   applyFusionSettings,
+  applyFusionPresetComposition,
   FUSION_SETTINGS_DEFAULTS,
 } from './fusion-settings'
 
@@ -194,5 +195,30 @@ min_answered = 1
     expect(next).toContain('[runtime]')
     expect(next).toContain('default = "x.y"')
     expect(next).toContain('judge = "j"')
+  })
+
+  it('writes active flat preset panel runtimes and judge runtime', () => {
+    const next = applyFusionPresetComposition(SAMPLE, {
+      preset: 'trio',
+      panel: ['a', 'b', 'd', 'd', ' '],
+      judge: 'meta.judge',
+    })
+
+    const trio = next.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0] ?? ''
+    expect(trio).toContain('panel = ["a", "b", "d"]')
+    expect(trio).toContain('judge = "meta.judge"')
+    expect(trio).toContain('min_answered = 2')
+  })
+
+  it('refuses to flatten grouped panel presets', () => {
+    const grouped = `${SAMPLE}
+[[fusion.presets.trio.panels]]
+panel = ["a", "b"]
+`
+    expect(() => applyFusionPresetComposition(grouped, {
+      preset: 'trio',
+      panel: ['x'],
+      judge: 'j',
+    })).toThrow(/grouped fusion panel presets/)
   })
 })

--- a/dashboard/src/lib/fusion-settings.ts
+++ b/dashboard/src/lib/fusion-settings.ts
@@ -16,7 +16,7 @@
 // inside a `[section]` (dotted section names like `fusion.presets.trio` are
 // matched as literal headers). Inline tables and multi-line string values are
 // out of scope — the fusion keys here are all scalar single-line values.
-import { deleteRuntimeTomlKey, getRuntimeTomlKey, setRuntimeTomlKey } from './runtime-toml-config'
+import { deleteRuntimeTomlKey, getRuntimeTomlKey, setRuntimeTomlKey, setRuntimeTomlStringArrayKey } from './runtime-toml-config'
 
 // TOML section/key names, kept in one place rather than inlined at each call
 // site (mirrors lib/fusion_core/fusion_config.ml — the OCaml parser is the SSOT
@@ -26,6 +26,8 @@ const KEY_ENABLED = 'enabled'
 const KEY_DEFAULT_PRESET = 'default_preset'
 const KEY_MAX_CONCURRENT_PANELS = 'max_concurrent_panels'
 const KEY_MIN_ANSWERED = 'min_answered'
+const KEY_PANEL = 'panel'
+const KEY_JUDGE = 'judge'
 const presetSection = (preset: string): string => `${SECTION_FUSION}.presets.${preset}`
 
 export interface FusionSettings {
@@ -34,6 +36,12 @@ export interface FusionSettings {
   readonly maxConcurrentPanels: number
   // min_answered for the default preset (RFC-0252 answered-panel quorum).
   readonly minAnswered: number
+}
+
+export interface FusionPresetComposition {
+  readonly preset: string
+  readonly panel: readonly string[]
+  readonly judge: string
 }
 
 export interface FusionSettingsParseIssue {
@@ -162,6 +170,23 @@ function sectionExists(sourceText: string, sectionName: string): boolean {
   return new RegExp(`^\\s*\\[${escaped}\\]\\s*(?:#.*)?$`, 'm').test(sourceText)
 }
 
+function hasArrayOfTables(sourceText: string, sectionName: string, child: string): boolean {
+  const escaped = `${sectionName}.${child}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^\\s*\\[\\[${escaped}\\]\\]\\s*(?:#.*)?$`, 'm').test(sourceText)
+}
+
+function uniqueNonEmpty(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (trimmed === '' || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+  return result
+}
+
 export function readFusionSettingsResult(sourceText: string): FusionSettingsReadResult {
   const issues: FusionSettingsParseIssue[] = []
   const enabledParsed = parseBoolean(
@@ -273,5 +298,22 @@ export function applyFusionSettings(sourceText: string, s: FusionSettings): stri
   if (s.defaultPreset !== '') {
     text = setRuntimeTomlKey(text, presetSection(s.defaultPreset), KEY_MIN_ANSWERED, s.minAnswered)
   }
+  return text
+}
+
+export function applyFusionPresetComposition(sourceText: string, composition: FusionPresetComposition): string {
+  const preset = composition.preset.trim()
+  if (preset === '') throw new Error('fusion preset composition requires a default_preset')
+  const section = presetSection(preset)
+  if (hasArrayOfTables(sourceText, section, 'panels')) {
+    throw new Error('grouped fusion panel presets cannot be edited by the flat preset writer')
+  }
+  const panel = uniqueNonEmpty(composition.panel)
+  let text = sourceText
+  text = setRuntimeTomlStringArrayKey(text, section, KEY_PANEL, panel)
+  const judge = composition.judge.trim()
+  text = judge === ''
+    ? deleteRuntimeTomlKey(text, section, KEY_JUDGE)
+    : setRuntimeTomlKey(text, section, KEY_JUDGE, judge)
   return text
 }

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -13,6 +13,7 @@ import {
   setRuntimeTomlModelField,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
+  setRuntimeTomlStringArrayKey,
   cascadeDeleteProvider,
 } from './runtime-toml-config'
 
@@ -140,6 +141,31 @@ mad-improver = "runpod_mtp.qwen"
     // only the value should change, not the key syntax the TOML author chose.
     expect(next).toContain('"nick0cave" = "ollama_cloud.kimi-k2-6"')
     expect(next).not.toContain('\nnick0cave = ')
+  })
+
+  it('rewrites a multi-line TOML string array without leaving stale elements behind', () => {
+    const withFusionPreset = `${sourceText}
+
+[fusion.presets.trio]
+panel = [
+  "old.a",
+  "old.b",
+]
+judge = "meta.old"
+`
+
+    const next = setRuntimeTomlStringArrayKey(
+      withFusionPreset,
+      'fusion.presets.trio',
+      'panel',
+      ['new.a', 'new.b'],
+    )
+
+    const preset = next.split('[fusion.presets.trio]')[1] ?? ''
+    expect(preset).toContain('panel = ["new.a", "new.b"]')
+    expect(preset).toContain('judge = "meta.old"')
+    expect(preset).not.toContain('old.a')
+    expect(preset).not.toContain('old.b')
   })
 
   it('does not write a keeper name requiring quotes as an invalid bare key', () => {

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -428,6 +428,54 @@ function serializeValue(value: string | number | boolean): string {
   return String(value)
 }
 
+function serializeStringArray(values: readonly string[]): string {
+  return `[${values.map(serializeString).join(', ')}]`
+}
+
+function tomlArrayValueEndLine(
+  lines: readonly string[],
+  startIndex: number,
+  sectionEnd: number,
+  firstValueRaw: string,
+): number | null {
+  let quote: '"' | "'" | null = null
+  let escaped = false
+  let depth = 0
+  let sawOpen = false
+  for (let index = startIndex; index < sectionEnd; index += 1) {
+    const segment = index === startIndex ? firstValueRaw : lines[index] ?? ''
+    for (let offset = 0; offset < segment.length; offset += 1) {
+      const char = segment[offset]
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\' && quote === '"') {
+        escaped = true
+        continue
+      }
+      if (char === '"' && quote !== "'") {
+        quote = quote === '"' ? null : '"'
+        continue
+      }
+      if (char === "'" && quote !== '"') {
+        quote = quote === "'" ? null : "'"
+        continue
+      }
+      if (char === '#' && quote === null) break
+      if (quote !== null) continue
+      if (char === '[') {
+        sawOpen = true
+        depth += 1
+      } else if (char === ']' && sawOpen) {
+        depth -= 1
+        if (depth <= 0) return index
+      }
+    }
+  }
+  return sawOpen ? null : startIndex
+}
+
 function joinLines(lines: string[]): string {
   return lines.join('\n')
 }
@@ -465,6 +513,32 @@ export function setRuntimeTomlKey(
       // deliberately by the backend/SSOT writer), so updating only the value
       // must not silently normalize `"nick0cave"` down to `nick0cave`.
       lines[index] = `${match[1] ?? ''}${match[2]}${match[3] ?? ' = '}${serialized}`
+      return joinLines(lines)
+    }
+  }
+  lines.splice(section.end, 0, `${serializeTomlKey(key)} = ${serialized}`)
+  return joinLines(lines)
+}
+
+export function setRuntimeTomlStringArrayKey(
+  sourceText: string,
+  sectionName: string,
+  key: string,
+  values: readonly string[],
+): string {
+  const initial = parseDocument(sourceText)
+  const ensured = ensureSection([...initial.lines], initial, sectionName)
+  const lines = ensured.lines
+  const section = ensured.section
+  const serialized = serializeStringArray(values)
+  for (let index = section.start + 1; index < section.end; index += 1) {
+    const match = keyLineMatch(lines[index] ?? '')
+    if (match && dequoteTomlKey(match[2]) === key) {
+      const endIndex = tomlArrayValueEndLine(lines, index, section.end, match[4] ?? '')
+      if (endIndex === null) {
+        throw new Error(`Cannot rewrite unterminated TOML array for [${sectionName}].${key}`)
+      }
+      lines.splice(index, endIndex - index + 1, `${match[1] ?? ''}${match[2]}${match[3] ?? ' = '}${serialized}`)
       return joinLines(lines)
     }
   }

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -1270,6 +1270,12 @@
   background: var(--volt-wash);
 }
 
+.set-fusion-composition {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 /* fusion settings editor rows — classes referenced by fusion-settings-panel.ts
    (set-fusion-editor / set-line) but never defined, which left label+control
    rendered inline. Mirrors .set-row / .set-input tokens. */
@@ -1282,8 +1288,15 @@
   display: flex;
   align-items: center;
   gap: 14px;
+  min-width: 0;
   padding: 12px 0;
   border-top: 1px solid var(--border-soft);
+}
+
+.set-line-stack {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .set-line:first-child {
@@ -1298,7 +1311,8 @@
 }
 
 .set-line > input[type='text'],
-.set-line > input[type='number'] {
+.set-line > input[type='number'],
+.set-line > select {
   flex: none;
   width: 230px;
   font-family: var(--font-mono);
@@ -1312,9 +1326,60 @@
 }
 
 .set-line > input[type='text']:focus,
-.set-line > input[type='number']:focus {
+.set-line > input[type='number']:focus,
+.set-line > select:focus {
   border-color: var(--volt-dim);
   box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+.set-fusion-runtime-list {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+}
+
+.set-fusion-runtime-chips {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  min-width: 0;
+}
+
+.set-fusion-runtime-chip {
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  display: inline-flex;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 5px 7px;
+}
+
+.set-fusion-runtime-chip button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: inline-flex;
+  flex: none;
+  font-size: var(--fs-13);
+  justify-content: center;
+  padding: 0 2px;
+}
+
+.set-fusion-runtime-chip button:hover {
+  color: var(--status-fail);
+}
+
+.set-fusion-runtime-add {
+  max-width: 100%;
+  min-width: 0;
 }
 
 .set-line > input[type='checkbox'] {


### PR DESCRIPTION
## Summary

- add a writable Fusion preset composition editor for the active flat preset: panel runtime chips/add/remove and a judge/JoJ runtime select sourced from runtime.toml bindings
- persist `panel = [...]` and top-level `judge = "..."` through the existing raw runtime config save path, then refresh runtime consumers after save
- keep grouped `[[fusion.presets.<preset>.panels]]` presets fail-visible/read-only instead of flattening them, and harden the string-array writer so multi-line TOML arrays are replaced as one value

## Notes

- This is the follow-up for the Fusion gap left after #23212: the Settings page could save scalar Fusion settings but could not configure the actual panel/JoJ runtime composition.
- `[[fusion.presets.<preset>.judges]]` first-pass judge tables are still displayed as JoJ context but not edited in this slice; the writable field here is the top-level meta judge/JoJ runtime.
- Full build verdict is CI-owned per repo workflow.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/lib/fusion-settings.test.ts src/lib/runtime-toml-config.test.ts src/components/fusion-settings-panel.test.ts src/lib/runtime-catalog-resource.test.ts src/lib/runtime-config-refresh.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- `pnpm exec eslint src/components/fusion-settings-panel.ts src/components/fusion-settings-panel.test.ts src/lib/fusion-settings.ts src/lib/fusion-settings.test.ts src/lib/runtime-toml-config.ts src/lib/runtime-toml-config.test.ts src/styles/settings-surface.css`
  - exit 0; current ESLint config reports ignore warnings for several `src/lib/*`, test, and CSS paths
- `python3 /tmp/masc_fusion_playwright_smoke.py`
  - mocked `/api/v1/runtime/config/raw`; verified POST contains `panel = ["a.one", "b.two", "c.three"]` and `judge = "meta.new"` and drops stale multiline array lines
  - console: one existing PerformanceMonitor slow-frame warning, no save/runtime-config errors
