### PR TITLE
[codex] measure dashboard external fanout duration

### DIFF
--- a/lib/otel_metric_store/otel_transport_metric_names.ml
+++ b/lib/otel_metric_store/otel_transport_metric_names.ml
@@ -13,6 +13,10 @@ let metric_sse_external_subscriber_callback_failures =
   Otel_metric_store_core.declare_counter "masc_sse_external_subscriber_callback_failures_total"
 ;;
 
+let metric_sse_external_fanout_duration_seconds =
+  "masc_sse_external_fanout_duration_seconds"
+;;
+
 let metric_oas_sse_relay_drop_marker_failures =
   Otel_metric_store_core.declare_counter "masc_oas_sse_relay_drop_marker_failures_total"
 ;;

--- a/lib/otel_metric_store/otel_transport_metric_names.mli
+++ b/lib/otel_metric_store/otel_transport_metric_names.mli
@@ -9,6 +9,7 @@ val metric_sse_broadcast_duration : string
 val metric_sse_broadcast_events : string
 val metric_sse_broadcast_failures : string
 val metric_sse_external_subscriber_callback_failures : string
+val metric_sse_external_fanout_duration_seconds : string
 val metric_oas_sse_relay_drop_marker_failures : string
 val metric_sse_stream_queue_depth : string
 val metric_sse_queue_depth_avg : string

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -837,40 +837,50 @@ let remove_external_subscribers ids =
     Dead subscribers (where [is_alive] returns [false]) are automatically
     removed during iteration, preventing resource leaks. *)
 let notify_external_subscribers event =
-  (* [Atomic.get] returns an immutable [SMap.t] snapshot — concurrent
-     subscribe/unsubscribe builds a new map via [Lockfree_atomic.update_with_commit]
-     and never mutates the one we hold here. So we can iterate the map
-     directly without first materializing it as a list, saving one [cons]
-     per subscriber per broadcast. At fleet sizes (14 keepers × dashboard
-     subs ≈ 30-50) and high event rates this trims sustained allocation
-     pressure on the hot fanout path. *)
-  let subscribers = (Atomic.get external_subscribers).subscribers in
-  let dead = ref [] in
-  SMap.iter (fun _ (sub : external_subscriber) ->
-    if not (sub.is_alive ()) then
-      dead := sub.sub_id :: !dead
-    else begin
-      try sub.callback event
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        (* P1 silent-failure fix: previously only logged.  Increment a
-           counter so dashboards distinguish "all subscribers healthy"
-           from "subscribers exist but every callback throws." *)
-        Transport_metrics.inc_external_subscriber_callback_failure ();
-        Log.Misc.warn "External subscriber %s failed: %s"
-          sub.sub_id (Printexc.to_string exn)
-    end
-  ) subscribers;
-  (* Remove dead subscribers *)
-  if !dead <> [] then begin
-    let removed_ids, count = remove_external_subscribers !dead in
-    List.iter
-      (fun id -> Log.Misc.info "Auto-removed dead external subscriber: %s" id)
-      removed_ids;
-    if removed_ids <> [] then
-      Transport_metrics.set_sse_external_subscribers count
-  end
+  let t0 = Time_compat.now () in
+  let record_duration () =
+    Transport_metrics.observe_external_subscriber_fanout_duration
+      (Time_compat.now () -. t0)
+  in
+  try
+    (* [Atomic.get] returns an immutable [SMap.t] snapshot — concurrent
+       subscribe/unsubscribe builds a new map via [Lockfree_atomic.update_with_commit]
+       and never mutates the one we hold here. So we can iterate the map
+       directly without first materializing it as a list, saving one [cons]
+       per subscriber per broadcast. At fleet sizes (14 keepers × dashboard
+       subs ≈ 30-50) and high event rates this trims sustained allocation
+       pressure on the hot fanout path. *)
+    let subscribers = (Atomic.get external_subscribers).subscribers in
+    let dead = ref [] in
+    SMap.iter
+      (fun _ (sub : external_subscriber) ->
+        if not (sub.is_alive ())
+        then dead := sub.sub_id :: !dead
+        else
+          try sub.callback event with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              (* P1 silent-failure fix: previously only logged.  Increment a
+                 counter so dashboards distinguish "all subscribers healthy"
+                 from "subscribers exist but every callback throws." *)
+              Transport_metrics.inc_external_subscriber_callback_failure ();
+              Log.Misc.warn "External subscriber %s failed: %s" sub.sub_id
+                (Printexc.to_string exn))
+      subscribers;
+    (* Remove dead subscribers *)
+    if !dead <> [] then begin
+      let removed_ids, count = remove_external_subscribers !dead in
+      List.iter
+        (fun id -> Log.Misc.info "Auto-removed dead external subscriber: %s" id)
+        removed_ids;
+      if removed_ids <> [] then
+        Transport_metrics.set_sse_external_subscribers count
+    end;
+    record_duration ()
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+      record_duration ();
+      raise e
 
 (** Actively reap dead external subscribers.
     Unlike [notify_external_subscribers] which only checks [is_alive] during

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -78,6 +78,12 @@ let inc_external_subscriber_callback_failure () =
   Otel_metric_store.inc_counter Otel_metric_store.metric_sse_external_subscriber_callback_failures ()
 ;;
 
+let observe_external_subscriber_fanout_duration seconds =
+  Otel_metric_store.observe_histogram
+    Otel_metric_store.metric_sse_external_fanout_duration_seconds
+    (max 0.0 seconds)
+;;
+
 (* P2 silent-failure fix (transport scan):
    The OAS relay drop-marker is the operator-visible signal that an
    OAS event was dropped after exhausting retries.  If the drop marker
@@ -562,6 +568,17 @@ let transport_health_json ~config =
   let broadcast_avg =
     if broadcast_count > 0.0 then broadcast_sum /. broadcast_count else 0.0
   in
+  let external_fanout_sum =
+    v Otel_metric_store.metric_sse_external_fanout_duration_seconds ()
+  in
+  let external_fanout_count =
+    v (Otel_metric_store.metric_sse_external_fanout_duration_seconds ^ "_count") ()
+  in
+  let external_fanout_avg =
+    if external_fanout_count > 0.0
+    then external_fanout_sum /. external_fanout_count
+    else 0.0
+  in
   let grpc_streams = v Otel_metric_store.metric_grpc_active_streams () in
   let grpc_subscribers = v Otel_metric_store.metric_grpc_subscribers () in
   let grpc_heartbeat_sum = v Otel_metric_store.metric_grpc_heartbeat_latency () in
@@ -635,6 +652,9 @@ let transport_health_json ~config =
           ; "external_subscribers", `Int sse_external_subscribers
           ; "broadcast_avg_seconds", `Float broadcast_avg
           ; "broadcast_count", `Int (int_of_float broadcast_count)
+          ; "external_fanout_avg_seconds", `Float external_fanout_avg
+          ; "external_fanout_count", `Int (int_of_float external_fanout_count)
+          ; "external_fanout_sum_seconds", `Float external_fanout_sum
           ; "queue_avg_depth", `Float sse_queue_avg
           ; "queue_max_depth", `Int sse_queue_max
           ; "relay_queue_depth", `Int relay_queue_depth

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -67,6 +67,12 @@ val inc_broadcast_failure : ?target:string -> unit -> unit
     the warn log line. *)
 val inc_external_subscriber_callback_failure : unit -> unit
 
+(** Records the synchronous duration of
+    [Sse.notify_external_subscribers] for one durable broadcast.  This is the
+    Wave-A main-domain occupancy probe for the external subscriber fan-out
+    section that delivers dashboard WebSocket deltas. *)
+val observe_external_subscriber_fanout_duration : float -> unit
+
 (** Increments [masc_oas_sse_relay_drop_marker_failures_total].
     Distinct from {!inc_broadcast_failure} so the
     recovery-path failure rate is isolated from normal broadcast

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -349,6 +349,10 @@ let test_transport_health_json () =
     Otel_metric_store.metric_total
       (Otel_metric_store.metric_ws_dashboard_hello_latency_seconds ^ "_count")
   in
+  let external_fanout_count_before =
+    Otel_metric_store.metric_total
+      (Otel_metric_store.metric_sse_external_fanout_duration_seconds ^ "_count")
+  in
   TM.observe_ws_dashboard_hello_latency ~success:true 0.125;
   Masc.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   Masc.Sse.sync_transport_snapshot ~force:true ();
@@ -377,6 +381,21 @@ let test_transport_health_json () =
     (sse_json |> U.member "relay_retry_total" |> U.to_int);
   check int "relay drops total" 4
     (sse_json |> U.member "relay_drop_total" |> U.to_int);
+  check bool "external fanout avg surfaced" true
+    (match sse_json |> U.member "external_fanout_avg_seconds" with
+     | `Float _ | `Int _ -> true
+     | _ -> false);
+  check bool "external fanout count surfaced" true
+    (match sse_json |> U.member "external_fanout_count" with
+     | `Int _ -> true
+     | _ -> false);
+  check bool "external fanout count advances" true
+    (float_of_int (sse_json |> U.member "external_fanout_count" |> U.to_int)
+     >= external_fanout_count_before +. 1.0);
+  check bool "external fanout sum surfaced" true
+    (match sse_json |> U.member "external_fanout_sum_seconds" with
+     | `Float _ | `Int _ -> true
+     | _ -> false);
   check bool "streamable http configured field exists" true
     (match streamable_json |> U.member "configured" with
     | `Bool _ -> true


### PR DESCRIPTION
## What changed

- Add `masc_sse_external_fanout_duration_seconds` to measure the synchronous external subscriber fan-out section for each durable SSE broadcast.
- Surface external fan-out sum/count/avg in `/health?full=1` transport JSON under the SSE section.
- Guard the health JSON fields and counter advancement in `test_transport_metrics`.

## Why

PR #23339 removed per-session dashboard delta payload reserialization. This follow-up adds the Wave A G-MAIN-OCC probe from the perf-collapse matrix: operators can now measure whether the external fan-out section that carries dashboard WebSocket deltas stays bounded after rollout.

## Validation

- `ocamlformat --check lib/sse.ml lib/transport_metrics.ml lib/transport_metrics.mli lib/otel_metric_store/otel_transport_metric_names.ml lib/otel_metric_store/otel_transport_metric_names.mli test/test_transport_metrics.ml`
- `git diff --check`

Local dune build intentionally not run; CI is the OCaml build authority for this repo.
