### PR TITLE
Expose effective capability source in runtime summaries

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -387,8 +387,8 @@ describe('RuntimeMonitor', () => {
       'controls tool-choice,required,named,parallel,extended-thinking,reasoning-budget,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,computer-use,code-exec',
     )
     expect(container.textContent).toContain('price-in 0.1')
-    expect(container.textContent).toContain('effective · ctx 131,072 · out 65,536')
-    expect(container.textContent).toContain('effective · ctx 131,072 · out 65,536 · tools · tool_choice+required+named+parallel')
+    expect(container.textContent).toContain('effective · source oas-provider-config-model · ctx 131,072 · out 65,536')
+    expect(container.textContent).toContain('source oas-provider-config-model · ctx 131,072 · out 65,536 · tools · tool_choice+required+named+parallel')
     expect(container.textContent).toContain('runtime-mcp-tools')
     expect(container.textContent).toContain('reasoning · extended · budget · effort low,medium,high')
     expect(container.textContent).toContain('reasoning-stream delta-reasoning-field:reasoning_content')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -794,6 +794,7 @@ function runtimeEffectiveCapabilitiesText(provider: DashboardRuntimeProviderSnap
   ].filter((value): value is string => Boolean(value))
   const reasoningStream = runtimeReasoningStreamingFormatText(caps.reasoning_streaming_format)
   const parts = [
+    caps.source ? `source ${caps.source}` : null,
     context,
     output,
     caps.supports_tools ? 'tools' : null,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1076,7 +1076,7 @@ describe('SettingsSurface', () => {
       expect(cards[0]?.textContent).toContain('system-prompt')
       expect(cards[0]?.textContent).toContain('sampling:top_k:40,min_p:0.05')
       expect(cards[0]?.textContent).toContain('tool:required')
-      expect(cards[0]?.textContent).toContain('ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')
+      expect(cards[0]?.textContent).toContain('source:oas-provider-config-model · ctx:131072 · out:4096 · tools · tool-choice+required+named+parallel')
       expect(cards[0]?.textContent).toContain('ignored:temperature,top_p,presence_penalty,frequency_penalty')
       expect(cards[0]?.textContent).toContain('input:multimodal,image,audio')
       expect(cards[0]?.textContent).toContain('modality:visual-first')

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -279,6 +279,7 @@ export function runtimeCatalogEffectiveCapabilities(item: DashboardRuntimeProvid
     : null
   const reasoningStream = runtimeReasoningStreamingFormatSummary(caps.reasoning_streaming_format)
   const parts = nonEmptyParts([
+    caps.source ? `source:${caps.source}` : null,
     context,
     output,
     caps.supports_tools ? 'tools' : null,


### PR DESCRIPTION
## Summary
- include effective capability source in the runtime monitor compact effective capability summary
- include the same effective source in settings runtime catalog diagnostics
- update dashboard assertions so OAS Provider_config model provenance stays visible outside detail rows

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-monitor.test.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check