### PR TITLE
[codex] split dashboard delta payload serialization

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1037,6 +1037,45 @@ describe('dashboard websocket route subscriptions', () => {
     expect(dashboardWsLastSeq.value).toBe(42)
   })
 
+  it('hydrates payload-only dashboard deltas without acking', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+    const sentBeforeDelta = socket.sent.length
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: {
+        slice: 'execution',
+        event_type: 'execution_snapshot',
+        payload: { agents: [] },
+      },
+    })
+
+    expect(dashboardWsLastSeq.value).toBe(1)
+    expect(socket.sent).toHaveLength(sentBeforeDelta)
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'execution',
+      { agents: [] },
+      'execution_snapshot',
+    )
+  })
+
   it('parses inbound deltas inline on the main thread', async () => {
     installWebSocketMocks()
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -678,6 +678,8 @@ function applyDelta(raw: unknown): void {
       })
     }
     noteDashboardWsEvent()
+    // Server fan-out may split one logical delta into a shared payload frame
+    // and a small per-session seq frame. A seq-only frame is an ACK checkpoint.
     if (typeof delta.slice !== 'string') return
     hydrateRouteDashboardSlice(
       delta.slice,

--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -107,6 +107,11 @@ let metric_ws_slice_fanout_skipped = Otel_metric_store_core.declare_counter "mas
 let metric_ws_bytes_sent = Otel_metric_store_core.declare_counter "masc_ws_bytes_sent_total"
 let metric_grpc_bytes_sent = Otel_metric_store_core.declare_counter "masc_grpc_bytes_sent_total"
 let metric_ws_delta_built = Otel_metric_store_core.declare_counter "masc_ws_delta_built_total"
+
+let metric_ws_delta_payload_serializations =
+  Otel_metric_store_core.declare_counter "masc_ws_delta_payload_serializations_total"
+;;
+
 let metric_ws_message_bytes = "masc_ws_message_bytes"
 
 let metric_grpc_backlog_replay_lines_scanned =

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -148,6 +148,7 @@ val metric_ws_slice_fanout_skipped : string
 val metric_ws_bytes_sent : string
 val metric_grpc_bytes_sent : string
 val metric_ws_delta_built : string
+val metric_ws_delta_payload_serializations : string
 
 (** Histogram of WebSocket message payload size in bytes, observed at
     the wire boundary. Labels: [direction = send | recv]. Complements

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -366,6 +366,11 @@ let jsonrpc_notification method_ params =
       ("params", params);
     ]
 
+type dashboard_delta_payload_frame = {
+  slice: string;
+  text: string;
+}
+
 (* Cross-domain-safe seq allocator: [fetch_and_add] atomically claims a unique
    slot, so two domains never hand out the same seq.  The old plain
    read-modify-write lost ~half its updates under true parallelism (RFC-0204
@@ -647,7 +652,7 @@ let parse_cache : (string * parsed_sse_event option) Atomic.t =
     [Yojson.Safe.from_string].
 
     The earlier implementation skipped this step, so every production
-    parse failed and dashboard_delta_for_sse always fell through to
+    parse failed and send_dashboard_delta_for_sse always fell through to
     raw-SSE-forward — defeating the parse cache, slice-aware fanout
     (Phase 2 of #10119), and delta-built counter.  Pure-JSON inputs
     (the unit-test path) still work via the [_ -> Some sse_event]
@@ -735,35 +740,75 @@ let parse_sse_dashboard_event sse_event =
     result
   end
 
-(** Build a dashboard/delta notification from an already-parsed SSE
-    event when the session subscribes to its slice.  Pulled out of the
-    earlier [dashboard_delta_for_sse] so callers that already have the
-    parsed event in hand do not re-enter [parse_sse_dashboard_event]
-    just to feed it back through; see [send_dashboard_or_raw_sse]. *)
-let dashboard_delta_for_parsed session parsed =
-  match parsed with
-  | Some { event_type; slice = Some slice; payload; broadcast_ts }
-    when List.mem slice (Atomic.get session.dashboard_slices) ->
-      Transport_metrics.inc_ws_delta_built ();
-      let seq = next_dashboard_seq session in
+(** Shared dashboard/delta payload-frame cache.
+
+    The per-session [seq] is intentionally excluded from [text].  That keeps
+    the expensive payload serialization keyed by the physical SSE broadcast
+    reference instead of by recipient, so a fan-out pays one
+    [Yojson.Safe.to_string] for the payload frame. *)
+let dashboard_delta_payload_text_cache :
+    (string * dashboard_delta_payload_frame option) Atomic.t =
+  Atomic.make ("", None)
+
+let dashboard_delta_payload_text_for_parsed sse_event parsed =
+  let cached_event, cached_payload =
+    Atomic.get dashboard_delta_payload_text_cache
+  in
+  if cached_event == sse_event then cached_payload
+  else begin
+    let payload_frame =
+      match parsed with
+      | Some { event_type; slice = Some slice; payload; broadcast_ts } ->
+          Transport_metrics.inc_ws_delta_payload_serialization ();
+          Some
+            {
+              slice;
+              text =
+                Yojson.Safe.to_string
+                  (jsonrpc_notification "dashboard/delta"
+                     (`Assoc
+                       [
+                         ("protocol", `String "dashboard-ws.v1");
+                         ("slice", `String slice);
+                         ("event_type", `String event_type);
+                         ("mode", `String "snapshot");
+                         ("payload", payload);
+                         ("ts_unix", `Float broadcast_ts);
+                       ]));
+            }
+      | _ -> None
+    in
+    Atomic.set dashboard_delta_payload_text_cache (sse_event, payload_frame);
+    payload_frame
+  end
+
+let dashboard_delta_seq_notification seq =
+  jsonrpc_notification "dashboard/delta"
+    (`Assoc [ ("protocol", `String "dashboard-ws.v1"); ("seq", `Int seq) ])
+
+let send_dashboard_delta_frame session { slice; text } =
+  if not (List.mem slice (Atomic.get session.dashboard_slices)) then false
+  else begin
+    Transport_metrics.inc_ws_delta_built ();
+    let seq = next_dashboard_seq session in
+    if send_text_shared_checked ~context:"dashboard-delta-payload" session text
+    then begin
       Atomic.set session.dashboard_last_delta_seq seq;
       Atomic.set session.dashboard_last_delta_at (Time_compat.now ());
-      Some
-        (jsonrpc_notification "dashboard/delta"
-           (`Assoc
-             [
-               ("protocol", `String "dashboard-ws.v1");
-               ("seq", `Int seq);
-               ("slice", `String slice);
-               ("event_type", `String event_type);
-               ("mode", `String "snapshot");
-               ("payload", payload);
-               ("ts_unix", `Float broadcast_ts);
-             ]))
-  | _ -> None
+      send_json_checked ~context:"dashboard-delta-seq" session
+        (dashboard_delta_seq_notification seq)
+    end
+    else false
+  end
 
-let dashboard_delta_for_sse session sse_event =
-  dashboard_delta_for_parsed session (parse_sse_dashboard_event sse_event)
+let send_dashboard_delta_for_parsed session sse_event parsed =
+  match dashboard_delta_payload_text_for_parsed sse_event parsed with
+  | Some frame -> send_dashboard_delta_frame session frame
+  | None -> false
+
+let send_dashboard_delta_for_sse session sse_event =
+  send_dashboard_delta_for_parsed session sse_event
+    (parse_sse_dashboard_event sse_event)
 
 (** TTL cache for env-var reads on the fan-out hot path.
 
@@ -900,12 +945,11 @@ let send_dashboard_or_raw_sse session sse_event =
        difference.  At fanout fleet scale (100+ authenticated dashboard
        sessions) the second call is pure overhead. *)
     let parsed = parse_sse_dashboard_event sse_event in
-    match dashboard_delta_for_parsed session parsed with
-    | Some delta ->
-        (* Delta carries a per-session [seq], so the encoded text is unique
-           per session and cannot be shared. *)
-        send_json_checked ~context:"dashboard-delta" session delta
-    | None ->
+    match parsed with
+    | Some { slice = Some slice; _ }
+      when List.mem slice (Atomic.get session.dashboard_slices) ->
+        send_dashboard_delta_for_parsed session sse_event parsed
+    | _ ->
         (* Two sub-cases lead here:
            1. The event has a parsed slice but this session's route is
               not subscribed.  Today we raw-forward anyway so the client
@@ -922,7 +966,7 @@ let send_dashboard_or_raw_sse session sse_event =
            [parsed] (captured above) is the source of truth for which
            case applies.  A [Some _] result with a [Some slice] field
            means case 1 (slice known, session did not subscribe —
-           [dashboard_delta_for_parsed] would have returned [Some]
+           [send_dashboard_delta_for_parsed] would have sent the split delta
            otherwise).  Anything else is case 2. *)
         let is_slice_mismatch =
           match parsed with
@@ -1051,6 +1095,10 @@ let __test_missed_pong_threshold = missed_pong_threshold
    equals the total number of calls (no lost updates). *)
 let __test_next_dashboard_seq = next_dashboard_seq
 let __test_dashboard_seq_value session = Atomic.get session.dashboard_seq
+
+let __test_dashboard_delta_payload_text_for_sse sse_event =
+  dashboard_delta_payload_text_for_parsed sse_event
+    (parse_sse_dashboard_event sse_event)
 
 let start_upgrade_heartbeat ?sw ?clock session_id session =
   match sw, clock with

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -3,7 +3,7 @@
     replacing SSE for dashboard / agent connections that
     need full-duplex.
 
-    External surface (20 entries + 5 types):
+    External surface:
     - {b session record} ({!ws_session}) — concrete because
       [server_ws_standalone] passes session values to
       {!read_inbound_message_frame} /
@@ -56,8 +56,12 @@
     [verify_dashboard_token], [dashboard_snapshot],
     [parse_cache] / [sse_data_prefix] /
     [extract_sse_data_*],
-    [dashboard_delta_for_parsed] /
-    [dashboard_delta_for_sse], [env_cache_ttl_s],
+    [dashboard_delta_payload_text_cache] /
+    [dashboard_delta_payload_text_for_parsed] /
+    [dashboard_delta_seq_notification] /
+    [send_dashboard_delta_frame] /
+    [send_dashboard_delta_for_parsed] /
+    [send_dashboard_delta_for_sse], [env_cache_ttl_s],
     [client_buffer_limit_cache] /
     [client_buffer_limit_bytes],
     [dashboard_ack_stale_threshold_cache] /
@@ -145,6 +149,14 @@ type parsed_sse_event = {
 (** Result of {!parse_sse_dashboard_event}.  Exposed for
     the [#10194] regression test which pattern-matches on
     [parsed.event_type] / [parsed.slice]. *)
+
+type dashboard_delta_payload_frame = {
+  slice : string;
+  text : string;
+}
+(** Shared dashboard/delta payload frame for one SSE broadcast.  [text] is a
+    serialized JSON-RPC notification without the per-session [seq], so every
+    subscribed session can share the same physical string/bytes in fan-out. *)
 
 (** {1 Send outcome} *)
 
@@ -485,3 +497,10 @@ val __test_dashboard_seq_value : ws_session -> int
 (** Test-only seam: reads the current per-session dashboard seq counter so the
     cross-domain gate can assert the final value equals the total number of
     allocations (no lost updates under true parallelism). *)
+
+val __test_dashboard_delta_payload_text_for_sse :
+  string -> dashboard_delta_payload_frame option
+(** Test-only seam: serializes the shared dashboard/delta payload frame for
+    one SSE broadcast.  The returned text deliberately excludes the
+    per-session seq so tests can prove payload serialization is cached by
+    physical broadcast reference rather than multiplied by session count. *)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -241,6 +241,10 @@ let inc_grpc_bytes_sent ~bytes =
 
 let inc_ws_delta_built () = Otel_metric_store.inc_counter Otel_metric_store.metric_ws_delta_built ()
 
+let inc_ws_delta_payload_serialization () =
+  Otel_metric_store.inc_counter Otel_metric_store.metric_ws_delta_payload_serializations ()
+;;
+
 let inc_grpc_backlog_replay_lines_scanned ?(delta = 1) () =
   if delta > 0
   then
@@ -490,6 +494,7 @@ type ws_delivery_metric_names =
   ; bytes_cache_misses : string
   ; client_acks : string
   ; throttled_deliveries : string
+  ; delta_payload_serializations : string
   ; client_buffered_bytes : string
   ; client_buffered_bytes_count : string
   ; hello_latency : string
@@ -503,6 +508,7 @@ let ws_delivery_metric_names =
   ; bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
   ; client_acks = "masc_ws_client_acks_total"
   ; throttled_deliveries = "masc_ws_throttled_deliveries_total"
+  ; delta_payload_serializations = "masc_ws_delta_payload_serializations_total"
   ; client_buffered_bytes = "masc_ws_client_buffered_bytes"
   ; client_buffered_bytes_count = "masc_ws_client_buffered_bytes_count"
   ; hello_latency = Otel_metric_store.metric_ws_dashboard_hello_latency_seconds
@@ -686,6 +692,10 @@ let transport_health_json ~config =
                   , `Int (int_of_float (v ws_delivery_metrics.client_acks ())) )
                 ; ( "throttled_deliveries"
                   , `Int (int_of_float (v ws_delivery_metrics.throttled_deliveries ())) )
+                ; ( "delta_payload_serializations"
+                  , `Int
+                      (int_of_float
+                         (v ws_delivery_metrics.delta_payload_serializations ())) )
                 ; (* Histogram sum + auto _count give operators enough to compute
            average buffered bytes per ack without external telemetry queries. *)
                   ( "client_buffered_bytes_sum"

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -242,6 +242,12 @@ val observe_ws_message_bytes_recv : int -> unit
 (** Increments [masc_ws_delta_built]. *)
 val inc_ws_delta_built : unit -> unit
 
+(** Increments [masc_ws_delta_payload_serializations_total] once when a
+    broadcast's shared dashboard/delta payload frame is serialized.  This is
+    the Wave-A proof counter for keeping payload serialization independent of
+    subscribed WS session count. *)
+val inc_ws_delta_payload_serialization : unit -> unit
+
 (** {1 Transport listen state} *)
 
 (** Explanatory status for why gRPC is or is not listening.

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -517,6 +517,64 @@ let test_bytes_cache_counters () =
   Alcotest.(check (float 0.001)) "fresh allocation forces another miss"
     2.0 (read_counter misses_name -. misses0)
 
+let test_dashboard_delta_payload_text_excludes_seq () =
+  let event =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("type", `String "goal_loop_status");
+          ("payload", `Assoc [ ("status", `String "running") ]);
+        ])
+  in
+  match Ws.__test_dashboard_delta_payload_text_for_sse event with
+  | None -> Alcotest.fail "expected shared dashboard delta payload"
+  | Some frame ->
+      Alcotest.(check string) "slice" "goals" frame.slice;
+      let json = Yojson.Safe.from_string frame.text in
+      let params =
+        match json with
+        | `Assoc fields -> List.assoc "params" fields
+        | _ -> Alcotest.fail "expected JSON-RPC object"
+      in
+      let fields =
+        match params with
+        | `Assoc fields -> fields
+        | _ -> Alcotest.fail "expected params object"
+      in
+      Alcotest.(check bool) "seq is split out"
+        false
+        (List.mem_assoc "seq" fields);
+      Alcotest.(check (option string)) "event type preserved"
+        (Some "goal_loop_status")
+        (Option.bind (List.assoc_opt "event_type" fields) (function
+          | `String s -> Some s
+          | _ -> None))
+
+let test_dashboard_delta_payload_serializes_once_per_broadcast_ref () =
+  let metric_name =
+    Masc.Otel_metric_store.metric_ws_delta_payload_serializations
+  in
+  let before = read_counter metric_name in
+  let event =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("type", `String "execution_snapshot");
+          ("payload", `Assoc [ ("agents", `List []) ]);
+        ])
+  in
+  let first = Ws.__test_dashboard_delta_payload_text_for_sse event in
+  let second = Ws.__test_dashboard_delta_payload_text_for_sse event in
+  let after = read_counter metric_name in
+  Alcotest.(check bool) "payload frame exists" true (Option.is_some first);
+  Alcotest.(check bool) "same broadcast ref reuses same text"
+    true
+    (match first, second with
+     | Some a, Some b -> a.text == b.text
+     | _ -> false);
+  Alcotest.(check (float 0.001)) "one payload serialization"
+    1.0 (after -. before)
+
 (* ====== dashboard/ack observability metrics ====== *)
 
 (* The server needs to see how fast each dashboard client is draining its
@@ -1179,6 +1237,10 @@ let () =
         test_bytes_of_shared_text_invalidates_on_new_ref;
       Alcotest.test_case "hit/miss counters track reuse" `Quick
         test_bytes_cache_counters;
+      Alcotest.test_case "dashboard delta shared payload excludes seq" `Quick
+        test_dashboard_delta_payload_text_excludes_seq;
+      Alcotest.test_case "dashboard delta payload serializes once per broadcast ref" `Quick
+        test_dashboard_delta_payload_serializes_once_per_broadcast_ref;
     ]);
     ("ack_observability", [
       Alcotest.test_case "buffered_bytes sum and count track observations" `Quick


### PR DESCRIPTION
## What changed

- Split WebSocket `dashboard/delta` delivery into a shared payload frame plus a small per-session seq frame.
- Cache the serialized dashboard delta payload by the physical SSE broadcast reference so fan-out pays one payload `Yojson.Safe.to_string` per broadcast instead of one per subscribed session.
- Add `masc_ws_delta_payload_serializations_total` and expose it in transport delivery health so the Wave A target can be measured after CI/runtime rollout.
- Keep dashboard client compatibility by treating payload-only deltas as hydration frames and seq-only deltas as ACK checkpoints.

## Why

The perf-collapse report identified per-session dashboard delta reserialization as the hot path: `N sessions x payload bytes` can monopolize the single Eio serving domain during fan-out. The per-session monotonic seq still exists, but it no longer forces the large payload to be unique for every recipient.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/dashboard-ws.ts src/dashboard-ws.test.ts`
- `ocamlformat --check lib/server/server_mcp_transport_ws.ml lib/server/server_mcp_transport_ws.mli lib/transport_metrics.ml lib/transport_metrics.mli lib/otel_metric_store/otel_transport_metric_names.ml lib/otel_metric_store/otel_transport_metric_names.mli test/test_ws_transport.ml`
- `git diff --check`

Local dune build intentionally not run; CI is the OCaml build authority for this repo.