### PR TITLE
fix(ide): extract structured tool input paths

### DIFF
--- a/lib/attribution/tool_input_path.ml
+++ b/lib/attribution/tool_input_path.ml
@@ -6,13 +6,83 @@ let non_empty_string_member name input =
   | _ -> None
 ;;
 
-let tool_input_file_path input =
-  let rec first = function
-    | [] -> None
-    | name :: rest ->
-      (match non_empty_string_member name input with
-       | Some _ as path -> path
-       | None -> first rest)
-  in
-  first [ "path"; "file_path" ]
+let non_empty_string = function
+  | `String raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
+  | _ -> None
+;;
+
+let direct_path_keys =
+  [ "path"
+  ; "file_path"
+  ; "target_path"
+  ; "output_path"
+  ; "destination_path"
+  ]
+;;
+
+let nested_object_keys = [ "arguments"; "args"; "params"; "input" ]
+;;
+
+let list_path_keys =
+  [ "paths"
+  ; "file_paths"
+  ; "files"
+  ; "targets"
+  ; "edits"
+  ; "patches"
+  ; "changes"
+  ]
+;;
+
+let rec first_path_in_value = function
+  | `String _ as json -> non_empty_string json
+  | `Assoc _ as json -> tool_input_file_path json
+  | _ -> None
+
+and first_path_in_list = function
+  | [] -> None
+  | item :: rest ->
+    (match first_path_in_value item with
+     | Some _ as path -> path
+     | None -> first_path_in_list rest)
+
+and first_member_path names input =
+  match names with
+  | [] -> None
+  | name :: rest ->
+    (match non_empty_string_member name input with
+     | Some _ as path -> path
+     | None -> first_member_path rest input)
+
+and first_nested_object_path names input =
+  match names with
+  | [] -> None
+  | name :: rest ->
+    (match Yojson.Safe.Util.member name input with
+     | `Assoc _ as nested ->
+       (match tool_input_file_path nested with
+        | Some _ as path -> path
+        | None -> first_nested_object_path rest input)
+     | _ -> first_nested_object_path rest input)
+
+and first_list_path names input =
+  match names with
+  | [] -> None
+  | name :: rest ->
+    (match Yojson.Safe.Util.member name input with
+     | `List items ->
+       (match first_path_in_list items with
+        | Some _ as path -> path
+        | None -> first_list_path rest input)
+     | _ -> first_list_path rest input)
+
+and tool_input_file_path input =
+  match first_member_path direct_path_keys input with
+  | Some _ as path -> path
+  | None ->
+    (match first_nested_object_path nested_object_keys input with
+     | Some _ as path -> path
+     | None -> first_list_path list_path_keys input)
 ;;

--- a/lib/attribution/tool_input_path.mli
+++ b/lib/attribution/tool_input_path.mli
@@ -3,4 +3,7 @@ val tool_input_file_path : Yojson.Safe.t -> string option
 
     Key priority is shared across IDE tool events, IDE cursor attribution, and
     keeper observation attribution. Caller-specific base-path or cwd fallback
-    remains outside this helper. *)
+    remains outside this helper.
+
+    Direct path fields win first, then structured argument objects and path
+    lists are inspected. Free-form command strings are intentionally ignored. *)

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -456,6 +456,44 @@ let test_hook_and_cursor_share_blank_path_fallback () =
     | _ -> fail "expected one tool event and one cursor")
 ;;
 
+let test_hook_and_cursor_share_nested_arguments_path () =
+  with_temp_dir (fun base_dir ->
+    let input =
+      `Assoc
+        [ ( "arguments"
+          , `Assoc [ "file_path", `String "lib/from-arguments.ml" ] )
+        ; "line", `Int 9
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~tool_name:"fs_edit"
+      ~keeper_id:"k1"
+      ~turn_id:"turn-9"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:50.0
+      ~output_text:"edited"
+      ~input;
+    let events = Ide_bridge.list_events ~base_path:base_dir () in
+    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
+    match events, cursors with
+    | event :: _, [ cursor ] ->
+      check
+        string
+        "tool event nested arguments path"
+        "lib/from-arguments.ml"
+        (json_string "file_path" event);
+      check
+        string
+        "cursor nested arguments path"
+        "lib/from-arguments.ml"
+        (json_string "file_path" cursor)
+    | _ -> fail "expected one tool event and one cursor")
+;;
+
 let test_hook_no_file_path () =
   with_temp_dir (fun base_dir ->
     let input = `Assoc [ "command", `String "ls" ] in
@@ -1138,6 +1176,10 @@ let () =
             "tool event and cursor share blank path fallback"
             `Quick
             test_hook_and_cursor_share_blank_path_fallback
+        ; test_case
+            "tool event and cursor share nested arguments path"
+            `Quick
+            test_hook_and_cursor_share_nested_arguments_path
         ; test_case "no file_path (execute)" `Quick test_hook_no_file_path
         ; test_case "summary truncation" `Quick test_hook_summary_truncation
         ; test_case "typed_outcome mapping" `Quick test_hook_typed_outcome_mapping

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -96,6 +96,59 @@ let test_path_priority_matches_ide_helper () =
        ])
 ;;
 
+let test_nested_arguments_path_is_observed () =
+  check
+    string
+    "nested arguments path"
+    "repos/masc/lib/nested.ml"
+    (observed_path
+       [ ( "arguments"
+         , `Assoc [ "path", `String "repos/masc/lib/nested.ml" ] )
+       ])
+;;
+
+let test_nested_arguments_relative_path_uses_cwd () =
+  check
+    string
+    "nested arguments cwd"
+    "repos/masc/lib/nested.ml"
+    (observed_path
+       [ ( "arguments"
+         , `Assoc [ "file_path", `String "lib/nested.ml" ] )
+       ; "cwd", `String "repos/masc"
+       ])
+;;
+
+let test_paths_list_uses_first_string_path () =
+  check
+    string
+    "paths list"
+    "repos/masc/lib/a.ml"
+    (observed_path
+       [ ( "paths"
+         , `List
+             [ `String "repos/masc/lib/a.ml"
+             ; `String "repos/masc/lib/b.ml"
+             ] )
+       ])
+;;
+
+let test_files_list_uses_first_object_file_path () =
+  check
+    string
+    "files object file_path"
+    "repos/masc/lib/from-file-object.ml"
+    (observed_path
+       [ ( "files"
+         , `List
+             [ `Assoc
+                 [ "file_path"
+                 , `String "repos/masc/lib/from-file-object.ml"
+                 ]
+             ] )
+       ])
+;;
+
 let test_missing_path_falls_back_to_base_path () =
   check string "base fallback" "/tmp/masc-base" (observed_path [])
 ;;
@@ -141,6 +194,14 @@ let () =
             test_blank_path_falls_back_to_file_path
         ; test_case "path priority matches IDE helper" `Quick
             test_path_priority_matches_ide_helper
+        ; test_case "nested arguments path is observed" `Quick
+            test_nested_arguments_path_is_observed
+        ; test_case "nested arguments relative path uses cwd" `Quick
+            test_nested_arguments_relative_path_uses_cwd
+        ; test_case "paths list uses first string path" `Quick
+            test_paths_list_uses_first_string_path
+        ; test_case "files list uses first object file_path" `Quick
+            test_files_list_uses_first_object_file_path
         ; test_case "missing path falls back to base_path" `Quick
             test_missing_path_falls_back_to_base_path
         ] )


### PR DESCRIPTION
## Summary
- Extend the shared `Tool_input_path.tool_input_file_path` helper beyond top-level `path`/`file_path`.
- Preserve direct path priority, then inspect structured argument objects and path lists for write-path attribution.
- Keep free-form command strings ignored so attribution remains structured, not heuristic shell parsing.

## Scope
This is a focused implementation slice for #23309. It improves shared path extraction used by IDE tool events, derived cursor attribution, and keeper observation attribution. It does not complete the broader typed `IdeScope` wire contract, JSON error responses, keeper_id provenance rejection, dashboard fake-field removal, or write-failure response work from the issue.

## Validation
- `scripts/dune-local.sh build test/test_keeper_run_tools_hooks.exe test/test_ide_bridge.exe`
- `_build/default/test/test_keeper_run_tools_hooks.exe` (11 tests)
- `_build/default/test/test_ide_bridge.exe` (43 tests)
- `git diff --check`

Refs #23309