### PR TITLE
fix(ci): diff pull request scopes from merge base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,14 @@ jobs:
 
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             bash scripts/ci/git-fetch-retry.sh origin "${GITHUB_BASE_REF}" --depth=200
-            base_ref="origin/${GITHUB_BASE_REF}"
             head_ref="${GITHUB_HEAD_SHA}"
+            base_branch_ref="origin/${GITHUB_BASE_REF}"
+            if ! merge_base="$(git merge-base "${base_branch_ref}" "${head_ref}")"; then
+              echo "::warning::Unable to resolve PR merge-base at depth=200; deepening ${GITHUB_BASE_REF} history"
+              bash scripts/ci/git-fetch-retry.sh origin "${GITHUB_BASE_REF}" --deepen=1000
+              merge_base="$(git merge-base "${base_branch_ref}" "${head_ref}")"
+            fi
+            base_ref="${merge_base}"
           elif [ -n "${GITHUB_BEFORE}" ] && [ "${GITHUB_BEFORE}" != "0000000000000000000000000000000000000000" ]; then
             base_ref="${GITHUB_BEFORE}"
           fi


### PR DESCRIPTION
## Summary
- compute PR changed-file scopes from merge-base(base, head) instead of origin/base..head
- avoid stale branches pulling unrelated main changes into CI surface detection
- keep an explicit deepen retry before failing merge-base resolution

## Evidence
- #23260 PR files: dashboard/src/components/runtime-monitor.test.ts, dashboard/src/components/runtime-monitor.ts, dashboard/src/lib/runtime-provider-summary.ts
- Existing CI run 28713892942 detected stale extra lib/test files and set build=true/tla=true
- Local simulation with merge-base returns only the 3 #23260 dashboard files

## Validation
- bash scripts/lint/yaml-syntax.sh
- local merge-base diff simulation for #23260 head
