### PR TITLE
fix: restore activity route build on main

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -268,12 +268,12 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
     | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, source)
     | Ok None ->
         Error
-          ( `Bad_request,
-            Printf.sprintf "target_keeper %S is not a registered keeper" requested )
+          (`Bad_request
+             (Printf.sprintf "target_keeper %S is not a registered keeper" requested))
     | Error msg ->
         Error
-          ( `Internal_server_error,
-            Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg )
+          (`Internal_server_error
+             (Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg))
   in
   match target_keeper with
   | Some requested -> resolve Explicit_target requested
@@ -283,14 +283,14 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
        | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, Post_author)
        | Ok None ->
            Error
-             ( `Bad_request,
-               Printf.sprintf
-                 "target_keeper is required because board post author %S is not a registered keeper"
-                 author )
+             (`Bad_request
+                (Printf.sprintf
+                  "target_keeper is required because board post author %S is not a registered keeper"
+                  author))
        | Error msg ->
            Error
-             ( `Internal_server_error,
-               Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg ))
+             (`Internal_server_error
+                (Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg)))
 
 let non_empty_json_string_member field json =
   match json_assoc_member field json with
@@ -388,9 +388,12 @@ let handle_board_context_inference_request ~state ~sw ~clock ~request reqd body 
               match
                 resolve_board_context_inference_target ~config post target_keeper
               with
-              | Error (status, message) ->
-                  respond_board_context_inference_error request reqd ~status
-                    ~message
+              | Error (`Bad_request message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Bad_request ~message
+              | Error (`Internal_server_error message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Internal_server_error ~message
               | Ok (target_keeper, target_source) -> (
                   match
                     dispatch_board_context_inference ~state ~sw ~clock ~request

--- a/test/dune
+++ b/test/dune
@@ -713,6 +713,7 @@
   test_log_severity_outcome_level
   test_env_keeper_scrub
   test_event_log
+  test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes
   test_board_context_inference_resolution)


### PR DESCRIPTION
## Summary
- Fix `resolve_board_context_inference_target` to return the payload-bearing error variants declared by the mli.
- Update `test/dune` so `test_relation_materializer` is listed in both the test names and modules list.

## Evidence
- Fixes main build failure tracked in #23278.
- Failure source: push CI run 28734195802 / job 85205412639 at current main `2b472b1ab3ac18cdc45eeb0de213f39f8db6b7fc`.

## Validation
- `ocamlformat --check lib/server/server_routes_http_routes_activity.ml`
- `scripts/dune-local.sh build lib/server/.masc_server.objs/byte/server_routes_http_routes_activity.cmo test/test_board_context_inference_resolution.exe`
- `_build/default/test/test_board_context_inference_resolution.exe`
