### PR TITLE
refactor(server): derive LSP handled_methods from entries SSOT

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -134,31 +134,31 @@ module Lsp_method_catalog = struct
     { method_; wire_method; classification }
   ;;
 
-  let handled_methods =
-    [ Initialize
-    ; Initialized
-    ; Shutdown
-    ; Exit
-    ; Masc_lsp_status
-    ; Did_open
-    ; Did_change
-    ; Did_save
-    ; Did_close
-    ; Hover
-    ; CodeLens
-    ; InlayHint
-    ; Diagnostic
-    ; Definition
-    ; References
-    ; Completion
-    ; CodeAction
-    ; Document_symbol
-    ; Folding_range
-    ; Document_highlight
+  let entries =
+    [ entry Initialize
+    ; entry Initialized
+    ; entry Shutdown
+    ; entry Exit
+    ; entry Masc_lsp_status
+    ; entry Did_open
+    ; entry Did_change
+    ; entry Did_save
+    ; entry Did_close
+    ; entry Hover
+    ; entry CodeLens
+    ; entry InlayHint
+    ; entry Diagnostic
+    ; entry Definition
+    ; entry References
+    ; entry Completion
+    ; entry CodeAction
+    ; entry Document_symbol
+    ; entry Folding_range
+    ; entry Document_highlight
     ]
   ;;
 
-  let entries = List.map entry handled_methods
+  let handled_methods = List.map (fun (e : entry) -> e.method_) entries
 
   let of_string method_ =
     List.find_map


### PR DESCRIPTION
## Summary

Follow-up to the merged #23209 review (P3 nit). `Lsp_method_catalog` kept `handled_methods` (a separate variant list) plus `entries = List.map entry handled_methods`. A future variant added to `lsp_method` and to the `entry` match could still be forgotten in `handled_methods`, leaving `of_string` returning `None` at runtime with no compile warning.

## Change

Make `entries` the single explicit source (an `entry V` list) and derive `handled_methods = List.map (fun e -> e.method_) entries` from it. The `entry` match stays exhaustive, so a new variant still forces a compile-time case in `entry`. The canonical 20-method catalog test (`test_handled_lsp_method_catalog_is_classified`) guards against entries-list omissions — if a variant is missing from `entries`, `handled_lsp_methods ()` no longer returns it and that test fails.

## Verified

`dune build --root .` + `dune runtest --root . test/test_server_ide_lsp_proxy.exe` green in worktree.

Net 22/22 (list rebuild, no semantic change).

Co-Authored-By: Claude <noreply@anthropic.com>

# ci:skip-test-coverage

