### PR TITLE
Expose effective input modality flags in runtime summaries

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -393,6 +393,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field:reasoning_content')
     expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
+    expect(container.textContent).toContain('input multimodal,image,audio')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('preserve chat-template-kwargs-preserve-thinking')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -770,6 +770,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
   ].filter((value): value is string => Boolean(value))
   const ignoredSampling = caps.ignored_sampling_parameters.join(',')
   const modalities = [
+    caps.supports_multimodal_inputs ? 'multimodal' : null,
     caps.supports_image_input ? 'image' : null,
     caps.supports_audio_input ? 'audio' : null,
     caps.supports_video_input ? 'video' : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -936,6 +936,10 @@ describe('SettingsSurface', () => {
             ignored_sampling_parameters: ['temperature', 'top_p', 'presence_penalty', 'frequency_penalty'],
             supports_code_execution: true,
             emits_usage_tokens: true,
+            supports_multimodal_inputs: true,
+            supports_image_input: true,
+            supports_audio_input: true,
+            supports_video_input: false,
             modality_priority: 'visual-first',
             task: 'transcription',
             supported_models: ['m1'],
@@ -1073,6 +1077,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('tool:required')
       expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')
       expect(cards[0]?.textContent).toContain('ignored:temperature,top_p,presence_penalty,frequency_penalty')
+      expect(cards[0]?.textContent).toContain('input:multimodal,image,audio')
       expect(cards[0]?.textContent).toContain('modality:visual-first')
       expect(cards[0]?.textContent).toContain('tool-content:empty-string')
       expect(cards[0]?.textContent).toContain('extended-thinking')

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -264,6 +264,12 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     caps.supports_response_format_json ? 'json' : null,
     caps.supports_structured_output ? 'schema' : null,
   ])
+  const input = nonEmptyParts([
+    caps.supports_multimodal_inputs ? 'multimodal' : null,
+    caps.supports_image_input ? 'image' : null,
+    caps.supports_audio_input ? 'audio' : null,
+    caps.supports_video_input ? 'video' : null,
+  ])
   const toolChoice = caps.supports_tool_choice
     ? `tool-choice${nonEmptyParts([
       caps.supports_required_tool_choice ? 'required' : null,
@@ -282,6 +288,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     format.length > 0 ? `format:${format.join(',')}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
     ignoredSampling ? `ignored:${ignoredSampling}` : null,
+    input.length > 0 ? `input:${input.join(',')}` : null,
     caps.modality_priority ? `modality:${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content:${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,


### PR DESCRIPTION
## Summary
- include effective multimodal/image/audio/video flags in the runtime monitor compact effective capability summary
- include the same effective input modality flags in settings runtime catalog diagnostics
- extend dashboard fixtures/assertions so OAS effective capability input flags stay visible

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check