### PR TITLE
[codex] Persist Keeper Chat stream lifecycle contracts

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -94,6 +94,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-1780648779957-00000#4071',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       }),
@@ -103,6 +104,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       status: 'backend_trace_join',
       turn_ref: 'trace-1780648779957-00000#4071',
       trace_event_count: 2,
+      delivery_receipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -121,6 +123,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
             'TEXT_MESSAGE_END',
             'RUN_FINISHED',
           ],
+          delivery_receipt: 'server_lifecycle_replay_only',
           reason: 'history row records durable server stream lifecycle replay',
         },
       }),
@@ -136,6 +139,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
         'TEXT_MESSAGE_END',
         'RUN_FINISHED',
       ],
+      delivery_receipt: 'server_lifecycle_replay_only',
       reason: 'history row records durable server stream lifecycle replay',
     })
   })

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -107,6 +107,39 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     })
   })
 
+  it('passes durable backend lifecycle stream contracts through when present', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-1780648779957-00000#4071',
+          event_name: 'RUN_FINISHED',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'TEXT_MESSAGE_START',
+            'TEXT_MESSAGE_END',
+            'RUN_FINISHED',
+          ],
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      }),
+    )
+    expect(out?.stream_contract).toEqual({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turn_ref: 'trace-1780648779957-00000#4071',
+      event_name: 'RUN_FINISHED',
+      lifecycle_events: [
+        'RUN_STARTED',
+        'TEXT_MESSAGE_START',
+        'TEXT_MESSAGE_END',
+        'RUN_FINISHED',
+      ],
+      reason: 'history row records durable server stream lifecycle replay',
+    })
+  })
+
   it('returns null when stream_contract has the wrong shape', () => {
     expect(
       safeParseKeeperChatHistoryMessage(

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -229,6 +229,8 @@ export const KeeperChatHistoryStreamContractSchema = object({
   traceEventCount: optional(number()),
   lifecycle_events: optional(array(string())),
   lifecycleEvents: optional(array(string())),
+  delivery_receipt: optional(string()),
+  deliveryReceipt: optional(string()),
   reason: optional(string()),
 })
 

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -227,6 +227,8 @@ export const KeeperChatHistoryStreamContractSchema = object({
   turnRef: optional(string()),
   trace_event_count: optional(number()),
   traceEventCount: optional(number()),
+  lifecycle_events: optional(array(string())),
+  lifecycleEvents: optional(array(string())),
   reason: optional(string()),
 })
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -665,6 +665,19 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('img[alt="screenshot.png"]')).not.toBeNull()
     expect(container.textContent).toContain('log.txt')
     expect(container.textContent).not.toContain('상세 보기')
+    const bubble = container.querySelector('[data-chat-entry-id="u1"]')
+    expect(bubble?.getAttribute('data-chat-attachment-count')).toBe('2')
+    expect(bubble?.getAttribute('data-chat-server-attach-block-count')).toBe('0')
+    expect(bubble?.getAttribute('data-chat-multimodal-sources')).toBe('persisted_attachment')
+    expect(bubble?.getAttribute('data-chat-multimodal-kinds')).toBe('image,document')
+    const imageCard = container.querySelector('[data-chat-attachment-card="att-1"]')
+    expect(imageCard?.getAttribute('data-chat-multimodal-source')).toBe('persisted_attachment')
+    expect(imageCard?.getAttribute('data-chat-multimodal-kind')).toBe('image')
+    expect(imageCard?.getAttribute('data-chat-multimodal-mime')).toBe('image/png')
+    expect(imageCard?.getAttribute('data-chat-multimodal-size-bytes')).toBe('1024')
+    const fileCard = container.querySelector('[data-chat-attachment-card="att-2"]')
+    expect(fileCard?.getAttribute('data-chat-multimodal-kind')).toBe('document')
+    expect(fileCard?.getAttribute('data-chat-multimodal-mime')).toBe('text/plain')
   })
 
   it('does not show streaming ellipsis before elapsed time starts', () => {
@@ -1303,11 +1316,15 @@ describe('Keeper v2 chat blocks', () => {
             blocks: [
               {
                 t: 'attach',
+                id: 'srv-att-1',
                 name: 'screen.png',
+                kind: 'image',
                 dims: '100×100',
                 src: 'https://example.com/screen.png',
                 via: 'vision',
                 size: '12 KB',
+                mimeType: 'image/png',
+                sizeBytes: 12_288,
               },
             ],
           }),
@@ -1319,9 +1336,20 @@ describe('Keeper v2 chat blocks', () => {
 
     const blocks = container.querySelector('[data-chat-blocks]')
     const attach = container.querySelector('[data-chat-block="attach"]')
+    const bubble = container.querySelector('[data-chat-entry-id="u-rich"]')
     expect(blocks).not.toBeNull()
     expect(attach?.textContent).toContain('screen.png')
     expect(attach?.querySelector('img')?.getAttribute('src')).toBe('https://example.com/screen.png')
+    expect(bubble?.getAttribute('data-chat-attachment-count')).toBe('0')
+    expect(bubble?.getAttribute('data-chat-server-attach-block-count')).toBe('1')
+    expect(bubble?.getAttribute('data-chat-multimodal-sources')).toBe('server_block')
+    expect(bubble?.getAttribute('data-chat-multimodal-kinds')).toBe('image')
+    expect(attach?.getAttribute('data-chat-multimodal-source')).toBe('server_block')
+    expect(attach?.getAttribute('data-chat-multimodal-kind')).toBe('image')
+    expect(attach?.getAttribute('data-chat-multimodal-attachment-id')).toBe('srv-att-1')
+    expect(attach?.getAttribute('data-chat-multimodal-mime')).toBe('image/png')
+    expect(attach?.getAttribute('data-chat-multimodal-size-bytes')).toBe('12288')
+    expect(attach?.getAttribute('data-chat-attach-via')).toBe('vision')
   })
 
   it('blocks unsafe attach image src and falls back to placeholder', () => {
@@ -1337,6 +1365,8 @@ describe('Keeper v2 chat blocks', () => {
     ])
 
     expect(container.querySelector('[data-chat-block="attach"] img')).toBeNull()
+    expect(container.querySelector('[data-chat-block="attach"]')?.getAttribute('data-chat-multimodal-source')).toBe('server_block')
+    expect(container.querySelector('[data-chat-block="attach"]')?.getAttribute('data-chat-multimodal-kind')).toBeNull()
     expect(container.textContent).toContain('unsafe URL')
   })
 
@@ -2135,6 +2165,60 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(chat.getAttribute('data-chat-trace-entry-id')).toBe('a-provenance')
     expect(chat.getAttribute('data-chat-trace-source')).toBe('direct_assistant')
     expect(chat.getAttribute('data-chat-trace-turn-ref')).toBe('trace-prov#7')
+  })
+
+  it('exposes structural turn order without timestamp sorting', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-t-order',
+            label: 'keeper_context_status',
+            text: '{"ok":true}',
+            timestamp: '2026-03-24T00:00:01.000Z',
+            turnRef: 'trace-order#1',
+          }),
+          entry({
+            id: 'assistant-order',
+            text: '완료했습니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            timestamp: '2026-03-24T00:00:00.000Z',
+            turnRef: 'trace-order#1',
+            traceSteps: [
+              { kind: 'think', text: 'first structural thought', ts: '2026-03-24T00:00:04.000Z' },
+              {
+                kind: 'tool',
+                name: 'keeper_context_status',
+                toolCallId: 't-order',
+                status: 'ok',
+                ts: '2026-03-24T00:00:02.000Z',
+              },
+              { kind: 'think', text: 'second structural thought', ts: '2026-03-24T00:00:03.000Z' },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement
+    expect(trace.getAttribute('data-chat-turn-order-signature')).toBe(
+      'trace:think|tool:t-order|trace:think|chat:assistant-order',
+    )
+
+    const ordered = [...trace.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered).toHaveLength(4)
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual(['trace', 'tool', 'trace', 'chat'])
+
+    const tool = ordered[1] as HTMLElement
+    expect(tool.getAttribute('data-chat-trace-tool-call-id')).toBe('t-order')
+    expect(tool.getAttribute('data-chat-trace-entry-id')).toBe('tool-t-order')
+    expect(tool.getAttribute('data-chat-trace-link-state')).toBe('joined')
   })
 
   it('renders thinking text as sanitized markdown with newlines preserved', async () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -202,6 +202,7 @@ describe('ChatTranscript', () => {
                 'TEXT_MESSAGE_END',
                 'RUN_FINISHED',
               ],
+              deliveryReceipt: 'server_lifecycle_replay_only',
               reason: 'history row records durable server stream lifecycle replay',
             },
             surface: {
@@ -231,6 +232,9 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-contract-event')).toBe('RUN_FINISHED')
     expect(bubble.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe(
       'RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_END,RUN_FINISHED',
+    )
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe(
+      'server_lifecycle_replay_only',
     )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -252,6 +252,7 @@ describe('ChatTranscript', () => {
             streamContract: {
               source: 'rest_history',
               status: 'history_without_stream_events',
+              deliveryReceipt: 'no_delivery_receipt',
               reason: 'tool history rows carry arguments, not live stream lifecycle',
             },
           }),
@@ -271,6 +272,7 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
     expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
     expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -192,11 +192,17 @@ describe('ChatTranscript', () => {
             rawText: 'channel reply',
             turnRef: 'trace-ui#9',
             streamContract: {
-              source: 'backend_turn_trace',
-              status: 'backend_trace_join',
+              source: 'backend_stream_lifecycle',
+              status: 'backend_lifecycle_replay',
               turnRef: 'trace-ui#9',
-              traceEventCount: 2,
-              reason: 'turn_ref joined to retained trajectory/internal-history events',
+              eventName: 'RUN_FINISHED',
+              lifecycleEvents: [
+                'RUN_STARTED',
+                'TEXT_MESSAGE_START',
+                'TEXT_MESSAGE_END',
+                'RUN_FINISHED',
+              ],
+              reason: 'history row records durable server stream lifecycle replay',
             },
             surface: {
               kind: 'discord',
@@ -219,10 +225,13 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('discord')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-ui#9')
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
-    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_turn_trace')
-    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_trace_join')
+    expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('backend_stream_lifecycle')
+    expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('backend_lifecycle_replay')
     expect(bubble.getAttribute('data-chat-stream-contract-turn-ref')).toBe('trace-ui#9')
-    expect(bubble.getAttribute('data-chat-stream-contract-trace-events')).toBe('2')
+    expect(bubble.getAttribute('data-chat-stream-contract-event')).toBe('RUN_FINISHED')
+    expect(bubble.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe(
+      'RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_END,RUN_FINISHED',
+    )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
   })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2124,6 +2124,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2498,6 +2499,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2832,6 +2834,7 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-trace-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-trace-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2930,6 +2933,7 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
       data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
       data-chat-turn-stream-contract-lifecycle-events=${assistant?.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-turn-stream-contract-delivery-receipt=${assistant?.streamContract?.deliveryReceipt ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1095,10 +1095,43 @@ function ChatIssueBlock({ repo, number, title, status, url, meta }: ChatIssueBlo
   `
 }
 
-function ChatAttachBlock({ name, dims, src, svg, ph, via, size }: { name: string; dims?: string; src?: string; svg?: string; ph?: string; via?: string; size?: string }) {
+function ChatAttachBlock({
+  name,
+  dims,
+  src,
+  svg,
+  ph,
+  via,
+  size,
+  id,
+  kind,
+  mimeType,
+  sizeBytes,
+}: {
+  name: string
+  dims?: string
+  src?: string
+  svg?: string
+  ph?: string
+  via?: string
+  size?: string
+  id?: string
+  kind?: string
+  mimeType?: string
+  sizeBytes?: number
+}) {
   const safeSrc = src && isSafeMediaUrl(src, ['data:image/']) ? src : null
   return html`
-    <figure class="chat-block-attach" data-chat-block="attach">
+    <figure
+      class="chat-block-attach"
+      data-chat-block="attach"
+      data-chat-multimodal-source="server_block"
+      data-chat-multimodal-kind=${kind || undefined}
+      data-chat-multimodal-attachment-id=${id || undefined}
+      data-chat-multimodal-mime=${mimeType || undefined}
+      data-chat-multimodal-size-bytes=${sizeBytes ?? undefined}
+      data-chat-attach-via=${via || undefined}
+    >
       <div class="chat-block-attach-hd">
         <span>◫</span>
         <span class="chat-block-attach-name">${name}</span>
@@ -1286,7 +1319,15 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   `
 }
 
-function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; streaming?: boolean }) {
+function ChatTraceStep({
+  step,
+  streaming = false,
+  orderIndex,
+}: {
+  step: ChatTraceStep
+  streaming?: boolean
+  orderIndex?: number
+}) {
   const [open, setOpen] = useState(false)
   const sourceBadge = traceSourceBadge(step)
 
@@ -1299,6 +1340,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep think"
         data-chat-trace-step="think"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
         data-chat-trace-ts=${step.ts ?? undefined}
@@ -1347,6 +1390,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep reason ${open ? 'exp' : ''}"
         data-chat-trace-step="reason"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-ts=${step.ts ?? undefined}
       >
@@ -1372,6 +1417,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="tool"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${step.toolCallId?.trim() || undefined}
       data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
@@ -1773,7 +1820,7 @@ function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: s
     case 'chart': return html`<${ChatChartBlock} title=${block.title} series=${block.series} labels=${block.labels} xLabel=${block.xLabel} yMax=${block.yMax} />`
     case 'suggestions': return html`<${ChatSuggestionsBlock} items=${block.items} />`
     case 'issue': return html`<${ChatIssueBlock} repo=${block.repo} number=${block.number} title=${block.title} status=${block.status} url=${block.url} meta=${block.meta} />`
-    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} />`
+    case 'attach': return html`<${ChatAttachBlock} name=${block.name} dims=${block.dims} src=${block.src} svg=${block.svg} ph=${block.ph} via=${block.via} size=${block.size} id=${block.id} kind=${block.kind} mimeType=${block.mimeType} sizeBytes=${block.sizeBytes} />`
     case 'voice': return html`<${ChatVoiceBlock} secs=${block.secs} wave=${block.wave} via=${block.via} size=${block.size} transcript=${block.transcript} src=${block.src} />`
     case 'image': return html`<${ChatImageBlock} src=${block.src} ph=${block.ph} cap=${block.cap} />`
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
@@ -1822,11 +1869,17 @@ function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachme
   const canDownload = isSafeAttachmentHref(attachment)
   const meta = attachmentMeta(attachment)
   const isImage = isRenderableImageAttachment(attachment)
+  const multimodalKind = userInputMediaKindForAttachment(attachment)
 
   return html`
     <div
       class="overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
       data-chat-attachment-card=${attachment.id}
+      data-chat-multimodal-source="persisted_attachment"
+      data-chat-multimodal-kind=${multimodalKind}
+      data-chat-multimodal-attachment-id=${attachment.id}
+      data-chat-multimodal-mime=${attachment.mimeType}
+      data-chat-multimodal-size-bytes=${attachment.size}
     >
       ${isImage
         ? html`
@@ -2101,6 +2154,16 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const timestamp = timeLabel(entry.timestamp)
   const sourceBadge = showSourceBadge ? sourceBadgeInfo(entry) : null
   const attachments = entry.attachments ?? []
+  const attachBlocks = effectiveBlocks.filter((block): block is Extract<ChatBlock, { t: 'attach' }> => block.t === 'attach')
+  const persistedAttachmentKinds = attachments.map(userInputMediaKindForAttachment)
+  const serverAttachKinds = attachBlocks
+    .map(block => block.kind?.trim())
+    .filter((value): value is string => Boolean(value))
+  const multimodalKinds = Array.from(new Set([...persistedAttachmentKinds, ...serverAttachKinds]))
+  const multimodalSources = [
+    attachments.length > 0 ? 'persisted_attachment' : null,
+    attachBlocks.length > 0 ? 'server_block' : null,
+  ].filter((value): value is string => value !== null)
   const surfaceInfo = surfaceLink(entry.surface)
 
   return html`
@@ -2127,6 +2190,10 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-attachment-count=${attachments.length}
+      data-chat-server-attach-block-count=${attachBlocks.length}
+      data-chat-multimodal-sources=${multimodalSources.length > 0 ? multimodalSources.join(',') : undefined}
+      data-chat-multimodal-kinds=${multimodalKinds.length > 0 ? multimodalKinds.join(',') : undefined}
     >
       <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
         <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
@@ -2634,6 +2701,8 @@ function ToolTraceStep({
   coverageState = 'not-applicable',
   hydrationFailureReason = null,
   traceStep,
+  orderIndex,
+  orderKind = 'tool',
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
@@ -2641,6 +2710,8 @@ function ToolTraceStep({
   coverageState?: ToolOutputCoverageState
   hydrationFailureReason?: string | null
   traceStep?: ChatTraceToolStep
+  orderIndex?: number
+  orderKind?: 'tool' | 'tool-entry'
 }) {
   const [open, setOpen] = useState(false)
   const name = traceStep?.name || entry?.label || 'tool'
@@ -2679,6 +2750,8 @@ function ToolTraceStep({
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind=${orderKind}
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${callId ?? undefined}
       data-chat-trace-oas-block-index=${traceStep?.oasBlockIndex ?? undefined}
@@ -2814,7 +2887,13 @@ function chatResponsePreview(entry: KeeperConversationEntry): string {
   return text.length > 96 ? `${text.slice(0, 96)}…` : text
 }
 
-function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
+function ChatResponseTraceStep({
+  entry,
+  orderIndex,
+}: {
+  entry: KeeperConversationEntry
+  orderIndex?: number
+}) {
   const sourceBadge: TraceSourceBadgeInfo = {
     label: 'reply',
     title: 'source: assistant reply entry',
@@ -2824,6 +2903,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
     <div
       class="chat-block-tstep chat"
       data-chat-trace-step="chat"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="chat"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-entry-id=${entry.id}
       data-chat-trace-source=${entry.source}
@@ -2889,6 +2970,12 @@ function ToolTraceCard({
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
+  const orderSignature = ordered.map((item) => {
+    if (item.kind === 'trace') return `trace:${item.step.kind}`
+    if (item.kind === 'tool') return `tool:${toolTraceCallId(item.entry, item.step) ?? item.step.name}`
+    if (item.kind === 'tool-entry') return `tool-entry:${toolTraceCallId(item.entry) ?? item.entry.id}`
+    return `chat:${item.entry.id}`
+  }).join('|')
   const orderedToolSteps = ordered.filter(isToolOrderItem)
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
   const failN = orderedToolSteps.filter(
@@ -2939,6 +3026,7 @@ function ToolTraceCard({
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}
       data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
       data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
+      data-chat-turn-order-signature=${orderSignature || undefined}
     >
       <button
         type="button"
@@ -2971,6 +3059,7 @@ function ToolTraceCard({
                   ? html`<${ChatTraceStep}
                       key=${`trace-${index}`}
                       step=${item.step}
+                      orderIndex=${index}
                       streaming=${assistant !== null && !turnComplete}
                     />`
                   : item.kind === 'tool'
@@ -2983,6 +3072,8 @@ function ToolTraceCard({
                           coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
+                          orderIndex=${index}
+                          orderKind="tool"
                         />`
                       })()
                     : item.kind === 'tool-entry'
@@ -2993,8 +3084,10 @@ function ToolTraceCard({
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
                           coverageState=${coverageStateForEntry(item.entry)}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
+                          orderIndex=${index}
+                          orderKind="tool-entry"
                         />`
-                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
+                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} orderIndex=${index} />`)}
             </div>
           `
         : null}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2123,6 +2123,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2496,6 +2497,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-request-id=${entry.streamContract?.requestId ?? undefined}
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2829,6 +2831,7 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-event=${entry.streamContract?.eventName ?? undefined}
       data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
+      data-chat-trace-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2926,6 +2929,7 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-request-id=${assistant?.streamContract?.requestId ?? undefined}
       data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
       data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
+      data-chat-turn-stream-contract-lifecycle-events=${assistant?.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -27,6 +27,9 @@ vi.mock('../keeper-actions', () => ({
 
 vi.mock('../keeper-state', async () => {
   const { signal } = await import('@preact/signals')
+  const withoutUndefined = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined))
+
   return {
     keeperActionErrors: signal({}),
     keeperHydrating: signal({}),
@@ -37,6 +40,20 @@ vi.mock('../keeper-state', async () => {
     keeperStreamStartedAt: signal({}),
     keeperStreamLastEventAt: signal({}),
     keeperThreads: signal({}),
+    keeperStreamContract: (source: string, status: string, opts: Record<string, unknown> = {}) => withoutUndefined({
+      source,
+      status,
+      eventName: opts.eventName ?? undefined,
+      requestId: opts.requestId ?? undefined,
+      turnRef: opts.turnRef ?? undefined,
+      traceEventCount: opts.traceEventCount ?? undefined,
+      lifecycleEvents: opts.lifecycleEvents ?? undefined,
+      deliveryReceipt: opts.deliveryReceipt ?? undefined,
+      reason: opts.reason ?? undefined,
+    }),
+    setRecordValue: (state: { value: Record<string, unknown> }, key: string, value: unknown) => {
+      state.value = { ...state.value, [key]: value }
+    },
     isDefaultVisibleConversationEntry: vi.fn((entry: { role?: string; source?: string }) =>
       entry.role === 'tool'
         || ((entry.role === 'user' || entry.role === 'assistant')
@@ -76,7 +93,7 @@ import {
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
-import type { ChatBlock, KeeperConversationEntry } from '../types'
+import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
   KeeperConversationPanel,
   KeeperDiagnosticSummary,
@@ -460,6 +477,58 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
     expect(container.querySelector('[data-chat-block="voice"]')).not.toBeNull()
     expect(container.textContent).toContain('hello voice')
+  })
+
+  it('keeps queued attachment drafts visible with multimodal provenance and no delivery receipt', async () => {
+    keeperSending.value = { sangsu: true }
+    const attachments: KeeperConversationAttachment[] = [
+      {
+        id: 'queued-att',
+        type: 'image',
+        name: 'queued.png',
+        size: 1024,
+        mimeType: 'image/png',
+        data: 'data:image/png;base64,iVBORw0KGgo=',
+      },
+    ]
+    const displayBlocks: ChatBlock[] = [
+      {
+        t: 'attach',
+        id: 'queued-att',
+        name: 'queued.png',
+        kind: 'image',
+        src: 'data:image/png;base64,iVBORw0KGgo=',
+        mimeType: 'image/png',
+        sizeBytes: 1024,
+      },
+    ]
+    const userBlocks: KeeperUserInputBlock[] = [
+      {
+        type: 'image',
+        attachmentId: 'queued-att',
+        name: 'queued.png',
+        mimeType: 'image/png',
+        size: 1024,
+      },
+    ]
+    enqueueInput('sangsu', '', attachments, 'queued-attachment-1', displayBlocks, userBlocks)
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const bubble = container.querySelector('[data-chat-entry-id^="queued-user-"]') as HTMLElement
+    expect(bubble.getAttribute('data-chat-delivery-state')).toBe('queued')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(bubble.getAttribute('data-chat-attachment-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-server-attach-block-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-multimodal-sources')).toBe('persisted_attachment,server_block')
+    expect(bubble.getAttribute('data-chat-multimodal-kinds')).toBe('image')
+    expect(bubble.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-attachment-card="queued-att"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-block="attach"][data-chat-multimodal-source="server_block"]')).not.toBeNull()
   })
 
   it('renders queued drafts with invalid timestamps without throwing', async () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -273,6 +273,7 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     delivery: 'queued',
     streamState: undefined,
     streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'client-side composer queue item; not yet submitted to keeper runtime',
     }),
     attachments: msg.attachments,

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -229,6 +229,7 @@ describe('hydrateKeeperChatHistory', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-hydrate#2',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -242,6 +243,7 @@ describe('hydrateKeeperChatHistory', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-hydrate#2',
       traceEventCount: 2,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -965,6 +967,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(reply?.delivery).toBe('interrupted')
     expect(reply?.text).toContain('부분 응답')
     expect(reply?.error).toContain('끊겼습니다')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('no_delivery_receipt')
     expect(keeperActionErrors.value.echo).toContain('끊겼습니다')
   })
 
@@ -982,6 +985,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
     expect(reply?.delivery).toBe('delivered')
     expect(reply?.text).toContain('완료된 응답')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     // Regression guard: the per-message force refresh re-rendered the
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -48,6 +48,7 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
+  keeperClientObservedSseStreamContract,
   keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
@@ -1015,6 +1016,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: cutMessage,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: cutMessage,
         }),
       })
@@ -1037,6 +1039,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: EMPTY_VISIBLE_REPLY_TEXT,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: EMPTY_VISIBLE_REPLY_TEXT,
         }),
       })
@@ -1058,7 +1061,7 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
-      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
+      streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
         eventName: 'RUN_FINISHED',
       }),
     })
@@ -1086,6 +1089,7 @@ export async function sendKeeperThreadMessage(
         delivery: 'cancelled',
         error: null,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1098,6 +1102,7 @@ export async function sendKeeperThreadMessage(
         error: null,
         timestamp: new Date().toISOString(),
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1114,6 +1119,7 @@ export async function sendKeeperThreadMessage(
       error: errorMessage,
       timestamp: new Date().toISOString(),
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),
@@ -1122,6 +1128,7 @@ export async function sendKeeperThreadMessage(
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -372,6 +372,7 @@ describe('thread history merge & persistence', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-rest#8',
           trace_event_count: 3,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -382,6 +383,7 @@ describe('thread history merge & persistence', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-rest#8',
       traceEventCount: 3,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -405,6 +407,7 @@ describe('thread history merge & persistence', () => {
             'TEXT_MESSAGE_END',
             'RUN_FINISHED',
           ],
+          delivery_receipt: 'server_lifecycle_replay_only',
           reason: 'history row records durable server stream lifecycle replay',
         },
       },
@@ -421,6 +424,7 @@ describe('thread history merge & persistence', () => {
         'TEXT_MESSAGE_END',
         'RUN_FINISHED',
       ],
+      deliveryReceipt: 'server_lifecycle_replay_only',
       reason: 'history row records durable server stream lifecycle replay',
     })
   })

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -386,6 +386,45 @@ describe('thread history merge & persistence', () => {
     })
   })
 
+  it('normalizes durable backend lifecycle stream contracts from REST chat history', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        source: 'direct_assistant',
+        content: 'reply from durable lifecycle replay',
+        ts: 1_780_000_001,
+        turn_ref: 'trace-rest#9',
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-rest#9',
+          event_name: 'RUN_FINISHED',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'TEXT_MESSAGE_START',
+            'TEXT_MESSAGE_END',
+            'RUN_FINISHED',
+          ],
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      },
+    ])
+
+    expect(entries[0]?.streamContract).toEqual({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turnRef: 'trace-rest#9',
+      eventName: 'RUN_FINISHED',
+      lifecycleEvents: [
+        'RUN_STARTED',
+        'TEXT_MESSAGE_START',
+        'TEXT_MESSAGE_END',
+        'RUN_FINISHED',
+      ],
+      reason: 'history row records durable server stream lifecycle replay',
+    })
+  })
+
   it('falls back explicitly when REST chat history carries an unknown stream contract', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -228,6 +228,7 @@ export function keeperStreamContract(
     requestId?: string | null
     turnRef?: string | null
     traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -238,6 +239,7 @@ export function keeperStreamContract(
     requestId: opts.requestId ?? undefined,
     turnRef: opts.turnRef ?? undefined,
     traceEventCount: opts.traceEventCount ?? undefined,
+    lifecycleEvents: opts.lifecycleEvents ?? undefined,
     reason: opts.reason ?? undefined,
   })
 }
@@ -246,6 +248,8 @@ function normalizeStreamContractSource(value: unknown): KeeperConversationStream
   switch (asString(value)?.trim()) {
     case 'keeper_chat_store':
       return 'keeper_chat_store'
+    case 'backend_stream_lifecycle':
+      return 'backend_stream_lifecycle'
     case 'backend_turn_trace':
       return 'backend_turn_trace'
     case 'rest_history':
@@ -273,6 +277,8 @@ function normalizeStreamContractStatus(value: unknown): KeeperConversationStream
       return 'backend_stream_event'
     case 'backend_terminal_event':
       return 'backend_terminal_event'
+    case 'backend_lifecycle_replay':
+      return 'backend_lifecycle_replay'
     case 'backend_trace_join':
       return 'backend_trace_join'
     case 'history_without_turn_ref':
@@ -304,6 +310,7 @@ function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract
     requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
     turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
     traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    lifecycleEvents: normalizeStringArray(raw.lifecycle_events) ?? normalizeStringArray(raw.lifecycleEvents) ?? null,
     reason: asString(raw.reason) ?? null,
   })
 }

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -11,6 +11,7 @@ import type {
   KeeperConversationRole,
   KeeperConversationSource,
   KeeperConversationStreamContract,
+  KeeperConversationStreamDeliveryReceipt,
   KeeperConversationStreamContractSource,
   KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
@@ -229,6 +230,7 @@ export function keeperStreamContract(
     turnRef?: string | null
     traceEventCount?: number | null
     lifecycleEvents?: string[] | null
+    deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -240,7 +242,26 @@ export function keeperStreamContract(
     turnRef: opts.turnRef ?? undefined,
     traceEventCount: opts.traceEventCount ?? undefined,
     lifecycleEvents: opts.lifecycleEvents ?? undefined,
+    deliveryReceipt: opts.deliveryReceipt ?? undefined,
     reason: opts.reason ?? undefined,
+  })
+}
+
+export function keeperClientObservedSseStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return keeperStreamContract(source, status, {
+    ...opts,
+    deliveryReceipt: 'client_observed_sse_event',
   })
 }
 
@@ -300,6 +321,19 @@ function normalizeStreamContractStatus(value: unknown): KeeperConversationStream
   }
 }
 
+function normalizeStreamDeliveryReceipt(value: unknown): KeeperConversationStreamDeliveryReceipt | null {
+  switch (asString(value)?.trim()) {
+    case 'client_observed_sse_event':
+      return 'client_observed_sse_event'
+    case 'server_lifecycle_replay_only':
+      return 'server_lifecycle_replay_only'
+    case 'no_delivery_receipt':
+      return 'no_delivery_receipt'
+    default:
+      return null
+  }
+}
+
 function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
   if (!isRecord(raw)) return null
   const source = normalizeStreamContractSource(raw.source)
@@ -311,6 +345,7 @@ function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract
     turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
     traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
     lifecycleEvents: normalizeStringArray(raw.lifecycle_events) ?? normalizeStringArray(raw.lifecycleEvents) ?? null,
+    deliveryReceipt: normalizeStreamDeliveryReceipt(raw.delivery_receipt) ?? normalizeStreamDeliveryReceipt(raw.deliveryReceipt) ?? null,
     reason: asString(raw.reason) ?? null,
   })
 }
@@ -968,6 +1003,7 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
     delivery: 'streaming',
     streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
       eventName: 'TEXT_MESSAGE_CONTENT',
+      deliveryReceipt: 'client_observed_sse_event',
     }),
   }))
 }
@@ -1026,6 +1062,7 @@ function writeAssistantThinkingText(
       delivery: 'streaming',
       streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
         eventName: 'KEEPER_THINKING_DELTA',
+        deliveryReceipt: 'client_observed_sse_event',
       }),
     }
   })

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -49,6 +49,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('안녕')
     expect(entry?.delivery).toBe('streaming')
     expect(entry?.streamState).toBe('streaming')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('ignores retired TEXT_DELTA events', () => {
@@ -87,6 +88,7 @@ describe('applyKeeperStreamEvent', () => {
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('queued')
     expect(entry?.streamState).toBe('opening')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('surfaces failed request terminal events before stream error close', () => {
@@ -107,6 +109,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBe('Timeout after 630.0s')
     expect(entry?.text).toBe('Keeper request failed: Timeout after 630.0s')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('renders cancelled request terminal events without an error bubble', () => {
@@ -127,6 +130,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
     expect(entry?.text).toBe('요청이 취소되었습니다.')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('finalizes successful request terminal events after streamed thinking', () => {
@@ -165,6 +169,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.delivery).toBe('delivered')
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,7 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
-  keeperStreamContract,
+  keeperClientObservedSseStreamContract,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -351,7 +351,7 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
@@ -363,7 +363,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'opening',
         'sending',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
       )
       return null
     case 'TEXT_MESSAGE_START':
@@ -377,7 +377,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'streaming',
         'streaming',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
       )
       return null
     case 'TEXT_MESSAGE_CONTENT': {
@@ -418,7 +418,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -469,7 +469,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
+          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
       return null
@@ -492,7 +492,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
         )
         return null
       }
@@ -521,7 +521,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
         )
         return null
       }
@@ -539,7 +539,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
         )
         return null
       }
@@ -556,7 +556,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
         )
         return null
       }
@@ -581,7 +581,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
           )
         }
         return null
@@ -609,7 +609,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
           )
         }
         return null
@@ -621,7 +621,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
         )
         return null
       }
@@ -632,7 +632,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'opening',
           'queued',
-          keeperStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
+          keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
         )
         return null
       }
@@ -651,7 +651,7 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'queued',
           streamState: null,
-          streamContract: keeperStreamContract('queue_event', 'queue_request_event', {
+          streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
             eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
           }),
         }))
@@ -683,7 +683,7 @@ export function applyKeeperStreamEvent(
             delivery: 'cancelled',
             streamState: null,
             error: null,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
             }),
@@ -702,7 +702,7 @@ export function applyKeeperStreamEvent(
             delivery: 'error',
             streamState: null,
             error: message,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
               reason: message,
@@ -723,7 +723,7 @@ export function applyKeeperStreamEvent(
               delivery,
               streamState: null,
               error: null,
-              streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
                 eventName: 'KEEPER_REQUEST_TERMINAL',
                 requestId: terminalRequestId,
               }),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -922,6 +922,11 @@ export type KeeperConversationStreamContractStatus =
   | 'client_reconciled_history'
   | 'contract_gap'
 
+export type KeeperConversationStreamDeliveryReceipt =
+  | 'client_observed_sse_event'
+  | 'server_lifecycle_replay_only'
+  | 'no_delivery_receipt'
+
 export interface KeeperConversationStreamContract {
   source: KeeperConversationStreamContractSource
   status: KeeperConversationStreamContractStatus
@@ -930,6 +935,7 @@ export interface KeeperConversationStreamContract {
   turnRef?: string | null
   traceEventCount?: number | null
   lifecycleEvents?: string[] | null
+  deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
   reason?: string | null
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -899,6 +899,7 @@ export type KeeperConversationStreamState =
 
 export type KeeperConversationStreamContractSource =
   | 'keeper_chat_store'
+  | 'backend_stream_lifecycle'
   | 'backend_turn_trace'
   | 'rest_history'
   | 'sse_event'
@@ -911,6 +912,7 @@ export type KeeperConversationStreamContractSource =
 export type KeeperConversationStreamContractStatus =
   | 'backend_stream_event'
   | 'backend_terminal_event'
+  | 'backend_lifecycle_replay'
   | 'backend_trace_join'
   | 'history_without_turn_ref'
   | 'history_without_stream_events'
@@ -927,6 +929,7 @@ export interface KeeperConversationStreamContract {
   requestId?: string | null
   turnRef?: string | null
   traceEventCount?: number | null
+  lifecycleEvents?: string[] | null
   reason?: string | null
 }
 

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -248,6 +248,7 @@ let all_entries =
       ~meets_main_gate:true
       ~rationale:"Dedicated keeper roster, conversation, and context workspace."
       ~route_hash:"#keepers"
+      ~fixture_harness:"./scripts/harness_dashboard_keeper_chat_contract_smoke.sh"
       ~live_spotcheck:"/api/v1/keepers/composite"
       ~tool_name:"masc_operator_snapshot"
       ()

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -116,6 +116,28 @@ module Row_kind = struct
     | (Utterance | Transport_failure), _ -> false
 end
 
+type stream_lifecycle_event =
+  | Run_started
+  | Text_message_start
+  | Text_message_end
+  | Run_finished
+  | Run_error
+
+let stream_lifecycle_event_to_label = function
+  | Run_started -> "RUN_STARTED"
+  | Text_message_start -> "TEXT_MESSAGE_START"
+  | Text_message_end -> "TEXT_MESSAGE_END"
+  | Run_finished -> "RUN_FINISHED"
+  | Run_error -> "RUN_ERROR"
+
+let stream_lifecycle_event_of_label = function
+  | "RUN_STARTED" -> Some Run_started
+  | "TEXT_MESSAGE_START" -> Some Text_message_start
+  | "TEXT_MESSAGE_END" -> Some Text_message_end
+  | "RUN_FINISHED" -> Some Run_finished
+  | "RUN_ERROR" -> Some Run_error
+  | _ -> None
+
 type speaker_authority =
   | Owner
   | External
@@ -195,6 +217,11 @@ type chat_message = {
          inbound user lines (no turn yet) and rows written before §7.  A
          malformed persisted value is reported as a persistence read drop
          and reads as [None]; the row stays valid. *)
+  stream_lifecycle : stream_lifecycle_event list option;
+      (* K1f: closed list of server lifecycle events for the direct chat
+         stream response represented by this row. [None] means pre-K1f row or
+         no lifecycle proof. Malformed persisted values are reported and read
+         as [None], keeping the row valid. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -421,6 +448,38 @@ let blocks_fields = function
   | Some blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let stream_lifecycle_fields = function
+  | None | Some [] -> []
+  | Some events ->
+      [
+        ( "stream_lifecycle",
+          `List
+            (List.map
+               (fun event -> `String (stream_lifecycle_event_to_label event))
+               events) );
+      ]
+
+let parse_stream_lifecycle ~path json =
+  let invalid detail =
+    report_persistence_read_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+      ~path ~detail;
+    None
+  in
+  let rec parse_items acc = function
+    | [] -> Some (List.rev acc)
+    | `String label :: rest -> (
+        match stream_lifecycle_event_of_label label with
+        | Some event -> parse_items (event :: acc) rest
+        | None ->
+            invalid (Printf.sprintf "unknown stream_lifecycle event %S" label))
+    | _ :: _ -> invalid "stream_lifecycle contains non-string event"
+  in
+  match json with
+  | `List [] -> None
+  | `List items -> parse_items [] items
+  | _ -> invalid "stream_lifecycle field is not a list"
+
 (* R3: producer-assigned message id.  [encode_line] is the sole writer, so
    minting here makes it impossible to persist a row without an id.  The
    process-monotonic counter disambiguates the user/tool/assistant rows of
@@ -450,7 +509,8 @@ let legacy_message_id ~ts ~content =
 
 let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     ?tool_call_name ?surface ?conversation_id ?external_message_id ?speaker
-    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref ()
+    ?audio ?blocks ?(mentions = []) ?(kind = Row_kind.Utterance) ?turn_ref
+    ?stream_lifecycle ()
     : string =
   (* RFC-0232 P5: the label is a derivation of the typed surface — the
      single site that turns a [Surface_ref.t] into the legacy [source]
@@ -529,6 +589,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?attachments ?tool_call_id
     @ audio_fields audio
     @ blocks_fields blocks
     @ opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string turn_ref)
+    @ stream_lifecycle_fields stream_lifecycle
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
@@ -555,6 +616,7 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     ?(assistant_kind = Row_kind.Utterance)
     ?blocks
     ?turn_ref
+    ?stream_lifecycle
     ~(assistant_content : string)
     () =
   try
@@ -597,7 +659,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     in
     let asst_line =
       encode_line ~role:Role.Assistant ~content:assistant_content ~ts ?surface
-        ?conversation_id ~kind:assistant_kind ?blocks ?turn_ref ()
+        ?conversation_id ~kind:assistant_kind ?blocks ?turn_ref
+        ?stream_lifecycle ()
     in
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
@@ -621,8 +684,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
 let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref () : (unit, string) result
-    =
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
+    (unit, string) result =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -632,7 +695,8 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ?turn_ref ()
+      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
+        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
     in
     Fs_compat.append_file path (line ^ "\n");
     Ok ()
@@ -651,10 +715,10 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
    failure is already counted + logged inside the [_result] variant). New callers
    that must surface the failure call [append_assistant_message_result] directly. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref () =
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () =
   ignore
     (append_assistant_message_result ~base_dir ~keeper_name ~content ?surface
-       ?conversation_id ?audio ?blocks ?turn_ref ()
+       ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
       : (unit, string) result)
 
 (* RFC-0226: inbound user line recorded at delivery time, before (and
@@ -891,6 +955,12 @@ let parse_line ~file_path (line : string) : chat_message option =
                 ~detail:(Printf.sprintf "invalid turn_ref %S" s);
               None)
     in
+    let stream_lifecycle =
+      match Json_util.assoc_member_opt "stream_lifecycle" json with
+      | None -> None
+      | Some stream_lifecycle_json ->
+          parse_stream_lifecycle ~path:file_path stream_lifecycle_json
+    in
     if role_label = "" || content = "" then (
       report_persistence_read_drop
         ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -923,7 +993,7 @@ let parse_line ~file_path (line : string) : chat_message option =
           Some
             { id; role; content; ts; attachments; tool_call_id; tool_call_name;
               source; surface; conversation_id; external_message_id; speaker;
-              audio; blocks; mentions; kind; turn_ref }
+              audio; blocks; mentions; kind; turn_ref; stream_lifecycle }
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -1139,6 +1209,11 @@ let blocks_fields_of_list = function
   | blocks -> [ ("blocks", Keeper_chat_blocks.blocks_to_yojson blocks) ]
 ;;
 
+let rec last_opt = function
+  | [] -> None
+  | [ x ] -> Some x
+  | _ :: rest -> last_opt rest
+
 let chat_stream_contract_json ~trace_lookup_available ~trace_block
     (m : chat_message) =
   let field key value = (key, value) in
@@ -1146,39 +1221,52 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
   let base_fields =
     opt_string_field "turn_ref" (Option.map Ids.Turn_ref.to_string m.turn_ref)
   in
-  match m.turn_ref with
-  | None ->
+  match m.stream_lifecycle with
+  | Some (_ :: _ as events) ->
+      let labels = List.map stream_lifecycle_event_to_label events in
       `Assoc
-        ([ string_field "source" "keeper_chat_store"
-         ; string_field "status" "history_without_turn_ref"
+        ([ string_field "source" "backend_stream_lifecycle"
+         ; string_field "status" "backend_lifecycle_replay"
          ; string_field "reason"
-             "history row has no persisted turn_ref; no causal stream join is possible"
+             "history row records durable server stream lifecycle replay"
+         ; field "lifecycle_events"
+             (`List (List.map (fun label -> `String label) labels))
          ]
+        @ opt_string_field "event_name" (last_opt labels)
         @ base_fields)
-  | Some _ -> (
-      match trace_block with
-      | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
-          `Assoc
-            ([ string_field "source" "backend_turn_trace"
-             ; string_field "status" "backend_trace_join"
-             ; string_field "reason"
-                 "turn_ref joined to retained trajectory/internal-history events"
-             ; field "trace_event_count" (`Int (List.length trace))
-             ]
-            @ base_fields)
-      | Some _ | None ->
-          let reason =
-            if trace_lookup_available then
-              "turn_ref persisted but no retained trajectory/internal-history events were available"
-            else
-              "history route served without trace enrichment"
-          in
+  | None | Some [] -> (
+      match m.turn_ref with
+      | None ->
           `Assoc
             ([ string_field "source" "keeper_chat_store"
-             ; string_field "status" "history_without_stream_events"
-             ; string_field "reason" reason
+             ; string_field "status" "history_without_turn_ref"
+             ; string_field "reason"
+                 "history row has no persisted turn_ref; no causal stream join is possible"
              ]
-            @ base_fields))
+            @ base_fields)
+      | Some _ -> (
+          match trace_block with
+          | Some (Keeper_chat_blocks.Trace { trace }) when trace <> [] ->
+              `Assoc
+                ([ string_field "source" "backend_turn_trace"
+                 ; string_field "status" "backend_trace_join"
+                 ; string_field "reason"
+                     "turn_ref joined to retained trajectory/internal-history events"
+                 ; field "trace_event_count" (`Int (List.length trace))
+                 ]
+                @ base_fields)
+          | Some _ | None ->
+              let reason =
+                if trace_lookup_available then
+                  "turn_ref persisted but no retained trajectory/internal-history events were available"
+                else "history route served without trace enrichment"
+              in
+              `Assoc
+                ([ string_field "source" "keeper_chat_store"
+                 ; string_field "status" "history_without_stream_events"
+                 ; string_field "reason" reason
+                 ]
+                @ base_fields)))
 
 let to_json_array ?base_dir ?trace_block_by_turn_ref
     (messages : chat_message list) : Yojson.Safe.t =

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1214,6 +1214,9 @@ let rec last_opt = function
   | [ x ] -> Some x
   | _ :: rest -> last_opt rest
 
+let stream_delivery_receipt_field value =
+  [ ("delivery_receipt", `String value) ]
+
 let chat_stream_contract_json ~trace_lookup_available ~trace_block
     (m : chat_message) =
   let field key value = (key, value) in
@@ -1232,6 +1235,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
          ; field "lifecycle_events"
              (`List (List.map (fun label -> `String label) labels))
          ]
+        @ stream_delivery_receipt_field "server_lifecycle_replay_only"
         @ opt_string_field "event_name" (last_opt labels)
         @ base_fields)
   | None | Some [] -> (
@@ -1243,6 +1247,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
              ; string_field "reason"
                  "history row has no persisted turn_ref; no causal stream join is possible"
              ]
+            @ stream_delivery_receipt_field "no_delivery_receipt"
             @ base_fields)
       | Some _ -> (
           match trace_block with
@@ -1254,6 +1259,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
                      "turn_ref joined to retained trajectory/internal-history events"
                  ; field "trace_event_count" (`Int (List.length trace))
                  ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
                 @ base_fields)
           | Some _ | None ->
               let reason =
@@ -1266,6 +1272,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
                  ; string_field "status" "history_without_stream_events"
                  ; string_field "reason" reason
                  ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
                 @ base_fields)))
 
 let to_json_array ?base_dir ?trace_block_by_turn_ref

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -71,6 +71,16 @@ module Row_kind : sig
   val equal : t -> t -> bool
 end
 
+(** Closed, durable names for AG-UI lifecycle events recorded by the direct
+    Keeper chat stream. This is server lifecycle provenance, not a
+    client-delivery receipt. *)
+type stream_lifecycle_event =
+  | Run_started
+  | Text_message_start
+  | Text_message_end
+  | Run_finished
+  | Run_error
+
 (** Authority class of the human (or agent) whose message opened a
     turn. Derived structurally from the arrival route, never from
     message content: the authenticated dashboard route is [Owner];
@@ -174,6 +184,12 @@ type chat_message = {
           on inbound user lines (no turn yet) and rows written before §7.
           A malformed persisted value is reported as a persistence read
           drop and reads as [None]; the row stays valid. *)
+  stream_lifecycle : stream_lifecycle_event list option;
+      (** K1f: durable server lifecycle replay for the chat stream response
+          represented by this row. [None] means the row predates this field or
+          the writer could not prove lifecycle events. Malformed persisted
+          values are reported as persistence read drops and read as [None];
+          the row stays valid. *)
 }
 
 (** {1 I/O} *)
@@ -204,6 +220,7 @@ val append_turn :
   ?assistant_kind:Row_kind.t ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   assistant_content:string ->
   unit ->
   unit
@@ -221,6 +238,7 @@ val append_assistant_message_result :
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
   (unit, string) result
 
@@ -238,6 +256,7 @@ val append_assistant_message :
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
   ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
   unit
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -970,6 +970,20 @@ let process_single_turn ~connector_user_line_recorded_upstream
     (Run_started { run_id; thread_id });
   Keeper_chat_events.publish events
     (Text_message_start { message_id; role = Assistant });
+  let completed_stream_lifecycle =
+    [ Keeper_chat_store.Run_started
+    ; Keeper_chat_store.Text_message_start
+    ; Keeper_chat_store.Text_message_end
+    ; Keeper_chat_store.Run_finished
+    ]
+  in
+  let errored_stream_lifecycle =
+    [ Keeper_chat_store.Run_started
+    ; Keeper_chat_store.Text_message_start
+    ; Keeper_chat_store.Text_message_end
+    ; Keeper_chat_store.Run_error
+    ]
+  in
   let args = args_of_request payload in
   (* Stream model text deltas live with per-delta redaction — the same
      treatment ThinkingDelta and Tool_call_args already get in
@@ -1086,6 +1100,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
          ~keeper_name:payload.name
          ~content:(persisted_error_reply err)
          ~surface:chat_surface
+         ~stream_lifecycle:errored_stream_lifecycle
          ()
      else
        Keeper_chat_store.append_turn
@@ -1097,6 +1112,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
          ~speaker:chat_speaker
          ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
          ~assistant_content:(persisted_error_reply err)
+         ~stream_lifecycle:errored_stream_lifecycle
          ());
     Keeper_chat_broadcast.chat_appended
       ~keeper_name:payload.name ~source:chat_source
@@ -1222,6 +1238,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                        ~surface:chat_surface
                        ?blocks
                        ?turn_ref
+                       ~stream_lifecycle:completed_stream_lifecycle
                        ()
                    else
                      Keeper_chat_store.append_turn
@@ -1234,6 +1251,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                        ~assistant_content
                        ?blocks
                        ?turn_ref
+                       ~stream_lifecycle:completed_stream_lifecycle
                        ()
                  in
                  let broadcast_chat_appended ?content () =

--- a/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+pick_free_port() {
+  node <<'NODE'
+const net = require('net');
+const server = net.createServer();
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  console.log(address && typeof address === 'object' ? address.port : 8961);
+  server.close();
+});
+NODE
+}
+
+log() {
+  printf '[keeper-chat-contract-smoke] %s\n' "$*" >&2
+}
+
+run_with_timeout() {
+  local timeout_sec="$1"
+  local label="$2"
+  shift 2
+
+  "$@" &
+  local cmd_pid=$!
+
+  (
+    sleep "$timeout_sec"
+    if kill -0 "$cmd_pid" >/dev/null 2>&1; then
+      printf '[keeper-chat-contract-smoke] timeout after %ss: %s\n' "$timeout_sec" "$label" >&2
+      kill "$cmd_pid" >/dev/null 2>&1 || true
+    fi
+  ) &
+  local watchdog_pid=$!
+
+  local status=0
+  wait "$cmd_pid" || status=$?
+  kill "$watchdog_pid" >/dev/null 2>&1 || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  return "$status"
+}
+
+PORT="${PORT:-$(pick_free_port)}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}/dashboard/}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-keeper-chat-contract.XXXXXX")}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+KEEP_BASE_PATH="${KEEP_BASE_PATH:-0}"
+KEEPER_NAME="${KEEPER_NAME:-chat-contract-smoke}"
+SERVER_LOG="${SERVER_LOG:-${BASE_PATH}/keeper-chat-contract-server.log}"
+SERVER_EXE="${SERVER_EXE:-$REPO_ROOT/_build/default/bin/main_eio.exe}"
+SERVER_WAIT_SEC="${SERVER_WAIT_SEC:-45}"
+CONTRACT_TIMEOUT_SEC="${CONTRACT_TIMEOUT_SEC:-30}"
+CONTRACT_SCRIPT="${CONTRACT_SCRIPT:-${BASE_PATH}/keeper-chat-contract.smoke.js}"
+RUNTIME_CONFIG_SOURCE="${RUNTIME_CONFIG_SOURCE:-$REPO_ROOT/config/runtime.toml}"
+
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    if [ "$KEEP_SERVER" = "1" ]; then
+      echo "Keeping server running: pid=$SERVER_PID log=$SERVER_LOG"
+    else
+      kill "$SERVER_PID" >/dev/null 2>&1 || true
+      wait "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [ "$KEEP_BASE_PATH" != "1" ]; then
+    rm -rf "$BASE_PATH"
+  else
+    echo "Keeping fixture base path: $BASE_PATH"
+  fi
+}
+
+trap cleanup EXIT
+
+if [ ! -f "$RUNTIME_CONFIG_SOURCE" ]; then
+  echo "Runtime config seed missing: $RUNTIME_CONFIG_SOURCE" >&2
+  exit 1
+fi
+
+mkdir -p "$BASE_PATH/.masc/config/keepers" "$BASE_PATH/.masc/keepers" "$BASE_PATH/.masc/keeper_chat"
+cp "$RUNTIME_CONFIG_SOURCE" "$BASE_PATH/.masc/config/runtime.toml"
+
+cat >"$BASE_PATH/.masc/config/keepers/${KEEPER_NAME}.toml" <<EOF_TOML
+[keeper]
+autoboot_enabled = false
+EOF_TOML
+
+KEEPER_NAME="$KEEPER_NAME" BASE_PATH="$BASE_PATH" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.env.BASE_PATH;
+const keeper = process.env.KEEPER_NAME;
+const chatPath = path.join(basePath, '.masc', 'keeper_chat', `${keeper}.jsonl`);
+const metaPath = path.join(basePath, '.masc', 'keepers', `${keeper}.json`);
+const turnRef = 'trace-chat-contract-smoke#7';
+
+const rows = [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'prove server lifecycle replay',
+    ts: 1783300000.001,
+    source: 'dashboard',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-tool',
+    role: 'tool',
+    content: '{}',
+    ts: 1783300000.002,
+    source: 'dashboard',
+    tool_call_id: 'toolu_smoke_contract',
+    tool_call_name: 'keeper_context_status',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-assistant',
+    role: 'assistant',
+    content: 'contract replay complete',
+    ts: 1783300000.003,
+    source: 'dashboard',
+    turn_ref: turnRef,
+    stream_lifecycle: [
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ],
+  },
+];
+
+fs.writeFileSync(chatPath, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+fs.writeFileSync(metaPath, `${JSON.stringify({
+  name: keeper,
+  agent_name: `${keeper}-agent`,
+  trace_id: 'trace-chat-contract-smoke',
+  goal: 'fixture keeper for dashboard chat contract smoke',
+  tool_access: [],
+})}\n`);
+NODE
+
+log "base_path=$BASE_PATH port=$PORT keeper=$KEEPER_NAME"
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-45}"
+  local i=1
+  while [ "$i" -le "$attempts" ]; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      log "http ready: $url"
+      return 0
+    fi
+    if [ $((i % 5)) -eq 0 ]; then
+      log "waiting for http ($i/$attempts): $url"
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+log "starting server"
+if [ -x "$SERVER_EXE" ]; then
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+else
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$REPO_ROOT/start-masc.sh" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+fi
+SERVER_PID=$!
+log "server_pid=$SERVER_PID log=$SERVER_LOG"
+
+if ! wait_for_http "http://${HOST}:${PORT}/health" "$SERVER_WAIT_SEC"; then
+  echo "MASC server did not become healthy. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+cat >"$CONTRACT_SCRIPT" <<'NODE'
+const base = process.env.BASE_URL;
+const keeper = process.env.KEEPER_NAME;
+const checks = [];
+
+function record(name, pass, details = {}) {
+  checks.push({ name, pass, details });
+}
+
+function requireContract(row, id) {
+  if (!row || !row.stream_contract) {
+    throw new Error(`missing stream_contract for ${id}`);
+  }
+  return row.stream_contract;
+}
+
+(async () => {
+  const historyUrl = new URL(`/api/v1/keepers/${encodeURIComponent(keeper)}/chat/history`, base);
+  const res = await fetch(historyUrl);
+  record('history endpoint returns 200', res.ok, { status: res.status });
+  if (!res.ok) throw new Error(`history endpoint failed: ${res.status} ${res.statusText}`);
+
+  const rows = await res.json();
+  record('history response is an array', Array.isArray(rows), { length: Array.isArray(rows) ? rows.length : null });
+  if (!Array.isArray(rows)) throw new Error('history response is not an array');
+
+  const byId = new Map(rows.map(row => [row.id, row]));
+  const userContract = requireContract(byId.get('smoke-user'), 'smoke-user');
+  const toolContract = requireContract(byId.get('smoke-tool'), 'smoke-tool');
+  const assistantContract = requireContract(byId.get('smoke-assistant'), 'smoke-assistant');
+
+  record('assistant row replays durable server lifecycle first', assistantContract.source === 'backend_stream_lifecycle' && assistantContract.status === 'backend_lifecycle_replay', assistantContract);
+  record('assistant row labels replay as server-only receipt', assistantContract.delivery_receipt === 'server_lifecycle_replay_only', assistantContract);
+  record('assistant row exposes terminal lifecycle event', assistantContract.event_name === 'RUN_FINISHED', assistantContract);
+  record(
+    'assistant row preserves closed lifecycle sequence',
+    JSON.stringify(assistantContract.lifecycle_events) === JSON.stringify([
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ]),
+    assistantContract,
+  );
+  record('user row has no client delivery receipt', userContract.delivery_receipt === 'no_delivery_receipt', userContract);
+  record('tool row has no client delivery receipt', toolContract.delivery_receipt === 'no_delivery_receipt', toolContract);
+  record(
+    'server history never claims dashboard client-observed SSE delivery',
+    rows.every(row => row.stream_contract?.delivery_receipt !== 'client_observed_sse_event'),
+    rows.map(row => ({ id: row.id, delivery_receipt: row.stream_contract?.delivery_receipt })),
+  );
+
+  console.log(JSON.stringify({ base, keeper, checks }, null, 2));
+  const failed = checks.filter(check => !check.pass);
+  if (failed.length > 0) process.exit(1);
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+NODE
+
+log "running contract smoke"
+if ! run_with_timeout "$CONTRACT_TIMEOUT_SEC" "keeper chat contract smoke" \
+  env BASE_URL="$BASE_URL" KEEPER_NAME="$KEEPER_NAME" node "$CONTRACT_SCRIPT"; then
+  echo "Keeper chat contract smoke failed. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+log "keeper chat contract smoke passed"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1550,6 +1550,8 @@ let test_to_json_array_stream_contract_without_turn_ref () =
             (contract |> member "source" |> to_string);
           Alcotest.(check string) "status" "history_without_turn_ref"
             (contract |> member "status" |> to_string);
+          Alcotest.(check string) "delivery receipt absent" "no_delivery_receipt"
+            (contract |> member "delivery_receipt" |> to_string);
           Alcotest.(check bool) "reason says no turn_ref" true
             (contains_substring
                (contract |> member "reason" |> to_string)
@@ -1593,6 +1595,9 @@ let test_to_json_array_stream_contract_trace_join () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-stream#5"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "trace join is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check int) "trace event count" 1
         (contract |> member "trace_event_count" |> to_int))
 
@@ -1623,6 +1628,9 @@ let test_to_json_array_stream_contract_trace_unavailable () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-no-events#9"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "missing trace is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check bool) "reason says no retained trace" true
         (contains_substring
            (contract |> member "reason" |> to_string)
@@ -1706,6 +1714,9 @@ let test_to_json_array_stream_contract_lifecycle_replay () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "terminal event" "RUN_FINISHED"
         (contract |> member "event_name" |> to_string);
+      Alcotest.(check string) "lifecycle replay is server-side only"
+        "server_lifecycle_replay_only"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check (list string)) "lifecycle events"
         [ "RUN_STARTED"; "TEXT_MESSAGE_START"; "TEXT_MESSAGE_END"; "RUN_FINISHED" ]
         (json_string_list (contract |> member "lifecycle_events")))

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1628,6 +1628,112 @@ let test_to_json_array_stream_contract_trace_unavailable () =
            (contract |> member "reason" |> to_string)
            "no retained trajectory/internal-history events"))
 
+let json_string_list json =
+  Yojson.Safe.Util.to_list json |> List.map Yojson.Safe.Util.to_string
+
+let test_to_json_array_stream_contract_lifecycle_replay () =
+  let base_dir =
+    temp_base_path "keeper-chat-store-stream-contract-lifecycle"
+  in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-stream-contract-lifecycle" in
+      let tref =
+        Ids.Turn_ref.make ~trace_id:"trace-lifecycle" ~absolute_turn:6
+      in
+      let stream_lifecycle =
+        [ K.Run_started
+        ; K.Text_message_start
+        ; K.Text_message_end
+        ; K.Run_finished
+        ]
+      in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"inspect"
+        ~user_attachments:[]
+        ~tool_calls:[ { K.call_id = "toolu_life"; call_name = "Read"; args = "{}" } ]
+        ~turn_ref:tref ~stream_lifecycle ~assistant_content:"done" ();
+      (match K.load ~base_dir ~keeper_name with
+       | [ user; tool; assistant ] ->
+           Alcotest.(check bool) "user row carries no stream lifecycle" true
+             (Option.is_none user.stream_lifecycle);
+           Alcotest.(check bool) "tool row carries no stream lifecycle" true
+             (Option.is_none tool.stream_lifecycle);
+           Alcotest.(check (option (list string)))
+             "stream lifecycle roundtrips on assistant row"
+             (Some
+                [ "RUN_STARTED"
+                ; "TEXT_MESSAGE_START"
+                ; "TEXT_MESSAGE_END"
+                ; "RUN_FINISHED"
+                ])
+             (Option.map
+                (List.map (fun event ->
+                   match event with
+                   | K.Run_started -> "RUN_STARTED"
+                   | K.Text_message_start -> "TEXT_MESSAGE_START"
+                   | K.Text_message_end -> "TEXT_MESSAGE_END"
+                   | K.Run_finished -> "RUN_FINISHED"
+                   | K.Run_error -> "RUN_ERROR"))
+                assistant.stream_lifecycle)
+       | messages ->
+           Alcotest.failf "expected user/tool/assistant rows, got %d"
+             (List.length messages));
+      let trace_block_by_turn_ref turn_ref =
+        if Ids.Turn_ref.equal turn_ref tref then
+          Some
+            (B.Trace
+               { trace =
+                   [ B.Trace_think
+                       { text = "retained trace";
+                         ts = Some "2026-07-05T00:00:00Z";
+                         oas_block_index = None;
+                       };
+                   ];
+               })
+        else None
+      in
+      let rows =
+        Yojson.Safe.Util.to_list
+          (K.to_json_array ~trace_block_by_turn_ref
+             (K.load ~base_dir ~keeper_name))
+      in
+      let contract = stream_contract_of (assistant_row rows) in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "source" "backend_stream_lifecycle"
+        (contract |> member "source" |> to_string);
+      Alcotest.(check string) "status" "backend_lifecycle_replay"
+        (contract |> member "status" |> to_string);
+      Alcotest.(check string) "terminal event" "RUN_FINISHED"
+        (contract |> member "event_name" |> to_string);
+      Alcotest.(check (list string)) "lifecycle events"
+        [ "RUN_STARTED"; "TEXT_MESSAGE_START"; "TEXT_MESSAGE_END"; "RUN_FINISHED" ]
+        (json_string_list (contract |> member "lifecycle_events")))
+
+let test_malformed_stream_lifecycle_reads_none () =
+  let base_dir = temp_base_path "keeper-chat-store-lifecycle-bad" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-store-lifecycle-bad" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = drop_value invalid_payload in
+      write_file path
+        ({|{"role":"assistant","content":"x","ts":1.0,"turn_ref":"trace-life#7","stream_lifecycle":["RUN_STARTED","NOT_A_REAL_EVENT"]}|}
+        ^ "\n");
+      (match K.load ~base_dir ~keeper_name with
+       | [ m ] ->
+           Alcotest.(check bool) "malformed lifecycle reads as None" true
+             (Option.is_none m.stream_lifecycle);
+           Alcotest.(check bool) "turn_ref still parsed" true
+             (Option.is_some m.turn_ref)
+       | messages ->
+           Alcotest.failf "expected 1 message, got %d" (List.length messages));
+      Alcotest.(check (float 0.001)) "drop counted as invalid payload"
+        1.0
+        (drop_value invalid_payload -. before))
+
 (* A malformed persisted turn_ref is surfaced as a read drop and reads as
    [None] — never repaired — while the row itself stays valid. *)
 let test_turn_ref_malformed_reads_none () =
@@ -1773,6 +1879,10 @@ let () =
             test_to_json_array_stream_contract_trace_join;
           Alcotest.test_case "history stream contract marks missing trace" `Quick
             test_to_json_array_stream_contract_trace_unavailable;
+          Alcotest.test_case "history stream contract replays durable lifecycle" `Quick
+            test_to_json_array_stream_contract_lifecycle_replay;
+          Alcotest.test_case "malformed stream lifecycle reads as None" `Quick
+            test_malformed_stream_lifecycle_reads_none;
         ] );
       ( "row_kind",
         [

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -65,6 +65,7 @@ let msg ~role ?(ts = Some 1.0) ?(source = None) ?(speaker = None)
   ; mentions = Masc.Keeper_lane_mentions.mention_ids_of_content content
   ; kind
   ; turn_ref = None
+  ; stream_lifecycle = None
   }
 ;;
 
@@ -205,6 +206,7 @@ let tool_line : Store.chat_message =
   ; mentions = []
   ; kind = Store.Row_kind.Utterance
   ; turn_ref = None
+  ; stream_lifecycle = None
   }
 ;;
 

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -29,6 +29,7 @@ let msg ?ts ?source ?speaker ~role content : Store.chat_message =
     mentions = [];
     kind = Store.Row_kind.Utterance;
     turn_ref = None;
+    stream_lifecycle = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## Summary
- persist a closed-list `stream_lifecycle` replay on direct Keeper Chat assistant rows for server lifecycle events
- expose the durable lifecycle replay through `/chat/history` `stream_contract` before retained-trace fallback
- normalize and render lifecycle replay provenance in the dashboard DOM contract attributes

## Boundaries
- This is server-side lifecycle provenance, not a client-delivery receipt.
- `append_turn` stores lifecycle replay only on the assistant/failure row, not on user or tool rows.
- Malformed persisted lifecycle payloads increment persistence read-drop telemetry and read as `None`; the row remains valid.

## Verification
- `scripts/dune-local.sh build test/test_keeper_chat_store.exe && ./_build/default/test/test_keeper_chat_store.exe`
- `scripts/dune-local.sh build test/test_keeper_surface_read.exe test/test_keeper_mention_scope.exe`
- `./_build/default/test/test_keeper_surface_read.exe`
- `./_build/default/test/test_keeper_mention_scope.exe`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/schemas/keeper-chat-history.test.ts src/keeper-state.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run --if-present build`