### PR TITLE
fix: preserve keeper stream draft on refresh

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -901,6 +901,51 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     await sendPromise
   })
 
+  it('persists the live assistant draft while the stream is in flight', async () => {
+    let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { onEvent: (event: KeeperChatStreamEvent) => void },
+    ) => {
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_QUEUE_REQUEST',
+        value: { request_id: 'kmsg_echo_draft', status: 'queued' },
+      })
+      opts.onEvent({ type: 'TEXT_MESSAGE_START' })
+      opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: '부분 응답' })
+      opts.onEvent({
+        type: 'TOOL_CALL_START',
+        toolCallId: 'tc-draft',
+        toolCallName: 'keeper_board_list',
+      })
+      return new Promise<{ terminal: boolean }>(resolve => {
+        resolveStream = resolve
+      })
+    })
+
+    const sendPromise = sendKeeperThreadMessage('echo', '진행 상황?')
+    await Promise.resolve()
+
+    const [pending] = pendingKeeperChatRequestsForKeeper('echo')
+    expect(pending?.assistantDraft?.text).toBe('부분 응답')
+    expect(pending?.assistantDraft?.delivery).toBe('streaming')
+    expect(pending?.assistantDraft?.streamState).toBe('streaming')
+    expect(pending?.assistantDraft?.traceSteps).toEqual([
+      expect.objectContaining({
+        kind: 'tool',
+        name: 'keeper_board_list',
+        toolCallId: 'tc-draft',
+        status: 'pending',
+      }),
+    ])
+
+    resolveStream({ terminal: true })
+    await sendPromise
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+  })
+
   it('marks the reply interrupted when the stream ends without a terminal event', async () => {
     streamKeeperMessage.mockImplementation(emitting([
       { type: 'RUN_STARTED' },
@@ -1458,6 +1503,81 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       expect(thread.filter(entry => entry.role === 'user')).toHaveLength(1)
       expect(thread.some(entry => entry.role === 'assistant' && entry.delivery === 'delivered')).toBe(true)
       expect(keeperActionErrors.value.echo).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('restores the partial assistant draft after page reload while the request is still running', async () => {
+    vi.useFakeTimers()
+    try {
+      _resetChatHydrationForTests()
+      _clearPendingKeeperChatRequestsForTests()
+      upsertPendingKeeperChatRequest({
+        requestId: 'kmsg_echo_draft',
+        keeperName: 'echo',
+        message: '진행 상황?',
+        submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
+        assistantDraft: {
+          text: '부분 응답',
+          rawText: '부분 응답',
+          delivery: 'streaming',
+          streamState: 'streaming',
+          traceSteps: [
+            { kind: 'think', text: '상태 확인 중' },
+            {
+              kind: 'tool',
+              name: 'keeper_board_list',
+              toolCallId: 'tc-draft',
+              status: 'pending',
+              args: '{"limit":5}',
+            },
+          ],
+        },
+      })
+
+      fetchKeeperChatHistory.mockResolvedValue([
+        { role: 'user', content: '진행 상황?', ts: 1_780_000_000 },
+      ])
+
+      let pollCount = 0
+      fetchQueuedKeeperMessageResult.mockImplementation(() => {
+        pollCount += 1
+        if (pollCount === 1) {
+          return Promise.resolve({ status: 'queued' })
+        }
+        return Promise.resolve({ status: 'done', ok: true, result: { reply: '완료' } })
+      })
+
+      await hydrateKeeperChatHistory('echo')
+      const resumePromise = resumePendingKeeperChatRequests('echo')
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      const pendingAssistant = (keeperThreads.value.echo ?? [])
+        .find(entry => entry.id === 'pending-assistant-kmsg_echo_draft')
+      expect(pendingAssistant).toEqual(expect.objectContaining({
+        role: 'assistant',
+        text: '부분 응답',
+        delivery: 'streaming',
+        streamState: 'streaming',
+      }))
+      expect(pendingAssistant?.traceSteps).toEqual([
+        { kind: 'think', text: '상태 확인 중' },
+        {
+          kind: 'tool',
+          name: 'keeper_board_list',
+          toolCallId: 'tc-draft',
+          status: 'pending',
+          args: '{"limit":5}',
+        },
+      ])
+
+      await vi.advanceTimersByTimeAsync(2_000)
+      await resumePromise
+
+      const thread = keeperThreads.value.echo ?? []
+      expect(thread.some(entry => entry.role === 'assistant' && entry.text === '완료')).toBe(true)
+      expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
     } finally {
       vi.useRealTimers()
     }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -75,6 +75,7 @@ import {
   pendingKeeperChatRequestsForKeeper,
   removePendingKeeperChatRequest,
   type PendingKeeperChatRequest,
+  updatePendingKeeperChatAssistantDraft,
   upsertPendingKeeperChatRequest,
 } from './keeper-chat-pending'
 
@@ -455,6 +456,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
   const existing = keeperThreads.value[request.keeperName] ?? []
   const userId = pendingUserEntryId(request.requestId)
   const assistantId = pendingAssistantEntryId(request.requestId)
+  const assistantDraft = request.assistantDraft
   if (!existing.some(entry => entry.id === userId)) {
     appendThreadEntry(request.keeperName, {
       id: userId,
@@ -475,15 +477,29 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       role: 'assistant',
       source: 'direct_assistant',
       label: request.keeperName,
-      text: '',
-      rawText: '',
-      timestamp: null,
-      delivery: 'queued',
-      streamState: 'opening',
+      text: assistantDraft?.text ?? '',
+      rawText: assistantDraft?.rawText ?? '',
+      timestamp: assistantDraft?.timestamp ?? null,
+      delivery: assistantDraft?.delivery ?? 'queued',
+      streamState: assistantDraft ? assistantDraft.streamState : 'opening',
+      traceSteps: assistantDraft?.traceSteps,
+      error: assistantDraft?.error ?? null,
       details: null,
     })
   }
   return assistantId
+}
+
+function persistPendingAssistantDraft(
+  keeperName: string,
+  requestId: string | null,
+  assistantEntryId: string,
+): void {
+  if (!requestId) return
+  const entry = (keeperThreads.value[keeperName] ?? [])
+    .find(candidate => candidate.id === assistantEntryId) ?? null
+  if (!entry) return
+  updatePendingKeeperChatAssistantDraft(requestId, entry)
 }
 
 let localIdCounter = 0
@@ -937,6 +953,7 @@ export async function sendKeeperThreadMessage(
         if (error) {
           throw new Error(error)
         }
+        persistPendingAssistantDraft(keeperName, requestId, assistantId)
         if (event.type === 'TOOL_CALL_END') {
           toolCallEnded = true
           void hydrateKeeperToolOutputs(keeperName)

--- a/dashboard/src/keeper-chat-pending.test.ts
+++ b/dashboard/src/keeper-chat-pending.test.ts
@@ -39,4 +39,51 @@ describe('keeper chat pending request storage', () => {
       'kmsg_echo_2',
     ])
   })
+
+  it('preserves the in-flight assistant draft for page reload recovery', () => {
+    upsertPendingKeeperChatRequest({
+      requestId: 'kmsg_echo_1',
+      keeperName: 'echo',
+      message: 'status?',
+      submittedAt: 1_780_000_000,
+      assistantDraft: {
+        text: '부분 응답',
+        rawText: '부분 응답',
+        delivery: 'streaming',
+        streamState: 'thinking',
+        traceSteps: [
+          { kind: 'think', text: '상태 확인 중' },
+          {
+            kind: 'tool',
+            name: 'keeper_board_list',
+            toolCallId: 'tc-1',
+            status: 'pending',
+            args: '{"limit":5}',
+          },
+        ],
+      },
+    })
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([
+      expect.objectContaining({
+        requestId: 'kmsg_echo_1',
+        assistantDraft: expect.objectContaining({
+          text: '부분 응답',
+          rawText: '부분 응답',
+          delivery: 'streaming',
+          streamState: 'thinking',
+          traceSteps: [
+            { kind: 'think', text: '상태 확인 중' },
+            {
+              kind: 'tool',
+              name: 'keeper_board_list',
+              toolCallId: 'tc-1',
+              status: 'pending',
+              args: '{"limit":5}',
+            },
+          ],
+        }),
+      }),
+    ])
+  })
 })

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -1,4 +1,21 @@
-import type { KeeperConversationAttachment } from './types'
+import type {
+  ChatTraceStep,
+  KeeperConversationAttachment,
+  KeeperConversationDelivery,
+  KeeperConversationEntry,
+  KeeperConversationStreamState,
+} from './types'
+import { IN_FLIGHT_DELIVERY } from './lib/keeper-delivery'
+
+export interface PendingKeeperChatAssistantDraft {
+  text: string
+  rawText: string
+  delivery: KeeperConversationDelivery
+  streamState: KeeperConversationStreamState
+  timestamp?: string | null
+  traceSteps?: ChatTraceStep[]
+  error?: string | null
+}
 
 export interface PendingKeeperChatRequest {
   requestId: string
@@ -6,14 +23,23 @@ export interface PendingKeeperChatRequest {
   message: string
   submittedAt: number
   attachments?: KeeperConversationAttachment[]
+  assistantDraft?: PendingKeeperChatAssistantDraft
 }
 
 const STORAGE_KEY = 'masc_keeper_chat_pending_requests_v1'
+const KEEPER_STREAM_STATES = [
+  'opening',
+  'thinking',
+  'streaming',
+  'finalizing',
+] as const satisfies ReadonlyArray<Exclude<KeeperConversationStreamState, null>>
+const TRACE_TOOL_STATUSES = ['pending', 'ok', 'err'] as const
 
 function storage(): Storage | null {
   try {
     return typeof window === 'undefined' ? null : window.localStorage
-  } catch {
+  } catch (err) {
+    console.warn('[keeper-chat-pending] localStorage unavailable', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -27,6 +53,27 @@ function stringField(record: Record<string, unknown>, key: string): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function nullableStringValue(value: unknown): string | null | undefined {
+  if (value === null) return null
+  return stringValue(value)
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function parseMember<const T extends string>(
+  values: readonly T[],
+  value: unknown,
+): T | undefined {
+  if (typeof value !== 'string') return undefined
+  return values.includes(value as T) ? (value as T) : undefined
+}
+
 function normalizeAttachment(raw: unknown): KeeperConversationAttachment | null {
   if (!isRecord(raw)) return null
   const id = stringField(raw, 'id')
@@ -37,6 +84,97 @@ function normalizeAttachment(raw: unknown): KeeperConversationAttachment | null 
   const size = typeof raw.size === 'number' && Number.isFinite(raw.size) ? raw.size : 0
   if (!id || (type !== 'image' && type !== 'file') || !name || !mimeType || !data) return null
   return { id, type, name, size, mimeType, data }
+}
+
+function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
+  if (!isRecord(raw)) return null
+  const kind = stringValue(raw.kind)
+  if (kind === 'think') {
+    const text = stringValue(raw.text)
+    if (text === undefined) return null
+    const step: ChatTraceStep = { kind, text }
+    const ts = stringValue(raw.ts)
+    const oasBlockIndex = numberValue(raw.oasBlockIndex)
+    if (ts !== undefined) step.ts = ts
+    if (oasBlockIndex !== undefined) step.oasBlockIndex = oasBlockIndex
+    return step
+  }
+  if (kind === 'reason') {
+    const text = stringValue(raw.text)
+    if (text === undefined) return null
+    const step: ChatTraceStep = { kind, text }
+    const detail = stringValue(raw.detail)
+    const ts = stringValue(raw.ts)
+    if (detail !== undefined) step.detail = detail
+    if (ts !== undefined) step.ts = ts
+    return step
+  }
+  if (kind === 'tool') {
+    const name = stringValue(raw.name)
+    if (name === undefined) return null
+    const step: ChatTraceStep = { kind, name }
+    const toolCallId = stringValue(raw.toolCallId)
+    const status = parseMember(TRACE_TOOL_STATUSES, raw.status)
+    const dur = stringValue(raw.dur)
+    const args = stringValue(raw.args)
+    const result = stringValue(raw.result)
+    const ts = stringValue(raw.ts)
+    const oasBlockIndex = numberValue(raw.oasBlockIndex)
+    if (toolCallId !== undefined) step.toolCallId = toolCallId
+    if (status !== undefined) step.status = status
+    if (dur !== undefined) step.dur = dur
+    if (args !== undefined) step.args = args
+    if (result !== undefined) step.result = result
+    if (ts !== undefined) step.ts = ts
+    if (oasBlockIndex !== undefined) step.oasBlockIndex = oasBlockIndex
+    return step
+  }
+  return null
+}
+
+function normalizeTraceSteps(raw: unknown): ChatTraceStep[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const steps = raw.map(normalizeTraceStep)
+  if (steps.some(step => step === null)) return undefined
+  return steps.length > 0 ? (steps as ChatTraceStep[]) : undefined
+}
+
+function normalizeAssistantDraft(raw: unknown): PendingKeeperChatAssistantDraft | null {
+  if (!isRecord(raw)) return null
+  const text = stringValue(raw.text)
+  if (text === undefined) return null
+  const rawText = stringValue(raw.rawText) ?? text
+  const delivery = parseMember(IN_FLIGHT_DELIVERY, raw.delivery) ?? 'queued'
+  const streamState =
+    raw.streamState === null
+      ? null
+      : parseMember(KEEPER_STREAM_STATES, raw.streamState) ?? null
+  const timestamp = nullableStringValue(raw.timestamp)
+  const traceSteps = normalizeTraceSteps(raw.traceSteps)
+  const error = nullableStringValue(raw.error)
+  return {
+    text,
+    rawText,
+    delivery,
+    streamState,
+    ...(timestamp !== undefined ? { timestamp } : {}),
+    ...(traceSteps ? { traceSteps } : {}),
+    ...(error !== undefined ? { error } : {}),
+  }
+}
+
+function assistantDraftFromEntry(entry: KeeperConversationEntry): PendingKeeperChatAssistantDraft | null {
+  if (entry.role !== 'assistant') return null
+  const traceSteps = normalizeTraceSteps(entry.traceSteps)
+  return {
+    text: entry.text,
+    rawText: entry.rawText ?? entry.text,
+    delivery: entry.delivery,
+    streamState: entry.streamState ?? null,
+    timestamp: entry.timestamp ?? null,
+    ...(traceSteps ? { traceSteps } : {}),
+    ...(entry.error !== undefined ? { error: entry.error } : {}),
+  }
 }
 
 function normalizePendingRequest(raw: unknown): PendingKeeperChatRequest | null {
@@ -52,12 +190,14 @@ function normalizePendingRequest(raw: unknown): PendingKeeperChatRequest | null 
   const attachments = Array.isArray(raw.attachments)
     ? raw.attachments.map(normalizeAttachment).filter((att): att is KeeperConversationAttachment => att !== null)
     : []
+  const assistantDraft = normalizeAssistantDraft(raw.assistantDraft)
   return {
     requestId,
     keeperName,
     message,
     submittedAt,
     ...(attachments.length > 0 ? { attachments } : {}),
+    ...(assistantDraft ? { assistantDraft } : {}),
   }
 }
 
@@ -72,7 +212,8 @@ function readAll(): PendingKeeperChatRequest[] {
     return parsed
       .map(normalizePendingRequest)
       .filter((request): request is PendingKeeperChatRequest => request !== null)
-  } catch {
+  } catch (err) {
+    console.warn('[keeper-chat-pending] failed to read pending requests', err instanceof Error ? err.message : err)
     return []
   }
 }
@@ -86,8 +227,8 @@ function writeAll(requests: PendingKeeperChatRequest[]): void {
     } else {
       store.setItem(STORAGE_KEY, JSON.stringify(requests))
     }
-  } catch {
-    // Best-effort resilience only; the live stream remains the primary path.
+  } catch (err) {
+    console.warn('[keeper-chat-pending] failed to write pending requests', err instanceof Error ? err.message : err)
   }
 }
 
@@ -102,14 +243,35 @@ export function upsertPendingKeeperChatRequest(request: PendingKeeperChatRequest
   const keeperName = request.keeperName.trim()
   const message = request.message.trim()
   if (!requestId || !keeperName || !message) return
+  const assistantDraft = normalizeAssistantDraft(request.assistantDraft)
   const normalized: PendingKeeperChatRequest = {
-    ...request,
     requestId,
     keeperName,
     message,
+    submittedAt: request.submittedAt,
+    ...(request.attachments && request.attachments.length > 0 ? { attachments: request.attachments } : {}),
+    ...(assistantDraft ? { assistantDraft } : {}),
   }
   const next = readAll().filter(existing => existing.requestId !== requestId)
   next.push(normalized)
+  writeAll(next)
+}
+
+export function updatePendingKeeperChatAssistantDraft(
+  requestId: string,
+  entry: KeeperConversationEntry,
+): void {
+  const id = requestId.trim()
+  const assistantDraft = assistantDraftFromEntry(entry)
+  if (!id || !assistantDraft) return
+  const requests = readAll()
+  let found = false
+  const next = requests.map(request => {
+    if (request.requestId !== id) return request
+    found = true
+    return { ...request, assistantDraft }
+  })
+  if (!found) return
   writeAll(next)
 }
 

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -24,6 +24,7 @@ import {
   activeStreamEntryId,
   activeStreamRequestId,
   getStreamController,
+  keeperThreads,
   keeperSending,
   keeperStreamStartedAt,
   setRecordValue,
@@ -31,6 +32,7 @@ import {
 import { isRecord, asNumber, asString } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
 import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
+import { updatePendingKeeperChatAssistantDraft } from './keeper-chat-pending'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
@@ -74,6 +76,15 @@ function fullPendingThinkingText(pending: PendingThinkingState): string {
   return pending.chunks.join('')
 }
 
+function persistActiveAssistantDraft(keeperName: string, assistantEntryId: string): void {
+  const requestId = activeStreamRequestId(keeperName)
+  if (!requestId) return
+  const entry = (keeperThreads.value[keeperName] ?? [])
+    .find(candidate => candidate.id === assistantEntryId) ?? null
+  if (!entry) return
+  updatePendingKeeperChatAssistantDraft(requestId, entry)
+}
+
 function flushPendingThinkingDeltas(
   keeperName: string,
   assistantEntryId: string,
@@ -90,12 +101,14 @@ function flushPendingThinkingDeltas(
     setAssistantThinkingSnapshot(keeperName, assistantEntryId, pending.preview, {
       oasBlockIndex: pending.oasBlockIndex,
     })
+    persistActiveAssistantDraft(keeperName, assistantEntryId)
     return
   }
   pendingThinkingDeltas.delete(key)
   setAssistantThinkingSnapshot(keeperName, assistantEntryId, fullPendingThinkingText(pending), {
     oasBlockIndex: pending.oasBlockIndex,
   })
+  persistActiveAssistantDraft(keeperName, assistantEntryId)
 }
 
 function dropPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {


### PR DESCRIPTION
Summary
- Persist in-flight keeper assistant text/trace state into the pending request record.
- Restore that draft when a refreshed page resumes a still-running keeper request.
- Add storage and action regression coverage for partial stream recovery.

Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/keeper-chat-pending.test.ts src/keeper-actions.test.ts
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint