### PR TITLE
[codex] expose scheduler wake queue receipts

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -76,6 +76,20 @@ export interface DashboardScheduledAutomationExecution {
   error?: string | null
 }
 
+export interface DashboardScheduledAutomationDispatchReceipt {
+  projection_status: 'recognized' | 'unrecognized_detail'
+  kind?: string
+  queue?: string
+  stimulus?: string
+  keeper_name?: string
+  schedule_id?: string
+  urgency?: string
+  post_id?: string
+  author?: string
+  hearth?: string | null
+  reason?: string
+}
+
 export interface DashboardScheduledAutomationKeeperToolStatus {
   name: string
   registered_schema?: boolean
@@ -150,6 +164,7 @@ export interface DashboardScheduledAutomationRequest {
   requires_separate_human_grant?: boolean
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
+  dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -90,6 +90,27 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   reason?: string
 }
 
+export interface DashboardScheduledAutomationKeeperQueueEvidence {
+  projection_status: 'matched_pending' | 'matched_inflight' | 'not_found' | 'read_error' | 'unrecognized_receipt'
+  source?: string
+  queue?: string
+  stimulus?: string
+  keeper_name?: string
+  schedule_id?: string
+  post_id?: string
+  pending_count?: number
+  inflight_count?: number
+  matched_bucket?: string
+  matched_post_id?: string
+  matched_schedule_id?: string | null
+  matched_payload_kind?: string
+  matched_arrived_at?: number
+  matched_arrived_at_iso?: string
+  matched_age_seconds?: number
+  read_errors?: Array<{ kind?: string; path?: string | null; message?: string }>
+  reason?: string
+}
+
 export interface DashboardScheduledAutomationKeeperToolStatus {
   name: string
   registered_schema?: boolean
@@ -165,6 +186,7 @@ export interface DashboardScheduledAutomationRequest {
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
+  keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,7 @@ export type {
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
   DashboardScheduledAutomationDispatchReceipt,
+  DashboardScheduledAutomationKeeperQueueEvidence,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,
   DashboardScheduledAutomationSignal,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -187,6 +187,7 @@ export type {
   ToolMetricsResponse,
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
+  DashboardScheduledAutomationDispatchReceipt,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,
   DashboardScheduledAutomationSignal,

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -611,6 +611,25 @@ describe('ScheduledAutomationPanel', () => {
           urgency: 'immediate',
           post_id: 'schedule-due:sched-keeper-wake',
         },
+        keeper_queue_evidence: {
+          projection_status: 'matched_pending',
+          source: 'durable_event_queue_snapshot',
+          queue: 'keeper_event_queue',
+          stimulus: 'schedule_due',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          post_id: 'schedule-due:sched-keeper-wake',
+          pending_count: 1,
+          inflight_count: 0,
+          matched_bucket: 'pending',
+          matched_post_id: 'schedule-due:sched-keeper-wake',
+          matched_schedule_id: 'sched-keeper-wake',
+          matched_payload_kind: 'schedule_due',
+          matched_arrived_at: 201,
+          matched_arrived_at_iso: '2026-06-21T00:03:21Z',
+          matched_age_seconds: 0,
+          read_errors: [],
+        },
       }),
     ])
 
@@ -623,6 +642,12 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
     expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
     expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const queueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(queueEvidence).not.toBeNull()
+    expect(queueEvidence?.getAttribute('data-schedule-keeper-queue-evidence-source')).toBe('durable_event_queue_snapshot')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_bucket"]')?.textContent).toContain('pending')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="pending_count"]')?.textContent).toContain('1')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_payload_kind"]')?.textContent).toContain('schedule_due')
 
     render(null, container)
     render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
@@ -640,6 +665,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2Receipt?.textContent).toContain('keeper_event_queue')
     expect(v2Receipt?.textContent).toContain('schedule_due')
     expect(v2Receipt?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const v2QueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(v2QueueEvidence).not.toBeNull()
+    expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
+    expect(v2QueueEvidence?.textContent).toContain('matched pending')
+    expect(v2QueueEvidence?.textContent).toContain('schedule_due')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -573,6 +573,75 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).toContain('페이로드')
   })
 
+  it('renders keeper wake dispatch receipts as queue proof in diagnostics and v2', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-keeper-wake',
+        status: 'succeeded',
+        effective_status: 'succeeded',
+        execution_readiness: 'terminal',
+        operator_action: null,
+        approval_required: false,
+        risk_class: 'workspace_write',
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+        payload_target: 'keeper:schedule-keeper',
+        payload_summary: 'Scheduled lane wake',
+        last_execution: {
+          execution_id: 'exec-keeper-wake',
+          schedule_id: 'sched-keeper-wake',
+          status: 'succeeded',
+          detail: {
+            kind: 'masc.keeper_wake.enqueued',
+            queue: 'keeper_event_queue',
+            stimulus: 'schedule_due',
+            keeper_name: 'schedule-keeper',
+            schedule_id: 'sched-keeper-wake',
+            urgency: 'immediate',
+            post_id: 'schedule-due:sched-keeper-wake',
+          },
+        },
+        dispatch_receipt: {
+          projection_status: 'recognized',
+          kind: 'masc.keeper_wake.enqueued',
+          queue: 'keeper_event_queue',
+          stimulus: 'schedule_due',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          urgency: 'immediate',
+          post_id: 'schedule-due:sched-keeper-wake',
+        },
+      }),
+    ])
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} />`, container)
+
+    const receipt = container.querySelector('[data-schedule-dispatch-receipt="recognized"]')
+    expect(receipt).not.toBeNull()
+    expect(receipt?.getAttribute('data-schedule-dispatch-receipt-kind')).toBe('masc.keeper_wake.enqueued')
+    expect(container.querySelector('[data-dispatch-receipt-row="queue"]')?.textContent).toContain('keeper_event_queue')
+    expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
+    expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
+    expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const doneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    doneFilter.click()
+    await Promise.resolve()
+
+    const openDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
+    openDetail.click()
+    await Promise.resolve()
+
+    const v2Receipt = container.querySelector('[data-schedule-dispatch-receipt="recognized"]')
+    expect(v2Receipt).not.toBeNull()
+    expect(v2Receipt?.textContent).toContain('keeper_event_queue')
+    expect(v2Receipt?.textContent).toContain('schedule_due')
+    expect(v2Receipt?.textContent).toContain('schedule-due:sched-keeper-wake')
+  })
+
   it('filters schedule cards without filtering the wake signal feed', async () => {
     render(html`<${ScheduledAutomationPanel} automation=${sampleAutomation()} />`, container)
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -5,6 +5,7 @@ import {
   type DashboardScheduleDecision,
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
+  type DashboardScheduledAutomationDispatchReceipt,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
@@ -395,6 +396,71 @@ function executionDetailRows(detail: unknown): Array<{ label: string; value: str
     .slice(0, 6)
 }
 
+function dispatchReceiptTone(
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined,
+): StatusChipTone {
+  if (!receipt) return 'neutral'
+  return receipt.projection_status === 'recognized' ? 'ok' : 'warn'
+}
+
+function dispatchReceiptRows(
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!receipt) return []
+  const rows: Array<{ label: string; value: string | null | undefined }> = [
+    { label: 'kind', value: receipt.kind },
+    { label: 'queue', value: receipt.queue },
+    { label: 'stimulus', value: receipt.stimulus },
+    { label: 'keeper', value: receipt.keeper_name },
+    { label: 'schedule', value: receipt.schedule_id },
+    { label: 'urgency', value: receipt.urgency },
+    { label: 'post_id', value: receipt.post_id },
+    { label: 'author', value: receipt.author },
+    { label: 'hearth', value: receipt.hearth },
+    { label: 'reason', value: receipt.reason },
+  ]
+  return rows.filter((row): row is { label: string; value: string } => {
+    return typeof row.value === 'string' && row.value.trim() !== ''
+  })
+}
+
+function DispatchReceiptBlock({
+  receipt,
+  compact = false,
+}: {
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  compact?: boolean
+}) {
+  if (!receipt) return null
+  const rows = dispatchReceiptRows(receipt)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-dispatch-receipt=${receipt.projection_status}
+      data-schedule-dispatch-receipt-kind=${receipt.kind ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">dispatch_receipt</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">dispatch receipt</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${dispatchReceiptTone(receipt)} uppercase=${false}>
+            ${enumLabel(receipt.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[5.5rem_minmax(0,1fr)] gap-2'} data-dispatch-receipt-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -654,7 +720,13 @@ function ScheduleCard({
   `
 }
 
-function LastExecutionBlock({ execution }: { execution: DashboardScheduledAutomationExecution | null | undefined }) {
+function LastExecutionBlock({
+  execution,
+  dispatchReceipt,
+}: {
+  execution: DashboardScheduledAutomationExecution | null | undefined
+  dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+}) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
   }
@@ -693,6 +765,7 @@ function LastExecutionBlock({ execution }: { execution: DashboardScheduledAutoma
             </div>
           `
         : null}
+      <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
     </div>
   `
 }
@@ -781,7 +854,10 @@ function ScheduleDetailPanel({
         </div>
         <div>
           <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">최근 실행</div>
-          <${LastExecutionBlock} execution=${execution} />
+          <${LastExecutionBlock}
+            execution=${execution}
+            dispatchReceipt=${request.dispatch_receipt ?? null}
+          />
         </div>
       </div>
     </section>
@@ -1341,7 +1417,10 @@ function SchDetail({
 
           <div class="turn-sec">
             <h4>최근 실행 기록</h4>
-            <${SchExecution} execution=${execution} />
+            <${SchExecution}
+              execution=${execution}
+              dispatchReceipt=${request.dispatch_receipt ?? null}
+            />
           </div>
 
           <${SchDetailActions} request=${request} onResolved=${onResolved} onClose=${onClose} />
@@ -1351,7 +1430,13 @@ function SchDetail({
   `
 }
 
-function SchExecution({ execution }: { execution: DashboardScheduledAutomationExecution | null | undefined }) {
+function SchExecution({
+  execution,
+  dispatchReceipt,
+}: {
+  execution: DashboardScheduledAutomationExecution | null | undefined
+  dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+}) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
   }
@@ -1365,6 +1450,7 @@ function SchExecution({ execution }: { execution: DashboardScheduledAutomationEx
         <div class="sch-kv" data-execution-detail-row=${row.label}><span class="k">${row.label}</span><span class="v mono">${row.value}</span></div>
       `)}
     </div>
+    <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -6,6 +6,7 @@ import {
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
+  type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
@@ -461,6 +462,83 @@ function DispatchReceiptBlock({
   `
 }
 
+function queueEvidenceTone(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): StatusChipTone {
+  if (!evidence) return 'neutral'
+  if (evidence.projection_status === 'matched_pending' || evidence.projection_status === 'matched_inflight') return 'ok'
+  if (evidence.projection_status === 'not_found' || evidence.projection_status === 'read_error') return 'warn'
+  return 'bad'
+}
+
+function queueEvidenceRows(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!evidence) return []
+  const readErrors = (evidence.read_errors ?? [])
+    .map(error => [error.kind, error.path, error.message].filter(Boolean).join(': '))
+    .filter(value => value.trim() !== '')
+    .join(' | ')
+  const rows: Array<{ label: string; value: string | number | null | undefined }> = [
+    { label: 'source', value: evidence.source },
+    { label: 'queue', value: evidence.queue },
+    { label: 'stimulus', value: evidence.stimulus },
+    { label: 'keeper', value: evidence.keeper_name },
+    { label: 'schedule', value: evidence.schedule_id },
+    { label: 'post_id', value: evidence.post_id },
+    { label: 'pending_count', value: evidence.pending_count },
+    { label: 'inflight_count', value: evidence.inflight_count },
+    { label: 'matched_bucket', value: evidence.matched_bucket },
+    { label: 'matched_payload_kind', value: evidence.matched_payload_kind },
+    { label: 'matched_post_id', value: evidence.matched_post_id },
+    { label: 'matched_schedule_id', value: evidence.matched_schedule_id },
+    { label: 'matched_arrived_at', value: evidence.matched_arrived_at_iso },
+    { label: 'matched_age_seconds', value: evidence.matched_age_seconds },
+    { label: 'read_errors', value: readErrors },
+    { label: 'reason', value: evidence.reason },
+  ]
+  return rows
+    .map(row => ({ label: row.label, value: row.value == null ? '' : String(row.value) }))
+    .filter(row => row.value.trim() !== '')
+}
+
+function QueueEvidenceBlock({
+  evidence,
+  compact = false,
+}: {
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  compact?: boolean
+}) {
+  if (!evidence) return null
+  const rows = queueEvidenceRows(evidence)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-keeper-queue-evidence=${evidence.projection_status}
+      data-schedule-keeper-queue-evidence-source=${evidence.source ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">keeper_queue_evidence</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">keeper queue evidence</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${queueEvidenceTone(evidence)} uppercase=${false}>
+            ${enumLabel(evidence.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2'} data-keeper-queue-evidence-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -723,9 +801,11 @@ function ScheduleCard({
 function LastExecutionBlock({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
@@ -766,6 +846,7 @@ function LastExecutionBlock({
           `
         : null}
       <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
+      <${QueueEvidenceBlock} evidence=${queueEvidence} />
     </div>
   `
 }
@@ -857,6 +938,7 @@ function ScheduleDetailPanel({
           <${LastExecutionBlock}
             execution=${execution}
             dispatchReceipt=${request.dispatch_receipt ?? null}
+            queueEvidence=${request.keeper_queue_evidence ?? null}
           />
         </div>
       </div>
@@ -1420,6 +1502,7 @@ function SchDetail({
             <${SchExecution}
               execution=${execution}
               dispatchReceipt=${request.dispatch_receipt ?? null}
+              queueEvidence=${request.keeper_queue_evidence ?? null}
             />
           </div>
 
@@ -1433,9 +1516,11 @@ function SchDetail({
 function SchExecution({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
@@ -1451,6 +1536,7 @@ function SchExecution({
       `)}
     </div>
     <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
+    <${QueueEvidenceBlock} evidence=${queueEvidence} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2721,6 +2721,143 @@ let schedule_dispatch_receipt_dashboard_json
          ]))
 ;;
 
+let schedule_queue_read_error_dashboard_json
+  (error : Keeper_event_queue_persistence.snapshot_read_error)
+  =
+  `Assoc
+    [ "kind", `String (Keeper_event_queue_persistence.snapshot_read_error_kind_to_string error.kind)
+    ; ( "path"
+      , match error.path with
+        | None -> `Null
+        | Some path -> `String path )
+    ; "message", `String error.message
+    ]
+;;
+
+let schedule_queue_match
+  ~(schedule_id : string)
+  ~(due_at : float)
+  ~(payload_digest : string)
+  ~(post_id : string)
+  ~(stimulus_label : string)
+  (queue : Keeper_event_queue.t)
+  =
+  queue
+  |> Keeper_event_queue.to_list
+  |> List.find_opt (fun (stimulus : Keeper_event_queue.stimulus) ->
+    String.equal stimulus.post_id post_id
+    && String.equal (Keeper_event_queue.payload_kind_label stimulus.payload) stimulus_label
+    &&
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake ->
+      String.equal wake.schedule_id schedule_id
+      && Float.equal wake.due_at due_at
+      && String.equal wake.payload_digest payload_digest
+    | _ -> false)
+;;
+
+let schedule_queue_match_fields ~now bucket (stimulus : Keeper_event_queue.stimulus) =
+  let scheduled_wake =
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake -> Some wake
+    | _ -> None
+  in
+  [ "matched_bucket", `String bucket
+  ; "matched_post_id", `String stimulus.post_id
+  ; "matched_payload_kind", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+  ; "matched_arrived_at", `Float stimulus.arrived_at
+  ; "matched_arrived_at_iso", unix_iso_json stimulus.arrived_at
+  ; ( "matched_schedule_id"
+    , match scheduled_wake with
+      | Some wake -> `String wake.schedule_id
+      | None -> `Null )
+  ; ( "matched_due_at"
+    , match scheduled_wake with
+      | Some wake -> `Float wake.due_at
+      | None -> `Null )
+  ; ( "matched_due_at_iso"
+    , match scheduled_wake with
+      | Some wake -> unix_iso_json wake.due_at
+      | None -> `Null )
+  ; ( "matched_payload_digest"
+    , match scheduled_wake with
+      | Some wake -> `String wake.payload_digest
+      | None -> `Null )
+  ; "matched_age_seconds", `Float (Float.max 0.0 (now -. stimulus.arrived_at))
+  ]
+;;
+
+let schedule_keeper_queue_evidence_dashboard_json
+  ~now
+  (config : Workspace.config)
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error reason ->
+          `Assoc
+            [ "projection_status", `String "unrecognized_receipt"
+            ; "reason", `String reason
+            ]
+        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+          let due_at = execution.Schedule_domain.due_at in
+          let payload_digest = execution.Schedule_domain.payload_digest in
+          let snapshot =
+            Keeper_event_queue_persistence.load_snapshot_pair_with_errors
+              ~base_path:config.Workspace_utils.base_path
+              ~keeper_name
+          in
+          let pending_match =
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.pending
+          in
+          let inflight_match =
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.inflight
+          in
+          let read_errors =
+            List.map schedule_queue_read_error_dashboard_json snapshot.read_errors
+          in
+          let base_fields =
+            [ "source", `String "durable_event_queue_snapshot"
+            ; "queue", `String queue
+            ; "stimulus", `String stimulus
+            ; "keeper_name", `String keeper_name
+            ; "schedule_id", `String schedule_id
+            ; "post_id", `String post_id
+            ; "execution_due_at", `Float due_at
+            ; "execution_due_at_iso", unix_iso_json due_at
+            ; "execution_payload_digest", `String payload_digest
+            ; "pending_count", `Int (Keeper_event_queue.length snapshot.pending)
+            ; "inflight_count", `Int (Keeper_event_queue.length snapshot.inflight)
+            ; "read_errors", `List read_errors
+            ]
+          in
+          (match pending_match, inflight_match, snapshot.read_errors with
+           | Some match_, _, _ ->
+             `Assoc
+               (("projection_status", `String "matched_pending")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "pending" match_)
+           | None, Some match_, _ ->
+             `Assoc
+               (("projection_status", `String "matched_inflight")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "inflight" match_)
+           | None, None, _ :: _ ->
+             `Assoc (("projection_status", `String "read_error") :: base_fields)
+           | None, None, [] ->
+             `Assoc (("projection_status", `String "not_found") :: base_fields))))
+;;
+
 let schedule_signal_projection_limit = 20
 
 let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
@@ -2751,6 +2888,7 @@ let schedule_signal_dashboard_json (signal : Schedule_runner.wake_signal) =
 
 let schedule_request_dashboard_json
   ~now
+  ~config
   ~state
   ?last_execution
   (request : Schedule_domain.schedule_request)
@@ -2823,6 +2961,7 @@ let schedule_request_dashboard_json
         | None -> `Null
         | Some execution -> execution_record_dashboard_json execution )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
+    ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_execution
     ]
 ;;
 
@@ -2932,7 +3071,7 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
                   Schedule_store.last_execution_for_schedule state
                     ~schedule_id:request.Schedule_domain.schedule_id
                 in
-                schedule_request_dashboard_json ~now ~state ?last_execution request)
+                schedule_request_dashboard_json ~now ~config ~state ?last_execution request)
              request_rows) )
     ]
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2700,6 +2700,27 @@ let execution_record_dashboard_json (execution : Schedule_domain.execution_recor
   | other -> other
 ;;
 
+let schedule_dispatch_receipt_dashboard_json
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+    (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+     | Ok receipt ->
+       (match Server_schedule_consumers.dispatch_receipt_to_yojson receipt with
+        | `Assoc fields -> `Assoc (("projection_status", `String "recognized") :: fields)
+        | other -> other)
+     | Error reason ->
+       `Assoc
+         [ "projection_status", `String "unrecognized_detail"
+         ; "reason", `String reason
+         ]))
+;;
+
 let schedule_signal_projection_limit = 20
 
 let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
@@ -2801,6 +2822,7 @@ let schedule_request_dashboard_json
       , match last_execution with
         | None -> `Null
         | Some execution -> execution_record_dashboard_json execution )
+    ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
     ]
 ;;
 

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -3,6 +3,9 @@
    loop logs aggregate dispatch counts for runtime telemetry. *)
 
 let supported_payload_kinds = Schedule_supported_kinds.supported
+let board_post_created_kind = "masc.board_post.created"
+let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
+let keeper_event_queue_label = "keeper_event_queue"
 
 let ( let* ) = Result.bind
 
@@ -65,6 +68,63 @@ let optional_assoc_field name fields =
   | None | Some `Null -> Ok None
   | Some (`Assoc _ as value) -> Ok (Some value)
   | Some _ -> Error ("expected object field: " ^ name)
+;;
+
+type dispatch_receipt =
+  | Board_post_created of
+      { post_id : string
+      ; author : string
+      ; hearth : string option
+      }
+  | Keeper_wake_enqueued of
+      { keeper_name : string
+      ; schedule_id : string
+      ; urgency : string
+      ; post_id : string
+      ; queue : string
+      ; stimulus : string
+      }
+
+let dispatch_receipt_of_detail = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    if String.equal kind board_post_created_kind
+    then
+      let* post_id = string_field "post_id" fields in
+      let* author = string_field "author" fields in
+      let* hearth = optional_string_field "hearth" fields in
+      Ok (Board_post_created { post_id; author; hearth })
+    else if String.equal kind keeper_wake_enqueued_kind
+    then
+      let* keeper_name = keeper_name_field "keeper_name" fields in
+      let* schedule_id = string_field "schedule_id" fields in
+      let* urgency = string_field "urgency" fields in
+      let* post_id = string_field "post_id" fields in
+      let* queue = string_field "queue" fields in
+      let* stimulus = string_field "stimulus" fields in
+      Ok (Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus })
+    else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
+  | _ -> Error "schedule dispatch receipt detail must be an object"
+;;
+
+let dispatch_receipt_to_yojson = function
+  | Board_post_created { post_id; author; hearth } ->
+    `Assoc
+      [ "kind", `String board_post_created_kind
+      ; "post_id", `String post_id
+      ; "author", `String author
+      ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
+      ]
+  | Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus } ->
+    `Assoc
+      [ "kind", `String keeper_wake_enqueued_kind
+      ; "queue", `String queue
+      ; "stimulus", `String stimulus
+      ; "keeper_name", `String keeper_name
+      ; "schedule_id", `String schedule_id
+      ; "urgency", `String urgency
+      ; "post_id", `String post_id
+      ]
 ;;
 
 type payload_view =
@@ -172,7 +232,7 @@ let dispatch_board_post request payload =
     let post_id = Board.Post_id.to_string post.id in
     Ok
       (`Assoc
-        [ "kind", `String "masc.board_post.created"
+        [ "kind", `String board_post_created_kind
         ; "post_id", `String post_id
         ; "author", `String author
         ; ( "hearth"
@@ -215,7 +275,9 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     stimulus;
   Ok
     (`Assoc
-      [ "kind", `String "masc.keeper_wake.enqueued"
+      [ "kind", `String keeper_wake_enqueued_kind
+      ; "queue", `String keeper_event_queue_label
+      ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
       ; "keeper_name", `String keeper_name
       ; "schedule_id", `String request.schedule_id
       ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -1,5 +1,25 @@
 val supported_payload_kinds : string list
 
+type dispatch_receipt =
+  | Board_post_created of
+      { post_id : string
+      ; author : string
+      ; hearth : string option
+      }
+  | Keeper_wake_enqueued of
+      { keeper_name : string
+      ; schedule_id : string
+      ; urgency : string
+      ; post_id : string
+      ; queue : string
+      ; stimulus : string
+      }
+
+val dispatch_receipt_of_detail :
+  Yojson.Safe.t -> (dispatch_receipt, string) result
+
+val dispatch_receipt_to_yojson : dispatch_receipt -> Yojson.Safe.t
+
 val consumer : Schedule_runner.consumer
 (** Production scheduled-automation consumer adapter.
 

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -254,6 +254,10 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
         let open Yojson.Safe.Util in
         check string "execution detail kind" "masc.keeper_wake.enqueued"
           (detail |> member "kind" |> to_string);
+        check string "execution detail queue" "keeper_event_queue"
+          (detail |> member "queue" |> to_string);
+        check string "execution detail stimulus" "schedule_due"
+          (detail |> member "stimulus" |> to_string);
         check string "execution keeper" "schedule-keeper"
           (detail |> member "keeper_name" |> to_string)
       | None -> fail "execution detail missing"));
@@ -283,7 +287,40 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       | _ -> fail "expected Schedule_due payload"))
   ;
   check int "keeper wake does not create board posts" 0
-    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+    (List.length (Board_dispatch.list_posts ~limit:10 ()));
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  match row with
+  | None -> fail "keeper wake schedule missing from dashboard projection"
+  | Some row ->
+    let receipt = row |> member "dispatch_receipt" in
+    check string "receipt recognized" "recognized"
+      (receipt |> member "projection_status" |> to_string);
+    check string "receipt kind" "masc.keeper_wake.enqueued"
+      (receipt |> member "kind" |> to_string);
+    check string "receipt queue" "keeper_event_queue"
+      (receipt |> member "queue" |> to_string);
+    check string "receipt stimulus" "schedule_due"
+      (receipt |> member "stimulus" |> to_string);
+    check string "receipt keeper" "schedule-keeper"
+      (receipt |> member "keeper_name" |> to_string);
+    check string "receipt schedule" request.schedule_id
+      (receipt |> member "schedule_id" |> to_string);
+    check string "receipt urgency" "immediate"
+      (receipt |> member "urgency" |> to_string);
+    check string "receipt post id" "schedule-due:keeper-wake-sched-1"
+      (receipt |> member "post_id" |> to_string)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -320,7 +320,122 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
     check string "receipt urgency" "immediate"
       (receipt |> member "urgency" |> to_string);
     check string "receipt post id" "schedule-due:keeper-wake-sched-1"
-      (receipt |> member "post_id" |> to_string)
+      (receipt |> member "post_id" |> to_string);
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "queue evidence matched" "matched_pending"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check string "queue evidence source" "durable_event_queue_snapshot"
+      (queue_evidence |> member "source" |> to_string);
+    check string "queue evidence keeper" "schedule-keeper"
+      (queue_evidence |> member "keeper_name" |> to_string);
+    check string "queue evidence stimulus" "schedule_due"
+      (queue_evidence |> member "stimulus" |> to_string);
+    check string "queue evidence matched bucket" "pending"
+      (queue_evidence |> member "matched_bucket" |> to_string);
+    check string "queue evidence matched payload" "schedule_due"
+      (queue_evidence |> member "matched_payload_kind" |> to_string);
+    check string "queue evidence matched schedule" request.schedule_id
+      (queue_evidence |> member "matched_schedule_id" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check (float 0.001) "queue evidence matched due_at" request.due_at
+      (queue_evidence |> member "matched_due_at" |> to_float);
+    check string "queue evidence matched digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "matched_payload_digest" |> to_string);
+    check int "queue evidence pending count" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int);
+    check int "queue evidence read errors" 0
+      (queue_evidence |> member "read_errors" |> to_list |> List.length)
+;;
+
+let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let request = create_pending_keeper_wake_schedule config in
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  ignore (tick_ok config ~now:201.0 : Schedule_runner.tick_result);
+  let expected_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at
+    ; payload_digest = Schedule_domain.payload_digest request.payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run the scheduled maintenance lane now."
+    }
+  in
+  let post_id = Keeper_event_queue.schedule_due_post_id expected_wake in
+  (match Keeper_registry_event_queue.drop_by_post_id ~base_path keeper_name ~post_id with
+   | Error message -> fail ("drop failed: " ^ message)
+   | Ok removed -> check int "removed current occurrence" 1 (List.length removed));
+  let stale_payload_json =
+    `Assoc
+      [ "kind", `String "masc.keeper_wake"
+      ; "schema_version", `Int 1
+      ; ( "body"
+        , `Assoc
+            [ "keeper_name", `String keeper_name
+            ; "title", `String "Scheduled lane wake"
+            ; "message", `String "Run a different scheduled occurrence."
+            ; "urgency", `String "immediate"
+            ] )
+      ]
+  in
+  let stale_payload =
+    match Schedule_domain.payload_of_yojson stale_payload_json with
+    | Ok payload -> payload
+    | Error message -> fail ("stale payload parse failed: " ^ message)
+  in
+  let stale_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at +. 60.0
+    ; payload_digest = Schedule_domain.payload_digest stale_payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run a different scheduled occurrence."
+    }
+  in
+  let stale_stimulus : Keeper_event_queue.stimulus =
+    { post_id = Keeper_event_queue.schedule_due_post_id stale_wake
+    ; urgency = Keeper_event_queue.Immediate
+    ; arrived_at = request.due_at +. 61.0
+    ; payload = Keeper_event_queue.Schedule_due stale_wake
+    }
+  in
+  Keeper_registry_event_queue.enqueue ~base_path keeper_name stale_stimulus;
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  match row with
+  | None -> fail "keeper wake schedule missing from dashboard projection"
+  | Some row ->
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "stale occurrence does not match" "not_found"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check int "stale occurrence still visible as pending" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
@@ -394,6 +509,8 @@ let () =
             test_board_post_consumer_rejects_read_only_risk
         ; test_case "keeper wake enqueues typed stimulus" `Quick
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
+        ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
+            test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -878,7 +878,13 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check string "last execution status" "succeeded"
       (row |> member "last_execution" |> member "status" |> to_string);
     check string "last execution detail" "test.exec"
-      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string)
+      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string);
+    check string "unrecognized dispatch receipt status" "unrecognized_detail"
+      (row |> member "dispatch_receipt" |> member "projection_status" |> to_string);
+    check bool "unrecognized dispatch receipt reason" true
+      (String_util.contains_substring
+         (row |> member "dispatch_receipt" |> member "reason" |> to_string)
+         "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 
 let test_dashboard_projection_surfaces_schedule_runner_signals () =

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -884,6 +884,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check bool "unrecognized dispatch receipt reason" true
       (String_util.contains_substring
          (row |> member "dispatch_receipt" |> member "reason" |> to_string)
+         "unsupported schedule dispatch receipt kind: test.exec");
+    check string "unrecognized queue evidence status" "unrecognized_receipt"
+      (row |> member "keeper_queue_evidence" |> member "projection_status" |> to_string);
+    check bool "unrecognized queue evidence reason" true
+      (String_util.contains_substring
+         (row |> member "keeper_queue_evidence" |> member "reason" |> to_string)
          "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 


### PR DESCRIPTION
## Summary
- persist typed dispatch receipt fields for supported `masc.keeper_wake` schedules, including queue and stimulus proof from the keeper event queue contract
- project recognized/unrecognized dispatch receipts into scheduled automation dashboard JSON
- render receipt proof in diagnostics and v2 schedule detail surfaces

## Validation
- `ocamlformat --check lib/server/server_schedule_consumers.ml lib/server/server_schedule_consumers.mli lib/server/server_dashboard_http_runtime_info.ml test/test_schedule_consumer_dispatch.ml test/test_schedule_tool_wiring.ml`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts src/components/schedule/schedule-surface.test.ts src/components/tools/tools-main.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `env GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py`
- `git diff --check`

Local Dune build/test was not run; per repo workflow, Dune build authority remains CI.