### PR TITLE
[codex] Preserve Keeper Chat transcript provenance

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -215,6 +215,33 @@ describe('ChatTranscript', () => {
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })
 
+  it('exposes tool-call transcript provenance as rendered attributes', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-toolu_prov',
+            label: 'keeper_context_status',
+            turnRef: 'trace-tool#3',
+            delivery: 'history',
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${false}
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-variant="tool-call"]') as HTMLElement
+    expect(bubble).not.toBeNull()
+    expect(bubble.getAttribute('data-chat-entry-id')).toBe('tool-toolu_prov')
+    expect(bubble.getAttribute('data-chat-role')).toBe('tool')
+    expect(bubble.getAttribute('data-chat-source')).toBe('tool_result')
+    expect(bubble.getAttribute('data-chat-delivery-state')).toBe('history')
+    expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
+    expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
+  })
+
   it('marks a failed tool call with the error status glyph', () => {
     recordToolCallOutputs([
       toolCallOutput({ tool_use_id: 'toolu_y', success: false, output: 'boom' }),
@@ -2029,6 +2056,7 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
             text: '답합니다',
             role: 'assistant',
             source: 'direct_assistant',
+            turnRef: 'trace-prov#7',
             traceSteps: [
               { kind: 'think', text: 'checking context', oasBlockIndex: 3 },
               {
@@ -2054,6 +2082,24 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(badges).toContain('OAS #3')
     expect(badges).toContain('OAS #4')
     expect(badges).toContain('reply')
+
+    const think = container.querySelector('[data-chat-trace-step="think"]') as HTMLElement
+    expect(think.getAttribute('data-chat-trace-provenance')).toBe('OAS #3')
+    expect(think.getAttribute('data-chat-trace-oas-block-index')).toBe('3')
+
+    const tool = container.querySelector('[data-chat-trace-step="tool"]') as HTMLElement
+    expect(tool.getAttribute('data-chat-trace-provenance')).toBe('OAS #4')
+    expect(tool.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-prov')
+    expect(tool.getAttribute('data-chat-trace-oas-block-index')).toBe('4')
+    expect(tool.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
+    expect(tool.getAttribute('data-chat-trace-output-state')).toBe('ok')
+    expect(tool.getAttribute('data-chat-trace-entry-id')).toBeNull()
+
+    const chat = container.querySelector('[data-chat-trace-step="chat"]') as HTMLElement
+    expect(chat.getAttribute('data-chat-trace-provenance')).toBe('reply')
+    expect(chat.getAttribute('data-chat-trace-entry-id')).toBe('a-provenance')
+    expect(chat.getAttribute('data-chat-trace-source')).toBe('direct_assistant')
+    expect(chat.getAttribute('data-chat-trace-turn-ref')).toBe('trace-prov#7')
   })
 
   it('renders thinking text as sanitized markdown with newlines preserved', async () => {
@@ -2323,6 +2369,10 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(step?.querySelector('.chat-block-tstep-status.unlinked')).not.toBeNull()
     expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
     expect(step?.querySelector('[data-chat-trace-provenance]')?.getAttribute('data-chat-trace-provenance')).toBe('unlinked_trace')
+    expect(step?.getAttribute('data-chat-trace-link-state')).toBe('unlinked')
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('unlinked')
+    expect(step?.getAttribute('data-chat-trace-tool-call-id')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-entry-id')).toBeNull()
 
     ;(step?.querySelector('.chat-block-tstep-row') as HTMLElement).click()
     await flushUi()

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -179,6 +179,42 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-blocks]')).toBeNull()
   })
 
+  it('exposes entry provenance as rendered attributes and surface links', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'discord-1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: 'channel reply',
+            rawText: 'channel reply',
+            turnRef: 'trace-ui#9',
+            surface: {
+              kind: 'discord',
+              guild_id: 'guild-1',
+              channel_id: 'channel-1',
+              thread_id: 'thread-1',
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+        showSourceBadge=${true}
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-entry-id="discord-1"]') as HTMLElement
+    expect(bubble).not.toBeNull()
+    expect(bubble.getAttribute('data-chat-source')).toBe('direct_assistant')
+    expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
+    expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
+    const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
+    expect(surfaceLink?.textContent).toContain('Discord Thread')
+  })
+
   it('marks a failed tool call with the error status glyph', () => {
     recordToolCallOutputs([
       toolCallOutput({ tool_use_id: 'toolu_y', success: false, output: 'boom' }),

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2091,6 +2091,12 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
           : 'max-w-[90%] gap-3 rounded-[var(--r-5)] px-4 py-3'
       }`}
       data-chat-variant=${variant}
+      data-chat-entry-id=${entry.id}
+      data-chat-role=${entry.role}
+      data-chat-source=${entry.source}
+      data-chat-delivery-state=${entry.delivery}
+      data-chat-surface-kind=${entry.surface?.kind ?? undefined}
+      data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -25,7 +25,7 @@ import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, C
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
-import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById, toolEntryIdFromCallId } from '../../tool-call-output-store'
+import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
@@ -1295,7 +1295,13 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       ? `${step.text.slice(0, THINKING_TRACE_PREVIEW_CHARS).trimEnd()}\n\n... ${step.text.length - THINKING_TRACE_PREVIEW_CHARS} chars hidden`
       : step.text
     return html`
-      <div class="chat-block-tstep think" data-chat-trace-step="think">
+      <div
+        class="chat-block-tstep think"
+        data-chat-trace-step="think"
+        data-chat-trace-provenance=${sourceBadge.label}
+        data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
+        data-chat-trace-ts=${step.ts ?? undefined}
+      >
         <span class="chat-block-tnode"></span>
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row">
@@ -1337,7 +1343,12 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
   if (step.kind === 'reason') {
     const exp = !!step.detail
     return html`
-      <div class="chat-block-tstep reason ${open ? 'exp' : ''}" data-chat-trace-step="reason">
+      <div
+        class="chat-block-tstep reason ${open ? 'exp' : ''}"
+        data-chat-trace-step="reason"
+        data-chat-trace-provenance=${sourceBadge.label}
+        data-chat-trace-ts=${step.ts ?? undefined}
+      >
         <span class="chat-block-tnode"></span>
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row ${exp ? 'click' : ''}" onClick=${() => { if (exp) setOpen((o) => !o) }}>
@@ -1357,7 +1368,16 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
   const statusUi = traceToolStatusUi(step.status)
 
   return html`
-    <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
+    <div
+      class="chat-block-tstep tool ${open ? 'exp' : ''}"
+      data-chat-trace-step="tool"
+      data-chat-trace-provenance=${sourceBadge.label}
+      data-chat-trace-tool-call-id=${step.toolCallId?.trim() || undefined}
+      data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
+      data-chat-trace-link-state=${step.toolCallId?.trim() ? 'trace-only' : 'unlinked'}
+      data-chat-trace-output-state=${step.status ?? 'pending'}
+      data-chat-trace-ts=${step.ts ?? undefined}
+    >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
         <div class="chat-block-tstep-row click" onClick=${() => setOpen((o) => !o)}>
@@ -2429,6 +2449,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   const [expanded, setExpanded] = useState(false)
   const timestamp = timeLabel(entry.timestamp)
   const toolName = entry.label || 'tool'
+  const toolCallId = toolCallIdFromToolEntryId(entry.id)
   const displayArgs = prettyJsonish(entry.text || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
 
@@ -2456,6 +2477,12 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
     <article
       class="chat-bubble tool flex w-full flex-col rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
       data-chat-variant="tool-call"
+      data-chat-entry-id=${entry.id}
+      data-chat-role=${entry.role}
+      data-chat-source=${entry.source}
+      data-chat-delivery-state=${entry.delivery}
+      data-chat-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-tool-call-id=${toolCallId ?? undefined}
     >
       <button
         type="button"
@@ -2549,15 +2576,15 @@ function isToolOutputCoveredByHydration(
     && timestampMs <= coveredThroughMs
 }
 
-function toolTraceCallId(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): string | null {
+function toolTraceCallId(entry: KeeperConversationEntry | null, traceStep?: ChatTraceToolStep): string | null {
   const traceCallId = traceStep?.toolCallId?.trim()
   if (traceCallId) return traceCallId
-  return toolCallIdFromToolEntryId(entry.id)
+  return entry ? toolCallIdFromToolEntryId(entry.id) : null
 }
 
-function toolTraceSourceBadge(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): TraceSourceBadgeInfo {
+function toolTraceSourceBadge(entry: KeeperConversationEntry | null, traceStep?: ChatTraceToolStep): TraceSourceBadgeInfo {
   if (traceStep) return traceSourceBadge(traceStep)
-  const callId = toolCallIdFromToolEntryId(entry.id)
+  const callId = entry ? toolCallIdFromToolEntryId(entry.id) : null
   return callId
     ? {
         label: 'tool_call_id',
@@ -2571,28 +2598,8 @@ function toolTraceSourceBadge(entry: KeeperConversationEntry, traceStep?: ChatTr
       }
 }
 
-function isUnlinkedTraceTool(entry: KeeperConversationEntry, traceStep?: ChatTraceToolStep): boolean {
+function isUnlinkedTraceTool(entry: KeeperConversationEntry | null, traceStep?: ChatTraceToolStep): boolean {
   return traceStep !== undefined && toolTraceCallId(entry, traceStep) === null
-}
-
-// One step of a grouped tool-trace card: a single tool call rendered from REAL
-// data only. Name + input args come from the chat entry; status, duration and
-// result are joined from the tool-call output store. A null output is "pending"
-// until the owning turn and output hydration have both settled; after that, a
-// still-null output is "missing" (unknown outcome).
-function toolEntryFromTraceStep(step: ChatTraceToolStep): KeeperConversationEntry {
-  return {
-    id: step.toolCallId ? toolEntryIdFromCallId(step.toolCallId) : `trace-tool-${step.name}-${step.ts ?? 'unknown'}`,
-    role: 'tool',
-    source: 'tool_result',
-    label: step.name,
-    text: step.args ?? '',
-    rawText: step.args ?? '',
-    timestamp: step.ts ?? null,
-    delivery: step.status === 'err' ? 'error' : step.status === 'ok' ? 'delivered' : 'streaming',
-    streamState: step.status === 'pending' || step.status === undefined ? 'streaming' : null,
-    details: null,
-  }
 }
 
 function ToolTraceStep({
@@ -2601,14 +2608,15 @@ function ToolTraceStep({
   canMarkMissing = false,
   traceStep,
 }: {
-  entry: KeeperConversationEntry
+  entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
   canMarkMissing?: boolean
   traceStep?: ChatTraceToolStep
 }) {
   const [open, setOpen] = useState(false)
-  const name = traceStep?.name || entry.label || 'tool'
-  const displayArgs = prettyJsonish(entry.text || traceStep?.args || '')
+  const name = traceStep?.name || entry?.label || 'tool'
+  const callId = toolTraceCallId(entry, traceStep)
+  const displayArgs = prettyJsonish(entry?.text || traceStep?.args || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
   const unlinkedTraceTool = isUnlinkedTraceTool(entry, traceStep)
   const sourceBadge = toolTraceSourceBadge(entry, traceStep)
@@ -2635,7 +2643,16 @@ function ToolTraceStep({
   const hasBody = unlinkedTraceTool || !isEmptyArgs || hasResult || output === null
 
   return html`
-    <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
+    <div
+      class="chat-block-tstep tool ${open ? 'exp' : ''}"
+      data-chat-trace-step="tool"
+      data-chat-trace-provenance=${sourceBadge.label}
+      data-chat-trace-tool-call-id=${callId ?? undefined}
+      data-chat-trace-oas-block-index=${traceStep?.oasBlockIndex ?? undefined}
+      data-chat-trace-entry-id=${entry?.id ?? undefined}
+      data-chat-trace-link-state=${unlinkedTraceTool ? 'unlinked' : entry ? 'joined' : 'trace-only'}
+      data-chat-trace-output-state=${status}
+    >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
         <div
@@ -2762,7 +2779,14 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
     tone: 'reply',
   }
   return html`
-    <div class="chat-block-tstep chat" data-chat-trace-step="chat">
+    <div
+      class="chat-block-tstep chat"
+      data-chat-trace-step="chat"
+      data-chat-trace-provenance=${sourceBadge.label}
+      data-chat-trace-entry-id=${entry.id}
+      data-chat-trace-source=${entry.source}
+      data-chat-trace-turn-ref=${entry.turnRef ?? undefined}
+    >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
         <div class="chat-block-tstep-row">
@@ -2865,10 +2889,9 @@ function ToolTraceCard({
                     />`
                   : item.kind === 'tool'
                     ? (() => {
-                        const entry = item.entry ?? toolEntryFromTraceStep(item.step)
                         return html`<${ToolTraceStep}
                           key=${`tool-trace-${item.entry?.id ?? item.step.toolCallId ?? item.step.name}-${index}`}
-                          entry=${entry}
+                          entry=${item.entry}
                           output=${item.output}
                           canMarkMissing=${item.entry !== null && canMarkMissingForEntry(item.entry)}
                           traceStep=${item.step}

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -323,6 +323,42 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.timestamp).toBeTruthy()
   })
 
+  it('preserves REST chat history provenance instead of re-inferring it away', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'user',
+        source: 'world_state_prompt',
+        content: 'state snapshot',
+        ts: 1_780_000_000,
+        surface: { kind: 'dashboard', session_id: 'sess-1' },
+      },
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from channel context',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#7',
+        surface: {
+          kind: 'discord',
+          guild_id: 'guild-1',
+          channel_id: 'channel-1',
+          thread_id: 'thread-1',
+        },
+      },
+    ])
+
+    expect(entries[0]?.source).toBe('world_state_prompt')
+    expect(entries[0]?.surface).toEqual({ kind: 'dashboard', session_id: 'sess-1' })
+    expect(entries[1]?.source).toBe('direct_assistant')
+    expect(entries[1]?.surface).toEqual({
+      kind: 'discord',
+      guild_id: 'guild-1',
+      channel_id: 'channel-1',
+      thread_id: 'thread-1',
+    })
+    expect(entries[1]?.turnRef).toBe('trace-rest#7')
+  })
+
   it('preserves object payloads in persisted tool trace blocks', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1323,6 +1323,8 @@ export function chatHistoryEntriesFromRest(
         role: message.role,
         content: message.content,
         ts_unix: message.ts,
+        source: message.source,
+        surface: message.surface,
         audio: message.audio,
         attachments: message.attachments,
         kind: message.kind,


### PR DESCRIPTION
## Summary
- Preserve REST chat-history `source` and `surface` fields when hydrating visible Keeper Chat entries instead of re-inferring them away.
- Add transcript entry provenance attributes (`data-chat-source`, `data-chat-surface-kind`, `data-chat-turn-ref`, role, delivery) so review/debug tooling can prove where a rendered row came from.
- Keep connector/dashboard surface chips backed by the persisted `surface` object; no synthetic channel labels are introduced.

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/keeper-state.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1` (173 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
- `pnpm --dir dashboard run build`
- Chrome DevTools Protocol smoke against `http://127.0.0.1:5176/dashboard/keepers?keeper=verifier` with live backend `http://127.0.0.1:8935`:
  - desktop 1440x1000 and mobile 390x844 loaded `MASC · Keepers`
  - 100 chat entries rendered, 86 carried `data-chat-surface-kind="dashboard"`
  - first entries exposed `source`, `delivery`, `surface`, and `turnRef` attributes from persisted history
  - metadata toggle interaction succeeded
  - no console/page errors, no framework overlay
  - screenshots: `/tmp/chat-transcript-provenance-cdp-desktop.png`, `/tmp/chat-transcript-provenance-cdp-mobile.png`

## CI Notes
- Current head: `ee1c6bed6abf3d93fc11cc44bebd812630c8dacd`.
- Initial GitHub checks are green: `PR Axis Cross-Check / check`, `Test Coverage Check / check`.

## Stack
- Base: #23277 / `codex/fix-activity-target-error` to avoid the known #23283 source-side Lint blocker while it is still pending on `main`.
