### PR TITLE
Add goal hygiene review gate

### DIFF
--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -108,6 +108,26 @@ Lifecycle status/phase fields are intentionally omitted here; use masc_goal_tran
           ];
     };
     {
+      name = "masc_goal_hygiene_review";
+      description =
+        "Review Goal Store hygiene for G-GHYG: stale executing goals and active \
+metricless goals. By default this is read-only and returns a typed issue rollup. \
+When apply=true, actor is required and must be the authenticated operator; \
+apply blocks executable hygiene violations instead of inventing metrics.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("apply", `Assoc [ ("type", `String "boolean") ]);
+                  ("actor", goal_principal_schema);
+                ] );
+            ("additionalProperties", `Bool false);
+          ];
+    };
+    {
       name = "masc_goal_transition";
       description =
         "Apply an explicit Goal FSM transition such as request_complete, pause, unblock, or approval resolution. \

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -712,6 +712,7 @@ let dispatch_bindings : (string * dispatch_handler) list =
   ; "masc_heartbeat", handle_heartbeat
   ; "masc_goal_list", Workspace_goals.handle_goal_list
   ; "masc_goal_upsert", Workspace_goals.handle_goal_upsert
+  ; "masc_goal_hygiene_review", Workspace_goals.handle_goal_hygiene_review
   ; "masc_goal_transition", Workspace_goals.handle_goal_transition
   ; "masc_goal_verify", Workspace_goals.handle_goal_verify
   ; "masc_reset", handle_reset

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -663,6 +663,225 @@ let cancel_created_verification_request ctx ~goal_id ~request_id ~reason =
     Error cleanup_msg
 ;;
 
+let goal_hygiene_policy_id = "G-GHYG"
+let goal_hygiene_stale_executing_age_days = 14
+
+let goal_hygiene_stale_executing_age_seconds =
+  Masc_time_constants.days_to_seconds goal_hygiene_stale_executing_age_days
+;;
+
+type goal_hygiene_issue_kind =
+  | Stale_executing
+  | Metric_missing_active
+  | Invalid_updated_at
+
+type goal_hygiene_issue =
+  { kind : goal_hygiene_issue_kind
+  ; goal : Goal_store.goal
+  ; age_days : float option
+  ; detail : string
+  ; applyable : bool
+  }
+
+let goal_hygiene_issue_kind_to_string = function
+  | Stale_executing -> "stale_executing"
+  | Metric_missing_active -> "metric_missing_active"
+  | Invalid_updated_at -> "invalid_updated_at"
+;;
+
+let goal_hygiene_active_metric_phase = function
+  | Goal_phase.Executing
+  | Goal_phase.Awaiting_verification
+  | Goal_phase.Awaiting_approval ->
+    true
+  | Goal_phase.Blocked
+  | Goal_phase.Paused
+  | Goal_phase.Completed
+  | Goal_phase.Dropped ->
+    false
+;;
+
+let goal_hygiene_trimmed_string = function
+  | Some value when String.trim value <> "" -> Some value
+  | Some _ | None -> None
+;;
+
+let goal_hygiene_goal_missing_metric (goal : Goal_store.goal) =
+  Option.is_none (goal_hygiene_trimmed_string goal.metric)
+;;
+
+let goal_hygiene_age_days age_seconds = age_seconds /. Masc_time_constants.day
+
+let goal_hygiene_updated_age_seconds ~now (goal : Goal_store.goal) =
+  match Masc_domain.parse_iso8601_opt goal.updated_at with
+  | Some updated_at -> Ok (Float.max 0.0 (now -. updated_at))
+  | None -> Error goal.updated_at
+;;
+
+let goal_hygiene_issue_to_yojson (issue : goal_hygiene_issue) =
+  `Assoc
+    [ "kind", `String (goal_hygiene_issue_kind_to_string issue.kind)
+    ; "goal_id", `String issue.goal.id
+    ; "title", `String issue.goal.title
+    ; "phase", Goal_phase.to_yojson issue.goal.phase
+    ; "updated_at", `String issue.goal.updated_at
+    ; ( "age_days"
+      , match issue.age_days with
+        | Some days -> `Float days
+        | None -> `Null )
+    ; "detail", `String issue.detail
+    ; "applyable", `Bool issue.applyable
+    ]
+;;
+
+let goal_hygiene_count kind issues =
+  List_util.count_if (fun issue -> issue.kind = kind) issues
+;;
+
+let goal_hygiene_issue_goal_ids issues =
+  issues
+  |> List.filter_map (fun issue ->
+    if issue.applyable then Some issue.goal.id else None)
+  |> List.sort_uniq String.compare
+;;
+
+let goal_hygiene_issues_for_goal issues ~goal_id =
+  List.filter (fun issue -> String.equal issue.goal.id goal_id) issues
+;;
+
+let goal_hygiene_collect_issues ~now goals =
+  let collect_goal (goal : Goal_store.goal) =
+    let timestamp_issues, age_seconds =
+      match goal_hygiene_updated_age_seconds ~now goal with
+      | Ok age_seconds -> [], Some age_seconds
+      | Error raw ->
+        ( [ { kind = Invalid_updated_at
+            ; goal
+            ; age_days = None
+            ; detail = Printf.sprintf "updated_at is not parseable ISO-8601: %s" raw
+            ; applyable = false
+            }
+          ]
+        , None )
+    in
+    let stale_issues =
+      match goal.phase, age_seconds with
+      | Goal_phase.Executing, Some age_seconds
+        when Float.compare age_seconds goal_hygiene_stale_executing_age_seconds >= 0 ->
+        let days = goal_hygiene_age_days age_seconds in
+        [ { kind = Stale_executing
+          ; goal
+          ; age_days = Some days
+          ; detail =
+              Printf.sprintf
+                "executing goal has not updated for %.1f days; threshold=%d days"
+                days
+                goal_hygiene_stale_executing_age_days
+          ; applyable = true
+          }
+        ]
+      | ( Goal_phase.Executing
+        | Goal_phase.Awaiting_verification
+        | Goal_phase.Awaiting_approval
+        | Goal_phase.Blocked
+        | Goal_phase.Paused
+        | Goal_phase.Completed
+        | Goal_phase.Dropped ), _ ->
+        []
+    in
+    let metric_issues =
+      if
+        goal_hygiene_active_metric_phase goal.phase
+        && goal_hygiene_goal_missing_metric goal
+      then
+        [ { kind = Metric_missing_active
+          ; goal
+          ; age_days = Option.map goal_hygiene_age_days age_seconds
+          ; detail = "active goal has no metric; block until metric is set"
+          ; applyable = goal.phase = Goal_phase.Executing
+          }
+        ]
+      else []
+    in
+    timestamp_issues @ stale_issues @ metric_issues
+  in
+  List.concat_map collect_goal goals
+;;
+
+let goal_hygiene_summary_json ~issues =
+  let applyable_goal_ids = goal_hygiene_issue_goal_ids issues in
+  `Assoc
+    [ "policy", `String goal_hygiene_policy_id
+    ; "stale_executing_age_days", `Int goal_hygiene_stale_executing_age_days
+    ; "issue_count", `Int (List.length issues)
+    ; "stale_executing_count", `Int (goal_hygiene_count Stale_executing issues)
+    ; ( "metric_missing_active_count"
+      , `Int (goal_hygiene_count Metric_missing_active issues) )
+    ; "invalid_updated_at_count", `Int (goal_hygiene_count Invalid_updated_at issues)
+    ; "applyable_goal_count", `Int (List.length applyable_goal_ids)
+    ; ( "applyable_goal_ids"
+      , `List (List.map (fun goal_id -> `String goal_id) applyable_goal_ids) )
+    ; "issues", `List (List.map goal_hygiene_issue_to_yojson issues)
+    ]
+;;
+
+let goal_hygiene_block_note ~actor_id ~issues =
+  let reasons =
+    issues
+    |> List.map (fun issue -> goal_hygiene_issue_kind_to_string issue.kind)
+    |> List.sort_uniq String.compare
+    |> String.concat ","
+  in
+  Printf.sprintf
+    "%s auto-review by %s: blocked executing goal for %s"
+    goal_hygiene_policy_id
+    actor_id
+    reasons
+;;
+
+let goal_hygiene_apply_block ctx ~actor_id ~issues ~goal_id =
+  match goal_hygiene_issues_for_goal issues ~goal_id with
+  | [] -> Error (Printf.sprintf "no hygiene issue found for %s" goal_id)
+  | goal_issues ->
+    let note = goal_hygiene_block_note ~actor_id ~issues:goal_issues in
+    let reviewed_at = Masc_domain.now_iso () in
+    (match
+       Goal_store.update_goal ctx.config ~goal_id (fun goal ->
+         { goal with
+           phase = Goal_phase.Blocked
+         ; status = Goal_store.goal_status_of_phase Goal_phase.Blocked
+         ; last_review_note = Some note
+         ; last_review_at = Some reviewed_at
+         })
+     with
+     | Error msg -> Error msg
+     | Ok updated_goal ->
+       emit_goal_event
+         ctx
+         ~goal_id
+         ~event_type:"goal_hygiene_review"
+         ~payload:
+           (`Assoc
+               [ "policy", `String goal_hygiene_policy_id
+               ; "actor_id", `String actor_id
+               ; "action", `String "operator_block"
+               ; "note", `String note
+               ; ( "issues"
+                 , `List (List.map goal_hygiene_issue_to_yojson goal_issues) )
+               ]);
+       emit_goal_event
+         ctx
+         ~goal_id
+         ~event_type:"goal_phase"
+         ~payload:
+           (`Assoc
+               [ "phase", Goal_phase.to_yojson updated_goal.phase
+               ; "actor_id", `String actor_id
+               ; "policy", `String goal_hygiene_policy_id
+               ]);
+       Ok updated_goal)
+;;
+
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( reject_retired_goal_list_status args
@@ -673,6 +892,9 @@ let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.r
   | Ok (), Ok phase ->
     let goals = Goal_store.list_goals ctx.config ?phase () in
     let rollup = Goal_store.compute_rollup goals in
+    let hygiene_issues =
+      goal_hygiene_collect_issues ~now:(Time_compat.now ()) goals
+    in
     ok_result
       ~tool_name
       ~start_time
@@ -680,7 +902,92 @@ let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.r
       ; "count", `Int (List.length goals)
       ; "goals", `List (List.map Goal_store.goal_to_yojson goals)
       ; "rollup", Goal_store.rollup_to_yojson rollup
+      ; "hygiene", goal_hygiene_summary_json ~issues:hygiene_issues
       ]
+;;
+
+let handle_goal_hygiene_review
+      ~tool_name
+      ~start_time
+      (ctx : context)
+      args
+  : Tool_result.result
+  =
+  match parse_optional_bool args "apply", parse_optional_principal args "actor" with
+  | Error err, _ | _, Error err ->
+    validation_error_result ~tool_name ~start_time [ err ]
+  | Ok apply_opt, Ok actor_opt ->
+    let apply =
+      match apply_opt with
+      | Some apply -> apply
+      | None -> false
+    in
+    let actor_result =
+      match actor_opt with
+      | Some actor when not (principal_matches_authenticated_caller ctx actor) ->
+        Error (principal_binding_error ~field:"actor" ctx actor)
+      | Some actor -> Ok actor
+      | None when apply -> Error "actor is required when apply=true"
+      | None -> Ok (canonical_principal_for_authenticated_caller ctx)
+    in
+    (match actor_result with
+     | Error msg ->
+       error_result_typed ~tool_name ~start_time ~code:Validation_error msg
+     | Ok actor ->
+       if apply && not (caller_is_goal_operator ctx)
+       then
+         error_result_typed
+           ~tool_name
+           ~start_time
+           ~code:Conflict
+           (operator_action_error Goal_phase.Operator_block)
+       else
+         let goals = Goal_store.list_goals ctx.config () in
+         let issues = goal_hygiene_collect_issues ~now:(Time_compat.now ()) goals in
+         let applyable_goal_ids = goal_hygiene_issue_goal_ids issues in
+         if not apply
+         then
+           ok_result
+             ~tool_name
+             ~start_time
+             [ "generated_at", `String (Masc_domain.now_iso ())
+             ; "applied", `Bool false
+             ; "hygiene", goal_hygiene_summary_json ~issues
+             ]
+         else
+           let applied, errors =
+             List.fold_left
+               (fun (applied, errors) goal_id ->
+                  match goal_hygiene_apply_block ctx ~actor_id:actor.id ~issues ~goal_id with
+                  | Ok goal -> goal :: applied, errors
+                  | Error msg -> applied, (goal_id, msg) :: errors)
+               ([], [])
+               applyable_goal_ids
+           in
+           if errors <> []
+           then
+             let message =
+               errors
+               |> List.rev
+               |> List.map (fun (goal_id, msg) -> goal_id ^ ": " ^ msg)
+               |> String.concat "; "
+             in
+             error_result_typed ~tool_name ~start_time ~code:Internal_error message
+           else
+             let refreshed_goals = Goal_store.list_goals ctx.config () in
+             let refreshed_issues =
+               goal_hygiene_collect_issues ~now:(Time_compat.now ()) refreshed_goals
+             in
+             ok_result
+               ~tool_name
+               ~start_time
+               [ "generated_at", `String (Masc_domain.now_iso ())
+               ; "applied", `Bool true
+               ; "applied_count", `Int (List.length applied)
+               ; ( "applied_goal_ids"
+                 , `List (List.map (fun goal -> `String goal.Goal_store.id) applied) )
+               ; "hygiene", goal_hygiene_summary_json ~issues:refreshed_issues
+               ])
 ;;
 
 let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result.result =

--- a/lib/workspace_goals.mli
+++ b/lib/workspace_goals.mli
@@ -61,6 +61,18 @@ val handle_goal_transition
   -> Yojson.Safe.t
   -> Tool_result.result
 
+(** [handle_goal_hygiene_review ctx args] handles
+    [masc_goal_hygiene_review].  Reports G-GHYG hygiene issues
+    for active goals and, when [apply=true] is supplied by an
+    authorized operator, blocks stale executing goals that need
+    review without inventing missing metric values. *)
+val handle_goal_hygiene_review
+  :  tool_name:string
+  -> start_time:float
+  -> Workspace_types.context
+  -> Yojson.Safe.t
+  -> Tool_result.result
+
 (** [handle_goal_verify ctx args] handles [masc_goal_verify] —
     record an operator/keeper verification vote (approve /
     reject) on a goal completion claim.  Updates the goal's

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -212,6 +212,20 @@ let create_done_task config ~goal_id ~title =
   step Masc_domain.Done_action "test fixture done"
 ;;
 
+let restamp_goal_updated_at config ~goal_id ~updated_at =
+  let state = Goal_store.read_state config in
+  Goal_store.write_state
+    config
+    { state with
+      goals =
+        List.map
+          (fun (goal : Goal_store.goal) ->
+             if String.equal goal.id goal_id then { goal with updated_at } else goal)
+          state.goals
+    ; updated_at
+    }
+;;
+
 let expect_error (result : Tool_result.result option) =
   match result with
   | Some r when not (Tool_result.is_success r) -> Yojson.Safe.from_string ((Tool_result.message r))
@@ -310,6 +324,125 @@ let test_goal_list_filters_by_phase () =
   | [ goal_json ] ->
     check string "phase filter honored" "blocked" (get_string_field goal_json "phase")
   | _ -> fail "expected one filtered goal"
+;;
+
+let test_goal_list_includes_hygiene_rollup () =
+  with_workspace
+  @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Metricless executing goal" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let listed =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_list"
+      ~args:(`Assoc [])
+  in
+  let listed_json =
+    match listed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_list not handled"
+  in
+  let hygiene = Yojson.Safe.Util.member "hygiene" listed_json in
+  check
+    int
+    "metricless active goal is counted"
+    1
+    (Yojson.Safe.Util.member "metric_missing_active_count" hygiene
+     |> Yojson.Safe.Util.to_int);
+  check
+    (list string)
+    "metricless goal is applyable"
+    [ goal.id ]
+    (get_string_list_field hygiene "applyable_goal_ids")
+;;
+
+let test_goal_hygiene_review_blocks_stale_metricless_executing_goal () =
+  with_workspace
+  @@ fun config ->
+  seed_goal_operator config ~agent_name:"operator";
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Stale metricless goal" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let old_updated_at =
+    Masc_domain.iso8601_of_unix_seconds
+      (Time_compat.now () -. Masc_time_constants.days_to_seconds 15)
+  in
+  restamp_goal_updated_at config ~goal_id:goal.id ~updated_at:old_updated_at;
+  let reviewed =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_hygiene_review"
+      ~args:(`Assoc [])
+  in
+  let reviewed_json =
+    match reviewed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_hygiene_review not handled"
+  in
+  let hygiene = Yojson.Safe.Util.member "hygiene" reviewed_json in
+  check
+    int
+    "stale executing goal counted"
+    1
+    (Yojson.Safe.Util.member "stale_executing_count" hygiene
+     |> Yojson.Safe.Util.to_int);
+  check
+    int
+    "metricless active goal counted before apply"
+    1
+    (Yojson.Safe.Util.member "metric_missing_active_count" hygiene
+     |> Yojson.Safe.Util.to_int);
+  let applied =
+    Tool_workspace.dispatch
+      (workspace_ctx ~agent_name:"operator" config)
+      ~name:"masc_goal_hygiene_review"
+      ~args:
+        (`Assoc
+            [ "apply", `Bool true
+            ; "actor", principal_json ~id:"operator"
+            ])
+  in
+  let applied_json =
+    match applied with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_hygiene_review apply not handled"
+  in
+  check
+    int
+    "one goal blocked"
+    1
+    (Yojson.Safe.Util.member "applied_count" applied_json |> Yojson.Safe.Util.to_int);
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after hygiene apply"
+  in
+  check string "goal blocked" "blocked" (Goal_phase.to_string saved_goal.phase);
+  check
+    bool
+    "review note names G-GHYG"
+    true
+    (match saved_goal.last_review_note with
+     | Some note -> contains_substring note "G-GHYG"
+     | None -> false);
+  let refreshed_hygiene = Yojson.Safe.Util.member "hygiene" applied_json in
+  check
+    int
+    "blocked goal no longer stale executing"
+    0
+    (Yojson.Safe.Util.member "stale_executing_count" refreshed_hygiene
+     |> Yojson.Safe.Util.to_int);
+  check
+    int
+    "blocked goal no longer active metricless"
+    0
+    (Yojson.Safe.Util.member "metric_missing_active_count" refreshed_hygiene
+     |> Yojson.Safe.Util.to_int)
 ;;
 
 let test_goal_list_ignores_blank_optional_filters () =
@@ -1954,6 +2087,14 @@ let () =
     [ ( "tool_workspace"
       , [ test_case "upsert and list" `Quick test_goal_upsert_and_list
         ; test_case "list filters by phase" `Quick test_goal_list_filters_by_phase
+        ; test_case
+            "list includes hygiene rollup"
+            `Quick
+            test_goal_list_includes_hygiene_rollup
+        ; test_case
+            "hygiene review blocks stale metricless executing goal"
+            `Quick
+            test_goal_hygiene_review_blocks_stale_metricless_executing_goal
         ; test_case
             "list ignores blank optional filters"
             `Quick


### PR DESCRIPTION
## Summary
- add `masc_goal_hygiene_review` for G-GHYG stale executing and active metricless goal hygiene review
- add `hygiene` rollup to `masc_goal_list` with typed issue counts and applicable goal ids
- allow operator-only `apply=true` to block executable hygiene violations without inventing metrics

## Validation
- `ocamlformat --check lib/workspace_goals.ml lib/workspace_goals.mli lib/tool_workspace.ml lib/tool_schemas/tool_schemas_workspace_extra.ml test/test_goal_tools.ml`
- `git diff --check`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- pre-rebase: `scripts/dune-local.sh build test/test_goal_tools.exe`
- pre-rebase: `./_build/default/test/test_goal_tools.exe` (32 tests)

## Note
- post-rebase focused dune rerun was attempted, but repo-local wrapper refused because another session was running bare `dune build .`; CI should be treated as build authority for this branch.