### PR TITLE
Show runtime catalog spec in config probe

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DashboardRuntimeDiagnostic } from '../../api/dashboard'
 import { ConfigResolutionPanel, filterDiagnostics } from './config-resolution-panel'
+import { resetRuntimeCatalog } from '../../lib/runtime-catalog-resource'
 
 function diag(
   kind: string,
@@ -21,61 +22,269 @@ async function flush(): Promise<void> {
   }
 }
 
+function runtimeProvidersPayload() {
+  return {
+    updated_at: '2026-07-05T00:00:00Z',
+    summary: {
+      providers: 1,
+      runtimes: 1,
+      local_models: 0,
+      cloud_models: 1,
+      cli_models: 0,
+      default_runtime_id: 'runpod_mtp.qwen',
+    },
+    providers: [
+      {
+        provider: 'runpod_mtp.qwen',
+        runtime_id: 'runpod_mtp.qwen',
+        provider_id: 'runpod_mtp',
+        provider_display_name: 'RunPod MTP',
+        model_id: 'qwen',
+        model_api_name: 'Qwen/Qwen3-32B',
+        models: ['Qwen/Qwen3-32B'],
+        status: 'configured',
+        available: true,
+        source: 'runtime.toml',
+        parameter_policy: {
+          reasoning_toggle_wire: 'chat_template_kwargs',
+          reasoning_replay_policy: 'preserve_always',
+          requires_reasoning_replay_on_tool_call: true,
+          ignored_sampling_params: ['temperature'],
+          always_ignored_sampling_params: [],
+        },
+        request_config: {
+          source: 'oas-provider-config',
+          provider_kind: 'openai_compat',
+          request_path: '/chat/completions',
+          request_path_targets_responses_api: false,
+          enable_thinking: true,
+          preserve_thinking: true,
+          thinking_budget: 32768,
+          glm_replay_reasoning: true,
+        },
+        declared_spec: {
+          source: 'runtime.toml',
+          provider: {
+            id: 'runpod_mtp',
+            display_name: 'RunPod MTP',
+            protocol: 'openai-compatible-http',
+            api_format: 'chat-completions',
+            transport: 'http',
+            auth_kind: 'env:RUNPOD_API_KEY',
+            is_non_interactive: true,
+            has_capabilities: true,
+            behavior_capabilities: {
+              supports_inline_tools: true,
+              requires_per_keeper_bridging_for_bound_actor_tools: true,
+              identity_runtime_mcp_header_keys: ['x-masc-keeper'],
+              argv_prompt_preflight: false,
+              uses_anthropic_caching: false,
+              max_turns_per_attempt: null,
+              tolerates_bound_actor_fallback: false,
+            },
+            custom_header_count: 1,
+            connect_timeout_s: 120,
+          },
+          model: {
+            id: 'qwen',
+            api_name: 'Qwen/Qwen3-32B',
+            tools_support: true,
+            max_context: 128000,
+            thinking_support: true,
+            preserve_thinking: true,
+            max_thinking_budget: 32768,
+            streaming: true,
+            temperature: 0.65,
+            capabilities: {
+              source: 'runtime.toml',
+              supports_tool_choice: true,
+              supports_required_tool_choice: true,
+              supports_named_tool_choice: true,
+              supports_parallel_tool_calls: true,
+              supports_extended_thinking: true,
+              supports_reasoning_budget: true,
+              thinking_control_format: 'chat-template-kwargs',
+              supports_multimodal_inputs: true,
+              supports_image_input: true,
+              supports_audio_input: true,
+              supports_video_input: false,
+              supports_response_format_json: true,
+              supports_structured_output: true,
+            },
+            match_prefixes: ['Qwen/'],
+          },
+          binding: {
+            provider_id: 'runpod_mtp',
+            model_id: 'qwen',
+            is_default: true,
+            max_concurrent: 4,
+            price_input: 0.1,
+            price_output: 0.2,
+            keep_alive: '30m',
+            num_ctx: 131072,
+          },
+        },
+        effective_capabilities: {
+          source: 'oas-provider-config-model',
+          max_context_tokens: 131072,
+          max_output_tokens: 65536,
+          supports_tools: true,
+          supports_tool_choice: true,
+          supports_required_tool_choice: true,
+          supports_named_tool_choice: true,
+          supports_parallel_tool_calls: true,
+          supports_runtime_mcp_tools: true,
+          supports_runtime_tool_events: true,
+          supports_reasoning: true,
+          supports_extended_thinking: true,
+          supports_reasoning_budget: true,
+          accepted_reasoning_efforts: ['low', 'medium', 'high'],
+          thinking_control_format: 'chat-template-kwargs',
+          preserve_thinking_control_format: 'chat-template-kwargs-preserve-thinking',
+          reasoning_output_format: 'split-reasoning-fields',
+          reasoning_streaming_format: {
+            kind: 'delta-reasoning-field',
+            field: 'reasoning_content',
+          },
+          supports_multimodal_inputs: true,
+          supports_image_input: true,
+          supports_audio_input: true,
+          supports_video_input: false,
+          ignored_sampling_parameters: ['temperature'],
+        },
+      },
+    ],
+  }
+}
+
+function nativeProbePayload() {
+  return {
+    generated_at: '2026-04-10T00:00:00Z',
+    cache_hit: true,
+    cache_age_sec: 3.2,
+    probe: {
+      source: 'ollama native runtime',
+      effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
+      server_url: 'http://127.0.0.1:11434',
+      model_loaded_before_probe: true,
+      model_loaded_after_probe: true,
+      loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
+      runs: [
+        {
+          load_duration_ms: 33.6,
+          prompt_tokens_per_second: 26.1,
+          generation_tokens_per_second: 65.5,
+        },
+      ],
+      kv_cache_assessment: {
+        signal: 'likely_reused',
+        note: 'Prompt evaluation time dropped materially on a repeated prompt.',
+        prompt_eval_duration_reduction_ratio: 0.42,
+      },
+      observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
+      errors: [],
+      probe_ok: true,
+    },
+  }
+}
+
+function providerProbePayload() {
+  return {
+    generated_at: '2026-07-05T00:00:00Z',
+    cache_hit: false,
+    cache_age_sec: 0,
+    probe: {
+      source: 'runtime.toml',
+      status: 'reachable',
+      checked_at: '2026-07-05T00:00:00Z',
+      probe_ok: true,
+      summary: {
+        runtimes: 1,
+        probed: 1,
+        reachable: 1,
+        failed: 0,
+        skipped: 0,
+        default_runtime_id: 'runpod_mtp.qwen',
+      },
+      providers: [
+        {
+          runtime_id: 'runpod_mtp.qwen',
+          provider_id: 'runpod_mtp',
+          model_api_name: 'Qwen/Qwen3-32B',
+          status: 'reachable',
+          reachable: true,
+          http_status: 200,
+          latency_ms: 42.5,
+          probe_url: 'https://example.invalid/v1/models',
+        },
+      ],
+      errors: [],
+    },
+  }
+}
+
+function runtimeResolutionPayload() {
+  return {
+    status: 'ready',
+    warnings: [],
+    base_path: { path: '/tmp/runtime-input', exists: true, source: 'input' },
+    workspace_path: { path: '/tmp/workspace', exists: true, source: 'workspace' },
+    resolved_base_path: { path: '/tmp/workspace', exists: true, source: 'resolved_base' },
+    data_root: { path: '/tmp/workspace/.masc', exists: true, source: 'runtime_data' },
+    prompt_markdown_dir: { path: '/tmp/shared/prompts', exists: true, source: 'prompt_registry' },
+    server_repo_path: { path: '/tmp/masc', exists: true, source: 'server_binary' },
+    server_repo_git_commit: 'feedbee',
+    workspace_git_commit: 'cafef00d',
+    resolved_base_git_commit: 'cafef00d',
+    source_mismatch: false,
+    server_workspace_mismatch: false,
+    diagnostics: [],
+    build: {
+      release_version: 'dev',
+      commit: 'deadbee',
+      started_at: '2026-03-27T00:00:00Z',
+      uptime_seconds: 42,
+    },
+    keeper_runtime: null,
+    fleet_safety: null,
+    fd_accountant: null,
+    cdal: null,
+  }
+}
+
+function responseForPayload(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function stubRuntimeFetch(probePayload: unknown = nativeProbePayload()): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      const path = typeof input === 'string' ? input : input.toString()
+      if (path.includes('/api/v1/providers')) return responseForPayload(runtimeProvidersPayload())
+      if (path.includes('/api/v1/dashboard/runtime-probe')) return responseForPayload(probePayload)
+      return responseForPayload({})
+    }),
+  )
+}
+
 describe('ConfigResolutionPanel', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    // Mint a fresh Response per fetch call: a Response body is
-    // single-use, and fetchDashboardRuntimeProbe issues more than one
-    // fetch since #20734 (ensureDevToken precedes the probe request).
-    // A shared mockResolvedValue Response makes the second read fail
-    // with "failed to read response body".
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockImplementation(async () =>
-        new Response(
-          JSON.stringify({
-            generated_at: '2026-04-10T00:00:00Z',
-            cache_hit: true,
-            cache_age_sec: 3.2,
-            probe: {
-              source: 'ollama native runtime',
-              effective_model: 'qwen3.5:35b-a3b-coding-nvfp4',
-              server_url: 'http://127.0.0.1:11434',
-              model_loaded_before_probe: true,
-              model_loaded_after_probe: true,
-              loaded_models_after: [{ name: 'qwen3.5:35b-a3b-coding-nvfp4' }],
-              runs: [
-                {
-                  load_duration_ms: 33.6,
-                  prompt_tokens_per_second: 26.1,
-                  generation_tokens_per_second: 65.5,
-                },
-              ],
-              kv_cache_assessment: {
-                signal: 'likely_reused',
-                note: 'Prompt evaluation time dropped materially on a repeated prompt.',
-                prompt_eval_duration_reduction_ratio: 0.42,
-              },
-              observations: ['Repeated prompt_eval_duration_ms dropped enough to suggest repeated-prefix reuse.'],
-              errors: [],
-              probe_ok: true,
-            },
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        ),
-      ),
-    )
+    resetRuntimeCatalog()
+    stubRuntimeFetch()
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
+    resetRuntimeCatalog()
     vi.unstubAllGlobals()
   })
 
@@ -170,6 +379,42 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('default')
     expect(container.textContent).not.toContain('derived')
   })
+
+  it('surfaces provider catalog spec beside provider reachability rows', async () => {
+    resetRuntimeCatalog()
+    stubRuntimeFetch(providerProbePayload())
+
+    render(
+      html`<${ConfigResolutionPanel}
+        resolution=${{
+          status: 'ready',
+          warnings: [],
+          config_root: { path: '/tmp/root-config', exists: true, source: 'env' },
+          prompts: { path: '/tmp/root-config/prompts', exists: true, source: 'env' },
+          keepers: { path: '/tmp/root-config/keepers', exists: true, source: 'env' },
+          personas: { path: '/tmp/root-config/personas', exists: true, source: 'env' },
+        }}
+        runtimeResolution=${runtimeResolutionPayload()}
+      />`,
+      container,
+    )
+
+    await flush()
+
+    expect(container.textContent).toContain('provider reachability')
+    expect(container.textContent).toContain('provider catalog')
+    expect(container.textContent).toContain('1 runtime specs')
+    expect(container.querySelector('[data-testid="runtime-probe-catalog-spec"]')).not.toBeNull()
+    expect(container.textContent).toContain('effective')
+    expect(container.textContent).toContain('source:oas-provider-config-model')
+    expect(container.textContent).toContain('request')
+    expect(container.textContent).toContain('think:on')
+    expect(container.textContent).toContain('declared')
+    expect(container.textContent).toContain('api:chat-completions')
+    expect(container.textContent).toContain('policy')
+    expect(container.textContent).toContain('wire:chat_template_kwargs')
+  })
+
   it('keeps the full path on hover title and hides duplicate source badges', () => {
     render(
       html`<${ConfigResolutionPanel}

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -6,11 +6,14 @@ import type {
   DashboardConfigResolutionItem,
   DashboardRuntimeDiagnostic,
   DashboardRuntimeProbeResponse,
+  DashboardRuntimeProviderProbe,
+  DashboardRuntimeProviderSnapshot,
   DashboardRuntimeResolution,
   KeeperRuntimeResolved,
   KeeperRuntimeField,
 } from '../../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../../api/dashboard'
+import type { AsyncState } from '../../lib/async-state'
 import { MISSING_DATA_DASH, errorToString } from '../../lib/format-string'
 import { Btn } from '../btn'
 import { SectionCard } from '../common/card'
@@ -18,6 +21,18 @@ import { StatusChip } from '../common/status-chip'
 import { CopyIdButton } from '../common/copy-id-button'
 import { TextInput } from '../common/input'
 import { formatNumber } from '../../lib/format-number'
+import {
+  findRuntimeCatalogEntry,
+  loadRuntimeCatalog,
+  runtimeCatalogState,
+} from '../../lib/runtime-catalog-resource'
+import {
+  runtimeCatalogDeclaredSpec,
+  runtimeCatalogEffectiveCapabilities,
+  runtimeCatalogParameterPolicy,
+  runtimeCatalogRequestConfig,
+  runtimeCatalogSnapshotFacts,
+} from '../../lib/runtime-provider-summary'
 
 function ConfigCard({
   class: cx,
@@ -347,6 +362,42 @@ function providerProbeLabel(status: string | null | undefined, reachable: boolea
   }
 }
 
+function runtimeProbeCatalogEntry(
+  catalog: readonly DashboardRuntimeProviderSnapshot[],
+  probe: DashboardRuntimeProviderProbe,
+): DashboardRuntimeProviderSnapshot | null {
+  if (probe.runtime_id) {
+    const entry = findRuntimeCatalogEntry(catalog, probe.runtime_id)
+    if (entry) return entry
+  }
+  const providerId = probe.provider_id?.trim()
+  if (!providerId) return null
+  return catalog.find(entry => {
+    const ids = [entry.provider_id, entry.provider]
+    return ids.some(id => id?.trim() === providerId)
+  }) ?? null
+}
+
+function runtimeProbeCatalogStatus(
+  state: AsyncState<DashboardRuntimeProviderSnapshot[]>,
+  probe: DashboardRuntimeProviderProbe,
+): string {
+  if (state.status === 'idle' || state.status === 'loading') return `catalog ${state.status}`
+  if (state.status === 'error') return `catalog error: ${state.message}`
+  return `catalog missing for ${probe.runtime_id ?? probe.provider_id ?? '(unknown runtime)'}`
+}
+
+function runtimeProbeCatalogRows(entry: DashboardRuntimeProviderSnapshot): readonly (readonly [string, string])[] {
+  const rows: Array<readonly [string, string | null]> = [
+    ['snapshot', runtimeCatalogSnapshotFacts(entry)],
+    ['effective', runtimeCatalogEffectiveCapabilities(entry)],
+    ['request', runtimeCatalogRequestConfig(entry)],
+    ['declared', runtimeCatalogDeclaredSpec(entry)],
+    ['policy', runtimeCatalogParameterPolicy(entry)],
+  ]
+  return rows.filter((row): row is readonly [string, string] => typeof row[1] === 'string' && row[1].trim() !== '')
+}
+
 const KEEPER_RUNTIME_ROWS: Array<{
   key: keyof KeeperRuntimeResolved
   label: string
@@ -472,6 +523,7 @@ function RuntimeProbePanel() {
 
   useEffect(() => {
     void load(false)
+    loadRuntimeCatalog()
   }, [])
 
   const probe = state.value.data?.probe
@@ -481,6 +533,11 @@ function RuntimeProbePanel() {
   const providerProbes = probe?.providers ?? []
   const providerSummary = probe?.summary ?? null
   const isProviderProbe = providerProbes.length > 0
+  const catalog = runtimeCatalogState.value
+  const catalogEntries = catalog.status === 'loaded' ? catalog.data : []
+  const catalogSummary = catalog.status === 'loaded'
+    ? `${catalogEntries.length} runtime specs`
+    : catalog.status
 
   return html`
     <${ConfigCard} class="mt-4 px-4 py-4">
@@ -532,9 +589,13 @@ function RuntimeProbePanel() {
                     <${RuntimeMetaRow} label="failed" value=${String(providerSummary?.failed ?? 0)} />
                     <${RuntimeMetaRow} label="skipped" value=${String(providerSummary?.skipped ?? 0)} />
                     <${RuntimeMetaRow} label="default runtime" value=${providerSummary?.default_runtime_id ?? MISSING_DATA_DASH} />
+                    <${RuntimeMetaRow} label="provider catalog" value=${catalogSummary} />
                   </div>
                   <div class="mt-3 flex flex-col gap-2">
-                    ${providerProbes.map(item => html`
+                    ${providerProbes.map(item => {
+                      const catalogEntry = runtimeProbeCatalogEntry(catalogEntries, item)
+                      const catalogRows = catalogEntry ? runtimeProbeCatalogRows(catalogEntry) : []
+                      return html`
                       <div class="v2-lab-row rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-3 py-2">
                         <div class="flex flex-wrap items-center justify-between gap-2">
                           <div class="min-w-0">
@@ -549,8 +610,27 @@ function RuntimeProbePanel() {
                         ${item.error
                           ? html`<div class="mt-2 text-2xs text-[var(--rose-fg)]">${item.error}</div>`
                           : null}
+                        ${catalogRows.length > 0
+                          ? html`
+                            <div
+                              class="mt-2 grid gap-1 border-t border-[var(--color-border-default)]/60 pt-2 text-2xs"
+                              data-testid="runtime-probe-catalog-spec"
+                            >
+                              ${catalogRows.map(([label, value]) => html`
+                                <div class="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-2">
+                                  <span class="text-[var(--color-fg-muted)]">${label}</span>
+                                  <span class="min-w-0 break-words font-mono text-[var(--color-fg-secondary)]" title=${value}>${value}</span>
+                                </div>
+                              `)}
+                            </div>
+                          `
+                          : html`
+                            <div class="mt-2 text-2xs text-[var(--color-fg-muted)]" data-testid="runtime-probe-catalog-status">
+                              ${runtimeProbeCatalogStatus(catalog, item)}
+                            </div>
+                          `}
                       </div>
-                    `)}
+                    `})}
                   </div>
                 `
               : html`


### PR DESCRIPTION
Summary
- Load the shared runtime catalog in the config resolution runtime probe panel.
- Show matching Provider x Model catalog summary beside provider reachability rows.
- Surface explicit catalog loading/error/missing status instead of silently omitting missing specs.

Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/config-resolution-panel.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check