### PR TITLE
feat(dashboard): show binding runtime catalog spec

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -1,10 +1,43 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { fireEvent } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
 import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
 import { keepers } from '../store'
 import type { Keeper } from '../types/core'
+
+const runtimeCatalogMock = vi.hoisted(() => ({
+  state: {
+    value: { status: 'idle' } as
+      | { status: 'idle' }
+      | { status: 'loading' }
+      | { status: 'error'; message: string }
+      | { status: 'loaded'; data: unknown[] },
+  },
+  loadRuntimeCatalog: vi.fn(),
+}))
+
+vi.mock('../lib/runtime-catalog-resource', () => ({
+  findRuntimeCatalogEntry: (
+    catalog: readonly { runtime_id?: string | null; provider?: string | null }[],
+    runtimeId: string,
+  ) => {
+    const needle = runtimeId.trim()
+    if (needle === '') return null
+    return catalog.find(item =>
+      [item.runtime_id, item.provider].some(id => id?.trim() === needle),
+    ) ?? null
+  },
+  loadRuntimeCatalog: runtimeCatalogMock.loadRuntimeCatalog,
+  runtimeCatalogState: runtimeCatalogMock.state,
+}))
+
+afterEach(() => {
+  runtimeCatalogMock.state.value = { status: 'idle' }
+  runtimeCatalogMock.loadRuntimeCatalog.mockReset()
+  keepers.value = []
+})
 
 // Regression for the live ~/.masc/config/runtime.toml shape: keeper names
 // under [runtime.assignments] are quoted TOML keys. The parser fix lives in
@@ -63,10 +96,6 @@ function mountEditor(
 }
 
 describe('RuntimeEnvironmentEditor assignments section', () => {
-  afterEach(() => {
-    keepers.value = []
-  })
-
   it('groups a keeper with an explicit quoted-key assignment as pinned, not default 폴백', () => {
     const fixtureKeepers: Keeper[] = [
       { name: 'nick0cave', status: 'idle' },
@@ -262,6 +291,111 @@ describe('RuntimeEnvironmentEditor capability projection', () => {
     expect(text).toContain('$0.14/$0.28 per M')
     expect(text).toContain('effort reasoning-effort')
     expect(text).not.toContain('가격/effort 미수집')
+
+    render(null, container)
+  })
+
+  it('shows the exact runtime catalog spec for a binding id', async () => {
+    const catalogEntry: DashboardRuntimeProviderSnapshot = {
+      provider: 'ollama_cloud.minimax-m3',
+      runtime_id: 'ollama_cloud.minimax-m3',
+      provider_id: 'ollama_cloud',
+      provider_display_name: 'Ollama Cloud',
+      model_id: 'minimax-m3',
+      model_api_name: 'minimax-m3-api',
+      model_count: 1,
+      max_context: 524288,
+      capabilities_declared: true,
+      supports_response_format_json: true,
+      supports_structured_output: true,
+      supports_multimodal_inputs: true,
+      source: 'oas-provider-config-model',
+      models: ['minimax-m3-api'],
+      effective_capabilities: {
+        source: 'oas-provider-config-model',
+        max_context_tokens: 524288,
+        max_output_tokens: 65536,
+        supports_tools: true,
+        supports_tool_choice: true,
+        supports_required_tool_choice: true,
+        supports_named_tool_choice: true,
+        supports_parallel_tool_calls: true,
+        supports_response_format_json: true,
+        supports_structured_output: true,
+        supports_reasoning: true,
+        accepted_reasoning_efforts: ['low', 'medium'],
+        thinking_control_format: 'responses.reasoning',
+        ignored_sampling_parameters: ['temperature'],
+        supported_models: ['minimax-m3-api'],
+      },
+      request_config: {
+        source: 'oas-provider-config-model',
+        provider_kind: 'openai_compat',
+        request_path_targets_responses_api: true,
+        enable_thinking: true,
+        resolved_reasoning_effort: 'medium',
+        response_format: { kind: 'json_schema', has_schema: true },
+      },
+      declared_spec: {
+        source: 'runtime.toml',
+        provider: {
+          protocol: 'openai-compatible-http',
+          api_format: 'chat-completions',
+          transport: 'http',
+          auth_kind: 'env',
+        },
+        model: {
+          api_name: 'minimax-m3-api',
+          max_context: 524288,
+          tools_support: true,
+          thinking_support: true,
+          streaming: true,
+          capabilities: {
+            thinking_control_format: 'responses.reasoning',
+            supports_response_format_json: true,
+            supports_structured_output: true,
+          },
+          match_prefixes: [],
+        },
+        binding: {
+          provider_id: 'ollama_cloud',
+          model_id: 'minimax-m3',
+          is_default: true,
+          price_input: 0.14,
+          price_output: 0.28,
+        },
+      },
+      parameter_policy: {
+        reasoning_toggle_wire: 'responses.reasoning',
+        reasoning_replay_policy: 'preserve',
+        requires_reasoning_replay_on_tool_call: true,
+        ignored_sampling_params: ['temperature'],
+        always_ignored_sampling_params: ['top_k'],
+      },
+    }
+    runtimeCatalogMock.state.value = { status: 'loaded', data: [catalogEntry] }
+
+    const container = document.createElement('div')
+    mountSection(container, 'bindings')
+
+    await waitFor(() => expect(runtimeCatalogMock.loadRuntimeCatalog).toHaveBeenCalledTimes(1))
+    const spec = container.querySelector(
+      '[data-testid="runtime-binding-ollama_cloud.minimax-m3-catalog-spec"]',
+    )
+    const text = spec?.textContent ?? ''
+
+    expect(text).toContain('runtime catalog')
+    expect(text).toContain('ollama_cloud.minimax-m3')
+    expect(text).toContain('provider')
+    expect(text).toContain('Ollama Cloud')
+    expect(text).toContain('model')
+    expect(text).toContain('minimax-m3-api')
+    expect(text).toContain('source:oas-provider-config-model')
+    expect(text).toContain('kind:openai_compat')
+    expect(text).toContain('responses-api')
+    expect(text).toContain('api:chat-completions')
+    expect(text).toContain('wire:responses.reasoning')
+    expect(text).toContain('tool-call-replay:required')
 
     render(null, container)
   })

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,5 +1,18 @@
 import { html } from 'htm/preact'
-import { useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
+import {
+  findRuntimeCatalogEntry,
+  loadRuntimeCatalog,
+  runtimeCatalogState,
+} from '../lib/runtime-catalog-resource'
+import {
+  runtimeCatalogDeclaredSpec,
+  runtimeCatalogEffectiveCapabilities,
+  runtimeCatalogParameterPolicy,
+  runtimeCatalogRequestConfig,
+  runtimeCatalogSnapshotFacts,
+} from '../lib/runtime-provider-summary'
 import {
   isRuntimeTomlNonMaterializableProtocol,
   isReservedRuntimeTomlId,
@@ -182,6 +195,68 @@ function capChip(on: boolean, label: string) {
   return html`<span class="rt-cap ${on ? 'on' : ''}">${on ? '✓' : '·'} ${label}</span>`
 }
 
+interface RuntimeCatalogBindingRow {
+  readonly key: string
+  readonly label: string
+  readonly value: string | null
+}
+
+interface RuntimeCatalogBindingResolvedRow extends RuntimeCatalogBindingRow {
+  readonly value: string
+}
+
+function runtimeCatalogBindingRows(entry: DashboardRuntimeProviderSnapshot): ReadonlyArray<RuntimeCatalogBindingRow> {
+  return [
+    { key: 'runtime', label: 'runtime catalog', value: entry.runtime_id ?? entry.provider },
+    { key: 'provider', label: 'provider', value: entry.provider_display_name ?? entry.provider_id ?? entry.provider },
+    { key: 'model', label: 'model', value: entry.model_api_name ?? entry.model_id ?? null },
+    { key: 'snapshot', label: 'snapshot', value: runtimeCatalogSnapshotFacts(entry) },
+    { key: 'effective', label: 'effective', value: runtimeCatalogEffectiveCapabilities(entry) },
+    { key: 'request', label: 'request', value: runtimeCatalogRequestConfig(entry) },
+    { key: 'declared', label: 'declared', value: runtimeCatalogDeclaredSpec(entry) },
+    { key: 'policy', label: 'policy', value: runtimeCatalogParameterPolicy(entry) },
+  ]
+}
+
+function RuntimeBindingCatalogSpec({ runtimeId }: { runtimeId: string }) {
+  const state = runtimeCatalogState.value
+  if (state.status === 'idle' || state.status === 'loading') {
+    return html`
+      <div class="rt-bind-catalog mono" data-testid=${`runtime-binding-${runtimeId}-catalog-spec`}>
+        <span class="rt-bind-catalog-state">runtime catalog loading: ${runtimeId}</span>
+      </div>
+    `
+  }
+  if (state.status === 'error') {
+    return html`
+      <div class="rt-bind-catalog mono" data-testid=${`runtime-binding-${runtimeId}-catalog-spec`}>
+        <span class="rt-bind-catalog-state">runtime catalog error for ${runtimeId}: ${state.message}</span>
+      </div>
+    `
+  }
+  const entry = findRuntimeCatalogEntry(state.data, runtimeId)
+  if (!entry) {
+    return html`
+      <div class="rt-bind-catalog mono" data-testid=${`runtime-binding-${runtimeId}-catalog-spec`}>
+        <span class="rt-bind-catalog-state">runtime catalog missing exact entry: ${runtimeId}</span>
+      </div>
+    `
+  }
+  const rows = runtimeCatalogBindingRows(entry).filter((row): row is RuntimeCatalogBindingResolvedRow =>
+    typeof row.value === 'string' && row.value.trim() !== '',
+  )
+  return html`
+    <div class="rt-bind-catalog mono" data-testid=${`runtime-binding-${runtimeId}-catalog-spec`}>
+      ${rows.map(row => html`
+        <div class="rt-bind-catalog-row" data-testid=${`runtime-binding-${runtimeId}-catalog-${row.key}`}>
+          <span class="rt-bind-catalog-k">${row.label}</span>
+          <span class="rt-bind-catalog-v">${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 // keeper.status -> StatusDot tone (bg). Mirrors copilot-dock's run/idle/bad
 // split; tone classes are the existing --color-status-* tokens.
 function keeperDotTone(status: string): string {
@@ -241,6 +316,12 @@ export function RuntimeEnvironmentEditor({
     const query = modelQuery.toLowerCase()
     return model.id.toLowerCase().includes(query) || model.apiName.toLowerCase().includes(query)
   })
+
+  useEffect(() => {
+    if (section === 'bindings' && runtimeIds.length > 0) {
+      loadRuntimeCatalog()
+    }
+  }, [section, runtimeIds.length])
 
   function updateDefault(runtimeId: string) {
     if (runtimeId !== '') onRoutingChange('default', runtimeId)
@@ -1009,6 +1090,7 @@ export function RuntimeEnvironmentEditor({
                       ? html` · $${binding.priceInput}/$${binding.priceOutput ?? '—'} per M`
                       : null}
                   </div>
+                  <${RuntimeBindingCatalogSpec} runtimeId=${binding.id} />
                 </div>
                 <div class="rt-bind-fields">
                   <label class="rt-mini">

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -88,6 +88,11 @@
 .rt-bind-key { font-size: 12.5px; color: var(--text-bright); display: flex; align-items: center; gap: 8px; }
 .rt-default-tag { font-family: var(--font-ui); font-size: var(--fs-9); letter-spacing: 0.08em; text-transform: uppercase; color: var(--volt); border: 1px solid var(--volt-dim); padding: 1px 6px; border-radius: var(--radius-pill); }
 .rt-bind-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 3px; }
+.rt-bind-catalog { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; color: var(--text-dim); font-size: var(--fs-10); line-height: 1.35; max-width: 100%; }
+.rt-bind-catalog-row { display: grid; grid-template-columns: minmax(84px, max-content) minmax(0, 1fr); gap: 9px; align-items: baseline; }
+.rt-bind-catalog-k { color: var(--text-mid); }
+.rt-bind-catalog-v { color: var(--text-dim); overflow-wrap: anywhere; }
+.rt-bind-catalog-state { color: var(--text-mid); overflow-wrap: anywhere; }
 .rt-bind-fields { display: flex; gap: 10px; flex: none; }
 .rt-mini { display: flex; flex-direction: column; gap: 3px; font-family: var(--font-ui); font-size: var(--fs-9); letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-dim); }
 .rt-input-sm { width: 58px; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 5px 7px; color: var(--text-bright); font-size: 11.5px; }

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -400,6 +400,25 @@ html[data-skin="v2"] .rt-default-tag {
   border-radius: var(--radius-pill);
 }
 html[data-skin="v2"] .rt-bind-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 3px; } /* runtime.css:86 */
+html[data-skin="v2"] .rt-bind-catalog {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-dim);
+  font-size: var(--fs-10);
+  line-height: 1.35;
+  max-width: 100%;
+}
+html[data-skin="v2"] .rt-bind-catalog-row {
+  display: grid;
+  grid-template-columns: minmax(84px, max-content) minmax(0, 1fr);
+  gap: 9px;
+  align-items: baseline;
+}
+html[data-skin="v2"] .rt-bind-catalog-k { color: var(--text-mid); }
+html[data-skin="v2"] .rt-bind-catalog-v { color: var(--text-dim); overflow-wrap: anywhere; }
+html[data-skin="v2"] .rt-bind-catalog-state { color: var(--text-mid); overflow-wrap: anywhere; }
 html[data-skin="v2"] .rt-bind-fields { display: flex; gap: 10px; flex: none; } /* runtime.css:87 */
 html[data-skin="v2"] .rt-mini {
   /* runtime.css:88 */


### PR DESCRIPTION
## Summary

- show the shared runtime catalog snapshot under each runtime.toml binding row
- reuse existing runtime provider summary helpers for snapshot/effective/request/declared/policy facts
- load the catalog only when the structured editor is on the bindings section

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/runtime-environment-editor.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
