### PR TITLE
Fix dashboard delta checkpoint event counting

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -24,7 +24,9 @@ import {
 } from './config/constants'
 import { DASHBOARD_PUSH_SLICES } from './dashboard-slices'
 import {
+  _resetDashboardWsCounterForTests,
   dashboardWsConnected,
+  dashboardWsEventCount60s,
   dashboardWsLastError,
   dashboardWsLastPingAt,
   dashboardWsLastPongAt,
@@ -221,6 +223,7 @@ afterEach(() => {
   dashboardWsLastPongLatencyMs.value = null
   dashboardWsLastSeq.value = 0
   dashboardWsReady.value = false
+  _resetDashboardWsCounterForTests()
   clearStoredToken()
   vi.useRealTimers()
   vi.unstubAllGlobals()
@@ -1035,6 +1038,7 @@ describe('dashboard websocket route subscriptions', () => {
     })
     expect(ack).not.toHaveProperty('id')
     expect(dashboardWsLastSeq.value).toBe(42)
+    expect(dashboardWsEventCount60s.value).toBe(0)
   })
 
   it('hydrates payload-only dashboard deltas without acking', async () => {
@@ -1068,6 +1072,7 @@ describe('dashboard websocket route subscriptions', () => {
     })
 
     expect(dashboardWsLastSeq.value).toBe(1)
+    expect(dashboardWsEventCount60s.value).toBe(1)
     expect(socket.sent).toHaveLength(sentBeforeDelta)
     expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
       'execution',

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -677,10 +677,10 @@ function applyDelta(raw: unknown): void {
         bufferedAmount: socket?.bufferedAmount ?? 0,
       })
     }
-    noteDashboardWsEvent()
     // Server fan-out may split one logical delta into a shared payload frame
     // and a small per-session seq frame. A seq-only frame is an ACK checkpoint.
     if (typeof delta.slice !== 'string') return
+    noteDashboardWsEvent()
     hydrateRouteDashboardSlice(
       delta.slice,
       delta.payload,


### PR DESCRIPTION
## Summary
- Keep the dashboard WS seq-only delta frame as an ACK checkpoint only.
- Count only payload-bearing dashboard/delta frames as applied WS events.
- Add regression assertions for seq-only and payload-only split delta frames.

## Verification
- git diff --check origin/main...HEAD
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec tsc --noEmit --pretty
