### PR TITLE
Wire runtime sampling parameters through OAS dispatch

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1037,12 +1037,7 @@ let run_turn
           ~ttfrc_ms
           ~sampling:
             { temperature = Some temperature
-            ; top_p = None
-              (* TODO: top_p is not yet threaded through Keeper_run_context /
-                 Keeper_turn_driver / Runtime_agent_context. The dashboard
-                 previously fabricated 0.95; we now render absence until the
-                 runtime pipeline exposes the effective value. See PR
-                 description for adversarial gap analysis. *)
+            ; top_p = Runtime.top_p_of_runtime_id runtime_id_string
             ; max_tokens =
                 (match pre_dispatch_max_tokens_error with
                  | None -> Some max_tokens

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1104,6 +1104,24 @@ let temperature_of_runtime_id (id : string) : float option =
   | None -> None
 ;;
 
+let top_p_of_runtime_id (id : string) : float option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.provider_config.top_p
+  | None -> None
+;;
+
+let top_k_of_runtime_id (id : string) : int option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.provider_config.top_k
+  | None -> None
+;;
+
+let min_p_of_runtime_id (id : string) : float option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.provider_config.min_p
+  | None -> None
+;;
+
 let default_preserve_thinking_for_model (_rt : t) : bool option =
   (* OAS owns provider/model capability truth and can preserve reasoning when
      the provider contract requires it. MASC must not turn "request-side

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -291,6 +291,19 @@ val temperature_of_runtime_id : string -> float option
     set and its caller fallback ([MASC_KEEPER_UNIFIED_TEMP]) otherwise.  Required
     for models that reject the default temperature (Kimi K2.7 accepts only 1.0). *)
 
+val top_p_of_runtime_id : string -> float option
+(** Request [top_p] from the materialized OAS provider config for runtime [id],
+    or [None] when the runtime is not configured or no explicit value is
+    declared.  This projects the Provider_config SSOT used for dispatch. *)
+
+val top_k_of_runtime_id : string -> int option
+(** Request [top_k] from the materialized OAS provider config for runtime [id],
+    or [None] when absent. *)
+
+val min_p_of_runtime_id : string -> float option
+(** Request [min_p] from the materialized OAS provider config for runtime [id],
+    or [None] when absent. *)
+
 val preserve_thinking_of_runtime_id : string -> bool option
 (** Explicit [preserve-thinking] for runtime [id]. [None] means unknown runtime,
     uninitialized cache, or no explicit TOML field.

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -83,6 +83,8 @@ type config =
           to scrub [STATE] blocks before the 100-char truncation. *)
   execution_idle_timeout_s : float option;
   thinking_budget : int option;
+  top_p : float option;
+  top_k : int option;
   min_p : float option;
   on_run_complete : (bool -> unit) option;
   disclosure_level : Agent_sdk.Tool.disclosure_level option;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -201,6 +201,11 @@ let request_runtime_fields_on_base_config
     ~(base : Llm_provider.Provider_config.t)
     (req_config : Llm_provider.Provider_config.t)
   =
+  let request_option_or_base req base =
+    match req with
+    | Some _ as value -> value
+    | None -> base
+  in
   let response_format, output_schema =
     match req_config.response_format, req_config.output_schema with
     | Agent_sdk.Types.Off, None -> base.response_format, base.output_schema
@@ -217,9 +222,9 @@ let request_runtime_fields_on_base_config
   { base with
     max_tokens = req_config.max_tokens;
     temperature = req_config.temperature;
-    top_p = req_config.top_p;
-    top_k = req_config.top_k;
-    min_p = req_config.min_p;
+    top_p = request_option_or_base req_config.top_p base.top_p;
+    top_k = request_option_or_base req_config.top_k base.top_k;
+    min_p = request_option_or_base req_config.min_p base.min_p;
     system_prompt = req_config.system_prompt;
     enable_thinking = req_config.enable_thinking;
     preserve_thinking = req_config.preserve_thinking;

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -94,6 +94,8 @@ type config = Runtime_agent_context.config = {
   summarizer : (Agent_sdk.Types.message list -> string) option;
   execution_idle_timeout_s : float option;
   thinking_budget : int option;
+  top_p : float option;
+  top_k : int option;
   min_p : float option;
   on_run_complete : (bool -> unit) option;
   disclosure_level : Agent_sdk.Tool.disclosure_level option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -96,6 +96,12 @@ type config =
     (** Token budget for extended thinking, forwarded to OAS
         [Builder.with_thinking_budget]. Only meaningful when
         [enable_thinking = Some true]. *)
+  ; top_p : float option
+    (** Nucleus sampling probability forwarded to OAS [Builder.with_top_p].
+        [None] leaves the provider/model default intact. *)
+  ; top_k : int option
+    (** Top-k sampling limit forwarded to OAS [Builder.with_top_k].
+        [None] leaves the provider/model default intact. *)
   ; min_p : float option
     (** Minimum probability threshold for nucleus sampling, forwarded
         to OAS [Builder.with_min_p]. [None] leaves the provider default;
@@ -180,7 +186,9 @@ let default_config
   ; summarizer = None
   ; execution_idle_timeout_s = None
   ; thinking_budget = None
-  ; min_p = None
+  ; top_p = provider_cfg.top_p
+  ; top_k = provider_cfg.top_k
+  ; min_p = provider_cfg.min_p
   ; on_run_complete = None
   ; disclosure_level = None
   ; disclosure_resolver = None
@@ -355,6 +363,16 @@ let builder_without_approval
     | None -> builder
   in
   let builder =
+    match config.top_p with
+    | Some top_p -> Agent_sdk.Builder.with_top_p top_p builder
+    | None -> builder
+  in
+  let builder =
+    match config.top_k with
+    | Some top_k -> Agent_sdk.Builder.with_top_k top_k builder
+    | None -> builder
+  in
+  let builder =
     match config.min_p with
     | Some min_p -> Agent_sdk.Builder.with_min_p min_p builder
     | None -> builder
@@ -415,6 +433,9 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
       Agent_sdk.Checkpoint.model = config.model_id
     ; system_prompt = Some config.system_prompt
     ; temperature = Some config.temperature
+    ; top_p = config.top_p
+    ; top_k = config.top_k
+    ; min_p = config.min_p
     ; enable_thinking = config.enable_thinking
     ; preserve_thinking = config.preserve_thinking
     ; thinking_budget = config.thinking_budget
@@ -438,6 +459,9 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; max_tokens = Some config.max_tokens
     ; max_turns = max_turns_for_resume
     ; temperature = Some config.temperature
+    ; top_p = config.top_p
+    ; top_k = config.top_k
+    ; min_p = config.min_p
     ; enable_thinking = config.enable_thinking
     ; preserve_thinking = config.preserve_thinking
     ; thinking_budget = config.thinking_budget

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -95,6 +95,12 @@ type config = {
       (** Token budget for extended thinking, forwarded to OAS
           [Builder.with_thinking_budget]. Only meaningful when
           [enable_thinking = Some true]. *)
+  top_p : float option;
+      (** Nucleus sampling probability forwarded to OAS [Builder.with_top_p].
+          [None] leaves the provider/model default intact. *)
+  top_k : int option;
+      (** Top-k sampling limit forwarded to OAS [Builder.with_top_k].
+          [None] leaves the provider/model default intact. *)
   min_p : float option;
       (** Minimum probability threshold for nucleus sampling, forwarded
           to OAS [Builder.with_min_p]. [None] leaves the provider default
@@ -107,7 +113,7 @@ type config = {
   tool_selector : Agent_sdk.Tool_selector.strategy option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
 }
-(** Per-worker configuration.  57 fields — concrete record because
+(** Per-worker configuration.  59 fields — concrete record because
     callers ({!Runtime_agent}, keeper workers) construct + tweak
     fields field-by-field at the dispatch site. *)
 

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1113,6 +1113,84 @@ let test_runtime_agent_context_uses_configured_turn_budget () =
   check int "resume adds fresh per-call turn budget" 31
     prepared.agent_config.max_turns
 
+let test_runtime_agent_context_preserves_provider_sampling_config () =
+  let provider_cfg =
+    { (provider_cfg ()) with
+      Llm_provider.Provider_config.top_p = Some 0.91
+    ; top_k = Some 42
+    ; min_p = Some 0.07
+    }
+  in
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg
+      ~system_prompt:""
+      ~tools:[]
+  in
+  check (option (float 0.0001)) "config top_p" (Some 0.91) config.top_p;
+  check (option int) "config top_k" (Some 42) config.top_k;
+  check (option (float 0.0001)) "config min_p" (Some 0.07) config.min_p;
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let builder =
+        Runtime_agent_context.builder_without_approval
+          ~net:(Eio.Stdenv.net env)
+          ~config
+          ()
+      in
+      match Agent_sdk.Builder.build_safe builder with
+      | Error err -> fail (Agent_sdk.Error.to_string err)
+      | Ok agent ->
+        let agent_config = (Agent_sdk.Agent.state agent).config in
+        check (option (float 0.0001)) "builder top_p" (Some 0.91)
+          agent_config.top_p;
+        check (option int) "builder top_k" (Some 42) agent_config.top_k;
+        check (option (float 0.0001)) "builder min_p" (Some 0.07)
+          agent_config.min_p;
+        Eio.Switch.on_release sw (fun () ->
+          Agent_sdk.Agent.close agent)));
+  let checkpoint =
+    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
+    ; session_id = "session"
+    ; agent_name = "oas-runpod_mtp.qwen"
+    ; model = "qwen"
+    ; system_prompt = Some ""
+    ; messages = []
+    ; usage = Agent_sdk.Types.empty_usage
+    ; turn_count = 3
+    ; created_at = 0.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = Some 0.3
+    ; top_p = Some 0.12
+    ; top_k = Some 7
+    ; min_p = Some 0.02
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.default_config.response_format
+    ; thinking_budget = None
+    ; cache_system_prompt = false
+    ; context = Agent_sdk.Context.create_sync ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+  in
+  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
+  check (option (float 0.0001)) "resume checkpoint top_p" (Some 0.91)
+    prepared.patched_checkpoint.top_p;
+  check (option int) "resume checkpoint top_k" (Some 42)
+    prepared.patched_checkpoint.top_k;
+  check (option (float 0.0001)) "resume checkpoint min_p" (Some 0.07)
+    prepared.patched_checkpoint.min_p;
+  check (option (float 0.0001)) "resume agent top_p" (Some 0.91)
+    prepared.agent_config.top_p;
+  check (option int) "resume agent top_k" (Some 42)
+    prepared.agent_config.top_k;
+  check (option (float 0.0001)) "resume agent min_p" (Some 0.07)
+    prepared.agent_config.min_p
+
 let test_runtime_agent_context_preserves_unbounded_resume_budget () =
   let config =
     Runtime_agent.default_config
@@ -1433,6 +1511,10 @@ let () =
             "runtime agent context uses configured turn budget"
             `Quick
             test_runtime_agent_context_uses_configured_turn_budget
+        ; test_case
+            "runtime agent context preserves provider sampling config"
+            `Quick
+            test_runtime_agent_context_preserves_provider_sampling_config
         ; test_case
             "runtime agent context preserves unbounded resume budget"
             `Quick

--- a/test/test_runtime_request_config_merge.ml
+++ b/test/test_runtime_request_config_merge.ml
@@ -158,6 +158,45 @@ let test_base_json_mode_survives_opinionless_request () =
   check bool "base output_schema None survives request None" true
     (Option.is_none merged.Llm_provider.Provider_config.output_schema)
 
+let test_base_sampling_survives_opinionless_request () =
+  let base =
+    { (base_with_schema ()) with
+      Llm_provider.Provider_config.top_p = Some 0.91
+    ; top_k = Some 42
+    ; min_p = Some 0.07
+    }
+  in
+  let merged = merge ~base (request_without_opinion ()) in
+  check (option (float 0.0001)) "base top_p survives request None" (Some 0.91)
+    merged.Llm_provider.Provider_config.top_p;
+  check (option int) "base top_k survives request None" (Some 42)
+    merged.Llm_provider.Provider_config.top_k;
+  check (option (float 0.0001)) "base min_p survives request None" (Some 0.07)
+    merged.Llm_provider.Provider_config.min_p
+
+let test_request_sampling_overrides_base_sampling () =
+  let base =
+    { (base_with_schema ()) with
+      Llm_provider.Provider_config.top_p = Some 0.91
+    ; top_k = Some 42
+    ; min_p = Some 0.07
+    }
+  in
+  let req =
+    { (request_without_opinion ()) with
+      Llm_provider.Provider_config.top_p = Some 0.12
+    ; top_k = Some 7
+    ; min_p = Some 0.02
+    }
+  in
+  let merged = merge ~base req in
+  check (option (float 0.0001)) "request top_p wins" (Some 0.12)
+    merged.Llm_provider.Provider_config.top_p;
+  check (option int) "request top_k wins" (Some 7)
+    merged.Llm_provider.Provider_config.top_k;
+  check (option (float 0.0001)) "request min_p wins" (Some 0.02)
+    merged.Llm_provider.Provider_config.min_p
+
 (* Mismatched request-side response_format/output_schema pairs must be
    normalized by the merge rather than propagated to the wire.  A request can
    only express a schema opinion through [output_schema] or an explicit
@@ -236,6 +275,10 @@ let () =
             test_both_opinionless_stays_off
         ; test_case "base JsonMode survives opinionless request" `Quick
             test_base_json_mode_survives_opinionless_request
+        ; test_case "base sampling survives opinionless request" `Quick
+            test_base_sampling_survives_opinionless_request
+        ; test_case "request sampling overrides base sampling" `Quick
+            test_request_sampling_overrides_base_sampling
         ] )
     ; ( "response_format/output_schema mismatch normalization"
       , [ test_case "Off + Some schema" `Quick


### PR DESCRIPTION
## Summary
- Preserve OAS Provider_config sampling fields (top_p, top_k, min_p) in MASC RuntimeAgent config instead of dropping them at dispatch setup.
- Forward those fields into OAS Builder and resume agent/checkpoint config so resumed runs keep the same provider-declared sampling contract.
- Record completed-turn top_p from the materialized runtime Provider_config instead of leaving the dashboard turn record permanently empty.

## Evidence
- [근거] Kimi official docs, checked 2026-07-05 KST, High: Kimi K2.7 Code is latest/code-focused, always emits reasoning_content, and provider parameter constraints differ by model family. https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- [근거] Z.AI official docs, checked 2026-07-05 KST, High: GLM thinking/preserved-thinking uses typed request fields such as thinking.clear_thinking and reasoning_content preservation. https://docs.z.ai/guides/capabilities/thinking-mode

## Validation
- scripts/dune-local.sh build test/test_runtime_provider_auth_headers.exe
- scripts/dune-local.sh exec test/test_runtime_provider_auth_headers.exe
