### PR TITLE
fix(test): main test 빌드 복구 — dashboard http test에서 Client_registry_eio를 Masc.로 qualify

### DIFF
--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -734,9 +734,13 @@ let test_dashboard_proof_route_registered_in_http_routers () =
 let test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Fun.protect
-    ~finally:Client_registry_eio.reset_for_testing
+    (* [Client_registry_eio] lives in the wrapped [masc] library; this file does
+       not [open Masc] (it uses qualified [Masc.X] access), so the module must be
+       qualified. [Server_dashboard_http]/[Ide_paths] resolve bare because they
+       come from the unwrapped [masc.server] library. *)
+    ~finally:Masc.Client_registry_eio.reset_for_testing
     (fun () ->
-      Client_registry_eio.reset_for_testing ();
+      Masc.Client_registry_eio.reset_for_testing ();
       let json = Server_dashboard_http.dashboard_ide_snapshot_json ~config in
       let partition = Ide_paths.Legacy_default in
       let open Yojson.Safe.Util in


### PR DESCRIPTION
## 🔴 main test 빌드 복구 (hotfix)

`dune build .`가 main에서 실패:

```
test/test_dashboard_http_core.ml:737: Unbound module Client_registry_eio
```

### 원인 — #23211
- `test_dashboard_http_core.ml`은 `open Masc`가 없고 `Masc.X` qualified alias만 사용.
- `Client_registry_eio`는 **wrapped `masc`** lib 소속 → bare 참조 불가(`Masc.` 필요). (`Server_dashboard_http`/`Ide_paths`는 **unwrapped `masc.server`** lib이라 bare OK.)
- #23211이 새 테스트에 bare `Client_registry_eio.reset_for_testing`(737/739)를 추가.

### 수정
파일 기존 관습대로 `Masc.Client_registry_eio`로 qualify(737/739). `open Masc` 추가는 unwrapped `masc.server` 모듈과 충돌 위험이라 배제.

### 검증
- 최신 main(7fd0f8561b) 기준 `dune build ./test/test_dashboard_http_core.exe` 컴파일 성공
- `test_dashboard_http_core` 46/46 통과

### 배경
lib 쪽 build fix(ide_bridge exit_semantics)는 #23224로 이미 머지됨. 이 PR은 같은 `dune build .` 장애의 두 번째 근본원인(test)입니다. (원래 #23224에 함께 담았으나 #23224가 먼저 squash 머지되며 test 커밋이 분리됨.)

### 참고 (프로세스 갭)
#23196·#23211 모두 **test 빌드를 하지 않는 CI**를 통과해 main에 들어온 것으로 보입니다. 별도 이슈로 CI에 `dune build .`/`@check` 게이트 추가 권장.

**빠른 머지 요망** — 머지 전까지 main `dune build .` red.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
