### PR TITLE
[codex] Budget lane no-progress retries

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -123,23 +123,34 @@ let runtime_failed_decision ~idx ~runtime_id error =
       ("error_kind", `String (Oas_compat.error_kind error));
     ]
 
-let lane_retry_checkpoint ~is_last ~resume_checkpoint ~checkpoint_after error =
+let lane_retry_checkpoint
+    ~is_last
+    ~allow_accept_no_progress_retry
+    ~resume_checkpoint
+    ~checkpoint_after
+    error =
   if is_last then
     None
   else if Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next error
   then
-    Some
-      (Keeper_turn_driver_try_runtime.checkpoint_for_accept_rejected_retry
-         ~resume_checkpoint
-         ~checkpoint_after
-         error)
+    if allow_accept_no_progress_retry
+    then
+      Some
+        (Keeper_turn_driver_try_runtime.checkpoint_for_accept_rejected_retry
+           ~resume_checkpoint
+           ~checkpoint_after
+           error)
+    else None
   else
     match Keeper_turn_driver_try_runtime.sdk_error_to_http_error error with
     | Some http_err when Runtime_attempt_fsm.should_try_next http_err ->
       Some checkpoint_after
     | _ -> None
 
-let attempt_runtime_candidates ~runtime_id ~runtime_id_of
+let attempt_runtime_candidates
+    ?(allow_accept_no_progress_retry = fun ~runtime_id:_ ~attempt:_ _error ->
+      true)
+    ~runtime_id ~runtime_id_of
     ~(emit_runtime_manifest :
        ?status:string ->
        ?decision:Yojson.Safe.t ->
@@ -172,8 +183,20 @@ let attempt_runtime_candidates ~runtime_id ~runtime_id_of
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
          (match
+            let allow_accept_no_progress_retry =
+              if
+                Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next
+                  error
+              then
+                allow_accept_no_progress_retry
+                  ~runtime_id:attempt_runtime_id
+                  ~attempt:idx
+                  error
+              else true
+            in
             lane_retry_checkpoint
               ~is_last
+              ~allow_accept_no_progress_retry
               ~resume_checkpoint
               ~checkpoint_after
               error
@@ -182,6 +205,39 @@ let attempt_runtime_candidates ~runtime_id ~runtime_id_of
           | None -> Error error))
   in
   loop 0 None candidates
+
+let elapsed_seconds_since started_at =
+  let ns =
+    Mtime.Span.to_uint64_ns (Mtime.span started_at (Mtime_clock.now ()))
+  in
+  Int64.to_float ns /. 1_000_000_000.
+
+let lane_accept_no_progress_retry_slot_available ~turn_start =
+  let elapsed_s = Float.max 0.0 (elapsed_seconds_since turn_start) in
+  let budget_s =
+    Env_config_keeper.KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec
+  in
+  elapsed_s < budget_s
+
+let log_lane_accept_no_progress_retry_suppressed
+    ~keeper_name
+    ~runtime_id
+    ~attempt
+    ~turn_start
+    error =
+  let elapsed_s = Float.max 0.0 (elapsed_seconds_since turn_start) in
+  let budget_s =
+    Env_config_keeper.KeeperRetryBackoff.degraded_retry_slot_phase_budget_sec
+  in
+  Log.Keeper.warn
+    "%s: suppressing lane no-progress retry for runtime=%s attempt=%d \
+     elapsed=%.3fs budget=%.3fs error=%s"
+    keeper_name
+    runtime_id
+    attempt
+    elapsed_s
+    budget_s
+    (Agent_sdk.Error.to_string error)
 
 let runtime_candidate_missing_error id =
   Agent_sdk.Error.Internal
@@ -539,6 +595,23 @@ let run_named
     ~runtime_id
     ~runtime_id_of:(fun (runtime : Runtime.t) -> runtime.Runtime.id)
     ~emit_runtime_manifest
+    ~allow_accept_no_progress_retry:
+      (fun ~runtime_id:attempt_runtime_id ~attempt error ->
+         if
+           not
+             (Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next
+                error)
+         then true
+         else if lane_accept_no_progress_retry_slot_available ~turn_start then
+           true
+         else (
+           log_lane_accept_no_progress_retry_suppressed
+             ~keeper_name
+             ~runtime_id:attempt_runtime_id
+             ~attempt
+             ~turn_start
+             error;
+           false))
     ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id:attempt_runtime_id runtime ->
       let error_runtime_id = attempt_runtime_id in
       let inference_policy =

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -233,6 +233,8 @@ module For_testing : sig
     attempt_inference_policy
 
   val attempt_runtime_candidates :
+    ?allow_accept_no_progress_retry:
+      (runtime_id:string -> attempt:int -> Agent_sdk.Error.sdk_error -> bool) ->
     runtime_id:string ->
     runtime_id_of:('candidate -> string) ->
     emit_runtime_manifest:

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -268,12 +268,17 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
     | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, source)
     | Ok None ->
         Error
-          ( `Bad_request,
-            Printf.sprintf "target_keeper %S is not a registered keeper" requested )
+          (`Bad_request
+             (Printf.sprintf
+                "target_keeper %S is not a registered keeper"
+                requested))
     | Error msg ->
         Error
-          ( `Internal_server_error,
-            Printf.sprintf "failed to read keeper metadata for %S: %s" requested msg )
+          (`Internal_server_error
+             (Printf.sprintf
+                "failed to read keeper metadata for %S: %s"
+                requested
+                msg))
   in
   match target_keeper with
   | Some requested -> resolve Explicit_target requested
@@ -283,14 +288,17 @@ let resolve_board_context_inference_target ~config (post : Board.post) target_ke
        | Ok (Some (resolved_name, _meta)) -> Ok (resolved_name, Post_author)
        | Ok None ->
            Error
-             ( `Bad_request,
-               Printf.sprintf
-                 "target_keeper is required because board post author %S is not a registered keeper"
-                 author )
+             (`Bad_request
+                (Printf.sprintf
+                   "target_keeper is required because board post author %S is not a registered keeper"
+                   author))
        | Error msg ->
            Error
-             ( `Internal_server_error,
-               Printf.sprintf "failed to read keeper metadata for board author %S: %s" author msg ))
+             (`Internal_server_error
+                (Printf.sprintf
+                   "failed to read keeper metadata for board author %S: %s"
+                   author
+                   msg)))
 
 let non_empty_json_string_member field json =
   match json_assoc_member field json with
@@ -388,8 +396,13 @@ let handle_board_context_inference_request ~state ~sw ~clock ~request reqd body 
               match
                 resolve_board_context_inference_target ~config post target_keeper
               with
-              | Error (status, message) ->
-                  respond_board_context_inference_error request reqd ~status
+              | Error (`Bad_request message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Bad_request
+                    ~message
+              | Error (`Internal_server_error message) ->
+                  respond_board_context_inference_error request reqd
+                    ~status:`Internal_server_error
                     ~message
               | Ok (target_keeper, target_source) -> (
                   match

--- a/test/dune
+++ b/test/dune
@@ -713,6 +713,7 @@
   test_log_severity_outcome_level
   test_env_keeper_scrub
   test_event_log
+  test_relation_materializer
   test_keeper_wire_capture
   test_board_rest_routes
   test_board_context_inference_resolution)

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -77,6 +77,12 @@ let make_post ~id ~author =
     origin = None;
   }
 
+let check_bad_request label expected = function
+  | Error (`Bad_request msg) -> check string label expected msg
+  | Error (`Internal_server_error msg) ->
+    fail (Printf.sprintf "expected Bad_request, got Internal_server_error: %s" msg)
+  | Ok _ -> fail "expected Bad_request error"
+
 let test_parse_request () =
   (* 1. Valid payload *)
   let json = `Assoc [("post_id", `String "post-123"); ("target_keeper", `String "sangsu")] in
@@ -117,10 +123,11 @@ let test_target_resolution_explicit_registered () =
 let test_target_resolution_explicit_unregistered () =
   with_workspace (fun config ->
     let post = make_post ~id:"post-1" ~author:"operator" in
-    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post (Some "chulsoo") with
-    | Error (`Bad_request msg) ->
-      check string "error message" "target_keeper \"chulsoo\" is not a registered keeper" msg
-    | _ -> fail "expected Bad_request error")
+    Server_routes_http_routes_activity.resolve_board_context_inference_target
+      ~config post (Some "chulsoo")
+    |> check_bad_request
+         "error message"
+         "target_keeper \"chulsoo\" is not a registered keeper")
 
 let test_target_resolution_implicit_registered_author () =
   with_workspace (fun config ->
@@ -141,10 +148,11 @@ let test_target_resolution_implicit_unregistered_author () =
   with_workspace (fun config ->
     (* Post author is "operator", which is not a registered keeper *)
     let post = make_post ~id:"post-1" ~author:"operator" in
-    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post None with
-    | Error (`Bad_request msg) ->
-      check string "error message" "target_keeper is required because board post author \"operator\" is not a registered keeper" msg
-    | _ -> fail "expected Bad_request error")
+    Server_routes_http_routes_activity.resolve_board_context_inference_target
+      ~config post None
+    |> check_bad_request
+         "error message"
+         "target_keeper is required because board post author \"operator\" is not a registered keeper")
 
 let () =
   run "Server board context inference resolution"

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -676,7 +676,11 @@ let test_attempt_loop_blocks_no_progress_when_gate_denies () =
       ~runtime_id_of:(fun runtime_id -> runtime_id)
       ~emit_runtime_manifest:(emit_manifest_collector events)
       ~allow_accept_no_progress_retry:(fun ~runtime_id ~attempt error ->
-        gate_calls := (runtime_id, attempt, Agent_sdk.Error.to_string error) :: !gate_calls;
+        gate_calls
+        := ( runtime_id,
+             attempt,
+             Driver.For_testing.accept_no_progress_should_try_next error )
+           :: !gate_calls;
         false)
       ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
         attempts := !attempts @ [ runtime_id ];
@@ -705,13 +709,13 @@ let test_attempt_loop_blocks_no_progress_when_gate_denies () =
     [ "primary.test_model" ]
     !attempts;
   (match List.rev !gate_calls with
-   | [ (runtime_id, attempt, error_text) ] ->
+   | [ (runtime_id, attempt, should_try_next) ] ->
      Alcotest.(check string) "gate runtime" "primary.test_model" runtime_id;
      Alcotest.(check int) "gate attempt" 0 attempt;
      Alcotest.(check bool)
        "gate sees no-progress error"
        true
-       (contains ~needle:"no_usable_progress" error_text)
+       should_try_next
    | calls ->
      Alcotest.failf "expected one no-progress gate call, got %d"
        (List.length calls));

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -66,6 +66,19 @@ let retryable_network_error message =
     (Agent_sdk.Retry.NetworkError
        { message; kind = Llm_provider.Http_client.Unknown })
 
+let accept_empty_no_progress_error scope =
+  Driver.sdk_error_of_masc_internal_error
+    (Driver.Accept_rejected
+       { scope
+       ; model = Some "runtime"
+       ; reason_kind = Some Driver.Accept_no_usable_progress
+       ; response_shape = Some Driver.Accept_response_empty
+       ; last_tool_effect = None
+       ; any_mutating_tool = None
+       ; tool_effects_seen = []
+       ; reason = "empty assistant response"
+       })
+
 let runtime_toml_with_lane =
   {|
 [runtime]
@@ -651,6 +664,113 @@ let test_attempt_loop_retries_network_error_with_checkpoint () =
        ])
     (List.map (fun (event, _, _) -> event_name event) events)
 
+let test_attempt_loop_blocks_no_progress_when_gate_denies () =
+  let attempts = ref [] in
+  let gate_calls = ref [] in
+  let events = ref [] in
+  let checkpoint_after_primary = checkpoint_with_session_id "after-primary" in
+  let primary_error = accept_empty_no_progress_error "primary.test_model" in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~allow_accept_no_progress_retry:(fun ~runtime_id ~attempt error ->
+        gate_calls := (runtime_id, attempt, Agent_sdk.Error.to_string error) :: !gate_calls;
+        false)
+      ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          Alcotest.(check bool)
+            "primary starts from initial checkpoint"
+            false
+            (Option.is_some resume_checkpoint);
+          Error primary_error, Some checkpoint_after_primary
+        | "fallback.test_model" ->
+          Alcotest.fail "no-progress retry gate should block fallback candidate"
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Error err ->
+     Alcotest.(check string)
+       "primary no-progress error preserved"
+       (Agent_sdk.Error.to_string primary_error)
+       (Agent_sdk.Error.to_string err)
+   | Ok runtime_id ->
+     Alcotest.failf "unexpected fallback success: %s" runtime_id);
+  Alcotest.(check (list string))
+    "attempted candidates"
+    [ "primary.test_model" ]
+    !attempts;
+  (match List.rev !gate_calls with
+   | [ (runtime_id, attempt, error_text) ] ->
+     Alcotest.(check string) "gate runtime" "primary.test_model" runtime_id;
+     Alcotest.(check int) "gate attempt" 0 attempt;
+     Alcotest.(check bool)
+       "gate sees no-progress error"
+       true
+       (contains ~needle:"no_usable_progress" error_text)
+   | calls ->
+     Alcotest.failf "expected one no-progress gate call, got %d"
+       (List.length calls));
+  let events = List.rev !events in
+  Alcotest.(check (list string))
+    "manifest events"
+    (List.map event_name
+       [
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_failed;
+       ])
+    (List.map (fun (event, _, _) -> event_name event) events)
+
+let test_attempt_loop_does_not_gate_network_retry () =
+  let attempts = ref [] in
+  let gate_called = ref false in
+  let events = ref [] in
+  let checkpoint_after_primary = checkpoint_with_session_id "after-primary" in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~allow_accept_no_progress_retry:(fun ~runtime_id:_ ~attempt:_ _ ->
+        gate_called := true;
+        false)
+      ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          Alcotest.(check bool)
+            "primary starts from initial checkpoint"
+            false
+            (Option.is_some resume_checkpoint);
+          Error (retryable_network_error "primary network failed"), Some checkpoint_after_primary
+        | "fallback.test_model" -> Ok runtime_id, None
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok runtime_id ->
+     Alcotest.(check string) "fallback selected" "fallback.test_model" runtime_id
+   | Error e ->
+     Alcotest.failf
+       "expected fallback success, got %s"
+       (Agent_sdk.Error.to_string e));
+  Alcotest.(check bool)
+    "network retry does not call no-progress gate"
+    false
+    !gate_called;
+  Alcotest.(check (list string))
+    "attempted candidates"
+    [ "primary.test_model"; "fallback.test_model" ]
+    !attempts;
+  Alcotest.(check int)
+    "network retry still emits all manifest events"
+    4
+    (List.length !events)
+
 let test_attempt_loop_preserves_last_sdk_error () =
   let events = ref [] in
   let result =
@@ -738,6 +858,14 @@ let () =
             "attempt loop retries network error with checkpoint"
             `Quick
             test_attempt_loop_retries_network_error_with_checkpoint;
+          Alcotest.test_case
+            "attempt loop blocks no-progress when gate denies"
+            `Quick
+            test_attempt_loop_blocks_no_progress_when_gate_denies;
+          Alcotest.test_case
+            "attempt loop does not gate network retry"
+            `Quick
+            test_attempt_loop_does_not_gate_network_retry;
           Alcotest.test_case
             "attempt loop preserves last SDK error"
             `Quick


### PR DESCRIPTION
## Summary
- Gate lane-internal accept no-progress fallback with the existing degraded retry slot budget.
- Leave network/HTTP retry behavior unchanged.
- Add focused tests proving no-progress gate denial blocks fallback while network retry bypasses the gate.

## Root Cause
The keeper runtime path already has a budget-aware degraded retry loop, but `run_named` could rotate lane candidates internally before that budget layer saw an accept-contract no-progress error. With thinking/tool loops and long checkpoints, that can replay large contexts across providers and amplify token use.

## Runtime Evidence
- Live mad-improver trace `trace-1782437332896-00000` recorded 5,611 API calls, 318,152,316 input tokens, and repeated `no_usable_progress` / `max_tokens` empty responses.
- This is provider-agnostic: the failing runtime evidence involved `runpod_mtp.qwen36-35b-a3b-mtp`, while the original billing concern was observed through MiMo usage. The fix keys on typed no-progress response shape, not provider names.

## Validation
- `ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli test/test_keeper_turn_driver_failover.ml`
- `git diff --check codex/fix-activity-target-error..HEAD`

Local Dune build intentionally not run; CI is the Dune authority for this repo.

Stacked on #23277. Retarget to main after #23277 lands.