### PR TITLE
dashboard: mark chat trace provenance

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1922,6 +1922,42 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(bundle?.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('곧 답합니다')
   })
 
+  it('badges turn timeline rows with field-level provenance', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a-provenance',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [
+              { kind: 'think', text: 'checking context', oasBlockIndex: 3 },
+              {
+                kind: 'tool',
+                name: 'keeper_board_list',
+                toolCallId: 'tc-prov',
+                status: 'ok',
+                args: '{"limit":1}',
+                oasBlockIndex: 4,
+              },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const badges = [...container.querySelectorAll('[data-chat-trace-provenance]')]
+      .map(node => node.getAttribute('data-chat-trace-provenance'))
+    expect(badges).toContain('OAS #3')
+    expect(badges).toContain('OAS #4')
+    expect(badges).toContain('reply')
+  })
+
   it('renders thinking text as sanitized markdown with newlines preserved', async () => {
     render(
       html`<${ChatTranscript}
@@ -2162,6 +2198,39 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     await flushUi()
     const step = container.querySelector('[data-chat-trace-step="tool"]')
     expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+  })
+
+  it('marks trace-only tool steps without tool_call_id as unlinked, not pending', async () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a-unlinked-trace-tool',
+            text: 'legacy trace',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [{ kind: 'tool', name: 'legacy_tool_without_id' }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    expect(bundle?.textContent).toContain('조인 불가 1')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(step?.querySelector('.chat-block-tstep-status.unlinked')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(step?.querySelector('[data-chat-trace-provenance]')?.getAttribute('data-chat-trace-provenance')).toBe('unlinked_trace')
+
+    ;(step?.querySelector('.chat-block-tstep-row') as HTMLElement).click()
+    await flushUi()
+
+    expect(step?.textContent).toContain('도구 호출 ID 없음')
+    expect(step?.textContent).not.toContain('출력 대기 중')
   })
 
   it('marks an unjoined tool step as missing once the owning turn has settled', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -65,6 +65,13 @@ export interface ChatComposerCommand {
 }
 
 type TraceToolStatus = NonNullable<ChatTraceToolStep['status']>
+type TraceSourceBadgeTone = 'stream' | 'tool' | 'reply' | 'warn'
+
+interface TraceSourceBadgeInfo {
+  label: string
+  title: string
+  tone: TraceSourceBadgeTone
+}
 
 const TRACE_TOOL_STATUS_UI: Record<TraceToolStatus, { className: 'ok' | 'bad' | 'pending'; title: string }> = {
   pending: { className: 'pending', title: '출력 대기 중' },
@@ -76,6 +83,59 @@ export const CHAT_SUGGESTIONS_LABEL = '추천 후속 질문'
 
 function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'ok' | 'bad' | 'pending'; title: string } {
   return TRACE_TOOL_STATUS_UI[status ?? 'pending']
+}
+
+function oasBlockBadge(index: number | undefined): string | null {
+  return index === undefined ? null : `OAS #${index}`
+}
+
+function traceSourceBadge(step: ChatTraceStep): TraceSourceBadgeInfo {
+  const oasBlock = step.kind === 'think' || step.kind === 'tool'
+    ? oasBlockBadge(step.oasBlockIndex)
+    : null
+  if (step.kind === 'think') {
+    return {
+      label: oasBlock ?? 'thinking_delta',
+      title: oasBlock
+        ? `source: KEEPER_THINKING_DELTA, content block ${step.oasBlockIndex}`
+        : 'source: KEEPER_THINKING_DELTA',
+      tone: 'stream',
+    }
+  }
+  if (step.kind === 'reason') {
+    return {
+      label: 'reason_trace',
+      title: 'source: trace.kind=reason',
+      tone: 'stream',
+    }
+  }
+  const callId = step.toolCallId?.trim()
+  if (callId) {
+    return {
+      label: oasBlock ?? 'tool_call_id',
+      title: oasBlock
+        ? `source: TOOL_CALL_*, tool_call_id=${callId}, content block ${step.oasBlockIndex}`
+        : `source: TOOL_CALL_*, tool_call_id=${callId}`,
+      tone: 'tool',
+    }
+  }
+  return {
+    label: 'unlinked_trace',
+    title: 'source: trace.kind=tool without tool_call_id',
+    tone: 'warn',
+  }
+}
+
+function TraceSourceBadge({ info }: { info: TraceSourceBadgeInfo }) {
+  return html`
+    <span
+      class=${`chat-block-source-badge ${info.tone}`}
+      title=${info.title}
+      data-chat-trace-provenance=${info.label}
+    >
+      ${info.label}
+    </span>
+  `
 }
 
 /** Status dot wrapper — maps keeper-v2 status strings to shared StatusDot tones. */
@@ -1247,6 +1307,7 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
 
 function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; streaming?: boolean }) {
   const [open, setOpen] = useState(false)
+  const sourceBadge = traceSourceBadge(step)
 
   if (step.kind === 'think') {
     const longThinking = !streaming && step.text.length > THINKING_TRACE_PREVIEW_CHARS
@@ -1259,6 +1320,7 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row">
             <span class="chat-block-tstep-kind">Thinking</span>
+            <${TraceSourceBadge} info=${sourceBadge} />
             ${longThinking
               ? html`
                   <button
@@ -1300,6 +1362,7 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row ${exp ? 'click' : ''}" onClick=${() => { if (exp) setOpen((o) => !o) }}>
             <span class="chat-block-tstep-kind">Reasoning</span>
+            <${TraceSourceBadge} info=${sourceBadge} />
             <span class="chat-block-tstep-text" dangerouslySetInnerHTML=${{ __html: sanitizeHtml(step.text) }} />
             ${exp ? html`<span class="chat-block-tstep-chev">▶</span>` : null}
           </div>
@@ -1319,6 +1382,7 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div class="min-w-0 flex-1">
         <div class="chat-block-tstep-row click" onClick=${() => setOpen((o) => !o)}>
           <span class="chat-block-tstep-kind">Tool</span>
+          <${TraceSourceBadge} info=${sourceBadge} />
           <span class="chat-block-tstep-name">${step.name}</span>
           <span
             class="chat-block-tstep-status ${statusUi.className}"
@@ -2469,9 +2533,12 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
-const TOOL_STATUS_TITLE: Record<'pending' | 'missing' | 'ok' | 'bad', string> = {
+type ToolTraceDisplayStatus = 'pending' | 'missing' | 'unlinked' | 'ok' | 'bad'
+
+const TOOL_STATUS_TITLE: Record<ToolTraceDisplayStatus, string> = {
   pending: '출력 대기 중',
   missing: '결과 누락 — 턴이 끝났는데 출력이 도착하지 않음',
+  unlinked: '도구 호출 ID 없음 — 출력 조인 불가',
   ok: '성공',
   bad: '실패',
 }
@@ -2494,6 +2561,32 @@ function isToolOutputCoveredByHydration(
   return Number.isFinite(timestampMs)
     && (coveredSinceMs == null || timestampMs >= coveredSinceMs)
     && timestampMs <= coveredThroughMs
+}
+
+function toolTraceCallId(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): string | null {
+  const traceCallId = traceStep?.toolCallId?.trim()
+  if (traceCallId) return traceCallId
+  return toolCallIdFromToolEntryId(entry.id)
+}
+
+function toolTraceSourceBadge(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): TraceSourceBadgeInfo {
+  if (traceStep) return traceSourceBadge(traceStep)
+  const callId = toolCallIdFromToolEntryId(entry.id)
+  return callId
+    ? {
+        label: 'tool_call_id',
+        title: `source: tool transcript row, tool_call_id=${callId}`,
+        tone: 'tool',
+      }
+    : {
+        label: 'unlinked_row',
+        title: 'source: tool transcript row without tool_call_id',
+        tone: 'warn',
+      }
+}
+
+function isUnlinkedTraceTool(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): boolean {
+  return traceStep !== undefined && toolTraceCallId(entry, traceStep) === null
 }
 
 // One step of a grouped tool-trace card: a single tool call rendered from REAL
@@ -2531,8 +2624,12 @@ function ToolTraceStep({
   const name = traceStep?.name || entry.label || 'tool'
   const displayArgs = prettyJsonish(entry.text || traceStep?.args || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
-  const status: 'pending' | 'missing' | 'ok' | 'bad' =
-    output === null
+  const unlinkedTraceTool = isUnlinkedTraceTool(entry, traceStep)
+  const sourceBadge = toolTraceSourceBadge(entry, traceStep)
+  const status: ToolTraceDisplayStatus =
+    unlinkedTraceTool
+      ? 'unlinked'
+      : output === null
       ? traceStep?.status === 'err'
         ? 'bad'
         : traceStep?.status === 'ok'
@@ -2549,7 +2646,7 @@ function ToolTraceStep({
   const hasResult = resultView !== null && resultView.text.trim() !== ''
   // Expandable when there is anything to show: args, a result, or a still-pending
   // call (so the operator can open it and see "출력 대기 중…").
-  const hasBody = !isEmptyArgs || hasResult || output === null
+  const hasBody = unlinkedTraceTool || !isEmptyArgs || hasResult || output === null
 
   return html`
     <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
@@ -2560,6 +2657,7 @@ function ToolTraceStep({
           onClick=${() => { if (hasBody) setOpen((o) => !o) }}
         >
           <span class="chat-block-tstep-kind">Tool</span>
+          <${TraceSourceBadge} info=${sourceBadge} />
           <span class="chat-block-tstep-name">${name}</span>
           <span
             class="chat-block-tstep-status ${status}"
@@ -2571,8 +2669,10 @@ function ToolTraceStep({
         </div>
         ${open && hasBody
           ? html`
-              <div class="chat-block-tool-body">
-                ${isEmptyArgs
+            <div class="chat-block-tool-body">
+                ${unlinkedTraceTool
+                  ? html`<div class="chat-block-tool-label">도구 호출 ID 없음 — 출력 조인 불가</div>`
+                  : isEmptyArgs
                   ? html`<div class="chat-block-tool-label">입력 없음</div>`
                   : html`
                       <div class="chat-block-tool-label">args</div>
@@ -2584,7 +2684,9 @@ function ToolTraceStep({
                       <pre class="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap break-all text-2xs">${resultView.text}</pre>
                     `
                   : output === null
-                    ? html`<div class="chat-block-tool-label">${canMarkMissing ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
+                    ? unlinkedTraceTool
+                      ? null
+                      : html`<div class="chat-block-tool-label">${canMarkMissing ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
                     : null}
               </div>
             `
@@ -2668,12 +2770,18 @@ function chatResponsePreview(entry: KeeperConversationEntry): string {
 }
 
 function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
+  const sourceBadge: TraceSourceBadgeInfo = {
+    label: 'reply',
+    title: 'source: assistant reply entry',
+    tone: 'reply',
+  }
   return html`
     <div class="chat-block-tstep chat" data-chat-trace-step="chat">
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
         <div class="chat-block-tstep-row">
           <span class="chat-block-tstep-kind">Chat</span>
+          <${TraceSourceBadge} info=${sourceBadge} />
           <span class="chat-block-tstep-name">응답</span>
           <span class="chat-block-tstep-text">${chatResponsePreview(entry)}</span>
         </div>
@@ -2725,6 +2833,9 @@ function ToolTraceCard({
   const missingN = orderedToolSteps.filter(
     (s) => s.output === null && s.entry !== null && canMarkMissingForEntry(s.entry),
   ).length
+  const unlinkedN = orderedToolSteps.filter(
+    (s) => s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
+  ).length
   const totalMs = orderedToolSteps.reduce(
     (sum, s) => sum + (s.output?.duration_ms ?? (s.kind === 'tool' ? traceStepDurationMs(s.step.dur) : 0)),
     0,
@@ -2751,6 +2862,7 @@ function ToolTraceCard({
           ${chatN > 0 ? html`<span>Chat ${chatN}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
+          ${unlinkedN > 0 ? html`<span class="text-[var(--color-status-warn)]">조인 불가 ${unlinkedN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
       </button>

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -176,6 +176,45 @@
   color: var(--color-fg-muted);
 }
 
+.chat-block-source-badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 180px;
+  min-height: 18px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-0);
+  padding: 1px 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--color-fg-muted);
+  background: var(--color-bg-surface);
+}
+
+.chat-block-source-badge.stream {
+  border-color: var(--color-accent-soft);
+  color: var(--color-accent-fg);
+  background: var(--accent-10);
+}
+
+.chat-block-source-badge.tool {
+  border-color: rgb(var(--color-status-ok-glow) / 0.4);
+  color: var(--color-status-ok);
+}
+
+.chat-block-source-badge.reply {
+  color: var(--color-fg-secondary);
+}
+
+.chat-block-source-badge.warn {
+  border-color: rgb(var(--color-status-warn-glow) / 0.4);
+  color: var(--color-status-warn);
+  background: var(--warn-10);
+}
+
 .chat-block-tstep-name {
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
@@ -208,6 +247,11 @@
    the muted in-flight "pending" dot and from a reported failure. */
 .chat-block-tstep-status.missing {
   background: var(--color-status-warn);
+}
+
+.chat-block-tstep-status.unlinked {
+  border: 1px solid var(--color-status-warn);
+  background: transparent;
 }
 
 .chat-block-tstep-dur {


### PR DESCRIPTION
## Summary
- add trace-row provenance badges from existing thinking/tool/chat fields
- mark trace-only tool steps without a real tool_call_id as unlinked instead of pending forever
- add regression coverage for provenance and unjoinable tool traces

## Validation
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/chat/primitives-interleave.test.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run lint
- git diff --check