### PR TITLE
fix(server): disambiguate capability manifest env source

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -144,7 +144,9 @@ let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
 	           | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
 	           | None -> None)))
 
-let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root () =
+let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root ()
+  : capability_manifest_env_resolution option
+  =
   match nonempty_env env oas_capability_manifest_env_var_name with
   | Some path -> Some { path; source = Capability_manifest_env_var }
   | None ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -125,11 +125,15 @@ let make_config_root root =
   write_file (Filename.concat config "personas/example.txt") "persona";
   config
 
-let model_catalog_resolution_source_label resolution =
+let model_catalog_resolution_source_label
+    (resolution : Server_runtime_bootstrap.model_catalog_env_resolution)
+  =
   Server_runtime_bootstrap.model_catalog_env_source_to_string
     resolution.Server_runtime_bootstrap.source
 
-let capability_manifest_resolution_source_label resolution =
+let capability_manifest_resolution_source_label
+    (resolution : Server_runtime_bootstrap.capability_manifest_env_resolution)
+  =
   Server_runtime_bootstrap.capability_manifest_env_source_to_string
     resolution.Server_runtime_bootstrap.source
 


### PR DESCRIPTION
## Summary
- Fix the `server_runtime_bootstrap.ml` build break from ambiguous `{ path; source }` record inference.
- Add explicit types for the capability-manifest resolver and the paired test helper labels.

## Product impact
- Restores compilation of the runtime bootstrap capability-manifest path added on current `main`.
- Keeps model-catalog and capability-manifest env source records distinct despite sharing field labels.

## Evidence
- Root cause: `model_catalog_env_resolution` and `capability_manifest_env_resolution` both expose `path` and `source`; OCaml inferred the capability-manifest record literal as the model-catalog record type.
- Fix: type the capability-manifest resolver as `capability_manifest_env_resolution option` and type the test helpers by their expected resolution record.

## Direct evidence
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe`
- `_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 0-2`
- `git diff --check origin/main...HEAD`

## Review evidence
- Focused compile covers the original failing module and the bootstrap test executable.
- Bootstrap tests `0-2` cover explicit model catalog env, explicit capability manifest env, and config-root capability manifest resolution.

## Linked issue
- Fixes the local build failure:
  `There is no constructor Capability_manifest_env_var within type model_catalog_env_source`
