### PR TITLE
Expose reasoning stream field in runtime summaries

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -391,7 +391,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('effective · ctx 131,072 · out 65,536 · tools · tool_choice+required+named+parallel')
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
-    expect(container.textContent).toContain('reasoning-stream delta-reasoning-field')
+    expect(container.textContent).toContain('reasoning-stream delta-reasoning-field:reasoning_content')
     expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -11,6 +11,7 @@ import {
   type DashboardRuntimeProviderProbe,
   type DashboardRuntimeProviderSnapshot,
   type DashboardRuntimeProvidersResponse,
+  type DashboardRuntimeReasoningStreamingFormat,
 } from '../api/dashboard'
 import { ActionButton } from './common/button'
 import { SectionCard } from './common/card'
@@ -454,6 +455,13 @@ function runtimeEffectiveReasoningText(provider: DashboardRuntimeProviderSnapsho
   ])
 }
 
+function runtimeReasoningStreamingFormatText(
+  format: DashboardRuntimeReasoningStreamingFormat | null | undefined,
+): string | null {
+  if (!format?.kind) return null
+  return format.field ? `${format.kind}:${format.field}` : format.kind
+}
+
 function runtimeEffectiveInputText(provider: DashboardRuntimeProviderSnapshot): string | null {
   const caps = provider.effective_capabilities
   if (!caps) return null
@@ -783,6 +791,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     caps.supports_response_format_json ? 'json' : null,
     caps.supports_structured_output ? 'schema' : null,
   ].filter((value): value is string => Boolean(value))
+  const reasoningStream = runtimeReasoningStreamingFormatText(caps.reasoning_streaming_format)
   const parts = [
     context,
     output,
@@ -804,7 +813,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
       : null,
     caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
-    caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,
+    reasoningStream ? `reasoning-stream ${reasoningStream}` : null,
     caps.reasoning_replay_override ? `replay ${caps.reasoning_replay_override}` : null,
     caps.task ? `task ${caps.task}` : null,
     caps.supports_native_streaming ? 'native-stream' : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1079,6 +1079,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('reasoning-budget')
       expect(cards[0]?.textContent).toContain('effort:low,medium,high')
       expect(cards[0]?.textContent).toContain('preserve:always-preserved')
+      expect(cards[0]?.textContent).toContain('reasoning-stream:delta-reasoning-field:reasoning_content')
       expect(cards[0]?.textContent).toContain('task:transcription · native-stream')
       expect(cards[0]?.textContent).toContain('declared:api:chat-completions')
       expect(cards[0]?.textContent).toContain('transport:http')

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -1,4 +1,7 @@
-import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
+import type {
+  DashboardRuntimeProviderSnapshot,
+  DashboardRuntimeReasoningStreamingFormat,
+} from '../api/dashboard'
 
 function nonEmptyParts(parts: Array<string | null | undefined>): string[] {
   return parts.filter((value): value is string => Boolean(value))
@@ -91,6 +94,13 @@ function runtimeCatalogRequestFormat(item: DashboardRuntimeProviderSnapshot): st
   const format = item.request_config?.response_format
   if (!format?.kind) return null
   return format.has_schema ? `${format.kind}+schema` : format.kind
+}
+
+function runtimeReasoningStreamingFormatSummary(
+  format: DashboardRuntimeReasoningStreamingFormat | null | undefined,
+): string | null {
+  if (!format?.kind) return null
+  return format.field ? `${format.kind}:${format.field}` : format.kind
 }
 
 export function runtimeCatalogRequestConfig(item: DashboardRuntimeProviderSnapshot): string | null {
@@ -261,6 +271,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
       caps.supports_parallel_tool_calls ? 'parallel' : null,
     ]).map(flag => `+${flag}`).join('')}`
     : null
+  const reasoningStream = runtimeReasoningStreamingFormatSummary(caps.reasoning_streaming_format)
   const parts = nonEmptyParts([
     context,
     output,
@@ -281,7 +292,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
       : null,
     caps.preserve_thinking_control_format ? `preserve:${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out:${caps.reasoning_output_format}` : null,
-    caps.reasoning_streaming_format?.kind ? `reasoning-stream:${caps.reasoning_streaming_format.kind}` : null,
+    reasoningStream ? `reasoning-stream:${reasoningStream}` : null,
     caps.reasoning_replay_override ? `replay:${caps.reasoning_replay_override}` : null,
     caps.task ? `task:${caps.task}` : null,
     caps.supports_native_streaming ? 'native-stream' : null,


### PR DESCRIPTION
## Summary
- keep OAS effective reasoning streaming field visible in runtime monitor summaries
- keep the same field visible in settings runtime catalog diagnostics
- tighten dashboard tests so reasoning_content survives through summary rendering

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check