### PR TITLE
dashboard: prove keeper config live-backed fields

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -89,6 +89,38 @@ function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['workspace
     .filter((item): item is KeeperConfig['workspace']['active_goals'][number] => item !== null)
 }
 
+function dedupeStringList(values: readonly string[]): string[] {
+  return Array.from(new Set(values.filter(value => value.trim() !== '').map(value => value.trim())))
+}
+
+function collectRawFieldPaths(raw: unknown, prefix = ''): string[] {
+  if (!isRecord(raw)) return []
+  const paths: string[] = []
+  for (const [key, value] of Object.entries(raw)) {
+    if (prefix === '' && key === 'field_presence') continue
+    const path = prefix === '' ? key : `${prefix}.${key}`
+    paths.push(path)
+    paths.push(...collectRawFieldPaths(value, path))
+  }
+  return paths
+}
+
+function normalizeKeeperConfigFieldPresence(data: Record<string, unknown>): KeeperConfig['field_presence'] {
+  const raw = isRecord(data.field_presence) ? data.field_presence : null
+  const presentPaths = raw
+    ? normalizeStringList(raw.present_paths)
+    : collectRawFieldPaths(data)
+  return {
+    schema: raw
+      ? asNullableString(raw.schema) ?? 'keeper.config.field_presence.v1'
+      : 'keeper.config.field_presence.client-derived.v1',
+    producer: raw
+      ? asNullableString(raw.producer) ?? 'unknown'
+      : 'dashboard-keeper-config.normalizer',
+    present_paths: dedupeStringList(presentPaths),
+  }
+}
+
 function normalizePromptBlock(raw: unknown, fallbackKey: string): { key: string; source: string; text: string } {
   if (!isRecord(raw)) {
     return {
@@ -278,6 +310,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       last_output_tokens_per_sec: asLooseNullableNumber(metrics.last_output_tokens_per_sec),
       compaction_count: asInt(metrics.compaction_count) ?? 0,
     },
+    field_presence: normalizeKeeperConfigFieldPresence(data),
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2078,6 +2078,70 @@ describe('fetchKeeperConfig', () => {
     expect(result.workspace.active_goal_ids).toEqual(['goal-runtime'])
     expect(result.workspace.active_goals[0]?.title).toBe('Ship runtime clarity')
     expect(result.runtime_trust?.disposition).toBe('Pass')
+    expect(result.field_presence?.present_paths).toContain('prompt.system_prompt_blocks.capabilities.text')
+    expect(result.field_presence?.present_paths).toContain('tools.tool_access')
+    expect(result.field_presence?.producer).toBe('dashboard-keeper-config.normalizer')
+  })
+
+  it('tracks raw keeper config field presence before defaults are normalized', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'keeper-sangsu',
+          prompt: {
+            goal: 'raw goal only',
+          },
+          metrics: {},
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperConfig('keeper-sangsu')
+
+    expect(result.prompt.goal).toBe('raw goal only')
+    expect(result.prompt.instructions).toBe('')
+    expect(result.metrics.last_model_used).toBe('')
+    expect(result.field_presence?.present_paths).toContain('prompt.goal')
+    expect(result.field_presence?.present_paths).toContain('metrics')
+    expect(result.field_presence?.present_paths).not.toContain('prompt.instructions')
+    expect(result.field_presence?.present_paths).not.toContain('metrics.last_model_used')
+  })
+
+  it('preserves backend keeper config field-presence proof when supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'keeper-sangsu',
+          field_presence: {
+            schema: 'keeper.config.field_presence.v1',
+            producer: 'dashboard_http_keeper_snapshot',
+            present_paths: ['name', 'prompt', 'prompt.goal'],
+          },
+          prompt: {
+            goal: 'server proof',
+            instructions: 'present but intentionally absent from proof',
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperConfig('keeper-sangsu')
+
+    expect(result.field_presence).toEqual({
+      schema: 'keeper.config.field_presence.v1',
+      producer: 'dashboard_http_keeper_snapshot',
+      present_paths: ['name', 'prompt', 'prompt.goal'],
+    })
   })
 
   it('normalizes default per-provider timeout mode without legacy label', async () => {

--- a/dashboard/src/components/keeper-cognition-inspector.test.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.test.ts
@@ -65,6 +65,25 @@ describe('KeeperCognitionInspector', () => {
     expect(rows.find(row => row.label === 'approval policy')?.value).toBe('3 allow · 1 deny · 2 persisted')
   })
 
+  it('does not fabricate social runtime success while recognition is missing', () => {
+    expect(
+      toolAccessRowsForKeeper(keeper({ social_model_recognized: null }))
+        .find(row => row.label === 'social runtime')?.value,
+    ).toBe('unknown')
+    expect(
+      toolAccessRowsForKeeper(keeper({}))
+        .find(row => row.label === 'social runtime')?.value,
+    ).toBe('unknown')
+    expect(
+      toolAccessRowsForKeeper(keeper({ social_model_recognized: true }))
+        .find(row => row.label === 'social runtime')?.value,
+    ).toBe('recognized')
+    expect(
+      toolAccessRowsForKeeper(keeper({ social_model_recognized: false }))
+        .find(row => row.label === 'social runtime')?.value,
+    ).toBe('needs attention')
+  })
+
   it('renders the tool access focus surface from the cognition keeper route', () => {
     const container = document.createElement('div')
     keepers.value = [

--- a/dashboard/src/components/keeper-cognition-inspector.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.ts
@@ -57,6 +57,12 @@ function listLabel(values: readonly string[] | null | undefined): string {
   return clean.length === 0 ? '-' : clean.join(' · ')
 }
 
+function socialRuntimeLabel(recognized: boolean | null | undefined): string {
+  if (recognized === false) return 'needs attention'
+  if (recognized === true) return 'recognized'
+  return 'unknown'
+}
+
 export function toolAccessRowsForKeeper(keeper: Keeper): ToolAccessRow[] {
   const policy = keeper.approval_policy_effective
   const recentTools = keeper.recent_tool_names?.length
@@ -93,7 +99,7 @@ export function toolAccessRowsForKeeper(keeper: Keeper): ToolAccessRow[] {
     },
     {
       label: 'social runtime',
-      value: keeper.social_model_recognized === false ? 'needs attention' : 'runtime',
+      value: socialRuntimeLabel(keeper.social_model_recognized),
     },
   ]
 }

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -425,6 +425,23 @@ describe('keeperConfigControlInventory', () => {
     expect(contextStatus.kind).toBe('ok')
   })
 
+  it('uses backend field-presence proof instead of normalized defaults for contract gaps', () => {
+    const c = makeKeeperConfig({
+      field_presence: {
+        schema: 'keeper.config.field_presence.v1',
+        producer: 'dashboard_http_keeper_snapshot',
+        present_paths: ['hooks', 'hooks.slots'],
+      },
+    })
+
+    const hookSlots = findItem('hooks', c, 'kcf-hooks-slots')
+    const hookStatus = keeperConfigControlContractStatus(hookSlots.contracts, c)
+
+    expect(c.hooks?.deny_list).toEqual([])
+    expect(hookStatus.kind).toBe('missing-config-field')
+    expect(hookStatus.missingConfigFields).toEqual(['hooks.deny_list', 'hooks.cost_budget'])
+  })
+
   it('keeps separate API writers live even when runtime manifest writes are unsupported', () => {
     const base = makeKeeperConfig()
     const persona = makeKeeperConfig({

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -439,6 +439,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function keeperConfigHasField(config: KeeperConfig, path: KeeperConfigFieldPath): boolean {
+  const presentPaths = config.field_presence?.present_paths
+  if (presentPaths) return presentPaths.includes(path)
+
   let current: unknown = config
   for (const segment of path.split('.')) {
     if (!isRecord(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1539,6 +1539,12 @@ interface KeeperConfigLimits {
   max_context_override_tokens: number | null
 }
 
+export interface KeeperConfigFieldPresence {
+  schema: string
+  producer: string
+  present_paths: string[]
+}
+
 export interface KeeperHookSlot {
   active: boolean
   source: string
@@ -1580,4 +1586,5 @@ export interface KeeperConfig {
   tools: KeeperConfigTools
   sources: KeeperConfigSources
   metrics: KeeperConfigMetrics
+  field_presence?: KeeperConfigFieldPresence
 }

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -7,6 +7,35 @@ open Dashboard_http_keeper_types
 open Dashboard_http_helpers
 open Keeper_status_bridge
 
+let keeper_config_field_presence_json config_json =
+  let rec collect prefix json acc =
+    match json with
+    | `Assoc fields ->
+      List.fold_left
+        (fun acc (key, value) ->
+          let path = if prefix = "" then key else prefix ^ "." ^ key in
+          collect path value (path :: acc))
+        acc
+        fields
+    | _ -> acc
+  in
+  let present_paths =
+    collect "" config_json [] |> List.sort_uniq String.compare
+  in
+  `Assoc
+    [ ("schema", `String "keeper.config.field_presence.v1")
+    ; ("producer", `String "dashboard_http_keeper_snapshot")
+    ; ("present_paths", Json_util.json_string_list present_paths)
+    ]
+;;
+
+let with_keeper_config_field_presence = function
+  | `Assoc fields as config_json ->
+    `Assoc
+      (fields @ [ ("field_presence", keeper_config_field_presence_json config_json) ])
+  | other -> other
+;;
+
 (** Build a structured config JSON for a single keeper, grouped by category.
     Returns (http_status, json). *)
 let keeper_config_json (config : Workspace.config) (name : string)
@@ -285,7 +314,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
         | Some entry -> entry.last_error
         | None -> None
       in
-      (`OK,
+      let body =
        `Assoc [
          ("name", `String m.name);
          ("active_goal_ids", active_goal_ids_json);
@@ -325,7 +354,9 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("workspace", workspace);
          ("sources", source_provenance_json config m);
          ("metrics", metrics);
-       ])
+       ]
+      in
+      (`OK, with_keeper_config_field_presence body)
 
 (** Per-keeper cost/latency aggregates for the O4 cost dashboard.
 


### PR DESCRIPTION
## Summary
- Add server-generated `field_presence.present_paths` to `/api/v1/keepers/:name/config` so Keeper config controls can prove which fields were actually projected.
- Make the Keeper config control ledger validate against raw/backend field presence instead of normalized defaults, preventing fabricated defaults from looking live-backed.
- Stop the cognition inspector from rendering missing `social_model_recognized` as the fake successful `runtime` value; it now distinguishes `unknown`, `recognized`, and `needs attention`.

## Validation
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/keeper-config-panel.test.ts src/components/keeper-cognition-inspector.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `opam exec -- ocamlformat --check lib/dashboard/dashboard_http_keeper_snapshot.ml`
- `scripts/dune-local.sh build lib/dashboard/masc_dashboard.cmxa`

## Task Notes
- Related to #23309 / MASC task-1823.
- This closes the live-backed field proof slice and one social-runtime fake value. Remaining audit items include broader redacted runtime/model labels, bootstrap synthetic-empty metadata, state-diagram placeholders, and runtime-lens lane completeness.