### PR TITLE
[codex] Polish board surface interactions

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -10,7 +10,9 @@ import {
   fetchBoardKarmaLedger,
   fetchBoardPost,
   fetchBoardReactions,
+  normalizeBoardContextInferenceSubmission,
   normalizeBoardKarmaLedger,
+  requestBoardContextInference,
   sanitizeBoardTitle,
   toggleReaction,
   voteComment,
@@ -1237,5 +1239,84 @@ describe('board reactions', () => {
       last_ok: true,
       sample_count: 1,
     })
+  })
+})
+
+describe('board context inference', () => {
+  it('normalizes queued keeper submissions', () => {
+    expect(normalizeBoardContextInferenceSubmission({
+      ok: true,
+      request_id: 'kmsg-1',
+      keeper_name: 'luna',
+      post_id: 'post-1',
+      status: 'queued',
+      target_source: 'explicit_target',
+      message: 'queued',
+    })).toEqual({
+      ok: true,
+      requestId: 'kmsg-1',
+      keeperName: 'luna',
+      postId: 'post-1',
+      status: 'queued',
+      targetSource: 'explicit_target',
+      message: 'queued',
+    })
+  })
+
+  it('rejects malformed context inference submissions', () => {
+    expect(normalizeBoardContextInferenceSubmission({ ok: true, keeper_name: 'luna' })).toBeNull()
+    expect(normalizeBoardContextInferenceSubmission({ ok: false })).toBeNull()
+  })
+
+  it('requests board context inference with an explicit target keeper', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        request_id: 'kmsg-ctx',
+        keeper_name: 'luna',
+        post_id: 'post-1',
+        status: 'queued',
+        target_source: 'explicit_target',
+      }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await requestBoardContextInference(' post-1 ', ' luna ')
+
+    expect(result).toMatchObject({
+      requestId: 'kmsg-ctx',
+      keeperName: 'luna',
+      postId: 'post-1',
+      status: 'queued',
+      targetSource: 'explicit_target',
+    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/board/context-inference')
+    expect(JSON.parse(String(init.body))).toEqual({
+      post_id: 'post-1',
+      target_keeper: 'luna',
+    })
+  })
+
+  it('fails when the server returns a malformed context inference response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        keeper_name: 'luna',
+        post_id: 'post-1',
+        status: 'queued',
+      }), {
+        status: 202,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(requestBoardContextInference('post-1')).rejects.toThrow(
+      'Malformed board context inference response',
+    )
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -28,6 +28,18 @@ export interface BoardFlair {
   label: string
 }
 
+export type BoardContextInferenceTargetSource = 'explicit_target' | 'post_author'
+
+export interface BoardContextInferenceSubmission {
+  ok: true
+  requestId: string
+  keeperName: string
+  postId: string
+  status: string
+  targetSource?: BoardContextInferenceTargetSource
+  message?: string
+}
+
 function toIsoTimestamp(value: unknown): string | null {
   if (typeof value === 'string' && value.trim()) return value
   if (typeof value !== 'number' || Number.isNaN(value)) return null
@@ -841,6 +853,30 @@ function normalizeBoardReactionToggleResult(raw: unknown): BoardReactionToggleRe
   }
 }
 
+function normalizeBoardContextInferenceTargetSource(raw: unknown): BoardContextInferenceTargetSource | undefined {
+  const source = asString(raw, '').trim()
+  return source === 'explicit_target' || source === 'post_author' ? source : undefined
+}
+
+export function normalizeBoardContextInferenceSubmission(raw: unknown): BoardContextInferenceSubmission | null {
+  if (!isRecord(raw) || raw.ok !== true) return null
+  const requestId = asString(raw.request_id, '').trim()
+  const keeperName = asString(raw.keeper_name, '').trim()
+  const postId = asString(raw.post_id, '').trim()
+  const status = asString(raw.status, '').trim()
+  if (!requestId || !keeperName || !postId || !status) return null
+  const message = asString(raw.message, '').trim()
+  return {
+    ok: true,
+    requestId,
+    keeperName,
+    postId,
+    status,
+    targetSource: normalizeBoardContextInferenceTargetSource(raw.target_source),
+    message: message || undefined,
+  }
+}
+
 export async function fetchBoard(
   sortBy?: BoardSortMode,
   options?: {
@@ -997,6 +1033,25 @@ export async function toggleReaction(
     }
     return normalized
   })
+}
+
+export async function requestBoardContextInference(
+  postId: string,
+  targetKeeper?: string,
+): Promise<BoardContextInferenceSubmission> {
+  const normalizedPostId = postId.trim()
+  if (!normalizedPostId) throw new Error('postId is required')
+  const body: Record<string, string> = {
+    post_id: normalizedPostId,
+  }
+  const normalizedTargetKeeper = targetKeeper?.trim()
+  if (normalizedTargetKeeper) body.target_keeper = normalizedTargetKeeper
+  const raw = await post<unknown>('/api/v1/board/context-inference', body)
+  const normalized = normalizeBoardContextInferenceSubmission(raw)
+  if (!normalized) {
+    throw new Error('Malformed board context inference response')
+  }
+  return normalized
 }
 
 export function createPost(

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -491,6 +491,11 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
   const source = asString(raw.source, '').trim() || undefined
   const band = normalizeBoardContributorBand(raw.band)
   const autonomyLevel = asString(raw.autonomy_level, '').trim() || undefined
+  const rawEvidenceState = asString(raw.evidence_state, '').trim()
+  const evidenceState = rawEvidenceState === 'measured' || rawEvidenceState === 'default'
+    ? rawEvidenceState
+    : undefined
+
   if (
     score === undefined
     && completionRate === undefined
@@ -502,6 +507,7 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
     && source === undefined
     && band === undefined
     && autonomyLevel === undefined
+    && evidenceState === undefined
   ) return null
   return {
     score,
@@ -514,6 +520,7 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
     accountability_score: accountabilityScore,
     autonomy_level: autonomyLevel,
     thompson_confidence: thompsonConfidence,
+    evidence_state: evidenceState,
   }
 }
 

--- a/dashboard/src/components/board/board-state.test.ts
+++ b/dashboard/src/components/board/board-state.test.ts
@@ -109,30 +109,32 @@ describe('contentCategory', () => {
     expect(contentCategory(makePost({ post_kind: 'system' }))).toBe('system')
   })
 
-  it('classifies review by title keywords', () => {
-    expect(contentCategory(makePost({ title: 'verdict: 코드 품질 양호' }))).toBe('review')
-    expect(contentCategory(makePost({ title: 'PR 리뷰 완료' }))).toBe('review')
-    expect(contentCategory(makePost({ title: 'Code Review 결과' }))).toBe('review')
+  it('uses explicit content category metadata before fallback policy', () => {
+    expect(contentCategory(makePost({
+      title: '일반 제목',
+      meta: { content_category: 'review' },
+    }))).toBe('review')
+    expect(contentCategory(makePost({
+      title: '일반 제목',
+      meta: { board_category: 'notice' },
+    }))).toBe('notice')
   })
 
-  it('classifies notice by title keywords', () => {
-    expect(contentCategory(makePost({ title: 'alert: 서버 과부하' }))).toBe('notice')
-    expect(contentCategory(makePost({ title: '상태 업데이트' }))).toBe('notice')
-    expect(contentCategory(makePost({ title: 'Warning: CPU 90%' }))).toBe('notice')
+  it('does not use flair labels as category signals', () => {
+    expect(contentCategory(makePost({ flair: 'review' }))).toBe('article')
+    expect(contentCategory(makePost({ flair: 'notice', post_kind: 'automation' }))).toBe('notice')
   })
 
-  it('classifies article by title keywords', () => {
-    expect(contentCategory(makePost({ title: '기술 탐색: WebAssembly' }))).toBe('article')
-    expect(contentCategory(makePost({ title: '연구 결과' }))).toBe('article')
-    expect(contentCategory(makePost({ title: 'POC 실험' }))).toBe('article')
+  it('does not infer category from title keywords', () => {
+    expect(contentCategory(makePost({ title: 'verdict: 코드 품질 양호' }))).toBe('article')
+    expect(contentCategory(makePost({ title: 'alert: 서버 과부하' }))).toBe('article')
   })
 
-  it('falls back to article for long body content', () => {
-    const longBody = 'x'.repeat(301)
-    expect(contentCategory(makePost({ title: '일반 제목', body: longBody }))).toBe('article')
+  it('falls back to notice for automation posts', () => {
+    expect(contentCategory(makePost({ post_kind: 'automation' }))).toBe('notice')
   })
 
-  it('falls back to article for default case', () => {
+  it('falls back to article for direct posts', () => {
     expect(contentCategory(makePost({ title: '일반 제목', body: '보통 내용' }))).toBe('article')
   })
 })

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -57,7 +57,7 @@ export const SORT_MODES: { id: BoardSortMode; label: string }[] = [
   { id: 'hot', label: '인기순' },
   { id: 'trending', label: '급상승' },
   { id: 'updated', label: '최근 갱신' },
-  { id: 'discussed', label: '토론 많은 순' },
+  { id: 'discussed', label: '댓글 많은 순' },
 ]
 
 // ── Signals: detail view ───────────────────────────────────────────
@@ -187,30 +187,31 @@ export function boardPostKind(post: BoardPost): 'direct' | 'automation' | 'syste
 // ── Content-based category (replaces post_kind for filtering) ─────
 export type ContentCategory = 'article' | 'review' | 'notice' | 'system'
 
-const ARTICLE_SIGNALS = ['기술 탐색', '탐색:', '발견', 'poc', '실험', '연구', '분석', '핵심 발견', '코드스멜', 'exploration', 'research']
-const REVIEW_SIGNALS = ['verdict', '판정', 'pr 리뷰', 'pr review', 'code review', '리뷰:', 'issue 사냥', 'issue 현황', 'assignee', 'needs-evidence', '우회 누적']
-const NOTICE_SIGNALS = ['alert', '알림', '경고', 'warning', '상태 업데이트', 'status', 'sprint 상태', '불균형 경고', 'health check']
-
-function matchesAny(text: string, signals: string[]): boolean {
-  const lower = text.toLowerCase()
-  return signals.some(s => lower.includes(s))
+function contentCategoryFromValue(value: unknown): ContentCategory | null {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  switch (normalized) {
+    case 'article':
+      return 'article'
+    case 'review':
+      return 'review'
+    case 'notice':
+      return 'notice'
+    case 'system':
+      return 'system'
+    default:
+      return null
+  }
 }
 
 export function contentCategory(post: BoardPost): ContentCategory {
   if (boardPostKind(post) === 'system') return 'system'
 
-  const title = post.title || ''
-  const body = post.body || ''
+  const metaCategory = contentCategoryFromValue(post.meta?.content_category)
+    ?? contentCategoryFromValue(post.meta?.category)
+    ?? contentCategoryFromValue(post.meta?.board_category)
+  if (metaCategory) return metaCategory
 
-  if (matchesAny(title, REVIEW_SIGNALS)) return 'review'
-  if (matchesAny(title, NOTICE_SIGNALS)) return 'notice'
-  if (matchesAny(title, ARTICLE_SIGNALS)) return 'article'
-
-  // Fallback: long content is likely an article, short is notice
-  if (body.length > 300) return 'article'
-  if (body.length < 80 && boardPostKind(post) !== 'direct') return 'notice'
-
-  return 'article'
+  return boardPostKind(post) === 'automation' ? 'notice' : 'article'
 }
 
 export const CONTENT_CATEGORIES: { id: ContentCategory; label: string; icon: string }[] = [

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -135,28 +135,28 @@ function getLocalStorageItem(key: string): string | null {
 
 // ── Content category classifier tests ─────────────────────────────
 describe('contentCategory', () => {
-  it('classifies tech exploration titles as article', () => {
-    const post = makePost({ id: '1', title: '기술 탐색: GraphRAG', author: 'ani1999', body: 'long content...' })
+  it('classifies direct posts as article without title heuristics', () => {
+    const post = makePost({ id: '1', title: '기술 탐색: GraphRAG', author: 'ani1999', body: 'long content...', post_kind: 'direct' })
     expect(contentCategory(post)).toBe('article')
   })
 
-  it('classifies verdict titles as review', () => {
-    const post = makePost({ id: '2', title: 'Verdict: 7건 일괄 판정', author: 'verdict', body: 'details' })
+  it('classifies explicit category metadata as review', () => {
+    const post = makePost({ id: '2', title: 'ordinary title', author: 'verdict', body: 'details', meta: { category: 'review' } })
     expect(contentCategory(post)).toBe('review')
   })
 
-  it('classifies PR review titles as review', () => {
-    const post = makePost({ id: '3', title: 'PR 리뷰: #7106 refactor', author: 'sojin', body: 'review content' })
-    expect(contentCategory(post)).toBe('review')
+  it('ignores non-canonical category metadata tokens', () => {
+    const post = makePost({ id: '3', title: 'ordinary title', author: 'sojin', body: 'review content', meta: { content_category: 'verdict' }, post_kind: 'direct' })
+    expect(contentCategory(post)).toBe('article')
   })
 
-  it('classifies alert titles as notice', () => {
-    const post = makePost({ id: '4', title: 'PR/Task 불균형 경고', author: 'poe', body: 'alert details' })
-    expect(contentCategory(post)).toBe('notice')
+  it('does not classify flair labels as categories', () => {
+    const post = makePost({ id: '4', title: 'PR/Task 불균형 경고', author: 'poe', body: 'alert details', flair: 'status', post_kind: 'direct' })
+    expect(contentCategory(post)).toBe('article')
   })
 
-  it('classifies status update titles as notice', () => {
-    const post = makePost({ id: '5', title: 'Sprint 상태 업데이트 #3', author: 'poe', body: 'status info' })
+  it('classifies automation fallback as notice', () => {
+    const post = makePost({ id: '5', title: 'Sprint 상태 업데이트 #3', author: 'poe', body: 'status info', post_kind: 'automation' })
     expect(contentCategory(post)).toBe('notice')
   })
 
@@ -165,24 +165,9 @@ describe('contentCategory', () => {
     expect(contentCategory(post)).toBe('system')
   })
 
-  it('falls back to article for long body without title signals', () => {
-    const post = makePost({ id: '7', title: 'Some random title', author: 'keeper', body: 'x'.repeat(400) })
+  it('does not classify issue-triage wording as review without explicit metadata', () => {
+    const post = makePost({ id: '9', title: 'Open Issue 20건 — Assignee 제안', author: 'sojin', body: 'proposals', post_kind: 'direct' })
     expect(contentCategory(post)).toBe('article')
-  })
-
-  it('falls back to notice for short body from non-direct author', () => {
-    const post = makePost({ id: '8', title: 'Short note', author: 'keeper', body: 'brief' })
-    expect(contentCategory(post)).toBe('notice')
-  })
-
-  it('classifies issue triage as review', () => {
-    const post = makePost({ id: '9', title: 'Open Issue 20건 — Assignee 제안', author: 'sojin', body: 'proposals' })
-    expect(contentCategory(post)).toBe('review')
-  })
-
-  it('classifies needs-evidence as review', () => {
-    const post = makePost({ id: '10', title: 'Verdict: #7112 needs-evidence', author: 'verdict', body: 'details' })
-    expect(contentCategory(post)).toBe('review')
   })
 })
 
@@ -564,6 +549,7 @@ describe('BoardSurface Component', () => {
         contributor_quality: {
           accountability_score: 0.72,
           source: 'agent_reputation',
+          board_posts: 1,
         },
       }),
     ]
@@ -571,6 +557,31 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.getByLabelText(/기여자 품질 72점/)).toHaveTextContent('품질 72')
+  })
+
+  it('hides default contributor quality priors on post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-quality-prior',
+        title: 'Quality prior',
+        body: 'content',
+        author: 'ani1999',
+        contributor_quality: {
+          accountability_score: 1,
+          source: 'agent_reputation',
+          board_posts: 0,
+          board_comments: 0,
+          completion_rate: 0,
+          response_rate: 0,
+          autonomy_level: 'standard',
+          thompson_confidence: 0.5,
+        },
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.queryByText(/품질 100/)).not.toBeInTheDocument()
   })
 
   it('renders a state block panel when the post body contains one', () => {
@@ -642,6 +653,42 @@ describe('BoardSurface Component', () => {
 
     fireEvent.click(screen.getByTestId('bd-filter-state'))
     expect(boardFilterMode.value).toBe('state')
+  })
+
+  it('changes the server-backed board sort mode from the feed head', () => {
+    boardPosts.value = [
+      makePost({ id: 'post-sort', title: 'Sort target', body: 'content', author: 'keeper', post_kind: 'direct' }),
+    ]
+
+    render(h(BoardSurface, null))
+    const sort = screen.getByTestId('bd-sort-mode') as HTMLSelectElement
+
+    expect(sort).toHaveValue('recent')
+    fireEvent.change(sort, { target: { value: 'discussed' } })
+
+    expect(boardSortMode.value).toBe('discussed')
+    expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE)
+  })
+
+  it('renders permalink, trackback, context inference, and X share actions for a post', () => {
+    boardPosts.value = [
+      makePost({ id: 'post-share', title: 'Share **this**', body: 'content', author: 'keeper', post_kind: 'direct' }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByTestId('bd-share-post-share')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-share-link-post-share')).toHaveAttribute('aria-label', '게시글 링크 복사: post-share')
+    expect(screen.getByTestId('bd-share-trackback-post-share')).toHaveAttribute('aria-label', '트랙백 링크 복사: post-share')
+    expect(screen.getByTestId('bd-context-infer-post-share')).toHaveAttribute('aria-label', '맥락 추론 요청: post-share')
+
+    const xShare = screen.getByTestId('bd-share-x-post-share') as HTMLAnchorElement
+    expect(xShare).toHaveAttribute('target', '_blank')
+    expect(xShare).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(xShare.href).toContain('https://twitter.com/intent/tweet?')
+    const xUrl = new URL(xShare.href)
+    expect(xUrl.searchParams.get('text')).toBe('Share this - MASC Board')
+    expect(xUrl.searchParams.get('url')).toContain('#board?post=post-share')
   })
 
   it('opens a thread detail side panel when a post is selected', () => {
@@ -1056,5 +1103,30 @@ describe('BoardSurface Component', () => {
     expect(sigil).not.toBeNull()
     expect(sigil?.classList.contains('op')).toBe(false)
     expect(sigil?.textContent).toBe('SA')
+  })
+
+  it('does not collapse every keeper author sigil to KE when identity key is generic', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'kp-generic-key-post',
+        title: 'keeper identity note',
+        body: 'keeper authored content',
+        author: 'keeper',
+        post_kind: 'direct',
+        author_identity: {
+          kind: 'keeper',
+          id: 'albini',
+          key: 'keeper',
+          display_name: 'albini',
+          raw: 'keeper-albini-agent',
+        },
+      }),
+    ]
+
+    const { container } = render(h(BoardSurface, null))
+
+    const sigil = container.querySelector<HTMLElement>('.bd-sigil')
+    expect(sigil).not.toBeNull()
+    expect(sigil?.textContent).toBe('AL')
   })
 })

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -9,9 +9,10 @@ import {
   BoardSurface,
   normalizeBoardDetailWidth,
 } from './board-surface'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary } from '../../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter, boardHearthFilter, boardHasMore, boardLoadingMore, messages, shellAuthSummary, keepers } from '../../store'
 import { route } from '../../router'
 import { createPost, sendBroadcast } from '../../api'
+import { requestBoardContextInference } from '../../api/board'
 import { dispatchOperatorAction, operatorSnapshot } from '../../operator-store'
 import { PAGE_SIZE, boardFlairs, boardFlairsError, boardHearths, boardHearthsError, categoryVisibleLimits, contentCategory, selectedBoardPostId, boardFilterMode, boardComposerMode } from './board-state'
 import { resetBoardLatencyMetrics } from '../../board-metrics'
@@ -47,6 +48,10 @@ vi.mock('../../api', () => ({
 
 vi.mock('../../api/actions', () => ({
   deleteBoardPost: vi.fn(),
+}))
+
+vi.mock('../../api/board', () => ({
+  requestBoardContextInference: vi.fn(),
 }))
 
 vi.mock('../../operator-store', async (importOriginal) => {
@@ -575,6 +580,7 @@ describe('BoardSurface Component', () => {
           response_rate: 0,
           autonomy_level: 'standard',
           thompson_confidence: 0.5,
+          evidence_state: 'default',
         },
       }),
     ]
@@ -582,6 +588,26 @@ describe('BoardSurface Component', () => {
     render(h(BoardSurface, null))
 
     expect(screen.queryByText(/품질 100/)).not.toBeInTheDocument()
+  })
+
+  it('renders contributor quality badges even when score is 100 if evidence_state is measured', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-quality-100-measured',
+        title: 'Quality measured 100',
+        body: 'content',
+        author: 'ani1999',
+        contributor_quality: {
+          accountability_score: 1,
+          source: 'agent_reputation',
+          evidence_state: 'measured',
+        },
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText(/기여자 품질 100점/)).toHaveTextContent('품질 100')
   })
 
   it('renders a state block panel when the post body contains one', () => {
@@ -1128,5 +1154,66 @@ describe('BoardSurface Component', () => {
     const sigil = container.querySelector<HTMLElement>('.bd-sigil')
     expect(sigil).not.toBeNull()
     expect(sigil?.textContent).toBe('AL')
+  })
+
+  it('disables context inference button for non-keeper authored posts when keepers list is empty', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-non-keeper',
+        title: 'non keeper post',
+        body: 'hello world',
+        author: 'operator',
+        post_kind: 'direct',
+        author_identity: {
+          kind: 'agent',
+          id: 'operator-1',
+          key: 'operator',
+          display_name: 'Operator',
+          raw: 'operator-1',
+        },
+      }),
+    ]
+    keepers.value = []
+
+    render(h(BoardSurface, null))
+
+    const button = screen.getByTestId('bd-context-infer-post-non-keeper') as HTMLButtonElement
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('title', '맥락 추론을 실행할 등록된 keeper가 없습니다')
+  })
+
+  it('enables context inference button for non-keeper authored posts and uses first keeper as fallback', async () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-non-keeper-2',
+        title: 'non keeper post 2',
+        body: 'hello world 2',
+        author: 'operator',
+        post_kind: 'direct',
+        author_identity: {
+          kind: 'agent',
+          id: 'operator-1',
+          key: 'operator',
+          display_name: 'Operator',
+          raw: 'operator-1',
+        },
+      }),
+    ]
+    keepers.value = [
+      { name: 'keeper-sangsu' } as any,
+      { name: 'keeper-chulsoo' } as any,
+    ]
+
+    const mockInfer = vi.mocked(requestBoardContextInference)
+    mockInfer.mockResolvedValueOnce({ keeperName: 'keeper-sangsu', score: 1.0 } as any)
+
+    render(h(BoardSurface, null))
+
+    const button = screen.getByTestId('bd-context-infer-post-non-keeper-2') as HTMLButtonElement
+    expect(button).not.toBeDisabled()
+    expect(button).toHaveAttribute('title', '맥락 추론 요청 (keeper-sangsu)')
+
+    fireEvent.click(button)
+    expect(mockInfer).toHaveBeenCalledWith('post-non-keeper-2', 'keeper-sangsu')
   })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -28,6 +28,7 @@ import { extractMentionTargets, MentionInbox, MentionInboxPanel } from './mentio
 import { PostDetail, CommentThread, CommentForm } from './post-detail'
 import { FusionBoardEvidence } from './fusion-evidence'
 import { ReactionBar } from './reaction-bar'
+import { PostShareActions } from './post-share-actions'
 import { StateBlockMessages } from './state-block-messages'
 import {
   ComposerV2,
@@ -40,8 +41,8 @@ import type { ComposerAttachmentDraft, ComposerV2Mode, ComposerVoiceDraft } from
 import { ensureStateBlockDraft, stateBlockKeys } from '../ops/ops-state'
 import { navigateBoard } from './board-route'
 import {
-  boardActorAvatarKey,
   boardActorDisplayName,
+  boardActorSigilLabel,
   boardActorTitle,
   contributorQualityBadgeClass,
   contributorQualityPercent,
@@ -85,11 +86,13 @@ import {
   refreshBoardFlairs,
   selectedBoardPostId,
   boardFilterMode,
+  boardSortMode,
   boardComposerMode,
+  SORT_MODES,
   postHasStateBlock,
   getPostStateBlock,
 } from './board-state'
-import type { BoardPost, ContentCategory, ParsedStateBlock } from './board-state'
+import type { BoardPost, BoardSortMode, ContentCategory, ParsedStateBlock } from './board-state'
 
 export const BOARD_DETAIL_WIDTH_STORAGE_KEY = 'dashboard:board-detail-width'
 export const BOARD_DETAIL_WIDTH_DEFAULT = 360
@@ -344,12 +347,12 @@ function BoardSummary() {
 }
 
 // ── Author sigil (v2) ──────────────────────────────────────────────
-function BdAuthor({ name, size = 24 }: { name: string; size?: number }) {
-  const isOperator = name.toLowerCase() === 'operator' || name.toLowerCase() === 'dashboard'
+function BdAuthor({ label, size = 24 }: { label: string; size?: number }) {
+  const isOperator = label.toLowerCase() === 'operator' || label.toLowerCase() === 'dashboard'
   // Prototype board.jsx:8 renders the operator avatar as the literal "OP"
   // glyph; keepers use a 2-letter monogram (SigilBadge style, fleet.jsx:8).
-  const label = isOperator ? 'OP' : name.slice(0, 2).toUpperCase()
-  return html`<span class=${`bd-sigil ${isOperator ? 'op' : ''}`} style=${{ width: size, height: size }}>${label}</span>`
+  const sigil = isOperator ? 'OP' : label.slice(0, 2).toUpperCase()
+  return html`<span class=${`bd-sigil ${isOperator ? 'op' : ''}`} style=${{ width: size, height: size }}>${sigil}</span>`
 }
 
 // ── State block chip (v2) ──────────────────────────────────────────
@@ -369,7 +372,7 @@ function PostCard({ post }: { post: BoardPost }) {
   const isDeleting = deletingPostId.value === post.id
   const previewBody = dedupeLeadingHeading(post.title, stripStateBlocks(post.body))
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
-  const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+  const authorSigilLabel = boardActorSigilLabel(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
@@ -450,7 +453,7 @@ function PostCard({ post }: { post: BoardPost }) {
       onKeyDown=${handlePostKeyDown}
     >
       <div class="bd-post-h">
-        <${BdAuthor} name=${authorAvatarKey} />
+        <${BdAuthor} label=${authorSigilLabel} />
         <a
           class="who"
           href=${`#monitoring/agents/${encodeURIComponent(post.author_identity?.raw ?? post.author)}`}
@@ -504,6 +507,7 @@ function PostCard({ post }: { post: BoardPost }) {
           onClick=${(event: Event) => handleVote('down', event)}
         >▼</button>
         <span class="replies">답글 ${post.comment_count}</span>
+        <${PostShareActions} post=${post} compact />
         <span class="ml-auto hidden group-hover:inline-flex items-center gap-1">
           <${ActionButton}
             variant="ghost"
@@ -596,12 +600,14 @@ function BdRail({ activeSub, onSub, onMentions }: {
   `
 }
 
-function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuery }: {
+function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuery, sortMode, onSort }: {
   activeFilter: 'all' | 'state' | 'mod'
   onFilter: (filter: 'all' | 'state' | 'mod') => void
   count: number
   contentQuery: string
   onContentQuery: (value: string) => void
+  sortMode: BoardSortMode
+  onSort: (sortMode: BoardSortMode) => void
 }) {
   const activeHearth = boardHearthFilter.value
   // Prototype board.jsx:158 renders the bare hearth label (e.g. "core/scheduler")
@@ -624,6 +630,14 @@ function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuer
         ariaLabel="게시글 본문 필터"
         onInput=${(e: Event) => onContentQuery((e.target as HTMLInputElement).value)}
         class="min-w-40 max-w-64 !px-2 !py-1 !text-xs"
+      />
+      <${Select}
+        value=${sortMode}
+        options=${SORT_MODES.map(mode => ({ value: mode.id, label: mode.label }))}
+        ariaLabel="게시글 정렬"
+        testId="bd-sort-mode"
+        class="!w-auto min-w-32 !px-2 !py-1 !text-xs"
+        onInput=${(value: string) => onSort(value as BoardSortMode)}
       />
       <span class="spacer"></span>
       ${filters.map(f => html`
@@ -716,7 +730,7 @@ function BdThreadDetail({
   }, [post.id])
 
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
-  const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+  const authorSigilLabel = boardActorSigilLabel(post.author, post.author_identity)
   const evidencePost = detailPostId.value === post.id && detailPost.value ? detailPost.value : post
 
   return html`
@@ -728,11 +742,12 @@ function BdThreadDetail({
       </div>
       <div class="bd-detail-scroll">
         <div class="bd-th">
-          <${BdAuthor} name=${authorAvatarKey} size=${26} />
+          <${BdAuthor} label=${authorSigilLabel} size=${26} />
           <div>
             <div class="bd-th-hd"><span class="who">${authorLabel}</span><span class="ts mono"><${TimeAgo} timestamp=${post.created_at} /></span></div>
             <div class="bd-th-body">
               <div class="text-sm font-semibold mb-1">${stripInlineMarkdown(post.title)}</div>
+              <div class="mb-2"><${PostShareActions} post=${post} /></div>
               <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
               <${FusionBoardEvidence} post=${evidencePost} class="mt-3" />
             </div>
@@ -1377,6 +1392,19 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
         count=${filteredByMode.length}
         contentQuery=${contentQuery}
         onContentQuery=${setContentQuery}
+        sortMode=${boardSortMode.value}
+        onSort=${(sortMode: BoardSortMode) => {
+          if (boardSortMode.value === sortMode) return
+          boardSortMode.value = sortMode
+          categoryVisibleLimits.value = {
+            article: PAGE_SIZE,
+            review: PAGE_SIZE,
+            notice: PAGE_SIZE,
+            system: PAGE_SIZE,
+          }
+          selectedBoardPostId.value = null
+          refreshBoard()
+        }}
       />
       <${BdMobileQueues}
         activeFilter=${boardFilterMode.value}

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -46,6 +46,14 @@ vi.mock('../../api/board', () => ({
   fetchBoardReactions: vi.fn().mockResolvedValue([]),
   votePost: vi.fn().mockResolvedValue(undefined),
   voteComment: vi.fn().mockResolvedValue(undefined),
+  requestBoardContextInference: vi.fn().mockResolvedValue({
+    ok: true,
+    requestId: 'kmsg-post-share',
+    keeperName: 'sleepers',
+    postId: 'post-share',
+    status: 'queued',
+    targetSource: 'explicit_target',
+  }),
   toggleReaction: vi.fn().mockResolvedValue({
     target_type: 'comment',
     target_id: 'c1',
@@ -113,7 +121,7 @@ import {
   filterCommentTree,
 } from './post-detail'
 import { detailComments } from './board-state'
-import { toggleReaction, voteComment, votePost } from '../../api/board'
+import { requestBoardContextInference, toggleReaction, voteComment, votePost } from '../../api/board'
 import type { BoardComment } from '../../types/core'
 
 afterEach(() => {
@@ -625,6 +633,43 @@ describe('PostDetail', () => {
     render(h(PostDetail, { post }))
 
     expect(screen.getByLabelText('게시글 점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
+  })
+
+  it('renders permalink, trackback, context inference, and X share actions on the full post detail route', async () => {
+    const post = {
+      id: 'post-share',
+      author: 'sleepers',
+      author_identity: {
+        kind: 'keeper',
+        id: 'sleepers',
+        key: 'keeper:sleepers',
+        display_name: 'Sleepers',
+        raw: 'sleepers',
+      },
+      title: 'Share **this**',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.getByTestId('bd-share-post-share')).toBeInTheDocument()
+    expect(screen.getByTestId('bd-share-link-post-share')).toHaveAttribute('aria-label', '게시글 링크 복사: post-share')
+    expect(screen.getByTestId('bd-share-trackback-post-share')).toHaveAttribute('aria-label', '트랙백 링크 복사: post-share')
+    expect(screen.getByTestId('bd-context-infer-post-share')).toHaveAttribute('aria-label', '맥락 추론 요청: post-share')
+    expect(screen.getByTestId('bd-share-x-post-share')).toHaveAttribute('href', expect.stringContaining('https://twitter.com/intent/tweet?'))
+
+    fireEvent.click(screen.getByTestId('bd-context-infer-post-share'))
+
+    await waitFor(() => {
+      expect(requestBoardContextInference).toHaveBeenCalledWith('post-share', 'sleepers')
+    })
   })
 
   it('renders board visibility audit details on post detail', () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -17,6 +17,7 @@ import { route } from '../../router'
 import { votePost, voteComment } from '../../api/board'
 import { ModerationBadge } from './moderation-badge'
 import { ReactionBar } from './reaction-bar'
+import { PostShareActions } from './post-share-actions'
 import { FusionBoardEvidence } from './fusion-evidence'
 import {
   boardActorAvatarKey,
@@ -578,6 +579,9 @@ export function PostDetail({ post }: { post: BoardPost }) {
         <div class="flex flex-col gap-4">
           <div>
             <h1 class="m-0 text-2xl font-semibold leading-tight text-[var(--color-fg-secondary)]">${post.title}</h1>
+            <div class="mt-2">
+              <${PostShareActions} post=${post} />
+            </div>
           </div>
 
           <div class="text-sm text-[var(--color-fg-primary)] leading-loose">

--- a/dashboard/src/components/board/post-share-actions.ts
+++ b/dashboard/src/components/board/post-share-actions.ts
@@ -5,6 +5,7 @@ import { ActionButton } from '../common/button'
 import { copyToClipboard } from '../common/copyable-code'
 import { showToast } from '../common/toast'
 import { requestBoardContextInference } from '../../api/board'
+import { keepers } from '../../store'
 import {
   boardPostPermalink,
   boardPostTrackbackMarkdown,
@@ -14,8 +15,11 @@ import type { BoardPost } from './board-state'
 
 function contextInferenceTargetKeeper(post: BoardPost): string | undefined {
   const identity = post.author_identity
-  if (identity?.kind !== 'keeper') return undefined
-  return identity.id?.trim() || identity.runtime_agent_name?.trim() || identity.raw?.trim() || post.author.trim() || undefined
+  if (identity?.kind === 'keeper') {
+    return identity.id?.trim() || identity.runtime_agent_name?.trim() || identity.raw?.trim() || post.author.trim() || undefined
+  }
+  const list = keepers.value
+  return list[0]?.name || undefined
 }
 
 export function PostShareActions({ post, compact = false }: { post: BoardPost; compact?: boolean }) {
@@ -52,6 +56,12 @@ export function PostShareActions({ post, compact = false }: { post: BoardPost; c
     }
   }
 
+  const targetKeeper = contextInferenceTargetKeeper(post)
+  const isContextInferDisabled = contextPending || !targetKeeper
+  const contextInferTooltip = targetKeeper
+    ? `맥락 추론 요청 (${targetKeeper})`
+    : '맥락 추론을 실행할 등록된 keeper가 없습니다'
+
   return html`
     <span
       class=${`inline-flex items-center gap-1 ${compact ? 'text-2xs' : 'text-xs'}`}
@@ -81,10 +91,10 @@ export function PostShareActions({ post, compact = false }: { post: BoardPost; c
         variant="ghost"
         size="sm"
         class=${buttonClass}
-        disabled=${contextPending}
+        disabled=${isContextInferDisabled}
         ariaBusy=${contextPending}
         ariaLabel=${`맥락 추론 요청: ${post.id}`}
-        title="맥락 추론 요청"
+        title=${contextInferTooltip}
         testId=${`bd-context-infer-${post.id}`}
         onClick=${inferContext}
       ><${Sparkles} size=${13} strokeWidth=${2.2} aria-hidden="true" /><//>

--- a/dashboard/src/components/board/post-share-actions.ts
+++ b/dashboard/src/components/board/post-share-actions.ts
@@ -1,0 +1,105 @@
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { Link2, Quote, Share2, Sparkles } from 'lucide-preact'
+import { ActionButton } from '../common/button'
+import { copyToClipboard } from '../common/copyable-code'
+import { showToast } from '../common/toast'
+import { requestBoardContextInference } from '../../api/board'
+import {
+  boardPostPermalink,
+  boardPostTrackbackMarkdown,
+  boardPostXShareUrl,
+} from '../../lib/board-utils'
+import type { BoardPost } from './board-state'
+
+function contextInferenceTargetKeeper(post: BoardPost): string | undefined {
+  const identity = post.author_identity
+  if (identity?.kind !== 'keeper') return undefined
+  return identity.id?.trim() || identity.runtime_agent_name?.trim() || identity.raw?.trim() || post.author.trim() || undefined
+}
+
+export function PostShareActions({ post, compact = false }: { post: BoardPost; compact?: boolean }) {
+  const [contextPending, setContextPending] = useState(false)
+  const permalink = boardPostPermalink(post.id)
+  const trackback = boardPostTrackbackMarkdown(post)
+  const xShareUrl = boardPostXShareUrl(post)
+  const buttonClass = `v2-workspace-action !px-1.5 ${compact ? '!py-0.5' : '!py-1'}`
+
+  const copyLink = async (event: Event) => {
+    event.stopPropagation()
+    const ok = await copyToClipboard(permalink)
+    showToast(ok ? '게시글 링크를 복사했습니다' : '게시글 링크 복사에 실패했습니다', ok ? 'success' : 'error')
+  }
+
+  const copyTrackback = async (event: Event) => {
+    event.stopPropagation()
+    const ok = await copyToClipboard(trackback)
+    showToast(ok ? '트랙백 링크를 복사했습니다' : '트랙백 링크 복사에 실패했습니다', ok ? 'success' : 'error')
+  }
+
+  const inferContext = async (event: Event) => {
+    event.stopPropagation()
+    if (contextPending) return
+    setContextPending(true)
+    try {
+      const result = await requestBoardContextInference(post.id, contextInferenceTargetKeeper(post))
+      showToast(`맥락 추론을 ${result.keeperName}에게 요청했습니다`, 'success')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      showToast(`맥락 추론 요청에 실패했습니다: ${message}`, 'error')
+    } finally {
+      setContextPending(false)
+    }
+  }
+
+  return html`
+    <span
+      class=${`inline-flex items-center gap-1 ${compact ? 'text-2xs' : 'text-xs'}`}
+      data-testid=${`bd-share-${post.id}`}
+      onClick=${(event: Event) => event.stopPropagation()}
+      onKeyDown=${(event: KeyboardEvent) => event.stopPropagation()}
+    >
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class=${buttonClass}
+        ariaLabel=${`게시글 링크 복사: ${post.id}`}
+        title="링크 복사"
+        testId=${`bd-share-link-${post.id}`}
+        onClick=${copyLink}
+      ><${Link2} size=${13} strokeWidth=${2.2} aria-hidden="true" /><//>
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class=${buttonClass}
+        ariaLabel=${`트랙백 링크 복사: ${post.id}`}
+        title="트랙백 복사"
+        testId=${`bd-share-trackback-${post.id}`}
+        onClick=${copyTrackback}
+      ><${Quote} size=${13} strokeWidth=${2.2} aria-hidden="true" /><//>
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class=${buttonClass}
+        disabled=${contextPending}
+        ariaBusy=${contextPending}
+        ariaLabel=${`맥락 추론 요청: ${post.id}`}
+        title="맥락 추론 요청"
+        testId=${`bd-context-infer-${post.id}`}
+        onClick=${inferContext}
+      ><${Sparkles} size=${13} strokeWidth=${2.2} aria-hidden="true" /><//>
+      <a
+        href=${xShareUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class=${`${buttonClass} inline-flex items-center justify-center rounded-md border border-solid border-border bg-transparent text-text-primary hover:bg-surface-subtle`}
+        aria-label=${`X에 공유: ${post.id}`}
+        title="X 공유"
+        data-testid=${`bd-share-x-${post.id}`}
+        onClick=${(event: Event) => event.stopPropagation()}
+      >
+        <${Share2} size=${13} strokeWidth=${2.2} aria-hidden="true" />
+      </a>
+    </span>
+  `
+}

--- a/dashboard/src/components/common/markdown-renderer.test.ts
+++ b/dashboard/src/components/common/markdown-renderer.test.ts
@@ -106,6 +106,20 @@ describe('MarkdownContent', () => {
     expect(container.querySelector('script')).toBeNull()
   })
 
+  it('renders sanitized HTML blocks without unsafe attributes', () => {
+    const container = document.createElement('div')
+    render(h(MarkdownContent, {
+      text: '<div class="idea-card" onclick="alert(1)"><span data-x="bad">HTML idea</span></div>',
+    }), container)
+
+    const div = container.querySelector('.idea-card') as HTMLDivElement | null
+    const span = container.querySelector('span') as HTMLSpanElement | null
+    expect(div).not.toBeNull()
+    expect(div?.textContent).toContain('HTML idea')
+    expect(div?.getAttribute('onclick')).toBeNull()
+    expect(span?.getAttribute('data-x')).toBeNull()
+  })
+
   it('renders think block as details', () => {
     const container = document.createElement('div')
     render(h(MarkdownContent, { text: '<think>hidden thought</think>' }), container)

--- a/dashboard/src/components/common/markdown-renderer.ts
+++ b/dashboard/src/components/common/markdown-renderer.ts
@@ -41,6 +41,7 @@ const PURIFY_CONFIG = {
     'href', 'title', 'target', 'rel', 'src', 'alt', 'class',
     'align',
   ],
+  ALLOW_DATA_ATTR: false,
 }
 
 function sanitize(raw: string): string {

--- a/dashboard/src/components/common/rich-content-utils.test.ts
+++ b/dashboard/src/components/common/rich-content-utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   convertStandaloneImageUrlsToMarkdown,
+  extractMediaEmbeds,
   extractPreviewUrls,
   extractStandaloneImageUrls,
+  mediaEmbedForUrl,
   prepareRichContent,
 } from './rich-content-utils'
 
@@ -35,5 +37,41 @@ describe('rich-content-utils', () => {
     )
     expect(prepared.markdownText).toContain('```ts')
     expect(prepared.previewUrls).toEqual(['https://example.com/card'])
+    expect(prepared.mediaEmbeds).toEqual([])
+  })
+
+  it('extracts direct video and audio URLs as playable media embeds', () => {
+    expect(extractMediaEmbeds(
+      'https://cdn.example.com/demo.mp4\nhttps://cdn.example.com/sound.mp3',
+    )).toEqual([
+      { kind: 'video', url: 'https://cdn.example.com/demo.mp4' },
+      { kind: 'audio', url: 'https://cdn.example.com/sound.mp3' },
+    ])
+  })
+
+  it('normalizes YouTube and Vimeo URLs to safe iframe embed URLs', () => {
+    expect(mediaEmbedForUrl('https://youtu.be/dQw4w9WgXcQ')).toEqual({
+      kind: 'iframe',
+      url: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      title: 'youtu.be',
+    })
+    expect(mediaEmbedForUrl('https://vimeo.com/123456789')).toEqual({
+      kind: 'iframe',
+      url: 'https://player.vimeo.com/video/123456789',
+      title: 'vimeo.com',
+    })
+  })
+
+  it('removes standalone media lines from markdown and link previews', () => {
+    const prepared = prepareRichContent(
+      'before\nhttps://cdn.example.com/demo.mp4\nhttps://example.com/card',
+      4,
+    )
+    expect(prepared.markdownText).toContain('before')
+    expect(prepared.markdownText).not.toContain('demo.mp4')
+    expect(prepared.previewUrls).toEqual(['https://example.com/card'])
+    expect(prepared.mediaEmbeds).toEqual([
+      { kind: 'video', url: 'https://cdn.example.com/demo.mp4' },
+    ])
   })
 })

--- a/dashboard/src/components/common/rich-content-utils.ts
+++ b/dashboard/src/components/common/rich-content-utils.ts
@@ -3,14 +3,76 @@ const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*]\((https?:\/\/[^)\s]+)\)/gi
 const STANDALONE_URL_PATTERN = /^<?(https?:\/\/\S+)>?$/
 
 const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.avif']
+const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.ogv', '.mov', '.m4v']
+const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.aac', '.flac', '.oga', '.ogg']
+
+export type RichMediaEmbed =
+  | { kind: 'video'; url: string }
+  | { kind: 'audio'; url: string }
+  | { kind: 'iframe'; url: string; title: string }
 
 function isImageUrl(url: string): boolean {
   const normalized = url.toLowerCase()
   return IMAGE_EXTENSIONS.some(ext => normalized.endsWith(ext))
 }
 
+function hasExtension(url: string, extensions: readonly string[]): boolean {
+  let pathname = ''
+  try {
+    pathname = new URL(url).pathname
+  } catch {
+    pathname = url
+  }
+  const normalized = pathname.toLowerCase()
+  return extensions.some(ext => normalized.endsWith(ext))
+}
+
+function isVideoUrl(url: string): boolean {
+  return hasExtension(url, VIDEO_EXTENSIONS)
+}
+
+function isAudioUrl(url: string): boolean {
+  return hasExtension(url, AUDIO_EXTENSIONS)
+}
+
 function cleanUrl(url: string): string {
   return url.replace(/[)>.,;:!?]+$/g, '')
+}
+
+function youtubeEmbedUrl(url: URL): string | null {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase()
+  let id: string | null = null
+  if (host === 'youtu.be') {
+    id = url.pathname.split('/').filter(Boolean)[0] ?? null
+  } else if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
+    if (url.pathname === '/watch') id = url.searchParams.get('v')
+    else if (url.pathname.startsWith('/shorts/') || url.pathname.startsWith('/embed/')) {
+      id = url.pathname.split('/').filter(Boolean)[1] ?? null
+    }
+  }
+  if (!id || !/^[a-zA-Z0-9_-]{6,}$/.test(id)) return null
+  return `https://www.youtube-nocookie.com/embed/${id}`
+}
+
+function vimeoEmbedUrl(url: URL): string | null {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase()
+  if (host !== 'vimeo.com' && host !== 'player.vimeo.com') return null
+  const id = url.pathname.split('/').filter(Boolean).find(part => /^\d+$/.test(part))
+  return id ? `https://player.vimeo.com/video/${id}` : null
+}
+
+export function mediaEmbedForUrl(rawUrl: string): RichMediaEmbed | null {
+  const url = cleanUrl(rawUrl)
+  if (!url) return null
+  if (isVideoUrl(url)) return { kind: 'video', url }
+  if (isAudioUrl(url)) return { kind: 'audio', url }
+  try {
+    const parsed = new URL(url)
+    const embedUrl = youtubeEmbedUrl(parsed) ?? vimeoEmbedUrl(parsed)
+    return embedUrl ? { kind: 'iframe', url: embedUrl, title: parsed.hostname } : null
+  } catch {
+    return null
+  }
 }
 
 export function convertStandaloneImageUrlsToMarkdown(text: string): string {
@@ -39,13 +101,16 @@ export function extractStandaloneImageUrls(text: string): string[] {
 export function extractPreviewUrls(text: string, maxCount = 4): string[] {
   if (maxCount <= 0) return []
   const excluded = new Set<string>(extractStandaloneImageUrls(text))
+  const mediaUrls = new Set(extractMediaEmbeds(text).map(embed => embed.url))
   const withoutMarkdownImages = text.replace(MARKDOWN_IMAGE_PATTERN, '')
   const urls = withoutMarkdownImages.match(URL_PATTERN) ?? []
   const deduped: string[] = []
 
   for (const raw of urls) {
     const url = cleanUrl(raw)
+    const embed = mediaEmbedForUrl(url)
     if (!url || excluded.has(url) || isImageUrl(url)) continue
+    if (embed && mediaUrls.has(embed.url)) continue
     if (!deduped.includes(url)) deduped.push(url)
     if (deduped.length >= maxCount) break
   }
@@ -53,13 +118,43 @@ export function extractPreviewUrls(text: string, maxCount = 4): string[] {
   return deduped
 }
 
+export function extractMediaEmbeds(text: string, maxCount = 4): RichMediaEmbed[] {
+  if (maxCount <= 0) return []
+  const embeds: RichMediaEmbed[] = []
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim()
+    const match = trimmed.match(STANDALONE_URL_PATTERN)
+    if (!match) continue
+    const embed = mediaEmbedForUrl(match[1] ?? '')
+    if (!embed) continue
+    if (!embeds.some(existing => existing.kind === embed.kind && existing.url === embed.url)) {
+      embeds.push(embed)
+    }
+    if (embeds.length >= maxCount) break
+  }
+  return embeds
+}
+
+function removeStandaloneMediaEmbedLines(text: string): string {
+  return text
+    .split('\n')
+    .filter(line => {
+      const match = line.trim().match(STANDALONE_URL_PATTERN)
+      return !match || mediaEmbedForUrl(match[1] ?? '') === null
+    })
+    .join('\n')
+}
+
 export function prepareRichContent(text: string, previewLimit = 4): {
   markdownText: string
   previewUrls: string[]
+  mediaEmbeds: RichMediaEmbed[]
 } {
+  const markdownSource = removeStandaloneMediaEmbedLines(text)
   return {
-    markdownText: convertStandaloneImageUrlsToMarkdown(text),
+    markdownText: convertStandaloneImageUrlsToMarkdown(markdownSource),
     previewUrls: extractPreviewUrls(text, previewLimit),
+    mediaEmbeds: extractMediaEmbeds(text, previewLimit),
   }
 }
 

--- a/dashboard/src/components/common/rich-content.test.ts
+++ b/dashboard/src/components/common/rich-content.test.ts
@@ -112,4 +112,26 @@ describe('RichContent', () => {
     expect(urls).not.toContain('https://img.com/pic.png')
     render(null, container)
   })
+
+  it('renders standalone video URLs as playable media instead of link cards', async () => {
+    const container = document.createElement('div')
+    render(h(RichContent, { text: 'https://cdn.example.com/demo.mp4' }), container)
+    const video = container.querySelector('video') as HTMLVideoElement | null
+    expect(video?.getAttribute('src')).toBe('https://cdn.example.com/demo.mp4')
+    expect(video?.hasAttribute('controls')).toBe(true)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mockedFetchLinkPreviews).not.toHaveBeenCalled()
+    render(null, container)
+  })
+
+  it('renders standalone YouTube URLs as safe iframe embeds', async () => {
+    const container = document.createElement('div')
+    render(h(RichContent, { text: 'https://youtu.be/dQw4w9WgXcQ' }), container)
+    const frame = container.querySelector('iframe') as HTMLIFrameElement | null
+    expect(frame?.getAttribute('src')).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')
+    expect(frame?.getAttribute('referrerpolicy')).toBe('strict-origin-when-cross-origin')
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mockedFetchLinkPreviews).not.toHaveBeenCalled()
+    render(null, container)
+  })
 })

--- a/dashboard/src/components/common/rich-content.ts
+++ b/dashboard/src/components/common/rich-content.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import { Markdown } from './markdown'
 import { fetchLinkPreviews, type LinkPreview } from '../../api/link-previews'
-import { prepareRichContent } from './rich-content-utils'
+import { prepareRichContent, type RichMediaEmbed } from './rich-content-utils'
 
 function previewCard(preview: LinkPreview) {
   const href = preview.canonical_url || preview.url
@@ -49,6 +49,43 @@ function previewCard(preview: LinkPreview) {
   `
 }
 
+function mediaEmbed(embed: RichMediaEmbed) {
+  if (embed.kind === 'video') {
+    return html`
+      <video
+        key=${embed.url}
+        src=${embed.url}
+        controls
+        preload="metadata"
+        class="block w-full max-h-[480px] rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-black"
+      />
+    `
+  }
+  if (embed.kind === 'audio') {
+    return html`
+      <audio
+        key=${embed.url}
+        src=${embed.url}
+        controls
+        preload="metadata"
+        class="block w-full"
+      />
+    `
+  }
+  return html`
+    <iframe
+      key=${embed.url}
+      src=${embed.url}
+      title=${embed.title}
+      loading="lazy"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowfullscreen
+      class="block aspect-video w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
+    />
+  `
+}
+
 export function RichContent({
   text,
   class: className,
@@ -84,6 +121,9 @@ export function RichContent({
   return html`
     <div class=${wrapperClass}>
       <${Markdown} text=${prepared.markdownText} />
+      ${prepared.mediaEmbeds.length > 0
+        ? html`<div class="grid gap-2">${prepared.mediaEmbeds.map(embed => mediaEmbed(embed))}</div>`
+        : null}
       ${cards.length > 0
         ? html`<div class="grid gap-2">${cards.map(card => previewCard(card))}</div>`
         : null}

--- a/dashboard/src/lib/board-utils.test.ts
+++ b/dashboard/src/lib/board-utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
+  boardActorSigilLabel,
+  boardPostHash,
+  boardPostPermalink,
+  boardPostTrackbackMarkdown,
+  boardPostXShareUrl,
   contributorQualityBandLabel,
+  contributorQualityBadgeClass,
   contributorQualityPercent,
   dedupeLeadingHeading,
   stripInlineMarkdown,
@@ -79,16 +85,86 @@ describe('dedupeLeadingHeading', () => {
   })
 })
 
+describe('board post sharing helpers', () => {
+  it('builds the canonical board hash route for a post', () => {
+    expect(boardPostHash('post 1')).toBe('#board?post=post%201')
+  })
+
+  it('builds an absolute permalink from the current dashboard URL', () => {
+    expect(boardPostPermalink(
+      'p-1',
+      'http://localhost:5179/dashboard/#board',
+    )).toBe('http://localhost:5179/dashboard/#board?post=p-1')
+  })
+
+  it('builds markdown trackback text with stripped title markdown', () => {
+    expect(boardPostTrackbackMarkdown(
+      { id: 'p-1', title: '**Idea** post' },
+      'http://localhost:5179/dashboard/#board',
+    )).toBe('[Idea post](http://localhost:5179/dashboard/#board?post=p-1)')
+  })
+
+  it('builds an X share intent URL with the board permalink', () => {
+    const url = new URL(boardPostXShareUrl(
+      { id: 'p-1', title: 'Share me' },
+      'http://localhost:5179/dashboard/#board',
+    ))
+
+    expect(url.origin).toBe('https://twitter.com')
+    expect(url.pathname).toBe('/intent/tweet')
+    expect(url.searchParams.get('text')).toBe('Share me - MASC Board')
+    expect(url.searchParams.get('url')).toBe('http://localhost:5179/dashboard/#board?post=p-1')
+  })
+})
+
 describe('contributor quality helpers', () => {
-  it('uses accountability_score when legacy score is absent', () => {
+  it('uses accountability_score when legacy score is absent and evidence exists', () => {
     const quality = {
       source: 'agent_reputation',
       completion_rate: 0.8,
       response_rate: 0.6,
+      board_posts: 1,
       accountability_score: 0.9,
     }
 
     expect(contributorQualityPercent(quality)).toBe(90)
-    expect(contributorQualityBandLabel(quality)).toBe('우수')
+    expect(contributorQualityBandLabel(quality)).toBe('품질')
+    expect(contributorQualityBadgeClass(quality)).toContain('color-bg-muted')
+  })
+
+  it('does not render default reputation priors as a numeric quality score', () => {
+    expect(contributorQualityPercent({
+      source: 'agent_reputation',
+      completion_rate: 0,
+      response_rate: 0,
+      board_posts: 0,
+      board_comments: 0,
+      accountability_score: 1,
+      autonomy_level: 'standard',
+      thompson_confidence: 0.5,
+    })).toBeNull()
+  })
+
+  it('uses backend-supplied quality band without inventing thresholds', () => {
+    const quality = {
+      accountability_score: 0.4,
+      board_comments: 2,
+      band: 'strong' as const,
+    }
+    expect(contributorQualityPercent(quality)).toBe(40)
+    expect(contributorQualityBandLabel(quality)).toBe('강함')
+    expect(contributorQualityBadgeClass(quality)).toContain('ok-10')
+  })
+})
+
+describe('boardActorSigilLabel', () => {
+  it('prefers the specific display name over a generic keeper key', () => {
+    expect(boardActorSigilLabel('keeper', {
+      kind: 'keeper',
+      id: 'sangsu',
+      key: 'keeper',
+      display_name: 'sangsu',
+      raw: 'keeper-sangsu-agent',
+    })).toBe('sangsu')
   })
 })

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -54,7 +54,7 @@ import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
 import { stripStateBlocks } from '../keeper-message'
 import { clampPct } from './format-number'
-import type { BoardActorIdentity, BoardContributorQuality } from '../types'
+import type { BoardActorIdentity, BoardContributorQuality, BoardPost } from '../types'
 
 /** Strip inline markdown formatting from title text (bold, italic, code). */
 export function stripInlineMarkdown(text: string): string {
@@ -85,6 +85,43 @@ export function dedupeLeadingHeading(title: string, body: string): string {
   return body
 }
 
+export function boardPostHash(postId: string): string {
+  return `#board?post=${encodeURIComponent(postId)}`
+}
+
+export function boardPostPermalink(postId: string, baseHref?: string): string {
+  const hash = boardPostHash(postId)
+  const base = baseHref ?? (typeof window !== 'undefined' ? window.location.href : '')
+  if (!base) return hash
+  try {
+    return new URL(hash, base).toString()
+  } catch {
+    return hash
+  }
+}
+
+function boardPostDisplayTitle(post: Pick<BoardPost, 'id' | 'title'>): string {
+  return stripInlineMarkdown(post.title).trim() || post.id
+}
+
+export function boardPostTrackbackMarkdown(
+  post: Pick<BoardPost, 'id' | 'title'>,
+  baseHref?: string,
+): string {
+  return `[${boardPostDisplayTitle(post)}](${boardPostPermalink(post.id, baseHref)})`
+}
+
+export function boardPostXShareUrl(
+  post: Pick<BoardPost, 'id' | 'title'>,
+  baseHref?: string,
+): string {
+  const params = new URLSearchParams({
+    text: `${boardPostDisplayTitle(post)} - MASC Board`,
+    url: boardPostPermalink(post.id, baseHref),
+  })
+  return `https://twitter.com/intent/tweet?${params.toString()}`
+}
+
 export function boardActorDisplayName(
   authorName: string,
   identity?: BoardActorIdentity | null,
@@ -111,6 +148,37 @@ export function boardActorAvatarKey(
   return identity?.key?.trim() || boardActorDisplayName(authorName, identity)
 }
 
+const GENERIC_ACTOR_SIGIL_KEYS = new Set([
+  'agent',
+  'keeper',
+  'raw_agent',
+  'unknown',
+])
+
+function firstSpecificActorLabel(candidates: Array<string | null | undefined>): string | null {
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim()
+    if (!trimmed) continue
+    if (GENERIC_ACTOR_SIGIL_KEYS.has(trimmed.toLowerCase())) continue
+    return trimmed
+  }
+  return null
+}
+
+export function boardActorSigilLabel(
+  authorName: string,
+  identity?: BoardActorIdentity | null,
+): string {
+  return firstSpecificActorLabel([
+    identity?.display_name,
+    identity?.runtime_agent_name,
+    identity?.id,
+    identity?.raw,
+    identity?.key,
+    authorName,
+  ]) ?? authorName
+}
+
 export function boardActorTitle(
   authorName: string,
   identity?: BoardActorIdentity | null,
@@ -121,6 +189,7 @@ export function boardActorTitle(
 }
 
 export function contributorQualityPercent(quality?: BoardContributorQuality | null): number | null {
+  if (!contributorQualityHasEvidence(quality)) return null
   const score = contributorQualityDisplayScore(quality)
   return score === null ? null : clampPct(Math.round(score * 100))
 }
@@ -171,12 +240,20 @@ function contributorQualityDisplayBand(
   quality?: BoardContributorQuality | null,
 ): BoardContributorQuality['band'] | null {
   if (quality?.band) return quality.band
-  const score = contributorQualityDisplayScore(quality)
-  if (score === null) return null
-  if (score >= 0.85) return 'excellent'
-  if (score >= 0.65) return 'strong'
-  if (score >= 0.35) return 'watch'
-  return 'low'
+  return null
+}
+
+function contributorQualityHasEvidence(quality?: BoardContributorQuality | null): boolean {
+  if (!quality) return false
+  if (quality.band) return true
+  if (quality.score !== undefined && Number.isFinite(quality.score)) return true
+  if ((quality.board_posts ?? 0) > 0) return true
+  if ((quality.board_comments ?? 0) > 0) return true
+  if ((quality.completion_rate ?? 0) > 0) return true
+  if ((quality.response_rate ?? 0) > 0) return true
+  if (quality.accountability_score !== undefined && quality.accountability_score < 1) return true
+  if (quality.thompson_confidence !== undefined && quality.thompson_confidence !== 0.5) return true
+  return quality.autonomy_level !== undefined && quality.autonomy_level !== 'standard'
 }
 
 /** Navigate to keeper detail if author is a keeper, otherwise agent profile. */

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -245,15 +245,23 @@ function contributorQualityDisplayBand(
 
 function contributorQualityHasEvidence(quality?: BoardContributorQuality | null): boolean {
   if (!quality) return false
+  if (quality.evidence_state !== undefined) {
+    return quality.evidence_state === 'measured'
+  }
   if (quality.band) return true
   if (quality.score !== undefined && Number.isFinite(quality.score)) return true
   if ((quality.board_posts ?? 0) > 0) return true
   if ((quality.board_comments ?? 0) > 0) return true
   if ((quality.completion_rate ?? 0) > 0) return true
   if ((quality.response_rate ?? 0) > 0) return true
-  if (quality.accountability_score !== undefined && quality.accountability_score < 1) return true
-  if (quality.thompson_confidence !== undefined && quality.thompson_confidence !== 0.5) return true
-  return quality.autonomy_level !== undefined && quality.autonomy_level !== 'standard'
+
+  const DEFAULT_ACCOUNTABILITY_SCORE = 1.0
+  const DEFAULT_THOMPSON_CONFIDENCE = 0.5
+  const DEFAULT_AUTONOMY_LEVEL = 'standard'
+
+  if (quality.accountability_score !== undefined && quality.accountability_score < DEFAULT_ACCOUNTABILITY_SCORE) return true
+  if (quality.thompson_confidence !== undefined && quality.thompson_confidence !== DEFAULT_THOMPSON_CONFIDENCE) return true
+  return quality.autonomy_level !== undefined && quality.autonomy_level !== DEFAULT_AUTONOMY_LEVEL
 }
 
 /** Navigate to keeper detail if author is a keeper, otherwise agent profile. */

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -145,6 +145,7 @@ export interface BoardContributorQuality {
   accountability_score?: number
   autonomy_level?: string
   thompson_confidence?: number
+  evidence_state?: 'default' | 'measured'
 }
 
 export interface BoardActorIdentity {

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -507,6 +507,18 @@ let get_comments store ~post_id : (comment list, board_error) Result.t =
            comments))
 ;;
 
+let get_comment store ~comment_id : (comment, board_error) Result.t =
+  maybe_sweep store;
+  match Comment_id.of_string comment_id with
+  | Error e -> Error e
+  | Ok cid ->
+    with_lock store (fun () ->
+      let comment_key = Comment_id.to_string cid in
+      match Hashtbl.find_opt store.comments comment_key with
+      | Some comment -> Ok comment
+      | None -> Error (Comment_not_found comment_id))
+;;
+
 (** List all comments (for profile aggregation) *)
 let list_comments store ?(limit = 1000) () : comment list =
   maybe_sweep store;

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -387,6 +387,9 @@ val add_comment
     [created_at] ascending. *)
 val get_comments : store -> post_id:string -> (comment list, board_error) Result.t
 
+(** Returns one comment by id. *)
+val get_comment : store -> comment_id:string -> (comment, board_error) Result.t
+
 (** Returns up to [limit] (default 1000) most recent
     comments across every post.  Used by the profile
     aggregator. *)

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -75,6 +75,15 @@ type backend_state =
 type board_signal_kind =
   | Board_post_created
   | Board_comment_added
+  | Board_reaction_changed of board_reaction_change
+
+and board_reaction_change = {
+  target_type : Board.reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+}
 
 type board_signal = {
   kind : board_signal_kind;
@@ -551,11 +560,56 @@ let vote_comment ~voter ~comment_id ~direction =
          comment_id voter (Board_types.show_board_error e));
   result
 
+let post_for_reaction_target store ~target_type ~target_id =
+  match target_type with
+  | Board.Reaction_post -> Board.get_post store ~post_id:target_id
+  | Board.Reaction_comment ->
+      (match Board.get_comment store ~comment_id:target_id with
+       | Error _ as err -> err
+       | Ok comment ->
+           let post_id = Board.Post_id.to_string comment.post_id in
+           Board.get_post store ~post_id)
+
+let emit_reaction_board_signal store (toggled : Board.reaction_toggle_result) =
+  match
+    post_for_reaction_target store ~target_type:toggled.target_type
+      ~target_id:toggled.target_id
+  with
+  | Ok post ->
+      emit_board_signal
+        {
+          kind =
+            Board_reaction_changed
+              {
+                target_type = toggled.target_type;
+                target_id = toggled.target_id;
+                user_id = toggled.user_id;
+                emoji = toggled.emoji;
+                reacted = toggled.reacted;
+              };
+          post_id = Board.Post_id.to_string post.id;
+          author = toggled.user_id;
+          title = post.title;
+          content = post.content;
+          hearth = post.hearth;
+          updated_at = Some post.updated_at;
+        }
+  | Error e ->
+      Log.BoardLog.warn
+        "board reaction signal skipped: target=%s:%s user=%s emoji=%s: %s"
+        (Board.reaction_target_type_to_string toggled.target_type)
+        toggled.target_id toggled.user_id toggled.emoji
+        (Board_types.show_board_error e)
+
 let toggle_reaction ~target_type ~target_id ~user_id ~emoji =
   let result =
     match backend () with
     | Jsonl store ->
-        Board.toggle_reaction store ~target_type ~target_id ~user_id ~emoji
+        (match Board.toggle_reaction store ~target_type ~target_id ~user_id ~emoji with
+         | Ok toggled as ok ->
+             emit_reaction_board_signal store toggled;
+             ok
+         | Error _ as err -> err)
   in
   (match result with
    | Ok toggled ->

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -36,6 +36,15 @@ val valid_sort_order_strings : string list
 type board_signal_kind =
   | Board_post_created
   | Board_comment_added
+  | Board_reaction_changed of board_reaction_change
+
+and board_reaction_change = {
+  target_type : Board.reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+}
 
 type board_signal = {
   kind : board_signal_kind;
@@ -80,8 +89,8 @@ type board_sse_event =
     }
 
 val set_board_signal_hook : (board_signal -> unit) -> unit
-(** Replace the in-process hook invoked from {!create_post} and
-    {!add_comment}. *)
+(** Replace the in-process hook invoked from {!create_post}, {!add_comment},
+    and {!toggle_reaction}. *)
 
 val set_board_sse_hook : (board_sse_event -> unit) -> unit
 (** Replace the in-process SSE hook invoked from every mutating

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -352,6 +352,30 @@ let board_wakeup_dedup_key ~post_id ~author ~title ~content =
     "cfp:" ^ Digest.to_hex (Digest.string (author ^ "\x00" ^ normalized)))
 ;;
 
+let board_signal_wakeup_dedup_key (signal : Board_dispatch.board_signal) =
+  let base =
+    board_wakeup_dedup_key
+      ~post_id:signal.post_id
+      ~author:signal.author
+      ~title:signal.title
+      ~content:signal.content
+  in
+  match signal.kind with
+  | Board_dispatch.Board_post_created | Board_dispatch.Board_comment_added -> base
+  | Board_dispatch.Board_reaction_changed reaction ->
+    let reaction_key =
+      String.concat
+        "\x00"
+        [ Board.reaction_target_type_to_string reaction.target_type
+        ; reaction.target_id
+        ; reaction.user_id
+        ; reaction.emoji
+        ; string_of_bool reaction.reacted
+        ]
+    in
+    base ^ ":reaction:" ^ Digest.to_hex (Digest.string reaction_key)
+;;
+
 let board_reactive_wakeup_allowed
       ~base_path
       ~keeper_name
@@ -360,12 +384,7 @@ let board_reactive_wakeup_allowed
   Keeper_registry.board_wakeup_allowed
     ~base_path
     keeper_name
-    ~dedup_key:
-      (board_wakeup_dedup_key
-         ~post_id:signal.post_id
-         ~author:signal.author
-         ~title:signal.title
-         ~content:signal.content)
+    ~dedup_key:(board_signal_wakeup_dedup_key signal)
     ~debounce_sec:board_reactive_debounce_sec
 ;;
 
@@ -408,7 +427,10 @@ let select_board_wakeup_candidates
     |> List.filter_map (fun (item, reason) ->
       match reason with
       | Some Board_wake.Explicit_mention -> Some (item, Board_wake.Explicit_mention)
-      | Some (Board_wake.Stigmergy _ | Board_wake.Thread_reply_after_self_comment)
+      | Some
+          ( Board_wake.Stigmergy _
+          | Board_wake.Thread_reply_after_self_comment
+          | Board_wake.Reaction_after_self_activity )
       | None -> None)
   in
   match explicit with
@@ -430,6 +452,23 @@ let select_board_wakeup_candidates
    here it only picks urgency (explicit mentions are [Immediate]). It is not
    carried in the payload — the next prompt re-derives board context from the
    typed [Board_signal] payload, not from a wake-reason string. *)
+let queue_reaction_target_of_board = function
+  | Board.Reaction_post -> Keeper_event_queue.Reaction_post
+  | Board.Reaction_comment -> Keeper_event_queue.Reaction_comment
+;;
+
+let queue_reaction_change_of_board
+      (reaction : Board_dispatch.board_reaction_change)
+  : Keeper_event_queue.board_reaction_change
+  =
+  { target_type = queue_reaction_target_of_board reaction.target_type
+  ; target_id = reaction.target_id
+  ; user_id = reaction.user_id
+  ; emoji = reaction.emoji
+  ; reacted = reaction.reacted
+  }
+;;
+
 let board_signal_stimulus
       ~(reason : Board_wake.wake_reason)
       (signal : Board_dispatch.board_signal)
@@ -439,7 +478,9 @@ let board_signal_stimulus
       { kind =
           (match signal.kind with
            | Board_dispatch.Board_post_created -> Keeper_event_queue.Post_created
-           | Board_dispatch.Board_comment_added -> Keeper_event_queue.Comment_added)
+           | Board_dispatch.Board_comment_added -> Keeper_event_queue.Comment_added
+           | Board_dispatch.Board_reaction_changed reaction ->
+             Keeper_event_queue.Reaction_changed (queue_reaction_change_of_board reaction))
       ; author = signal.author
       ; title = signal.title
       ; content = signal.content
@@ -451,7 +492,9 @@ let board_signal_stimulus
   ; urgency =
       (match reason with
        | Board_wake.Explicit_mention -> Keeper_event_queue.Immediate
-       | Board_wake.Stigmergy _ | Board_wake.Thread_reply_after_self_comment ->
+       | Board_wake.Stigmergy _
+       | Board_wake.Thread_reply_after_self_comment
+       | Board_wake.Reaction_after_self_activity ->
          Keeper_event_queue.Normal)
   ; arrived_at = Time_compat.now ()
   ; payload
@@ -533,6 +576,7 @@ let wakeup_relevant_keeper_for_board_signal
     match signal.kind with
     | Board_dispatch.Board_post_created -> "post_created"
     | Board_dispatch.Board_comment_added -> "comment_added"
+    | Board_dispatch.Board_reaction_changed _ -> "reaction_changed"
   in
   (* Yield meter: scanning all running keepers' meta files is CPU-bound
      when many keepers share a domain.  Yield every ~1000 iterations. *)

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -154,7 +154,17 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "board_signal kind=%s author=%s title=%s"
       (match bs.kind with
        | Keeper_event_queue.Post_created -> "post_created"
-       | Keeper_event_queue.Comment_added -> "comment_added")
+       | Keeper_event_queue.Comment_added -> "comment_added"
+       | Keeper_event_queue.Reaction_changed reaction ->
+         Printf.sprintf
+           "reaction_changed target=%s:%s user=%s emoji=%s active=%b"
+           (match reaction.target_type with
+            | Keeper_event_queue.Reaction_post -> "post"
+            | Keeper_event_queue.Reaction_comment -> "comment")
+           reaction.target_id
+           reaction.user_id
+           reaction.emoji
+           reaction.reacted)
       bs.author
       title
   | Keeper_event_queue.Bootstrap -> "bootstrap"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -135,9 +135,40 @@ type board_line =
   | Trusted_line of string
   | Observation_line of string
 
+let board_event_kind_label = function
+  | Keeper_world_observation.Board_post_created -> "post_created"
+  | Keeper_world_observation.Board_comment_added -> "comment_added"
+  | Keeper_world_observation.Board_reaction_changed _ -> "reaction_changed"
+  | Keeper_world_observation.Fusion_completed -> "fusion_completed"
+  | Keeper_world_observation.Bg_completed -> "bg_completed"
+  | Keeper_world_observation.External_attention -> "external_attention"
+;;
+
+let board_reaction_note (reaction : Keeper_world_observation.board_reaction_event) =
+  Printf.sprintf
+    " reaction=%s target=%s:%s user=%s emoji=%S"
+    (if reaction.reacted then "added" else "removed")
+    (Board.reaction_target_type_to_string reaction.target_type)
+    reaction.target_id
+    reaction.user_id
+    reaction.emoji
+;;
+
+let board_event_note = function
+  | Keeper_world_observation.Board_reaction_changed reaction ->
+    board_reaction_note reaction
+  | Keeper_world_observation.Board_post_created
+  | Keeper_world_observation.Board_comment_added
+  | Keeper_world_observation.Fusion_completed
+  | Keeper_world_observation.Bg_completed
+  | Keeper_world_observation.External_attention -> ""
+;;
+
 let format_board_event_text
     (event : Keeper_world_observation.pending_board_event) : string =
   let kind = provenance_label event.provenance in
+  let event_label = board_event_kind_label event.event_kind in
+  let event_note = board_event_note event.event_kind in
   let mention_note =
     if event.explicit_mention then
       let targets =
@@ -162,13 +193,15 @@ let format_board_event_text
          | _ -> "")
     else ""
   in
-  Printf.sprintf "- [%s] post_id=%s title=%S author=%s%s%s%s preview: %s"
+  Printf.sprintf "- [%s] event=%s post_id=%s title=%S author=%s%s%s%s%s preview: %s"
     kind
+    event_label
     event.post_id
     (Keeper_types_profile.short_preview ~max_len:80 event.title)
     event.author
     hearth_note
     mention_note
+    event_note
     self_note
     event.preview
 ;;

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -30,8 +30,25 @@ type observation_provenance =
          id); defaults to the quarantine side — see {!should_quarantine} *)
 [@@deriving show, eq]
 
+type board_reaction_event =
+  { target_type : Board.reaction_target_type
+  ; target_id : string
+  ; user_id : string
+  ; emoji : string
+  ; reacted : bool
+  }
+
+type pending_board_event_kind =
+  | Board_post_created
+  | Board_comment_added
+  | Board_reaction_changed of board_reaction_event
+  | Fusion_completed
+  | Bg_completed
+  | External_attention
+
 type pending_board_event =
-  { post_id : string
+  { event_kind : pending_board_event_kind
+  ; post_id : string
   ; author : string
   ; title : string
   ; preview : string
@@ -375,6 +392,26 @@ let read_scheduled_automation_observation ~(config : Workspace.config) ~now =
 (** Board event cursor bootstrap window (seconds). *)
 let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
 
+let board_reaction_event_of_dispatch
+      (reaction : Board_dispatch.board_reaction_change)
+  : board_reaction_event
+  =
+  { target_type = reaction.target_type
+  ; target_id = reaction.target_id
+  ; user_id = reaction.user_id
+  ; emoji = reaction.emoji
+  ; reacted = reaction.reacted
+  }
+;;
+
+let pending_board_event_kind_of_signal (signal : Board_dispatch.board_signal) =
+  match signal.kind with
+  | Board_dispatch.Board_post_created -> Board_post_created
+  | Board_dispatch.Board_comment_added -> Board_comment_added
+  | Board_dispatch.Board_reaction_changed reaction ->
+    Board_reaction_changed (board_reaction_event_of_dispatch reaction)
+;;
+
 let pending_board_event_of_board_signal
       ~continuity_summary
       ~(meta : keeper_meta)
@@ -404,6 +441,7 @@ let pending_board_event_of_board_signal
       , Board.Human_post
       , arrived_at )
   in
+  let event_kind = pending_board_event_kind_of_signal signal in
   let self_commented, new_external_since, latest_external_author, latest_external_preview =
     match signal.kind with
     | Board_dispatch.Board_post_created -> false, 0, None, None
@@ -414,8 +452,13 @@ let pending_board_event_of_board_signal
          true, 0, Some signal.author, Some (short_preview ~max_len:60 signal.content)
        | `Never ->
          false, 1, Some signal.author, Some (short_preview ~max_len:60 signal.content))
+    | Board_dispatch.Board_reaction_changed _ ->
+      (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+       | `Never -> false, 0, None, None
+       | `No_new_external | `New_external _ -> true, 0, None, None)
   in
-  { post_id = signal.post_id
+  { event_kind
+  ; post_id = signal.post_id
   ; author = signal.author
   ; title
   ; preview
@@ -462,7 +505,8 @@ let pending_board_event_of_fusion_completion
     then Printf.sprintf "Fusion deliberation complete (run %s)" fc.run_id
     else Printf.sprintf "Fusion deliberation failed (run %s)" fc.run_id
   in
-  { post_id
+  { event_kind = Fusion_completed
+  ; post_id
   ; author = meta.name
   ; title
   ; preview = short_preview ~max_len:fusion_result_preview_max_len fc.resolved_answer
@@ -505,7 +549,8 @@ let pending_board_event_of_bg_job_completion
     | Keeper_event_queue.Bg_failed _ ->
       Printf.sprintf "Background %s failed (run %s)" kind c.bg_run_id
   in
-  { post_id
+  { event_kind = Bg_completed
+  ; post_id
   ; author = meta.name
   ; title
   ; preview =
@@ -551,7 +596,8 @@ let pending_board_event_of_external_attention
     | Keeper_external_attention.System ->
       false, []
   in
-  { post_id = "connector-attention:" ^ item.event_id
+  { event_kind = External_attention
+  ; post_id = "connector-attention:" ^ item.event_id
   ; author = actor
   ; title =
       Printf.sprintf
@@ -689,7 +735,8 @@ let collect_board_events_with_cursor_policy
              consume_posts
                
                (Some next_cursor)
-               ({ post_id
+               ({ event_kind = Board_post_created
+                ; post_id
                 ; author = Board.Agent_id.to_string p.author
                 ; title = p.title
                 ; preview = short_preview ~max_len:80 p.content
@@ -724,7 +771,8 @@ let collect_board_events_with_cursor_policy
              consume_posts
                
                (Some next_cursor)
-               ({ post_id
+               ({ event_kind = Board_post_created
+                ; post_id
                 ; author = Board.Agent_id.to_string p.author
                 ; title = p.title
                 ; preview = short_preview ~max_len:80 p.content

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -40,7 +40,24 @@ val provenance_of :
 val should_quarantine : observation_provenance -> bool
 
 (** Structured board activity delivered to keepers without routing heuristics. *)
+type board_reaction_event = {
+  target_type : Board_types.reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+}
+
+type pending_board_event_kind =
+  | Board_post_created
+  | Board_comment_added
+  | Board_reaction_changed of board_reaction_event
+  | Fusion_completed
+  | Bg_completed
+  | External_attention
+
 type pending_board_event = {
+  event_kind : pending_board_event_kind;
   post_id : string;
   author : string;
   title : string;

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -14,6 +14,23 @@ type match_result =
 
 type comment_status = [ `Never | `No_new_external | `New_external of int * string * string ]
 
+let board_reaction_target_of_queue = function
+  | Keeper_event_queue.Reaction_post -> Board.Reaction_post
+  | Keeper_event_queue.Reaction_comment -> Board.Reaction_comment
+;;
+
+let board_reaction_change_of_queue
+      (reaction : Keeper_event_queue.board_reaction_change)
+  : Board_dispatch.board_reaction_change
+  =
+  { target_type = board_reaction_target_of_queue reaction.target_type
+  ; target_id = reaction.target_id
+  ; user_id = reaction.user_id
+  ; emoji = reaction.emoji
+  ; reacted = reaction.reacted
+  }
+;;
+
 (* RFC-0020: board signals are carried as a typed [Keeper_event_queue.board_stimulus]
    end-to-end. This total conversion rebuilds the [Board_dispatch.board_signal]
    the downstream matchers expect from the typed payload, taking the board post
@@ -27,7 +44,9 @@ let board_signal_of_board_stimulus
   { Board_dispatch.kind =
       (match bs.kind with
        | Keeper_event_queue.Post_created -> Board_dispatch.Board_post_created
-       | Keeper_event_queue.Comment_added -> Board_dispatch.Board_comment_added)
+       | Keeper_event_queue.Comment_added -> Board_dispatch.Board_comment_added
+       | Keeper_event_queue.Reaction_changed reaction ->
+         Board_dispatch.Board_reaction_changed (board_reaction_change_of_queue reaction))
   ; post_id
   ; author = bs.author
   ; title = bs.title
@@ -186,11 +205,35 @@ type wake_reason =
           match strength from {!stigmergy_match}. *)
   | Thread_reply_after_self_comment
       (** A new external comment arrived on a post the keeper had commented on. *)
+  | Reaction_after_self_activity
+      (** An external reaction landed on a post the keeper authored or a thread
+          the keeper had commented on. *)
 
 let wake_reason_label = function
   | Explicit_mention -> "explicit_mention"
   | Stigmergy { score } -> "stigmergy: score=" ^ string_of_int score
   | Thread_reply_after_self_comment -> "thread_reply_after_self_comment"
+  | Reaction_after_self_activity -> "reaction_after_self_activity"
+;;
+
+let self_authored_post ~self_ids ~(post_id : string) =
+  match Board_dispatch.get_post ~post_id with
+  | Error _ -> false
+  | Ok post ->
+    Message_scope.is_self_author ~self_ids (Board.Agent_id.to_string post.author)
+;;
+
+let reaction_touches_self_activity ~self_ids ~(signal : Board_dispatch.board_signal) =
+  match signal.kind with
+  | Board_dispatch.Board_reaction_changed _ ->
+    (not (Message_scope.is_self_author ~self_ids signal.author))
+    &&
+    (self_authored_post ~self_ids ~post_id:signal.post_id
+     ||
+     match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+     | `Never -> false
+     | `No_new_external | `New_external _ -> true)
+  | Board_dispatch.Board_post_created | Board_dispatch.Board_comment_added -> false
 ;;
 
 let wake_reason
@@ -203,15 +246,22 @@ let wake_reason
   if matched.explicit_mention
   then Some Explicit_mention
   else (
-    let stigmergy = stigmergy_match ~meta ~signal in
-    if stigmergy.overall_score > 0
-    then Some (Stigmergy { score = stigmergy.overall_score })
-    else (
-      let self_ids = Message_scope.self_ids meta in
-      match signal.kind with
-      | Board_dispatch.Board_comment_added ->
-        (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
-         | `New_external _ -> Some Thread_reply_after_self_comment
-         | `Never | `No_new_external -> None)
-      | Board_dispatch.Board_post_created -> None))
+    let self_ids = Message_scope.self_ids meta in
+    match signal.kind with
+    | Board_dispatch.Board_reaction_changed _ ->
+      if reaction_touches_self_activity ~self_ids ~signal
+      then Some Reaction_after_self_activity
+      else None
+    | Board_dispatch.Board_post_created | Board_dispatch.Board_comment_added ->
+      let stigmergy = stigmergy_match ~meta ~signal in
+      if stigmergy.overall_score > 0
+      then Some (Stigmergy { score = stigmergy.overall_score })
+      else (
+        match signal.kind with
+        | Board_dispatch.Board_comment_added ->
+          (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+           | `New_external _ -> Some Thread_reply_after_self_comment
+           | `Never | `No_new_external -> None)
+        | Board_dispatch.Board_post_created
+        | Board_dispatch.Board_reaction_changed _ -> None))
 ;;

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -223,6 +223,8 @@ let self_authored_post ~self_ids ~(post_id : string) =
     Message_scope.is_self_author ~self_ids (Board.Agent_id.to_string post.author)
 ;;
 
+(* TEL-OK: pure wake predicate; board persistence and keeper wake execution own
+   telemetry at their action boundaries. *)
 let reaction_touches_self_activity ~self_ids ~(signal : Board_dispatch.board_signal) =
   match signal.kind with
   | Board_dispatch.Board_reaction_changed _ ->

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -36,6 +36,7 @@ type wake_reason =
   | Explicit_mention
   | Stigmergy of { score : int }
   | Thread_reply_after_self_comment
+  | Reaction_after_self_activity
 (** Closed set of reasons a keeper wakes for a board signal (RFC-0020).
     Replaces the prior [string option] contract; consumers match exhaustively
     so the previously dead ["board_activity"] generic bucket is gone. *)

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -13,6 +13,19 @@ type post_id = string
 type board_stimulus_kind =
   | Post_created
   | Comment_added
+  | Reaction_changed of board_reaction_change
+
+and board_reaction_target_type =
+  | Reaction_post
+  | Reaction_comment
+
+and board_reaction_change = {
+  target_type : board_reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+}
 
 type board_stimulus = {
   kind : board_stimulus_kind;
@@ -262,17 +275,37 @@ let urgency_of_string = function
 let board_stimulus_kind_to_string = function
   | Post_created -> "post_created"
   | Comment_added -> "comment_added"
+  | Reaction_changed _ -> "reaction_changed"
 
 let board_stimulus_kind_of_string = function
   | "post_created" -> Ok Post_created
   | "comment_added" -> Ok Comment_added
+  | "reaction_changed" ->
+    Error "reaction_changed board stimulus requires reaction payload fields"
   | value -> Error (Printf.sprintf "unknown board stimulus kind: %s" value)
+
+let board_reaction_target_type_to_string = function
+  | Reaction_post -> "post"
+  | Reaction_comment -> "comment"
+
+let board_reaction_target_type_of_string = function
+  | "post" -> Ok Reaction_post
+  | "comment" -> Ok Reaction_comment
+  | value -> Error (Printf.sprintf "unknown board reaction target type: %s" value)
 
 let option_json f = function
   | Some value -> f value
   | None -> `Null
 
 let ( let* ) = Result.bind
+
+let board_reaction_change_fields (reaction : board_reaction_change) =
+  [ "reaction_target_type", `String (board_reaction_target_type_to_string reaction.target_type)
+  ; "reaction_target_id", `String reaction.target_id
+  ; "reaction_user_id", `String reaction.user_id
+  ; "reaction_emoji", `String reaction.emoji
+  ; "reaction_active", `Bool reaction.reacted
+  ]
 
 let assoc_fields ~context = function
   | `Assoc fields -> Ok fields
@@ -330,14 +363,18 @@ let float_field ~context name fields =
 let payload_to_yojson = function
   | Board_signal board ->
     `Assoc
-      [ "kind", `String "board_signal"
-      ; "board_kind", `String (board_stimulus_kind_to_string board.kind)
-      ; "author", `String board.author
-      ; "title", `String board.title
-      ; "content", `String board.content
-      ; "hearth", option_json (fun value -> `String value) board.hearth
-      ; "updated_at_unix", option_json (fun value -> `Float value) board.updated_at
-      ]
+      ([ "kind", `String "board_signal"
+       ; "board_kind", `String (board_stimulus_kind_to_string board.kind)
+       ; "author", `String board.author
+       ; "title", `String board.title
+       ; "content", `String board.content
+       ; "hearth", option_json (fun value -> `String value) board.hearth
+       ; "updated_at_unix", option_json (fun value -> `Float value) board.updated_at
+       ]
+       @
+       (match board.kind with
+       | Post_created | Comment_added -> []
+       | Reaction_changed reaction -> board_reaction_change_fields reaction))
   | Bootstrap -> `Assoc [ "kind", `String "bootstrap" ]
   | No_progress_recovery -> `Assoc [ "kind", `String "no_progress_recovery" ]
   | Fusion_completed fusion ->
@@ -379,7 +416,18 @@ let payload_of_yojson json =
   match kind with
   | "board_signal" ->
     let* board_kind = string_field ~context "board_kind" fields in
-    let* kind = board_stimulus_kind_of_string board_kind in
+    let* kind =
+      match board_kind with
+      | "reaction_changed" ->
+        let* target_type_raw = string_field ~context "reaction_target_type" fields in
+        let* target_type = board_reaction_target_type_of_string target_type_raw in
+        let* target_id = string_field ~context "reaction_target_id" fields in
+        let* user_id = string_field ~context "reaction_user_id" fields in
+        let* emoji = string_field ~context "reaction_emoji" fields in
+        let* reacted = bool_field ~context "reaction_active" fields in
+        Ok (Reaction_changed { target_type; target_id; user_id; emoji; reacted })
+      | _ -> board_stimulus_kind_of_string board_kind
+    in
     let* author = string_field ~context "author" fields in
     let* title = string_field ~context "title" fields in
     let* content = string_field ~context "content" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -34,6 +34,19 @@ type post_id = string
 type board_stimulus_kind =
   | Post_created
   | Comment_added
+  | Reaction_changed of board_reaction_change
+
+and board_reaction_target_type =
+  | Reaction_post
+  | Reaction_comment
+
+and board_reaction_change = {
+  target_type : board_reaction_target_type;
+  target_id : string;
+  user_id : string;
+  emoji : string;
+  reacted : bool;
+}
 
 type board_stimulus = {
   kind : board_stimulus_kind;

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -56,6 +56,7 @@ type agent_reputation = {
   thompson_confidence: float; [@default 0.5]
   (** Thompson Sampling Beta expected value (alpha/(alpha+beta)).
       0.5 is the neutral prior (alpha=1.0, beta=1.0). *)
+  evidence_state: string; [@default "default"]
 } [@@deriving yojson { strict = false }]
 
 (** {1 Defaults} *)
@@ -83,6 +84,7 @@ let default_reputation ~(agent_name : string) : agent_reputation =
     safety_compliance = 1.0;
     autonomy_level = "standard";
     thompson_confidence = 0.5;
+    evidence_state = "default";
   }
 
 (** {1 JSON Serialization}
@@ -356,6 +358,21 @@ let compute_reputation (config : Workspace.config) ~(agent_name : string)
       ~safety_compliance:v2_metrics.Reputation_ledger_v2.safety_compliance
       ~accountability_score:(clamp01 accountability_score)
   in
+  let has_evidence =
+    tasks_claimed > 0
+    || mentions_received > 0
+    || board_posts > 0
+    || board_comments > 0
+    || accountability_source <> "none"
+    || v2_metrics.Reputation_ledger_v2.tool_calls > 0
+    || v2_metrics.Reputation_ledger_v2.goal_completions > 0
+    || v2_metrics.Reputation_ledger_v2.safety_violations > 0
+    || (let stats = Thompson_sampling.get_stats agent_name in
+        stats.Thompson_sampling.total_votes_up > 0
+        || stats.Thompson_sampling.total_votes_down > 0
+        || stats.Thompson_sampling.selections > 0)
+  in
+  let evidence_state = if has_evidence then "measured" else "default" in
   { agent_name;
     tasks_completed; tasks_claimed; completion_rate;
     mentions_received; mentions_responded; response_rate;
@@ -373,4 +390,5 @@ let compute_reputation (config : Workspace.config) ~(agent_name : string)
     safety_compliance = v2_metrics.Reputation_ledger_v2.safety_compliance;
     autonomy_level = Reputation_autonomy.autonomy_level_to_string autonomy;
     thompson_confidence;
+    evidence_state;
   }

--- a/lib/reputation.mli
+++ b/lib/reputation.mli
@@ -60,6 +60,8 @@ type agent_reputation = {
   thompson_confidence: float;
   (** Thompson Sampling Beta expected value (alpha/(alpha+beta)).
       0.5 is the neutral prior (alpha=1.0, beta=1.0). *)
+  evidence_state: string;
+  (** "measured" if there is any backlog, mention, board, ledger or TS activity; otherwise "default". *)
 }
 
 val agent_reputation_to_yojson : agent_reputation -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -639,7 +639,7 @@ let add_routes ~sw ~clock router =
          (fun state _req reqd ->
          Http.Request.read_body_async reqd
            (handle_board_context_inference_request ~state ~sw ~clock ~request
-              reqd)
+              reqd))
          request reqd)
 
   |> Http.Router.post "/api/v1/board/sub-boards" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -167,6 +167,206 @@ let board_karma_ledger_json req =
              totals) );
     ]
 
+type board_context_inference_target_source =
+  | Explicit_target
+  | Post_author
+
+let board_context_inference_target_source_to_string = function
+  | Explicit_target -> "explicit_target"
+  | Post_author -> "post_author"
+
+type board_context_inference_request =
+  { post_id : string
+  ; target_keeper : string option
+  }
+
+let json_assoc_member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let trimmed_json_string_member ~field json =
+  match json_assoc_member field json with
+  | None | Some `Null -> Ok None
+  | Some (`String value) ->
+      let value = String.trim value in
+      Ok (if value = "" then None else Some value)
+  | Some _ -> Error (Printf.sprintf "%s must be a string" field)
+
+let required_trimmed_json_string_member ~field json =
+  match trimmed_json_string_member ~field json with
+  | Ok (Some value) -> Ok value
+  | Ok None -> Error (Printf.sprintf "%s is required" field)
+  | Error _ as err -> err
+
+let parse_board_context_inference_request = function
+  | `Assoc _ as json -> (
+      match required_trimmed_json_string_member ~field:"post_id" json with
+      | Error msg -> Error msg
+      | Ok post_id -> (
+          match trimmed_json_string_member ~field:"target_keeper" json with
+          | Error msg -> Error msg
+          | Ok target_keeper -> Ok { post_id; target_keeper }))
+  | _ -> Error "request body must be a JSON object"
+
+let board_context_string_option_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let board_context_field key value =
+  `Assoc [ ("k", `String key); ("v", value) ]
+
+let board_context_comment_json (comment : Board.comment) =
+  `Assoc
+    [
+      ("id", `String (Board.Comment_id.to_string comment.id));
+      ("post_id", `String (Board.Post_id.to_string comment.post_id));
+      ( "parent_id",
+        board_context_string_option_json
+          (Option.map Board.Comment_id.to_string comment.parent_id) );
+      ("author", `String (Board.Agent_id.to_string comment.author));
+      ("content", `String comment.content);
+      ("created_at", `Float comment.created_at);
+    ]
+
+let board_context_inference_surface_context (post : Board.post) comments =
+  let post_id = Board.Post_id.to_string post.id in
+  let author = Board.Agent_id.to_string post.author in
+  `Assoc
+    [
+      ("label", `String "Board post context inference");
+      ("route", `String (Printf.sprintf "#board?post=%s" post_id));
+      ("scene", `String "board_post_context");
+      ( "fields",
+        `List
+          [
+            board_context_field "board_post_id" (`String post_id);
+            board_context_field "author" (`String author);
+            board_context_field "title" (`String post.title);
+            board_context_field "body" (`String post.body);
+            board_context_field "content" (`String post.content);
+            board_context_field "post_kind" (`String (Board.post_kind_to_string post.post_kind));
+            board_context_field "visibility" (`String (Board.visibility_to_string post.visibility));
+            board_context_field "hearth" (board_context_string_option_json post.hearth);
+            board_context_field "thread_id" (board_context_string_option_json post.thread_id);
+            board_context_field "reply_count" (`Int post.reply_count);
+            board_context_field "comment_count" (`Int (List.length comments));
+            board_context_field "comments" (`List (List.map board_context_comment_json comments));
+          ] );
+    ]
+
+let board_context_inference_message (post : Board.post) =
+  Printf.sprintf
+    "Infer the context of board post %s. Use the supplied board surface \
+     context and MASC tools as needed. Identify related work, missing context, \
+     and whether a follow-up action or board comment is warranted. Do not \
+     invent facts that are not present in board context, memory, or tools."
+    (Board.Post_id.to_string post.id)
+
+let resolve_board_context_inference_target ~config (post : Board.post) target_keeper =
+  let resolve source requested =
+    match Keeper_meta_store.read_meta_resolved config requested with
+    | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, source)
+    | Ok None ->
+        Error
+          ( `Bad_request,
+            Printf.sprintf "target_keeper %S is not a registered keeper" requested )
+    | Error msg ->
+        Error
+          ( `Internal_server_error,
+            Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg )
+  in
+  match target_keeper with
+  | Some requested -> resolve Explicit_target requested
+  | None ->
+      let author = Board.Agent_id.to_string post.author in
+      (match Keeper_meta_store.read_meta_resolved config author with
+       | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, Post_author)
+       | Ok None ->
+           Error
+             ( `Bad_request,
+               Printf.sprintf
+                 "target_keeper is required because board post author %S is not a registered keeper"
+                 author )
+       | Error msg ->
+           Error
+             ( `Internal_server_error,
+               Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg ))
+
+let non_empty_json_string_member field json =
+  match json_assoc_member field json with
+  | Some (`String value) ->
+      let value = String.trim value in
+      if value = "" then None else Some value
+  | _ -> None
+
+let board_context_inference_submission_json ~post_id ~target_source tool_data =
+  match
+    ( non_empty_json_string_member "request_id" tool_data,
+      non_empty_json_string_member "keeper_name" tool_data,
+      non_empty_json_string_member "status" tool_data )
+  with
+  | Some request_id, Some keeper_name, Some status ->
+      let fields =
+        [
+          ("ok", `Bool true);
+          ("request_id", `String request_id);
+          ("keeper_name", `String keeper_name);
+          ("post_id", `String post_id);
+          ("status", `String status);
+          ( "target_source",
+            `String (board_context_inference_target_source_to_string target_source) );
+        ]
+      in
+      let fields =
+        match non_empty_json_string_member "message" tool_data with
+        | Some message -> fields @ [ ("message", `String message) ]
+        | None -> fields
+      in
+      Ok (`Assoc fields)
+  | _ -> Error "masc_keeper_msg returned a malformed queue submission"
+
+let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
+    ~target_source ~(post : Board.post) ~comments =
+  let config = Mcp_server.workspace_config state in
+  let agent_name = board_tool_agent_name_from_request request in
+  let keeper_ctx : _ Keeper_tool_surface.context =
+    {
+      config;
+      agent_name;
+      sw;
+      clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
+      net = state.Mcp_server.net;
+    }
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let args =
+    `Assoc
+      [
+        ("name", `String target_keeper);
+        ("message", `String (board_context_inference_message post));
+        ("direct_reply", `Bool true);
+        ( "surface_context",
+          board_context_inference_surface_context post comments );
+      ]
+  in
+  match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
+  | None -> Error (`Internal_server_error, "masc_keeper_msg tool is unavailable")
+  | Some result ->
+      if Tool_result.is_success result
+      then
+        (match
+           board_context_inference_submission_json ~post_id ~target_source
+             (Tool_result.data result)
+         with
+         | Ok json -> Ok json
+         | Error msg -> Error (`Internal_server_error, msg))
+      else Error (`Bad_request, Tool_result.message result)
+
+let respond_board_context_inference_error request reqd ~status ~message =
+  respond_json_value_with_cors ~status request reqd
+    (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
+
 let respond_board_json reqd json =
   Http.Response.json_value json reqd
 
@@ -397,6 +597,49 @@ let add_routes ~sw ~clock router =
 
   |> Http.Router.get "/api/v1/board/sub-boards" (fun _request reqd ->
        respond_board_json reqd (board_sub_boards_json ()))
+
+  |> Http.Router.post "/api/v1/board/context-inference" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_keeper_msg"
+         (fun state _req reqd ->
+         Http.Request.read_body_async reqd (fun body ->
+           try
+             let parsed = Yojson.Safe.from_string body in
+             match parse_board_context_inference_request parsed with
+             | Error message ->
+                 respond_board_context_inference_error request reqd
+                   ~status:`Bad_request ~message
+             | Ok { post_id; target_keeper } -> (
+                 match Board_dispatch.get_post_and_comments ~post_id () with
+                 | Error err ->
+                     respond_board_context_inference_error request reqd
+                       ~status:`Bad_request
+                       ~message:(Board_tool.board_error_to_string err)
+                 | Ok (post, comments) -> (
+                     let config = Mcp_server.workspace_config state in
+                     match
+                       resolve_board_context_inference_target ~config post
+                         target_keeper
+                     with
+                     | Error (status, message) ->
+                         respond_board_context_inference_error request reqd
+                           ~status ~message
+                     | Ok (target_keeper, target_source) -> (
+                         match
+                           dispatch_board_context_inference ~state ~sw ~clock
+                             ~request ~target_keeper ~target_source ~post
+                             ~comments
+                         with
+                         | Ok json ->
+                             respond_json_value_with_cors ~status:`Accepted
+                               request reqd json
+                         | Error (status, message) ->
+                             respond_board_context_inference_error request reqd
+                               ~status ~message))))
+           with Yojson.Json_error msg ->
+             respond_board_context_inference_error request reqd
+               ~status:`Bad_request
+               ~message:("Invalid JSON: " ^ msg)))
+         request reqd)
 
   |> Http.Router.post "/api/v1/board/sub-boards" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_board_sub_board_create"

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -367,6 +367,42 @@ let respond_board_context_inference_error request reqd ~status ~message =
   respond_json_value_with_cors ~status request reqd
     (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
 
+let handle_board_context_inference_request ~state ~sw ~clock ~request reqd body =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg ->
+      respond_board_context_inference_error request reqd ~status:`Bad_request
+        ~message:("Invalid JSON: " ^ msg)
+  | parsed -> (
+      match parse_board_context_inference_request parsed with
+      | Error message ->
+          respond_board_context_inference_error request reqd ~status:`Bad_request
+            ~message
+      | Ok { post_id; target_keeper } -> (
+          match Board_dispatch.get_post_and_comments ~post_id () with
+          | Error err ->
+              respond_board_context_inference_error request reqd
+                ~status:`Bad_request
+                ~message:(Board_tool.board_error_to_string err)
+          | Ok (post, comments) -> (
+              let config = Mcp_server.workspace_config state in
+              match
+                resolve_board_context_inference_target ~config post target_keeper
+              with
+              | Error (status, message) ->
+                  respond_board_context_inference_error request reqd ~status
+                    ~message
+              | Ok (target_keeper, target_source) -> (
+                  match
+                    dispatch_board_context_inference ~state ~sw ~clock ~request
+                      ~target_keeper ~target_source ~post ~comments
+                  with
+                  | Ok json ->
+                      respond_json_value_with_cors ~status:`Accepted request reqd
+                        json
+                  | Error (status, message) ->
+                      respond_board_context_inference_error request reqd ~status
+                        ~message))))
+
 let respond_board_json reqd json =
   Http.Response.json_value json reqd
 
@@ -601,44 +637,9 @@ let add_routes ~sw ~clock router =
   |> Http.Router.post "/api/v1/board/context-inference" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_keeper_msg"
          (fun state _req reqd ->
-         Http.Request.read_body_async reqd (fun body ->
-           try
-             let parsed = Yojson.Safe.from_string body in
-             match parse_board_context_inference_request parsed with
-             | Error message ->
-                 respond_board_context_inference_error request reqd
-                   ~status:`Bad_request ~message
-             | Ok { post_id; target_keeper } -> (
-                 match Board_dispatch.get_post_and_comments ~post_id () with
-                 | Error err ->
-                     respond_board_context_inference_error request reqd
-                       ~status:`Bad_request
-                       ~message:(Board_tool.board_error_to_string err)
-                 | Ok (post, comments) -> (
-                     let config = Mcp_server.workspace_config state in
-                     match
-                       resolve_board_context_inference_target ~config post
-                         target_keeper
-                     with
-                     | Error (status, message) ->
-                         respond_board_context_inference_error request reqd
-                           ~status ~message
-                     | Ok (target_keeper, target_source) -> (
-                         match
-                           dispatch_board_context_inference ~state ~sw ~clock
-                             ~request ~target_keeper ~target_source ~post
-                             ~comments
-                         with
-                         | Ok json ->
-                             respond_json_value_with_cors ~status:`Accepted
-                               request reqd json
-                         | Error (status, message) ->
-                             respond_board_context_inference_error request reqd
-                               ~status ~message))))
-           with Yojson.Json_error msg ->
-             respond_board_context_inference_error request reqd
-               ~status:`Bad_request
-               ~message:("Invalid JSON: " ^ msg)))
+         Http.Request.read_body_async reqd
+           (handle_board_context_inference_request ~state ~sw ~clock ~request
+              reqd)
          request reqd)
 
   |> Http.Router.post "/api/v1/board/sub-boards" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_activity.mli
+++ b/lib/server/server_routes_http_routes_activity.mli
@@ -9,3 +9,24 @@ val add_routes :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
+
+type board_context_inference_target_source =
+  | Explicit_target
+  | Post_author
+
+val board_context_inference_target_source_to_string :
+  board_context_inference_target_source -> string
+
+type board_context_inference_request = {
+  post_id : string;
+  target_keeper : string option;
+}
+
+val parse_board_context_inference_request :
+  Yojson.Safe.t -> (board_context_inference_request, string) result
+
+val resolve_board_context_inference_target :
+  config:Workspace.config ->
+  Board.post ->
+  string option ->
+  (string * board_context_inference_target_source, [ `Bad_request of string | `Internal_server_error of string ]) result

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -237,6 +237,7 @@ let board_contributor_quality_json
       ("accountability_score", `Float rep.accountability_score);
       ("autonomy_level", `String rep.autonomy_level);
       ("thompson_confidence", `Float rep.thompson_confidence);
+      ("evidence_state", `String rep.evidence_state);
     ]
 
 let board_contributor_quality_lookup ?config () =

--- a/test/dune
+++ b/test/dune
@@ -365,9 +365,9 @@
   test_env_keeper_scrub
   test_event_log
   test_relation_materializer
-  test_keeper_behavior_trace
   test_keeper_wire_capture
-  test_board_rest_routes)
+  test_board_rest_routes
+  test_board_context_inference_resolution)
  (modules
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
@@ -713,10 +713,9 @@
   test_log_severity_outcome_level
   test_env_keeper_scrub
   test_event_log
-  test_relation_materializer
-  test_keeper_behavior_trace
   test_keeper_wire_capture
-  test_board_rest_routes)
+  test_board_rest_routes
+  test_board_context_inference_resolution)
  (libraries masc_test_deps multimodal bigstringaf))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.

--- a/test/test_board_content_dedup.ml
+++ b/test/test_board_content_dedup.ml
@@ -150,7 +150,8 @@ let test_exact_duplicate_comment_returns_same_comment () =
   Board_dispatch.set_board_signal_hook (fun signal ->
     match signal.kind with
     | Board_dispatch.Board_comment_added -> incr keeper_comment_signals
-    | Board_dispatch.Board_post_created -> ());
+    | Board_dispatch.Board_post_created
+    | Board_dispatch.Board_reaction_changed _ -> ());
   Board_dispatch.set_board_sse_hook (function
     | Board_dispatch.Comment_added _ -> incr sse_comment_events
     | Board_dispatch.Post_created _

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -1,0 +1,159 @@
+open Alcotest
+open Masc
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_board_inference_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  rm dir
+
+let with_workspace f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some "keeper-sangsu-agent"));
+      f config)
+
+let make_meta name : Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let post_id_of_string s =
+  match Board.Post_id.of_string s with
+  | Ok id -> id
+  | Error _ -> Alcotest.failf "failed to parse post_id %S" s
+
+let agent_id_of_string s =
+  match Board.Agent_id.of_string s with
+  | Ok id -> id
+  | Error _ -> Alcotest.failf "failed to parse agent_id %S" s
+
+let make_post ~id ~author =
+  { Board.id = post_id_of_string id;
+    author = agent_id_of_string author;
+    title = "Test post";
+    body = "Test body";
+    content = "Test content";
+    post_kind = Board.Human_post;
+    meta_json = None;
+    visibility = Board.Internal;
+    created_at = Unix.gettimeofday ();
+    updated_at = Unix.gettimeofday ();
+    expires_at = Unix.gettimeofday () +. 3600.0;
+    votes_up = 0;
+    votes_down = 0;
+    reply_count = 0;
+    pinned = false;
+    hearth = None;
+    thread_id = None;
+    origin = None;
+  }
+
+let test_parse_request () =
+  (* 1. Valid payload *)
+  let json = `Assoc [("post_id", `String "post-123"); ("target_keeper", `String "sangsu")] in
+  (match Server_routes_http_routes_activity.parse_board_context_inference_request json with
+   | Ok req ->
+     check string "post_id parsed" "post-123" req.post_id;
+     check (option string) "target_keeper parsed" (Some "sangsu") req.target_keeper
+   | Error err -> fail ("parse failed: " ^ err));
+
+  (* 2. Missing post_id *)
+  let json = `Assoc [("target_keeper", `String "sangsu")] in
+  (match Server_routes_http_routes_activity.parse_board_context_inference_request json with
+   | Error err -> check string "error on missing post_id" "post_id is required" err
+   | Ok _ -> fail "expected parsing error");
+
+  (* 3. Whitespace target_keeper *)
+  let json = `Assoc [("post_id", `String "post-123"); ("target_keeper", `String "  ")] in
+  (match Server_routes_http_routes_activity.parse_board_context_inference_request json with
+   | Ok req ->
+     check string "post_id parsed" "post-123" req.post_id;
+     check (option string) "target_keeper parsed as None" None req.target_keeper
+   | Error err -> fail ("parse failed: " ^ err))
+
+let test_target_resolution_explicit_registered () =
+  with_workspace (fun config ->
+    (* Register keeper "sangsu" *)
+    (match Keeper_meta_store.write_meta config (make_meta "sangsu") with
+     | Ok _ -> ()
+     | Error msg -> fail ("write_meta failed: " ^ msg));
+
+    let post = make_post ~id:"post-1" ~author:"operator" in
+    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post (Some "sangsu") with
+    | Ok (resolved_name, source) ->
+      check string "resolved name" "sangsu" resolved_name;
+      check bool "source is Explicit_target" true (source = Server_routes_http_routes_activity.Explicit_target)
+    | Error _ -> fail "expected resolution to succeed")
+
+let test_target_resolution_explicit_unregistered () =
+  with_workspace (fun config ->
+    let post = make_post ~id:"post-1" ~author:"operator" in
+    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post (Some "chulsoo") with
+    | Error (`Bad_request msg) ->
+      check string "error message" "target_keeper \"chulsoo\" is not a registered keeper" msg
+    | _ -> fail "expected Bad_request error")
+
+let test_target_resolution_implicit_registered_author () =
+  with_workspace (fun config ->
+    (* Register keeper "sangsu" *)
+    (match Keeper_meta_store.write_meta config (make_meta "sangsu") with
+     | Ok _ -> ()
+     | Error msg -> fail ("write_meta failed: " ^ msg));
+
+    (* Post author matches a registered keeper (either by short name or full agent name) *)
+    let post = make_post ~id:"post-1" ~author:"sangsu" in
+    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post None with
+    | Ok (resolved_name, source) ->
+      check string "resolved name" "sangsu" resolved_name;
+      check bool "source is Post_author" true (source = Server_routes_http_routes_activity.Post_author)
+    | Error _ -> fail "expected resolution to succeed")
+
+let test_target_resolution_implicit_unregistered_author () =
+  with_workspace (fun config ->
+    (* Post author is "operator", which is not a registered keeper *)
+    let post = make_post ~id:"post-1" ~author:"operator" in
+    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post None with
+    | Error (`Bad_request msg) ->
+      check string "error message" "target_keeper is required because board post author \"operator\" is not a registered keeper" msg
+    | _ -> fail "expected Bad_request error")
+
+let () =
+  run "Server board context inference resolution"
+    [ ( "parse_request",
+        [ test_case "parse request payloads" `Quick test_parse_request ] )
+    ; ( "target_resolution",
+        [ test_case "explicit registered target" `Quick test_target_resolution_explicit_registered
+        ; test_case "explicit unregistered target" `Quick test_target_resolution_explicit_unregistered
+        ; test_case "implicit registered author" `Quick test_target_resolution_implicit_registered_author
+        ; test_case "implicit unregistered author" `Quick test_target_resolution_implicit_unregistered_author
+        ] )
+    ]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1203,6 +1203,53 @@ let test_board_sse_reaction_changed () =
   | Some _ -> Alcotest.fail "expected reaction_changed SSE event"
   | None -> Alcotest.fail "expected board SSE event"
 
+let test_board_signal_reaction_changed_resolves_comment_parent () =
+  let post =
+    match
+      Board_dispatch.create_post ~author:"reaction-author"
+        ~title:"Reaction parent title"
+        ~content:"reaction parent content @keeper-alpha"
+        ~post_kind:Board.Human_post ()
+    with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok post -> post
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"comment-author"
+        ~content:"comment target" ()
+    with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok comment -> comment
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  let seen = ref None in
+  Board_dispatch.set_board_signal_hook (fun signal -> seen := Some signal);
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+       ~target_id:comment_id ~user_id:"reactor" ~emoji:"👏"
+   with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok _ -> ());
+  match !seen with
+  | Some signal ->
+    (match signal.Board_dispatch.kind with
+     | Board_dispatch.Board_reaction_changed
+         { target_type; target_id; user_id; emoji; reacted } ->
+      Alcotest.(check string) "parent post id" post_id signal.Board_dispatch.post_id;
+      Alcotest.(check string) "signal author is reactor" "reactor" signal.author;
+      Alcotest.(check string) "target type" "comment"
+        (Board.reaction_target_type_to_string target_type);
+      Alcotest.(check string) "target id" comment_id target_id;
+      Alcotest.(check string) "user" "reactor" user_id;
+      Alcotest.(check string) "emoji" "👏" emoji;
+      Alcotest.(check bool) "reacted" true reacted;
+      Alcotest.(check string) "parent title" "Reaction parent title" signal.title;
+      Alcotest.(check string) "parent content" "reaction parent content @keeper-alpha" signal.content
+     | _ -> Alcotest.fail "expected reaction_changed board signal")
+  | None -> Alcotest.fail "expected reaction_changed board signal"
+
 let test_reaction_rejects_unsupported_emoji () =
   match
     Board_dispatch.create_post ~author:"reaction-author"
@@ -1774,6 +1821,8 @@ let () =
         (with_eio test_reaction_summary_batch);
       Alcotest.test_case "SSE reaction_changed" `Quick
         (with_eio test_board_sse_reaction_changed);
+      Alcotest.test_case "board signal reaction_changed resolves comment parent" `Quick
+        (with_eio test_board_signal_reaction_changed_resolves_comment_parent);
       Alcotest.test_case "unsupported emoji rejected" `Quick
         (with_eio test_reaction_rejects_unsupported_emoji);
     ];

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -36,6 +36,59 @@ let () =
   assert (String.equal (payload_kind_label Bootstrap) "bootstrap");
   assert (String.equal (payload_kind_label No_progress_recovery) "no_progress_recovery");
 
+  let reaction_payload () =
+    Board_signal
+      { kind =
+          Reaction_changed
+            { target_type = Reaction_comment
+            ; target_id = "c1"
+            ; user_id = "reactor"
+            ; emoji = "👏"
+            ; reacted = true
+            }
+      ; author = "reactor"
+      ; title = "parent"
+      ; content = "body"
+      ; hearth = Some "research"
+      ; updated_at = Some 5.0
+      }
+  in
+  (match
+     stimulus_of_yojson
+       (stimulus_to_yojson
+          { post_id = "p-reaction"
+          ; urgency = Normal
+          ; arrived_at = 5.0
+          ; payload = reaction_payload ()
+          })
+   with
+   | Ok s ->
+     (match s.payload with
+      | Board_signal
+          { kind =
+              Reaction_changed
+                { target_type = Reaction_comment
+                ; target_id
+                ; user_id
+                ; emoji
+                ; reacted
+                }
+          ; author
+          ; hearth = Some hearth
+          ; updated_at = Some updated_at
+          ; _
+          } ->
+        assert (String.equal s.post_id "p-reaction");
+        assert (String.equal target_id "c1");
+        assert (String.equal user_id "reactor");
+        assert (String.equal emoji "👏");
+        assert reacted;
+        assert (String.equal author "reactor");
+        assert (String.equal hearth "research");
+        assert (Float.equal updated_at 5.0)
+      | _ -> Alcotest.fail "reaction board stimulus round-trip changed payload shape")
+   | Error msg -> Alcotest.fail ("reaction board stimulus round-trip failed: " ^ msg));
+
   (* RFC-0266: Fusion_completed is a non-board stimulus with its own label. *)
   let fusion_payload () =
     Fusion_completed

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -25,6 +25,7 @@ let base_observation : WO.world_observation =
 
 let sample_board_event : WO.pending_board_event =
   {
+    event_kind = WO.Board_post_created;
     post_id = "board-post-1";
     author = "alice";
     title = "Need help";
@@ -214,6 +215,39 @@ let test_quarantined_board_event_wraps_in_envelope () =
     (contains_sub "observational-data" human_msg)
 ;;
 
+let test_board_reaction_event_renders_reaction_context () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  let reaction_event =
+    {
+      sample_board_event with
+      event_kind =
+        WO.Board_reaction_changed
+          {
+            target_type = Masc.Board.Reaction_comment;
+            target_id = "comment-1";
+            user_id = "reactor";
+            emoji = "👏";
+            reacted = true;
+          };
+      post_id = "reaction-parent";
+      author = "reactor";
+    }
+  in
+  let obs = { base_observation with pending_board_events = [ reaction_event ] } in
+  let _, user_msg =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs ()
+  in
+  check bool "prompt labels reaction board event" true
+    (contains_sub "event=reaction_changed" user_msg);
+  check bool "prompt includes reaction target" true
+    (contains_sub "target=comment:comment-1" user_msg);
+  check bool "prompt includes reaction actor" true
+    (contains_sub "user=reactor" user_msg);
+  check bool "prompt includes reaction emoji" true
+    (contains_sub "emoji=\"👏\"" user_msg)
+;;
+
 let test_task_claim_requires_matched_backlog () =
   let obs =
     { base_observation with unclaimed_task_count = 3; claimable_task_count = 0 }
@@ -352,6 +386,9 @@ let () =
           test_case
             "trust: quarantined board event wraps in envelope (RFC-0248 PR-2)"
             `Quick test_quarantined_board_event_wraps_in_envelope;
+          test_case
+            "prompt: board reaction event renders reaction context"
+            `Quick test_board_reaction_event_renders_reaction_context;
           test_case "affordance: task claim requires matched backlog" `Quick
             test_task_claim_requires_matched_backlog;
           test_case "affordance: task claim present for claimable backlog" `Quick

--- a/test/test_reputation_multi_dim.ml
+++ b/test/test_reputation_multi_dim.ml
@@ -117,17 +117,22 @@ let test_default_reputation_v2_fields () =
   check (float 0.0001) "safety_compliance default" 1.0
     rep.safety_compliance;
   check string "autonomy_level default" "standard"
-    rep.autonomy_level
+    rep.autonomy_level;
+  check string "evidence_state default" "default"
+    rep.evidence_state
 
 let test_reputation_json_roundtrip_v2_fields () =
-  let rep = Reputation.default_reputation ~agent_name:"json-test" in
+  let rep = { (Reputation.default_reputation ~agent_name:"json-test") with
+              evidence_state = "measured" } in
   let json = Reputation.reputation_to_json rep in
   match Reputation.reputation_of_json json with
   | Some r ->
     check (float 0.0001) "execution_reliability preserved" 1.0
       r.execution_reliability;
     check string "autonomy_level preserved" "standard"
-      r.autonomy_level
+      r.autonomy_level;
+    check string "evidence_state preserved" "measured"
+      r.evidence_state
   | None ->
     fail "reputation_of_json returned None"
 


### PR DESCRIPTION
## What changed

- Reworked board feed controls so sort/category behavior is explicit and server-backed, including discussed/comment-heavy ordering.
- Removed title/body keyword heuristics and default hardcoded contributor-quality priors from board presentation.
- Added richer board content rendering for embedded HTML/media and standalone video/audio/Youtube/Vimeo content.
- Added permalink, trackback, X share, and board context-inference actions for posts.
- Wired board emoji reactions into Keeper wake/context flow so reactions after Keeper activity are observable and actionable.
- Added a board context inference HTTP route that queues a real `masc_keeper_msg` turn with board post/comment surface context instead of faking an LLM action in the UI.

## Why

The board surface had several affordances that looked interactive but did not feed back into Keeper behavior or actual collaboration workflows. This change keeps the board weakly coupled while making reactions, sharing, rich content, and Keeper-launched context inference real production paths.

## Impact

- Dashboard users get usable blog-style post actions and richer idea/media rendering.
- Keeper-authored posts no longer collapse all sigils to generic `KE` when better identity data is available.
- Context inference launches an async Keeper turn through the existing `masc_keeper_msg` queue with explicit registered-Keeper resolution.
- Board reaction changes can wake Keepers through typed runtime events instead of remaining dashboard-only state.

## Validation

- `ocamlformat --check lib/server/server_routes_http_routes_activity.ml`
- `pnpm --dir dashboard exec vitest run src/api/board.test.ts src/components/board/post-detail.test.ts src/components/board/board-surface.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`

Local Dune build was intentionally not run; this repo uses CI for Dune build validation.