### PR TITLE
[codex] dashboard: prove API hydration success reaches chat DOM

### DIFF
--- a/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
+++ b/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko" data-skin="v2" data-volt="brass">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MASC - Keeper Chat Tool Output Failure Contract Fixture</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts"></script>
+</body>
+</html>

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ToolCallEntry } from '../api/dashboard'
+
+const {
+  cancelQueuedKeeperMessage,
+  fetchKeeperChatHistory,
+  fetchQueuedKeeperMessageResult,
+  isTerminalQueuedKeeperMessage,
+  queuedKeeperMessageError,
+  queuedKeeperMessageToReply,
+  streamKeeperMessage,
+} = vi.hoisted(() => ({
+  cancelQueuedKeeperMessage: vi.fn(async () => undefined),
+  fetchKeeperChatHistory: vi.fn(),
+  fetchQueuedKeeperMessageResult: vi.fn(),
+  isTerminalQueuedKeeperMessage: vi.fn((result: { status: string }) => result.status === 'done'),
+  queuedKeeperMessageError: vi.fn((result: { status: string }) => `request ${result.status}`),
+  queuedKeeperMessageToReply: vi.fn((result: { result?: { reply?: string } }) => ({
+    text: result.result?.reply ?? '(empty reply)',
+    details: null,
+  })),
+  streamKeeperMessage: vi.fn(),
+}))
+
+const { fetchKeeperToolCalls } = vi.hoisted(() => ({
+  fetchKeeperToolCalls: vi.fn(async (): Promise<{ entries: ToolCallEntry[] }> => ({ entries: [] })),
+}))
+
+vi.mock('../api/keeper', () => ({
+  cancelQueuedKeeperMessage,
+  fetchKeeperChatHistory,
+  fetchQueuedKeeperMessageResult,
+  isTerminalQueuedKeeperMessage,
+  queuedKeeperMessageError,
+  queuedKeeperMessageToReply,
+  streamKeeperMessage,
+}))
+
+vi.mock('../api/dashboard', () => ({ fetchKeeperToolCalls }))
+vi.mock('../api/mcp', () => ({ callMcpTool: vi.fn() }))
+vi.mock('../api/core', () => ({ runOperatorAction: vi.fn() }))
+vi.mock('../store', async () => {
+  const { signal } = await import('@preact/signals')
+  return {
+    invalidateDashboardCache: vi.fn(),
+    refreshDashboard: vi.fn(async () => undefined),
+    shellAuthSummary: signal(null),
+  }
+})
+vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
+
+import { KeeperConversationPanel } from './keeper-shared'
+import { _resetChatHydrationForTests } from '../keeper-actions'
+import {
+  activeKeeperName,
+  keeperActionErrors,
+  keeperHydrating,
+  keeperProbing,
+  keeperRecovering,
+  keeperSending,
+  keeperStatusDetails,
+  keeperStreamLastEventAt,
+  keeperStreamStartedAt,
+  keeperThreads,
+} from '../keeper-state'
+import {
+  resetToolCallOutputs,
+  toolCallOutputHydrationFailureReason,
+  toolCallOutputHydrationStatus,
+} from '../tool-call-output-store'
+import { _clearPendingKeeperChatRequestsForTests } from '../keeper-chat-pending'
+import { _resetChatStoreForTests } from '../keeper-chat-store'
+import { keeperCatchupDigests } from '../keeper-digest-signals'
+
+describe('KeeperConversationPanel hydration wiring', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
+    fetchKeeperChatHistory.mockReset()
+    fetchKeeperToolCalls.mockReset()
+    fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
+    keeperThreads.value = {}
+    keeperActionErrors.value = {}
+    keeperHydrating.value = {}
+    keeperProbing.value = {}
+    keeperRecovering.value = {}
+    keeperSending.value = {}
+    keeperStatusDetails.value = {}
+    keeperStreamStartedAt.value = {}
+    keeperStreamLastEventAt.value = {}
+    activeKeeperName.value = ''
+    keeperCatchupDigests.value = {}
+    _resetChatHydrationForTests()
+    _clearPendingKeeperChatRequestsForTests()
+    _resetChatStoreForTests()
+    resetToolCallOutputs()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+    _resetChatHydrationForTests()
+    _clearPendingKeeperChatRequestsForTests()
+    _resetChatStoreForTests()
+    resetToolCallOutputs()
+  })
+
+  it('drives live transcript hydration-failed DOM from a real tool-call endpoint failure', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    fetchKeeperChatHistory.mockResolvedValueOnce([
+      {
+        id: 'tool-history-api-hydration',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_201,
+        tool_call_id: 'tc-api-hydration',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-api-hydration#1',
+      },
+      {
+        id: 'assistant-history-api-hydration',
+        role: 'assistant',
+        content: '도구 출력을 확인했습니다.',
+        ts: 1_783_267_202,
+        source: 'dashboard',
+        turn_ref: 'trace-api-hydration#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ])
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 502'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 502')
+    })
+
+    const traceSelector =
+      '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
+
+    consoleWarn.mockRestore()
+  })
+})

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -69,9 +69,12 @@ import {
   keeperThreads,
 } from '../keeper-state'
 import {
+  lookupToolCallOutput,
   resetToolCallOutputs,
   toolCallOutputHydrationFailureReason,
   toolCallOutputHydrationStatus,
+  toolCallOutputsCoveredSinceMs,
+  toolCallOutputsCoveredThroughMs,
 } from '../tool-call-output-store'
 import { _clearPendingKeeperChatRequestsForTests } from '../keeper-chat-pending'
 import { _resetChatStoreForTests } from '../keeper-chat-store'
@@ -190,5 +193,107 @@ describe('KeeperConversationPanel hydration wiring', () => {
     })
 
     consoleWarn.mockRestore()
+  })
+
+  it('joins successful tool-call endpoint output into the live transcript DOM', async () => {
+    fetchKeeperChatHistory.mockResolvedValueOnce([
+      {
+        id: 'tool-history-api-success',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_211,
+        tool_call_id: 'tc-api-success',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-api-success#1',
+      },
+      {
+        id: 'assistant-history-api-success',
+        role: 'assistant',
+        content: '도구 출력 조인이 완료되었습니다.',
+        ts: 1_783_267_212,
+        source: 'dashboard',
+        turn_ref: 'trace-api-success#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ])
+    fetchKeeperToolCalls.mockResolvedValueOnce({
+      entries: [
+        {
+          ts: 1_783_267_211,
+          keeper: 'sangsu',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'context status joined from tool_calls_endpoint',
+          success: true,
+          duration_ms: 42,
+          tool_use_id: 'tc-api-success',
+        },
+      ],
+    })
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBeNull()
+      expect(lookupToolCallOutput('tool-tc-api-success')?.output).toBe(
+        'context status joined from tool_calls_endpoint',
+      )
+      expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_783_267_211_000)
+      expect(toolCallOutputsCoveredThroughMs('sangsu')).not.toBeNull()
+    })
+
+    const coveredThrough = toolCallOutputsCoveredThroughMs('sangsu')
+    const traceSelector =
+      '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267211000')
+      expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(coveredThrough))
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-source')).toBe('sse_event')
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-success"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(step.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.hydration-failed')).toBeNull()
+      expect(container.textContent).not.toContain('결과 누락 1')
+      expect(container.textContent).not.toContain('출력 범위 밖 1')
+      expect(container.textContent).not.toContain('출력 hydration 실패 1')
+    })
+
+    const joinedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-api-success"]',
+    ) as HTMLElement
+    fireEvent.click(joinedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(joinedStep.textContent).toContain('result')
+      expect(joinedStep.textContent).toContain('context status joined from tool_calls_endpoint')
+      expect(joinedStep.textContent).not.toContain('출력 대기 중')
+      expect(joinedStep.textContent).not.toContain('결과 없음')
+      expect(joinedStep.textContent).not.toContain('출력 hydration 실패')
+      expect(joinedStep.textContent).not.toContain('출력 tail 범위 밖')
+    })
   })
 })

--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -296,4 +296,179 @@ describe('KeeperConversationPanel hydration wiring', () => {
       expect(joinedStep.textContent).not.toContain('출력 tail 범위 밖')
     })
   })
+
+  it('keeps simultaneous live panel hydration isolated by keeper', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    fetchKeeperChatHistory.mockImplementation(async (keeperName: string) => {
+      if (keeperName === 'alpha') {
+        return [
+          {
+            id: 'tool-history-alpha-scope',
+            role: 'tool',
+            content: '{}',
+            ts: 1_783_267_221,
+            tool_call_id: 'tc-alpha-scope',
+            tool_call_name: 'keeper_context_status',
+            source: 'dashboard',
+            turn_ref: 'trace-alpha-scope#1',
+          },
+          {
+            id: 'assistant-history-alpha-scope',
+            role: 'assistant',
+            content: 'alpha 도구 출력 조인이 완료되었습니다.',
+            ts: 1_783_267_222,
+            source: 'dashboard',
+            turn_ref: 'trace-alpha-scope#1',
+            stream_contract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              event_name: 'RUN_FINISHED',
+              delivery_receipt: 'client_observed_sse_event',
+            },
+          },
+        ]
+      }
+      if (keeperName === 'beta') {
+        return [
+          {
+            id: 'tool-history-beta-scope',
+            role: 'tool',
+            content: '{}',
+            ts: 1_783_267_231,
+            tool_call_id: 'tc-beta-scope',
+            tool_call_name: 'keeper_context_status',
+            source: 'dashboard',
+            turn_ref: 'trace-beta-scope#1',
+          },
+          {
+            id: 'assistant-history-beta-scope',
+            role: 'assistant',
+            content: 'beta 도구 출력은 아직 조인되지 않았습니다.',
+            ts: 1_783_267_232,
+            source: 'dashboard',
+            turn_ref: 'trace-beta-scope#1',
+            stream_contract: {
+              source: 'sse_event',
+              status: 'backend_terminal_event',
+              event_name: 'RUN_FINISHED',
+              delivery_receipt: 'client_observed_sse_event',
+            },
+          },
+        ]
+      }
+      throw new Error(`unexpected keeper ${keeperName}`)
+    })
+    fetchKeeperToolCalls.mockImplementation(async (keeperName?: string) => {
+      if (keeperName === 'alpha') {
+        return {
+          entries: [
+            {
+              ts: 1_783_267_221,
+              keeper: 'alpha',
+              tool: 'keeper_context_status',
+              input: {},
+              output: 'alpha output joined from tool_calls_endpoint',
+              success: true,
+              duration_ms: 31,
+              tool_use_id: 'tc-alpha-scope',
+            },
+          ],
+        }
+      }
+      if (keeperName === 'beta') {
+        throw new Error('HTTP 503 beta')
+      }
+      throw new Error(`unexpected keeper ${keeperName}`)
+    })
+
+    render(
+      html`
+        <div>
+          <section data-testid="alpha-panel">
+            <${KeeperConversationPanel} keeperName="alpha" placeholder="alpha message" layout="workspace" />
+          </section>
+          <section data-testid="beta-panel">
+            <${KeeperConversationPanel} keeperName="beta" placeholder="beta message" layout="workspace" />
+          </section>
+        </div>
+      `,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('alpha')
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('beta')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('alpha', 200)
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('beta', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('alpha')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('alpha')).toBeNull()
+      expect(toolCallOutputHydrationStatus('beta')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('beta')).toBe('HTTP 503 beta')
+      expect(lookupToolCallOutput('tool-tc-alpha-scope')?.output).toBe(
+        'alpha output joined from tool_calls_endpoint',
+      )
+      expect(lookupToolCallOutput('tool-tc-beta-scope')).toBeNull()
+    })
+
+    const alphaPanel = container.querySelector('[data-testid="alpha-panel"]') as HTMLElement
+    const betaPanel = container.querySelector('[data-testid="beta-panel"]') as HTMLElement
+    const alphaCoveredThrough = toolCallOutputsCoveredThroughMs('alpha')
+
+    await waitFor(() => {
+      const alphaTrace = alphaPanel.querySelector('[data-chat-work-trace]')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267221000')
+      expect(alphaTrace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(alphaCoveredThrough))
+      expect(alphaTrace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const betaTrace = betaPanel.querySelector('[data-chat-work-trace]')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 503 beta')
+      expect(betaTrace?.getAttribute('data-chat-tool-output-covered-since')).toBeNull()
+      expect(betaTrace?.getAttribute('data-chat-tool-output-covered-through')).toBeNull()
+      expect(betaTrace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      const alphaStep = alphaPanel.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-alpha-scope"]',
+      ) as HTMLElement
+      expect(alphaStep.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(alphaStep.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(alphaStep.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(alphaStep.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+
+      const betaStep = betaPanel.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-beta-scope"]',
+      ) as HTMLElement
+      expect(betaStep.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(betaStep.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(betaStep.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(betaStep.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+      expect(betaStep.querySelector('.chat-block-tstep-status.ok')).toBeNull()
+      expect(betaPanel.textContent).toContain('출력 hydration 실패 1')
+      expect(betaPanel.textContent).not.toContain('alpha output joined from tool_calls_endpoint')
+    })
+
+    const alphaStep = alphaPanel.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-alpha-scope"]',
+    ) as HTMLElement
+    const betaStep = betaPanel.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-beta-scope"]',
+    ) as HTMLElement
+
+    fireEvent.click(alphaStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+    fireEvent.click(betaStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(alphaStep.textContent).toContain('alpha output joined from tool_calls_endpoint')
+      expect(alphaStep.textContent).not.toContain('HTTP 503 beta')
+      expect(betaStep.textContent).toContain('출력 hydration 실패 — HTTP 503 beta')
+      expect(betaStep.textContent).not.toContain('alpha output joined from tool_calls_endpoint')
+      expect(betaStep.textContent).not.toContain('result')
+    })
+
+    consoleWarn.mockRestore()
+  })
 })

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -92,6 +92,11 @@ import {
   sendKeeperThreadMessage,
 } from '../keeper-actions'
 import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
+import {
+  markToolCallOutputsHydrationFailed,
+  markToolCallOutputsHydrating,
+  resetToolCallOutputs,
+} from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry, KeeperUserInputBlock } from '../types'
 import {
@@ -186,6 +191,7 @@ describe('KeeperConversationPanel', () => {
     render(null, container)
     container.remove()
     _resetChatStoreForTests()
+    resetToolCallOutputs()
     vi.unstubAllGlobals()
   })
 
@@ -485,6 +491,97 @@ describe('KeeperConversationPanel', () => {
       'client-side composer queue item; not yet submitted to keeper runtime',
       'client-side composer queue item; not yet submitted to keeper runtime',
     ])
+  })
+
+  it('wires the live tool-output hydration contract store into the transcript', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'tool-tc-live-hydration',
+          role: 'tool',
+          source: 'tool_result',
+          label: 'keeper_context_status',
+          text: '{}',
+          rawText: '{}',
+          timestamp: '2026-03-24T00:00:01.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'assistant-live-hydration',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '도구 출력을 확인했습니다.',
+          rawText: '도구 출력을 확인했습니다.',
+          timestamp: '2026-03-24T00:00:02.000Z',
+          turnRef: 'trace-live-hydration#1',
+          delivery: 'history',
+          streamState: null,
+          streamContract: {
+            source: 'sse_event',
+            status: 'backend_terminal_event',
+            eventName: 'RUN_FINISHED',
+          },
+          traceSteps: [
+            {
+              kind: 'tool',
+              name: 'keeper_context_status',
+              toolCallId: 'tc-live-hydration',
+              ts: '2026-03-24T00:00:01.000Z',
+            },
+          ],
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const traceSelector = '[data-chat-work-trace][data-chat-tool-output-hydration-source="tool_calls_endpoint"]'
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('idle')
+    })
+
+    const initialStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    expect(initialStep.getAttribute('data-chat-trace-output-state')).toBe('pending')
+    expect(initialStep.getAttribute('data-chat-trace-output-coverage')).toBe('not-hydrated')
+
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrationFailed('sangsu', 'HTTP 502')
+
+    await waitFor(() => {
+      const trace = container.querySelector(traceSelector)
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe('HTTP 502')
+
+      const step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    const failedStep = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-live-hydration"]',
+    ) as HTMLElement
+    fireEvent.click(failedStep.querySelector('.chat-block-tstep-row') as HTMLElement)
+
+    await waitFor(() => {
+      expect(failedStep.textContent).toContain('출력 hydration 실패 — HTTP 502')
+    })
   })
 
   it('renders queued voice draft display blocks inside the transcript', async () => {

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.test.ts
@@ -1,0 +1,121 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  COVERAGE_GAP_COVERED_THROUGH_MS,
+  COVERAGE_GAP_ORDER_SIGNATURE,
+  HYDRATION_FAILED_ORDER_SIGNATURE,
+  TOOL_OUTPUT_FAILURE_REASON,
+  ToolOutputFailureContractFixture,
+  coverageGapEntries,
+  coverageGapToolCount,
+  hydrationFailedEntries,
+  hydrationFailedToolCount,
+  installToolOutputFailureFixtureStore,
+  toolOutputFailureFixtureStatus,
+} from './keeper-chat-tool-output-failure-contract-fixture'
+import { resetToolCallOutputs } from '../tool-call-output-store'
+
+describe('Keeper Chat tool output failure contract fixture', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (container) {
+      render(null, container)
+      container.remove()
+      container = null
+    }
+    resetToolCallOutputs()
+  })
+
+  it('keeps deterministic failure-state fixture rows', () => {
+    expect(hydrationFailedEntries).toHaveLength(2)
+    expect(coverageGapEntries).toHaveLength(2)
+    expect(hydrationFailedToolCount).toBe(1)
+    expect(coverageGapToolCount).toBe(1)
+    expect(toolOutputFailureFixtureStatus).toBe('ok')
+
+    const hydrationAssistant = hydrationFailedEntries.find(entry => entry.id === 'assistant-hydration-failed')
+    const coverageAssistant = coverageGapEntries.find(entry => entry.id === 'assistant-coverage-gap')
+    expect(hydrationAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    expect(coverageAssistant?.traceSteps?.map(step => step.kind)).toEqual(['tool'])
+    const hydrationToolStep = hydrationAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    const coverageToolStep = coverageAssistant?.traceSteps?.find(step => step.kind === 'tool')
+    expect(hydrationToolStep?.toolCallId).toBe('tc-hydration-failed')
+    expect(coverageToolStep?.toolCallId).toBe('tc-coverage-gap')
+  })
+
+  it('renders hydration-failed and coverage-gap states without silent pending fallback', () => {
+    container = document.createElement('div')
+    document.body.append(container)
+    installToolOutputFailureFixtureStore()
+
+    render(html`<${ToolOutputFailureContractFixture} />`, container)
+
+    expect(
+      container.querySelector(
+        '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]',
+      ),
+    ).not.toBeNull()
+
+    const hydrationScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="hydration-failed"]',
+    ) as HTMLElement | null
+    const hydrationTrace = hydrationScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(hydrationTrace?.getAttribute('data-chat-turn-order-signature')).toBe(HYDRATION_FAILED_ORDER_SIGNATURE)
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('failed')
+    expect(hydrationTrace?.getAttribute('data-chat-tool-output-hydration-failure')).toBe(TOOL_OUTPUT_FAILURE_REASON)
+    expect(hydrationScenario?.textContent).toContain('출력 hydration 실패 1')
+
+    const hydrationTool = hydrationScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(hydrationTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(hydrationTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+    expect(hydrationTool?.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.hydration-failed')).not.toBeNull()
+    expect(hydrationTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+
+    const hydrationToolRow = hydrationTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(hydrationToolRow).not.toBeNull()
+    if (!hydrationToolRow) {
+      throw new Error('expected hydration failure tool row')
+    }
+    fireEvent.click(hydrationToolRow)
+    expect(hydrationTool?.textContent).toContain(`출력 hydration 실패 — ${TOOL_OUTPUT_FAILURE_REASON}`)
+
+    const coverageScenario = container.querySelector(
+      '[data-tool-output-failure-scenario="coverage-gap"]',
+    ) as HTMLElement | null
+    const coverageTrace = coverageScenario?.querySelector('[data-chat-work-trace]') as HTMLElement | null
+    expect(coverageTrace?.getAttribute('data-chat-turn-order-signature')).toBe(COVERAGE_GAP_ORDER_SIGNATURE)
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-source')).toBe('tool_calls_endpoint')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+    expect(coverageTrace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(COVERAGE_GAP_COVERED_THROUGH_MS))
+    expect(coverageScenario?.textContent).toContain('출력 범위 밖 1')
+
+    const coverageTool = coverageScenario?.querySelector('[data-chat-trace-step="tool"]') as HTMLElement | null
+    expect(coverageTool?.getAttribute('data-chat-turn-order-index')).toBe('0')
+    expect(coverageTool?.getAttribute('data-chat-turn-order-kind')).toBe('tool')
+    expect(coverageTool?.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-entry-id')).toBe('tool-tc-coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-link-state')).toBe('joined')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-state')).toBe('coverage-gap')
+    expect(coverageTool?.getAttribute('data-chat-trace-output-coverage')).toBe('coverage-gap')
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.coverage-gap')).not.toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    expect(coverageTool?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+
+    const coverageToolRow = coverageTool?.querySelector('.chat-block-tstep-row') as HTMLElement | null
+    expect(coverageToolRow).not.toBeNull()
+    if (!coverageToolRow) {
+      throw new Error('expected coverage gap tool row')
+    }
+    fireEvent.click(coverageToolRow)
+    expect(coverageTool?.textContent).toContain('출력 tail 범위 밖')
+  })
+})

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
@@ -1,0 +1,210 @@
+import '../styles/ds-theme-tokens.css'
+import '../styles/global.css'
+import '../styles/keeper-workspace.css'
+
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { ChatTranscript } from '../components/chat/primitives'
+import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import {
+  resetToolCallOutputs,
+  type ToolCallOutputHydrationContract,
+} from '../tool-call-output-store'
+import type { KeeperConversationEntry } from '../types'
+
+export const TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER = 'sangsu'
+export const TOOL_OUTPUT_FAILURE_REASON = 'tool_calls_endpoint_502'
+export const HYDRATION_FAILED_ORDER_SIGNATURE = 'tool:tc-hydration-failed|chat:assistant-hydration-failed'
+export const COVERAGE_GAP_ORDER_SIGNATURE = 'tool:tc-coverage-gap|chat:assistant-coverage-gap'
+export const HYDRATION_FAILED_STARTED_AT_MS = Date.parse('2026-07-05T15:09:50.000Z')
+export const HYDRATION_FAILED_COMPLETED_AT_MS = Date.parse('2026-07-05T15:10:05.000Z')
+export const COVERAGE_GAP_COVERED_SINCE_MS = Date.parse('2026-07-05T15:11:00.000Z')
+export const COVERAGE_GAP_COVERED_THROUGH_MS = Date.parse('2026-07-05T15:11:10.000Z')
+
+export const hydrationFailedContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'failed',
+  failureReason: TOOL_OUTPUT_FAILURE_REASON,
+  startedAtMs: HYDRATION_FAILED_STARTED_AT_MS,
+  completedAtMs: HYDRATION_FAILED_COMPLETED_AT_MS,
+  coveredSinceMs: null,
+  coveredThroughMs: null,
+}
+
+export const coverageGapContract: ToolCallOutputHydrationContract = {
+  source: 'tool_calls_endpoint',
+  status: 'hydrated',
+  failureReason: null,
+  startedAtMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  completedAtMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+  coveredSinceMs: COVERAGE_GAP_COVERED_SINCE_MS,
+  coveredThroughMs: COVERAGE_GAP_COVERED_THROUGH_MS,
+}
+
+export const hydrationFailedEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-hydration-failed',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_context_status',
+    text: '{"scope":"current"}',
+    rawText: '{"scope":"current"}',
+    timestamp: '2026-07-05T15:10:01.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-hydration-failed',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'The tool output surface failed, so this cannot be reported as pending.',
+    rawText: 'The tool output surface failed, so this cannot be reported as pending.',
+    timestamp: '2026-07-05T15:10:02.000Z',
+    turnRef: 'tool-output-failure#1',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#1',
+      reason: 'terminal event observed before tool output hydration failed',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_context_status',
+        toolCallId: 'tc-hydration-failed',
+        args: '{"scope":"current"}',
+        ts: '2026-07-05T15:10:01.000Z',
+        oasBlockIndex: 21,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const coverageGapEntries: KeeperConversationEntry[] = [
+  {
+    id: 'tool-tc-coverage-gap',
+    role: 'tool',
+    source: 'tool_result',
+    label: 'keeper_board_comment',
+    text: '{"post_id":"post-7","body":"ack"}',
+    rawText: '{"post_id":"post-7","body":"ack"}',
+    timestamp: '2026-07-05T15:11:30.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+  },
+  {
+    id: 'assistant-coverage-gap',
+    role: 'assistant',
+    source: 'direct_assistant',
+    label: TOOL_OUTPUT_FAILURE_FIXTURE_KEEPER,
+    text: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    rawText: 'Hydration completed for an older tail, so this newer tool is a coverage gap.',
+    timestamp: '2026-07-05T15:11:31.000Z',
+    turnRef: 'tool-output-failure#2',
+    delivery: 'delivered',
+    streamState: null,
+    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      eventName: 'RUN_FINISHED',
+      turnRef: 'tool-output-failure#2',
+      reason: 'terminal event observed after an older tool-output tail hydrated',
+    }),
+    traceSteps: [
+      {
+        kind: 'tool',
+        name: 'keeper_board_comment',
+        toolCallId: 'tc-coverage-gap',
+        args: '{"post_id":"post-7","body":"ack"}',
+        ts: '2026-07-05T15:11:30.000Z',
+        oasBlockIndex: 22,
+      },
+    ],
+    details: null,
+    error: null,
+  },
+]
+
+export const hydrationFailedToolCount = hydrationFailedEntries.filter(entry => entry.role === 'tool').length
+export const coverageGapToolCount = coverageGapEntries.filter(entry => entry.role === 'tool').length
+export const toolOutputFailureFixtureStatus =
+  hydrationFailedToolCount === 1 && coverageGapToolCount === 1 ? 'ok' : 'invalid'
+
+export function installToolOutputFailureFixtureStore(): void {
+  resetToolCallOutputs()
+}
+
+export function ToolOutputFailureContractFixture() {
+  return html`
+    <main
+      class="min-h-screen px-4 py-8"
+      style="background: var(--bg-deep);"
+      data-keeper-chat-layout="workspace"
+      data-tool-output-failure-contract-fixture
+      data-tool-output-failure-contract-fixture-status=${toolOutputFailureFixtureStatus}
+      data-tool-output-failure-hydration-failed-count=${hydrationFailedToolCount}
+      data-tool-output-failure-coverage-gap-count=${coverageGapToolCount}
+    >
+      <section class="mx-auto max-w-[900px]">
+        <header class="mb-5">
+          <p class="font-mono text-2xs uppercase tracking-[0.2em]" style="color: var(--text-dim);">
+            Keeper Chat Tool Output Failure Contract Fixture
+          </p>
+          <h1 class="mt-2 text-xl font-semibold" style="color: var(--text-main);">
+            Tool output failures are explicit
+          </h1>
+        </header>
+        <div class="grid gap-4">
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="hydration-failed"
+            data-tool-output-failure-order-signature=${HYDRATION_FAILED_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${hydrationFailedEntries}
+              emptyText="No hydration failure rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputHydrationContract=${hydrationFailedContract}
+            />
+          </section>
+          <section
+            class="kw-chat rounded-[var(--r-2)] border p-4"
+            style="background: var(--bg-panel); border-color: var(--border-main);"
+            data-tool-output-failure-scenario="coverage-gap"
+            data-tool-output-failure-order-signature=${COVERAGE_GAP_ORDER_SIGNATURE}
+          >
+            <${ChatTranscript}
+              entries=${coverageGapEntries}
+              emptyText="No coverage gap rows"
+              variant="messenger"
+              size="primary"
+              showMetadata=${false}
+              groupToolCalls=${true}
+              toolOutputsCoveredSinceMs=${COVERAGE_GAP_COVERED_SINCE_MS}
+              toolOutputsCoveredThroughMs=${COVERAGE_GAP_COVERED_THROUGH_MS}
+              toolOutputHydrationContract=${coverageGapContract}
+            />
+          </section>
+        </div>
+      </section>
+    </main>
+  `
+}
+
+const root = document.getElementById('app')
+if (root) {
+  installToolOutputFailureFixtureStore()
+  render(html`<${ToolOutputFailureContractFixture} />`, root)
+}

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASHBOARD_DIR="${ROOT_DIR}/dashboard"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-5187}"
+PROXY_TARGET="${MASC_DASHBOARD_PROXY_TARGET:-http://127.0.0.1:8935}"
+FIXTURE_URL="http://${HOST}:${PORT}/dashboard/dev-fixtures/keeper-chat-tool-output-failure-contract-fixture.html"
+SERVER_LOG="${TMPDIR:-/tmp}/masc-dashboard-tool-output-failure-contract-vite-${PORT}.log"
+DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-desktop.png"
+MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
+HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
+COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+
+HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
+COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
+STATUS_SELECTOR='[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+HYDRATION_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"hydration-failed\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${HYDRATION_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"failed\"][data-chat-tool-output-hydration-failure=\"tool_calls_endpoint_502\"]"
+HYDRATION_TOOL_SELECTOR='[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-hydration-failed"][data-chat-trace-entry-id="tool-tc-hydration-failed"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+COVERAGE_TRACE_SELECTOR="[data-tool-output-failure-scenario=\"coverage-gap\"] [data-chat-work-trace][data-chat-turn-order-signature=\"${COVERAGE_SIGNATURE}\"][data-chat-tool-output-hydration-source=\"tool_calls_endpoint\"][data-chat-tool-output-hydration-status=\"hydrated\"][data-chat-tool-output-covered-through=\"1783264270000\"]"
+COVERAGE_TOOL_SELECTOR='[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-turn-order-index="0"][data-chat-turn-order-kind="tool"][data-chat-trace-tool-call-id="tc-coverage-gap"][data-chat-trace-entry-id="tool-tc-coverage-gap"][data-chat-trace-link-state="joined"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+
+server_pid=""
+cleanup() {
+  if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+    kill "${server_pid}" 2>/dev/null || true
+    wait "${server_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright --version >/dev/null
+
+MASC_DASHBOARD_PROXY_TARGET="${PROXY_TARGET}" \
+  pnpm --dir "${DASHBOARD_DIR}" exec vite --host "${HOST}" --port "${PORT}" --strictPort \
+  >"${SERVER_LOG}" 2>&1 &
+server_pid="$!"
+
+for _ in {1..80}; do
+  if curl -fsS "${FIXTURE_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${server_pid}" 2>/dev/null; then
+    cat "${SERVER_LOG}" >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+curl -fsS "${FIXTURE_URL}" >/dev/null
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${DESKTOP_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${HYDRATION_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${HYDRATION_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TRACE_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 1440,900 \
+  --timeout 30000 \
+  --wait-for-selector "${COVERAGE_TOOL_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${COVERAGE_SCREENSHOT}"
+
+pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
+  --browser chromium \
+  --viewport-size 390,844 \
+  --timeout 30000 \
+  --wait-for-selector "${STATUS_SELECTOR}" \
+  "${FIXTURE_URL}" \
+  "${MOBILE_SCREENSHOT}"
+
+printf 'keeper chat tool output failure contract DOM smoke passed\n'
+printf 'fixture_url=%s\n' "${FIXTURE_URL}"
+printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
+printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
+printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
+printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"

--- a/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
+++ b/scripts/harness_dashboard_keeper_chat_tool_output_failure_contract_dom_smoke.sh
@@ -12,6 +12,10 @@ DESKTOP_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixtu
 MOBILE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-fixture-mobile.png"
 HYDRATION_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-failed.png"
 COVERAGE_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-gap.png"
+HYDRATION_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-hydration-expanded.png"
+COVERAGE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-coverage-expanded.png"
+MOBILE_EXPANDED_SCREENSHOT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-mobile-expanded.png"
+BROWSER_SCRIPT="${TMPDIR:-/tmp}/masc-chat-tool-output-failure-contract-interaction-${PORT}.py"
 
 HYDRATION_SIGNATURE='tool:tc-hydration-failed|chat:assistant-hydration-failed'
 COVERAGE_SIGNATURE='tool:tc-coverage-gap|chat:assistant-coverage-gap'
@@ -98,9 +102,116 @@ pnpm --dir "${DASHBOARD_DIR}" exec playwright screenshot \
   "${FIXTURE_URL}" \
   "${MOBILE_SCREENSHOT}"
 
+PLAYWRIGHT_PYTHON="${PLAYWRIGHT_PYTHON:-}"
+PLAYWRIGHT_PYTHON_CMD=()
+if [[ -n "${PLAYWRIGHT_PYTHON}" ]]; then
+  PLAYWRIGHT_PYTHON_CMD=("${PLAYWRIGHT_PYTHON}")
+elif pnpm --dir "${DASHBOARD_DIR}" exec python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(pnpm --dir "${DASHBOARD_DIR}" exec python3)
+elif python3 -c 'import playwright' >/dev/null 2>&1; then
+  PLAYWRIGHT_PYTHON_CMD=(python3)
+else
+  echo "Python Playwright module not found. Set PLAYWRIGHT_PYTHON=/abs/path/to/python with playwright installed." >&2
+  exit 1
+fi
+
+cat >"${BROWSER_SCRIPT}" <<'PY'
+import os
+from playwright.sync_api import sync_playwright
+
+fixture_url = os.environ["FIXTURE_URL"]
+hydration_expanded_screenshot = os.environ["HYDRATION_EXPANDED_SCREENSHOT"]
+coverage_expanded_screenshot = os.environ["COVERAGE_EXPANDED_SCREENSHOT"]
+mobile_expanded_screenshot = os.environ["MOBILE_EXPANDED_SCREENSHOT"]
+status_selector = '[data-tool-output-failure-contract-fixture-status="ok"][data-tool-output-failure-hydration-failed-count="1"][data-tool-output-failure-coverage-gap-count="1"]'
+hydration_tool_selector = '[data-tool-output-failure-scenario="hydration-failed"] [data-chat-trace-step="tool"][data-chat-trace-output-state="hydration-failed"][data-chat-trace-output-coverage="hydration-failed"]'
+coverage_tool_selector = '[data-tool-output-failure-scenario="coverage-gap"] [data-chat-trace-step="tool"][data-chat-trace-output-state="coverage-gap"][data-chat-trace-output-coverage="coverage-gap"]'
+hydration_explanation = '출력 hydration 실패 — tool_calls_endpoint_502'
+coverage_explanation = '출력 tail 범위 밖'
+expected_title = 'MASC - Keeper Chat Tool Output Failure Contract Fixture'
+
+
+def assert_visible_text(page, text):
+    page.wait_for_function(
+        "expected => document.body.innerText.includes(expected)",
+        arg=text,
+        timeout=10_000,
+    )
+
+
+def open_tool(page, selector):
+    page.locator(f"{selector} .chat-block-tstep-row").click()
+
+
+def verify_page_health(page):
+    page.goto(fixture_url, wait_until="domcontentloaded", timeout=20_000)
+    page.wait_for_selector(status_selector, timeout=15_000)
+    title = page.title()
+    if title != expected_title:
+        raise RuntimeError(f"unexpected title: {title}")
+    body_text = page.locator("body").inner_text()
+    if "Tool output failures are explicit" not in body_text:
+        raise RuntimeError("fixture body did not render expected heading")
+    if page.locator("vite-error-overlay, [data-nextjs-dialog-overlay]").count() > 0:
+        raise RuntimeError("framework error overlay detected")
+
+
+with sync_playwright() as pw:
+    browser = pw.chromium.launch(headless=True)
+    browser_errors = []
+
+    desktop_context = browser.new_context(viewport={"width": 1440, "height": 900})
+    desktop = desktop_context.new_page()
+    desktop.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    desktop.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(desktop)
+    open_tool(desktop, hydration_tool_selector)
+    assert_visible_text(desktop, hydration_explanation)
+    desktop.screenshot(path=hydration_expanded_screenshot, full_page=False)
+
+    open_tool(desktop, coverage_tool_selector)
+    assert_visible_text(desktop, coverage_explanation)
+    desktop.screenshot(path=coverage_expanded_screenshot, full_page=False)
+    desktop_context.close()
+
+    mobile_context = browser.new_context(viewport={"width": 390, "height": 844})
+    mobile = mobile_context.new_page()
+    mobile.on("console", lambda message: browser_errors.append(message.text) if message.type == "error" else None)
+    mobile.on("pageerror", lambda error: browser_errors.append(str(error)))
+
+    verify_page_health(mobile)
+    open_tool(mobile, hydration_tool_selector)
+    assert_visible_text(mobile, hydration_explanation)
+    open_tool(mobile, coverage_tool_selector)
+    assert_visible_text(mobile, coverage_explanation)
+    mobile.screenshot(path=mobile_expanded_screenshot, full_page=False)
+    mobile_context.close()
+
+    browser.close()
+
+    if browser_errors:
+        raise RuntimeError(f"browser console/page errors: {' | '.join(browser_errors)}")
+
+print('pass\tfixture page identity, nonblank body, and no framework overlay')
+print('pass\tdesktop hydration-failed row expands visible explanation')
+print('pass\tdesktop coverage-gap row expands visible explanation')
+print('pass\tmobile hydration-failed and coverage-gap rows expand visible explanations')
+PY
+
+env \
+  FIXTURE_URL="${FIXTURE_URL}" \
+  HYDRATION_EXPANDED_SCREENSHOT="${HYDRATION_EXPANDED_SCREENSHOT}" \
+  COVERAGE_EXPANDED_SCREENSHOT="${COVERAGE_EXPANDED_SCREENSHOT}" \
+  MOBILE_EXPANDED_SCREENSHOT="${MOBILE_EXPANDED_SCREENSHOT}" \
+  "${PLAYWRIGHT_PYTHON_CMD[@]}" "${BROWSER_SCRIPT}"
+
 printf 'keeper chat tool output failure contract DOM smoke passed\n'
 printf 'fixture_url=%s\n' "${FIXTURE_URL}"
 printf 'desktop_screenshot=%s\n' "${DESKTOP_SCREENSHOT}"
 printf 'mobile_screenshot=%s\n' "${MOBILE_SCREENSHOT}"
 printf 'hydration_failed_screenshot=%s\n' "${HYDRATION_SCREENSHOT}"
 printf 'coverage_gap_screenshot=%s\n' "${COVERAGE_SCREENSHOT}"
+printf 'hydration_expanded_screenshot=%s\n' "${HYDRATION_EXPANDED_SCREENSHOT}"
+printf 'coverage_expanded_screenshot=%s\n' "${COVERAGE_EXPANDED_SCREENSHOT}"
+printf 'mobile_expanded_screenshot=%s\n' "${MOBILE_EXPANDED_SCREENSHOT}"


### PR DESCRIPTION
## Summary
- Adds a live KeeperConversationPanel integration proof for the successful hydrateKeeperChatHistory tool-call output path.
- Uses REST history-shaped tool/assistant rows plus a real tool-calls endpoint-shaped entry keyed by tool_use_id, then asserts the live ChatTranscript DOM renders the joined output as ok/covered instead of pending, missing, coverage-gap, or hydration-failed.

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-shared-hydration.integration.test.ts
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-shared-hydration.integration.test.ts src/components/keeper-shared.test.ts src/keeper-actions.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- GITHUB_BASE_REF=codex/chat-api-hydration-failure-live-dom-20260706 python3 scripts/check_test_coverage.py
- git diff --check

Local Dune was not run; dashboard-only change and CI remains the build authority.