### PR TITLE
feat(keeper): HITL 평가자를 모델 fleet 전체에서 동작하게 (dedicated judge + graceful degradation)

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -255,6 +255,25 @@ type summary_mode =
   | Native_structured
   | Plain_json_text
 
+type summary_llm_error =
+  { mode : summary_mode
+  ; error : Agent_sdk.Error.sdk_error
+  }
+
+let plain_mode_degradation_outcomes = function
+  | Plain_json_text -> [ "degraded_plain_json" ]
+  | Native_structured -> []
+;;
+
+let summary_llm_error_outcomes ~mode error =
+  let terminal =
+    match error with
+    | Agent_sdk.Error.Api (Timeout _) -> "timeout"
+    | _ -> "provider_error"
+  in
+  plain_mode_degradation_outcomes mode @ [ terminal ]
+;;
+
 (** Appended on the [Plain_json_text] path so a model without native structured
     output still returns a parseable object. The schema is the SSOT for both
     paths (native applies it as [response_format]; here it is inlined). *)
@@ -314,13 +333,16 @@ let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) 
 let call_summary_llm ~sw ~net ~provider_config ~context_bundle () =
   let config, mode = provider_config_for_summary provider_config in
   let messages = messages_for_summary ~mode ~context_bundle in
-  Keeper_llm_bridge.run_with_timeout_and_fallback
-    ~timeout_s:(Keeper_config.hitl_summary_timeout_sec ())
-    (fun () ->
-       Llm_provider.Complete.complete ~sw ~net ~config ~messages ()
-       |> Result.map (fun response -> response, mode)
-       |> Result.map_error (fun http_err ->
-            Agent_sdk.Error.Internal (Provider_http_error.to_message http_err)))
+  match
+    Keeper_llm_bridge.run_with_timeout_and_fallback
+      ~timeout_s:(Keeper_config.hitl_summary_timeout_sec ())
+      (fun () ->
+         Llm_provider.Complete.complete ~sw ~net ~config ~messages ()
+         |> Result.map_error (fun http_err ->
+              Agent_sdk.Error.Internal (Provider_http_error.to_message http_err)))
+  with
+  | Ok response -> Ok (response, mode)
+  | Error error -> Error { mode; error }
 ;;
 
 (* ── Parsing ────────────────────────────────────── *)
@@ -448,12 +470,16 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
                 | Error reason ->
                   record_outcome ~risk_level:entry.risk_level "parse_error";
                   on_failure ~reason ~retryable:true)
-             | Error (Agent_sdk.Error.Api (Timeout _)) ->
-               record_outcome ~risk_level:entry.risk_level "timeout";
+             | Error { mode; error = (Agent_sdk.Error.Api (Timeout _) as error) } ->
+               List.iter
+                 (record_outcome ~risk_level:entry.risk_level)
+                 (summary_llm_error_outcomes ~mode error);
                on_failure ~reason:"HITL summary LLM call timed out" ~retryable:true
-             | Error err ->
-               record_outcome ~risk_level:entry.risk_level "provider_error";
-               on_failure ~reason:(Agent_sdk.Error.to_string err) ~retryable:true))
+             | Error { mode; error } ->
+               List.iter
+                 (record_outcome ~risk_level:entry.risk_level)
+                 (summary_llm_error_outcomes ~mode error);
+               on_failure ~reason:(Agent_sdk.Error.to_string error) ~retryable:true))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
@@ -475,6 +501,7 @@ module For_testing = struct
   let summary_of_response = summary_of_response
   let provider_config_for_summary = provider_config_for_summary
   let extract_json_object = extract_json_object
+  let summary_llm_error_outcomes = summary_llm_error_outcomes
   let summary_version = summary_version
 end
 ;;

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -29,7 +29,10 @@ let () =
     ~help:
       "Total HITL context-summary worker outcomes classified by [outcome]. \
        Labels: [outcome] (ok_summary | parse_error | provider_error | timeout | \
-       no_provider_config | no_net | slot_unavailable | crashed), [risk_level]."
+       no_provider_config | no_net | slot_unavailable | crashed | \
+       degraded_plain_json), [risk_level]. [degraded_plain_json] is emitted \
+       alongside the terminal outcome when the judge endpoint could not serve \
+       native structured output and the plain-text JSON path was used."
     ()
 ;;
 
@@ -239,14 +242,48 @@ let build_context_bundle ~(entry : pending_approval) : Yojson.Safe.t =
 
 let message role text = Agent_sdk.Types.text_message role text
 
-let messages_for_summary ~context_bundle =
-  [ message Agent_sdk.Types.System system_prompt
-  ; message Agent_sdk.Types.User (Yojson.Safe.to_string context_bundle)
-  ]
+(** How the judge model is asked to return the summary.
+
+    [Native_structured] uses provider-native json_schema structured output.
+    [Plain_json_text] is the graceful-degradation path for judge endpoints that
+    cannot serve a native json_schema request — GLM exposes json_object only,
+    and raw OpenAI-compatible endpoints (e.g. mimo, runpod proxies) are not
+    declared in the OAS catalog. In that mode we prompt for a bare JSON object
+    and parse the model's visible text best-effort; a parse failure is surfaced
+    as [Summary_failed] by the caller, never silently dropped. *)
+type summary_mode =
+  | Native_structured
+  | Plain_json_text
+
+(** Appended on the [Plain_json_text] path so a model without native structured
+    output still returns a parseable object. The schema is the SSOT for both
+    paths (native applies it as [response_format]; here it is inlined). *)
+let plain_json_instruction =
+  Printf.sprintf
+    "Return ONLY a single JSON object with no markdown fences and no prose. It \
+     must conform to this JSON Schema:\n%s"
+    (Yojson.Safe.to_string Keeper_structured_output_schema.hitl_context_summary_schema)
 ;;
 
-(** Cap cost and sampling for the summary LLM call. Mirrors the guard in
-    [keeper_memory_llm_summary.provider_for_summary]. *)
+let messages_for_summary ~mode ~context_bundle =
+  let base =
+    [ message Agent_sdk.Types.System system_prompt
+    ; message Agent_sdk.Types.User (Yojson.Safe.to_string context_bundle)
+    ]
+  in
+  match mode with
+  | Native_structured -> base
+  | Plain_json_text -> base @ [ message Agent_sdk.Types.User plain_json_instruction ]
+;;
+
+(** Cap cost and sampling for the summary LLM call (mirrors the guard in
+    [keeper_memory_llm_summary.provider_for_summary]) and decide the output mode.
+
+    We ask OAS whether this judge endpoint can serve a native json_schema request
+    ([validate_output_schema_request]) rather than string-matching the eventual
+    provider error. If it cannot, we return the un-schema'd config plus
+    [Plain_json_text] so the evaluator still produces a judgment for every
+    keeper's model fleet instead of failing outright. *)
 let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
   let summary_max_tokens = Keeper_config.hitl_summary_max_tokens () in
   let max_tokens =
@@ -258,22 +295,30 @@ let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) 
       Some summary_max_tokens
     | None -> Some summary_max_tokens
   in
-  { provider_cfg with
-    max_tokens
-  ; temperature = Some (Keeper_config.hitl_summary_temperature ())
-  ; tool_choice = None
-  ; disable_parallel_tool_use = true
-  }
-  |> Keeper_structured_output_schema.apply_hitl_summary_schema_to_config
+  let clamped =
+    { provider_cfg with
+      max_tokens
+    ; temperature = Some (Keeper_config.hitl_summary_temperature ())
+    ; tool_choice = None
+    ; disable_parallel_tool_use = true
+    }
+  in
+  let structured =
+    Keeper_structured_output_schema.apply_hitl_summary_schema_to_config clamped
+  in
+  match Llm_provider.Provider_config.validate_output_schema_request structured with
+  | Ok () -> structured, Native_structured
+  | Error _ -> clamped, Plain_json_text
 ;;
 
 let call_summary_llm ~sw ~net ~provider_config ~context_bundle () =
-  let config = provider_config_for_summary provider_config in
-  let messages = messages_for_summary ~context_bundle in
+  let config, mode = provider_config_for_summary provider_config in
+  let messages = messages_for_summary ~mode ~context_bundle in
   Keeper_llm_bridge.run_with_timeout_and_fallback
     ~timeout_s:(Keeper_config.hitl_summary_timeout_sec ())
     (fun () ->
        Llm_provider.Complete.complete ~sw ~net ~config ~messages ()
+       |> Result.map (fun response -> response, mode)
        |> Result.map_error (fun http_err ->
             Agent_sdk.Error.Internal (Provider_http_error.to_message http_err)))
 ;;
@@ -321,18 +366,52 @@ let parse_summary ~generated_at ~model_run_id json =
   }
 ;;
 
-let summary_of_response ~generated_at (response : Agent_sdk.Types.api_response) =
-  match
-    Agent_sdk_response.structured_json_of_response
-      ~schema_name:"hitl_context_summary"
-      response
-  with
-  | Ok json ->
-    (try Ok (parse_summary ~generated_at ~model_run_id:response.id json) with
-     | exn ->
-       Error (Printf.sprintf "HITL summary parse failed: %s" (Printexc.to_string exn)))
-  | Error detail ->
-    Error (Printf.sprintf "HITL summary structured response parse failed: %s" detail)
+(** Best-effort extraction of a single JSON object from a model's visible text,
+    used only on the [Plain_json_text] degradation path. Tries the trimmed text
+    as-is, then the first ['{'] .. last ['}'] span (which also covers a fenced
+    ```json block, since the braces sit inside the fence). Returns [Error]
+    rather than a partial object so the caller surfaces [Summary_failed] instead
+    of silently accepting non-conforming output. *)
+let extract_json_object (text : string) : (Yojson.Safe.t, string) result =
+  let try_parse s =
+    match Yojson.Safe.from_string (String.trim s) with
+    | `Assoc _ as json -> Some json
+    | _ -> None
+    | exception _ -> None
+  in
+  let brace_span () =
+    match String.index_opt text '{', String.rindex_opt text '}' with
+    | Some i, Some j when j > i -> Some (String.sub text i (j - i + 1))
+    | _ -> None
+  in
+  match try_parse text with
+  | Some json -> Ok json
+  | None ->
+    (match Option.bind (brace_span ()) try_parse with
+     | Some json -> Ok json
+     | None -> Error "HITL summary: no JSON object found in model response text")
+;;
+
+let summary_of_response ~generated_at ~mode (response : Agent_sdk.Types.api_response) =
+  let parse_json json =
+    try Ok (parse_summary ~generated_at ~model_run_id:response.id json) with
+    | exn ->
+      Error (Printf.sprintf "HITL summary parse failed: %s" (Printexc.to_string exn))
+  in
+  match mode with
+  | Native_structured ->
+    (match
+       Agent_sdk_response.structured_json_of_response
+         ~schema_name:"hitl_context_summary"
+         response
+     with
+     | Ok json -> parse_json json
+     | Error detail ->
+       Error (Printf.sprintf "HITL summary structured response parse failed: %s" detail))
+  | Plain_json_text ->
+    (match extract_json_object (Agent_sdk_response.text_of_response response) with
+     | Ok json -> parse_json json
+     | Error detail -> Error detail)
 ;;
 
 (* ── Spawn ──────────────────────────────────────── *)
@@ -354,8 +433,15 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
             on_failure ~reason:"HITL summary worker: Eio net unavailable" ~retryable:true
           | Some net ->
             (match call_summary_llm ~sw ~net ~provider_config ~context_bundle () with
-             | Ok response ->
-               (match summary_of_response ~generated_at response with
+             | Ok (response, mode) ->
+               (* Record the degradation itself (not just its outcome) so
+                  operators can see when the judge fleet lacks native structured
+                  output, rather than it being invisible behind ok/parse_error. *)
+               (match mode with
+                | Plain_json_text ->
+                  record_outcome ~risk_level:entry.risk_level "degraded_plain_json"
+                | Native_structured -> ());
+               (match summary_of_response ~generated_at ~mode response with
                 | Ok summary ->
                   record_outcome ~risk_level:entry.risk_level "ok_summary";
                   on_summary summary
@@ -380,10 +466,15 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
 ;;
 
 module For_testing = struct
+  type nonrec summary_mode = summary_mode =
+    | Native_structured
+    | Plain_json_text
+
   let build_context_bundle = build_context_bundle
   let parse_summary = parse_summary
   let summary_of_response = summary_of_response
   let provider_config_for_summary = provider_config_for_summary
+  let extract_json_object = extract_json_object
   let summary_version = summary_version
 end
 ;;

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -13,6 +13,13 @@ val spawn
   -> unit
 
 module For_testing : sig
+  (** How the judge is asked to return the summary. [Native_structured] uses
+      provider-native json_schema; [Plain_json_text] is the degradation path for
+      endpoints OAS cannot serve native structured output for. *)
+  type summary_mode =
+    | Native_structured
+    | Plain_json_text
+
   val build_context_bundle
     : entry:Keeper_approval_queue_rules_types.pending_approval -> Yojson.Safe.t
 
@@ -24,11 +31,19 @@ module For_testing : sig
 
   val summary_of_response
     :  generated_at:float
+    -> mode:summary_mode
     -> Agent_sdk.Types.api_response
     -> (Keeper_approval_queue_rules_types.hitl_context_summary, string) result
 
+  (** Returns the clamped config plus the chosen output mode: [Native_structured]
+      when {!Llm_provider.Provider_config.validate_output_schema_request} accepts
+      a json_schema request for this endpoint, else [Plain_json_text]. *)
   val provider_config_for_summary
-    : Llm_provider.Provider_config.t -> Llm_provider.Provider_config.t
+    :  Llm_provider.Provider_config.t
+    -> Llm_provider.Provider_config.t * summary_mode
+
+  (** Best-effort single-JSON-object extraction from model text (plain path). *)
+  val extract_json_object : string -> (Yojson.Safe.t, string) result
 
   val summary_version : int
 end

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -45,5 +45,14 @@ module For_testing : sig
   (** Best-effort single-JSON-object extraction from model text (plain path). *)
   val extract_json_object : string -> (Yojson.Safe.t, string) result
 
+  (** Metric outcomes emitted when the LLM call fails after [summary_mode] has
+      been selected. Plain-mode failures include [degraded_plain_json] before
+      the terminal failure outcome so degradation is observable even without a
+      model response. *)
+  val summary_llm_error_outcomes
+    :  mode:summary_mode
+    -> Agent_sdk.Error.sdk_error
+    -> string list
+
   val summary_version : int
 end

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -745,14 +745,24 @@ let record_summary_failure ~id ~reason ~retryable =
 ;;
 
 let provider_config_for_summary ~keeper_name =
-  let runtime_id =
+  (* The HITL evaluator is a dedicated judge (mirroring the memory-os librarian's
+     dedicated runtime), not the requesting keeper's own model. Route to
+     [runtime].structured_judge so the evaluation is consistent and can target a
+     structured-output-capable model regardless of which keeper — e.g. a raw
+     OpenAI-compatible endpoint such as mimo, which OAS cannot wire native
+     structured output for — asked for approval. Fall back to the keeper's own
+     runtime only when the judge runtime cannot be resolved. *)
+  let resolve id =
+    Option.map (fun rt -> rt.Runtime.provider_config) (Runtime.get_runtime_by_id id)
+  in
+  let keeper_runtime_id () =
     match Runtime.runtime_id_for_keeper keeper_name with
     | Some id when String.trim id <> "" -> id
     | Some _ | None -> Keeper_config.default_runtime_id ()
   in
-  match Runtime.get_runtime_by_id runtime_id with
-  | Some rt -> Some rt.Runtime.provider_config
-  | None -> None
+  match resolve (Runtime.runtime_id_for_structured_judge ()) with
+  | Some _ as cfg -> cfg
+  | None -> resolve (keeper_runtime_id ())
 ;;
 
 let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -151,7 +151,12 @@ let test_parse_summary_failure () =
     ; telemetry = None
     }
   in
-  match H.For_testing.summary_of_response ~generated_at:1234567890.0 response with
+  match
+    H.For_testing.summary_of_response
+      ~generated_at:1234567890.0
+      ~mode:H.For_testing.Native_structured
+      response
+  with
   | Ok _ -> fail "expected summary_of_response to return Error"
   | Error reason -> check bool "error reason non-empty" true (String.length reason > 0)
 ;;
@@ -182,7 +187,12 @@ let test_parse_summary_rejects_unknown_risk_delta () =
     ; telemetry = None
     }
   in
-  match H.For_testing.summary_of_response ~generated_at:1234567890.0 response with
+  match
+    H.For_testing.summary_of_response
+      ~generated_at:1234567890.0
+      ~mode:H.For_testing.Native_structured
+      response
+  with
   | Ok _ -> fail "expected unknown risk delta to fail parsing"
   | Error reason ->
     check bool "error names estimated_risk_delta" true
@@ -335,7 +345,7 @@ let test_provider_config_for_summary_caps_tokens_and_temperature () =
       ~response_format:Llm_provider.Types.JsonMode
       ()
   in
-  let cfg = H.For_testing.provider_config_for_summary provider_cfg in
+  let cfg, mode = H.For_testing.provider_config_for_summary provider_cfg in
   check bool "max_tokens capped to policy" true
     (match cfg.max_tokens with
      | Some n -> n <= Keeper_config.hitl_summary_max_tokens ()
@@ -344,7 +354,61 @@ let test_provider_config_for_summary_caps_tokens_and_temperature () =
     (Some (Keeper_config.hitl_summary_temperature ())) cfg.temperature;
   check bool "tool_choice cleared" true (Option.is_none cfg.tool_choice);
   check bool "disable_parallel_tool_use true" true cfg.disable_parallel_tool_use;
-  check bool "output_schema set" true (Option.is_some cfg.output_schema)
+  (* An undeclared OpenAI-compatible endpoint (http://localhost, no catalog row)
+     cannot serve a native json_schema request, so the worker degrades to the
+     plain-text path: no [output_schema] is attached and the mode is plain. *)
+  check bool "mode is plain for undeclared endpoint" true (mode = H.For_testing.Plain_json_text);
+  check bool "output_schema absent on plain path" true (Option.is_none cfg.output_schema)
+;;
+
+(* ── Graceful-degradation tests ─────────────────── *)
+
+let test_extract_json_object_variants () =
+  let ok label input expected_summary =
+    match H.For_testing.extract_json_object input with
+    | Ok (`Assoc _ as json) ->
+      check string label expected_summary
+        (Yojson.Safe.Util.(member "context_summary" json |> to_string))
+    | Ok other -> failf "%s: expected object, got %s" label (Yojson.Safe.to_string other)
+    | Error e -> failf "%s: expected Ok, got Error %s" label e
+  in
+  ok "bare json" {|{"context_summary":"bare"}|} "bare";
+  ok "fenced json"
+    "```json\n{\"context_summary\":\"fenced\"}\n```" "fenced";
+  ok "prose-wrapped json"
+    "Here is the result:\n{\"context_summary\":\"wrapped\"}\nThanks!" "wrapped";
+  (match H.For_testing.extract_json_object "no json here at all" with
+   | Error _ -> ()
+   | Ok _ -> fail "expected Error for text with no JSON object")
+;;
+
+let test_summary_of_response_plain_json_text_parses_prose_wrapped () =
+  (* Plain path: a model without native structured output returns JSON embedded
+     in prose. [summary_of_response ~mode:Plain_json_text] must still parse it. *)
+  let text =
+    "Sure, here is the judgment:\n"
+    ^ Yojson.Safe.to_string valid_summary_json
+    ^ "\nLet me know if you need more."
+  in
+  let response : Agent_sdk.Types.api_response =
+    { id = "run-plain"
+    ; model = "test-model"
+    ; stop_reason = Agent_sdk.Types.EndTurn
+    ; content = [ Agent_sdk.Types.Text text ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match
+    H.For_testing.summary_of_response
+      ~generated_at:1234567890.0
+      ~mode:H.For_testing.Plain_json_text
+      response
+  with
+  | Ok summary ->
+    check string "context_summary parsed" "A tool request is pending." summary.context_summary;
+    check int "suggested_options length" 1 (List.length summary.suggested_options)
+  | Error e -> failf "expected plain-path parse to succeed, got %s" e
 ;;
 
 (* ── Runner ───────────────────────────────────── *)
@@ -373,6 +437,12 @@ let () =
             test_build_context_bundle_with_real_workspace
         ; test_case "provider_config_for_summary caps tokens and temperature" `Quick
             test_provider_config_for_summary_caps_tokens_and_temperature
+        ] )
+    ; ( "graceful_degradation"
+      , [ test_case "extract_json_object handles bare/fenced/prose/invalid" `Quick
+            test_extract_json_object_variants
+        ; test_case "summary_of_response plain path parses prose-wrapped JSON" `Quick
+            test_summary_of_response_plain_json_text_parses_prose_wrapped
         ] )
     ]
 ;;

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -411,6 +411,32 @@ let test_summary_of_response_plain_json_text_parses_prose_wrapped () =
   | Error e -> failf "expected plain-path parse to succeed, got %s" e
 ;;
 
+let test_plain_mode_error_outcomes_record_degradation () =
+  let provider_error = Agent_sdk.Error.Internal "synthetic provider failure" in
+  let timeout_error =
+    Agent_sdk.Error.Api
+      (Agent_sdk.Retry.Timeout { message = "synthetic timeout"; phase = None })
+  in
+  check (list string)
+    "plain provider error includes degradation then terminal outcome"
+    [ "degraded_plain_json"; "provider_error" ]
+    (H.For_testing.summary_llm_error_outcomes
+       ~mode:H.For_testing.Plain_json_text
+       provider_error);
+  check (list string)
+    "plain timeout includes degradation then terminal outcome"
+    [ "degraded_plain_json"; "timeout" ]
+    (H.For_testing.summary_llm_error_outcomes
+       ~mode:H.For_testing.Plain_json_text
+       timeout_error);
+  check (list string)
+    "native provider error emits terminal outcome only"
+    [ "provider_error" ]
+    (H.For_testing.summary_llm_error_outcomes
+       ~mode:H.For_testing.Native_structured
+       provider_error)
+;;
+
 (* ── Runner ───────────────────────────────────── *)
 
 let () =
@@ -443,6 +469,8 @@ let () =
             test_extract_json_object_variants
         ; test_case "summary_of_response plain path parses prose-wrapped JSON" `Quick
             test_summary_of_response_plain_json_text_parses_prose_wrapped
+        ; test_case "plain-mode errors keep degradation observable" `Quick
+            test_plain_mode_error_outcomes_record_degradation
         ] )
     ]
 ;;


### PR DESCRIPTION
## HITL 평가자를 모델 fleet 전체에서 동작하게 (dedicated judge + graceful degradation)

### 문제
HITL context-summary/judgment worker(#23112)는 대시보드 승인 큐에 LLM 판정(요약·핵심 질문·추천 옵션·위험 근거·불확실도)을 붙여 운영자가 맥락을 보고 승인/거부하게 하는 기능입니다. 그러나 실제로는 **거의 모든 keeper에서 실패**하고 있었습니다.

화면 증상:
```
컨텍스트 요약 실패 · 재시도 예정
Internal error: native structured output is only wired for declared
OpenAI-compatible endpoints, got https://token-plan-sgp.xiaomimimo.com/v1
```

근본 원인 2가지:
1. worker가 **승인을 요청한 keeper 자신의 모델**로 판정을 호출 (rondo=mimo, executor=runpod 등).
2. worker가 **provider-native json_schema structured output을 하드 요구**. 사용자 fleet의 대부분(mimo·runpod=미선언 OpenAI-compat, GLM=json_object only)이 이를 못 해서 즉시 실패.

결과: 운영자는 판정 대신 실패 메시지만 보고, 맥락 없이 "그냥 승인"하게 됨.

### 수정

**1. 전용 judge 라우팅** (`keeper_approval_queue.provider_config_for_summary`)
- keeper 자신의 런타임 대신 `[runtime].structured_judge` 전용 런타임으로 라우팅 (memory-os 라이브러리안이 전용 런타임을 쓰는 것과 동일 패턴).
- judge 런타임 해석 실패 시에만 keeper 런타임으로 fallback.
- 평가자가 **어느 keeper가 요청했든 일관된 판정자**가 됨.

**2. 우아한 강등** (`hitl_summary_worker`)
- native vs plain 판정을 **문자열 매칭이 아니라 typed OAS API** (`Provider_config.validate_output_schema_request`)로 결정.
- native json_schema 불가 endpoint면 bare JSON 객체를 프롬프트로 요청하고, 모델의 visible text에서 best-effort로 JSON 추출(`extract_json_object`: bare/fenced/prose-wrapped 처리).
- 파싱 실패는 `Summary_failed`로 노출(silent 금지). 강등 자체는 `degraded_plain_json` metric outcome으로 관측화.

`[runtime].structured_judge`를 structured-output 가능한 모델로 지정하는 것은 **선택** — 파싱 안정성만 향상. 미설정이어도(현재처럼 GLM으로 fallback) plain 경로로 동작.

### 검증
- `test_hitl_summary_worker` **12/12 통과**. 신규: `extract_json_object`(bare/fenced/prose/invalid), plain-path prose-wrapped JSON 파싱, undeclared endpoint의 mode 판정.
- `dune build ./bin/main_eio.exe` (전체 lib) 컴파일 성공. ocamlformat clean.

### Workaround self-check (CLAUDE.md 시그니처)
- plain-text JSON 경로 = write-boundary 없는 대상에서 LLM 텍스트를 파싱하는 표준 기법(“JSON normalize on read” 안티패턴과 무관). 판정은 typed API. 파싱 실패=명시적 Summary_failed. `degraded_plain_json` counter는 실제 코드경로 관측이지 fix 대체 아님. → 게이트 비해당.

### 설계 근거
`docs/superpowers/plans/2026-07-03-hitl-context-summary-worker-plan.md`, #23112/#23182 (RFC-0304 HITL) 확장.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
