### PR TITLE
Expose effective runtime wire in keeper rail

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -265,10 +265,15 @@ describe('KeeperWorkspaceRail', () => {
             assistant_tool_content_format: 'null',
             supports_response_format_json: true,
             supports_structured_output: true,
+            supports_multimodal_inputs: true,
+            supports_image_input: true,
+            supports_audio_input: true,
+            supports_video_input: false,
             supports_reasoning: true,
             supports_extended_thinking: true,
             supports_reasoning_budget: true,
             accepted_reasoning_efforts: ['low', 'medium', 'high'],
+            thinking_control_format: 'chat-template-kwargs',
             preserve_thinking_control_format: 'always-preserved',
             reasoning_output_format: 'split-reasoning-fields',
             reasoning_streaming_format: {
@@ -406,14 +411,18 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain(
       'controls tool-choice,required,named,parallel,extended-thinking,reasoning-budget,native-stream,system-prompt,cache,prompt-cache@1024,seed+images,usage,code-exec',
     )
+    expect(container.textContent).toContain('source oas-provider-config-model')
     expect(container.textContent).toContain('ctx 131072 · out 65536 · tools · tool_choice+required+named+parallel')
     expect(container.textContent).toContain('ignored temperature,top_p,presence_penalty,frequency_penalty')
+    expect(container.textContent).toContain('input multimodal,image,audio')
     expect(container.textContent).toContain('modality visual-first')
     expect(container.textContent).toContain('tool-content null')
     expect(container.textContent).toContain('extended thinking')
     expect(container.textContent).toContain('reasoning budget')
     expect(container.textContent).toContain('effort low,medium,high')
+    expect(container.textContent).toContain('wire chat-template-kwargs')
     expect(container.textContent).toContain('preserve always-preserved')
+    expect(container.textContent).toContain('reasoning-stream delta-reasoning-field:reasoning_content')
     expect(container.textContent).toContain('task transcription · native-stream')
     // the "no source" stub is replaced once the catalog reports capabilities
     expect(container.textContent).not.toContain('조정 정보 미수신')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -313,6 +313,13 @@ function runtimeDeclaredSpecSummary(
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
+function runtimeReasoningStreamingFormatSummary(
+  format: { kind?: string | null; field?: string | null } | null | undefined,
+): string | null {
+  if (!format?.kind) return null
+  return format.field ? `${format.kind}:${format.field}` : format.kind
+}
+
 function runtimeEffectiveCapabilitySummary(
   entry: NonNullable<ReturnType<typeof findRuntimeCatalogEntry>>,
 ): string | null {
@@ -328,7 +335,15 @@ function runtimeEffectiveCapabilitySummary(
     caps.supports_response_format_json ? 'json' : null,
     caps.supports_structured_output ? 'schema' : null,
   ].filter((value): value is string => Boolean(value))
+  const inputs = [
+    caps.supports_multimodal_inputs ? 'multimodal' : null,
+    caps.supports_image_input ? 'image' : null,
+    caps.supports_audio_input ? 'audio' : null,
+    caps.supports_video_input ? 'video' : null,
+  ].filter((value): value is string => Boolean(value))
+  const reasoningStream = runtimeReasoningStreamingFormatSummary(caps.reasoning_streaming_format)
   const parts = [
+    caps.source ? `source ${caps.source}` : null,
     typeof caps.max_context_tokens === 'number' ? `ctx ${caps.max_context_tokens}` : null,
     typeof caps.max_output_tokens === 'number' ? `out ${caps.max_output_tokens}` : null,
     caps.supports_tools ? 'tools' : null,
@@ -344,6 +359,7 @@ function runtimeEffectiveCapabilitySummary(
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     ignoredSampling ? `ignored ${ignoredSampling}` : null,
+    inputs.length > 0 ? `input ${inputs.join(',')}` : null,
     caps.modality_priority ? `modality ${caps.modality_priority}` : null,
     caps.assistant_tool_content_format ? `tool-content ${caps.assistant_tool_content_format}` : null,
     caps.supports_reasoning ? 'reasoning' : null,
@@ -352,9 +368,10 @@ function runtimeEffectiveCapabilitySummary(
     caps.accepted_reasoning_efforts && caps.accepted_reasoning_efforts.length > 0
       ? `effort ${caps.accepted_reasoning_efforts.join(',')}`
       : null,
+    caps.thinking_control_format ? `wire ${caps.thinking_control_format}` : null,
     caps.preserve_thinking_control_format ? `preserve ${caps.preserve_thinking_control_format}` : null,
     caps.reasoning_output_format ? `reasoning-out ${caps.reasoning_output_format}` : null,
-    caps.reasoning_streaming_format?.kind ? `reasoning-stream ${caps.reasoning_streaming_format.kind}` : null,
+    reasoningStream ? `reasoning-stream ${reasoningStream}` : null,
     caps.reasoning_replay_override ? `replay ${caps.reasoning_replay_override}` : null,
     caps.task ? `task ${caps.task}` : null,
     caps.supports_native_streaming ? 'native-stream' : null,


### PR DESCRIPTION
## Summary
- include effective capability source in the keeper workspace runtime rail summary
- surface effective input modality flags and thinking-control wire in the same compact rail summary
- preserve reasoning streaming field detail instead of showing only the streaming kind

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check

Dune was not run locally; this is a dashboard-only slice and CI remains the build authority.