### PR TITLE
[codex] dashboard: prove sse reconnect chat boundary

### DIFF
--- a/dashboard/src/components/keeper-shared-hydration.integration.test.ts
+++ b/dashboard/src/components/keeper-shared-hydration.integration.test.ts
@@ -55,7 +55,11 @@ vi.mock('../store', async () => {
 vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
 
 import { KeeperConversationPanel } from './keeper-shared'
-import { _resetChatHydrationForTests, hydrateKeeperChatHistory } from '../keeper-actions'
+import {
+  _resetChatHydrationForTests,
+  hydrateKeeperChatHistory,
+  refreshActiveKeeperChatHistory,
+} from '../keeper-actions'
 import {
   activeKeeperName,
   keeperActionErrors,
@@ -586,6 +590,127 @@ describe('KeeperConversationPanel hydration wiring', () => {
       expect(step.textContent).toContain('recovered output joined from forced refresh')
       expect(step.textContent).not.toContain('출력 hydration 실패')
       expect(step.textContent).not.toContain('HTTP 504 first refresh')
+      expect(step.textContent).not.toContain('출력 tail 범위 밖')
+    })
+
+    consoleWarn.mockRestore()
+  })
+
+  it('recovers stale hydration-failed DOM through the active-keeper reconnect refresh path', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const reconnectHistory = [
+      {
+        id: 'tool-history-reconnect-recovery',
+        role: 'tool',
+        content: '{}',
+        ts: 1_783_267_251,
+        tool_call_id: 'tc-reconnect-recovery',
+        tool_call_name: 'keeper_context_status',
+        source: 'dashboard',
+        turn_ref: 'trace-reconnect-recovery#1',
+      },
+      {
+        id: 'assistant-history-reconnect-recovery',
+        role: 'assistant',
+        content: 'SSE reconnect 이후 도구 출력 조인이 복구되었습니다.',
+        ts: 1_783_267_252,
+        source: 'dashboard',
+        turn_ref: 'trace-reconnect-recovery#1',
+        stream_contract: {
+          source: 'sse_event',
+          status: 'backend_terminal_event',
+          event_name: 'RUN_FINISHED',
+          delivery_receipt: 'client_observed_sse_event',
+        },
+      },
+    ]
+    activeKeeperName.value = 'sangsu'
+    fetchKeeperChatHistory.mockResolvedValueOnce(reconnectHistory)
+    fetchKeeperToolCalls.mockRejectedValueOnce(new Error('HTTP 504 reconnect gap'))
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." layout="workspace" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledWith('sangsu')
+      expect(fetchKeeperToolCalls).toHaveBeenCalledWith('sangsu', 200)
+    })
+    await waitFor(() => {
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('failed')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBe('HTTP 504 reconnect gap')
+    })
+
+    let step = container.querySelector(
+      '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-reconnect-recovery"]',
+    ) as HTMLElement
+    fireEvent.click(step.querySelector('.chat-block-tstep-row') as HTMLElement)
+    await waitFor(() => {
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('hydration-failed')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('hydration-failed')
+      expect(step.textContent).toContain('출력 hydration 실패 — HTTP 504 reconnect gap')
+      expect(container.textContent).toContain('출력 hydration 실패 1')
+    })
+
+    fetchKeeperChatHistory.mockResolvedValueOnce(reconnectHistory)
+    fetchKeeperToolCalls.mockResolvedValueOnce({
+      entries: [
+        {
+          ts: 1_783_267_251,
+          keeper: 'sangsu',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'recovered output joined from active reconnect refresh',
+          success: true,
+          duration_ms: 39,
+          tool_use_id: 'tc-reconnect-recovery',
+        },
+      ],
+    })
+
+    refreshActiveKeeperChatHistory({ force: true })
+
+    await waitFor(() => {
+      expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+      expect(fetchKeeperToolCalls).toHaveBeenCalledTimes(2)
+      expect(toolCallOutputHydrationStatus('sangsu')).toBe('hydrated')
+      expect(toolCallOutputHydrationFailureReason('sangsu')).toBeNull()
+      expect(lookupToolCallOutput('tool-tc-reconnect-recovery')?.output).toBe(
+        'recovered output joined from active reconnect refresh',
+      )
+      expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_783_267_251_000)
+      expect(toolCallOutputsCoveredThroughMs('sangsu')).not.toBeNull()
+    })
+
+    const coveredThrough = toolCallOutputsCoveredThroughMs('sangsu')
+    await waitFor(() => {
+      const trace = container.querySelector('[data-chat-work-trace]')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-status')).toBe('hydrated')
+      expect(trace?.getAttribute('data-chat-tool-output-hydration-failure')).toBeNull()
+      expect(trace?.getAttribute('data-chat-tool-output-covered-since')).toBe('1783267251000')
+      expect(trace?.getAttribute('data-chat-tool-output-covered-through')).toBe(String(coveredThrough))
+      expect(trace?.getAttribute('data-chat-turn-stream-contract-event')).toBe('RUN_FINISHED')
+
+      step = container.querySelector(
+        '[data-chat-trace-step="tool"][data-chat-trace-tool-call-id="tc-reconnect-recovery"]',
+      ) as HTMLElement
+      expect(step.getAttribute('data-chat-trace-link-state')).toBe('joined')
+      expect(step.getAttribute('data-chat-trace-output-state')).toBe('ok')
+      expect(step.getAttribute('data-chat-trace-output-coverage')).toBe('covered')
+      expect(step.querySelector('.chat-block-tstep-status.ok')).not.toBeNull()
+      expect(step.querySelector('.chat-block-tstep-status.hydration-failed')).toBeNull()
+      expect(container.textContent).not.toContain('출력 hydration 실패 1')
+      expect(container.textContent).not.toContain('HTTP 504 reconnect gap')
+      expect(container.textContent).not.toContain('출력 대기 중')
+      expect(container.textContent).not.toContain('결과 없음')
+    })
+
+    await waitFor(() => {
+      expect(step.textContent).toContain('result')
+      expect(step.textContent).toContain('recovered output joined from active reconnect refresh')
+      expect(step.textContent).not.toContain('출력 hydration 실패')
+      expect(step.textContent).not.toContain('HTTP 504 reconnect gap')
       expect(step.textContent).not.toContain('출력 tail 범위 밖')
     })
 

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -133,7 +133,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     showToast.mockClear()
     replayOasRuntimeTelemetry.mockClear()
     replayOasRuntimeTelemetry.mockResolvedValue(undefined)
-    refreshActiveKeeperChatHistory.mockClear()
+    refreshActiveKeeperChatHistory.mockReset()
     hydrateFleetCompositeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockReturnValue(true)
@@ -218,6 +218,32 @@ describe('setupSSEReaction reconnect hydration', () => {
 
     vi.clearAllTimers()
     cleanup()
+  })
+
+  it('surfaces active keeper chat reconnect refresh boundary failures without stopping recovery', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    refreshActiveKeeperChatHistory.mockImplementationOnce(() => {
+      throw new Error('keeper chat reconnect refresh exploded')
+    })
+    const { sseStore, sse } = await loadSseStore()
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.connected.value = true
+    sse.lastDisconnectedAt.value = Date.now() - 1_000
+    sse.reconnectCount.value += 1
+    await flushAsyncWork()
+
+    expect(refreshActiveKeeperChatHistory).toHaveBeenCalledWith({ force: true })
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[SSE] reconnect keeper chat re-hydration unavailable',
+      'keeper chat reconnect refresh exploded',
+    )
+    expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
+    expect(requestNamespaceTruthNow).toHaveBeenCalledTimes(1)
+
+    vi.clearAllTimers()
+    cleanup()
+    consoleWarn.mockRestore()
   })
 
   it('routes an approval:pending SSE event to the governance refresh (HITL badge contract)', async () => {


### PR DESCRIPTION
## Summary
- Adds a reconnect-path test proving the actual SSE reconnect watcher invokes `refreshActiveKeeperChatHistory({ force: true })` through the dynamic `keeper-runtime` boundary.
- Covers the failure boundary: if the active keeper chat refresh throws, reconnect recovery logs an explicit warning and continues namespace/dashboard recovery instead of silently swallowing the break.

## Why
The previous proof covered the active-keeper wrapper itself. This PR pins the outer SSE reconnect recovery path so replay-buffer gap recovery remains route-independent and observable when the keeper refresh boundary is broken.

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/sse-store.test.ts`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/sse-store.test.ts src/components/keeper-shared-hydration.integration.test.ts src/keeper-actions.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `GITHUB_BASE_REF=codex/chat-hydration-reconnect-active-live-dom-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`

Local Dune build intentionally not run; dashboard validation only.
