### PR TITLE
dashboard: fail closed scheduler wake signals

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -208,6 +208,36 @@ describe('selectWakeSignals', () => {
     expect(signals[0]?.readiness).toBe('blocked_approval')
   })
 
+  it('excludes payload-blocked rows from upcoming wake signals', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({
+          schedule_id: 's-supported',
+          next_due_at: 100,
+          execution_readiness: 'scheduled',
+          payload_kind: 'keeper.smoke',
+          payload_support: 'supported',
+        }),
+        request({
+          schedule_id: 's-unsupported',
+          next_due_at: 200,
+          execution_readiness: 'scheduled',
+          payload_kind: 'orphan_auto_release',
+          payload_support: 'unsupported',
+        }),
+        request({
+          schedule_id: 's-unknown',
+          next_due_at: 300,
+          execution_readiness: 'scheduled',
+          payload_kind: 'keeper.future',
+          payload_support: 'unknown',
+        }),
+      ]),
+    )
+
+    expect(signals.map(s => s.id)).toEqual(['s-supported'])
+  })
+
   it('uses the recurrence label as kind when payload_kind is absent', () => {
     const signals = selectWakeSignals(
       automation([
@@ -533,6 +563,46 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).toContain('sched-run-smoke')
   })
 
+  it('keeps payload-blocked rows out of every request-derived wake feed', () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-supported',
+        next_due_at: 100,
+        next_due_at_iso: '2026-06-21T00:10:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'keeper.smoke',
+        payload_support: 'supported',
+      }),
+      request({
+        schedule_id: 'sched-unsupported',
+        next_due_at: 200,
+        next_due_at_iso: '2026-06-21T00:20:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'orphan_auto_release',
+        payload_support: 'unsupported',
+      }),
+      request({
+        schedule_id: 'sched-unknown',
+        next_due_at: 300,
+        next_due_at_iso: '2026-06-21T00:30:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'keeper.future',
+        payload_support: 'unknown',
+      }),
+    ])
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} />`, container)
+
+    expect(container.querySelector('[data-schedule-id="sched-unsupported"]')).not.toBeNull()
+    const wakeSignalFeed = container.querySelector('[data-testid="sch-signals"]')
+    expect(wakeSignalFeed?.textContent).toContain('sched-supported')
+    expect(wakeSignalFeed?.textContent).not.toContain('sched-unsupported')
+    expect(wakeSignalFeed?.textContent).not.toContain('sched-unknown')
+    expect(container.querySelector('[data-schedule-signal-schedule="sched-supported"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-signal-schedule="sched-unsupported"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-signal-schedule="sched-unknown"]')).toBeNull()
+  })
+
   it('uses explicit ready and terminal status matching', async () => {
     const automation = sampleAutomation()
     automation.requests = [
@@ -760,5 +830,44 @@ describe('ScheduleAside', () => {
     const pendingButton = aside?.querySelector('[data-schedule-aside-open="pending-1"]') as HTMLElement
     pendingButton.click()
     expect(onOpen).toHaveBeenCalledWith('pending-1')
+  })
+
+  it('does not classify payload-blocked rows as actionable aside work', () => {
+    const onOpen = vi.fn()
+    const requests: DashboardScheduledAutomationRequest[] = [
+      request({ schedule_id: 'due-ok', status: 'due', payload_summary: 'supported due work' }),
+      request({
+        schedule_id: 'due-unsupported',
+        status: 'due',
+        payload_support: 'unsupported',
+        payload_kind: 'orphan_auto_release',
+        payload_summary: 'unsupported due work',
+      }),
+      request({
+        schedule_id: 'pending-unknown',
+        status: 'pending_approval',
+        payload_support: 'unknown',
+        payload_kind: 'keeper.future',
+        payload_summary: 'unknown pending work',
+      }),
+    ]
+
+    render(
+      html`<${ScheduleAside}
+        requests=${requests}
+        sum=${{ scheduled: 0, dueRunning: 1, pending: 1, total: 3 }}
+        onOpen=${onOpen}
+      />`,
+      container,
+    )
+
+    const todoText = Array.from(container.querySelectorAll('.wka-todo'))
+      .map(element => element.textContent ?? '')
+      .join('\n')
+    expect(todoText).toContain('supported due work')
+    expect(todoText).not.toContain('unsupported due work')
+    expect(todoText).not.toContain('unknown pending work')
+    expect(container.textContent).toContain('unsupported · orphan_auto_release')
+    expect(container.textContent).toContain('unknown · keeper.future')
   })
 })

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -391,6 +391,12 @@ function sampleAutomation(): DashboardScheduledAutomation {
       due_execution_ready: 1,
       expired_effective: 0,
     },
+    payload_support: {
+      supported_kinds: ['keeper.review', 'keeper.smoke'],
+      unsupported_request_count: 0,
+      unsupported_kinds: [],
+      unknown_request_count: 0,
+    },
     fsm: {
       state: 'blocked_approval',
       active_count: 2,
@@ -683,6 +689,55 @@ describe('ScheduledAutomationPanel', () => {
       expect(container.querySelector('[data-schedule-signal-schedule="sched-supported"]')).not.toBeNull()
       expect(container.querySelector('[data-schedule-signal-schedule="sched-unsupported"]')).toBeNull()
       expect(container.querySelector('[data-schedule-signal-schedule="sched-unknown"]')).toBeNull()
+    }
+  })
+
+  it('keeps unsupported durable wake signals hidden when the request row is absent', () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-supported',
+        next_due_at: 100,
+        next_due_at_iso: '2026-06-21T00:10:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'keeper.smoke',
+        payload_support: 'supported',
+      }),
+    ])
+    auto.payload_support = {
+      supported_kinds: ['keeper.smoke'],
+      unsupported_request_count: 1,
+      unsupported_kinds: [{ kind: 'orphan_auto_release', count: 1 }],
+      unknown_request_count: 1,
+    }
+    auto.signal_source = 'schedule_runner_signals'
+    auto.signal_count = 3
+    auto.signals = [
+      signal({
+        signal_id: 'sig-supported',
+        schedule_id: 'sched-supported',
+        payload_kind: 'keeper.smoke',
+      }),
+      signal({
+        signal_id: 'sig-unsupported-missing-row',
+        schedule_id: 'sched-unsupported-missing-row',
+        payload_kind: 'orphan_auto_release',
+      }),
+      signal({
+        signal_id: 'sig-unknown-missing-row',
+        schedule_id: 'sched-unknown-missing-row',
+      }),
+    ]
+
+    for (const variant of [undefined, 'v2'] as const) {
+      render(null, container)
+      render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
+
+      expect(container.querySelector('[data-schedule-signal-id="sig-supported"]')).not.toBeNull()
+      expect(container.querySelector('[data-schedule-signal-id="sig-unsupported-missing-row"]')).toBeNull()
+      expect(container.querySelector('[data-schedule-signal-id="sig-unknown-missing-row"]')).toBeNull()
+      expect(container.querySelector('[data-schedule-signal-schedule="sched-supported"]')).not.toBeNull()
+      expect(container.querySelector('[data-schedule-signal-schedule="sched-unsupported-missing-row"]')).toBeNull()
+      expect(container.querySelector('[data-schedule-signal-schedule="sched-unknown-missing-row"]')).toBeNull()
     }
   })
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -247,12 +247,32 @@ function payloadBlockedScheduleIds(
   return blockedIds
 }
 
+function supportedPayloadKindSet(
+  automation: DashboardScheduledAutomation,
+): ReadonlySet<string> | null {
+  const kinds = automation.payload_support?.supported_kinds
+  if (!kinds) return null
+  return new Set(kinds.map(kind => kind.trim()).filter(Boolean))
+}
+
+function durableSignalPayloadBlocksWake(
+  signal: DashboardScheduledAutomationSignal,
+  supportedKinds: ReadonlySet<string> | null,
+): boolean {
+  if (!supportedKinds) return false
+  const kind = signal.payload_kind?.trim()
+  return !kind || !supportedKinds.has(kind)
+}
+
 function selectDurableWakeSignals(
   automation: DashboardScheduledAutomation,
 ): DashboardScheduledAutomationSignal[] {
   const blockedIds = payloadBlockedScheduleIds(automation.requests ?? [])
+  const supportedKinds = supportedPayloadKindSet(automation)
   return [...(automation.signals ?? [])]
-    .filter(signal => !blockedIds.has(signal.schedule_id))
+    .filter(signal =>
+      !blockedIds.has(signal.schedule_id)
+      && !durableSignalPayloadBlocksWake(signal, supportedKinds))
     .sort((a, b) => signalTimestamp(a) - signalTimestamp(b))
 }
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -218,10 +218,24 @@ const NON_UPCOMING_WAKE_STATUS: ReadonlySet<string> = new Set([
   'terminal',
   'expired',
   'cancelled',
+  'canceled',
   'succeeded',
   'failed',
   'rejected',
 ])
+
+function payloadSupportBlocksWake(request: DashboardScheduledAutomationRequest): boolean {
+  return request.payload_support === 'unsupported' || request.payload_support === 'unknown'
+}
+
+function canProjectUpcomingWake(request: DashboardScheduledAutomationRequest): boolean {
+  if (payloadSupportBlocksWake(request)) return false
+  const readiness = normalized(request.execution_readiness)
+  const status = normalized(effectiveStatus(request))
+  if (readiness && NON_UPCOMING_WAKE_READINESS.has(readiness)) return false
+  if (NON_UPCOMING_WAKE_STATUS.has(status)) return false
+  return true
+}
 
 export function selectWakeSignals(
   automation: DashboardScheduledAutomation | null | undefined,
@@ -229,13 +243,12 @@ export function selectWakeSignals(
   if (!automation) return []
   const signals: WakeSignal[] = []
   for (const request of automation.requests ?? []) {
+    if (!canProjectUpcomingWake(request)) continue
     const at = request.next_due_at ?? request.due_at ?? null
     // No concrete wake time → no signal to surface (parse, don't validate).
     if (at == null) continue
     const readiness = request.execution_readiness ?? null
     const status = request.effective_status ?? request.status
-    if (readiness != null && NON_UPCOMING_WAKE_READINESS.has(readiness)) continue
-    if (NON_UPCOMING_WAKE_STATUS.has(status)) continue
     signals.push({
       id: request.schedule_id,
       at,
@@ -1492,10 +1505,10 @@ export function ScheduleAside({
 }) {
   const asideStatus = (request: DashboardScheduledAutomationRequest): string =>
     normalized(effectiveStatus(request))
-  const unsupportedPayloads = requests.filter(isUnsupportedPayloadRequest)
-  const failed = requests.filter(request => asideStatus(request) === 'failed' && !isUnsupportedPayloadRequest(request))
-  const pending = requests.filter(request => SCHEDULE_ASIDE_PENDING.has(asideStatus(request)))
-  const due = requests.filter(request => SCHEDULE_ASIDE_DUE.has(asideStatus(request)))
+  const payloadBlocked = requests.filter(payloadSupportBlocksWake)
+  const failed = requests.filter(request => asideStatus(request) === 'failed' && !payloadSupportBlocksWake(request))
+  const pending = requests.filter(request => SCHEDULE_ASIDE_PENDING.has(asideStatus(request)) && !payloadSupportBlocksWake(request))
+  const due = requests.filter(request => SCHEDULE_ASIDE_DUE.has(asideStatus(request)) && !payloadSupportBlocksWake(request))
   const recent = requests
     .filter(request => SCHEDULE_ASIDE_TERMINAL.has(asideStatus(request)))
     .slice(0, SCHEDULE_ASIDE_RECENT_MAX)
@@ -1510,22 +1523,26 @@ export function ScheduleAside({
           <span class="wka-pulse-i"><b class=${`mono ${sum.dueRunning > 0 ? 'volt' : ''}`}>${sum.dueRunning}</b> due·실행</span>
           <span class="wka-pulse-i"><b class=${`mono ${sum.pending > 0 ? 'warn' : ''}`}>${sum.pending}</b> 승인대기</span>
         </div>
-        ${unsupportedPayloads.length === 0 && failed.length === 0
+        ${payloadBlocked.length === 0 && failed.length === 0
           ? html`<div class="wka-calm mono">실패한 실행 없음</div>`
           : html`
               <div class="wka-list">
-                ${unsupportedPayloads.map(request => html`
-                  <button
-                    type="button"
-                    class="wka-flag st-bad"
-                    data-schedule-aside-open=${request.schedule_id}
-                    onClick=${() => { onOpen(request.schedule_id) }}
-                  >
-                    <span class="wka-flag-tag bad">payload</span>
-                    <span class="wka-flag-title">${scheduleAsideSummary(request)}</span>
-                    <span class="wka-flag-reason mono">${request.payload_kind ?? 'payload_kind 없음'}</span>
-                  </button>
-                `)}
+                ${payloadBlocked.map(request => {
+                  const support = request.payload_support === 'unknown' ? 'unknown' : 'unsupported'
+                  const tone = support === 'unknown' ? 'warn' : 'bad'
+                  return html`
+                    <button
+                      type="button"
+                      class=${`wka-flag st-${tone}`}
+                      data-schedule-aside-open=${request.schedule_id}
+                      onClick=${() => { onOpen(request.schedule_id) }}
+                    >
+                      <span class=${`wka-flag-tag ${tone}`}>payload</span>
+                      <span class="wka-flag-title">${scheduleAsideSummary(request)}</span>
+                      <span class="wka-flag-reason mono">${support} · ${request.payload_kind ?? 'payload_kind 없음'}</span>
+                    </button>
+                  `
+                })}
                 ${failed.map(request => html`
                   <button
                     type="button"
@@ -1640,7 +1657,9 @@ export function ScheduledAutomationPanel({
   const rows = automation.requests ?? []
   const wakeSignals = selectWakeSignals(automation)
   const filteredRows = rows.filter(request => filterMatches(activeFilter, request))
-  const wakeRows = [...rows].sort((a, b) => dueTimestamp(a) - dueTimestamp(b))
+  const wakeRows = rows
+    .filter(canProjectUpcomingWake)
+    .sort((a, b) => dueTimestamp(a) - dueTimestamp(b))
   const durableSignals = [...(automation.signals ?? [])].sort((a, b) => signalTimestamp(a) - signalTimestamp(b))
   const hasDurableSignals = durableSignals.length > 0
   const selectedRequest =

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -268,12 +268,12 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
     | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, source)
     | Ok None ->
         Error
-          ( `Bad_request,
-            Printf.sprintf "target_keeper %S is not a registered keeper" requested )
+          (`Bad_request
+            (Printf.sprintf "target_keeper %S is not a registered keeper" requested))
     | Error msg ->
         Error
-          ( `Internal_server_error,
-            Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg )
+          (`Internal_server_error
+            (Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg))
   in
   match target_keeper with
   | Some requested -> resolve Explicit_target requested
@@ -283,14 +283,14 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
        | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, Post_author)
        | Ok None ->
            Error
-             ( `Bad_request,
-               Printf.sprintf
-                 "target_keeper is required because board post author %S is not a registered keeper"
-                 author )
+             (`Bad_request
+               (Printf.sprintf
+                  "target_keeper is required because board post author %S is not a registered keeper"
+                  author))
        | Error msg ->
            Error
-             ( `Internal_server_error,
-               Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg ))
+             (`Internal_server_error
+               (Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg)))
 
 let non_empty_json_string_member field json =
   match json_assoc_member field json with
@@ -351,7 +351,7 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
       ]
   in
   match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
-  | None -> Error (`Internal_server_error, "masc_keeper_msg tool is unavailable")
+  | None -> Error (`Internal_server_error "masc_keeper_msg tool is unavailable")
   | Some result ->
       if Tool_result.is_success result
       then
@@ -360,8 +360,8 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
              (Tool_result.data result)
          with
          | Ok json -> Ok json
-         | Error msg -> Error (`Internal_server_error, msg))
-      else Error (`Bad_request, Tool_result.message result)
+         | Error msg -> Error (`Internal_server_error msg))
+      else Error (`Bad_request (Tool_result.message result))
 
 let respond_board_context_inference_error request reqd ~status ~message =
   respond_json_value_with_cors ~status request reqd
@@ -388,9 +388,12 @@ let handle_board_context_inference_request ~state ~sw ~clock ~request reqd body 
               match
                 resolve_board_context_inference_target ~config post target_keeper
               with
-              | Error (status, message) ->
-                  respond_board_context_inference_error request reqd ~status
-                    ~message
+              | Error (`Bad_request message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Bad_request ~message
+              | Error (`Internal_server_error message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Internal_server_error ~message
               | Ok (target_keeper, target_source) -> (
                   match
                     dispatch_board_context_inference ~state ~sw ~clock ~request
@@ -399,9 +402,12 @@ let handle_board_context_inference_request ~state ~sw ~clock ~request reqd body 
                   | Ok json ->
                       respond_json_value_with_cors ~status:`Accepted request reqd
                         json
-                  | Error (status, message) ->
-                      respond_board_context_inference_error request reqd ~status
-                        ~message))))
+                  | Error (`Bad_request message) ->
+                      respond_board_context_inference_error request reqd
+                        ~status:`Bad_request ~message
+                  | Error (`Internal_server_error message) ->
+                      respond_board_context_inference_error request reqd
+                        ~status:`Internal_server_error ~message))))
 
 let respond_board_json reqd json =
   Http.Response.json_value json reqd

--- a/test/dune
+++ b/test/dune
@@ -713,6 +713,7 @@
   test_log_severity_outcome_level
   test_env_keeper_scrub
   test_event_log
+  test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes
   test_board_context_inference_resolution)


### PR DESCRIPTION
## Summary
- Fail closed schedule wake projection for `payload_support: unsupported | unknown`, so dashboard-only wake feeds do not imply runnable keeper wake work.
- Keep blocked payload rows visible as Schedule aside payload flags, separate from actionable due/pending work.

## Verification
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/schedule/schedule-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `git diff --check`
- Python Playwright smoke over Vite dev server with mocked `/api/v1/dashboard/tools`:
  - `#lab?section=tools`: wake feed/signal items include supported rows only; `sched-unsupported` and `sched-unknown` stay out.
  - `#schedule`: aside todo includes supported due work only; unsupported/unknown rows render as payload flags.

## Notes
- Local Dune was not run; repository guidance says Dune build authority is CI.