### PR TITLE
[codex] Fix keeper dashboard burst backpressure

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -319,6 +319,46 @@ let mark_lost_after_recovery (entry : entry) =
   lost
 ;;
 
+let request_has_live_worker request_id =
+  Eio.Mutex.use_ro mu (fun () -> Hashtbl.mem pending request_id)
+;;
+
+let recover_lost_disk_records ~base_path =
+  let dir = request_dir ~base_path in
+  try
+    if (not (Sys.file_exists dir)) || not (Sys.is_directory dir)
+    then 0
+    else
+      Sys.readdir dir
+      |> Array.fold_left
+           (fun recovered name ->
+              match request_id_of_record_filename name with
+              | None -> recovered
+              | Some request_id ->
+                let path = Filename.concat dir name in
+                if Sys.is_directory path
+                then recovered
+                else (
+                  match load_record ~base_path ~request_id with
+                  | Found ({ status = Queued | Running; _ } as entry) ->
+                    if request_has_live_worker request_id
+                    then recovered
+                    else (
+                      ignore (mark_lost_after_recovery entry : entry);
+                      recovered + 1)
+                  | Found _ | Absent | Unreadable _ -> recovered))
+           0
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "keeper_msg_async: recovery scan failed base_path=%s dir=%s error=%s"
+      base_path
+      dir
+      (Printexc.to_string exn);
+    0
+;;
+
 let generate_request_id ~keeper_name =
   let n = Atomic.fetch_and_add counter 1 in
   let safe_keeper_name =
@@ -595,6 +635,7 @@ module For_testing = struct
   let record_path = record_path
   let load_record = load_record
   let gc_stale_disk = gc_stale_disk
+  let recover_lost_disk_records = recover_lost_disk_records
   let active_switch_count () =
     Eio.Mutex.use_ro mu (fun () -> Hashtbl.length active_switches)
   ;;

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -344,6 +344,7 @@ let recover_lost_disk_records ~base_path =
                     if request_has_live_worker request_id
                     then recovered
                     else (
+                      (* See mark_lost_after_recovery: persisted status change is enough. *)
                       ignore (mark_lost_after_recovery entry : entry);
                       recovered + 1)
                   | Found _ | Absent | Unreadable _ -> recovered))

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -72,6 +72,13 @@ val submit
     returned as [Lost] and the terminal lost state is persisted. *)
 val poll : ?base_path:string -> string -> load_result
 
+(** Mark persisted non-terminal request records that have no live in-memory
+    worker as [Lost], returning the number of records transitioned. This is
+    intended for server startup/recovery sweeps: current-process workers remain
+    protected by the in-memory pending table, while disk-only [Queued]/[Running]
+    records from a previous process stop looking indefinitely active. *)
+val recover_lost_disk_records : base_path:string -> int
+
 (** [cancel ?base_path request_id] aborts a running async keeper_msg request.
     Returns [true] if it was successfully cancelled, [false] if not found
     or already finished. *)
@@ -97,6 +104,7 @@ module For_testing : sig
   val record_path : base_path:string -> request_id:string -> string option
   val load_record : base_path:string -> request_id:string -> load_result
   val gc_stale_disk : base_path:string -> int
+  val recover_lost_disk_records : base_path:string -> int
   val active_switch_count : unit -> int
   val effective_timeout_sec : ?timeout_sec:float -> unit -> float
 end

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1412,3 +1412,19 @@ let handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx args : tool_result
              name
              waiting
              in_flight_text)
+
+let handle_keeper_msg_if_free ?on_text_delta ?on_event ?event_bus ctx args =
+  let event_bus =
+    match event_bus with
+    | Some _ -> event_bus
+    | None -> Keeper_event_bus.get ()
+  in
+  let name = get_string args "name" "" in
+  if not (validate_name name) then
+    `Ran (run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)
+  else
+    Keeper_turn_admission.run_chat_if_free
+      ~base_path:ctx.config.base_path
+      ~keeper_name:name
+      (fun () ->
+        run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -144,5 +144,17 @@ val handle_keeper_msg :
     async wrappers should pass an explicit value captured before submitting the
     background turn. *)
 
+val handle_keeper_msg_if_free :
+  ?on_text_delta:(string -> unit) ->
+  ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?event_bus:Agent_sdk.Event_bus.t ->
+  _ Keeper_types_profile.context ->
+  Yojson.Safe.t ->
+  [ `Ran of tool_result | `Busy of Keeper_turn_admission.rejection ]
+(** Non-blocking chat entrypoint for direct dashboard streaming. It runs the
+    same admitted turn body as [handle_keeper_msg] only when the keeper slot is
+    immediately available; otherwise it returns [`Busy] without parking behind
+    an in-flight turn. *)
+
 (** Stop a running keeper agent. *)
 val handle_keeper_down : _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -125,6 +125,20 @@ let run_serialized ~base_path ~keeper_name f =
     run_locked slot ~lane:Chat f)
 ;;
 
+let rejection_snapshot slot =
+  let waiting = waiting_count slot in
+  { waiting; in_flight = peek_info slot }
+;;
+
+let run_chat_if_free ~base_path ~keeper_name f =
+  let slot = slot_for ~base_path ~keeper_name in
+  if waiting_count slot > 0
+  then `Busy (rejection_snapshot slot)
+  else if Eio.Mutex.try_lock slot.turn_mu
+  then run_locked slot ~lane:Chat f
+  else `Busy (rejection_snapshot slot)
+;;
+
 let in_flight ~base_path ~keeper_name =
   let key = Keeper_registry_types.registry_key ~base_path keeper_name in
   match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -84,6 +84,18 @@ val run_serialized
     only by the caller's turn budget — do not call this from within an
     admitted turn of the same keeper. *)
 
+val run_chat_if_free
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit -> 'a)
+  -> [ `Ran of 'a | `Busy of rejection ]
+(** Run [f] holding the chat lane only if the keeper slot can be acquired
+    immediately. Unlike [run_serialized], this never parks the caller behind an
+    in-flight turn. Dashboard direct-stream callers use this to preserve live
+    streaming for idle keepers while atomically routing busy keepers to the
+    durable chat queue. Existing parked chat waiters have priority: when
+    [chat_waiting] is true this returns [`Busy] without attempting the lock. *)
+
 val in_flight
   :  base_path:string
   -> keeper_name:string

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -532,6 +532,8 @@ let runtime_missing_from_report (report : missing_catalog_report) runtime_id =
     report.missing_models
 ;;
 
+let runtime_default_route_name = "[runtime].default"
+
 let dropped_assignment_label (entry : dropped_runtime_assignment) =
   Printf.sprintf "[runtime.assignments].%s=%S" entry.keeper_name entry.runtime_id
 ;;
@@ -550,6 +552,8 @@ let dropped_lane_label (prefix : string) (entry : dropped_runtime_lane) =
 
 let missing_reference_error
     ~(config_path : string)
+    ~(configured_default_runtime_id : string)
+    ~(default_drop : dropped_runtime_route option)
     ~(dropped_assignments : dropped_runtime_assignment list)
     ~(dropped_routes : dropped_runtime_route list)
     ~(dropped_media_failover : string list)
@@ -573,13 +577,29 @@ let missing_reference_error
       ; List.map (dropped_lane_label "[runtime.lanes].dropped") dropped_lanes
       ]
   in
+  let default_fallback_explanation =
+    match default_drop with
+    | Some _ ->
+      Printf.sprintf
+        "Configured %s=%S is absent from the OAS capability catalog; degraded \
+         boot will not select a different default runtime."
+        runtime_default_route_name
+        configured_default_runtime_id
+    | None ->
+      Printf.sprintf
+        "Configured %s=%S remains catalog-known, but degraded boot would erase \
+         the missing references above into that default fallback."
+        runtime_default_route_name
+        configured_default_runtime_id
+  in
   Printf.sprintf
     "%s: cannot use degraded runtime boot because catalog-missing runtime ids \
-     are referenced by routing config: %s. Add catalog rows to oas-models.toml \
-     or remove those routing references; MASC will not erase explicit runtime \
-     intent into default fallback."
+     are referenced by routing config: %s. %s Add catalog rows to \
+     oas-models.toml or remove those routing references; MASC will not erase \
+     explicit runtime intent into default fallback."
     config_path
     (String.concat "; " references)
+    default_fallback_explanation
 ;;
 
 let degrade_loaded_for_missing_catalog
@@ -624,7 +644,7 @@ let degrade_loaded_for_missing_catalog
   in
   let default_drop =
     if is_missing configured_default.id
-    then Some { route_name = "[runtime].default"; runtime_id = configured_default.id }
+    then Some { route_name = runtime_default_route_name; runtime_id = configured_default.id }
     else None
   in
   let drop_route route_name = function
@@ -707,6 +727,8 @@ let degrade_loaded_for_missing_catalog
     Error
       (missing_reference_error
          ~config_path:report.config_path
+         ~configured_default_runtime_id:configured_default.id
+         ~default_drop
          ~dropped_assignments
          ~dropped_routes
          ~dropped_media_failover

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -261,6 +261,15 @@ let start_keeper_loops
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
   Atomic.set Workspace_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
   Atomic.set Workspace_hooks.runtime_agents_fn keeper_registry_runtime_agents;
+  let base_path = (Mcp_server.workspace_config state).base_path in
+  let recovered_keeper_msg_requests =
+    Keeper_msg_async.recover_lost_disk_records ~base_path
+  in
+  if recovered_keeper_msg_requests > 0
+  then
+    Log.Keeper.warn
+      "keeper_msg_async: recovered %d disk-only non-terminal request record(s) as lost"
+      recovered_keeper_msg_requests;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems.
      Configuration is sourced from [Masc_event_bus_policy.oas_runtime] so the
      buffer-size/policy choice is auditable in source rather than implicit in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -173,6 +173,69 @@ let modalities_for_request payload =
   | [] -> [ "text" ]
   | labels -> labels
 
+type dashboard_deferred_chat =
+  { in_flight : Keeper_turn_admission.in_flight_info option
+  ; chat_waiting : bool
+  ; queue_length : int
+  }
+
+let dashboard_busy_queue_state ~base_path ~keeper_name =
+  let in_flight = Keeper_turn_admission.in_flight ~base_path ~keeper_name in
+  let chat_waiting = Keeper_turn_admission.chat_waiting ~base_path ~keeper_name in
+  match in_flight, chat_waiting with
+  | None, false -> None
+  | _ -> Some (in_flight, chat_waiting)
+
+let dashboard_deferred_ack_text ~keeper_name =
+  Printf.sprintf
+    "%s is busy; your message is queued and will be answered after the current \
+     turn finishes."
+    keeper_name
+
+let dashboard_deferred_chat_to_json ~keeper_name
+    ({ in_flight; chat_waiting; queue_length } : dashboard_deferred_chat) =
+  let in_flight_fields =
+    match in_flight with
+    | None -> []
+    | Some { Keeper_turn_admission.lane; started_at } ->
+        [ ( "in_flight_lane"
+          , `String (Keeper_turn_admission.lane_to_string lane) )
+        ; ( "in_flight_started_at"
+          , `Float started_at )
+        ]
+  in
+  `Assoc
+    ([ ("keeper_name", `String keeper_name)
+     ; ("status", `String "queued")
+     ; ("queue", `String "keeper_chat_queue")
+     ; ("queue_length", `Int queue_length)
+     ; ("chat_waiting", `Bool chat_waiting)
+     ]
+     @ in_flight_fields)
+
+let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
+  Keeper_chat_queue.enqueue ~keeper_name:payload.name
+    { Keeper_chat_queue.content = payload.message
+    ; user_blocks = payload.user_blocks
+    ; attachments = payload.attachments
+    ; timestamp = Eio.Time.now clock
+    ; source = Keeper_chat_queue.Dashboard
+    };
+  { in_flight
+  ; chat_waiting
+  ; queue_length = Keeper_chat_queue.length ~keeper_name:payload.name
+  }
+
+let dashboard_deferred_chat_of_rejection ~clock payload
+    ({ Keeper_turn_admission.waiting; in_flight } : Keeper_turn_admission.rejection) =
+  enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting:(waiting > 0)
+
+let defer_dashboard_payload_if_busy ~base_path ~clock payload =
+  match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
+  | None -> `Not_busy
+  | Some (in_flight, chat_waiting) ->
+      `Queued (enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting)
+
 let keeper_chat_request_prefixes =
   [
     "/api/v1/gate/message/requests/";
@@ -658,6 +721,95 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
     ~tool_name:"masc_keeper_msg" ~success ~duration_ms ();
   (success, body)
 
+let execute_keeper_stream_tool_streaming_if_free ~sw ~clock ?auth_token:_ ?on_event state
+    ~agent_name ~arguments ~on_text_delta =
+  let start_time = Eio.Time.now clock in
+  let outcome =
+    try
+      let keeper_ctx : _ Keeper_tool_surface.context =
+        {
+          config = (Mcp_server.workspace_config state);
+          agent_name;
+          sw;
+          clock;
+          proc_mgr = state.Mcp_server.proc_mgr;
+          net = state.Mcp_server.net;
+        }
+      in
+      match
+        Keeper_turn.handle_keeper_msg_if_free ~on_text_delta ?on_event keeper_ctx
+          arguments
+      with
+      | `Busy rejection -> `Busy rejection
+      | `Ran result ->
+          let success = Tool_result.is_success result in
+          let body = Tool_result.message result in
+          let failure_class =
+            match Tool_result.failure_class result with
+            | Some cls -> cls
+            | None -> Tool_result.Runtime_failure
+          in
+          `Ran (success, body, failure_class)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Workspace.Not_initialized ->
+        `Ran
+          ( false
+          , Masc_domain.masc_error_to_string
+              (Masc_domain.System Masc_domain.System_error.NotInitialized)
+          , Tool_result.Runtime_failure )
+    | exn ->
+        let err = Printexc.to_string exn in
+        Log.Mcp.error "tools/call crashed (stream if-free): %s" err;
+        `Ran (false, Printf.sprintf "Internal error: %s" err, Tool_result.Runtime_failure)
+  in
+  match outcome with
+  | `Busy rejection -> `Busy rejection
+  | `Ran (success, body, failure_class) ->
+      let end_time = Eio.Time.now clock in
+      let duration_ms = Keeper_timing.elapsed_duration_ms ~start_time ~end_time in
+      let error_detail =
+        if success then None
+        else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
+      in
+      Audit_log.log_tool_call (Mcp_server.workspace_config state)
+        ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success
+        ~error_msg:error_detail ();
+      if not success then
+        Log.Keeper.emit Log.Error
+          ~details:
+            (keeper_tool_failure_log_details ~tool_name:"masc_keeper_msg"
+               ~agent_name ~duration_ms ~streaming:true ~error_body:body
+               ~failure_class)
+          "keeper tool call failed: masc_keeper_msg";
+      let telemetry_enabled = Env_config_core.telemetry_enabled () in
+      if telemetry_enabled then (
+        match state.Mcp_server.fs with
+        | Some fs ->
+            (try
+               let telemetry_error_kind =
+                 if success then None
+                 else Some (Telemetry_eio.error_kind_of_string "tool_failure")
+               in
+               let telemetry_failure_class =
+                 if success then None else Some failure_class
+               in
+               Telemetry_eio.track_tool_called ~fs
+                 (Mcp_server.workspace_config state)
+                 ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
+                 ~duration_ms ~source:(Tool_registry.string_of_source Agent_internal)
+                 ?failure_class:telemetry_failure_class
+                 ?error_kind:telemetry_error_kind ?error_message:error_detail ()
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Misc.error "telemetry tracking failed: %s"
+                 (Printexc.to_string exn))
+        | None -> ());
+      Tool_registry.record_call_if_known ~source:Agent_internal
+        ~tool_name:"masc_keeper_msg" ~success ~duration_ms ();
+      `Ran (success, body)
+
 (** Send a Run_error AG-UI event with the given message. *)
 let send_keeper_error ?on_closed writer mutex closed ~thread_id ~run_id err =
   ignore
@@ -777,6 +929,7 @@ let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
 type keeper_stream_worker_event =
   | Stream_event of Agent_sdk.Types.sse_event
   | Stream_client_disconnected
+  | Stream_dashboard_queued of dashboard_deferred_chat
   | Stream_terminal of
       { ok : bool
       ; status : string
@@ -824,9 +977,15 @@ let process_single_turn ~connector_user_line_recorded_upstream
   let worker_events = Eio.Stream.create worker_events_buffer_size in
   let terminal_pushed = Atomic.make false in
   let client_disconnected = Atomic.make false in
+  let stream_projection_done, stream_projection_done_resolver =
+    Eio.Promise.create ()
+  in
+  let signal_stream_projection_done () =
+    ignore (Eio.Promise.try_resolve stream_projection_done_resolver () : bool)
+  in
   let push_worker_event event =
     match event with
-    | Stream_terminal _ ->
+    | Stream_dashboard_queued _ | Stream_terminal _ ->
         if Atomic.compare_and_set terminal_pushed false true then
           (try Eio.Stream.add worker_events event
            with
@@ -940,6 +1099,9 @@ let process_single_turn ~connector_user_line_recorded_upstream
       ()
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
+  let dashboard_direct_stream =
+    (not connector_user_line_recorded_upstream) && not (has_external_speaker payload)
+  in
   let request_id =
     Keeper_msg_async.submit ?timeout_sec ~clock ~sw
       ~base_path
@@ -948,27 +1110,53 @@ let process_single_turn ~connector_user_line_recorded_upstream
         let start_time = Time_compat.now () in
         let dispatch_result =
           try
-            Ok
-              (execute_keeper_stream_tool_streaming ~sw ~clock
-                 ?auth_token
-                 state ~agent_name ~arguments:args ~on_event ~on_text_delta:(fun _ -> ()))
+            if dashboard_direct_stream then
+              match
+                execute_keeper_stream_tool_streaming_if_free ~sw ~clock
+                  ?auth_token
+                  state ~agent_name ~arguments:args ~on_event
+                  ~on_text_delta:(fun _ -> ())
+              with
+              | `Ran result -> Ok (`Ran result)
+              | `Busy rejection ->
+                  let queued =
+                    dashboard_deferred_chat_of_rejection ~clock payload rejection
+                  in
+                  push_worker_event (Stream_dashboard_queued queued);
+                  Ok (`Queued queued)
+            else
+              Ok
+                (`Ran
+                   (execute_keeper_stream_tool_streaming ~sw ~clock
+                      ?auth_token
+                      state ~agent_name ~arguments:args ~on_event
+                      ~on_text_delta:(fun _ -> ())))
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
               Log.Keeper.warn
                 "keeper_stream: streaming dispatch raised: %s"
                 (Printexc.to_string exn);
-              (try
-                 Ok
-                   (execute_keeper_stream_tool ~sw ~clock
-                      ?auth_token
-                      state ~agent_name ~arguments:args)
-               with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn2 -> Error (Printexc.to_string exn2))
+              if dashboard_direct_stream then Error (Printexc.to_string exn)
+              else
+                (try
+                   Ok
+                     (`Ran
+                        (execute_keeper_stream_tool ~sw ~clock
+                           ?auth_token
+                           state ~agent_name ~arguments:args))
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn2 -> Error (Printexc.to_string exn2))
         in
         match dispatch_result with
-        | Ok (true, body) ->
+        | Ok (`Queued queued) ->
+            Tool_result.ok
+              ~tool_name:"masc_keeper_msg"
+              ~start_time
+              (Yojson.Safe.to_string
+                 (dashboard_deferred_chat_to_json ~keeper_name:payload.name queued))
+        | Ok (`Ran (true, body)) ->
             let payload_json_opt, visible_reply = extract_visible_reply body in
             let streamed_text =
               Keeper_stream_text_accum.streamed_text worker_text_accum
@@ -1070,7 +1258,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                  push_worker_event
                    (Stream_terminal { ok = true; status = "done"; body });
                  Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body)
-        | Ok (false, err) ->
+        | Ok (`Ran (false, err)) ->
             persist_failure_reply err;
             push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
@@ -1084,14 +1272,24 @@ let process_single_turn ~connector_user_line_recorded_upstream
    | None -> ()
    | Some (disconnect_sw, disconnects) ->
        Eio.Fiber.fork ~sw:disconnect_sw (fun () ->
-         let _ = Eio.Stream.take disconnects in
-         if not (Atomic.get terminal_pushed) then begin
-           Atomic.set client_disconnected true;
-           Log.Keeper.info
-             "keeper_stream: client disconnected keeper=%s request_id=%s; request continues for polling"
-             payload.name request_id;
-           push_worker_event Stream_client_disconnected
-         end));
+         match
+           Eio.Fiber.first
+             (fun () ->
+               Eio.Stream.take disconnects;
+               `Client_disconnected)
+             (fun () ->
+               Eio.Promise.await stream_projection_done;
+               `Projection_done)
+         with
+         | `Projection_done -> ()
+         | `Client_disconnected ->
+             if not (Atomic.get terminal_pushed) then begin
+               Atomic.set client_disconnected true;
+               Log.Keeper.info
+                 "keeper_stream: client disconnected keeper=%s request_id=%s; request continues for polling"
+                 payload.name request_id;
+               push_worker_event Stream_client_disconnected
+             end));
   Log.Keeper.info
     "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
     payload.name request_id
@@ -1148,6 +1346,17 @@ let process_single_turn ~connector_user_line_recorded_upstream
         in
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
+    | Stream_dashboard_queued queued ->
+        let message = dashboard_deferred_ack_text ~keeper_name:payload.name in
+        publish_terminal ~status:"queued" ~ok:true ~message ();
+        Keeper_chat_events.publish events (Text_delta message);
+        Keeper_chat_events.publish events
+          (Custom
+             { name = "KEEPER_CHAT_QUEUED";
+               value = dashboard_deferred_chat_to_json ~keeper_name:payload.name queued
+             });
+        Keeper_chat_events.publish events Text_message_end;
+        Keeper_chat_events.publish events (Run_finished { run_id })
     | Stream_terminal { ok = false; status = "cancelled"; body = message } ->
         let message = redact_text message in
         publish_terminal ~status:"cancelled" ~ok:false ~message ();
@@ -1156,6 +1365,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
     | Stream_terminal { ok = false; status; body = err } ->
         let err = redact_text err in
         publish_terminal ~status ~ok:false ~message:err ();
+        Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Event_error { message = err })
     | Stream_terminal { ok = true; body; _ } -> (
         try
@@ -1214,11 +1424,29 @@ let process_single_turn ~connector_user_line_recorded_upstream
         | exn ->
             let message = redact_text (Printexc.to_string exn) in
             publish_terminal ~status:"error" ~ok:false ~message ();
+            Keeper_chat_events.publish events Text_message_end;
             Keeper_chat_events.publish events
               (Event_error { message }))
   in
-  consume_worker_events empty_keeper_stream_bridge_state
+  match consume_worker_events empty_keeper_stream_bridge_state with
+  | () -> signal_stream_projection_done ()
+  | exception exn ->
+      signal_stream_projection_done ();
+      raise exn
 
+let keeper_chat_stream_headers origin =
+  Httpun.Headers.of_list
+    ([
+       ("content-type", "text/event-stream");
+       ("cache-control", "no-cache");
+       (* This route is a per-turn SSE response. Httpun does not add a
+          Content-Length for streaming bodies, so the terminal delimiter is the
+          writer close; advertising keep-alive makes clients wait for a
+          response end that cannot be framed. *)
+       ("connection", "close");
+       ("x-accel-buffering", "no");
+     ]
+    @ cors_headers origin)
 
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let redaction =
@@ -1229,16 +1457,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let redact_text = Keeper_secret_redaction.redact_text redaction in
   let redact_json = Keeper_secret_redaction.redact_json redaction in
   let origin = get_origin request in
-  let headers =
-    Httpun.Headers.of_list
-      ([
-         ("content-type", "text/event-stream");
-         ("cache-control", "no-cache");
-         ("connection", "keep-alive");
-         ("x-accel-buffering", "no");
-       ]
-      @ cors_headers origin)
-  in
+  let headers = keeper_chat_stream_headers origin in
   let response = Httpun.Response.create ~headers `OK in
   let writer = Httpun.Reqd.respond_with_streaming reqd response in
   let mutex = Eio.Mutex.create () in
@@ -1265,7 +1484,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
 
-  let sse_adapter_loop ~events ~writer ~mutex ~closed ~on_closed =
+  let sse_adapter_loop ~events ~writer ~mutex ~closed ~on_closed ~on_finished =
     let current_thread_id = ref Ag_ui.default_thread_id in
     let current_run_id = ref None in
     let current_message_id = ref None in
@@ -1482,7 +1701,11 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                    make_event ~thread_id:!current_thread_id ~run_id:(Some run_id)
                      Run_finished))
     in
-    loop ()
+    match loop () with
+    | () -> on_finished ()
+    | exception exn ->
+        on_finished ();
+        raise exn
   in
 
 
@@ -1510,18 +1733,75 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            let run_id = Printf.sprintf "keeper-run-%d" (now_id ()) in
            let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
            let events = Keeper_chat_events.create () in
+           let adapter_finished, adapter_finished_resolver =
+             Eio.Promise.create ()
+           in
+           let signal_adapter_finished () =
+             ignore (Eio.Promise.try_resolve adapter_finished_resolver () : bool)
+           in
            Eio.Fiber.fork ~sw:stream_sw (fun () ->
              sse_adapter_loop ~events ~writer ~mutex ~closed
-               ~on_closed:notify_disconnect);
-           (* Dashboard stream route: no gate inbound boundary recorded this
-              user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
-           process_single_turn ~connector_user_line_recorded_upstream:false
-             ~state ~clock ~sw
-             ~auth_token:(auth_token_from_request request)
-             ~thread_id ~closed
-             ~client_disconnects:(Some (stream_sw, client_disconnects))
-             ~payload ~run_id ~message_id ~agent_name ~events;
-           (* Queue drain is now handled by Keeper_chat_consumer
+               ~on_closed:notify_disconnect ~on_finished:signal_adapter_finished);
+           let base_path = (Mcp_server.workspace_config state).base_path in
+           let wait_for_adapter_finished () =
+             Eio.Promise.await adapter_finished
+           in
+           let run_now () =
+             (* Dashboard stream route: no gate inbound boundary recorded this
+                user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
+             process_single_turn ~connector_user_line_recorded_upstream:false
+               ~state ~clock ~sw
+               ~auth_token:(auth_token_from_request request)
+               ~thread_id ~closed
+               ~client_disconnects:(Some (stream_sw, client_disconnects))
+               ~payload ~run_id ~message_id ~agent_name ~events;
+             wait_for_adapter_finished ()
+           in
+           if has_external_speaker payload then run_now ()
+           else
+             match
+               try defer_dashboard_payload_if_busy ~base_path ~clock payload
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn -> `Queue_error (Printexc.to_string exn)
+             with
+             | `Not_busy -> run_now ()
+             | `Queued queued ->
+                 Log.Keeper.info
+                   "keeper_stream: deferred busy dashboard message keeper=%s queue_length=%d"
+                   payload.name queued.queue_length;
+                 Keeper_chat_events.publish events
+                   (Run_started { run_id; thread_id });
+                 Keeper_chat_events.publish events
+                   (Text_message_start
+                      { message_id; role = Keeper_chat_events.Assistant });
+                 Keeper_chat_events.publish events
+                   (Text_delta
+                      (dashboard_deferred_ack_text ~keeper_name:payload.name));
+                 Keeper_chat_events.publish events
+                   (Custom
+                      { name = "KEEPER_CHAT_QUEUED";
+                        value =
+                          dashboard_deferred_chat_to_json
+                            ~keeper_name:payload.name queued
+                 });
+                 Keeper_chat_events.publish events Text_message_end;
+                 Keeper_chat_events.publish events (Run_finished { run_id });
+                 wait_for_adapter_finished ()
+             | `Queue_error message ->
+                 Log.Keeper.error
+                   "keeper_stream: failed to defer busy dashboard message keeper=%s: %s"
+                   payload.name message;
+                 Keeper_chat_events.publish events
+                   (Run_started { run_id; thread_id });
+                 Keeper_chat_events.publish events
+                   (Event_error
+                      { message =
+                          "keeper chat queue persistence failed: " ^ message
+                      });
+                 Keeper_chat_events.publish events (Run_finished { run_id });
+                 wait_for_adapter_finished ();
+           (* Queue drain is handled by Keeper_chat_consumer
               (started in server_bootstrap_loops). *)
            ))
 
@@ -1537,6 +1817,11 @@ module For_testing = struct
   let turn_instructions_for_request = turn_instructions_for_request
   let args_of_request = args_of_request
   let modalities_for_request = modalities_for_request
+  let defer_dashboard_payload_if_busy ~base_path ~clock payload =
+    match defer_dashboard_payload_if_busy ~base_path ~clock payload with
+    | `Not_busy -> `Not_busy
+    | `Queued queued -> `Queued queued.queue_length
+
   let extract_visible_reply = extract_visible_reply
   let direct_reply_terminal_error = direct_reply_terminal_error
   let visible_reply_with_stream_fallback = visible_reply_with_stream_fallback
@@ -1549,4 +1834,5 @@ module For_testing = struct
   let empty_stream_bridge_state = empty_keeper_stream_bridge_state
   let translate_oas_stream_event = translate_oas_stream_event
   let keeper_tool_failure_log_details = keeper_tool_failure_log_details
+  let keeper_chat_stream_headers = keeper_chat_stream_headers
 end

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -182,11 +182,13 @@ type dashboard_deferred_chat =
 let dashboard_busy_queue_state ~base_path ~keeper_name =
   let in_flight = Keeper_turn_admission.in_flight ~base_path ~keeper_name in
   let chat_waiting = Keeper_turn_admission.chat_waiting ~base_path ~keeper_name in
-  match in_flight, chat_waiting with
-  | None, false -> None
-  | None, true -> Some (None, true)
-  | Some info, false -> Some (Some info, false)
-  | Some info, true -> Some (Some info, true)
+  let queue_waiting = Keeper_chat_queue.length ~keeper_name > 0 in
+  match in_flight, chat_waiting, queue_waiting with
+  | None, false, false -> None
+  | None, false, true -> Some (None, false)
+  | None, true, _ -> Some (None, true)
+  | Some info, false, _ -> Some (Some info, false)
+  | Some info, true, _ -> Some (Some info, true)
 
 let dashboard_deferred_ack_text ~keeper_name =
   Printf.sprintf

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -184,7 +184,9 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
   let chat_waiting = Keeper_turn_admission.chat_waiting ~base_path ~keeper_name in
   match in_flight, chat_waiting with
   | None, false -> None
-  | _ -> Some (in_flight, chat_waiting)
+  | None, true -> Some (None, true)
+  | Some info, false -> Some (Some info, false)
+  | Some info, true -> Some (Some info, true)
 
 let dashboard_deferred_ack_text ~keeper_name =
   Printf.sprintf
@@ -981,6 +983,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
     Eio.Promise.create ()
   in
   let signal_stream_projection_done () =
+    (* fire-and-forget: completion is idempotent and may race disconnect cleanup. *)
     ignore (Eio.Promise.try_resolve stream_projection_done_resolver () : bool)
   in
   let push_worker_event event =
@@ -1737,6 +1740,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
              Eio.Promise.create ()
            in
            let signal_adapter_finished () =
+             (* fire-and-forget: the adapter-finished signal is idempotent. *)
              ignore (Eio.Promise.try_resolve adapter_finished_resolver () : bool)
            in
            Eio.Fiber.fork ~sw:stream_sw (fun () ->

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -205,6 +205,12 @@ module For_testing : sig
   val turn_instructions_for_request : keeper_chat_stream_request -> string option
   val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
   val modalities_for_request : keeper_chat_stream_request -> string list
+  val keeper_chat_stream_headers : string -> Httpun.Headers.t
+  val defer_dashboard_payload_if_busy :
+    base_path:string ->
+    clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+    keeper_chat_stream_request ->
+    [ `Not_busy | `Queued of int ]
   val extract_visible_reply : string -> Yojson.Safe.t option * string
   val direct_reply_terminal_error :
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option

--- a/test/dune
+++ b/test/dune
@@ -905,6 +905,7 @@
 (tests
  (names
   test_keeper_busy_connector_deferred
+  test_keeper_busy_dashboard_deferred
   test_keeper_chat_consumer_delivery
   test_keeper_chat_consumer_dispatch
   test_runtime_params
@@ -1101,6 +1102,7 @@
   test_board_moderation)
  (modules
   test_keeper_busy_connector_deferred
+  test_keeper_busy_dashboard_deferred
   test_keeper_chat_consumer_delivery
   test_keeper_chat_consumer_dispatch
   test_runtime_params

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -1,0 +1,220 @@
+(* test_keeper_busy_dashboard_deferred.ml
+
+   A dashboard message that arrives while a keeper turn is already in flight
+   must not park a new HTTP/SSE request behind the turn slot. It is accepted
+   into the durable chat queue instead; the standalone consumer drains it when
+   the slot frees. *)
+
+open Masc
+
+let failures = ref 0
+
+let check name cond =
+  if cond
+  then Printf.printf "  ok: %s\n%!" name
+  else (
+    incr failures;
+    Printf.printf "  fail: %s\n%!" name)
+;;
+
+let keeper_name = "busy-dashboard-keeper"
+
+let payload ?(name = keeper_name) ?(content = "are you there?") ()
+    : Server_routes_http_keeper_stream.keeper_chat_stream_request =
+  { name
+  ; message = content
+  ; user_blocks = []
+  ; timeout_sec = None
+  ; turn_instructions = None
+  ; surface_context = None
+  ; channel = ""
+  ; channel_user_id = ""
+  ; channel_user_name = ""
+  ; channel_workspace_id = ""
+  ; attachments = []
+  }
+;;
+
+let with_env body =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-busy-dashboard-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree base)
+    (fun () ->
+      Eio_main.run
+      @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      Keeper_chat_queue.For_testing.reset ();
+      body ~base ~clock)
+;;
+
+let with_busy_slot ~base ~sw ?(keeper_name = keeper_name) f =
+  let started, set_started = Eio.Promise.create () in
+  let release, set_release = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    ignore
+      (Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name (fun () ->
+         Eio.Promise.resolve set_started ();
+         Eio.Promise.await release)));
+  Eio.Promise.await started;
+  Fun.protect
+    ~finally:(fun () -> Eio.Promise.resolve set_release ())
+    f
+;;
+
+let with_busy_slots ~base ~sw keeper_names f =
+  let slots =
+    List.map
+      (fun keeper_name ->
+         let started, set_started = Eio.Promise.create () in
+         let release, set_release = Eio.Promise.create () in
+         Eio.Fiber.fork ~sw (fun () ->
+           ignore
+             (Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
+                (fun () ->
+                   Eio.Promise.resolve set_started ();
+                   Eio.Promise.await release)));
+         (started, set_release))
+      keeper_names
+  in
+  List.iter (fun (started, _) -> Eio.Promise.await started) slots;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter (fun (_, set_release) -> Eio.Promise.resolve set_release ()) slots)
+    f
+;;
+
+let test_busy_dashboard_enqueues () =
+  Printf.printf "Test: busy dashboard dispatch enqueues onto Keeper_chat_queue\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Eio.Switch.run
+  @@ fun sw ->
+  with_busy_slot ~base ~sw
+  @@ fun () ->
+  (match
+     Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
+       ~base_path:base
+       ~clock
+       (payload ())
+   with
+   | `Queued len -> check "queue length is reported" (len = 1)
+   | `Not_busy -> check "busy keeper was deferred" false);
+  check "exactly one dashboard message enqueued" (Keeper_chat_queue.length ~keeper_name = 1);
+  (match Keeper_chat_queue.dequeue ~keeper_name with
+   | Some { Keeper_chat_queue.content; source = Dashboard; _ } ->
+     check "queued content is the user's message" (String.equal content "are you there?")
+   | Some _ -> check "queued source is dashboard" false
+   | None -> check "queue holds the dashboard message" false)
+;;
+
+let test_free_dashboard_not_enqueued () =
+  Printf.printf "Test: free dashboard dispatch is not deferred\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  (match
+     Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
+       ~base_path:base
+       ~clock
+       (payload ~content:"run now" ())
+   with
+   | `Not_busy -> check "free keeper stays on direct stream path" true
+   | `Queued _ -> check "free keeper must not enqueue" false);
+  check "queue remains empty" (Keeper_chat_queue.length ~keeper_name = 0)
+;;
+
+let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
+  Printf.printf
+    "Test: concurrent busy dashboard dispatches enqueue per keeper\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let keeper_names =
+    List.init 8 (fun i -> Printf.sprintf "%s-%02d" keeper_name i)
+  in
+  with_busy_slots ~base ~sw keeper_names
+  @@ fun () ->
+  let results = Array.make (List.length keeper_names) None in
+  let done_promises = Array.make (List.length keeper_names) None in
+  keeper_names
+  |> List.iteri (fun i keeper_name ->
+    let done_, set_done = Eio.Promise.create () in
+    done_promises.(i) <- Some done_;
+    Eio.Fiber.fork ~sw (fun () ->
+      let result =
+        Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
+          ~base_path:base
+          ~clock
+          (payload ~name:keeper_name
+             ~content:(Printf.sprintf "burst message %d" i)
+             ())
+      in
+      results.(i) <- Some result;
+      Eio.Promise.resolve set_done ()));
+  Array.iter
+    (function
+      | Some done_ -> Eio.Promise.await done_
+      | None -> ())
+    done_promises;
+  keeper_names
+  |> List.iteri (fun i keeper_name ->
+    match results.(i) with
+    | Some (`Queued 1) ->
+      check
+        (Printf.sprintf "keeper %s queued exactly one message" keeper_name)
+        (Keeper_chat_queue.length ~keeper_name = 1)
+    | Some (`Queued n) ->
+      check
+        (Printf.sprintf "keeper %s queued exactly one message (got %d)" keeper_name n)
+        false
+    | Some `Not_busy ->
+      check
+        (Printf.sprintf "keeper %s was busy and should defer" keeper_name)
+        false
+    | None ->
+      check
+        (Printf.sprintf "keeper %s defer fiber completed" keeper_name)
+        false);
+  let total_queued =
+    keeper_names
+    |> List.fold_left
+         (fun acc keeper_name -> acc + Keeper_chat_queue.length ~keeper_name)
+         0
+  in
+  check "all busy dashboard messages are preserved" (total_queued = 8)
+;;
+
+let test_stream_headers_close_per_turn_response () =
+  Printf.printf "Test: dashboard stream response advertises connection close\n%!";
+  let headers =
+    Server_routes_http_keeper_stream.For_testing.keeper_chat_stream_headers ""
+  in
+  check "content type is event-stream"
+    (Httpun.Headers.get headers "content-type" = Some "text/event-stream");
+  check "per-turn stream uses close-delimited response"
+    (Httpun.Headers.get headers "connection" = Some "close")
+;;
+
+let () =
+  test_busy_dashboard_enqueues ();
+  test_free_dashboard_not_enqueued ();
+  test_concurrent_busy_dashboard_enqueues_are_per_keeper ();
+  test_stream_headers_close_per_turn_response ();
+  if !failures > 0
+  then (
+    Printf.printf "FAILED: %d check(s)\n%!" !failures;
+    exit 1)
+  else Printf.printf "All keeper_busy_dashboard_deferred checks passed\n%!"
+;;

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -134,6 +134,35 @@ let test_free_dashboard_not_enqueued () =
   check "queue remains empty" (Keeper_chat_queue.length ~keeper_name = 0)
 ;;
 
+let test_existing_backlog_defers_new_dashboard_message () =
+  Printf.printf "Test: existing dashboard backlog keeps newer messages queued\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Keeper_chat_queue.enqueue ~keeper_name
+    { Keeper_chat_queue.content = "older queued message"
+    ; user_blocks = []
+    ; attachments = []
+    ; timestamp = Eio.Time.now clock
+    ; source = Dashboard
+    };
+  (match
+     Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
+       ~base_path:base
+       ~clock
+       (payload ~content:"newer dashboard message" ())
+   with
+   | `Queued len -> check "newer message joins existing backlog" (len = 2)
+   | `Not_busy -> check "existing backlog should force queue path" false);
+  (match Keeper_chat_queue.dequeue ~keeper_name with
+   | Some { Keeper_chat_queue.content; _ } ->
+     check "older queued message stays first" (String.equal content "older queued message")
+   | None -> check "older queued message is present" false);
+  (match Keeper_chat_queue.dequeue ~keeper_name with
+   | Some { Keeper_chat_queue.content; _ } ->
+     check "newer dashboard message stays second" (String.equal content "newer dashboard message")
+   | None -> check "newer queued message is present" false)
+;;
+
 let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
   Printf.printf
     "Test: concurrent busy dashboard dispatches enqueue per keeper\n%!";
@@ -210,6 +239,7 @@ let test_stream_headers_close_per_turn_response () =
 let () =
   test_busy_dashboard_enqueues ();
   test_free_dashboard_not_enqueued ();
+  test_existing_backlog_defers_new_dashboard_message ();
   test_concurrent_busy_dashboard_enqueues_are_per_keeper ();
   test_stream_headers_close_per_turn_response ();
   if !failures > 0

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -254,6 +254,52 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
     Alcotest.fail "expected persisted request"
 ;;
 
+let test_keeper_msg_async_recovery_sweep_marks_only_disk_only_inflight_lost () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-recover-sweep-" in
+  let promise, _resolver = Eio.Promise.create () in
+  let request_id =
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"sweep"
+      ~f:(fun () ->
+        Eio.Promise.await promise;
+        tr_ok "{}")
+      ()
+  in
+  ignore (wait_for_running request_id : Keeper_msg_async.entry);
+  Alcotest.(check int)
+    "live in-memory worker is not recovered as lost"
+    0
+    (Keeper_msg_async.For_testing.recover_lost_disk_records ~base_path);
+  (match Keeper_msg_async.For_testing.load_record ~base_path ~request_id with
+   | Keeper_msg_async.Found { Keeper_msg_async.status = Running; _ } -> ()
+   | Keeper_msg_async.Found entry ->
+     Alcotest.failf
+       "expected live request to remain running, got %s"
+       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+   | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+     Alcotest.fail "expected persisted running request");
+  Keeper_msg_async.For_testing.forget request_id;
+  Alcotest.(check int)
+    "disk-only in-flight request is recovered as lost"
+    1
+    (Keeper_msg_async.For_testing.recover_lost_disk_records ~base_path);
+  match Keeper_msg_async.For_testing.load_record ~base_path ~request_id with
+  | Keeper_msg_async.Found { Keeper_msg_async.status = Lost { reason }; _ } ->
+    Alcotest.(check bool) "lost reason retained" true (String.length reason > 0)
+  | Keeper_msg_async.Found entry ->
+    Alcotest.failf
+      "expected recovered lost request, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+  | Keeper_msg_async.Absent | Keeper_msg_async.Unreadable _ ->
+    Alcotest.fail "expected persisted lost request"
+;;
+
 let test_keeper_msg_async_marks_cancelled_worker_cancelled () =
   with_eio_env
   @@ fun _env ->
@@ -690,6 +736,10 @@ let () =
             "recover in-flight request as lost"
             `Quick
             test_keeper_msg_async_marks_recovered_inflight_lost
+        ; test_case
+            "recovery sweep marks only disk-only in-flight lost"
+            `Quick
+            test_keeper_msg_async_recovery_sweep_marks_only_disk_only_inflight_lost
         ; test_case
             "cancelled worker is terminal cancelled"
             `Quick

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -34,6 +34,43 @@ let test_free_slot_admits () =
   | `Ran _ | `Rejected _ -> check "run_serialized admits on a free slot" false
 ;;
 
+let test_chat_if_free_never_parks () =
+  reset ();
+  Printf.printf "Test 1b: run_chat_if_free runs only on an immediately free slot\n%!";
+  (match Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () -> "ok") with
+   | `Ran "ok" -> check "run_chat_if_free admits on a free slot" true
+   | `Ran _ | `Busy _ -> check "run_chat_if_free admits on a free slot" false);
+  Eio.Switch.run (fun sw ->
+    let started, set_started = Eio.Promise.create () in
+    let release, set_release = Eio.Promise.create () in
+    Eio.Fiber.fork ~sw (fun () ->
+      ignore
+        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_started ();
+           Eio.Promise.await release)));
+    Eio.Promise.await started;
+    (match Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () -> ()) with
+     | `Busy { Keeper_turn_admission.in_flight = Some { lane = Chat; _ }; waiting = 0 } ->
+       check "run_chat_if_free reports busy in-flight chat without parking" true
+     | `Busy _ ->
+       check "run_chat_if_free reports busy in-flight chat without parking" false
+     | `Ran () -> check "run_chat_if_free must not run while slot is held" false);
+    let parked_ran = ref false in
+    Eio.Fiber.fork ~sw (fun () ->
+      ignore
+        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
+           parked_ran := true)));
+    check
+      "parked waiter is observable before if-free attempt"
+      (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name);
+    (match Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () -> ()) with
+     | `Busy { Keeper_turn_admission.waiting; _ } ->
+       check "run_chat_if_free yields to an already parked chat" (waiting > 0)
+     | `Ran () -> check "run_chat_if_free must not overtake a parked chat" false);
+    check "parked chat did not run before holder release" (not !parked_ran);
+    Eio.Promise.resolve set_release ())
+;;
+
 let test_autonomous_skips_in_flight_chat () =
   reset ();
   Printf.printf "Test 2: autonomous lane skips while a chat turn is in flight\n%!";
@@ -315,6 +352,7 @@ let test_idle_loop_yields_to_parked_chat () =
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
+  test_chat_if_free_never_parks ();
   test_autonomous_skips_in_flight_chat ();
   test_chat_turns_serialize ();
   test_distinct_keepers_do_not_block_each_other ();


### PR DESCRIPTION
## Summary

Fix the dashboard keeper chat burst path so simultaneous messages to multiple keepers do not park HTTP/SSE requests behind busy keeper turns or leave clients waiting for an unframed stream end.

## Root Cause

The live failure was a compound runtime issue:

- dashboard stream requests could enter the normal direct-turn path even when the target keeper already had an in-flight or waiting chat turn;
- that let HTTP/SSE requests sit behind per-keeper turn admission instead of accepting the user message into the durable keeper chat queue;
- the per-turn SSE route advertised a streaming response without a reliable close-delimited framing contract for clients;
- terminal events could be published by the worker before the SSE adapter had consumed and flushed them to the response writer;
- stale disk-only async request records could remain `queued`/`running` after a restart.

## Changes

- Add dashboard busy pre-checking and durable `Keeper_chat_queue` enqueue for busy dashboard messages.
- Close the race at turn admission with `run_chat_if_free` and direct dashboard dispatch admission handling.
- Emit queued ACK events for busy dashboard requests instead of keeping their HTTP request parked.
- Make the per-turn dashboard SSE response close-delimited with `connection: close`.
- Wait for the SSE adapter to project the terminal frame before the request switch closes the writer.
- Recover stale disk-only keeper message request records as `lost` during startup.
- Add focused regression coverage for 8 concurrent busy dashboard messages, admission behavior, and request recovery.

## Validation

Local focused checks on head `40fa91ccc5`:

```sh
ocamlformat --check lib/keeper/keeper_msg_async.ml lib/keeper/keeper_msg_async.mli lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/keeper/keeper_turn_admission.ml lib/keeper/keeper_turn_admission.mli lib/server/server_bootstrap_loops.ml lib/server/server_routes_http_keeper_stream.ml lib/server/server_routes_http_keeper_stream.mli test/test_keeper_busy_dashboard_deferred.ml test/test_keeper_mutex_coverage.ml test/test_keeper_turn_admission.ml
git diff --check origin/main...HEAD
bash scripts/ci/check-determinism-contract.sh
env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_turn_admission.exe test/test_keeper_mutex_coverage.exe test/test_keeper_busy_dashboard_deferred.exe test/test_keeper_busy_connector_deferred.exe test/test_keeper_chat_consumer_delivery.exe bin/main_eio.exe
_build/default/test/test_keeper_turn_admission.exe
_build/default/test/test_keeper_mutex_coverage.exe
_build/default/test/test_keeper_busy_dashboard_deferred.exe
_build/default/test/test_keeper_busy_connector_deferred.exe
_build/default/test/test_keeper_chat_consumer_delivery.exe
```

Live runtime proof on the keeper backpressure patch in this worktree:

- stopped root-main `masc-main-8935` and started this worktree on `127.0.0.1:8935`;
- `/health?full=1` confirmed `build.repo_root=/Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/keeper-busy-root-cause-20260704`;
- after autoboot: `overall_status=ok`, fleet `13/13` healthy, log recent errors `0`;
- ran 8 simultaneous valid dashboard stream requests to `analyst,base,idealist,nick0cave,ramarama,rondo,sangsu,verifier`;
- all 8 returned HTTP 200, `connection=close`, EOF true, terminal `RUN_FINISHED`, failure count `0`;
- no recent request files remained in `queued`, `running`, or `lost`;
- follow-up 48-way GET smoke across `/health`, `/health?full=1`, `/api/v1/dashboard/shell`, and `/api/v1/dashboard/transport-health` returned `48/48` HTTP 200, max latency `43ms`.

## Notes

Draft until CI confirms the full suite. Local Dune validation was intentionally focused; CI remains the build authority for the full repository.
