### PR TITLE
[codex] Expose Keeper Chat turn order proof

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2167,6 +2167,60 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(chat.getAttribute('data-chat-trace-turn-ref')).toBe('trace-prov#7')
   })
 
+  it('exposes structural turn order without timestamp sorting', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-t-order',
+            label: 'keeper_context_status',
+            text: '{"ok":true}',
+            timestamp: '2026-03-24T00:00:01.000Z',
+            turnRef: 'trace-order#1',
+          }),
+          entry({
+            id: 'assistant-order',
+            text: '완료했습니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            timestamp: '2026-03-24T00:00:00.000Z',
+            turnRef: 'trace-order#1',
+            traceSteps: [
+              { kind: 'think', text: 'first structural thought', ts: '2026-03-24T00:00:04.000Z' },
+              {
+                kind: 'tool',
+                name: 'keeper_context_status',
+                toolCallId: 't-order',
+                status: 'ok',
+                ts: '2026-03-24T00:00:02.000Z',
+              },
+              { kind: 'think', text: 'second structural thought', ts: '2026-03-24T00:00:03.000Z' },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement
+    expect(trace.getAttribute('data-chat-turn-order-signature')).toBe(
+      'trace:think|tool:t-order|trace:think|chat:assistant-order',
+    )
+
+    const ordered = [...trace.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered).toHaveLength(4)
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual(['trace', 'tool', 'trace', 'chat'])
+
+    const tool = ordered[1] as HTMLElement
+    expect(tool.getAttribute('data-chat-trace-tool-call-id')).toBe('t-order')
+    expect(tool.getAttribute('data-chat-trace-entry-id')).toBe('tool-t-order')
+    expect(tool.getAttribute('data-chat-trace-link-state')).toBe('joined')
+  })
+
   it('renders thinking text as sanitized markdown with newlines preserved', async () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1319,7 +1319,15 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   `
 }
 
-function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; streaming?: boolean }) {
+function ChatTraceStep({
+  step,
+  streaming = false,
+  orderIndex,
+}: {
+  step: ChatTraceStep
+  streaming?: boolean
+  orderIndex?: number
+}) {
   const [open, setOpen] = useState(false)
   const sourceBadge = traceSourceBadge(step)
 
@@ -1332,6 +1340,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep think"
         data-chat-trace-step="think"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
         data-chat-trace-ts=${step.ts ?? undefined}
@@ -1380,6 +1390,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
       <div
         class="chat-block-tstep reason ${open ? 'exp' : ''}"
         data-chat-trace-step="reason"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
         data-chat-trace-provenance=${sourceBadge.label}
         data-chat-trace-ts=${step.ts ?? undefined}
       >
@@ -1405,6 +1417,8 @@ function ChatTraceStep({ step, streaming = false }: { step: ChatTraceStep; strea
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="tool"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${step.toolCallId?.trim() || undefined}
       data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
@@ -2687,6 +2701,8 @@ function ToolTraceStep({
   coverageState = 'not-applicable',
   hydrationFailureReason = null,
   traceStep,
+  orderIndex,
+  orderKind = 'tool',
 }: {
   entry: KeeperConversationEntry | null
   output: ToolCallEntry | null
@@ -2694,6 +2710,8 @@ function ToolTraceStep({
   coverageState?: ToolOutputCoverageState
   hydrationFailureReason?: string | null
   traceStep?: ChatTraceToolStep
+  orderIndex?: number
+  orderKind?: 'tool' | 'tool-entry'
 }) {
   const [open, setOpen] = useState(false)
   const name = traceStep?.name || entry?.label || 'tool'
@@ -2732,6 +2750,8 @@ function ToolTraceStep({
     <div
       class="chat-block-tstep tool ${open ? 'exp' : ''}"
       data-chat-trace-step="tool"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind=${orderKind}
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-tool-call-id=${callId ?? undefined}
       data-chat-trace-oas-block-index=${traceStep?.oasBlockIndex ?? undefined}
@@ -2867,7 +2887,13 @@ function chatResponsePreview(entry: KeeperConversationEntry): string {
   return text.length > 96 ? `${text.slice(0, 96)}…` : text
 }
 
-function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
+function ChatResponseTraceStep({
+  entry,
+  orderIndex,
+}: {
+  entry: KeeperConversationEntry
+  orderIndex?: number
+}) {
   const sourceBadge: TraceSourceBadgeInfo = {
     label: 'reply',
     title: 'source: assistant reply entry',
@@ -2877,6 +2903,8 @@ function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
     <div
       class="chat-block-tstep chat"
       data-chat-trace-step="chat"
+      data-chat-turn-order-index=${orderIndex ?? undefined}
+      data-chat-turn-order-kind="chat"
       data-chat-trace-provenance=${sourceBadge.label}
       data-chat-trace-entry-id=${entry.id}
       data-chat-trace-source=${entry.source}
@@ -2942,6 +2970,12 @@ function ToolTraceCard({
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
+  const orderSignature = ordered.map((item) => {
+    if (item.kind === 'trace') return `trace:${item.step.kind}`
+    if (item.kind === 'tool') return `tool:${toolTraceCallId(item.entry, item.step) ?? item.step.name}`
+    if (item.kind === 'tool-entry') return `tool-entry:${toolTraceCallId(item.entry) ?? item.entry.id}`
+    return `chat:${item.entry.id}`
+  }).join('|')
   const orderedToolSteps = ordered.filter(isToolOrderItem)
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
   const failN = orderedToolSteps.filter(
@@ -2992,6 +3026,7 @@ function ToolTraceCard({
       data-chat-tool-output-hydration-failure=${toolOutputHydrationContract?.failureReason ?? undefined}
       data-chat-tool-output-covered-since=${toolOutputsCoveredSinceMs ?? undefined}
       data-chat-tool-output-covered-through=${toolOutputsCoveredThroughMs ?? undefined}
+      data-chat-turn-order-signature=${orderSignature || undefined}
     >
       <button
         type="button"
@@ -3024,6 +3059,7 @@ function ToolTraceCard({
                   ? html`<${ChatTraceStep}
                       key=${`trace-${index}`}
                       step=${item.step}
+                      orderIndex=${index}
                       streaming=${assistant !== null && !turnComplete}
                     />`
                   : item.kind === 'tool'
@@ -3036,6 +3072,8 @@ function ToolTraceCard({
                           coverageState=${item.entry !== null ? coverageStateForEntry(item.entry) : 'not-applicable'}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
                           traceStep=${item.step}
+                          orderIndex=${index}
+                          orderKind="tool"
                         />`
                       })()
                     : item.kind === 'tool-entry'
@@ -3046,8 +3084,10 @@ function ToolTraceCard({
                           canMarkMissing=${canMarkMissingForEntry(item.entry)}
                           coverageState=${coverageStateForEntry(item.entry)}
                           hydrationFailureReason=${toolOutputHydrationContract?.failureReason ?? null}
+                          orderIndex=${index}
+                          orderKind="tool-entry"
                         />`
-                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
+                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} orderIndex=${index} />`)}
             </div>
           `
         : null}

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -27,6 +27,9 @@ vi.mock('../keeper-actions', () => ({
 
 vi.mock('../keeper-state', async () => {
   const { signal } = await import('@preact/signals')
+  const withoutUndefined = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined))
+
   return {
     keeperActionErrors: signal({}),
     keeperHydrating: signal({}),
@@ -37,6 +40,20 @@ vi.mock('../keeper-state', async () => {
     keeperStreamStartedAt: signal({}),
     keeperStreamLastEventAt: signal({}),
     keeperThreads: signal({}),
+    keeperStreamContract: (source: string, status: string, opts: Record<string, unknown> = {}) => withoutUndefined({
+      source,
+      status,
+      eventName: opts.eventName ?? undefined,
+      requestId: opts.requestId ?? undefined,
+      turnRef: opts.turnRef ?? undefined,
+      traceEventCount: opts.traceEventCount ?? undefined,
+      lifecycleEvents: opts.lifecycleEvents ?? undefined,
+      deliveryReceipt: opts.deliveryReceipt ?? undefined,
+      reason: opts.reason ?? undefined,
+    }),
+    setRecordValue: (state: { value: Record<string, unknown> }, key: string, value: unknown) => {
+      state.value = { ...state.value, [key]: value }
+    },
     isDefaultVisibleConversationEntry: vi.fn((entry: { role?: string; source?: string }) =>
       entry.role === 'tool'
         || ((entry.role === 'user' || entry.role === 'assistant')
@@ -76,7 +93,7 @@ import {
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
-import type { ChatBlock, KeeperConversationEntry } from '../types'
+import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
   KeeperConversationPanel,
   KeeperDiagnosticSummary,
@@ -460,6 +477,58 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
     expect(container.querySelector('[data-chat-block="voice"]')).not.toBeNull()
     expect(container.textContent).toContain('hello voice')
+  })
+
+  it('keeps queued attachment drafts visible with multimodal provenance and no delivery receipt', async () => {
+    keeperSending.value = { sangsu: true }
+    const attachments: KeeperConversationAttachment[] = [
+      {
+        id: 'queued-att',
+        type: 'image',
+        name: 'queued.png',
+        size: 1024,
+        mimeType: 'image/png',
+        data: 'data:image/png;base64,iVBORw0KGgo=',
+      },
+    ]
+    const displayBlocks: ChatBlock[] = [
+      {
+        t: 'attach',
+        id: 'queued-att',
+        name: 'queued.png',
+        kind: 'image',
+        src: 'data:image/png;base64,iVBORw0KGgo=',
+        mimeType: 'image/png',
+        sizeBytes: 1024,
+      },
+    ]
+    const userBlocks: KeeperUserInputBlock[] = [
+      {
+        type: 'image',
+        attachmentId: 'queued-att',
+        name: 'queued.png',
+        mimeType: 'image/png',
+        size: 1024,
+      },
+    ]
+    enqueueInput('sangsu', '', attachments, 'queued-attachment-1', displayBlocks, userBlocks)
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const bubble = container.querySelector('[data-chat-entry-id^="queued-user-"]') as HTMLElement
+    expect(bubble.getAttribute('data-chat-delivery-state')).toBe('queued')
+    expect(bubble.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(bubble.getAttribute('data-chat-attachment-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-server-attach-block-count')).toBe('1')
+    expect(bubble.getAttribute('data-chat-multimodal-sources')).toBe('persisted_attachment,server_block')
+    expect(bubble.getAttribute('data-chat-multimodal-kinds')).toBe('image')
+    expect(bubble.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-attachment-card="queued-att"]')).not.toBeNull()
+    expect(bubble.querySelector('[data-chat-block="attach"][data-chat-multimodal-source="server_block"]')).not.toBeNull()
   })
 
   it('renders queued drafts with invalid timestamps without throwing', async () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -273,6 +273,7 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     delivery: 'queued',
     streamState: undefined,
     streamContract: keeperStreamContract('client_local_send', 'client_placeholder', {
+      deliveryReceipt: 'no_delivery_receipt',
       reason: 'client-side composer queue item; not yet submitted to keeper runtime',
     }),
     attachments: msg.attachments,


### PR DESCRIPTION
## Summary
- Expose DOM-verifiable turn-order indices and signatures from the existing structural Keeper Chat timeline renderer.
- Keep queued attachment draft rows explicit as client placeholders with no delivery receipt, while preserving persisted attachment and server attach-block provenance.
- Add regression coverage for structural trace/tool/chat ordering and queued multimodal draft provenance.

## Boundaries
- Dashboard-only change; no OAS/provider changes.
- Does not add durable client receipt logs.
- Does not synthesize transcript rows or sort timeline steps by timestamp.

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- git diff --check
- Browser plugin unavailable in this session; Playwright CLI fallback screenshot: /tmp/masc-chat-turn-order-proof-keepers.png