### PR TITLE
[codex] Add Keeper Chat contract replay smoke

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -94,6 +94,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-1780648779957-00000#4071',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       }),
@@ -103,6 +104,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
       status: 'backend_trace_join',
       turn_ref: 'trace-1780648779957-00000#4071',
       trace_event_count: 2,
+      delivery_receipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -121,6 +123,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
             'TEXT_MESSAGE_END',
             'RUN_FINISHED',
           ],
+          delivery_receipt: 'server_lifecycle_replay_only',
           reason: 'history row records durable server stream lifecycle replay',
         },
       }),
@@ -136,6 +139,7 @@ describe('safeParseKeeperChatHistoryMessage', () => {
         'TEXT_MESSAGE_END',
         'RUN_FINISHED',
       ],
+      delivery_receipt: 'server_lifecycle_replay_only',
       reason: 'history row records durable server stream lifecycle replay',
     })
   })

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -229,6 +229,8 @@ export const KeeperChatHistoryStreamContractSchema = object({
   traceEventCount: optional(number()),
   lifecycle_events: optional(array(string())),
   lifecycleEvents: optional(array(string())),
+  delivery_receipt: optional(string()),
+  deliveryReceipt: optional(string()),
   reason: optional(string()),
 })
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -202,6 +202,7 @@ describe('ChatTranscript', () => {
                 'TEXT_MESSAGE_END',
                 'RUN_FINISHED',
               ],
+              deliveryReceipt: 'server_lifecycle_replay_only',
               reason: 'history row records durable server stream lifecycle replay',
             },
             surface: {
@@ -231,6 +232,9 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-contract-event')).toBe('RUN_FINISHED')
     expect(bubble.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe(
       'RUN_STARTED,TEXT_MESSAGE_START,TEXT_MESSAGE_END,RUN_FINISHED',
+    )
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe(
+      'server_lifecycle_replay_only',
     )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -252,6 +252,7 @@ describe('ChatTranscript', () => {
             streamContract: {
               source: 'rest_history',
               status: 'history_without_stream_events',
+              deliveryReceipt: 'no_delivery_receipt',
               reason: 'tool history rows carry arguments, not live stream lifecycle',
             },
           }),
@@ -271,6 +272,7 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-state')).toBe('complete')
     expect(bubble.getAttribute('data-chat-stream-contract-source')).toBe('rest_history')
     expect(bubble.getAttribute('data-chat-stream-contract-status')).toBe('history_without_stream_events')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
     expect(bubble.getAttribute('data-chat-turn-ref')).toBe('trace-tool#3')
     expect(bubble.getAttribute('data-chat-tool-call-id')).toBe('toolu_prov')
   })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2124,6 +2124,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
     >
@@ -2498,6 +2499,7 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-tool-call-id=${toolCallId ?? undefined}
     >
@@ -2832,6 +2834,7 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
       data-chat-trace-stream-contract-turn-ref=${entry.streamContract?.turnRef ?? undefined}
       data-chat-trace-stream-contract-trace-events=${entry.streamContract?.traceEventCount ?? undefined}
       data-chat-trace-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-trace-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
     >
       <span class="chat-block-tnode"></span>
       <div class="min-w-0 flex-1">
@@ -2930,6 +2933,7 @@ function ToolTraceCard({
       data-chat-turn-stream-contract-turn-ref=${assistant?.streamContract?.turnRef ?? undefined}
       data-chat-turn-stream-contract-trace-events=${assistant?.streamContract?.traceEventCount ?? undefined}
       data-chat-turn-stream-contract-lifecycle-events=${assistant?.streamContract?.lifecycleEvents?.join(',') ?? undefined}
+      data-chat-turn-stream-contract-delivery-receipt=${assistant?.streamContract?.deliveryReceipt ?? undefined}
       data-chat-tool-output-hydration-source=${toolOutputHydrationContract?.source ?? undefined}
       data-chat-tool-output-hydration-status=${toolOutputHydrationContract?.status ?? 'not-requested'}
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -229,6 +229,7 @@ describe('hydrateKeeperChatHistory', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-hydrate#2',
           trace_event_count: 2,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -242,6 +243,7 @@ describe('hydrateKeeperChatHistory', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-hydrate#2',
       traceEventCount: 2,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -965,6 +967,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(reply?.delivery).toBe('interrupted')
     expect(reply?.text).toContain('부분 응답')
     expect(reply?.error).toContain('끊겼습니다')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('no_delivery_receipt')
     expect(keeperActionErrors.value.echo).toContain('끊겼습니다')
   })
 
@@ -982,6 +985,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
     expect(reply?.delivery).toBe('delivered')
     expect(reply?.text).toContain('완료된 응답')
+    expect(reply?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     // Regression guard: the per-message force refresh re-rendered the
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -48,6 +48,7 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
+  keeperClientObservedSseStreamContract,
   keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
@@ -1015,6 +1016,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: cutMessage,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: cutMessage,
         }),
       })
@@ -1037,6 +1039,7 @@ export async function sendKeeperThreadMessage(
         timestamp: new Date().toISOString(),
         error: EMPTY_VISIBLE_REPLY_TEXT,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           reason: EMPTY_VISIBLE_REPLY_TEXT,
         }),
       })
@@ -1058,7 +1061,7 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
-      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
+      streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
         eventName: 'RUN_FINISHED',
       }),
     })
@@ -1086,6 +1089,7 @@ export async function sendKeeperThreadMessage(
         delivery: 'cancelled',
         error: null,
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1098,6 +1102,7 @@ export async function sendKeeperThreadMessage(
         error: null,
         timestamp: new Date().toISOString(),
         streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+          deliveryReceipt: 'no_delivery_receipt',
           requestId: requestId ?? undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
@@ -1114,6 +1119,7 @@ export async function sendKeeperThreadMessage(
       error: errorMessage,
       timestamp: new Date().toISOString(),
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),
@@ -1122,6 +1128,7 @@ export async function sendKeeperThreadMessage(
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
       streamContract: keeperStreamContract('client_reconciliation', 'contract_gap', {
+        deliveryReceipt: 'no_delivery_receipt',
         requestId: requestId ?? undefined,
         reason: errorMessage,
       }),

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -372,6 +372,7 @@ describe('thread history merge & persistence', () => {
           status: 'backend_trace_join',
           turn_ref: 'trace-rest#8',
           trace_event_count: 3,
+          delivery_receipt: 'no_delivery_receipt',
           reason: 'turn_ref joined to retained trajectory/internal-history events',
         },
       },
@@ -382,6 +383,7 @@ describe('thread history merge & persistence', () => {
       status: 'backend_trace_join',
       turnRef: 'trace-rest#8',
       traceEventCount: 3,
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'turn_ref joined to retained trajectory/internal-history events',
     })
   })
@@ -405,6 +407,7 @@ describe('thread history merge & persistence', () => {
             'TEXT_MESSAGE_END',
             'RUN_FINISHED',
           ],
+          delivery_receipt: 'server_lifecycle_replay_only',
           reason: 'history row records durable server stream lifecycle replay',
         },
       },
@@ -421,6 +424,7 @@ describe('thread history merge & persistence', () => {
         'TEXT_MESSAGE_END',
         'RUN_FINISHED',
       ],
+      deliveryReceipt: 'server_lifecycle_replay_only',
       reason: 'history row records durable server stream lifecycle replay',
     })
   })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -11,6 +11,7 @@ import type {
   KeeperConversationRole,
   KeeperConversationSource,
   KeeperConversationStreamContract,
+  KeeperConversationStreamDeliveryReceipt,
   KeeperConversationStreamContractSource,
   KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
@@ -229,6 +230,7 @@ export function keeperStreamContract(
     turnRef?: string | null
     traceEventCount?: number | null
     lifecycleEvents?: string[] | null
+    deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
     reason?: string | null
   } = {},
 ): KeeperConversationStreamContract {
@@ -240,7 +242,26 @@ export function keeperStreamContract(
     turnRef: opts.turnRef ?? undefined,
     traceEventCount: opts.traceEventCount ?? undefined,
     lifecycleEvents: opts.lifecycleEvents ?? undefined,
+    deliveryReceipt: opts.deliveryReceipt ?? undefined,
     reason: opts.reason ?? undefined,
+  })
+}
+
+export function keeperClientObservedSseStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return keeperStreamContract(source, status, {
+    ...opts,
+    deliveryReceipt: 'client_observed_sse_event',
   })
 }
 
@@ -300,6 +321,19 @@ function normalizeStreamContractStatus(value: unknown): KeeperConversationStream
   }
 }
 
+function normalizeStreamDeliveryReceipt(value: unknown): KeeperConversationStreamDeliveryReceipt | null {
+  switch (asString(value)?.trim()) {
+    case 'client_observed_sse_event':
+      return 'client_observed_sse_event'
+    case 'server_lifecycle_replay_only':
+      return 'server_lifecycle_replay_only'
+    case 'no_delivery_receipt':
+      return 'no_delivery_receipt'
+    default:
+      return null
+  }
+}
+
 function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
   if (!isRecord(raw)) return null
   const source = normalizeStreamContractSource(raw.source)
@@ -311,6 +345,7 @@ function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract
     turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
     traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
     lifecycleEvents: normalizeStringArray(raw.lifecycle_events) ?? normalizeStringArray(raw.lifecycleEvents) ?? null,
+    deliveryReceipt: normalizeStreamDeliveryReceipt(raw.delivery_receipt) ?? normalizeStreamDeliveryReceipt(raw.deliveryReceipt) ?? null,
     reason: asString(raw.reason) ?? null,
   })
 }
@@ -968,6 +1003,7 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
     delivery: 'streaming',
     streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
       eventName: 'TEXT_MESSAGE_CONTENT',
+      deliveryReceipt: 'client_observed_sse_event',
     }),
   }))
 }
@@ -1026,6 +1062,7 @@ function writeAssistantThinkingText(
       delivery: 'streaming',
       streamContract: entry.streamContract ?? keeperStreamContract('sse_event', 'backend_stream_event', {
         eventName: 'KEEPER_THINKING_DELTA',
+        deliveryReceipt: 'client_observed_sse_event',
       }),
     }
   })

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -49,6 +49,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.text).toBe('안녕')
     expect(entry?.delivery).toBe('streaming')
     expect(entry?.streamState).toBe('streaming')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('ignores retired TEXT_DELTA events', () => {
@@ -87,6 +88,7 @@ describe('applyKeeperStreamEvent', () => {
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('queued')
     expect(entry?.streamState).toBe('opening')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('surfaces failed request terminal events before stream error close', () => {
@@ -107,6 +109,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBe('Timeout after 630.0s')
     expect(entry?.text).toBe('Keeper request failed: Timeout after 630.0s')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('renders cancelled request terminal events without an error bubble', () => {
@@ -127,6 +130,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
     expect(entry?.text).toBe('요청이 취소되었습니다.')
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
   it('finalizes successful request terminal events after streamed thinking', () => {
@@ -165,6 +169,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.delivery).toBe('delivered')
     expect(entry?.streamState).toBeNull()
     expect(entry?.error).toBeNull()
+    expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
     expect(activeStreamRequestId('sangsu')).toBeNull()
   })
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,7 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
-  keeperStreamContract,
+  keeperClientObservedSseStreamContract,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -351,7 +351,7 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
@@ -363,7 +363,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'opening',
         'sending',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
       )
       return null
     case 'TEXT_MESSAGE_START':
@@ -377,7 +377,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'streaming',
         'streaming',
-        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
       )
       return null
     case 'TEXT_MESSAGE_CONTENT': {
@@ -418,7 +418,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
-        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
+        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -469,7 +469,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
+          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
         }))
       }
       return null
@@ -492,7 +492,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
         )
         return null
       }
@@ -521,7 +521,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
         )
         return null
       }
@@ -539,7 +539,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
         )
         return null
       }
@@ -556,7 +556,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
         )
         return null
       }
@@ -581,7 +581,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
           )
         }
         return null
@@ -609,7 +609,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
           )
         }
         return null
@@ -621,7 +621,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
         )
         return null
       }
@@ -632,7 +632,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'opening',
           'queued',
-          keeperStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
+          keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
         )
         return null
       }
@@ -651,7 +651,7 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'queued',
           streamState: null,
-          streamContract: keeperStreamContract('queue_event', 'queue_request_event', {
+          streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
             eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
           }),
         }))
@@ -683,7 +683,7 @@ export function applyKeeperStreamEvent(
             delivery: 'cancelled',
             streamState: null,
             error: null,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
             }),
@@ -702,7 +702,7 @@ export function applyKeeperStreamEvent(
             delivery: 'error',
             streamState: null,
             error: message,
-            streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+            streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
               eventName: 'KEEPER_REQUEST_TERMINAL',
               requestId: terminalRequestId,
               reason: message,
@@ -723,7 +723,7 @@ export function applyKeeperStreamEvent(
               delivery,
               streamState: null,
               error: null,
-              streamContract: keeperStreamContract('queue_event', 'backend_terminal_event', {
+              streamContract: keeperClientObservedSseStreamContract('queue_event', 'backend_terminal_event', {
                 eventName: 'KEEPER_REQUEST_TERMINAL',
                 requestId: terminalRequestId,
               }),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -922,6 +922,11 @@ export type KeeperConversationStreamContractStatus =
   | 'client_reconciled_history'
   | 'contract_gap'
 
+export type KeeperConversationStreamDeliveryReceipt =
+  | 'client_observed_sse_event'
+  | 'server_lifecycle_replay_only'
+  | 'no_delivery_receipt'
+
 export interface KeeperConversationStreamContract {
   source: KeeperConversationStreamContractSource
   status: KeeperConversationStreamContractStatus
@@ -930,6 +935,7 @@ export interface KeeperConversationStreamContract {
   turnRef?: string | null
   traceEventCount?: number | null
   lifecycleEvents?: string[] | null
+  deliveryReceipt?: KeeperConversationStreamDeliveryReceipt | null
   reason?: string | null
 }
 

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -248,6 +248,7 @@ let all_entries =
       ~meets_main_gate:true
       ~rationale:"Dedicated keeper roster, conversation, and context workspace."
       ~route_hash:"#keepers"
+      ~fixture_harness:"./scripts/harness_dashboard_keeper_chat_contract_smoke.sh"
       ~live_spotcheck:"/api/v1/keepers/composite"
       ~tool_name:"masc_operator_snapshot"
       ()

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1214,6 +1214,9 @@ let rec last_opt = function
   | [ x ] -> Some x
   | _ :: rest -> last_opt rest
 
+let stream_delivery_receipt_field value =
+  [ ("delivery_receipt", `String value) ]
+
 let chat_stream_contract_json ~trace_lookup_available ~trace_block
     (m : chat_message) =
   let field key value = (key, value) in
@@ -1232,6 +1235,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
          ; field "lifecycle_events"
              (`List (List.map (fun label -> `String label) labels))
          ]
+        @ stream_delivery_receipt_field "server_lifecycle_replay_only"
         @ opt_string_field "event_name" (last_opt labels)
         @ base_fields)
   | None | Some [] -> (
@@ -1243,6 +1247,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
              ; string_field "reason"
                  "history row has no persisted turn_ref; no causal stream join is possible"
              ]
+            @ stream_delivery_receipt_field "no_delivery_receipt"
             @ base_fields)
       | Some _ -> (
           match trace_block with
@@ -1254,6 +1259,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
                      "turn_ref joined to retained trajectory/internal-history events"
                  ; field "trace_event_count" (`Int (List.length trace))
                  ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
                 @ base_fields)
           | Some _ | None ->
               let reason =
@@ -1266,6 +1272,7 @@ let chat_stream_contract_json ~trace_lookup_available ~trace_block
                  ; string_field "status" "history_without_stream_events"
                  ; string_field "reason" reason
                  ]
+                @ stream_delivery_receipt_field "no_delivery_receipt"
                 @ base_fields)))
 
 let to_json_array ?base_dir ?trace_block_by_turn_ref

--- a/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_contract_smoke.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+pick_free_port() {
+  node <<'NODE'
+const net = require('net');
+const server = net.createServer();
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  console.log(address && typeof address === 'object' ? address.port : 8961);
+  server.close();
+});
+NODE
+}
+
+log() {
+  printf '[keeper-chat-contract-smoke] %s\n' "$*" >&2
+}
+
+run_with_timeout() {
+  local timeout_sec="$1"
+  local label="$2"
+  shift 2
+
+  "$@" &
+  local cmd_pid=$!
+
+  (
+    sleep "$timeout_sec"
+    if kill -0 "$cmd_pid" >/dev/null 2>&1; then
+      printf '[keeper-chat-contract-smoke] timeout after %ss: %s\n' "$timeout_sec" "$label" >&2
+      kill "$cmd_pid" >/dev/null 2>&1 || true
+    fi
+  ) &
+  local watchdog_pid=$!
+
+  local status=0
+  wait "$cmd_pid" || status=$?
+  kill "$watchdog_pid" >/dev/null 2>&1 || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  return "$status"
+}
+
+PORT="${PORT:-$(pick_free_port)}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}/dashboard/}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-keeper-chat-contract.XXXXXX")}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+KEEP_BASE_PATH="${KEEP_BASE_PATH:-0}"
+KEEPER_NAME="${KEEPER_NAME:-chat-contract-smoke}"
+SERVER_LOG="${SERVER_LOG:-${BASE_PATH}/keeper-chat-contract-server.log}"
+SERVER_EXE="${SERVER_EXE:-$REPO_ROOT/_build/default/bin/main_eio.exe}"
+SERVER_WAIT_SEC="${SERVER_WAIT_SEC:-45}"
+CONTRACT_TIMEOUT_SEC="${CONTRACT_TIMEOUT_SEC:-30}"
+CONTRACT_SCRIPT="${CONTRACT_SCRIPT:-${BASE_PATH}/keeper-chat-contract.smoke.js}"
+RUNTIME_CONFIG_SOURCE="${RUNTIME_CONFIG_SOURCE:-$REPO_ROOT/config/runtime.toml}"
+
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    if [ "$KEEP_SERVER" = "1" ]; then
+      echo "Keeping server running: pid=$SERVER_PID log=$SERVER_LOG"
+    else
+      kill "$SERVER_PID" >/dev/null 2>&1 || true
+      wait "$SERVER_PID" 2>/dev/null || true
+    fi
+  fi
+  if [ "$KEEP_BASE_PATH" != "1" ]; then
+    rm -rf "$BASE_PATH"
+  else
+    echo "Keeping fixture base path: $BASE_PATH"
+  fi
+}
+
+trap cleanup EXIT
+
+if [ ! -f "$RUNTIME_CONFIG_SOURCE" ]; then
+  echo "Runtime config seed missing: $RUNTIME_CONFIG_SOURCE" >&2
+  exit 1
+fi
+
+mkdir -p "$BASE_PATH/.masc/config/keepers" "$BASE_PATH/.masc/keepers" "$BASE_PATH/.masc/keeper_chat"
+cp "$RUNTIME_CONFIG_SOURCE" "$BASE_PATH/.masc/config/runtime.toml"
+
+cat >"$BASE_PATH/.masc/config/keepers/${KEEPER_NAME}.toml" <<EOF_TOML
+[keeper]
+autoboot_enabled = false
+EOF_TOML
+
+KEEPER_NAME="$KEEPER_NAME" BASE_PATH="$BASE_PATH" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const basePath = process.env.BASE_PATH;
+const keeper = process.env.KEEPER_NAME;
+const chatPath = path.join(basePath, '.masc', 'keeper_chat', `${keeper}.jsonl`);
+const metaPath = path.join(basePath, '.masc', 'keepers', `${keeper}.json`);
+const turnRef = 'trace-chat-contract-smoke#7';
+
+const rows = [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'prove server lifecycle replay',
+    ts: 1783300000.001,
+    source: 'dashboard',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-tool',
+    role: 'tool',
+    content: '{}',
+    ts: 1783300000.002,
+    source: 'dashboard',
+    tool_call_id: 'toolu_smoke_contract',
+    tool_call_name: 'keeper_context_status',
+    turn_ref: turnRef,
+  },
+  {
+    id: 'smoke-assistant',
+    role: 'assistant',
+    content: 'contract replay complete',
+    ts: 1783300000.003,
+    source: 'dashboard',
+    turn_ref: turnRef,
+    stream_lifecycle: [
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ],
+  },
+];
+
+fs.writeFileSync(chatPath, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+fs.writeFileSync(metaPath, `${JSON.stringify({
+  name: keeper,
+  agent_name: `${keeper}-agent`,
+  trace_id: 'trace-chat-contract-smoke',
+  goal: 'fixture keeper for dashboard chat contract smoke',
+  tool_access: [],
+})}\n`);
+NODE
+
+log "base_path=$BASE_PATH port=$PORT keeper=$KEEPER_NAME"
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-45}"
+  local i=1
+  while [ "$i" -le "$attempts" ]; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      log "http ready: $url"
+      return 0
+    fi
+    if [ $((i % 5)) -eq 0 ]; then
+      log "waiting for http ($i/$attempts): $url"
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+log "starting server"
+if [ -x "$SERVER_EXE" ]; then
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+else
+  nohup env \
+    MASC_BASE_PATH="$BASE_PATH" \
+    MASC_CONFIG_DIR="$BASE_PATH/.masc/config" \
+    MASC_ORCHESTRATOR_ENABLED=false \
+    MASC_AUTONOMY_ENABLED=false \
+    MASC_DASHBOARD_BRIEFING_MODELS=disabled \
+    "$REPO_ROOT/start-masc.sh" --port "$PORT" --base-path "$BASE_PATH" >"$SERVER_LOG" 2>&1 &
+fi
+SERVER_PID=$!
+log "server_pid=$SERVER_PID log=$SERVER_LOG"
+
+if ! wait_for_http "http://${HOST}:${PORT}/health" "$SERVER_WAIT_SEC"; then
+  echo "MASC server did not become healthy. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+cat >"$CONTRACT_SCRIPT" <<'NODE'
+const base = process.env.BASE_URL;
+const keeper = process.env.KEEPER_NAME;
+const checks = [];
+
+function record(name, pass, details = {}) {
+  checks.push({ name, pass, details });
+}
+
+function requireContract(row, id) {
+  if (!row || !row.stream_contract) {
+    throw new Error(`missing stream_contract for ${id}`);
+  }
+  return row.stream_contract;
+}
+
+(async () => {
+  const historyUrl = new URL(`/api/v1/keepers/${encodeURIComponent(keeper)}/chat/history`, base);
+  const res = await fetch(historyUrl);
+  record('history endpoint returns 200', res.ok, { status: res.status });
+  if (!res.ok) throw new Error(`history endpoint failed: ${res.status} ${res.statusText}`);
+
+  const rows = await res.json();
+  record('history response is an array', Array.isArray(rows), { length: Array.isArray(rows) ? rows.length : null });
+  if (!Array.isArray(rows)) throw new Error('history response is not an array');
+
+  const byId = new Map(rows.map(row => [row.id, row]));
+  const userContract = requireContract(byId.get('smoke-user'), 'smoke-user');
+  const toolContract = requireContract(byId.get('smoke-tool'), 'smoke-tool');
+  const assistantContract = requireContract(byId.get('smoke-assistant'), 'smoke-assistant');
+
+  record('assistant row replays durable server lifecycle first', assistantContract.source === 'backend_stream_lifecycle' && assistantContract.status === 'backend_lifecycle_replay', assistantContract);
+  record('assistant row labels replay as server-only receipt', assistantContract.delivery_receipt === 'server_lifecycle_replay_only', assistantContract);
+  record('assistant row exposes terminal lifecycle event', assistantContract.event_name === 'RUN_FINISHED', assistantContract);
+  record(
+    'assistant row preserves closed lifecycle sequence',
+    JSON.stringify(assistantContract.lifecycle_events) === JSON.stringify([
+      'RUN_STARTED',
+      'TEXT_MESSAGE_START',
+      'TEXT_MESSAGE_END',
+      'RUN_FINISHED',
+    ]),
+    assistantContract,
+  );
+  record('user row has no client delivery receipt', userContract.delivery_receipt === 'no_delivery_receipt', userContract);
+  record('tool row has no client delivery receipt', toolContract.delivery_receipt === 'no_delivery_receipt', toolContract);
+  record(
+    'server history never claims dashboard client-observed SSE delivery',
+    rows.every(row => row.stream_contract?.delivery_receipt !== 'client_observed_sse_event'),
+    rows.map(row => ({ id: row.id, delivery_receipt: row.stream_contract?.delivery_receipt })),
+  );
+
+  console.log(JSON.stringify({ base, keeper, checks }, null, 2));
+  const failed = checks.filter(check => !check.pass);
+  if (failed.length > 0) process.exit(1);
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+NODE
+
+log "running contract smoke"
+if ! run_with_timeout "$CONTRACT_TIMEOUT_SEC" "keeper chat contract smoke" \
+  env BASE_URL="$BASE_URL" KEEPER_NAME="$KEEPER_NAME" node "$CONTRACT_SCRIPT"; then
+  echo "Keeper chat contract smoke failed. See $SERVER_LOG" >&2
+  exit 1
+fi
+
+log "keeper chat contract smoke passed"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1550,6 +1550,8 @@ let test_to_json_array_stream_contract_without_turn_ref () =
             (contract |> member "source" |> to_string);
           Alcotest.(check string) "status" "history_without_turn_ref"
             (contract |> member "status" |> to_string);
+          Alcotest.(check string) "delivery receipt absent" "no_delivery_receipt"
+            (contract |> member "delivery_receipt" |> to_string);
           Alcotest.(check bool) "reason says no turn_ref" true
             (contains_substring
                (contract |> member "reason" |> to_string)
@@ -1593,6 +1595,9 @@ let test_to_json_array_stream_contract_trace_join () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-stream#5"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "trace join is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check int) "trace event count" 1
         (contract |> member "trace_event_count" |> to_int))
 
@@ -1623,6 +1628,9 @@ let test_to_json_array_stream_contract_trace_unavailable () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "turn_ref" "trace-no-events#9"
         (contract |> member "turn_ref" |> to_string);
+      Alcotest.(check string) "missing trace is not delivery receipt"
+        "no_delivery_receipt"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check bool) "reason says no retained trace" true
         (contains_substring
            (contract |> member "reason" |> to_string)
@@ -1706,6 +1714,9 @@ let test_to_json_array_stream_contract_lifecycle_replay () =
         (contract |> member "status" |> to_string);
       Alcotest.(check string) "terminal event" "RUN_FINISHED"
         (contract |> member "event_name" |> to_string);
+      Alcotest.(check string) "lifecycle replay is server-side only"
+        "server_lifecycle_replay_only"
+        (contract |> member "delivery_receipt" |> to_string);
       Alcotest.(check (list string)) "lifecycle events"
         [ "RUN_STARTED"; "TEXT_MESSAGE_START"; "TEXT_MESSAGE_END"; "RUN_FINISHED" ]
         (json_string_list (contract |> member "lifecycle_events")))


### PR DESCRIPTION
## Summary
- add a deterministic temp-base smoke harness for `/api/v1/keepers/:name/chat/history`
- seed real `.masc/keeper_chat/<keeper>.jsonl` rows and assert server lifecycle replay receipts are not client SSE receipts
- wire the Keeper surface readiness fixture evidence to the new harness while preserving `/api/v1/keepers/composite` as the live spotcheck
- extend the ChatTranscript DOM test to assert `no_delivery_receipt` on tool/history rows

This PR does not add durable client-delivery receipt persistence. It only locks the current replay contract so server history cannot falsely claim dashboard-observed SSE delivery.

## Verification
- `bash -n scripts/harness_dashboard_keeper_chat_contract_smoke.sh`
- `scripts/dune-local.sh build test/test_dashboard_surface_readiness.exe`
- `_build/default/test/test_dashboard_surface_readiness.exe`
- `scripts/dune-local.sh build bin/main_eio.exe`
- `scripts/harness_dashboard_keeper_chat_contract_smoke.sh`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `opam exec -- ocamlformat --check lib/dashboard/dashboard_surface_readiness.ml`
- `git diff --check`
