### PR TITLE
Wake keepers on failed goal verification

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -147,7 +147,8 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Schedule_due _
       | Keeper_event_queue.Bootstrap
       | Keeper_event_queue.No_progress_recovery
-      | Keeper_event_queue.Hitl_resolved _ ->
+      | Keeper_event_queue.Hitl_resolved _
+      | Keeper_event_queue.Goal_verification_failed _ ->
         None)
     stimuli
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -83,7 +83,8 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Fusion_completed _
   | Keeper_event_queue.Bg_completed _
-  | Keeper_event_queue.Hitl_resolved _ ->
+  | Keeper_event_queue.Hitl_resolved _
+  | Keeper_event_queue.Goal_verification_failed _ ->
     (* No dedicated turn_reason: like the other async-completion wakes, the
        stimulus itself forces the keeper to re-run its cycle. Once the resolved
        approval has left the queue the keeper no longer skips on
@@ -139,6 +140,17 @@ let consume_single_heartbeat_stimulus
       "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
       sw.schedule_id
       sw.due_at
+      meta_after_triage.name;
+    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+  | Keeper_event_queue.Goal_verification_failed failure ->
+    (* A rejected completion claim is actionable work for the assigned keeper.
+       Promote it to a pending observation so the cycle does not wake empty. *)
+    Log.Keeper.info
+      "turn entry: goal verification failure delivered goal_id=%s request_id=%s \
+       rejected_by=%s (keeper=%s)"
+      failure.goal_id
+      failure.request_id
+      failure.rejected_by
       meta_after_triage.name;
     pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
   | Keeper_event_queue.Bootstrap ->

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -13,6 +13,8 @@ type stimulus_kind =
   | Connector_attention
       (* RFC-connector-ambient-attention-wake: ambient connector message wake *)
   | Hitl_resolved  (* HITL approval resolution wake — unblocks Skip Approval_pending *)
+  | Goal_verification_failed
+      (* Goal verification rejection wake — resumes assigned goal work. *)
 
 type reaction_kind =
   | Turn_started
@@ -34,6 +36,7 @@ let stimulus_kind_to_string = function
   | Schedule_due -> "schedule_due"
   | Connector_attention -> "connector_attention"
   | Hitl_resolved -> "hitl_resolved"
+  | Goal_verification_failed -> "goal_verification_failed"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -49,6 +52,7 @@ let stimulus_kind_of_string = function
   | "schedule_due" -> Some Schedule_due
   | "connector_attention" -> Some Connector_attention
   | "hitl_resolved" -> Some Hitl_resolved
+  | "goal_verification_failed" -> Some Goal_verification_failed
   | _ -> None
 ;;
 
@@ -96,6 +100,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Schedule_due _ -> Schedule_due
   | Keeper_event_queue.Connector_attention _ -> Connector_attention
   | Keeper_event_queue.Hitl_resolved _ -> Hitl_resolved
+  | Keeper_event_queue.Goal_verification_failed _ -> Goal_verification_failed
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -189,6 +194,12 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "hitl_resolved approval=%s decision=%s"
       r.approval_id
       (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
+  | Keeper_event_queue.Goal_verification_failed failure ->
+    Printf.sprintf
+      "goal_verification_failed goal_id=%s request_id=%s rejected_by=%s"
+      failure.goal_id
+      failure.request_id
+      failure.rejected_by
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -204,7 +215,8 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Bg_completed _
     | Keeper_event_queue.Schedule_due _
     | Keeper_event_queue.Connector_attention _
-    | Keeper_event_queue.Hitl_resolved _ -> None
+    | Keeper_event_queue.Hitl_resolved _
+    | Keeper_event_queue.Goal_verification_failed _ -> None
   in
   `Assoc
     (base_fields
@@ -825,7 +837,8 @@ let summarize_rows ~keeper_name ~limit rows =
           강제한다 (catch-all 금지). *)
        | Some
            ( Board_signal | Bootstrap | No_progress_recovery | Fusion_completed
-           | Bg_completed | Schedule_due | Connector_attention | Hitl_resolved )
+           | Bg_completed | Schedule_due | Connector_attention | Hitl_resolved
+           | Goal_verification_failed )
          -> ())
   in
   let note_payload_parse_error row =
@@ -918,8 +931,9 @@ let summarize_rows ~keeper_name ~limit rows =
         match Option.bind (Hashtbl.find_opt stimulus_kind_by_id id) stimulus_kind_of_string with
         | Some No_progress_recovery -> true
         | Some
-            ( Board_signal | Bootstrap | Fusion_completed | Bg_completed | Schedule_due
-            | Connector_attention | Hitl_resolved )
+            ( Board_signal | Bootstrap | Fusion_completed | Bg_completed
+            | Schedule_due | Connector_attention | Hitl_resolved
+            | Goal_verification_failed )
         | None ->
           false)
       pending_stimulus_ids

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -18,8 +18,10 @@ type stimulus_kind =
   | Bg_completed  (** RFC-0290: generic background job completion wake *)
   | Schedule_due  (** Scheduled automation due wake for a specific keeper *)
   | Connector_attention
-  | Hitl_resolved  (** HITL approval resolution wake — unblocks [Skip Approval_pending] *)
       (** RFC-connector-ambient-attention-wake: ambient connector message wake *)
+  | Hitl_resolved  (** HITL approval resolution wake — unblocks [Skip Approval_pending] *)
+  | Goal_verification_failed
+      (** Goal verification rejection wake — resumes assigned goal work. *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -143,6 +143,7 @@ let board_event_kind_label = function
   | Keeper_world_observation.Bg_completed -> "bg_completed"
   | Keeper_world_observation.Schedule_due -> "schedule_due"
   | Keeper_world_observation.External_attention -> "external_attention"
+  | Keeper_world_observation.Goal_verification_failed -> "goal_verification_failed"
 ;;
 
 let quote_prompt_field value =
@@ -179,7 +180,8 @@ let board_event_note = function
   | Keeper_world_observation.Fusion_completed
   | Keeper_world_observation.Bg_completed
   | Keeper_world_observation.Schedule_due
-  | Keeper_world_observation.External_attention -> ""
+  | Keeper_world_observation.External_attention
+  | Keeper_world_observation.Goal_verification_failed -> ""
 ;;
 
 let format_board_event_text

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -46,6 +46,7 @@ type pending_board_event_kind =
   | Bg_completed
   | Schedule_due
   | External_attention
+  | Goal_verification_failed
 
 type pending_board_event =
   { event_kind : pending_board_event_kind
@@ -653,6 +654,69 @@ let pending_board_event_of_external_attention
   }
 ;;
 
+let goal_verification_failure_author =
+  Tool_name.Goal_name.to_string Tool_name.Goal_name.Goal_verify
+;;
+
+let goal_verification_failure_preview
+      (failure : Keeper_event_queue.goal_verification_failure)
+  =
+  let metric_line =
+    match failure.metric, failure.target_value with
+    | Some metric, Some target ->
+      Printf.sprintf " metric=%s target=%s" metric target
+    | Some metric, None -> Printf.sprintf " metric=%s" metric
+    | None, Some target -> Printf.sprintf " target=%s" target
+    | None, None -> ""
+  in
+  let note_line =
+    match failure.note with
+    | Some note when String.trim note <> "" -> " note=" ^ note
+    | Some _ | None -> ""
+  in
+  let evidence_line =
+    match failure.evidence_refs with
+    | [] -> ""
+    | refs -> " evidence_refs=" ^ String.concat "," refs
+  in
+  Printf.sprintf
+    "Goal verification rejected by %s; goal returned to phase=%s.%s%s%s"
+    failure.rejected_by
+    failure.phase
+    metric_line
+    note_line
+    evidence_line
+;;
+
+let pending_board_event_of_goal_verification_failure
+      ~(meta : keeper_meta)
+      ~(arrived_at : float)
+      (failure : Keeper_event_queue.goal_verification_failure)
+  : pending_board_event
+  =
+  let author = goal_verification_failure_author in
+  let self_ids = self_ids meta in
+  { event_kind = Goal_verification_failed
+  ; post_id = Keeper_event_queue.goal_verification_failure_post_id failure
+  ; author
+  ; title = Printf.sprintf "Goal verification failed: %s" failure.goal_title
+  ; preview =
+      short_preview
+        ~max_len:fusion_result_preview_max_len
+        (goal_verification_failure_preview failure)
+  ; hearth = None
+  ; post_kind = Board.System_post
+  ; updated_at = arrived_at
+  ; explicit_mention = false
+  ; matched_targets = []
+  ; self_commented = false
+  ; new_external_since = 1
+  ; latest_external_author = Some failure.rejected_by
+  ; latest_external_preview = failure.note
+  ; provenance = provenance_of ~self_ids Board.System_post ~author
+  }
+;;
+
 let pending_board_event_of_stimulus
       ~continuity_summary
       ~(meta : keeper_meta)
@@ -674,6 +738,12 @@ let pending_board_event_of_stimulus
       (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c)
   | Keeper_event_queue.Schedule_due sw ->
     Some (pending_board_event_of_scheduled_wake ~meta ~arrived_at:stimulus.arrived_at sw)
+  | Keeper_event_queue.Goal_verification_failed failure ->
+    Some
+      (pending_board_event_of_goal_verification_failure
+         ~meta
+         ~arrived_at:stimulus.arrived_at
+         failure)
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.No_progress_recovery
   | Keeper_event_queue.Connector_attention _

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -56,6 +56,7 @@ type pending_board_event_kind =
   | Bg_completed
   | Schedule_due
   | External_attention
+  | Goal_verification_failed
 
 type pending_board_event = {
   event_kind : pending_board_event_kind;
@@ -326,9 +327,19 @@ val pending_board_event_of_external_attention :
   Keeper_external_attention.item ->
   pending_board_event
 
+(** Build the actionable observation for a rejected goal verification. The
+    event is synthetic system output, not trusted operator direction, but it is
+    actionable because the assigned keeper must resume goal work. *)
+val pending_board_event_of_goal_verification_failure :
+  meta:Keeper_meta_contract.keeper_meta ->
+  arrived_at:float ->
+  Keeper_event_queue.goal_verification_failure ->
+  pending_board_event
+
 (** Convert a queued Event Layer stimulus back into structured board activity
     for the next keeper prompt. [Board_signal], [Fusion_completed] (RFC-0266),
-    [Bg_completed] (RFC-0290), and [Schedule_due] produce [Some];
+    [Bg_completed] (RFC-0290), [Schedule_due], and
+    [Goal_verification_failed] produce [Some];
     [Bootstrap]/[No_progress_recovery] return [None] (no prompt injection). *)
 val pending_board_event_of_stimulus :
   continuity_summary:string ->

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -67,6 +67,11 @@ type stimulus_payload =
          30-minute approval janitor. Mirrors [Fusion_completed]/[Bg_completed]:
          a HITL decision is an async completion the waiting keeper must be
          notified of. *)
+  | Goal_verification_failed of goal_verification_failure
+      (* A goal completion verification was rejected for a goal assigned to this
+         keeper. Wakes the keeper lane so it resumes the goal after the phase
+         returns to [executing], instead of discovering the rejection only via
+         unrelated board/task activity. *)
 
 and fusion_completion = {
   run_id : string;
@@ -120,6 +125,18 @@ and scheduled_wake = {
   message : string;
 }
 
+and goal_verification_failure = {
+  goal_id : string;
+  request_id : string;
+  goal_title : string;
+  phase : string;
+  metric : string option;
+  target_value : string option;
+  rejected_by : string;
+  note : string option;
+  evidence_refs : string list;
+}
+
 let fusion_completion_post_id (fc : fusion_completion) =
   if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
   else fc.board_post_id
@@ -131,6 +148,9 @@ let bg_job_completion_post_id (c : bg_job_completion) =
 let schedule_due_post_id (sw : scheduled_wake) = "schedule-due:" ^ sw.schedule_id
 
 let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
+
+let goal_verification_failure_post_id (failure : goal_verification_failure) =
+  "goal-verification-failed:" ^ failure.goal_id ^ ":" ^ failure.request_id
 
 let hitl_resolution_decision_to_string = function
   | Hitl_approved -> "approve"
@@ -257,11 +277,13 @@ let payload_kind_label = function
   | Schedule_due _ -> "schedule_due"
   | Connector_attention _ -> "connector_attention"
   | Hitl_resolved _ -> "hitl_resolved"
+  | Goal_verification_failed _ -> "goal_verification_failed"
 
 let is_board_signal = function
   | Board_signal _ -> true
   | Bootstrap | No_progress_recovery | Fusion_completed _ | Bg_completed _
-  | Schedule_due _ | Connector_attention _ | Hitl_resolved _ ->
+  | Schedule_due _ | Connector_attention _ | Hitl_resolved _
+  | Goal_verification_failed _ ->
     false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
@@ -368,6 +390,19 @@ let string_field ~context name fields =
   let* json = required_field ~context name fields in
   string_of_json ~context:(context ^ "." ^ name) json
 
+let string_list_field ~context name fields =
+  let* json = required_field ~context name fields in
+  match json with
+  | `List items ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | item :: rest ->
+        let* value = string_of_json ~context:(context ^ "." ^ name) item in
+        loop (value :: acc) rest
+    in
+    loop [] items
+  | _ -> Error (Printf.sprintf "%s.%s must be a JSON list" context name)
+
 let bool_field ~context name fields =
   let* json = required_field ~context name fields in
   bool_of_json ~context:(context ^ "." ^ name) json
@@ -433,6 +468,19 @@ let payload_to_yojson = function
       ; "approval_id", `String r.approval_id
       ; "decision", `String (hitl_resolution_decision_to_string r.decision)
       ]
+  | Goal_verification_failed failure ->
+    `Assoc
+      [ "kind", `String "goal_verification_failed"
+      ; "goal_id", `String failure.goal_id
+      ; "request_id", `String failure.request_id
+      ; "goal_title", `String failure.goal_title
+      ; "phase", `String failure.phase
+      ; "metric", option_json (fun value -> `String value) failure.metric
+      ; "target_value", option_json (fun value -> `String value) failure.target_value
+      ; "rejected_by", `String failure.rejected_by
+      ; "note", option_json (fun value -> `String value) failure.note
+      ; "evidence_refs", `List (List.map (fun value -> `String value) failure.evidence_refs)
+      ]
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -493,6 +541,28 @@ let payload_of_yojson json =
     let* decision_s = string_field ~context "decision" fields in
     let* decision = hitl_resolution_decision_of_string decision_s in
     Ok (Hitl_resolved { approval_id; decision })
+  | "goal_verification_failed" ->
+    let* goal_id = string_field ~context "goal_id" fields in
+    let* request_id = string_field ~context "request_id" fields in
+    let* goal_title = string_field ~context "goal_title" fields in
+    let* phase = string_field ~context "phase" fields in
+    let* metric = optional_string_field ~context "metric" fields in
+    let* target_value = optional_string_field ~context "target_value" fields in
+    let* rejected_by = string_field ~context "rejected_by" fields in
+    let* note = optional_string_field ~context "note" fields in
+    let* evidence_refs = string_list_field ~context "evidence_refs" fields in
+    Ok
+      (Goal_verification_failed
+         { goal_id
+         ; request_id
+         ; goal_title
+         ; phase
+         ; metric
+         ; target_value
+         ; rejected_by
+         ; note
+         ; evidence_refs
+         })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -87,6 +87,11 @@ type stimulus_payload =
           Wakes the keeper so it re-evaluates immediately instead of stalling
           until an unrelated stimulus, no-progress recovery, or the 30-minute
           approval janitor. Mirrors [Fusion_completed]/[Bg_completed]. *)
+  | Goal_verification_failed of goal_verification_failure
+      (** A goal completion verification was rejected for a goal assigned to
+          this keeper. Wakes the keeper lane so it resumes work on the goal
+          after the goal phase returns to [executing], instead of waiting for
+          unrelated board/task activity. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -158,6 +163,21 @@ and scheduled_wake = {
     preserves a stable audit correlation to the schedule payload without
     duplicating its raw JSON envelope in the keeper queue. *)
 
+and goal_verification_failure = {
+  goal_id : string;
+  request_id : string;
+  goal_title : string;
+  phase : string;
+  metric : string option;
+  target_value : string option;
+  rejected_by : string;
+  note : string option;
+  evidence_refs : string list;
+}
+(** Payload for [Goal_verification_failed]. The queue stores the durable
+    verification result summary needed by the next keeper prompt; [phase] is
+    display-only and produced by the goal phase SSOT at enqueue time. *)
+
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
     sink created a board evidence post, otherwise falls back to
@@ -174,6 +194,9 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 (** Dedup/correlation id for [Hitl_resolved]: ["hitl-approval:<approval_id>"].
     De-dups repeat resolve wakes for the same approval within the dedup
     window. *)
+
+val goal_verification_failure_post_id : goal_verification_failure -> post_id
+(** Dedup/correlation id for [Goal_verification_failed]. *)
 
 val hitl_resolution_decision_to_string : hitl_resolution_decision -> string
 (** Stable wire/log label for a HITL resolution wake decision. *)

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -67,6 +67,112 @@ let canonical_principal_for_authenticated_caller (ctx : context)
   { id = ctx.agent_name; display_name = None }
 ;;
 
+let list_mem_string needle values =
+  List.exists (String.equal needle) values
+;;
+
+let uniq_strings values =
+  List.fold_left
+    (fun acc value -> if list_mem_string value acc then acc else value :: acc)
+    []
+    values
+  |> List.rev
+;;
+
+let keeper_assigned_to_goal ~goal_id (meta : Keeper_meta_contract.keeper_meta) =
+  list_mem_string goal_id meta.active_goal_ids
+;;
+
+let assigned_keeper_names_for_goal (config : Workspace.config) ~goal_id =
+  let registered =
+    Keeper_registry.all ~base_path:config.base_path ()
+    |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
+      if keeper_assigned_to_goal ~goal_id entry.meta then Some entry.name else None)
+  in
+  let persisted =
+    Keeper_meta_store.keeper_names config
+    |> List.filter_map (fun keeper_name ->
+      match Keeper_meta_store.read_meta config keeper_name with
+      | Ok (Some meta) ->
+        if keeper_assigned_to_goal ~goal_id meta then Some meta.name else None
+      | Ok None -> None
+      | Error msg ->
+        Log.Keeper.warn
+          "goal verification wake: failed to read keeper meta keeper=%s goal_id=%s: %s"
+          keeper_name
+          goal_id
+          msg;
+        None)
+  in
+  uniq_strings (registered @ persisted)
+;;
+
+let wake_summary_json keeper_names =
+  `Assoc
+    [ "keeper_names", `List (List.map (fun name -> `String name) keeper_names)
+    ; "keeper_count", `Int (List.length keeper_names)
+    ]
+;;
+
+let enqueue_goal_verification_failed_wake
+      (ctx : context)
+      ~(goal : Goal_store.goal)
+      ~(request : Goal_verification.goal_verification_request)
+      ~(principal : Goal_verification.goal_principal)
+      ?note
+      ~(evidence_refs : string list)
+      ()
+  =
+  let failure : Keeper_event_queue.goal_verification_failure =
+    { goal_id = goal.id
+    ; request_id = request.id
+    ; goal_title = goal.title
+    ; phase = Goal_phase.to_string goal.phase
+    ; metric = goal.metric
+    ; target_value = goal.target_value
+    ; rejected_by = principal.id
+    ; note
+    ; evidence_refs
+    }
+  in
+  let stimulus : Keeper_event_queue.stimulus =
+    { post_id = Keeper_event_queue.goal_verification_failure_post_id failure
+    ; urgency = Keeper_event_queue.Immediate
+    ; arrived_at = Time_compat.now ()
+    ; payload = Keeper_event_queue.Goal_verification_failed failure
+    }
+  in
+  let keeper_names = assigned_keeper_names_for_goal ctx.config ~goal_id:goal.id in
+  (match keeper_names with
+   | [] ->
+     Log.Keeper.warn
+       "goal verification wake: no keeper has active_goal_ids containing goal_id=%s"
+       goal.id
+   | _ ->
+     List.iter
+       (fun keeper_name ->
+          Keeper_registry_event_queue.enqueue
+            ~base_path:ctx.config.base_path
+            keeper_name
+            stimulus;
+          match Keeper_registry.get ~base_path:ctx.config.base_path keeper_name with
+          | Some entry when entry.phase = Keeper_state_machine.Running ->
+            Keeper_registry.wakeup ~base_path:ctx.config.base_path keeper_name
+          | Some entry ->
+            Log.Keeper.info
+              "goal verification wake queued without fiber wake keeper=%s phase=%s goal_id=%s"
+              keeper_name
+              (Keeper_state_machine.phase_to_string entry.phase)
+              goal.id
+          | None ->
+            Log.Keeper.info
+              "goal verification wake persisted for unregistered keeper=%s goal_id=%s"
+              keeper_name
+              goal.id)
+       keeper_names);
+  keeper_names
+;;
+
 let caller_is_goal_operator (ctx : context) =
   if not (Auth.is_auth_enabled ctx.config.base_path)
   then true
@@ -1075,7 +1181,7 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                            Goal_verification.goal_verification_vote_to_yojson last_vote
                          | [] -> `Null )
                      ]);
-             let finalize ~phase ~event_status =
+             let finalize_with_extra ~phase ~event_status ~extra_fields =
                match
                  update_goal_phase
                    ctx
@@ -1102,11 +1208,9 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                    ~goal_id
                    ~event_type:"goal_phase"
                    ~payload:(`Assoc [ "phase", Goal_phase.to_yojson updated_goal.phase ]);
-                 ok_result
-                   ~tool_name
-                   ~start_time
-                 [ "goal_id", `String goal_id
-                 ; "goal", Goal_store.goal_to_yojson updated_goal
+                 let fields =
+                   [ "goal_id", `String goal_id
+                   ; "goal", Goal_store.goal_to_yojson updated_goal
                    ; ( "verification_request"
                      , Goal_verification.goal_verification_request_to_yojson request )
                    ; ( "verification_summary"
@@ -1118,6 +1222,15 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                           then Some request
                           else None) )
                    ]
+                   @ extra_fields updated_goal
+                 in
+                 ok_result ~tool_name ~start_time fields
+             in
+             let finalize ~phase ~event_status =
+               finalize_with_extra
+                 ~phase
+                 ~event_status
+                 ~extra_fields:(fun (_ : Goal_store.goal) -> [])
              in
              (match quorum_result with
               | Goal_verification.Pending ->
@@ -1161,7 +1274,21 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                    result)
                 else finalize ~phase:Goal_phase.Completed ~event_status:"approved"
               | Goal_verification.Failed ->
-                finalize ~phase:Goal_phase.Executing ~event_status:"rejected"))))
+                finalize_with_extra
+                  ~phase:Goal_phase.Executing
+                  ~event_status:"rejected"
+                  ~extra_fields:(fun updated_goal ->
+                    let keeper_names =
+                      enqueue_goal_verification_failed_wake
+                        ctx
+                        ~goal:updated_goal
+                        ~request
+                        ~principal
+                        ?note
+                        ~evidence_refs
+                        ()
+                    in
+                    [ "goal_verification_failed_wake", wake_summary_json keeper_names ])))))
   | Ok _, Ok None, _, _ ->
     validation_error_result
       ~tool_name

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -110,6 +110,28 @@ let seed_goal_operator (config : Workspace.config) ~agent_name =
   Auth_credential_base.write_initial_admin config.base_path agent_name
 ;;
 
+let make_keeper_meta ~name ~active_goal_ids =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String ("agent-" ^ name)
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "goal", `String "goal verification wake test"
+          ; ( "active_goal_ids"
+            , `List (List.map (fun goal_id -> `String goal_id) active_goal_ids) )
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json_fixture failed: " ^ err)
+;;
+
+let write_keeper_meta config meta =
+  match Keeper_meta_store.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> fail ("write_meta failed: " ^ err)
+;;
+
 let get_string_field json field =
   match Yojson.Safe.Util.member field json with
   | `String value -> value
@@ -582,6 +604,8 @@ let test_goal_transition_rejected_verification_retains_evidence () =
     | Ok payload -> payload
     | Error msg -> fail msg
   in
+  let keeper_name = "goal-retry-keeper" in
+  write_keeper_meta config (make_keeper_meta ~name:keeper_name ~active_goal_ids:[ goal.id ]);
   create_done_task config ~goal_id:goal.id ~title:"Reject done task";
   let transitioned =
     Tool_workspace.dispatch
@@ -648,6 +672,41 @@ let test_goal_transition_rejected_verification_retains_evidence () =
     "latest request status rejected"
     "rejected"
     (get_string_field latest_request "status");
+  let wake_json =
+    Yojson.Safe.Util.member "goal_verification_failed_wake" rejected_json
+  in
+  check
+    int
+    "one assigned keeper got verification failure wake"
+    1
+    (Yojson.Safe.Util.member "keeper_count" wake_json |> Yojson.Safe.Util.to_int);
+  check
+    (list string)
+    "wake targets assigned keeper"
+    [ keeper_name ]
+    (get_string_list_field wake_json "keeper_names");
+  let queued =
+    Keeper_registry_event_queue.snapshot ~base_path:config.base_path keeper_name
+    |> Keeper_event_queue.to_list
+  in
+  let failure =
+    queued
+    |> List.find_map (fun (stimulus : Keeper_event_queue.stimulus) ->
+      match stimulus.payload with
+      | Keeper_event_queue.Goal_verification_failed failure -> Some (stimulus, failure)
+      | _ -> None)
+  in
+  (match failure with
+   | None -> fail "expected Goal_verification_failed stimulus"
+   | Some (stimulus, failure) ->
+     check string "stimulus goal id" goal.id failure.goal_id;
+     check string "stimulus request id" request_id failure.request_id;
+     check string "stimulus rejected by" "agent-alpha" failure.rejected_by;
+     check
+       string
+       "stimulus post id"
+       (Keeper_event_queue.goal_verification_failure_post_id failure)
+       stimulus.post_id);
   let vote =
     match
       latest_request |> Yojson.Safe.Util.member "votes" |> Yojson.Safe.Util.to_list

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -221,7 +221,53 @@ let () =
         assert (decision = Hitl_approved);
         assert (String.equal s.post_id "hitl-approval:appr-9")
       | _ -> Alcotest.fail "Hitl_resolved codec round-trip changed payload shape")
-   | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));
+  | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));
+
+  (* Goal_verification_failed survives the codec round-trip: the goal-loop wake
+     must remain replayable from the durable per-keeper queue. *)
+  let goal_failure =
+    { goal_id = "goal-1"
+    ; request_id = "gvr-1"
+    ; goal_title = "Ship retry"
+    ; phase = "executing"
+    ; metric = Some "tests"
+    ; target_value = Some "pass"
+    ; rejected_by = "agent-alpha"
+    ; note = Some "receipt did not prove completion"
+    ; evidence_refs = [ "receipt:agent-alpha:turn-7" ]
+    }
+  in
+  assert (
+    String.equal
+      (goal_verification_failure_post_id goal_failure)
+      "goal-verification-failed:goal-1:gvr-1");
+  assert (
+    String.equal
+      (payload_kind_label (Goal_verification_failed goal_failure))
+      "goal_verification_failed");
+  (match
+     stimulus_of_yojson
+       (stimulus_to_yojson
+          { post_id = goal_verification_failure_post_id goal_failure
+          ; urgency = Immediate
+          ; arrived_at = 6.0
+          ; payload = Goal_verification_failed goal_failure
+          })
+   with
+   | Ok s ->
+     (match s.payload with
+      | Goal_verification_failed failure ->
+        assert (String.equal failure.goal_id "goal-1");
+        assert (String.equal failure.request_id "gvr-1");
+        assert (String.equal failure.rejected_by "agent-alpha");
+        assert (failure.metric = Some "tests");
+        assert (failure.target_value = Some "pass");
+        assert (failure.evidence_refs = [ "receipt:agent-alpha:turn-7" ])
+      | _ ->
+        Alcotest.fail
+          "Goal_verification_failed codec round-trip changed payload shape")
+   | Error msg ->
+     Alcotest.fail ("Goal_verification_failed stimulus round-trip failed: " ^ msg));
 
   (* --- queue operations preserved --- *)
   let board_stim =

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1183,6 +1183,9 @@ let test_stimulus_kind_string_roundtrip () =
     ; Keeper_reaction_ledger.Fusion_completed
     ; Keeper_reaction_ledger.Bg_completed
     ; Keeper_reaction_ledger.Schedule_due
+    ; Keeper_reaction_ledger.Connector_attention
+    ; Keeper_reaction_ledger.Hitl_resolved
+    ; Keeper_reaction_ledger.Goal_verification_failed
     ];
   check bool "unknown stimulus kind string is None" true
     (Option.is_none (Keeper_reaction_ledger.stimulus_kind_of_string "totally_unknown"))


### PR DESCRIPTION
## Summary
- add typed Goal_verification_failed event-queue stimulus with durable JSON round-trip support
- surface rejected goal verification as actionable keeper observation/prompt input
- enqueue failed-verification wakes for keepers whose active_goal_ids include the rejected goal

## Verification
- ocamlformat --check lib/keeper_runtime/keeper_event_queue.mli lib/keeper_runtime/keeper_event_queue.ml lib/keeper/keeper_world_observation.mli lib/keeper/keeper_world_observation.ml lib/keeper/keeper_heartbeat_stimulus_intake.ml lib/keeper/keeper_unified_prompt.ml lib/keeper/keeper_reaction_ledger.mli lib/keeper/keeper_reaction_ledger.ml lib/keeper/keeper_heartbeat_loop.ml lib/workspace_goals.ml test/test_goal_tools.ml test/test_keeper_event_queue.ml test/test_keeper_reaction_ledger.ml
- git diff --check
- scripts/dune-local.sh build test/test_goal_tools.exe test/test_keeper_event_queue.exe test/test_keeper_reaction_ledger.exe test/test_fusion_wake.exe
- ./_build/default/test/test_goal_tools.exe
- ./_build/default/test/test_keeper_event_queue.exe
- ./_build/default/test/test_keeper_reaction_ledger.exe
- ./_build/default/test/test_fusion_wake.exe
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD (PASS; existing WARN only)