### PR TITLE
fix(server): repair IDE memory response syntax

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -1100,7 +1100,7 @@ let add_routes router =
                  ; ("retrieval_status", `String ide_memory_retrieval_status)
                  ; ("semantic_memory_status", `String ide_memory_semantic_status)
                  ; ("episodic_memory_status", `String ide_memory_episodic_status)
-                 ] );
+                 ] )
            ] in
            let origin = get_origin request in
            let headers =


### PR DESCRIPTION
## Summary

- Fixes the IDE memory response JSON list terminator in `lib/server/server_ide_http.ml`.
- Unblocks unrelated PR CI jobs that currently fail during OCaml parsing with `Syntax error: ) expected` at `server_ide_http.ml:1115`.

## Test Plan

- `git diff --check`
- `opam exec -- ocamlformat --check lib/server/server_ide_http.ml`
- `opam exec -- ocamlc -stop-after parsing lib/server/server_ide_http.ml`
- Attempted `scripts/dune-local.sh build lib/server/server_ide_http.pp.ml`; stopped while waiting on the shared `/tmp/me-dune-local.lock` held by another worktree build.

[근거] `gh api repos/jeong-sik/masc/actions/jobs/85147368517/logs`; `gh api repos/jeong-sik/masc/actions/jobs/85147368526/logs`; `gh api repos/jeong-sik/masc/actions/jobs/85147368513/logs`; local validation commands above; checked 2026-07-05 KST; 신뢰도 High.