### PR TITLE
Show runtime catalog spec in keeper config

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -635,6 +635,143 @@ const mocks = vi.hoisted(() => {
         },
       ],
     })),
+    fetchRuntimeProviders: vi.fn(async () => ({
+      updated_at: '2026-07-05T00:00:00Z',
+      summary: {
+        providers: 1,
+        runtimes: 1,
+        local_models: 0,
+        cloud_models: 1,
+        cli_models: 0,
+        default_runtime_id: 'tier-group.keeper_unified',
+      },
+      providers: [
+        {
+          provider: 'tier-group.keeper_unified',
+          runtime_id: 'tier-group.keeper_unified',
+          provider_id: 'runpod_mtp',
+          provider_display_name: 'RunPod MTP',
+          model_id: 'qwen',
+          model_api_name: 'Qwen/Qwen3-32B',
+          models: ['Qwen/Qwen3-32B'],
+          status: 'configured',
+          available: true,
+          source: 'runtime.toml',
+          supports_multimodal_inputs: true,
+          supports_image_input: true,
+          supports_audio_input: true,
+          supports_video_input: false,
+          parameter_policy: {
+            reasoning_toggle_wire: 'chat_template_kwargs',
+            reasoning_replay_policy: 'preserve_always',
+            requires_reasoning_replay_on_tool_call: true,
+            ignored_sampling_params: ['temperature'],
+            always_ignored_sampling_params: [],
+          },
+          request_config: {
+            source: 'oas-provider-config',
+            provider_kind: 'openai_compat',
+            request_path: '/chat/completions',
+            request_path_targets_responses_api: false,
+            enable_thinking: true,
+            preserve_thinking: true,
+            thinking_budget: 32768,
+            glm_replay_reasoning: true,
+            has_model_capabilities_override: true,
+          },
+          declared_spec: {
+            source: 'runtime.toml',
+            provider: {
+              id: 'runpod_mtp',
+              display_name: 'RunPod MTP',
+              protocol: 'openai-compatible-http',
+              api_format: 'chat-completions',
+              transport: 'http',
+              auth_kind: 'env:RUNPOD_API_KEY',
+              is_non_interactive: true,
+              has_capabilities: true,
+              behavior_capabilities: {
+                supports_inline_tools: true,
+                requires_per_keeper_bridging_for_bound_actor_tools: true,
+                identity_runtime_mcp_header_keys: ['x-masc-keeper'],
+                argv_prompt_preflight: true,
+                uses_anthropic_caching: false,
+                max_turns_per_attempt: 3,
+                tolerates_bound_actor_fallback: true,
+              },
+              custom_header_count: 1,
+              connect_timeout_s: 120,
+            },
+            model: {
+              id: 'qwen',
+              api_name: 'Qwen/Qwen3-32B',
+              tools_support: true,
+              max_context: 128000,
+              thinking_support: true,
+              preserve_thinking: true,
+              max_thinking_budget: 32768,
+              streaming: true,
+              temperature: 0.65,
+              capabilities: {
+                source: 'runtime.toml',
+                supports_tool_choice: true,
+                supports_required_tool_choice: true,
+                supports_named_tool_choice: true,
+                supports_parallel_tool_calls: true,
+                supports_extended_thinking: true,
+                supports_reasoning_budget: true,
+                thinking_control_format: 'chat-template-kwargs',
+                supports_multimodal_inputs: true,
+                supports_image_input: true,
+                supports_audio_input: true,
+                supports_video_input: false,
+                supports_response_format_json: true,
+                supports_structured_output: true,
+              },
+              match_prefixes: ['Qwen/'],
+            },
+            binding: {
+              provider_id: 'runpod_mtp',
+              model_id: 'qwen',
+              is_default: true,
+              max_concurrent: 4,
+              price_input: 0.1,
+              price_output: 0.2,
+              keep_alive: '30m',
+              num_ctx: 131072,
+            },
+          },
+          effective_capabilities: {
+            source: 'oas-provider-config-model',
+            max_context_tokens: 131072,
+            max_output_tokens: 65536,
+            supports_tools: true,
+            supports_tool_choice: true,
+            supports_required_tool_choice: true,
+            supports_named_tool_choice: true,
+            supports_parallel_tool_calls: true,
+            supports_runtime_mcp_tools: true,
+            supports_runtime_tool_events: true,
+            supports_reasoning: true,
+            supports_extended_thinking: true,
+            supports_reasoning_budget: true,
+            accepted_reasoning_efforts: ['low', 'medium', 'high'],
+            thinking_control_format: 'chat-template-kwargs',
+            preserve_thinking_control_format: 'chat-template-kwargs-preserve-thinking',
+            reasoning_output_format: 'split-reasoning-fields',
+            reasoning_streaming_format: {
+              kind: 'delta-reasoning-field',
+              field: 'reasoning_content',
+            },
+            supports_multimodal_inputs: true,
+            supports_image_input: true,
+            supports_audio_input: true,
+            supports_video_input: false,
+            ignored_sampling_parameters: ['temperature'],
+          },
+        },
+      ],
+    })),
     patchKeeperConfig: vi.fn(),
     updateKeeperRuntime: vi.fn(async () => ({ ok: true })),
     setKeeperToolPolicy: vi.fn(async () => makeKeeperConfig()),
@@ -658,6 +795,7 @@ vi.mock('../api/dashboard', () => ({
   fetchRuntimeProfiles: mocks.fetchRuntimeProfiles,
   fetchDashboardGoalsTree: mocks.fetchDashboardGoalsTree,
   fetchKeeperConfig: mocks.fetchKeeperConfig,
+  fetchRuntimeProviders: mocks.fetchRuntimeProviders,
   patchKeeperConfig: mocks.patchKeeperConfig,
   updateKeeperRuntime: mocks.updateKeeperRuntime,
   setKeeperToolPolicy: mocks.setKeeperToolPolicy,
@@ -678,6 +816,7 @@ import {
   loadKeeperConfig,
   resetKeeperConfig,
 } from './keeper-config-panel'
+import { resetRuntimeCatalog } from '../lib/runtime-catalog-resource'
 import type { GoalTreeNode } from '../types'
 
 async function flush() {
@@ -702,9 +841,11 @@ describe('KeeperConfigPanel', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     resetKeeperConfig()
+    resetRuntimeCatalog()
     mocks.fetchKeeperConfig.mockClear()
     mocks.fetchDashboardGoalsTree.mockClear()
     mocks.fetchRuntimeProfiles.mockClear()
+    mocks.fetchRuntimeProviders.mockClear()
     mocks.patchKeeperConfig.mockClear()
     mocks.updateKeeperRuntime.mockClear()
     mocks.setKeeperToolPolicy.mockClear()
@@ -718,6 +859,7 @@ describe('KeeperConfigPanel', () => {
     render(null, container)
     container.remove()
     resetKeeperConfig()
+    resetRuntimeCatalog()
   })
 
   it('separates editable prompt controls from read-only runtime metadata', async () => {
@@ -741,6 +883,15 @@ describe('KeeperConfigPanel', () => {
     await flush()
     expect(container.textContent).toContain('Runtime 선택')
     expect(container.textContent).toContain('tier-group.keeper_unified')
+    expect(container.textContent).toContain('Runtime catalog spec')
+    expect(container.textContent).toContain('RunPod MTP')
+    expect(container.textContent).toContain('Qwen/Qwen3-32B')
+    expect(container.textContent).toContain('effective')
+    expect(container.textContent).toContain('source:oas-provider-config-model')
+    expect(container.textContent).toContain('request')
+    expect(container.textContent).toContain('think:on')
+    expect(container.textContent).toContain('policy')
+    expect(container.textContent).toContain('wire:chat_template_kwargs')
     expect(container.textContent).toContain('활성 런타임')
 
     // goals tab: assigned goal-store bindings.

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -12,17 +12,30 @@ import {
   setKeeperToolPolicy,
 } from '../api/dashboard'
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
-import type { DashboardToolInventoryItem, KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode } from '../api/dashboard'
+import type { DashboardRuntimeProviderSnapshot, DashboardToolInventoryItem, KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import { formatTokens, formatPct, formatCost } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
 import { MISSING_DATA_DASH } from '../lib/format-string'
+import type { AsyncState } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { BTN_FILLED_BASE } from './common/button-filled-base'
 import { ExpandableTextarea } from './common/expandable-textarea'
 import { KeeperToolAccessSummary } from './keeper-tool-access'
 import { createAsyncResource } from '../lib/async-state'
+import {
+  findRuntimeCatalogEntry,
+  loadRuntimeCatalog,
+  runtimeCatalogState,
+} from '../lib/runtime-catalog-resource'
+import {
+  runtimeCatalogDeclaredSpec,
+  runtimeCatalogEffectiveCapabilities,
+  runtimeCatalogParameterPolicy,
+  runtimeCatalogRequestConfig,
+  runtimeCatalogSnapshotFacts,
+} from '../lib/runtime-provider-summary'
 import { refreshKeeperRuntimeStatus } from '../store'
 import { SetupGuideCard } from './setup-guide-card'
 import { SectionHeader } from './common/section-header'
@@ -407,6 +420,63 @@ function dedupeStrings(values: readonly string[]): string[] {
     next.push(value)
   }
   return next
+}
+
+function runtimeCatalogRuntimeKey(entry: DashboardRuntimeProviderSnapshot): string {
+  return entry.runtime_id?.trim() || entry.provider.trim()
+}
+
+function runtimeCatalogProviderLabel(entry: DashboardRuntimeProviderSnapshot): string {
+  return entry.provider_display_name ?? entry.provider_id ?? entry.provider
+}
+
+function runtimeCatalogModelLabel(entry: DashboardRuntimeProviderSnapshot): string {
+  return entry.model_api_name ?? entry.model_id ?? entry.models[0] ?? MISSING_DATA_DASH
+}
+
+function selectedRuntimeCatalogEntry(
+  state: AsyncState<DashboardRuntimeProviderSnapshot[]>,
+  runtimeId: string,
+): DashboardRuntimeProviderSnapshot | null {
+  if (state.status !== 'loaded') return null
+  return findRuntimeCatalogEntry(state.data, runtimeId)
+}
+
+function runtimeCatalogStateRows(
+  state: AsyncState<DashboardRuntimeProviderSnapshot[]>,
+  runtimeId: string,
+  entry: DashboardRuntimeProviderSnapshot | null,
+): readonly KcfFactRow[] {
+  if (state.status === 'idle' || state.status === 'loading') {
+    return [['catalog 상태', state.status]]
+  }
+  if (state.status === 'error') {
+    return [
+      ['catalog 상태', 'error'],
+      ['catalog error', state.message, true],
+    ]
+  }
+  if (runtimeId.trim() !== '' && !entry) {
+    return [
+      ['catalog 상태', 'runtime 미수집'],
+      ['선택 runtime', runtimeId, true],
+      ['catalog entries', String(state.data.length)],
+    ]
+  }
+  return []
+}
+
+function runtimeCatalogSpecRows(entry: DashboardRuntimeProviderSnapshot): readonly KcfFactRow[] {
+  return [
+    ['runtime catalog', runtimeCatalogRuntimeKey(entry), true],
+    ['provider', runtimeCatalogProviderLabel(entry)],
+    ['model', runtimeCatalogModelLabel(entry), true],
+    ['snapshot', runtimeCatalogSnapshotFacts(entry), true],
+    ['effective', runtimeCatalogEffectiveCapabilities(entry), true],
+    ['request', runtimeCatalogRequestConfig(entry), true],
+    ['declared', runtimeCatalogDeclaredSpec(entry), true],
+    ['policy', runtimeCatalogParameterPolicy(entry), true],
+  ]
 }
 
 function updateRuntimeActiveGoalIds(values: readonly string[]) {
@@ -1014,6 +1084,9 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   if (toolInventoryState.value.status === 'idle') {
     void loadToolInventory()
   }
+  if (runtimeCatalogState.value.status === 'idle') {
+    loadRuntimeCatalog()
+  }
 
   // Loading / error states render inside the same .kcf-overlay frame so the
   // modal does not pop in only after the config resolves (the panel is mounted
@@ -1071,6 +1144,12 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         ...(c.execution.runtime_options ?? []),
       ])
     : []
+  const runtimeCatalog = runtimeCatalogState.value
+  const selectedRuntimeId = rd?.runtime_id || (c.execution.selected_runtime_id ?? '')
+  const selectedRuntimeCatalog = selectedRuntimeCatalogEntry(runtimeCatalog, selectedRuntimeId)
+  const selectedRuntimeCatalogRows = selectedRuntimeCatalog
+    ? runtimeCatalogSpecRows(selectedRuntimeCatalog)
+    : runtimeCatalogStateRows(runtimeCatalog, selectedRuntimeId, selectedRuntimeCatalog)
 
   async function saveRuntimeConfig() {
     if (!rd) return
@@ -1337,6 +1416,14 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         ? html`<${KcfFacts} rows=${[['정규화 runtime', c.execution.selected_runtime_canonical, true]]} />`
         : null}
     </${KcfSec}>
+
+    ${selectedRuntimeCatalogRows.length > 0
+      ? html`
+        <${KcfSec} title="Runtime catalog spec" desc="선택 runtime 의 /api/v1/providers Provider × Model projection입니다. 요청 파라미터와 effective capability는 여기서 읽기 전용으로 확인합니다.">
+          <${KcfFacts} rows=${selectedRuntimeCatalogRows} />
+        </${KcfSec}>
+      `
+      : null}
 
     <${KcfSec} title="실행" desc="런타임 후보·타임아웃은 읽기 전용입니다. fallback 은 마지막 runtime 을 제외한 항목에 순서대로 적용됩니다.">
       <${KcfFacts} rows=${[


### PR DESCRIPTION
Summary
- Load the shared runtime catalog in KeeperConfigPanel.
- Show selected runtime Provider x Model catalog spec on the runtime tab.
- Surface snapshot, effective capabilities, request config, declared spec, and parameter policy without changing runtime_id PATCH behavior.

Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check