### PR TITLE
Show effective runtime caps in agent strip

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.test.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.test.ts
@@ -13,6 +13,7 @@ const mockFindRuntimeCatalogEntry = vi.hoisted(() => vi.fn())
 const mockLoadRuntimeCatalog = vi.hoisted(() => vi.fn())
 const mockRuntimeCatalogState = vi.hoisted(() => ({ value: { status: 'idle' } }))
 const mockRuntimeCatalogSnapshotFacts = vi.hoisted(() => vi.fn())
+const mockRuntimeCatalogEffectiveCapabilities = vi.hoisted(() => vi.fn())
 
 vi.mock('../../lib/keeper-utils', () => ({
   findKeeper: (...args: Parameters<typeof mockFindKeeper>) => mockFindKeeper(...args),
@@ -32,6 +33,8 @@ vi.mock('../../lib/runtime-catalog-resource', () => ({
 }))
 
 vi.mock('../../lib/runtime-provider-summary', () => ({
+  runtimeCatalogEffectiveCapabilities: (...args: Parameters<typeof mockRuntimeCatalogEffectiveCapabilities>) =>
+    mockRuntimeCatalogEffectiveCapabilities(...args),
   runtimeCatalogSnapshotFacts: (...args: Parameters<typeof mockRuntimeCatalogSnapshotFacts>) =>
     mockRuntimeCatalogSnapshotFacts(...args),
 }))
@@ -55,6 +58,7 @@ describe('AgentRuntimeStrip', () => {
     mockFindRuntimeCatalogEntry.mockReset()
     mockLoadRuntimeCatalog.mockReset()
     mockRuntimeCatalogSnapshotFacts.mockReset()
+    mockRuntimeCatalogEffectiveCapabilities.mockReset()
     mockKeeperDisplayRuntime.mockReturnValue(null)
     mockRuntimeCatalogState.value = { status: 'idle' }
     mockFormatDuration.mockImplementation((s: number) => `${s}s`)
@@ -141,6 +145,7 @@ describe('AgentRuntimeStrip', () => {
     expect(mockLoadRuntimeCatalog).not.toHaveBeenCalled()
     expect(mockFindRuntimeCatalogEntry).not.toHaveBeenCalled()
     expect(mockRuntimeCatalogSnapshotFacts).not.toHaveBeenCalled()
+    expect(mockRuntimeCatalogEffectiveCapabilities).not.toHaveBeenCalled()
   })
 
   it('renders runtime lane when present', () => {
@@ -172,11 +177,19 @@ describe('AgentRuntimeStrip', () => {
     mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
     mockFindRuntimeCatalogEntry.mockReturnValue(entry)
     mockRuntimeCatalogSnapshotFacts.mockReturnValue('caps:declared · format:json,schema')
+    mockRuntimeCatalogEffectiveCapabilities.mockReturnValue(
+      'source:oas-provider-config-model · input:multimodal,image · wire:chat-template-kwargs',
+    )
     const container = document.createElement('div')
     render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
     expect(mockFindRuntimeCatalogEntry).toHaveBeenCalledWith([entry], 'oas.primary')
+    expect(mockRuntimeCatalogSnapshotFacts).toHaveBeenCalledWith(entry)
+    expect(mockRuntimeCatalogEffectiveCapabilities).toHaveBeenCalledWith(entry)
     expect(container.textContent).toContain('SPEC')
     expect(container.textContent).toContain('caps:declared · format:json,schema')
+    expect(container.textContent).toContain('source:oas-provider-config-model')
+    expect(container.textContent).toContain('input:multimodal,image')
+    expect(container.textContent).toContain('wire:chat-template-kwargs')
   })
 
   it('renders explicit spec status when the catalog load failed', () => {

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -16,7 +16,10 @@ import {
   loadRuntimeCatalog,
   runtimeCatalogState,
 } from '../../lib/runtime-catalog-resource'
-import { runtimeCatalogSnapshotFacts } from '../../lib/runtime-provider-summary'
+import {
+  runtimeCatalogEffectiveCapabilities,
+  runtimeCatalogSnapshotFacts,
+} from '../../lib/runtime-provider-summary'
 
 function ctxBarClass(ratio: number | null | undefined): string {
   if (ratio == null) return ''
@@ -45,12 +48,15 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const catalog = catalogState?.status === 'loaded' ? catalogState.data : []
   const runtimeEntry = runtime ? findRuntimeCatalogEntry(catalog, runtime.value) : null
   const runtimeFacts = runtimeEntry ? runtimeCatalogSnapshotFacts(runtimeEntry) : null
+  const effectiveCapabilities = runtimeEntry ? runtimeCatalogEffectiveCapabilities(runtimeEntry) : null
+  const runtimeSpecFacts = [runtimeFacts, effectiveCapabilities].filter((value): value is string => Boolean(value))
+  const runtimeSpecSummary = runtimeSpecFacts.length > 0 ? runtimeSpecFacts.join(' · ') : null
   const runtimeSpecState = runtime
-    ? runtimeFacts
+    ? runtimeSpecSummary
       ?? (catalogState?.status === 'error' ? 'catalog unavailable' : null)
       ?? (catalogState?.status === 'loaded' && runtimeEntry === null ? 'catalog entry missing' : null)
     : null
-  const runtimeSpecTitle = runtimeFacts
+  const runtimeSpecTitle = runtimeSpecSummary
     ?? (catalogState?.status === 'error' ? catalogState.message : runtimeSpecState)
 
   return html`


### PR DESCRIPTION
## Summary
- append the shared effective runtime capability summary to the agent monitor runtime strip
- keep existing catalog unavailable / missing fallback behavior intact
- pin source, input modality, and thinking wire visibility in the strip test

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/agent-monitor/runtime-strip.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check

Dune was not run locally; this is a dashboard-only slice and CI remains the build authority.