### PR TITLE
[codex] Load config-root capability manifest at bootstrap

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -15,12 +15,21 @@ type model_catalog_env_resolution =
   ; source : model_catalog_env_source
   }
 
+and capability_manifest_env_resolution =
+  { path : string
+  ; source : capability_manifest_env_source
+  }
+
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
   | Parent_file of
       { origin : model_catalog_parent_origin
       ; filename : string
       }
+
+and capability_manifest_env_source =
+  | Capability_manifest_env_var
+  | Config_root_file of string
 
 and model_catalog_env_var =
   | Oas_model_catalog
@@ -43,8 +52,15 @@ let model_catalog_env_source_to_string = function
   | Parent_file { origin; filename } ->
     Printf.sprintf "%s:%s" (model_catalog_parent_origin_label origin) filename
 
+let oas_capability_manifest_env_var_name = "OAS_CAPABILITY_MANIFEST"
+
+let capability_manifest_env_source_to_string = function
+  | Capability_manifest_env_var -> oas_capability_manifest_env_var_name
+  | Config_root_file filename -> Printf.sprintf "config-root:%s" filename
+
 let models_toml_filename = "models.toml"
 let oas_models_toml_filename = "oas-models.toml"
+let capability_manifest_filename = "capability-manifest.json"
 
 let nonempty_env env name =
   match env name with
@@ -122,11 +138,45 @@ let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
            | [] -> "")
        in
        (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
-        | Some _ as found -> found
-        | None ->
-          (match argv0_parent_dir ~cwd:process_cwd argv0 with
-           | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
-           | None -> None)))
+	        | Some _ as found -> found
+	        | None ->
+	          (match argv0_parent_dir ~cwd:process_cwd argv0 with
+	           | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
+	           | None -> None)))
+
+let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root () =
+  match nonempty_env env oas_capability_manifest_env_var_name with
+  | Some path -> Some { path; source = Capability_manifest_env_var }
+  | None ->
+    let candidate = Filename.concat config_root capability_manifest_filename in
+    (match existing_file candidate with
+     | Some path -> Some { path; source = Config_root_file capability_manifest_filename }
+     | None -> None)
+
+let configure_oas_capability_manifest_env
+      ?(env = Sys.getenv_opt)
+      ~config_root
+      ?(putenv = Unix.putenv)
+      ()
+  =
+  match resolve_oas_capability_manifest_path ~env ~config_root () with
+  | Some { source = Capability_manifest_env_var; path } as resolution ->
+    Log.Misc.info
+      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s already configured"
+      path;
+    resolution
+  | Some { source; path } as resolution ->
+    putenv oas_capability_manifest_env_var_name path;
+    Log.Misc.info
+      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s resolved from %s"
+      path
+      (capability_manifest_env_source_to_string source);
+    resolution
+  | None ->
+    Log.Misc.info
+      "capability_manifest: no config-root capability-manifest.json found; using \
+       agent_sdk ambient capability manifest state";
+    None
 
 let configure_oas_model_catalog_env
       ?(env = Sys.getenv_opt)
@@ -302,6 +352,10 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Unix.putenv Env_config_core.base_path_env_key base_path;
   ensure_thompson_persistence ~base_path;
   bootstrap_base_path_config_root ~base_path;
+  let config_root = (startup_config_resolution ~base_path).config_root.path in
+  let (_ : capability_manifest_env_resolution option) =
+    configure_oas_capability_manifest_env ~config_root ()
+  in
   (* Apply keeper runtime overrides from the resolved config root's
      runtime.toml. Must run before any module that reads
      [Env_config_keeper.KeeperKeepalive] env vars at init time. Existing

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -15,12 +15,21 @@ type model_catalog_env_resolution =
   ; source : model_catalog_env_source
   }
 
+and capability_manifest_env_resolution =
+  { path : string
+  ; source : capability_manifest_env_source
+  }
+
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
   | Parent_file of
       { origin : model_catalog_parent_origin
       ; filename : string
       }
+
+and capability_manifest_env_source =
+  | Capability_manifest_env_var
+  | Config_root_file of string
 
 and model_catalog_env_var =
   | Oas_model_catalog
@@ -31,6 +40,7 @@ and model_catalog_parent_origin =
   | Argv0_parent
 
 val model_catalog_env_source_to_string : model_catalog_env_source -> string
+val capability_manifest_env_source_to_string : capability_manifest_env_source -> string
 
 val resolve_oas_model_catalog_path :
   ?env:(string -> string option) ->
@@ -38,6 +48,12 @@ val resolve_oas_model_catalog_path :
   ?argv0:string ->
   unit ->
   model_catalog_env_resolution option
+
+val resolve_oas_capability_manifest_path :
+  ?env:(string -> string option) ->
+  config_root:string ->
+  unit ->
+  capability_manifest_env_resolution option
 
 val configure_oas_model_catalog_env :
   ?env:(string -> string option) ->
@@ -48,6 +64,13 @@ val configure_oas_model_catalog_env :
   ?agent_sdk_catalog:(unit -> Llm_provider.Model_catalog.t option) ->
   unit ->
   model_catalog_env_resolution option
+
+val configure_oas_capability_manifest_env :
+  ?env:(string -> string option) ->
+  config_root:string ->
+  ?putenv:(string -> string -> unit) ->
+  unit ->
+  capability_manifest_env_resolution option
 
 (** {1 Runtime Context}
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -129,6 +129,10 @@ let model_catalog_resolution_source_label resolution =
   Server_runtime_bootstrap.model_catalog_env_source_to_string
     resolution.Server_runtime_bootstrap.source
 
+let capability_manifest_resolution_source_label resolution =
+  Server_runtime_bootstrap.capability_manifest_env_source_to_string
+    resolution.Server_runtime_bootstrap.source
+
 let test_model_catalog_resolution_prefers_explicit_env () =
   let env = function
     | "OAS_MODEL_CATALOG" -> Some "/explicit/oas-models.toml"
@@ -170,9 +174,61 @@ let test_model_catalog_resolution_prefers_explicit_env () =
       "MASC_MODEL_CATALOG"
       (model_catalog_resolution_source_label resolution);
     Alcotest.(check string)
-      "path"
-      "/explicit/masc-models.toml"
-      resolution.Server_runtime_bootstrap.path
+	      "path"
+	      "/explicit/masc-models.toml"
+	      resolution.Server_runtime_bootstrap.path
+
+let test_capability_manifest_resolution_prefers_explicit_env () =
+  let env = function
+    | "OAS_CAPABILITY_MANIFEST" -> Some "/explicit/capability-manifest.json"
+    | _ -> None
+  in
+  with_temp_dir "capability-manifest-bootstrap-explicit" (fun dir ->
+    match
+      Server_runtime_bootstrap.resolve_oas_capability_manifest_path
+        ~env
+        ~config_root:dir
+        ()
+    with
+    | None -> Alcotest.fail "expected explicit OAS_CAPABILITY_MANIFEST resolution"
+    | Some resolution ->
+      Alcotest.(check string)
+        "source"
+        "OAS_CAPABILITY_MANIFEST"
+        (capability_manifest_resolution_source_label resolution);
+      Alcotest.(check string)
+        "path"
+        "/explicit/capability-manifest.json"
+        resolution.Server_runtime_bootstrap.path)
+
+let test_capability_manifest_configuration_uses_config_root_file () =
+  with_temp_dir "capability-manifest-bootstrap-config-root" (fun config_root ->
+    let manifest = Filename.concat config_root "capability-manifest.json" in
+    write_file manifest {|{"schema_version":1,"models":[]}|};
+    let putenv_calls = ref [] in
+    let env _ = None in
+    let result =
+      Server_runtime_bootstrap.configure_oas_capability_manifest_env
+        ~env
+        ~config_root
+        ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
+        ()
+    in
+    (match result with
+     | None -> Alcotest.fail "expected config-root capability manifest resolution"
+     | Some resolution ->
+       Alcotest.(check string)
+         "source"
+         "config-root:capability-manifest.json"
+         (capability_manifest_resolution_source_label resolution);
+       Alcotest.(check string)
+         "path"
+         (canonical_path manifest)
+         (canonical_path resolution.Server_runtime_bootstrap.path));
+    Alcotest.(check (list (pair string string)))
+      "putenv"
+      [ "OAS_CAPABILITY_MANIFEST", manifest ]
+      (List.rev !putenv_calls))
 
 let test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path () =
   with_temp_dir "model-catalog-bootstrap" (fun dir ->
@@ -4183,6 +4239,12 @@ let () =
           Alcotest.test_case
             "model catalog resolution prefers explicit env"
             `Quick test_model_catalog_resolution_prefers_explicit_env;
+          Alcotest.test_case
+            "capability manifest resolution prefers explicit env"
+            `Quick test_capability_manifest_resolution_prefers_explicit_env;
+          Alcotest.test_case
+            "capability manifest configuration uses config root"
+            `Quick test_capability_manifest_configuration_uses_config_root_file;
           Alcotest.test_case
             "model catalog resolution falls back to executable parent"
             `Quick


### PR DESCRIPTION
## Summary
- resolve config-root `capability-manifest.json` into `OAS_CAPABILITY_MANIFEST` during server bootstrap
- keep explicit `OAS_CAPABILITY_MANIFEST` env var precedence
- add bootstrap tests for explicit env resolution and config-root manifest injection

## Why
Live runtime config roots can carry runtime-local capability overrides in `.masc/config/capability-manifest.json`. The server already resolves the OAS TOML catalog, but did not wire the config-root JSON manifest into OAS before runtime initialization, so local/custom capability rows could be ignored and runtime startup could still fail catalog checks.

This does not weaken the strict catalog gate or route uncatalogued referenced runtimes through `provider_default`; it only makes the intended runtime-local override surface participate in capability lookup.

## Verification
- `ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check`

Focused Dune build was not run locally because another session has a bare `dune build --root .` process active, and `scripts/dune-local.sh` correctly refused to start a second local build. Per repo guidance, CI is the build authority for this slice.