### PR TITLE
fix(runtime): correct Option.bind/filter pipe in catalog resolution (main broken)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -159,8 +159,11 @@ let resolve_oas_model_catalog_path
        (match
           config_root
           |> Option.map String.trim
-          |> Option.filter (fun value -> not (String.equal value ""))
-          |> Option.bind find_catalog_in_config_root
+          |> (fun opt ->
+               match opt with
+               | Some value when not (String.equal value "") -> Some value
+               | _ -> None)
+          |> (fun root -> Option.bind root find_catalog_in_config_root)
         with
         | Some _ as found -> found
         | None ->


### PR DESCRIPTION
## Summary

origin/main fails to build in `lib/server/server_runtime_bootstrap.ml`. Two distinct errors in the same `Option` pipe chain in `find_catalog_in_config_root` resolution:

1. `Option.filter` is **not in stdlib Option** (OCaml 5.x) → `Unbound value Option.filter`.
2. `Option.bind` argument order is `'a option -> ('a -> 'b option) -> 'b option`, incompatible with `|>` (the pipe puts the piped value into the first/opt slot), so `prev |> Option.bind f` mis-applies `f` as the option.

## Fix

Replace `Option.filter` with an inline match lambda and wrap `Option.bind` in a pipe lambda:
```ocaml
|> (fun opt -> match opt with Some v when not (String.equal v "") -> Some v | _ -> None)
|> (fun root -> Option.bind root find_catalog_in_config_root)
```

## Context

main has **multiple compounding build regressions** from the recent runtime-summary PRs (#23246 and neighbors). This PR addresses the `server_runtime_bootstrap` site. CI verification of the full build depends on the other broken sites being repaired (tracked in #23243). Local build was advancing through these specific errors before committing.

## Notes

- `Option.filter` does not exist in stdlib — the recent code assumed it did. Consider adding a project-local `Option.filter` helper if this pattern is used elsewhere, rather than inlining every time.
- `Option.bind` + `|>` is a recurring foot-gun; the pipe-lambda form is the safe idiom.

Co-Authored-By: Claude <noreply@anthropic.com>
