### PR TITLE
[codex] Preload explicit OAS capability catalogs

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -153,24 +153,64 @@ let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root ()
      | Some path -> Some { path; source = Config_root_file capability_manifest_filename }
      | None -> None)
 
+let install_runtime_model_catalog_override ~clear_catalog ~load_catalog ~set_catalog path =
+  clear_catalog ();
+  match load_catalog path with
+  | Some catalog ->
+    set_catalog catalog;
+    true
+  | None -> false
+
+let install_runtime_capability_manifest_override
+      ~clear_manifest
+      ~load_manifest
+      ~set_manifest
+      path
+  =
+  clear_manifest ();
+  match load_manifest path with
+  | Some manifest ->
+    set_manifest manifest;
+    true
+  | None -> false
+
 let configure_oas_capability_manifest_env
       ?(env = Sys.getenv_opt)
       ~config_root
       ?(putenv = Unix.putenv)
+      ?(clear_manifest = Llm_provider.Capability_manifest.clear_global)
+      ?(load_manifest = Llm_provider.Capability_manifest.load_runtime_file)
+      ?(set_manifest = Llm_provider.Capability_manifest.set_global)
       ()
   =
   match resolve_oas_capability_manifest_path ~env ~config_root () with
   | Some { source = Capability_manifest_env_var; path } as resolution ->
+    let installed =
+      install_runtime_capability_manifest_override
+        ~clear_manifest
+        ~load_manifest
+        ~set_manifest
+        path
+    in
     Log.Misc.info
-      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s already configured"
-      path;
+      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s already configured%s"
+      path
+      (if installed then " and loaded" else "");
     resolution
   | Some { source; path } as resolution ->
     putenv oas_capability_manifest_env_var_name path;
+    let installed =
+      install_runtime_capability_manifest_override
+        ~clear_manifest
+        ~load_manifest
+        ~set_manifest
+        path
+    in
     Log.Misc.info
-      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s resolved from %s"
+      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s resolved from %s%s"
       path
-      (capability_manifest_env_source_to_string source);
+      (capability_manifest_env_source_to_string source)
+      (if installed then " and loaded" else "");
     resolution
   | None ->
     Log.Misc.info
@@ -185,18 +225,39 @@ let configure_oas_model_catalog_env
       ?(putenv = Unix.putenv)
       ?(preload_agent_sdk_catalog = Llm_provider.Model_catalog.preload_global)
       ?(agent_sdk_catalog = Llm_provider.Model_catalog.global)
+      ?(clear_catalog = Llm_provider.Model_catalog.clear_global)
+      ?(load_catalog = Llm_provider.Model_catalog.load_runtime_file)
+      ?(set_catalog = Llm_provider.Model_catalog.set_global)
       ()
   =
   match resolve_oas_model_catalog_path ~env ?cwd ?argv0 () with
   | Some { source = Env_var Oas_model_catalog; path } as resolution ->
-    Log.Misc.info "model_catalog: OAS_MODEL_CATALOG=%s already configured" path;
+    let installed =
+      install_runtime_model_catalog_override
+        ~clear_catalog
+        ~load_catalog
+        ~set_catalog
+        path
+    in
+    Log.Misc.info
+      "model_catalog: OAS_MODEL_CATALOG=%s already configured%s"
+      path
+      (if installed then " and loaded" else "");
     resolution
   | Some { source; path } as resolution ->
     putenv (model_catalog_env_var_name Oas_model_catalog) path;
+    let installed =
+      install_runtime_model_catalog_override
+        ~clear_catalog
+        ~load_catalog
+        ~set_catalog
+        path
+    in
     Log.Misc.info
-      "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s"
+      "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s%s"
       path
-      (model_catalog_env_source_to_string source);
+      (model_catalog_env_source_to_string source)
+      (if installed then " and loaded" else "");
     resolution
   | None ->
     preload_agent_sdk_catalog ();

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -62,6 +62,9 @@ val configure_oas_model_catalog_env :
   ?putenv:(string -> string -> unit) ->
   ?preload_agent_sdk_catalog:(unit -> unit) ->
   ?agent_sdk_catalog:(unit -> Llm_provider.Model_catalog.t option) ->
+  ?clear_catalog:(unit -> unit) ->
+  ?load_catalog:(string -> Llm_provider.Model_catalog.t option) ->
+  ?set_catalog:(Llm_provider.Model_catalog.t -> unit) ->
   unit ->
   model_catalog_env_resolution option
 
@@ -69,6 +72,9 @@ val configure_oas_capability_manifest_env :
   ?env:(string -> string option) ->
   config_root:string ->
   ?putenv:(string -> string -> unit) ->
+  ?clear_manifest:(unit -> unit) ->
+  ?load_manifest:(string -> Llm_provider.Capability_manifest.t option) ->
+  ?set_manifest:(Llm_provider.Capability_manifest.t -> unit) ->
   unit ->
   capability_manifest_env_resolution option
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -206,12 +206,20 @@ let test_capability_manifest_configuration_uses_config_root_file () =
     let manifest = Filename.concat config_root "capability-manifest.json" in
     write_file manifest {|{"schema_version":1,"models":[]}|};
     let putenv_calls = ref [] in
+    let clear_calls = ref 0 in
+    let load_calls = ref [] in
+    let set_calls = ref 0 in
     let env _ = None in
     let result =
       Server_runtime_bootstrap.configure_oas_capability_manifest_env
         ~env
         ~config_root
         ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
+        ~clear_manifest:(fun () -> incr clear_calls)
+        ~load_manifest:(fun path ->
+          load_calls := path :: !load_calls;
+          Some [])
+        ~set_manifest:(fun (_ : Llm_provider.Capability_manifest.t) -> incr set_calls)
         ()
     in
     (match result with
@@ -228,7 +236,56 @@ let test_capability_manifest_configuration_uses_config_root_file () =
     Alcotest.(check (list (pair string string)))
       "putenv"
       [ "OAS_CAPABILITY_MANIFEST", manifest ]
-      (List.rev !putenv_calls))
+      (List.rev !putenv_calls);
+    Alcotest.(check int) "clear manifest cache" 1 !clear_calls;
+    Alcotest.(check (list string)) "load manifest" [ manifest ] (List.rev !load_calls);
+    Alcotest.(check int) "set manifest override" 1 !set_calls)
+
+let test_model_catalog_configuration_installs_resolved_catalog () =
+  with_temp_dir "model-catalog-bootstrap-install" (fun dir ->
+    let repo = Filename.concat dir "repo" in
+    let cwd = Filename.concat dir "base" in
+    let bin = Filename.concat repo "_build/default/bin/main_eio.exe" in
+    let catalog = Filename.concat repo "oas-models.toml" in
+    mkdir_p (Filename.dirname bin);
+    mkdir_p cwd;
+    write_file bin "";
+    write_file catalog "[[models]]\nid_prefix = \"example\"\n";
+    let putenv_calls = ref [] in
+    let clear_calls = ref 0 in
+    let load_calls = ref [] in
+    let set_calls = ref 0 in
+    let result =
+      Server_runtime_bootstrap.configure_oas_model_catalog_env
+        ~env:(fun _ -> None)
+        ~cwd
+        ~argv0:bin
+        ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
+        ~clear_catalog:(fun () -> incr clear_calls)
+        ~load_catalog:(fun path ->
+          load_calls := path :: !load_calls;
+          Some Llm_provider.Model_catalog.empty)
+        ~set_catalog:(fun (_ : Llm_provider.Model_catalog.t) -> incr set_calls)
+        ()
+    in
+    (match result with
+     | None -> Alcotest.fail "expected executable-parent model catalog resolution"
+     | Some resolution ->
+       Alcotest.(check string)
+         "source"
+         "argv0-parent:oas-models.toml"
+         (model_catalog_resolution_source_label resolution);
+       Alcotest.(check string)
+         "path"
+         (canonical_path catalog)
+         (canonical_path resolution.Server_runtime_bootstrap.path));
+    Alcotest.(check (list (pair string string)))
+      "putenv"
+      [ "OAS_MODEL_CATALOG", catalog ]
+      (List.rev !putenv_calls);
+    Alcotest.(check int) "clear catalog cache" 1 !clear_calls;
+    Alcotest.(check (list string)) "load catalog" [ catalog ] (List.rev !load_calls);
+    Alcotest.(check int) "set catalog override" 1 !set_calls)
 
 let test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path () =
   with_temp_dir "model-catalog-bootstrap" (fun dir ->
@@ -4245,6 +4302,9 @@ let () =
           Alcotest.test_case
             "capability manifest configuration uses config root"
             `Quick test_capability_manifest_configuration_uses_config_root_file;
+          Alcotest.test_case
+            "model catalog configuration installs resolved catalog"
+            `Quick test_model_catalog_configuration_installs_resolved_catalog;
           Alcotest.test_case
             "model catalog resolution falls back to executable parent"
             `Quick


### PR DESCRIPTION
## Summary
- load explicit OAS model catalog paths into the OAS runtime override immediately after resolving `OAS_MODEL_CATALOG`
- do the same for config-root/explicit `OAS_CAPABILITY_MANIFEST`
- cover both bootstrap paths with focused tests so stale ambient catalog caches cannot shadow the intended runtime catalog

## Why
The live boot logs showed MASC resolving the catalog env path but still treating routed runtime models as catalog-missing. OAS caches ambient catalog/manifest loads after first access, so setting env alone is not sufficient if the cache was already populated.

This keeps the bootstrap fail-closed behavior while preventing stale provider_default fallback from being the reason boot cannot proceed.

## Validation
- `ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check HEAD~1..HEAD`
- Focused Dune target attempted, but local Dune was held by `/tmp/me-dune-local.lock` from another test build; build authority is CI for this change.
