### PR TITLE
fix(dashboard): share IDE route view parsing

### DIFF
--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -8,6 +8,7 @@ import {
   workspaceFetchIssueFromError,
   workspaceTreeIdentity,
 } from './ide-data-workspace-store'
+import { isDiffEditorView, viewFromRoute } from './ide-view-route'
 import type { Repository } from '../../api/repositories'
 
 function repo(
@@ -239,6 +240,17 @@ describe('workspace fetch diagnostics', () => {
       [repositoryIssue, oldTreeIssue, oldFileIssue, currentDiffIssue],
       { filePath: 'README.md', repoId: 'current-repo' },
     )).toEqual([repositoryIssue, currentDiffIssue])
+  })
+})
+
+describe('ide route view helpers', () => {
+  it('normalizes legacy diff aliases through one shared helper', () => {
+    expect(viewFromRoute('split')).toBe('split-diff')
+    expect(viewFromRoute('split_diff')).toBe('split-diff')
+    expect(viewFromRoute('merge')).toBe('split-diff')
+    expect(isDiffEditorView(viewFromRoute('merge'))).toBe(true)
+    expect(isDiffEditorView(viewFromRoute('unified'))).toBe(true)
+    expect(isDiffEditorView(viewFromRoute('blame'))).toBe(false)
   })
 })
 

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -38,6 +38,7 @@ import {
 } from '../../api/ide'
 import { registerIdeWorkspaceRefresh } from '../../sse-store'
 import { isAbortError } from '../../lib/async-state'
+import { isDiffEditorView, viewFromRoute } from './ide-view-route'
 
 export interface IdeDataWorkspaceStore {
   readonly documentStore: CodeDocumentStore
@@ -473,10 +474,12 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       })
     })
 
-    // Load blame & diff conditionally on view tab to prevent over-fetching
-    const currentView = route.value.params.view?.trim().toLowerCase() || 'source'
+    // Load blame & diff conditionally on view tab to prevent over-fetching.
+    // Use the same route normalization as IdeShell so legacy aliases such as
+    // "merge" do not silently suppress the diff fetch.
+    const currentView = viewFromRoute(route.value.params.view)
     const isBlameView = currentView === 'blame'
-    const isDiffView = currentView === 'split-diff' || currentView === 'split' || currentView === 'unified' || currentView === 'diff'
+    const isDiffView = isDiffEditorView(currentView)
 
     if (isBlameView) {
       fetchGitBlame(filePath, opts).then(blocks => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -55,6 +55,7 @@ import {
   parseActive,
   serializeActive,
 } from '../../../design-system/headless-core/layered-overlay'
+import { viewFromRoute } from './ide-view-route'
 
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
@@ -156,17 +157,6 @@ interface IdeStatusbarInput {
   readonly workspaceIssues?: ReadonlyArray<WorkspaceFetchIssue>
   readonly dashboardConnected?: boolean
   readonly lspStatus?: LspStatusSnapshot
-}
-
-function viewFromRoute(raw: string | null | undefined): ViewTab {
-  const normalized = raw
-    ?.trim()
-    .toLowerCase()
-    .replace(/[_\s]+/g, '-')
-  if (normalized === 'split' || normalized === 'split-diff' || normalized === 'merge') return 'split-diff'
-  if (normalized === 'unified') return 'unified'
-  if (normalized === 'blame') return 'blame'
-  return 'source'
 }
 
 function focusFromRoute(raw: string | null | undefined): IdeFocus | null {

--- a/dashboard/src/components/ide/ide-view-route.ts
+++ b/dashboard/src/components/ide/ide-view-route.ts
@@ -1,0 +1,16 @@
+import type { IdeEditorView } from './ide-editor'
+
+export function viewFromRoute(raw: string | null | undefined): IdeEditorView {
+  const normalized = raw
+    ?.trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+  if (normalized === 'split' || normalized === 'split-diff' || normalized === 'merge') return 'split-diff'
+  if (normalized === 'unified') return 'unified'
+  if (normalized === 'blame') return 'blame'
+  return 'source'
+}
+
+export function isDiffEditorView(view: IdeEditorView): boolean {
+  return view === 'split-diff' || view === 'unified'
+}


### PR DESCRIPTION
## Summary
- Extract the IDE route view normalization into a shared helper used by both `IdeShell` and `createIdeDataWorkspaceStore`.
- Keep legacy diff aliases such as `split`, `split_diff`, and `merge` mapped to `split-diff` before deciding whether to fetch git diff data.
- Add a focused helper regression so route aliases do not drift again.

## Why
Post-merge review of #23213 found that the dashboard store reimplemented `IdeShell`'s route view parsing with a narrower string check. That made legacy `view=merge` normalize to split diff in the shell while the store treated it as a non-diff view, silently suppressing the git diff fetch. This PR removes the duplicate parser instead of widening another local string match.

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/ide/ide-data-workspace-store.test.ts src/components/ide/ide-shell.test.ts --no-file-parallelism --maxWorkers=1` (2 files / 57 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check origin/main...HEAD`

Local Dune was not run; CI remains build authority.
