### PR TITLE
Expose effective thinking wire in runtime summaries

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -395,6 +395,7 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
+    expect(container.textContent).toContain('wire chat-template-kwargs · preserve chat-template-kwargs-preserve-thinking')
     expect(container.textContent).toContain('preserve chat-template-kwargs-preserve-thinking')
     expect(container.textContent).toContain('task transcription · native-stream')
     expect(container.textContent).toContain('seed+images')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -811,6 +811,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
     caps.accepted_reasoning_efforts && caps.accepted_reasoning_efforts.length > 0
       ? `effort ${caps.accepted_reasoning_efforts.join(',')}`
       : null,
+    caps.thinking_control_format ? `wire ${caps.thinking_control_format}` : null,
     caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
     reasoningStream ? `reasoning-stream ${reasoningStream}` : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -917,6 +917,7 @@ describe('SettingsSurface', () => {
             supports_extended_thinking: true,
             supports_reasoning_budget: true,
             accepted_reasoning_efforts: ['low', 'medium', 'high'],
+            thinking_control_format: 'reasoning-effort',
             preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
@@ -1078,6 +1079,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('extended-thinking')
       expect(cards[0]?.textContent).toContain('reasoning-budget')
       expect(cards[0]?.textContent).toContain('effort:low,medium,high')
+      expect(cards[0]?.textContent).toContain('wire:reasoning-effort')
       expect(cards[0]?.textContent).toContain('preserve:always-preserved')
       expect(cards[0]?.textContent).toContain('reasoning-stream:delta-reasoning-field:reasoning_content')
       expect(cards[0]?.textContent).toContain('task:transcription · native-stream')

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -290,6 +290,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     caps.accepted_reasoning_efforts && caps.accepted_reasoning_efforts.length > 0
       ? `effort:${caps.accepted_reasoning_efforts.join(',')}`
       : null,
+    caps.thinking_control_format ? `wire:${caps.thinking_control_format}` : null,
     caps.preserve_thinking_control_format ? `preserve:${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out:${caps.reasoning_output_format}` : null,
     reasoningStream ? `reasoning-stream:${reasoningStream}` : null,


### PR DESCRIPTION
## Summary
- include effective thinking_control_format in the runtime monitor compact effective capability summary
- include the same effective thinking wire in settings runtime catalog diagnostics
- extend dashboard fixtures/assertions so the OAS effective thinking wire stays visible outside the detail rows

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check