### PR TITLE
fix(keeper): stateful stream redaction for split-chunk secrets (#23315 follow-up)

### DIFF
--- a/lib/keeper/keeper_secret_redaction.ml
+++ b/lib/keeper/keeper_secret_redaction.ml
@@ -123,6 +123,36 @@ let redact_text t text =
   in
   Observability_redact.redact_text text
 
+(* Streaming chunk redaction. [redact_text] is stateless: a single-line
+   secret split across chunk N's tail and chunk N+1's head matches in
+   neither call. [stream_state] buffers raw bytes up to the last ['\n'] so
+   the containing line is reassembled before redaction. Multi-line secrets
+   (a value containing ['\n'], e.g. a PEM block) may still partially
+   surface if the buffer's last ['\n'] falls inside the secret; this is
+   strictly better than the pre-fix behaviour where every cross-chunk split
+   leaked. *)
+type stream_state = { pending : Buffer.t }
+
+let create_stream_state () = { pending = Buffer.create 256 }
+
+let redact_stream_chunk t state chunk =
+  Buffer.add_string state.pending chunk;
+  let contents = Buffer.contents state.pending in
+  match String.rindex_opt contents '\n' with
+  | None -> ""
+  | Some nl_pos ->
+    let safe_len = nl_pos + 1 in
+    let safe_raw = String.sub contents 0 safe_len in
+    let held = String.sub contents safe_len (String.length contents - safe_len) in
+    Buffer.clear state.pending;
+    Buffer.add_string state.pending held;
+    redact_text t safe_raw
+
+let redact_stream_finish t state =
+  let contents = Buffer.contents state.pending in
+  Buffer.clear state.pending;
+  if String.equal contents "" then "" else redact_text t contents
+
 let rec redact_json_exact t = function
   | `String s -> `String (redact_text t s)
   | `Assoc fields ->

--- a/lib/keeper/keeper_secret_redaction.mli
+++ b/lib/keeper/keeper_secret_redaction.mli
@@ -18,6 +18,21 @@ val redact_text : t -> string -> string
     with [\[REDACTED\]], preserving message length semantics except for
     the replacements themselves. *)
 
+type stream_state
+
+val create_stream_state : unit -> stream_state
+
+val redact_stream_chunk : t -> stream_state -> string -> string
+(** Stateful chunk redaction for streaming output. Buffers raw bytes up to
+    the last ['\n'] so a single-line secret split across chunk boundaries is
+    reassembled into one {!redact_text} call. Returns only the bytes safe
+    to emit now; the remainder is held until the next chunk or
+    {!redact_stream_finish}. *)
+
+val redact_stream_finish : t -> stream_state -> string
+(** Flush any remaining buffered bytes at end of stream and redact them as
+    one unit. *)
+
 val redact_json : t -> Yojson.Safe.t -> Yojson.Safe.t
 (** Redact all string leaves in a JSON value, preserving shape. *)
 

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -490,7 +490,6 @@ let handle_tool_execute_typed
   let output_redaction =
     execute_secret_redaction ~base_path:config.base_path ~keeper_name:meta.name
   in
-  let redact_execute_text_value = redact_execute_text output_redaction in
   match
     Keeper_tool_execute_path.resolve_tool_execute_cwd
       ~config
@@ -786,6 +785,12 @@ let handle_tool_execute_typed
                 "execute stream start callback failed keeper=%s: %s"
                 meta.name
                 (Printexc.to_string exn));
+          let stdout_redact_state =
+            Keeper_secret_redaction.create_stream_state ()
+          in
+          let stderr_redact_state =
+            Keeper_secret_redaction.create_stream_state ()
+          in
           let on_output_chunk chunk =
             if stream_dispatch
             then (
@@ -794,7 +799,15 @@ let handle_tool_execute_typed
                 | `Stdout s -> `Stdout, s
                 | `Stderr s -> `Stderr, s
               in
-              let data = redact_execute_text_value data in
+              let data =
+                match stream with
+                | `Stdout ->
+                  Keeper_secret_redaction.redact_stream_chunk
+                    output_redaction stdout_redact_state data
+                | `Stderr ->
+                  Keeper_secret_redaction.redact_stream_chunk
+                    output_redaction stderr_redact_state data
+              in
               try
                 Keeper_keepalive_signal.record_execute_stream_chunk
                   ~keeper_name:meta.name
@@ -949,6 +962,28 @@ let handle_tool_execute_typed
             in
             if stream_dispatch
             then (
+              let flush_remaining stream state =
+                let remaining =
+                  Keeper_secret_redaction.redact_stream_finish
+                    output_redaction state
+                in
+                if not (String.equal remaining "")
+                then (
+                  try
+                    Keeper_keepalive_signal.record_execute_stream_chunk
+                      ~keeper_name:meta.name
+                      ~stream
+                      remaining
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                    Log.Dashboard.warn
+                      "execute stream flush callback failed keeper=%s: %s"
+                      meta.name
+                      (Printexc.to_string exn))
+              in
+              flush_remaining `Stdout stdout_redact_state;
+              flush_remaining `Stderr stderr_redact_state;
               try
                 Keeper_keepalive_signal.record_execute_stream_end
                   ~keeper_name:meta.name

--- a/test/test_keeper_secret_redaction.ml
+++ b/test/test_keeper_secret_redaction.ml
@@ -151,6 +151,47 @@ let test_execute_output_redaction_uses_keeper_snapshot () =
   contains "stdout marker present" stdout "[REDACTED]";
   contains "stderr marker present" stderr "[REDACTED]"
 
+let test_stream_redaction_reassembles_split_secret () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let keeper_name = "stream" in
+  let root = secret_root_default ~base ~keeper_name in
+  let secret = "stream.secret!" in
+  write_file (Filename.concat (Filename.concat root "env") "STREAM_TOKEN") secret;
+  let redaction = R.snapshot ~base_path:base ~keeper_name in
+  let state = R.create_stream_state () in
+  let first = R.redact_stream_chunk redaction state "prefix stream." in
+  Alcotest.(check string) "unterminated line is held" "" first;
+  let second = R.redact_stream_chunk redaction state "secret! suffix\nnext\n" in
+  not_contains "split secret hidden" second secret;
+  contains "split secret marker present" second "[REDACTED]";
+  contains "complete trailing line emitted" second "next\n";
+  Alcotest.(check string)
+    "finish after newline has no held bytes"
+    ""
+    (R.redact_stream_finish redaction state)
+
+let test_stream_redaction_finish_redacts_held_tail () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "MASC_SECRET_DIR" "" @@ fun () ->
+  let keeper_name = "stream-tail" in
+  let root = secret_root_default ~base ~keeper_name in
+  let secret = "tail.secret!" in
+  write_file (Filename.concat (Filename.concat root "env") "TAIL_TOKEN") secret;
+  let redaction = R.snapshot ~base_path:base ~keeper_name in
+  let state = R.create_stream_state () in
+  let emitted = R.redact_stream_chunk redaction state ("tail=" ^ secret) in
+  Alcotest.(check string) "unterminated tail is held" "" emitted;
+  let flushed = R.redact_stream_finish redaction state in
+  not_contains "held tail secret hidden" flushed secret;
+  contains "held tail marker present" flushed "[REDACTED]";
+  Alcotest.(check string)
+    "finish clears held bytes"
+    ""
+    (R.redact_stream_finish redaction state)
+
 let () =
   Alcotest.run
     "keeper secret redaction"
@@ -165,5 +206,9 @@ let () =
             test_json_redaction_preserves_shape;
           Alcotest.test_case "redacts Execute stdout stderr and combined output" `Quick
             test_execute_output_redaction_uses_keeper_snapshot;
+          Alcotest.test_case "reassembles split stream secrets" `Quick
+            test_stream_redaction_reassembles_split_secret;
+          Alcotest.test_case "redacts held stream tail on finish" `Quick
+            test_stream_redaction_finish_redacts_held_tail;
         ] )
     ]


### PR DESCRIPTION
## Summary

Follow-up to #23315 (Guard keeper execute credentials). The Execute stream redaction added there was applied **per-chunk** via the stateless `Keeper_secret_redaction.redact_text`, so a single-line secret split across a 4096-byte chunk boundary (token tail in chunk N, head in N+1) matched in **neither** call and leaked into the broadcast/persisted stream. The final whole-output redaction does not re-emit replacement events on the streaming path, so the leak was not recovered. (Raised by adversarial review on #23315.)

## Fix

Adds a **stateful line-boundary redactor** to `Keeper_secret_redaction`:
- `stream_state` (per-stream buffer of raw bytes after the last `\n`)
- `redact_stream_chunk t state chunk` — buffers, redacts the complete-line prefix, holds the remainder
- `redact_stream_finish t state` — flushes the remaining buffered bytes as one redacted unit

The runtime keeps separate stdout/stderr stream states and flushes both at stream end (before `record_execute_stream_end`).

Why line-boundary and not an overlap window: `redact_text` changes string length (`[REDACTED]` != secret length), so there is no way to map raw-byte positions back to redacted-byte positions for a sliding window. Line boundaries give an exact reassembly point without position tracking.

## Regression Coverage

Adds tests for:
- a single-line secret split across two stream chunks, held until newline and then emitted redacted
- an unterminated stream tail flushed at `redact_stream_finish` without leaking the secret

## Known limitation (not a regression)

Multi-line secrets (a value containing `\n`, e.g. a PEM block) may still partially surface if the buffer's last `\n` falls inside the secret. This is strictly better than the pre-fix behaviour where **every** cross-chunk split leaked.

## Verified

- `opam exec -- ocamlformat --check lib/keeper/keeper_secret_redaction.ml lib/keeper/keeper_secret_redaction.mli lib/keeper/keeper_tool_execute_runtime.ml test/test_keeper_secret_redaction.ml`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_test_coverage.py`
- `scripts/dune-local.sh build test/test_keeper_secret_redaction.exe`

Local full Dune build was not run; per repo workflow, Dune build authority remains CI.

Co-Authored-By: Claude <noreply@anthropic.com>
