### PR TITLE
fix(server): close IDE annotation post match

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -636,7 +636,7 @@ let add_routes router =
                              ~status:`Bad_request
                              ~request
                              (json_error msg)
-                             reqd)))
+                             reqd))))
              | _ ->
                Http.Response.json_value
                  ~status:`Bad_request


### PR DESCRIPTION
## Summary
- close the nested `bind_mutation_keeper_id` match in the IDE annotation POST route
- restores parsing of the remaining IDE HTTP router chain

## Validation
- `ocamlformat --check lib/server/server_ide_http.ml`
- `git diff --check`

Note: focused Dune build is currently blocked locally by another long-running machine-wide `scripts/dune-local.sh` lock; CI is the build authority for this PR.