### PR TITLE
Wire model sampling parameters into runtime catalog

### DIFF
--- a/dashboard/src/api/dashboard-runtime.ts
+++ b/dashboard/src/api/dashboard-runtime.ts
@@ -134,6 +134,9 @@ export interface DashboardRuntimeDeclaredModelSpec {
   max_thinking_budget?: number | null
   streaming?: boolean
   temperature?: number | null
+  top_p?: number | null
+  top_k?: number | null
+  min_p?: number | null
   capabilities?: DashboardRuntimeDeclaredModelCapabilities | null
   match_prefixes: string[]
 }
@@ -228,6 +231,10 @@ export interface DashboardRuntimeProviderSnapshot {
   /** Per-model sampling temperature override ([models.<id>].temperature);
    *  null when unset (runtime keeps the fleet fallback). */
   temperature?: number | null
+  /** Per-model sampling overrides from [models.<id>]; null when unset. */
+  top_p?: number | null
+  top_k?: number | null
+  min_p?: number | null
   capabilities_declared?: boolean
   max_output_tokens?: number | null
   supports_tool_choice?: boolean
@@ -601,6 +608,9 @@ function decodeRuntimeDeclaredModelSpec(raw: unknown): DashboardRuntimeDeclaredM
     max_thinking_budget: asNumber(raw.max_thinking_budget) ?? null,
     streaming: asBoolean(raw.streaming),
     temperature: asNumber(raw.temperature) ?? null,
+    top_p: asNumber(raw.top_p) ?? null,
+    top_k: asNumber(raw.top_k) ?? null,
+    min_p: asNumber(raw.min_p) ?? null,
     capabilities: decodeRuntimeDeclaredModelCapabilities(raw.capabilities),
     match_prefixes: asStringArray(raw.match_prefixes),
   }
@@ -728,6 +738,9 @@ function decodeRuntimeProviderSnapshot(raw: unknown): DashboardRuntimeProviderSn
     thinking_support: asBoolean(raw.thinking_support),
     streaming: asBoolean(raw.streaming),
     temperature: asNumber(raw.temperature) ?? null,
+    top_p: asNumber(raw.top_p) ?? null,
+    top_k: asNumber(raw.top_k) ?? null,
+    min_p: asNumber(raw.min_p) ?? null,
     capabilities_declared: asBoolean(raw.capabilities_declared),
     max_output_tokens: asNumber(raw.max_output_tokens) ?? null,
     supports_tool_choice: asBoolean(raw.supports_tool_choice),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2423,6 +2423,9 @@ describe('fetchRuntimeProviders', () => {
             model_count: 1,
             models: ['Qwen/Qwen3-32B'],
             temperature: 0.65,
+            top_p: 0.91,
+            top_k: 42,
+            min_p: 0.07,
             max_output_tokens: 65536,
             supports_tool_choice: true,
             supports_required_tool_choice: true,
@@ -2572,6 +2575,9 @@ describe('fetchRuntimeProviders', () => {
                 max_thinking_budget: 32768,
                 streaming: true,
                 temperature: 0.65,
+                top_p: 0.91,
+                top_k: 42,
+                min_p: 0.07,
                 capabilities: {
                   source: 'runtime.toml',
                   max_output_tokens: 65536,
@@ -2700,6 +2706,9 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.kind).toBe('cloud')
     expect(result.providers[0]?.runtime_kind).toBe('http')
     expect(result.providers[0]?.temperature).toBe(0.65)
+    expect(result.providers[0]?.top_p).toBe(0.91)
+    expect(result.providers[0]?.top_k).toBe(42)
+    expect(result.providers[0]?.min_p).toBe(0.07)
     expect(result.providers[0]?.max_output_tokens).toBe(65536)
     expect(result.providers[0]?.supports_tool_choice).toBe(true)
     expect(result.providers[0]?.supports_required_tool_choice).toBe(true)
@@ -2755,6 +2764,9 @@ describe('fetchRuntimeProviders', () => {
     expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_system_prompt).toBe(true)
     expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_seed_with_images).toBe(true)
     expect(result.providers[0]?.declared_spec?.model?.capabilities?.supports_code_execution).toBe(true)
+    expect(result.providers[0]?.declared_spec?.model?.top_p).toBe(0.91)
+    expect(result.providers[0]?.declared_spec?.model?.top_k).toBe(42)
+    expect(result.providers[0]?.declared_spec?.model?.min_p).toBe(0.07)
     expect(result.providers[0]?.declared_spec?.binding?.max_concurrent).toBe(4)
     expect(result.providers[1]?.temperature).toBeNull()
     expect(result.providers[0]?.discovery?.discovered_model).toBe('Qwen/Qwen3-32B')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -330,6 +330,9 @@ describe('KeeperWorkspaceRail', () => {
               max_thinking_budget: 32768,
               streaming: true,
               temperature: 0.65,
+              top_p: 0.91,
+              top_k: 42,
+              min_p: 0.07,
               capabilities: {
                 source: 'runtime.toml',
                 max_output_tokens: 65536,
@@ -406,6 +409,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('transport http')
     expect(container.textContent).toContain('headers 1')
     expect(container.textContent).toContain('temp 0.65')
+    expect(container.textContent).toContain('sampling config top_p 0.91,top_k 42,min_p 0.07')
     expect(container.textContent).toContain('budget 32768')
     expect(container.textContent).toContain('behavior inline-tools,keeper-bridge')
     expect(container.textContent).toContain(

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -227,6 +227,11 @@ function runtimeDeclaredSpecSummary(
   const spec = entry.declared_spec
   if (!spec) return null
   const caps = spec.model?.capabilities
+  const samplingConfig = [
+    typeof spec.model?.top_p === 'number' ? `top_p ${spec.model.top_p}` : null,
+    typeof spec.model?.top_k === 'number' ? `top_k ${spec.model.top_k}` : null,
+    typeof spec.model?.min_p === 'number' ? `min_p ${spec.model.min_p}` : null,
+  ].filter((value): value is string => Boolean(value))
   const sampling = [
     caps?.supports_top_k ? 'top_k' : null,
     caps?.supports_min_p ? 'min_p' : null,
@@ -300,6 +305,7 @@ function runtimeDeclaredSpecSummary(
     typeof caps?.max_output_tokens === 'number' ? `out ${caps.max_output_tokens}` : null,
     formats.length > 0 ? `format ${formats.join(',')}` : null,
     inputs.length > 0 ? `input ${inputs.join(',')}` : null,
+    samplingConfig.length > 0 ? `sampling config ${samplingConfig.join(',')}` : null,
     sampling.length > 0 ? `sampling ${sampling.join(',')}` : null,
     controls.length > 0 ? `controls ${controls.join(',')}` : null,
     spec.model?.match_prefixes.length ? `match ${spec.model.match_prefixes.join(',')}` : null,

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -55,6 +55,9 @@ describe('RuntimeMonitor', () => {
           thinking_support: true,
           streaming: true,
           temperature: 0.7,
+          top_p: 0.91,
+          top_k: 42,
+          min_p: 0.07,
           capabilities_declared: true,
           max_output_tokens: 65536,
           supports_tool_choice: true,
@@ -206,6 +209,9 @@ describe('RuntimeMonitor', () => {
               max_thinking_budget: 32768,
               streaming: true,
               temperature: 0.65,
+              top_p: 0.91,
+              top_k: 42,
+              min_p: 0.07,
               capabilities: {
                 source: 'runtime.toml',
                 max_output_tokens: 65536,
@@ -372,8 +378,12 @@ describe('RuntimeMonitor', () => {
     expect(container.textContent).toContain('snapshot · source:runtime.toml')
     expect(container.textContent).toContain('protocol:openai-http')
     expect(container.textContent).toContain('model-temp:0.7')
+    expect(container.textContent).toContain('model-top_p:0.91')
+    expect(container.textContent).toContain('model-top_k:42')
+    expect(container.textContent).toContain('model-min_p:0.07')
     expect(container.textContent).toContain('caps:declared')
     expect(container.textContent).toContain('format:json,schema')
+    expect(container.textContent).toContain('sampling-config:top_p:0.91,top_k:42,min_p:0.07')
     expect(container.textContent).toContain('sampling:top_k,min_p,seed')
     expect(container.textContent).toContain('tools:on · thinking:on · streaming:on')
     expect(container.textContent).toContain('multimodal:on · image:on · audio:on · video:off')

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -375,11 +375,18 @@ function runtimeParameterDetailRows(
         typeof request.min_p === 'number' ? `min_p ${request.min_p}` : null,
       ])
     : null
-  const declaredSampling = declaredCaps
+  const hasDeclaredSampling = Boolean(declaredCaps)
+    || typeof declaredModel?.top_p === 'number'
+    || typeof declaredModel?.top_k === 'number'
+    || typeof declaredModel?.min_p === 'number'
+  const declaredSampling = hasDeclaredSampling
     ? textList([
-        flagText(declaredCaps.supports_top_k, 'top_k'),
-        flagText(declaredCaps.supports_min_p, 'min_p'),
-        flagText(declaredCaps.supports_seed, 'seed'),
+        typeof declaredModel?.top_p === 'number' ? `top_p ${declaredModel.top_p}` : null,
+        typeof declaredModel?.top_k === 'number' ? `top_k ${declaredModel.top_k}` : null,
+        typeof declaredModel?.min_p === 'number' ? `min_p ${declaredModel.min_p}` : null,
+        flagText(declaredCaps?.supports_top_k, 'top_k'),
+        flagText(declaredCaps?.supports_min_p, 'min_p'),
+        flagText(declaredCaps?.supports_seed, 'seed'),
       ])
     : null
   const effectiveSampling = caps
@@ -465,11 +472,11 @@ function runtimeParameterDetailRows(
     detailRow('declared model', 'preserve thinking', onOffText(declaredModel?.preserve_thinking)),
     detailRow('declared model', 'thinking budget', numberText(declaredModel?.max_thinking_budget)),
     detailRow('declared model', 'temperature', numberText(declaredModel?.temperature)),
+    detailRow('declared model', 'sampling', declaredSampling),
     detailRow('declared model', 'capability source', declaredCaps?.source),
     detailRow('declared model', 'max output', numberText(declaredCaps?.max_output_tokens)),
     detailRow('declared model', 'thinking wire', declaredCaps?.thinking_control_format),
     detailRow('declared model', 'format', declaredFormat),
-    detailRow('declared model', 'sampling', declaredSampling),
     detailRow('declared model', 'inputs', runtimeDeclaredInputText(provider)),
     detailRow('declared model', 'controls', runtimeDeclaredModelControlText(provider)),
     detailRow('declared model', 'match prefixes', stringArrayText(declaredModel?.match_prefixes)),

--- a/dashboard/src/lib/runtime-provider-summary.ts
+++ b/dashboard/src/lib/runtime-provider-summary.ts
@@ -50,6 +50,9 @@ export function runtimeCatalogSnapshotFacts(item: DashboardRuntimeProviderSnapsh
     typeof item.max_context === 'number' ? `ctx:${item.max_context}` : null,
     typeof item.max_output_tokens === 'number' ? `out:${item.max_output_tokens}` : null,
     typeof item.temperature === 'number' ? `model-temp:${item.temperature}` : null,
+    typeof item.top_p === 'number' ? `model-top_p:${item.top_p}` : null,
+    typeof item.top_k === 'number' ? `model-top_k:${item.top_k}` : null,
+    typeof item.min_p === 'number' ? `model-min_p:${item.min_p}` : null,
     typeof item.capabilities_declared === 'boolean'
       ? `caps:${item.capabilities_declared ? 'declared' : 'missing'}`
       : null,
@@ -168,6 +171,11 @@ export function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapsho
   const spec = item.declared_spec
   if (!spec) return null
   const caps = spec.model?.capabilities
+  const samplingConfig = nonEmptyParts([
+    typeof spec.model?.top_p === 'number' ? `top_p:${spec.model.top_p}` : null,
+    typeof spec.model?.top_k === 'number' ? `top_k:${spec.model.top_k}` : null,
+    typeof spec.model?.min_p === 'number' ? `min_p:${spec.model.min_p}` : null,
+  ])
   const sampling = nonEmptyParts([
     caps?.supports_top_k ? 'top_k' : null,
     caps?.supports_min_p ? 'min_p' : null,
@@ -241,6 +249,7 @@ export function runtimeCatalogDeclaredSpec(item: DashboardRuntimeProviderSnapsho
     typeof caps?.max_output_tokens === 'number' ? `out:${caps.max_output_tokens}` : null,
     formats.length > 0 ? `format:${formats.join(',')}` : null,
     inputs.length > 0 ? `input:${inputs.join(',')}` : null,
+    samplingConfig.length > 0 ? `sampling-config:${samplingConfig.join(',')}` : null,
     sampling.length > 0 ? `sampling:${sampling.join(',')}` : null,
     controls.length > 0 ? `controls:${controls.join(',')}` : null,
     spec.model?.match_prefixes.length ? `match:${spec.model.match_prefixes.join(',')}` : null,

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -332,6 +332,9 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~max_context:spec.max_context
             ?supports_tool_choice_override
             ?max_tokens
+            ?top_p:spec.top_p
+            ?top_k:spec.top_k
+            ?min_p:spec.min_p
             ?keep_alive
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s
@@ -350,6 +353,9 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~max_context:spec.max_context
             ?supports_tool_choice_override
             ?max_tokens
+            ?top_p:spec.top_p
+            ?top_k:spec.top_k
+            ?min_p:spec.min_p
             ?keep_alive
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -176,6 +176,17 @@ type model_spec =
         value at request time ("only 1 is allowed for this model"). Resolved via
         {!Runtime.temperature_of_runtime_id} → {!Runtime_inference.resolve_temperature},
         symmetric to the [max-output-tokens]/[max_tokens] path. *)
+  ; top_p : float option
+    (** [top_p] — per-model nucleus sampling probability forwarded through the
+        materialized OAS [Provider_config]. [None] leaves the caller/OAS profile
+        unchanged. *)
+  ; top_k : int option
+    (** [top_k] — per-model top-k sampling cap forwarded through the materialized
+        OAS [Provider_config]. [None] leaves the caller/OAS profile unchanged. *)
+  ; min_p : float option
+    (** [min_p] — per-model minimum probability sampling value forwarded through
+        the materialized OAS [Provider_config]. [None] leaves the caller/OAS
+        profile unchanged. *)
   ; capabilities : model_capabilities option
   ; match_prefixes : string list
   }

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -121,6 +121,9 @@ type model_spec =
   ; max_thinking_budget : int option
   ; streaming : bool
   ; temperature : float option
+  ; top_p : float option
+  ; top_k : int option
+  ; min_p : float option
   ; capabilities : model_capabilities option
   ; match_prefixes : string list
   }

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -563,6 +563,39 @@ let positive_int_opt_field ~(path : string) ~(key : string) (tbl : Otoml.t)
                value))
 ;;
 
+let sampling_capability_errors
+      ~(path : string)
+      ~(capabilities : Runtime_schema.model_capabilities option)
+      ~(top_k : int option)
+      ~(min_p : float option)
+  : parse_error list
+  =
+  match capabilities with
+  | None -> []
+  | Some capabilities ->
+    let top_k_errors =
+      match top_k with
+      | Some _ when not capabilities.supports_top_k ->
+        error
+          (path ^ ".top-k")
+          (Printf.sprintf
+             "top-k is set but %s.capabilities.supports-top-k is false"
+             path)
+      | Some _ | None -> []
+    in
+    let min_p_errors =
+      match min_p with
+      | Some _ when not capabilities.supports_min_p ->
+        error
+          (path ^ ".min-p")
+          (Printf.sprintf
+             "min-p is set but %s.capabilities.supports-min-p is false"
+             path)
+      | Some _ | None -> []
+    in
+    top_k_errors @ min_p_errors
+;;
+
 let parse_model (id : string) (tbl : Otoml.t)
   : (Runtime_schema.model_spec, parse_error list) result
   =
@@ -629,22 +662,25 @@ let parse_model (id : string) (tbl : Otoml.t)
     let* top_p = top_p_result in
     let* top_k = top_k_result in
     let* min_p = min_p_result in
-    Ok
-      { Runtime_schema.id
-      ; api_name
-      ; tools_support
-      ; max_context
-      ; thinking_support
-      ; preserve_thinking
-      ; max_thinking_budget
-      ; streaming
-      ; temperature
-      ; top_p
-      ; top_k
-      ; min_p
-      ; capabilities
-      ; match_prefixes
-      })
+    match sampling_capability_errors ~path ~capabilities ~top_k ~min_p with
+    | _ :: _ as errors -> Error errors
+    | [] ->
+      Ok
+        { Runtime_schema.id
+        ; api_name
+        ; tools_support
+        ; max_context
+        ; thinking_support
+        ; preserve_thinking
+        ; max_thinking_budget
+        ; streaming
+        ; temperature
+        ; top_p
+        ; top_k
+        ; min_p
+        ; capabilities
+        ; match_prefixes
+        })
 ;;
 
 let parse_models (toml : Otoml.t)

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -474,16 +474,13 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
    positive-float path. *)
 let temperature_min = 0.0
 let temperature_max = 2.0
+let probability_min = 0.0
+let probability_max = 1.0
 
-(* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)
-   both read as a float so an operator is not tripped by "1 vs 1.0". Absent →
-   [Ok None] (caller keeps its fallback). Wrong type or out of
-   [temperature_min, temperature_max] → parse error: reject at load rather than
-   send an out-of-range value the provider would reject at request time. *)
-let temperature_opt_field ~(path : string) (tbl : Otoml.t)
+let number_opt_field ~(path : string) ~(key : string) (tbl : Otoml.t)
   : (float option, parse_error list) result
   =
-  match Otoml.find_opt tbl Fun.id [ "temperature" ] with
+  match Otoml.find_opt tbl Fun.id [ key ] with
   | None -> Ok None
   | Some value ->
     let as_float =
@@ -493,19 +490,77 @@ let temperature_opt_field ~(path : string) (tbl : Otoml.t)
       | _ -> None
     in
     (match as_float with
-     | None ->
-       Error (error (path ^ ".temperature") "temperature must be a number (e.g. 1.0)")
-     | Some t when Float.is_finite t && t >= temperature_min && t <= temperature_max ->
-       Ok (Some t)
-     | Some t ->
+     | None -> Error (error (path ^ "." ^ key) (key ^ " must be a number"))
+     | Some value -> Ok (Some value))
+;;
+
+let bounded_number_opt_field
+      ~(path : string)
+      ~(key : string)
+      ~(lower : float)
+      ~(upper : float)
+      (tbl : Otoml.t)
+  : (float option, parse_error list) result
+  =
+  match number_opt_field ~path ~key tbl with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when Float.is_finite value && value >= lower && value <= upper ->
+    Ok (Some value)
+  | Ok (Some value) ->
+    Error
+      (error
+         (path ^ "." ^ key)
+         (Printf.sprintf
+            "%s must be a finite number in [%g, %g]; got %g"
+            key
+            lower
+            upper
+            value))
+;;
+
+(* Read the optional per-model [temperature]. A TOML integer (1) or float (1.0)
+   both read as a float so an operator is not tripped by "1 vs 1.0". Absent →
+   [Ok None] (caller keeps its fallback). Wrong type or out of
+   [temperature_min, temperature_max] → parse error: reject at load rather than
+   send an out-of-range value the provider would reject at request time. *)
+let temperature_opt_field ~(path : string) (tbl : Otoml.t)
+  : (float option, parse_error list) result
+  =
+  bounded_number_opt_field
+    ~path
+    ~key:"temperature"
+    ~lower:temperature_min
+    ~upper:temperature_max
+    tbl
+;;
+
+let probability_opt_field ~(path : string) ~(key : string) (tbl : Otoml.t)
+  : (float option, parse_error list) result
+  =
+  bounded_number_opt_field
+    ~path
+    ~key
+    ~lower:probability_min
+    ~upper:probability_max
+    tbl
+;;
+
+let positive_int_opt_field ~(path : string) ~(key : string) (tbl : Otoml.t)
+  : (int option, parse_error list) result
+  =
+  match typed_find "an integer" path tbl key Otoml.get_integer with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when value > 0 -> Ok (Some value)
+  | Ok (Some value) ->
        Error
          (error
-            (path ^ ".temperature")
+            (path ^ "." ^ key)
             (Printf.sprintf
-               "temperature must be a finite number in [%g, %g]; got %g"
-               temperature_min
-               temperature_max
-               t)))
+               "%s must be a positive integer; got %d"
+               key
+               value))
 ;;
 
 let parse_model (id : string) (tbl : Otoml.t)
@@ -565,9 +620,15 @@ let parse_model (id : string) (tbl : Otoml.t)
            [])
     in
     let temperature_result = temperature_opt_field ~path tbl in
+    let top_p_result = probability_opt_field ~path ~key:"top-p" tbl in
+    let top_k_result = positive_int_opt_field ~path ~key:"top-k" tbl in
+    let min_p_result = probability_opt_field ~path ~key:"min-p" tbl in
     let ( let* ) = Result.bind in
     let* capabilities = capabilities_result in
     let* temperature = temperature_result in
+    let* top_p = top_p_result in
+    let* top_k = top_k_result in
+    let* min_p = min_p_result in
     Ok
       { Runtime_schema.id
       ; api_name
@@ -578,6 +639,9 @@ let parse_model (id : string) (tbl : Otoml.t)
       ; max_thinking_budget
       ; streaming
       ; temperature
+      ; top_p
+      ; top_k
+      ; min_p
       ; capabilities
       ; match_prefixes
       })

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1658,6 +1658,9 @@ let runtime_declared_spec_json (rt : Runtime.t) =
           ; "max_thinking_budget", Json_util.int_opt_to_json rt.model.max_thinking_budget
           ; "streaming", `Bool rt.model.streaming
           ; "temperature", Json_util.float_opt_to_json rt.model.temperature
+          ; "top_p", Json_util.float_opt_to_json rt.model.top_p
+          ; "top_k", Json_util.int_opt_to_json rt.model.top_k
+          ; "min_p", Json_util.float_opt_to_json rt.model.min_p
           ; "capabilities", runtime_declared_model_capabilities_json rt.model.capabilities
           ; "match_prefixes", Json_util.json_string_list rt.model.match_prefixes
           ] )
@@ -1812,6 +1815,9 @@ let runtime_inventory_entry_json ~default_id (rt : Runtime.t) =
       , match rt.model.temperature with
         | Some t -> `Float t
         | None -> `Null )
+    ; "top_p", Json_util.float_opt_to_json rt.model.top_p
+    ; "top_k", Json_util.int_opt_to_json rt.model.top_k
+    ; "min_p", Json_util.float_opt_to_json rt.model.min_p
       (* Additive capability projection for dashboard runtime snapshot cards.
          These mirrors are declared model capabilities from runtime.toml only;
          [capabilities_declared=false] below keeps the all-false fallback from

--- a/test/test_runtime_model_temperature_toml.ml
+++ b/test/test_runtime_model_temperature_toml.ml
@@ -1,4 +1,4 @@
-(** Tests for the per-model [temperature] field in the [[models.<id>]] parser
+(** Tests for the per-model sampling fields in the [[models.<id>]] parser
     ([Runtime_toml.parse_model]).
 
     Pinned invariants:
@@ -14,6 +14,9 @@
        an invalid temperature is rejected at load rather than sent to the
        provider, which would reject it at request time.
     6. A non-number value fails the parse.
+    7. [top-p], [top-k], and [min-p] parse into model sampling fields.
+    8. Sampling probability fields are finite numbers in [0.0, 1.0].
+    9. [top-k] is a positive integer.
 
     Motivation: Kimi K2.7 (kimi-for-coding) accepts only [temperature = 1.0] and
     rejects any other value ("only 1 is allowed for this model"). This field lets
@@ -50,43 +53,99 @@ let model_temperature cfg id =
   | None -> failf "model %S absent from parsed config" id
 ;;
 
+let model_sampling cfg id =
+  match List.find_opt (fun (m : Schema.model_spec) -> String.equal m.id id) cfg.Schema.models with
+  | Some m -> m.Schema.top_p, m.Schema.top_k, m.Schema.min_p
+  | None -> failf "model %S absent from parsed config" id
+;;
+
 (* A minimal valid [[models.<id>]] table needs [max-context]; [temperature] is
    optional and appended per case. *)
-let model_toml ~temperature_line =
-  Printf.sprintf "[models.m]\nmax-context = 200000\n%s" temperature_line
+let model_toml ~extra_lines =
+  Printf.sprintf "[models.m]\nmax-context = 200000\n%s" extra_lines
 ;;
 
 let test_float_temperature_parses () =
-  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 1.0\n") in
+  let cfg = parse_string_or_fail (model_toml ~extra_lines:"temperature = 1.0\n") in
   check (option (float 0.0001)) "temperature = 1.0 → Some 1.0" (Some 1.0) (model_temperature cfg "m")
 ;;
 
 let test_integer_temperature_parses_as_float () =
-  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 1\n") in
+  let cfg = parse_string_or_fail (model_toml ~extra_lines:"temperature = 1\n") in
   check (option (float 0.0001)) "temperature = 1 → Some 1.0" (Some 1.0) (model_temperature cfg "m")
 ;;
 
 let test_zero_temperature_is_valid () =
-  let cfg = parse_string_or_fail (model_toml ~temperature_line:"temperature = 0.0\n") in
+  let cfg = parse_string_or_fail (model_toml ~extra_lines:"temperature = 0.0\n") in
   check (option (float 0.0001)) "temperature = 0.0 → Some 0.0 (greedy is valid)"
     (Some 0.0) (model_temperature cfg "m")
 ;;
 
 let test_absent_temperature_is_none () =
-  let cfg = parse_string_or_fail (model_toml ~temperature_line:"") in
+  let cfg = parse_string_or_fail (model_toml ~extra_lines:"") in
   check (option (float 0.0001)) "absent temperature → None" None (model_temperature cfg "m")
 ;;
 
 let test_out_of_range_temperature_fails_closed () =
   parse_string_expect_error "temperature = 5.0 (above 2.0 ceiling)"
-    (model_toml ~temperature_line:"temperature = 5.0\n");
+    (model_toml ~extra_lines:"temperature = 5.0\n");
   parse_string_expect_error "temperature = -1.0 (below 0.0 floor)"
-    (model_toml ~temperature_line:"temperature = -1.0\n")
+    (model_toml ~extra_lines:"temperature = -1.0\n")
 ;;
 
 let test_non_number_temperature_fails_closed () =
   parse_string_expect_error "temperature = \"hot\" (not a number)"
-    (model_toml ~temperature_line:"temperature = \"hot\"\n")
+    (model_toml ~extra_lines:"temperature = \"hot\"\n")
+;;
+
+let test_sampling_fields_parse () =
+  let cfg =
+    parse_string_or_fail
+      (model_toml ~extra_lines:"top-p = 0.91\ntop-k = 42\nmin-p = 0.07\n")
+  in
+  let top_p, top_k, min_p = model_sampling cfg "m" in
+  check (option (float 0.0001)) "top-p parses" (Some 0.91) top_p;
+  check (option int) "top-k parses" (Some 42) top_k;
+  check (option (float 0.0001)) "min-p parses" (Some 0.07) min_p
+;;
+
+let test_sampling_probability_integer_bounds_parse () =
+  let cfg =
+    parse_string_or_fail (model_toml ~extra_lines:"top-p = 1\nmin-p = 0\n")
+  in
+  let top_p, top_k, min_p = model_sampling cfg "m" in
+  check (option (float 0.0001)) "top-p = 1 parses" (Some 1.0) top_p;
+  check (option int) "absent top-k remains None" None top_k;
+  check (option (float 0.0001)) "min-p = 0 parses" (Some 0.0) min_p
+;;
+
+let test_absent_sampling_fields_are_none () =
+  let cfg = parse_string_or_fail (model_toml ~extra_lines:"") in
+  let top_p, top_k, min_p = model_sampling cfg "m" in
+  check (option (float 0.0001)) "absent top-p" None top_p;
+  check (option int) "absent top-k" None top_k;
+  check (option (float 0.0001)) "absent min-p" None min_p
+;;
+
+let test_sampling_probability_out_of_range_fails_closed () =
+  parse_string_expect_error "top-p = 1.1 (above probability ceiling)"
+    (model_toml ~extra_lines:"top-p = 1.1\n");
+  parse_string_expect_error "min-p = -0.1 (below probability floor)"
+    (model_toml ~extra_lines:"min-p = -0.1\n")
+;;
+
+let test_sampling_probability_non_number_fails_closed () =
+  parse_string_expect_error "top-p = \"wide\" (not a number)"
+    (model_toml ~extra_lines:"top-p = \"wide\"\n");
+  parse_string_expect_error "min-p = \"narrow\" (not a number)"
+    (model_toml ~extra_lines:"min-p = \"narrow\"\n")
+;;
+
+let test_top_k_invalid_values_fail_closed () =
+  parse_string_expect_error "top-k = 0 (not positive)"
+    (model_toml ~extra_lines:"top-k = 0\n");
+  parse_string_expect_error "top-k = 1.5 (not integer)"
+    (model_toml ~extra_lines:"top-k = 1.5\n")
 ;;
 
 let () =
@@ -97,12 +156,23 @@ let () =
             test_integer_temperature_parses_as_float
         ; test_case "zero temperature is valid (greedy)" `Quick test_zero_temperature_is_valid
         ; test_case "absent temperature is None" `Quick test_absent_temperature_is_none
+        ; test_case "sampling fields parse" `Quick test_sampling_fields_parse
+        ; test_case "sampling probability integer bounds parse" `Quick
+            test_sampling_probability_integer_bounds_parse
+        ; test_case "absent sampling fields are None" `Quick
+            test_absent_sampling_fields_are_none
         ] )
     ; ( "invalid values fail closed"
       , [ test_case "out-of-range temperature fails parse" `Quick
             test_out_of_range_temperature_fails_closed
         ; test_case "non-number temperature fails parse" `Quick
             test_non_number_temperature_fails_closed
+        ; test_case "sampling probability out-of-range fails parse" `Quick
+            test_sampling_probability_out_of_range_fails_closed
+        ; test_case "sampling probability non-number fails parse" `Quick
+            test_sampling_probability_non_number_fails_closed
+        ; test_case "top-k invalid values fail parse" `Quick
+            test_top_k_invalid_values_fail_closed
         ] )
     ]
 ;;

--- a/test/test_runtime_model_temperature_toml.ml
+++ b/test/test_runtime_model_temperature_toml.ml
@@ -17,6 +17,8 @@
     7. [top-p], [top-k], and [min-p] parse into model sampling fields.
     8. Sampling probability fields are finite numbers in [0.0, 1.0].
     9. [top-k] is a positive integer.
+    10. [top-k]/[min-p] fail closed when declared model capabilities say the
+        field is unsupported.
 
     Motivation: Kimi K2.7 (kimi-for-coding) accepts only [temperature = 1.0] and
     rejects any other value ("only 1 is allowed for this model"). This field lets
@@ -45,6 +47,19 @@ let parse_string_expect_error label s =
   match Toml.parse_string s with
   | Ok _ -> failf "%s: expected parse error, got Ok" label
   | Error _ -> ()
+;;
+
+let parse_string_expect_error_entry label ~path ~message s =
+  match Toml.parse_string s with
+  | Ok _ -> failf "%s: expected parse error, got Ok" label
+  | Error errors ->
+    let found =
+      List.exists
+        (fun (err : Toml.parse_error) ->
+           String.equal err.path path && String.equal err.message message)
+        errors
+    in
+    check bool label true found
 ;;
 
 let model_temperature cfg id =
@@ -119,6 +134,18 @@ let test_sampling_probability_integer_bounds_parse () =
   check (option (float 0.0001)) "min-p = 0 parses" (Some 0.0) min_p
 ;;
 
+let test_sampling_fields_parse_with_declared_capabilities () =
+  let cfg =
+    parse_string_or_fail
+      (model_toml
+         ~extra_lines:
+           "top-k = 42\nmin-p = 0.07\n[models.m.capabilities]\nsupports-top-k = true\nsupports-min-p = true\n")
+  in
+  let _, top_k, min_p = model_sampling cfg "m" in
+  check (option int) "top-k parses when declared supported" (Some 42) top_k;
+  check (option (float 0.0001)) "min-p parses when declared supported" (Some 0.07) min_p
+;;
+
 let test_absent_sampling_fields_are_none () =
   let cfg = parse_string_or_fail (model_toml ~extra_lines:"") in
   let top_p, top_k, min_p = model_sampling cfg "m" in
@@ -148,6 +175,24 @@ let test_top_k_invalid_values_fail_closed () =
     (model_toml ~extra_lines:"top-k = 1.5\n")
 ;;
 
+let test_sampling_fields_conflicting_declared_capabilities_fail_closed () =
+  let content =
+    model_toml
+      ~extra_lines:
+        "top-k = 42\nmin-p = 0.07\n[models.m.capabilities]\nsupports-top-k = false\nsupports-min-p = false\n"
+  in
+  parse_string_expect_error_entry
+    "top-k conflicts with declared capabilities"
+    ~path:"models.m.top-k"
+    ~message:"top-k is set but models.m.capabilities.supports-top-k is false"
+    content;
+  parse_string_expect_error_entry
+    "min-p conflicts with declared capabilities"
+    ~path:"models.m.min-p"
+    ~message:"min-p is set but models.m.capabilities.supports-min-p is false"
+    content
+;;
+
 let () =
   run "runtime_model_temperature_toml"
     [ ( "valid values"
@@ -159,6 +204,8 @@ let () =
         ; test_case "sampling fields parse" `Quick test_sampling_fields_parse
         ; test_case "sampling probability integer bounds parse" `Quick
             test_sampling_probability_integer_bounds_parse
+        ; test_case "sampling fields parse with declared capabilities" `Quick
+            test_sampling_fields_parse_with_declared_capabilities
         ; test_case "absent sampling fields are None" `Quick
             test_absent_sampling_fields_are_none
         ] )
@@ -173,6 +220,8 @@ let () =
             test_sampling_probability_non_number_fails_closed
         ; test_case "top-k invalid values fail parse" `Quick
             test_top_k_invalid_values_fail_closed
+        ; test_case "sampling fields conflict with declared capabilities" `Quick
+            test_sampling_fields_conflicting_declared_capabilities_fail_closed
         ] )
     ]
 ;;

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1013,6 +1013,9 @@ api-name = "qwen36-35b-a3b-mtp"
 max-context = 128000
 tools-support = true
 thinking-support = true
+top-p = 0.91
+top-k = 42
+min-p = 0.07
 streaming = true
 
 [models.thinkexplicitoff]
@@ -1359,6 +1362,18 @@ let test_runtime_inventory_surfaces_request_config () =
       "request max context"
       128000
       (request |> J.member "max_context" |> J.to_int);
+    Alcotest.(check (float 0.0001))
+      "request top_p"
+      0.91
+      (request |> J.member "top_p" |> J.to_float);
+    Alcotest.(check int)
+      "request top_k"
+      42
+      (request |> J.member "top_k" |> J.to_int);
+    Alcotest.(check (float 0.0001))
+      "request min_p"
+      0.07
+      (request |> J.member "min_p" |> J.to_float);
     Alcotest.(check string)
       "response format kind"
       "off"
@@ -1399,6 +1414,18 @@ let test_runtime_inventory_surfaces_declared_spec () =
     let provider = spec |> J.member "provider" in
     let model = spec |> J.member "model" in
     let binding = spec |> J.member "binding" in
+    Alcotest.(check (float 0.0001))
+      "snapshot top_p"
+      0.91
+      (thinkdefault |> J.member "top_p" |> J.to_float);
+    Alcotest.(check int)
+      "snapshot top_k"
+      42
+      (thinkdefault |> J.member "top_k" |> J.to_int);
+    Alcotest.(check (float 0.0001))
+      "snapshot min_p"
+      0.07
+      (thinkdefault |> J.member "min_p" |> J.to_float);
     Alcotest.(check string)
       "declared spec source"
       "runtime.toml"
@@ -1442,6 +1469,18 @@ let test_runtime_inventory_surfaces_declared_spec () =
       "declared thinking support"
       true
       (model |> J.member "thinking_support" |> J.to_bool);
+    Alcotest.(check (float 0.0001))
+      "declared top_p"
+      0.91
+      (model |> J.member "top_p" |> J.to_float);
+    Alcotest.(check int)
+      "declared top_k"
+      42
+      (model |> J.member "top_k" |> J.to_int);
+    Alcotest.(check (float 0.0001))
+      "declared min_p"
+      0.07
+      (model |> J.member "min_p" |> J.to_float);
     (match model |> J.member "capabilities" with
      | `Null -> ()
      | _ -> Alcotest.fail "absent model capabilities must remain null");

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -51,6 +51,9 @@ let qwen_model =
   ; max_thinking_budget = None
   ; streaming = true
   ; temperature = None
+  ; top_p = None
+  ; top_k = None
+  ; min_p = None
   ; capabilities = None
   ; match_prefixes = []
   }
@@ -66,7 +69,7 @@ let runpod_binding =
   ; num_ctx = None
   }
 
-let runtime_toml_with_credentials ?(provider_extra = "") credentials =
+let runtime_toml_with_credentials ?(provider_extra = "") ?(model_extra = "") credentials =
   Printf.sprintf
     {|
 [runtime]
@@ -85,6 +88,7 @@ endpoint = "https://example-runpod.proxy.runpod.net/v1"
 api-name = "qwen"
 max-context = 160000
 tools-support = true
+%s
 
 [runpod_mtp.qwen]
 is-default = true
@@ -92,6 +96,7 @@ max-concurrent = 4
 |}
     provider_extra
     credentials
+    model_extra
 
 let check_parse_error errors expected_path expected_message =
   let matches =
@@ -166,6 +171,47 @@ let test_runtime_toml_threads_provider_connect_timeout () =
      | providers, bindings ->
        failf "expected one provider/binding, got %d/%d"
          (List.length providers)
+         (List.length bindings))
+
+let test_runtime_toml_threads_model_sampling_config () =
+  let content =
+    runtime_toml_with_credentials
+      ~model_extra:{|top-p = 0.91
+top-k = 42
+min-p = 0.07
+|}
+      inline_credentials
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    failf
+      "expected runtime TOML model sampling config to parse: %s"
+      (String.concat
+         "; "
+         (List.map
+            (fun (err : Runtime_toml.parse_error) ->
+               Printf.sprintf "%s: %s" err.path err.message)
+            errors))
+  | Ok cfg ->
+    (match cfg.models, cfg.bindings with
+     | [ model ], [ binding ] ->
+       check (option (float 0.0001)) "model top_p" (Some 0.91)
+         model.Runtime_schema.top_p;
+       check (option int) "model top_k" (Some 42) model.Runtime_schema.top_k;
+       check (option (float 0.0001)) "model min_p" (Some 0.07)
+         model.Runtime_schema.min_p;
+       (match Runtime_adapter.binding_to_provider_config cfg binding with
+        | Error msg -> failf "unexpected adapter error: %s" msg
+        | Ok provider_cfg ->
+          check (option (float 0.0001)) "provider config top_p" (Some 0.91)
+            provider_cfg.top_p;
+          check (option int) "provider config top_k" (Some 42)
+            provider_cfg.top_k;
+          check (option (float 0.0001)) "provider config min_p" (Some 0.07)
+            provider_cfg.min_p)
+     | models, bindings ->
+       failf "expected one model/binding, got %d/%d"
+         (List.length models)
          (List.length bindings))
 
 let test_runtime_toml_rejects_non_positive_provider_connect_timeout () =
@@ -1435,6 +1481,10 @@ let () =
             "runtime TOML threads provider connect timeout"
             `Quick
             test_runtime_toml_threads_provider_connect_timeout
+        ; test_case
+            "runtime TOML threads model sampling config"
+            `Quick
+            test_runtime_toml_threads_model_sampling_config
         ; test_case
             "runtime TOML rejects non-positive provider connect timeout"
             `Quick


### PR DESCRIPTION
## Summary
- Add typed per-model `top-p`, `top-k`, and `min-p` fields to `runtime.toml` parsing and `Runtime_schema.model_spec`.
- Thread declared model sampling values into OAS `Provider_config.make` without changing the MASC/OAS boundary.
- Expose declared model sampling values in `/api/v1/providers` top-level snapshots and `declared_spec.model`, then surface them in dashboard runtime summaries.

## Validation
- `scripts/dune-local.sh build test/test_runtime_model_temperature_toml.exe test/test_runtime_provider_auth_headers.exe test/test_runtime_per_keeper_routing.exe`
- `_build/default/test/test_runtime_model_temperature_toml.exe`
- `_build/default/test/test_runtime_provider_auth_headers.exe`
- `_build/default/test/test_runtime_per_keeper_routing.exe`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/runtime-monitor.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`
