### PR TITLE
Show runtime catalog spec in keeper detail

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -1,10 +1,24 @@
 import { h } from 'preact'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
+const runtimeCatalogRefs = vi.hoisted(() => ({
+  fetchRuntimeProviders: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', async () => {
+  const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
+  return {
+    ...actual,
+    fetchRuntimeProviders: runtimeCatalogRefs.fetchRuntimeProviders,
+  }
+})
+
+import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
 import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
+import { resetRuntimeCatalog } from '../lib/runtime-catalog-resource'
 import {
   AllowlistPreview,
   BudgetSourceBadge,
@@ -23,9 +37,92 @@ import {
   resolveKeeperToolPolicy,
 } from './keeper-detail-source'
 
+beforeEach(() => {
+  resetRuntimeCatalog()
+  runtimeCatalogRefs.fetchRuntimeProviders.mockReset()
+  runtimeCatalogRefs.fetchRuntimeProviders.mockResolvedValue({ providers: [] })
+})
+
 afterEach(() => {
   cleanup()
+  resetRuntimeCatalog()
 })
+
+function runtimeProviderFixture(runtimeId: string): DashboardRuntimeProviderSnapshot {
+  const [providerId, modelId] = runtimeId.split('.', 2)
+  return {
+    provider: runtimeId,
+    runtime_id: runtimeId,
+    provider_id: providerId,
+    provider_display_name: 'Runtime Provider',
+    model_id: modelId,
+    model_api_name: 'model-api',
+    capabilities_declared: true,
+    supports_multimodal_inputs: true,
+    supports_image_input: true,
+    supports_audio_input: true,
+    source: 'runtime.toml',
+    models: ['model-api'],
+    effective_capabilities: {
+      source: 'oas-provider-config-model',
+      accepted_reasoning_efforts: null,
+      thinking_control_format: 'responses.reasoning',
+      supports_multimodal_inputs: true,
+      supports_image_input: true,
+      supports_audio_input: true,
+      supports_video_input: false,
+      ignored_sampling_parameters: ['temperature'],
+      supported_models: ['model-api'],
+    },
+    parameter_policy: {
+      reasoning_toggle_wire: 'responses.reasoning',
+      reasoning_replay_policy: 'preserve',
+      requires_reasoning_replay_on_tool_call: true,
+      ignored_sampling_params: ['top_k'],
+      always_ignored_sampling_params: ['min_p'],
+    },
+    request_config: {
+      source: 'runtime.toml',
+      provider_kind: 'cloud',
+      request_path_targets_responses_api: true,
+    },
+    declared_spec: {
+      source: 'runtime.toml',
+      provider: {
+        id: providerId,
+        display_name: 'Runtime Provider',
+        protocol: 'openai-compatible-http',
+        api_format: 'responses',
+        transport: 'http',
+        auth_kind: 'env:RUNTIME_API_KEY',
+        is_non_interactive: true,
+        behavior_capabilities: {
+          identity_runtime_mcp_header_keys: ['x-masc-keeper'],
+        },
+      },
+      model: {
+        id: modelId,
+        api_name: 'model-api',
+        match_prefixes: ['model-'],
+        capabilities: {
+          source: 'runtime.toml',
+          thinking_control_format: 'responses.reasoning',
+          supports_multimodal_inputs: true,
+          supports_image_input: true,
+          supports_audio_input: true,
+          supports_video_input: false,
+        },
+      },
+      binding: {
+        provider_id: providerId,
+        model_id: modelId,
+        is_default: false,
+        max_concurrent: 4,
+        keep_alive: '10m',
+      },
+    },
+  }
+}
 
 describe('resolveKeeperToolPolicy', () => {
   it('uses keeper config as the authoritative policy source', () => {
@@ -706,6 +803,8 @@ describe('RuntimeLensSection', () => {
     render(h(RuntimeLensSection, { trace: runtimeTraceFixture() }))
 
     expect(screen.getByTestId('runtime-lens')).toBeInTheDocument()
+    expect(screen.getByTestId('runtime-lens-catalog-spec')).toHaveTextContent('no runtime id observed')
+    expect(runtimeCatalogRefs.fetchRuntimeProviders).not.toHaveBeenCalled()
     expect(screen.getByText('keeper / agent turn')).toBeInTheDocument()
     expect(screen.getByText('7 / 3')).toBeInTheDocument()
     expect(screen.getByText('trace id')).toBeInTheDocument()
@@ -741,6 +840,40 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('inj 1/1 · flush success 1 · error 0 · ep/proc ep 2 · proc 1')).toBeInTheDocument()
     expect(screen.getByText('Provider')).toBeInTheDocument()
     expect(screen.getByText('Tool Runtime')).toBeInTheDocument()
+  })
+
+  it('renders catalog-backed runtime spec for the observed live runtime id', async () => {
+    const trace = runtimeTraceFixture()
+    trace.runtime_lens.axes.config_drift = {
+      ...trace.runtime_lens.axes.config_drift,
+      present: true,
+      status: 'override',
+      has_live_override: true,
+      runtime_override: true,
+      override_fields: ['runtime_id'],
+      default_runtime_id: 'provider.default',
+      live_runtime_id: 'provider.model',
+    }
+    runtimeCatalogRefs.fetchRuntimeProviders.mockResolvedValueOnce({
+      providers: [runtimeProviderFixture('provider.model')],
+    })
+
+    render(h(RuntimeLensSection, { trace }))
+
+    await waitFor(() => expect(screen.getByTestId('runtime-lens-catalog-spec')).toHaveTextContent('runtime catalog spec'))
+    const catalog = screen.getByTestId('runtime-lens-catalog-spec')
+    expect(catalog).toHaveTextContent('runtime catalog spec')
+    expect(catalog).toHaveTextContent('provider.model')
+    expect(catalog).toHaveTextContent('Runtime Provider')
+    expect(catalog).toHaveTextContent('model-api')
+    expect(catalog).toHaveTextContent('source:oas-provider-config-model')
+    expect(catalog).toHaveTextContent('input:multimodal,image,audio')
+    expect(catalog).toHaveTextContent('wire:responses.reasoning')
+    expect(catalog).toHaveTextContent('tool-call-replay:required')
+    expect(catalog).toHaveTextContent('responses-api')
+    expect(catalog).toHaveTextContent('declared')
+    expect(catalog).toHaveTextContent('api:responses')
+    expect(catalog).toHaveTextContent('concurrency:4')
   })
 
   it('renders an empty state while runtime trace is unavailable', () => {

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -20,6 +20,7 @@ import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { toolCategory } from './tool-call-shared'
 import { formatIndependentCounters, formatRatioPair } from './counter-format'
 import type { Keeper } from '../types'
+import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
 import type {
   KeeperCompositeSnapshot,
   KeeperSecretProjection,
@@ -51,6 +52,18 @@ import {
   peekKeeperConfigLoadStatus,
   peekLoadedKeeperConfig,
 } from './keeper-config-panel'
+import {
+  findRuntimeCatalogEntry,
+  loadRuntimeCatalog,
+  runtimeCatalogState,
+} from '../lib/runtime-catalog-resource'
+import {
+  runtimeCatalogDeclaredSpec,
+  runtimeCatalogEffectiveCapabilities,
+  runtimeCatalogParameterPolicy,
+  runtimeCatalogRequestConfig,
+  runtimeCatalogSnapshotFacts,
+} from '../lib/runtime-provider-summary'
 
 const DEFAULT_ALLOWLIST_PREVIEW_LIMIT = 12
 
@@ -1123,6 +1136,112 @@ function RuntimeLensLaneRow({ lane }: { lane: KeeperRuntimeLensLane }) {
   `
 }
 
+function runtimeLensCatalogId(trace: KeeperRuntimeTraceResponse): string | null {
+  const drift = trace.runtime_lens.axes.config_drift
+  const live = drift.live_runtime_id?.trim()
+  if (live) return live
+  const defaultRuntime = drift.default_runtime_id?.trim()
+  return defaultRuntime || null
+}
+
+function RuntimeLensCatalogDetailRow({ label, value }: { label: string; value: string }) {
+  return html`
+    <div class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-3 py-2">
+      <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${label}</div>
+      <div class="break-words font-mono text-3xs leading-relaxed text-[var(--color-fg-secondary)]" title=${value}>${value}</div>
+    </div>
+  `
+}
+
+function RuntimeLensCatalogSummary({
+  runtimeId,
+  entry,
+  status,
+  errorMessage,
+}: {
+  runtimeId: string | null
+  entry: DashboardRuntimeProviderSnapshot | null
+  status: 'idle' | 'loading' | 'loaded' | 'error'
+  errorMessage?: string
+}) {
+  if (!runtimeId) {
+    return html`
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
+        data-testid="runtime-lens-catalog-spec"
+      >
+        runtime catalog: no runtime id observed in config drift axis
+      </div>
+    `
+  }
+
+  if (status === 'idle' || status === 'loading') {
+    return html`
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs text-[var(--color-fg-muted)]"
+        data-testid="runtime-lens-catalog-spec"
+      >
+        runtime catalog loading: ${runtimeId}
+      </div>
+    `
+  }
+
+  if (status === 'error') {
+    return html`
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--color-status-bad)]/40 bg-[var(--color-bg-surface)] px-3 py-2 text-2xs text-[var(--color-status-bad)]"
+        data-testid="runtime-lens-catalog-spec"
+      >
+        runtime catalog error for ${runtimeId}: ${errorMessage ?? 'unknown error'}
+      </div>
+    `
+  }
+
+  if (!entry) {
+    return html`
+      <div
+        class="rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--color-bg-surface)] px-3 py-2 text-2xs text-[var(--color-status-warn)]"
+        data-testid="runtime-lens-catalog-spec"
+      >
+        runtime catalog missing exact entry: ${runtimeId}
+      </div>
+    `
+  }
+
+  const provider = entry.provider_display_name ?? entry.provider_id ?? entry.provider
+  const model = entry.model_api_name ?? entry.model_id ?? 'model unknown'
+  const snapshotFacts = runtimeCatalogSnapshotFacts(entry)
+  const effectiveCapabilities = runtimeCatalogEffectiveCapabilities(entry)
+  const declaredSpec = runtimeCatalogDeclaredSpec(entry)
+  const parameterPolicy = runtimeCatalogParameterPolicy(entry)
+  const requestConfig = runtimeCatalogRequestConfig(entry)
+
+  return html`
+    <div
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      data-testid="runtime-lens-catalog-spec"
+    >
+      <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div class="min-w-0">
+          <div class="text-xs font-semibold text-[var(--color-fg-primary)]">runtime catalog spec</div>
+          <div class="truncate font-mono text-3xs text-[var(--color-fg-muted)]" title=${runtimeId}>${runtimeId}</div>
+        </div>
+        <div class="min-w-0 text-right">
+          <div class="truncate text-xs font-medium text-[var(--color-fg-secondary)]" title=${provider}>${provider}</div>
+          <div class="truncate font-mono text-3xs text-[var(--color-fg-muted)]" title=${model}>${model}</div>
+        </div>
+      </div>
+      <div class="grid gap-1.5">
+        ${snapshotFacts ? html`<${RuntimeLensCatalogDetailRow} label="snapshot" value=${snapshotFacts} />` : null}
+        ${effectiveCapabilities ? html`<${RuntimeLensCatalogDetailRow} label="effective" value=${effectiveCapabilities} />` : null}
+        ${declaredSpec ? html`<${RuntimeLensCatalogDetailRow} label="declared" value=${declaredSpec} />` : null}
+        ${parameterPolicy ? html`<${RuntimeLensCatalogDetailRow} label="policy" value=${parameterPolicy} />` : null}
+        ${requestConfig ? html`<${RuntimeLensCatalogDetailRow} label="request" value=${requestConfig} />` : null}
+      </div>
+    </div>
+  `
+}
+
 export function RuntimeLensSection({
   trace,
 }: {
@@ -1146,6 +1265,12 @@ export function RuntimeLensSection({
   const artifacts = trace.linked_artifacts
   const clockEdges = lens.clock_edges
   const clockGroups = lens.clock_groups
+  const runtimeId = runtimeLensCatalogId(trace)
+  if (runtimeId) loadRuntimeCatalog()
+  const catalogState = runtimeCatalogState.value
+  const runtimeCatalogEntry = catalogState.status === 'loaded'
+    ? findRuntimeCatalogEntry(catalogState.data, runtimeId ?? '')
+    : null
   const swimlanes = [
     lens.swimlanes.keeper,
     lens.swimlanes.masc_policy_runtime,
@@ -1204,6 +1329,13 @@ export function RuntimeLensSection({
         <${SignalRow} label="memory evidence" value=${runtimeTraceMemoryEvidence(trace)} />
         <${SignalRow} label="stale reason" value=${compactToken(trace.stale_reason, 'none')} />
       </div>
+
+      <${RuntimeLensCatalogSummary}
+        runtimeId=${runtimeId}
+        entry=${runtimeCatalogEntry}
+        status=${catalogState.status}
+        errorMessage=${catalogState.status === 'error' ? catalogState.message : undefined}
+      />
 
       <div class="flex flex-wrap gap-1.5 min-w-0" data-testid="runtime-lens-gaps">
         ${lens.gaps.length > 0


### PR DESCRIPTION
## Summary
- show the `/api/v1/providers` runtime catalog spec inside the keeper detail runtime lens
- resolve the catalog entry from the observed `config_drift` runtime id only: live runtime first, then default runtime
- render explicit loading/error/missing/no-runtime-id states instead of silently omitting catalog evidence

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
