### PR TITLE
dashboard: gate keeper config writes by source

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1633,6 +1633,60 @@ describe('KeeperConfigPanel', () => {
     ) as HTMLButtonElement
     expect(saveButton.disabled).toBe(true)
   })
+
+  it('resets runtime draft when switching from keeper A to keeper B to prevent stale settings leakage', async () => {
+    const configA = makeKeeperConfig({
+      name: 'keeper-a',
+      execution: {
+        selected_runtime_id: 'ollama_cloud.deepseek-v4-flash',
+        runtime_options: ['ollama_cloud.deepseek-v4-flash', 'ollama_cloud.qwen-2.5-coder'],
+        selected_runtime_canonical: 'ollama_cloud.deepseek-v4-flash',
+        models: ['ollama_cloud.deepseek-v4-flash'],
+      } as any,
+    })
+    const configB = makeKeeperConfig({
+      name: 'keeper-b',
+      execution: {
+        selected_runtime_id: 'ollama_cloud.qwen-2.5-coder',
+        runtime_options: ['ollama_cloud.deepseek-v4-flash', 'ollama_cloud.qwen-2.5-coder'],
+        selected_runtime_canonical: 'ollama_cloud.qwen-2.5-coder',
+        models: ['ollama_cloud.qwen-2.5-coder'],
+      } as any,
+    })
+
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(configA)
+    render(html`<${KeeperConfigPanel} keeperName="keeper-a" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '런타임')
+    await flush()
+
+    const select = container.querySelector('select[aria-label="runtime_id"]') as HTMLSelectElement
+    expect(select.value).toBe('ollama_cloud.deepseek-v4-flash')
+
+    select.value = 'ollama_cloud.qwen-2.5-coder'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(configB)
+    render(html`<${KeeperConfigPanel} keeperName="keeper-b" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '런타임')
+    await flush()
+
+    const finalSelect = container.querySelector('select[aria-label="runtime_id"]') as HTMLSelectElement
+    expect(finalSelect.value).toBe('ollama_cloud.qwen-2.5-coder')
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('저장'),
+    ) as HTMLButtonElement
+    if (saveButton) {
+      expect(saveButton.disabled).toBe(true)
+    }
+  })
 })
 
 describe('filterGoalOptions', () => {

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -9,6 +9,8 @@ import {
   filterHookSlots,
   hookSlotDetails,
   initRuntimeDraftFromConfig,
+  keeperRuntimeConfigCanWrite,
+  keeperRuntimeConfigWriteUnsupportedReason,
   type HookSlotEntry,
   type RuntimeDraft,
 } from './keeper-config-panel'
@@ -266,6 +268,42 @@ describe('sandbox coerce helpers', () => {
     expect(coerceNetworkMode(undefined)).toBe('inherit')
   })
 
+})
+
+describe('keeperRuntimeConfigCanWrite', () => {
+  it('allows writes only for a TOML-backed keeper manifest', () => {
+    const base = makeKeeperConfig()
+    expect(keeperRuntimeConfigCanWrite(base)).toBe(true)
+    expect(keeperRuntimeConfigWriteUnsupportedReason(base)).toBeNull()
+  })
+
+  it('rejects persona-backed config even when a path-like value is present', () => {
+    const base = makeKeeperConfig()
+    const c = makeKeeperConfig({
+      sources: {
+        ...base.sources,
+        default_source_kind: 'persona',
+        default_manifest_path: '/tmp/config/keepers/default.toml',
+      },
+    })
+
+    expect(keeperRuntimeConfigCanWrite(c)).toBe(false)
+    expect(keeperRuntimeConfigWriteUnsupportedReason(c)).toContain('현재 기본 소스: persona')
+  })
+
+  it('rejects TOML config without a manifest path', () => {
+    const base = makeKeeperConfig()
+    const c = makeKeeperConfig({
+      sources: {
+        ...base.sources,
+        default_source_kind: 'toml',
+        default_manifest_path: null,
+      },
+    })
+
+    expect(keeperRuntimeConfigCanWrite(c)).toBe(false)
+    expect(keeperRuntimeConfigWriteUnsupportedReason(c)).toContain('기본 매니페스트 경로')
+  })
 })
 
 function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
@@ -1061,6 +1099,75 @@ describe('KeeperConfigPanel', () => {
     expect(tokenGateInput!.type).toBe('number')
     // Value reflects the loaded config (makeKeeperConfig compaction.token_gate = 24000).
     expect(tokenGateInput!.value).toBe('24000')
+  })
+
+  it('keeps runtime config controls read-only when the keeper is not manifest-backed', async () => {
+    const base = makeKeeperConfig()
+    const personaConfig = makeKeeperConfig({
+      sources: {
+        ...base.sources,
+        default_source_kind: 'persona',
+        default_manifest_path: null,
+      },
+    })
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(personaConfig)
+    mocks.setKeeperToolPolicy.mockResolvedValueOnce(personaConfig)
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '런타임')
+    await flush()
+    expect(container.querySelector('[data-testid="keeper-runtime-write-unsupported"]')).not.toBeNull()
+    expect(container.textContent).toContain('현재 기본 소스: persona')
+    expect(container.querySelector('select[aria-label="runtime_id"]')).toBeNull()
+    expect(container.querySelector('input[aria-label="컨텍스트 오버라이드"]')).toBeNull()
+    expect(container.textContent).toContain('tier-group.keeper_unified')
+
+    selectKcfTab(container, '실행 정책')
+    await flush()
+    expect(container.querySelector('select[aria-label="compaction_profile"]')).toBeNull()
+    expect(container.querySelector('input[aria-label="토큰 게이트"]')).toBeNull()
+    expect(container.querySelector('button[aria-label="자동 부팅"]')).toBeNull()
+    expect(container.querySelector('textarea[aria-label="tool_access"]')).not.toBeNull()
+    const denylist = container.querySelector('textarea[aria-label="tool_denylist"]') as HTMLTextAreaElement | null
+    expect(denylist).not.toBeNull()
+    denylist!.value = 'Execute\nDangerTool'
+    denylist!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+    const policySave = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('정책 저장'),
+    )
+    policySave?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+    expect(mocks.setKeeperToolPolicy).toHaveBeenCalledWith('keeper-sangsu', {
+      tool_access: ['tool_read_file'],
+      deny: ['Execute', 'DangerTool'],
+    })
+
+    selectKcfTab(container, '권한·샌드박스')
+    await flush()
+    expect(container.querySelector('select[aria-label="sandbox_profile"]')).toBeNull()
+    expect(container.querySelector('select[aria-label="network_mode"]')).toBeNull()
+    expect(container.querySelector('textarea[aria-label="allowed_paths"]')).toBeNull()
+    expect(container.querySelector('textarea[aria-label="mention_targets"]')).toBeNull()
+    expect(container.textContent).toContain('allowed_paths')
+    expect(container.textContent).toContain('/tmp/workspace')
+
+    selectKcfTab(container, '목표')
+    await flush()
+    expect(container.querySelector('input[aria-label="goal 검색"]')).toBeNull()
+    expect(container.querySelectorAll('.kcf-goal').length).toBe(0)
+    expect(container.textContent).toContain('goal-runtime')
+    expect(container.textContent).toContain('읽기 전용')
+
+    const runtimeSave = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
+    )
+    expect(runtimeSave).toBeUndefined()
+    expect(mocks.patchKeeperConfig).not.toHaveBeenCalled()
   })
 
   it('saves the tool denylist via set_policy, echoing current tool_access and deduping entries', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1145,7 +1145,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   const runtimeCanEdit = runtimeWriteUnsupportedReason === null
 
   // Initialize runtime draft if not yet set
-  if (!runtimeDraft.value) {
+  if (!runtimeDraft.value && c.name === keeperName) {
     runtimeDraft.value = initRuntimeDraftFromConfig(c)
   }
   const rd = runtimeDraft.value

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -93,7 +93,7 @@ const kcfTab = signal<KcfTabId>('identity')
 const goalOptionsResource = createAsyncResource<GoalTreeNode[]>()
 const goalOptionsState = goalOptionsResource.state
 // Client-only search over the goal catalogue (title/id substring). The catalogue
-// runs 70+ entries, so the goals tab filters the rendered list without a fetch.
+// can be large, so the goals tab filters the rendered list without a fetch.
 const goalSearchQuery = signal('')
 // Live tool registry (GET /api/v1/dashboard/tools) — the per-tool policy grid is
 // derived from this, never a hardcoded catalogue, so a tool added to the runtime
@@ -325,6 +325,22 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
     handoff_threshold: c.handoff.threshold,
     handoff_cooldown_sec: c.handoff.cooldown_sec,
   }
+}
+
+export function keeperRuntimeConfigWriteUnsupportedReason(c: KeeperConfig): string | null {
+  const kind = c.sources.default_source_kind ?? 'unknown'
+  if (kind !== 'toml') {
+    return `runtime 설정 저장은 TOML-backed keeper manifest에서만 지원됩니다. 현재 기본 소스: ${kind}.`
+  }
+  const manifestPath = c.sources.default_manifest_path?.trim()
+  if (!manifestPath) {
+    return 'runtime 설정 저장은 기본 매니페스트 경로가 확인될 때만 지원됩니다.'
+  }
+  return null
+}
+
+export function keeperRuntimeConfigCanWrite(c: KeeperConfig): boolean {
+  return keeperRuntimeConfigWriteUnsupportedReason(c) === null
 }
 
 export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
@@ -1125,7 +1141,8 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   const c = state.data
   const isEditing = editMode.value
   const isSaving = saving.value
-  const runtimeCanEdit = c.sources.default_source_kind === 'toml' && Boolean(c.sources.default_manifest_path)
+  const runtimeWriteUnsupportedReason = keeperRuntimeConfigWriteUnsupportedReason(c)
+  const runtimeCanEdit = runtimeWriteUnsupportedReason === null
 
   // Initialize runtime draft if not yet set
   if (!runtimeDraft.value) {
@@ -1134,7 +1151,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   const rd = runtimeDraft.value
   const dirtyFlags = rd ? computeRuntimeDirtyFlags(rd, c) : {}
 
-  const runtimeHasChanges = rd ? Object.keys(buildRuntimePayload(rd, c)).length > 0 : false
+  const runtimeHasChanges = runtimeCanEdit && rd ? Object.keys(buildRuntimePayload(rd, c)).length > 0 : false
   const maxContextOverrideTokens = c.limits.max_context_override_tokens ?? undefined
   const runtimeOptions = rd
     ? dedupeStrings([
@@ -1150,9 +1167,17 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   const selectedRuntimeCatalogRows = selectedRuntimeCatalog
     ? runtimeCatalogSpecRows(selectedRuntimeCatalog)
     : runtimeCatalogStateRows(runtimeCatalog, selectedRuntimeId, selectedRuntimeCatalog)
+  const runtimeWriteUnsupportedNotice = runtimeWriteUnsupportedReason ? html`
+    <div data-testid="keeper-runtime-write-unsupported" class="mb-3">
+      <${Callout}
+        title="런타임 설정 읽기 전용"
+        body=${`${runtimeWriteUnsupportedReason} runtime.toml [runtime.assignments]와 keeper manifest 출처가 확인되면 이 패널의 runtime 설정 쓰기가 활성화됩니다.`}
+      />
+    </div>
+  ` : null
 
   async function saveRuntimeConfig() {
-    if (!rd) return
+    if (!rd || !runtimeCanEdit) return
     const payload = buildRuntimePayload(rd, c)
     if (Object.keys(payload).length === 0) return
     runtimeSaving.value = true
@@ -1399,6 +1424,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
   // runtime ◷ — runtime selection + execution profile (read-only introspection + runtime_id picker)
   const runtimeTab = html`
+    ${runtimeWriteUnsupportedNotice}
     <${KcfSec} title="Runtime 선택" desc=${runtimeSelectionSummary(c)}>
       ${rd && runtimeCanEdit ? html`
         <${InlineSelectRow}
@@ -1430,14 +1456,14 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         ['활성 런타임', c.execution.active_model ? 'runtime' : null],
         ['runtime timeout', perProviderTimeoutLabel(c.execution), true],
       ]} />
-      ${rd ? html`
+      ${rd && runtimeCanEdit ? html`
         <${InlineNumberRow} label="컨텍스트 오버라이드" value=${rd.max_context_override}
           onChange=${(v: number) => updateRuntimeDraft('max_context_override', normalizeMaxContextOverrideDraft(v, c.limits.max_context_override_tokens))}
           min=${0} max=${maxContextOverrideTokens} step=${1000} suffix="tok"
           dirty=${dirtyFlags.max_context_override} />
-      ` : c.max_context_override != null ? html`
-        <${ConfigRow} label="컨텍스트 오버라이드" value=${formatTokens(c.max_context_override)} />
-      ` : null}
+      ` : html`
+        <${ConfigRow} label="컨텍스트 오버라이드" value=${c.max_context_override != null ? formatTokens(c.max_context_override) : MISSING_DATA_DASH} />
+      `}
       <div style="margin-top:14px;">
         <div class="kcf-tf-h"><label>런타임 후보</label></div>
         <${RuntimeList} runtimes=${c.execution.models} />
@@ -1447,11 +1473,12 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
   // policy ⚖ — verify gate + compaction + proactive + handoff + tool policy
   const policyTab = html`
+    ${runtimeWriteUnsupportedNotice}
     <${MajorSectionHeader} title="검증" />
     <${BoolRow} label="검증" value=${c.execution.verify} />
 
     <${SectionHeader} title="컴팩션" />
-    ${rd ? html`
+    ${rd && runtimeCanEdit ? html`
       <${InlineSelectRow}
         label="compaction_profile"
         value=${rd.compaction_profile}
@@ -1485,7 +1512,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     `}
 
     <${SectionHeader} title="프로액티브" />
-    ${rd ? html`
+    ${rd && runtimeCanEdit ? html`
       <${SetRow} label="자동 부팅" hint="서버 시작 시 keeper 등록" dirty=${dirtyFlags.autoboot_enabled}>
         <${SetToggle} ariaLabel="자동 부팅" on=${rd.autoboot_enabled}
           onChange=${(v: boolean) => updateRuntimeDraft('autoboot_enabled', v)} />
@@ -1510,7 +1537,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     `}
 
     <${SectionHeader} title="핸드오프" />
-    ${rd ? html`
+    ${rd && runtimeCanEdit ? html`
       <${SetRow} label="자동" hint="컨텍스트 임계 도달 시 자동 인계" dirty=${dirtyFlags.auto_handoff}>
         <${SetToggle} ariaLabel="자동 핸드오프" on=${rd.auto_handoff}
           onChange=${(v: boolean) => updateRuntimeDraft('auto_handoff', v)} />
@@ -1640,8 +1667,9 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
   // access ⚿ — sandbox / network / allowed_paths + mention targets + bound namespaces
   const accessTab = html`
+    ${runtimeWriteUnsupportedNotice}
     <${MajorSectionHeader} title="실행 범위 · 샌드박스" />
-    ${rd ? html`
+    ${rd && runtimeCanEdit ? html`
       <${InlineSelectRow}
         label="sandbox_profile"
         value=${rd.sandbox_profile}
@@ -1704,7 +1732,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     ` : null}
 
     <${SectionHeader} title="멘션 · 네임스페이스" />
-    ${rd ? html`
+    ${rd && runtimeCanEdit ? html`
       <div class="py-2.5 px-4 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] mb-2 ${dirtyFlags.mention_targets ? 'border-l-4 border-l-[var(--color-accent-fg)]' : ''} v2-monitoring-panel">
         <div class="flex items-center justify-between mb-2">
           <span class="text-sm text-[var(--color-fg-secondary)]">mention_targets</span>
@@ -1732,13 +1760,14 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   // goals ◎ — assigned goal-store bindings (active_goal_ids picker)
   const filteredGoalOptions = filterGoalOptions(goalOptions, goalSearchQuery.value)
   const goalsTab = html`
+    ${runtimeWriteUnsupportedNotice}
     <${KcfSec}
       title="배정 목표"
-      desc="goal store 카탈로그에서 이 keeper가 소유할 goal을 고릅니다."
+      desc=${runtimeCanEdit ? 'goal store 카탈로그에서 이 keeper가 소유할 goal을 고릅니다.' : '현재 배정된 goal-store 연결을 읽기 전용으로 표시합니다.'}
       right=${html`<span class="kcf-goals-count mono">active_goal_ids · ${selectedActiveGoalIds.length} 배정</span>`}
     >
       <div class="kcf-goals">
-        ${goalOptions.length > 0 && rd ? html`
+        ${goalOptions.length > 0 && rd && runtimeCanEdit ? html`
           <div class="kcf-goals-bar">
             <div class="kcf-search">
               <span class="kcf-search-ic" aria-hidden="true">◌</span>
@@ -1757,7 +1786,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
           <div class="text-2xs text-[var(--color-fg-muted)]" role="status">목표 목록 로딩 중...</div>
         ` : goalState.status === 'error' ? html`
           <div class="text-2xs text-[var(--color-status-err)]">${goalState.message}</div>
-        ` : goalOptions.length > 0 && rd ? (
+        ` : goalOptions.length > 0 && rd && runtimeCanEdit ? (
           filteredGoalOptions.length > 0 ? html`
           <div class="kcf-goals-list">
             ${filteredGoalOptions.map((goal) => {

--- a/dashboard/src/components/keeper-config-state.ts
+++ b/dashboard/src/components/keeper-config-state.ts
@@ -41,7 +41,12 @@ export async function loadKeeperConfig(
 ): Promise<void> {
   const force = options?.force === true
   if (!force && configKeeperName.value === name && configState.value.status === 'loaded') return
-  if (configKeeperName.value !== name || force) {
+  if (configKeeperName.value !== name) {
+    configResource.reset()
+    for (const handler of resetHandlers) {
+      handler()
+    }
+  } else if (force) {
     configResource.reset()
   }
   configKeeperName.value = name

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -591,7 +591,7 @@ function KeeperConfigOverlay({
   // buttons are rendered by the panel itself.)
   return html`
     <${Suspense} fallback=${html`<div class="kcf-overlay" data-testid="kw-config-overlay"><div class="kcf v2-monitoring-surface">설정 로딩…</div></div>`}>
-      <${LazyKeeperConfigPanel} keeperName=${keeperName} onClose=${onClose} />
+      <${LazyKeeperConfigPanel} key=${keeperName} keeperName=${keeperName} onClose=${onClose} />
     <//>
   `
 }

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -452,7 +452,7 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(keeperDetailPageSource).toContain('kw-detail-content')
     expect(keeperDetailPageSource).toContain('kw-detail-full-head')
     expect(keeperDetailPageSource).toContain("await import('./keeper-config-panel')")
-    expect(keeperDetailPageSource).toContain('<${LazyKeeperConfigPanel} keeperName=${keeperName} onClose=${onClose} />')
+    expect(keeperDetailPageSource).toContain('<${LazyKeeperConfigPanel} key=${keeperName} keeperName=${keeperName} onClose=${onClose} />')
     expect(keeperDetailPageSource).toContain('panel now owns the full .kcf-overlay modal shell')
     expect(keeperDetailBodySource).toContain('kw-detail-body')
     expect(keeperDetailShellSource).toContain('kw-detail-section-rail')


### PR DESCRIPTION
## Summary
- Gate Keeper Config runtime mutation controls on the existing source truth: `sources.default_source_kind === "toml"` plus a non-empty `default_manifest_path`.
- Downgrade runtime policy, sandbox/access, max context, and goal assignment controls to read-only when the keeper is persona/no-manifest backed.
- Keep separately-backed tool policy editing available through `set_policy`, and remove the stale fixed "70+ goals" catalog claim.

## Verification
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- Rendered smoke: `node /private/tmp/keeper-config-write-capability-smoke.js` against `http://127.0.0.1:5187/dashboard/#/keepers?keeper=analyst`; captured `/private/tmp/keeper-config-write-capability-modal.png`.

## Notes
- Dune build intentionally not run locally; dashboard-only TypeScript/frontend change and CI remains the build authority for repo-wide checks.
