### PR TITLE
refactor(server): collapse git-diff cache envelope and de-dup source_to_string

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -133,20 +133,23 @@ let sanitize_header_value s =
     let code = Char.code c in
     if code < 0x20 || code = 0x7f then '_' else c) s
 
+(* Single SSOT encoding of the workspace source variant. Used by
+   [source_header] (HTTP header — sanitized there) and by the
+   tree/blame/diff cache keys (internal string, no sanitization). *)
+let source_to_string = function
+  | `Project -> "project"
+  | `Repository repo_id -> "repository:" ^ repo_id
+  | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
+  | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
+  | `Playground name -> "playground:" ^ name
+  | `PlaygroundMissing name -> "playground_missing:" ^ name
+  | `KeeperUnknown name -> "keeper_unknown:" ^ name
+
 (* Encode the workspace source tag as a single header value so the
    frontend can render hints ("Playground 없음 — 프로젝트로 fallback")
    without parsing the JSON body. *)
 let source_header source =
-  let v = match source with
-    | `Project -> "project"
-    | `Repository repo_id -> "repository:" ^ sanitize_header_value repo_id
-    | `RepositoryMissing repo_id -> "repository_missing:" ^ sanitize_header_value repo_id
-    | `RepositoryUnknown repo_id -> "repository_unknown:" ^ sanitize_header_value repo_id
-    | `Playground name -> "playground:" ^ sanitize_header_value name
-    | `PlaygroundMissing name -> "playground_missing:" ^ sanitize_header_value name
-    | `KeeperUnknown name -> "keeper_unknown:" ^ sanitize_header_value name
-  in
-  [("X-Workspace-Source", v)]
+  [("X-Workspace-Source", sanitize_header_value (source_to_string source))]
 
 let json_response_with_source ~status ~source req reqd json =
   Http.Response.json_value ~status ~extra_headers:(source_header source)
@@ -787,14 +790,7 @@ let add_routes router =
            let cache_key =
              Printf.sprintf "workspace:tree:%s:%s:%d:%d:%b"
                base
-               (match source with
-                | `Project -> "project"
-                | `Repository repo_id -> "repository:" ^ repo_id
-                | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
-                | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
-                | `Playground name -> "playground:" ^ name
-                | `PlaygroundMissing name -> "playground_missing:" ^ name
-                | `KeeperUnknown name -> "keeper_unknown:" ^ name)
+               (source_to_string source)
                effective_depth effective_max_nodes include_diff
            in
            let json =
@@ -944,14 +940,7 @@ let add_routes router =
                   let cache_key =
                     Printf.sprintf "git:blame:%s:%s:%s"
                       base
-                      (match source with
-                       | `Project -> "project"
-                       | `Repository repo_id -> "repository:" ^ repo_id
-                       | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
-                       | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
-                       | `Playground name -> "playground:" ^ name
-                       | `PlaygroundMissing name -> "playground_missing:" ^ name
-                       | `KeeperUnknown name -> "keeper_unknown:" ^ name)
+                      (source_to_string source)
                       rel
                   in
                   let json =
@@ -974,70 +963,60 @@ let add_routes router =
   |> Http.Router.get "/api/v1/git/diff" (fun request reqd ->
        with_public_read
          (fun state _req reqd ->
-            let uri = Uri.of_string request.target in
-            let base, source = resolve_workspace_base ~state ~uri in
-            let file_path =
-              match Uri.get_query_param uri "path" with
-              | Some p -> p
-              | None -> ""
-            in
-            if file_path = "" then
-              json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
-            else
-              let base_ref =
-                match Uri.get_query_param uri "base_ref" with
-                | Some r -> r
-                | None -> "HEAD"
-              in
-              if not (valid_git_ref base_ref) then
-                json_response ~status:`Bad_request request reqd
-                  (json_error "Invalid base_ref")
-              else
-              (match resolve_workspace_file base file_path with
-               | Error _ ->
-                 json_response ~status:`Bad_request request reqd (json_error "Invalid path")
-               | Ok safe ->
-                 let rel = rel_under base safe.lexical_path in
-                 let cache_key =
-                   Printf.sprintf "git:diff:%s:%s:%s:%s"
-                     base
-                     (match source with
-                      | `Project -> "project"
-                      | `Repository repo_id -> "repository:" ^ repo_id
-                      | `RepositoryMissing repo_id -> "repository_missing:" ^ repo_id
-                      | `RepositoryUnknown repo_id -> "repository_unknown:" ^ repo_id
-                      | `Playground name -> "playground:" ^ name
-                      | `PlaygroundMissing name -> "playground_missing:" ^ name
-                      | `KeeperUnknown name -> "keeper_unknown:" ^ name)
-                     base_ref
-                     rel
-                 in
-                 let json =
-                   Dashboard_cache.get_or_compute cache_key
-                     ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
-                     (fun () ->
-                        Domain_pool_ref.submit_io_or_inline (fun () ->
-                          match git_run_lines_or_error ~cwd:base
-                                  ["diff"; base_ref; "--"; rel]
-                          with
-                          | Error _ ->
-                            `Assoc [("ok", `Bool false); ("error", `String "git diff failed")]
-                          | Ok [] ->
-                            `Assoc [("ok", `Bool true); ("data", `Assoc [("unified", `List []); ("has_changes", `Bool false)])]
-                          | Ok diff_lines ->
-                            let unified = parse_unified_diff diff_lines in
-                            `Assoc [("ok", `Bool true); ("data", `Assoc [("unified", `List unified); ("has_changes", `Bool true)])]))
-                 in
-                 (match json with
-                  | `Assoc fields ->
-                    (match List.assoc_opt "ok" fields with
-                     | Some (`Bool true) ->
-                       let data = List.assoc "data" fields in
-                       json_response_with_source ~status:`OK ~source request reqd data
-                     | _ ->
-                       json_response ~status:`Bad_request request reqd
-                         (json_error "git diff failed"))
-                  | _ ->
-                    json_response ~status:`Bad_request request reqd
-                      (json_error "git diff failed"))))
+           let uri = Uri.of_string request.target in
+           let base, source = resolve_workspace_base ~state ~uri in
+           let file_path =
+             match Uri.get_query_param uri "path" with
+             | Some p -> p
+             | None -> ""
+           in
+           if file_path = "" then
+             json_response ~status:`Bad_request request reqd (json_error "Missing path parameter")
+           else
+             let base_ref =
+               match Uri.get_query_param uri "base_ref" with
+               | Some r -> r
+               | None -> "HEAD"
+             in
+             if not (valid_git_ref base_ref) then
+               json_response ~status:`Bad_request request reqd
+                 (json_error "Invalid base_ref")
+             else
+             (match resolve_workspace_file base file_path with
+              | Error _ ->
+                json_response ~status:`Bad_request request reqd (json_error "Invalid path")
+              | Ok safe ->
+                let rel = rel_under base safe.lexical_path in
+                let cache_key =
+                  Printf.sprintf "git:diff:%s:%s:%s:%s"
+                    base
+                    (source_to_string source)
+                    base_ref
+                    rel
+                in
+                let result =
+                  Dashboard_cache.get_or_compute cache_key
+                    ~ttl:Server_dashboard_http_core_cache.realtime_cache_ttl_s
+                    (fun () ->
+                       Domain_pool_ref.submit_io_or_inline (fun () ->
+                         match git_run_lines_or_error ~cwd:base
+                                 ["diff"; base_ref; "--"; rel]
+                         with
+                         | Error _ ->
+                           observe_workspace_route_failure
+                             ~site:"git_run" ~path:rel
+                             (Failure "git diff failed");
+                           `Null
+                         | Ok [] ->
+                           `Assoc [("unified", `List []); ("has_changes", `Bool false)]
+                         | Ok diff_lines ->
+                           let unified = parse_unified_diff diff_lines in
+                           `Assoc [("unified", `List unified); ("has_changes", `Bool true)]))
+                in
+                (match result with
+                 | `Null ->
+                   json_response ~status:`Bad_request request reqd
+                     (json_error "git diff failed")
+                 | data ->
+                   json_response_with_source ~status:`OK ~source request reqd data)))
          request reqd)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -36,6 +36,20 @@ val classify_workspace_query :
     so the frontend can render hints (e.g. "Playground 없음 — 프로젝트로
     fallback") without parsing the JSON body. Exposed for unit
     testing. *)
+
+(** Single SSOT encoding of the workspace source variant. Used by
+    {!source_header} (sanitized there) and by the tree/blame/diff
+    cache keys (internal string, no sanitization). *)
+val source_to_string :
+  [ `Project
+  | `Repository of string
+  | `RepositoryMissing of string
+  | `RepositoryUnknown of string
+  | `Playground of string
+  | `PlaygroundMissing of string
+  | `KeeperUnknown of string ] ->
+  string
+
 val source_header :
   [ `Project
   | `Repository of string


### PR DESCRIPTION
## Summary

Follow-up to the merged #23213 review, addressing the **root-cause:STR** finding (ok/data envelope + List.assoc_opt "ok" / List.assoc "data" string-key dispatch). Three surgical cleanups in `lib/server/server_routes_http_routes_workspace.ml`. No behavioral change on the success path; failure path is observability-equivalent.

## Changes

1. **`source_to_string` SSOT.** The 7-arm match encoding `[ `Project | `Repository of string | … ]` was inlined in **3 cache-key sites** (`/workspace/tree`, `/git/blame`, `/git/diff`) plus `source_header` (4 total). Extracted to one helper; `source_header` is now a one-liner over the same helper. A new variant now produces one exhaustiveness warning instead of four.
2. **`/api/v1/git/diff` envelope removed.** The handler no longer wraps the cached payload in `{"ok":true,"data":{...}}` and string-dispatches it back. The cached value is the bare payload (matching `/git/blame`). Failure (`Error _` from `git_run_lines_or_error`) is encoded as `\`Null` and decoded back to a 400 at the call site, with `observe_workspace_route_failure ~site ~path (Failure "git diff failed")` for visibility. The `List.assoc_opt "ok"` / `List.assoc "data"` dispatch is gone.
3. **Indentation regression fixed.** The diff handler body had drifted +1 space vs the blame handler; realigned byte-for-byte.

## Why

The `("ok",_)( "data",_)` envelope was a closed-variant-shaped hole punched through a free-form `Yojson.Safe.t`, then re-parsed by string key on the way out — the "String/Substring 분류기" anti-pattern in CLAUDE.md. The cache contract is Yojson-opaque; the envelope was a call-site choice, so it was removed at the call site. Extending `Dashboard_cache` to be polymorphic was considered and rejected (moderate-cost, ~780 lines of SWR/locking machinery would need to fork).

## Behavioral delta

| Path | Before | After |
|---|---|---|
| Diff success | `200 {unified, has_changes}` (envelope was internal only) | unchanged |
| Diff failure (git error) | `400 {error: "git diff failed"}` (not cached) | `400 {error: "git diff failed"}` (cached for `realtime_cache_ttl_s`=15s, matches blame) |
| Failure observability | implicit via `Error _` | explicit `observe_workspace_route_failure` before `\`Null` |
| FE | reads `data.unified` | unchanged (already bare-payload; verified via `dashboard/src/api/workspace.ts` test mocks) |
| `source_header` output | `"repository:<id>"` sanitized | unchanged (sanitize equivalence: `sanitize_header_value` is a char-class map, ASCII prefix `"repository:"` is a fixed point) |

## Test plan

- [ ] CI Build and Test green
- [ ] `dune runtest test/test_workspace_routes_keeper.ml` — 7 header tests pass unchanged
- [ ] `rg '"ok".*"data"|\\.data\\.unified' dashboard/src/` — confirm FE already reads bare payload

## Out of scope

- Lifting the source variant into a typed cache (would require polymorphic `Dashboard_cache`)
- Length-prefixing the cache-key encoding against `:`-in-`repo_id` (pre-existing, not introduced here)

Co-Authored-By: Claude <noreply@anthropic.com>
