### PR TITLE
dashboard: stop treating task counts as goal metrics

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -1,3 +1,6 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { render } from 'preact'
 import { describe, it, expect } from 'vitest'
 import {
   priorityStars,
@@ -11,6 +14,8 @@ import {
   taskSearchQuery,
   countAwaitingVerificationTasks,
   countAwaitingVerificationInTree,
+  formatProgressPct,
+  TaskProgressBar,
 } from './goal-helpers'
 import type { Task } from '../../types'
 
@@ -241,6 +246,34 @@ describe('resetTaskSearch', () => {
     taskSearchQuery.value = 'something'
     resetTaskSearch()
     expect(taskSearchQuery.value).toBe('')
+  })
+})
+
+// ================================================================
+// task completion display truth
+// ================================================================
+
+describe('task completion display truth', () => {
+  it('does not turn zero linked tasks into a fake 0% goal progress value', () => {
+    expect(formatProgressPct({ done: 0, total: 0, ratio: 0 })).toBe('no linked tasks')
+  })
+
+  it('formats linked task counts instead of a goal-attainment percentage', () => {
+    expect(formatProgressPct({ done: 2, total: 5, ratio: 0.4 })).toBe('2/5 tasks')
+  })
+
+  it('renders the task-count meter with neutral source metadata', () => {
+    const container = document.createElement('div')
+    render(html`<${TaskProgressBar} done=${1} total=${4} size="sm" />`, container)
+
+    const meter = container.querySelector('[data-task-count-meter]') as HTMLElement | null
+    expect(meter).not.toBeNull()
+    expect(meter?.getAttribute('data-task-count-meter-pct')).toBe('25')
+    expect(meter?.getAttribute('title')).toContain('not a goal-attainment metric')
+    const fill = meter?.firstElementChild as HTMLElement | null
+    expect(fill?.className).toContain('bg-[var(--color-accent-fg)]')
+    expect(fill?.className).not.toContain('status-ok')
+    expect(fill?.className).not.toContain('status-err')
   })
 })
 

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -61,12 +61,10 @@ export function goalById(id: string): Goal | undefined {
   return goals.value.find(g => g.id === id)
 }
 
-// -- Derived progress (Phase F-G1) -------------------------------
-// Phase 2 spec (`design-system/preview/cb-group-d.jsx:GoalHorizonTrack`)
-// expects per-goal `progress` / `total`. Backend `Goal` does not surface
-// these — we derive them from linked tasks. `cancelled` tasks are excluded
-// from the denominator so cancelling a task moves the ratio up rather than
-// counting it as failed work.
+// -- Task completion counts --------------------------------------
+// This is not a goal-attainment metric. It is a count of linked tasks from
+// the planning store, used only where the richer dashboard goal-tree summary
+// is not available yet. Metric/attainment truth belongs to the goal-tree API.
 
 export interface GoalProgress {
   done: number
@@ -109,24 +107,23 @@ export function goalProgressFor(goalId: string): GoalProgress {
 }
 
 export function formatProgressPct(p: GoalProgress): string {
-  if (p.total === 0) return '0%'
-  return `${Math.round(p.ratio * 100)}%`
+  if (p.total === 0) return 'no linked tasks'
+  return `${p.done}/${p.total} tasks`
 }
 
 export function TaskProgressBar({ done, total, size = 'md' }: { done: number; total: number; size?: 'sm' | 'md' }) {
   const ratio = total > 0 ? done / total : 0
   const pct = Math.round(ratio * 100)
-  const barColor =
-    pct >= 80 ? 'var(--color-status-ok)'
-    : pct >= 50 ? 'var(--amber-bright)'
-    : pct >= 20 ? 'var(--color-orange-400)'
-    : 'var(--color-status-err)'
-
   const h = size === 'sm' ? 'h-1.5' : 'h-2.5'
   return html`
     <div class="flex items-center gap-2">
-      <div class="flex-1 ${h} rounded-[var(--r-0)] bg-[var(--color-bg-hover)] overflow-hidden">
-        <div class="${h} rounded-[var(--r-0)] transition-[width] duration-[var(--t-xslow)]" style="width:${pct}%;background:${barColor}"></div>
+      <div
+        class="flex-1 ${h} rounded-[var(--r-0)] bg-[var(--color-bg-hover)] overflow-hidden"
+        title="Linked task completion count. This is not a goal-attainment metric."
+        data-task-count-meter
+        data-task-count-meter-pct=${pct}
+      >
+        <div class="${h} rounded-[var(--r-0)] transition-[width] duration-[var(--t-xslow)] bg-[var(--color-accent-fg)]" style="width:${pct}%"></div>
       </div>
       <span class="text-2xs font-semibold tabular-nums text-text-muted w-14 text-right">${done}/${total}</span>
     </div>

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -265,6 +265,78 @@ describe('GoalTree', () => {
       .toContain('requested completion')
   })
 
+  it('does not render unevaluated metric completion pct as goal progress truth', async () => {
+    const goal = {
+      ...makeGoal('goal-unevaluated', 'Unevaluated metric goal'),
+      metric: '신규 3축 갭 해소 PR 수',
+      target_value: '6',
+      task_count: 15,
+      task_done_count: 5,
+      attainment: {
+        state: 'in_progress',
+        basis: 'metric_target_count',
+        metric: '신규 3축 갭 해소 PR 수',
+        metric_evaluation: 'unevaluated',
+        target_value: '6',
+        target_parse_status: 'parseable',
+        unit: 'count',
+        observed_value: 5,
+        target_numeric: 6,
+        attainment_pct: 83,
+        task_done_count: 5,
+        task_count: 15,
+        note: 'Derived from completed linked tasks against a count target.',
+      },
+      completion_summary: {
+        state: 'in_progress',
+        pct: 83,
+        pct_source: 'attainment',
+        attainment_state: 'in_progress',
+        attainment_basis: 'metric_target_count',
+        metric_evaluation: 'unevaluated',
+        task_total: 15,
+        task_done: 5,
+        task_open: 9,
+        is_complete: false,
+        is_terminal: false,
+        ready_to_request_completion: false,
+        gate: 'none',
+        requires_verifier: false,
+        requires_completion_approval: false,
+        active_verification_request: false,
+        blocking_source: 'goal_linkage',
+        blocking_reason: 'Linked tasks exist, but no keeper is assigned or linked.',
+      },
+    } satisfies GoalTreeNode
+    const treePayload: DashboardGoalsTreeResponse = {
+      tree: [goal],
+      summary: { ...emptySummary(), total_goals: 1, active_goals: 1, total_tasks: 15, done_tasks: 5 },
+    }
+    const detailPayload: DashboardGoalDetailResponse = {
+      goal,
+      linked_tasks: [],
+      linked_keepers: [],
+      approvals: [],
+      execution_receipts: [],
+      timeline: [],
+    }
+    mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
+    mocks.fetchDashboardGoalDetail.mockResolvedValue(detailPayload)
+
+    const { container } = render(html`<${GoalTree} />`)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-detail-panel').getAttribute('data-selected-goal-id'))
+        .toBe('goal-unevaluated')
+    })
+    const completion = container.querySelector('[data-goal-completion-summary]') as HTMLElement | null
+    expect(completion).not.toBeNull()
+    expect(completion?.textContent).toContain('metric unevaluated')
+    expect(completion?.textContent).not.toContain('83%')
+    expect(completion?.querySelector('[data-goal-completion-metric-evaluation="unevaluated"]'))
+      .not.toBeNull()
+  })
+
   it('renders a loading indicator while the goal tree is refreshing', async () => {
     const goal = makeGoal('goal-loading', 'Loading goal')
     const treePayload: DashboardGoalsTreeResponse = {

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -32,6 +32,7 @@ import type { GoalDossierProps, GoalDossierRelatedItem } from '../memory/goal-do
 import type {
   DashboardGoalDetailResponse,
   DashboardWorkspaceFsmViolation,
+  GoalCompletionSummary,
   GoalDetailKeeper,
   GoalDetailTimelineEvent,
   GoalFsmProjection,
@@ -764,6 +765,27 @@ function TreeTask({ task }: { task: GoalTreeTask }) {
   `
 }
 
+function goalCompletionPctLabel(summary: GoalCompletionSummary): string {
+  if (summary.metric_evaluation === 'unevaluated') return 'metric unevaluated'
+  if (summary.pct == null) return 'unmeasured'
+  return `${summary.pct}%`
+}
+
+function goalCompletionTruthTitle(
+  summary: GoalCompletionSummary,
+  label: string,
+  gateLabel: string,
+): string {
+  const pct = summary.pct == null ? 'pct=unmeasured' : `pct=${summary.pct}%`
+  const metric = `metric_evaluation=${summary.metric_evaluation}`
+  const source = `source=${summary.pct_source}`
+  const unevaluated =
+    summary.metric_evaluation === 'unevaluated'
+      ? '; pct is task-derived/proxy data, not an evaluated goal metric'
+      : ''
+  return `Completion: ${label}; ${pct}; ${source}; ${metric}; ${gateLabel}${unevaluated}`
+}
+
 function GoalCompletionStrip({
   node,
   compact = false,
@@ -774,14 +796,17 @@ function GoalCompletionStrip({
   const summary = goalCompletionSummaryForNode(node)
   const tone = goalCompletionTone(summary)
   const label = goalCompletionLabel(summary)
-  const pctLabel = summary.pct == null ? 'unmeasured' : `${summary.pct}%`
+  const pctLabel = goalCompletionPctLabel(summary)
   const gateLabel = goalCompletionGateLabel(summary)
+  const title = goalCompletionTruthTitle(summary, label, gateLabel)
 
   if (compact) {
     return html`
       <span
         class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold ${completionToneClass(tone)}"
-        title=${`Completion: ${label}; ${pctLabel}; ${gateLabel}`}
+        title=${title}
+        data-goal-completion-metric-evaluation=${summary.metric_evaluation}
+        data-goal-completion-pct-source=${summary.pct_source}
       >
         ${label}
       </span>
@@ -802,7 +827,14 @@ function GoalCompletionStrip({
       <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-2 text-xs">
         <div class="rounded-[var(--r-1)] border border-card-border/50 bg-[var(--color-bg-surface)] p-2">
           <div class="text-3xs uppercase text-text-muted">basis</div>
-          <div class="mt-1 font-semibold text-text-strong">${summary.pct_source}</div>
+          <div
+            class="mt-1 font-semibold text-text-strong"
+            title=${title}
+            data-goal-completion-metric-evaluation=${summary.metric_evaluation}
+            data-goal-completion-pct-source=${summary.pct_source}
+          >
+            ${summary.pct_source}${summary.metric_evaluation === 'unevaluated' ? ' · metric unevaluated' : ''}
+          </div>
         </div>
         <div class="rounded-[var(--r-1)] border border-card-border/50 bg-[var(--color-bg-surface)] p-2">
           <div class="text-3xs uppercase text-text-muted">task open</div>

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -639,7 +639,7 @@ describe('IdeActivityPanel', () => {
       expect(container.textContent).toContain('GOAL TRACK')
       expect(container.textContent).toContain('Runtime goal')
       expect(container.textContent).toContain('1/2 tasks')
-      expect(container.textContent).toContain('50%')
+      expect(container.textContent).not.toContain('50%')
     })
 
     const goalLinks = [...container.querySelectorAll<HTMLButtonElement>('.ide-run-progress-goal-links button')]
@@ -898,7 +898,7 @@ describe('IdeActivityPanel', () => {
         taskId: 'task-runtime',
         title: 'Runtime goal',
         progress: { done: 1, total: 2, ratio: 0.5 },
-        progressLabel: '50%',
+        progressLabel: '1/2 tasks',
       },
     })
     expect(summary.surfaceCounts.map(surface => [surface.label, surface.count])).toEqual([

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -124,7 +124,7 @@ describe('IdeKeeperWorkPanel', () => {
     expect(container.textContent).not.toContain('no active keeper task')
   })
 
-  it('shows the current task goal progress and links back to planning', () => {
+  it('shows the current task goal task count and links back to planning', () => {
     keepers.value = [keeperFixture()]
     goals.value = [goalFixture()]
     tasks.value = [
@@ -135,10 +135,10 @@ describe('IdeKeeperWorkPanel', () => {
 
     render(h(IdeKeeperWorkPanel, { keeperName: 'sangsu' }), container)
 
-    expect(container.textContent).toContain('GOAL PROGRESS')
+    expect(container.textContent).toContain('GOAL TASKS')
     expect(container.textContent).toContain('Runtime goal')
     expect(container.textContent).toContain('1/2 tasks')
-    expect(container.textContent).toContain('50%')
+    expect(container.textContent).not.toContain('50%')
     expect(container.textContent).toContain('Goal')
     expect(container.textContent).toContain('Task')
     expect(container.querySelectorAll('.ide-keeper-work-card.v2-ide-card').length).toBeGreaterThanOrEqual(1)

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -205,21 +205,20 @@ function GoalProgressCard(
   progress: GoalProgress | null,
   taskId: string | null,
 ) {
-  const pctLabel = progress ? formatProgressPct(progress) : '0%'
+  const taskCountLabel = progress ? formatProgressPct(progress) : 'no linked tasks'
   const pctValue = progress ? Math.round(progress.ratio * 100) : 0
   return html`
-    <div class="ide-keeper-work-goal v2-ide-card" role="status" aria-label=${`Goal ${goal.id} progress ${pctLabel}`}>
+    <div class="ide-keeper-work-goal v2-ide-card" role="status" aria-label=${`Goal ${goal.id} linked task count ${taskCountLabel}`}>
       <div class="ide-keeper-work-card-top">
-        <span>GOAL PROGRESS</span>
+        <span>GOAL TASKS</span>
         <span>${goalPhaseLabel(goal.phase)}</span>
       </div>
       <strong title=${goal.title}>${goal.title}</strong>
-      <div class="ide-keeper-work-goal-bar" aria-hidden="true">
+      <div class="ide-keeper-work-goal-bar" aria-hidden="true" title="Linked task count only; metric attainment is not available on this IDE summary card.">
         <span style=${{ width: `${pctValue}%` }} />
       </div>
       <div class="ide-keeper-work-goal-meta">
-        <span>${progress ? `${progress.done}/${progress.total} tasks` : '0/0 tasks'}</span>
-        <span>${pctLabel}</span>
+        <span>${taskCountLabel}</span>
         ${goal.metric ? html`<span title=${goal.metric}>${goal.metric}</span>` : null}
         ${goal.target_value ? html`<span title=${goal.target_value}>target ${goal.target_value}</span>` : null}
       </div>


### PR DESCRIPTION
## Summary

Goal/Task dashboard truth slice for the keeper-v2 matrix.

- stops presenting linked-task counts as evaluated goal progress
- shows `metric unevaluated` when `completion_summary.metric_evaluation=unevaluated`, even if backend also sends a task-derived pct
- changes the IDE keeper work card from `GOAL PROGRESS` to `GOAL TASKS` because that surface only has flat planning task counts
- keeps backend-provided counts visible, but removes client-side threshold color judgement from the task-count meter

## Evidence

Live endpoint sample checked on 2026-07-05 02:45:33 KST:

- `GET http://127.0.0.1:8935/api/v1/dashboard/goals`
- first live goal had `attainment.metric_evaluation = "unevaluated"`
- the same goal also had `attainment.attainment_pct = 83` and `completion_summary.pct = 83`
- UI now renders this as `metric unevaluated`, not as a goal metric success percentage

## Verification

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/goals/goal-helpers.test.ts src/components/goals/goal-tree.test.ts src/components/goals/goal-metric-unevaluated.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `git diff --cached --check`

Rendered checks:

- `env MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935 pnpm --dir dashboard exec vite --host 127.0.0.1 --port 5175`
- `pnpm --dir dashboard exec playwright screenshot --viewport-size 1440,1000 --wait-for-selector '[data-goal-completion-metric-evaluation="unevaluated"]' --timeout 30000 'http://127.0.0.1:5175/dashboard/#workspace?section=planning&view=goal-tree' /private/tmp/masc-goal-metric-truth-desktop.png`
- `pnpm --dir dashboard exec playwright screenshot --viewport-size 390,844 --full-page --wait-for-selector '[data-goal-completion-metric-evaluation="unevaluated"]' --timeout 30000 'http://127.0.0.1:5175/dashboard/#workspace?section=planning&view=goal-tree' /private/tmp/masc-goal-metric-truth-mobile-full.png`

## Notes

- No OCaml/Dune local build was run; dashboard-only change and CI remains the Dune authority.
- This does not change backend goal semantics. It only stops the dashboard from over-claiming metric truth from task-count proxy values.
