### PR TITLE
[codex] Reject mismatched IDE annotation post scope

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -75,6 +75,58 @@ let resolve_partition_for_query ~state ~uri =
      | _ -> Ide_paths.Legacy_default)
 ;;
 
+type annotation_scope_error =
+  | File_path_repo_id_mismatch
+  | File_path_canonical_url_mismatch
+
+let annotation_scope_error_message = function
+  | File_path_repo_id_mismatch -> "file_path does not belong to requested repo_id"
+  | File_path_canonical_url_mismatch ->
+    "file_path does not belong to requested canonical_url"
+;;
+
+let nonempty_query_param uri key =
+  match Uri.get_query_param uri key with
+  | Some raw ->
+    let value = String.trim raw in
+    if String.equal value "" then None else Some value
+  | None -> None
+;;
+
+let validate_annotation_post_scope ~state ~uri ~file_path =
+  if Filename.is_relative file_path then Ok ()
+  else (
+    let project_base = base_path_of_state state in
+    match nonempty_query_param uri "canonical_url" with
+    | Some canonical_url ->
+      (match Ide_paths.canonical_url_of_remote canonical_url with
+       | None -> Ok ()
+       | Some requested_slug ->
+         (match Repo_store.find_repo_by_path_prefix ~base_path:project_base file_path with
+          | Some (repo, _) ->
+            (match Ide_paths.canonical_url_of_remote repo.url with
+             | Some actual_slug when String.equal actual_slug requested_slug -> Ok ()
+             | Some _ | None -> Error File_path_canonical_url_mismatch)
+          | None -> Error File_path_canonical_url_mismatch))
+    | None ->
+      (match nonempty_query_param uri "repo_id" with
+       | None -> Ok ()
+       | Some requested_repo_id ->
+         (match Repo_store.find ~base_path:project_base requested_repo_id with
+          | Error _ -> Ok ()
+          | Ok _ ->
+            (match Repo_store.find_repo_by_path_prefix ~base_path:project_base file_path with
+             | Some (repo, _) when String.equal repo.id requested_repo_id -> Ok ()
+             | Some _ | None -> Error File_path_repo_id_mismatch))))
+;;
+
+let resolve_partition_for_annotation_post ~state ~uri ~file_path =
+  let partition = resolve_partition_for_query ~state ~uri in
+  match validate_annotation_post_scope ~state ~uri ~file_path with
+  | Ok () -> Ok partition
+  | Error err -> Error (annotation_scope_error_message err)
+;;
+
 let orphan_read_reason_label = function
   | Ide_paths.By_url _ -> None
   | Ide_paths.No_canonical_url -> Some "no_canonical_url"
@@ -541,41 +593,50 @@ let add_routes router =
                      let session_id = find_string "session_id" in
                      let operation_id = find_string "operation_id" in
                      let worker_run_id = find_string "worker_run_id" in
-                     let partition = resolve_partition_for_query ~state ~uri in
                      (match
-                        Ide_annotations.create
-                          ~base_dir:base
-                          ~partition
-                          ~keeper_id
-                          ~file_path
-                          ~line_start
-                          ~line_end
-                          ~kind
-                          ~content
-                          ?goal_id
-                          ?task_id
-                          ?board_post_id
-                          ?comment_id
-                          ?pr_id
-                          ?git_ref
-                          ?log_id
-                          ?session_id
-                          ?operation_id
-                          ?worker_run_id
-                          ()
+                        resolve_partition_for_annotation_post ~state ~uri ~file_path
                       with
-                      | Ok annotation ->
-                        Http.Response.json_value
-                          ~status:`Created
-                          ~request
-                          (json_ok (Ide_annotation_types.annotation_to_json annotation))
-                          reqd
                       | Error msg ->
                         Http.Response.json_value
                           ~status:`Bad_request
                           ~request
                           (json_error msg)
-                          reqd)))
+                          reqd
+                      | Ok partition ->
+                        (match
+                           Ide_annotations.create
+                             ~base_dir:base
+                             ~partition
+                             ~keeper_id
+                             ~file_path
+                             ~line_start
+                             ~line_end
+                             ~kind
+                             ~content
+                             ?goal_id
+                             ?task_id
+                             ?board_post_id
+                             ?comment_id
+                             ?pr_id
+                             ?git_ref
+                             ?log_id
+                             ?session_id
+                             ?operation_id
+                             ?worker_run_id
+                             ()
+                         with
+                         | Ok annotation ->
+                           Http.Response.json_value
+                             ~status:`Created
+                             ~request
+                             (json_ok (Ide_annotation_types.annotation_to_json annotation))
+                             reqd
+                         | Error msg ->
+                           Http.Response.json_value
+                             ~status:`Bad_request
+                             ~request
+                             (json_error msg)
+                             reqd)))
              | _ ->
                Http.Response.json_value
                  ~status:`Bad_request

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -78,6 +78,51 @@ let create_worker_token base_path agent_name =
     failf "create_token failed for %s: %s" agent_name (Masc_domain.masc_error_to_string e)
 ;;
 
+let repository_fixture ~id ~url ~local_path : Repo_manager_types.repository =
+  { id
+  ; name = id
+  ; url
+  ; local_path
+  ; aliases = []
+  ; default_branch = "main"
+  ; keepers = []
+  ; status = Repo_manager_types.Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = Int64.zero
+  ; updated_at = Int64.zero
+  }
+;;
+
+let seed_annotation_scope_repos base_path =
+  let masc_path = Filename.concat base_path "workspace/masc" in
+  let oas_path = Filename.concat base_path "workspace/oas" in
+  let repos =
+    [ repository_fixture
+        ~id:"masc"
+        ~url:"https://github.com/jeong-sik/masc.git"
+        ~local_path:masc_path
+    ; repository_fixture
+        ~id:"oas"
+        ~url:"https://github.com/jeong-sik/oas.git"
+        ~local_path:oas_path
+    ]
+  in
+  match Repo_store.save_all ~base_path repos with
+  | Ok () -> masc_path, oas_path
+  | Error msg -> failf "save repositories failed: %s" msg
+;;
+
+let annotation_body ~file_path =
+  Yojson.Safe.to_string
+    (`Assoc
+       [ "file_path", `String file_path
+       ; "line_start", `Int 1
+       ; "line_end", `Int 2
+       ; "content", `String "note"
+       ])
+;;
+
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   Fun.protect
@@ -221,6 +266,14 @@ let error_message_of_response response =
   |> json_string_member "error response" "error"
 ;;
 
+let annotation_count router path =
+  let request = http_request ~meth:`GET ~path () in
+  let response = dispatch router request in
+  check_status "GET annotations succeeds" 200 response;
+  let json = response |> response_body |> Yojson.Safe.from_string in
+  List.length (json_list_member "annotations response" "data" json)
+;;
+
 let setup_state base_path =
   save_auth_config base_path;
   let state = Masc.Mcp_server.create_state ~base_path in
@@ -346,6 +399,91 @@ let test_post_cursors_honors_canonical_url_scope () =
     | cursor :: _ ->
       check string "scoped cursor file" "lib/a.ml" (json_string_member "cursor" "file_path" cursor)
     | [] -> fail "expected scoped cursor")
+;;
+
+let test_post_annotations_accepts_matching_repo_scope () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let masc_path, _oas_path = seed_annotation_scope_repos base_path in
+    let token = create_worker_token base_path "alice" in
+    let file_path = Filename.concat masc_path "lib/a.ml" in
+    let request =
+      http_request
+        ~meth:`POST
+        ~path:"/api/v1/ide/annotations?repo_id=masc"
+        ~body:(annotation_body ~file_path)
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "POST annotation with matching repo_id returns 201" 201 response;
+    check
+      int
+      "matching annotation is visible in requested partition"
+      1
+      (annotation_count router "/api/v1/ide/annotations?repo_id=masc");
+    check
+      int
+      "matching annotation is not written to other partition"
+      0
+      (annotation_count router "/api/v1/ide/annotations?repo_id=oas"))
+;;
+
+let test_post_annotations_rejects_repo_scope_mismatch () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let _masc_path, oas_path = seed_annotation_scope_repos base_path in
+    let token = create_worker_token base_path "alice" in
+    let file_path = Filename.concat oas_path "lib/a.ml" in
+    let request =
+      http_request
+        ~meth:`POST
+        ~path:"/api/v1/ide/annotations?repo_id=masc"
+        ~body:(annotation_body ~file_path)
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "POST annotation with mismatched repo_id returns 400" 400 response;
+    check
+      string
+      "repo scope mismatch error"
+      "file_path does not belong to requested repo_id"
+      (error_message_of_response response);
+    check
+      int
+      "mismatched annotation is not written to requested partition"
+      0
+      (annotation_count router "/api/v1/ide/annotations?repo_id=masc");
+    check
+      int
+      "mismatched annotation is not written to actual partition"
+      0
+      (annotation_count router "/api/v1/ide/annotations?repo_id=oas"))
+;;
+
+let test_post_annotations_rejects_canonical_scope_mismatch () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let _masc_path, oas_path = seed_annotation_scope_repos base_path in
+    let token = create_worker_token base_path "alice" in
+    let file_path = Filename.concat oas_path "lib/a.ml" in
+    let scoped_path =
+      "/api/v1/ide/annotations?canonical_url="
+      ^ Uri.pct_encode "https://github.com/jeong-sik/masc.git"
+    in
+    let request =
+      http_request
+        ~meth:`POST
+        ~path:scoped_path
+        ~body:(annotation_body ~file_path)
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "POST annotation with mismatched canonical_url returns 400" 400 response;
+    check
+      string
+      "canonical scope mismatch error"
+      "file_path does not belong to requested canonical_url"
+      (error_message_of_response response))
 ;;
 
 let test_post_annotations_requires_auth () =
@@ -593,6 +731,12 @@ let () =
             test_post_cursors_persists_valid_focus_mode
         ; test_case "POST cursor honors canonical_url scope" `Quick
             test_post_cursors_honors_canonical_url_scope
+        ; test_case "POST annotation accepts matching repo scope" `Quick
+            test_post_annotations_accepts_matching_repo_scope
+        ; test_case "POST annotation rejects repo scope mismatch" `Quick
+            test_post_annotations_rejects_repo_scope_mismatch
+        ; test_case "POST annotation rejects canonical scope mismatch" `Quick
+            test_post_annotations_rejects_canonical_scope_mismatch
         ; test_case "POST annotation requires auth" `Quick
             test_post_annotations_requires_auth
         ; test_case "DELETE annotation requires auth" `Quick


### PR DESCRIPTION
## Summary
- add POST-only annotation scope validation for explicit repo_id/canonical_url queries
- reject absolute file_path values that belong to a different registered repository scope
- keep relative file_path and legacy no-query annotation writes unchanged
- add black-box HTTP tests for matched repo scope, repo mismatch no-write, and canonical mismatch rejection

## Validation
- opam exec -- ocamlformat --check lib/server/server_ide_http.ml test/test_server_ide_http.ml
- git diff --check

Dune and CI were intentionally not run/waited locally per workflow.