### PR TITLE
dashboard: expose settings control backing

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -9,6 +9,7 @@ import {
   logEntryToSysRow,
   logRowStatus,
   normalizeSettingsSection,
+  settingsControlInventory,
 } from './settings-surface'
 import type {
   ConfigEntry,
@@ -491,7 +492,14 @@ describe('SettingsSurface', () => {
     render(html`<${SettingsSurface} />`, container)
 
     expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent)
-      .toContain('theme/density live')
+      .toContain('browser-local shell state')
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
+    expect(container.querySelector('[data-testid="settings-control-ledger"]')?.textContent)
+      .toContain('browser shell only')
+    expect(container.querySelector('[data-control-id="settings-theme-density"]')?.getAttribute('data-control-kind'))
+      .toBe('browser-local')
+    expect(container.querySelector('[data-control-id="settings-display-locale"]')?.getAttribute('data-control-kind'))
+      .toBe('unsupported')
     expect(container.querySelector('[data-testid="display-live-summary"]')?.textContent)
       .toContain('spacious')
 
@@ -727,6 +735,10 @@ describe('SettingsSurface', () => {
       expect(container.textContent).toContain('70%')
       expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('live thresholds read-only')
       expect(container.querySelector('[data-testid="notify-routing-readonly"]')?.textContent).toContain('no writer')
+      expect(container.querySelector('[data-control-id="settings-notify-thresholds"]')?.getAttribute('data-control-kind'))
+        .toBe('live-read')
+      expect(container.querySelector('[data-control-id="settings-notify-routing"]')?.getAttribute('data-control-kind'))
+        .toBe('unsupported')
     })
 
     expect(container.querySelector('[data-testid="notify-local-summary"]')).toBeNull()
@@ -1166,6 +1178,10 @@ describe('SettingsSurface', () => {
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="runtime-routing-summary"]')?.textContent).toContain('Librarian')
+      expect(container.querySelector('[data-testid="settings-control-ledger"]')?.textContent)
+        .toContain('PATCH /api/v1/runtime/routing')
+      expect(container.querySelector('[data-control-id="runtime-routing-lanes"]')?.getAttribute('data-control-kind'))
+        .toBe('live-write')
       expect(container.querySelector('[data-testid="runtime-media-failover-reality"]')?.textContent)
         .toContain('수동 reroute')
       expect(container.querySelector('[data-testid="runtime-media-failover-reality"]')?.textContent)
@@ -1487,6 +1503,26 @@ describe('SettingsSurface shell route', () => {
 })
 
 describe('settings read-surface helpers', () => {
+  it('settingsControlInventory classifies browser-local and unsupported controls explicitly', () => {
+    const displayKinds = settingsControlInventory('display').map(item => [item.id, item.kind])
+    expect(displayKinds).toContainEqual(['settings-theme-density', 'browser-local'])
+    expect(displayKinds).toContainEqual(['settings-display-locale', 'unsupported'])
+
+    const notifyKinds = settingsControlInventory('notify').map(item => [item.id, item.kind])
+    expect(notifyKinds).toContainEqual(['settings-notify-thresholds', 'live-read'])
+    expect(notifyKinds).toContainEqual(['settings-notify-routing', 'unsupported'])
+  })
+
+  it('settingsControlInventory records runtime routing writers as live-backed actions', () => {
+    const routing = settingsControlInventory('routing')
+    expect(routing.map(item => item.id)).toEqual([
+      'runtime-routing-lanes',
+      'runtime-media-failover',
+    ])
+    expect(routing.every(item => item.kind === 'live-write')).toBe(true)
+    expect(routing.map(item => item.action).join('\n')).toContain('/api/v1/runtime/routing')
+  })
+
   it('mcpExposedToolNames keeps only public_mcp tools, sorted', () => {
     const names = mcpExposedToolNames([
       makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -21,6 +21,7 @@ import type {
   RuntimeDefaultsResponse,
 } from '../api/dashboard'
 import { DashboardMain } from './dashboard-shell'
+import { SETTINGS_ROUTE_SECTION_IDS } from '../config/navigation'
 import { route } from '../router'
 import { connected } from '../sse'
 import { tweaksDensity } from './tweaks-panel'
@@ -1503,6 +1504,19 @@ describe('SettingsSurface shell route', () => {
 })
 
 describe('settings read-surface helpers', () => {
+  it('settingsControlInventory covers every settings route section with unique ids', () => {
+    const items = SETTINGS_ROUTE_SECTION_IDS.flatMap(section => settingsControlInventory(section))
+    const ids = new Set<string>()
+
+    for (const section of SETTINGS_ROUTE_SECTION_IDS) {
+      expect(settingsControlInventory(section).length).toBeGreaterThan(0)
+    }
+    for (const item of items) {
+      expect(ids.has(item.id)).toBe(false)
+      ids.add(item.id)
+    }
+  })
+
   it('settingsControlInventory classifies browser-local and unsupported controls explicitly', () => {
     const displayKinds = settingsControlInventory('display').map(item => [item.id, item.kind])
     expect(displayKinds).toContainEqual(['settings-theme-density', 'browser-local'])

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -51,9 +51,18 @@ type SectionId = SettingsRouteSectionId
 
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
 type RuntimeRoutingSaveState = 'idle' | 'saving' | 'saved' | 'error'
+type SettingsControlKind = 'live-read' | 'live-write' | 'browser-local' | 'unsupported'
 type RuntimeSelectOption = {
   readonly id: string
   readonly label: string
+}
+export type SettingsControlInventoryItem = {
+  readonly id: string
+  readonly section: SectionId
+  readonly label: string
+  readonly kind: SettingsControlKind
+  readonly source: string
+  readonly action: string
 }
 const SETTINGS_ROUTE_SECTION_SET = new Set<string>(SETTINGS_ROUTE_SECTION_IDS)
 const DEFAULT_SETTINGS_SECTION: SectionId = 'runtime'
@@ -92,6 +101,141 @@ const MCP_PUBLIC_SURFACE = 'public_mcp'
 const SETTINGS_LOG_LIMIT = 50
 const SETTINGS_LOG_POLL_MS = 3000
 const DISPLAY_DENSITY_OPTIONS: Density[] = ['compact', 'regular', 'spacious']
+
+const SETTINGS_CONTROL_INVENTORY: readonly SettingsControlInventoryItem[] = [
+  {
+    id: 'runtime-default-runtime',
+    section: 'runtime',
+    label: 'Default runtime',
+    kind: 'live-write',
+    source: 'GET /api/v1/dashboard/runtime-defaults + runtime provider catalog',
+    action: 'PATCH /api/v1/runtime/routing lane=default',
+  },
+  {
+    id: 'runtime-catalog-summary',
+    section: 'runtime',
+    label: 'Runtime catalog cards',
+    kind: 'live-read',
+    source: 'GET /api/v1/dashboard/runtime-providers, fallback runtime-defaults projection',
+    action: 'read-only projection',
+  },
+  {
+    id: 'runtime-routing-lanes',
+    section: 'routing',
+    label: 'Model routing lanes',
+    kind: 'live-write',
+    source: 'GET /api/v1/dashboard/runtime-defaults',
+    action: 'PATCH /api/v1/runtime/routing for default/librarian/structured_judge/cross_verifier',
+  },
+  {
+    id: 'runtime-media-failover',
+    section: 'routing',
+    label: 'Media failover list',
+    kind: 'live-write',
+    source: '[runtime].media_failover in runtime.toml',
+    action: 'PATCH /api/v1/runtime/media-failover',
+  },
+  {
+    id: 'runtime-toml-editor',
+    section: 'runtimes',
+    label: 'runtime.toml editor',
+    kind: 'live-write',
+    source: 'GET /api/v1/runtime/config/raw',
+    action: 'PUT /api/v1/runtime/config/raw',
+  },
+  {
+    id: 'settings-path-resolution',
+    section: 'paths',
+    label: 'Resolved paths',
+    kind: 'live-read',
+    source: 'dashboard shell path/config resolution + config projection',
+    action: 'read-only projection',
+  },
+  {
+    id: 'settings-mcp-status',
+    section: 'mcp',
+    label: 'MCP status check',
+    kind: 'live-read',
+    source: 'public MCP server + dashboard tool inventory',
+    action: 'call masc_status; no settings mutation',
+  },
+  {
+    id: 'settings-repositories',
+    section: 'repositories',
+    label: 'Repository settings',
+    kind: 'live-write',
+    source: 'repositories API',
+    action: 'SettingsRepositoriesSection owned writer',
+  },
+  {
+    id: 'settings-notify-thresholds',
+    section: 'notify',
+    label: 'Alert thresholds',
+    kind: 'live-read',
+    source: 'GET /api/v1/dashboard/config',
+    action: 'read-only projection',
+  },
+  {
+    id: 'settings-notify-routing',
+    section: 'notify',
+    label: 'Notification routing',
+    kind: 'unsupported',
+    source: 'no dashboard writer exposed',
+    action: 'render read-only unsupported state',
+  },
+  {
+    id: 'settings-prompts',
+    section: 'prompts',
+    label: 'Prompt registry',
+    kind: 'live-write',
+    source: 'prompt registry API',
+    action: 'PromptRegistryPanel owned writer',
+  },
+  {
+    id: 'settings-fusion',
+    section: 'fusion',
+    label: 'Fusion settings',
+    kind: 'live-write',
+    source: 'runtime.toml fusion settings',
+    action: 'FusionSettingsPanel owned writer',
+  },
+  {
+    id: 'settings-logs',
+    section: 'logs',
+    label: 'System log filters',
+    kind: 'live-read',
+    source: 'GET /api/v1/dashboard/logs',
+    action: 'client-side filter only',
+  },
+  {
+    id: 'settings-theme-density',
+    section: 'display',
+    label: 'Theme and density',
+    kind: 'browser-local',
+    source: 'DOM dataset + localStorage persistent signals',
+    action: 'browser shell only; no server settings write',
+  },
+  {
+    id: 'settings-display-locale',
+    section: 'display',
+    label: 'Locale / time format',
+    kind: 'unsupported',
+    source: 'no renderer-wide setting exposed',
+    action: 'render read-only unsupported state',
+  },
+  {
+    id: 'settings-html-snapshot',
+    section: 'display',
+    label: 'HTML snapshot export',
+    kind: 'browser-local',
+    source: 'current DOM outerHTML',
+    action: 'download DOM snapshot; no standalone resource claim',
+  },
+]
+
+export function settingsControlInventory(section: SectionId): readonly SettingsControlInventoryItem[] {
+  return SETTINGS_CONTROL_INVENTORY.filter(item => item.section === section)
+}
 
 export function normalizeSettingsSection(value: string | null | undefined): SectionId {
   return SETTINGS_ROUTE_SECTION_SET.has(value ?? '') ? (value as SectionId) : DEFAULT_SETTINGS_SECTION
@@ -190,6 +334,42 @@ function PreviewBadge({ label }: { label: string }) {
     >
       ${label}
     </span>
+  `
+}
+
+function settingsControlKindLabel(kind: SettingsControlKind): string {
+  if (kind === 'live-write') return 'live write'
+  if (kind === 'live-read') return 'live read'
+  if (kind === 'browser-local') return 'browser local'
+  return 'unsupported'
+}
+
+function SettingsControlLedger({ section }: { section: SectionId }) {
+  const items = settingsControlInventory(section)
+  if (items.length === 0) return null
+  return html`
+    <section class="set-control-ledger" data-testid="settings-control-ledger">
+      <div class="set-control-ledger-h">
+        <span>Control backing</span>
+        <span class="mono" data-testid="settings-control-ledger-count">${items.length}</span>
+      </div>
+      <div class="set-control-ledger-grid">
+        ${items.map(item => html`
+          <div
+            key=${item.id}
+            class=${`set-control-ledger-row ${item.kind}`}
+            data-testid="settings-control-ledger-row"
+            data-control-id=${item.id}
+            data-control-kind=${item.kind}
+          >
+            <span class="set-control-kind">${settingsControlKindLabel(item.kind)}</span>
+            <span class="set-control-label">${item.label}</span>
+            <span class="set-control-source mono" title=${item.source}>${item.source}</span>
+            <span class="set-control-action" title=${item.action}>${item.action}</span>
+          </div>
+        `)}
+      </div>
+    </section>
   `
 }
 
@@ -638,7 +818,7 @@ function settingsSectionState(
   if (section === 'repositories') return { mode: 'live', label: 'repositories API live-backed' }
   if (section === 'logs') return { mode: 'mixed', label: 'live logs + local filters' }
   if (section === 'notify') return { mode: 'live', label: 'live thresholds read-only' }
-  if (section === 'display') return { mode: 'live', label: 'theme/density live' }
+  if (section === 'display') return { mode: 'local', label: 'browser-local shell state' }
   return { mode: 'local', label: 'read-only preview' }
 }
 
@@ -1099,6 +1279,7 @@ export function SettingsSurface() {
             data-preview-locked="false"
             data-settings-mode=${sectionState.mode}
           >
+            <${SettingsControlLedger} section=${sec} />
             ${sec === 'mcp' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
                 현재 대시보드가 사용하는 HTTP MCP 서버 상태와 public MCP 도구 노출 목록입니다. 도구 노출은 서버 capability registry가 SSOT입니다.

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -247,6 +247,95 @@
   border-style: dashed;
 }
 
+.set-control-ledger {
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-well);
+  margin: 0 0 14px;
+  overflow: hidden;
+}
+
+.set-control-ledger-h {
+  align-items: center;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-mid);
+  display: flex;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  justify-content: space-between;
+  padding: 8px 10px;
+  text-transform: uppercase;
+}
+
+.set-control-ledger-grid {
+  display: grid;
+  gap: 0;
+}
+
+.set-control-ledger-row {
+  align-items: start;
+  border-top: 1px solid var(--border-soft);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(88px, 0.7fr) minmax(140px, 1fr) minmax(180px, 1.25fr) minmax(180px, 1.25fr);
+  min-width: 0;
+  padding: 9px 10px;
+}
+
+.set-control-ledger-row:first-child {
+  border-top: 0;
+}
+
+.set-control-kind {
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  color: var(--text-dim);
+  display: inline-flex;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  justify-content: center;
+  line-height: 1.2;
+  padding: 3px 6px;
+  text-transform: uppercase;
+  width: fit-content;
+}
+
+.set-control-ledger-row.live-write .set-control-kind {
+  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent);
+  color: var(--status-ok);
+}
+
+.set-control-ledger-row.browser-local .set-control-kind {
+  border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
+  color: var(--status-warn);
+}
+
+.set-control-ledger-row.unsupported .set-control-kind {
+  border-color: color-mix(in oklab, var(--status-fail) 45%, transparent);
+  color: var(--status-fail);
+}
+
+.set-control-label {
+  color: var(--text-primary);
+  font-size: var(--fs-12);
+  min-width: 0;
+}
+
+.set-control-source,
+.set-control-action {
+  color: var(--text-dim);
+  font-size: var(--fs-11);
+  line-height: 1.4;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 900px) {
+  .set-control-ledger-row {
+    grid-template-columns: 1fr;
+  }
+}
+
 .settings-surf .set-card-b {
   padding: 8px 28px 40px;
   max-width: 760px;


### PR DESCRIPTION
## Summary
- add a Settings control backing ledger so each visible settings section exposes whether its controls are live-read, live-write, browser-local, or unsupported
- downgrade Display from backend-live wording to browser-local shell state, keeping locale/time as explicit unsupported/read-only instead of fake settings
- cover routing, notify, and display backing truth in unit tests

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/settings-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- git diff --check
- Playwright fallback smoke (Browser plugin not available): #settings?section=display, #settings?section=routing, #settings?section=notify with mocked settings APIs; screenshots saved to /tmp/masc-settings-ledger-display.png, /tmp/masc-settings-ledger-routing.png, /tmp/masc-settings-ledger-notify.png; console and HTTP error lists empty in the clean run

## Notes
- This is Goal A / PR-KC1b groundwork from the keeper-v2 dashboard matrix: it makes backed vs local vs unsupported settings controls explicit before adding or polishing more controls.
- No local Dune build was run; CI remains the OCaml build authority.