### PR TITLE
[codex] prove live chat hydration contract wiring

### DIFF
--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -92,6 +92,11 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
+import {
+  markToolCallOutputsHydrationFailed,
+  markToolCallOutputsHydrating,
+  resetToolCallOutputs,
+} from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
@@ -186,6 +191,7 @@ describe('KeeperConversationPanel', () => {
     render(null, container)
     container.remove()
     _resetChatStoreForTests()
+    resetToolCallOutputs()
     vi.unstubAllGlobals()
   })
 
@@ -485,6 +491,97 @@ describe('KeeperConversationPanel', () => {
       'client-side composer queue item; not yet submitted to keeper runtime',
       'client-side composer queue item; not yet submitted to keeper runtime',
     ])
+  })
+
+  it('wires the live tool-output hydration contract store into the transcript', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'tool-tc-live-hydration',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_context_status',
+          text: '{}',
+          rawText: '{}',
+          timestamp: '2026-03-24T00:00:01.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'assistant-live-hydration',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '도구 출력을 확인했습니다.',
+          rawText: '도구 출력을 확인했습니다.',
+          timestamp: '2026-03-24T00:00:02.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          streamContract: {
+            source: 'sse_event',
+            status: 'backend_terminal_event',
+            eventName: 'RUN_FINISHED',
+          },
+          traceSteps: [
+            {
+              kind: 'tool',
+              name: 'keeper_context_status',
+              toolCallId: 'tc-live-hydration',
+              ts: '2026-03-24T00:00:01.000Z',
+            },
+          ],
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const traceSelector = '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('idle')
+    })
+
+    const initialStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    expect(initialStep.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(initialStep.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
+
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
   })
 
   it('renders queued voice draft display blocks inside the transcript', async () => {

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -12,6 +12,10 @@ DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixtu
 MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
 HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
 COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+HYDRATION_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-expanded.png"
+COVERAGE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-expanded.png"
+MOBILE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-mobile-expanded.png"
+BROWSER_SCRIPT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-interaction-${PORT}.py"
 
 HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
 COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
@@ -98,9 +102,116 @@ pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
   "${FIXTURE_URL}" \
   "${MOBILE_SCREENSHOT}"
 
+PLAYWRIGHT_PYTHON="${PLAYWRIGHT_PYTHON:-}"
+PLAYWRIGHT_PYTHON_CMD=()
+if [[ -n "${PLAYWRIGHT_PYTHON}" ]]; then
+  PLAYWRIGHT_PYTHON_CMD=("${PLAYWRIGHT_PYTHON}")
+elif pnpm --dir "${DASHBOARD_DIR}" exec python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(pnpm --dir "${DASHBOARD_DIR}" exec python3)
+elif python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(python3)
+else
+  echo "Python Playwright module not found. Set PLAYWRIGHT_PYTHON=/abs/path/to/python with playwright installed." >&2
+  exit 1
+fi
+
+cat >"${BROWSER_SCRIPT}" <<'PY'
+import os
+from playwright.sync_api import sync_playwright
+
+fixture_url = os.environ["FIXTURE_URL"]
+hydration_expanded_screenshot = os.environ["HYDRATION_EXPANDED_SCREENSHOT"]
+coverage_expanded_screenshot = os.environ["COVERAGE_EXPANDED_SCREENSHOT"]
+mobile_expanded_screenshot = os.environ["MOBILE_EXPANDED_SCREENSHOT"]
+status_selector = '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+hydration_tool_selector = '[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+coverage_tool_selector = '[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+hydration_explanation = '출력 hydration 실패 — tool_calls_endpoint_502'
+coverage_explanation = '출력 tail 범위 밖'
+expected_title = 'MASC - Keeper Chat Tool Output Failure Contract Fixture'
+
+
+def assert_visible_text(page, text):
+    page.wait_for_function(
+        "expected => document.body.innerText.includes(expected)",
+        arg=text,
+        timeout=10_000,
+    )
+
+
+def open_tool(page, selector):
+    page.locator(f"{selector} .chat-block-tstep-row").click()
+
+
+def verify_page_health(page):
+    page.goto(fixture_url, wait_until="domcontentloaded", timeout=20_000)
+    page.wait_for_selector(status_selector, timeout=15_000)
+    title = page.title()
+    if title != expected_title:
+        raise RuntimeError(f"unexpected title: {title}")
+    body_text = page.locator("body").inner_text()
+    if "Tool output failures are explicit" not in body_text:
+        raise RuntimeError("fixture body did not render expected heading")
+    if page.locator("vite-error-overlay, [data-nextjs-dialog-overlay]").count() > 0:
+        raise RuntimeError("framework error overlay detected")
+
+
+with sync_playwright() as pw:
+    browser = pw.chromium.launch(headless=True)
+    browser_errors = []
+
+    desktop_context = browser.new_context(viewport={"width": 1440, "height": 900})
+    desktop = desktop_context.new_page()
+    desktop.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    desktop.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(desktop)
+    open_tool(desktop, hydration_tool_selector)
+    assert_visible_text(desktop, hydration_explanation)
+    desktop.screenshot(path=hydration_expanded_screenshot, full_page=False)
+
+    open_tool(desktop, coverage_tool_selector)
+    assert_visible_text(desktop, coverage_explanation)
+    desktop.screenshot(path=coverage_expanded_screenshot, full_page=False)
+    desktop_context.close()
+
+    mobile_context = browser.new_context(viewport={"width": 390, "height": 844})
+    mobile = mobile_context.new_page()
+    mobile.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    mobile.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(mobile)
+    open_tool(mobile, hydration_tool_selector)
+    assert_visible_text(mobile, hydration_explanation)
+    open_tool(mobile, coverage_tool_selector)
+    assert_visible_text(mobile, coverage_explanation)
+    mobile.screenshot(path=mobile_expanded_screenshot, full_page=False)
+    mobile_context.close()
+
+    browser.close()
+
+    if browser_errors:
+        raise RuntimeError(f"browser console/page errors: {' | '.join(browser_errors)}")
+
+print('pass\tfixture page identity, nonblank body, and no framework overlay')
+print('pass\tdesktop hydration-failed row expands visible explanation')
+print('pass\tdesktop coverage-gap row expands visible explanation')
+print('pass\tmobile hydration-failed and coverage-gap rows expand visible explanations')
+PY
+
+env \
+  FIXTURE_URL="${FIXTURE_URL}" \
+  HYDRATION_EXPANDED_SCREENSHOT="${HYDRATION_EXPANDED_SCREENSHOT}" \
+  COVERAGE_EXPANDED_SCREENSHOT="${COVERAGE_EXPANDED_SCREENSHOT}" \
+  MOBILE_EXPANDED_SCREENSHOT="${MOBILE_EXPANDED_SCREENSHOT}" \
+  "${PLAYWRIGHT_PYTHON_CMD[@]}" "${BROWSER_SCRIPT}"
+
 printf 'keeper chat tool output failure contract DOM smoke passed\n'
 printf 'fixture_url=%s\n' "${FIXTURE_URL}"
 printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
 printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
 printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
 printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"
+printf 'hydration_expanded_screenshot=%s\n' "${HYDRATION_EXPANDED_SCREENSHOT}"
+printf 'coverage_expanded_screenshot=%s\n' "${COVERAGE_EXPANDED_SCREENSHOT}"
+printf 'mobile_expanded_screenshot=%s\n' "${MOBILE_EXPANDED_SCREENSHOT}"


### PR DESCRIPTION
## What

- Adds a KeeperConversationPanel regression test for the live Keeper Chat path.
- The test renders the real shared panel, updates the tool-output hydration store from idle to failed, and asserts ChatTranscript DOM updates to `hydration-failed` with the endpoint failure reason.

## Why

Previous PRs proved fixture-level failure-state rendering. This PR proves the live panel wiring reads the keeper-scoped hydration contract from the store and forwards it into ChatTranscript instead of relying on fixture props.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-shared.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `GITHUB_BASE_REF=codex/chat-failure-interaction-smoke-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`