### PR TITLE
[codex] Add Keeper Chat tool-output failure fixture

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Interleave Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-interleave-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Replay Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-replay-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Tool Output Failure Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -15,6 +15,7 @@ import {
   type ChatComposerSendPayload,
 } from './primitives'
 import { _resetChatStoreForTests, readKeeperDraft } from '../../keeper-chat-store'
+import { chatHistoryEntriesFromRest } from '../../keeper-state'
 import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
 import { fetchBoardPost } from '../../api/board'
@@ -279,6 +280,77 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-stream-contract-reason')).toBe(
       '스트림이 종료 신호 없이 끊겼습니다. 응답이 불완전할 수 있습니다.',
     )
+  })
+
+  it('renders REST replay failure and no-turn-ref gaps as visible stream contract badges', () => {
+    const entries = chatHistoryEntriesFromRest('sangsu', [
+      {
+        id: 'smoke-legacy-user',
+        role: 'user',
+        content: 'legacy row without turn ref',
+        ts: 1_780_000_000,
+        stream_contract: {
+          source: 'keeper_chat_store',
+          status: 'history_without_turn_ref',
+          delivery_receipt: 'no_delivery_receipt',
+          reason: 'history row has no durable turn_ref; cannot join stream events',
+        },
+      },
+      {
+        id: 'smoke-error-assistant',
+        role: 'assistant',
+        content: 'Keeper request failed: Timeout after 630.0s',
+        ts: 1_780_000_001,
+        kind: 'transport_failure',
+        turn_ref: 'trace-chat-contract-smoke#8',
+        stream_contract: {
+          source: 'backend_stream_lifecycle',
+          status: 'backend_lifecycle_replay',
+          turn_ref: 'trace-chat-contract-smoke#8',
+          event_name: 'RUN_ERROR',
+          lifecycle_events: [
+            'RUN_STARTED',
+            'RUN_ERROR',
+          ],
+          delivery_receipt: 'server_lifecycle_replay_only',
+          reason: 'history row records durable server stream lifecycle replay',
+        },
+      },
+    ])
+
+    render(
+      html`<${ChatTranscript}
+        entries=${entries}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const legacy = container.querySelector('[data-chat-entry-id="smoke-legacy-user"]') as HTMLElement
+    expect(legacy).not.toBeNull()
+    expect(legacy.getAttribute('data-chat-stream-contract-source')).toBe('keeper_chat_store')
+    expect(legacy.getAttribute('data-chat-stream-contract-status')).toBe('history_without_turn_ref')
+    expect(legacy.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
+    expect(legacy.getAttribute('data-chat-stream-contract-badge-state')).toBe('no-turn-ref')
+    expect(legacy.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('턴 연결 없음')
+
+    const failure = container.querySelector('[data-chat-entry-id="smoke-error-assistant"]') as HTMLElement
+    expect(failure).not.toBeNull()
+    expect(failure.getAttribute('data-chat-delivery-state')).toBe('error')
+    expect(failure.getAttribute('data-chat-turn-ref')).toBe('trace-chat-contract-smoke#8')
+    expect(failure.getAttribute('data-chat-stream-contract-source')).toBe('backend_stream_lifecycle')
+    expect(failure.getAttribute('data-chat-stream-contract-status')).toBe('backend_lifecycle_replay')
+    expect(failure.getAttribute('data-chat-stream-contract-event')).toBe('RUN_ERROR')
+    expect(failure.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe('RUN_STARTED,RUN_ERROR')
+    expect(failure.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('server_lifecycle_replay_only')
+    expect(failure.getAttribute('data-chat-stream-contract-badge-state')).toBe('server-replay')
+    expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 replay')
+    expect(failure.textContent).toContain('Timeout after 630.0s')
+    expect(
+      [...container.querySelectorAll('[data-chat-stream-contract-delivery-receipt]')]
+        .map(node => node.getAttribute('data-chat-stream-contract-delivery-receipt')),
+    ).not.toContain('client_observed_sse_event')
   })
 
   it('exposes tool-call transcript provenance as rendered attributes', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -327,6 +327,64 @@ function sourceBadgeInfo(entry: KeeperConversationEntry): { label: string; cls: 
   return SOURCE_BADGE[entry.source] ?? null
 }
 
+type StreamContractBadgeInfo = {
+  label: string
+  title: string
+  state: 'contract-gap' | 'no-turn-ref' | 'server-replay'
+}
+
+function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContractBadgeInfo | null {
+  const contract = entry.streamContract
+  if (!contract) return null
+  const title = [
+    `source=${contract.source}`,
+    `status=${contract.status}`,
+    contract.eventName ? `event=${contract.eventName}` : null,
+    contract.deliveryReceipt ? `receipt=${contract.deliveryReceipt}` : null,
+    contract.reason ?? null,
+  ].filter((value): value is string => Boolean(value)).join(' · ')
+  switch (contract.deliveryReceipt) {
+    case 'server_lifecycle_replay_only':
+      return { label: '서버 replay', title, state: 'server-replay' }
+    case 'no_delivery_receipt':
+      switch (contract.status) {
+        case 'history_without_turn_ref':
+          return { label: '턴 연결 없음', title, state: 'no-turn-ref' }
+        case 'contract_gap':
+          return { label: '수신 gap', title, state: 'contract-gap' }
+        default:
+          return null
+      }
+    default:
+      return null
+  }
+}
+
+function streamContractBadgeClass(state: StreamContractBadgeInfo['state']): string {
+  switch (state) {
+    case 'server-replay':
+      return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'contract-gap':
+      return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'no-turn-ref':
+      return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]'
+  }
+}
+
+function StreamContractBadge({ badge, compact }: { badge: StreamContractBadgeInfo | null; compact: boolean }) {
+  if (!badge) return null
+  const paddingClass = compact ? 'px-2 py-0.5' : 'px-2.5 py-1'
+  return html`
+    <span
+      class=${`inline-flex items-center rounded-[var(--r-0)] border ${paddingClass} text-2xs font-semibold ${streamContractBadgeClass(badge.state)}`}
+      title=${badge.title}
+      data-chat-stream-contract-badge=${badge.state}
+    >
+      ${badge.label}
+    </span>
+  `
+}
+
 // C1: group transcript messages by calendar day for the workspace day divider.
 // Absolute "M월 D일" labels (not relative 오늘/어제) so the output is a pure
 // function of the timestamp — deterministic and snapshot-test stable.
@@ -2153,6 +2211,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const delivery = deliveryLabel(entry)
   const timestamp = timeLabel(entry.timestamp)
   const sourceBadge = showSourceBadge ? sourceBadgeInfo(entry) : null
+  const streamContractBadge = streamContractBadgeInfo(entry)
   const attachments = entry.attachments ?? []
   const attachBlocks = effectiveBlocks.filter((block): block is Extract<ChatBlock, { t: 'attach' }> => block.t === 'attach')
   const persistedAttachmentKinds = attachments.map(userInputMediaKindForAttachment)
@@ -2189,6 +2248,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-stream-contract-lifecycle-events=${entry.streamContract?.lifecycleEvents?.join(',') ?? undefined}
       data-chat-stream-contract-delivery-receipt=${entry.streamContract?.deliveryReceipt ?? undefined}
       data-chat-stream-contract-reason=${entry.streamContract?.reason ?? undefined}
+      data-chat-stream-contract-badge-state=${streamContractBadge?.state ?? undefined}
       data-chat-queue-seq=${entry.queueSeq ?? undefined}
       data-chat-queue-client-action-id=${entry.queueClientActionId ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
@@ -2230,6 +2290,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${StreamContractBadge} badge=${streamContractBadge} compact=${true} />
                     ${surfaceInfo && surfaceInfo.url !== '#'
                       ? html`
                           <a
@@ -2280,6 +2341,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${StreamContractBadge} badge=${streamContractBadge} compact=${false} />
                     ${surfaceInfo && surfaceInfo.url !== '#'
                       ? html`
                           <a

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -92,6 +92,11 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
+import {
+  markToolCallOutputsHydrationFailed,
+  markToolCallOutputsHydrating,
+  resetToolCallOutputs,
+} from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
@@ -186,6 +191,7 @@ describe('KeeperConversationPanel', () => {
     render(null, container)
     container.remove()
     _resetChatStoreForTests()
+    resetToolCallOutputs()
     vi.unstubAllGlobals()
   })
 
@@ -485,6 +491,97 @@ describe('KeeperConversationPanel', () => {
       'client-side composer queue item; not yet submitted to keeper runtime',
       'client-side composer queue item; not yet submitted to keeper runtime',
     ])
+  })
+
+  it('wires the live tool-output hydration contract store into the transcript', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'tool-tc-live-hydration',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_context_status',
+          text: '{}',
+          rawText: '{}',
+          timestamp: '2026-03-24T00:00:01.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'assistant-live-hydration',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '도구 출력을 확인했습니다.',
+          rawText: '도구 출력을 확인했습니다.',
+          timestamp: '2026-03-24T00:00:02.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          streamContract: {
+            source: 'sse_event',
+            status: 'backend_terminal_event',
+            eventName: 'RUN_FINISHED',
+          },
+          traceSteps: [
+            {
+              kind: 'tool',
+              name: 'keeper_context_status',
+              toolCallId: 'tc-live-hydration',
+              ts: '2026-03-24T00:00:01.000Z',
+            },
+          ],
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const traceSelector = '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('idle')
+    })
+
+    const initialStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    expect(initialStep.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(initialStep.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
+
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
   })
 
   it('renders queued voice draft display blocks inside the transcript', async () => {

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.test.ts
@@ -1,0 +1,98 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  INTERLEAVE_ORDER_SIGNATURE,
+  InterleaveContractFixture,
+  installInterleaveFixtureToolOutputs,
+  interleaveEntries,
+  interleaveFixtureStatus,
+  joinedToolCount,
+  traceOnlyToolCount,
+} from './keeper-chat-interleave-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat interleave contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic fixture rows for joined and trace-only tool states', () => {
+    expect(interleaveEntries).toHaveLength(2)
+    expect(joinedToolCount).toBe(1)
+    expect(traceOnlyToolCount).toBe(1)
+    expect(interleaveFixtureStatus).toBe('ok')
+
+    const assistant = interleaveEntries.find(entry => entry.id === 'assistant-interleave')
+    expect(assistant?.traceSteps?.map(step => step.kind)).toEqual(['think', 'tool', 'think', 'tool'])
+    expect(assistant?.traceSteps?.map(step => step.ts)).toEqual([
+      '2026-07-05T14:20:05.000Z',
+      '2026-07-05T14:20:01.000Z',
+      '2026-07-05T14:20:02.000Z',
+      '2026-07-05T14:20:03.000Z',
+    ])
+  })
+
+  it('renders structural order and tool-output join state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installInterleaveFixtureToolOutputs()
+
+    render(html`<${InterleaveContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        `[data-interleave-contract-fixture-status="ok"][data-interleave-order-signature="${INTERLEAVE_ORDER_SIGNATURE}"][data-interleave-joined-tool-count="1"][data-interleave-trace-only-tool-count="1"]`,
+      ),
+    ).not.toBeNull()
+
+    const trace = container.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(trace).not.toBeNull()
+    expect(trace?.getAttribute('data-chat-turn-order-signature')).toBe(INTERLEAVE_ORDER_SIGNATURE)
+    expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(INTERLEAVE_FIXTURE_COVERED_THROUGH_MS))
+
+    const ordered = [...container.querySelectorAll('[data-chat-turn-order-index]')] as HTMLElement[]
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-index'))).toEqual(['0', '1', '2', '3', '4'])
+    expect(ordered.map(node => node.getAttribute('data-chat-turn-order-kind'))).toEqual([
+      'trace',
+      'tool',
+      'trace',
+      'tool',
+      'chat',
+    ])
+
+    expect(ordered[0]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:05.000Z')
+    expect(ordered[1]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-context')
+    expect(ordered[1]?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-state')).toBe('ok')
+    expect(ordered[1]?.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+    expect(ordered[2]?.getAttribute('data-chat-trace-ts')).toBe('2026-07-05T14:20:02.000Z')
+    expect(ordered[3]?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-missing')
+    expect(ordered[3]?.getAttribute('data-chat-trace-entry-id')).toBeNull()
+    expect(ordered[3]?.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
+    expect(ordered[3]?.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(ordered[4]?.getAttribute('data-chat-trace-entry-id')).toBe('assistant-interleave')
+
+    const joinedToolRow = ordered[1]
+    expect(joinedToolRow).toBeDefined()
+    if (!joinedToolRow) {
+      throw new Error('expected joined tool row at structural order index 1')
+    }
+
+    expect(container.textContent).not.toContain('context status joined from tool_calls_endpoint')
+    fireEvent.click(joinedToolRow.querySelector('.chat-block-tstep-row') as HTMLElement)
+    expect(container.textContent).toContain('context status joined from tool_calls_endpoint')
+    expect(container.textContent).not.toContain('unrelated output')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -1,0 +1,171 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import type { ToolCallEntry } from '../api/dashboard'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  recordToolCallOutputs,
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const INTERLEAVE_FIXTURE_KEEPER = 'sangsu'
+export const INTERLEAVE_ORDER_SIGNATURE =
+  'trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+export const INTERLEAVE_FIXTURE_COVERED_SINCE_MS = Date.parse('2026-07-05T14:19:50.000Z')
+export const INTERLEAVE_FIXTURE_COVERED_THROUGH_MS = Date.parse('2026-07-05T14:20:10.000Z')
+
+const joinedToolOutput: ToolCallEntry = {
+  ts: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS / 1000,
+  keeper: INTERLEAVE_FIXTURE_KEEPER,
+  tool: 'keeper_context_status',
+  tool_use_id: 'tc-context',
+  input: { scope: 'current' },
+  output: 'context status joined from tool_calls_endpoint',
+  success: true,
+  semantic_success: true,
+  duration_ms: 84,
+}
+
+export const interleaveHydrationContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  completedAtMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+  coveredSinceMs: INTERLEAVE_FIXTURE_COVERED_SINCE_MS,
+  coveredThroughMs: INTERLEAVE_FIXTURE_COVERED_THROUGH_MS,
+}
+
+export const interleaveEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-context',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T14:20:01.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-interleave',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: INTERLEAVE_FIXTURE_KEEPER,
+    text: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    rawText: 'Structural order stayed intact without timestamp sorting or fake tool output.',
+    timestamp: '2026-07-05T14:20:00.000Z',
+    turnRef: 'trace-interleave#9',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'trace-interleave#9',
+      reason: 'live terminal event observed by dashboard SSE client',
+    }),
+    traceSteps: [
+      {
+        kind: 'think',
+        text: 'First structural thought appears before the tool even though its timestamp is later.',
+        ts: '2026-07-05T14:20:05.000Z',
+        oasBlockIndex: 10,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-context',
+        status: 'ok',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T14:20:01.000Z',
+        oasBlockIndex: 11,
+      },
+      {
+        kind: 'think',
+        text: 'Second structural thought must remain after the joined tool despite an earlier timestamp.',
+        ts: '2026-07-05T14:20:02.000Z',
+        oasBlockIndex: 12,
+      },
+      {
+        kind: 'tool',
+        name: 'keeper_memory_search',
+        toolCallId: 'tc-missing',
+        args: '{"query":"old task context"}',
+        ts: '2026-07-05T14:20:03.000Z',
+        oasBlockIndex: 13,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const joinedToolCount = interleaveEntries.filter(entry => entry.role === 'tool').length
+export const traceOnlyToolCount = interleaveEntries
+  .flatMap(entry => entry.traceSteps ?? [])
+  .filter(step => step.kind === 'tool' && step.toolCallId === 'tc-missing')
+  .length
+export const interleaveFixtureStatus =
+  joinedToolCount === 1 && traceOnlyToolCount === 1 ? 'ok' : 'invalid'
+
+export function installInterleaveFixtureToolOutputs(): void {
+  resetToolCallOutputs()
+  recordToolCallOutputs([joinedToolOutput])
+}
+
+export function InterleaveContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-interleave-contract-fixture
+      data-interleave-contract-fixture-status=${interleaveFixtureStatus}
+      data-interleave-order-signature=${INTERLEAVE_ORDER_SIGNATURE}
+      data-interleave-joined-tool-count=${joinedToolCount}
+      data-interleave-trace-only-tool-count=${traceOnlyToolCount}
+    >
+      <section class="mx-auto max-w-[820px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Interleave Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Structural thinking/tool order
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${interleaveEntries}
+            emptyText="No interleave rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+            groupToolCalls=${true}
+            toolOutputsCoveredSinceMs=${INTERLEAVE_FIXTURE_COVERED_SINCE_MS}
+            toolOutputsCoveredThroughMs=${INTERLEAVE_FIXTURE_COVERED_THROUGH_MS}
+            toolOutputHydrationContract=${interleaveHydrationContract}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installInterleaveFixtureToolOutputs()
+  render(html`<${InterleaveContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
@@ -1,0 +1,67 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ReplayContractFixture,
+  clientObservedCount,
+  fixtureStatus,
+  replayEntries,
+} from './keeper-chat-replay-contract-fixture'
+
+describe('Keeper Chat replay contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+  })
+
+  it('keeps the replay rows deterministic without client-observed stream receipts', () => {
+    expect(replayEntries).toHaveLength(3)
+    expect(clientObservedCount).toBe(0)
+    expect(fixtureStatus).toBe('ok')
+
+    const legacyEntry = replayEntries.find(entry => entry.id === 'smoke-legacy-user')
+    expect(legacyEntry?.streamContract).toMatchObject({
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const serverReplayEntry = replayEntries.find(entry => entry.id === 'smoke-error-assistant')
+    expect(serverReplayEntry?.streamContract).toMatchObject({
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      eventName: 'RUN_ERROR',
+      deliveryReceipt: 'server_lifecycle_replay_only',
+    })
+  })
+
+  it('renders replay contract badge state into durable DOM attributes', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+
+    render(html`<${ReplayContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]',
+      ),
+    ).not.toBeNull()
+  })
+})

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.test.ts
@@ -5,7 +5,9 @@ import {
   ReplayContractFixture,
   clientObservedCount,
   fixtureStatus,
+  noDeliveryReceiptCount,
   replayEntries,
+  serverReplayOnlyCount,
 } from './keeper-chat-replay-contract-fixture'
 
 describe('Keeper Chat replay contract fixture', () => {
@@ -19,9 +21,11 @@ describe('Keeper Chat replay contract fixture', () => {
     }
   })
 
-  it('keeps the replay rows deterministic without client-observed stream receipts', () => {
-    expect(replayEntries).toHaveLength(3)
-    expect(clientObservedCount).toBe(0)
+  it('keeps replay, queue, and finalization rows deterministic with explicit receipt classes', () => {
+    expect(replayEntries).toHaveLength(6)
+    expect(clientObservedCount).toBe(1)
+    expect(noDeliveryReceiptCount).toBe(4)
+    expect(serverReplayOnlyCount).toBe(1)
     expect(fixtureStatus).toBe('ok')
 
     const legacyEntry = replayEntries.find(entry => entry.id === 'smoke-legacy-user')
@@ -38,6 +42,34 @@ describe('Keeper Chat replay contract fixture', () => {
       eventName: 'RUN_ERROR',
       deliveryReceipt: 'server_lifecycle_replay_only',
     })
+
+    const queuePlaceholder = replayEntries.find(entry => entry.id === 'smoke-queued-assistant')
+    expect(queuePlaceholder).toMatchObject({
+      delivery: 'queued',
+      streamState: 'opening',
+    })
+    expect(queuePlaceholder?.streamContract).toMatchObject({
+      source: 'pending_request_store',
+      status: 'client_placeholder',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const queueResult = replayEntries.find(entry => entry.id === 'smoke-queue-result-assistant')
+    expect(queueResult?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+
+    const liveFinal = replayEntries.find(entry => entry.id === 'smoke-live-final-assistant')
+    expect(liveFinal?.streamContract).toMatchObject({
+      source: 'sse_event',
+      status: 'backend_terminal_event',
+      eventName: 'RUN_FINISHED',
+      deliveryReceipt: 'client_observed_sse_event',
+    })
   })
 
   it('renders replay contract badge state into durable DOM attributes', () => {
@@ -48,7 +80,7 @@ describe('Keeper Chat replay contract fixture', () => {
 
     expect(
       container.querySelector(
-        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]',
+        '[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]',
       ),
     ).not.toBeNull()
 
@@ -61,6 +93,24 @@ describe('Keeper Chat replay contract fixture', () => {
     expect(
       container.querySelector(
         '[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]',
+      ),
+    ).not.toBeNull()
+
+    expect(
+      container.querySelector(
+        '[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]',
       ),
     ).not.toBeNull()
   })

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
@@ -1,0 +1,104 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import { chatHistoryEntriesFromRest } from '../keeper-state'
+
+export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
+  {
+    id: 'smoke-user',
+    role: 'user',
+    content: 'please run the long check',
+    ts: 1_780_000_000,
+    turn_ref: 'trace-chat-contract-smoke#7',
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_stream_events',
+      turn_ref: 'trace-chat-contract-smoke#7',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'user history rows are persisted chat input, not a live client stream receipt',
+    },
+  },
+  {
+    id: 'smoke-legacy-user',
+    role: 'user',
+    content: 'legacy row without turn ref',
+    ts: 1_780_000_001,
+    stream_contract: {
+      source: 'keeper_chat_store',
+      status: 'history_without_turn_ref',
+      delivery_receipt: 'no_delivery_receipt',
+      reason: 'history row has no durable turn_ref; cannot join stream events',
+    },
+  },
+  {
+    id: 'smoke-error-assistant',
+    role: 'assistant',
+    content: 'Keeper request failed: Timeout after 630.0s',
+    ts: 1_780_000_002,
+    kind: 'transport_failure',
+    turn_ref: 'trace-chat-contract-smoke#8',
+    stream_contract: {
+      source: 'backend_stream_lifecycle',
+      status: 'backend_lifecycle_replay',
+      turn_ref: 'trace-chat-contract-smoke#8',
+      event_name: 'RUN_ERROR',
+      lifecycle_events: [
+        'RUN_STARTED',
+        'RUN_ERROR',
+      ],
+      delivery_receipt: 'server_lifecycle_replay_only',
+      reason: 'history row records durable server stream lifecycle replay',
+    },
+  },
+])
+
+export const clientObservedCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'client_observed_sse_event',
+).length
+export const fixtureStatus = replayEntries.length === 3 && clientObservedCount === 0 ? 'ok' : 'invalid'
+
+export function ReplayContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-replay-contract-fixture
+      data-replay-contract-fixture-status=${fixtureStatus}
+      data-replay-contract-fixture-row-count=${replayEntries.length}
+      data-replay-contract-fixture-client-observed-count=${clientObservedCount}
+    >
+      <section class="mx-auto max-w-[760px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Replay Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Rendered replay contracts
+          </h1>
+        </header>
+        <div
+          class="kw-chat rounded-[var(--r-2)] border p-4"
+          style="background: var(--bg-panel); border-color: var(--border-main);"
+        >
+          <${ChatTranscript}
+            entries=${replayEntries}
+            emptyText="No replay rows"
+            variant="messenger"
+            size="primary"
+            showMetadata=${false}
+          />
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  render(html`<${ReplayContractFixture} />`, root)
+}

--- a/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-replay-contract-fixture.ts
@@ -5,9 +5,14 @@ import '../styles/keeper-workspace.css'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { ChatTranscript } from '../components/chat/primitives'
-import { chatHistoryEntriesFromRest } from '../keeper-state'
+import {
+  chatHistoryEntriesFromRest,
+  keeperClientObservedSseStreamContract,
+  keeperStreamContract,
+} from '../keeper-state'
+import type { KeeperConversationEntry } from '../types'
 
-export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
+const historyReplayEntries = chatHistoryEntriesFromRest('sangsu', [
   {
     id: 'smoke-user',
     role: 'user',
@@ -56,10 +61,79 @@ export const replayEntries = chatHistoryEntriesFromRest('sangsu', [
   },
 ])
 
+const queueAndFinalizationEntries: KeeperConversationEntry[] = [
+  {
+    id: 'smoke-queued-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: '',
+    rawText: '',
+    timestamp: null,
+    delivery: 'queued',
+    streamState: 'opening',
+    streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'awaiting queued request poll result',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-queue-result-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'queued request finished through dashboard polling',
+    rawText: 'queued request finished through dashboard polling',
+    timestamp: '2026-07-05T14:14:03.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+      requestId: 'req-chat-contract-smoke-1',
+      deliveryReceipt: 'no_delivery_receipt',
+      reason: 'terminal queued poll result observed by dashboard polling, not SSE delivery',
+    }),
+    details: null,
+  },
+  {
+    id: 'smoke-live-final-assistant',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: 'sangsu',
+    text: 'live stream finished with a client-observed terminal event',
+    rawText: 'live stream finished with a client-observed terminal event',
+    timestamp: '2026-07-05T14:14:04.000Z',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      reason: 'live stream terminal event observed by dashboard SSE client',
+    }),
+    details: null,
+  },
+]
+
+export const replayEntries = [
+  ...historyReplayEntries,
+  ...queueAndFinalizationEntries,
+]
+
 export const clientObservedCount = replayEntries.filter(
   entry => entry.streamContract?.deliveryReceipt === 'client_observed_sse_event',
 ).length
-export const fixtureStatus = replayEntries.length === 3 && clientObservedCount === 0 ? 'ok' : 'invalid'
+export const noDeliveryReceiptCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'no_delivery_receipt',
+).length
+export const serverReplayOnlyCount = replayEntries.filter(
+  entry => entry.streamContract?.deliveryReceipt === 'server_lifecycle_replay_only',
+).length
+export const fixtureStatus = replayEntries.length === 6
+  && clientObservedCount === 1
+  && noDeliveryReceiptCount === 4
+  && serverReplayOnlyCount === 1
+  ? 'ok'
+  : 'invalid'
 
 export function ReplayContractFixture() {
   return html`
@@ -71,6 +145,8 @@ export function ReplayContractFixture() {
       data-replay-contract-fixture-status=${fixtureStatus}
       data-replay-contract-fixture-row-count=${replayEntries.length}
       data-replay-contract-fixture-client-observed-count=${clientObservedCount}
+      data-replay-contract-fixture-no-delivery-count=${noDeliveryReceiptCount}
+      data-replay-contract-fixture-server-replay-count=${serverReplayOnlyCount}
     >
       <section class="mx-auto max-w-[760px]">
         <header class="mb-5">

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  COVERAGE_GAP_COVERED_THROUGH_MS,
+  COVERAGE_GAP_ORDER_SIGNATURE,
+  HYDRATION_FAILED_ORDER_SIGNATURE,
+  TOOL_OUTPUT_FAILURE_REASON,
+  ToolOutputFailureContractFixture,
+  coverageGapEntries,
+  coverageGapToolCount,
+  hydrationFailedEntries,
+  hydrationFailedToolCount,
+  installToolOutputFailureFixtureStore,
+  toolOutputFailureFixtureStatus,
+} from './keeper-chat-tool-output-failure-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat tool output failure contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic failure-state fixture rows', () => {
+    expect(hydrationFailedEntries).toHaveLength(2)
+    expect(coverageGapEntries).toHaveLength(2)
+    expect(hydrationFailedToolCount).toBe(1)
+    expect(coverageGapToolCount).toBe(1)
+    expect(toolOutputFailureFixtureStatus).toBe('ok')
+
+    const hydrationAssistant = hydrationFailedEntries.find(entry => entry.id === 'assistant-hydration-failed')
+    const coverageAssistant = coverageGapEntries.find(entry => entry.id === 'assistant-coverage-gap')
+    expect(hydrationAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    expect(coverageAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    const hydrationToolStep = hydrationAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    const coverageToolStep = coverageAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    expect(hydrationToolStep?.toolCallId).toBe('tc-hydration-failed')
+    expect(coverageToolStep?.toolCallId).toBe('tc-coverage-gap')
+  })
+
+  it('renders hydration-failed and coverage-gap states without silent pending fallback', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installToolOutputFailureFixtureStore()
+
+    render(html`<${ToolOutputFailureContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]',
+      ),
+    ).not.toBeNull()
+
+    const hydrationScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="hydration-failed"]',
+    ) as HTMLElement | null
+    const hydrationTrace = hydrationScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(hydrationTrace?.getAttribute('data-chat-turn-order-signature')).toBe(HYDRATION_FAILED_ORDER_SIGNATURE)
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe(TOOL_OUTPUT_FAILURE_REASON)
+    expect(hydrationScenario?.textContent).toContain('출력 hydration 실패 1')
+
+    const hydrationTool = hydrationScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(hydrationTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+
+    const hydrationToolRow = hydrationTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(hydrationToolRow).not.toBeNull()
+    if (!hydrationToolRow) {
+      throw new Error('expected hydration failure tool row')
+    }
+    fireEvent.click(hydrationToolRow)
+    expect(hydrationTool?.textContent).toContain(`출력 hydration 실패 — ${TOOL_OUTPUT_FAILURE_REASON}`)
+
+    const coverageScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="coverage-gap"]',
+    ) as HTMLElement | null
+    const coverageTrace = coverageScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(coverageTrace?.getAttribute('data-chat-turn-order-signature')).toBe(COVERAGE_GAP_ORDER_SIGNATURE)
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(COVERAGE_GAP_COVERED_THROUGH_MS))
+    expect(coverageScenario?.textContent).toContain('출력 범위 밖 1')
+
+    const coverageTool = coverageScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(coverageTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(coverageTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(coverageTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-state')).toBe('coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-coverage')).toBe('coverage-gap')
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.coverage-gap')).not.toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+
+    const coverageToolRow = coverageTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(coverageToolRow).not.toBeNull()
+    if (!coverageToolRow) {
+      throw new Error('expected coverage gap tool row')
+    }
+    fireEvent.click(coverageToolRow)
+    expect(coverageTool?.textContent).toContain('출력 tail 범위 밖')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
@@ -1,0 +1,210 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER = 'sangsu'
+export const TOOL_OUTPUT_FAILURE_REASON = 'tool_calls_endpoint_502'
+export const HYDRATION_FAILED_ORDER_SIGNATURE = 'tool:tc-hydration-failed|chat:assistant-hydration-failed'
+export const COVERAGE_GAP_ORDER_SIGNATURE = 'tool:tc-coverage-gap|chat:assistant-coverage-gap'
+export const HYDRATION_FAILED_STARTED_AT_MS = Date.parse('2026-07-05T15:09:50.000Z')
+export const HYDRATION_FAILED_COMPLETED_AT_MS = Date.parse('2026-07-05T15:10:05.000Z')
+export const COVERAGE_GAP_COVERED_SINCE_MS = Date.parse('2026-07-05T15:11:00.000Z')
+export const COVERAGE_GAP_COVERED_THROUGH_MS = Date.parse('2026-07-05T15:11:10.000Z')
+
+export const hydrationFailedContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'failed',
+  failureReason: TOOL_OUTPUT_FAILURE_REASON,
+  startedAtMs: HYDRATION_FAILED_STARTED_AT_MS,
+  completedAtMs: HYDRATION_FAILED_COMPLETED_AT_MS,
+  coveredSinceMs: null,
+  coveredThroughMs: null,
+}
+
+export const coverageGapContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  completedAtMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+  coveredSinceMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  coveredThroughMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+}
+
+export const hydrationFailedEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-hydration-failed',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T15:10:01.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-hydration-failed',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'The tool output surface failed, so this cannot be reported as pending.',
+    rawText: 'The tool output surface failed, so this cannot be reported as pending.',
+    timestamp: '2026-07-05T15:10:02.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#1',
+      reason: 'terminal event observed before tool output hydration failed',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-hydration-failed',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T15:10:01.000Z',
+        oasBlockIndex: 21,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const coverageGapEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-coverage-gap',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_board_comment',
+    text: '{"post_id":"post-7","body":"ack"}',
+    rawText: '{"post_id":"post-7","body":"ack"}',
+    timestamp: '2026-07-05T15:11:30.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-coverage-gap',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    rawText: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    timestamp: '2026-07-05T15:11:31.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#2',
+      reason: 'terminal event observed after an older tool-output tail hydrated',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_board_comment',
+        toolCallId: 'tc-coverage-gap',
+        args: '{"post_id":"post-7","body":"ack"}',
+        ts: '2026-07-05T15:11:30.000Z',
+        oasBlockIndex: 22,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const hydrationFailedToolCount = hydrationFailedEntries.filter(entry => entry.role === 'tool').length
+export const coverageGapToolCount = coverageGapEntries.filter(entry => entry.role === 'tool').length
+export const toolOutputFailureFixtureStatus =
+  hydrationFailedToolCount === 1 && coverageGapToolCount === 1 ? 'ok' : 'invalid'
+
+export function installToolOutputFailureFixtureStore(): void {
+  resetToolCallOutputs()
+}
+
+export function ToolOutputFailureContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-tool-output-failure-contract-fixture
+      data-tool-output-failure-contract-fixture-status=${toolOutputFailureFixtureStatus}
+      data-tool-output-failure-hydration-failed-count=${hydrationFailedToolCount}
+      data-tool-output-failure-coverage-gap-count=${coverageGapToolCount}
+    >
+      <section class="mx-auto max-w-[900px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Tool Output Failure Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Tool output failures are explicit
+          </h1>
+        </header>
+        <div class="grid gap-4">
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="hydration-failed"
+            data-tool-output-failure-order-signature=${HYDRATION_FAILED_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${hydrationFailedEntries}
+              emptyText="No hydration failure rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputHydrationContract=${hydrationFailedContract}
+            />
+          </section>
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="coverage-gap"
+            data-tool-output-failure-order-signature=${COVERAGE_GAP_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${coverageGapEntries}
+              emptyText="No coverage gap rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputsCoveredSinceMs=${COVERAGE_GAP_COVERED_SINCE_MS}
+              toolOutputsCoveredThroughMs=${COVERAGE_GAP_COVERED_THROUGH_MS}
+              toolOutputHydrationContract=${coverageGapContract}
+            />
+          </section>
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installToolOutputFailureFixtureStore()
+  render(html`<${ToolOutputFailureContractFixture} />`, root)
+}

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1202,6 +1202,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '진행 상황?', 'delivered'],
       ['assistant', 'polling으로 복구됨', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
   })
 
   it('reconciles a stream network failure when the server history has the completed reply', async () => {
@@ -1250,6 +1262,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'delivered'],
       ['assistant', '여기까지 했습니다.', 'delivered'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
   })
 
@@ -1438,6 +1462,18 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       ['user', '어디까지 했어?', 'error'],
       ['assistant', '', 'error'],
     ])
+    expect(thread[0]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
+    expect(thread[1]?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'contract_gap',
+      requestId: 'kmsg_echo_1',
+      deliveryReceipt: 'no_delivery_receipt',
+    })
     expect(keeperActionErrors.value.echo).toContain('서버 재시작')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
   })
@@ -1503,7 +1539,16 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
       // During the first sleep the assistant should still be queued.
       await vi.advanceTimersByTimeAsync(1_000)
-      expect((keeperThreads.value.echo ?? []).some(entry => entry.role === 'assistant' && entry.delivery === 'queued')).toBe(true)
+      const queuedAssistant = (keeperThreads.value.echo ?? []).find(
+        entry => entry.role === 'assistant' && entry.delivery === 'queued',
+      )
+      expect(queuedAssistant).not.toBeUndefined()
+      expect(queuedAssistant?.streamContract).toMatchObject({
+        source: 'pending_request_store',
+        status: 'client_placeholder',
+        requestId: 'kmsg_echo_1',
+        deliveryReceipt: 'no_delivery_receipt',
+      })
 
       // Let the resume loop finish.
       await vi.advanceTimersByTimeAsync(2_000)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -469,6 +469,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: null,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'restored pending queued request from browser storage',
       }),
       attachments: request.attachments,
@@ -488,6 +489,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       streamState: 'opening',
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: 'awaiting queued request poll result',
       }),
       details: null,
@@ -590,6 +592,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -611,6 +614,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
@@ -627,6 +631,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -639,6 +644,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
           requestId: request.requestId,
+          deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
@@ -654,6 +660,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
@@ -666,6 +673,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
         requestId: request.requestId,
+        deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })

--- a/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_interleave_contract_dom_smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5186}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-interleave-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-interleave-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-fixture-mobile.png"
+TRACE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace.png"
+JOINED_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-joined-tool.png"
+TRACE_ONLY_TOOL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-trace-only-tool.png"
+CHAT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-interleave-contract-chat.png"
+
+ORDER_SIGNATURE='trace:think|tool:tc-context|trace:think|tool:tc-missing|chat:assistant-interleave'
+STATUS_SELECTOR="[data-interleave-contract-fixture-status=\"ok\"][data-interleave-order-signature=\"${ORDER_SIGNATURE}\"][data-interleave-joined-tool-count=\"1\"][data-interleave-trace-only-tool-count=\"1\"]"
+TRACE_SELECTOR="[data-chat-work-trace][data-chat-turn-order-signature=\"${ORDER_SIGNATURE}\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783261210000\"]"
+JOINED_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="1"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-context"][data-chat-trace-entry-id="tool-tc-context"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="ok"][data-chat-trace-output-coverage="covered"]'
+TRACE_ONLY_TOOL_SELECTOR='[data-chat-trace-step="tool"][data-chat-turn-order-index="3"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-missing"][data-chat-trace-link-state="trace-only"][data-chat-trace-output-state="pending"]'
+CHAT_SELECTOR='[data-chat-trace-step="chat"][data-chat-turn-order-index="4"][data-chat-turn-order-kind="chat"][data-chat-trace-entry-id="assistant-interleave"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${JOINED_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${JOINED_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${TRACE_ONLY_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${TRACE_ONLY_TOOL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${CHAT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${CHAT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat interleave contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'trace_screenshot=%s\n' "${TRACE_SCREENSHOT}"
+printf 'joined_tool_screenshot=%s\n' "${JOINED_TOOL_SCREENSHOT}"
+printf 'trace_only_tool_screenshot=%s\n' "${TRACE_ONLY_TOOL_SCREENSHOT}"
+printf 'chat_screenshot=%s\n' "${CHAT_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5184}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-replay-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-replay-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-mobile.png"
+SERVER_REPLAY_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-server-replay.png"
+NO_TURN_REF_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-no-turn-ref.png"
+
+STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]'
+SERVER_REPLAY_SELECTOR='[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]'
+NO_TURN_REF_SELECTOR='[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${SERVER_REPLAY_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${SERVER_REPLAY_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${NO_TURN_REF_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${NO_TURN_REF_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat replay contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_replay_contract_dom_smoke.sh
@@ -12,10 +12,16 @@ DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-desktop.pn
 MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-fixture-mobile.png"
 SERVER_REPLAY_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-server-replay.png"
 NO_TURN_REF_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-no-turn-ref.png"
+QUEUE_PLACEHOLDER_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-placeholder.png"
+QUEUE_RESULT_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-queue-result.png"
+LIVE_TERMINAL_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-replay-contract-live-terminal.png"
 
-STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="3"][data-replay-contract-fixture-client-observed-count="0"]'
+STATUS_SELECTOR='[data-replay-contract-fixture-status="ok"][data-replay-contract-fixture-row-count="6"][data-replay-contract-fixture-client-observed-count="1"][data-replay-contract-fixture-no-delivery-count="4"][data-replay-contract-fixture-server-replay-count="1"]'
 SERVER_REPLAY_SELECTOR='[data-chat-entry-id="smoke-error-assistant"][data-chat-stream-contract-badge-state="server-replay"][data-chat-stream-contract-event="RUN_ERROR"][data-chat-stream-contract-delivery-receipt="server_lifecycle_replay_only"] [data-chat-stream-contract-badge="server-replay"]'
 NO_TURN_REF_SELECTOR='[data-chat-entry-id="smoke-legacy-user"][data-chat-stream-contract-badge-state="no-turn-ref"][data-chat-stream-contract-status="history_without_turn_ref"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"] [data-chat-stream-contract-badge="no-turn-ref"]'
+QUEUE_PLACEHOLDER_SELECTOR='[data-chat-entry-id="smoke-queued-assistant"][data-chat-delivery-state="queued"][data-chat-stream-state="opening"][data-chat-stream-contract-source="pending_request_store"][data-chat-stream-contract-status="client_placeholder"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+QUEUE_RESULT_SELECTOR='[data-chat-entry-id="smoke-queue-result-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="queue_poll"][data-chat-stream-contract-status="queue_poll_result"][data-chat-stream-contract-request-id="req-chat-contract-smoke-1"][data-chat-stream-contract-delivery-receipt="no_delivery_receipt"]'
+LIVE_TERMINAL_SELECTOR='[data-chat-entry-id="smoke-live-final-assistant"][data-chat-delivery-state="delivered"][data-chat-stream-contract-source="sse_event"][data-chat-stream-contract-status="backend_terminal_event"][data-chat-stream-contract-event="RUN_FINISHED"][data-chat-stream-contract-delivery-receipt="client_observed_sse_event"]'
 
 server_pid=""
 cleanup() {
@@ -72,6 +78,30 @@ pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
 
 pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
   --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_PLACEHOLDER_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${QUEUE_RESULT_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${QUEUE_RESULT_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${LIVE_TERMINAL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${LIVE_TERMINAL_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
   --viewport-size 390,844 \
   --timeout 30000 \
   --wait-for-selector "${STATUS_SELECTOR}" \
@@ -82,3 +112,6 @@ printf 'keeper chat replay contract DOM smoke passed\n'
 printf 'fixture_url=%s\n' "${FIXTURE_URL}"
 printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
 printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'queue_placeholder_screenshot=%s\n' "${QUEUE_PLACEHOLDER_SCREENSHOT}"
+printf 'queue_result_screenshot=%s\n' "${QUEUE_RESULT_SCREENSHOT}"
+printf 'live_terminal_screenshot=%s\n' "${LIVE_TERMINAL_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5187}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-tool-output-failure-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
+HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
+COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+
+HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
+COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
+STATUS_SELECTOR='[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+HYDRATION_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"hydration-failed\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${HYDRATION_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"failed\"][data-chat-tool-output-hydration-failure=\"tool_calls_endpoint_502\"]"
+HYDRATION_TOOL_SELECTOR='[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-hydration-failed"][data-chat-trace-entry-id="tool-tc-hydration-failed"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+COVERAGE_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"coverage-gap\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${COVERAGE_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783264270000\"]"
+COVERAGE_TOOL_SELECTOR='[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-coverage-gap"][data-chat-trace-entry-id="tool-tc-coverage-gap"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat tool output failure contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
+printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -12,6 +12,10 @@ DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixtu
 MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
 HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
 COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+HYDRATION_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-expanded.png"
+COVERAGE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-expanded.png"
+MOBILE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-mobile-expanded.png"
+BROWSER_SCRIPT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-interaction-${PORT}.py"
 
 HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
 COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
@@ -98,9 +102,116 @@ pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
   "${FIXTURE_URL}" \
   "${MOBILE_SCREENSHOT}"
 
+PLAYWRIGHT_PYTHON="${PLAYWRIGHT_PYTHON:-}"
+PLAYWRIGHT_PYTHON_CMD=()
+if [[ -n "${PLAYWRIGHT_PYTHON}" ]]; then
+  PLAYWRIGHT_PYTHON_CMD=("${PLAYWRIGHT_PYTHON}")
+elif pnpm --dir "${DASHBOARD_DIR}" exec python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(pnpm --dir "${DASHBOARD_DIR}" exec python3)
+elif python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(python3)
+else
+  echo "Python Playwright module not found. Set PLAYWRIGHT_PYTHON=/abs/path/to/python with playwright installed." >&2
+  exit 1
+fi
+
+cat >"${BROWSER_SCRIPT}" <<'PY'
+import os
+from playwright.sync_api import sync_playwright
+
+fixture_url = os.environ["FIXTURE_URL"]
+hydration_expanded_screenshot = os.environ["HYDRATION_EXPANDED_SCREENSHOT"]
+coverage_expanded_screenshot = os.environ["COVERAGE_EXPANDED_SCREENSHOT"]
+mobile_expanded_screenshot = os.environ["MOBILE_EXPANDED_SCREENSHOT"]
+status_selector = '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+hydration_tool_selector = '[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+coverage_tool_selector = '[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+hydration_explanation = '출력 hydration 실패 — tool_calls_endpoint_502'
+coverage_explanation = '출력 tail 범위 밖'
+expected_title = 'MASC - Keeper Chat Tool Output Failure Contract Fixture'
+
+
+def assert_visible_text(page, text):
+    page.wait_for_function(
+        "expected => document.body.innerText.includes(expected)",
+        arg=text,
+        timeout=10_000,
+    )
+
+
+def open_tool(page, selector):
+    page.locator(f"{selector} .chat-block-tstep-row").click()
+
+
+def verify_page_health(page):
+    page.goto(fixture_url, wait_until="domcontentloaded", timeout=20_000)
+    page.wait_for_selector(status_selector, timeout=15_000)
+    title = page.title()
+    if title != expected_title:
+        raise RuntimeError(f"unexpected title: {title}")
+    body_text = page.locator("body").inner_text()
+    if "Tool output failures are explicit" not in body_text:
+        raise RuntimeError("fixture body did not render expected heading")
+    if page.locator("vite-error-overlay, [data-nextjs-dialog-overlay]").count() > 0:
+        raise RuntimeError("framework error overlay detected")
+
+
+with sync_playwright() as pw:
+    browser = pw.chromium.launch(headless=True)
+    browser_errors = []
+
+    desktop_context = browser.new_context(viewport={"width": 1440, "height": 900})
+    desktop = desktop_context.new_page()
+    desktop.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    desktop.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(desktop)
+    open_tool(desktop, hydration_tool_selector)
+    assert_visible_text(desktop, hydration_explanation)
+    desktop.screenshot(path=hydration_expanded_screenshot, full_page=False)
+
+    open_tool(desktop, coverage_tool_selector)
+    assert_visible_text(desktop, coverage_explanation)
+    desktop.screenshot(path=coverage_expanded_screenshot, full_page=False)
+    desktop_context.close()
+
+    mobile_context = browser.new_context(viewport={"width": 390, "height": 844})
+    mobile = mobile_context.new_page()
+    mobile.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    mobile.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(mobile)
+    open_tool(mobile, hydration_tool_selector)
+    assert_visible_text(mobile, hydration_explanation)
+    open_tool(mobile, coverage_tool_selector)
+    assert_visible_text(mobile, coverage_explanation)
+    mobile.screenshot(path=mobile_expanded_screenshot, full_page=False)
+    mobile_context.close()
+
+    browser.close()
+
+    if browser_errors:
+        raise RuntimeError(f"browser console/page errors: {' | '.join(browser_errors)}")
+
+print('pass\tfixture page identity, nonblank body, and no framework overlay')
+print('pass\tdesktop hydration-failed row expands visible explanation')
+print('pass\tdesktop coverage-gap row expands visible explanation')
+print('pass\tmobile hydration-failed and coverage-gap rows expand visible explanations')
+PY
+
+env \
+  FIXTURE_URL="${FIXTURE_URL}" \
+  HYDRATION_EXPANDED_SCREENSHOT="${HYDRATION_EXPANDED_SCREENSHOT}" \
+  COVERAGE_EXPANDED_SCREENSHOT="${COVERAGE_EXPANDED_SCREENSHOT}" \
+  MOBILE_EXPANDED_SCREENSHOT="${MOBILE_EXPANDED_SCREENSHOT}" \
+  "${PLAYWRIGHT_PYTHON_CMD[@]}" "${BROWSER_SCRIPT}"
+
 printf 'keeper chat tool output failure contract DOM smoke passed\n'
 printf 'fixture_url=%s\n' "${FIXTURE_URL}"
 printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
 printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
 printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
 printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"
+printf 'hydration_expanded_screenshot=%s\n' "${HYDRATION_EXPANDED_SCREENSHOT}"
+printf 'coverage_expanded_screenshot=%s\n' "${COVERAGE_EXPANDED_SCREENSHOT}"
+printf 'mobile_expanded_screenshot=%s\n' "${MOBILE_EXPANDED_SCREENSHOT}"


### PR DESCRIPTION
## Summary
- add a deterministic Keeper Chat tool-output failure fixture for explicit hydration-failed and coverage-gap states
- prove settled joined tool rows do not collapse into silent pending when `/tool-calls` hydration fails or only covers an older output tail
- add a Playwright CLI DOM smoke that waits for fixture status, hydration-failed trace/tool selectors, coverage-gap trace/tool selectors, and mobile render

## Validation
- pnpm --dir dashboard install --frozen-lockfile
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts src/components/chat/primitives.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
- GITHUB_BASE_REF=codex/chat-replay-contract-fixture-20260705 python3 scripts/check_test_coverage.py
- git diff --check && git diff --cached --check

Browser plugin is not available in this environment, so rendered validation used the repo-local Playwright CLI fallback.
