### PR TITLE
fix(runtime): disambiguate capability manifest record

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -148,11 +148,15 @@ let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root ()
   : capability_manifest_env_resolution option
   =
   match nonempty_env env oas_capability_manifest_env_var_name with
-  | Some path -> Some { path; source = Capability_manifest_env_var }
+  | Some path ->
+    Some ({ path; source = Capability_manifest_env_var } : capability_manifest_env_resolution)
   | None ->
     let candidate = Filename.concat config_root capability_manifest_filename in
     (match existing_file candidate with
-     | Some path -> Some { path; source = Config_root_file capability_manifest_filename }
+     | Some path ->
+       Some
+         ({ path; source = Config_root_file capability_manifest_filename }
+          : capability_manifest_env_resolution)
      | None -> None)
 
 let install_runtime_model_catalog_override ~clear_catalog ~load_catalog ~set_catalog path =


### PR DESCRIPTION
## Summary
- add explicit `capability_manifest_env_resolution` annotations when constructing capability manifest env resolution records
- prevents OCaml record disambiguation from selecting the model catalog env resolution type at this site

## Validation
- `ocamlformat --check lib/server/server_runtime_bootstrap.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build bin/main_eio.exe`