### PR TITLE
[codex] Surface Keeper Chat history turn contracts

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -86,6 +86,35 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.turn_ref).toBe('trace-1780648779957-00000#4071')
   })
 
+  it('passes the backend stream contract read model through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-1780648779957-00000#4071',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      }),
+    )
+    expect(out?.stream_contract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turn_ref: 'trace-1780648779957-00000#4071',
+      trace_event_count: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('returns null when stream_contract has the wrong shape', () => {
+    expect(
+      safeParseKeeperChatHistoryMessage(
+        validMessage({ stream_contract: { source: 'backend_turn_trace' } }),
+      ),
+    ).toBeNull()
+  })
+
   it('leaves turn_ref undefined on legacy rows without dropping the message', () => {
     const out = safeParseKeeperChatHistoryMessage(validMessage())
     expect(out).not.toBeNull()
@@ -200,6 +229,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
           { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
           { t: 'link', url: 'https://example.com', title: 'Example' },
+          {
+            t: 'trace',
+            trace: [
+              { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+              { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+            ],
+          },
+          { t: 'thinking', content: '', redacted: true },
         ],
       }),
     )
@@ -211,6 +248,14 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
       { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
       { t: 'link', url: 'https://example.com', title: 'Example' },
+      {
+        t: 'trace',
+        trace: [
+          { kind: 'think', text: 'checking', ts: '2026-07-05T00:00:00Z' },
+          { kind: 'tool', name: 'keeper_tasks_list', tool_call_id: 'tc-1', status: 'ok', args: {}, result: { ok: true } },
+        ],
+      },
+      { t: 'thinking', content: '', redacted: true },
     ])
   })
 

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -89,6 +89,35 @@ const KeeperChatTableCellSchema = union([
   }),
 ])
 
+const KeeperChatTraceStepSchema = union([
+  object({
+    kind: literal('think'),
+    text: string(),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+  object({
+    kind: literal('reason'),
+    text: string(),
+    detail: optional(string()),
+    ts: optional(string()),
+  }),
+  object({
+    kind: literal('tool'),
+    name: string(),
+    tool_call_id: optional(string()),
+    toolCallId: optional(string()),
+    status: optional(union([literal('pending'), literal('ok'), literal('err')])),
+    dur: optional(string()),
+    args: optional(unknown()),
+    result: optional(unknown()),
+    ts: optional(string()),
+    oas_block_index: optional(number()),
+    oasBlockIndex: optional(number()),
+  }),
+])
+
 // RFC-0235 P3: server-parsed rich chat blocks carried on persisted history
 // rows. Keep this aligned with keeper_chat_blocks.ml and the dashboard
 // renderer's ChatBlock union; malformed block arrays cause the whole row to be
@@ -174,9 +203,34 @@ export const KeeperChatBlockSchema = union([
     board_post_id: string(),
     run_id: optional(string()),
   }),
+  object({
+    t: literal('trace'),
+    trace: array(KeeperChatTraceStepSchema),
+  }),
+  object({
+    t: literal('thinking'),
+    content: string(),
+    redacted: optional(boolean()),
+  }),
 ])
 
 export type KeeperChatBlock = InferOutput<typeof KeeperChatBlockSchema>
+
+export const KeeperChatHistoryStreamContractSchema = object({
+  source: string(),
+  status: string(),
+  event_name: optional(string()),
+  eventName: optional(string()),
+  request_id: optional(string()),
+  requestId: optional(string()),
+  turn_ref: optional(string()),
+  turnRef: optional(string()),
+  trace_event_count: optional(number()),
+  traceEventCount: optional(number()),
+  reason: optional(string()),
+})
+
+export type KeeperChatHistoryStreamContract = InferOutput<typeof KeeperChatHistoryStreamContractSchema>
 
 export const KeeperChatHistoryMessageSchema = object({
   // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
@@ -234,6 +288,11 @@ export const KeeperChatHistoryMessageSchema = object({
   // so a reload can tell a failed request apart from a real keeper reply;
   // open string() per the same deploy-window rationale as `role`.
   kind: optional(string()),
+  // K1e read model: backend-owned provenance for what a history row can prove
+  // about the stream/turn lifecycle. Kept optional for deploy windows and
+  // legacy endpoints; consumers fall back to explicit "history without stream
+  // events" instead of inventing a lifecycle.
+  stream_contract: optional(KeeperChatHistoryStreamContractSchema),
 })
 
 export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -192,9 +192,11 @@ describe('ChatTranscript', () => {
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
             streamContract: {
-              source: 'rest_history',
-              status: 'history_without_stream_events',
-              reason: 'history rows do not carry stream lifecycle events',
+              source: 'backend_turn_trace',
+              status: 'backend_trace_join',
+              turnRef: 'trace-ui#9',
+              traceEventCount: 2,
+              reason: 'turn_ref joined to retained trajectory/internal-history events',
             },
             surface: {
               kind: 'discord',
@@ -217,8 +219,10 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
-    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
-    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_turn_trace')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_trace_join')
+    expect(bubble.getAttribute('data-chat-stream-contract-turn-ref')).toBe('trace-ui#9')
+    expect(bubble.getAttribute('data-chat-stream-contract-trace-events')).toBe('2')
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2121,6 +2121,8 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2492,6 +2494,8 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
+      data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2823,6 +2827,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-source=${entry.streamContract?.source ?? 'unspecified'}
       data-chat-trace-stream-contract-status=${entry.streamContract?.status ?? 'unspecified'}
       data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
+      data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
+      data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2918,6 +2924,8 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-status=${assistant?.streamContract?.status ?? undefined}
       data-chat-turn-stream-contract-event=${assistant?.streamContract?.eventName ?? undefined}
       data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
+      data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
+      data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -217,6 +217,35 @@ describe('hydrateKeeperChatHistory', () => {
     expect(thread[1]?.role).toBe('assistant')
   })
 
+  it('keeps backend stream contracts when hydrating server history', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'assistant',
+        content: 'done',
+        ts: 1_780_000_000,
+        turn_ref: 'trace-hydrate#2',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-hydrate#2',
+          trace_event_count: 2,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    await hydrateKeeperChatHistory('echo')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-hydrate#2',
+      traceEventCount: 2,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
   it('fetches only once per keeper per page lifetime', async () => {
     fetchKeeperChatHistory.mockResolvedValue([])
 

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -359,6 +359,53 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.turnRef).toBe('trace-rest#7')
   })
 
+  it('prefers backend stream contracts from REST chat history', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from retained trace',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#8',
+        stream_contract: {
+          source: 'backend_turn_trace',
+          status: 'backend_trace_join',
+          turn_ref: 'trace-rest#8',
+          trace_event_count: 3,
+          reason: 'turn_ref joined to retained trajectory/internal-history events',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toEqual({
+      source: 'backend_turn_trace',
+      status: 'backend_trace_join',
+      turnRef: 'trace-rest#8',
+      traceEventCount: 3,
+      reason: 'turn_ref joined to retained trajectory/internal-history events',
+    })
+  })
+
+  it('falls back explicitly when REST chat history carries an unknown stream contract', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply',
+        ts: 1_780_000_001,
+        stream_contract: {
+          source: 'future_backend_source',
+          status: 'future_status',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toMatchObject({
+      source: 'rest_history',
+      status: 'history_without_stream_events',
+    })
+  })
+
   it('preserves object payloads in persisted tool trace blocks', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -226,6 +226,8 @@ export function keeperStreamContract(
   opts: {
     eventName?: string | null
     requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -234,7 +236,75 @@ export function keeperStreamContract(
     status,
     eventName: opts.eventName ?? undefined,
     requestId: opts.requestId ?? undefined,
+    turnRef: opts.turnRef ?? undefined,
+    traceEventCount: opts.traceEventCount ?? undefined,
     reason: opts.reason ?? undefined,
+  })
+}
+
+function normalizeStreamContractSource(value: unknown): KeeperConversationStreamContractSource | null {
+  switch (asString(value)?.trim()) {
+    case 'keeper_chat_store':
+      return 'keeper_chat_store'
+    case 'backend_turn_trace':
+      return 'backend_turn_trace'
+    case 'rest_history':
+      return 'rest_history'
+    case 'sse_event':
+      return 'sse_event'
+    case 'queue_event':
+      return 'queue_event'
+    case 'queue_poll':
+      return 'queue_poll'
+    case 'pending_request_store':
+      return 'pending_request_store'
+    case 'client_local_send':
+      return 'client_local_send'
+    case 'client_reconciliation':
+      return 'client_reconciliation'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContractStatus(value: unknown): KeeperConversationStreamContractStatus | null {
+  switch (asString(value)?.trim()) {
+    case 'backend_stream_event':
+      return 'backend_stream_event'
+    case 'backend_terminal_event':
+      return 'backend_terminal_event'
+    case 'backend_trace_join':
+      return 'backend_trace_join'
+    case 'history_without_turn_ref':
+      return 'history_without_turn_ref'
+    case 'history_without_stream_events':
+      return 'history_without_stream_events'
+    case 'queue_request_event':
+      return 'queue_request_event'
+    case 'queue_poll_result':
+      return 'queue_poll_result'
+    case 'client_placeholder':
+      return 'client_placeholder'
+    case 'client_reconciled_history':
+      return 'client_reconciled_history'
+    case 'contract_gap':
+      return 'contract_gap'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
+  if (!isRecord(raw)) return null
+  const source = normalizeStreamContractSource(raw.source)
+  const status = normalizeStreamContractStatus(raw.status)
+  if (source === null || status === null) return null
+  return keeperStreamContract(source, status, {
+    eventName: asString(raw.event_name) ?? asString(raw.eventName) ?? null,
+    requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
+    turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
+    traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    reason: asString(raw.reason) ?? null,
   })
 }
 
@@ -761,6 +831,10 @@ function normalizeHistoryEntry(
     ?? ((role === 'assistant' || role === 'system') && text
       ? parseTextToChatBlocks(text)
       : undefined)
+  const streamContract = normalizeStreamContract(raw.stream_contract)
+    ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
+      reason: 'history rows do not carry stream lifecycle events',
+    })
   return {
     // R3: key off the producer-assigned server id when present so the
     // render key is stable across history-page merges (the former
@@ -776,9 +850,7 @@ function normalizeHistoryEntry(
     turnRef,
     delivery,
     streamState: null,
-    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
-      reason: 'history rows do not carry stream lifecycle events',
-    }),
+    streamContract,
     details: null,
     surface,
     audio,
@@ -1303,7 +1375,8 @@ interface RestChatHistoryMessage {
   kind?: string
   // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
   // prefers them over its local parser.
-  blocks?: ChatBlock[]
+  blocks?: unknown
+  stream_contract?: unknown
 }
 
 /** Convert a persisted tool-call row into the same entry shape the live
@@ -1325,7 +1398,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     timestamp: toIsoTimestamp(message.ts),
     delivery: 'history',
     streamState: null,
-    streamContract: keeperStreamContract('rest_history', 'history_without_stream_events', {
+    streamContract: normalizeStreamContract(message.stream_contract) ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
       reason: 'tool history rows carry arguments, not live stream lifecycle',
     }),
     details: null,
@@ -1365,6 +1438,7 @@ export function chatHistoryEntriesFromRest(
         kind: message.kind,
         blocks: message.blocks,
         turn_ref: message.turn_ref,
+        stream_contract: message.stream_contract,
       },
       keeperName,
       previousSource,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -898,6 +898,8 @@ export type KeeperConversationStreamState =
   | null
 
 export type KeeperConversationStreamContractSource =
+  | 'keeper_chat_store'
+  | 'backend_turn_trace'
   | 'rest_history'
   | 'sse_event'
   | 'queue_event'
@@ -909,6 +911,8 @@ export type KeeperConversationStreamContractSource =
 export type KeeperConversationStreamContractStatus =
   | 'backend_stream_event'
   | 'backend_terminal_event'
+  | 'backend_trace_join'
+  | 'history_without_turn_ref'
   | 'history_without_stream_events'
   | 'queue_request_event'
   | 'queue_poll_result'
@@ -921,6 +925,8 @@ export interface KeeperConversationStreamContract {
   status: KeeperConversationStreamContractStatus
   eventName?: string | null
   requestId?: string | null
+  turnRef?: string | null
+  traceEventCount?: number | null
   reason?: string | null
 }
 

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1119,17 +1119,19 @@ let audio_fields_with_expired ~base_dir audio =
       in
       [ ("audio", `Assoc (audio_to_json { a with expired })) ]
 
-let blocks_with_trace ~trace_block_by_turn_ref (m : chat_message) =
+let trace_block_for_turn ~trace_block_by_turn_ref (m : chat_message) =
+  match m.turn_ref, trace_block_by_turn_ref with
+  | Some turn_ref, Some trace_block_by_turn_ref -> trace_block_by_turn_ref turn_ref
+  | None, _ | Some _, None -> None
+
+let blocks_with_trace_block ~trace_block (m : chat_message) =
   let base =
     match m.blocks with
     | Some blocks -> blocks
     | None -> []
   in
-  match m.role, m.turn_ref, trace_block_by_turn_ref with
-  | Role.Assistant, Some turn_ref, Some trace_block_by_turn_ref -> (
-      match trace_block_by_turn_ref turn_ref with
-      | Some trace_block -> base @ [ trace_block ]
-      | None -> base)
+  match m.role, trace_block with
+  | Role.Assistant, Some trace_block -> base @ [ trace_block ]
   | _ -> base
 
 let blocks_fields_of_list = function
@@ -1137,11 +1139,53 @@ let blocks_fields_of_list = function
   | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let chat_stream_contract_json ~trace_lookup_available ~trace_block
+    (m : chat_message) =
+  let field key value = (key, value) in
+  let string_field key value = field key (`String value) in
+  let base_fields =
+    opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string m.turn_ref)
+  in
+  match m.turn_ref with
+  | None ->
+      `Assoc
+        ([ string_field "source" "keeper_chat_store"
+         ; string_field "status" "history_without_turn_ref"
+         ; string_field "reason"
+             "history row has no persisted turn_ref; no causal stream join is possible"
+         ]
+        @ base_fields)
+  | Some _ -> (
+      match trace_block with
+      | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
+          `Assoc
+            ([ string_field "source" "backend_turn_trace"
+             ; string_field "status" "backend_trace_join"
+             ; string_field "reason"
+                 "turn_ref joined to retained trajectory/internal-history events"
+             ; field "trace_event_count" (`Int (List.length trace))
+             ]
+            @ base_fields)
+      | Some _ | None ->
+          let reason =
+            if trace_lookup_available then
+              "turn_ref persisted but no retained trajectory/internal-history events were available"
+            else
+              "history route served without trace enrichment"
+          in
+          `Assoc
+            ([ string_field "source" "keeper_chat_store"
+             ; string_field "status" "history_without_stream_events"
+             ; string_field "reason" reason
+             ]
+            @ base_fields))
+
 let to_json_array ?base_dir ?trace_block_by_turn_ref
     (messages : chat_message list) : Yojson.Safe.t =
   `List
     (List.map
        (fun m ->
+         let trace_block = trace_block_for_turn ~trace_block_by_turn_ref m in
          `Assoc
            ([ ("id", `String m.id);
               ("role", `String (Role.to_label m.role));
@@ -1186,7 +1230,12 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                      ) atts in
                      [("attachments", `List att_json)])
               @ audio_fields_with_expired ~base_dir m.audio
-              @ blocks_fields_of_list (blocks_with_trace ~trace_block_by_turn_ref m)
+              @ [ ("stream_contract",
+                    chat_stream_contract_json
+                      ~trace_lookup_available:(Option.is_some trace_block_by_turn_ref)
+                      ~trace_block m )
+                ]
+              @ blocks_fields_of_list (blocks_with_trace_block ~trace_block m)
               @ opt_string_field "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1517,6 +1517,117 @@ let test_to_json_array_appends_trace_block_to_assistant_turn () =
           (last |> member "trace" |> to_list |> List.length)
       | None -> Alcotest.fail "assistant json missing blocks")
 
+let assistant_row rows =
+  List.find
+    (function
+      | `Assoc fields -> (
+          match List.assoc_opt "role" fields with
+          | Some (`String "assistant") -> true
+          | _ -> false)
+      | _ -> false)
+    rows
+
+let stream_contract_of row =
+  let open Yojson.Safe.Util in
+  member "stream_contract" row
+
+let test_to_json_array_stream_contract_without_turn_ref () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-legacy" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-legacy" in
+      K.append_user_message ~base_dir ~keeper_name ~content:"legacy hi" ();
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array (K.load ~base_dir ~keeper_name))
+      in
+      match rows with
+      | [ row ] ->
+          let open Yojson.Safe.Util in
+          let contract = stream_contract_of row in
+          Alcotest.(check string) "source" "keeper_chat_store"
+            (contract |> member "source" |> to_string);
+          Alcotest.(check string) "status" "history_without_turn_ref"
+            (contract |> member "status" |> to_string);
+          Alcotest.(check bool) "reason says no turn_ref" true
+            (contains_substring
+               (contract |> member "reason" |> to_string)
+               "no persisted turn_ref")
+      | other ->
+          Alcotest.failf "expected one row, got %d" (List.length other))
+
+let test_to_json_array_stream_contract_trace_join () =
+  let base_dir = temp_base_path "keeper-chat-store-stream-contract-trace" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-trace" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-stream" ~absolute_turn:5 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref then
+          Some
+            (B.Trace
+               { trace =
+                   [ B.Trace_think
+                       { text = "thinking";
+                         ts = Some "2026-07-05T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "backend_turn_trace"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "backend_trace_join"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-stream#5"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check int) "trace event count" 1
+        (contract |> member "trace_event_count" |> to_int))
+
+let test_to_json_array_stream_contract_trace_unavailable () =
+  let base_dir =
+    temp_base_path "keeper-chat-store-stream-contract-no-trace"
+  in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-no-trace" in
+      let tref =
+        Ids.Turn_ref.make ~trace_id:"trace-no-events" ~absolute_turn:9
+      in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"done" ();
+      let trace_block_by_turn_ref _turn_ref = None in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "keeper_chat_store"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "history_without_stream_events"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "turn_ref" "trace-no-events#9"
+        (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check bool) "reason says no retained trace" true
+        (contains_substring
+           (contract |> member "reason" |> to_string)
+           "no retained trajectory/internal-history events"))
+
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
 let test_turn_ref_malformed_reads_none () =
@@ -1656,6 +1767,12 @@ let () =
             test_append_assistant_message_redacts_audio;
           Alcotest.test_case "assistant history appends trace block" `Quick
             test_to_json_array_appends_trace_block_to_assistant_turn;
+          Alcotest.test_case "history stream contract marks no turn_ref" `Quick
+            test_to_json_array_stream_contract_without_turn_ref;
+          Alcotest.test_case "history stream contract joins turn trace" `Quick
+            test_to_json_array_stream_contract_trace_join;
+          Alcotest.test_case "history stream contract marks missing trace" `Quick
+            test_to_json_array_stream_contract_trace_unavailable;
         ] );
       ( "row_kind",
         [


### PR DESCRIPTION
## Summary

- Emit a `stream_contract` read model for every Keeper chat history row from the backend store.
- Distinguish causal backend trace joins from explicit absence states instead of inventing lifecycle events for old history rows.
- Teach the dashboard history schema/store to accept backend `trace`/`thinking` blocks and prefer backend `stream_contract` when present.
- Expose `turn_ref` and trace-event count in chat DOM provenance attributes for rendered/Playwright-style checks.

## Contract Shape

- `backend_turn_trace` / `backend_trace_join`: row has `turn_ref` and retained trace block joined by `turn_ref`.
- `keeper_chat_store` / `history_without_turn_ref`: old row has no turn ref, so no causal stream join is possible.
- `keeper_chat_store` / `history_without_stream_events`: row has turn ref, but no retained trace block is available for history enrichment.

This keeps the read model honest: it surfaces what the backend can prove from durable history today, without faking run lifecycle replay.

## Validation

- `scripts/dune-local.sh build test/test_keeper_chat_store.exe`
- `./_build/default/test/test_keeper_chat_store.exe` (46 tests)
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/schemas/keeper-chat-history.test.ts src/keeper-state.test.ts src/keeper-actions.test.ts src/components/chat/primitives.test.ts src/components/chat/primitives-interleave.test.ts --no-file-parallelism --maxWorkers=1` (280 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- Rendered smoke via headless Chrome CDP against `http://127.0.0.1:5181/dashboard/#keepers?keeper=verifier` at 1440x1000 and 390x844.

Rendered smoke note: the live MASC runtime serving `:8935` was existing repo binary `cc9011d287`, not this branch, so the rendered page correctly showed dashboard fallback provenance (`rest_history` / `history_without_stream_events`). The new backend `stream_contract` wire shape is covered by focused OCaml tests and dashboard schema/store tests in this PR.

## Evidence

[근거] local commands above, checked 2026-07-05 20:44:56 KST, confidence High.
