### PR TITLE
[codex] expose scheduler queue evidence

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -90,6 +90,27 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   reason?: string
 }
 
+export interface DashboardScheduledAutomationKeeperQueueEvidence {
+  projection_status: 'matched_pending' | 'matched_inflight' | 'not_found' | 'read_error' | 'unrecognized_receipt'
+  source?: string
+  queue?: string
+  stimulus?: string
+  keeper_name?: string
+  schedule_id?: string
+  post_id?: string
+  pending_count?: number
+  inflight_count?: number
+  matched_bucket?: string
+  matched_post_id?: string
+  matched_schedule_id?: string | null
+  matched_payload_kind?: string
+  matched_arrived_at?: number
+  matched_arrived_at_iso?: string
+  matched_age_seconds?: number
+  read_errors?: Array<{ kind?: string; path?: string | null; message?: string }>
+  reason?: string
+}
+
 export interface DashboardScheduledAutomationKeeperToolStatus {
   name: string
   registered_schema?: boolean
@@ -165,6 +186,7 @@ export interface DashboardScheduledAutomationRequest {
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
+  keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,7 @@ export type {
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
   DashboardScheduledAutomationDispatchReceipt,
+  DashboardScheduledAutomationKeeperQueueEvidence,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,
   DashboardScheduledAutomationSignal,

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -611,6 +611,25 @@ describe('ScheduledAutomationPanel', () => {
           urgency: 'immediate',
           post_id: 'schedule-due:sched-keeper-wake',
         },
+        keeper_queue_evidence: {
+          projection_status: 'matched_pending',
+          source: 'durable_event_queue_snapshot',
+          queue: 'keeper_event_queue',
+          stimulus: 'schedule_due',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          post_id: 'schedule-due:sched-keeper-wake',
+          pending_count: 1,
+          inflight_count: 0,
+          matched_bucket: 'pending',
+          matched_post_id: 'schedule-due:sched-keeper-wake',
+          matched_schedule_id: 'sched-keeper-wake',
+          matched_payload_kind: 'schedule_due',
+          matched_arrived_at: 201,
+          matched_arrived_at_iso: '2026-06-21T00:03:21Z',
+          matched_age_seconds: 0,
+          read_errors: [],
+        },
       }),
     ])
 
@@ -623,6 +642,12 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
     expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
     expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const queueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(queueEvidence).not.toBeNull()
+    expect(queueEvidence?.getAttribute('data-schedule-keeper-queue-evidence-source')).toBe('durable_event_queue_snapshot')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_bucket"]')?.textContent).toContain('pending')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="pending_count"]')?.textContent).toContain('1')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_payload_kind"]')?.textContent).toContain('schedule_due')
 
     render(null, container)
     render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
@@ -640,6 +665,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2Receipt?.textContent).toContain('keeper_event_queue')
     expect(v2Receipt?.textContent).toContain('schedule_due')
     expect(v2Receipt?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const v2QueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(v2QueueEvidence).not.toBeNull()
+    expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
+    expect(v2QueueEvidence?.textContent).toContain('matched pending')
+    expect(v2QueueEvidence?.textContent).toContain('schedule_due')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -6,6 +6,7 @@ import {
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
+  type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
@@ -461,6 +462,83 @@ function DispatchReceiptBlock({
   `
 }
 
+function queueEvidenceTone(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): StatusChipTone {
+  if (!evidence) return 'neutral'
+  if (evidence.projection_status === 'matched_pending' || evidence.projection_status === 'matched_inflight') return 'ok'
+  if (evidence.projection_status === 'not_found' || evidence.projection_status === 'read_error') return 'warn'
+  return 'bad'
+}
+
+function queueEvidenceRows(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!evidence) return []
+  const readErrors = (evidence.read_errors ?? [])
+    .map(error => [error.kind, error.path, error.message].filter(Boolean).join(': '))
+    .filter(value => value.trim() !== '')
+    .join(' | ')
+  const rows: Array<{ label: string; value: string | number | null | undefined }> = [
+    { label: 'source', value: evidence.source },
+    { label: 'queue', value: evidence.queue },
+    { label: 'stimulus', value: evidence.stimulus },
+    { label: 'keeper', value: evidence.keeper_name },
+    { label: 'schedule', value: evidence.schedule_id },
+    { label: 'post_id', value: evidence.post_id },
+    { label: 'pending_count', value: evidence.pending_count },
+    { label: 'inflight_count', value: evidence.inflight_count },
+    { label: 'matched_bucket', value: evidence.matched_bucket },
+    { label: 'matched_payload_kind', value: evidence.matched_payload_kind },
+    { label: 'matched_post_id', value: evidence.matched_post_id },
+    { label: 'matched_schedule_id', value: evidence.matched_schedule_id },
+    { label: 'matched_arrived_at', value: evidence.matched_arrived_at_iso },
+    { label: 'matched_age_seconds', value: evidence.matched_age_seconds },
+    { label: 'read_errors', value: readErrors },
+    { label: 'reason', value: evidence.reason },
+  ]
+  return rows
+    .map(row => ({ label: row.label, value: row.value == null ? '' : String(row.value) }))
+    .filter(row => row.value.trim() !== '')
+}
+
+function QueueEvidenceBlock({
+  evidence,
+  compact = false,
+}: {
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  compact?: boolean
+}) {
+  if (!evidence) return null
+  const rows = queueEvidenceRows(evidence)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-keeper-queue-evidence=${evidence.projection_status}
+      data-schedule-keeper-queue-evidence-source=${evidence.source ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">keeper_queue_evidence</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">keeper queue evidence</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${queueEvidenceTone(evidence)} uppercase=${false}>
+            ${enumLabel(evidence.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2'} data-keeper-queue-evidence-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -723,9 +801,11 @@ function ScheduleCard({
 function LastExecutionBlock({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
@@ -766,6 +846,7 @@ function LastExecutionBlock({
           `
         : null}
       <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
+      <${QueueEvidenceBlock} evidence=${queueEvidence} />
     </div>
   `
 }
@@ -857,6 +938,7 @@ function ScheduleDetailPanel({
           <${LastExecutionBlock}
             execution=${execution}
             dispatchReceipt=${request.dispatch_receipt ?? null}
+            queueEvidence=${request.keeper_queue_evidence ?? null}
           />
         </div>
       </div>
@@ -1420,6 +1502,7 @@ function SchDetail({
             <${SchExecution}
               execution=${execution}
               dispatchReceipt=${request.dispatch_receipt ?? null}
+              queueEvidence=${request.keeper_queue_evidence ?? null}
             />
           </div>
 
@@ -1433,9 +1516,11 @@ function SchDetail({
 function SchExecution({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
@@ -1451,6 +1536,7 @@ function SchExecution({
       `)}
     </div>
     <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
+    <${QueueEvidenceBlock} evidence=${queueEvidence} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2736,6 +2736,8 @@ let schedule_queue_read_error_dashboard_json
 
 let schedule_queue_match
   ~(schedule_id : string)
+  ~(due_at : float)
+  ~(payload_digest : string)
   ~(post_id : string)
   ~(stimulus_label : string)
   (queue : Keeper_event_queue.t)
@@ -2749,19 +2751,38 @@ let schedule_queue_match
     match stimulus.payload with
     | Keeper_event_queue.Schedule_due wake ->
       String.equal wake.schedule_id schedule_id
+      && Float.equal wake.due_at due_at
+      && String.equal wake.payload_digest payload_digest
     | _ -> false)
 ;;
 
 let schedule_queue_match_fields ~now bucket (stimulus : Keeper_event_queue.stimulus) =
+  let scheduled_wake =
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake -> Some wake
+    | _ -> None
+  in
   [ "matched_bucket", `String bucket
   ; "matched_post_id", `String stimulus.post_id
   ; "matched_payload_kind", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
   ; "matched_arrived_at", `Float stimulus.arrived_at
   ; "matched_arrived_at_iso", unix_iso_json stimulus.arrived_at
   ; ( "matched_schedule_id"
-    , match stimulus.payload with
-      | Keeper_event_queue.Schedule_due wake -> `String wake.schedule_id
-      | _ -> `Null )
+    , match scheduled_wake with
+      | Some wake -> `String wake.schedule_id
+      | None -> `Null )
+  ; ( "matched_due_at"
+    , match scheduled_wake with
+      | Some wake -> `Float wake.due_at
+      | None -> `Null )
+  ; ( "matched_due_at_iso"
+    , match scheduled_wake with
+      | Some wake -> unix_iso_json wake.due_at
+      | None -> `Null )
+  ; ( "matched_payload_digest"
+    , match scheduled_wake with
+      | Some wake -> `String wake.payload_digest
+      | None -> `Null )
   ; "matched_age_seconds", `Float (Float.max 0.0 (now -. stimulus.arrived_at))
   ]
 ;;
@@ -2787,16 +2808,20 @@ let schedule_keeper_queue_evidence_dashboard_json
         | Ok
             (Server_schedule_consumers.Keeper_wake_enqueued
               { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+          let due_at = execution.Schedule_domain.due_at in
+          let payload_digest = execution.Schedule_domain.payload_digest in
           let snapshot =
             Keeper_event_queue_persistence.load_snapshot_pair_with_errors
               ~base_path:config.Workspace_utils.base_path
               ~keeper_name
           in
           let pending_match =
-            schedule_queue_match ~schedule_id ~post_id ~stimulus_label:stimulus snapshot.pending
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.pending
           in
           let inflight_match =
-            schedule_queue_match ~schedule_id ~post_id ~stimulus_label:stimulus snapshot.inflight
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.inflight
           in
           let read_errors =
             List.map schedule_queue_read_error_dashboard_json snapshot.read_errors
@@ -2808,6 +2833,9 @@ let schedule_keeper_queue_evidence_dashboard_json
             ; "keeper_name", `String keeper_name
             ; "schedule_id", `String schedule_id
             ; "post_id", `String post_id
+            ; "execution_due_at", `Float due_at
+            ; "execution_due_at_iso", unix_iso_json due_at
+            ; "execution_payload_digest", `String payload_digest
             ; "pending_count", `Int (Keeper_event_queue.length snapshot.pending)
             ; "inflight_count", `Int (Keeper_event_queue.length snapshot.inflight)
             ; "read_errors", `List read_errors

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2721,6 +2721,115 @@ let schedule_dispatch_receipt_dashboard_json
          ]))
 ;;
 
+let schedule_queue_read_error_dashboard_json
+  (error : Keeper_event_queue_persistence.snapshot_read_error)
+  =
+  `Assoc
+    [ "kind", `String (Keeper_event_queue_persistence.snapshot_read_error_kind_to_string error.kind)
+    ; ( "path"
+      , match error.path with
+        | None -> `Null
+        | Some path -> `String path )
+    ; "message", `String error.message
+    ]
+;;
+
+let schedule_queue_match
+  ~(schedule_id : string)
+  ~(post_id : string)
+  ~(stimulus_label : string)
+  (queue : Keeper_event_queue.t)
+  =
+  queue
+  |> Keeper_event_queue.to_list
+  |> List.find_opt (fun (stimulus : Keeper_event_queue.stimulus) ->
+    String.equal stimulus.post_id post_id
+    && String.equal (Keeper_event_queue.payload_kind_label stimulus.payload) stimulus_label
+    &&
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake ->
+      String.equal wake.schedule_id schedule_id
+    | _ -> false)
+;;
+
+let schedule_queue_match_fields ~now bucket (stimulus : Keeper_event_queue.stimulus) =
+  [ "matched_bucket", `String bucket
+  ; "matched_post_id", `String stimulus.post_id
+  ; "matched_payload_kind", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+  ; "matched_arrived_at", `Float stimulus.arrived_at
+  ; "matched_arrived_at_iso", unix_iso_json stimulus.arrived_at
+  ; ( "matched_schedule_id"
+    , match stimulus.payload with
+      | Keeper_event_queue.Schedule_due wake -> `String wake.schedule_id
+      | _ -> `Null )
+  ; "matched_age_seconds", `Float (Float.max 0.0 (now -. stimulus.arrived_at))
+  ]
+;;
+
+let schedule_keeper_queue_evidence_dashboard_json
+  ~now
+  (config : Workspace.config)
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error reason ->
+          `Assoc
+            [ "projection_status", `String "unrecognized_receipt"
+            ; "reason", `String reason
+            ]
+        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+          let snapshot =
+            Keeper_event_queue_persistence.load_snapshot_pair_with_errors
+              ~base_path:config.Workspace_utils.base_path
+              ~keeper_name
+          in
+          let pending_match =
+            schedule_queue_match ~schedule_id ~post_id ~stimulus_label:stimulus snapshot.pending
+          in
+          let inflight_match =
+            schedule_queue_match ~schedule_id ~post_id ~stimulus_label:stimulus snapshot.inflight
+          in
+          let read_errors =
+            List.map schedule_queue_read_error_dashboard_json snapshot.read_errors
+          in
+          let base_fields =
+            [ "source", `String "durable_event_queue_snapshot"
+            ; "queue", `String queue
+            ; "stimulus", `String stimulus
+            ; "keeper_name", `String keeper_name
+            ; "schedule_id", `String schedule_id
+            ; "post_id", `String post_id
+            ; "pending_count", `Int (Keeper_event_queue.length snapshot.pending)
+            ; "inflight_count", `Int (Keeper_event_queue.length snapshot.inflight)
+            ; "read_errors", `List read_errors
+            ]
+          in
+          (match pending_match, inflight_match, snapshot.read_errors with
+           | Some match_, _, _ ->
+             `Assoc
+               (("projection_status", `String "matched_pending")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "pending" match_)
+           | None, Some match_, _ ->
+             `Assoc
+               (("projection_status", `String "matched_inflight")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "inflight" match_)
+           | None, None, _ :: _ ->
+             `Assoc (("projection_status", `String "read_error") :: base_fields)
+           | None, None, [] ->
+             `Assoc (("projection_status", `String "not_found") :: base_fields))))
+;;
+
 let schedule_signal_projection_limit = 20
 
 let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
@@ -2751,6 +2860,7 @@ let schedule_signal_dashboard_json (signal : Schedule_runner.wake_signal) =
 
 let schedule_request_dashboard_json
   ~now
+  ~config
   ~state
   ?last_execution
   (request : Schedule_domain.schedule_request)
@@ -2823,6 +2933,7 @@ let schedule_request_dashboard_json
         | None -> `Null
         | Some execution -> execution_record_dashboard_json execution )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
+    ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_execution
     ]
 ;;
 
@@ -2932,7 +3043,7 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
                   Schedule_store.last_execution_for_schedule state
                     ~schedule_id:request.Schedule_domain.schedule_id
                 in
-                schedule_request_dashboard_json ~now ~state ?last_execution request)
+                schedule_request_dashboard_json ~now ~config ~state ?last_execution request)
              request_rows) )
     ]
 ;;

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -374,7 +374,7 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
   (match Keeper_registry_event_queue.drop_by_post_id ~base_path keeper_name ~post_id with
    | Error message -> fail ("drop failed: " ^ message)
    | Ok removed -> check int "removed current occurrence" 1 (List.length removed));
-  let stale_payload =
+  let stale_payload_json =
     `Assoc
       [ "kind", `String "masc.keeper_wake"
       ; "schema_version", `Int 1
@@ -386,6 +386,11 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
             ; "urgency", `String "immediate"
             ] )
       ]
+  in
+  let stale_payload =
+    match Schedule_domain.payload_of_yojson stale_payload_json with
+    | Ok payload -> payload
+    | Error message -> fail ("stale payload parse failed: " ^ message)
   in
   let stale_wake : Keeper_event_queue.scheduled_wake =
     { schedule_id = request.schedule_id

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -336,12 +336,101 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (queue_evidence |> member "matched_payload_kind" |> to_string);
     check string "queue evidence matched schedule" request.schedule_id
       (queue_evidence |> member "matched_schedule_id" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check (float 0.001) "queue evidence matched due_at" request.due_at
+      (queue_evidence |> member "matched_due_at" |> to_float);
+    check string "queue evidence matched digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "matched_payload_digest" |> to_string);
     check int "queue evidence pending count" 1
       (queue_evidence |> member "pending_count" |> to_int);
     check int "queue evidence inflight count" 0
       (queue_evidence |> member "inflight_count" |> to_int);
     check int "queue evidence read errors" 0
       (queue_evidence |> member "read_errors" |> to_list |> List.length)
+;;
+
+let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let request = create_pending_keeper_wake_schedule config in
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  ignore (tick_ok config ~now:201.0 : Schedule_runner.tick_result);
+  let expected_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at
+    ; payload_digest = Schedule_domain.payload_digest request.payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run the scheduled maintenance lane now."
+    }
+  in
+  let post_id = Keeper_event_queue.schedule_due_post_id expected_wake in
+  (match Keeper_registry_event_queue.drop_by_post_id ~base_path keeper_name ~post_id with
+   | Error message -> fail ("drop failed: " ^ message)
+   | Ok removed -> check int "removed current occurrence" 1 (List.length removed));
+  let stale_payload =
+    `Assoc
+      [ "kind", `String "masc.keeper_wake"
+      ; "schema_version", `Int 1
+      ; ( "body"
+        , `Assoc
+            [ "keeper_name", `String keeper_name
+            ; "title", `String "Scheduled lane wake"
+            ; "message", `String "Run a different scheduled occurrence."
+            ; "urgency", `String "immediate"
+            ] )
+      ]
+  in
+  let stale_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at +. 60.0
+    ; payload_digest = Schedule_domain.payload_digest stale_payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run a different scheduled occurrence."
+    }
+  in
+  let stale_stimulus : Keeper_event_queue.stimulus =
+    { post_id = Keeper_event_queue.schedule_due_post_id stale_wake
+    ; urgency = Keeper_event_queue.Immediate
+    ; arrived_at = request.due_at +. 61.0
+    ; payload = Keeper_event_queue.Schedule_due stale_wake
+    }
+  in
+  Keeper_registry_event_queue.enqueue ~base_path keeper_name stale_stimulus;
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  match row with
+  | None -> fail "keeper wake schedule missing from dashboard projection"
+  | Some row ->
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "stale occurrence does not match" "not_found"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check int "stale occurrence still visible as pending" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
@@ -415,6 +504,8 @@ let () =
             test_board_post_consumer_rejects_read_only_risk
         ; test_case "keeper wake enqueues typed stimulus" `Quick
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
+        ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
+            test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -320,7 +320,28 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
     check string "receipt urgency" "immediate"
       (receipt |> member "urgency" |> to_string);
     check string "receipt post id" "schedule-due:keeper-wake-sched-1"
-      (receipt |> member "post_id" |> to_string)
+      (receipt |> member "post_id" |> to_string);
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "queue evidence matched" "matched_pending"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check string "queue evidence source" "durable_event_queue_snapshot"
+      (queue_evidence |> member "source" |> to_string);
+    check string "queue evidence keeper" "schedule-keeper"
+      (queue_evidence |> member "keeper_name" |> to_string);
+    check string "queue evidence stimulus" "schedule_due"
+      (queue_evidence |> member "stimulus" |> to_string);
+    check string "queue evidence matched bucket" "pending"
+      (queue_evidence |> member "matched_bucket" |> to_string);
+    check string "queue evidence matched payload" "schedule_due"
+      (queue_evidence |> member "matched_payload_kind" |> to_string);
+    check string "queue evidence matched schedule" request.schedule_id
+      (queue_evidence |> member "matched_schedule_id" |> to_string);
+    check int "queue evidence pending count" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int);
+    check int "queue evidence read errors" 0
+      (queue_evidence |> member "read_errors" |> to_list |> List.length)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -884,6 +884,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check bool "unrecognized dispatch receipt reason" true
       (String_util.contains_substring
          (row |> member "dispatch_receipt" |> member "reason" |> to_string)
+         "unsupported schedule dispatch receipt kind: test.exec");
+    check string "unrecognized queue evidence status" "unrecognized_receipt"
+      (row |> member "keeper_queue_evidence" |> member "projection_status" |> to_string);
+    check bool "unrecognized queue evidence reason" true
+      (String_util.contains_substring
+         (row |> member "keeper_queue_evidence" |> member "reason" |> to_string)
          "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 


### PR DESCRIPTION
## Summary
- add `keeper_queue_evidence` to scheduled automation dashboard rows by reading durable keeper event queue snapshots for `masc.keeper_wake` receipts
- distinguish matched pending, matched inflight, not found, read error, and unrecognized receipt states instead of treating a stored dispatch receipt as queue proof
- render the queue evidence block in both diagnostics and v2 schedule detail surfaces

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml test/test_schedule_consumer_dispatch.ml test/test_schedule_tool_wiring.ml`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts src/components/schedule/schedule-surface.test.ts src/components/tools/tools-main.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `env GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py`
- `git diff --check`

Local Dune build/test was not run; per repo workflow, Dune build authority remains CI.

Stacked on #23340 / `codex/scheduler-wake-queue-receipt-20260706`.