### PR TITLE
dashboard: surface schedule payload support truth

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -413,6 +413,70 @@ function sampleAutomation(): DashboardScheduledAutomation {
   }
 }
 
+function payloadSupportAutomation(): DashboardScheduledAutomation {
+  const auto = sampleAutomation()
+  auto.request_count = 3
+  auto.counts = { failed: 1, scheduled: 1, expired: 1 }
+  auto.derived_counts = {
+    due_effective: 0,
+    blocked_approval: 0,
+    due_execution_ready: 0,
+    expired_effective: 1,
+    unsupported_payload_kind: 2,
+    unknown_payload_kind: 1,
+  }
+  auto.payload_support = {
+    supported_kinds: ['keeper.smoke'],
+    unsupported_request_count: 2,
+    unsupported_kinds: [
+      { kind: 'backlog_depletion_check', count: 1 },
+      { kind: 'orphan_auto_release', count: 1 },
+    ],
+    unknown_request_count: 1,
+  }
+  auto.requests = [
+    {
+      ...auto.requests[0]!,
+      schedule_id: 'sched-unsupported-failed',
+      status: 'failed',
+      effective_status: 'failed',
+      execution_readiness: 'terminal',
+      operator_action: null,
+      approval_required: false,
+      payload_kind: 'backlog_depletion_check',
+      payload_support: 'unsupported',
+      payload_summary: 'Backlog depletion check cannot be executed by the current payload catalog.',
+      last_execution: {
+        execution_id: 'exec-unsupported',
+        schedule_id: 'sched-unsupported-failed',
+        status: 'failed',
+        error: 'unsupported payload kind',
+      },
+    },
+    {
+      ...auto.requests[1]!,
+      schedule_id: 'sched-unsupported-expired',
+      status: 'expired',
+      effective_status: 'expired',
+      execution_readiness: 'expired',
+      payload_kind: 'orphan_auto_release',
+      payload_support: 'unsupported',
+      payload_summary: 'Orphan auto release payload is not registered.',
+    },
+    {
+      ...auto.requests[1]!,
+      schedule_id: 'sched-unknown-scheduled',
+      status: 'scheduled',
+      effective_status: 'scheduled',
+      execution_readiness: 'scheduled',
+      payload_kind: 'keeper.future',
+      payload_support: 'unknown',
+      payload_summary: 'Payload catalog has not classified this kind yet.',
+    },
+  ]
+  return auto
+}
+
 describe('ScheduledAutomationPanel', () => {
   let container: HTMLDivElement
 
@@ -550,6 +614,41 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).not.toContain('거부')
     expect(container.textContent).not.toContain('취소')
   })
+
+  it('surfaces v2 payload support failures from the scheduler projection', async () => {
+    render(
+      html`<${ScheduledAutomationPanel} automation=${payloadSupportAutomation()} variant="v2" />`,
+      container,
+    )
+
+    const alert = container.querySelector('[data-testid="schedule-payload-support-alert"]')
+    expect(alert).not.toBeNull()
+    expect(alert?.textContent).toContain('2 unsupported')
+    expect(alert?.textContent).toContain('1 unknown')
+    expect(alert?.textContent).toContain('backlog_depletion_check')
+    expect(alert?.textContent).toContain('orphan_auto_release')
+    expect(container.querySelector('[data-schedule-payload-support-row="sched-unsupported-failed"]')).not.toBeNull()
+
+    const alertRow = container.querySelector(
+      '[data-schedule-payload-support-row="sched-unsupported-failed"]',
+    ) as HTMLButtonElement
+    alertRow.click()
+    await flush()
+
+    const detail = container.querySelector('[data-schedule-detail-panel="sched-unsupported-failed"]')
+    expect(detail).not.toBeNull()
+    expect(detail?.textContent).toContain('payload unsupported')
+    expect(detail?.textContent).toContain('backlog_depletion_check')
+    expect(detail?.textContent).toContain('"support": "unsupported"')
+    expect(container.querySelector('[data-payload-support="unsupported"]')).not.toBeNull()
+
+    const doneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    doneFilter.click()
+    await flush()
+
+    expect(container.querySelector('[data-schedule-id="sched-unsupported-failed"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-unsupported-expired"]')).not.toBeNull()
+  })
 })
 
 describe('filterMatches', () => {
@@ -625,13 +724,20 @@ describe('ScheduleAside', () => {
         payload_summary: 'it broke',
         last_execution: { execution_id: 'exec-1', schedule_id: 'failed-1', status: 'execution_failed', error: 'runtime refused' },
       }),
+      request({
+        schedule_id: 'unsupported-1',
+        status: 'expired',
+        payload_support: 'unsupported',
+        payload_kind: 'orphan_auto_release',
+        payload_summary: 'unsupported payload row',
+      }),
       request({ schedule_id: 'done-1', status: 'succeeded', payload_summary: 'all good' }),
     ]
 
     render(
       html`<${ScheduleAside}
         requests=${requests}
-        sum=${{ scheduled: 2, dueRunning: 1, pending: 1, total: 4 }}
+        sum=${{ scheduled: 2, dueRunning: 1, pending: 1, total: 5 }}
         onOpen=${onOpen}
       />`,
       container,
@@ -645,6 +751,8 @@ describe('ScheduleAside', () => {
     expect(aside?.textContent).toContain('due soon') // due → 해야 할 일
     expect(aside?.textContent).toContain('it broke') // failed → 지금 상황
     expect(aside?.textContent).toContain('runtime refused') // failed execution error
+    expect(aside?.textContent).toContain('unsupported payload row') // unsupported payload → 지금 상황
+    expect(aside?.textContent).toContain('orphan_auto_release')
     expect(aside?.textContent).toContain('all good') // terminal → 최근 실행
     // Read-only: the aside never renders mutation controls.
     expect(aside?.querySelectorAll('[data-schedule-mutation]')).toHaveLength(0)

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -882,6 +882,166 @@ function riskSpecForLive(risk: string | null | undefined): { lbl: string; cls: s
   return schedRiskSpec(key ?? risk ?? undefined)
 }
 
+type PayloadSupportState = NonNullable<DashboardScheduledAutomationRequest['payload_support']>
+
+function payloadSupportLabel(support: PayloadSupportState): string {
+  switch (support) {
+    case 'supported':
+      return 'payload supported'
+    case 'unsupported':
+      return 'payload unsupported'
+    case 'unknown':
+      return 'payload unknown'
+    default:
+      return assertNever(support)
+  }
+}
+
+function payloadSupportToneClass(support: PayloadSupportState): string {
+  switch (support) {
+    case 'supported':
+      return 'ok'
+    case 'unsupported':
+      return 'bad'
+    case 'unknown':
+      return 'warn'
+    default:
+      return assertNever(support)
+  }
+}
+
+function isUnsupportedPayloadRequest(request: DashboardScheduledAutomationRequest): boolean {
+  return request.payload_support === 'unsupported'
+}
+
+function isUnknownPayloadRequest(request: DashboardScheduledAutomationRequest): boolean {
+  return request.payload_support === 'unknown'
+}
+
+function kindCountsFromRequests(
+  requests: readonly DashboardScheduledAutomationRequest[],
+): Array<{ kind: string; count: number }> {
+  const counts = new Map<string, number>()
+  for (const request of requests) {
+    const kind = request.payload_kind?.trim() || 'payload_kind 없음'
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([kind, count]) => ({ kind, count }))
+    .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind))
+}
+
+interface PayloadSupportSummary {
+  unsupportedCount: number
+  unknownCount: number
+  unsupportedKinds: Array<{ kind: string; count: number }>
+  unsupportedRequests: DashboardScheduledAutomationRequest[]
+  unknownRequests: DashboardScheduledAutomationRequest[]
+}
+
+function payloadSupportSummary(automation: DashboardScheduledAutomation): PayloadSupportSummary {
+  const requests = automation.requests ?? []
+  const unsupportedRequests = requests.filter(isUnsupportedPayloadRequest)
+  const unknownRequests = requests.filter(isUnknownPayloadRequest)
+  const unsupportedCount = Math.max(
+    automation.payload_support?.unsupported_request_count
+      ?? automation.derived_counts?.unsupported_payload_kind
+      ?? 0,
+    unsupportedRequests.length,
+  )
+  const unknownCount = Math.max(
+    automation.payload_support?.unknown_request_count
+      ?? automation.derived_counts?.unknown_payload_kind
+      ?? 0,
+    unknownRequests.length,
+  )
+  const projectedKinds = automation.payload_support?.unsupported_kinds ?? []
+  return {
+    unsupportedCount,
+    unknownCount,
+    unsupportedKinds: projectedKinds.length > 0 ? projectedKinds : kindCountsFromRequests(unsupportedRequests),
+    unsupportedRequests,
+    unknownRequests,
+  }
+}
+
+function SchPayloadSupportChip({
+  support,
+}: {
+  support: PayloadSupportState
+}) {
+  return html`
+    <span
+      class=${`sch-payload-support ${payloadSupportToneClass(support)}`}
+      data-payload-support=${support}
+    >
+      ${payloadSupportLabel(support)}
+    </span>
+  `
+}
+
+function SchPayloadSupportBanner({
+  summary,
+  onOpen,
+}: {
+  summary: PayloadSupportSummary
+  onOpen: (scheduleId: string) => void
+}) {
+  if (summary.unsupportedCount === 0 && summary.unknownCount === 0) return null
+  const affectedRows = [...summary.unsupportedRequests, ...summary.unknownRequests].slice(0, 6)
+  const hasUnsupported = summary.unsupportedCount > 0
+  return html`
+    <section
+      class=${`sch-banner payload ${hasUnsupported ? 'bad' : 'warn'}`}
+      data-testid="schedule-payload-support-alert"
+    >
+      <span class="sch-banner-ico">!</span>
+      <div class="sch-banner-txt">
+        <div>
+          <b>payload support</b>
+          ${hasUnsupported
+            ? html`<span class="mono"> ${summary.unsupportedCount.toLocaleString()} unsupported</span>`
+            : null}
+          ${summary.unknownCount > 0
+            ? html`<span class="mono"> ${summary.unknownCount.toLocaleString()} unknown</span>`
+            : null}
+        </div>
+        <div class="sch-banner-sub">
+          scheduler projection이 실행 불가 또는 확인 필요로 표시한 payload입니다.
+        </div>
+        ${summary.unsupportedKinds.length > 0
+          ? html`
+              <div class="sch-payload-kinds" aria-label="Unsupported payload kinds">
+                ${summary.unsupportedKinds.map(kind => html`
+                  <span class="sch-payload-kind">
+                    <span class="mono">${kind.count.toLocaleString()}</span>
+                    <span class="mono">${kind.kind}</span>
+                  </span>
+                `)}
+              </div>
+            `
+          : null}
+        ${affectedRows.length > 0
+          ? html`
+              <div class="sch-payload-rows" aria-label="Affected schedule requests">
+                ${affectedRows.map(request => html`
+                  <button
+                    type="button"
+                    class="sch-payload-row mono"
+                    data-schedule-payload-support-row=${request.schedule_id}
+                    onClick=${() => { onOpen(request.schedule_id) }}
+                  >
+                    ${request.schedule_id}
+                  </button>
+                `)}
+              </div>
+            `
+          : null}
+      </div>
+    </section>
+  `
+}
+
 // Card rail tone class. SCHED_STATUS specs only ever yield warn/info/ok/bad/dim
 // for statuses; .sch-card.st-volt is not defined, so clamp anything else to dim.
 const CARD_RAIL_TONES: ReadonlySet<string> = new Set(['ok', 'warn', 'bad', 'info', 'dim'])
@@ -968,6 +1128,9 @@ function SchCard({
           <span class="sch-kind">${payload.glyph} ${payload.lbl}</span>
           <span class="sch-id mono">${request.schedule_id}</span>
           <${SchRiskChip} risk=${request.risk_class} />
+          ${request.payload_support && request.payload_support !== 'supported'
+            ? html`<${SchPayloadSupportChip} support=${request.payload_support} />`
+            : null}
           <span class="sch-rec mono" title="recurrence">↻ ${recurrenceText(request)}</span>
           <span class="sch-head-sp"></span>
           <${SchStatusPill} status=${status} />
@@ -1022,6 +1185,7 @@ function SchDetail({
   const payloadEnvelope = JSON.stringify(
     {
       kind: request.payload_kind ?? null,
+      support: request.payload_support ?? null,
       digest: request.payload_digest ?? null,
       target: request.payload_target ?? null,
       summary: summary,
@@ -1090,6 +1254,20 @@ function SchDetail({
 
           <div class="turn-sec">
             <h4>payload 봉투</h4>
+            <div class="sch-kvs sch-payload-kvs">
+              <div class="sch-kv">
+                <span class="k">payload_support</span>
+                <span class="v mono">
+                  ${request.payload_support
+                    ? html`<${SchPayloadSupportChip} support=${request.payload_support} />`
+                    : html`<span data-stub="payload_support absent">projection field 없음</span>`}
+                </span>
+              </div>
+              <div class="sch-kv">
+                <span class="k">payload_kind</span>
+                <span class="v mono">${request.payload_kind ?? '-'}</span>
+              </div>
+            </div>
             <pre class="turn-pre" data-stub="payload body not in projection">${payloadEnvelope}</pre>
           </div>
 
@@ -1208,9 +1386,15 @@ function SchedulePrototypeSurface({
   const selected = selectedScheduleId
     ? rows.find(request => request.schedule_id === selectedScheduleId) ?? null
     : null
+  const payloadSummary = payloadSupportSummary(automation)
 
   return html`
     <div class="sch-panel">
+      <${SchPayloadSupportBanner}
+        summary=${payloadSummary}
+        onOpen=${setSelectedScheduleId}
+      />
+
       <div class="sch-tabs" role="tablist" aria-label="예약 필터">
         ${SCH_TABS.map(definition => {
           const count = definition.statuses === null
@@ -1308,7 +1492,8 @@ export function ScheduleAside({
 }) {
   const asideStatus = (request: DashboardScheduledAutomationRequest): string =>
     normalized(effectiveStatus(request))
-  const failed = requests.filter(request => asideStatus(request) === 'failed')
+  const unsupportedPayloads = requests.filter(isUnsupportedPayloadRequest)
+  const failed = requests.filter(request => asideStatus(request) === 'failed' && !isUnsupportedPayloadRequest(request))
   const pending = requests.filter(request => SCHEDULE_ASIDE_PENDING.has(asideStatus(request)))
   const due = requests.filter(request => SCHEDULE_ASIDE_DUE.has(asideStatus(request)))
   const recent = requests
@@ -1325,10 +1510,22 @@ export function ScheduleAside({
           <span class="wka-pulse-i"><b class=${`mono ${sum.dueRunning > 0 ? 'volt' : ''}`}>${sum.dueRunning}</b> due·실행</span>
           <span class="wka-pulse-i"><b class=${`mono ${sum.pending > 0 ? 'warn' : ''}`}>${sum.pending}</b> 승인대기</span>
         </div>
-        ${failed.length === 0
+        ${unsupportedPayloads.length === 0 && failed.length === 0
           ? html`<div class="wka-calm mono">실패한 실행 없음</div>`
           : html`
               <div class="wka-list">
+                ${unsupportedPayloads.map(request => html`
+                  <button
+                    type="button"
+                    class="wka-flag st-bad"
+                    data-schedule-aside-open=${request.schedule_id}
+                    onClick=${() => { onOpen(request.schedule_id) }}
+                  >
+                    <span class="wka-flag-tag bad">payload</span>
+                    <span class="wka-flag-title">${scheduleAsideSummary(request)}</span>
+                    <span class="wka-flag-reason mono">${request.payload_kind ?? 'payload_kind 없음'}</span>
+                  </button>
+                `)}
                 ${failed.map(request => html`
                   <button
                     type="button"

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -28,16 +28,26 @@
 .sch-banner.approve { border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
 .sch-banner.reject { border-color: color-mix(in oklab, var(--status-bad) 38%, transparent); background: color-mix(in oklab, var(--status-bad) 7%, transparent); }
 .sch-banner.cancel { border-color: var(--border-highlight); }
+.sch-banner.payload { align-items: flex-start; border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
+.sch-banner.payload.bad { border-color: color-mix(in oklab, var(--status-bad) 44%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+.sch-banner.payload.warn { border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
 .sch-banner-ico { flex: none; font-size: var(--fs-14); }
 .sch-banner.approve .sch-banner-ico { color: var(--status-ok); }
 .sch-banner.reject .sch-banner-ico { color: var(--status-bad); }
 .sch-banner.cancel .sch-banner-ico { color: var(--text-dim); }
+.sch-banner.payload.bad .sch-banner-ico { color: var(--status-bad); }
+.sch-banner.payload.warn .sch-banner-ico { color: var(--status-warn); }
 .sch-banner-txt { flex: 1; min-width: 0; }
 .sch-banner-txt b { color: var(--text-bright); }
+.sch-banner-sub { margin-top: 3px; color: var(--text-mid); line-height: 1.45; }
 .sch-banner-go { flex: none; background: none; border: 1px solid var(--border-highlight); color: var(--text-mid); border-radius: var(--radius-pill); font-family: var(--font-ui); font-size: 11.5px; padding: 4px 12px; cursor: pointer; transition: 0.14s; }
 .sch-banner-go:hover { border-color: var(--volt-dim); color: var(--volt); }
 .sch-banner-x { flex: none; background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: var(--fs-12); padding: 2px 4px; }
 .sch-banner-x:hover { color: var(--text-bright); }
+.sch-payload-kinds, .sch-payload-rows { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.sch-payload-kind { display: inline-flex; align-items: center; gap: 6px; border: 1px solid color-mix(in oklab, var(--status-bad) 32%, transparent); border-radius: var(--radius-pill); padding: 2px 8px; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 7%, transparent); font-size: var(--fs-10); }
+.sch-payload-row { border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-sunken); color: var(--text-mid); cursor: pointer; font-size: var(--fs-10); padding: 2px 8px; }
+.sch-payload-row:hover { border-color: var(--volt-dim); color: var(--volt); }
 
 /* ── schedule cards ── */
 .sch-list { display: flex; flex-direction: column; gap: 11px; }
@@ -64,6 +74,10 @@
 .sch-risk.warn { --tone: var(--status-warn); }
 .sch-risk.bad  { --tone: var(--status-bad); }
 .sch-risk.volt { --tone: var(--volt-strong); }
+.sch-payload-support { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 7px; border-radius: var(--radius-pill); color: var(--tone); border: 1px solid color-mix(in oklab, var(--tone) 34%, transparent); background: color-mix(in oklab, var(--tone) 8%, transparent); white-space: nowrap; }
+.sch-payload-support.ok { --tone: var(--status-ok); }
+.sch-payload-support.warn { --tone: var(--status-warn); }
+.sch-payload-support.bad { --tone: var(--status-bad); }
 
 .sch-summary { display: block; width: 100%; text-align: left; background: none; border: 0; padding: 9px 0 0; cursor: pointer; font-size: var(--fs-13); line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
 .sch-summary:hover { color: var(--text-bright); }
@@ -99,6 +113,7 @@
 .sch-badges { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .sch-src { font-size: 10.5px; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
 .sch-kvs { display: flex; flex-direction: column; gap: 6px; }
+.sch-payload-kvs { margin-bottom: 9px; }
 .sch-kv { display: flex; align-items: baseline; gap: 12px; }
 .sch-kv .k { flex: none; width: 130px; font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
 .sch-kv .v { font-size: 12.5px; color: var(--text-bright); word-break: break-word; }


### PR DESCRIPTION
## Summary
- surface scheduled_automation.payload_support on the dedicated Schedule v2 surface
- add request-level payload support chips in cards/details and an unsupported payload alert banner
- include unsupported payload requests in the schedule operations aside even when their status is expired/terminal

## Evidence
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/schedule/schedule-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run lint
- dev-server HTTP proxy check: /api/v1/dashboard/tools returned request_count=4, unsupported_request_count=4, unsupported kinds backlog_depletion_check, keeper_surface_post, orphan_auto_release, task_goal_generation

## Notes
- No OCaml dune build run locally; dune build remains CI authority.
- Browser plugin unavailable and local Playwright CLI is broken in this environment, so rendered browser screenshot validation was not available.