### PR TITLE
dashboard: stop fabricating runtime labels

### DIFF
--- a/dashboard/src/api/dashboard-keeper-cost.ts
+++ b/dashboard/src/api/dashboard-keeper-cost.ts
@@ -7,10 +7,27 @@ import { isRecord, asInt, asNumber, asNullableString, asString, asStringArray, a
 import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import { decodeDashboardFeedMetadata, type DashboardFeedMetadata } from './dashboard-shared'
 
-// Label helper used by the cost-matrix decoder (column fallback when the
-// server omits a model name). Mirrors the runtime-providers lane labelling.
-function runtimeLaneLabel(index: number): string {
-  return `runtime_lane_${index + 1}`
+const REDACTED_RUNTIME_LABEL = 'runtime'
+const UNKNOWN_MODEL_LABEL = 'unknown_model'
+const UNKNOWN_PROVIDER_LABEL = 'unknown_provider'
+const MODEL_PLACEHOLDERS = new Set(['unknown', 'none', '-', 'n/a', 'null', 'undefined', 'default', 'auto'])
+
+function normalizedModelEvidence(value: string | null | undefined): string | null {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!text || MODEL_PLACEHOLDERS.has(text.toLowerCase())) return null
+  return text
+}
+
+function publicRuntimeModelLabel(value: string | null | undefined): string {
+  const model = normalizedModelEvidence(value)
+  if (model == null) return UNKNOWN_MODEL_LABEL
+  if (model === REDACTED_RUNTIME_LABEL || model.startsWith('runtime_lane_')) return model
+  return REDACTED_RUNTIME_LABEL
+}
+
+function costMatrixModelLabel(value: string | undefined, index: number): string {
+  const label = publicRuntimeModelLabel(value)
+  return label === UNKNOWN_MODEL_LABEL ? `${UNKNOWN_MODEL_LABEL}_${index + 1}` : label
 }
 
 export interface KeeperCostMetric {
@@ -35,11 +52,16 @@ function decodeKeeperCostMetric(raw: unknown): KeeperCostMetric | null {
   if (!isRecord(raw)) return null
   const keeperName = asString(raw.keeper_name)
   if (!keeperName) return null
-  const runtimeCost = Array.isArray(raw.model_breakdown)
-    ? (raw.model_breakdown as unknown[])
-        .filter(isRecord)
-        .reduce((sum, item) => sum + (asNumber(item.cost_usd) ?? 0), 0)
-    : 0
+  const modelCosts = new Map<string, number>()
+  if (Array.isArray(raw.model_breakdown)) {
+    for (const item of raw.model_breakdown) {
+      if (!isRecord(item)) continue
+      const cost = asNumber(item.cost_usd) ?? 0
+      if (!Number.isFinite(cost) || cost <= 0) continue
+      const model = publicRuntimeModelLabel(asString(item.model))
+      modelCosts.set(model, (modelCosts.get(model) ?? 0) + cost)
+    }
+  }
   return {
     keeper_name: keeperName,
     total_cost_usd: asNumber(raw.total_cost_usd) ?? 0,
@@ -49,7 +71,7 @@ function decodeKeeperCostMetric(raw: unknown): KeeperCostMetric | null {
     p50_latency_ms: asNumber(raw.p50_latency_ms) ?? null,
     p95_latency_ms: asNumber(raw.p95_latency_ms) ?? null,
     sample_count: asNumber(raw.sample_count) ?? 0,
-    model_breakdown: runtimeCost > 0 ? [{ model: 'runtime', cost_usd: runtimeCost }] : [],
+    model_breakdown: Array.from(modelCosts.entries()).map(([model, cost_usd]) => ({ model, cost_usd })),
   }
 }
 
@@ -245,6 +267,7 @@ function decodeCostPerAgentRow(raw: unknown): CostPerAgentRow | null {
 function decodeCostMatrix(raw: unknown): CostMatrix | null {
   if (!isRecord(raw)) return null
   const rawModels = asStringArray(raw.models)
+  const rawProviders = asStringArray(raw.providers)
   const rawGrid = Array.isArray(raw.grid)
     ? (raw.grid as unknown[]).map(row =>
         Array.isArray(row)
@@ -257,9 +280,12 @@ function decodeCostMatrix(raw: unknown): CostMatrix | null {
     rawGrid.reduce((max, row) => Math.max(max, row.length), 0),
   )
   const models = Array.from({ length: colCount }, (_, index) =>
-    rawModels[index] ?? runtimeLaneLabel(index),
+    costMatrixModelLabel(rawModels[index], index),
   )
-  const providers = colCount > 0 || asStringArray(raw.providers).length > 0 ? ['runtime'] : []
+  const hasProviderEvidence = rawProviders.some(provider => normalizedModelEvidence(provider) != null)
+  const providers = colCount > 0 || rawProviders.length > 0
+    ? [hasProviderEvidence ? REDACTED_RUNTIME_LABEL : UNKNOWN_PROVIDER_LABEL]
+    : []
   const grid = providers.length === 0
     ? []
     : [

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -2987,6 +2987,34 @@ describe('fetchKeeperCostMetrics', () => {
       { model: 'runtime', cost_usd: 0.5 },
     ])
   })
+
+  it('marks missing model breakdown labels as unknown instead of fabricating runtime', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        keepers: [
+          {
+            keeper_name: 'keeper-alpha',
+            total_cost_usd: 0.5,
+            sample_count: 2,
+            model_breakdown: [
+              { cost_usd: 0.2 },
+              { model: ' ', cost_usd: 0.3 },
+            ],
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperCostMetrics(60)
+
+    expect(result.keepers[0]?.model_breakdown).toEqual([
+      { model: 'unknown_model', cost_usd: 0.5 },
+    ])
+  })
 })
 
 describe('fetchKeeperDecisions', () => {
@@ -3111,6 +3139,31 @@ describe('fetchCostLatency', () => {
     expect(result.perAgent[0]?.p95_ms).toBeNull()
     expect(result.matrix.providers).toEqual(['runtime'])
     expect(result.matrix.models).toEqual(['runtime_lane_7'])
+  })
+
+  it('marks unlabeled cost-matrix lanes as unknown instead of synthetic runtime lanes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        perAgent: [],
+        matrix: {
+          providers: [],
+          models: [],
+          grid: [[0.01, 0.02]],
+        },
+        latencyBuckets: [],
+        total_cost_usd: 0.03,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCostLatency(60)
+
+    expect(result.matrix.providers).toEqual(['unknown_provider'])
+    expect(result.matrix.models).toEqual(['unknown_model_1', 'unknown_model_2'])
+    expect(result.matrix.grid).toEqual([[0.01, 0.02]])
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -450,7 +450,7 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('1 주의')
   }, 30_000)
 
-  it('falls back to runtime model and tool audit data when quality rows are sparse', async () => {
+  it('keeps unknown model while using tool audit data when quality rows are sparse', async () => {
     const keepers = normalizeKeepers([
       {
         name: 'keeper-sparse',
@@ -486,14 +486,14 @@ describe('FleetTelemetryPanel', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({
       name: 'keeper-sparse',
-      model: 'runtime',
+      model: 'unknown',
       tool_calls: 3,
       tool_activity_known: true,
     })
     expect(rows[0]?.recent_tools).toEqual(['masc_status', 'keeper_board_post'])
   })
 
-  it('redacts display model and uses freshest keeper activity helpers for fleet rows', async () => {
+  it('keeps unknown display model and uses freshest keeper activity helpers for fleet rows', async () => {
     vi.setSystemTime(new Date('2026-04-24T18:00:00Z'))
     const keepers = normalizeKeepers([
       {
@@ -518,7 +518,7 @@ describe('FleetTelemetryPanel', () => {
     const rows = buildFleetRows(keepers, { ...toolQualityResponse, by_keeper: [] })
 
     expect(rows).toHaveLength(1)
-    expect(rows[0]?.model).toBe('runtime')
+    expect(rows[0]?.model).toBe('unknown')
     expect(rows[0]).toMatchObject({
       activity_label: '하트비트',
       activity_source: 'heartbeat',

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -226,6 +226,18 @@ describe('buildFleetRows runtime labels', () => {
     })
   })
 
+  it('does not fabricate a runtime model label when model evidence is absent', () => {
+    const [row] = buildFleetRows([
+      {
+        name: 'unknown-model-keeper',
+        status: 'active',
+        keepalive_running: true,
+      },
+    ], EMPTY_TOOL_QUALITY)
+
+    expect(row?.model).toBe('unknown')
+  })
+
   it('projects the keeper stop_cause into fleet rows', () => {
     const [row] = buildFleetRows([
       {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -119,6 +119,8 @@ export function normalizeText(value: string | null | undefined): string | null {
 }
 
 const MODEL_PLACEHOLDERS = new Set(['unknown', 'none', '-', 'n/a', 'null', 'undefined', 'default', 'auto'])
+const REDACTED_RUNTIME_MODEL_LABEL = 'runtime'
+const UNKNOWN_MODEL_LABEL = 'unknown'
 
 export function isPlaceholderModel(value: string): boolean {
   return MODEL_PLACEHOLDERS.has(value.toLowerCase())
@@ -141,8 +143,22 @@ export function uniqueStrings(values: Array<string | null | undefined>): string[
   return items
 }
 
-function keeperModel(_keeper: Keeper): string {
-  return 'runtime'
+function keeperModel(keeper: Keeper): string {
+  const latest = latestRuntimeMetric(keeper)
+  const evidence = [
+    keeper.active_model_label,
+    keeper.last_model_used_label,
+    keeper.active_model,
+    keeper.last_model_used,
+    keeper.primary_model,
+    keeper.model,
+    keeper.trust?.execution_summary?.provider_selected_model,
+    latest?.runtime_selected_model,
+    latest?.model_used,
+  ]
+  return evidence.some(value => normalizeModelText(value) != null)
+    ? REDACTED_RUNTIME_MODEL_LABEL
+    : UNKNOWN_MODEL_LABEL
 }
 
 function latestRuntimeMetric(keeper: Keeper) {

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -210,6 +210,11 @@ let runtime_lens_swimlane_completeness scan lane =
   else if mandatory_present then "mandatory_present"
   else "incomplete"
 
+let runtime_lens_swimlane_rendered_completeness scan lane event_count =
+  if String.equal lane "tool_runtime" && event_count = 0
+  then "not_observed"
+  else runtime_lens_swimlane_completeness scan lane
+
 let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
     ~terminal_status ~synthetic_events =
   let gap_codes = runtime_lens_gap_codes_for_lane gaps lane in
@@ -251,7 +256,9 @@ let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
       ("label", `String label);
       ("event_count", `Int event_count);
       ("terminal_status", `String terminal_status);
-      ("completeness", `String (runtime_lens_swimlane_completeness scan lane));
+      ( "completeness",
+        `String
+          (runtime_lens_swimlane_rendered_completeness scan lane event_count) );
       ("gap_codes", Json_util.json_string_list gap_codes);
       ( "gap_badge",
         match gap_codes with

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -2,6 +2,8 @@ open Alcotest
 open Masc
 module Trace = Server_dashboard_http_keeper_api_trace
 module Types = Server_dashboard_http_keeper_api_types
+module Runtime_lens_scan = Server_dashboard_http_keeper_runtime_manifest_scan
+module Runtime_lens_swimlane = Server_dashboard_http_keeper_runtime_lens_swimlane
 module T = Trajectory
 
 let mk_thinking_with_turn ~turn ~ts ~redacted ~content =
@@ -210,6 +212,39 @@ let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
       (Option.is_none (trace_block_by_turn_ref disallowed_ref)))
 ;;
 
+let string_member key = function
+  | `Assoc fields -> (
+    match List.assoc_opt key fields with
+    | Some (`String value) -> value
+    | Some _ -> fail (Printf.sprintf "%s is not a string" key)
+    | None -> fail (Printf.sprintf "%s missing" key))
+  | _ -> fail "expected object"
+;;
+
+let test_tool_runtime_zero_event_lane_is_not_observed () =
+  let scan =
+    Runtime_lens_scan.make_runtime_manifest_scan
+      ~path:"/tmp/empty-runtime-manifest.jsonl"
+      ~limit:10
+      ~scan_line_limit:10
+      ~scan_scope:"test"
+  in
+  let json =
+    Runtime_lens_swimlane.runtime_lens_swimlane_json
+      scan
+      []
+      ~lane:"tool_runtime"
+      ~label:"Tool Runtime"
+      ~events:[]
+      ~terminal_status:"not_observed"
+      ~synthetic_events:[]
+  in
+  check string "terminal status" "not_observed"
+    (string_member "terminal_status" json);
+  check string "empty tool-runtime lane is not complete" "not_observed"
+    (string_member "completeness" json)
+;;
+
 let () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.init_eio_clock env;
@@ -239,6 +274,12 @@ let () =
              "reads allowed trace_history trace ids"
              `Quick
              test_chat_trace_block_by_turn_ref_reads_allowed_trace_history
+         ] )
+     ; ( "runtime_lens_swimlane"
+       , [ test_case
+             "tool_runtime zero-event lane is not observed"
+             `Quick
+             test_tool_runtime_zero_event_lane_is_not_observed
          ] )
      ]
 ;;


### PR DESCRIPTION
Summary:
- Require real model evidence before fleet rows show the redacted runtime model label; otherwise show unknown.
- Preserve or redact supplied cost labels, but use unknown_model and unknown_provider when cost provenance is omitted.
- Mark zero-event tool_runtime runtime-lens lanes as not_observed instead of complete.

Validation:
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/fleet-telemetry-utils.test.ts
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- opam exec -- ocamlformat --check lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml test/test_server_dashboard_http_keeper_api_trace.ml
- scripts/dune-local.sh exec test/test_server_dashboard_http_keeper_api_trace.exe passed before rebase; post-rebase rerun blocked by root bare dune build PID 38238