### PR TITLE
[codex] Expose Keeper Chat stream contract gaps

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -86,6 +86,35 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.turn_ref).toBe('trace-1780648779957-00000#4071')
   })
 
+  it('passes the backend stream contract read model through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-1780648779957-00000#4071',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      }),
+    )
+    expect(out?.stream_contract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turn_ref: 'trace-1780648779957-00000#4071',
+      trace_event_count: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('returns null when stream_contract has the wrong shape', () => {
+    expect(
+      safeParseKeeperChatHistoryMessage(
+        validMessage({ stream_contract: { source: 'backend_turn_trace' } }),
+      ),
+    ).toBeNull()
+  })
+
   it('leaves turn_ref undefined on legacy rows without dropping the message', () => {
     const out = safeParseKeeperChatHistoryMessage(validMessage())
     expect(out).not.toBeNull()
@@ -200,6 +229,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
           { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
           { t: 'link', url: 'https://example.com', title: 'Example' },
+          {
+            t: 'trace',
+            trace: [
+              { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+              { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+            ],
+          },
+          { t: 'thinking', content: '', redacted: true },
         ],
       }),
     )
@@ -211,6 +248,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
       { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
       { t: 'link', url: 'https://example.com', title: 'Example' },
+      {
+        t: 'trace',
+        trace: [
+          { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+          { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+        ],
+      },
+      { t: 'thinking', content: '', redacted: true },
     ])
   })
 

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -89,6 +89,35 @@ const KeeperChatTableCellSchema = union([
   }),
 ])
 
+const KeeperChatTraceStepSchema = union([
+  object({
+    kind: literal('think'),
+    text: string(),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+  object({
+    kind: literal('reason'),
+    text: string(),
+    detail: optional(string()),
+    ts: optional(string()),
+  }),
+  object({
+    kind: literal('tool'),
+    name: string(),
+    tool_call_id: optional(string()),
+    toolCallId: optional(string()),
+    status: optional(union([literal('pending'), literal('ok'), literal('err')])),
+    dur: optional(string()),
+    args: optional(unknown()),
+    result: optional(unknown()),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+])
+
 // RFC-0235 P3: server-parsed rich chat blocks carried on persisted history
 // rows. Keep this aligned with keeper_chat_blocks.ml and the dashboard
 // renderer's ChatBlock union; malformed block arrays cause the whole row to be
@@ -174,9 +203,34 @@ export const KeeperChatBlockSchema = union([
     board_post_id: string(),
     run_id: optional(string()),
   }),
+  object({
+    t: literal('trace'),
+    trace: array(KeeperChatTraceStepSchema),
+  }),
+  object({
+    t: literal('thinking'),
+    content: string(),
+    redacted: optional(boolean()),
+  }),
 ])
 
 export type KeeperChatBlock = InferOutput<typeof KeeperChatBlockSchema>
+
+export const KeeperChatHistoryStreamContractSchema = object({
+  source: string(),
+  status: string(),
+  event_name: optional(string()),
+  eventName: optional(string()),
+  request_id: optional(string()),
+  requestId: optional(string()),
+  turn_ref: optional(string()),
+  turnRef: optional(string()),
+  trace_event_count: optional(number()),
+  traceEventCount: optional(number()),
+  reason: optional(string()),
+})
+
+export type KeeperChatHistoryStreamContract = InferOutput<typeof KeeperChatHistoryStreamContractSchema>
 
 export const KeeperChatHistoryMessageSchema = object({
   // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
@@ -234,6 +288,11 @@ export const KeeperChatHistoryMessageSchema = object({
   // so a reload can tell a failed request apart from a real keeper reply;
   // open string() per the same deploy-window rationale as `role`.
   kind: optional(string()),
+  // K1e read model: backend-owned provenance for what a history row can prove
+  // about the stream/turn lifecycle. Kept optional for deploy windows and
+  // legacy endpoints; consumers fall back to explicit "history without stream
+  // events" instead of inventing a lifecycle.
+  stream_contract: optional(KeeperChatHistoryStreamContractSchema),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -192,9 +192,11 @@ describe('ChatTranscript', () => {
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
             streamContract: {
-              source: 'rest_history',
-              status: 'history_without_stream_events',
-              reason: 'history rows do not carry stream lifecycle events',
+              source: 'backend_turn_trace',
+              status: 'backend_trace_join',
+              turnRef: 'trace-ui#9',
+              traceEventCount: 2,
+              reason: 'turn_ref joined to retained trajectory/internal-history events',
             },
             surface: {
               kind: 'discord',
@@ -217,8 +219,10 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
-    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
-    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_turn_trace')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_trace_join')
+    expect(bubble.getAttribute('data-chat-stream-contract-turn-ref')).toBe('trace-ui#9')
+    expect(bubble.getAttribute('data-chat-stream-contract-trace-events')).toBe('2')
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -191,6 +191,11 @@ describe('ChatTranscript', () => {
             text: 'channel reply',
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
+            streamContract: {
+              source: 'rest_history',
+              status: 'history_without_stream_events',
+              reason: 'history rows do not carry stream lifecycle events',
+            },
             surface: {
               kind: 'discord',
               guild_id: 'guild-1',
@@ -212,6 +217,8 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })
@@ -225,6 +232,11 @@ describe('ChatTranscript', () => {
             label: 'keeper_context_status',
             turnRef: 'trace-tool#3',
             delivery: 'history',
+            streamContract: {
+              source: 'rest_history',
+              status: 'history_without_stream_events',
+              reason: 'tool history rows carry arguments, not live stream lifecycle',
+            },
           }),
         ]}
         emptyText="empty"
@@ -240,6 +252,8 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-source')).toBe('tool_result')
     expect(bubble.getAttribute('data-chat-delivery-state')).toBe('history')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })
@@ -2452,6 +2466,60 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(step?.getAttribute('data-chat-trace-output-state')).toBe('pending')
     expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
     expect(bundle?.textContent).not.toContain('결과 누락')
+  })
+
+  it('marks settled unjoined tool steps as hydration-failed when the output surface failed', async () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-unjoined-hydration-failed', label: 'keeper_context_status', turnRef: 'trace-f#1' }),
+          entry({
+            id: 'a-hydration-failed',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-f#1',
+            streamState: null,
+            streamContract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              eventName: 'RUN_FINISHED',
+            },
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        toolOutputHydrationContract=${{
+          source: 'tool_calls_endpoint',
+          status: 'failed',
+          failureReason: 'HTTP 502',
+          startedAtMs: 1_000,
+          completedAtMs: 1_500,
+          coveredSinceMs: null,
+          coveredThroughMs: null,
+        }}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const trace = bundle?.querySelector('[data-chat-tool-trace]') as HTMLElement | null
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-status')).toBe('backend_terminal_event')
+    expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(step?.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(step?.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+    expect(step?.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+    expect(bundle?.textContent).toContain('출력 hydration 실패 1')
+
+    ;(step?.querySelector('.chat-block-tstep-row') as HTMLElement).click()
+    await flushUi()
+    expect(step?.textContent).toContain('출력 hydration 실패 — HTTP 502')
   })
 
   it('marks a settled unjoined tool step as coverage-gap when only older output hydration completed', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -26,6 +26,7 @@ import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperC
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
 import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById } from '../../tool-call-output-store'
+import type { ToolCallOutputHydrationContract } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
@@ -2116,6 +2117,10 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
       data-chat-stream-state=${entry.streamState ?? 'complete'}
+      data-chat-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2483,6 +2488,10 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-source=${entry.source}
       data-chat-delivery-state=${entry.delivery}
       data-chat-stream-state=${entry.streamState ?? 'complete'}
+      data-chat-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2548,13 +2557,14 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
-type ToolTraceDisplayStatus = 'pending' | 'missing' | 'coverage-gap' | 'unlinked' | 'ok' | 'bad'
-type ToolOutputCoverageState = 'not-hydrated' | 'covered' | 'coverage-gap' | 'not-applicable'
+type ToolTraceDisplayStatus = 'pending' | 'missing' | 'coverage-gap' | 'hydration-failed' | 'unlinked' | 'ok' | 'bad'
+type ToolOutputCoverageState = 'not-hydrated' | 'hydrating' | 'hydration-failed' | 'covered' | 'coverage-gap' | 'not-applicable'
 
 const TOOL_STATUS_TITLE: Record<ToolTraceDisplayStatus, string> = {
   pending: '출력 대기 중',
   missing: '결과 누락 — 턴이 끝났는데 출력이 도착하지 않음',
   'coverage-gap': '출력 tail 범위 밖 — 결과 누락 여부를 확정할 수 없음',
+  'hydration-failed': '출력 hydration 실패 — 결과 누락 여부를 확정할 수 없음',
   unlinked: '도구 호출 ID 없음 — 출력 조인 불가',
   ok: '성공',
   bad: '실패',
@@ -2572,8 +2582,10 @@ function toolOutputCoverageState(
   entry: KeeperConversationEntry,
   coveredSinceMs: number | null | undefined,
   coveredThroughMs: number | null | undefined,
+  hydrationStatus: ToolCallOutputHydrationContract['status'] | null | undefined,
 ): ToolOutputCoverageState {
-  if (coveredThroughMs == null) return 'not-hydrated'
+  if (hydrationStatus === 'failed') return 'hydration-failed'
+  if (coveredThroughMs == null) return hydrationStatus === 'hydrating' ? 'hydrating' : 'not-hydrated'
   const timestampMs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
   if (!Number.isFinite(timestampMs)) return 'coverage-gap'
   if (coveredSinceMs != null && timestampMs < coveredSinceMs) return 'coverage-gap'
@@ -2612,12 +2624,14 @@ function ToolTraceStep({
   output,
   canMarkMissing = false,
   coverageState = 'not-applicable',
+  hydrationFailureReason = null,
   traceStep,
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
   canMarkMissing?: boolean
   coverageState?: ToolOutputCoverageState
+  hydrationFailureReason?: string | null
   traceStep?: ChatTraceToolStep
 }) {
   const [open, setOpen] = useState(false)
@@ -2627,18 +2641,22 @@ function ToolTraceStep({
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
   const unlinkedTraceTool = isUnlinkedTraceTool(entry, traceStep)
   const sourceBadge = toolTraceSourceBadge(entry, traceStep)
-  const status: ToolTraceDisplayStatus =
-    unlinkedTraceTool
-      ? 'unlinked'
-      : output === null
-      ? traceStep?.status === 'err'
-        ? 'bad'
-        : traceStep?.status === 'ok'
-          ? 'ok'
-          : (coverageState === 'coverage-gap' ? 'coverage-gap' : canMarkMissing ? 'missing' : 'pending')
-      : output.success === false || output.semantic_success === false
-        ? 'bad'
-        : 'ok'
+  let status: ToolTraceDisplayStatus
+  if (unlinkedTraceTool) {
+    status = 'unlinked'
+  } else if (output !== null) {
+    status = output.success === false || output.semantic_success === false ? 'bad' : 'ok'
+  } else if (traceStep?.status === 'err') {
+    status = 'bad'
+  } else if (traceStep?.status === 'ok') {
+    status = 'ok'
+  } else if (coverageState === 'hydration-failed') {
+    status = 'hydration-failed'
+  } else if (coverageState === 'coverage-gap') {
+    status = 'coverage-gap'
+  } else {
+    status = canMarkMissing ? 'missing' : 'pending'
+  }
   const durLabel =
     output?.duration_ms != null && output.duration_ms > 0
       ? formatMsCompact(output.duration_ms)
@@ -2698,7 +2716,9 @@ function ToolTraceStep({
                     ? unlinkedTraceTool
                       ? null
                       : html`<div class="chat-block-tool-label">${
-                          coverageState === 'coverage-gap'
+                          coverageState === 'hydration-failed'
+                            ? `출력 hydration 실패${hydrationFailureReason ? ` — ${hydrationFailureReason}` : ''}`
+                            : coverageState === 'coverage-gap'
                             ? '출력 tail 범위 밖 — 이 도구 시점을 덮는 결과 hydration이 아직 없음'
                             : canMarkMissing
                               ? '결과 없음 — 출력이 도착하지 않음'
@@ -2800,6 +2820,9 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-entry-id=${entry.id}
       data-chat-trace-source=${entry.source}
       data-chat-trace-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-trace-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
+      data-chat-trace-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
+      data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2821,6 +2844,7 @@ function ToolTraceCard({
   turnComplete = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
+  toolOutputHydrationContract = null,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
@@ -2828,6 +2852,7 @@ function ToolTraceCard({
   turnComplete?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
+  toolOutputHydrationContract?: ToolCallOutputHydrationContract | null
 }) {
   const liveTurn = assistant !== null && !turnComplete
   const userToggledRef = useRef(false)
@@ -2841,7 +2866,12 @@ function ToolTraceCard({
   }
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const coverageStateForEntry = (entry: KeeperConversationEntry): ToolOutputCoverageState =>
-    toolOutputCoverageState(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
+    toolOutputCoverageState(
+      entry,
+      toolOutputsCoveredSinceMs,
+      toolOutputsCoveredThroughMs,
+      toolOutputHydrationContract?.status ?? null,
+    )
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
     turnComplete && coverageStateForEntry(entry) === 'covered'
   const ordered = assistant
@@ -2862,6 +2892,9 @@ function ToolTraceCard({
   const coverageGapN = orderedToolSteps.filter(
     (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'coverage-gap',
   ).length
+  const hydrationFailedN = orderedToolSteps.filter(
+    (s) => s.output === null && s.entry !== null && turnComplete && coverageStateForEntry(s.entry) === 'hydration-failed',
+  ).length
   const unlinkedN = orderedToolSteps.filter(
     (s) => s.kind === 'tool' && s.entry === null && !s.step.toolCallId?.trim(),
   ).length
@@ -2881,6 +2914,13 @@ function ToolTraceCard({
       data-chat-tool-trace
       data-chat-turn-stream-state=${assistant ? (assistant.streamState ?? 'complete') : undefined}
       data-chat-turn-complete=${turnComplete ? 'true' : 'false'}
+      data-chat-turn-stream-contract-source=${assistant?.streamContract?.source ?? undefined}
+      data-chat-turn-stream-contract-status=${assistant?.streamContract?.status ?? undefined}
+      data-chat-turn-stream-contract-event=${assistant?.streamContract?.eventName ?? undefined}
+      data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
+      data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
+      data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
+      data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}
       data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
       data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
     >
@@ -2901,6 +2941,7 @@ function ToolTraceCard({
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
           ${coverageGapN > 0 ? html`<span class="text-[var(--color-status-warn)]">출력 범위 밖 ${coverageGapN}</span>` : null}
+          ${hydrationFailedN > 0 ? html`<span class="text-[var(--color-status-warn)]">출력 hydration 실패 ${hydrationFailedN}</span>` : null}
           ${unlinkedN > 0 ? html`<span class="text-[var(--color-status-warn)]">조인 불가 ${unlinkedN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
@@ -2924,6 +2965,7 @@ function ToolTraceCard({
                           output=${item.output}
                           canMarkMissing=${item.entry !== null && canMarkMissingForEntry(item.entry)}
                           coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
+                          hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
                         />`
                       })()
@@ -2934,6 +2976,7 @@ function ToolTraceCard({
                           output=${item.output}
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
                           coverageState=${coverageStateForEntry(item.entry)}
+                          hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                         />`
                     : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>
@@ -2958,6 +3001,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   showSourceBadge,
   toolOutputsCoveredSinceMs,
   toolOutputsCoveredThroughMs,
+  toolOutputHydrationContract,
   action,
 }: {
   tools: KeeperConversationEntry[]
@@ -2967,6 +3011,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   showSourceBadge: boolean
   toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
+  toolOutputHydrationContract: ToolCallOutputHydrationContract | null
   action?: ChatTranscriptAction
 }) {
   const traceSteps = assistant.traceSteps ?? []
@@ -2982,6 +3027,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
         turnComplete=${turnComplete}
         toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
       />
       <${ChatMessageBubble}
         entry=${assistant}
@@ -3000,6 +3046,7 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
   && prev.showSourceBadge === next.showSourceBadge
   && prev.toolOutputsCoveredSinceMs === next.toolOutputsCoveredSinceMs
   && prev.toolOutputsCoveredThroughMs === next.toolOutputsCoveredThroughMs
+  && prev.toolOutputHydrationContract === next.toolOutputHydrationContract
   && prev.action === next.action
 )
 
@@ -3125,12 +3172,13 @@ function renderChatTranscriptBody(opts: {
   showSourceBadge: boolean
   toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
+  toolOutputHydrationContract: ToolCallOutputHydrationContract | null
   // Since-last-seen cursor (unix seconds) for the unread divider; null on every
   // non-keeper chat surface so those transcripts render unchanged.
   unreadAfterTs: number | null
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, unreadAfterTs, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract, unreadAfterTs, action } = opts
   const units = buildChatRenderUnits(entries, groupToolCalls)
   const unreadAnchorKey = unreadDividerAnchorKey(
     units.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
@@ -3157,7 +3205,13 @@ function renderChatTranscriptBody(opts: {
       out.push(html`<div class="kw-daydiv kw-unreaddiv" key="unread-divider">${UNREAD_DIVIDER_LABEL}</div>`)
     }
     if (unit.kind === 'toolGroup') {
-      out.push(html`<${ToolTraceCard} key=${unit.id} tools=${unit.entries} />`)
+      out.push(html`<${ToolTraceCard}
+        key=${unit.id}
+        tools=${unit.entries}
+        toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+        toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
+      />`)
     } else if (unit.kind === 'turnBundle') {
       out.push(html`<${TurnWorkBundle}
         key=${unit.id}
@@ -3168,6 +3222,7 @@ function renderChatTranscriptBody(opts: {
         showSourceBadge=${showSourceBadge}
         toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+        toolOutputHydrationContract=${toolOutputHydrationContract}
         action=${action}
       />`)
     } else if (unit.entry.role === 'tool') {
@@ -3207,6 +3262,7 @@ export function ChatTranscript({
   showSourceBadge = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
+  toolOutputHydrationContract = null,
   unreadAfterTs = null,
   onSeenBottom,
   action,
@@ -3225,6 +3281,7 @@ export function ChatTranscript({
   showSourceBadge?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
+  toolOutputHydrationContract?: ToolCallOutputHydrationContract | null
   // Since-last-seen cursor (unix seconds) driving the unread divider. Null on
   // non-keeper surfaces -> no divider.
   unreadAfterTs?: number | null
@@ -3247,7 +3304,7 @@ export function ChatTranscript({
   )
   const toolOutputSignature = useMemo(
     () => {
-      const coverageSig = `${toolOutputsCoveredSinceMs ?? ''}:${toolOutputsCoveredThroughMs ?? ''}`
+      const coverageSig = `${toolOutputsCoveredSinceMs ?? ''}:${toolOutputsCoveredThroughMs ?? ''}:${toolOutputHydrationContract?.status ?? ''}:${toolOutputHydrationContract?.failureReason ?? ''}`
       return entries
         .filter(entry => entry.role === 'tool')
         .map((entry) => {
@@ -3258,7 +3315,7 @@ export function ChatTranscript({
         })
         .join('|')
     },
-    [entries, toolCallOutputsById.value, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs],
+    [entries, toolCallOutputsById.value, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract],
   )
 
   const scrollToBottom = () => {
@@ -3346,6 +3403,7 @@ export function ChatTranscript({
               showSourceBadge,
               toolOutputsCoveredSinceMs,
               toolOutputsCoveredThroughMs,
+              toolOutputHydrationContract,
               unreadAfterTs,
               action,
             })}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2121,6 +2121,8 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2492,6 +2494,8 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2823,6 +2827,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
       data-chat-trace-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2918,6 +2924,8 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-status=${assistant?.streamContract?.status ?? undefined}
       data-chat-turn-stream-contract-event=${assistant?.streamContract?.eventName ?? undefined}
       data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
+      data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
+      data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -35,6 +35,7 @@ import {
   keeperStreamStartedAt,
   keeperStreamLastEventAt,
   keeperThreads,
+  keeperStreamContract,
   setRecordValue,
 } from '../keeper-state'
 import { isDefaultVisibleConversationEntry } from '../keeper-state'
@@ -66,6 +67,7 @@ import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
 import {
+  toolCallOutputHydrationContract,
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from '../tool-call-output-store'
@@ -248,6 +250,9 @@ function liveAssistantPlaceholder(keeperName: string): KeeperConversationEntry {
     timestamp: null,
     delivery: 'streaming',
     streamState: 'streaming',
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'UI-only placeholder while active stream entry mounts',
+    }),
     details: null,
     error: null,
   }
@@ -267,6 +272,9 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     timestamp: queuedTimestampIso(msg.timestamp),
     delivery: 'queued',
     streamState: undefined,
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'client-side composer queue item; not yet submitted to keeper runtime',
+    }),
     attachments: msg.attachments,
     blocks: msg.blocks,
     details: null,
@@ -835,6 +843,7 @@ export function KeeperConversationPanel({
               showSourceBadge=${true}
               toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+              toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
               unreadAfterTs=${unreadAfterTs}
               onSeenBottom=${markTranscriptSeen}
               action=${inspectAction}
@@ -971,6 +980,7 @@ export function KeeperConversationPanel({
           groupToolCalls=${true}
           toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+          toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
           unreadAfterTs=${unreadAfterTs}
           onSeenBottom=${markTranscriptSeen}
           action=${inspectAction}
@@ -1090,6 +1100,7 @@ export function KeeperConversationPanel({
             groupToolCalls=${true}
             toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
+            toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
             unreadAfterTs=${unreadAfterTs}
             onSeenBottom=${markTranscriptSeen}
             action=${inspectAction}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -90,6 +90,9 @@ import {
 import { KEEPER_HISTORY_TAIL_MESSAGES } from './config/constants'
 import {
   resetToolCallOutputs,
+  toolCallOutputHydrationContract,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from './tool-call-output-store'
@@ -207,6 +210,10 @@ describe('hydrateKeeperChatHistory', () => {
     const thread = keeperThreads.value.echo ?? []
     expect(thread).toHaveLength(2)
     expect(thread[0]?.delivery).toBe('history')
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'rest_history',
+      status: 'history_without_stream_events',
+    })
     expect(thread[1]?.role).toBe('assistant')
   })
 
@@ -258,6 +265,21 @@ describe('hydrateKeeperChatHistory', () => {
 
     expect(toolCallOutputsCoveredSinceMs('echo')).toBe(Number.POSITIVE_INFINITY)
     expect(toolCallOutputsCoveredThroughMs('echo')).not.toBeNull()
+  })
+
+  it('records tool-output hydration failures with a visible contract reason', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 502'))
+
+    await hydrateKeeperChatHistory('echo')
+
+    expect(toolCallOutputHydrationStatus('echo')).toBe('failed')
+    expect(toolCallOutputHydrationFailureReason('echo')).toBe('HTTP 502')
+    expect(toolCallOutputHydrationContract('echo')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'failed',
+      failureReason: 'HTTP 502',
+    })
   })
 
   it('allows a retry after a failed fetch', async () => {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -217,6 +217,35 @@ describe('hydrateKeeperChatHistory', () => {
     expect(thread[1]?.role).toBe('assistant')
   })
 
+  it('keeps backend stream contracts when hydrating server history', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'assistant',
+        content: 'done',
+        ts: 1_780_000_000,
+        turn_ref: 'trace-hydrate#2',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-hydrate#2',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    await hydrateKeeperChatHistory('echo')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-hydrate#2',
+      traceEventCount: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
   it('fetches only once per keeper per page lifetime', async () => {
     fetchKeeperChatHistory.mockResolvedValue([])
 

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -48,6 +48,7 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
+  keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
   normalizeKeeperProbeResult,
@@ -350,8 +351,8 @@ async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
       toolOutputCoveredSinceMs(response.entries),
     )
   } catch (err) {
-    markToolCallOutputsHydrationFailed(keeperName)
     const message = err instanceof Error ? err.message : String(err)
+    markToolCallOutputsHydrationFailed(keeperName, message)
     console.warn(`[keeper] tool-call output hydration failed for ${keeperName}:`, message)
   }
 }
@@ -465,6 +466,10 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: new Date(request.submittedAt).toISOString(),
       delivery: 'delivered',
       streamState: null,
+      streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+        requestId: request.requestId,
+        reason: 'restored pending queued request from browser storage',
+      }),
       attachments: request.attachments,
       details: null,
     })
@@ -480,6 +485,10 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       timestamp: null,
       delivery: 'queued',
       streamState: 'opening',
+      streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+        requestId: request.requestId,
+        reason: 'awaiting queued request poll result',
+      }),
       details: null,
     })
   }
@@ -578,6 +587,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
         delivery: userDelivery,
         error: errorMessage,
+        streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+          requestId: request.requestId,
+          reason: errorMessage,
+        }),
       })
       let assistantText = reply.text
       let assistantRawText = reply.details?.replyText ?? reply.text
@@ -595,6 +608,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         timestamp: new Date().toISOString(),
         details: reply.details,
         error: errorMessage,
+        streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+          requestId: request.requestId,
+          reason: errorMessage,
+        }),
       })
       if (errorMessage) setRecordValue(keeperActionErrors, request.keeperName, errorMessage)
       removePendingKeeperChatRequest(request.requestId)
@@ -607,6 +624,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
         delivery: 'error',
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+          requestId: request.requestId,
+          reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        }),
       })
       finalizeAssistantEntry(request.keeperName, assistantId, {
         text: '',
@@ -615,6 +636,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         streamState: null,
         timestamp: new Date().toISOString(),
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+          requestId: request.requestId,
+          reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
+        }),
       })
       setRecordValue(keeperActionErrors, request.keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
       await hydrateKeeperChatHistory(request.keeperName, { force: true })
@@ -626,6 +651,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
     finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
       delivery: 'error',
       error: message,
+      streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+        requestId: request.requestId,
+        reason: message,
+      }),
     })
     finalizeAssistantEntry(request.keeperName, assistantId, {
       text: '',
@@ -634,6 +663,10 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       streamState: null,
       timestamp: new Date().toISOString(),
       error: message,
+      streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
+        requestId: request.requestId,
+        reason: message,
+      }),
     })
     setRecordValue(keeperActionErrors, request.keeperName, message)
     await hydrateKeeperChatHistory(request.keeperName, { force: true })
@@ -863,6 +896,9 @@ export async function sendKeeperThreadMessage(
     timestamp: new Date().toISOString(),
     delivery: 'sending',
     streamState: null,
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'local optimistic user row before server history confirmation',
+    }),
     attachments,
     blocks,
     details: null,
@@ -877,6 +913,9 @@ export async function sendKeeperThreadMessage(
     timestamp: null,
     delivery: 'sending',
     streamState: 'opening',
+    streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      reason: 'local assistant placeholder before stream event',
+    }),
     details: null,
   })
   setRecordValue(keeperSending, keeperName, true)
@@ -975,6 +1014,9 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         timestamp: new Date().toISOString(),
         error: cutMessage,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          reason: cutMessage,
+        }),
       })
       setRecordValue(keeperActionErrors, keeperName, cutMessage)
       if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
@@ -994,6 +1036,9 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         timestamp: new Date().toISOString(),
         error: EMPTY_VISIBLE_REPLY_TEXT,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          reason: EMPTY_VISIBLE_REPLY_TEXT,
+        }),
       })
       setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
       if (requestId) {
@@ -1013,6 +1058,9 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
+      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
+        eventName: 'RUN_FINISHED',
+      }),
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (requestId) {
@@ -1037,6 +1085,10 @@ export async function sendKeeperThreadMessage(
       finalizeAssistantEntry(keeperName, localId, {
         delivery: 'cancelled',
         error: null,
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          requestId: requestId ?? undefined,
+          reason: KEEPER_MESSAGE_CANCELLED_TEXT,
+        }),
       })
       finalizeAssistantEntry(keeperName, assistantId, {
         text: KEEPER_MESSAGE_CANCELLED_TEXT,
@@ -1045,6 +1097,10 @@ export async function sendKeeperThreadMessage(
         streamState: null,
         error: null,
         timestamp: new Date().toISOString(),
+        streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          requestId: requestId ?? undefined,
+          reason: KEEPER_MESSAGE_CANCELLED_TEXT,
+        }),
       })
       if (cancelSucceeded) setRecordValue(keeperActionErrors, keeperName, null)
       throw err
@@ -1057,10 +1113,18 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       error: errorMessage,
       timestamp: new Date().toISOString(),
+      streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        requestId: requestId ?? undefined,
+        reason: errorMessage,
+      }),
     })
     finalizeAssistantEntry(keeperName, localId, {
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
+      streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        requestId: requestId ?? undefined,
+        reason: errorMessage,
+      }),
     })
     if (requestTerminalSeen && requestId) {
       removePendingKeeperChatRequest(requestId)

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -359,6 +359,53 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.turnRef).toBe('trace-rest#7')
   })
 
+  it('prefers backend stream contracts from REST chat history', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from retained trace',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#8',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-rest#8',
+          trace_event_count: 3,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-rest#8',
+      traceEventCount: 3,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('falls back explicitly when REST chat history carries an unknown stream contract', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply',
+        ts: 1_780_000_001,
+        stream_contract: {
+          source: 'future_backend_source',
+          status: 'future_status',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toMatchObject({
+      source: 'rest_history',
+      status: 'history_without_stream_events',
+    })
+  })
+
   it('preserves object payloads in persisted tool trace blocks', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -10,6 +10,9 @@ import type {
   KeeperConversationEntry,
   KeeperConversationRole,
   KeeperConversationSource,
+  KeeperConversationStreamContract,
+  KeeperConversationStreamContractSource,
+  KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
   KeeperConversationDelivery,
   KeeperDiagnostic,
@@ -215,6 +218,24 @@ function withoutUndefined<const T extends Record<string, unknown>>(record: T): T
     if (value !== undefined) next[key] = value
   }
   return next as T
+}
+
+export function keeperStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return withoutUndefined({
+    source,
+    status,
+    eventName: opts.eventName ?? undefined,
+    requestId: opts.requestId ?? undefined,
+    reason: opts.reason ?? undefined,
+  })
 }
 
 function normalizeTableCell(raw: unknown): ChatTableCellValue | null {
@@ -755,6 +776,9 @@ function normalizeHistoryEntry(
     turnRef,
     delivery,
     streamState: null,
+    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'history rows do not carry stream lifecycle events',
+    }),
     details: null,
     surface,
     audio,
@@ -846,11 +870,13 @@ export function setAssistantStreamState(
   entryId: string,
   streamState: KeeperConversationStreamState,
   delivery: KeeperConversationDelivery,
+  streamContract?: KeeperConversationStreamContract,
 ): void {
   updateThreadEntry(name, entryId, entry => ({
     ...entry,
     streamState,
     delivery,
+    streamContract: streamContract ?? entry.streamContract,
   }))
 }
 
@@ -861,6 +887,9 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
     text: formatKeeperVisibleReply(`${entry.rawText ?? entry.text}${delta}`),
     streamState: 'streaming',
     delivery: 'streaming',
+    streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
+      eventName: 'TEXT_MESSAGE_CONTENT',
+    }),
   }))
 }
 
@@ -916,6 +945,9 @@ function writeAssistantThinkingText(
       traceSteps,
       streamState: 'thinking',
       delivery: 'streaming',
+      streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
+        eventName: 'KEEPER_THINKING_DELTA',
+      }),
     }
   })
 }
@@ -1293,6 +1325,9 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     timestamp: toIsoTimestamp(message.ts),
     delivery: 'history',
     streamState: null,
+    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'tool history rows carry arguments, not live stream lifecycle',
+    }),
     details: null,
     surface: message.surface ?? null,
     // Tool rows share the same untrusted REST boundary; reject malformed

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -226,6 +226,8 @@ export function keeperStreamContract(
   opts: {
     eventName?: string | null
     requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -234,7 +236,75 @@ export function keeperStreamContract(
     status,
     eventName: opts.eventName ?? undefined,
     requestId: opts.requestId ?? undefined,
+    turnRef: opts.turnRef ?? undefined,
+    traceEventCount: opts.traceEventCount ?? undefined,
     reason: opts.reason ?? undefined,
+  })
+}
+
+function normalizeStreamContractSource(value: unknown): KeeperConversationStreamContractSource | null {
+  switch (asString(value)?.trim()) {
+    case 'keeper_chat_store':
+      return 'keeper_chat_store'
+    case 'backend_turn_trace':
+      return 'backend_turn_trace'
+    case 'rest_history':
+      return 'rest_history'
+    case 'sse_event':
+      return 'sse_event'
+    case 'queue_event':
+      return 'queue_event'
+    case 'queue_poll':
+      return 'queue_poll'
+    case 'pending_request_store':
+      return 'pending_request_store'
+    case 'client_local_send':
+      return 'client_local_send'
+    case 'client_reconciliation':
+      return 'client_reconciliation'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContractStatus(value: unknown): KeeperConversationStreamContractStatus | null {
+  switch (asString(value)?.trim()) {
+    case 'backend_stream_event':
+      return 'backend_stream_event'
+    case 'backend_terminal_event':
+      return 'backend_terminal_event'
+    case 'backend_trace_join':
+      return 'backend_trace_join'
+    case 'history_without_turn_ref':
+      return 'history_without_turn_ref'
+    case 'history_without_stream_events':
+      return 'history_without_stream_events'
+    case 'queue_request_event':
+      return 'queue_request_event'
+    case 'queue_poll_result':
+      return 'queue_poll_result'
+    case 'client_placeholder':
+      return 'client_placeholder'
+    case 'client_reconciled_history':
+      return 'client_reconciled_history'
+    case 'contract_gap':
+      return 'contract_gap'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
+  if (!isRecord(raw)) return null
+  const source = normalizeStreamContractSource(raw.source)
+  const status = normalizeStreamContractStatus(raw.status)
+  if (source === null || status === null) return null
+  return keeperStreamContract(source, status, {
+    eventName: asString(raw.event_name) ?? asString(raw.eventName) ?? null,
+    requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
+    turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
+    traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    reason: asString(raw.reason) ?? null,
   })
 }
 
@@ -761,6 +831,10 @@ function normalizeHistoryEntry(
     ?? ((role === 'assistant' || role === 'system') && text
       ? parseTextToChatBlocks(text)
       : undefined)
+  const streamContract = normalizeStreamContract(raw.stream_contract)
+    ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'history rows do not carry stream lifecycle events',
+    })
   return {
     // R3: key off the producer-assigned server id when present so the
     // render key is stable across history-page merges (the former
@@ -776,9 +850,7 @@ function normalizeHistoryEntry(
     turnRef,
     delivery,
     streamState: null,
-    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
-      reason: 'history rows do not carry stream lifecycle events',
-    }),
+    streamContract,
     details: null,
     surface,
     audio,
@@ -1303,7 +1375,8 @@ interface RestChatHistoryMessage {
   kind?: string
   // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
   // prefers them over its local parser.
-  blocks?: ChatBlock[]
+  blocks?: unknown
+  stream_contract?: unknown
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -1325,7 +1398,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     timestamp: toIsoTimestamp(message.ts),
     delivery: 'history',
     streamState: null,
-    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
+    streamContract: normalizeStreamContract(message.stream_contract) ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
       reason: 'tool history rows carry arguments, not live stream lifecycle',
     }),
     details: null,
@@ -1365,6 +1438,7 @@ export function chatHistoryEntriesFromRest(
         kind: message.kind,
         blocks: message.blocks,
         turn_ref: message.turn_ref,
+        stream_contract: message.stream_contract,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,6 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
+  keeperStreamContract,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -342,7 +343,7 @@ export function applyKeeperStreamEvent(
       appendAssistantDelta(keeperName, assistantEntryId, payload)
     }
   }
-  const markFinalizingIfLive = (): void => {
+  const markFinalizingIfLive = (eventName: string): void => {
     updateThreadEntry(keeperName, assistantEntryId, entry => {
       if (entry.streamState === null) return entry
       if (entry.delivery !== 'sending' && entry.delivery !== 'streaming') return entry
@@ -350,13 +351,20 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
 
   switch (event.type) {
     case 'RUN_STARTED':
-      setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'sending')
+      setAssistantStreamState(
+        keeperName,
+        assistantEntryId,
+        'opening',
+        'sending',
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+      )
       return null
     case 'TEXT_MESSAGE_START':
       // Flush any buffered thinking deltas before entering the text phase so a
@@ -364,7 +372,13 @@ export function applyKeeperStreamEvent(
       // 'thinking' after text streaming has begun. Mirrors TEXT_MESSAGE_END and
       // TOOL_CALL_START, which flush at their phase boundaries.
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
-      setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+      setAssistantStreamState(
+        keeperName,
+        assistantEntryId,
+        'streaming',
+        'streaming',
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+      )
       return null
     case 'TEXT_MESSAGE_CONTENT': {
       applyTextDelta(event.delta)
@@ -373,7 +387,7 @@ export function applyKeeperStreamEvent(
     case 'TEXT_MESSAGE_END':
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-      markFinalizingIfLive()
+      markFinalizingIfLive('TEXT_MESSAGE_END')
       return null
     case 'TOOL_CALL_START': {
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
@@ -404,6 +418,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -454,6 +469,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
+          streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
       return null
@@ -471,7 +487,13 @@ export function applyKeeperStreamEvent(
         if (usage) patch.usage = usage
         if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
         if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_DELTA') {
@@ -484,17 +506,23 @@ export function applyKeeperStreamEvent(
         if (usage) patch.usage = usage
         if (usage?.costUsd !== undefined) patch.costUsd = usage.costUsd
         if (Object.keys(patch).length > 0) mergeAssistantStreamDetails(keeperName, assistantEntryId, patch)
-        if (stopReason) markFinalizingIfLive()
+        if (stopReason) markFinalizingIfLive('KEEPER_STREAM_MESSAGE_DELTA')
         return null
       }
       if (event.name === 'KEEPER_STREAM_MESSAGE_STOP') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-        markFinalizingIfLive()
+        markFinalizingIfLive('KEEPER_STREAM_MESSAGE_STOP')
         return null
       }
       if (event.name === 'KEEPER_STREAM_PING') {
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_START') {
@@ -506,7 +534,13 @@ export function applyKeeperStreamEvent(
         if (toolCallId && toolName) {
           rememberOasToolBlockIndex(keeperName, assistantEntryId, toolCallId, oasBlockIndex)
         }
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTENT_BLOCK_STOP') {
@@ -517,7 +551,13 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           asNumber(value?.index) ?? asNumber(value?.block_index),
         )
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_THINKING_DELTA') {
@@ -535,7 +575,15 @@ export function applyKeeperStreamEvent(
           ? asNumber(value.index) ?? asNumber(value.block_index)
           : undefined
         if (delta) enqueueThinkingDelta(keeperName, assistantEntryId, delta, { oasBlockIndex })
-        else setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+        else {
+          setAssistantStreamState(
+            keeperName,
+            assistantEntryId,
+            'thinking',
+            'streaming',
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+          )
+        }
         return null
       }
       if (event.name === 'KEEPER_STREAM_PROTOCOL_ERROR') {
@@ -556,18 +604,36 @@ export function applyKeeperStreamEvent(
       }
       if (event.name === 'KEEPER_THINKING_SIGNATURE_DELTA') {
         if (!pendingThinkingDeltas.has(streamEntryKey(keeperName, assistantEntryId))) {
-          setAssistantStreamState(keeperName, assistantEntryId, 'thinking', 'streaming')
+          setAssistantStreamState(
+            keeperName,
+            assistantEntryId,
+            'thinking',
+            'streaming',
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+          )
         }
         return null
       }
       if (event.name === 'KEEPER_MEDIA_DELTA') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
-        setAssistantStreamState(keeperName, assistantEntryId, 'streaming', 'streaming')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'streaming',
+          'streaming',
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
-        setAssistantStreamState(keeperName, assistantEntryId, 'opening', 'queued')
+        setAssistantStreamState(
+          keeperName,
+          assistantEntryId,
+          'opening',
+          'queued',
+          keeperStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
+        )
         return null
       }
       if (event.name === 'KEEPER_CONTINUATION_CHECKPOINT') {
@@ -585,6 +651,9 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'queued',
           streamState: null,
+          streamContract: keeperStreamContract('queue_event', 'queue_request_event', {
+            eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
+          }),
         }))
         return null
       }
@@ -614,6 +683,10 @@ export function applyKeeperStreamEvent(
             delivery: 'cancelled',
             streamState: null,
             error: null,
+            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              eventName: 'KEEPER_REQUEST_TERMINAL',
+              requestId: terminalRequestId,
+            }),
           }))
           return null
         }
@@ -629,6 +702,11 @@ export function applyKeeperStreamEvent(
             delivery: 'error',
             streamState: null,
             error: message,
+            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              eventName: 'KEEPER_REQUEST_TERMINAL',
+              requestId: terminalRequestId,
+              reason: message,
+            }),
           }))
           return message
         }
@@ -645,6 +723,10 @@ export function applyKeeperStreamEvent(
               delivery,
               streamState: null,
               error: null,
+              streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+                eventName: 'KEEPER_REQUEST_TERMINAL',
+                requestId: terminalRequestId,
+              }),
             }
           })
         }

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -254,6 +254,11 @@
   background: color-mix(in oklab, var(--color-status-warn) 28%, transparent);
 }
 
+.chat-block-tstep-status.hydration-failed {
+  border: 1px solid var(--color-status-warn);
+  background: color-mix(in oklab, var(--color-status-warn) 42%, transparent);
+}
+
 .chat-block-tstep-status.unlinked {
   border: 1px solid var(--color-status-warn);
   background: transparent;

--- a/dashboard/src/tool-call-output-store.test.ts
+++ b/dashboard/src/tool-call-output-store.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { ToolCallEntry } from './api/dashboard'
 import {
   lookupToolCallOutput,
+  markToolCallOutputsHydrationFailed,
   markToolCallOutputsHydrated,
   markToolCallOutputsHydrating,
   recordToolCallOutputs,
   resetToolCallOutputs,
+  toolCallOutputHydrationContract,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
   toolCallIdFromToolEntryId,
   toolCallOutputsById,
   toolCallOutputsCoveredSinceMs,
@@ -94,10 +98,19 @@ describe('tool-call-output-store', () => {
 
   it('tracks bounded hydration coverage for tail-limited output fetches', () => {
     markToolCallOutputsHydrating('sangsu')
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrating')
     markToolCallOutputsHydrated('sangsu', 2_000, 1_000)
 
     expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_000)
     expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(2_000)
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+    expect(toolCallOutputHydrationContract('sangsu')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'hydrated',
+      failureReason: null,
+      coveredSinceMs: 1_000,
+      coveredThroughMs: 2_000,
+    })
   })
 
   it('merges unbounded hydration coverage without retaining an old lower bound', () => {
@@ -106,5 +119,18 @@ describe('tool-call-output-store', () => {
 
     expect(toolCallOutputsCoveredSinceMs('sangsu')).toBeNull()
     expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(3_000)
+  })
+
+  it('records hydration failure reason instead of collapsing it to pending', () => {
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+    expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 502')
+    expect(toolCallOutputHydrationContract('sangsu')).toMatchObject({
+      source: 'tool_calls_endpoint',
+      status: 'failed',
+      failureReason: 'HTTP 502',
+    })
   })
 })

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -37,9 +37,24 @@ interface ToolCallOutputHydrationState {
   coveredSinceMs: number | null
   coveredThroughMs: number | null
   failed: boolean
+  failureReason: string | null
+  lastStartedAtMs: number | null
+  lastCompletedAtMs: number | null
 }
 
 export const toolCallOutputHydrationByKeeper = signal<Record<string, ToolCallOutputHydrationState>>({})
+
+export type ToolCallOutputHydrationStatus = 'idle' | 'hydrating' | 'hydrated' | 'failed'
+
+export interface ToolCallOutputHydrationContract {
+  source: 'tool_calls_endpoint'
+  status: ToolCallOutputHydrationStatus
+  failureReason: string | null
+  startedAtMs: number | null
+  completedAtMs: number | null
+  coveredSinceMs: number | null
+  coveredThroughMs: number | null
+}
 
 function keeperKey(keeperName: string): string {
   return keeperName.trim()
@@ -51,6 +66,9 @@ function currentHydrationState(keeperName: string): ToolCallOutputHydrationState
     coveredSinceMs: null,
     coveredThroughMs: null,
     failed: false,
+    failureReason: null,
+    lastStartedAtMs: null,
+    lastCompletedAtMs: null,
   }
 }
 
@@ -67,6 +85,9 @@ function updateHydrationState(
     && current.coveredSinceMs === next.coveredSinceMs
     && current.coveredThroughMs === next.coveredThroughMs
     && current.failed === next.failed
+    && current.failureReason === next.failureReason
+    && current.lastStartedAtMs === next.lastStartedAtMs
+    && current.lastCompletedAtMs === next.lastCompletedAtMs
   ) return
   toolCallOutputHydrationByKeeper.value = {
     ...toolCallOutputHydrationByKeeper.value,
@@ -82,6 +103,8 @@ export function markToolCallOutputsHydrating(keeperName: string): number {
     ...current,
     inFlight: current.inFlight + 1,
     failed: false,
+    failureReason: null,
+    lastStartedAtMs: startedAtMs,
   }))
   return startedAtMs
 }
@@ -97,22 +120,30 @@ export function markToolCallOutputsHydrated(
   coveredSinceMs: number | null = null,
 ): void {
   updateHydrationState(keeperName, current => ({
+    ...current,
     inFlight: Math.max(0, current.inFlight - 1),
     coveredSinceMs: current.coveredThroughMs == null
       ? coveredSinceMs
       : mergeCoveredSince(current.coveredSinceMs, coveredSinceMs),
     coveredThroughMs: Math.max(current.coveredThroughMs ?? 0, coveredThroughMs),
     failed: false,
+    failureReason: null,
+    lastCompletedAtMs: Date.now(),
   }))
 }
 
-export function markToolCallOutputsHydrationFailed(keeperName: string): void {
+export function markToolCallOutputsHydrationFailed(
+  keeperName: string,
+  reason: string | null = null,
+): void {
   const key = keeperKey(keeperName)
   if (!key) return
   updateHydrationState(key, current => ({
     ...current,
     inFlight: Math.max(0, current.inFlight - 1),
     failed: true,
+    failureReason: reason,
+    lastCompletedAtMs: Date.now(),
   }))
 }
 
@@ -124,6 +155,38 @@ export function toolCallOutputsCoveredThroughMs(keeperName: string): number | nu
 export function toolCallOutputsCoveredSinceMs(keeperName: string): number | null {
   const key = keeperKey(keeperName)
   return key ? (toolCallOutputHydrationByKeeper.value[key]?.coveredSinceMs ?? null) : null
+}
+
+export function toolCallOutputHydrationStatus(keeperName: string): ToolCallOutputHydrationStatus {
+  const key = keeperKey(keeperName)
+  if (!key) return 'idle'
+  const state = toolCallOutputHydrationByKeeper.value[key]
+  if (!state) return 'idle'
+  if (state.inFlight > 0) return 'hydrating'
+  if (state.failed) return 'failed'
+  if (state.coveredThroughMs != null) return 'hydrated'
+  return 'idle'
+}
+
+export function toolCallOutputHydrationFailureReason(keeperName: string): string | null {
+  const key = keeperKey(keeperName)
+  return key ? (toolCallOutputHydrationByKeeper.value[key]?.failureReason ?? null) : null
+}
+
+export function toolCallOutputHydrationContract(
+  keeperName: string,
+): ToolCallOutputHydrationContract {
+  const key = keeperKey(keeperName)
+  const state = key ? toolCallOutputHydrationByKeeper.value[key] : undefined
+  return {
+    source: 'tool_calls_endpoint',
+    status: key ? toolCallOutputHydrationStatus(key) : 'idle',
+    failureReason: state?.failureReason ?? null,
+    startedAtMs: state?.lastStartedAtMs ?? null,
+    completedAtMs: state?.lastCompletedAtMs ?? null,
+    coveredSinceMs: state?.coveredSinceMs ?? null,
+    coveredThroughMs: state?.coveredThroughMs ?? null,
+  }
 }
 
 /** Merge tool-call entries into the store, keyed by tool_use_id. Entries

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -897,6 +897,33 @@ export type KeeperConversationStreamState =
   | 'finalizing'
   | null
 
+export type KeeperConversationStreamContractSource =
+  | 'rest_history'
+  | 'sse_event'
+  | 'queue_event'
+  | 'queue_poll'
+  | 'pending_request_store'
+  | 'client_local_send'
+  | 'client_reconciliation'
+
+export type KeeperConversationStreamContractStatus =
+  | 'backend_stream_event'
+  | 'backend_terminal_event'
+  | 'history_without_stream_events'
+  | 'queue_request_event'
+  | 'queue_poll_result'
+  | 'client_placeholder'
+  | 'client_reconciled_history'
+  | 'contract_gap'
+
+export interface KeeperConversationStreamContract {
+  source: KeeperConversationStreamContractSource
+  status: KeeperConversationStreamContractStatus
+  eventName?: string | null
+  requestId?: string | null
+  reason?: string | null
+}
+
 export interface SurfaceRef {
   kind: 'dashboard' | 'discord' | 'slack' | 'github' | 'webhook' | 'agent' | 'gate' | string
   session_id?: string
@@ -928,6 +955,7 @@ export interface KeeperConversationEntry {
   turnRef?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
+  streamContract?: KeeperConversationStreamContract | null
   attachments?: KeeperConversationAttachment[]
   blocks?: ChatBlock[]
   traceSteps?: ChatTraceStep[]

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -898,6 +898,8 @@ export type KeeperConversationStreamState =
   | null
 
 export type KeeperConversationStreamContractSource =
+  | 'keeper_chat_store'
+  | 'backend_turn_trace'
   | 'rest_history'
   | 'sse_event'
   | 'queue_event'
@@ -909,6 +911,8 @@ export type KeeperConversationStreamContractSource =
 export type KeeperConversationStreamContractStatus =
   | 'backend_stream_event'
   | 'backend_terminal_event'
+  | 'backend_trace_join'
+  | 'history_without_turn_ref'
   | 'history_without_stream_events'
   | 'queue_request_event'
   | 'queue_poll_result'
@@ -921,6 +925,8 @@ export interface KeeperConversationStreamContract {
   status: KeeperConversationStreamContractStatus
   eventName?: string | null
   requestId?: string | null
+  turnRef?: string | null
+  traceEventCount?: number | null
   reason?: string | null
 }
 

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1119,17 +1119,19 @@ let audio_fields_with_expired ~base_dir audio =
       in
       [ ("audio", `Assoc (audio_to_json { a with expired })) ]
 
-let blocks_with_trace ~trace_block_by_turn_ref (m : chat_message) =
+let trace_block_for_turn ~trace_block_by_turn_ref (m : chat_message) =
+  match m.turn_ref, trace_block_by_turn_ref with
+  | Some turn_ref, Some trace_block_by_turn_ref -> trace_block_by_turn_ref turn_ref
+  | None, _ | Some _, None -> None
+
+let blocks_with_trace_block ~trace_block (m : chat_message) =
   let base =
     match m.blocks with
     | Some blocks -> blocks
     | None -> []
   in
-  match m.role, m.turn_ref, trace_block_by_turn_ref with
-  | Role.Assistant, Some turn_ref, Some trace_block_by_turn_ref -> (
-      match trace_block_by_turn_ref turn_ref with
-      | Some trace_block -> base @ [ trace_block ]
-      | None -> base)
+  match m.role, trace_block with
+  | Role.Assistant, Some trace_block -> base @ [ trace_block ]
   | _ -> base
 
 let blocks_fields_of_list = function
@@ -1137,11 +1139,53 @@ let blocks_fields_of_list = function
   | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let chat_stream_contract_json ~trace_lookup_available ~trace_block
+    (m : chat_message) =
+  let field key value = (key, value) in
+  let string_field key value = field key (`String value) in
+  let base_fields =
+    opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string m.turn_ref)
+  in
+  match m.turn_ref with
+  | None ->
+      `Assoc
+        ([ string_field "source" "keeper_chat_store"
+         ; string_field "status" "history_without_turn_ref"
+         ; string_field "reason"
+             "history row has no persisted turn_ref; no causal stream join is possible"
+         ]
+        @ base_fields)
+  | Some _ -> (
+      match trace_block with
+      | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
+          `Assoc
+            ([ string_field "source" "backend_turn_trace"
+             ; string_field "status" "backend_trace_join"
+             ; string_field "reason"
+                 "turn_ref joined to retained trajectory/internal-history events"
+             ; field "trace_event_count" (`Int (List.length trace))
+             ]
+            @ base_fields)
+      | Some _ | None ->
+          let reason =
+            if trace_lookup_available then
+              "turn_ref persisted but no retained trajectory/internal-history events were available"
+            else
+              "history route served without trace enrichment"
+          in
+          `Assoc
+            ([ string_field "source" "keeper_chat_store"
+             ; string_field "status" "history_without_stream_events"
+             ; string_field "reason" reason
+             ]
+            @ base_fields))
+
 let to_json_array ?base_dir ?trace_block_by_turn_ref
     (messages : chat_message list) : Yojson.Safe.t =
   `List
     (List.map
        (fun m ->
+         let trace_block = trace_block_for_turn ~trace_block_by_turn_ref m in
          `Assoc
            ([ ("id", `String m.id);
               ("role", `String (Role.to_label m.role));
@@ -1186,7 +1230,12 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                      ) atts in
                      [("attachments", `List att_json)])
               @ audio_fields_with_expired ~base_dir m.audio
-              @ blocks_fields_of_list (blocks_with_trace ~trace_block_by_turn_ref m)
+              @ [ ("stream_contract",
+                    chat_stream_contract_json
+                      ~trace_lookup_available:(Option.is_some trace_block_by_turn_ref)
+                      ~trace_block m )
+                ]
+              @ blocks_fields_of_list (blocks_with_trace_block ~trace_block m)
               @ opt_string_field "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1517,6 +1517,117 @@ let test_to_json_array_appends_trace_block_to_assistant_turn () =
           (last |> member "trace" |> to_list |> List.length)
       | None -> Alcotest.fail "assistant json missing blocks")
 
+let assistant_row rows =
+  List.find
+    (function
+      | `Assoc fields -> (
+          match List.assoc_opt "role" fields with
+          | Some (`String "assistant") -> true
+          | _ -> false)
+      | _ -> false)
+    rows
+
+let stream_contract_of row =
+  let open Yojson.Safe.Util in
+  member "stream_contract" row
+
+let test_to_json_array_stream_contract_without_turn_ref () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-legacy" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-legacy" in
+      K.append_user_message ~base_dir ~keeper_name ~content:"legacy hi" ();
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array (K.load ~base_dir ~keeper_name))
+      in
+      match rows with
+      | [ row ] ->
+          let open Yojson.Safe.Util in
+          let contract = stream_contract_of row in
+          Alcotest.(check string) "source" "keeper_chat_store"
+            (contract |> member "source" |> to_string);
+          Alcotest.(check string) "status" "history_without_turn_ref"
+            (contract |> member "status" |> to_string);
+          Alcotest.(check bool) "reason says no turn_ref" true
+            (contains_substring
+               (contract |> member "reason" |> to_string)
+               "no persisted turn_ref")
+      | other ->
+          Alcotest.failf "expected one row, got %d" (List.length other))
+
+let test_to_json_array_stream_contract_trace_join () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-trace" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-trace" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-stream" ~absolute_turn:5 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref then
+          Some
+            (B.Trace
+               { trace =
+                   [ B.Trace_think
+                       { text = "thinking";
+                         ts = Some "2026-07-05T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "backend_turn_trace"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "backend_trace_join"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-stream#5"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check int) "trace event count" 1
+        (contract |> member "trace_event_count" |> to_int))
+
+let test_to_json_array_stream_contract_trace_unavailable () =
+  let base_dir =
+    temp_base_path "keeper-chat-store-stream-contract-no-trace"
+  in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-no-trace" in
+      let tref =
+        Ids.Turn_ref.make ~trace_id:"trace-no-events" ~absolute_turn:9
+      in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref _turn_ref = None in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "keeper_chat_store"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "history_without_stream_events"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-no-events#9"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check bool) "reason says no retained trace" true
+        (contains_substring
+           (contract |> member "reason" |> to_string)
+           "no retained trajectory/internal-history events"))
+
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
 let test_turn_ref_malformed_reads_none () =
@@ -1656,6 +1767,12 @@ let () =
             test_append_assistant_message_redacts_audio;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
+          Alcotest.test_case "history stream contract marks no turn_ref" `Quick
+            test_to_json_array_stream_contract_without_turn_ref;
+          Alcotest.test_case "history stream contract joins turn trace" `Quick
+            test_to_json_array_stream_contract_trace_join;
+          Alcotest.test_case "history stream contract marks missing trace" `Quick
+            test_to_json_array_stream_contract_trace_unavailable;
         ] );
       ( "row_kind",
         [


### PR DESCRIPTION
## Summary
- add typed stream-contract provenance for keeper chat transcript entries
- stamp REST history/tool history/local queue projections as explicit contract states instead of implying live stream truth
- track tool-output hydration status/failure reasons and render hydration-failed trace state when the endpoint fails
- expose stream/hydration contract data attributes for rendered QA and future backend lifecycle replacement

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/tool-call-output-store.test.ts src/keeper-actions.test.ts src/components/chat/primitives.test.ts src/components/chat/primitives-interleave.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check
- pnpm --dir dashboard run build
- rendered smoke via Chrome CDP against http://127.0.0.1:5180/dashboard/keepers?keeper=verifier, desktop 1440x1000 and mobile 390x844

## Notes
- build still reports the existing unresolved Cinzel font and large chunk warnings
- Dune/OCaml build intentionally left to CI per repo workflow
