### PR TITLE
[codex] Wire goal completion convergence gate

### DIFF
--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -33,9 +33,10 @@ let metric_evaluation_of_string = function
   | "absent" -> Some Metric_absent
   | _ -> None
 
-(* A goal with a declared metric is always [Metric_unevaluated]: no evaluator
-   is wired (Convergence.check_convergence has no caller), so [goal.metric] is
-   never turned into an observed value. See the type comment in
+(* A goal with a declared metric is always [Metric_unevaluated]: the task
+   convergence gate may use [Convergence.check_convergence], but no metric
+   measurement source is wired yet, so [goal.metric] is never turned into an
+   observed value. See the type comment in
    Dashboard_goals_types_accessor. *)
 let metric_evaluation_of_goal (goal : Goal_store.goal) =
   match goal.metric with

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -400,17 +400,39 @@ let parse_optional_transition_action args field =
          ~received:(Yojson.Safe.to_string json))
 ;;
 
-let validate_goal_completion_ready config ~goal_id ~override_note =
+let goal_completion_override_present = function
+  | Some note -> not (String.equal (String.trim note) "")
+  | None -> false
+;;
+
+let task_progress_of_linked_task ~goal_id (task : Masc_domain.task)
+  : Convergence.task_progress
+  =
+  { goal_id = Some goal_id
+  ; is_terminal = Masc_domain.task_status_is_terminal task.task_status
+  ; is_completed = Masc_domain.task_status_is_done task.task_status
+  }
+;;
+
+let validate_goal_completion_ready config ~(goal : Goal_store.goal) ~override_note =
   match override_note with
-  | Some note when not (String.equal (String.trim note) "") -> Ok ()
+  | _ when goal_completion_override_present override_note -> Ok ()
   | _ ->
+    (match goal.metric with
+     | Some metric when not (String.equal (String.trim metric) "") ->
+       Error
+         (Printf.sprintf
+            "goal completion blocked: metric %S has not been evaluated; provide \
+             override_note to force"
+            metric)
+     | Some _ | None ->
     let index =
       Workspace_goal_index.build_goal_task_index_for_config
         config
         (Workspace_query.get_tasks_safe config)
     in
     let linked_tasks =
-      Workspace_goal_index.tasks_for_goal index ~goal_id
+      Workspace_goal_index.tasks_for_goal index ~goal_id:goal.id
     in
     let open_count =
       linked_tasks
@@ -424,27 +446,44 @@ let validate_goal_completion_ready config ~goal_id ~override_note =
         Masc_domain.task_status_is_done task.task_status)
       |> List.length
     in
-    if
-      match linked_tasks with
-      | [] -> true
-      | _ -> false
+    if linked_tasks = []
     then
       Error
         "goal completion requires at least one linked task; provide override_note to \
          force"
-    else if open_count > 0
-    then
-      Error
-        (Printf.sprintf
-           "goal completion blocked: %d linked task(s) are still open; provide \
-            override_note to force"
-           open_count)
-    else if done_count = 0
-    then
-      Error
-        "goal completion blocked: linked tasks are terminal but none are done; provide \
-         override_note to force"
-    else Ok ()
+    else
+      let task_progress =
+        List.map (task_progress_of_linked_task ~goal_id:goal.id) linked_tasks
+      in
+      match
+        Convergence.check_convergence
+          ~goal_id:goal.id
+          ~tasks:task_progress
+          (* Completion readiness is a point-in-time gate; it does not own the
+             cross-turn stagnation counter, so it supplies the neutral current
+             no-progress count. *)
+          ~iterations_without_progress:0
+          ()
+      with
+      | Some (Convergence.AllSubTasksDone _) | Some (Convergence.MetricMet _) ->
+        Ok ()
+      | Some (Convergence.StagnationDetected _) | None ->
+        if open_count > 0
+        then
+          Error
+            (Printf.sprintf
+               "goal completion blocked: %d linked task(s) are still open; provide \
+                override_note to force"
+               open_count)
+        else if done_count = 0
+        then
+          Error
+            "goal completion blocked: linked tasks are terminal but none are done; \
+             provide override_note to force"
+        else
+          Error
+            "goal completion blocked: linked tasks have not converged; provide \
+             override_note to force")
 ;;
 
 let parse_optional_string_list args field =
@@ -643,7 +682,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
       | Some goal ->
         (match
            if action = Goal_phase.Request_complete
-           then validate_goal_completion_ready ctx.config ~goal_id ~override_note
+           then validate_goal_completion_ready ctx.config ~goal ~override_note
            else Ok ()
          with
          | Error msg -> error_result_typed ~tool_name ~start_time ~code:Conflict msg

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -1,14 +1,14 @@
 (** task-1743 — typed "metric unevaluated" state for the goal panel.
 
-    A goal's [metric] is stored but never evaluated: the convergence
-    evaluator (Convergence.check_convergence) has no caller, so the metric
-    is only ever declared. The dashboard attainment projection derives its
-    percentages from linked task completion, not from the metric, yet
-    labels them "metric_target_*" — presenting task progress as a metric
-    result. These tests pin the additive typed [metric_evaluation] field
-    that keeps the two apart: a declared metric is "unevaluated" regardless
-    of how the task-derived attainment looks, and that is distinct from a
-    goal with no metric ("absent"). *)
+    A goal's [metric] is stored but never evaluated: task convergence may be
+    checked, but no metric measurement source turns the declared metric into an
+    observed value. The dashboard attainment projection derives its percentages
+    from linked task completion, not from the metric, yet labels them
+    "metric_target_*" — presenting task progress as a metric result. These
+    tests pin the additive typed [metric_evaluation] field that keeps the two
+    apart: a declared metric is "unevaluated" regardless of how the
+    task-derived attainment looks, and that is distinct from a goal with no
+    metric ("absent"). *)
 
 open Alcotest
 open Masc

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1612,6 +1612,46 @@ let test_goal_completion_blocks_open_tasks () =
     (get_string_field error_json "error_code")
 ;;
 
+let test_goal_completion_blocks_unevaluated_metric () =
+  with_workspace
+  @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal
+        config
+        ~title:"Metric completion"
+        ~metric:"coverage %"
+        ~target_value:"80%"
+        ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Metric done task";
+  let completed =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "action", `String "request_complete"
+            ; "actor", principal_json ~id:"planner"
+            ])
+  in
+  let error_json = expect_error completed in
+  check
+    string
+    "metric completion blocked"
+    "conflict"
+    (get_string_field error_json "error_code");
+  check
+    bool
+    "error mentions metric evaluation"
+    true
+    (contains_substring (Yojson.Safe.to_string error_json) "has not been evaluated")
+;;
+
 let test_goal_completion_override_allows_empty_goal () =
   with_workspace
   @@ fun config ->
@@ -1936,6 +1976,10 @@ let () =
             "completion blocks open tasks"
             `Quick
             test_goal_completion_blocks_open_tasks
+        ; test_case
+            "completion blocks unevaluated metric"
+            `Quick
+            test_goal_completion_blocks_unevaluated_metric
         ; test_case
             "completion override allows empty goal"
             `Quick


### PR DESCRIPTION
## Summary

- Route `masc_goal_transition request_complete` through the existing `Convergence.check_convergence` task-progress evaluator instead of hand-rolled task completion checks.
- Keep metric-bearing goals blocked from completion without `override_note` while no metric measurement source exists, matching the dashboard `metric_evaluation=unevaluated` contract.
- Add regression coverage for metric goals with done tasks not being completion-ready, and update stale comments that claimed Convergence had no caller.

## Validation

- `ocamlformat --check lib/workspace_goals.ml test/test_goal_tools.ml lib/dashboard/dashboard_goals_types_attainment.ml test/test_goal_metric_unevaluated.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_goal_tools.exe test/test_goal_metric_unevaluated.exe`
- `./_build/default/test/test_goal_tools.exe`
- `./_build/default/test/test_goal_metric_unevaluated.exe`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD` (PASS; existing WARN output only)

## Audit Goal

G-GVERIFY first slice: make the existing convergence evaluator live on the goal completion path and keep declared-but-unevaluated metrics from being silently treated as complete.
