### PR TITLE
[codex] expose scheduler wake payload contract

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -732,6 +732,10 @@ describe('ScheduledAutomationPanel', () => {
       render(null, container)
       render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
 
+      const contract = container.querySelector('[data-schedule-durable-signal-contract="payload_support"]')
+      expect(contract?.getAttribute('data-schedule-durable-signal-raw')).toBe('3')
+      expect(contract?.getAttribute('data-schedule-durable-signal-visible')).toBe('1')
+      expect(contract?.getAttribute('data-schedule-durable-signal-hidden')).toBe('2')
       expect(container.querySelector('[data-schedule-signal-id="sig-supported"]')).not.toBeNull()
       expect(container.querySelector('[data-schedule-signal-id="sig-unsupported-missing-row"]')).toBeNull()
       expect(container.querySelector('[data-schedule-signal-id="sig-unknown-missing-row"]')).toBeNull()
@@ -739,6 +743,61 @@ describe('ScheduledAutomationPanel', () => {
       expect(container.querySelector('[data-schedule-signal-schedule="sched-unsupported-missing-row"]')).toBeNull()
       expect(container.querySelector('[data-schedule-signal-schedule="sched-unknown-missing-row"]')).toBeNull()
     }
+  })
+
+  it('marks request-derived fallback when all durable runner signals are hidden by payload support', () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-supported-request',
+        next_due_at: 100,
+        next_due_at_iso: '2026-06-21T00:10:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'keeper.smoke',
+        payload_support: 'supported',
+      }),
+    ])
+    auto.payload_support = {
+      supported_kinds: ['keeper.smoke'],
+      unsupported_request_count: 1,
+      unsupported_kinds: [{ kind: 'orphan_auto_release', count: 1 }],
+      unknown_request_count: 1,
+    }
+    auto.signal_source = 'schedule_runner_signals'
+    auto.signal_count = 2
+    auto.signals = [
+      signal({
+        signal_id: 'sig-unsupported-only',
+        schedule_id: 'sched-unsupported-only',
+        payload_kind: 'orphan_auto_release',
+      }),
+      signal({
+        signal_id: 'sig-unknown-only',
+        schedule_id: 'sched-unknown-only',
+      }),
+    ]
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} />`, container)
+
+    const contract = container.querySelector('[data-schedule-durable-signal-contract="payload_support"]')
+    expect(contract?.getAttribute('data-schedule-durable-signal-raw')).toBe('2')
+    expect(contract?.getAttribute('data-schedule-durable-signal-visible')).toBe('0')
+    expect(contract?.getAttribute('data-schedule-durable-signal-hidden')).toBe('2')
+    expect(contract?.textContent).toContain('payload support로 2 durable runner signal 숨김')
+    expect(contract?.textContent).toContain('request rows에서 파생했습니다')
+    expect(container.querySelector('[data-schedule-signal-id="sig-unsupported-only"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-signal-id="sig-unknown-only"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-signal-schedule="sched-supported-request"]')).not.toBeNull()
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const v2Contract = container.querySelector('[data-schedule-durable-signal-contract="payload_support"]')
+    expect(v2Contract?.getAttribute('data-schedule-durable-signal-raw')).toBe('2')
+    expect(v2Contract?.getAttribute('data-schedule-durable-signal-visible')).toBe('0')
+    expect(v2Contract?.getAttribute('data-schedule-durable-signal-hidden')).toBe('2')
+    expect(v2Contract?.textContent).toContain('payload support로 2 durable wake signal 숨김')
+    expect(container.querySelector('[data-schedule-signal-id="sig-unsupported-only"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-signal-id="sig-unknown-only"]')).toBeNull()
   })
 
   it('uses explicit ready and terminal status matching', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -276,6 +276,22 @@ function selectDurableWakeSignals(
     .sort((a, b) => signalTimestamp(a) - signalTimestamp(b))
 }
 
+function durableWakeSignalContract(automation: DashboardScheduledAutomation): {
+  rawCount: number
+  visibleCount: number
+  hiddenByPayloadSupport: number
+  visibleSignals: DashboardScheduledAutomationSignal[]
+} {
+  const visibleSignals = selectDurableWakeSignals(automation)
+  const rawCount = automation.signals?.length ?? 0
+  return {
+    rawCount,
+    visibleCount: visibleSignals.length,
+    hiddenByPayloadSupport: Math.max(0, rawCount - visibleSignals.length),
+    visibleSignals,
+  }
+}
+
 export function selectWakeSignals(
   automation: DashboardScheduledAutomation | null | undefined,
 ): WakeSignal[] {
@@ -1434,8 +1450,8 @@ function SchedulePrototypeSurface({
   const tabDef = SCH_TABS.find(definition => definition.key === tab) ?? SCH_TABS[0]!
   const filtered = rows.filter(request => schTabMatches(tabDef, request))
   // Durable runner signals (real source). Keep one feed (audit P0/P1 #9).
-  const durableSignals = selectDurableWakeSignals(automation)
-  const rawDurableSignalCount = automation.signals?.length ?? 0
+  const durableSignalContract = durableWakeSignalContract(automation)
+  const durableSignals = durableSignalContract.visibleSignals
   const selected = selectedScheduleId
     ? rows.find(request => request.schedule_id === selectedScheduleId) ?? null
     : null
@@ -1480,10 +1496,22 @@ function SchedulePrototypeSurface({
             </div>
           `}
 
-      <section class="sch-signals">
+      <section
+        class="sch-signals"
+        data-schedule-durable-signal-contract="payload_support"
+        data-schedule-durable-signal-raw=${durableSignalContract.rawCount}
+        data-schedule-durable-signal-visible=${durableSignalContract.visibleCount}
+        data-schedule-durable-signal-hidden=${durableSignalContract.hiddenByPayloadSupport}
+      >
         <div class="ov-card-h"><h3>wake signal 피드 · schedule_runner.tick</h3></div>
         ${durableSignals.length === 0
-          ? html`<div class="sch-empty" data-stub="no durable runner signals">${rawDurableSignalCount > 0 ? '표시 가능한 durable wake signal 없음' : 'durable wake signal 없음'}</div>`
+          ? html`
+              <div class="sch-empty" data-stub="no durable runner signals">
+                ${durableSignalContract.hiddenByPayloadSupport > 0
+                  ? `payload support로 ${durableSignalContract.hiddenByPayloadSupport.toLocaleString()} durable wake signal 숨김`
+                  : 'durable wake signal 없음'}
+              </div>
+            `
           : html`
               <div class="sch-sig-list">
                 ${durableSignals.map(signal => {
@@ -1700,8 +1728,9 @@ export function ScheduledAutomationPanel({
   const wakeRows = rows
     .filter(canProjectUpcomingWake)
     .sort((a, b) => dueTimestamp(a) - dueTimestamp(b))
-  const durableSignals = selectDurableWakeSignals(automation)
-  const rawDurableSignalCount = automation.signals?.length ?? 0
+  const durableSignalContract = durableWakeSignalContract(automation)
+  const durableSignals = durableSignalContract.visibleSignals
+  const rawDurableSignalCount = durableSignalContract.rawCount
   const hasDurableSignals = durableSignals.length > 0
   const selectedRequest =
     rows.find(request => request.schedule_id === selectedScheduleId)
@@ -1837,15 +1866,22 @@ export function ScheduledAutomationPanel({
               </div>
               <aside class="grid content-start gap-2">
                 <${ScheduleDetailPanel} request=${selectedRequest} onResolved=${onResolved} />
-                <div>
+                <div
+                  data-schedule-durable-signal-contract="payload_support"
+                  data-schedule-durable-signal-raw=${durableSignalContract.rawCount}
+                  data-schedule-durable-signal-visible=${durableSignalContract.visibleCount}
+                  data-schedule-durable-signal-hidden=${durableSignalContract.hiddenByPayloadSupport}
+                >
                   <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
                     ${hasDurableSignals ? 'durable wake signal feed' : 'request-derived wake signal feed'}
                   </div>
                   <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
                     ${hasDurableSignals
                       ? `출처 ${automation.signal_source ?? 'schedule_runner_signals'} · ${durableSignals.length.toLocaleString()} / ${(automation.signal_count ?? durableSignals.length).toLocaleString()} signals 표시`
-                      : rawDurableSignalCount > 0
-                        ? '표시 가능한 durable runner signal이 없어 request rows에서 파생했습니다.'
+                      : durableSignalContract.hiddenByPayloadSupport > 0
+                        ? `payload support로 ${durableSignalContract.hiddenByPayloadSupport.toLocaleString()} durable runner signal 숨김 · request rows에서 파생했습니다.`
+                        : rawDurableSignalCount > 0
+                          ? '표시 가능한 durable runner signal이 없어 request rows에서 파생했습니다.'
                         : 'durable runner signal이 없어 request rows에서 파생했습니다.'}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- expose the durable wake signal payload-support contract in the scheduler panel DOM
- show raw/visible/hidden durable signal counts for diagnostics and v2 surfaces
- mark request-derived fallback when all durable runner signals are hidden by supported payload kinds

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts src/components/schedule/schedule-surface.test.ts src/components/tools/tools-main.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- pnpm --dir dashboard run build
- GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py
- git diff --check

## Notes
- No local Dune build was run; Dune remains CI authority for this repo.