### PR TITLE
fix: record Gemma4 E2B Ollama capability baseline

### DIFF
--- a/scripts/ollama-caps-baseline.json
+++ b/scripts/ollama-caps-baseline.json
@@ -145,6 +145,15 @@
         "vision"
       ]
     },
+    "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL": {
+      "provider": "ollama",
+      "capabilities": [
+        "tools",
+        "completion",
+        "vision",
+        "audio"
+      ]
+    },
     "kimi-k2.5": {
       "provider": "ollama_cloud",
       "capabilities": [


### PR DESCRIPTION
## Summary
- Add the `/api/show` capability baseline row for `hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`.
- Keep the fix scoped to the RFC-0265 no-network drift gate baseline after #23326 added the runtime seed.

## Evidence
- [근거] MASC main CI run `28747063360`, job `85239699506`, checked 2026-07-06 KST: `Check Ollama capability drift (RFC-0265)` failed with `UNVERIFIED-DECLARED` for `gemma4-e2b-it-qat`, declared `image=True audio=True`, baseline absent. Trust: High, GitHub Actions job log.
- [근거] `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL` checked 2026-07-06 KST reports capabilities `tools`, `completion`, `vision`, `audio`. Trust: High, local Ollama runtime command.

## Validation
- `python3 scripts/masc-sync-ollama-caps.py --check` passed: `OK: 41 Ollama-family model(s) match baseline (0 unverified)`.
- `git diff --check` passed.