### PR TITLE
[codex] Classify IDE relation trace surfaces

### DIFF
--- a/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.test.ts
@@ -79,6 +79,54 @@ describe('bridgeRunActivityEventsToTrace', () => {
     expect(keeperTraceState.value.events[0]?.count).toBe(1)
   })
 
+  it('labels typed comment and runtime activity surfaces without kind fallback', () => {
+    const emitted = bridgeRunActivityEventsToTrace([
+      activity({
+        id: 'evt-comment',
+        kind: 'note',
+        context: {
+          file_path: 'lib/comment.ml',
+          line: 11,
+          comment_id: 'comment-11',
+        },
+      }),
+      activity({
+        id: 'evt-runtime',
+        kind: 'note',
+        context: {
+          file_path: 'lib/runtime.ml',
+          line: 12,
+          session_id: 'session-12',
+          operation_id: 'operation-12',
+          worker_run_id: 'worker-12',
+        },
+      }),
+    ], new Set())
+
+    expect([...emitted]).toEqual([
+      'activity:run-default:evt-comment',
+      'activity:run-default:evt-runtime',
+    ])
+    expect(keeperTraceState.value.events).toMatchObject([
+      {
+        id: 'activity:run-default:evt-comment',
+        filePath: 'lib/comment.ml',
+        line: 11,
+        surface: 'Comment',
+        commentId: 'comment-11',
+      },
+      {
+        id: 'activity:run-default:evt-runtime',
+        filePath: 'lib/runtime.ml',
+        line: 12,
+        surface: 'Runtime',
+        sessionId: 'session-12',
+        operationId: 'operation-12',
+        workerRunId: 'worker-12',
+      },
+    ])
+  })
+
   it('skips unscoped lines and unsafe file paths without poisoning later enrichment', () => {
     const unscoped = activity({
       id: 'evt-1',

--- a/dashboard/src/components/ide/run-activity-trace-bridge.ts
+++ b/dashboard/src/components/ide/run-activity-trace-bridge.ts
@@ -56,5 +56,9 @@ function activityTraceSurface(event: RunActivityEvent): string {
   if (event.context?.task_id) return 'Task'
   if (event.context?.git_ref) return 'Git'
   if (event.context?.log_id) return 'Log'
+  if (event.context?.comment_id) return 'Comment'
+  if (event.context?.session_id || event.context?.operation_id || event.context?.worker_run_id) {
+    return 'Runtime'
+  }
   return event.kind?.trim() || 'Activity'
 }


### PR DESCRIPTION
## Summary
- classify comment-only activity traces as Comment from typed context
- classify runtime-only activity traces as Runtime from session/operation/worker ids
- keep existing PR/Board/Goal/Task/Git/Log surface precedence unchanged

## Validation
- pnpm --dir dashboard install --frozen-lockfile
- pnpm --dir dashboard exec vitest run src/components/ide/run-activity-trace-bridge.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check

Dune/CI intentionally not run locally per workflow; CI can build OCaml.