### PR TITLE
[codex] Show secret projection for offline keepers

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -840,11 +840,16 @@ let cached_keeper_config_json config name =
   | other -> `OK, other
 ;;
 
-let offline_keeper_composite_json name (m : Keeper_meta_contract.keeper_meta) =
+let offline_keeper_composite_json ~config name (m : Keeper_meta_contract.keeper_meta) =
   let now = Time_compat.now () in
   let phase = if m.paused then "paused" else "offline" in
   let reason =
     if m.paused then "paused_without_registry_entry" else "registry_absent"
+  in
+  let secret_projection =
+    Keeper_secret_projection.dashboard_status_json
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:name
   in
   `Assoc
     [ "keeper", `String name
@@ -872,6 +877,7 @@ let offline_keeper_composite_json name (m : Keeper_meta_contract.keeper_meta) =
     ; "last_turn_ts", `Float m.runtime.usage.last_turn_ts
     ; "fsm_guard_violations", `Int 0
     ; "fsm_guard_violation_breakdown", `List []
+    ; "secret_projection", secret_projection
     ; ( "runtime_attention"
       , `Assoc
           [ "state", `String phase
@@ -919,7 +925,7 @@ let cached_keeper_composite_json config name =
              | Ok None ->
                ( `Not_found
                , error_json (Printf.sprintf "keeper %S not found" name) )
-             | Ok (Some m) -> `OK, offline_keeper_composite_json name m))
+             | Ok (Some m) -> `OK, offline_keeper_composite_json ~config name m))
       in
       `Assoc
         [ "status", `String (keeper_composite_status_to_string status)

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -112,6 +112,12 @@ val keeper_runtime_trace_json :
   [ `Not_found | `OK ] * Yojson.Safe.t
 (** Runtime manifest + receipt evidence chain for [GET /runtime-trace]. *)
 
+val offline_keeper_composite_json :
+  config:Workspace.config ->
+  string -> Keeper_meta_contract.keeper_meta -> Yojson.Safe.t
+(** Offline/paused composite fallback for keepers missing from the live
+    registry. Exposed so dashboard tests can pin the JSON shape. *)
+
 val handle_keeper_checkpoints_post :
   Mcp_server.server_state ->
   Httpun.Request.t -> Httpun.Reqd.t -> string -> unit

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1173,6 +1173,54 @@ let test_dashboard_fleet_composite_envelope_is_cached () =
     "second fleet-composite poll hits cache (identical generated_at)"
     true (gen1 = gen2)
 
+let test_offline_keeper_composite_exposes_secret_projection () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Workspace.init config ~agent_name:None);
+  let keeper_name = "offline-secret-keeper" in
+  let sentinel = "ghs_offline_secret_projection_regression" in
+  (match
+     Masc.Keeper_secret_projection.set_env_entry
+       ~base_path:config.base_path
+       ~keeper_name
+       ~scope:Masc.Keeper_secret_projection.Shared_secret
+       ~name:"GH_TOKEN"
+       ~value:sentinel
+   with
+   | Ok () -> ()
+   | Error err -> Alcotest.failf "set shared secret failed: %s" err);
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+           [ "name", `String keeper_name
+           ; "agent_name", `String keeper_name
+           ; "trace_id", `String "offline-secret-trace"
+           ])
+    with
+    | Ok meta -> { meta with Masc.Keeper_meta_contract.paused = true }
+    | Error err -> Alcotest.failf "meta fixture failed: %s" err
+  in
+  let json =
+    Server_dashboard_http_keeper_api.offline_keeper_composite_json
+      ~config
+      keeper_name
+      meta
+  in
+  let open Yojson.Safe.Util in
+  let projection = json |> member "secret_projection" in
+  Alcotest.(check string)
+    "offline composite includes ready secret projection"
+    "ready"
+    (projection |> member "status" |> to_string);
+  Alcotest.(check (list string))
+    "offline composite reports projected env names"
+    [ "GH_TOKEN" ]
+    (projection |> member "env_names" |> to_list |> List.map to_string);
+  Alcotest.(check bool)
+    "offline composite redacts secret values"
+    false
+    (contains_substring (Yojson.Safe.to_string json) sentinel)
+
 let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   ignore (Workspace.init config ~agent_name:None);
@@ -1612,6 +1660,8 @@ let () =
             test_telemetry_n_default_is_bounded;
           test_case "fleet-composite envelope is cached across polls" `Quick
             test_dashboard_fleet_composite_envelope_is_cached;
+          test_case "offline keeper composite exposes secret projection" `Quick
+            test_offline_keeper_composite_exposes_secret_projection;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick


### PR DESCRIPTION
## Summary
- include `secret_projection` in the offline/paused keeper composite fallback
- expose the fallback helper for dashboard shape tests
- add regression coverage proving the field is present and secret values remain redacted

## Verification
- `git diff --check`
- `ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/server/server_dashboard_http_keeper_api.mli test/test_dashboard_http_core.ml`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe test/test_keeper_secret_projection.exe test/test_keeper_secret_redaction.exe test/test_env_git_noninteractive.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `./_build/default/test/test_keeper_secret_projection.exe`
- `./_build/default/test/test_keeper_secret_redaction.exe && ./_build/default/test/test_env_git_noninteractive.exe`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/schemas/keeper-composite.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1`

## Best Programmer Self-Review
- Goal: keep the Keeper dashboard credential surface complete by exposing the existing redacted `secret_projection` status for paused/offline keeper composite fallbacks.
- Changed files: `lib/server/server_dashboard_http_keeper_api.ml`, `lib/server/server_dashboard_http_keeper_api.mli`, `test/test_dashboard_http_core.ml`.
- Directness check: every changed line either passes `Workspace.config` into the offline fallback, adds the existing `Keeper_secret_projection.dashboard_status_json` payload, exposes the helper for shape testing, or pins that shape with a regression test.
- Risk: this touches an operator/dashboard composite JSON path for security-sensitive metadata; the main risk is accidentally exposing raw secret values. The implementation uses the existing redacted projection helper and the regression asserts the sentinel token value is absent from serialized JSON.
- Scope check: no new secret storage path, env knob, Docker behavior, SSE writer, credential materialization, or OAS/provider behavior is introduced.
- Local verification: `git diff --check`; `ocamlformat --check` on touched files; focused `dune-local` build; `test_dashboard_http_core`; keeper secret projection/redaction tests; `test_env_git_noninteractive`; dashboard typecheck; targeted keeper composite/runtime vitest.
- Still unverified before Ready: none for the touched surface. Required GitHub `CI Gate` is green; full `Build and Test`, lint, health, canary, ocamlformat, and fast checks completed successfully. One non-required Fundamental Check row remains stale-looking as `IN_PROGRESS` with `SUCCESS` metadata.
