### PR TITLE
fix(test): qualify Client_registry_eio under Masc namespace (main broken)

### DIFF
--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -734,9 +734,9 @@ let test_dashboard_proof_route_registered_in_http_routers () =
 let test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Fun.protect
-    ~finally:Client_registry_eio.reset_for_testing
+    ~finally:Masc.Client_registry_eio.reset_for_testing
     (fun () ->
-      Client_registry_eio.reset_for_testing ();
+      Masc.Client_registry_eio.reset_for_testing ();
       let json = Server_dashboard_http.dashboard_ide_snapshot_json ~config in
       let partition = Ide_paths.Legacy_default in
       let open Yojson.Safe.Util in


### PR DESCRIPTION
## Summary
`main` is broken: `dune build .` fails at `test/test_dashboard_http_core.ml:737` with `Error: Unbound module Client_registry_eio`. This is a namespace qualification bug introduced by #23211 (merged 2026-07-04 14:30 UTC), which has been breaking main for ~15 commits.

## Root cause
The `masc` library is **wrapped** (default, no `(wrapped false)` in `lib/dune`), so its modules live under the `Masc.` namespace. `test/test_dashboard_http_core.ml` intentionally has **no `open Masc`** — it accesses the lib via `Masc.Auth`, `Masc.Workspace`, `module Lib = Masc`. PR #23211 added bare `Client_registry_eio.reset_for_testing` calls at lines 737/739, which are unbound without `open Masc` or full qualification.

Other tests that reference bare `Client_registry_eio` (`test_identity_e2e`, `test_identity_edge_cases`, `test_client_registry_eio`) all have `open Masc` at the top — that is why they build and this file does not. The dune `libraries` field is correct (`masc_test_deps` does `re_export masc`); no dune change is needed.

## Fix
Qualify both call sites as `Masc.Client_registry_eio.reset_for_testing`, matching the file's existing convention (surgical, no blanket `open Masc`). 2-line change.

## Verified
`dune build --root . test/test_dashboard_http_core.exe` exits 0 in the worktree on top of `origin/main`.

## CI gate observation (separate concern, not addressed here)
#23211's PR checks were green, yet its merge commit fails to build this target on main. The Build and Test job likely did not exercise `test_dashboard_http_core.exe` on the PR (or main post-merge re-run was skipped). Recommend a follow-up to confirm this executable is always part of the build target set, so a namespace miss like this cannot land green and break main again. This is the same shape as the earlier auto-merge red-CI incident (#22871 → #22938).

## Checklist
- [x] Root cause identified (wrapped-lib namespace, not dune deps)
- [x] Local build green (`dune build --root . test/test_dashboard_http_core.exe`)
- [x] Surgical change, follows file convention (no blanket `open`)
- [ ] CI green on this PR (main CI was queue-stuck at the time of opening — re-run if still stuck)
- RFC scope: test-only change, no credential/identity/repo/operator/sandbox/hooks surface — RFC check N/A

Co-Authored-By: Claude <noreply@anthropic.com>
