### PR TITLE
[codex] Emit raw tool_execute PR action metrics

### DIFF
--- a/lib/command_descriptor/command_descriptor.ml
+++ b/lib/command_descriptor/command_descriptor.ml
@@ -15,6 +15,39 @@ type t =
   | Pipe_chain of { first_cmd : string; last_cmd : string; length : int }
   | Generic
 
+type pr_action_surface =
+  | Gh_cli
+
+type pr_action =
+  | Create
+  | Merge
+  | Comment
+  | Close
+  | Edit
+  | Review
+  | Reopen
+  | Ready
+
+type pr_action_event =
+  { surface : pr_action_surface
+  ; action : pr_action
+  }
+
+let pr_action_surface_to_string = function
+  | Gh_cli -> "gh_cli"
+;;
+
+let pr_action_to_string = function
+  | Create -> "create"
+  | Merge -> "merge"
+  | Comment -> "comment"
+  | Close -> "close"
+  | Edit -> "edit"
+  | Review -> "review"
+  | Reopen -> "reopen"
+  | Ready -> "ready"
+;;
+
 let to_json = function
   | Gh_pr_create { title; base; draft } ->
     `Assoc
@@ -116,6 +149,18 @@ let extract_number_from_rest rest =
 let string_or default = function
   | Some value -> value
   | None -> default
+;;
+
+let pr_action_of_gh_action = function
+  | Some "create" -> Some Create
+  | Some "merge" -> Some Merge
+  | Some "comment" -> Some Comment
+  | Some "close" -> Some Close
+  | Some "edit" -> Some Edit
+  | Some "review" -> Some Review
+  | Some "reopen" -> Some Reopen
+  | Some "ready" -> Some Ready
+  | Some _ | None -> None
 ;;
 
 let compute_typed : type i o r s. (i, o, r, s) Typed.command -> t = function
@@ -333,4 +378,134 @@ let rec compute ir =
           | Gh_api_pr_comment _
           | Pipe_chain _ ) as known -> known)
      | [] -> Generic)
+;;
+
+let pr_action_event_of_typed
+  : type i o r s. (i, o, r, s) Typed.command -> pr_action_event option
+  = function
+  | Typed.Gh { subcommand; action; _ } when String.equal subcommand "pr" ->
+    Option.map (fun action -> { surface = Gh_cli; action }) (pr_action_of_gh_action action)
+  | Typed.Gh _
+  | Typed.Ls _
+  | Typed.Cat _
+  | Typed.Rg _
+  | Typed.Git_status _
+  | Typed.Git_clone _
+  | Typed.Curl _
+  | Typed.Rm _
+  | Typed.Sudo _
+  | Typed.Find _
+  | Typed.Head _
+  | Typed.Tail _
+  | Typed.Grep _
+  | Typed.Mkdir _
+  | Typed.Wc _
+  | Typed.Git_diff _
+  | Typed.Git_log _
+  | Typed.Git_commit _
+  | Typed.Git_push _
+  | Typed.Git_pull _
+  | Typed.Git_stash _
+  | Typed.Git_rebase _
+  | Typed.Git_merge _
+  | Typed.Git_branch _
+  | Typed.Git_checkout _
+  | Typed.Git_fetch _
+  | Typed.Git_show _
+  | Typed.Git_reset _
+  | Typed.Git_blame _
+  | Typed.Git_add _
+  | Typed.Pwd _
+  | Typed.Echo _
+  | Typed.Which _
+  | Typed.Sort _
+  | Typed.Cut _
+  | Typed.Tr _
+  | Typed.Date _
+  | Typed.Env _
+  | Typed.Printenv _
+  | Typed.Uniq _
+  | Typed.Basename _
+  | Typed.Dirname _
+  | Typed.Test _
+  | Typed.Stat _
+  | Typed.Hostname _
+  | Typed.Whoami _
+  | Typed.Du _
+  | Typed.Df _
+  | Typed.File _
+  | Typed.Printf _
+  | Typed.Uname _
+  | Typed.Ps _
+  | Typed.Tty _
+  | Typed.Wget _
+  | Typed.Ssh _
+  | Typed.Scp _
+  | Typed.Tar _
+  | Typed.Make _
+  | Typed.Diff _
+  | Typed.Sed _
+  | Typed.Rsync _
+  | Typed.Node _
+  | Typed.Python _
+  | Typed.Python3 _
+  | Typed.Pip _
+  | Typed.Patch _
+  | Typed.Npm _
+  | Typed.Cargo _
+  | Typed.Go _
+  | Typed.Chmod _
+  | Typed.Chown _
+  | Typed.Docker _
+  | Typed.Opam _
+  | Typed.Npx _
+  | Typed.Yarn _
+  | Typed.Pnpm _
+  | Typed.Uv _
+  | Typed.Glab _
+  | Typed.Pytest _
+  | Typed.Terminal_notifier _
+  | Typed.Ruff _
+  | Typed.Pyright _
+  | Typed.Tsc _
+  | Typed.Ocamlfind _
+  | Typed.Rustc _
+  | Typed.Gofmt _
+  | Typed.Gradle _
+  | Typed.Ninja _
+  | Typed.Java _
+  | Typed.Javac _
+  | Typed.Mvn _
+  | Typed.Cmake _
+  | Typed.Dune_local_sh _
+  | Typed.Osascript _
+  | Typed.Play _
+  | Typed.Rec _
+  | Typed.Ffplay _
+  | Typed.Mpg123 _
+  | Typed.Open _
+  | Typed.Su _
+  | Typed.Dd _
+  | Typed.Mkfs _
+  | Typed.Cp _
+  | Typed.Mv _
+  | Typed.Ln _
+  | Typed.Touch _
+  | Typed.Tee _
+  | Typed.Awk _
+  | Typed.Xargs _
+  | Typed.Generic _ -> None
+;;
+
+let pr_action_events_of_simple simple =
+  match Masc_exec.Shell_ir_typed.of_simple simple with
+  | Typed.W command ->
+    (match pr_action_event_of_typed command with
+     | Some event -> [ event ]
+     | None -> [])
+;;
+
+let rec pr_action_events_of_ir = function
+  | Masc_exec.Shell_ir.Simple simple -> pr_action_events_of_simple simple
+  | Masc_exec.Shell_ir.Pipeline cmds -> List.concat_map pr_action_events_of_ir cmds
 ;;

--- a/lib/command_descriptor/command_descriptor.mli
+++ b/lib/command_descriptor/command_descriptor.mli
@@ -21,5 +21,26 @@ type t =
   | Pipe_chain of { first_cmd : string; last_cmd : string; length : int }
   | Generic
 
+type pr_action_surface =
+  | Gh_cli
+
+type pr_action =
+  | Create
+  | Merge
+  | Comment
+  | Close
+  | Edit
+  | Review
+  | Reopen
+  | Ready
+
+type pr_action_event =
+  { surface : pr_action_surface
+  ; action : pr_action
+  }
+
 val to_json : t -> Yojson.Safe.t
 val compute : Masc_exec.Shell_ir.t -> t
+val pr_action_surface_to_string : pr_action_surface -> string
+val pr_action_to_string : pr_action -> string
+val pr_action_events_of_ir : Masc_exec.Shell_ir.t -> pr_action_event list

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -305,12 +305,35 @@ let dispatch_error_deterministic_retry_fields error =
   | Some reason -> Keeper_tool_deterministic_error.deterministic_retry_fields reason
   | None -> []
 
+let pr_action_status_label = function
+  | Unix.WEXITED 0 -> "success"
+  | Unix.WEXITED _ -> "exit_nonzero"
+  | Unix.WSIGNALED _ -> "signaled"
+  | Unix.WSTOPPED _ -> "stopped"
+;;
+
+let record_pr_action_metric ~keeper_name ~risk_class ~status ir =
+  Command_descriptor.pr_action_events_of_ir ir
+  |> List.iter (fun (event : Command_descriptor.pr_action_event) ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ToolExecutePrActionTotal)
+      ~labels:
+        [ "keeper", keeper_name
+        ; "surface", Command_descriptor.pr_action_surface_to_string event.surface
+        ; "action", Command_descriptor.pr_action_to_string event.action
+        ; "status", pr_action_status_label status
+        ; "risk_class", Masc_exec.Shell_ir_risk.string_of_risk_class risk_class
+        ]
+      ())
+;;
+
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
   let path_probe_json ~cwd path = path_probe_json ~cwd (path_probe ~cwd path)
   let repo_root_public_prefix_from_cwd = repo_root_public_prefix_from_cwd
   let repo_cwd_relative_rewrite = repo_cwd_relative_rewrite
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
+  let record_pr_action_metric = record_pr_action_metric
   let dispatch_error_deterministic_retry_fields =
     dispatch_error_deterministic_retry_fields
 end
@@ -855,6 +878,12 @@ let handle_tool_execute_typed
                of live traffic observable. An offline scan of typed_hit=true
                / total gives the real exercise rate of the typed model vs the
                Generic escape hatch. *)
+            let risk_class = Masc_exec.Shell_ir_risk.risk_class envelope in
+            record_pr_action_metric
+              ~keeper_name:meta.name
+              ~risk_class
+              ~status:result.status
+              ir;
             let effects = Masc_exec.Exec_effect.extract ir in
             let effects_str = Format.asprintf "%a" Masc_exec.Exec_effect.pp_set effects in
             Log.Keeper.info
@@ -863,16 +892,14 @@ let handle_tool_execute_typed
               (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
               (Keeper_sandbox_exec_failure.status_label result.status)
               elapsed_ms
-              (Masc_exec.Shell_ir_risk.string_of_risk_class
-                 (Masc_exec.Shell_ir_risk.risk_class envelope))
+              (Masc_exec.Shell_ir_risk.string_of_risk_class risk_class)
               (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir)
               effects_str;
             Otel_spans.add_attrs
               ~attrs:[
                 ( "shell_ir.risk_class"
                 , `String
-                    (Masc_exec.Shell_ir_risk.string_of_risk_class
-                       (Masc_exec.Shell_ir_risk.risk_class envelope)) )
+                    (Masc_exec.Shell_ir_risk.string_of_risk_class risk_class) )
               ; ( "shell_ir.typed_hit"
                 , `Bool (Masc_exec.Shell_ir_risk.typed_hit_of_ir ir) )
               ; "shell_ir.effects", `String effects_str

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -22,6 +22,12 @@ module For_testing : sig
     cwd:string ->
     sandbox_extra_fields:(string * Yojson.Safe.t) list ->
     Yojson.Safe.t
+  val record_pr_action_metric :
+    keeper_name:string ->
+    risk_class:Masc_exec.Shell_ir_risk.risk_class ->
+    status:Unix.process_status ->
+    Masc_exec.Shell_ir.t ->
+    unit
   val dispatch_error_deterministic_retry_fields :
     Keeper_tool_execute_shell_ir.dispatch_error -> (string * Yojson.Safe.t) list
 end

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -243,6 +243,7 @@ type t =
   | KeeperToolCallRetryLoop     (* counter: consecutive identical tool calls with errors *)
   | AttemptWatchdogFired        (* counter: 1800s safety-cap watchdog killed a stuck attempt *)
   | ShellIrEffectTotal          (* counter: fine-grained Shell IR effect decomposition *)
+  | ToolExecutePrActionTotal    (* counter: raw tool_execute gh PR actions *)
   | KeeperRepoMappingDefaultScopeAllowed (* counter: missing mapping default-scope access allowed *)
   | KeeperRepoMappingDeniedUnregistered (* counter: repository policy denied an unregistered repo id *)
   | KeeperRepoMappingDeniedNotInMapping (* counter: keeper repo mapping decision: repo not in mapping *)
@@ -514,6 +515,7 @@ let to_string = function
   | KeeperToolCallRetryLoop -> "masc_keeper_tool_call_retry_loop_total"
   | AttemptWatchdogFired -> "masc_keeper_attempt_watchdog_fired_total"
   | ShellIrEffectTotal -> "masc_keeper_shell_ir_effect_total"
+  | ToolExecutePrActionTotal -> "masc_keeper_tool_execute_pr_action_total"
   | KeeperRepoMappingDefaultScopeAllowed ->
     "masc_keeper_repo_mapping_default_scope_allowed_total"
   | KeeperRepoMappingDeniedUnregistered ->
@@ -591,7 +593,7 @@ let all : t list =
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; RuntimeHttpProbeJsonParseFailures;
     VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
-    KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal;
+    KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;
   KeeperRepoMappingDefaultScopeAllowed; KeeperRepoMappingDeniedUnregistered;
   KeeperRepoMappingDeniedNotInMapping; KeeperRepoMappingLoadError;
   KeeperRepoMappingRepositoryIdentityMismatch; KeeperRepoMappingRepositoryStoreError;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -233,6 +233,7 @@ type t =
   | KeeperToolCallRetryLoop
   | AttemptWatchdogFired
   | ShellIrEffectTotal
+  | ToolExecutePrActionTotal
   | KeeperRepoMappingDefaultScopeAllowed
   | KeeperRepoMappingDeniedUnregistered
   | KeeperRepoMappingDeniedNotInMapping

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -200,6 +200,85 @@ let test_pipe_chain_git_push () =
   | other -> failf "expected Git_push, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
 ;;
 
+(** {1 PR action metrics} *)
+
+let single_pr_action_labels ir =
+  match Desc.pr_action_events_of_ir ir with
+  | [ event ] ->
+    ( Desc.pr_action_surface_to_string event.surface
+    , Desc.pr_action_to_string event.action )
+  | events -> failf "expected one PR action event, got %d" (List.length events)
+;;
+
+let test_pr_action_projection_uses_typed_gh_only () =
+  let surface, action =
+    parse_ir "gh pr create --title 'feat: metrics' --draft"
+    |> single_pr_action_labels
+  in
+  check string "surface" "gh_cli" surface;
+  check string "action" "create" action;
+  let pipeline_surface, pipeline_action =
+    parse_ir "cat body.md | gh pr comment 123 --body LGTM"
+    |> single_pr_action_labels
+  in
+  check string "pipeline surface" "gh_cli" pipeline_surface;
+  check string "pipeline action" "comment" pipeline_action;
+  let git_merge_ir = parse_ir "git merge feature-branch --squash" in
+  check int "git merge is not gh PR action" 0
+    (List.length (Desc.pr_action_events_of_ir git_merge_ir))
+;;
+
+let test_tool_execute_pr_action_metric_labels () =
+  let ir = parse_ir "gh pr create --title 'feat: metrics' --draft" in
+  let metric = Keeper_metrics.(to_string ToolExecutePrActionTotal) in
+  let keeper_name = "test-pr-action-metric" in
+  let labels =
+    [ "keeper", keeper_name
+    ; "surface", "gh_cli"
+    ; "action", "create"
+    ; "status", "success"
+    ; "risk_class", "R1"
+    ]
+  in
+  let before = Otel_metric_store.metric_value_or_zero metric ~labels () in
+  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+    ~keeper_name
+    ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    ~status:(Unix.WEXITED 0)
+    ir;
+  let after = Otel_metric_store.metric_value_or_zero metric ~labels () in
+  check bool "success metric increments" true (after >= before +. 1.0);
+  let failed_labels =
+    [ "keeper", keeper_name
+    ; "surface", "gh_cli"
+    ; "action", "create"
+    ; "status", "exit_nonzero"
+    ; "risk_class", "R1"
+    ]
+  in
+  let failed_before =
+    Otel_metric_store.metric_value_or_zero metric ~labels:failed_labels ()
+  in
+  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+    ~keeper_name
+    ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    ~status:(Unix.WEXITED 1)
+    ir;
+  let failed_after =
+    Otel_metric_store.metric_value_or_zero metric ~labels:failed_labels ()
+  in
+  check bool "failed attempt metric increments" true
+    (failed_after >= failed_before +. 1.0);
+  let total_before = Otel_metric_store.metric_total metric in
+  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+    ~keeper_name
+    ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    ~status:(Unix.WEXITED 0)
+    (parse_ir "git merge feature-branch --squash");
+  let total_after = Otel_metric_store.metric_total metric in
+  check (float 0.0) "non-gh command does not increment" total_before total_after
+;;
+
 (** {1 Exit code semantics} *)
 
 let test_exit_code_grep_no_match () =
@@ -345,6 +424,10 @@ let () =
       , [ test_case "rg|grep|head" `Quick test_pipe_chain_rg_grep_head
         ; test_case "gh in last position" `Quick test_pipe_chain_gh_in_last
         ; test_case "git push in last" `Quick test_pipe_chain_git_push
+        ] )
+    ; ( "pr_action_metrics"
+      , [ test_case "typed gh projection" `Quick test_pr_action_projection_uses_typed_gh_only
+        ; test_case "tool_execute metric labels" `Quick test_tool_execute_pr_action_metric_labels
         ] )
     ; ( "exit_code_semantics"
       , [ test_case "grep no match" `Quick test_exit_code_grep_no_match

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -3,6 +3,8 @@
 open Alcotest
 
 module Desc = Command_descriptor
+module Execute_runtime = Masc.Keeper_tool_execute_runtime.For_testing
+module Metrics = Masc.Otel_metric_store
 
 let with_temp_dir f =
   let dir = Filename.temp_file "cmd_desc_test" "" in
@@ -240,13 +242,13 @@ let test_tool_execute_pr_action_metric_labels () =
     ; "risk_class", "R1"
     ]
   in
-  let before = Otel_metric_store.metric_value_or_zero metric ~labels () in
-  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+  let before = Metrics.metric_value_or_zero metric ~labels () in
+  Execute_runtime.record_pr_action_metric
     ~keeper_name
     ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
     ~status:(Unix.WEXITED 0)
     ir;
-  let after = Otel_metric_store.metric_value_or_zero metric ~labels () in
+  let after = Metrics.metric_value_or_zero metric ~labels () in
   check bool "success metric increments" true (after >= before +. 1.0);
   let failed_labels =
     [ "keeper", keeper_name
@@ -257,25 +259,25 @@ let test_tool_execute_pr_action_metric_labels () =
     ]
   in
   let failed_before =
-    Otel_metric_store.metric_value_or_zero metric ~labels:failed_labels ()
+    Metrics.metric_value_or_zero metric ~labels:failed_labels ()
   in
-  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+  Execute_runtime.record_pr_action_metric
     ~keeper_name
     ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
     ~status:(Unix.WEXITED 1)
     ir;
   let failed_after =
-    Otel_metric_store.metric_value_or_zero metric ~labels:failed_labels ()
+    Metrics.metric_value_or_zero metric ~labels:failed_labels ()
   in
   check bool "failed attempt metric increments" true
     (failed_after >= failed_before +. 1.0);
-  let total_before = Otel_metric_store.metric_total metric in
-  Keeper_tool_execute_runtime.For_testing.record_pr_action_metric
+  let total_before = Metrics.metric_total metric in
+  Execute_runtime.record_pr_action_metric
     ~keeper_name
     ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
     ~status:(Unix.WEXITED 0)
     (parse_ir "git merge feature-branch --squash");
-  let total_after = Otel_metric_store.metric_total metric in
+  let total_after = Metrics.metric_total metric in
   check (float 0.0) "non-gh command does not increment" total_before total_after
 ;;
 


### PR DESCRIPTION
## Summary
- add a typed PR-action projection from Shell IR gh pr commands in Command_descriptor
- emit masc_keeper_tool_execute_pr_action_total from the raw tool_execute Shell IR dispatch path
- include bounded labels for keeper, surface, action, process outcome, and risk class
- cover success, failed attempt, pipeline, and non-gh-pr no-op behavior in test_command_descriptor

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD
- scripts/dune-local.sh build test/test_command_descriptor.exe
- ./_build/default/test/test_command_descriptor.exe

## CI Note
- CI is the build authority for this branch.
- Previous Health failure on e4260b3665 was a test namespace compile error. Fixed in eee2ec5c14.