### PR TITLE
[codex] Surface Keeper Chat stream coverage gaps

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Interleave Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-interleave-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Replay Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-replay-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Tool Output Failure Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -86,6 +86,35 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.turn_ref).toBe('trace-1780648779957-00000#4071')
   })
 
+  it('passes the backend stream contract read model through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-1780648779957-00000#4071',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      }),
+    )
+    expect(out?.stream_contract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turn_ref: 'trace-1780648779957-00000#4071',
+      trace_event_count: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('returns null when stream_contract has the wrong shape', () => {
+    expect(
+      safeParseKeeperChatHistoryMessage(
+        validMessage({ stream_contract: { source: 'backend_turn_trace' } }),
+      ),
+    ).toBeNull()
+  })
+
   it('leaves turn_ref undefined on legacy rows without dropping the message', () => {
     const out = safeParseKeeperChatHistoryMessage(validMessage())
     expect(out).not.toBeNull()
@@ -200,6 +229,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
           { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
           { t: 'link', url: 'https://example.com', title: 'Example' },
+          {
+            t: 'trace',
+            trace: [
+              { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+              { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+            ],
+          },
+          { t: 'thinking', content: '', redacted: true },
         ],
       }),
     )
@@ -211,6 +248,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
       { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
       { t: 'link', url: 'https://example.com', title: 'Example' },
+      {
+        t: 'trace',
+        trace: [
+          { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+          { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+        ],
+      },
+      { t: 'thinking', content: '', redacted: true },
     ])
   })
 

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -94,6 +94,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-1780648779957-00000#4071',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       }),
@@ -103,7 +104,43 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       status: 'backend_trace_join',
       turn_ref: 'trace-1780648779957-00000#4071',
       trace_event_count: 2,
+      delivery_receipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('passes durable backend lifecycle stream contracts through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-1780648779957-00000#4071',
+          event_name: 'RUN_FINISHED',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'TEXT_MESSAGE_START',
+            'TEXT_MESSAGE_END',
+            'RUN_FINISHED',
+          ],
+          delivery_receipt: 'server_lifecycle_replay_only',
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      }),
+    )
+    expect(out?.stream_contract).toEqual({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turn_ref: 'trace-1780648779957-00000#4071',
+      event_name: 'RUN_FINISHED',
+      lifecycle_events: [
+        'RUN_STARTED',
+        'TEXT_MESSAGE_START',
+        'TEXT_MESSAGE_END',
+        'RUN_FINISHED',
+      ],
+      delivery_receipt: 'server_lifecycle_replay_only',
+      reason: 'history row records durable server stream lifecycle replay',
     })
   })
 

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -89,6 +89,35 @@ const KeeperChatTableCellSchema = union([
   }),
 ])
 
+const KeeperChatTraceStepSchema = union([
+  object({
+    kind: literal('think'),
+    text: string(),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+  object({
+    kind: literal('reason'),
+    text: string(),
+    detail: optional(string()),
+    ts: optional(string()),
+  }),
+  object({
+    kind: literal('tool'),
+    name: string(),
+    tool_call_id: optional(string()),
+    toolCallId: optional(string()),
+    status: optional(union([literal('pending'), literal('ok'), literal('err')])),
+    dur: optional(string()),
+    args: optional(unknown()),
+    result: optional(unknown()),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+])
+
 // RFC-0235 P3: server-parsed rich chat blocks carried on persisted history
 // rows. Keep this aligned with keeper_chat_blocks.ml and the dashboard
 // renderer's ChatBlock union; malformed block arrays cause the whole row to be
@@ -174,9 +203,34 @@ export const KeeperChatBlockSchema = union([
     board_post_id: string(),
     run_id: optional(string()),
   }),
+  object({
+    t: literal('trace'),
+    trace: array(KeeperChatTraceStepSchema),
+  }),
+  object({
+    t: literal('thinking'),
+    content: string(),
+    redacted: optional(boolean()),
+  }),
 ])
 
 export type KeeperChatBlock = InferOutput<typeof KeeperChatBlockSchema>
+
+export const KeeperChatHistoryStreamContractSchema = object({
+  source: string(),
+  status: string(),
+  event_name: optional(string()),
+  eventName: optional(string()),
+  request_id: optional(string()),
+  requestId: optional(string()),
+  turn_ref: optional(string()),
+  turnRef: optional(string()),
+  trace_event_count: optional(number()),
+  traceEventCount: optional(number()),
+  reason: optional(string()),
+})
+
+export type KeeperChatHistoryStreamContract = InferOutput<typeof KeeperChatHistoryStreamContractSchema>
 
 export const KeeperChatHistoryMessageSchema = object({
   // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
@@ -234,6 +288,11 @@ export const KeeperChatHistoryMessageSchema = object({
   // so a reload can tell a failed request apart from a real keeper reply;
   // open string() per the same deploy-window rationale as `role`.
   kind: optional(string()),
+  // K1e read model: backend-owned provenance for what a history row can prove
+  // about the stream/turn lifecycle. Kept optional for deploy windows and
+  // legacy endpoints; consumers fall back to explicit "history without stream
+  // events" instead of inventing a lifecycle.
+  stream_contract: optional(KeeperChatHistoryStreamContractSchema),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -227,6 +227,10 @@ export const KeeperChatHistoryStreamContractSchema = object({
   turnRef: optional(string()),
   trace_event_count: optional(number()),
   traceEventCount: optional(number()),
+  lifecycle_events: optional(array(string())),
+  lifecycleEvents: optional(array(string())),
+  delivery_receipt: optional(string()),
+  deliveryReceipt: optional(string()),
   reason: optional(string()),
 })
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -191,6 +191,13 @@ describe('ChatTranscript', () => {
             text: 'channel reply',
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
+            streamContract: {
+              source: 'backend_turn_trace',
+              status: 'backend_trace_join',
+              turnRef: 'trace-ui#9',
+              traceEventCount: 2,
+              reason: 'turn_ref joined to retained trajectory/internal-history events',
+            },
             surface: {
               kind: 'discord',
               guild_id: 'guild-1',
@@ -212,6 +219,10 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_turn_trace')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_trace_join')
+    expect(bubble.getAttribute('data-chat-stream-contract-turn-ref')).toBe('trace-ui#9')
+    expect(bubble.getAttribute('data-chat-stream-contract-trace-events')).toBe('2')
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })
@@ -225,6 +236,11 @@ describe('ChatTranscript', () => {
             label: 'keeper_context_status',
             turnRef: 'trace-tool#3',
             delivery: 'history',
+            streamContract: {
+              source: 'rest_history',
+              status: 'history_without_stream_events',
+              reason: 'tool history rows carry arguments, not live stream lifecycle',
+            },
           }),
         ]}
         emptyText="empty"
@@ -240,6 +256,8 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-source')).toBe('tool_result')
     expect(bubble.getAttribute('data-chat-delivery-state')).toBe('history')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })
@@ -2452,6 +2470,60 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(step?.getAttribute('data-chat-trace-output-state')).toBe('pending')
     expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
     expect(bundle?.textContent).not.toContain('결과 누락')
+  })
+
+  it('marks settled unjoined tool steps as hydration-failed when the output surface failed', async () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-unjoined-hydration-failed', label: 'keeper_context_status', turnRef: 'trace-f#1' }),
+          entry({
+            id: 'a-hydration-failed',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-f#1',
+            streamState: null,
+            streamContract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              eventName: 'RUN_FINISHED',
+            },
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        toolOutputHydrationContract=${{
+          source: 'tool_calls_endpoint',
+          status: 'failed',
+          failureReason: 'HTTP 502',
+          startedAtMs: 1_000,
+          completedAtMs: 1_500,
+          coveredSinceMs: null,
+          coveredThroughMs: null,
+        }}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const trace = bundle?.querySelector('[data-chat-tool-trace]') as HTMLElement | null
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-status')).toBe('backend_terminal_event')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(step?.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+    expect(bundle?.textContent).toContain('출력 hydration 실패 1')
+
+    ;(step?.querySelector('.chat-block-tstep-row') as HTMLElement).click()
+    await flushUi()
+    expect(step?.textContent).toContain('출력 hydration 실패 — HTTP 502')
   })
 
   it('marks a settled unjoined tool step as coverage-gap when only older output hydration completed', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -211,6 +211,7 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-source')).toBe('direct_assistant')
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
+    expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })
@@ -238,6 +239,7 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-role')).toBe('tool')
     expect(bubble.getAttribute('data-chat-source')).toBe('tool_result')
     expect(bubble.getAttribute('data-chat-delivery-state')).toBe('history')
+    expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })
@@ -2201,6 +2203,8 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     const traceToggle = container.querySelector('.chat-block-trace-hd') as HTMLButtonElement | null
     expect(trace).not.toBeNull()
     expect(traceToggle).not.toBeNull()
+    expect(trace?.getAttribute('data-chat-turn-stream-state')).toBe('streaming')
+    expect(trace?.getAttribute('data-chat-turn-complete')).toBe('false')
     expect(traceToggle?.getAttribute('aria-expanded')).toBe('false')
     expect(trace?.textContent).toContain('턴 타임라인')
     expect(container.querySelector('[data-chat-trace-step="think"]')).toBeNull()
@@ -2261,6 +2265,9 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
       const settledToggle = container.querySelector('.chat-block-trace-hd') as HTMLButtonElement | null
       expect(settledToggle?.getAttribute('aria-expanded')).toBe('true')
     })
+    const settledTrace = container.querySelector('[data-chat-tool-trace]') as HTMLElement | null
+    expect(settledTrace?.getAttribute('data-chat-turn-stream-state')).toBe('complete')
+    expect(settledTrace?.getAttribute('data-chat-turn-complete')).toBe('true')
     expect(container.querySelector('[data-chat-trace-step="think"]')?.textContent).toContain(thinking)
     expect(container.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('완료된 응답')
   })
@@ -2405,10 +2412,15 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
 
     const bundle = container.querySelector('[data-chat-turn-bundle]')
     expect(bundle).not.toBeNull()
+    const trace = bundle?.querySelector('[data-chat-tool-trace]') as HTMLElement | null
+    expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe(`${Date.parse('2026-03-24T00:00:00.000Z')}`)
+    expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(`${Date.parse('2026-03-24T00:00:01.000Z')}`)
     const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
     // Settled turn + never-joined output is a real gap, not an indefinite pending.
     expect(step?.querySelector('.chat-block-tstep-status.missing')).not.toBeNull()
     expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('missing')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
     // The gap is surfaced in the card header so silent failures are visible.
     expect(bundle?.textContent).toContain('결과 누락 1')
   })
@@ -2437,10 +2449,12 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
     expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
     expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
     expect(bundle?.textContent).not.toContain('결과 누락')
   })
 
-  it('keeps a settled unjoined tool step pending when only older output hydration completed', () => {
+  it('marks a settled unjoined tool step as coverage-gap when only older output hydration completed', () => {
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -2468,12 +2482,16 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
 
     const bundle = container.querySelector('[data-chat-turn-bundle]')
     const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
-    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.coverage-gap')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
     expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('coverage-gap')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('coverage-gap')
     expect(bundle?.textContent).not.toContain('결과 누락')
+    expect(bundle?.textContent).toContain('출력 범위 밖 1')
   })
 
-  it('keeps a settled unjoined tool step pending when it predates the hydrated tool-output tail', () => {
+  it('marks a settled unjoined tool step as coverage-gap when it predates the hydrated tool-output tail', () => {
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -2502,9 +2520,13 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
 
     const bundle = container.querySelector('[data-chat-turn-bundle]')
     const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
-    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.coverage-gap')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
     expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('coverage-gap')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('coverage-gap')
     expect(bundle?.textContent).not.toContain('결과 누락')
+    expect(bundle?.textContent).toContain('출력 범위 밖 1')
   })
 
   it('keeps an unjoined tool step pending while the owning turn is still streaming', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -15,6 +15,7 @@ import {
   type ChatComposerSendPayload,
 } from './primitives'
 import { _resetChatStoreForTests, readKeeperDraft } from '../../keeper-chat-store'
+import { chatHistoryEntriesFromRest } from '../../keeper-state'
 import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
 import { fetchBoardPost } from '../../api/board'
@@ -236,8 +237,120 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe(
       'server_lifecycle_replay_only',
     )
+    expect(bubble.getAttribute('data-chat-stream-contract-reason')).toBe(
+      'history row records durable server stream lifecycle replay',
+    )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
+  })
+
+  it('exposes interrupted stream reconciliation as a no-receipt contract gap', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'assistant-interrupted',
+            text: 'partial answer',
+            role: 'assistant',
+            source: 'direct_assistant',
+            delivery: 'interrupted',
+            streamState: null,
+            error: '스트림이 종료 신호 없이 끊겼습니다. 응답이 불완전할 수 있습니다.',
+            streamContract: {
+              source: 'client_reconciliation',
+              status: 'contract_gap',
+              deliveryReceipt: 'no_delivery_receipt',
+              reason: '스트림이 종료 신호 없이 끊겼습니다. 응답이 불완전할 수 있습니다.',
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-entry-id="assistant-interrupted"]') as HTMLElement
+    expect(bubble).not.toBeNull()
+    expect(bubble.getAttribute('data-chat-delivery-state')).toBe('interrupted')
+    expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('client_reconciliation')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('contract_gap')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(bubble.getAttribute('data-chat-stream-contract-reason')).toBe(
+      '스트림이 종료 신호 없이 끊겼습니다. 응답이 불완전할 수 있습니다.',
+    )
+  })
+
+  it('renders REST replay failure and no-turn-ref gaps as visible stream contract badges', () => {
+    const entries = chatHistoryEntriesFromRest('sangsu', [
+      {
+        id: 'smoke-legacy-user',
+        role: 'user',
+        content: 'legacy row without turn ref',
+        ts: 1_780_000_000,
+        stream_contract: {
+          source: 'keeper_chat_store',
+          status: 'history_without_turn_ref',
+          delivery_receipt: 'no_delivery_receipt',
+          reason: 'history row has no durable turn_ref; cannot join stream events',
+        },
+      },
+      {
+        id: 'smoke-error-assistant',
+        role: 'assistant',
+        content: 'Keeper request failed: Timeout after 630.0s',
+        ts: 1_780_000_001,
+        kind: 'transport_failure',
+        turn_ref: 'trace-chat-contract-smoke#8',
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-chat-contract-smoke#8',
+          event_name: 'RUN_ERROR',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'RUN_ERROR',
+          ],
+          delivery_receipt: 'server_lifecycle_replay_only',
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      },
+    ])
+
+    render(
+      html`<${ChatTranscript}
+        entries=${entries}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const legacy = container.querySelector('[data-chat-entry-id="smoke-legacy-user"]') as HTMLElement
+    expect(legacy).not.toBeNull()
+    expect(legacy.getAttribute('data-chat-stream-contract-source')).toBe('keeper_chat_store')
+    expect(legacy.getAttribute('data-chat-stream-contract-status')).toBe('history_without_turn_ref')
+    expect(legacy.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(legacy.getAttribute('data-chat-stream-contract-badge-state')).toBe('no-turn-ref')
+    expect(legacy.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('턴 연결 없음')
+
+    const failure = container.querySelector('[data-chat-entry-id="smoke-error-assistant"]') as HTMLElement
+    expect(failure).not.toBeNull()
+    expect(failure.getAttribute('data-chat-delivery-state')).toBe('error')
+    expect(failure.getAttribute('data-chat-turn-ref')).toBe('trace-chat-contract-smoke#8')
+    expect(failure.getAttribute('data-chat-stream-contract-source')).toBe('backend_stream_lifecycle')
+    expect(failure.getAttribute('data-chat-stream-contract-status')).toBe('backend_lifecycle_replay')
+    expect(failure.getAttribute('data-chat-stream-contract-event')).toBe('RUN_ERROR')
+    expect(failure.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe('RUN_STARTED,RUN_ERROR')
+    expect(failure.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('server_lifecycle_replay_only')
+    expect(failure.getAttribute('data-chat-stream-contract-badge-state')).toBe('server-replay')
+    expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 replay')
+    expect(failure.textContent).toContain('Timeout after 630.0s')
+    expect(
+      [...container.querySelectorAll('[data-chat-stream-contract-delivery-receipt]')]
+        .map(node => node.getAttribute('data-chat-stream-contract-delivery-receipt')),
+    ).not.toContain('client_observed_sse_event')
   })
 
   it('exposes tool-call transcript provenance as rendered attributes', () => {
@@ -273,6 +386,9 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
     expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
     expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(bubble.getAttribute('data-chat-stream-contract-reason')).toBe(
+      'tool history rows carry arguments, not live stream lifecycle',
+    )
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -192,11 +192,18 @@ describe('ChatTranscript', () => {
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
             streamContract: {
-              source: 'backend_turn_trace',
-              status: 'backend_trace_join',
+              source: 'backend_stream_lifecycle',
+              status: 'backend_lifecycle_replay',
               turnRef: 'trace-ui#9',
-              traceEventCount: 2,
-              reason: 'turn_ref joined to retained trajectory/internal-history events',
+              eventName: 'RUN_FINISHED',
+              lifecycleEvents: [
+                'RUN_STARTED',
+                'TEXT_MESSAGE_START',
+                'TEXT_MESSAGE_END',
+                'RUN_FINISHED',
+              ],
+              deliveryReceipt: 'server_lifecycle_replay_only',
+              reason: 'history row records durable server stream lifecycle replay',
             },
             surface: {
               kind: 'discord',
@@ -219,10 +226,16 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
-    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_turn_trace')
-    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_trace_join')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_stream_lifecycle')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_lifecycle_replay')
     expect(bubble.getAttribute('data-chat-stream-contract-turn-ref')).toBe('trace-ui#9')
-    expect(bubble.getAttribute('data-chat-stream-contract-trace-events')).toBe('2')
+    expect(bubble.getAttribute('data-chat-stream-contract-event')).toBe('RUN_FINISHED')
+    expect(bubble.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe(
+      'RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_END,RUN_FINISHED',
+    )
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe(
+      'server_lifecycle_replay_only',
+    )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })
@@ -239,6 +252,7 @@ describe('ChatTranscript', () => {
             streamContract: {
               source: 'rest_history',
               status: 'history_without_stream_events',
+              deliveryReceipt: 'no_delivery_receipt',
               reason: 'tool history rows carry arguments, not live stream lifecycle',
             },
           }),
@@ -258,6 +272,7 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
     expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
     expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })
@@ -650,6 +665,19 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('img[alt="screenshot.png"]')).not.toBeNull()
     expect(container.textContent).toContain('log.txt')
     expect(container.textContent).not.toContain('상세 보기')
+    const bubble = container.querySelector('[data-chat-entry-id="u1"]')
+    expect(bubble?.getAttribute('data-chat-attachment-count')).toBe('2')
+    expect(bubble?.getAttribute('data-chat-server-attach-block-count')).toBe('0')
+    expect(bubble?.getAttribute('data-chat-multimodal-sources')).toBe('persisted_attachment')
+    expect(bubble?.getAttribute('data-chat-multimodal-kinds')).toBe('image,document')
+    const imageCard = container.querySelector('[data-chat-attachment-card="att-1"]')
+    expect(imageCard?.getAttribute('data-chat-multimodal-source')).toBe('persisted_attachment')
+    expect(imageCard?.getAttribute('data-chat-multimodal-kind')).toBe('image')
+    expect(imageCard?.getAttribute('data-chat-multimodal-mime')).toBe('image/png')
+    expect(imageCard?.getAttribute('data-chat-multimodal-size-bytes')).toBe('1024')
+    const fileCard = container.querySelector('[data-chat-attachment-card="att-2"]')
+    expect(fileCard?.getAttribute('data-chat-multimodal-kind')).toBe('document')
+    expect(fileCard?.getAttribute('data-chat-multimodal-mime')).toBe('text/plain')
   })
 
   it('does not show streaming ellipsis before elapsed time starts', () => {
@@ -1288,11 +1316,15 @@ describe('Keeper v2 chat blocks', () => {
             blocks: [
               {
                 t: 'attach',
+                id: 'srv-att-1',
                 name: 'screen.png',
+                kind: 'image',
                 dims: '100×100',
                 src: 'https://example.com/screen.png',
                 via: 'vision',
                 size: '12 KB',
+                mimeType: 'image/png',
+                sizeBytes: 12_288,
               },
             ],
           }),
@@ -1304,9 +1336,20 @@ describe('Keeper v2 chat blocks', () => {
 
     const blocks = container.querySelector('[data-chat-blocks]')
     const attach = container.querySelector('[data-chat-block="attach"]')
+    const bubble = container.querySelector('[data-chat-entry-id="u-rich"]')
     expect(blocks).not.toBeNull()
     expect(attach?.textContent).toContain('screen.png')
     expect(attach?.querySelector('img')?.getAttribute('src')).toBe('https://example.com/screen.png')
+    expect(bubble?.getAttribute('data-chat-attachment-count')).toBe('0')
+    expect(bubble?.getAttribute('data-chat-server-attach-block-count')).toBe('1')
+    expect(bubble?.getAttribute('data-chat-multimodal-sources')).toBe('server_block')
+    expect(bubble?.getAttribute('data-chat-multimodal-kinds')).toBe('image')
+    expect(attach?.getAttribute('data-chat-multimodal-source')).toBe('server_block')
+    expect(attach?.getAttribute('data-chat-multimodal-kind')).toBe('image')
+    expect(attach?.getAttribute('data-chat-multimodal-attachment-id')).toBe('srv-att-1')
+    expect(attach?.getAttribute('data-chat-multimodal-mime')).toBe('image/png')
+    expect(attach?.getAttribute('data-chat-multimodal-size-bytes')).toBe('12288')
+    expect(attach?.getAttribute('data-chat-attach-via')).toBe('vision')
   })
 
   it('blocks unsafe attach image src and falls back to placeholder', () => {
@@ -1322,6 +1365,8 @@ describe('Keeper v2 chat blocks', () => {
     ])
 
     expect(container.querySelector('[data-chat-block="attach"] img')).toBeNull()
+    expect(container.querySelector('[data-chat-block="attach"]')?.getAttribute('data-chat-multimodal-source')).toBe('server_block')
+    expect(container.querySelector('[data-chat-block="attach"]')?.getAttribute('data-chat-multimodal-kind')).toBeNull()
     expect(container.textContent).toContain('unsafe URL')
   })
 
@@ -2120,6 +2165,60 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(chat.getAttribute('data-chat-trace-entry-id')).toBe('a-provenance')
     expect(chat.getAttribute('data-chat-trace-source')).toBe('direct_assistant')
     expect(chat.getAttribute('data-chat-trace-turn-ref')).toBe('trace-prov#7')
+  })
+
+  it('exposes structural turn order without timestamp sorting', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-t-order',
+            label: 'keeper_context_status',
+            text: '{"ok":true}',
+            timestamp: '2026-03-24T00:00:01.000Z',
+            turnRef: 'trace-order#1',
+          }),
+          entry({
+            id: 'assistant-order',
+            text: '완료했습니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            timestamp: '2026-03-24T00:00:00.000Z',
+            turnRef: 'trace-order#1',
+            traceSteps: [
+              { kind: 'think', text: 'first structural thought', ts: '2026-03-24T00:00:04.000Z' },
+              {
+                kind: 'tool',
+                name: 'keeper_context_status',
+                toolCallId: 't-order',
+                status: 'ok',
+                ts: '2026-03-24T00:00:02.000Z',
+              },
+              { kind: 'think', text: 'second structural thought', ts: '2026-03-24T00:00:03.000Z' },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement
+    expect(trace.getAttribute('data-chat-turn-order-signature')).toBe(
+      'trace:think|tool:t-order|trace:think|chat:assistant-order',
+    )
+
+    const ordered = [...trace.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered).toHaveLength(4)
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual(['trace', 'tool', 'trace', 'chat'])
+
+    const tool = ordered[1] as HTMLElement
+    expect(tool.getAttribute('data-chat-trace-tool-call-id')).toBe('t-order')
+    expect(tool.getAttribute('data-chat-trace-entry-id')).toBe('tool-t-order')
+    expect(tool.getAttribute('data-chat-trace-link-state')).toBe('joined')
   })
 
   it('renders thinking text as sanitized markdown with newlines preserved', async () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -327,6 +327,64 @@ function sourceBadgeInfo(entry: KeeperConversationEntry): { label: string; cls: 
   return SOURCE_BADGE[entry.source] ?? null
 }
 
+type StreamContractBadgeInfo = {
+  label: string
+  title: string
+  state: 'contract-gap' | 'no-turn-ref' | 'server-replay'
+}
+
+function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContractBadgeInfo | null {
+  const contract = entry.streamContract
+  if (!contract) return null
+  const title = [
+    `source=${contract.source}`,
+    `status=${contract.status}`,
+    contract.eventName ? `event=${contract.eventName}` : null,
+    contract.deliveryReceipt ? `receipt=${contract.deliveryReceipt}` : null,
+    contract.reason ?? null,
+  ].filter((value): value is string => Boolean(value)).join(' · ')
+  switch (contract.deliveryReceipt) {
+    case 'server_lifecycle_replay_only':
+      return { label: '서버 replay', title, state: 'server-replay' }
+    case 'no_delivery_receipt':
+      switch (contract.status) {
+        case 'history_without_turn_ref':
+          return { label: '턴 연결 없음', title, state: 'no-turn-ref' }
+        case 'contract_gap':
+          return { label: '수신 gap', title, state: 'contract-gap' }
+        default:
+          return null
+      }
+    default:
+      return null
+  }
+}
+
+function streamContractBadgeClass(state: StreamContractBadgeInfo['state']): string {
+  switch (state) {
+    case 'server-replay':
+      return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'contract-gap':
+      return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'no-turn-ref':
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]'
+  }
+}
+
+function StreamContractBadge({ badge, compact }: { badge: StreamContractBadgeInfo | null; compact: boolean }) {
+  if (!badge) return null
+  const paddingClass = compact ? 'px-2 py-0.5' : 'px-2.5 py-1'
+  return html`
+    <span
+      class=${`inline-flex items-center rounded-[var(--r-0)] border ${paddingClass} text-2xs font-semibold ${streamContractBadgeClass(badge.state)}`}
+      title=${badge.title}
+      data-chat-stream-contract-badge=${badge.state}
+    >
+      ${badge.label}
+    </span>
+  `
+}
+
 // C1: group transcript messages by calendar day for the workspace day divider.
 // Absolute "M월 D일" labels (not relative 오늘/어제) so the output is a pure
 // function of the timestamp — deterministic and snapshot-test stable.
@@ -2153,6 +2211,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const delivery = deliveryLabel(entry)
   const timestamp = timeLabel(entry.timestamp)
   const sourceBadge = showSourceBadge ? sourceBadgeInfo(entry) : null
+  const streamContractBadge = streamContractBadgeInfo(entry)
   const attachments = entry.attachments ?? []
   const attachBlocks = effectiveBlocks.filter((block): block is Extract<ChatBlock, { t: 'attach' }> => block.t === 'attach')
   const persistedAttachmentKinds = attachments.map(userInputMediaKindForAttachment)
@@ -2188,6 +2247,10 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
+      data-chat-stream-contract-reason=${entry.streamContract?.reason ?? undefined}
+      data-chat-stream-contract-badge-state=${streamContractBadge?.state ?? undefined}
+      data-chat-queue-seq=${entry.queueSeq ?? undefined}
+      data-chat-queue-client-action-id=${entry.queueClientActionId ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-attachment-count=${attachments.length}
@@ -2227,6 +2290,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${StreamContractBadge} badge=${streamContractBadge} compact=${true} />
                     ${surfaceInfo && surfaceInfo.url !== '#'
                       ? html`
                           <a
@@ -2277,6 +2341,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${StreamContractBadge} badge=${streamContractBadge} compact=${false} />
                     ${surfaceInfo && surfaceInfo.url !== '#'
                       ? html`
                           <a
@@ -2567,6 +2632,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
+      data-chat-stream-contract-reason=${entry.streamContract?.reason ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -26,6 +26,7 @@ import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperC
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
 import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById } from '../../tool-call-output-store'
+import type { ToolCallOutputHydrationContract } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
@@ -2116,6 +2117,12 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
       data-chat-stream-state=${entry.streamState ?? 'complete'}
+      data-chat-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2483,6 +2490,12 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
       data-chat-stream-state=${entry.streamState ?? 'complete'}
+      data-chat-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2548,13 +2561,14 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
-type ToolTraceDisplayStatus = 'pending' | 'missing' | 'coverage-gap' | 'unlinked' | 'ok' | 'bad'
-type ToolOutputCoverageState = 'not-hydrated' | 'covered' | 'coverage-gap' | 'not-applicable'
+type ToolTraceDisplayStatus = 'pending' | 'missing' | 'coverage-gap' | 'hydration-failed' | 'unlinked' | 'ok' | 'bad'
+type ToolOutputCoverageState = 'not-hydrated' | 'hydrating' | 'hydration-failed' | 'covered' | 'coverage-gap' | 'not-applicable'
 
 const TOOL_STATUS_TITLE: Record<ToolTraceDisplayStatus, string> = {
   pending: '출력 대기 중',
   missing: '결과 누락 — 턴이 끝났는데 출력이 도착하지 않음',
   'coverage-gap': '출력 tail 범위 밖 — 결과 누락 여부를 확정할 수 없음',
+  'hydration-failed': '출력 hydration 실패 — 결과 누락 여부를 확정할 수 없음',
   unlinked: '도구 호출 ID 없음 — 출력 조인 불가',
   ok: '성공',
   bad: '실패',
@@ -2572,8 +2586,10 @@ function toolOutputCoverageState(
   entry: KeeperConversationEntry,
   coveredSinceMs: number | null | undefined,
   coveredThroughMs: number | null | undefined,
+  hydrationStatus: ToolCallOutputHydrationContract['status'] | null | undefined,
 ): ToolOutputCoverageState {
-  if (coveredThroughMs == null) return 'not-hydrated'
+  if (hydrationStatus === 'failed') return 'hydration-failed'
+  if (coveredThroughMs == null) return hydrationStatus === 'hydrating' ? 'hydrating' : 'not-hydrated'
   const timestampMs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
   if (!Number.isFinite(timestampMs)) return 'coverage-gap'
   if (coveredSinceMs != null && timestampMs < coveredSinceMs) return 'coverage-gap'
@@ -2612,12 +2628,14 @@ function ToolTraceStep({
   output,
   canMarkMissing = false,
   coverageState = 'not-applicable',
+  hydrationFailureReason = null,
   traceStep,
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
   canMarkMissing?: boolean
   coverageState?: ToolOutputCoverageState
+  hydrationFailureReason?: string | null
   traceStep?: ChatTraceToolStep
 }) {
   const [open, setOpen] = useState(false)
@@ -2627,18 +2645,22 @@ function ToolTraceStep({
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
   const unlinkedTraceTool = isUnlinkedTraceTool(entry, traceStep)
   const sourceBadge = toolTraceSourceBadge(entry, traceStep)
-  const status: ToolTraceDisplayStatus =
-    unlinkedTraceTool
-      ? 'unlinked'
-      : output === null
-      ? traceStep?.status === 'err'
-        ? 'bad'
-        : traceStep?.status === 'ok'
-          ? 'ok'
-          : (coverageState === 'coverage-gap' ? 'coverage-gap' : canMarkMissing ? 'missing' : 'pending')
-      : output.success === false || output.semantic_success === false
-        ? 'bad'
-        : 'ok'
+  let status: ToolTraceDisplayStatus
+  if (unlinkedTraceTool) {
+    status = 'unlinked'
+  } else if (output !== null) {
+    status = output.success === false || output.semantic_success === false ? 'bad' : 'ok'
+  } else if (traceStep?.status === 'err') {
+    status = 'bad'
+  } else if (traceStep?.status === 'ok') {
+    status = 'ok'
+  } else if (coverageState === 'hydration-failed') {
+    status = 'hydration-failed'
+  } else if (coverageState === 'coverage-gap') {
+    status = 'coverage-gap'
+  } else {
+    status = canMarkMissing ? 'missing' : 'pending'
+  }
   const durLabel =
     output?.duration_ms != null && output.duration_ms > 0
       ? formatMsCompact(output.duration_ms)
@@ -2698,7 +2720,9 @@ function ToolTraceStep({
                     ? unlinkedTraceTool
                       ? null
                       : html`<div class="chat-block-tool-label">${
-                          coverageState === 'coverage-gap'
+                          coverageState === 'hydration-failed'
+                            ? `출력 hydration 실패${hydrationFailureReason ? ` — ${hydrationFailureReason}` : ''}`
+                            : coverageState === 'coverage-gap'
                             ? '출력 tail 범위 밖 — 이 도구 시점을 덮는 결과 hydration이 아직 없음'
                             : canMarkMissing
                               ? '결과 없음 — 출력이 도착하지 않음'
@@ -2800,6 +2824,11 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-entry-id=${entry.id}
       data-chat-trace-source=${entry.source}
       data-chat-trace-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-trace-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-trace-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2821,6 +2850,7 @@ function ToolTraceCard({
   turnComplete = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
+  toolOutputHydrationContract = null,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
@@ -2828,6 +2858,7 @@ function ToolTraceCard({
   turnComplete?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
+  toolOutputHydrationContract?: ToolCallOutputHydrationContract | null
 }) {
   const liveTurn = assistant !== null && !turnComplete
   const userToggledRef = useRef(false)
@@ -2841,7 +2872,12 @@ function ToolTraceCard({
   }
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const coverageStateForEntry = (entry: KeeperConversationEntry): ToolOutputCoverageState =>
-    toolOutputCoverageState(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
+    toolOutputCoverageState(
+      entry,
+      toolOutputsCoveredSinceMs,
+      toolOutputsCoveredThroughMs,
+      toolOutputHydrationContract?.status ?? null,
+    )
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
     turnComplete && coverageStateForEntry(entry) === 'covered'
   const ordered = assistant
@@ -2862,6 +2898,9 @@ function ToolTraceCard({
   const coverageGapN = orderedToolSteps.filter(
     (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'coverage-gap',
   ).length
+  const hydrationFailedN = orderedToolSteps.filter(
+    (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'hydration-failed',
+  ).length
   const unlinkedN = orderedToolSteps.filter(
     (s) => s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
   ).length
@@ -2881,6 +2920,15 @@ function ToolTraceCard({
       data-chat-tool-trace
       data-chat-turn-stream-state=${assistant ? (assistant.streamState ?? 'complete') : undefined}
       data-chat-turn-complete=${turnComplete ? 'true' : 'false'}
+      data-chat-turn-stream-contract-source=${assistant?.streamContract?.source ?? undefined}
+      data-chat-turn-stream-contract-status=${assistant?.streamContract?.status ?? undefined}
+      data-chat-turn-stream-contract-event=${assistant?.streamContract?.eventName ?? undefined}
+      data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
+      data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
+      data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
+      data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
+      data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
+      data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}
       data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
       data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
     >
@@ -2901,6 +2949,7 @@ function ToolTraceCard({
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
           ${coverageGapN > 0 ? html`<span class="text-[var(--color-status-warn)]">출력 범위 밖 ${coverageGapN}</span>` : null}
+          ${hydrationFailedN > 0 ? html`<span class="text-[var(--color-status-warn)]">출력 hydration 실패 ${hydrationFailedN}</span>` : null}
           ${unlinkedN > 0 ? html`<span class="text-[var(--color-status-warn)]">조인 불가 ${unlinkedN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
@@ -2924,6 +2973,7 @@ function ToolTraceCard({
                           output=${item.output}
                           canMarkMissing=${item.entry !== null && canMarkMissingForEntry(item.entry)}
                           coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
+                          hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
                         />`
                       })()
@@ -2934,6 +2984,7 @@ function ToolTraceCard({
                           output=${item.output}
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
                           coverageState=${coverageStateForEntry(item.entry)}
+                          hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                         />`
                     : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>
@@ -2958,6 +3009,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   showSourceBadge,
   toolOutputsCoveredSinceMs,
   toolOutputsCoveredThroughMs,
+  toolOutputHydrationContract,
   action,
 }: {
   tools: KeeperConversationEntry[]
@@ -2967,6 +3019,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   showSourceBadge: boolean
   toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
+  toolOutputHydrationContract: ToolCallOutputHydrationContract | null
   action?: ChatTranscriptAction
 }) {
   const traceSteps = assistant.traceSteps ?? []
@@ -2982,6 +3035,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
         turnComplete=${turnComplete}
         toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
       />
       <${ChatMessageBubble}
         entry=${assistant}
@@ -3000,6 +3054,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   && prev.showSourceBadge === next.showSourceBadge
   && prev.toolOutputsCoveredSinceMs === next.toolOutputsCoveredSinceMs
   && prev.toolOutputsCoveredThroughMs === next.toolOutputsCoveredThroughMs
+  && prev.toolOutputHydrationContract === next.toolOutputHydrationContract
   && prev.action === next.action
 )
 
@@ -3125,12 +3180,13 @@ function renderChatTranscriptBody(opts: {
   showSourceBadge: boolean
   toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
+  toolOutputHydrationContract: ToolCallOutputHydrationContract | null
   // Since-last-seen cursor (unix seconds) for the unread divider; null on every
   // non-keeper chat surface so those transcripts render unchanged.
   unreadAfterTs: number | null
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, unreadAfterTs, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract, unreadAfterTs, action } = opts
   const units = buildChatRenderUnits(entries, groupToolCalls)
   const unreadAnchorKey = unreadDividerAnchorKey(
     units.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
@@ -3157,7 +3213,13 @@ function renderChatTranscriptBody(opts: {
       out.push(html`<div class="kw-daydiv kw-unreaddiv" key="unread-divider">${UNREAD_DIVIDER_LABEL}</div>`)
     }
     if (unit.kind === 'toolGroup') {
-      out.push(html`<${ToolTraceCard} key=${unit.id} tools=${unit.entries} />`)
+      out.push(html`<${ToolTraceCard}
+        key=${unit.id}
+        tools=${unit.entries}
+        toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+        toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
+      />`)
     } else if (unit.kind === 'turnBundle') {
       out.push(html`<${TurnWorkBundle}
         key=${unit.id}
@@ -3168,6 +3230,7 @@ function renderChatTranscriptBody(opts: {
         showSourceBadge=${showSourceBadge}
         toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
         action=${action}
       />`)
     } else if (unit.entry.role === 'tool') {
@@ -3207,6 +3270,7 @@ export function ChatTranscript({
   showSourceBadge = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
+  toolOutputHydrationContract = null,
   unreadAfterTs = null,
   onSeenBottom,
   action,
@@ -3225,6 +3289,7 @@ export function ChatTranscript({
   showSourceBadge?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
+  toolOutputHydrationContract?: ToolCallOutputHydrationContract | null
   // Since-last-seen cursor (unix seconds) driving the unread divider. Null on
   // non-keeper surfaces -> no divider.
   unreadAfterTs?: number | null
@@ -3247,7 +3312,7 @@ export function ChatTranscript({
   )
   const toolOutputSignature = useMemo(
     () => {
-      const coverageSig = `${toolOutputsCoveredSinceMs ?? ''}:${toolOutputsCoveredThroughMs ?? ''}`
+      const coverageSig = `${toolOutputsCoveredSinceMs ?? ''}:${toolOutputsCoveredThroughMs ?? ''}:${toolOutputHydrationContract?.status ?? ''}:${toolOutputHydrationContract?.failureReason ?? ''}`
       return entries
         .filter(entry => entry.role === 'tool')
         .map((entry) => {
@@ -3258,7 +3323,7 @@ export function ChatTranscript({
         })
         .join('|')
     },
-    [entries, toolCallOutputsById.value, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs],
+    [entries, toolCallOutputsById.value, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract],
   )
 
   const scrollToBottom = () => {
@@ -3346,6 +3411,7 @@ export function ChatTranscript({
               showSourceBadge,
               toolOutputsCoveredSinceMs,
               toolOutputsCoveredThroughMs,
+              toolOutputHydrationContract,
               unreadAfterTs,
               action,
             })}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2115,6 +2115,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-role=${entry.role}
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
+      data-chat-stream-state=${entry.streamState ?? 'complete'}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2481,6 +2482,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-role=${entry.role}
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
+      data-chat-stream-state=${entry.streamState ?? 'complete'}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2546,11 +2548,13 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
-type ToolTraceDisplayStatus = 'pending' | 'missing' | 'unlinked' | 'ok' | 'bad'
+type ToolTraceDisplayStatus = 'pending' | 'missing' | 'coverage-gap' | 'unlinked' | 'ok' | 'bad'
+type ToolOutputCoverageState = 'not-hydrated' | 'covered' | 'coverage-gap' | 'not-applicable'
 
 const TOOL_STATUS_TITLE: Record<ToolTraceDisplayStatus, string> = {
   pending: '출력 대기 중',
   missing: '결과 누락 — 턴이 끝났는데 출력이 도착하지 않음',
+  'coverage-gap': '출력 tail 범위 밖 — 결과 누락 여부를 확정할 수 없음',
   unlinked: '도구 호출 ID 없음 — 출력 조인 불가',
   ok: '성공',
   bad: '실패',
@@ -2564,16 +2568,17 @@ function isTurnStreaming(state: KeeperConversationEntry['streamState']): boolean
   return state === 'opening' || state === 'thinking' || state === 'streaming' || state === 'finalizing'
 }
 
-function isToolOutputCoveredByHydration(
+function toolOutputCoverageState(
   entry: KeeperConversationEntry,
   coveredSinceMs: number | null | undefined,
   coveredThroughMs: number | null | undefined,
-): boolean {
-  if (coveredThroughMs == null) return false
+): ToolOutputCoverageState {
+  if (coveredThroughMs == null) return 'not-hydrated'
   const timestampMs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
-  return Number.isFinite(timestampMs)
-    && (coveredSinceMs == null || timestampMs >= coveredSinceMs)
-    && timestampMs <= coveredThroughMs
+  if (!Number.isFinite(timestampMs)) return 'coverage-gap'
+  if (coveredSinceMs != null && timestampMs < coveredSinceMs) return 'coverage-gap'
+  if (timestampMs > coveredThroughMs) return 'coverage-gap'
+  return 'covered'
 }
 
 function toolTraceCallId(entry: KeeperConversationEntry | null, traceStep?: ChatTraceToolStep): string | null {
@@ -2606,11 +2611,13 @@ function ToolTraceStep({
   entry,
   output,
   canMarkMissing = false,
+  coverageState = 'not-applicable',
   traceStep,
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
   canMarkMissing?: boolean
+  coverageState?: ToolOutputCoverageState
   traceStep?: ChatTraceToolStep
 }) {
   const [open, setOpen] = useState(false)
@@ -2628,7 +2635,7 @@ function ToolTraceStep({
         ? 'bad'
         : traceStep?.status === 'ok'
           ? 'ok'
-          : (canMarkMissing ? 'missing' : 'pending')
+          : (coverageState === 'coverage-gap' ? 'coverage-gap' : canMarkMissing ? 'missing' : 'pending')
       : output.success === false || output.semantic_success === false
         ? 'bad'
         : 'ok'
@@ -2652,6 +2659,7 @@ function ToolTraceStep({
       data-chat-trace-entry-id=${entry?.id ?? undefined}
       data-chat-trace-link-state=${unlinkedTraceTool ? 'unlinked' : entry ? 'joined' : 'trace-only'}
       data-chat-trace-output-state=${status}
+      data-chat-trace-output-coverage=${coverageState}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2689,7 +2697,13 @@ function ToolTraceStep({
                   : output === null
                     ? unlinkedTraceTool
                       ? null
-                      : html`<div class="chat-block-tool-label">${canMarkMissing ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
+                      : html`<div class="chat-block-tool-label">${
+                          coverageState === 'coverage-gap'
+                            ? '출력 tail 범위 밖 — 이 도구 시점을 덮는 결과 hydration이 아직 없음'
+                            : canMarkMissing
+                              ? '결과 없음 — 출력이 도착하지 않음'
+                              : '출력 대기 중…'
+                        }</div>`
                     : null}
               </div>
             `
@@ -2826,8 +2840,10 @@ function ToolTraceCard({
     setOpen((o) => !o)
   }
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
+  const coverageStateForEntry = (entry: KeeperConversationEntry): ToolOutputCoverageState =>
+    toolOutputCoverageState(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
-    turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
+    turnComplete && coverageStateForEntry(entry) === 'covered'
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
@@ -2843,6 +2859,9 @@ function ToolTraceCard({
   const missingN = orderedToolSteps.filter(
     (s) => s.output === null && s.entry !== null && canMarkMissingForEntry(s.entry),
   ).length
+  const coverageGapN = orderedToolSteps.filter(
+    (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'coverage-gap',
+  ).length
   const unlinkedN = orderedToolSteps.filter(
     (s) => s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
   ).length
@@ -2855,7 +2874,16 @@ function ToolTraceCard({
   const stepN = ordered.length
 
   return html`
-    <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-work-trace data-chat-tool-trace>
+    <div
+      class="chat-block-trace ${open ? 'open' : ''}"
+      data-chat-block="trace"
+      data-chat-work-trace
+      data-chat-tool-trace
+      data-chat-turn-stream-state=${assistant ? (assistant.streamState ?? 'complete') : undefined}
+      data-chat-turn-complete=${turnComplete ? 'true' : 'false'}
+      data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
+      data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
+    >
       <button
         type="button"
         class="chat-block-trace-hd"
@@ -2872,6 +2900,7 @@ function ToolTraceCard({
           ${chatN > 0 ? html`<span>Chat ${chatN}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
+          ${coverageGapN > 0 ? html`<span class="text-[var(--color-status-warn)]">출력 범위 밖 ${coverageGapN}</span>` : null}
           ${unlinkedN > 0 ? html`<span class="text-[var(--color-status-warn)]">조인 불가 ${unlinkedN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
@@ -2894,6 +2923,7 @@ function ToolTraceCard({
                           entry=${item.entry}
                           output=${item.output}
                           canMarkMissing=${item.entry !== null && canMarkMissingForEntry(item.entry)}
+                          coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
                           traceStep=${item.step}
                         />`
                       })()
@@ -2903,6 +2933,7 @@ function ToolTraceCard({
                           entry=${item.entry}
                           output=${item.output}
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
+                          coverageState=${coverageStateForEntry(item.entry)}
                         />`
                     : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1095,10 +1095,43 @@ function ChatIssueBlock({ repo, number, title, status, url, meta }: ChatIssueBlo
   `
 }
 
-function ChatAttachBlock({ name, dims, src, svg, ph, via, size }: { name: string; dims?: string; src?: string; svg?: string; ph?: string; via?: string; size?: string }) {
+function ChatAttachBlock({
+  name,
+  dims,
+  src,
+  svg,
+  ph,
+  via,
+  size,
+  id,
+  kind,
+  mimeType,
+  sizeBytes,
+}: {
+  name: string
+  dims?: string
+  src?: string
+  svg?: string
+  ph?: string
+  via?: string
+  size?: string
+  id?: string
+  kind?: string
+  mimeType?: string
+  sizeBytes?: number
+}) {
   const safeSrc = src && isSafeMediaUrl(src, ['data:image/']) ? src : null
   return html`
-    <figure class="chat-block-attach" data-chat-block="attach">
+    <figure
+      class="chat-block-attach"
+      data-chat-block="attach"
+      data-chat-multimodal-source="server_block"
+      data-chat-multimodal-kind=${kind || undefined}
+      data-chat-multimodal-attachment-id=${id || undefined}
+      data-chat-multimodal-mime=${mimeType || undefined}
+      data-chat-multimodal-size-bytes=${sizeBytes ?? undefined}
+      data-chat-attach-via=${via || undefined}
+    >
       <div class="chat-block-attach-hd">
         <span>◫</span>
         <span class="chat-block-attach-name">${name}</span>
@@ -1286,7 +1319,15 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   `
 }
 
-function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; streaming?: boolean }) {
+function ChatTraceStep({
+  step,
+  streaming = false,
+  orderIndex,
+}: {
+  step: ChatTraceStep
+  streaming?: boolean
+  orderIndex?: number
+}) {
   const [open, setOpen] = useState(false)
   const sourceBadge = traceSourceBadge(step)
 
@@ -1299,6 +1340,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep think"
         data-chat-trace-step="think"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
         data-chat-trace-ts=${step.ts ?? undefined}
@@ -1347,6 +1390,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep reason ${open ? 'exp' : ''}"
         data-chat-trace-step="reason"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-ts=${step.ts ?? undefined}
       >
@@ -1372,6 +1417,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="tool"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${step.toolCallId?.trim() || undefined}
       data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
@@ -1773,7 +1820,7 @@ function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: s
     case 'chart': return html`<${ChatChartBlock} title=${block.title} series=${block.series} labels=${block.labels} xLabel=${block.xLabel} yMax=${block.yMax} />`
     case 'suggestions': return html`<${ChatSuggestionsBlock} items=${block.items} />`
     case 'issue': return html`<${ChatIssueBlock} repo=${block.repo} number=${block.number} title=${block.title} status=${block.status} url=${block.url} meta=${block.meta} />`
-    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
+    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} id=${block.id} kind=${block.kind} mimeType=${block.mimeType} sizeBytes=${block.sizeBytes} />`
     case 'voice': return html`<${ChatVoiceBlock} secs=${block.secs} wave=${block.wave} via=${block.via} size=${block.size} transcript=${block.transcript} src=${block.src} />`
     case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
@@ -1822,11 +1869,17 @@ function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachme
   const canDownload = isSafeAttachmentHref(attachment)
   const meta = attachmentMeta(attachment)
   const isImage = isRenderableImageAttachment(attachment)
+  const multimodalKind = userInputMediaKindForAttachment(attachment)
 
   return html`
     <div
       class="overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
       data-chat-attachment-card=${attachment.id}
+      data-chat-multimodal-source="persisted_attachment"
+      data-chat-multimodal-kind=${multimodalKind}
+      data-chat-multimodal-attachment-id=${attachment.id}
+      data-chat-multimodal-mime=${attachment.mimeType}
+      data-chat-multimodal-size-bytes=${attachment.size}
     >
       ${isImage
         ? html`
@@ -2101,6 +2154,16 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const timestamp = timeLabel(entry.timestamp)
   const sourceBadge = showSourceBadge ? sourceBadgeInfo(entry) : null
   const attachments = entry.attachments ?? []
+  const attachBlocks = effectiveBlocks.filter((block): block is Extract<ChatBlock, { t: 'attach' }> => block.t === 'attach')
+  const persistedAttachmentKinds = attachments.map(userInputMediaKindForAttachment)
+  const serverAttachKinds = attachBlocks
+    .map(block => block.kind?.trim())
+    .filter((value): value is string => Boolean(value))
+  const multimodalKinds = Array.from(new Set([...persistedAttachmentKinds, ...serverAttachKinds]))
+  const multimodalSources = [
+    attachments.length > 0 ? 'persisted_attachment' : null,
+    attachBlocks.length > 0 ? 'server_block' : null,
+  ].filter((value): value is string => value !== null)
   const surfaceInfo = surfaceLink(entry.surface)
 
   return html`
@@ -2123,8 +2186,14 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-attachment-count=${attachments.length}
+      data-chat-server-attach-block-count=${attachBlocks.length}
+      data-chat-multimodal-sources=${multimodalSources.length > 0 ? multimodalSources.join(',') : undefined}
+      data-chat-multimodal-kinds=${multimodalKinds.length > 0 ? multimodalKinds.join(',') : undefined}
     >
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
@@ -2496,6 +2565,8 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2630,6 +2701,8 @@ function ToolTraceStep({
   coverageState = 'not-applicable',
   hydrationFailureReason = null,
   traceStep,
+  orderIndex,
+  orderKind = 'tool',
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
@@ -2637,6 +2710,8 @@ function ToolTraceStep({
   coverageState?: ToolOutputCoverageState
   hydrationFailureReason?: string | null
   traceStep?: ChatTraceToolStep
+  orderIndex?: number
+  orderKind?: 'tool' | 'tool-entry'
 }) {
   const [open, setOpen] = useState(false)
   const name = traceStep?.name || entry?.label || 'tool'
@@ -2675,6 +2750,8 @@ function ToolTraceStep({
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind=${orderKind}
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${callId ?? undefined}
       data-chat-trace-oas-block-index=${traceStep?.oasBlockIndex ?? undefined}
@@ -2810,7 +2887,13 @@ function chatResponsePreview(entry: KeeperConversationEntry): string {
   return text.length > 96 ? `${text.slice(0, 96)}…` : text
 }
 
-function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
+function ChatResponseTraceStep({
+  entry,
+  orderIndex,
+}: {
+  entry: KeeperConversationEntry
+  orderIndex?: number
+}) {
   const sourceBadge: TraceSourceBadgeInfo = {
     label: 'reply',
     title: 'source: assistant reply entry',
@@ -2820,6 +2903,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
     <div
       class="chat-block-tstep chat"
       data-chat-trace-step="chat"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="chat"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-entry-id=${entry.id}
       data-chat-trace-source=${entry.source}
@@ -2829,6 +2914,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-trace-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-trace-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2883,6 +2970,12 @@ function ToolTraceCard({
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
+  const orderSignature = ordered.map((item) => {
+    if (item.kind === 'trace') return `trace:${item.step.kind}`
+    if (item.kind === 'tool') return `tool:${toolTraceCallId(item.entry, item.step) ?? item.step.name}`
+    if (item.kind === 'tool-entry') return `tool-entry:${toolTraceCallId(item.entry) ?? item.entry.id}`
+    return `chat:${item.entry.id}`
+  }).join('|')
   const orderedToolSteps = ordered.filter(isToolOrderItem)
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
   const failN = orderedToolSteps.filter(
@@ -2926,11 +3019,14 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
       data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
       data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
+      data-chat-turn-stream-contract-lifecycle-events=${assistant?.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-turn-stream-contract-delivery-receipt=${assistant?.streamContract?.deliveryReceipt ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}
       data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
       data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
+      data-chat-turn-order-signature=${orderSignature || undefined}
     >
       <button
         type="button"
@@ -2963,6 +3059,7 @@ function ToolTraceCard({
                   ? html`<${ChatTraceStep}
                       key=${`trace-${index}`}
                       step=${item.step}
+                      orderIndex=${index}
                       streaming=${assistant !== null && !turnComplete}
                     />`
                   : item.kind === 'tool'
@@ -2975,6 +3072,8 @@ function ToolTraceCard({
                           coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
+                          orderIndex=${index}
+                          orderKind="tool"
                         />`
                       })()
                     : item.kind === 'tool-entry'
@@ -2985,8 +3084,10 @@ function ToolTraceCard({
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
                           coverageState=${coverageStateForEntry(item.entry)}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
+                          orderIndex=${index}
+                          orderKind="tool-entry"
                         />`
-                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
+                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} orderIndex=${index} />`)}
             </div>
           `
         : null}

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -1,0 +1,474 @@
+// @vitest-environment jsdom
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ToolCallEntry } from '../api/dashboard'
+
+const {
+  cancelQueuedKeeperMessage,
+  fetchKeeperChatHistory,
+  fetchQueuedKeeperMessageResult,
+  isTerminalQueuedKeeperMessage,
+  queuedKeeperMessageError,
+  queuedKeeperMessageToReply,
+  streamKeeperMessage,
+} = vi.hoisted(() => ({
+  cancelQueuedKeeperMessage: vi.fn(async () => undefined),
+  fetchKeeperChatHistory: vi.fn(),
+  fetchQueuedKeeperMessageResult: vi.fn(),
+  isTerminalQueuedKeeperMessage: vi.fn((result: { status: string }) => result.status === 'done'),
+  queuedKeeperMessageError: vi.fn((result: { status: string }) => `request ${result.status}`),
+  queuedKeeperMessageToReply: vi.fn((result: { result?: { reply?: string } }) => ({
+    text: result.result?.reply ?? '(empty reply)',
+    details: null,
+  })),
+  streamKeeperMessage: vi.fn(),
+}))
+
+const { fetchKeeperToolCalls } = vi.hoisted(() => ({
+  fetchKeeperToolCalls: vi.fn(async (): Promise<{ entries: ToolCallEntry[] }> => ({ entries: [] })),
+}))
+
+vi.mock('../api/keeper', () => ({
+  cancelQueuedKeeperMessage,
+  fetchKeeperChatHistory,
+  fetchQueuedKeeperMessageResult,
+  isTerminalQueuedKeeperMessage,
+  queuedKeeperMessageError,
+  queuedKeeperMessageToReply,
+  streamKeeperMessage,
+}))
+
+vi.mock('../api/dashboard', () => ({ fetchKeeperToolCalls }))
+vi.mock('../api/mcp', () => ({ callMcpTool: vi.fn() }))
+vi.mock('../api/core', () => ({ runOperatorAction: vi.fn() }))
+vi.mock('../store', async () => {
+  const { signal } = await import('@preact/signals')
+  return {
+    invalidateDashboardCache: vi.fn(),
+    refreshDashboard: vi.fn(async () => undefined),
+    shellAuthSummary: signal(null),
+  }
+})
+vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
+
+import { KeeperConversationPanel } from './keeper-shared'
+import { _resetChatHydrationForTests } from '../keeper-actions'
+import {
+  activeKeeperName,
+  keeperActionErrors,
+  keeperHydrating,
+  keeperProbing,
+  keeperRecovering,
+  keeperSending,
+  keeperStatusDetails,
+  keeperStreamLastEventAt,
+  keeperStreamStartedAt,
+  keeperThreads,
+} from '../keeper-state'
+import {
+  lookupToolCallOutput,
+  resetToolCallOutputs,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
+  toolCallOutputsCoveredSinceMs,
+  toolCallOutputsCoveredThroughMs,
+} from '../tool-call-output-store'
+import { _clearPendingKeeperChatRequestsForTests } from '../keeper-chat-pending'
+import { _resetChatStoreForTests } from '../keeper-chat-store'
+import { keeperCatchupDigests } from '../keeper-digest-signals'
+
+describe('KeeperConversationPanel hydration wiring', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
+    fetchKeeperChatHistory.mockReset()
+    fetchKeeperToolCalls.mockReset()
+    fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
+    keeperThreads.value = {}
+    keeperActionErrors.value = {}
+    keeperHydrating.value = {}
+    keeperProbing.value = {}
+    keeperRecovering.value = {}
+    keeperSending.value = {}
+    keeperStatusDetails.value = {}
+    keeperStreamStartedAt.value = {}
+    keeperStreamLastEventAt.value = {}
+    activeKeeperName.value = ''
+    keeperCatchupDigests.value = {}
+    _resetChatHydrationForTests()
+    _clearPendingKeeperChatRequestsForTests()
+    _resetChatStoreForTests()
+    resetToolCallOutputs()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+    _resetChatHydrationForTests()
+    _clearPendingKeeperChatRequestsForTests()
+    _resetChatStoreForTests()
+    resetToolCallOutputs()
+  })
+
+  it('drives live transcript hydration-failed DOM from a real tool-call endpoint failure', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    fetchKeeperChatHistory.mockResolvedValueOnce([
+      {
+        id: 'tool-history-api-hydration',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_201,
+        tool_call_id: 'tc-api-hydration',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-api-hydration#1',
+      },
+      {
+        id: 'assistant-history-api-hydration',
+        role: 'assistant',
+        content: '도구 출력을 확인했습니다.',
+        ts: 1_783_267_202,
+        source: 'dashboard',
+        turn_ref: 'trace-api-hydration#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ])
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 502'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 502')
+    })
+
+    const traceSelector =
+      '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
+
+    consoleWarn.mockRestore()
+  })
+
+  it('joins successful tool-call endpoint output into the live transcript DOM', async () => {
+    fetchKeeperChatHistory.mockResolvedValueOnce([
+      {
+        id: 'tool-history-api-success',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_211,
+        tool_call_id: 'tc-api-success',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-api-success#1',
+      },
+      {
+        id: 'assistant-history-api-success',
+        role: 'assistant',
+        content: '도구 출력 조인이 완료되었습니다.',
+        ts: 1_783_267_212,
+        source: 'dashboard',
+        turn_ref: 'trace-api-success#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ])
+    fetchKeeperToolCalls.mockResolvedValueOnce({
+      entries: [
+        {
+          ts: 1_783_267_211,
+          keeper: 'sangsu',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'context status joined from tool_calls_endpoint',
+          success: true,
+          duration_ms: 42,
+          tool_use_id: 'tc-api-success',
+        },
+      ],
+    })
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBeNull()
+      expect(lookupToolCallOutput('tool-tc-api-success')?.output).toBe(
+        'context status joined from tool_calls_endpoint',
+      )
+      expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_783_267_211_000)
+      expect(toolCallOutputsCoveredThroughMs('sangsu')).not.toBeNull()
+    })
+
+    const coveredThrough = toolCallOutputsCoveredThroughMs('sangsu')
+    const traceSelector =
+      '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267211000')
+      expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(coveredThrough))
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-success"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(step.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.hydration-failed')).toBeNull()
+      expect(container.textContent).not.toContain('결과 누락 1')
+      expect(container.textContent).not.toContain('출력 범위 밖 1')
+      expect(container.textContent).not.toContain('출력 hydration 실패 1')
+    })
+
+    const joinedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-success"]',
+    ) as HTMLElement
+    fireEvent.click(joinedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(joinedStep.textContent).toContain('result')
+      expect(joinedStep.textContent).toContain('context status joined from tool_calls_endpoint')
+      expect(joinedStep.textContent).not.toContain('출력 대기 중')
+      expect(joinedStep.textContent).not.toContain('결과 없음')
+      expect(joinedStep.textContent).not.toContain('출력 hydration 실패')
+      expect(joinedStep.textContent).not.toContain('출력 tail 범위 밖')
+    })
+  })
+
+  it('keeps simultaneous live panel hydration isolated by keeper', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    fetchKeeperChatHistory.mockImplementation(async (keeperName: string) => {
+      if (keeperName === 'alpha') {
+        return [
+          {
+            id: 'tool-history-alpha-scope',
+            role: 'tool',
+            content: '{}',
+            ts: 1_783_267_221,
+            tool_call_id: 'tc-alpha-scope',
+            tool_call_name: 'keeper_context_status',
+            source: 'dashboard',
+            turn_ref: 'trace-alpha-scope#1',
+          },
+          {
+            id: 'assistant-history-alpha-scope',
+            role: 'assistant',
+            content: 'alpha 도구 출력 조인이 완료되었습니다.',
+            ts: 1_783_267_222,
+            source: 'dashboard',
+            turn_ref: 'trace-alpha-scope#1',
+            stream_contract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              event_name: 'RUN_FINISHED',
+              delivery_receipt: 'client_observed_sse_event',
+            },
+          },
+        ]
+      }
+      if (keeperName === 'beta') {
+        return [
+          {
+            id: 'tool-history-beta-scope',
+            role: 'tool',
+            content: '{}',
+            ts: 1_783_267_231,
+            tool_call_id: 'tc-beta-scope',
+            tool_call_name: 'keeper_context_status',
+            source: 'dashboard',
+            turn_ref: 'trace-beta-scope#1',
+          },
+          {
+            id: 'assistant-history-beta-scope',
+            role: 'assistant',
+            content: 'beta 도구 출력은 아직 조인되지 않았습니다.',
+            ts: 1_783_267_232,
+            source: 'dashboard',
+            turn_ref: 'trace-beta-scope#1',
+            stream_contract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              event_name: 'RUN_FINISHED',
+              delivery_receipt: 'client_observed_sse_event',
+            },
+          },
+        ]
+      }
+      throw new Error(`unexpected keeper ${keeperName}`)
+    })
+    fetchKeeperToolCalls.mockImplementation(async (keeperName?: string) => {
+      if (keeperName === 'alpha') {
+        return {
+          entries: [
+            {
+              ts: 1_783_267_221,
+              keeper: 'alpha',
+              tool: 'keeper_context_status',
+              input: {},
+              output: 'alpha output joined from tool_calls_endpoint',
+              success: true,
+              duration_ms: 31,
+              tool_use_id: 'tc-alpha-scope',
+            },
+          ],
+        }
+      }
+      if (keeperName === 'beta') {
+        throw new Error('HTTP 503 beta')
+      }
+      throw new Error(`unexpected keeper ${keeperName}`)
+    })
+
+    render(
+      html`
+        <div>
+          <section data-testid="alpha-panel">
+            <${KeeperConversationPanel} keeperName="alpha" placeholder="alpha message" layout="workspace" />
+          </section>
+          <section data-testid="beta-panel">
+            <${KeeperConversationPanel} keeperName="beta" placeholder="beta message" layout="workspace" />
+          </section>
+        </div>
+      `,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('alpha')
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('beta')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('alpha', 200)
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('beta', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('alpha')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('alpha')).toBeNull()
+      expect(toolCallOutputHydrationStatus('beta')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('beta')).toBe('HTTP 503 beta')
+      expect(lookupToolCallOutput('tool-tc-alpha-scope')?.output).toBe(
+        'alpha output joined from tool_calls_endpoint',
+      )
+      expect(lookupToolCallOutput('tool-tc-beta-scope')).toBeNull()
+    })
+
+    const alphaPanel = container.querySelector('[data-testid="alpha-panel"]') as HTMLElement
+    const betaPanel = container.querySelector('[data-testid="beta-panel"]') as HTMLElement
+    const alphaCoveredThrough = toolCallOutputsCoveredThroughMs('alpha')
+
+    await waitFor(() => {
+      const alphaTrace = alphaPanel.querySelector('[data-chat-work-trace]')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267221000')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(alphaCoveredThrough))
+      expect(alphaTrace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const betaTrace = betaPanel.querySelector('[data-chat-work-trace]')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 503 beta')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-covered-since')).toBeNull()
+      expect(betaTrace?.getAttribute('data-chat-tool-output-covered-through')).toBeNull()
+      expect(betaTrace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const alphaStep = alphaPanel.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-alpha-scope"]',
+      ) as HTMLElement
+      expect(alphaStep.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(alphaStep.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(alphaStep.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(alphaStep.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+
+      const betaStep = betaPanel.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-beta-scope"]',
+      ) as HTMLElement
+      expect(betaStep.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(betaStep.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(betaStep.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(betaStep.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+      expect(betaStep.querySelector('.chat-block-tstep-status.ok')).toBeNull()
+      expect(betaPanel.textContent).toContain('출력 hydration 실패 1')
+      expect(betaPanel.textContent).not.toContain('alpha output joined from tool_calls_endpoint')
+    })
+
+    const alphaStep = alphaPanel.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-alpha-scope"]',
+    ) as HTMLElement
+    const betaStep = betaPanel.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-beta-scope"]',
+    ) as HTMLElement
+
+    fireEvent.click(alphaStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+    fireEvent.click(betaStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(alphaStep.textContent).toContain('alpha output joined from tool_calls_endpoint')
+      expect(alphaStep.textContent).not.toContain('HTTP 503 beta')
+      expect(betaStep.textContent).toContain('출력 hydration 실패 — HTTP 503 beta')
+      expect(betaStep.textContent).not.toContain('alpha output joined from tool_calls_endpoint')
+      expect(betaStep.textContent).not.toContain('result')
+    })
+
+    consoleWarn.mockRestore()
+  })
+})

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -55,7 +55,11 @@ vi.mock('../store', async () => {
 vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
 
 import { KeeperConversationPanel } from './keeper-shared'
-import { _resetChatHydrationForTests } from '../keeper-actions'
+import {
+  _resetChatHydrationForTests,
+  hydrateKeeperChatHistory,
+  refreshActiveKeeperChatHistory,
+} from '../keeper-actions'
 import {
   activeKeeperName,
   keeperActionErrors,
@@ -467,6 +471,247 @@ describe('KeeperConversationPanel hydration wiring', () => {
       expect(betaStep.textContent).toContain('출력 hydration 실패 — HTTP 503 beta')
       expect(betaStep.textContent).not.toContain('alpha output joined from tool_calls_endpoint')
       expect(betaStep.textContent).not.toContain('result')
+    })
+
+    consoleWarn.mockRestore()
+  })
+
+  it('recovers stale hydration-failed DOM after a forced live refresh succeeds', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const recoveryHistory = [
+      {
+        id: 'tool-history-refresh-recovery',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_241,
+        tool_call_id: 'tc-refresh-recovery',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-refresh-recovery#1',
+      },
+      {
+        id: 'assistant-history-refresh-recovery',
+        role: 'assistant',
+        content: 'force refresh 이후 도구 출력 조인이 복구되었습니다.',
+        ts: 1_783_267_242,
+        source: 'dashboard',
+        turn_ref: 'trace-refresh-recovery#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ]
+    fetchKeeperChatHistory.mockResolvedValueOnce(recoveryHistory)
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 504 first refresh'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 504 first refresh')
+    })
+
+    let step = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-refresh-recovery"]',
+    ) as HTMLElement
+    fireEvent.click(step.querySelector('.chat-block-tstep-row') as HTMLElement)
+    await waitFor(() => {
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(step.textContent).toContain('출력 hydration 실패 — HTTP 504 first refresh')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    fetchKeeperChatHistory.mockResolvedValueOnce(recoveryHistory)
+    fetchKeeperToolCalls.mockResolvedValueOnce({
+      entries: [
+        {
+          ts: 1_783_267_241,
+          keeper: 'sangsu',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'recovered output joined from forced refresh',
+          success: true,
+          duration_ms: 37,
+          tool_use_id: 'tc-refresh-recovery',
+        },
+      ],
+    })
+
+    await hydrateKeeperChatHistory('sangsu', { force: true })
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+      expect(fetchKeeperToolCalls).toHaveBeenCalledTimes(2)
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBeNull()
+      expect(lookupToolCallOutput('tool-tc-refresh-recovery')?.output).toBe(
+        'recovered output joined from forced refresh',
+      )
+      expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_783_267_241_000)
+      expect(toolCallOutputsCoveredThroughMs('sangsu')).not.toBeNull()
+    })
+
+    const coveredThrough = toolCallOutputsCoveredThroughMs('sangsu')
+    await waitFor(() => {
+      const trace = container.querySelector('[data-chat-work-trace]')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267241000')
+      expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(coveredThrough))
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-refresh-recovery"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(step.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.hydration-failed')).toBeNull()
+      expect(container.textContent).not.toContain('출력 hydration 실패 1')
+      expect(container.textContent).not.toContain('HTTP 504 first refresh')
+      expect(container.textContent).not.toContain('출력 대기 중')
+      expect(container.textContent).not.toContain('결과 없음')
+    })
+
+    await waitFor(() => {
+      expect(step.textContent).toContain('result')
+      expect(step.textContent).toContain('recovered output joined from forced refresh')
+      expect(step.textContent).not.toContain('출력 hydration 실패')
+      expect(step.textContent).not.toContain('HTTP 504 first refresh')
+      expect(step.textContent).not.toContain('출력 tail 범위 밖')
+    })
+
+    consoleWarn.mockRestore()
+  })
+
+  it('recovers stale hydration-failed DOM through the active-keeper reconnect refresh path', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const reconnectHistory = [
+      {
+        id: 'tool-history-reconnect-recovery',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_251,
+        tool_call_id: 'tc-reconnect-recovery',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-reconnect-recovery#1',
+      },
+      {
+        id: 'assistant-history-reconnect-recovery',
+        role: 'assistant',
+        content: 'SSE reconnect 이후 도구 출력 조인이 복구되었습니다.',
+        ts: 1_783_267_252,
+        source: 'dashboard',
+        turn_ref: 'trace-reconnect-recovery#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ]
+    activeKeeperName.value = 'sangsu'
+    fetchKeeperChatHistory.mockResolvedValueOnce(reconnectHistory)
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 504 reconnect gap'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 504 reconnect gap')
+    })
+
+    let step = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-reconnect-recovery"]',
+    ) as HTMLElement
+    fireEvent.click(step.querySelector('.chat-block-tstep-row') as HTMLElement)
+    await waitFor(() => {
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(step.textContent).toContain('출력 hydration 실패 — HTTP 504 reconnect gap')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    fetchKeeperChatHistory.mockResolvedValueOnce(reconnectHistory)
+    fetchKeeperToolCalls.mockResolvedValueOnce({
+      entries: [
+        {
+          ts: 1_783_267_251,
+          keeper: 'sangsu',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'recovered output joined from active reconnect refresh',
+          success: true,
+          duration_ms: 39,
+          tool_use_id: 'tc-reconnect-recovery',
+        },
+      ],
+    })
+
+    refreshActiveKeeperChatHistory({ force: true })
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+      expect(fetchKeeperToolCalls).toHaveBeenCalledTimes(2)
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBeNull()
+      expect(lookupToolCallOutput('tool-tc-reconnect-recovery')?.output).toBe(
+        'recovered output joined from active reconnect refresh',
+      )
+      expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_783_267_251_000)
+      expect(toolCallOutputsCoveredThroughMs('sangsu')).not.toBeNull()
+    })
+
+    const coveredThrough = toolCallOutputsCoveredThroughMs('sangsu')
+    await waitFor(() => {
+      const trace = container.querySelector('[data-chat-work-trace]')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267251000')
+      expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(coveredThrough))
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-reconnect-recovery"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(step.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.hydration-failed')).toBeNull()
+      expect(container.textContent).not.toContain('출력 hydration 실패 1')
+      expect(container.textContent).not.toContain('HTTP 504 reconnect gap')
+      expect(container.textContent).not.toContain('출력 대기 중')
+      expect(container.textContent).not.toContain('결과 없음')
+    })
+
+    await waitFor(() => {
+      expect(step.textContent).toContain('result')
+      expect(step.textContent).toContain('recovered output joined from active reconnect refresh')
+      expect(step.textContent).not.toContain('출력 hydration 실패')
+      expect(step.textContent).not.toContain('HTTP 504 reconnect gap')
+      expect(step.textContent).not.toContain('출력 tail 범위 밖')
     })
 
     consoleWarn.mockRestore()

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -92,6 +92,11 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
+import {
+  markToolCallOutputsHydrationFailed,
+  markToolCallOutputsHydrating,
+  resetToolCallOutputs,
+} from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
@@ -186,6 +191,7 @@ describe('KeeperConversationPanel', () => {
     render(null, container)
     container.remove()
     _resetChatStoreForTests()
+    resetToolCallOutputs()
     vi.unstubAllGlobals()
   })
 
@@ -485,6 +491,97 @@ describe('KeeperConversationPanel', () => {
       'client-side composer queue item; not yet submitted to keeper runtime',
       'client-side composer queue item; not yet submitted to keeper runtime',
     ])
+  })
+
+  it('wires the live tool-output hydration contract store into the transcript', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'tool-tc-live-hydration',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_context_status',
+          text: '{}',
+          rawText: '{}',
+          timestamp: '2026-03-24T00:00:01.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'assistant-live-hydration',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '도구 출력을 확인했습니다.',
+          rawText: '도구 출력을 확인했습니다.',
+          timestamp: '2026-03-24T00:00:02.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          streamContract: {
+            source: 'sse_event',
+            status: 'backend_terminal_event',
+            eventName: 'RUN_FINISHED',
+          },
+          traceSteps: [
+            {
+              kind: 'tool',
+              name: 'keeper_context_status',
+              toolCallId: 'tc-live-hydration',
+              ts: '2026-03-24T00:00:01.000Z',
+            },
+          ],
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const traceSelector = '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('idle')
+    })
+
+    const initialStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    expect(initialStep.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(initialStep.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
+
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
   })
 
   it('renders queued voice draft display blocks inside the transcript', async () => {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -27,6 +27,9 @@ vi.mock('../keeper-actions', () => ({
 
 vi.mock('../keeper-state', async () => {
   const { signal } = await import('@preact/signals')
+  const withoutUndefined = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined))
+
   return {
     keeperActionErrors: signal({}),
     keeperHydrating: signal({}),
@@ -37,6 +40,20 @@ vi.mock('../keeper-state', async () => {
     keeperStreamStartedAt: signal({}),
     keeperStreamLastEventAt: signal({}),
     keeperThreads: signal({}),
+    keeperStreamContract: (source: string, status: string, opts: Record<string, unknown> = {}) => withoutUndefined({
+      source,
+      status,
+      eventName: opts.eventName ?? undefined,
+      requestId: opts.requestId ?? undefined,
+      turnRef: opts.turnRef ?? undefined,
+      traceEventCount: opts.traceEventCount ?? undefined,
+      lifecycleEvents: opts.lifecycleEvents ?? undefined,
+      deliveryReceipt: opts.deliveryReceipt ?? undefined,
+      reason: opts.reason ?? undefined,
+    }),
+    setRecordValue: (state: { value: Record<string, unknown> }, key: string, value: unknown) => {
+      state.value = { ...state.value, [key]: value }
+    },
     isDefaultVisibleConversationEntry: vi.fn((entry: { role?: string; source?: string }) =>
       entry.role === 'tool'
         || ((entry.role === 'user' || entry.role === 'assistant')
@@ -76,7 +93,7 @@ import {
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
-import type { ChatBlock, KeeperConversationEntry } from '../types'
+import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
   KeeperConversationPanel,
   KeeperDiagnosticSummary,
@@ -460,6 +477,58 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
     expect(container.querySelector('[data-chat-block="voice"]')).not.toBeNull()
     expect(container.textContent).toContain('hello voice')
+  })
+
+  it('keeps queued attachment drafts visible with multimodal provenance and no delivery receipt', async () => {
+    keeperSending.value = { sangsu: true }
+    const attachments: KeeperConversationAttachment[] = [
+      {
+        id: 'queued-att',
+        type: 'image',
+        name: 'queued.png',
+        size: 1024,
+        mimeType: 'image/png',
+        data: 'data:image/png;base64,iVBORw0KGgo=',
+      },
+    ]
+    const displayBlocks: ChatBlock[] = [
+      {
+        t: 'attach',
+        id: 'queued-att',
+        name: 'queued.png',
+        kind: 'image',
+        src: 'data:image/png;base64,iVBORw0KGgo=',
+        mimeType: 'image/png',
+        sizeBytes: 1024,
+      },
+    ]
+    const userBlocks: KeeperUserInputBlock[] = [
+      {
+        type: 'image',
+        attachmentId: 'queued-att',
+        name: 'queued.png',
+        mimeType: 'image/png',
+        size: 1024,
+      },
+    ]
+    enqueueInput('sangsu', '', attachments, 'queued-attachment-1', displayBlocks, userBlocks)
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const bubble = container.querySelector('[data-chat-entry-id^="queued-user-"]') as HTMLElement
+    expect(bubble.getAttribute('data-chat-delivery-state')).toBe('queued')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(bubble.getAttribute('data-chat-attachment-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-server-attach-block-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-multimodal-sources')).toBe('persisted_attachment,server_block')
+    expect(bubble.getAttribute('data-chat-multimodal-kinds')).toBe('image')
+    expect(bubble.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-attachment-card="queued-att"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-block="attach"][data-chat-multimodal-source="server_block"]')).not.toBeNull()
   })
 
   it('renders queued drafts with invalid timestamps without throwing', async () => {

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -453,6 +453,40 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
   })
 
+  it('renders queue card and transcript placeholder with the same FIFO identity', async () => {
+    keeperSending.value = { sangsu: true }
+    enqueueInput('sangsu', 'queued first', undefined, 'queued-click-1')
+    enqueueInput('sangsu', 'queued second', undefined, 'queued-click-2')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const queueCards = [...container.querySelectorAll('[data-chat-queue-item]')] as HTMLElement[]
+    const queuedBubbles = [...container.querySelectorAll('[data-chat-entry-id^="queued-user-"]')] as HTMLElement[]
+
+    expect(queueCards.map(node => node.getAttribute('data-chat-queue-seq'))).toEqual(['1', '2'])
+    expect(queuedBubbles.map(node => node.getAttribute('data-chat-queue-seq'))).toEqual(['1', '2'])
+    expect(queueCards.map(node => node.getAttribute('data-chat-queue-client-action-id'))).toEqual([
+      'queued-click-1',
+      'queued-click-2',
+    ])
+    expect(queuedBubbles.map(node => node.getAttribute('data-chat-queue-client-action-id'))).toEqual([
+      'queued-click-1',
+      'queued-click-2',
+    ])
+    expect(queuedBubbles.map(node => node.getAttribute('data-chat-stream-contract-delivery-receipt'))).toEqual([
+      'no_delivery_receipt',
+      'no_delivery_receipt',
+    ])
+    expect(queuedBubbles.map(node => node.getAttribute('data-chat-stream-contract-reason'))).toEqual([
+      'client-side composer queue item; not yet submitted to keeper runtime',
+      'client-side composer queue item; not yet submitted to keeper runtime',
+    ])
+  })
+
   it('renders queued voice draft display blocks inside the transcript', async () => {
     keeperSending.value = { sangsu: true }
     const voiceBlocks: ChatBlock[] = [

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -35,6 +35,7 @@ import {
   keeperStreamStartedAt,
   keeperStreamLastEventAt,
   keeperThreads,
+  keeperStreamContract,
   setRecordValue,
 } from '../keeper-state'
 import { isDefaultVisibleConversationEntry } from '../keeper-state'
@@ -66,6 +67,7 @@ import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
 import {
+  toolCallOutputHydrationContract,
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from '../tool-call-output-store'
@@ -248,6 +250,9 @@ function liveAssistantPlaceholder(keeperName: string): KeeperConversationEntry {
     timestamp: null,
     delivery: 'streaming',
     streamState: 'streaming',
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'UI-only placeholder while active stream entry mounts',
+    }),
     details: null,
     error: null,
   }
@@ -267,6 +272,9 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     timestamp: queuedTimestampIso(msg.timestamp),
     delivery: 'queued',
     streamState: undefined,
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'client-side composer queue item; not yet submitted to keeper runtime',
+    }),
     attachments: msg.attachments,
     blocks: msg.blocks,
     details: null,
@@ -835,6 +843,7 @@ export function KeeperConversationPanel({
               showSourceBadge=${true}
               toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+              toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
               unreadAfterTs=${unreadAfterTs}
               onSeenBottom=${markTranscriptSeen}
               action=${inspectAction}
@@ -971,6 +980,7 @@ export function KeeperConversationPanel({
           groupToolCalls=${true}
           toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+          toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
           unreadAfterTs=${unreadAfterTs}
           onSeenBottom=${markTranscriptSeen}
           action=${inspectAction}
@@ -1090,6 +1100,7 @@ export function KeeperConversationPanel({
             groupToolCalls=${true}
             toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+            toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
             unreadAfterTs=${unreadAfterTs}
             onSeenBottom=${markTranscriptSeen}
             action=${inspectAction}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -276,6 +276,8 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
       deliveryReceipt: 'no_delivery_receipt',
       reason: 'client-side composer queue item; not yet submitted to keeper runtime',
     }),
+    queueSeq: msg.sequence,
+    queueClientActionId: msg.clientActionId ?? null,
     attachments: msg.attachments,
     blocks: msg.blocks,
     details: null,
@@ -447,7 +449,12 @@ function QueueItemCard({ keeperName, msg, onMutate }: QueueItemCardProps) {
   }
 
   return html`
-    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2.5" data-chat-queue-item=${msg.id}>
+    <div
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2.5"
+      data-chat-queue-item=${msg.id}
+      data-chat-queue-seq=${msg.sequence}
+      data-chat-queue-client-action-id=${msg.clientActionId ?? undefined}
+    >
       ${editing
         ? html`
             <textarea

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -273,6 +273,7 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     delivery: 'queued',
     streamState: undefined,
     streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'client-side composer queue item; not yet submitted to keeper runtime',
     }),
     attachments: msg.attachments,

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
@@ -1,0 +1,98 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  INTERLEAVE_ORDER_SIGNATURE,
+  InterleaveContractFixture,
+  installInterleaveFixtureToolOutputs,
+  interleaveEntries,
+  interleaveFixtureStatus,
+  joinedToolCount,
+  traceOnlyToolCount,
+} from './keeper-chat-interleave-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat interleave contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic fixture rows for joined and trace-only tool states', () => {
+    expect(interleaveEntries).toHaveLength(2)
+    expect(joinedToolCount).toBe(1)
+    expect(traceOnlyToolCount).toBe(1)
+    expect(interleaveFixtureStatus).toBe('ok')
+
+    const assistant = interleaveEntries.find(entry => entry.id === 'assistant-interleave')
+    expect(assistant?.traceSteps?.map(step => step.kind)).toEqual(['think', 'tool', 'think', 'tool'])
+    expect(assistant?.traceSteps?.map(step => step.ts)).toEqual([
+      '2026-07-05T14:20:05.000Z',
+      '2026-07-05T14:20:01.000Z',
+      '2026-07-05T14:20:02.000Z',
+      '2026-07-05T14:20:03.000Z',
+    ])
+  })
+
+  it('renders structural order and tool-output join state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installInterleaveFixtureToolOutputs()
+
+    render(html`<${InterleaveContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        `[data-interleave-contract-fixture-status="ok"][data-interleave-order-signature="${INTERLEAVE_ORDER_SIGNATURE}"][data-interleave-joined-tool-count="1"][data-interleave-trace-only-tool-count="1"]`,
+      ),
+    ).not.toBeNull()
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(trace).not.toBeNull()
+    expect(trace?.getAttribute('data-chat-turn-order-signature')).toBe(INTERLEAVE_ORDER_SIGNATURE)
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(INTERLEAVE_FIXTURE_COVERED_THROUGH_MS))
+
+    const ordered = [...container.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3', '4'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual([
+      'trace',
+      'tool',
+      'trace',
+      'tool',
+      'chat',
+    ])
+
+    expect(ordered[0]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:05.000Z')
+    expect(ordered[1]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-state')).toBe('ok')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+    expect(ordered[2]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:02.000Z')
+    expect(ordered[3]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-missing')
+    expect(ordered[3]?.getAttribute('data-chat-trace-entry-id')).toBeNull()
+    expect(ordered[3]?.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
+    expect(ordered[3]?.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(ordered[4]?.getAttribute('data-chat-trace-entry-id')).toBe('assistant-interleave')
+
+    const joinedToolRow = ordered[1]
+    expect(joinedToolRow).toBeDefined()
+    if (!joinedToolRow) {
+      throw new Error('expected joined tool row at structural order index 1')
+    }
+
+    expect(container.textContent).not.toContain('context status joined from tool_calls_endpoint')
+    fireEvent.click(joinedToolRow.querySelector('.chat-block-tstep-row') as HTMLElement)
+    expect(container.textContent).toContain('context status joined from tool_calls_endpoint')
+    expect(container.textContent).not.toContain('unrelated output')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -1,0 +1,171 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { ToolCallEntry } from '../api/dashboard'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  recordToolCallOutputs,
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const INTERLEAVE_FIXTURE_KEEPER = 'sangsu'
+export const INTERLEAVE_ORDER_SIGNATURE =
+  'trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+export const INTERLEAVE_FIXTURE_COVERED_SINCE_MS = Date.parse('2026-07-05T14:19:50.000Z')
+export const INTERLEAVE_FIXTURE_COVERED_THROUGH_MS = Date.parse('2026-07-05T14:20:10.000Z')
+
+const joinedToolOutput: ToolCallEntry = {
+  ts: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS / 1000,
+  keeper: INTERLEAVE_FIXTURE_KEEPER,
+  tool: 'keeper_context_status',
+  tool_use_id: 'tc-context',
+  input: { scope: 'current' },
+  output: 'context status joined from tool_calls_endpoint',
+  success: true,
+  semantic_success: true,
+  duration_ms: 84,
+}
+
+export const interleaveHydrationContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  completedAtMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  coveredSinceMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  coveredThroughMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+}
+
+export const interleaveEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-context',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T14:20:01.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-interleave',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: INTERLEAVE_FIXTURE_KEEPER,
+    text: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    rawText: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    timestamp: '2026-07-05T14:20:00.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'trace-interleave#9',
+      reason: 'live terminal event observed by dashboard SSE client',
+    }),
+    traceSteps: [
+      {
+        kind: 'think',
+        text: 'First structural thought appears before the tool even though its timestamp is later.',
+        ts: '2026-07-05T14:20:05.000Z',
+        oasBlockIndex: 10,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-context',
+        status: 'ok',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T14:20:01.000Z',
+        oasBlockIndex: 11,
+      },
+      {
+        kind: 'think',
+        text: 'Second structural thought must remain after the joined tool despite an earlier timestamp.',
+        ts: '2026-07-05T14:20:02.000Z',
+        oasBlockIndex: 12,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_memory_search',
+        toolCallId: 'tc-missing',
+        args: '{"query":"old task context"}',
+        ts: '2026-07-05T14:20:03.000Z',
+        oasBlockIndex: 13,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const joinedToolCount = interleaveEntries.filter(entry => entry.role === 'tool').length
+export const traceOnlyToolCount = interleaveEntries
+  .flatMap(entry => entry.traceSteps ?? [])
+  .filter(step => step.kind === 'tool' && step.toolCallId === 'tc-missing')
+  .length
+export const interleaveFixtureStatus =
+  joinedToolCount === 1 && traceOnlyToolCount === 1 ? 'ok' : 'invalid'
+
+export function installInterleaveFixtureToolOutputs(): void {
+  resetToolCallOutputs()
+  recordToolCallOutputs([joinedToolOutput])
+}
+
+export function InterleaveContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-interleave-contract-fixture
+      data-interleave-contract-fixture-status=${interleaveFixtureStatus}
+      data-interleave-order-signature=${INTERLEAVE_ORDER_SIGNATURE}
+      data-interleave-joined-tool-count=${joinedToolCount}
+      data-interleave-trace-only-tool-count=${traceOnlyToolCount}
+    >
+      <section class="mx-auto max-w-[820px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Interleave Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Structural thinking/tool order
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${interleaveEntries}
+            emptyText="No interleave rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+            groupToolCalls=${true}
+            toolOutputsCoveredSinceMs=${INTERLEAVE_FIXTURE_COVERED_SINCE_MS}
+            toolOutputsCoveredThroughMs=${INTERLEAVE_FIXTURE_COVERED_THROUGH_MS}
+            toolOutputHydrationContract=${interleaveHydrationContract}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installInterleaveFixtureToolOutputs()
+  render(html`<${InterleaveContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
@@ -1,0 +1,117 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ReplayContractFixture,
+  clientObservedCount,
+  fixtureStatus,
+  noDeliveryReceiptCount,
+  replayEntries,
+  serverReplayOnlyCount,
+} from './keeper-chat-replay-contract-fixture'
+
+describe('Keeper Chat replay contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+  })
+
+  it('keeps replay, queue, and finalization rows deterministic with explicit receipt classes', () => {
+    expect(replayEntries).toHaveLength(6)
+    expect(clientObservedCount).toBe(1)
+    expect(noDeliveryReceiptCount).toBe(4)
+    expect(serverReplayOnlyCount).toBe(1)
+    expect(fixtureStatus).toBe('ok')
+
+    const legacyEntry = replayEntries.find(entry => entry.id === 'smoke-legacy-user')
+    expect(legacyEntry?.streamContract).toMatchObject({
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const serverReplayEntry = replayEntries.find(entry => entry.id === 'smoke-error-assistant')
+    expect(serverReplayEntry?.streamContract).toMatchObject({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      eventName: 'RUN_ERROR',
+      deliveryReceipt: 'server_lifecycle_replay_only',
+    })
+
+    const queuePlaceholder = replayEntries.find(entry => entry.id === 'smoke-queued-assistant')
+    expect(queuePlaceholder).toMatchObject({
+      delivery: 'queued',
+      streamState: 'opening',
+    })
+    expect(queuePlaceholder?.streamContract).toMatchObject({
+      source: 'pending_request_store',
+      status: 'client_placeholder',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const queueResult = replayEntries.find(entry => entry.id === 'smoke-queue-result-assistant')
+    expect(queueResult?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const liveFinal = replayEntries.find(entry => entry.id === 'smoke-live-final-assistant')
+    expect(liveFinal?.streamContract).toMatchObject({
+      source: 'sse_event',
+      status: 'backend_terminal_event',
+      eventName: 'RUN_FINISHED',
+      deliveryReceipt: 'client_observed_sse_event',
+    })
+  })
+
+  it('renders replay contract badge state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+
+    render(html`<${ReplayContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]',
+      ),
+    ).not.toBeNull()
+  })
+})

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
@@ -1,0 +1,180 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import {
+  chatHistoryEntriesFromRest,
+  keeperClientObservedSseStreamContract,
+  keeperStreamContract,
+} from '../keeper-state'
+import type { KeeperConversationEntry } from '../types'
+
+const historyReplayEntries = chatHistoryEntriesFromRest('sangsu', [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'please run the long check',
+    ts: 1_780_000_000,
+    turn_ref: 'trace-chat-contract-smoke#7',
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_stream_events',
+      turn_ref: 'trace-chat-contract-smoke#7',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'user history rows are persisted chat input, not a live client stream receipt',
+    },
+  },
+  {
+    id: 'smoke-legacy-user',
+    role: 'user',
+    content: 'legacy row without turn ref',
+    ts: 1_780_000_001,
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'history row has no durable turn_ref; cannot join stream events',
+    },
+  },
+  {
+    id: 'smoke-error-assistant',
+    role: 'assistant',
+    content: 'Keeper request failed: Timeout after 630.0s',
+    ts: 1_780_000_002,
+    kind: 'transport_failure',
+    turn_ref: 'trace-chat-contract-smoke#8',
+    stream_contract: {
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turn_ref: 'trace-chat-contract-smoke#8',
+      event_name: 'RUN_ERROR',
+      lifecycle_events: [
+        'RUN_STARTED',
+        'RUN_ERROR',
+      ],
+      delivery_receipt: 'server_lifecycle_replay_only',
+      reason: 'history row records durable server stream lifecycle replay',
+    },
+  },
+])
+
+const queueAndFinalizationEntries: KeeperConversationEntry[] = [
+  {
+    id: 'smoke-queued-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: '',
+    rawText: '',
+    timestamp: null,
+    delivery: 'queued',
+    streamState: 'opening',
+    streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'awaiting queued request poll result',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-queue-result-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'queued request finished through dashboard polling',
+    rawText: 'queued request finished through dashboard polling',
+    timestamp: '2026-07-05T14:14:03.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'terminal queued poll result observed by dashboard polling, not SSE delivery',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-live-final-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'live stream finished with a client-observed terminal event',
+    rawText: 'live stream finished with a client-observed terminal event',
+    timestamp: '2026-07-05T14:14:04.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      reason: 'live stream terminal event observed by dashboard SSE client',
+    }),
+    details: null,
+  },
+]
+
+export const replayEntries = [
+  ...historyReplayEntries,
+  ...queueAndFinalizationEntries,
+]
+
+export const clientObservedCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'client_observed_sse_event',
+).length
+export const noDeliveryReceiptCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'no_delivery_receipt',
+).length
+export const serverReplayOnlyCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'server_lifecycle_replay_only',
+).length
+export const fixtureStatus = replayEntries.length === 6
+  && clientObservedCount === 1
+  && noDeliveryReceiptCount === 4
+  && serverReplayOnlyCount === 1
+  ? 'ok'
+  : 'invalid'
+
+export function ReplayContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-replay-contract-fixture
+      data-replay-contract-fixture-status=${fixtureStatus}
+      data-replay-contract-fixture-row-count=${replayEntries.length}
+      data-replay-contract-fixture-client-observed-count=${clientObservedCount}
+      data-replay-contract-fixture-no-delivery-count=${noDeliveryReceiptCount}
+      data-replay-contract-fixture-server-replay-count=${serverReplayOnlyCount}
+    >
+      <section class="mx-auto max-w-[760px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Replay Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Rendered replay contracts
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${replayEntries}
+            emptyText="No replay rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  render(html`<${ReplayContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  COVERAGE_GAP_COVERED_THROUGH_MS,
+  COVERAGE_GAP_ORDER_SIGNATURE,
+  HYDRATION_FAILED_ORDER_SIGNATURE,
+  TOOL_OUTPUT_FAILURE_REASON,
+  ToolOutputFailureContractFixture,
+  coverageGapEntries,
+  coverageGapToolCount,
+  hydrationFailedEntries,
+  hydrationFailedToolCount,
+  installToolOutputFailureFixtureStore,
+  toolOutputFailureFixtureStatus,
+} from './keeper-chat-tool-output-failure-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat tool output failure contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic failure-state fixture rows', () => {
+    expect(hydrationFailedEntries).toHaveLength(2)
+    expect(coverageGapEntries).toHaveLength(2)
+    expect(hydrationFailedToolCount).toBe(1)
+    expect(coverageGapToolCount).toBe(1)
+    expect(toolOutputFailureFixtureStatus).toBe('ok')
+
+    const hydrationAssistant = hydrationFailedEntries.find(entry => entry.id === 'assistant-hydration-failed')
+    const coverageAssistant = coverageGapEntries.find(entry => entry.id === 'assistant-coverage-gap')
+    expect(hydrationAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    expect(coverageAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    const hydrationToolStep = hydrationAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    const coverageToolStep = coverageAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    expect(hydrationToolStep?.toolCallId).toBe('tc-hydration-failed')
+    expect(coverageToolStep?.toolCallId).toBe('tc-coverage-gap')
+  })
+
+  it('renders hydration-failed and coverage-gap states without silent pending fallback', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installToolOutputFailureFixtureStore()
+
+    render(html`<${ToolOutputFailureContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]',
+      ),
+    ).not.toBeNull()
+
+    const hydrationScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="hydration-failed"]',
+    ) as HTMLElement | null
+    const hydrationTrace = hydrationScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(hydrationTrace?.getAttribute('data-chat-turn-order-signature')).toBe(HYDRATION_FAILED_ORDER_SIGNATURE)
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe(TOOL_OUTPUT_FAILURE_REASON)
+    expect(hydrationScenario?.textContent).toContain('출력 hydration 실패 1')
+
+    const hydrationTool = hydrationScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(hydrationTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+
+    const hydrationToolRow = hydrationTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(hydrationToolRow).not.toBeNull()
+    if (!hydrationToolRow) {
+      throw new Error('expected hydration failure tool row')
+    }
+    fireEvent.click(hydrationToolRow)
+    expect(hydrationTool?.textContent).toContain(`출력 hydration 실패 — ${TOOL_OUTPUT_FAILURE_REASON}`)
+
+    const coverageScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="coverage-gap"]',
+    ) as HTMLElement | null
+    const coverageTrace = coverageScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(coverageTrace?.getAttribute('data-chat-turn-order-signature')).toBe(COVERAGE_GAP_ORDER_SIGNATURE)
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(COVERAGE_GAP_COVERED_THROUGH_MS))
+    expect(coverageScenario?.textContent).toContain('출력 범위 밖 1')
+
+    const coverageTool = coverageScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(coverageTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(coverageTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(coverageTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-state')).toBe('coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-coverage')).toBe('coverage-gap')
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.coverage-gap')).not.toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+
+    const coverageToolRow = coverageTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(coverageToolRow).not.toBeNull()
+    if (!coverageToolRow) {
+      throw new Error('expected coverage gap tool row')
+    }
+    fireEvent.click(coverageToolRow)
+    expect(coverageTool?.textContent).toContain('출력 tail 범위 밖')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
@@ -1,0 +1,210 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER = 'sangsu'
+export const TOOL_OUTPUT_FAILURE_REASON = 'tool_calls_endpoint_502'
+export const HYDRATION_FAILED_ORDER_SIGNATURE = 'tool:tc-hydration-failed|chat:assistant-hydration-failed'
+export const COVERAGE_GAP_ORDER_SIGNATURE = 'tool:tc-coverage-gap|chat:assistant-coverage-gap'
+export const HYDRATION_FAILED_STARTED_AT_MS = Date.parse('2026-07-05T15:09:50.000Z')
+export const HYDRATION_FAILED_COMPLETED_AT_MS = Date.parse('2026-07-05T15:10:05.000Z')
+export const COVERAGE_GAP_COVERED_SINCE_MS = Date.parse('2026-07-05T15:11:00.000Z')
+export const COVERAGE_GAP_COVERED_THROUGH_MS = Date.parse('2026-07-05T15:11:10.000Z')
+
+export const hydrationFailedContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'failed',
+  failureReason: TOOL_OUTPUT_FAILURE_REASON,
+  startedAtMs: HYDRATION_FAILED_STARTED_AT_MS,
+  completedAtMs: HYDRATION_FAILED_COMPLETED_AT_MS,
+  coveredSinceMs: null,
+  coveredThroughMs: null,
+}
+
+export const coverageGapContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  completedAtMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+  coveredSinceMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  coveredThroughMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+}
+
+export const hydrationFailedEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-hydration-failed',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T15:10:01.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-hydration-failed',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'The tool output surface failed, so this cannot be reported as pending.',
+    rawText: 'The tool output surface failed, so this cannot be reported as pending.',
+    timestamp: '2026-07-05T15:10:02.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#1',
+      reason: 'terminal event observed before tool output hydration failed',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-hydration-failed',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T15:10:01.000Z',
+        oasBlockIndex: 21,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const coverageGapEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-coverage-gap',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_board_comment',
+    text: '{"post_id":"post-7","body":"ack"}',
+    rawText: '{"post_id":"post-7","body":"ack"}',
+    timestamp: '2026-07-05T15:11:30.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-coverage-gap',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    rawText: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    timestamp: '2026-07-05T15:11:31.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#2',
+      reason: 'terminal event observed after an older tool-output tail hydrated',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_board_comment',
+        toolCallId: 'tc-coverage-gap',
+        args: '{"post_id":"post-7","body":"ack"}',
+        ts: '2026-07-05T15:11:30.000Z',
+        oasBlockIndex: 22,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const hydrationFailedToolCount = hydrationFailedEntries.filter(entry => entry.role === 'tool').length
+export const coverageGapToolCount = coverageGapEntries.filter(entry => entry.role === 'tool').length
+export const toolOutputFailureFixtureStatus =
+  hydrationFailedToolCount === 1 && coverageGapToolCount === 1 ? 'ok' : 'invalid'
+
+export function installToolOutputFailureFixtureStore(): void {
+  resetToolCallOutputs()
+}
+
+export function ToolOutputFailureContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-tool-output-failure-contract-fixture
+      data-tool-output-failure-contract-fixture-status=${toolOutputFailureFixtureStatus}
+      data-tool-output-failure-hydration-failed-count=${hydrationFailedToolCount}
+      data-tool-output-failure-coverage-gap-count=${coverageGapToolCount}
+    >
+      <section class="mx-auto max-w-[900px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Tool Output Failure Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Tool output failures are explicit
+          </h1>
+        </header>
+        <div class="grid gap-4">
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="hydration-failed"
+            data-tool-output-failure-order-signature=${HYDRATION_FAILED_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${hydrationFailedEntries}
+              emptyText="No hydration failure rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputHydrationContract=${hydrationFailedContract}
+            />
+          </section>
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="coverage-gap"
+            data-tool-output-failure-order-signature=${COVERAGE_GAP_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${coverageGapEntries}
+              emptyText="No coverage gap rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputsCoveredSinceMs=${COVERAGE_GAP_COVERED_SINCE_MS}
+              toolOutputsCoveredThroughMs=${COVERAGE_GAP_COVERED_THROUGH_MS}
+              toolOutputHydrationContract=${coverageGapContract}
+            />
+          </section>
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installToolOutputFailureFixtureStore()
+  render(html`<${ToolOutputFailureContractFixture} />`, root)
+}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1202,6 +1202,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '진행 상황?', 'delivered'],
       ['assistant', 'polling으로 복구됨', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
   })
 
   it('reconciles a stream network failure when the server history has the completed reply', async () => {
@@ -1250,6 +1262,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'delivered'],
       ['assistant', '여기까지 했습니다.', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
@@ -1438,6 +1462,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'error'],
       ['assistant', '', 'error'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(keeperActionErrors.value.echo).toContain('서버 재시작')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
   })
@@ -1503,7 +1539,16 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
       // During the first sleep the assistant should still be queued.
       await vi.advanceTimersByTimeAsync(1_000)
-      expect((keeperThreads.value.echo ?? []).some(entry => entry.role === 'assistant' && entry.delivery === 'queued')).toBe(true)
+      const queuedAssistant = (keeperThreads.value.echo ?? []).find(
+        entry => entry.role === 'assistant' && entry.delivery === 'queued',
+      )
+      expect(queuedAssistant).not.toBeUndefined()
+      expect(queuedAssistant?.streamContract).toMatchObject({
+        source: 'pending_request_store',
+        status: 'client_placeholder',
+        requestId: 'kmsg_echo_1',
+        deliveryReceipt: 'no_delivery_receipt',
+      })
 
       // Let the resume loop finish.
       await vi.advanceTimersByTimeAsync(2_000)

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -90,6 +90,9 @@ import {
 import { KEEPER_HISTORY_TAIL_MESSAGES } from './config/constants'
 import {
   resetToolCallOutputs,
+  toolCallOutputHydrationContract,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from './tool-call-output-store'
@@ -207,7 +210,40 @@ describe('hydrateKeeperChatHistory', () => {
     const thread = keeperThreads.value.echo ?? []
     expect(thread).toHaveLength(2)
     expect(thread[0]?.delivery).toBe('history')
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'rest_history',
+      status: 'history_without_stream_events',
+    })
     expect(thread[1]?.role).toBe('assistant')
+  })
+
+  it('keeps backend stream contracts when hydrating server history', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'assistant',
+        content: 'done',
+        ts: 1_780_000_000,
+        turn_ref: 'trace-hydrate#2',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-hydrate#2',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    await hydrateKeeperChatHistory('echo')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-hydrate#2',
+      traceEventCount: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
   })
 
   it('fetches only once per keeper per page lifetime', async () => {
@@ -258,6 +294,21 @@ describe('hydrateKeeperChatHistory', () => {
 
     expect(toolCallOutputsCoveredSinceMs('echo')).toBe(Number.POSITIVE_INFINITY)
     expect(toolCallOutputsCoveredThroughMs('echo')).not.toBeNull()
+  })
+
+  it('records tool-output hydration failures with a visible contract reason', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 502'))
+
+    await hydrateKeeperChatHistory('echo')
+
+    expect(toolCallOutputHydrationStatus('echo')).toBe('failed')
+    expect(toolCallOutputHydrationFailureReason('echo')).toBe('HTTP 502')
+    expect(toolCallOutputHydrationContract('echo')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'failed',
+      failureReason: 'HTTP 502',
+    })
   })
 
   it('allows a retry after a failed fetch', async () => {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -229,6 +229,7 @@ describe('hydrateKeeperChatHistory', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-hydrate#2',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -242,6 +243,7 @@ describe('hydrateKeeperChatHistory', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-hydrate#2',
       traceEventCount: 2,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -965,6 +967,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(reply?.delivery).toBe('interrupted')
     expect(reply?.text).toContain('부분 응답')
     expect(reply?.error).toContain('끊겼습니다')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('no_delivery_receipt')
     expect(keeperActionErrors.value.echo).toContain('끊겼습니다')
   })
 
@@ -982,6 +985,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
     expect(reply?.delivery).toBe('delivered')
     expect(reply?.text).toContain('완료된 응답')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     // Regression guard: the per-message force refresh re-rendered the
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -48,6 +48,7 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
+  keeperClientObservedSseStreamContract,
   keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
@@ -1015,6 +1016,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: cutMessage,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: cutMessage,
         }),
       })
@@ -1037,6 +1039,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: EMPTY_VISIBLE_REPLY_TEXT,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: EMPTY_VISIBLE_REPLY_TEXT,
         }),
       })
@@ -1058,7 +1061,7 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
-      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
+      streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
         eventName: 'RUN_FINISHED',
       }),
     })
@@ -1086,6 +1089,7 @@ export async function sendKeeperThreadMessage(
         delivery: 'cancelled',
         error: null,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1098,6 +1102,7 @@ export async function sendKeeperThreadMessage(
         error: null,
         timestamp: new Date().toISOString(),
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1114,6 +1119,7 @@ export async function sendKeeperThreadMessage(
       error: errorMessage,
       timestamp: new Date().toISOString(),
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),
@@ -1122,6 +1128,7 @@ export async function sendKeeperThreadMessage(
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -469,6 +469,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: null,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'restored pending queued request from browser storage',
       }),
       attachments: request.attachments,
@@ -488,6 +489,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: 'opening',
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'awaiting queued request poll result',
       }),
       details: null,
@@ -590,6 +592,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -611,6 +614,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -627,6 +631,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -639,6 +644,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -654,6 +660,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
@@ -666,6 +673,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -48,6 +48,7 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
+  keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
   normalizeKeeperProbeResult,
@@ -350,8 +351,8 @@ async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
       toolOutputCoveredSinceMs(response.entries),
     )
   } catch (err) {
-    markToolCallOutputsHydrationFailed(keeperName)
     const message = err instanceof Error ? err.message : String(err)
+    markToolCallOutputsHydrationFailed(keeperName, message)
     console.warn(`[keeper] tool-call output hydration failed for ${keeperName}:`, message)
   }
 }
@@ -465,6 +466,10 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: new Date(request.submittedAt).toISOString(),
       delivery: 'delivered',
       streamState: null,
+      streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+        requestId: request.requestId,
+        reason: 'restored pending queued request from browser storage',
+      }),
       attachments: request.attachments,
       details: null,
     })
@@ -480,6 +485,10 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: null,
       delivery: 'queued',
       streamState: 'opening',
+      streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+        requestId: request.requestId,
+        reason: 'awaiting queued request poll result',
+      }),
       details: null,
     })
   }
@@ -578,6 +587,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
         delivery: userDelivery,
         error: errorMessage,
+        streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+          requestId: request.requestId,
+          reason: errorMessage,
+        }),
       })
       let assistantText = reply.text
       let assistantRawText = reply.details?.replyText ?? reply.text
@@ -595,6 +608,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         timestamp: new Date().toISOString(),
         details: reply.details,
         error: errorMessage,
+        streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+          requestId: request.requestId,
+          reason: errorMessage,
+        }),
       })
       if (errorMessage) setRecordValue(keeperActionErrors, request.keeperName, errorMessage)
       removePendingKeeperChatRequest(request.requestId)
@@ -607,6 +624,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
         delivery: 'error',
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+          requestId: request.requestId,
+          reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        }),
       })
       finalizeAssistantEntry(request.keeperName, assistantId, {
         text: '',
@@ -615,6 +636,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         streamState: null,
         timestamp: new Date().toISOString(),
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+          requestId: request.requestId,
+          reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        }),
       })
       setRecordValue(keeperActionErrors, request.keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
       await hydrateKeeperChatHistory(request.keeperName, { force: true })
@@ -626,6 +651,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
     finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
       delivery: 'error',
       error: message,
+      streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+        requestId: request.requestId,
+        reason: message,
+      }),
     })
     finalizeAssistantEntry(request.keeperName, assistantId, {
       text: '',
@@ -634,6 +663,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       streamState: null,
       timestamp: new Date().toISOString(),
       error: message,
+      streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+        requestId: request.requestId,
+        reason: message,
+      }),
     })
     setRecordValue(keeperActionErrors, request.keeperName, message)
     await hydrateKeeperChatHistory(request.keeperName, { force: true })
@@ -863,6 +896,9 @@ export async function sendKeeperThreadMessage(
     timestamp: new Date().toISOString(),
     delivery: 'sending',
     streamState: null,
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'local optimistic user row before server history confirmation',
+    }),
     attachments,
     blocks,
     details: null,
@@ -877,6 +913,9 @@ export async function sendKeeperThreadMessage(
     timestamp: null,
     delivery: 'sending',
     streamState: 'opening',
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'local assistant placeholder before stream event',
+    }),
     details: null,
   })
   setRecordValue(keeperSending, keeperName, true)
@@ -975,6 +1014,9 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         timestamp: new Date().toISOString(),
         error: cutMessage,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          reason: cutMessage,
+        }),
       })
       setRecordValue(keeperActionErrors, keeperName, cutMessage)
       if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
@@ -994,6 +1036,9 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         timestamp: new Date().toISOString(),
         error: EMPTY_VISIBLE_REPLY_TEXT,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          reason: EMPTY_VISIBLE_REPLY_TEXT,
+        }),
       })
       setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
       if (requestId) {
@@ -1013,6 +1058,9 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
+      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
+        eventName: 'RUN_FINISHED',
+      }),
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (requestId) {
@@ -1037,6 +1085,10 @@ export async function sendKeeperThreadMessage(
       finalizeAssistantEntry(keeperName, localId, {
         delivery: 'cancelled',
         error: null,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          requestId: requestId ?? undefined,
+          reason: KEEPER_MESSAGE_CANCELLED_TEXT,
+        }),
       })
       finalizeAssistantEntry(keeperName, assistantId, {
         text: KEEPER_MESSAGE_CANCELLED_TEXT,
@@ -1045,6 +1097,10 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         error: null,
         timestamp: new Date().toISOString(),
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          requestId: requestId ?? undefined,
+          reason: KEEPER_MESSAGE_CANCELLED_TEXT,
+        }),
       })
       if (cancelSucceeded) setRecordValue(keeperActionErrors, keeperName, null)
       throw err
@@ -1057,10 +1113,18 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       error: errorMessage,
       timestamp: new Date().toISOString(),
+      streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        requestId: requestId ?? undefined,
+        reason: errorMessage,
+      }),
     })
     finalizeAssistantEntry(keeperName, localId, {
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
+      streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        requestId: requestId ?? undefined,
+        reason: errorMessage,
+      }),
     })
     if (requestTerminalSeen && requestId) {
       removePendingKeeperChatRequest(requestId)

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -54,6 +54,26 @@ describe('keeper-chat-store input queue', () => {
     expect(dequeueInput('keeper-q')).toBeNull()
   })
 
+  it('assigns stable enqueue sequence across dequeue and requeue', () => {
+    const first = enqueueInput('keeper-q', 'first')
+    const second = enqueueInput('keeper-q', 'second')
+
+    expect(first.sequence).toBe(1)
+    expect(second.sequence).toBe(2)
+
+    const msg = dequeueInput('keeper-q')
+    expect(msg!.sequence).toBe(1)
+
+    requeueInputFront('keeper-q', msg!)
+
+    const replay = dequeueInput('keeper-q')
+    expect(replay!.sequence).toBe(1)
+    markInputSent('keeper-q')
+
+    const next = dequeueInput('keeper-q')
+    expect(next!.sequence).toBe(2)
+  })
+
   it('prevents dequeue while sending', () => {
     enqueueInput('keeper-q', 'only')
     dequeueInput('keeper-q')

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -14,6 +14,7 @@ export interface QueuedMessage {
   id: string
   content: string
   timestamp: number
+  sequence: number
   sent: boolean
   attachments?: KeeperConversationAttachment[]
   blocks?: ChatBlock[]
@@ -27,6 +28,7 @@ export interface InputQueue {
 }
 
 const _queues = new Map<string, InputQueue>()
+let _nextQueueSequence = 0
 
 function _ensureQueue(keeperName: string): InputQueue {
   let q = _queues.get(keeperName)
@@ -94,6 +96,7 @@ export function enqueueInput(
     id: `${keeperName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     content,
     timestamp: Date.now(),
+    sequence: ++_nextQueueSequence,
     sent: false,
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
     ...(blocks && blocks.length > 0 ? { blocks } : {}),
@@ -210,4 +213,5 @@ export function getQueueTotal(keeperName: string): number {
 export function _resetChatStoreForTests(): void {
   _queues.clear()
   _drafts.clear()
+  _nextQueueSequence = 0
 }

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -372,6 +372,7 @@ describe('thread history merge & persistence', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-rest#8',
           trace_event_count: 3,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -382,7 +383,49 @@ describe('thread history merge & persistence', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-rest#8',
       traceEventCount: 3,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('normalizes durable backend lifecycle stream contracts from REST chat history', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from durable lifecycle replay',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#9',
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-rest#9',
+          event_name: 'RUN_FINISHED',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'TEXT_MESSAGE_START',
+            'TEXT_MESSAGE_END',
+            'RUN_FINISHED',
+          ],
+          delivery_receipt: 'server_lifecycle_replay_only',
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toEqual({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turnRef: 'trace-rest#9',
+      eventName: 'RUN_FINISHED',
+      lifecycleEvents: [
+        'RUN_STARTED',
+        'TEXT_MESSAGE_START',
+        'TEXT_MESSAGE_END',
+        'RUN_FINISHED',
+      ],
+      deliveryReceipt: 'server_lifecycle_replay_only',
+      reason: 'history row records durable server stream lifecycle replay',
     })
   })
 

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -359,6 +359,53 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.turnRef).toBe('trace-rest#7')
   })
 
+  it('prefers backend stream contracts from REST chat history', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from retained trace',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#8',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-rest#8',
+          trace_event_count: 3,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-rest#8',
+      traceEventCount: 3,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('falls back explicitly when REST chat history carries an unknown stream contract', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply',
+        ts: 1_780_000_001,
+        stream_contract: {
+          source: 'future_backend_source',
+          status: 'future_status',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toMatchObject({
+      source: 'rest_history',
+      status: 'history_without_stream_events',
+    })
+  })
+
   it('preserves object payloads in persisted tool trace blocks', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -11,6 +11,7 @@ import type {
   KeeperConversationRole,
   KeeperConversationSource,
   KeeperConversationStreamContract,
+  KeeperConversationStreamDeliveryReceipt,
   KeeperConversationStreamContractSource,
   KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
@@ -228,6 +229,8 @@ export function keeperStreamContract(
     requestId?: string | null
     turnRef?: string | null
     traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
+    deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -238,7 +241,27 @@ export function keeperStreamContract(
     requestId: opts.requestId ?? undefined,
     turnRef: opts.turnRef ?? undefined,
     traceEventCount: opts.traceEventCount ?? undefined,
+    lifecycleEvents: opts.lifecycleEvents ?? undefined,
+    deliveryReceipt: opts.deliveryReceipt ?? undefined,
     reason: opts.reason ?? undefined,
+  })
+}
+
+export function keeperClientObservedSseStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return keeperStreamContract(source, status, {
+    ...opts,
+    deliveryReceipt: 'client_observed_sse_event',
   })
 }
 
@@ -246,6 +269,8 @@ function normalizeStreamContractSource(value: unknown): KeeperConversationStream
   switch (asString(value)?.trim()) {
     case 'keeper_chat_store':
       return 'keeper_chat_store'
+    case 'backend_stream_lifecycle':
+      return 'backend_stream_lifecycle'
     case 'backend_turn_trace':
       return 'backend_turn_trace'
     case 'rest_history':
@@ -273,6 +298,8 @@ function normalizeStreamContractStatus(value: unknown): KeeperConversationStream
       return 'backend_stream_event'
     case 'backend_terminal_event':
       return 'backend_terminal_event'
+    case 'backend_lifecycle_replay':
+      return 'backend_lifecycle_replay'
     case 'backend_trace_join':
       return 'backend_trace_join'
     case 'history_without_turn_ref':
@@ -294,6 +321,19 @@ function normalizeStreamContractStatus(value: unknown): KeeperConversationStream
   }
 }
 
+function normalizeStreamDeliveryReceipt(value: unknown): KeeperConversationStreamDeliveryReceipt | null {
+  switch (asString(value)?.trim()) {
+    case 'client_observed_sse_event':
+      return 'client_observed_sse_event'
+    case 'server_lifecycle_replay_only':
+      return 'server_lifecycle_replay_only'
+    case 'no_delivery_receipt':
+      return 'no_delivery_receipt'
+    default:
+      return null
+  }
+}
+
 function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
   if (!isRecord(raw)) return null
   const source = normalizeStreamContractSource(raw.source)
@@ -304,6 +344,8 @@ function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract
     requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
     turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
     traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    lifecycleEvents: normalizeStringArray(raw.lifecycle_events) ?? normalizeStringArray(raw.lifecycleEvents) ?? null,
+    deliveryReceipt: normalizeStreamDeliveryReceipt(raw.delivery_receipt) ?? normalizeStreamDeliveryReceipt(raw.deliveryReceipt) ?? null,
     reason: asString(raw.reason) ?? null,
   })
 }
@@ -961,6 +1003,7 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
     delivery: 'streaming',
     streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
       eventName: 'TEXT_MESSAGE_CONTENT',
+      deliveryReceipt: 'client_observed_sse_event',
     }),
   }))
 }
@@ -1019,6 +1062,7 @@ function writeAssistantThinkingText(
       delivery: 'streaming',
       streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
         eventName: 'KEEPER_THINKING_DELTA',
+        deliveryReceipt: 'client_observed_sse_event',
       }),
     }
   })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -10,6 +10,9 @@ import type {
   KeeperConversationEntry,
   KeeperConversationRole,
   KeeperConversationSource,
+  KeeperConversationStreamContract,
+  KeeperConversationStreamContractSource,
+  KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
   KeeperConversationDelivery,
   KeeperDiagnostic,
@@ -215,6 +218,94 @@ function withoutUndefined<const T extends Record<string, unknown>>(record: T): T
     if (value !== undefined) next[key] = value
   }
   return next as T
+}
+
+export function keeperStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return withoutUndefined({
+    source,
+    status,
+    eventName: opts.eventName ?? undefined,
+    requestId: opts.requestId ?? undefined,
+    turnRef: opts.turnRef ?? undefined,
+    traceEventCount: opts.traceEventCount ?? undefined,
+    reason: opts.reason ?? undefined,
+  })
+}
+
+function normalizeStreamContractSource(value: unknown): KeeperConversationStreamContractSource | null {
+  switch (asString(value)?.trim()) {
+    case 'keeper_chat_store':
+      return 'keeper_chat_store'
+    case 'backend_turn_trace':
+      return 'backend_turn_trace'
+    case 'rest_history':
+      return 'rest_history'
+    case 'sse_event':
+      return 'sse_event'
+    case 'queue_event':
+      return 'queue_event'
+    case 'queue_poll':
+      return 'queue_poll'
+    case 'pending_request_store':
+      return 'pending_request_store'
+    case 'client_local_send':
+      return 'client_local_send'
+    case 'client_reconciliation':
+      return 'client_reconciliation'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContractStatus(value: unknown): KeeperConversationStreamContractStatus | null {
+  switch (asString(value)?.trim()) {
+    case 'backend_stream_event':
+      return 'backend_stream_event'
+    case 'backend_terminal_event':
+      return 'backend_terminal_event'
+    case 'backend_trace_join':
+      return 'backend_trace_join'
+    case 'history_without_turn_ref':
+      return 'history_without_turn_ref'
+    case 'history_without_stream_events':
+      return 'history_without_stream_events'
+    case 'queue_request_event':
+      return 'queue_request_event'
+    case 'queue_poll_result':
+      return 'queue_poll_result'
+    case 'client_placeholder':
+      return 'client_placeholder'
+    case 'client_reconciled_history':
+      return 'client_reconciled_history'
+    case 'contract_gap':
+      return 'contract_gap'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
+  if (!isRecord(raw)) return null
+  const source = normalizeStreamContractSource(raw.source)
+  const status = normalizeStreamContractStatus(raw.status)
+  if (source === null || status === null) return null
+  return keeperStreamContract(source, status, {
+    eventName: asString(raw.event_name) ?? asString(raw.eventName) ?? null,
+    requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
+    turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
+    traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    reason: asString(raw.reason) ?? null,
+  })
 }
 
 function normalizeTableCell(raw: unknown): ChatTableCellValue | null {
@@ -740,6 +831,10 @@ function normalizeHistoryEntry(
     ?? ((role === 'assistant' || role === 'system') && text
       ? parseTextToChatBlocks(text)
       : undefined)
+  const streamContract = normalizeStreamContract(raw.stream_contract)
+    ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'history rows do not carry stream lifecycle events',
+    })
   return {
     // R3: key off the producer-assigned server id when present so the
     // render key is stable across history-page merges (the former
@@ -755,6 +850,7 @@ function normalizeHistoryEntry(
     turnRef,
     delivery,
     streamState: null,
+    streamContract,
     details: null,
     surface,
     audio,
@@ -846,11 +942,13 @@ export function setAssistantStreamState(
   entryId: string,
   streamState: KeeperConversationStreamState,
   delivery: KeeperConversationDelivery,
+  streamContract?: KeeperConversationStreamContract,
 ): void {
   updateThreadEntry(name, entryId, entry => ({
     ...entry,
     streamState,
     delivery,
+    streamContract: streamContract ?? entry.streamContract,
   }))
 }
 
@@ -861,6 +959,9 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
     text: formatKeeperVisibleReply(`${entry.rawText ?? entry.text}${delta}`),
     streamState: 'streaming',
     delivery: 'streaming',
+    streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
+      eventName: 'TEXT_MESSAGE_CONTENT',
+    }),
   }))
 }
 
@@ -916,6 +1017,9 @@ function writeAssistantThinkingText(
       traceSteps,
       streamState: 'thinking',
       delivery: 'streaming',
+      streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
+        eventName: 'KEEPER_THINKING_DELTA',
+      }),
     }
   })
 }
@@ -1271,7 +1375,8 @@ interface RestChatHistoryMessage {
   kind?: string
   // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
   // prefers them over its local parser.
-  blocks?: ChatBlock[]
+  blocks?: unknown
+  stream_contract?: unknown
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -1293,6 +1398,9 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     timestamp: toIsoTimestamp(message.ts),
     delivery: 'history',
     streamState: null,
+    streamContract: normalizeStreamContract(message.stream_contract) ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'tool history rows carry arguments, not live stream lifecycle',
+    }),
     details: null,
     surface: message.surface ?? null,
     // Tool rows share the same untrusted REST boundary; reject malformed
@@ -1330,6 +1438,7 @@ export function chatHistoryEntriesFromRest(
         kind: message.kind,
         blocks: message.blocks,
         turn_ref: message.turn_ref,
+        stream_contract: message.stream_contract,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -49,6 +49,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('안녕')
     expect(entry?.delivery).toBe('streaming')
     expect(entry?.streamState).toBe('streaming')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('ignores retired TEXT_DELTA events', () => {
@@ -87,6 +88,7 @@ describe('applyKeeperStreamEvent', () => {
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('queued')
     expect(entry?.streamState).toBe('opening')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('surfaces failed request terminal events before stream error close', () => {
@@ -107,6 +109,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBe('Timeout after 630.0s')
     expect(entry?.text).toBe('Keeper request failed: Timeout after 630.0s')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('renders cancelled request terminal events without an error bubble', () => {
@@ -127,6 +130,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
     expect(entry?.text).toBe('요청이 취소되었습니다.')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('finalizes successful request terminal events after streamed thinking', () => {
@@ -165,6 +169,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.delivery).toBe('delivered')
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,7 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
-  keeperStreamContract,
+  keeperClientObservedSseStreamContract,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -351,7 +351,7 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
@@ -363,7 +363,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'opening',
         'sending',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
       )
       return null
     case 'TEXT_MESSAGE_START':
@@ -377,7 +377,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'streaming',
         'streaming',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
       )
       return null
     case 'TEXT_MESSAGE_CONTENT': {
@@ -418,7 +418,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -469,7 +469,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
+          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
       return null
@@ -492,7 +492,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
         )
         return null
       }
@@ -521,7 +521,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
         )
         return null
       }
@@ -539,7 +539,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
         )
         return null
       }
@@ -556,7 +556,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
         )
         return null
       }
@@ -581,7 +581,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
           )
         }
         return null
@@ -609,7 +609,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
           )
         }
         return null
@@ -621,7 +621,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
         )
         return null
       }
@@ -632,7 +632,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'opening',
           'queued',
-          keeperStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
+          keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
         )
         return null
       }
@@ -651,7 +651,7 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'queued',
           streamState: null,
-          streamContract: keeperStreamContract('queue_event', 'queue_request_event', {
+          streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
             eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
           }),
         }))
@@ -683,7 +683,7 @@ export function applyKeeperStreamEvent(
             delivery: 'cancelled',
             streamState: null,
             error: null,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
             }),
@@ -702,7 +702,7 @@ export function applyKeeperStreamEvent(
             delivery: 'error',
             streamState: null,
             error: message,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
               reason: message,
@@ -723,7 +723,7 @@ export function applyKeeperStreamEvent(
               delivery,
               streamState: null,
               error: null,
-              streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
                 eventName: 'KEEPER_REQUEST_TERMINAL',
                 requestId: terminalRequestId,
               }),

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,6 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
+  keeperStreamContract,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -342,7 +343,7 @@ export function applyKeeperStreamEvent(
       appendAssistantDelta(keeperName, assistantEntryId, payload)
     }
   }
-  const markFinalizingIfLive = (): void => {
+  const markFinalizingIfLive = (eventName: string): void => {
     updateThreadEntry(keeperName, assistantEntryId, entry => {
       if (entry.streamState === null) return entry
       if (entry.delivery !== 'sending' && entry.delivery !== 'streaming') return entry
@@ -350,13 +351,20 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
 
   switch (event.type) {
     case 'RUN_STARTED':
-      setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'sending')
+      setAssistantStreamState(
+        keeperName,
+        assistantEntryId,
+        'opening',
+        'sending',
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+      )
       return null
     case 'TEXT_MESSAGE_START':
       // Flush any buffered thinking deltas before entering the text phase so a
@@ -364,7 +372,13 @@ export function applyKeeperStreamEvent(
       // 'thinking' after text streaming has begun. Mirrors TEXT_MESSAGE_END and
       // TOOL_CALL_START, which flush at their phase boundaries.
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
-      setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+      setAssistantStreamState(
+        keeperName,
+        assistantEntryId,
+        'streaming',
+        'streaming',
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+      )
       return null
     case 'TEXT_MESSAGE_CONTENT': {
       applyTextDelta(event.delta)
@@ -373,7 +387,7 @@ export function applyKeeperStreamEvent(
     case 'TEXT_MESSAGE_END':
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-      markFinalizingIfLive()
+      markFinalizingIfLive('TEXT_MESSAGE_END')
       return null
     case 'TOOL_CALL_START': {
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
@@ -404,6 +418,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -454,6 +469,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
+          streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
       return null
@@ -471,7 +487,13 @@ export function applyKeeperStreamEvent(
         if (usage) patch.usage = usage
         if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
         if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_DELTA') {
@@ -484,17 +506,23 @@ export function applyKeeperStreamEvent(
         if (usage) patch.usage = usage
         if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
         if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
-        if (stopReason) markFinalizingIfLive()
+        if (stopReason) markFinalizingIfLive('KEEPER_STREAM_MESSAGE_DELTA')
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-        markFinalizingIfLive()
+        markFinalizingIfLive('KEEPER_STREAM_MESSAGE_STOP')
         return null
       }
       if (event.name === 'KEEPER_STREAM_PING') {
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_START') {
@@ -506,7 +534,13 @@ export function applyKeeperStreamEvent(
         if (toolCallId && toolName) {
           rememberOasToolBlockIndex(keeperName, assistantEntryId, toolCallId, oasBlockIndex)
         }
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_STOP') {
@@ -517,7 +551,13 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           asNumber(value?.index) ?? asNumber(value?.block_index),
         )
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_THINKING_DELTA') {
@@ -535,7 +575,15 @@ export function applyKeeperStreamEvent(
           ? asNumber(value.index) ?? asNumber(value.block_index)
           : undefined
         if (delta) enqueueThinkingDelta(keeperName, assistantEntryId, delta, { oasBlockIndex })
-        else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        else {
+          setAssistantStreamState(
+            keeperName,
+            assistantEntryId,
+            'thinking',
+            'streaming',
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+          )
+        }
         return null
       }
       if (event.name === 'KEEPER_STREAM_PROTOCOL_ERROR') {
@@ -556,18 +604,36 @@ export function applyKeeperStreamEvent(
       }
       if (event.name === 'KEEPER_THINKING_SIGNATURE_DELTA') {
         if (!pendingThinkingDeltas.has(streamEntryKey(keeperName, assistantEntryId))) {
-          setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+          setAssistantStreamState(
+            keeperName,
+            assistantEntryId,
+            'thinking',
+            'streaming',
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+          )
         }
         return null
       }
       if (event.name === 'KEEPER_MEDIA_DELTA') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
-        setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'queued')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'opening',
+          'queued',
+          keeperStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTINUATION_CHECKPOINT') {
@@ -585,6 +651,9 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'queued',
           streamState: null,
+          streamContract: keeperStreamContract('queue_event', 'queue_request_event', {
+            eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
+          }),
         }))
         return null
       }
@@ -614,6 +683,10 @@ export function applyKeeperStreamEvent(
             delivery: 'cancelled',
             streamState: null,
             error: null,
+            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              eventName: 'KEEPER_REQUEST_TERMINAL',
+              requestId: terminalRequestId,
+            }),
           }))
           return null
         }
@@ -629,6 +702,11 @@ export function applyKeeperStreamEvent(
             delivery: 'error',
             streamState: null,
             error: message,
+            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              eventName: 'KEEPER_REQUEST_TERMINAL',
+              requestId: terminalRequestId,
+              reason: message,
+            }),
           }))
           return message
         }
@@ -645,6 +723,10 @@ export function applyKeeperStreamEvent(
               delivery,
               streamState: null,
               error: null,
+              streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+                eventName: 'KEEPER_REQUEST_TERMINAL',
+                requestId: terminalRequestId,
+              }),
             }
           })
         }

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -133,7 +133,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     showToast.mockClear()
     replayOasRuntimeTelemetry.mockClear()
     replayOasRuntimeTelemetry.mockResolvedValue(undefined)
-    refreshActiveKeeperChatHistory.mockClear()
+    refreshActiveKeeperChatHistory.mockReset()
     hydrateFleetCompositeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockReturnValue(true)
@@ -218,6 +218,32 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     vi.clearAllTimers()
     cleanup()
+  })
+
+  it('surfaces active keeper chat reconnect refresh boundary failures without stopping recovery', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    refreshActiveKeeperChatHistory.mockImplementationOnce(() => {
+      throw new Error('keeper chat reconnect refresh exploded')
+    })
+    const { sseStore, sse } = await loadSseStore()
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.connected.value = true
+    sse.lastDisconnectedAt.value = Date.now() - 1_000
+    sse.reconnectCount.value += 1
+    await flushAsyncWork()
+
+    expect(refreshActiveKeeperChatHistory).toHaveBeenCalledWith({ force: true })
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[SSE] reconnect keeper chat re-hydration unavailable',
+      'keeper chat reconnect refresh exploded',
+    )
+    expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
+    expect(requestNamespaceTruthNow).toHaveBeenCalledTimes(1)
+
+    vi.clearAllTimers()
+    cleanup()
+    consoleWarn.mockRestore()
   })
 
   it('routes an approval:pending SSE event to the governance refresh (HITL badge contract)', async () => {

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -249,6 +249,11 @@
   background: var(--color-status-warn);
 }
 
+.chat-block-tstep-status.coverage-gap {
+  border: 1px solid var(--color-status-warn);
+  background: color-mix(in oklab, var(--color-status-warn) 28%, transparent);
+}
+
 .chat-block-tstep-status.unlinked {
   border: 1px solid var(--color-status-warn);
   background: transparent;

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -254,6 +254,11 @@
   background: color-mix(in oklab, var(--color-status-warn) 28%, transparent);
 }
 
+.chat-block-tstep-status.hydration-failed {
+  border: 1px solid var(--color-status-warn);
+  background: color-mix(in oklab, var(--color-status-warn) 42%, transparent);
+}
+
 .chat-block-tstep-status.unlinked {
   border: 1px solid var(--color-status-warn);
   background: transparent;

--- a/dashboard/src/tool-call-output-store.test.ts
+++ b/dashboard/src/tool-call-output-store.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { ToolCallEntry } from './api/dashboard'
 import {
   lookupToolCallOutput,
+  markToolCallOutputsHydrationFailed,
   markToolCallOutputsHydrated,
   markToolCallOutputsHydrating,
   recordToolCallOutputs,
   resetToolCallOutputs,
+  toolCallOutputHydrationContract,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
   toolCallIdFromToolEntryId,
   toolCallOutputsById,
   toolCallOutputsCoveredSinceMs,
@@ -94,10 +98,19 @@ describe('tool-call-output-store', () => {
 
   it('tracks bounded hydration coverage for tail-limited output fetches', () => {
     markToolCallOutputsHydrating('sangsu')
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrating')
     markToolCallOutputsHydrated('sangsu', 2_000, 1_000)
 
     expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_000)
     expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(2_000)
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+    expect(toolCallOutputHydrationContract('sangsu')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'hydrated',
+      failureReason: null,
+      coveredSinceMs: 1_000,
+      coveredThroughMs: 2_000,
+    })
   })
 
   it('merges unbounded hydration coverage without retaining an old lower bound', () => {
@@ -106,5 +119,18 @@ describe('tool-call-output-store', () => {
 
     expect(toolCallOutputsCoveredSinceMs('sangsu')).toBeNull()
     expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(3_000)
+  })
+
+  it('records hydration failure reason instead of collapsing it to pending', () => {
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+    expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 502')
+    expect(toolCallOutputHydrationContract('sangsu')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'failed',
+      failureReason: 'HTTP 502',
+    })
   })
 })

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -37,9 +37,24 @@ interface ToolCallOutputHydrationState {
   coveredSinceMs: number | null
   coveredThroughMs: number | null
   failed: boolean
+  failureReason: string | null
+  lastStartedAtMs: number | null
+  lastCompletedAtMs: number | null
 }
 
 export const toolCallOutputHydrationByKeeper = signal<Record<string, ToolCallOutputHydrationState>>({})
+
+export type ToolCallOutputHydrationStatus = 'idle' | 'hydrating' | 'hydrated' | 'failed'
+
+export interface ToolCallOutputHydrationContract {
+  source: 'tool_calls_endpoint'
+  status: ToolCallOutputHydrationStatus
+  failureReason: string | null
+  startedAtMs: number | null
+  completedAtMs: number | null
+  coveredSinceMs: number | null
+  coveredThroughMs: number | null
+}
 
 function keeperKey(keeperName: string): string {
   return keeperName.trim()
@@ -51,6 +66,9 @@ function currentHydrationState(keeperName: string): ToolCallOutputHydrationState
     coveredSinceMs: null,
     coveredThroughMs: null,
     failed: false,
+    failureReason: null,
+    lastStartedAtMs: null,
+    lastCompletedAtMs: null,
   }
 }
 
@@ -67,6 +85,9 @@ function updateHydrationState(
     && current.coveredSinceMs === next.coveredSinceMs
     && current.coveredThroughMs === next.coveredThroughMs
     && current.failed === next.failed
+    && current.failureReason === next.failureReason
+    && current.lastStartedAtMs === next.lastStartedAtMs
+    && current.lastCompletedAtMs === next.lastCompletedAtMs
   ) return
   toolCallOutputHydrationByKeeper.value = {
     ...toolCallOutputHydrationByKeeper.value,
@@ -82,6 +103,8 @@ export function markToolCallOutputsHydrating(keeperName: string): number {
     ...current,
     inFlight: current.inFlight + 1,
     failed: false,
+    failureReason: null,
+    lastStartedAtMs: startedAtMs,
   }))
   return startedAtMs
 }
@@ -97,22 +120,30 @@ export function markToolCallOutputsHydrated(
   coveredSinceMs: number | null = null,
 ): void {
   updateHydrationState(keeperName, current => ({
+    ...current,
     inFlight: Math.max(0, current.inFlight - 1),
     coveredSinceMs: current.coveredThroughMs == null
       ? coveredSinceMs
       : mergeCoveredSince(current.coveredSinceMs, coveredSinceMs),
     coveredThroughMs: Math.max(current.coveredThroughMs ?? 0, coveredThroughMs),
     failed: false,
+    failureReason: null,
+    lastCompletedAtMs: Date.now(),
   }))
 }
 
-export function markToolCallOutputsHydrationFailed(keeperName: string): void {
+export function markToolCallOutputsHydrationFailed(
+  keeperName: string,
+  reason: string | null = null,
+): void {
   const key = keeperKey(keeperName)
   if (!key) return
   updateHydrationState(key, current => ({
     ...current,
     inFlight: Math.max(0, current.inFlight - 1),
     failed: true,
+    failureReason: reason,
+    lastCompletedAtMs: Date.now(),
   }))
 }
 
@@ -124,6 +155,38 @@ export function toolCallOutputsCoveredThroughMs(keeperName: string): number | nu
 export function toolCallOutputsCoveredSinceMs(keeperName: string): number | null {
   const key = keeperKey(keeperName)
   return key ? (toolCallOutputHydrationByKeeper.value[key]?.coveredSinceMs ?? null) : null
+}
+
+export function toolCallOutputHydrationStatus(keeperName: string): ToolCallOutputHydrationStatus {
+  const key = keeperKey(keeperName)
+  if (!key) return 'idle'
+  const state = toolCallOutputHydrationByKeeper.value[key]
+  if (!state) return 'idle'
+  if (state.inFlight > 0) return 'hydrating'
+  if (state.failed) return 'failed'
+  if (state.coveredThroughMs != null) return 'hydrated'
+  return 'idle'
+}
+
+export function toolCallOutputHydrationFailureReason(keeperName: string): string | null {
+  const key = keeperKey(keeperName)
+  return key ? (toolCallOutputHydrationByKeeper.value[key]?.failureReason ?? null) : null
+}
+
+export function toolCallOutputHydrationContract(
+  keeperName: string,
+): ToolCallOutputHydrationContract {
+  const key = keeperKey(keeperName)
+  const state = key ? toolCallOutputHydrationByKeeper.value[key] : undefined
+  return {
+    source: 'tool_calls_endpoint',
+    status: key ? toolCallOutputHydrationStatus(key) : 'idle',
+    failureReason: state?.failureReason ?? null,
+    startedAtMs: state?.lastStartedAtMs ?? null,
+    completedAtMs: state?.lastCompletedAtMs ?? null,
+    coveredSinceMs: state?.coveredSinceMs ?? null,
+    coveredThroughMs: state?.coveredThroughMs ?? null,
+  }
 }
 
 /** Merge tool-call entries into the store, keyed by tool_use_id. Entries

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -897,6 +897,39 @@ export type KeeperConversationStreamState =
   | 'finalizing'
   | null
 
+export type KeeperConversationStreamContractSource =
+  | 'keeper_chat_store'
+  | 'backend_turn_trace'
+  | 'rest_history'
+  | 'sse_event'
+  | 'queue_event'
+  | 'queue_poll'
+  | 'pending_request_store'
+  | 'client_local_send'
+  | 'client_reconciliation'
+
+export type KeeperConversationStreamContractStatus =
+  | 'backend_stream_event'
+  | 'backend_terminal_event'
+  | 'backend_trace_join'
+  | 'history_without_turn_ref'
+  | 'history_without_stream_events'
+  | 'queue_request_event'
+  | 'queue_poll_result'
+  | 'client_placeholder'
+  | 'client_reconciled_history'
+  | 'contract_gap'
+
+export interface KeeperConversationStreamContract {
+  source: KeeperConversationStreamContractSource
+  status: KeeperConversationStreamContractStatus
+  eventName?: string | null
+  requestId?: string | null
+  turnRef?: string | null
+  traceEventCount?: number | null
+  reason?: string | null
+}
+
 export interface SurfaceRef {
   kind: 'dashboard' | 'discord' | 'slack' | 'github' | 'webhook' | 'agent' | 'gate' | string
   session_id?: string
@@ -928,6 +961,7 @@ export interface KeeperConversationEntry {
   turnRef?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
+  streamContract?: KeeperConversationStreamContract | null
   attachments?: KeeperConversationAttachment[]
   blocks?: ChatBlock[]
   traceSteps?: ChatTraceStep[]

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -899,6 +899,7 @@ export type KeeperConversationStreamState =
 
 export type KeeperConversationStreamContractSource =
   | 'keeper_chat_store'
+  | 'backend_stream_lifecycle'
   | 'backend_turn_trace'
   | 'rest_history'
   | 'sse_event'
@@ -911,6 +912,7 @@ export type KeeperConversationStreamContractSource =
 export type KeeperConversationStreamContractStatus =
   | 'backend_stream_event'
   | 'backend_terminal_event'
+  | 'backend_lifecycle_replay'
   | 'backend_trace_join'
   | 'history_without_turn_ref'
   | 'history_without_stream_events'
@@ -920,6 +922,11 @@ export type KeeperConversationStreamContractStatus =
   | 'client_reconciled_history'
   | 'contract_gap'
 
+export type KeeperConversationStreamDeliveryReceipt =
+  | 'client_observed_sse_event'
+  | 'server_lifecycle_replay_only'
+  | 'no_delivery_receipt'
+
 export interface KeeperConversationStreamContract {
   source: KeeperConversationStreamContractSource
   status: KeeperConversationStreamContractStatus
@@ -927,6 +934,8 @@ export interface KeeperConversationStreamContract {
   requestId?: string | null
   turnRef?: string | null
   traceEventCount?: number | null
+  lifecycleEvents?: string[] | null
+  deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
   reason?: string | null
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -971,6 +971,8 @@ export interface KeeperConversationEntry {
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   streamContract?: KeeperConversationStreamContract | null
+  queueSeq?: number | null
+  queueClientActionId?: string | null
   attachments?: KeeperConversationAttachment[]
   blocks?: ChatBlock[]
   traceSteps?: ChatTraceStep[]

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -248,6 +248,7 @@ let all_entries =
       ~meets_main_gate:true
       ~rationale:"Dedicated keeper roster, conversation, and context workspace."
       ~route_hash:"#keepers"
+      ~fixture_harness:"./scripts/harness_dashboard_keeper_chat_contract_smoke.sh"
       ~live_spotcheck:"/api/v1/keepers/composite"
       ~tool_name:"masc_operator_snapshot"
       ()

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -116,6 +116,28 @@ module Row_kind = struct
     | (Utterance | Transport_failure), _ -> false
 end
 
+type stream_lifecycle_event =
+  | Run_started
+  | Text_message_start
+  | Text_message_end
+  | Run_finished
+  | Run_error
+
+let stream_lifecycle_event_to_label = function
+  | Run_started -> "RUN_STARTED"
+  | Text_message_start -> "TEXT_MESSAGE_START"
+  | Text_message_end -> "TEXT_MESSAGE_END"
+  | Run_finished -> "RUN_FINISHED"
+  | Run_error -> "RUN_ERROR"
+
+let stream_lifecycle_event_of_label = function
+  | "RUN_STARTED" -> Some Run_started
+  | "TEXT_MESSAGE_START" -> Some Text_message_start
+  | "TEXT_MESSAGE_END" -> Some Text_message_end
+  | "RUN_FINISHED" -> Some Run_finished
+  | "RUN_ERROR" -> Some Run_error
+  | _ -> None
+
 type speaker_authority =
   | Owner
   | External
@@ -195,6 +217,11 @@ type chat_message = {
          inbound user lines (no turn yet) and rows written before §7.  A
          malformed persisted value is reported as a persistence read drop
          and reads as [None]; the row stays valid. *)
+  stream_lifecycle : stream_lifecycle_event list option;
+      (* K1f: closed list of server lifecycle events for the direct chat
+         stream response represented by this row. [None] means pre-K1f row or
+         no lifecycle proof. Malformed persisted values are reported and read
+         as [None], keeping the row valid. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -421,6 +448,38 @@ let blocks_fields = function
   | Some blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let stream_lifecycle_fields = function
+  | None | Some [] -> []
+  | Some events ->
+      [
+        ( "stream_lifecycle",
+          `List
+            (List.map
+               (fun event -> `String (stream_lifecycle_event_to_label event))
+               events) );
+      ]
+
+let parse_stream_lifecycle ~path json =
+  let invalid detail =
+    report_persistence_read_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+      ~path ~detail;
+    None
+  in
+  let rec parse_items acc = function
+    | [] -> Some (List.rev acc)
+    | `String label :: rest -> (
+        match stream_lifecycle_event_of_label label with
+        | Some event -> parse_items (event :: acc) rest
+        | None ->
+            invalid (Printf.sprintf "unknown stream_lifecycle event %S" label))
+    | _ :: _ -> invalid "stream_lifecycle contains non-string event"
+  in
+  match json with
+  | `List [] -> None
+  | `List items -> parse_items [] items
+  | _ -> invalid "stream_lifecycle field is not a list"
+
 (* R3: producer-assigned message id.  [encode_line] is the sole writer, so
    minting here makes it impossible to persist a row without an id.  The
    process-monotonic counter disambiguates the user/tool/assistant rows of
@@ -450,7 +509,8 @@ let legacy_message_id ~ts ~content =
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref ()
+    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref
+    ?stream_lifecycle ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -529,6 +589,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ audio_fields audio
     @ blocks_fields blocks
     @ opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string turn_ref)
+    @ stream_lifecycle_fields stream_lifecycle
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -555,6 +616,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ?(assistant_kind = Row_kind.Utterance)
     ?blocks
     ?turn_ref
+    ?stream_lifecycle
     ~(assistant_content : string)
     () =
   try
@@ -597,7 +659,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     in
     let asst_line =
       encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
-        ?conversation_id ~kind:assistant_kind ?blocks ?turn_ref ()
+        ?conversation_id ~kind:assistant_kind ?blocks ?turn_ref
+        ?stream_lifecycle ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -621,8 +684,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
 let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref () : (unit, string) result
-    =
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
+    (unit, string) result =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -632,7 +695,8 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ?turn_ref ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
+        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
     in
     Fs_compat.append_file path (line ^ "\n");
     Ok ()
@@ -651,10 +715,10 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
    failure is already counted + logged inside the [_result] variant). New callers
    that must surface the failure call [append_assistant_message_result] directly. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref () =
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () =
   ignore
     (append_assistant_message_result ~base_dir ~keeper_name ~content ?surface
-       ?conversation_id ?audio ?blocks ?turn_ref ()
+       ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
       : (unit, string) result)
 
 (* RFC-0226: inbound user line recorded at delivery time, before (and
@@ -891,6 +955,12 @@ let parse_line ~file_path (line : string) : chat_message option =
                 ~detail:(Printf.sprintf "invalid turn_ref %S" s);
               None)
     in
+    let stream_lifecycle =
+      match Json_util.assoc_member_opt "stream_lifecycle" json with
+      | None -> None
+      | Some stream_lifecycle_json ->
+          parse_stream_lifecycle ~path:file_path stream_lifecycle_json
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -923,7 +993,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              audio; blocks; mentions; kind; turn_ref }
+              audio; blocks; mentions; kind; turn_ref; stream_lifecycle }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -1139,6 +1209,14 @@ let blocks_fields_of_list = function
   | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let rec last_opt = function
+  | [] -> None
+  | [ x ] -> Some x
+  | _ :: rest -> last_opt rest
+
+let stream_delivery_receipt_field value =
+  [ ("delivery_receipt", `String value) ]
+
 let chat_stream_contract_json ~trace_lookup_available ~trace_block
     (m : chat_message) =
   let field key value = (key, value) in
@@ -1146,39 +1224,56 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
   let base_fields =
     opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string m.turn_ref)
   in
-  match m.turn_ref with
-  | None ->
+  match m.stream_lifecycle with
+  | Some (_ :: _ as events) ->
+      let labels = List.map stream_lifecycle_event_to_label events in
       `Assoc
-        ([ string_field "source" "keeper_chat_store"
-         ; string_field "status" "history_without_turn_ref"
+        ([ string_field "source" "backend_stream_lifecycle"
+         ; string_field "status" "backend_lifecycle_replay"
          ; string_field "reason"
-             "history row has no persisted turn_ref; no causal stream join is possible"
+             "history row records durable server stream lifecycle replay"
+         ; field "lifecycle_events"
+             (`List (List.map (fun label -> `String label) labels))
          ]
+        @ stream_delivery_receipt_field "server_lifecycle_replay_only"
+        @ opt_string_field "event_name" (last_opt labels)
         @ base_fields)
-  | Some _ -> (
-      match trace_block with
-      | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
-          `Assoc
-            ([ string_field "source" "backend_turn_trace"
-             ; string_field "status" "backend_trace_join"
-             ; string_field "reason"
-                 "turn_ref joined to retained trajectory/internal-history events"
-             ; field "trace_event_count" (`Int (List.length trace))
-             ]
-            @ base_fields)
-      | Some _ | None ->
-          let reason =
-            if trace_lookup_available then
-              "turn_ref persisted but no retained trajectory/internal-history events were available"
-            else
-              "history route served without trace enrichment"
-          in
+  | None | Some [] -> (
+      match m.turn_ref with
+      | None ->
           `Assoc
             ([ string_field "source" "keeper_chat_store"
-             ; string_field "status" "history_without_stream_events"
-             ; string_field "reason" reason
+             ; string_field "status" "history_without_turn_ref"
+             ; string_field "reason"
+                 "history row has no persisted turn_ref; no causal stream join is possible"
              ]
-            @ base_fields))
+            @ stream_delivery_receipt_field "no_delivery_receipt"
+            @ base_fields)
+      | Some _ -> (
+          match trace_block with
+          | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
+              `Assoc
+                ([ string_field "source" "backend_turn_trace"
+                 ; string_field "status" "backend_trace_join"
+                 ; string_field "reason"
+                     "turn_ref joined to retained trajectory/internal-history events"
+                 ; field "trace_event_count" (`Int (List.length trace))
+                 ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
+                @ base_fields)
+          | Some _ | None ->
+              let reason =
+                if trace_lookup_available then
+                  "turn_ref persisted but no retained trajectory/internal-history events were available"
+                else "history route served without trace enrichment"
+              in
+              `Assoc
+                ([ string_field "source" "keeper_chat_store"
+                 ; string_field "status" "history_without_stream_events"
+                 ; string_field "reason" reason
+                 ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
+                @ base_fields)))
 
 let to_json_array ?base_dir ?trace_block_by_turn_ref
     (messages : chat_message list) : Yojson.Safe.t =

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1119,17 +1119,19 @@ let audio_fields_with_expired ~base_dir audio =
       in
       [ ("audio", `Assoc (audio_to_json { a with expired })) ]
 
-let blocks_with_trace ~trace_block_by_turn_ref (m : chat_message) =
+let trace_block_for_turn ~trace_block_by_turn_ref (m : chat_message) =
+  match m.turn_ref, trace_block_by_turn_ref with
+  | Some turn_ref, Some trace_block_by_turn_ref -> trace_block_by_turn_ref turn_ref
+  | None, _ | Some _, None -> None
+
+let blocks_with_trace_block ~trace_block (m : chat_message) =
   let base =
     match m.blocks with
     | Some blocks -> blocks
     | None -> []
   in
-  match m.role, m.turn_ref, trace_block_by_turn_ref with
-  | Role.Assistant, Some turn_ref, Some trace_block_by_turn_ref -> (
-      match trace_block_by_turn_ref turn_ref with
-      | Some trace_block -> base @ [ trace_block ]
-      | None -> base)
+  match m.role, trace_block with
+  | Role.Assistant, Some trace_block -> base @ [ trace_block ]
   | _ -> base
 
 let blocks_fields_of_list = function
@@ -1137,11 +1139,53 @@ let blocks_fields_of_list = function
   | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let chat_stream_contract_json ~trace_lookup_available ~trace_block
+    (m : chat_message) =
+  let field key value = (key, value) in
+  let string_field key value = field key (`String value) in
+  let base_fields =
+    opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string m.turn_ref)
+  in
+  match m.turn_ref with
+  | None ->
+      `Assoc
+        ([ string_field "source" "keeper_chat_store"
+         ; string_field "status" "history_without_turn_ref"
+         ; string_field "reason"
+             "history row has no persisted turn_ref; no causal stream join is possible"
+         ]
+        @ base_fields)
+  | Some _ -> (
+      match trace_block with
+      | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
+          `Assoc
+            ([ string_field "source" "backend_turn_trace"
+             ; string_field "status" "backend_trace_join"
+             ; string_field "reason"
+                 "turn_ref joined to retained trajectory/internal-history events"
+             ; field "trace_event_count" (`Int (List.length trace))
+             ]
+            @ base_fields)
+      | Some _ | None ->
+          let reason =
+            if trace_lookup_available then
+              "turn_ref persisted but no retained trajectory/internal-history events were available"
+            else
+              "history route served without trace enrichment"
+          in
+          `Assoc
+            ([ string_field "source" "keeper_chat_store"
+             ; string_field "status" "history_without_stream_events"
+             ; string_field "reason" reason
+             ]
+            @ base_fields))
+
 let to_json_array ?base_dir ?trace_block_by_turn_ref
     (messages : chat_message list) : Yojson.Safe.t =
   `List
     (List.map
        (fun m ->
+         let trace_block = trace_block_for_turn ~trace_block_by_turn_ref m in
          `Assoc
            ([ ("id", `String m.id);
               ("role", `String (Role.to_label m.role));
@@ -1186,7 +1230,12 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                      ) atts in
                      [("attachments", `List att_json)])
               @ audio_fields_with_expired ~base_dir m.audio
-              @ blocks_fields_of_list (blocks_with_trace ~trace_block_by_turn_ref m)
+              @ [ ("stream_contract",
+                    chat_stream_contract_json
+                      ~trace_lookup_available:(Option.is_some trace_block_by_turn_ref)
+                      ~trace_block m )
+                ]
+              @ blocks_fields_of_list (blocks_with_trace_block ~trace_block m)
               @ opt_string_field "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -71,6 +71,16 @@ module Row_kind : sig
   val equal : t -> t -> bool
 end
 
+(** Closed, durable names for AG-UI lifecycle events recorded by the direct
+    Keeper chat stream. This is server lifecycle provenance, not a
+    client-delivery receipt. *)
+type stream_lifecycle_event =
+  | Run_started
+  | Text_message_start
+  | Text_message_end
+  | Run_finished
+  | Run_error
+
 (** Authority class of the human (or agent) whose message opened a
     turn. Derived structurally from the arrival route, never from
     message content: the authenticated dashboard route is [Owner];
@@ -174,6 +184,12 @@ type chat_message = {
           on inbound user lines (no turn yet) and rows written before §7.
           A malformed persisted value is reported as a persistence read
           drop and reads as [None]; the row stays valid. *)
+  stream_lifecycle : stream_lifecycle_event list option;
+      (** K1f: durable server lifecycle replay for the chat stream response
+          represented by this row. [None] means the row predates this field or
+          the writer could not prove lifecycle events. Malformed persisted
+          values are reported as persistence read drops and read as [None];
+          the row stays valid. *)
 }
 
 (** {1 I/O} *)
@@ -204,6 +220,7 @@ val append_turn :
   ?assistant_kind:Row_kind.t ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   assistant_content:string ->
   unit ->
   unit
@@ -221,6 +238,7 @@ val append_assistant_message_result :
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
   (unit, string) result
 
@@ -238,6 +256,7 @@ val append_assistant_message :
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
   unit
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -970,6 +970,20 @@ let process_single_turn ~connector_user_line_recorded_upstream
     (Run_started { run_id; thread_id });
   Keeper_chat_events.publish events
     (Text_message_start { message_id; role = Assistant });
+  let completed_stream_lifecycle =
+    [ Keeper_chat_store.Run_started
+    ; Keeper_chat_store.Text_message_start
+    ; Keeper_chat_store.Text_message_end
+    ; Keeper_chat_store.Run_finished
+    ]
+  in
+  let errored_stream_lifecycle =
+    [ Keeper_chat_store.Run_started
+    ; Keeper_chat_store.Text_message_start
+    ; Keeper_chat_store.Text_message_end
+    ; Keeper_chat_store.Run_error
+    ]
+  in
   let args = args_of_request payload in
   (* Stream model text deltas live with per-delta redaction — the same
      treatment ThinkingDelta and Tool_call_args already get in
@@ -1086,6 +1100,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
          ~keeper_name:payload.name
          ~content:(persisted_error_reply err)
          ~surface:chat_surface
+         ~stream_lifecycle:errored_stream_lifecycle
          ()
      else
        Keeper_chat_store.append_turn
@@ -1097,6 +1112,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
          ~speaker:chat_speaker
          ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
          ~assistant_content:(persisted_error_reply err)
+         ~stream_lifecycle:errored_stream_lifecycle
          ());
     Keeper_chat_broadcast.chat_appended
       ~keeper_name:payload.name ~source:chat_source
@@ -1222,6 +1238,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                        ~surface:chat_surface
                        ?blocks
                        ?turn_ref
+                       ~stream_lifecycle:completed_stream_lifecycle
                        ()
                    else
                      Keeper_chat_store.append_turn
@@ -1234,6 +1251,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                        ~assistant_content
                        ?blocks
                        ?turn_ref
+                       ~stream_lifecycle:completed_stream_lifecycle
                        ()
                  in
                  let broadcast_chat_appended ?content () =

--- a/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
@@ -100,8 +100,16 @@ const keeper = process.env.KEEPER_NAME;
 const chatPath = path.join(basePath, '.masc', 'keeper_chat', `${keeper}.jsonl`);
 const metaPath = path.join(basePath, '.masc', 'keepers', `${keeper}.json`);
 const turnRef = 'trace-chat-contract-smoke#7';
+const errorTurnRef = 'trace-chat-contract-smoke#8';
 
 const rows = [
+  {
+    id: 'smoke-legacy-user',
+    role: 'user',
+    content: 'legacy row without turn ref',
+    ts: 1783299999.999,
+    source: 'dashboard',
+  },
   {
     id: 'smoke-user',
     role: 'user',
@@ -132,6 +140,19 @@ const rows = [
       'TEXT_MESSAGE_START',
       'TEXT_MESSAGE_END',
       'RUN_FINISHED',
+    ],
+  },
+  {
+    id: 'smoke-error-assistant',
+    role: 'assistant',
+    content: 'Keeper request failed: Timeout after 630.0s',
+    ts: 1783300000.004,
+    source: 'dashboard',
+    kind: 'transport_failure',
+    turn_ref: errorTurnRef,
+    stream_lifecycle: [
+      'RUN_STARTED',
+      'RUN_ERROR',
     ],
   },
 ];
@@ -219,9 +240,12 @@ function requireContract(row, id) {
   if (!Array.isArray(rows)) throw new Error('history response is not an array');
 
   const byId = new Map(rows.map(row => [row.id, row]));
+  const legacyContract = requireContract(byId.get('smoke-legacy-user'), 'smoke-legacy-user');
   const userContract = requireContract(byId.get('smoke-user'), 'smoke-user');
   const toolContract = requireContract(byId.get('smoke-tool'), 'smoke-tool');
   const assistantContract = requireContract(byId.get('smoke-assistant'), 'smoke-assistant');
+  const errorRow = byId.get('smoke-error-assistant');
+  const errorContract = requireContract(errorRow, 'smoke-error-assistant');
 
   record('assistant row replays durable server lifecycle first', assistantContract.source === 'backend_stream_lifecycle' && assistantContract.status === 'backend_lifecycle_replay', assistantContract);
   record('assistant row labels replay as server-only receipt', assistantContract.delivery_receipt === 'server_lifecycle_replay_only', assistantContract);
@@ -238,6 +262,30 @@ function requireContract(row, id) {
   );
   record('user row has no client delivery receipt', userContract.delivery_receipt === 'no_delivery_receipt', userContract);
   record('tool row has no client delivery receipt', toolContract.delivery_receipt === 'no_delivery_receipt', toolContract);
+  record(
+    'legacy row without turn_ref is explicit no-receipt history gap',
+    legacyContract.source === 'keeper_chat_store'
+      && legacyContract.status === 'history_without_turn_ref'
+      && legacyContract.delivery_receipt === 'no_delivery_receipt',
+    legacyContract,
+  );
+  record('error assistant keeps typed transport-failure row kind', errorRow?.kind === 'transport_failure', errorRow);
+  record(
+    'error assistant row replays RUN_ERROR as server-only receipt',
+    errorContract.source === 'backend_stream_lifecycle'
+      && errorContract.status === 'backend_lifecycle_replay'
+      && errorContract.event_name === 'RUN_ERROR'
+      && errorContract.delivery_receipt === 'server_lifecycle_replay_only',
+    errorContract,
+  );
+  record(
+    'error assistant row preserves closed error lifecycle sequence',
+    JSON.stringify(errorContract.lifecycle_events) === JSON.stringify([
+      'RUN_STARTED',
+      'RUN_ERROR',
+    ]),
+    errorContract,
+  );
   record(
     'server history never claims dashboard client-observed SSE delivery',
     rows.every(row => row.stream_contract?.delivery_receipt !== 'client_observed_sse_event'),

--- a/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+pick_free_port() {
+  node <<'NODE'
+const net = require('net');
+const server = net.createServer();
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  console.log(address && typeof address === 'object' ? address.port : 8961);
+  server.close();
+});
+NODE
+}
+
+log() {
+  printf '[keeper-chat-contract-smoke] %s\n' "$*" >&2
+}
+
+run_with_timeout() {
+  local timeout_sec="$1"
+  local label="$2"
+  shift 2
+
+  "$@" &
+  local cmd_pid=$!
+
+  (
+    sleep "$timeout_sec"
+    if kill -0 "$cmd_pid" >/dev/null 2>&1; then
+      printf '[keeper-chat-contract-smoke] timeout after %ss: %s\n' "$timeout_sec" "$label" >&2
+      kill "$cmd_pid" >/dev/null 2>&1 || true
+    fi
+  ) &
+  local watchdog_pid=$!
+
+  local status=0
+  wait "$cmd_pid" || status=$?
+  kill "$watchdog_pid" >/dev/null 2>&1 || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  return "$status"
+}
+
+PORT="${PORT:-$(pick_free_port)}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}/dashboard/}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-keeper-chat-contract.XXXXXX")}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+KEEP_BASE_PATH="${KEEP_BASE_PATH:-0}"
+KEEPER_NAME="${KEEPER_NAME:-chat-contract-smoke}"
+SERVER_LOG="${SERVER_LOG:-${BASE_PATH}/keeper-chat-contract-server.log}"
+SERVER_EXE="${SERVER_EXE:-$REPO_ROOT/_build/default/bin/main_eio.exe}"
+SERVER_WAIT_SEC="${SERVER_WAIT_SEC:-45}"
+CONTRACT_TIMEOUT_SEC="${CONTRACT_TIMEOUT_SEC:-30}"
+CONTRACT_SCRIPT="${CONTRACT_SCRIPT:-${BASE_PATH}/keeper-chat-contract.smoke.js}"
+RUNTIME_CONFIG_SOURCE="${RUNTIME_CONFIG_SOURCE:-$REPO_ROOT/config/runtime.toml}"
+
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    if [ "$KEEP_SERVER" = "1" ]; then
+      echo "Keeping server running: pid=$SERVER_PID log=$SERVER_LOG"
+    else
+      kill "$SERVER_PID" >/dev/null 2>&1 || true
+      wait "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [ "$KEEP_BASE_PATH" != "1" ]; then
+    rm -rf "$BASE_PATH"
+  else
+    echo "Keeping fixture base path: $BASE_PATH"
+  fi
+}
+
+trap cleanup EXIT
+
+if [ ! -f "$RUNTIME_CONFIG_SOURCE" ]; then
+  echo "Runtime config seed missing: $RUNTIME_CONFIG_SOURCE" >&2
+  exit 1
+fi
+
+mkdir -p "$BASE_PATH/.masc/config/keepers" "$BASE_PATH/.masc/keepers" "$BASE_PATH/.masc/keeper_chat"
+cp "$RUNTIME_CONFIG_SOURCE" "$BASE_PATH/.masc/config/runtime.toml"
+
+cat >"$BASE_PATH/.masc/config/keepers/${KEEPER_NAME}.toml" <<EOF_TOML
+[keeper]
+autoboot_enabled = false
+EOF_TOML
+
+KEEPER_NAME="$KEEPER_NAME" BASE_PATH="$BASE_PATH" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.env.BASE_PATH;
+const keeper = process.env.KEEPER_NAME;
+const chatPath = path.join(basePath, '.masc', 'keeper_chat', `${keeper}.jsonl`);
+const metaPath = path.join(basePath, '.masc', 'keepers', `${keeper}.json`);
+const turnRef = 'trace-chat-contract-smoke#7';
+
+const rows = [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'prove server lifecycle replay',
+    ts: 1783300000.001,
+    source: 'dashboard',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-tool',
+    role: 'tool',
+    content: '{}',
+    ts: 1783300000.002,
+    source: 'dashboard',
+    tool_call_id: 'toolu_smoke_contract',
+    tool_call_name: 'keeper_context_status',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-assistant',
+    role: 'assistant',
+    content: 'contract replay complete',
+    ts: 1783300000.003,
+    source: 'dashboard',
+    turn_ref: turnRef,
+    stream_lifecycle: [
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ],
+  },
+];
+
+fs.writeFileSync(chatPath, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+fs.writeFileSync(metaPath, `${JSON.stringify({
+  name: keeper,
+  agent_name: `${keeper}-agent`,
+  trace_id: 'trace-chat-contract-smoke',
+  goal: 'fixture keeper for dashboard chat contract smoke',
+  tool_access: [],
+})}\n`);
+NODE
+
+log "base_path=$BASE_PATH port=$PORT keeper=$KEEPER_NAME"
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-45}"
+  local i=1
+  while [ "$i" -le "$attempts" ]; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      log "http ready: $url"
+      return 0
+    fi
+    if [ $((i % 5)) -eq 0 ]; then
+      log "waiting for http ($i/$attempts): $url"
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+log "starting server"
+if [ -x "$SERVER_EXE" ]; then
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+else
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$REPO_ROOT/start-masc.sh" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+fi
+SERVER_PID=$!
+log "server_pid=$SERVER_PID log=$SERVER_LOG"
+
+if ! wait_for_http "http://${HOST}:${PORT}/health" "$SERVER_WAIT_SEC"; then
+  echo "MASC server did not become healthy. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+cat >"$CONTRACT_SCRIPT" <<'NODE'
+const base = process.env.BASE_URL;
+const keeper = process.env.KEEPER_NAME;
+const checks = [];
+
+function record(name, pass, details = {}) {
+  checks.push({ name, pass, details });
+}
+
+function requireContract(row, id) {
+  if (!row || !row.stream_contract) {
+    throw new Error(`missing stream_contract for ${id}`);
+  }
+  return row.stream_contract;
+}
+
+(async () => {
+  const historyUrl = new URL(`/api/v1/keepers/${encodeURIComponent(keeper)}/chat/history`, base);
+  const res = await fetch(historyUrl);
+  record('history endpoint returns 200', res.ok, { status: res.status });
+  if (!res.ok) throw new Error(`history endpoint failed: ${res.status} ${res.statusText}`);
+
+  const rows = await res.json();
+  record('history response is an array', Array.isArray(rows), { length: Array.isArray(rows) ? rows.length : null });
+  if (!Array.isArray(rows)) throw new Error('history response is not an array');
+
+  const byId = new Map(rows.map(row => [row.id, row]));
+  const userContract = requireContract(byId.get('smoke-user'), 'smoke-user');
+  const toolContract = requireContract(byId.get('smoke-tool'), 'smoke-tool');
+  const assistantContract = requireContract(byId.get('smoke-assistant'), 'smoke-assistant');
+
+  record('assistant row replays durable server lifecycle first', assistantContract.source === 'backend_stream_lifecycle' && assistantContract.status === 'backend_lifecycle_replay', assistantContract);
+  record('assistant row labels replay as server-only receipt', assistantContract.delivery_receipt === 'server_lifecycle_replay_only', assistantContract);
+  record('assistant row exposes terminal lifecycle event', assistantContract.event_name === 'RUN_FINISHED', assistantContract);
+  record(
+    'assistant row preserves closed lifecycle sequence',
+    JSON.stringify(assistantContract.lifecycle_events) === JSON.stringify([
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ]),
+    assistantContract,
+  );
+  record('user row has no client delivery receipt', userContract.delivery_receipt === 'no_delivery_receipt', userContract);
+  record('tool row has no client delivery receipt', toolContract.delivery_receipt === 'no_delivery_receipt', toolContract);
+  record(
+    'server history never claims dashboard client-observed SSE delivery',
+    rows.every(row => row.stream_contract?.delivery_receipt !== 'client_observed_sse_event'),
+    rows.map(row => ({ id: row.id, delivery_receipt: row.stream_contract?.delivery_receipt })),
+  );
+
+  console.log(JSON.stringify({ base, keeper, checks }, null, 2));
+  const failed = checks.filter(check => !check.pass);
+  if (failed.length > 0) process.exit(1);
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+NODE
+
+log "running contract smoke"
+if ! run_with_timeout "$CONTRACT_TIMEOUT_SEC" "keeper chat contract smoke" \
+  env BASE_URL="$BASE_URL" KEEPER_NAME="$KEEPER_NAME" node "$CONTRACT_SCRIPT"; then
+  echo "Keeper chat contract smoke failed. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+log "keeper chat contract smoke passed"

--- a/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5186}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-interleave-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-mobile.png"
+TRACE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace.png"
+JOINED_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-joined-tool.png"
+TRACE_ONLY_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace-only-tool.png"
+CHAT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-chat.png"
+
+ORDER_SIGNATURE='trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+STATUS_SELECTOR="[data-interleave-contract-fixture-status=\"ok\"][data-interleave-order-signature=\"${ORDER_SIGNATURE}\"][data-interleave-joined-tool-count=\"1\"][data-interleave-trace-only-tool-count=\"1\"]"
+TRACE_SELECTOR="[data-chat-work-trace][data-chat-turn-order-signature=\"${ORDER_SIGNATURE}\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783261210000\"]"
+JOINED_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="1"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-context"][data-chat-trace-entry-id="tool-tc-context"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="ok"][data-chat-trace-output-coverage="covered"]'
+TRACE_ONLY_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="3"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-missing"][data-chat-trace-link-state="trace-only"][data-chat-trace-output-state="pending"]'
+CHAT_SELECTOR='[data-chat-trace-step="chat"][data-chat-turn-order-index="4"][data-chat-turn-order-kind="chat"][data-chat-trace-entry-id="assistant-interleave"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${JOINED_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${JOINED_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_ONLY_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_ONLY_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${CHAT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${CHAT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat interleave contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'trace_screenshot=%s\n' "${TRACE_SCREENSHOT}"
+printf 'joined_tool_screenshot=%s\n' "${JOINED_TOOL_SCREENSHOT}"
+printf 'trace_only_tool_screenshot=%s\n' "${TRACE_ONLY_TOOL_SCREENSHOT}"
+printf 'chat_screenshot=%s\n' "${CHAT_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5184}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-replay-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-mobile.png"
+SERVER_REPLAY_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-server-replay.png"
+NO_TURN_REF_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-no-turn-ref.png"
+QUEUE_PLACEHOLDER_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-placeholder.png"
+QUEUE_RESULT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-result.png"
+LIVE_TERMINAL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-live-terminal.png"
+
+STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]'
+SERVER_REPLAY_SELECTOR='[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]'
+NO_TURN_REF_SELECTOR='[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]'
+QUEUE_PLACEHOLDER_SELECTOR='[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+QUEUE_RESULT_SELECTOR='[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+LIVE_TERMINAL_SELECTOR='[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${SERVER_REPLAY_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${SERVER_REPLAY_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${NO_TURN_REF_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${NO_TURN_REF_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_PLACEHOLDER_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_RESULT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_RESULT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${LIVE_TERMINAL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${LIVE_TERMINAL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat replay contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'queue_placeholder_screenshot=%s\n' "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+printf 'queue_result_screenshot=%s\n' "${QUEUE_RESULT_SCREENSHOT}"
+printf 'live_terminal_screenshot=%s\n' "${LIVE_TERMINAL_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5187}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-tool-output-failure-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
+HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
+COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+HYDRATION_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-expanded.png"
+COVERAGE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-expanded.png"
+MOBILE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-mobile-expanded.png"
+BROWSER_SCRIPT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-interaction-${PORT}.py"
+
+HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
+COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
+STATUS_SELECTOR='[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+HYDRATION_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"hydration-failed\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${HYDRATION_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"failed\"][data-chat-tool-output-hydration-failure=\"tool_calls_endpoint_502\"]"
+HYDRATION_TOOL_SELECTOR='[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-hydration-failed"][data-chat-trace-entry-id="tool-tc-hydration-failed"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+COVERAGE_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"coverage-gap\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${COVERAGE_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783264270000\"]"
+COVERAGE_TOOL_SELECTOR='[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-coverage-gap"][data-chat-trace-entry-id="tool-tc-coverage-gap"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+PLAYWRIGHT_PYTHON="${PLAYWRIGHT_PYTHON:-}"
+PLAYWRIGHT_PYTHON_CMD=()
+if [[ -n "${PLAYWRIGHT_PYTHON}" ]]; then
+  PLAYWRIGHT_PYTHON_CMD=("${PLAYWRIGHT_PYTHON}")
+elif pnpm --dir "${DASHBOARD_DIR}" exec python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(pnpm --dir "${DASHBOARD_DIR}" exec python3)
+elif python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(python3)
+else
+  echo "Python Playwright module not found. Set PLAYWRIGHT_PYTHON=/abs/path/to/python with playwright installed." >&2
+  exit 1
+fi
+
+cat >"${BROWSER_SCRIPT}" <<'PY'
+import os
+from playwright.sync_api import sync_playwright
+
+fixture_url = os.environ["FIXTURE_URL"]
+hydration_expanded_screenshot = os.environ["HYDRATION_EXPANDED_SCREENSHOT"]
+coverage_expanded_screenshot = os.environ["COVERAGE_EXPANDED_SCREENSHOT"]
+mobile_expanded_screenshot = os.environ["MOBILE_EXPANDED_SCREENSHOT"]
+status_selector = '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+hydration_tool_selector = '[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+coverage_tool_selector = '[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+hydration_explanation = '출력 hydration 실패 — tool_calls_endpoint_502'
+coverage_explanation = '출력 tail 범위 밖'
+expected_title = 'MASC - Keeper Chat Tool Output Failure Contract Fixture'
+
+
+def assert_visible_text(page, text):
+    page.wait_for_function(
+        "expected => document.body.innerText.includes(expected)",
+        arg=text,
+        timeout=10_000,
+    )
+
+
+def open_tool(page, selector):
+    page.locator(f"{selector} .chat-block-tstep-row").click()
+
+
+def verify_page_health(page):
+    page.goto(fixture_url, wait_until="domcontentloaded", timeout=20_000)
+    page.wait_for_selector(status_selector, timeout=15_000)
+    title = page.title()
+    if title != expected_title:
+        raise RuntimeError(f"unexpected title: {title}")
+    body_text = page.locator("body").inner_text()
+    if "Tool output failures are explicit" not in body_text:
+        raise RuntimeError("fixture body did not render expected heading")
+    if page.locator("vite-error-overlay, [data-nextjs-dialog-overlay]").count() > 0:
+        raise RuntimeError("framework error overlay detected")
+
+
+with sync_playwright() as pw:
+    browser = pw.chromium.launch(headless=True)
+    browser_errors = []
+
+    desktop_context = browser.new_context(viewport={"width": 1440, "height": 900})
+    desktop = desktop_context.new_page()
+    desktop.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    desktop.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(desktop)
+    open_tool(desktop, hydration_tool_selector)
+    assert_visible_text(desktop, hydration_explanation)
+    desktop.screenshot(path=hydration_expanded_screenshot, full_page=False)
+
+    open_tool(desktop, coverage_tool_selector)
+    assert_visible_text(desktop, coverage_explanation)
+    desktop.screenshot(path=coverage_expanded_screenshot, full_page=False)
+    desktop_context.close()
+
+    mobile_context = browser.new_context(viewport={"width": 390, "height": 844})
+    mobile = mobile_context.new_page()
+    mobile.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    mobile.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(mobile)
+    open_tool(mobile, hydration_tool_selector)
+    assert_visible_text(mobile, hydration_explanation)
+    open_tool(mobile, coverage_tool_selector)
+    assert_visible_text(mobile, coverage_explanation)
+    mobile.screenshot(path=mobile_expanded_screenshot, full_page=False)
+    mobile_context.close()
+
+    browser.close()
+
+    if browser_errors:
+        raise RuntimeError(f"browser console/page errors: {' | '.join(browser_errors)}")
+
+print('pass\tfixture page identity, nonblank body, and no framework overlay')
+print('pass\tdesktop hydration-failed row expands visible explanation')
+print('pass\tdesktop coverage-gap row expands visible explanation')
+print('pass\tmobile hydration-failed and coverage-gap rows expand visible explanations')
+PY
+
+env \
+  FIXTURE_URL="${FIXTURE_URL}" \
+  HYDRATION_EXPANDED_SCREENSHOT="${HYDRATION_EXPANDED_SCREENSHOT}" \
+  COVERAGE_EXPANDED_SCREENSHOT="${COVERAGE_EXPANDED_SCREENSHOT}" \
+  MOBILE_EXPANDED_SCREENSHOT="${MOBILE_EXPANDED_SCREENSHOT}" \
+  "${PLAYWRIGHT_PYTHON_CMD[@]}" "${BROWSER_SCRIPT}"
+
+printf 'keeper chat tool output failure contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
+printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"
+printf 'hydration_expanded_screenshot=%s\n' "${HYDRATION_EXPANDED_SCREENSHOT}"
+printf 'coverage_expanded_screenshot=%s\n' "${COVERAGE_EXPANDED_SCREENSHOT}"
+printf 'mobile_expanded_screenshot=%s\n' "${MOBILE_EXPANDED_SCREENSHOT}"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1517,6 +1517,117 @@ let test_to_json_array_appends_trace_block_to_assistant_turn () =
           (last |> member "trace" |> to_list |> List.length)
       | None -> Alcotest.fail "assistant json missing blocks")
 
+let assistant_row rows =
+  List.find
+    (function
+      | `Assoc fields -> (
+          match List.assoc_opt "role" fields with
+          | Some (`String "assistant") -> true
+          | _ -> false)
+      | _ -> false)
+    rows
+
+let stream_contract_of row =
+  let open Yojson.Safe.Util in
+  member "stream_contract" row
+
+let test_to_json_array_stream_contract_without_turn_ref () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-legacy" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-legacy" in
+      K.append_user_message ~base_dir ~keeper_name ~content:"legacy hi" ();
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array (K.load ~base_dir ~keeper_name))
+      in
+      match rows with
+      | [ row ] ->
+          let open Yojson.Safe.Util in
+          let contract = stream_contract_of row in
+          Alcotest.(check string) "source" "keeper_chat_store"
+            (contract |> member "source" |> to_string);
+          Alcotest.(check string) "status" "history_without_turn_ref"
+            (contract |> member "status" |> to_string);
+          Alcotest.(check bool) "reason says no turn_ref" true
+            (contains_substring
+               (contract |> member "reason" |> to_string)
+               "no persisted turn_ref")
+      | other ->
+          Alcotest.failf "expected one row, got %d" (List.length other))
+
+let test_to_json_array_stream_contract_trace_join () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-trace" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-trace" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-stream" ~absolute_turn:5 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref then
+          Some
+            (B.Trace
+               { trace =
+                   [ B.Trace_think
+                       { text = "thinking";
+                         ts = Some "2026-07-05T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "backend_turn_trace"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "backend_trace_join"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-stream#5"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check int) "trace event count" 1
+        (contract |> member "trace_event_count" |> to_int))
+
+let test_to_json_array_stream_contract_trace_unavailable () =
+  let base_dir =
+    temp_base_path "keeper-chat-store-stream-contract-no-trace"
+  in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-no-trace" in
+      let tref =
+        Ids.Turn_ref.make ~trace_id:"trace-no-events" ~absolute_turn:9
+      in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref _turn_ref = None in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "keeper_chat_store"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "history_without_stream_events"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-no-events#9"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check bool) "reason says no retained trace" true
+        (contains_substring
+           (contract |> member "reason" |> to_string)
+           "no retained trajectory/internal-history events"))
+
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
 let test_turn_ref_malformed_reads_none () =
@@ -1656,6 +1767,12 @@ let () =
             test_append_assistant_message_redacts_audio;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
+          Alcotest.test_case "history stream contract marks no turn_ref" `Quick
+            test_to_json_array_stream_contract_without_turn_ref;
+          Alcotest.test_case "history stream contract joins turn trace" `Quick
+            test_to_json_array_stream_contract_trace_join;
+          Alcotest.test_case "history stream contract marks missing trace" `Quick
+            test_to_json_array_stream_contract_trace_unavailable;
         ] );
       ( "row_kind",
         [

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1550,6 +1550,8 @@ let test_to_json_array_stream_contract_without_turn_ref () =
             (contract |> member "source" |> to_string);
           Alcotest.(check string) "status" "history_without_turn_ref"
             (contract |> member "status" |> to_string);
+          Alcotest.(check string) "delivery receipt absent" "no_delivery_receipt"
+            (contract |> member "delivery_receipt" |> to_string);
           Alcotest.(check bool) "reason says no turn_ref" true
             (contains_substring
                (contract |> member "reason" |> to_string)
@@ -1593,6 +1595,9 @@ let test_to_json_array_stream_contract_trace_join () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-stream#5"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "trace join is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check int) "trace event count" 1
         (contract |> member "trace_event_count" |> to_int))
 
@@ -1623,10 +1628,122 @@ let test_to_json_array_stream_contract_trace_unavailable () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-no-events#9"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "missing trace is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check bool) "reason says no retained trace" true
         (contains_substring
            (contract |> member "reason" |> to_string)
            "no retained trajectory/internal-history events"))
+
+let json_string_list json =
+  Yojson.Safe.Util.to_list json |> List.map Yojson.Safe.Util.to_string
+
+let test_to_json_array_stream_contract_lifecycle_replay () =
+  let base_dir =
+    temp_base_path "keeper-chat-store-stream-contract-lifecycle"
+  in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-lifecycle" in
+      let tref =
+        Ids.Turn_ref.make ~trace_id:"trace-lifecycle" ~absolute_turn:6
+      in
+      let stream_lifecycle =
+        [ K.Run_started
+        ; K.Text_message_start
+        ; K.Text_message_end
+        ; K.Run_finished
+        ]
+      in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[]
+        ~tool_calls:[ { K.call_id = "toolu_life"; call_name = "Read"; args = "{}" } ]
+        ~turn_ref:tref ~stream_lifecycle ~assistant_content:"done" ();
+      (match K.load ~base_dir ~keeper_name with
+       | [ user; tool; assistant ] ->
+           Alcotest.(check bool) "user row carries no stream lifecycle" true
+             (Option.is_none user.stream_lifecycle);
+           Alcotest.(check bool) "tool row carries no stream lifecycle" true
+             (Option.is_none tool.stream_lifecycle);
+           Alcotest.(check (option (list string)))
+             "stream lifecycle roundtrips on assistant row"
+             (Some
+                [ "RUN_STARTED"
+                ; "TEXT_MESSAGE_START"
+                ; "TEXT_MESSAGE_END"
+                ; "RUN_FINISHED"
+                ])
+             (Option.map
+                (List.map (fun event ->
+                   match event with
+                   | K.Run_started -> "RUN_STARTED"
+                   | K.Text_message_start -> "TEXT_MESSAGE_START"
+                   | K.Text_message_end -> "TEXT_MESSAGE_END"
+                   | K.Run_finished -> "RUN_FINISHED"
+                   | K.Run_error -> "RUN_ERROR"))
+                assistant.stream_lifecycle)
+       | messages ->
+           Alcotest.failf "expected user/tool/assistant rows, got %d"
+             (List.length messages));
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref then
+          Some
+            (B.Trace
+               { trace =
+                   [ B.Trace_think
+                       { text = "retained trace";
+                         ts = Some "2026-07-05T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "backend_stream_lifecycle"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "backend_lifecycle_replay"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "terminal event" "RUN_FINISHED"
+        (contract |> member "event_name" |> to_string);
+      Alcotest.(check string) "lifecycle replay is server-side only"
+        "server_lifecycle_replay_only"
+        (contract |> member "delivery_receipt" |> to_string);
+      Alcotest.(check (list string)) "lifecycle events"
+        [ "RUN_STARTED"; "TEXT_MESSAGE_START"; "TEXT_MESSAGE_END"; "RUN_FINISHED" ]
+        (json_string_list (contract |> member "lifecycle_events")))
+
+let test_malformed_stream_lifecycle_reads_none () =
+  let base_dir = temp_base_path "keeper-chat-store-lifecycle-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-store-lifecycle-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"assistant","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
+        ^ "\n");
+      (match K.load ~base_dir ~keeper_name with
+       | [ m ] ->
+           Alcotest.(check bool) "malformed lifecycle reads as None" true
+             (Option.is_none m.stream_lifecycle);
+           Alcotest.(check bool) "turn_ref still parsed" true
+             (Option.is_some m.turn_ref)
+       | messages ->
+           Alcotest.failf "expected 1 message, got %d" (List.length messages));
+      Alcotest.(check (float 0.001)) "drop counted as invalid payload"
+        1.0
+        (drop_value invalid_payload -. before))
 
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
@@ -1773,6 +1890,10 @@ let () =
             test_to_json_array_stream_contract_trace_join;
           Alcotest.test_case "history stream contract marks missing trace" `Quick
             test_to_json_array_stream_contract_trace_unavailable;
+          Alcotest.test_case "history stream contract replays durable lifecycle" `Quick
+            test_to_json_array_stream_contract_lifecycle_replay;
+          Alcotest.test_case "malformed stream lifecycle reads as None" `Quick
+            test_malformed_stream_lifecycle_reads_none;
         ] );
       ( "row_kind",
         [

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -65,6 +65,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   ; kind
   ; turn_ref = None
+  ; stream_lifecycle = None
   }
 ;;
 
@@ -205,6 +206,7 @@ let tool_line : Store.chat_message =
   ; mentions = []
   ; kind = Store.Row_kind.Utterance
   ; turn_ref = None
+  ; stream_lifecycle = None
   }
 ;;
 

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -29,6 +29,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     mentions = [];
     kind = Store.Row_kind.Utterance;
     turn_ref = None;
+    stream_lifecycle = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## Summary

- expose stream lifecycle state on rendered Keeper Chat entries and turn timeline cards
- expose tool-output hydration coverage intervals on turn timeline cards
- split settled-but-outside-output-tail tool calls from ordinary pending calls as `coverage-gap`, with a visible warning dot/header label instead of silent pending

## Stack

- Base: `codex/chat-trace-provenance-20260705` / #23287
- Head: `codex/chat-stream-lifecycle-20260705`

## Validation

- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/chat/primitives-interleave.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
- `pnpm --dir dashboard run build`
- Rendered smoke via Chrome CDP against `http://127.0.0.1:5179/dashboard/keepers?keeper=verifier`
  - desktop 1440x1000 and mobile 390x844
  - page title `MASC · Keepers`, no framework overlay, no console errors
  - metadata toggle found/clicked
  - live verifier transcript rendered 100 `[data-chat-entry-id]`, 4 `[data-chat-tool-trace]`, and 23 `[data-chat-trace-step]` rows
  - entries carried `data-chat-stream-state=complete`
  - turn timelines carried `data-chat-turn-stream-state=complete`, `data-chat-turn-complete=true`, and tool-output coverage interval attrs
  - stale live tool rows surfaced as `data-chat-trace-output-state=coverage-gap` / `data-chat-trace-output-coverage=coverage-gap`
