### PR TITLE
[codex] Add Keeper Chat replay contract fixture smoke

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Interleave Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-interleave-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Replay Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-replay-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
@@ -1,0 +1,98 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  INTERLEAVE_ORDER_SIGNATURE,
+  InterleaveContractFixture,
+  installInterleaveFixtureToolOutputs,
+  interleaveEntries,
+  interleaveFixtureStatus,
+  joinedToolCount,
+  traceOnlyToolCount,
+} from './keeper-chat-interleave-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat interleave contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic fixture rows for joined and trace-only tool states', () => {
+    expect(interleaveEntries).toHaveLength(2)
+    expect(joinedToolCount).toBe(1)
+    expect(traceOnlyToolCount).toBe(1)
+    expect(interleaveFixtureStatus).toBe('ok')
+
+    const assistant = interleaveEntries.find(entry => entry.id === 'assistant-interleave')
+    expect(assistant?.traceSteps?.map(step => step.kind)).toEqual(['think', 'tool', 'think', 'tool'])
+    expect(assistant?.traceSteps?.map(step => step.ts)).toEqual([
+      '2026-07-05T14:20:05.000Z',
+      '2026-07-05T14:20:01.000Z',
+      '2026-07-05T14:20:02.000Z',
+      '2026-07-05T14:20:03.000Z',
+    ])
+  })
+
+  it('renders structural order and tool-output join state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installInterleaveFixtureToolOutputs()
+
+    render(html`<${InterleaveContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        `[data-interleave-contract-fixture-status="ok"][data-interleave-order-signature="${INTERLEAVE_ORDER_SIGNATURE}"][data-interleave-joined-tool-count="1"][data-interleave-trace-only-tool-count="1"]`,
+      ),
+    ).not.toBeNull()
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(trace).not.toBeNull()
+    expect(trace?.getAttribute('data-chat-turn-order-signature')).toBe(INTERLEAVE_ORDER_SIGNATURE)
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(INTERLEAVE_FIXTURE_COVERED_THROUGH_MS))
+
+    const ordered = [...container.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3', '4'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual([
+      'trace',
+      'tool',
+      'trace',
+      'tool',
+      'chat',
+    ])
+
+    expect(ordered[0]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:05.000Z')
+    expect(ordered[1]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-state')).toBe('ok')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+    expect(ordered[2]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:02.000Z')
+    expect(ordered[3]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-missing')
+    expect(ordered[3]?.getAttribute('data-chat-trace-entry-id')).toBeNull()
+    expect(ordered[3]?.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
+    expect(ordered[3]?.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(ordered[4]?.getAttribute('data-chat-trace-entry-id')).toBe('assistant-interleave')
+
+    const joinedToolRow = ordered[1]
+    expect(joinedToolRow).toBeDefined()
+    if (!joinedToolRow) {
+      throw new Error('expected joined tool row at structural order index 1')
+    }
+
+    expect(container.textContent).not.toContain('context status joined from tool_calls_endpoint')
+    fireEvent.click(joinedToolRow.querySelector('.chat-block-tstep-row') as HTMLElement)
+    expect(container.textContent).toContain('context status joined from tool_calls_endpoint')
+    expect(container.textContent).not.toContain('unrelated output')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -1,0 +1,171 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { ToolCallEntry } from '../api/dashboard'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  recordToolCallOutputs,
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const INTERLEAVE_FIXTURE_KEEPER = 'sangsu'
+export const INTERLEAVE_ORDER_SIGNATURE =
+  'trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+export const INTERLEAVE_FIXTURE_COVERED_SINCE_MS = Date.parse('2026-07-05T14:19:50.000Z')
+export const INTERLEAVE_FIXTURE_COVERED_THROUGH_MS = Date.parse('2026-07-05T14:20:10.000Z')
+
+const joinedToolOutput: ToolCallEntry = {
+  ts: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS / 1000,
+  keeper: INTERLEAVE_FIXTURE_KEEPER,
+  tool: 'keeper_context_status',
+  tool_use_id: 'tc-context',
+  input: { scope: 'current' },
+  output: 'context status joined from tool_calls_endpoint',
+  success: true,
+  semantic_success: true,
+  duration_ms: 84,
+}
+
+export const interleaveHydrationContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  completedAtMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  coveredSinceMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  coveredThroughMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+}
+
+export const interleaveEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-context',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T14:20:01.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-interleave',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: INTERLEAVE_FIXTURE_KEEPER,
+    text: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    rawText: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    timestamp: '2026-07-05T14:20:00.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'trace-interleave#9',
+      reason: 'live terminal event observed by dashboard SSE client',
+    }),
+    traceSteps: [
+      {
+        kind: 'think',
+        text: 'First structural thought appears before the tool even though its timestamp is later.',
+        ts: '2026-07-05T14:20:05.000Z',
+        oasBlockIndex: 10,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-context',
+        status: 'ok',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T14:20:01.000Z',
+        oasBlockIndex: 11,
+      },
+      {
+        kind: 'think',
+        text: 'Second structural thought must remain after the joined tool despite an earlier timestamp.',
+        ts: '2026-07-05T14:20:02.000Z',
+        oasBlockIndex: 12,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_memory_search',
+        toolCallId: 'tc-missing',
+        args: '{"query":"old task context"}',
+        ts: '2026-07-05T14:20:03.000Z',
+        oasBlockIndex: 13,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const joinedToolCount = interleaveEntries.filter(entry => entry.role === 'tool').length
+export const traceOnlyToolCount = interleaveEntries
+  .flatMap(entry => entry.traceSteps ?? [])
+  .filter(step => step.kind === 'tool' && step.toolCallId === 'tc-missing')
+  .length
+export const interleaveFixtureStatus =
+  joinedToolCount === 1 && traceOnlyToolCount === 1 ? 'ok' : 'invalid'
+
+export function installInterleaveFixtureToolOutputs(): void {
+  resetToolCallOutputs()
+  recordToolCallOutputs([joinedToolOutput])
+}
+
+export function InterleaveContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-interleave-contract-fixture
+      data-interleave-contract-fixture-status=${interleaveFixtureStatus}
+      data-interleave-order-signature=${INTERLEAVE_ORDER_SIGNATURE}
+      data-interleave-joined-tool-count=${joinedToolCount}
+      data-interleave-trace-only-tool-count=${traceOnlyToolCount}
+    >
+      <section class="mx-auto max-w-[820px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Interleave Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Structural thinking/tool order
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${interleaveEntries}
+            emptyText="No interleave rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+            groupToolCalls=${true}
+            toolOutputsCoveredSinceMs=${INTERLEAVE_FIXTURE_COVERED_SINCE_MS}
+            toolOutputsCoveredThroughMs=${INTERLEAVE_FIXTURE_COVERED_THROUGH_MS}
+            toolOutputHydrationContract=${interleaveHydrationContract}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installInterleaveFixtureToolOutputs()
+  render(html`<${InterleaveContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
@@ -1,0 +1,67 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ReplayContractFixture,
+  clientObservedCount,
+  fixtureStatus,
+  replayEntries,
+} from './keeper-chat-replay-contract-fixture'
+
+describe('Keeper Chat replay contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+  })
+
+  it('keeps the replay rows deterministic without client-observed stream receipts', () => {
+    expect(replayEntries).toHaveLength(3)
+    expect(clientObservedCount).toBe(0)
+    expect(fixtureStatus).toBe('ok')
+
+    const legacyEntry = replayEntries.find(entry => entry.id === 'smoke-legacy-user')
+    expect(legacyEntry?.streamContract).toMatchObject({
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const serverReplayEntry = replayEntries.find(entry => entry.id === 'smoke-error-assistant')
+    expect(serverReplayEntry?.streamContract).toMatchObject({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      eventName: 'RUN_ERROR',
+      deliveryReceipt: 'server_lifecycle_replay_only',
+    })
+  })
+
+  it('renders replay contract badge state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+
+    render(html`<${ReplayContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]',
+      ),
+    ).not.toBeNull()
+  })
+})

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
@@ -5,7 +5,9 @@ import {
   ReplayContractFixture,
   clientObservedCount,
   fixtureStatus,
+  noDeliveryReceiptCount,
   replayEntries,
+  serverReplayOnlyCount,
 } from './keeper-chat-replay-contract-fixture'
 
 describe('Keeper Chat replay contract fixture', () => {
@@ -19,9 +21,11 @@ describe('Keeper Chat replay contract fixture', () => {
     }
   })
 
-  it('keeps the replay rows deterministic without client-observed stream receipts', () => {
-    expect(replayEntries).toHaveLength(3)
-    expect(clientObservedCount).toBe(0)
+  it('keeps replay, queue, and finalization rows deterministic with explicit receipt classes', () => {
+    expect(replayEntries).toHaveLength(6)
+    expect(clientObservedCount).toBe(1)
+    expect(noDeliveryReceiptCount).toBe(4)
+    expect(serverReplayOnlyCount).toBe(1)
     expect(fixtureStatus).toBe('ok')
 
     const legacyEntry = replayEntries.find(entry => entry.id === 'smoke-legacy-user')
@@ -38,6 +42,34 @@ describe('Keeper Chat replay contract fixture', () => {
       eventName: 'RUN_ERROR',
       deliveryReceipt: 'server_lifecycle_replay_only',
     })
+
+    const queuePlaceholder = replayEntries.find(entry => entry.id === 'smoke-queued-assistant')
+    expect(queuePlaceholder).toMatchObject({
+      delivery: 'queued',
+      streamState: 'opening',
+    })
+    expect(queuePlaceholder?.streamContract).toMatchObject({
+      source: 'pending_request_store',
+      status: 'client_placeholder',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const queueResult = replayEntries.find(entry => entry.id === 'smoke-queue-result-assistant')
+    expect(queueResult?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const liveFinal = replayEntries.find(entry => entry.id === 'smoke-live-final-assistant')
+    expect(liveFinal?.streamContract).toMatchObject({
+      source: 'sse_event',
+      status: 'backend_terminal_event',
+      eventName: 'RUN_FINISHED',
+      deliveryReceipt: 'client_observed_sse_event',
+    })
   })
 
   it('renders replay contract badge state into durable DOM attributes', () => {
@@ -48,7 +80,7 @@ describe('Keeper Chat replay contract fixture', () => {
 
     expect(
       container.querySelector(
-        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]',
+        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]',
       ),
     ).not.toBeNull()
 
@@ -61,6 +93,24 @@ describe('Keeper Chat replay contract fixture', () => {
     expect(
       container.querySelector(
         '[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]',
       ),
     ).not.toBeNull()
   })

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
@@ -1,0 +1,104 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import { chatHistoryEntriesFromRest } from '../keeper-state'
+
+export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'please run the long check',
+    ts: 1_780_000_000,
+    turn_ref: 'trace-chat-contract-smoke#7',
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_stream_events',
+      turn_ref: 'trace-chat-contract-smoke#7',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'user history rows are persisted chat input, not a live client stream receipt',
+    },
+  },
+  {
+    id: 'smoke-legacy-user',
+    role: 'user',
+    content: 'legacy row without turn ref',
+    ts: 1_780_000_001,
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'history row has no durable turn_ref; cannot join stream events',
+    },
+  },
+  {
+    id: 'smoke-error-assistant',
+    role: 'assistant',
+    content: 'Keeper request failed: Timeout after 630.0s',
+    ts: 1_780_000_002,
+    kind: 'transport_failure',
+    turn_ref: 'trace-chat-contract-smoke#8',
+    stream_contract: {
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turn_ref: 'trace-chat-contract-smoke#8',
+      event_name: 'RUN_ERROR',
+      lifecycle_events: [
+        'RUN_STARTED',
+        'RUN_ERROR',
+      ],
+      delivery_receipt: 'server_lifecycle_replay_only',
+      reason: 'history row records durable server stream lifecycle replay',
+    },
+  },
+])
+
+export const clientObservedCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'client_observed_sse_event',
+).length
+export const fixtureStatus = replayEntries.length === 3 && clientObservedCount === 0 ? 'ok' : 'invalid'
+
+export function ReplayContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-replay-contract-fixture
+      data-replay-contract-fixture-status=${fixtureStatus}
+      data-replay-contract-fixture-row-count=${replayEntries.length}
+      data-replay-contract-fixture-client-observed-count=${clientObservedCount}
+    >
+      <section class="mx-auto max-w-[760px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Replay Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Rendered replay contracts
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${replayEntries}
+            emptyText="No replay rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  render(html`<${ReplayContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
@@ -5,9 +5,14 @@ import '../styles/keeper-workspace.css'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { ChatTranscript } from '../components/chat/primitives'
-import { chatHistoryEntriesFromRest } from '../keeper-state'
+import {
+  chatHistoryEntriesFromRest,
+  keeperClientObservedSseStreamContract,
+  keeperStreamContract,
+} from '../keeper-state'
+import type { KeeperConversationEntry } from '../types'
 
-export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
+const historyReplayEntries = chatHistoryEntriesFromRest('sangsu', [
   {
     id: 'smoke-user',
     role: 'user',
@@ -56,10 +61,79 @@ export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
   },
 ])
 
+const queueAndFinalizationEntries: KeeperConversationEntry[] = [
+  {
+    id: 'smoke-queued-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: '',
+    rawText: '',
+    timestamp: null,
+    delivery: 'queued',
+    streamState: 'opening',
+    streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'awaiting queued request poll result',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-queue-result-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'queued request finished through dashboard polling',
+    rawText: 'queued request finished through dashboard polling',
+    timestamp: '2026-07-05T14:14:03.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'terminal queued poll result observed by dashboard polling, not SSE delivery',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-live-final-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'live stream finished with a client-observed terminal event',
+    rawText: 'live stream finished with a client-observed terminal event',
+    timestamp: '2026-07-05T14:14:04.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      reason: 'live stream terminal event observed by dashboard SSE client',
+    }),
+    details: null,
+  },
+]
+
+export const replayEntries = [
+  ...historyReplayEntries,
+  ...queueAndFinalizationEntries,
+]
+
 export const clientObservedCount = replayEntries.filter(
   entry => entry.streamContract?.deliveryReceipt === 'client_observed_sse_event',
 ).length
-export const fixtureStatus = replayEntries.length === 3 && clientObservedCount === 0 ? 'ok' : 'invalid'
+export const noDeliveryReceiptCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'no_delivery_receipt',
+).length
+export const serverReplayOnlyCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'server_lifecycle_replay_only',
+).length
+export const fixtureStatus = replayEntries.length === 6
+  && clientObservedCount === 1
+  && noDeliveryReceiptCount === 4
+  && serverReplayOnlyCount === 1
+  ? 'ok'
+  : 'invalid'
 
 export function ReplayContractFixture() {
   return html`
@@ -71,6 +145,8 @@ export function ReplayContractFixture() {
       data-replay-contract-fixture-status=${fixtureStatus}
       data-replay-contract-fixture-row-count=${replayEntries.length}
       data-replay-contract-fixture-client-observed-count=${clientObservedCount}
+      data-replay-contract-fixture-no-delivery-count=${noDeliveryReceiptCount}
+      data-replay-contract-fixture-server-replay-count=${serverReplayOnlyCount}
     >
       <section class="mx-auto max-w-[760px]">
         <header class="mb-5">

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1202,6 +1202,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '진행 상황?', 'delivered'],
       ['assistant', 'polling으로 복구됨', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
   })
 
   it('reconciles a stream network failure when the server history has the completed reply', async () => {
@@ -1250,6 +1262,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'delivered'],
       ['assistant', '여기까지 했습니다.', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
@@ -1438,6 +1462,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'error'],
       ['assistant', '', 'error'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(keeperActionErrors.value.echo).toContain('서버 재시작')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
   })
@@ -1503,7 +1539,16 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
       // During the first sleep the assistant should still be queued.
       await vi.advanceTimersByTimeAsync(1_000)
-      expect((keeperThreads.value.echo ?? []).some(entry => entry.role === 'assistant' && entry.delivery === 'queued')).toBe(true)
+      const queuedAssistant = (keeperThreads.value.echo ?? []).find(
+        entry => entry.role === 'assistant' && entry.delivery === 'queued',
+      )
+      expect(queuedAssistant).not.toBeUndefined()
+      expect(queuedAssistant?.streamContract).toMatchObject({
+        source: 'pending_request_store',
+        status: 'client_placeholder',
+        requestId: 'kmsg_echo_1',
+        deliveryReceipt: 'no_delivery_receipt',
+      })
 
       // Let the resume loop finish.
       await vi.advanceTimersByTimeAsync(2_000)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -469,6 +469,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: null,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'restored pending queued request from browser storage',
       }),
       attachments: request.attachments,
@@ -488,6 +489,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: 'opening',
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'awaiting queued request poll result',
       }),
       details: null,
@@ -590,6 +592,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -611,6 +614,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -627,6 +631,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -639,6 +644,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -654,6 +660,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
@@ -666,6 +673,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })

--- a/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5186}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-interleave-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-mobile.png"
+TRACE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace.png"
+JOINED_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-joined-tool.png"
+TRACE_ONLY_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace-only-tool.png"
+CHAT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-chat.png"
+
+ORDER_SIGNATURE='trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+STATUS_SELECTOR="[data-interleave-contract-fixture-status=\"ok\"][data-interleave-order-signature=\"${ORDER_SIGNATURE}\"][data-interleave-joined-tool-count=\"1\"][data-interleave-trace-only-tool-count=\"1\"]"
+TRACE_SELECTOR="[data-chat-work-trace][data-chat-turn-order-signature=\"${ORDER_SIGNATURE}\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783261210000\"]"
+JOINED_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="1"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-context"][data-chat-trace-entry-id="tool-tc-context"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="ok"][data-chat-trace-output-coverage="covered"]'
+TRACE_ONLY_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="3"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-missing"][data-chat-trace-link-state="trace-only"][data-chat-trace-output-state="pending"]'
+CHAT_SELECTOR='[data-chat-trace-step="chat"][data-chat-turn-order-index="4"][data-chat-turn-order-kind="chat"][data-chat-trace-entry-id="assistant-interleave"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${JOINED_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${JOINED_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_ONLY_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_ONLY_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${CHAT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${CHAT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat interleave contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'trace_screenshot=%s\n' "${TRACE_SCREENSHOT}"
+printf 'joined_tool_screenshot=%s\n' "${JOINED_TOOL_SCREENSHOT}"
+printf 'trace_only_tool_screenshot=%s\n' "${TRACE_ONLY_TOOL_SCREENSHOT}"
+printf 'chat_screenshot=%s\n' "${CHAT_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5184}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-replay-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-mobile.png"
+SERVER_REPLAY_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-server-replay.png"
+NO_TURN_REF_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-no-turn-ref.png"
+
+STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]'
+SERVER_REPLAY_SELECTOR='[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]'
+NO_TURN_REF_SELECTOR='[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${SERVER_REPLAY_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${SERVER_REPLAY_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${NO_TURN_REF_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${NO_TURN_REF_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat replay contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
@@ -12,10 +12,16 @@ DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-desktop.pn
 MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-mobile.png"
 SERVER_REPLAY_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-server-replay.png"
 NO_TURN_REF_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-no-turn-ref.png"
+QUEUE_PLACEHOLDER_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-placeholder.png"
+QUEUE_RESULT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-result.png"
+LIVE_TERMINAL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-live-terminal.png"
 
-STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]'
+STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]'
 SERVER_REPLAY_SELECTOR='[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]'
 NO_TURN_REF_SELECTOR='[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]'
+QUEUE_PLACEHOLDER_SELECTOR='[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+QUEUE_RESULT_SELECTOR='[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+LIVE_TERMINAL_SELECTOR='[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]'
 
 server_pid=""
 cleanup() {
@@ -72,6 +78,30 @@ pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
 
 pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
   --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_PLACEHOLDER_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_RESULT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_RESULT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${LIVE_TERMINAL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${LIVE_TERMINAL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
   --viewport-size 390,844 \
   --timeout 30000 \
   --wait-for-selector "${STATUS_SELECTOR}" \
@@ -82,3 +112,6 @@ printf 'keeper chat replay contract DOM smoke passed\n'
 printf 'fixture_url=%s\n' "${FIXTURE_URL}"
 printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
 printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'queue_placeholder_screenshot=%s\n' "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+printf 'queue_result_screenshot=%s\n' "${QUEUE_RESULT_SCREENSHOT}"
+printf 'live_terminal_screenshot=%s\n' "${LIVE_TERMINAL_SCREENSHOT}"


### PR DESCRIPTION
## Summary
- Add a deterministic dashboard dev fixture for Keeper Chat replay-contract rows.
- Add a fixture unit test and Playwright CLI smoke harness that assert the fixture root, server-replay badge, no-turn-ref badge, and mobile render without live Keeper history.

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/demo/keeper-chat-replay-contract-fixture.test.ts src/components/chat/primitives.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- git diff --check
- git diff --cached --check
- bash -n scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
- scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
- GITHUB_BASE_REF=codex/chat-replay-dom-parity-20260705 python3 scripts/check_test_coverage.py

## Render QA
- Flow: /dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html -> replay contract rows render -> no-turn-ref/server-replay badges appear with durable DOM attributes.
- Browser plugin not available in this session; used Playwright CLI fallback.
- Desktop and mobile screenshots were captured by the smoke harness under TMPDIR.

## Notes
- This fixture is dev-server scoped and does not depend on a live Keeper runtime or historical chat data.