### PR TITLE
[codex] Surface IDE cursor stream degradation

### DIFF
--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -891,12 +891,22 @@ describe('IdeShell', () => {
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
   })
 
-  it('switches the IDE right rail tabs and renders cursor stream focus', () => {
+  it('switches the IDE right rail tabs and renders cursor stream focus', async () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
       postId: null,
     }
+    class MockEventSource {
+      onopen: ((event: Event) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+
+      constructor(_url: string) {}
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('EventSource', MockEventSource)
     cursorOverlaySignal.value = {
       cursors: new Map([[
         'sangsu',
@@ -918,6 +928,16 @@ describe('IdeShell', () => {
     }
 
     render(h(IdeShell, {}), container)
+    await waitFor(() => expect(cursorOverlaySignal.value.stream?.status).toBe('connecting'))
+    cursorOverlaySignal.value = {
+      ...cursorOverlaySignal.value,
+      stream: {
+        status: 'degraded',
+        failedCount: 2,
+        lastErrorMs: Date.UTC(2026, 6, 4, 1, 2, 3),
+        error: 'SSE transport error',
+      },
+    }
 
     fireEvent.click(buttonByText(container, 'Activity'))
     expect(buttonByText(container, 'Activity').getAttribute('aria-selected')).toBe('true')
@@ -936,6 +956,10 @@ describe('IdeShell', () => {
     expect(cursorRail?.textContent).toContain('str_replace')
     expect(cursorRail?.textContent).toContain('round.ml:94-96')
     expect(cursorRail?.textContent).toContain('L94')
+    expect(container.querySelector('[data-testid="ide-cursor-stream-status"]')?.textContent)
+      .toBe('stream degraded 2 failed')
+    expect(container.querySelector('[data-testid="ide-cursor-stream-status"]')?.getAttribute('data-state'))
+      .toBe('degraded')
 
     fireEvent.click(buttonByText(container, 'Focus'))
     expect(ideContextFocus.value).toMatchObject({

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -33,10 +33,12 @@ import { IdePersistencePanel } from './ide-persistence-panel'
 import { IdeMemoryPanel } from './ide-memory-panel'
 import { routeLinksForContext } from './ide-context-lens'
 import {
+  connectKeeperCursorStream,
   cursorOverlaySignal,
   getKeeperColor,
   type KeeperCursor,
   type KeeperCursorOverlay,
+  type KeeperCursorStreamState,
 } from './keeper-cursor-overlay'
 import { lspStatusSnapshot, type LspStatusSnapshot } from './ide-lsp-client'
 import { navigate, route } from '../../router'
@@ -608,6 +610,42 @@ function cursorAgeLabel(lastUpdate: number): string {
   return `${Math.round(minutes / 60)}h ago`
 }
 
+function cursorStreamStatusTone(status: KeeperCursorStreamState['status']): 'ghost' | 'info' | 'ok' | 'warn' {
+  switch (status) {
+    case 'connecting':
+      return 'info'
+    case 'live':
+      return 'ok'
+    case 'degraded':
+      return 'warn'
+    case 'closed':
+      return 'ghost'
+  }
+}
+
+function cursorStreamStatusLabel(stream: KeeperCursorStreamState): string {
+  switch (stream.status) {
+    case 'connecting':
+      return 'stream connecting'
+    case 'live':
+      return 'stream live'
+    case 'degraded':
+      return stream.failedCount > 0
+        ? `stream degraded ${stream.failedCount} failed`
+        : 'stream degraded'
+    case 'closed':
+      return 'stream closed'
+  }
+}
+
+function cursorStreamStatusTitle(stream: KeeperCursorStreamState): string {
+  const parts = [cursorStreamStatusLabel(stream)]
+  if (stream.lastOpenMs !== undefined) parts.push(`last open ${new Date(stream.lastOpenMs).toISOString()}`)
+  if (stream.lastErrorMs !== undefined) parts.push(`last error ${new Date(stream.lastErrorMs).toISOString()}`)
+  if (stream.error) parts.push(stream.error)
+  return parts.join(' · ')
+}
+
 function sortedCursors(overlay: KeeperCursorOverlay): ReadonlyArray<KeeperCursor> {
   return [...overlay.cursors.values()].sort((left, right) => {
     if (right.last_update !== left.last_update) return right.last_update - left.last_update
@@ -659,6 +697,16 @@ function IdeCursorRailPanel() {
         <span>KEEPER CURSORS</span>
         <span>${cursors.length} active</span>
       </div>
+      ${overlay.stream ? html`
+        <div
+          class=${`ide-cursor-stream-status chip sm is-${cursorStreamStatusTone(overlay.stream.status)}`}
+          data-testid="ide-cursor-stream-status"
+          data-state=${overlay.stream.status}
+          role="status"
+          aria-live="polite"
+          title=${cursorStreamStatusTitle(overlay.stream)}
+        >${cursorStreamStatusLabel(overlay.stream)}</div>
+      ` : null}
       ${overlay.active_file ? html`
         <div class="ide-cursor-rail-active-file" title=${overlay.active_file}>
           active file · ${shortCursorPath(overlay.active_file)}
@@ -853,6 +901,25 @@ export function IdeShell() {
     const unsubscribe = ideContextFocus.subscribe(setContextFocus)
     return () => unsubscribe()
   }, [])
+
+  useEffect(() => {
+    const repoId = activeRepositoryId?.trim()
+    if (!repoId) {
+      cursorOverlaySignal.value = {
+        ...cursorOverlaySignal.value,
+        stream: { status: 'closed', failedCount: 0 },
+      }
+      return
+    }
+    return connectKeeperCursorStream('', (overlay) => {
+      cursorOverlaySignal.value = { ...overlay, stream: cursorOverlaySignal.value.stream }
+    }, {
+      repoId,
+      onStatus: stream => {
+        cursorOverlaySignal.value = { ...cursorOverlaySignal.value, stream }
+      },
+    })
+  }, [activeRepositoryId])
 
   const routeFileFocus = routeFocusFile(route.value.params)
   const routeLineFocus = routeFocusLine(route.value.params)

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  buildKeeperCursorStreamUrl,
   connectKeeperCursorStream,
   getKeeperColor,
   normalizeKeeperCursorSnapshot,
@@ -10,6 +11,7 @@ afterEach(() => {
   vi.useRealTimers()
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  window.sessionStorage.clear()
 })
 
 describe('getKeeperColor', () => {
@@ -79,11 +81,13 @@ describe('getKeeperColor', () => {
   it('connects to the dedicated cursor stream endpoint', () => {
     const instances: Array<{
       readonly url: string
+      onopen: ((event: Event) => void) | null
       onmessage: ((event: MessageEvent) => void) | null
       onerror: ((event: Event) => void) | null
       close: () => void
     }> = []
     class MockEventSource {
+      onopen: ((event: Event) => void) | null = null
       onmessage: ((event: MessageEvent) => void) | null = null
       onerror: ((event: Event) => void) | null = null
       readonly url: string
@@ -104,17 +108,97 @@ describe('getKeeperColor', () => {
     expect(instances[0]?.close).toHaveBeenCalled()
   })
 
+  it('builds cursor stream URLs with repository and token scope', () => {
+    window.sessionStorage.setItem('masc_bearer_token', 'token-1')
+
+    expect(buildKeeperCursorStreamUrl('', ' masc ')).toBe(
+      '/api/v1/ide/cursors/stream?repo_id=masc&token=token-1',
+    )
+  })
+
+  it('reports a degraded cursor stream when EventSource is unavailable', () => {
+    vi.stubGlobal('EventSource', undefined)
+    const onStatus = vi.fn()
+
+    const cleanup = connectKeeperCursorStream('', () => {}, { onStatus })
+
+    expect(onStatus).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'degraded',
+      failedCount: 1,
+      error: 'EventSource unavailable',
+      lastErrorMs: expect.any(Number),
+    }))
+    cleanup()
+    expect(onStatus).toHaveBeenLastCalledWith({ status: 'closed', failedCount: 1 })
+  })
+
+  it('reports cursor stream lifecycle state to callers', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const instances: Array<{
+      readonly url: string
+      onopen: ((event: Event) => void) | null
+      onmessage: ((event: MessageEvent) => void) | null
+      onerror: ((event: Event) => void) | null
+      close: () => void
+    }> = []
+    class MockEventSource {
+      onopen: ((event: Event) => void) | null = null
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      readonly url: string
+
+      constructor(url: string) {
+        this.url = url
+        instances.push(this)
+      }
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('EventSource', MockEventSource)
+
+    const onStatus = vi.fn()
+    const cleanup = connectKeeperCursorStream('http://localhost:8935', () => {}, {
+      repoId: 'masc',
+      onStatus,
+    })
+
+    expect(instances[0]?.url).toBe('http://localhost:8935/api/v1/ide/cursors/stream?repo_id=masc')
+    expect(onStatus).toHaveBeenLastCalledWith({ status: 'connecting', failedCount: 0 })
+
+    instances[0]!.onopen?.(new Event('open'))
+    expect(onStatus).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'live',
+      failedCount: 0,
+      lastOpenMs: expect.any(Number),
+    }))
+
+    instances[0]!.onerror?.(new Event('error'))
+    expect(onStatus).toHaveBeenLastCalledWith(expect.objectContaining({
+      status: 'degraded',
+      failedCount: 1,
+      error: 'SSE transport error',
+      lastErrorMs: expect.any(Number),
+    }))
+
+    cleanup()
+    expect(onStatus).toHaveBeenLastCalledWith({ status: 'closed', failedCount: 1 })
+  })
+
   it('cancels cursor stream reconnect timers during cleanup', () => {
     vi.useFakeTimers()
     vi.spyOn(Math, 'random').mockReturnValue(0)
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const instances: Array<{
       readonly url: string
+      onopen: ((event: Event) => void) | null
       onmessage: ((event: MessageEvent) => void) | null
       onerror: ((event: Event) => void) | null
       close: () => void
     }> = []
     class MockEventSource {
+      onopen: ((event: Event) => void) | null = null
       onmessage: ((event: MessageEvent) => void) | null = null
       onerror: ((event: Event) => void) | null = null
       readonly url: string

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -5,6 +5,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { dashboardBearerToken } from '../../api/core'
 import { createSseTransport } from '../../transports/sse-transport'
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -30,6 +31,22 @@ export interface KeeperCursorOverlay {
     risk_level: 'low' | 'medium' | 'high'
   }>
   active_file: string | null
+  stream?: KeeperCursorStreamState
+}
+
+export type KeeperCursorStreamStatus = 'connecting' | 'live' | 'degraded' | 'closed'
+
+export interface KeeperCursorStreamState {
+  readonly status: KeeperCursorStreamStatus
+  readonly failedCount: number
+  readonly lastOpenMs?: number
+  readonly lastErrorMs?: number
+  readonly error?: string
+}
+
+export interface KeeperCursorStreamOptions {
+  readonly repoId?: string | null
+  readonly onStatus?: (state: KeeperCursorStreamState) => void
 }
 
 // ── Signals ──────────────────────────────────────────────────────
@@ -406,23 +423,67 @@ export function normalizeKeeperCursorSnapshot(snapshot: unknown): KeeperCursorOv
 export function connectKeeperCursorStream(
   baseUrl: string,
   onUpdate: (overlay: KeeperCursorOverlay) => void,
+  options: KeeperCursorStreamOptions = {},
 ): () => void {
-  const transport = createSseTransport(`${baseUrl}/api/v1/ide/cursors/stream`)
+  let failedCount = 0
+  options.onStatus?.({ status: 'connecting', failedCount })
+  if (typeof EventSource === 'undefined') {
+    failedCount = 1
+    options.onStatus?.({
+      status: 'degraded',
+      failedCount,
+      lastErrorMs: Date.now(),
+      error: 'EventSource unavailable',
+    })
+    return () => {
+      options.onStatus?.({ status: 'closed', failedCount })
+    }
+  }
+
+  const transport = createSseTransport(buildKeeperCursorStreamUrl(baseUrl, options.repoId))
   const unsubscribe = transport.subscribe((event) => {
+    if (event.type === 'open') {
+      failedCount = 0
+      options.onStatus?.({ status: 'live', failedCount, lastOpenMs: Date.now() })
+      return
+    }
     if (event.type === 'message') {
       onUpdate(normalizeKeeperCursorSnapshot(event.data))
       return
     }
     if (event.type === 'error') {
+      failedCount += 1
+      options.onStatus?.({
+        status: 'degraded',
+        failedCount,
+        lastErrorMs: Date.now(),
+        error: event.error.message,
+      })
       console.error('Keeper cursor stream error:', event.error)
+      return
+    }
+    if (event.type === 'close') {
+      options.onStatus?.({ status: 'closed', failedCount })
     }
   })
   transport.connect()
 
   return () => {
-    unsubscribe()
     transport.disconnect()
+    unsubscribe()
   }
+}
+
+export function buildKeeperCursorStreamUrl(baseUrl: string, repoId?: string | null): string {
+  const base = baseUrl.trim().replace(/\/+$/, '')
+  const endpoint = `${base}/api/v1/ide/cursors/stream`
+  const params = new URLSearchParams()
+  const trimmedRepoId = repoId?.trim()
+  const token = dashboardBearerToken()
+  if (trimmedRepoId) params.set('repo_id', trimmedRepoId)
+  if (token) params.set('token', token)
+  const query = params.toString()
+  return query ? `${endpoint}?${query}` : endpoint
 }
 
 // ── Helper to update cursor from tool call ───────────────────────


### PR DESCRIPTION
## Summary
- connect the IDE shell cursor rail to the repository-scoped cursor SSE stream only after an active repo id is available
- carry cursor stream lifecycle state in the cursor overlay snapshot and render degraded/closed/live state in the cursor rail
- include repo_id and dashboard bearer token in the cursor stream URL builder

## Validation
- pnpm --dir dashboard exec vitest run src/components/ide/keeper-cursor-overlay.test.ts src/components/ide/ide-shell.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check

Dune build is left to CI per repo workflow.