### PR TITLE
[codex] Add Keeper Chat interleave contract fixture

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Interleave Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-interleave-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
@@ -1,0 +1,98 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  INTERLEAVE_ORDER_SIGNATURE,
+  InterleaveContractFixture,
+  installInterleaveFixtureToolOutputs,
+  interleaveEntries,
+  interleaveFixtureStatus,
+  joinedToolCount,
+  traceOnlyToolCount,
+} from './keeper-chat-interleave-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat interleave contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic fixture rows for joined and trace-only tool states', () => {
+    expect(interleaveEntries).toHaveLength(2)
+    expect(joinedToolCount).toBe(1)
+    expect(traceOnlyToolCount).toBe(1)
+    expect(interleaveFixtureStatus).toBe('ok')
+
+    const assistant = interleaveEntries.find(entry => entry.id === 'assistant-interleave')
+    expect(assistant?.traceSteps?.map(step => step.kind)).toEqual(['think', 'tool', 'think', 'tool'])
+    expect(assistant?.traceSteps?.map(step => step.ts)).toEqual([
+      '2026-07-05T14:20:05.000Z',
+      '2026-07-05T14:20:01.000Z',
+      '2026-07-05T14:20:02.000Z',
+      '2026-07-05T14:20:03.000Z',
+    ])
+  })
+
+  it('renders structural order and tool-output join state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installInterleaveFixtureToolOutputs()
+
+    render(html`<${InterleaveContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        `[data-interleave-contract-fixture-status="ok"][data-interleave-order-signature="${INTERLEAVE_ORDER_SIGNATURE}"][data-interleave-joined-tool-count="1"][data-interleave-trace-only-tool-count="1"]`,
+      ),
+    ).not.toBeNull()
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(trace).not.toBeNull()
+    expect(trace?.getAttribute('data-chat-turn-order-signature')).toBe(INTERLEAVE_ORDER_SIGNATURE)
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(INTERLEAVE_FIXTURE_COVERED_THROUGH_MS))
+
+    const ordered = [...container.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3', '4'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual([
+      'trace',
+      'tool',
+      'trace',
+      'tool',
+      'chat',
+    ])
+
+    expect(ordered[0]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:05.000Z')
+    expect(ordered[1]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-state')).toBe('ok')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+    expect(ordered[2]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:02.000Z')
+    expect(ordered[3]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-missing')
+    expect(ordered[3]?.getAttribute('data-chat-trace-entry-id')).toBeNull()
+    expect(ordered[3]?.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
+    expect(ordered[3]?.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(ordered[4]?.getAttribute('data-chat-trace-entry-id')).toBe('assistant-interleave')
+
+    const joinedToolRow = ordered[1]
+    expect(joinedToolRow).toBeDefined()
+    if (!joinedToolRow) {
+      throw new Error('expected joined tool row at structural order index 1')
+    }
+
+    expect(container.textContent).not.toContain('context status joined from tool_calls_endpoint')
+    fireEvent.click(joinedToolRow.querySelector('.chat-block-tstep-row') as HTMLElement)
+    expect(container.textContent).toContain('context status joined from tool_calls_endpoint')
+    expect(container.textContent).not.toContain('unrelated output')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -1,0 +1,171 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { ToolCallEntry } from '../api/dashboard'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  recordToolCallOutputs,
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const INTERLEAVE_FIXTURE_KEEPER = 'sangsu'
+export const INTERLEAVE_ORDER_SIGNATURE =
+  'trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+export const INTERLEAVE_FIXTURE_COVERED_SINCE_MS = Date.parse('2026-07-05T14:19:50.000Z')
+export const INTERLEAVE_FIXTURE_COVERED_THROUGH_MS = Date.parse('2026-07-05T14:20:10.000Z')
+
+const joinedToolOutput: ToolCallEntry = {
+  ts: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS / 1000,
+  keeper: INTERLEAVE_FIXTURE_KEEPER,
+  tool: 'keeper_context_status',
+  tool_use_id: 'tc-context',
+  input: { scope: 'current' },
+  output: 'context status joined from tool_calls_endpoint',
+  success: true,
+  semantic_success: true,
+  duration_ms: 84,
+}
+
+export const interleaveHydrationContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  completedAtMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  coveredSinceMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  coveredThroughMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+}
+
+export const interleaveEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-context',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T14:20:01.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-interleave',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: INTERLEAVE_FIXTURE_KEEPER,
+    text: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    rawText: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    timestamp: '2026-07-05T14:20:00.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'trace-interleave#9',
+      reason: 'live terminal event observed by dashboard SSE client',
+    }),
+    traceSteps: [
+      {
+        kind: 'think',
+        text: 'First structural thought appears before the tool even though its timestamp is later.',
+        ts: '2026-07-05T14:20:05.000Z',
+        oasBlockIndex: 10,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-context',
+        status: 'ok',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T14:20:01.000Z',
+        oasBlockIndex: 11,
+      },
+      {
+        kind: 'think',
+        text: 'Second structural thought must remain after the joined tool despite an earlier timestamp.',
+        ts: '2026-07-05T14:20:02.000Z',
+        oasBlockIndex: 12,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_memory_search',
+        toolCallId: 'tc-missing',
+        args: '{"query":"old task context"}',
+        ts: '2026-07-05T14:20:03.000Z',
+        oasBlockIndex: 13,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const joinedToolCount = interleaveEntries.filter(entry => entry.role === 'tool').length
+export const traceOnlyToolCount = interleaveEntries
+  .flatMap(entry => entry.traceSteps ?? [])
+  .filter(step => step.kind === 'tool' && step.toolCallId === 'tc-missing')
+  .length
+export const interleaveFixtureStatus =
+  joinedToolCount === 1 && traceOnlyToolCount === 1 ? 'ok' : 'invalid'
+
+export function installInterleaveFixtureToolOutputs(): void {
+  resetToolCallOutputs()
+  recordToolCallOutputs([joinedToolOutput])
+}
+
+export function InterleaveContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-interleave-contract-fixture
+      data-interleave-contract-fixture-status=${interleaveFixtureStatus}
+      data-interleave-order-signature=${INTERLEAVE_ORDER_SIGNATURE}
+      data-interleave-joined-tool-count=${joinedToolCount}
+      data-interleave-trace-only-tool-count=${traceOnlyToolCount}
+    >
+      <section class="mx-auto max-w-[820px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Interleave Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Structural thinking/tool order
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${interleaveEntries}
+            emptyText="No interleave rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+            groupToolCalls=${true}
+            toolOutputsCoveredSinceMs=${INTERLEAVE_FIXTURE_COVERED_SINCE_MS}
+            toolOutputsCoveredThroughMs=${INTERLEAVE_FIXTURE_COVERED_THROUGH_MS}
+            toolOutputHydrationContract=${interleaveHydrationContract}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installInterleaveFixtureToolOutputs()
+  render(html`<${InterleaveContractFixture} />`, root)
+}

--- a/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5186}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-interleave-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-mobile.png"
+TRACE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace.png"
+JOINED_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-joined-tool.png"
+TRACE_ONLY_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace-only-tool.png"
+CHAT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-chat.png"
+
+ORDER_SIGNATURE='trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+STATUS_SELECTOR="[data-interleave-contract-fixture-status=\"ok\"][data-interleave-order-signature=\"${ORDER_SIGNATURE}\"][data-interleave-joined-tool-count=\"1\"][data-interleave-trace-only-tool-count=\"1\"]"
+TRACE_SELECTOR="[data-chat-work-trace][data-chat-turn-order-signature=\"${ORDER_SIGNATURE}\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783261210000\"]"
+JOINED_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="1"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-context"][data-chat-trace-entry-id="tool-tc-context"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="ok"][data-chat-trace-output-coverage="covered"]'
+TRACE_ONLY_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="3"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-missing"][data-chat-trace-link-state="trace-only"][data-chat-trace-output-state="pending"]'
+CHAT_SELECTOR='[data-chat-trace-step="chat"][data-chat-turn-order-index="4"][data-chat-turn-order-kind="chat"][data-chat-trace-entry-id="assistant-interleave"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${JOINED_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${JOINED_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_ONLY_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_ONLY_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${CHAT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${CHAT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat interleave contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'trace_screenshot=%s\n' "${TRACE_SCREENSHOT}"
+printf 'joined_tool_screenshot=%s\n' "${JOINED_TOOL_SCREENSHOT}"
+printf 'trace_only_tool_screenshot=%s\n' "${TRACE_ONLY_TOOL_SCREENSHOT}"
+printf 'chat_screenshot=%s\n' "${CHAT_SCREENSHOT}"


### PR DESCRIPTION
## Summary
- add a standalone Keeper Chat interleave contract fixture for structural think/tool/chat ordering
- prove joined tool output is hydrated from the tool_calls_endpoint contract while trace-only tools stay pending
- add a Playwright CLI DOM smoke that waits for status, trace, joined tool, trace-only tool, chat, and mobile selectors

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/demo/keeper-chat-interleave-contract-fixture.test.ts src/components/chat/primitives-interleave.test.ts src/components/chat/primitives.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
- GITHUB_BASE_REF=codex/chat-replay-queued-finalization-fixture-20260705 python3 scripts/check_test_coverage.py
- git diff --check --cached && git diff --check

Browser plugin is not available in this environment, so rendered validation used the repo-local Playwright CLI fallback.
