### PR TITLE
[codex] Gate keeper provider cooldown before dispatch

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -646,71 +646,103 @@ let run_named
             ~max_concurrent:runtime.Runtime.binding.max_concurrent
             provider_config
         in
-        let name = Printf.sprintf "oas-%s" attempt_runtime_id in
-        let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
-          { runtime_id = attempt_runtime_id
-          ; error_runtime_id
-          ; base_path
-          ; keeper_name
-          ; name
-          ; goal
-          ; goal_blocks
-          ; priority
-          ; session_id
-          ; system_prompt
-          ; tools
-          ; initial_messages
-          ; max_turns
-          ; max_idle_turns
-          ; stream_idle_timeout_s
-          ; execution_idle_timeout_s
-          ; body_timeout_s
-          ; temperature
-          ; max_tokens = inference_policy.attempt_max_tokens
-          ; accept
-          ; guardrails
-          ; hooks
-          ; context_reducer
-          ; raw_trace
-          ; transport_resolved
-          ; runtime_mcp_policy
-          ; allowed_paths
-          ; checkpoint_sidecar
-          ; cache_system_prompt
-          ; yield_on_tool
-          ; compact_ratio
-          ; context_window_tokens
-          ; oas_auto_context_overflow_retry
-          ; checkpoint_dir
-          ; context_injector
-          ; context
-          ; enable_thinking = inference_policy.attempt_enable_thinking
-          ; preserve_thinking = inference_policy.attempt_preserve_thinking
-          ; approval
-          ; exit_condition
-          ; exit_condition_result
-          ; summarizer
-          ; oas_checkpoint
-          ; trace_link
-          ; sw
-          ; net
-          ; on_event
-          ; on_yield
-          ; on_resume
-          ; agent_ref
-          ; on_runtime_observation
-          ; event_bus
-          ; runtime_manifest_context
-          ; runtime_manifest_append
-          ; turn_start
-          ; seq_ref
-          }
-        in
-        let result, checkpoint_after, _success_sample =
-          Keeper_turn_driver_try_provider.run_try_provider
-            try_provider_ctx ?resume_checkpoint ?per_provider_timeout_s candidate
-        in
-        result, checkpoint_after))
+        match provider_cooldown_block ~keeper_name candidate with
+        | Some block ->
+          emit_runtime_manifest
+            ~status:"provider_cooldown"
+            ~decision:(provider_cooldown_block_decision block)
+            Keeper_runtime_manifest.Provider_attempt_finished;
+          ( Error
+              (provider_cooldown_block_error
+                 ~runtime_id:attempt_runtime_id
+                 block)
+          , None )
+        | None ->
+          let name = Printf.sprintf "oas-%s" attempt_runtime_id in
+          let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
+            { runtime_id = attempt_runtime_id
+            ; error_runtime_id
+            ; base_path
+            ; keeper_name
+            ; name
+            ; goal
+            ; goal_blocks
+            ; priority
+            ; session_id
+            ; system_prompt
+            ; tools
+            ; initial_messages
+            ; max_turns
+            ; max_idle_turns
+            ; stream_idle_timeout_s
+            ; execution_idle_timeout_s
+            ; body_timeout_s
+            ; temperature
+            ; max_tokens = inference_policy.attempt_max_tokens
+            ; accept
+            ; guardrails
+            ; hooks
+            ; context_reducer
+            ; raw_trace
+            ; transport_resolved
+            ; runtime_mcp_policy
+            ; allowed_paths
+            ; checkpoint_sidecar
+            ; cache_system_prompt
+            ; yield_on_tool
+            ; compact_ratio
+            ; context_window_tokens
+            ; oas_auto_context_overflow_retry
+            ; checkpoint_dir
+            ; context_injector
+            ; context
+            ; enable_thinking = inference_policy.attempt_enable_thinking
+            ; preserve_thinking = inference_policy.attempt_preserve_thinking
+            ; approval
+            ; exit_condition
+            ; exit_condition_result
+            ; summarizer
+            ; oas_checkpoint
+            ; trace_link
+            ; sw
+            ; net
+            ; on_event
+            ; on_yield
+            ; on_resume
+            ; agent_ref
+            ; on_runtime_observation
+            ; event_bus
+            ; runtime_manifest_context
+            ; runtime_manifest_append
+            ; turn_start
+            ; seq_ref
+            }
+          in
+          let provider_attempt_started_at = Mtime_clock.now () in
+          let result, checkpoint_after, _success_sample =
+            Keeper_turn_driver_try_provider.run_try_provider
+              try_provider_ctx ?resume_checkpoint ?per_provider_timeout_s candidate
+          in
+          let latency_ms =
+            let ns =
+              Mtime.Span.to_uint64_ns
+                (Mtime.span provider_attempt_started_at (Mtime_clock.now ()))
+            in
+            Int64.to_float ns /. 1_000_000.
+          in
+          (match result with
+           | Ok _ ->
+             record_candidate_health_success
+               ~keeper_name
+               candidate
+               ~latency_ms
+           | Error err ->
+             (match classify_masc_internal_error err with
+              | Some (Accept_rejected { reason; _ }) ->
+                record_candidate_health_rejected ~keeper_name candidate ~reason
+              | Some _ | None ->
+                record_candidate_health_error ~keeper_name candidate err));
+          result, checkpoint_after))
     attempt_runtimes
 
 
@@ -718,6 +750,8 @@ module For_testing = struct
   let checkpoint_after_attempt = checkpoint_after_attempt
   let success_selected_model_raw = success_selected_model_raw
   let record_candidate_health_error = record_candidate_health_error
+  let provider_cooldown_block = provider_cooldown_block
+  let provider_cooldown_block_error = provider_cooldown_block_error
   let apply_accept = Keeper_turn_driver_try_provider.For_testing.apply_accept
   let max_execution_time_for_attempt =
     Keeper_turn_driver_try_provider.For_testing.max_execution_time_for_attempt

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -179,6 +179,16 @@ module For_testing : sig
   val record_candidate_health_error :
     keeper_name:string -> Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
 
+  val provider_cooldown_block :
+    keeper_name:string ->
+    Runtime_candidate.t ->
+    Keeper_turn_driver_provider_attempt.provider_cooldown_block option
+
+  val provider_cooldown_block_error :
+    runtime_id:string ->
+    Keeper_turn_driver_provider_attempt.provider_cooldown_block ->
+    Agent_sdk.Error.sdk_error
+
   val apply_accept :
     ?initial_messages:Agent_sdk.Types.message list ->
     runtime_id:string ->

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -138,10 +138,96 @@ let scoped_provider_key ~keeper_name provider_key =
   if String.equal keeper_name "" then provider_key
   else keeper_name ^ "@" ^ provider_key
 
-let record_candidate_health_success ~keeper_name candidate ~latency_ms =
+let scoped_health_keys ~keeper_name candidate =
   Runtime_candidate.health_keys candidate
+  |> List.map (scoped_provider_key ~keeper_name)
+
+let credential_pool_health_keys ~keeper_name candidate =
+  Runtime_candidate.health_keys candidate
+  |> List.concat_map (fun provider_key ->
+    let scoped_key = scoped_provider_key ~keeper_name provider_key in
+    if String.equal scoped_key provider_key
+    then [ provider_key ]
+    else [ scoped_key; provider_key ])
+  |> List.sort_uniq String.compare
+
+type provider_cooldown_block =
+  { blocked_provider_keys : string list
+  ; cooldown_remaining_sec : int
+  }
+
+let cooldown_remaining_sec_of_info info =
+  match info.Keeper_binding_health.cooldown_expires_at with
+  | None -> 0
+  | Some expires_at ->
+    int_of_float (Float.max 0.0 (Float.ceil (expires_at -. Time_compat.now ())))
+
+let provider_cooldown_block ~keeper_name candidate =
+  let provider_keys = Runtime_candidate.health_keys candidate in
+  let blocking_info_for_key provider_key =
+    let scoped_key = scoped_provider_key ~keeper_name provider_key in
+    let keys =
+      if String.equal scoped_key provider_key
+      then [ provider_key ]
+      else [ scoped_key; provider_key ]
+    in
+    keys
+    |> List.filter_map (fun provider_key ->
+      Keeper_binding_health.provider_info
+        Keeper_binding_health.global
+        ~provider_key
+      |> Option.map (fun info -> (provider_key, info)))
+    |> List.find_opt (fun (_, info) -> info.Keeper_binding_health.in_cooldown)
+  in
+  match provider_keys with
+  | [] -> None
+  | _ ->
+    let provider_infos =
+      provider_keys
+      |> List.filter_map blocking_info_for_key
+    in
+    if List.length provider_infos <> List.length provider_keys
+    then None
+    else
+      let cooldown_remaining_sec =
+        provider_infos
+        |> List.map (fun (_, info) -> cooldown_remaining_sec_of_info info)
+        |> function
+        | [] -> 0
+        | first :: rest -> List.fold_left min first rest
+      in
+      let blocked_provider_keys = List.map fst provider_infos in
+      Some { blocked_provider_keys; cooldown_remaining_sec }
+
+let provider_cooldown_block_decision block =
+  `Assoc
+    [ "blocker", `String "provider_cooldown"
+    ; "provider_attempt_started", `Bool false
+    ; ( "blocked_provider_keys"
+      , `List (List.map (fun key -> `String key) block.blocked_provider_keys) )
+    ; "cooldown_remaining_sec", `Int block.cooldown_remaining_sec
+    ; "retry_after_source", `String "provider_health_cooldown"
+    ]
+
+let provider_cooldown_block_error ~runtime_id block =
+  let retry_after =
+    if block.cooldown_remaining_sec > 0
+    then
+      Keeper_internal_error.Synthetic_default
+        (float_of_int block.cooldown_remaining_sec)
+    else Keeper_internal_error.No_retry_hint
+  in
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Capacity_backpressure
+       { runtime_id
+       ; source = Keeper_internal_error.Provider_capacity
+       ; detail = "provider health cooldown active before dispatch"
+       ; retry_after
+       })
+
+let record_candidate_health_success ~keeper_name candidate ~latency_ms =
+  scoped_health_keys ~keeper_name candidate
   |> List.iter (fun provider_key ->
-    let provider_key = scoped_provider_key ~keeper_name provider_key in
     Keeper_binding_health.record_success
       Keeper_binding_health.global
       ~provider_key
@@ -150,9 +236,8 @@ let record_candidate_health_success ~keeper_name candidate ~latency_ms =
 
 let record_candidate_health_rejected ~keeper_name candidate ~reason =
   let error_kind = health_error_kind "accept_rejected" in
-  Runtime_candidate.health_keys candidate
+  scoped_health_keys ~keeper_name candidate
   |> List.iter (fun provider_key ->
-    let provider_key = scoped_provider_key ~keeper_name provider_key in
     Keeper_binding_health.record_rejected
       Keeper_binding_health.global
       ~provider_key
@@ -375,9 +460,8 @@ let record_candidate_health_error ~keeper_name candidate sdk_err =
   if sdk_error_is_hard_quota sdk_err
   then (
     let error_kind = health_error_kind "hard_quota" in
-    health_keys
+    credential_pool_health_keys ~keeper_name candidate
     |> List.iter (fun provider_key ->
-      let provider_key = scoped_provider_key ~keeper_name provider_key in
       Keeper_binding_health.record_hard_quota
         Keeper_binding_health.global
         ~provider_key
@@ -412,9 +496,8 @@ let record_candidate_health_error ~keeper_name candidate sdk_err =
     match sdk_error_soft_rate_limited sdk_err with
     | Some retry_after_s ->
       let error_kind = health_error_kind "soft_rate_limited" in
-      health_keys
+      credential_pool_health_keys ~keeper_name candidate
       |> List.iter (fun provider_key ->
-        let provider_key = scoped_provider_key ~keeper_name provider_key in
         Keeper_binding_health.record_soft_rate_limited
           Keeper_binding_health.global
           ~provider_key

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -68,6 +68,20 @@ val success_selected_model_raw :
 
 val health_error_kind : string -> Keeper_binding_health.error_kind
 
+type provider_cooldown_block =
+  { blocked_provider_keys : string list
+  ; cooldown_remaining_sec : int
+  }
+
+val provider_cooldown_block :
+  keeper_name:string -> Runtime_candidate.t -> provider_cooldown_block option
+
+val provider_cooldown_block_decision :
+  provider_cooldown_block -> Yojson.Safe.t
+
+val provider_cooldown_block_error :
+  runtime_id:string -> provider_cooldown_block -> Agent_sdk.Error.sdk_error
+
 val record_candidate_health_success :
   keeper_name:string -> Runtime_candidate.t -> latency_ms:float -> unit
 

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -686,6 +686,93 @@ let test_provider_unavailable_records_server_error_cooldown () =
        ~window_s:BH.window_sec)
 ;;
 
+let test_soft_rate_limit_cooldown_blocks_candidate_before_dispatch () =
+  let candidate =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"pre-dispatch-rate-limit-test"
+      ~base_url:"https://pre-dispatch-rate-limit.example/v1"
+      ()
+    |> RC.of_provider_config ~max_concurrent:None
+  in
+  let keeper_name = "pre-dispatch-rate-limit-cooldown-test" in
+  let raw_provider_key =
+    match RC.health_keys candidate with
+    | [ key ] -> key
+    | keys ->
+      Alcotest.failf
+        "expected one health key, got [%s]"
+        (String.concat "; " keys)
+  in
+  let provider_key = keeper_name ^ "@" ^ raw_provider_key in
+  let err =
+    SdkE.Api
+      (Retry.RateLimited
+         { retry_after = Some 45.0; message = "transient rate limit" })
+  in
+  KTD.For_testing.record_candidate_health_error ~keeper_name candidate err;
+  let info =
+    match BH.provider_info BH.global ~provider_key with
+    | Some info -> info
+    | None -> Alcotest.failf "expected provider info for %s" provider_key
+  in
+  Alcotest.(check bool) "soft rate limit opens cooldown" true info.in_cooldown;
+  let block =
+    match KTD.For_testing.provider_cooldown_block ~keeper_name candidate with
+    | Some block -> block
+    | None -> Alcotest.fail "expected provider cooldown block"
+  in
+  Alcotest.(check (list string))
+    "blocked provider key"
+    [ provider_key ]
+    block.blocked_provider_keys;
+  Alcotest.(check bool)
+    "remaining cooldown is positive"
+    true
+    (block.cooldown_remaining_sec > 0);
+  let other_keeper_block =
+    match
+      KTD.For_testing.provider_cooldown_block
+        ~keeper_name:"pre-dispatch-rate-limit-other-keeper"
+        candidate
+    with
+    | Some block -> block
+    | None -> Alcotest.fail "expected credential-pool cooldown block"
+  in
+  Alcotest.(check (list string))
+    "credential-pool key blocks other keeper"
+    [ raw_provider_key ]
+    other_keeper_block.blocked_provider_keys;
+  let mapped =
+    KTD.For_testing.provider_cooldown_block_error
+      ~runtime_id:"runtime.pre-dispatch-rate-limit"
+      block
+  in
+  match KTD.classify_masc_internal_error mapped with
+  | Some
+      (KTD.Capacity_backpressure
+         { source = KTD.Provider_capacity
+         ; retry_after = KTD.Synthetic_default retry_after
+         ; detail
+         ; _
+         }) ->
+    Alcotest.(check string)
+      "detail is explicit"
+      "provider health cooldown active before dispatch"
+      detail;
+    Alcotest.(check bool)
+      "synthetic retry-after preserves cooldown"
+      true
+      (retry_after > 0.0)
+  | Some other ->
+    Alcotest.failf
+      "expected capacity_backpressure, got %s"
+      (KTD.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "expected typed keeper error, got %s"
+      (Agent_sdk.Error.to_string mapped)
+;;
+
 let test_read_only_no_progress_rotates_to_default_runtime () =
   init_rate_limit_pool_runtime ();
   let err = read_only_no_progress_err ~scope:"same.b" in
@@ -806,6 +893,10 @@ let () =
             "provider unavailable records server_error cooldown"
             `Quick
             test_provider_unavailable_records_server_error_cooldown
+        ; Alcotest.test_case
+            "soft rate limit blocks candidate before dispatch"
+            `Quick
+            test_soft_rate_limit_cooldown_blocks_candidate_before_dispatch
         ; Alcotest.test_case
             "generic accept rejection is completion contract violation"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -66,6 +66,15 @@ let retryable_network_error message =
     (Agent_sdk.Retry.NetworkError
        { message; kind = Llm_provider.Http_client.Unknown })
 
+let provider_cooldown_backpressure_error runtime_id =
+  Driver.sdk_error_of_masc_internal_error
+    (Driver.Capacity_backpressure
+       { runtime_id
+       ; source = Driver.Provider_capacity
+       ; detail = "provider health cooldown active before dispatch"
+       ; retry_after = Driver.Synthetic_default 30.0
+       })
+
 let accept_empty_no_progress_error scope =
   Driver.sdk_error_of_masc_internal_error
     (Driver.Accept_rejected
@@ -775,6 +784,59 @@ let test_attempt_loop_does_not_gate_network_retry () =
     4
     (List.length !events)
 
+let test_attempt_loop_retries_provider_cooldown_with_checkpoint () =
+  let attempts = ref [] in
+  let events = ref [] in
+  let checkpoint_after_primary = checkpoint_with_session_id "after-primary" in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"resilient"
+      ~runtime_id_of:(fun runtime_id -> runtime_id)
+      ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~run_attempt:(fun ?resume_checkpoint ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "primary.test_model" ->
+          Alcotest.(check bool)
+            "primary starts from initial checkpoint"
+            false
+            (Option.is_some resume_checkpoint);
+          ( Error (provider_cooldown_backpressure_error runtime_id)
+          , Some checkpoint_after_primary )
+        | "fallback.test_model" ->
+          Alcotest.(check (option string))
+            "fallback receives post-cooldown checkpoint"
+            (Some "after-primary")
+            (Option.map
+               (fun (cp : Agent_sdk.Checkpoint.t) -> cp.session_id)
+               resume_checkpoint);
+          Ok runtime_id, None
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "primary.test_model"; "fallback.test_model" ]
+  in
+  (match result with
+   | Ok runtime_id ->
+     Alcotest.(check string) "fallback selected" "fallback.test_model" runtime_id
+   | Error e ->
+     Alcotest.failf
+       "expected fallback success, got %s"
+       (Agent_sdk.Error.to_string e));
+  Alcotest.(check (list string))
+    "attempted candidates"
+    [ "primary.test_model"; "fallback.test_model" ]
+    !attempts;
+  let events = List.rev !events in
+  Alcotest.(check (list string))
+    "manifest events"
+    (List.map event_name
+       [
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_failed;
+         Runtime_manifest.Runtime_routed;
+         Runtime_manifest.Runtime_completed;
+       ])
+    (List.map (fun (event, _, _) -> event_name event) events)
+
 let test_attempt_loop_preserves_last_sdk_error () =
   let events = ref [] in
   let result =
@@ -870,6 +932,10 @@ let () =
             "attempt loop does not gate network retry"
             `Quick
             test_attempt_loop_does_not_gate_network_retry;
+          Alcotest.test_case
+            "attempt loop retries provider cooldown with checkpoint"
+            `Quick
+            test_attempt_loop_retries_provider_cooldown_with_checkpoint;
           Alcotest.test_case
             "attempt loop preserves last SDK error"
             `Quick


### PR DESCRIPTION
## Goal

G-REL follow-up from `Keeper Write-Path, Credential, Goal-Loop Audit & Goal Matrix - 2026-07-05.html`.

Live receipt sample before this slice (last 7d, `/Users/dancer/me/.masc/keepers/*/execution-receipts/*/*.jsonl`):

- total receipts: 44,605
- failed receipts: 6,013 (13.481%)
- `api_error_rate_limited`: 3,765 (largest terminal reason)

## Changes

- Restore provider-health recording on the live `Keeper_turn_driver.run_named` attempt path.
  - accepted response records success with latency
  - accept rejection records rejected health
  - provider/runtime error records typed health error
- Add pre-dispatch provider cooldown gate before `run_try_provider`.
  - cooled candidate emits a non-silent `Provider_attempt_finished` manifest with `provider_attempt_started=false`
  - returns typed `Capacity_backpressure` so lane fallback can try the next runtime candidate
- Record hard quota and soft rate-limit health on both keeper-scoped keys and credential-pool provider keys.
  - a soft 429 from one keeper now blocks the same provider candidate for other keepers before dispatch
  - success remains keeper-scoped, so one keeper success does not clear a fleet/account cooldown
- Add focused regression tests for:
  - soft rate-limit cooldown blocking before dispatch, including another keeper via credential-pool key
  - provider-cooldown typed backpressure preserving lane fallback checkpoint flow

## Validation

- `ocamlformat --check lib/keeper/keeper_turn_driver_provider_attempt.ml lib/keeper/keeper_turn_driver_provider_attempt.mli lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli test/test_keeper_sdk_error_typed_bridge.ml test/test_keeper_turn_driver_failover.ml`
- `git diff --check origin/main..HEAD`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

Focused local dune build was attempted:

- `scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe test/test_keeper_turn_driver_failover.exe`
- blocked by an unrelated live bare `dune build .` process (`PID 33803`), so CI is the dune build authority for this PR.
