### PR TITLE
[codex] Seed runtime model catalog into config root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
             | sort -z \
             | xargs -0 sha256sum > SHA256SUMS
           (cd ../config && sha256sum tool_policy.toml runtime.toml) >> SHA256SUMS
+          (cd .. && sha256sum oas-models.toml) >> SHA256SUMS
           cat SHA256SUMS
 
       - name: Create Release

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -22,6 +22,7 @@ and capability_manifest_env_resolution =
 
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
+  | Config_root_catalog_file of string
   | Parent_file of
       { origin : model_catalog_parent_origin
       ; filename : string
@@ -49,6 +50,7 @@ let model_catalog_parent_origin_label = function
 
 let model_catalog_env_source_to_string = function
   | Env_var var -> model_catalog_env_var_name var
+  | Config_root_catalog_file filename -> Printf.sprintf "config-root:%s" filename
   | Parent_file { origin; filename } ->
     Printf.sprintf "%s:%s" (model_catalog_parent_origin_label origin) filename
 
@@ -100,6 +102,17 @@ let find_catalog_in_parents ~origin dir =
        Some { path; source = Parent_file { origin; filename = oas_models_toml_filename } }
      | None -> None)
 
+let find_catalog_in_config_root config_root =
+  let catalog_file filename =
+    let candidate = Filename.concat config_root filename in
+    match existing_file candidate with
+    | Some path -> Some { path; source = Config_root_catalog_file filename }
+    | None -> None
+  in
+  match catalog_file models_toml_filename with
+  | Some _ as found -> found
+  | None -> catalog_file oas_models_toml_filename
+
 let absolute_or_cwd ~cwd path =
   let path = String.trim path in
   if String.equal path "" then
@@ -114,7 +127,13 @@ let argv0_parent_dir ~cwd argv0 =
   | None -> None
   | Some path -> Some (Filename.dirname path)
 
-let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
+let resolve_oas_model_catalog_path
+      ?(env = Sys.getenv_opt)
+      ?config_root
+      ?cwd
+      ?argv0
+      ()
+  =
   match nonempty_env env (model_catalog_env_var_name Oas_model_catalog) with
   | Some path -> Some { path; source = Env_var Oas_model_catalog }
   | None ->
@@ -137,12 +156,20 @@ let resolve_oas_model_catalog_path ?(env = Sys.getenv_opt) ?cwd ?argv0 () =
            | head :: _ -> head
            | [] -> "")
        in
-       (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
-	        | Some _ as found -> found
-	        | None ->
-	          (match argv0_parent_dir ~cwd:process_cwd argv0 with
-	           | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
-	           | None -> None)))
+       (match
+          config_root
+          |> Option.map String.trim
+          |> Option.filter (fun value -> not (String.equal value ""))
+          |> Option.bind find_catalog_in_config_root
+        with
+        | Some _ as found -> found
+        | None ->
+          (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
+           | Some _ as found -> found
+           | None ->
+             (match argv0_parent_dir ~cwd:process_cwd argv0 with
+              | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
+              | None -> None))))
 
 let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root ()
   : capability_manifest_env_resolution option
@@ -222,6 +249,7 @@ let configure_oas_capability_manifest_env
 
 let configure_oas_model_catalog_env
       ?(env = Sys.getenv_opt)
+      ?config_root
       ?cwd
       ?argv0
       ?(putenv = Unix.putenv)
@@ -232,7 +260,7 @@ let configure_oas_model_catalog_env
       ?(set_catalog = Llm_provider.Model_catalog.set_global)
       ()
   =
-  match resolve_oas_model_catalog_path ~env ?cwd ?argv0 () with
+  match resolve_oas_model_catalog_path ~env ?config_root ?cwd ?argv0 () with
   | Some { source = Env_var Oas_model_catalog; path } as resolution ->
     let installed =
       install_runtime_model_catalog_override
@@ -332,7 +360,6 @@ let init_runtime_context env =
   let domain_mgr = Eio.Stdenv.domain_mgr env in
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let fs = Eio.Stdenv.fs env in
-  let (_ : model_catalog_env_resolution option) = configure_oas_model_catalog_env () in
   (clock, mono_clock, net, domain_mgr, proc_mgr, fs)
 
 let metric_keeper_runtime_config_load_failures =
@@ -416,6 +443,9 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   ensure_thompson_persistence ~base_path;
   bootstrap_base_path_config_root ~base_path;
   let config_root = (startup_config_resolution ~base_path).config_root.path in
+  let (_ : model_catalog_env_resolution option) =
+    configure_oas_model_catalog_env ~config_root ()
+  in
   let (_ : capability_manifest_env_resolution option) =
     configure_oas_capability_manifest_env ~config_root ()
   in

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -22,6 +22,7 @@ and capability_manifest_env_resolution =
 
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
+  | Config_root_catalog_file of string
   | Parent_file of
       { origin : model_catalog_parent_origin
       ; filename : string
@@ -44,6 +45,7 @@ val capability_manifest_env_source_to_string : capability_manifest_env_source ->
 
 val resolve_oas_model_catalog_path :
   ?env:(string -> string option) ->
+  ?config_root:string ->
   ?cwd:string ->
   ?argv0:string ->
   unit ->
@@ -57,6 +59,7 @@ val resolve_oas_capability_manifest_path :
 
 val configure_oas_model_catalog_env :
   ?env:(string -> string option) ->
+  ?config_root:string ->
   ?cwd:string ->
   ?argv0:string ->
   ?putenv:(string -> string -> unit) ->

--- a/lib/server/server_runtime_config_root_bootstrap.ml
+++ b/lib/server/server_runtime_config_root_bootstrap.ml
@@ -59,6 +59,18 @@ let copy_file_if_missing ~src ~dst =
     Fs_compat.save_file dst (Fs_compat.load_file src))
 ;;
 
+let oas_models_toml_filename = "oas-models.toml"
+
+let existing_file path =
+  try Sys.file_exists path && not (Sys.is_directory path) with
+  | Sys_error _ -> false
+;;
+
+let existing_directory path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+;;
+
 let rec copy_missing_tree_count ~src ~dst =
   if Sys.is_directory src
   then
@@ -115,6 +127,23 @@ let copy_missing_prompt_seed ~src_config_root ~dst_config_root =
   else 0
 ;;
 
+let copy_missing_model_catalog_seed ~src_config_root ~dst_config_root =
+  let src = Filename.concat (Filename.dirname src_config_root) oas_models_toml_filename in
+  let dst = Filename.concat dst_config_root oas_models_toml_filename in
+  if existing_file src && not (Sys.file_exists dst)
+  then (
+    copy_file_if_missing ~src ~dst;
+    1)
+  else if existing_file src && existing_directory dst
+  then (
+    Log.Server.warn
+      "config bootstrap: refusing to replace directory with model catalog file (%s -> %s)"
+      src
+      dst;
+    0)
+  else 0
+;;
+
 let config_bootstrap_mode () =
   match Sys.getenv_opt "MASC_CONFIG_BOOTSTRAP" |> Env_config_core.trim_opt with
   | Some ("empty" | "EMPTY") -> `Empty
@@ -142,6 +171,7 @@ let copy_missing_config_root_seed ~src ~dst =
       copy_missing_tree
         ~src:(Filename.concat src name)
         ~dst:(Filename.concat dst name));
+  ignore (copy_missing_model_catalog_seed ~src_config_root:src ~dst_config_root:dst);
   Fs_compat.mkdir_p (Filename.concat dst "keepers")
 ;;
 
@@ -161,21 +191,29 @@ let bootstrap_base_path_config_root ~base_path =
       if Sys.is_directory config_root
       then (
         ensure_config_root_scaffold config_root;
-        let backfilled_prompts =
+        let backfilled_prompts, backfilled_model_catalog =
           match versioned_config_root_candidates () |> List.find_opt Sys.file_exists with
-          | Some source -> copy_missing_prompt_seed ~src_config_root:source ~dst_config_root:config_root
-          | None -> 0
+          | Some source ->
+            ( copy_missing_prompt_seed
+                ~src_config_root:source
+                ~dst_config_root:config_root
+            , copy_missing_model_catalog_seed
+                ~src_config_root:source
+                ~dst_config_root:config_root
+            )
+          | None -> 0, 0
         in
-        if backfilled_prompts > 0
+        if backfilled_prompts + backfilled_model_catalog > 0
         then (
           Log.Server.info
-            "backfilled %d missing prompt seed file(s) into existing base-path config root: %s"
+            "backfilled %d missing prompt seed file(s) and %d model catalog seed file(s) into existing base-path config root: %s"
             backfilled_prompts
+            backfilled_model_catalog
             config_root;
           Config_dir_resolver.reset ())
         else
           Log.Server.info
-            "preserved existing base-path config root without refilling non-prompt entries: %s"
+            "preserved existing base-path config root without refilling operator-owned entries: %s"
             config_root)
       else
         Log.Server.warn

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,18 +213,19 @@ if [ "$SEED_CONFIG" -eq 1 ]; then
   CONFIG_DIR="$BASE_PATH/.masc/config"
   CONFIG_FILE="$CONFIG_DIR/tool_policy.toml"
   RUNTIME_FILE="$CONFIG_DIR/runtime.toml"
+  MODEL_CATALOG_FILE="$CONFIG_DIR/oas-models.toml"
 
-  if [ -e "$CONFIG_FILE" ] && [ -e "$RUNTIME_FILE" ] && [ "$FORCE" -eq 0 ]; then
+  if [ -e "$CONFIG_FILE" ] && [ -e "$RUNTIME_FILE" ] && [ -e "$MODEL_CATALOG_FILE" ] && [ "$FORCE" -eq 0 ]; then
     log "config already present at $CONFIG_DIR, skipping seed"
   elif [ "$DRY_RUN" -eq 1 ]; then
-    log "[dry-run] would seed configs to $CONFIG_DIR from release"
+    log "[dry-run] would seed configs and model catalog to $CONFIG_DIR from release"
   else
-    log "seeding configs to $CONFIG_DIR"
+    log "seeding configs and model catalog to $CONFIG_DIR"
     mkdir -p "$CONFIG_DIR"
 
-    seed_config() {
-      local name="$1" dest="$2"
-      local raw="https://raw.githubusercontent.com/$REPO/$VERSION/config/$name"
+    seed_raw() {
+      local raw_path="$1" name="$2" dest="$3"
+      local raw="https://raw.githubusercontent.com/$REPO/$VERSION/$raw_path"
       local tmp="$dest.partial"
       curl -fsSL --max-time 60 --retry 3 -o "$tmp" "$raw" \
         || die "config seed failed (raw fetch from $raw)"
@@ -232,17 +233,23 @@ if [ "$SEED_CONFIG" -eq 1 ]; then
       mv "$tmp" "$dest"
     }
 
-    seed_config_if_missing() {
-      local name="$1" dest="$2"
+    seed_raw_if_missing() {
+      local raw_path="$1" name="$2" dest="$3"
       if [ -e "$dest" ] && [ "$FORCE" -eq 0 ]; then
         log "config already present: $dest, skipping seed"
       else
-        seed_config "$name" "$dest"
+        seed_raw "$raw_path" "$name" "$dest"
       fi
+    }
+
+    seed_config_if_missing() {
+      local name="$1" dest="$2"
+      seed_raw_if_missing "config/$name" "$name" "$dest"
     }
 
     seed_config_if_missing "tool_policy.toml" "$CONFIG_FILE"
     seed_config_if_missing "runtime.toml" "$RUNTIME_FILE"
+    seed_raw_if_missing "oas-models.toml" "oas-models.toml" "$MODEL_CATALOG_FILE"
   fi
 fi
 

--- a/test/test_install_script.ml
+++ b/test/test_install_script.ml
@@ -71,6 +71,14 @@ let test_config_seed_skips_each_existing_file_without_force () =
     "runtime uses per-file seed"
     script
     {|seed_config_if_missing "runtime.toml" "$RUNTIME_FILE"|};
+  assert_contains
+    "model catalog has config-root destination"
+    script
+    {|MODEL_CATALOG_FILE="$CONFIG_DIR/oas-models.toml"|};
+  assert_contains
+    "model catalog uses root release seed"
+    script
+    {|seed_raw_if_missing "oas-models.toml" "oas-models.toml" "$MODEL_CATALOG_FILE"|};
   assert_not_contains
     "no all-or-nothing seed calls"
     script
@@ -90,6 +98,18 @@ let test_release_requires_advertised_binary_assets () =
     "required release asset missing: $asset"
 ;;
 
+let test_release_checksums_include_model_catalog_seed () =
+  let workflow = release_workflow () in
+  assert_contains
+    "release checksum includes runtime config seeds"
+    workflow
+    "(cd ../config && sha256sum tool_policy.toml runtime.toml) >> SHA256SUMS";
+  assert_contains
+    "release checksum includes model catalog seed"
+    workflow
+    "(cd .. && sha256sum oas-models.toml) >> SHA256SUMS"
+;;
+
 let () =
   run
     "install_script"
@@ -102,6 +122,10 @@ let () =
             "advertised binary assets are release-required"
             `Quick
             test_release_requires_advertised_binary_assets
+        ; test_case
+            "release checksums include model catalog seed"
+            `Quick
+            test_release_checksums_include_model_catalog_seed
         ] )
     ]
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -48,6 +48,7 @@ let read_file path =
 
 let repo_runtime_toml = "# repo runtime seed\n"
 let local_runtime_toml = "# local runtime seed\n"
+let repo_model_catalog_toml = "[[models]]\nid_prefix = \"repo-runtime\"\n"
 
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
@@ -117,6 +118,7 @@ let make_config_root root =
   mkdir_p (Filename.concat config "prompts");
   mkdir_p (Filename.concat config "keepers");
   mkdir_p (Filename.concat config "personas");
+  write_file (Filename.concat root "oas-models.toml") repo_model_catalog_toml;
   write_file (Filename.concat config "runtime.toml") repo_runtime_toml;
   write_file (Filename.concat config "tool_policy.toml")
     "[groups.base]\ntools = [\"keeper_time_now\"]\n";
@@ -278,6 +280,51 @@ let test_model_catalog_configuration_installs_resolved_catalog () =
        Alcotest.(check string)
          "source"
          "argv0-parent:oas-models.toml"
+         (model_catalog_resolution_source_label resolution);
+       Alcotest.(check string)
+         "path"
+         (canonical_path catalog)
+         (canonical_path resolution.Server_runtime_bootstrap.path));
+    Alcotest.(check (list (pair string string)))
+      "putenv"
+      [ "OAS_MODEL_CATALOG", catalog ]
+      (List.rev !putenv_calls);
+    Alcotest.(check int) "clear catalog cache" 1 !clear_calls;
+    Alcotest.(check (list string)) "load catalog" [ catalog ] (List.rev !load_calls);
+    Alcotest.(check int) "set catalog override" 1 !set_calls)
+
+let test_model_catalog_configuration_prefers_config_root_catalog () =
+  with_temp_dir "model-catalog-bootstrap-config-root" (fun dir ->
+    let config_root = Filename.concat dir "config-root" in
+    let outside = Filename.concat dir "outside" in
+    let catalog = Filename.concat config_root "oas-models.toml" in
+    mkdir_p config_root;
+    mkdir_p outside;
+    write_file catalog "[[models]]\nid_prefix = \"config-root-runtime\"\n";
+    let putenv_calls = ref [] in
+    let clear_calls = ref 0 in
+    let load_calls = ref [] in
+    let set_calls = ref 0 in
+    let result =
+      Server_runtime_bootstrap.configure_oas_model_catalog_env
+        ~env:(fun _ -> None)
+        ~config_root
+        ~cwd:outside
+        ~argv0:(Filename.concat outside "main_eio.exe")
+        ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
+        ~clear_catalog:(fun () -> incr clear_calls)
+        ~load_catalog:(fun path ->
+          load_calls := path :: !load_calls;
+          Some Llm_provider.Model_catalog.empty)
+        ~set_catalog:(fun (_ : Llm_provider.Model_catalog.t) -> incr set_calls)
+        ()
+    in
+    (match result with
+     | None -> Alcotest.fail "expected config-root model catalog resolution"
+     | Some resolution ->
+       Alcotest.(check string)
+         "source"
+         "config-root:oas-models.toml"
          (model_catalog_resolution_source_label resolution);
        Alcotest.(check string)
          "path"
@@ -864,6 +911,8 @@ let test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers () =
         (read_file (Filename.concat config_root "runtime.toml"));
       Alcotest.(check bool) "tool policy not copied (deleted module)" false
         (Sys.file_exists (Filename.concat config_root "tool_policy.toml"));
+      Alcotest.(check string) "model catalog copied" repo_model_catalog_toml
+        (read_file (Filename.concat config_root "oas-models.toml"));
       Alcotest.(check bool) "prompt copied" true
         (Sys.file_exists
            (Filename.concat config_root "prompts/keeper.unified.system.md"));
@@ -872,7 +921,7 @@ let test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers () =
       Alcotest.(check bool) "repo keeper TOML not copied" false
         (Sys.file_exists (Filename.concat config_root "keepers/example.toml")))
 
-let test_bootstrap_base_path_config_root_backfills_missing_prompts_only () =
+let test_bootstrap_base_path_config_root_backfills_missing_prompts_and_catalog () =
   with_temp_dir "startup-config-preserve" (fun dir ->
       let repo = Filename.concat dir "repo" in
       mkdir_p repo;
@@ -898,6 +947,8 @@ let test_bootstrap_base_path_config_root_backfills_missing_prompts_only () =
            (Filename.concat config_root "prompts/keeper.unified.system.md"));
       Alcotest.(check string) "backfilled prompt content" "prompt"
         (read_file (Filename.concat config_root "prompts/keeper.unified.system.md"));
+      Alcotest.(check string) "model catalog backfilled" repo_model_catalog_toml
+        (read_file (Filename.concat config_root "oas-models.toml"));
       Alcotest.(check bool) "versioned persona not resurrected" false
         (Sys.file_exists (Filename.concat config_root "personas/example.txt"));
       Alcotest.(check bool) "tool policy not backfilled" false
@@ -4310,6 +4361,9 @@ let () =
             "model catalog configuration installs resolved catalog"
             `Quick test_model_catalog_configuration_installs_resolved_catalog;
           Alcotest.test_case
+            "model catalog configuration prefers config-root catalog"
+            `Quick test_model_catalog_configuration_prefers_config_root_catalog;
+          Alcotest.test_case
             "model catalog resolution falls back to executable parent"
             `Quick
             test_model_catalog_resolution_uses_executable_parent_when_cwd_is_base_path;
@@ -4326,9 +4380,9 @@ let () =
             `Quick
             test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers;
           Alcotest.test_case
-            "bootstrap base-path config backfills missing prompts only"
+            "bootstrap base-path config backfills prompts and catalog"
             `Quick
-            test_bootstrap_base_path_config_root_backfills_missing_prompts_only;
+            test_bootstrap_base_path_config_root_backfills_missing_prompts_and_catalog;
           Alcotest.test_case
             "bootstrap base-path config skips explicit override"
             `Quick


### PR DESCRIPTION
## Summary
- seed and backfill `oas-models.toml` into the MASC config root so reinstall/existing base-path boots keep runtime catalog intent
- resolve the OAS model catalog from the runtime config root after explicit env overrides and before ambient cwd/executable parent discovery
- include the catalog seed in the installer path and release checksums

## Root cause
`runtime.toml` can keep explicit runtime assignments under `/Users/dancer/me/.masc/config`, but reinstall/bootstrap did not seed `oas-models.toml` there. Installed boots whose cwd/executable parent could not expose the repo catalog treated those explicit runtime ids as catalog-missing and refused degraded startup.

## Validation
- `ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli lib/server/server_runtime_config_root_bootstrap.ml test/test_server_runtime_bootstrap.ml test/test_install_script.ml`
- `bash -n scripts/install.sh`
- `git diff --check`
- `bash scripts/lint/no-oas-prefix-in-lib.sh`
- `bash scripts/lint/no-roadmap-stale-hardcoding.sh`

Dune build/test intentionally left to PR CI per operator instruction.