### PR TITLE
fix(ide): allow query auth for cursor SSE

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -90,7 +90,8 @@ let observer_sse_query_token_from_request request =
   match request.Httpun.Request.meth with
   | `GET
     when (observer_stream_requested && String.equal path "/mcp")
-         || String.equal path "/events/presence" ->
+         || String.equal path "/events/presence"
+         || String.equal path "/api/v1/ide/cursors/stream" ->
       trim_opt (query_param request "token")
   | _ -> None
 
@@ -207,7 +208,7 @@ let verify_mcp_observer_stream_auth ~base_path request =
     | None ->
         Error
           "Authentication required. Use 'Authorization: Bearer <token>' header \
-           or 'token' query param for the observer/presence SSE stream."
+           or 'token' query param for the observer/presence/cursor SSE stream."
     | Some token -> (
         let* agent_name =
           resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token)
@@ -934,6 +935,27 @@ let rec with_public_read handler request reqd =
     match !server_state with
     | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
     | Some state -> handler state request reqd
+
+and with_observer_sse_read_auth handler request reqd =
+  let strict = http_auth_strict_enabled () in
+  let path = Http_server_eio.Request.path request in
+  if strict && not (is_public_read_path path) then
+    match !server_state with
+    | None -> Http_server_eio.Response.json (not_initialized_response path) reqd
+    | Some state ->
+      let base_path = (Mcp_server.workspace_config state).base_path in
+      (match verify_mcp_observer_stream_auth ~base_path request with
+       | Ok _ ->
+         (match check_agent_rate_limit request reqd with
+          | Ok () -> handler state request reqd
+          | Error () -> ())
+       | Error msg ->
+         Http_server_eio.Response.json
+           ~status:`Unauthorized
+           (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
+           reqd)
+  else
+    with_public_read handler request reqd
 
 and with_read_auth handler request reqd =
   match !server_state with

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -66,7 +66,7 @@ val auth_token_from_request : Httpun.Request.t -> string option
 (** Token from [Authorization: Bearer …] on the request. *)
 
 val observer_sse_query_token_from_request : Httpun.Request.t -> string option
-(** Observer/presence SSE allows the token via query string for browser
+(** Observer/presence/cursor SSE allows the token via query string for browser
     EventSource. *)
 
 val observer_sse_auth_token_from_request : Httpun.Request.t -> string option
@@ -330,6 +330,13 @@ val with_public_read :
    Httpun.Request.t -> Httpun.Reqd.t -> unit) ->
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Public-read combinator (no auth, looser CORS). *)
+
+val with_observer_sse_read_auth :
+  (Mcp_server.server_state ->
+   Httpun.Request.t -> Httpun.Reqd.t -> unit) ->
+  Httpun.Request.t -> Httpun.Reqd.t -> unit
+(** Read combinator for browser EventSource endpoints that must accept
+    [token] in the query string when strict HTTP auth is active. *)
 
 val with_read_auth :
   (Mcp_server.server_state ->

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -928,7 +928,7 @@ let add_routes router =
       request
       reqd)
   |> Http.Router.get "/api/v1/ide/cursors/stream" (fun request reqd ->
-    with_public_read
+    Server_auth.with_observer_sse_read_auth
       (fun state _req inner_reqd ->
          let uri = Uri.of_string request.target in
          match parse_pagination_query ~max_limit:200 uri with

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -78,6 +78,20 @@ let create_worker_token base_path agent_name =
     failf "create_token failed for %s: %s" agent_name (Masc_domain.masc_error_to_string e)
 ;;
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some old -> Unix.putenv name old
+      | None -> Unix.putenv name "")
+    (fun () ->
+       (match value with
+        | Some next -> Unix.putenv name next
+        | None -> Unix.putenv name "");
+       f ())
+;;
+
 let http_request ~meth ~path ?(body = "") ?(token = None) () =
   let headers =
     [ "host", "localhost"
@@ -378,6 +392,16 @@ let test_read_cursors_records_unmatched_repo_orphan_metric () =
     check (float 0.0001) "unmatched orphan read increments" (before +. 1.0) after)
 ;;
 
+let test_cursor_stream_accepts_query_token_under_strict_auth () =
+  with_env "MASC_HTTP_BASE_URL" (Some "https://masc.example.test") (fun () ->
+    with_ide_server (fun ~base_path ~state:_ ~router ->
+      let token = create_worker_token base_path "alice" in
+      let path = "/api/v1/ide/cursors/stream?repo_id=masc&token=" ^ Uri.pct_encode token in
+      let request = http_request ~meth:`GET ~path () in
+      let response = dispatch router request in
+      check_status "GET cursor stream with query token succeeds" 200 response))
+;;
+
 let test_memory_response_declares_annotation_source_contract () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     (match
@@ -535,6 +559,10 @@ let () =
             "GET cursors records unmatched repo orphan read metric"
             `Quick
             test_read_cursors_records_unmatched_repo_orphan_metric
+        ; test_case
+            "GET cursor stream accepts query token under strict auth"
+            `Quick
+            test_cursor_stream_accepts_query_token_under_strict_auth
         ; test_case
             "GET memory declares annotation source contract"
             `Quick


### PR DESCRIPTION
## Summary
- Fix the post-#23226 cursor SSE auth path so EventSource `token=` query auth is actually accepted under strict HTTP auth.
- Route `/api/v1/ide/cursors/stream` through a query-token-aware SSE read wrapper instead of generic `with_public_read` -> `with_read_auth`.
- Add a black-box strict-auth regression for `/api/v1/ide/cursors/stream?token=...`.

## Why
#23226 added `token=` to the cursor EventSource URL because EventSource cannot send Authorization headers. The merged server route still used the generic read-auth path, which only reads headers; under strict HTTP auth that query token would be ignored.

## Validation
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_server_ide_http.exe`
- `./_build/default/test/test_server_ide_http.exe` -> 20 tests passed
