### PR TITLE
fix: update keeper metrics zero-fill count

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -441,26 +441,14 @@ let queue_count_by_keeper_json ~now kind summary =
     ; "oldest_age_seconds", age_seconds_json ~now oldest_arrived_at
     ]
 
-let sorted_keeper_dir_names keepers_dir =
-  Sys.readdir keepers_dir
-  |> Array.to_list
-  |> List.filter (fun name ->
-       let path = Filename.concat keepers_dir name in
-       valid_keeper_name name && Sys.file_exists path && Sys.is_directory path)
-  |> List.sort String.compare
-
 let fleet_summary_json ~now ~base_path =
   let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-  let keeper_names, scan_errors =
-    if not (Sys.file_exists keepers_dir)
-    then [], []
-    else if not (Sys.is_directory keepers_dir)
-    then [], [ Printf.sprintf "keepers runtime path is not a directory: %s" keepers_dir ]
-    else
-      try sorted_keeper_dir_names keepers_dir, [] with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn ->
-        [], [ Printf.sprintf "failed to list keepers runtime dir %s: %s" keepers_dir (Printexc.to_string exn) ]
+  let discovery = discover_keeper_names_with_snapshots ~base_path in
+  let keeper_names = discovery.keeper_names in
+  let scan_errors =
+    match discovery.read_error with
+    | None -> []
+    | Some msg -> [ msg ]
   in
   let keepers =
     List.map (fun keeper_name -> keeper_queue_summary ~base_path ~keeper_name) keeper_names

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -615,11 +615,22 @@ let () =
         ~base_path
         ~keeper_name:inflight_keeper
         [ inflight ];
+      let noise_keeper_dir =
+        Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) "snapshotless"
+      in
+      Unix.mkdir noise_keeper_dir 0o755;
+      let dot_noise_keeper_dir =
+        Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) ".worktrees"
+      in
+      Unix.mkdir dot_noise_keeper_dir 0o755;
       let json =
         Keeper_event_queue_persistence.fleet_summary_json ~now:30.0 ~base_path
       in
       Alcotest.(check string) "summary status" "ok" (string_field "status" json);
-      Alcotest.(check int) "keeper_count" 2 (int_field "keeper_count" json);
+      Alcotest.(check int)
+        "keeper_count excludes snapshotless runtime dirs"
+        2
+        (int_field "keeper_count" json);
       Alcotest.(check int) "pending_count" 2 (int_field "pending_count" json);
       Alcotest.(check int) "inflight_count" 1 (int_field "inflight_count" json);
       Alcotest.(check int) "total_count" 3 (int_field "total_count" json);

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 242
+  check int "Keeper_metrics.all covers every constructor" 243
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
## Summary
- update the zero-fill Keeper_metrics.all drift tripwire from 242 to 243 after #23285 added one metric constructor
- filter keeper_event_queue fleet health through durable snapshot discovery so snapshotless runtime directories such as .worktrees or backups are not reported as keepers

## Verification
- opam exec -- ocamlformat --check test/test_otel_zero_fill.ml
- opam exec -- ocamlformat --check lib/keeper_runtime/keeper_event_queue_persistence.ml test/test_keeper_event_queue.ml
- git diff --check
- gtimeout 180 scripts/dune-local.sh build @test/runtest-test_otel_zero_fill
- gtimeout 180 scripts/dune-local.sh build test/test_keeper_event_queue.exe
- gtimeout 120 ./_build/default/test/test_keeper_event_queue.exe

## Context
Follow-up for merged #23285. CI Build and Test failed in quick suite because test_otel_zero_fill expected 242 while Keeper_metrics.all now has 243 entries.

A live /health?full=1 repro after #23285 showed the new durable queue health surfacing the stale backlog correctly, but the lower-level keeper_event_queue section also counted snapshotless runtime directories as keepers. This patch reuses the existing snapshot-bearing discovery boundary for that health section instead of scanning every valid-looking runtime directory.