### PR TITLE
dashboard: prove scheduler wake runtime lease

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -95,6 +95,7 @@ export interface DashboardScheduledAutomationDispatchReceipt {
 
 export interface DashboardScheduledAutomationKeeperReactionEvidence {
   projection_status:
+    | 'matched_consumed_ack'
     | 'matched_turn_started'
     | 'matched_stimulus'
     | 'not_found'
@@ -110,11 +111,14 @@ export interface DashboardScheduledAutomationKeeperReactionEvidence {
   reaction_kind?: string
   stimulus_seen?: boolean
   turn_started_seen?: boolean
+  event_queue_ack_seen?: boolean
   matched_record_count?: number
   stimulus_recorded_at?: number | null
   stimulus_recorded_at_iso?: string | null
   turn_started_recorded_at?: number | null
   turn_started_recorded_at_iso?: string | null
+  event_queue_ack_recorded_at?: number | null
+  event_queue_ack_recorded_at_iso?: string | null
   latest_recorded_at?: number | null
   latest_recorded_at_iso?: string | null
   reason?: string
@@ -227,6 +231,27 @@ export interface DashboardScheduledAutomationPayloadSupport {
   unknown_request_count?: number
 }
 
+export interface DashboardScheduledAutomationLiveSupportedNonTerminalEvidence {
+  schema?: string
+  source?: string
+  projection_status:
+    | 'matched_supported_non_terminal'
+    | 'no_supported_payload_rows'
+    | 'no_supported_non_terminal'
+  criteria?: string
+  reason?: string
+  request_count?: number
+  supported_request_count?: number
+  supported_non_terminal_count?: number
+  supported_live_count?: number
+  supported_terminal_or_expired_count?: number
+  unsupported_request_count?: number
+  unknown_request_count?: number
+  terminal_or_expired_count?: number
+  matched_schedule_ids?: string[]
+  matched_schedule_id_limit?: number
+}
+
 export interface DashboardScheduledAutomation {
   schema?: string
   source?: string
@@ -241,6 +266,7 @@ export interface DashboardScheduledAutomation {
   counts: Record<string, number>
   derived_counts?: Record<string, number>
   payload_support?: DashboardScheduledAutomationPayloadSupport
+  live_supported_non_terminal_evidence?: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence
   fsm: DashboardScheduledAutomationFsm
   requests: DashboardScheduledAutomationRequest[]
 }

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -76,6 +76,20 @@ export interface DashboardScheduledAutomationExecution {
   error?: string | null
 }
 
+export interface DashboardScheduledAutomationDispatchReceipt {
+  projection_status: 'recognized' | 'unrecognized_detail'
+  kind?: string
+  queue?: string
+  stimulus?: string
+  keeper_name?: string
+  schedule_id?: string
+  urgency?: string
+  post_id?: string
+  author?: string
+  hearth?: string | null
+  reason?: string
+}
+
 export interface DashboardScheduledAutomationKeeperToolStatus {
   name: string
   registered_schema?: boolean
@@ -150,6 +164,7 @@ export interface DashboardScheduledAutomationRequest {
   requires_separate_human_grant?: boolean
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
+  dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -81,12 +81,42 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   kind?: string
   queue?: string
   stimulus?: string
+  stimulus_id?: string | null
+  reaction_ledger_status?: string | null
+  reaction_ledger_error?: string | null
   keeper_name?: string
   schedule_id?: string
   urgency?: string
   post_id?: string
   author?: string
   hearth?: string | null
+  reason?: string
+}
+
+export interface DashboardScheduledAutomationKeeperReactionEvidence {
+  projection_status:
+    | 'matched_turn_started'
+    | 'matched_stimulus'
+    | 'not_found'
+    | 'missing_stimulus_id'
+    | 'unrecognized_receipt'
+  source?: string
+  keeper_name?: string
+  schedule_id?: string
+  post_id?: string
+  stimulus?: string
+  stimulus_id?: string
+  stimulus_kind?: string
+  reaction_kind?: string
+  stimulus_seen?: boolean
+  turn_started_seen?: boolean
+  matched_record_count?: number
+  stimulus_recorded_at?: number | null
+  stimulus_recorded_at_iso?: string | null
+  turn_started_recorded_at?: number | null
+  turn_started_recorded_at_iso?: string | null
+  latest_recorded_at?: number | null
+  latest_recorded_at_iso?: string | null
   reason?: string
 }
 
@@ -187,6 +217,7 @@ export interface DashboardScheduledAutomationRequest {
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
   keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null
+  keeper_reaction_evidence?: DashboardScheduledAutomationKeeperReactionEvidence | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -90,6 +90,27 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   reason?: string
 }
 
+export interface DashboardScheduledAutomationKeeperQueueEvidence {
+  projection_status: 'matched_pending' | 'matched_inflight' | 'not_found' | 'read_error' | 'unrecognized_receipt'
+  source?: string
+  queue?: string
+  stimulus?: string
+  keeper_name?: string
+  schedule_id?: string
+  post_id?: string
+  pending_count?: number
+  inflight_count?: number
+  matched_bucket?: string
+  matched_post_id?: string
+  matched_schedule_id?: string | null
+  matched_payload_kind?: string
+  matched_arrived_at?: number
+  matched_arrived_at_iso?: string
+  matched_age_seconds?: number
+  read_errors?: Array<{ kind?: string; path?: string | null; message?: string }>
+  reason?: string
+}
+
 export interface DashboardScheduledAutomationKeeperToolStatus {
   name: string
   registered_schema?: boolean
@@ -165,6 +186,7 @@ export interface DashboardScheduledAutomationRequest {
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
+  keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,7 @@ export type {
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
   DashboardScheduledAutomationDispatchReceipt,
+  DashboardScheduledAutomationKeeperQueueEvidence,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,
   DashboardScheduledAutomationSignal,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -195,6 +195,7 @@ export type {
   DashboardScheduledAutomationSignal,
   DashboardScheduledAutomationRequest,
   DashboardScheduledAutomationPayloadSupport,
+  DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
   DashboardScheduledAutomation,
   DashboardToolsResponse,
 } from './dashboard-tools-prompts'

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -187,6 +187,7 @@ export type {
   ToolMetricsResponse,
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
+  DashboardScheduledAutomationDispatchReceipt,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,
   DashboardScheduledAutomationSignal,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,7 @@ export type {
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
   DashboardScheduledAutomationDispatchReceipt,
+  DashboardScheduledAutomationKeeperReactionEvidence,
   DashboardScheduledAutomationKeeperQueueEvidence,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -595,6 +595,7 @@ describe('ScheduledAutomationPanel', () => {
             kind: 'masc.keeper_wake.enqueued',
             queue: 'keeper_event_queue',
             stimulus: 'schedule_due',
+            stimulus_id: 'stimulus:keeper-wake-digest',
             keeper_name: 'schedule-keeper',
             schedule_id: 'sched-keeper-wake',
             urgency: 'immediate',
@@ -606,6 +607,7 @@ describe('ScheduledAutomationPanel', () => {
           kind: 'masc.keeper_wake.enqueued',
           queue: 'keeper_event_queue',
           stimulus: 'schedule_due',
+          stimulus_id: 'stimulus:keeper-wake-digest',
           keeper_name: 'schedule-keeper',
           schedule_id: 'sched-keeper-wake',
           urgency: 'immediate',
@@ -630,6 +632,24 @@ describe('ScheduledAutomationPanel', () => {
           matched_age_seconds: 0,
           read_errors: [],
         },
+        keeper_reaction_evidence: {
+          projection_status: 'matched_stimulus',
+          source: 'keeper_reaction_ledger',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          post_id: 'schedule-due:sched-keeper-wake',
+          stimulus: 'schedule_due',
+          stimulus_id: 'stimulus:keeper-wake-digest',
+          stimulus_kind: 'schedule_due',
+          reaction_kind: 'turn_started',
+          stimulus_seen: true,
+          turn_started_seen: false,
+          matched_record_count: 1,
+          stimulus_recorded_at: 201,
+          stimulus_recorded_at_iso: '2026-06-21T00:03:21Z',
+          latest_recorded_at: 201,
+          latest_recorded_at_iso: '2026-06-21T00:03:21Z',
+        },
       }),
     ])
 
@@ -640,6 +660,7 @@ describe('ScheduledAutomationPanel', () => {
     expect(receipt?.getAttribute('data-schedule-dispatch-receipt-kind')).toBe('masc.keeper_wake.enqueued')
     expect(container.querySelector('[data-dispatch-receipt-row="queue"]')?.textContent).toContain('keeper_event_queue')
     expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
+    expect(container.querySelector('[data-dispatch-receipt-row="stimulus_id"]')?.textContent).toContain('stimulus:keeper-wake-digest')
     expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
     expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
     const queueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
@@ -648,6 +669,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-keeper-queue-evidence-row="matched_bucket"]')?.textContent).toContain('pending')
     expect(container.querySelector('[data-keeper-queue-evidence-row="pending_count"]')?.textContent).toContain('1')
     expect(container.querySelector('[data-keeper-queue-evidence-row="matched_payload_kind"]')?.textContent).toContain('schedule_due')
+    const reactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_stimulus"]')
+    expect(reactionEvidence).not.toBeNull()
+    expect(reactionEvidence?.getAttribute('data-schedule-keeper-reaction-evidence-source')).toBe('keeper_reaction_ledger')
+    expect(container.querySelector('[data-keeper-reaction-evidence-row="stimulus_id"]')?.textContent).toContain('stimulus:keeper-wake-digest')
+    expect(container.querySelector('[data-keeper-reaction-evidence-row="turn_started_seen"]')?.textContent).toContain('false')
 
     render(null, container)
     render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
@@ -670,6 +696,10 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
     expect(v2QueueEvidence?.textContent).toContain('matched pending')
     expect(v2QueueEvidence?.textContent).toContain('schedule_due')
+    const v2ReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_stimulus"]')
+    expect(v2ReactionEvidence).not.toBeNull()
+    expect(v2ReactionEvidence?.textContent).toContain('keeper_reaction_ledger')
+    expect(v2ReactionEvidence?.textContent).toContain('matched stimulus')
 
     const wakeRequest = auto.requests[0]!
     const inflightAuto = automation([
@@ -682,6 +712,16 @@ describe('ScheduledAutomationPanel', () => {
           pending_count: 0,
           inflight_count: 1,
           matched_bucket: 'inflight',
+        },
+        keeper_reaction_evidence: {
+          ...wakeRequest.keeper_reaction_evidence!,
+          projection_status: 'matched_turn_started',
+          turn_started_seen: true,
+          matched_record_count: 2,
+          turn_started_recorded_at: 202,
+          turn_started_recorded_at_iso: '2026-06-21T00:03:22Z',
+          latest_recorded_at: 202,
+          latest_recorded_at_iso: '2026-06-21T00:03:22Z',
         },
       },
     ])
@@ -703,6 +743,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(inflightQueueEvidence?.textContent).toContain('inflight_count')
     expect(inflightQueueEvidence?.textContent).toContain('1')
     expect(inflightQueueEvidence?.textContent).toContain('inflight')
+    const turnReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_turn_started"]')
+    expect(turnReactionEvidence).not.toBeNull()
+    expect(turnReactionEvidence?.textContent).toContain('matched turn started')
+    expect(turnReactionEvidence?.textContent).toContain('turn_started')
+    expect(turnReactionEvidence?.textContent).toContain('true')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -748,6 +748,62 @@ describe('ScheduledAutomationPanel', () => {
     expect(turnReactionEvidence?.textContent).toContain('matched turn started')
     expect(turnReactionEvidence?.textContent).toContain('turn_started')
     expect(turnReactionEvidence?.textContent).toContain('true')
+
+    const ackedAuto = automation([
+      {
+        ...wakeRequest,
+        schedule_id: 'sched-keeper-wake',
+        keeper_queue_evidence: {
+          ...wakeRequest.keeper_queue_evidence!,
+          projection_status: 'not_found',
+          pending_count: 0,
+          inflight_count: 0,
+          matched_bucket: undefined,
+          matched_post_id: undefined,
+          matched_schedule_id: undefined,
+          matched_payload_kind: undefined,
+          matched_arrived_at: undefined,
+          matched_arrived_at_iso: undefined,
+          matched_age_seconds: undefined,
+        },
+        keeper_reaction_evidence: {
+          ...wakeRequest.keeper_reaction_evidence!,
+          projection_status: 'matched_consumed_ack',
+          turn_started_seen: true,
+          event_queue_ack_seen: true,
+          matched_record_count: 3,
+          turn_started_recorded_at: 202,
+          turn_started_recorded_at_iso: '2026-06-21T00:03:22Z',
+          event_queue_ack_recorded_at: 203,
+          event_queue_ack_recorded_at_iso: '2026-06-21T00:03:23Z',
+          latest_recorded_at: 203,
+          latest_recorded_at_iso: '2026-06-21T00:03:23Z',
+        },
+      },
+    ])
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${ackedAuto} variant="v2" />`, container)
+
+    const ackDoneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    ackDoneFilter.click()
+    await Promise.resolve()
+
+    const openAckDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
+    openAckDetail.click()
+    await Promise.resolve()
+
+    const ackQueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="not_found"]')
+    expect(ackQueueEvidence).not.toBeNull()
+    expect(ackQueueEvidence?.textContent).toContain('not found')
+    expect(ackQueueEvidence?.textContent).toContain('pending_count')
+    expect(ackQueueEvidence?.textContent).toContain('0')
+    const ackReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_consumed_ack"]')
+    expect(ackReactionEvidence).not.toBeNull()
+    expect(ackReactionEvidence?.textContent).toContain('matched consumed ack')
+    expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_seen')
+    expect(ackReactionEvidence?.textContent).toContain('true')
+    expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_recorded_at')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {
@@ -975,6 +1031,83 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2Contract?.textContent).toContain('payload support로 2 durable wake signal 숨김')
     expect(container.querySelector('[data-schedule-signal-id="sig-unsupported-only"]')).toBeNull()
     expect(container.querySelector('[data-schedule-signal-id="sig-unknown-only"]')).toBeNull()
+  })
+
+  it('renders explicit live supported non-terminal evidence absence', () => {
+    const auto = payloadSupportAutomation()
+    auto.live_supported_non_terminal_evidence = {
+      schema: 'masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1',
+      source: 'schedule_store',
+      projection_status: 'no_supported_payload_rows',
+      criteria: 'payload_support=supported && execution_readiness not in {terminal,expired}',
+      reason: 'current live schedule_store has no rows with a supported payload kind',
+      request_count: 3,
+      supported_request_count: 0,
+      supported_non_terminal_count: 0,
+      supported_live_count: 0,
+      supported_terminal_or_expired_count: 0,
+      unsupported_request_count: 2,
+      unknown_request_count: 1,
+      terminal_or_expired_count: 2,
+      matched_schedule_ids: [],
+      matched_schedule_id_limit: 8,
+    }
+
+    for (const variant of [undefined, 'v2'] as const) {
+      render(null, container)
+      render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
+
+      const evidence = container.querySelector('[data-schedule-live-supported-evidence="no_supported_payload_rows"]')
+      expect(evidence).not.toBeNull()
+      expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('0')
+      expect(evidence?.getAttribute('data-schedule-live-supported-source')).toBe('schedule_store')
+      expect(evidence?.textContent).toContain('no supported payload rows')
+      expect(evidence?.textContent).toContain('payload_support=supported')
+      expect(evidence?.textContent).toContain('unsupported/unknown')
+      expect(evidence?.textContent).toContain('3')
+    }
+  })
+
+  it('renders matched live supported non-terminal evidence and opens matched rows', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-supported-live',
+        next_due_at: 100,
+        next_due_at_iso: '2026-06-21T00:10:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+      }),
+    ])
+    auto.live_supported_non_terminal_evidence = {
+      schema: 'masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1',
+      source: 'schedule_store',
+      projection_status: 'matched_supported_non_terminal',
+      criteria: 'payload_support=supported && execution_readiness not in {terminal,expired}',
+      reason: 'live schedule_store contains supported rows whose readiness is not terminal or expired',
+      request_count: 1,
+      supported_request_count: 1,
+      supported_non_terminal_count: 1,
+      supported_live_count: 1,
+      supported_terminal_or_expired_count: 0,
+      unsupported_request_count: 0,
+      unknown_request_count: 0,
+      terminal_or_expired_count: 0,
+      matched_schedule_ids: ['sched-supported-live'],
+      matched_schedule_id_limit: 8,
+    }
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const evidence = container.querySelector('[data-schedule-live-supported-evidence="matched_supported_non_terminal"]')
+    expect(evidence).not.toBeNull()
+    expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('1')
+    expect(evidence?.textContent).toContain('matched supported non-terminal')
+    const open = container.querySelector('[data-schedule-live-supported-open="sched-supported-live"]') as HTMLButtonElement
+    expect(open).not.toBeNull()
+    open.click()
+    await Promise.resolve()
+    expect(container.querySelector('[data-schedule-detail-panel="sched-supported-live"]')).not.toBeNull()
   })
 
   it('uses explicit ready and terminal status matching', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -611,6 +611,25 @@ describe('ScheduledAutomationPanel', () => {
           urgency: 'immediate',
           post_id: 'schedule-due:sched-keeper-wake',
         },
+        keeper_queue_evidence: {
+          projection_status: 'matched_pending',
+          source: 'durable_event_queue_snapshot',
+          queue: 'keeper_event_queue',
+          stimulus: 'schedule_due',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          post_id: 'schedule-due:sched-keeper-wake',
+          pending_count: 1,
+          inflight_count: 0,
+          matched_bucket: 'pending',
+          matched_post_id: 'schedule-due:sched-keeper-wake',
+          matched_schedule_id: 'sched-keeper-wake',
+          matched_payload_kind: 'schedule_due',
+          matched_arrived_at: 201,
+          matched_arrived_at_iso: '2026-06-21T00:03:21Z',
+          matched_age_seconds: 0,
+          read_errors: [],
+        },
       }),
     ])
 
@@ -623,6 +642,12 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
     expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
     expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const queueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(queueEvidence).not.toBeNull()
+    expect(queueEvidence?.getAttribute('data-schedule-keeper-queue-evidence-source')).toBe('durable_event_queue_snapshot')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_bucket"]')?.textContent).toContain('pending')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="pending_count"]')?.textContent).toContain('1')
+    expect(container.querySelector('[data-keeper-queue-evidence-row="matched_payload_kind"]')?.textContent).toContain('schedule_due')
 
     render(null, container)
     render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
@@ -640,6 +665,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2Receipt?.textContent).toContain('keeper_event_queue')
     expect(v2Receipt?.textContent).toContain('schedule_due')
     expect(v2Receipt?.textContent).toContain('schedule-due:sched-keeper-wake')
+    const v2QueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
+    expect(v2QueueEvidence).not.toBeNull()
+    expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
+    expect(v2QueueEvidence?.textContent).toContain('matched pending')
+    expect(v2QueueEvidence?.textContent).toContain('schedule_due')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -670,6 +670,39 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
     expect(v2QueueEvidence?.textContent).toContain('matched pending')
     expect(v2QueueEvidence?.textContent).toContain('schedule_due')
+
+    const wakeRequest = auto.requests[0]!
+    const inflightAuto = automation([
+      {
+        ...wakeRequest,
+        schedule_id: 'sched-keeper-wake',
+        keeper_queue_evidence: {
+          ...wakeRequest.keeper_queue_evidence!,
+          projection_status: 'matched_inflight',
+          pending_count: 0,
+          inflight_count: 1,
+          matched_bucket: 'inflight',
+        },
+      },
+    ])
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${inflightAuto} variant="v2" />`, container)
+
+    const inflightDoneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    inflightDoneFilter.click()
+    await Promise.resolve()
+
+    const openInflightDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
+    openInflightDetail.click()
+    await Promise.resolve()
+
+    const inflightQueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_inflight"]')
+    expect(inflightQueueEvidence).not.toBeNull()
+    expect(inflightQueueEvidence?.textContent).toContain('matched inflight')
+    expect(inflightQueueEvidence?.textContent).toContain('inflight_count')
+    expect(inflightQueueEvidence?.textContent).toContain('1')
+    expect(inflightQueueEvidence?.textContent).toContain('inflight')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -573,6 +573,75 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).toContain('페이로드')
   })
 
+  it('renders keeper wake dispatch receipts as queue proof in diagnostics and v2', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-keeper-wake',
+        status: 'succeeded',
+        effective_status: 'succeeded',
+        execution_readiness: 'terminal',
+        operator_action: null,
+        approval_required: false,
+        risk_class: 'workspace_write',
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+        payload_target: 'keeper:schedule-keeper',
+        payload_summary: 'Scheduled lane wake',
+        last_execution: {
+          execution_id: 'exec-keeper-wake',
+          schedule_id: 'sched-keeper-wake',
+          status: 'succeeded',
+          detail: {
+            kind: 'masc.keeper_wake.enqueued',
+            queue: 'keeper_event_queue',
+            stimulus: 'schedule_due',
+            keeper_name: 'schedule-keeper',
+            schedule_id: 'sched-keeper-wake',
+            urgency: 'immediate',
+            post_id: 'schedule-due:sched-keeper-wake',
+          },
+        },
+        dispatch_receipt: {
+          projection_status: 'recognized',
+          kind: 'masc.keeper_wake.enqueued',
+          queue: 'keeper_event_queue',
+          stimulus: 'schedule_due',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          urgency: 'immediate',
+          post_id: 'schedule-due:sched-keeper-wake',
+        },
+      }),
+    ])
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} />`, container)
+
+    const receipt = container.querySelector('[data-schedule-dispatch-receipt="recognized"]')
+    expect(receipt).not.toBeNull()
+    expect(receipt?.getAttribute('data-schedule-dispatch-receipt-kind')).toBe('masc.keeper_wake.enqueued')
+    expect(container.querySelector('[data-dispatch-receipt-row="queue"]')?.textContent).toContain('keeper_event_queue')
+    expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
+    expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
+    expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const doneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    doneFilter.click()
+    await Promise.resolve()
+
+    const openDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
+    openDetail.click()
+    await Promise.resolve()
+
+    const v2Receipt = container.querySelector('[data-schedule-dispatch-receipt="recognized"]')
+    expect(v2Receipt).not.toBeNull()
+    expect(v2Receipt?.textContent).toContain('keeper_event_queue')
+    expect(v2Receipt?.textContent).toContain('schedule_due')
+    expect(v2Receipt?.textContent).toContain('schedule-due:sched-keeper-wake')
+  })
+
   it('filters schedule cards without filtering the wake signal feed', async () => {
     render(html`<${ScheduledAutomationPanel} automation=${sampleAutomation()} />`, container)
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -5,6 +5,7 @@ import {
   type DashboardScheduleDecision,
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
+  type DashboardScheduledAutomationDispatchReceipt,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
@@ -395,6 +396,71 @@ function executionDetailRows(detail: unknown): Array<{ label: string; value: str
     .slice(0, 6)
 }
 
+function dispatchReceiptTone(
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined,
+): StatusChipTone {
+  if (!receipt) return 'neutral'
+  return receipt.projection_status === 'recognized' ? 'ok' : 'warn'
+}
+
+function dispatchReceiptRows(
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!receipt) return []
+  const rows: Array<{ label: string; value: string | null | undefined }> = [
+    { label: 'kind', value: receipt.kind },
+    { label: 'queue', value: receipt.queue },
+    { label: 'stimulus', value: receipt.stimulus },
+    { label: 'keeper', value: receipt.keeper_name },
+    { label: 'schedule', value: receipt.schedule_id },
+    { label: 'urgency', value: receipt.urgency },
+    { label: 'post_id', value: receipt.post_id },
+    { label: 'author', value: receipt.author },
+    { label: 'hearth', value: receipt.hearth },
+    { label: 'reason', value: receipt.reason },
+  ]
+  return rows.filter((row): row is { label: string; value: string } => {
+    return typeof row.value === 'string' && row.value.trim() !== ''
+  })
+}
+
+function DispatchReceiptBlock({
+  receipt,
+  compact = false,
+}: {
+  receipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  compact?: boolean
+}) {
+  if (!receipt) return null
+  const rows = dispatchReceiptRows(receipt)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-dispatch-receipt=${receipt.projection_status}
+      data-schedule-dispatch-receipt-kind=${receipt.kind ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">dispatch_receipt</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">dispatch receipt</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${dispatchReceiptTone(receipt)} uppercase=${false}>
+            ${enumLabel(receipt.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[5.5rem_minmax(0,1fr)] gap-2'} data-dispatch-receipt-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -654,7 +720,13 @@ function ScheduleCard({
   `
 }
 
-function LastExecutionBlock({ execution }: { execution: DashboardScheduledAutomationExecution | null | undefined }) {
+function LastExecutionBlock({
+  execution,
+  dispatchReceipt,
+}: {
+  execution: DashboardScheduledAutomationExecution | null | undefined
+  dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+}) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
   }
@@ -693,6 +765,7 @@ function LastExecutionBlock({ execution }: { execution: DashboardScheduledAutoma
             </div>
           `
         : null}
+      <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
     </div>
   `
 }
@@ -781,7 +854,10 @@ function ScheduleDetailPanel({
         </div>
         <div>
           <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">최근 실행</div>
-          <${LastExecutionBlock} execution=${execution} />
+          <${LastExecutionBlock}
+            execution=${execution}
+            dispatchReceipt=${request.dispatch_receipt ?? null}
+          />
         </div>
       </div>
     </section>
@@ -1341,7 +1417,10 @@ function SchDetail({
 
           <div class="turn-sec">
             <h4>최근 실행 기록</h4>
-            <${SchExecution} execution=${execution} />
+            <${SchExecution}
+              execution=${execution}
+              dispatchReceipt=${request.dispatch_receipt ?? null}
+            />
           </div>
 
           <${SchDetailActions} request=${request} onResolved=${onResolved} onClose=${onClose} />
@@ -1351,7 +1430,13 @@ function SchDetail({
   `
 }
 
-function SchExecution({ execution }: { execution: DashboardScheduledAutomationExecution | null | undefined }) {
+function SchExecution({
+  execution,
+  dispatchReceipt,
+}: {
+  execution: DashboardScheduledAutomationExecution | null | undefined
+  dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+}) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
   }
@@ -1365,6 +1450,7 @@ function SchExecution({ execution }: { execution: DashboardScheduledAutomationEx
         <div class="sch-kv" data-execution-detail-row=${row.label}><span class="k">${row.label}</span><span class="v mono">${row.value}</span></div>
       `)}
     </div>
+    <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -9,6 +9,7 @@ import {
   type DashboardScheduledAutomationKeeperReactionEvidence,
   type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
+  type DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
 } from '../../api'
@@ -547,7 +548,10 @@ function reactionEvidenceTone(
   evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
 ): StatusChipTone {
   if (!evidence) return 'neutral'
-  if (evidence.projection_status === 'matched_turn_started') return 'ok'
+  if (
+    evidence.projection_status === 'matched_consumed_ack' ||
+    evidence.projection_status === 'matched_turn_started'
+  ) return 'ok'
   if (
     evidence.projection_status === 'matched_stimulus' ||
     evidence.projection_status === 'not_found' ||
@@ -571,9 +575,11 @@ function reactionEvidenceRows(
     { label: 'reaction_kind', value: evidence.reaction_kind },
     { label: 'stimulus_seen', value: evidence.stimulus_seen },
     { label: 'turn_started_seen', value: evidence.turn_started_seen },
+    { label: 'event_queue_ack_seen', value: evidence.event_queue_ack_seen },
     { label: 'matched_record_count', value: evidence.matched_record_count },
     { label: 'stimulus_recorded_at', value: evidence.stimulus_recorded_at_iso },
     { label: 'turn_started_recorded_at', value: evidence.turn_started_recorded_at_iso },
+    { label: 'event_queue_ack_recorded_at', value: evidence.event_queue_ack_recorded_at_iso },
     { label: 'latest_recorded_at', value: evidence.latest_recorded_at_iso },
     { label: 'reason', value: evidence.reason },
   ]
@@ -1352,6 +1358,105 @@ function SchPayloadSupportBanner({
   `
 }
 
+type LiveSupportedEvidenceStatus =
+  DashboardScheduledAutomationLiveSupportedNonTerminalEvidence['projection_status']
+
+function liveSupportedEvidenceLabel(status: LiveSupportedEvidenceStatus): string {
+  switch (status) {
+    case 'matched_supported_non_terminal':
+      return 'matched supported non-terminal'
+    case 'no_supported_payload_rows':
+      return 'no supported payload rows'
+    case 'no_supported_non_terminal':
+      return 'no supported non-terminal'
+    default:
+      return assertNever(status)
+  }
+}
+
+function liveSupportedEvidenceBannerClass(status: LiveSupportedEvidenceStatus): string {
+  switch (status) {
+    case 'matched_supported_non_terminal':
+      return 'approve'
+    case 'no_supported_payload_rows':
+      return 'payload bad'
+    case 'no_supported_non_terminal':
+      return 'payload warn'
+    default:
+      return assertNever(status)
+  }
+}
+
+function SchLiveSupportedEvidence({
+  evidence,
+  onOpen,
+}: {
+  evidence: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence | null | undefined
+  onOpen: (scheduleId: string) => void
+}) {
+  if (!evidence) return null
+  const matchedIds = evidence.matched_schedule_ids ?? []
+  const status = evidence.projection_status
+  return html`
+    <section
+      class=${`sch-banner ${liveSupportedEvidenceBannerClass(status)}`}
+      data-schedule-live-supported-evidence=${status}
+      data-schedule-live-supported-count=${evidence.supported_live_count ?? 0}
+      data-schedule-live-supported-source=${evidence.source ?? ''}
+    >
+      <span class="sch-banner-ico">${status === 'matched_supported_non_terminal' ? '✓' : '!'}</span>
+      <div class="sch-banner-txt">
+        <div>
+          <b>live supported scheduler evidence</b>
+          <span class="mono"> ${liveSupportedEvidenceLabel(status)}</span>
+        </div>
+        <div class="sch-banner-sub">
+          <span class="mono">${evidence.criteria ?? 'payload_support=supported && non-terminal'}</span>
+        </div>
+        <div class="sch-evidence-counts" aria-label="Live supported scheduler counts">
+          <span class="sch-evidence-count">
+            <span>requests</span>
+            <span class="mono">${(evidence.request_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>supported</span>
+            <span class="mono">${(evidence.supported_request_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>live</span>
+            <span class="mono">${(evidence.supported_live_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>terminal/expired</span>
+            <span class="mono">${(evidence.terminal_or_expired_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>unsupported/unknown</span>
+            <span class="mono">${((evidence.unsupported_request_count ?? 0) + (evidence.unknown_request_count ?? 0)).toLocaleString()}</span>
+          </span>
+        </div>
+        ${evidence.reason
+          ? html`<div class="sch-banner-sub">${evidence.reason}</div>`
+          : null}
+        ${matchedIds.length > 0
+          ? html`
+              <div class="sch-payload-rows" aria-label="Live supported schedule ids">
+                ${matchedIds.map(scheduleId => html`
+                  <button
+                    type="button"
+                    class="sch-payload-row mono"
+                    data-schedule-live-supported-open=${scheduleId}
+                    onClick=${() => { onOpen(scheduleId) }}
+                  >${scheduleId}</button>
+                `)}
+              </div>
+            `
+          : null}
+      </div>
+    </section>
+  `
+}
+
 // Card rail tone class. SCHED_STATUS specs only ever yield warn/info/ok/bad/dim
 // for statuses; .sch-card.st-volt is not defined, so clamp anything else to dim.
 const CARD_RAIL_TONES: ReadonlySet<string> = new Set(['ok', 'warn', 'bad', 'info', 'dim'])
@@ -1723,6 +1828,10 @@ function SchedulePrototypeSurface({
         summary=${payloadSummary}
         onOpen=${setSelectedScheduleId}
       />
+      <${SchLiveSupportedEvidence}
+        evidence=${automation.live_supported_non_terminal_evidence ?? null}
+        onOpen=${setSelectedScheduleId}
+      />
 
       <div class="sch-tabs" role="tablist" aria-label="예약 필터">
         ${SCH_TABS.map(definition => {
@@ -2073,6 +2182,11 @@ export function ScheduledAutomationPanel({
             </div>
           `
         : null}
+
+      <${SchLiveSupportedEvidence}
+        evidence=${automation.live_supported_non_terminal_evidence ?? null}
+        onOpen=${setSelectedScheduleId}
+      />
 
       <div class="flex flex-wrap gap-2">
         ${nonzeroCounts.length > 0

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -6,6 +6,7 @@ import {
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
+  type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
@@ -461,6 +462,83 @@ function DispatchReceiptBlock({
   `
 }
 
+function queueEvidenceTone(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): StatusChipTone {
+  if (!evidence) return 'neutral'
+  if (evidence.projection_status === 'matched_pending' || evidence.projection_status === 'matched_inflight') return 'ok'
+  if (evidence.projection_status === 'not_found' || evidence.projection_status === 'read_error') return 'warn'
+  return 'bad'
+}
+
+function queueEvidenceRows(
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!evidence) return []
+  const readErrors = (evidence.read_errors ?? [])
+    .map(error => [error.kind, error.path, error.message].filter(Boolean).join(': '))
+    .filter(value => value.trim() !== '')
+    .join(' | ')
+  const rows: Array<{ label: string; value: string | number | null | undefined }> = [
+    { label: 'source', value: evidence.source },
+    { label: 'queue', value: evidence.queue },
+    { label: 'stimulus', value: evidence.stimulus },
+    { label: 'keeper', value: evidence.keeper_name },
+    { label: 'schedule', value: evidence.schedule_id },
+    { label: 'post_id', value: evidence.post_id },
+    { label: 'pending_count', value: evidence.pending_count },
+    { label: 'inflight_count', value: evidence.inflight_count },
+    { label: 'matched_bucket', value: evidence.matched_bucket },
+    { label: 'matched_payload_kind', value: evidence.matched_payload_kind },
+    { label: 'matched_post_id', value: evidence.matched_post_id },
+    { label: 'matched_schedule_id', value: evidence.matched_schedule_id },
+    { label: 'matched_arrived_at', value: evidence.matched_arrived_at_iso },
+    { label: 'matched_age_seconds', value: evidence.matched_age_seconds },
+    { label: 'read_errors', value: readErrors },
+    { label: 'reason', value: evidence.reason },
+  ]
+  return rows
+    .map(row => ({ label: row.label, value: row.value == null ? '' : String(row.value) }))
+    .filter(row => row.value.trim() !== '')
+}
+
+function QueueEvidenceBlock({
+  evidence,
+  compact = false,
+}: {
+  evidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  compact?: boolean
+}) {
+  if (!evidence) return null
+  const rows = queueEvidenceRows(evidence)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-keeper-queue-evidence=${evidence.projection_status}
+      data-schedule-keeper-queue-evidence-source=${evidence.source ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">keeper_queue_evidence</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">keeper queue evidence</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${queueEvidenceTone(evidence)} uppercase=${false}>
+            ${enumLabel(evidence.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2'} data-keeper-queue-evidence-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -723,9 +801,11 @@ function ScheduleCard({
 function LastExecutionBlock({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
@@ -766,6 +846,7 @@ function LastExecutionBlock({
           `
         : null}
       <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
+      <${QueueEvidenceBlock} evidence=${queueEvidence} />
     </div>
   `
 }
@@ -857,6 +938,7 @@ function ScheduleDetailPanel({
           <${LastExecutionBlock}
             execution=${execution}
             dispatchReceipt=${request.dispatch_receipt ?? null}
+            queueEvidence=${request.keeper_queue_evidence ?? null}
           />
         </div>
       </div>
@@ -1420,6 +1502,7 @@ function SchDetail({
             <${SchExecution}
               execution=${execution}
               dispatchReceipt=${request.dispatch_receipt ?? null}
+              queueEvidence=${request.keeper_queue_evidence ?? null}
             />
           </div>
 
@@ -1433,9 +1516,11 @@ function SchDetail({
 function SchExecution({
   execution,
   dispatchReceipt,
+  queueEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
+  queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
@@ -1451,6 +1536,7 @@ function SchExecution({
       `)}
     </div>
     <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
+    <${QueueEvidenceBlock} evidence=${queueEvidence} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -6,6 +6,7 @@ import {
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
+  type DashboardScheduledAutomationKeeperReactionEvidence,
   type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
@@ -412,6 +413,9 @@ function dispatchReceiptRows(
     { label: 'kind', value: receipt.kind },
     { label: 'queue', value: receipt.queue },
     { label: 'stimulus', value: receipt.stimulus },
+    { label: 'stimulus_id', value: receipt.stimulus_id },
+    { label: 'reaction_ledger_status', value: receipt.reaction_ledger_status },
+    { label: 'reaction_ledger_error', value: receipt.reaction_ledger_error },
     { label: 'keeper', value: receipt.keeper_name },
     { label: 'schedule', value: receipt.schedule_id },
     { label: 'urgency', value: receipt.urgency },
@@ -531,6 +535,82 @@ function QueueEvidenceBlock({
       </div>
       ${rows.map(row => html`
         <div class=${compact ? 'sch-kv' : 'grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2'} data-keeper-queue-evidence-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function reactionEvidenceTone(
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
+): StatusChipTone {
+  if (!evidence) return 'neutral'
+  if (evidence.projection_status === 'matched_turn_started') return 'ok'
+  if (
+    evidence.projection_status === 'matched_stimulus' ||
+    evidence.projection_status === 'not_found' ||
+    evidence.projection_status === 'missing_stimulus_id'
+  ) return 'warn'
+  return 'bad'
+}
+
+function reactionEvidenceRows(
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!evidence) return []
+  const rows: Array<{ label: string; value: string | number | boolean | null | undefined }> = [
+    { label: 'source', value: evidence.source },
+    { label: 'keeper', value: evidence.keeper_name },
+    { label: 'schedule', value: evidence.schedule_id },
+    { label: 'post_id', value: evidence.post_id },
+    { label: 'stimulus', value: evidence.stimulus },
+    { label: 'stimulus_id', value: evidence.stimulus_id },
+    { label: 'stimulus_kind', value: evidence.stimulus_kind },
+    { label: 'reaction_kind', value: evidence.reaction_kind },
+    { label: 'stimulus_seen', value: evidence.stimulus_seen },
+    { label: 'turn_started_seen', value: evidence.turn_started_seen },
+    { label: 'matched_record_count', value: evidence.matched_record_count },
+    { label: 'stimulus_recorded_at', value: evidence.stimulus_recorded_at_iso },
+    { label: 'turn_started_recorded_at', value: evidence.turn_started_recorded_at_iso },
+    { label: 'latest_recorded_at', value: evidence.latest_recorded_at_iso },
+    { label: 'reason', value: evidence.reason },
+  ]
+  return rows
+    .map(row => ({ label: row.label, value: row.value == null ? '' : String(row.value) }))
+    .filter(row => row.value.trim() !== '')
+}
+
+function ReactionEvidenceBlock({
+  evidence,
+  compact = false,
+}: {
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
+  compact?: boolean
+}) {
+  if (!evidence) return null
+  const rows = reactionEvidenceRows(evidence)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-keeper-reaction-evidence=${evidence.projection_status}
+      data-schedule-keeper-reaction-evidence-source=${evidence.source ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">keeper_reaction_evidence</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">keeper reaction evidence</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${reactionEvidenceTone(evidence)} uppercase=${false}>
+            ${enumLabel(evidence.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2'} data-keeper-reaction-evidence-row=${row.label}>
           <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
           <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
         </div>
@@ -802,10 +882,12 @@ function LastExecutionBlock({
   execution,
   dispatchReceipt,
   queueEvidence,
+  reactionEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
   queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  reactionEvidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
@@ -847,6 +929,7 @@ function LastExecutionBlock({
         : null}
       <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
       <${QueueEvidenceBlock} evidence=${queueEvidence} />
+      <${ReactionEvidenceBlock} evidence=${reactionEvidence} />
     </div>
   `
 }
@@ -939,6 +1022,7 @@ function ScheduleDetailPanel({
             execution=${execution}
             dispatchReceipt=${request.dispatch_receipt ?? null}
             queueEvidence=${request.keeper_queue_evidence ?? null}
+            reactionEvidence=${request.keeper_reaction_evidence ?? null}
           />
         </div>
       </div>
@@ -1503,6 +1587,7 @@ function SchDetail({
               execution=${execution}
               dispatchReceipt=${request.dispatch_receipt ?? null}
               queueEvidence=${request.keeper_queue_evidence ?? null}
+              reactionEvidence=${request.keeper_reaction_evidence ?? null}
             />
           </div>
 
@@ -1517,10 +1602,12 @@ function SchExecution({
   execution,
   dispatchReceipt,
   queueEvidence,
+  reactionEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
   queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  reactionEvidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
@@ -1537,6 +1624,7 @@ function SchExecution({
     </div>
     <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
     <${QueueEvidenceBlock} evidence=${queueEvidence} compact=${true} />
+    <${ReactionEvidenceBlock} evidence=${reactionEvidence} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -44,8 +44,9 @@
 .sch-banner-go:hover { border-color: var(--volt-dim); color: var(--volt); }
 .sch-banner-x { flex: none; background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: var(--fs-12); padding: 2px 4px; }
 .sch-banner-x:hover { color: var(--text-bright); }
-.sch-payload-kinds, .sch-payload-rows { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.sch-payload-kinds, .sch-payload-rows, .sch-evidence-counts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 .sch-payload-kind { display: inline-flex; align-items: center; gap: 6px; border: 1px solid color-mix(in oklab, var(--status-bad) 32%, transparent); border-radius: var(--radius-pill); padding: 2px 8px; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 7%, transparent); font-size: var(--fs-10); }
+.sch-evidence-count { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); padding: 2px 8px; color: var(--text-mid); background: var(--bg-sunken); font-size: var(--fs-10); }
 .sch-payload-row { border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-sunken); color: var(--text-mid); cursor: pointer; font-size: var(--fs-10); padding: 2px 8px; }
 .sch-payload-row:hover { border-color: var(--volt-dim); color: var(--volt); }
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -53,6 +53,10 @@ let record_event_queue_stimulus_turn_started =
   Stimulus_intake.record_event_queue_stimulus_turn_started
 ;;
 
+let record_event_queue_stimulus_ack =
+  Stimulus_intake.record_event_queue_stimulus_ack
+;;
+
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
@@ -163,6 +167,23 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
        match stimulus.payload with
        | Keeper_event_queue.Schedule_due _ ->
          record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.No_progress_recovery
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Goal_verification_failed _ -> ())
+    stimuli
+;;
+
+let record_schedule_due_event_queue_ack_reactions ~ctx ~keeper_name stimuli =
+  List.iter
+    (fun (stimulus : Keeper_event_queue.stimulus) ->
+       match stimulus.payload with
+       | Keeper_event_queue.Schedule_due _ ->
+         record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus
        | Keeper_event_queue.Board_signal _
        | Keeper_event_queue.Fusion_completed _
        | Keeper_event_queue.Bg_completed _
@@ -454,10 +475,27 @@ let run_keepalive_unified_turn
       then
         if !consumed_stimuli_turn_completed
         then (
-          Keeper_registry_event_queue.ack_consumed
-            ~base_path:ctx.config.base_path
-            meta_after_triage.name
-            !consumed_stimuli;
+          (match
+             Keeper_registry_event_queue.ack_consumed_result
+               ~base_path:ctx.config.base_path
+               meta_after_triage.name
+               !consumed_stimuli
+           with
+           | Ok () ->
+             record_schedule_due_event_queue_ack_reactions
+               ~ctx
+               ~keeper_name:meta_after_triage.name
+               !consumed_stimuli
+           | Error msg ->
+             Log.Keeper.warn
+               "registry: ack_consumed failed name=%s: %s"
+               meta_after_triage.name
+               msg);
+          (*
+             Connector post-turn handling preserves the existing behavior:
+             it is an external-attention lifecycle update, while
+             [event_queue_ack] evidence above is emitted only after durable
+             event-queue acknowledgement succeeds. *)
           mark_connector_attention_ignored_after_turn
             ~base_path:ctx.config.base_path
             ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -49,6 +49,10 @@ let record_recovery_stimulus_turn_started =
   Stimulus_intake.record_recovery_stimulus_turn_started
 ;;
 
+let record_event_queue_stimulus_turn_started =
+  Stimulus_intake.record_event_queue_stimulus_turn_started
+;;
+
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
@@ -150,6 +154,23 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Hitl_resolved _
       | Keeper_event_queue.Goal_verification_failed _ ->
         None)
+    stimuli
+;;
+
+let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
+  List.iter
+    (fun (stimulus : Keeper_event_queue.stimulus) ->
+       match stimulus.payload with
+       | Keeper_event_queue.Schedule_due _ ->
+         record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.No_progress_recovery
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Goal_verification_failed _ -> ())
     stimuli
 ;;
 
@@ -406,6 +427,10 @@ let run_keepalive_unified_turn
              admitted. The four prior inline pressure gates here were removed: they
              ran AFTER intake had already consumed the stimulus, forcing a
              consume/requeue churn loop, and logged only at DEBUG (a silent skip). *)
+          record_schedule_due_turn_started_reactions
+            ~ctx
+            ~keeper_name:meta_after_triage.name
+            !consumed_stimuli;
           let event_bus = Keeper_event_bus.get () in
           let meta_after_cycle =
             run_keeper_cycle

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -29,7 +29,7 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
     stim
 ;;
 
-let record_recovery_stimulus_turn_started
+let record_event_queue_stimulus_turn_started
       ~(ctx : _ context)
       ~keeper_name
       (stimulus : Keeper_event_queue.stimulus)
@@ -44,11 +44,15 @@ let record_recovery_stimulus_turn_started
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.error
-      "turn entry: failed to persist recovery stimulus reaction post_id=%s \
+      "turn entry: failed to persist event queue stimulus reaction post_id=%s \
        (keeper=%s): %s"
       stimulus.post_id
       keeper_name
       (Printexc.to_string exn)
+;;
+
+let record_recovery_stimulus_turn_started ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
 ;;
 
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -29,16 +29,17 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
     stim
 ;;
 
-let record_event_queue_stimulus_turn_started
+let record_event_queue_stimulus_reaction
       ~(ctx : _ context)
       ~keeper_name
+      ~reaction_kind
       (stimulus : Keeper_event_queue.stimulus)
   =
   try
     Keeper_reaction_ledger.record_event_queue_reaction
       ~base_path:ctx.config.base_path
       ~keeper_name
-      ~reaction_kind:Keeper_reaction_ledger.Turn_started
+      ~reaction_kind
       stimulus
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -49,6 +50,22 @@ let record_event_queue_stimulus_turn_started
       stimulus.post_id
       keeper_name
       (Printexc.to_string exn)
+;;
+
+let record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_reaction
+    ~ctx
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus
+;;
+
+let record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_reaction
+    ~ctx
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+    stimulus
 ;;
 
 let record_recovery_stimulus_turn_started ~ctx ~keeper_name stimulus =

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -30,6 +30,16 @@ val record_recovery_stimulus_turn_started
   -> Keeper_event_queue.stimulus
   -> unit
 
+(** [record_event_queue_stimulus_turn_started ~ctx ~keeper_name stim] writes
+    a generic [Turn_started] reaction for an event-queue stimulus after the
+    heartbeat scheduler has admitted a real keeper turn. Logs and swallows
+    errors except [Eio.Cancel.Cancelled]. *)
+val record_event_queue_stimulus_turn_started
+  :  ctx:_ context
+  -> keeper_name:string
+  -> Keeper_event_queue.stimulus
+  -> unit
+
 (** Result of one heartbeat intake — accumulated pending board events
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -40,6 +40,16 @@ val record_event_queue_stimulus_turn_started
   -> Keeper_event_queue.stimulus
   -> unit
 
+(** [record_event_queue_stimulus_ack ~ctx ~keeper_name stim] writes a durable
+    [Event_queue_ack] reaction only after the caller has confirmed
+    [ack_consumed] persisted. Logs and swallows errors except
+    [Eio.Cancel.Cancelled]. *)
+val record_event_queue_stimulus_ack
+  :  ctx:_ context
+  -> keeper_name:string
+  -> Keeper_event_queue.stimulus
+  -> unit
+
 (** Result of one heartbeat intake — accumulated pending board events
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -427,6 +427,79 @@ let bool_field name json =
   | _ -> false
 ;;
 
+type event_queue_reaction_evidence =
+  { keeper_name : string
+  ; stimulus_id : string
+  ; stimulus_seen : bool
+  ; turn_started_seen : bool
+  ; stimulus_recorded_at : float option
+  ; turn_started_recorded_at : float option
+  ; latest_recorded_at : float option
+  ; matched_record_count : int
+  }
+
+let max_recorded_at current candidate =
+  match current, candidate with
+  | None, None -> None
+  | Some value, None | None, Some value -> Some value
+  | Some left, Some right -> Some (Float.max left right)
+;;
+
+let reaction_kind_field row =
+  match assoc_field "reaction" row with
+  | Some reaction ->
+    (match string_field "kind" reaction with
+     | None -> None
+     | Some kind -> Some (reaction_kind_of_string kind))
+  | None -> None
+;;
+
+let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
+  let stimulus_seen = ref false in
+  let turn_started_seen = ref false in
+  let stimulus_recorded_at = ref None in
+  let turn_started_recorded_at = ref None in
+  let latest_recorded_at = ref None in
+  let matched_record_count = ref 0 in
+  let store = store_for_base_path ~base_path ~keeper_name in
+  Dated_jsonl.iter_all store (fun row ->
+    match string_field "stimulus_id" row with
+    | Some row_stimulus_id when String.equal row_stimulus_id stimulus_id ->
+      incr matched_record_count;
+      let recorded_at = float_field "recorded_at_unix" row in
+      latest_recorded_at := max_recorded_at !latest_recorded_at recorded_at;
+      (match string_field "record_kind" row with
+       | Some record_kind when String.equal record_kind "stimulus" ->
+         stimulus_seen := true;
+         stimulus_recorded_at := max_recorded_at !stimulus_recorded_at recorded_at
+       | Some record_kind when String.equal record_kind "reaction" ->
+         (match reaction_kind_field row with
+          | Some Turn_started ->
+            turn_started_seen := true;
+            turn_started_recorded_at
+              := max_recorded_at !turn_started_recorded_at recorded_at
+          | Some Execution_receipt
+          | Some Terminal_reason
+          | Some Cursor_ack
+          | Some Operator_escalation
+          | Some Supervisor_recovery_requested
+          | Some (Unknown_reaction _)
+          | None -> ())
+       | Some _
+       | None -> ())
+    | Some _
+    | None -> ());
+  { keeper_name
+  ; stimulus_id
+  ; stimulus_seen = !stimulus_seen
+  ; turn_started_seen = !turn_started_seen
+  ; stimulus_recorded_at = !stimulus_recorded_at
+  ; turn_started_recorded_at = !turn_started_recorded_at
+  ; latest_recorded_at = !latest_recorded_at
+  ; matched_record_count = !matched_record_count
+  }
+;;
+
 let string_list_field name json =
   list_field name json
   |> List.filter_map (function

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -18,6 +18,7 @@ type stimulus_kind =
 
 type reaction_kind =
   | Turn_started
+  | Event_queue_ack
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
@@ -58,6 +59,7 @@ let stimulus_kind_of_string = function
 
 let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
+  | Event_queue_ack -> "event_queue_ack"
   | Execution_receipt -> "execution_receipt"
   | Terminal_reason -> "terminal_reason"
   | Cursor_ack -> "cursor_ack"
@@ -72,6 +74,7 @@ let reaction_kind_to_string = function
    추가 시 컴파일러가 분류 누락을 강제한다(stimulus와 동일한 닫힌-합 안티패턴 방지). *)
 let reaction_kind_of_string = function
   | "turn_started" -> Turn_started
+  | "event_queue_ack" -> Event_queue_ack
   | "execution_receipt" -> Execution_receipt
   | "terminal_reason" -> Terminal_reason
   | "cursor_ack" -> Cursor_ack
@@ -432,8 +435,10 @@ type event_queue_reaction_evidence =
   ; stimulus_id : string
   ; stimulus_seen : bool
   ; turn_started_seen : bool
+  ; event_queue_ack_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
+  ; event_queue_ack_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   }
@@ -457,8 +462,10 @@ let reaction_kind_field row =
 let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   let stimulus_seen = ref false in
   let turn_started_seen = ref false in
+  let event_queue_ack_seen = ref false in
   let stimulus_recorded_at = ref None in
   let turn_started_recorded_at = ref None in
+  let event_queue_ack_recorded_at = ref None in
   let latest_recorded_at = ref None in
   let matched_record_count = ref 0 in
   let store = store_for_base_path ~base_path ~keeper_name in
@@ -478,6 +485,10 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
             turn_started_seen := true;
             turn_started_recorded_at
               := max_recorded_at !turn_started_recorded_at recorded_at
+          | Some Event_queue_ack ->
+            event_queue_ack_seen := true;
+            event_queue_ack_recorded_at
+              := max_recorded_at !event_queue_ack_recorded_at recorded_at
           | Some Execution_receipt
           | Some Terminal_reason
           | Some Cursor_ack
@@ -493,8 +504,10 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   ; stimulus_id
   ; stimulus_seen = !stimulus_seen
   ; turn_started_seen = !turn_started_seen
+  ; event_queue_ack_seen = !event_queue_ack_seen
   ; stimulus_recorded_at = !stimulus_recorded_at
   ; turn_started_recorded_at = !turn_started_recorded_at
+  ; event_queue_ack_recorded_at = !event_queue_ack_recorded_at
   ; latest_recorded_at = !latest_recorded_at
   ; matched_record_count = !matched_record_count
   }
@@ -768,6 +781,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let stimulus_count = ref 0 in
   let reaction_count = ref 0 in
   let turn_started_count = ref 0 in
+  let event_queue_ack_count = ref 0 in
   let cursor_ack_count = ref 0 in
   let execution_receipt_count = ref 0 in
   let terminal_reason_count = ref 0 in
@@ -858,6 +872,7 @@ let summarize_rows ~keeper_name ~limit rows =
     | Some raw ->
       (match reaction_kind_of_string raw with
        | Turn_started -> incr turn_started_count
+       | Event_queue_ack -> incr event_queue_ack_count
        | Cursor_ack -> incr cursor_ack_count
        | Execution_receipt -> incr execution_receipt_count
        | Terminal_reason -> incr terminal_reason_count
@@ -1036,6 +1051,7 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "stimulus_count", `Int !stimulus_count
     ; "reaction_count", `Int !reaction_count
     ; "turn_started_count", `Int !turn_started_count
+    ; "event_queue_ack_count", `Int !event_queue_ack_count
     ; "cursor_ack_count", `Int !cursor_ack_count
     ; "execution_receipt_count", `Int !execution_receipt_count
     ; "terminal_reason_count", `Int !terminal_reason_count
@@ -1407,6 +1423,7 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "stimulus_count", `Int (total_int "stimulus_count")
     ; "reaction_count", `Int (total_int "reaction_count")
     ; "turn_started_count", `Int (total_int "turn_started_count")
+    ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
     ; "cursor_ack_count", `Int (total_int "cursor_ack_count")
     ; "execution_receipt_count", `Int (total_int "execution_receipt_count")
     ; "terminal_reason_count", `Int (total_int "terminal_reason_count")

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -63,6 +63,23 @@ val record_event_queue_reaction :
   unit
 (** Append a [record_kind="reaction"] row tied to an event queue stimulus. *)
 
+type event_queue_reaction_evidence =
+  { keeper_name : string
+  ; stimulus_id : string
+  ; stimulus_seen : bool
+  ; turn_started_seen : bool
+  ; stimulus_recorded_at : float option
+  ; turn_started_recorded_at : float option
+  ; latest_recorded_at : float option
+  ; matched_record_count : int
+  }
+
+val event_queue_reaction_evidence :
+  base_path:string -> keeper_name:string -> stimulus_id:string -> event_queue_reaction_evidence
+(** Stream the durable reaction ledger for exact rows sharing [stimulus_id].
+    This intentionally does not use a "recent rows" limit, because dashboards
+    use it to prove a specific queue stimulus was observed by the keeper. *)
+
 val record_board_cursor_ack :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -25,6 +25,7 @@ type stimulus_kind =
 
 type reaction_kind =
   | Turn_started
+  | Event_queue_ack
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
@@ -68,8 +69,10 @@ type event_queue_reaction_evidence =
   ; stimulus_id : string
   ; stimulus_seen : bool
   ; turn_started_seen : bool
+  ; event_queue_ack_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
+  ; event_queue_ack_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   }

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -99,10 +99,12 @@ let requeue_front ~base_path name stimuli =
        loop ())
 ;;
 
+let ack_consumed_result ~base_path name stimuli =
+  Keeper_event_queue_persistence.ack_consumed ~base_path ~keeper_name:name stimuli
+;;
+
 let ack_consumed ~base_path name stimuli =
-  match
-    Keeper_event_queue_persistence.ack_consumed ~base_path ~keeper_name:name stimuli
-  with
+  match ack_consumed_result ~base_path name stimuli with
   | Ok () -> ()
   | Error msg ->
     Log.Keeper.warn "registry: ack_consumed failed name=%s: %s" name msg

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -31,6 +31,12 @@ val ack_consumed :
 (** Acknowledge consumed stimuli after a keepalive turn completes. Until this
     runs, a restart reloads the leased stimuli for at-least-once replay. *)
 
+val ack_consumed_result :
+  base_path:string -> string -> Keeper_event_queue.stimulus list -> (unit, string) result
+(** Result-returning variant of {!ack_consumed}. Callers that publish follow-on
+    evidence must use this so they do not claim an acknowledgement after durable
+    queue persistence failed. *)
+
 val drop_by_post_id :
   base_path:string
   -> string

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2419,11 +2419,26 @@ let schedule_payload_kind_supported kind =
   List.exists (String.equal kind) schedule_supported_payload_kinds
 ;;
 
-let schedule_payload_support_status (request : Schedule_domain.schedule_request) =
+type schedule_payload_support =
+  | Supported
+  | Unsupported
+  | Unknown
+
+let schedule_payload_support (request : Schedule_domain.schedule_request) =
   match Schedule_payload_projection.kind request with
-  | Some kind when schedule_payload_kind_supported kind -> "supported"
-  | Some _ -> "unsupported"
-  | None -> "unknown"
+  | Some kind when schedule_payload_kind_supported kind -> Supported
+  | Some _ -> Unsupported
+  | None -> Unknown
+;;
+
+let schedule_payload_support_to_string = function
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Unknown -> "unknown"
+;;
+
+let schedule_payload_support_status request =
+  schedule_payload_support request |> schedule_payload_support_to_string
 ;;
 
 let schedule_payload_support_json schedules =
@@ -2478,6 +2493,18 @@ let schedule_effectively_expired ~now (request : Schedule_domain.schedule_reques
 
 let schedule_request_effectively_active ~now request =
   schedule_request_active request && not (schedule_effectively_expired ~now request)
+;;
+
+let schedule_readiness_counts_as_live_supported = function
+  | Schedule_projection.Blocked_approval
+  | Schedule_projection.Awaiting_approval
+  | Schedule_projection.Due_pending_refresh
+  | Schedule_projection.Ready
+  | Schedule_projection.Approved
+  | Schedule_projection.Scheduled
+  | Schedule_projection.Running ->
+    true
+  | Schedule_projection.Expired | Schedule_projection.Terminal -> false
 ;;
 
 let schedule_effectively_due ~now (request : Schedule_domain.schedule_request) =
@@ -2924,7 +2951,9 @@ let schedule_keeper_reaction_evidence_dashboard_json
                  ~stimulus_id
              in
              let projection_status =
-               if evidence.turn_started_seen
+               if evidence.event_queue_ack_seen
+               then "matched_consumed_ack"
+               else if evidence.turn_started_seen
                then "matched_turn_started"
                else if evidence.stimulus_seen
                then "matched_stimulus"
@@ -2936,6 +2965,7 @@ let schedule_keeper_reaction_evidence_dashboard_json
                 @ [ "stimulus_id", `String stimulus_id
                   ; "stimulus_seen", `Bool evidence.stimulus_seen
                   ; "turn_started_seen", `Bool evidence.turn_started_seen
+                  ; "event_queue_ack_seen", `Bool evidence.event_queue_ack_seen
                   ; "matched_record_count", `Int evidence.matched_record_count
                   ; ( "stimulus_recorded_at"
                     , match evidence.stimulus_recorded_at with
@@ -2949,6 +2979,12 @@ let schedule_keeper_reaction_evidence_dashboard_json
                       | Some ts -> `Float ts )
                   ; ( "turn_started_recorded_at_iso"
                     , unix_iso_option_json evidence.turn_started_recorded_at )
+                  ; ( "event_queue_ack_recorded_at"
+                    , match evidence.event_queue_ack_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "event_queue_ack_recorded_at_iso"
+                    , unix_iso_option_json evidence.event_queue_ack_recorded_at )
                   ; ( "latest_recorded_at"
                     , match evidence.latest_recorded_at with
                       | None -> `Null
@@ -3067,6 +3103,127 @@ let schedule_request_dashboard_json
     ]
 ;;
 
+let live_supported_evidence_ids_limit = 8
+
+let schedule_live_supported_non_terminal_evidence_json ~now ~state schedules =
+  let
+    ( supported_request_count
+    , supported_non_terminal_count
+    , supported_live_count
+    , supported_terminal_or_expired_count
+    , unsupported_request_count
+    , unknown_request_count
+    , terminal_or_expired_count
+    , matched_ids )
+    =
+    List.fold_left
+      (fun
+        ( supported_count
+        , supported_non_terminal
+        , supported_live
+        , supported_terminal_or_expired
+        , unsupported_count
+        , unknown_count
+        , terminal_or_expired
+        , ids )
+        (request : Schedule_domain.schedule_request)
+       ->
+         let readiness = schedule_execution_readiness ~now state request in
+         let live_readiness =
+           schedule_readiness_counts_as_live_supported readiness
+         in
+         let terminal_or_expired_row = not live_readiness in
+         let terminal_or_expired =
+           if terminal_or_expired_row then terminal_or_expired + 1 else terminal_or_expired
+         in
+         match schedule_payload_support request with
+         | Supported ->
+           let non_terminal = not (Schedule_domain.is_terminal request.status) in
+           let supported_non_terminal =
+             if non_terminal then supported_non_terminal + 1 else supported_non_terminal
+           in
+           if live_readiness
+           then (
+             let ids =
+               if List.length ids < live_supported_evidence_ids_limit
+               then request.schedule_id :: ids
+               else ids
+             in
+             ( supported_count + 1
+             , supported_non_terminal
+             , supported_live + 1
+             , supported_terminal_or_expired
+             , unsupported_count
+             , unknown_count
+             , terminal_or_expired
+             , ids ))
+           else
+             ( supported_count + 1
+             , supported_non_terminal
+             , supported_live
+             , supported_terminal_or_expired + 1
+             , unsupported_count
+             , unknown_count
+             , terminal_or_expired
+             , ids )
+         | Unsupported ->
+           ( supported_count
+           , supported_non_terminal
+           , supported_live
+           , supported_terminal_or_expired
+           , unsupported_count + 1
+           , unknown_count
+           , terminal_or_expired
+           , ids )
+         | Unknown ->
+           ( supported_count
+           , supported_non_terminal
+           , supported_live
+           , supported_terminal_or_expired
+           , unsupported_count
+           , unknown_count + 1
+           , terminal_or_expired
+           , ids ))
+      (0, 0, 0, 0, 0, 0, 0, [])
+      schedules
+  in
+  let request_count = List.length schedules in
+  let projection_status =
+    if supported_live_count > 0
+    then "matched_supported_non_terminal"
+    else if supported_request_count = 0 && request_count > 0
+    then "no_supported_payload_rows"
+    else "no_supported_non_terminal"
+  in
+  let reason =
+    if supported_live_count > 0
+    then "live schedule_store contains supported rows whose readiness is not terminal or expired"
+    else if supported_request_count = 0 && request_count > 0
+    then "current live schedule_store has no rows with a supported payload kind"
+    else "supported rows are currently terminal or effectively expired"
+  in
+  `Assoc
+    [ "schema", `String "masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1"
+    ; "source", `String "schedule_store"
+    ; "projection_status", `String projection_status
+    ; ( "criteria"
+      , `String
+          "payload_support=supported && execution_readiness not in {terminal,expired}" )
+    ; "reason", `String reason
+    ; "request_count", `Int request_count
+    ; "supported_request_count", `Int supported_request_count
+    ; "supported_non_terminal_count", `Int supported_non_terminal_count
+    ; "supported_live_count", `Int supported_live_count
+    ; "supported_terminal_or_expired_count", `Int supported_terminal_or_expired_count
+    ; "unsupported_request_count", `Int unsupported_request_count
+    ; "unknown_request_count", `Int unknown_request_count
+    ; "terminal_or_expired_count", `Int terminal_or_expired_count
+    ; ( "matched_schedule_ids"
+      , `List (List.map (fun schedule_id -> `String schedule_id) (List.rev matched_ids)) )
+    ; "matched_schedule_id_limit", `Int live_supported_evidence_ids_limit
+    ]
+;;
+
 let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
   (* NDT-OK: dashboard read-model freshness clock; it derives display-only
      effective-due state and never mutates the schedule store or runs work. *)
@@ -3158,6 +3315,8 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
           ; "unknown_payload_kind", `Int unknown_payload_kind_count
           ] )
     ; "payload_support", payload_support
+    ; ( "live_supported_non_terminal_evidence"
+      , schedule_live_supported_non_terminal_evidence_json ~now ~state schedules )
     ; ( "fsm"
       , `Assoc
           [ "state", `String (schedule_fsm_state ~now state schedules)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2807,7 +2807,15 @@ let schedule_keeper_queue_evidence_dashboard_json
         | Ok Server_schedule_consumers.Board_post_created _ -> `Null
         | Ok
             (Server_schedule_consumers.Keeper_wake_enqueued
-              { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+              { keeper_name
+              ; schedule_id
+              ; urgency = _
+              ; post_id
+              ; queue
+              ; stimulus
+              ; stimulus_id = _
+              ; reaction_ledger_status = _
+              }) ->
           let due_at = execution.Schedule_domain.due_at in
           let payload_digest = execution.Schedule_domain.payload_digest in
           let snapshot =
@@ -2856,6 +2864,98 @@ let schedule_keeper_queue_evidence_dashboard_json
              `Assoc (("projection_status", `String "read_error") :: base_fields)
            | None, None, [] ->
              `Assoc (("projection_status", `String "not_found") :: base_fields))))
+;;
+
+let schedule_keeper_reaction_evidence_dashboard_json
+  (config : Workspace.config)
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error reason ->
+          `Assoc
+            [ "projection_status", `String "unrecognized_receipt"
+            ; "reason", `String reason
+            ]
+        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name
+              ; schedule_id
+              ; urgency = _
+              ; post_id
+              ; queue = _
+              ; stimulus
+              ; stimulus_id
+              ; reaction_ledger_status = _
+              }) ->
+          let base_fields =
+            [ "source", `String "keeper_reaction_ledger"
+            ; "keeper_name", `String keeper_name
+            ; "schedule_id", `String schedule_id
+            ; "post_id", `String post_id
+            ; "stimulus", `String stimulus
+            ; ( "reaction_kind"
+              , `String
+                  (Keeper_reaction_ledger.reaction_kind_to_string
+                     Keeper_reaction_ledger.Turn_started) )
+            ; ( "stimulus_kind"
+              , `String
+                  (Keeper_reaction_ledger.stimulus_kind_to_string
+                     Keeper_reaction_ledger.Schedule_due) )
+            ]
+          in
+          (match stimulus_id with
+           | None ->
+             `Assoc
+               (("projection_status", `String "missing_stimulus_id")
+                :: ("reason", `String "dispatch receipt predates stimulus_id projection")
+                :: base_fields)
+           | Some stimulus_id ->
+             let evidence =
+               Keeper_reaction_ledger.event_queue_reaction_evidence
+                 ~base_path:config.Workspace_utils.base_path
+                 ~keeper_name
+                 ~stimulus_id
+             in
+             let projection_status =
+               if evidence.turn_started_seen
+               then "matched_turn_started"
+               else if evidence.stimulus_seen
+               then "matched_stimulus"
+               else "not_found"
+             in
+             `Assoc
+               (("projection_status", `String projection_status)
+                :: base_fields
+                @ [ "stimulus_id", `String stimulus_id
+                  ; "stimulus_seen", `Bool evidence.stimulus_seen
+                  ; "turn_started_seen", `Bool evidence.turn_started_seen
+                  ; "matched_record_count", `Int evidence.matched_record_count
+                  ; ( "stimulus_recorded_at"
+                    , match evidence.stimulus_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "stimulus_recorded_at_iso"
+                    , unix_iso_option_json evidence.stimulus_recorded_at )
+                  ; ( "turn_started_recorded_at"
+                    , match evidence.turn_started_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "turn_started_recorded_at_iso"
+                    , unix_iso_option_json evidence.turn_started_recorded_at )
+                  ; ( "latest_recorded_at"
+                    , match evidence.latest_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "latest_recorded_at_iso"
+                    , unix_iso_option_json evidence.latest_recorded_at )
+                  ]))))
 ;;
 
 let schedule_signal_projection_limit = 20
@@ -2962,6 +3062,8 @@ let schedule_request_dashboard_json
         | Some execution -> execution_record_dashboard_json execution )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
     ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_execution
+    ; ( "keeper_reaction_evidence"
+      , schedule_keeper_reaction_evidence_dashboard_json config last_execution )
     ]
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2721,6 +2721,143 @@ let schedule_dispatch_receipt_dashboard_json
          ]))
 ;;
 
+let schedule_queue_read_error_dashboard_json
+  (error : Keeper_event_queue_persistence.snapshot_read_error)
+  =
+  `Assoc
+    [ "kind", `String (Keeper_event_queue_persistence.snapshot_read_error_kind_to_string error.kind)
+    ; ( "path"
+      , match error.path with
+        | None -> `Null
+        | Some path -> `String path )
+    ; "message", `String error.message
+    ]
+;;
+
+let schedule_queue_match
+  ~(schedule_id : string)
+  ~(due_at : float)
+  ~(payload_digest : string)
+  ~(post_id : string)
+  ~(stimulus_label : string)
+  (queue : Keeper_event_queue.t)
+  =
+  queue
+  |> Keeper_event_queue.to_list
+  |> List.find_opt (fun (stimulus : Keeper_event_queue.stimulus) ->
+    String.equal stimulus.post_id post_id
+    && String.equal (Keeper_event_queue.payload_kind_label stimulus.payload) stimulus_label
+    &&
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake ->
+      String.equal wake.schedule_id schedule_id
+      && Float.equal wake.due_at due_at
+      && String.equal wake.payload_digest payload_digest
+    | _ -> false)
+;;
+
+let schedule_queue_match_fields ~now bucket (stimulus : Keeper_event_queue.stimulus) =
+  let scheduled_wake =
+    match stimulus.payload with
+    | Keeper_event_queue.Schedule_due wake -> Some wake
+    | _ -> None
+  in
+  [ "matched_bucket", `String bucket
+  ; "matched_post_id", `String stimulus.post_id
+  ; "matched_payload_kind", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+  ; "matched_arrived_at", `Float stimulus.arrived_at
+  ; "matched_arrived_at_iso", unix_iso_json stimulus.arrived_at
+  ; ( "matched_schedule_id"
+    , match scheduled_wake with
+      | Some wake -> `String wake.schedule_id
+      | None -> `Null )
+  ; ( "matched_due_at"
+    , match scheduled_wake with
+      | Some wake -> `Float wake.due_at
+      | None -> `Null )
+  ; ( "matched_due_at_iso"
+    , match scheduled_wake with
+      | Some wake -> unix_iso_json wake.due_at
+      | None -> `Null )
+  ; ( "matched_payload_digest"
+    , match scheduled_wake with
+      | Some wake -> `String wake.payload_digest
+      | None -> `Null )
+  ; "matched_age_seconds", `Float (Float.max 0.0 (now -. stimulus.arrived_at))
+  ]
+;;
+
+let schedule_keeper_queue_evidence_dashboard_json
+  ~now
+  (config : Workspace.config)
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error reason ->
+          `Assoc
+            [ "projection_status", `String "unrecognized_receipt"
+            ; "reason", `String reason
+            ]
+        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+          let due_at = execution.Schedule_domain.due_at in
+          let payload_digest = execution.Schedule_domain.payload_digest in
+          let snapshot =
+            Keeper_event_queue_persistence.load_snapshot_pair_with_errors
+              ~base_path:config.Workspace_utils.base_path
+              ~keeper_name
+          in
+          let pending_match =
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.pending
+          in
+          let inflight_match =
+            schedule_queue_match ~schedule_id ~due_at ~payload_digest ~post_id
+              ~stimulus_label:stimulus snapshot.inflight
+          in
+          let read_errors =
+            List.map schedule_queue_read_error_dashboard_json snapshot.read_errors
+          in
+          let base_fields =
+            [ "source", `String "durable_event_queue_snapshot"
+            ; "queue", `String queue
+            ; "stimulus", `String stimulus
+            ; "keeper_name", `String keeper_name
+            ; "schedule_id", `String schedule_id
+            ; "post_id", `String post_id
+            ; "execution_due_at", `Float due_at
+            ; "execution_due_at_iso", unix_iso_json due_at
+            ; "execution_payload_digest", `String payload_digest
+            ; "pending_count", `Int (Keeper_event_queue.length snapshot.pending)
+            ; "inflight_count", `Int (Keeper_event_queue.length snapshot.inflight)
+            ; "read_errors", `List read_errors
+            ]
+          in
+          (match pending_match, inflight_match, snapshot.read_errors with
+           | Some match_, _, _ ->
+             `Assoc
+               (("projection_status", `String "matched_pending")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "pending" match_)
+           | None, Some match_, _ ->
+             `Assoc
+               (("projection_status", `String "matched_inflight")
+                :: base_fields
+                @ schedule_queue_match_fields ~now "inflight" match_)
+           | None, None, _ :: _ ->
+             `Assoc (("projection_status", `String "read_error") :: base_fields)
+           | None, None, [] ->
+             `Assoc (("projection_status", `String "not_found") :: base_fields))))
+;;
+
 let schedule_signal_projection_limit = 20
 
 let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
@@ -2751,6 +2888,7 @@ let schedule_signal_dashboard_json (signal : Schedule_runner.wake_signal) =
 
 let schedule_request_dashboard_json
   ~now
+  ~config
   ~state
   ?last_execution
   (request : Schedule_domain.schedule_request)
@@ -2823,6 +2961,7 @@ let schedule_request_dashboard_json
         | None -> `Null
         | Some execution -> execution_record_dashboard_json execution )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
+    ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_execution
     ]
 ;;
 
@@ -2932,7 +3071,7 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
                   Schedule_store.last_execution_for_schedule state
                     ~schedule_id:request.Schedule_domain.schedule_id
                 in
-                schedule_request_dashboard_json ~now ~state ?last_execution request)
+                schedule_request_dashboard_json ~now ~config ~state ?last_execution request)
              request_rows) )
     ]
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2700,6 +2700,27 @@ let execution_record_dashboard_json (execution : Schedule_domain.execution_recor
   | other -> other
 ;;
 
+let schedule_dispatch_receipt_dashboard_json
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+    (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+     | Ok receipt ->
+       (match Server_schedule_consumers.dispatch_receipt_to_yojson receipt with
+        | `Assoc fields -> `Assoc (("projection_status", `String "recognized") :: fields)
+        | other -> other)
+     | Error reason ->
+       `Assoc
+         [ "projection_status", `String "unrecognized_detail"
+         ; "reason", `String reason
+         ]))
+;;
+
 let schedule_signal_projection_limit = 20
 
 let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
@@ -2801,6 +2822,7 @@ let schedule_request_dashboard_json
       , match last_execution with
         | None -> `Null
         | Some execution -> execution_record_dashboard_json execution )
+    ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
     ]
 ;;
 

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -3,6 +3,9 @@
    loop logs aggregate dispatch counts for runtime telemetry. *)
 
 let supported_payload_kinds = Schedule_supported_kinds.supported
+let board_post_created_kind = "masc.board_post.created"
+let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
+let keeper_event_queue_label = "keeper_event_queue"
 
 let ( let* ) = Result.bind
 
@@ -65,6 +68,63 @@ let optional_assoc_field name fields =
   | None | Some `Null -> Ok None
   | Some (`Assoc _ as value) -> Ok (Some value)
   | Some _ -> Error ("expected object field: " ^ name)
+;;
+
+type dispatch_receipt =
+  | Board_post_created of
+      { post_id : string
+      ; author : string
+      ; hearth : string option
+      }
+  | Keeper_wake_enqueued of
+      { keeper_name : string
+      ; schedule_id : string
+      ; urgency : string
+      ; post_id : string
+      ; queue : string
+      ; stimulus : string
+      }
+
+let dispatch_receipt_of_detail = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    if String.equal kind board_post_created_kind
+    then
+      let* post_id = string_field "post_id" fields in
+      let* author = string_field "author" fields in
+      let* hearth = optional_string_field "hearth" fields in
+      Ok (Board_post_created { post_id; author; hearth })
+    else if String.equal kind keeper_wake_enqueued_kind
+    then
+      let* keeper_name = keeper_name_field "keeper_name" fields in
+      let* schedule_id = string_field "schedule_id" fields in
+      let* urgency = string_field "urgency" fields in
+      let* post_id = string_field "post_id" fields in
+      let* queue = string_field "queue" fields in
+      let* stimulus = string_field "stimulus" fields in
+      Ok (Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus })
+    else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
+  | _ -> Error "schedule dispatch receipt detail must be an object"
+;;
+
+let dispatch_receipt_to_yojson = function
+  | Board_post_created { post_id; author; hearth } ->
+    `Assoc
+      [ "kind", `String board_post_created_kind
+      ; "post_id", `String post_id
+      ; "author", `String author
+      ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
+      ]
+  | Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus } ->
+    `Assoc
+      [ "kind", `String keeper_wake_enqueued_kind
+      ; "queue", `String queue
+      ; "stimulus", `String stimulus
+      ; "keeper_name", `String keeper_name
+      ; "schedule_id", `String schedule_id
+      ; "urgency", `String urgency
+      ; "post_id", `String post_id
+      ]
 ;;
 
 type payload_view =
@@ -172,7 +232,7 @@ let dispatch_board_post request payload =
     let post_id = Board.Post_id.to_string post.id in
     Ok
       (`Assoc
-        [ "kind", `String "masc.board_post.created"
+        [ "kind", `String board_post_created_kind
         ; "post_id", `String post_id
         ; "author", `String author
         ; ( "hearth"
@@ -215,7 +275,9 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     stimulus;
   Ok
     (`Assoc
-      [ "kind", `String "masc.keeper_wake.enqueued"
+      [ "kind", `String keeper_wake_enqueued_kind
+      ; "queue", `String keeper_event_queue_label
+      ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
       ; "keeper_name", `String keeper_name
       ; "schedule_id", `String request.schedule_id
       ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -6,6 +6,8 @@ let supported_payload_kinds = Schedule_supported_kinds.supported
 let board_post_created_kind = "masc.board_post.created"
 let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
 let keeper_event_queue_label = "keeper_event_queue"
+let reaction_ledger_recorded_label = "recorded"
+let reaction_ledger_record_failed_label = "record_failed"
 
 let ( let* ) = Result.bind
 
@@ -70,6 +72,44 @@ let optional_assoc_field name fields =
   | Some _ -> Error ("expected object field: " ^ name)
 ;;
 
+type keeper_wake_reaction_ledger_status =
+  | Keeper_wake_reaction_ledger_recorded
+  | Keeper_wake_reaction_ledger_record_failed of string
+
+let keeper_wake_reaction_ledger_status_to_string = function
+  | Keeper_wake_reaction_ledger_recorded -> reaction_ledger_recorded_label
+  | Keeper_wake_reaction_ledger_record_failed _ -> reaction_ledger_record_failed_label
+;;
+
+let keeper_wake_reaction_ledger_error = function
+  | Keeper_wake_reaction_ledger_recorded -> None
+  | Keeper_wake_reaction_ledger_record_failed reason -> Some reason
+;;
+
+let keeper_wake_reaction_ledger_status_of_fields fields =
+  match optional_string_field "reaction_ledger_status" fields with
+  | Error reason -> Error reason
+  | Ok None -> Ok None
+  | Ok (Some value) when String.equal value reaction_ledger_recorded_label ->
+    Ok (Some Keeper_wake_reaction_ledger_recorded)
+  | Ok (Some value) when String.equal value reaction_ledger_record_failed_label ->
+    let* reason = string_field "reaction_ledger_error" fields in
+    Ok (Some (Keeper_wake_reaction_ledger_record_failed reason))
+  | Ok (Some value) -> Error ("unsupported reaction_ledger_status: " ^ value)
+;;
+
+let keeper_wake_reaction_ledger_status_json_fields = function
+  | None -> [ "reaction_ledger_status", `Null; "reaction_ledger_error", `Null ]
+  | Some status ->
+    [ "reaction_ledger_status"
+    , `String (keeper_wake_reaction_ledger_status_to_string status)
+    ; ( "reaction_ledger_error"
+      , match keeper_wake_reaction_ledger_error status with
+        | None -> `Null
+        | Some reason -> `String reason )
+    ]
+;;
+
 type dispatch_receipt =
   | Board_post_created of
       { post_id : string
@@ -83,6 +123,8 @@ type dispatch_receipt =
       ; post_id : string
       ; queue : string
       ; stimulus : string
+      ; stimulus_id : string option
+      ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
       }
 
 let dispatch_receipt_of_detail = function
@@ -102,7 +144,21 @@ let dispatch_receipt_of_detail = function
       let* post_id = string_field "post_id" fields in
       let* queue = string_field "queue" fields in
       let* stimulus = string_field "stimulus" fields in
-      Ok (Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus })
+      let* stimulus_id = optional_string_field "stimulus_id" fields in
+      let* reaction_ledger_status =
+        keeper_wake_reaction_ledger_status_of_fields fields
+      in
+      Ok
+        (Keeper_wake_enqueued
+           { keeper_name
+           ; schedule_id
+           ; urgency
+           ; post_id
+           ; queue
+           ; stimulus
+           ; stimulus_id
+           ; reaction_ledger_status
+           })
     else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
   | _ -> Error "schedule dispatch receipt detail must be an object"
 ;;
@@ -115,16 +171,27 @@ let dispatch_receipt_to_yojson = function
       ; "author", `String author
       ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
       ]
-  | Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus } ->
+  | Keeper_wake_enqueued
+      { keeper_name
+      ; schedule_id
+      ; urgency
+      ; post_id
+      ; queue
+      ; stimulus
+      ; stimulus_id
+      ; reaction_ledger_status
+      } ->
     `Assoc
-      [ "kind", `String keeper_wake_enqueued_kind
-      ; "queue", `String queue
-      ; "stimulus", `String stimulus
-      ; "keeper_name", `String keeper_name
-      ; "schedule_id", `String schedule_id
-      ; "urgency", `String urgency
-      ; "post_id", `String post_id
-      ]
+      ([ "kind", `String keeper_wake_enqueued_kind
+       ; "queue", `String queue
+       ; "stimulus", `String stimulus
+       ; "stimulus_id", (match stimulus_id with None -> `Null | Some value -> `String value)
+       ; "keeper_name", `String keeper_name
+       ; "schedule_id", `String schedule_id
+       ; "urgency", `String urgency
+       ; "post_id", `String post_id
+       ]
+       @ keeper_wake_reaction_ledger_status_json_fields reaction_ledger_status)
 ;;
 
 type payload_view =
@@ -242,6 +309,19 @@ let dispatch_board_post request payload =
         ])
 ;;
 
+let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
+  try
+    Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name stimulus;
+    Keeper_wake_reaction_ledger_recorded
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Keeper_wake_reaction_ledger_record_failed
+      (Printf.sprintf
+         "failed to persist keeper reaction ledger stimulus: %s"
+         (Printexc.to_string exn))
+;;
+
 let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request) payload =
   let* keeper_name = keeper_name_field "keeper_name" payload.body in
   let* message = string_field "message" payload.body in
@@ -269,20 +349,37 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     ; payload = Keeper_event_queue.Schedule_due wake
     }
   in
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
   Keeper_registry_event_queue.enqueue
     ~base_path:config.Workspace_utils.base_path
     keeper_name
     stimulus;
+  let reaction_ledger_status =
+    record_keeper_wake_stimulus
+      ~base_path:config.Workspace_utils.base_path
+      ~keeper_name
+      stimulus
+  in
+  (match reaction_ledger_status with
+   | Keeper_wake_reaction_ledger_recorded -> ()
+   | Keeper_wake_reaction_ledger_record_failed reason ->
+     Log.Keeper.warn
+       "schedule keeper wake reaction ledger append failed schedule_id=%s keeper=%s: %s"
+       request.schedule_id
+       keeper_name
+       reason);
   Ok
     (`Assoc
-      [ "kind", `String keeper_wake_enqueued_kind
-      ; "queue", `String keeper_event_queue_label
-      ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
-      ; "keeper_name", `String keeper_name
-      ; "schedule_id", `String request.schedule_id
-      ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)
-      ; "post_id", `String stimulus.post_id
-      ])
+      ([ "kind", `String keeper_wake_enqueued_kind
+       ; "queue", `String keeper_event_queue_label
+       ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+       ; "stimulus_id", `String stimulus_id
+       ; "keeper_name", `String keeper_name
+       ; "schedule_id", `String request.schedule_id
+       ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)
+       ; "post_id", `String stimulus.post_id
+       ]
+       @ keeper_wake_reaction_ledger_status_json_fields (Some reaction_ledger_status)))
 ;;
 
 let dispatch config ~now request =

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -1,5 +1,9 @@
 val supported_payload_kinds : string list
 
+type keeper_wake_reaction_ledger_status =
+  | Keeper_wake_reaction_ledger_recorded
+  | Keeper_wake_reaction_ledger_record_failed of string
+
 type dispatch_receipt =
   | Board_post_created of
       { post_id : string
@@ -13,6 +17,8 @@ type dispatch_receipt =
       ; post_id : string
       ; queue : string
       ; stimulus : string
+      ; stimulus_id : string option
+      ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
       }
 
 val dispatch_receipt_of_detail :

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -1,5 +1,25 @@
 val supported_payload_kinds : string list
 
+type dispatch_receipt =
+  | Board_post_created of
+      { post_id : string
+      ; author : string
+      ; hearth : string option
+      }
+  | Keeper_wake_enqueued of
+      { keeper_name : string
+      ; schedule_id : string
+      ; urgency : string
+      ; post_id : string
+      ; queue : string
+      ; stimulus : string
+      }
+
+val dispatch_receipt_of_detail :
+  Yojson.Safe.t -> (dispatch_receipt, string) result
+
+val dispatch_receipt_to_yojson : dispatch_receipt -> Yojson.Safe.t
+
 val consumer : Schedule_runner.consumer
 (** Production scheduled-automation consumer adapter.
 

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -54,6 +54,23 @@ let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
   }
 ;;
 
+let schedule_due_stimulus ?(schedule_id = "sched-ledger-1") () :
+  Keeper_event_queue.stimulus
+  =
+  { post_id = "schedule-due:" ^ schedule_id
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at = 1234.5
+  ; payload =
+      Keeper_event_queue.Schedule_due
+        { schedule_id
+        ; due_at = 1200.0
+        ; payload_digest = "payload-digest"
+        ; title = Some "Wake"
+        ; message = "Scheduled lane wake"
+        }
+  }
+;;
+
 let check_member_string label expected key json =
   check string label expected (json |> member key |> to_string)
 ;;
@@ -125,6 +142,54 @@ let test_event_queue_stimulus_and_turn_reaction () =
     "turn_started"
     "kind"
     (reaction_row |> member "reaction")
+;;
+
+let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "ledger-schedule-keeper" in
+  let stimulus = schedule_due_stimulus () in
+  let unrelated = schedule_due_stimulus ~schedule_id:"sched-ledger-other" () in
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    unrelated;
+  let stimulus_only =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "exact stimulus seen" true stimulus_only.stimulus_seen;
+  check bool "turn reaction absent" false stimulus_only.turn_started_seen;
+  check int "one exact row before reaction" 1 stimulus_only.matched_record_count;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus;
+  let reacted =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "exact stimulus still seen" true reacted.stimulus_seen;
+  check bool "turn reaction seen" true reacted.turn_started_seen;
+  check int "two exact rows after reaction" 2 reacted.matched_record_count;
+  let missing =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id:"stimulus:missing"
+  in
+  check bool "missing stimulus absent" false missing.stimulus_seen;
+  check bool "missing reaction absent" false missing.turn_started_seen;
+  check int "missing exact rows" 0 missing.matched_record_count
 ;;
 
 let test_cursor_ack_is_replayable_state_entry () =
@@ -1225,6 +1290,10 @@ let () =
             "event queue stimulus and turn reaction are durable"
             `Quick
             test_event_queue_stimulus_and_turn_reaction
+        ; test_case
+            "event queue reaction evidence matches exact stimulus id"
+            `Quick
+            test_event_queue_reaction_evidence_matches_exact_stimulus_id
         ; test_case
             "cursor ack is replayable state entry"
             `Quick

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -166,6 +166,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "exact stimulus seen" true stimulus_only.stimulus_seen;
   check bool "turn reaction absent" false stimulus_only.turn_started_seen;
+  check bool "event queue ack absent" false stimulus_only.event_queue_ack_seen;
   check int "one exact row before reaction" 1 stimulus_only.matched_record_count;
   Keeper_reaction_ledger.record_event_queue_reaction
     ~base_path
@@ -180,7 +181,28 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "exact stimulus still seen" true reacted.stimulus_seen;
   check bool "turn reaction seen" true reacted.turn_started_seen;
+  check bool "event queue ack still absent" false reacted.event_queue_ack_seen;
   check int "two exact rows after reaction" 2 reacted.matched_record_count;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+    stimulus;
+  let acknowledged =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "event queue ack seen" true acknowledged.event_queue_ack_seen;
+  check int "three exact rows after ack" 3 acknowledged.matched_record_count;
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "summary counts event queue ack" 1
+    (summary |> member "event_queue_ack_count" |> to_int);
+  check int "event queue ack is not unknown" 0
+    (summary |> member "unknown_reaction_count" |> to_int);
   let missing =
     Keeper_reaction_ledger.event_queue_reaction_evidence
       ~base_path
@@ -189,6 +211,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "missing stimulus absent" false missing.stimulus_seen;
   check bool "missing reaction absent" false missing.turn_started_seen;
+  check bool "missing ack absent" false missing.event_queue_ack_seen;
   check int "missing exact rows" 0 missing.matched_record_count
 ;;
 
@@ -1271,6 +1294,7 @@ let test_reaction_kind_string_roundtrip () =
     (fun k ->
       check bool "reaction_kind round-trips through string" true (roundtrips k))
     [ Keeper_reaction_ledger.Turn_started
+    ; Keeper_reaction_ledger.Event_queue_ack
     ; Keeper_reaction_ledger.Execution_receipt
     ; Keeper_reaction_ledger.Terminal_reason
     ; Keeper_reaction_ledger.Cursor_ack

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -23,6 +23,19 @@ let rm_rf dir =
   | _ -> ()
 ;;
 
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_empty_file path =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> ())
+;;
+
 let with_workspace f =
   Eio_main.run
   @@ fun env ->
@@ -338,6 +351,8 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (receipt |> member "urgency" |> to_string);
     check string "receipt post id" "schedule-due:keeper-wake-sched-1"
       (receipt |> member "post_id" |> to_string);
+    check string "receipt reaction ledger recorded" "recorded"
+      (receipt |> member "reaction_ledger_status" |> to_string);
     let queue_evidence = row |> member "keeper_queue_evidence" in
     check string "queue evidence matched" "matched_pending"
       (queue_evidence |> member "projection_status" |> to_string);
@@ -487,6 +502,25 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (pending_evidence |> member "pending_count" |> to_int);
       check int "inflight count before lease" 0
         (pending_evidence |> member "inflight_count" |> to_int);
+      let pending_receipt = pending_row |> member "dispatch_receipt" in
+      let stimulus_id = pending_receipt |> member "stimulus_id" |> to_string in
+      check bool "dispatch receipt includes stimulus id" true
+        (String.starts_with ~prefix:"stimulus:" stimulus_id);
+      let pending_reaction_evidence =
+        pending_row |> member "keeper_reaction_evidence"
+      in
+      check string "reaction evidence sees queued stimulus" "matched_stimulus"
+        (pending_reaction_evidence |> member "projection_status" |> to_string);
+      check string "reaction evidence source" "keeper_reaction_ledger"
+        (pending_reaction_evidence |> member "source" |> to_string);
+      check string "reaction evidence stimulus id" stimulus_id
+        (pending_reaction_evidence |> member "stimulus_id" |> to_string);
+      check bool "reaction evidence stimulus seen" true
+        (pending_reaction_evidence |> member "stimulus_seen" |> to_bool);
+      check bool "reaction evidence turn not started yet" false
+        (pending_reaction_evidence |> member "turn_started_seen" |> to_bool);
+      check int "one matched ledger row before turn" 1
+        (pending_reaction_evidence |> member "matched_record_count" |> to_int);
       let leased =
         match
           Keeper_registry_event_queue.dequeue
@@ -520,10 +554,72 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (inflight_evidence |> member "pending_count" |> to_int);
       check int "inflight count after lease" 1
         (inflight_evidence |> member "inflight_count" |> to_int);
+      Keeper_reaction_ledger.record_event_queue_reaction
+        ~base_path:config.Workspace_utils.base_path
+        ~keeper_name
+        ~reaction_kind:Keeper_reaction_ledger.Turn_started
+        leased;
+      let reacted_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let reaction_evidence = reacted_row |> member "keeper_reaction_evidence" in
+      check string "reaction evidence matched turn" "matched_turn_started"
+        (reaction_evidence |> member "projection_status" |> to_string);
+      check bool "reaction evidence turn started" true
+        (reaction_evidence |> member "turn_started_seen" |> to_bool);
+      check int "two matched ledger rows after turn" 2
+        (reaction_evidence |> member "matched_record_count" |> to_int);
       Keeper_registry_event_queue.ack_consumed
         ~base_path:config.Workspace_utils.base_path
         keeper_name
         [ leased ])
+;;
+
+let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_dir =
+    Filename.concat
+      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
+      keeper_name
+  in
+  mkdir_p keeper_dir;
+  write_empty_file (Filename.concat keeper_dir "reaction-ledger");
+  let request = create_pending_keeper_wake_schedule config in
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  let result = tick_ok config ~now:201.0 in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check string "dispatch status stays succeeded" "succeeded"
+    (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing"
+   | Some stored ->
+     check string "schedule succeeded" "succeeded"
+       (Schedule_domain.schedule_status_to_string stored.status));
+  check int "wake remains durably queued" 1
+    (Keeper_event_queue.length
+       (Keeper_registry_event_queue.snapshot ~base_path keeper_name));
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row = dashboard_schedule_row_exn dashboard ~schedule_id:request.schedule_id in
+  let receipt = row |> member "dispatch_receipt" in
+  check string "receipt recognized" "recognized"
+    (receipt |> member "projection_status" |> to_string);
+  check string "ledger failure visible" "record_failed"
+    (receipt |> member "reaction_ledger_status" |> to_string);
+  check bool "ledger failure reason visible" true
+    (String.length (receipt |> member "reaction_ledger_error" |> to_string) > 0);
+  let queue_evidence = row |> member "keeper_queue_evidence" in
+  check string "queue evidence still matched" "matched_pending"
+    (queue_evidence |> member "projection_status" |> to_string);
+  let reaction_evidence = row |> member "keeper_reaction_evidence" in
+  check string "reaction ledger miss visible" "not_found"
+    (reaction_evidence |> member "projection_status" |> to_string)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
@@ -601,6 +697,8 @@ let () =
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
             test_keeper_wake_dashboard_tracks_runtime_inflight_lease
+        ; test_case "keeper wake ledger failure keeps dispatch success visible" `Quick
+            test_keeper_wake_ledger_failure_keeps_dispatch_success_visible
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -254,6 +254,10 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
         let open Yojson.Safe.Util in
         check string "execution detail kind" "masc.keeper_wake.enqueued"
           (detail |> member "kind" |> to_string);
+        check string "execution detail queue" "keeper_event_queue"
+          (detail |> member "queue" |> to_string);
+        check string "execution detail stimulus" "schedule_due"
+          (detail |> member "stimulus" |> to_string);
         check string "execution keeper" "schedule-keeper"
           (detail |> member "keeper_name" |> to_string)
       | None -> fail "execution detail missing"));
@@ -283,7 +287,40 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       | _ -> fail "expected Schedule_due payload"))
   ;
   check int "keeper wake does not create board posts" 0
-    (List.length (Board_dispatch.list_posts ~limit:10 ()))
+    (List.length (Board_dispatch.list_posts ~limit:10 ()));
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  match row with
+  | None -> fail "keeper wake schedule missing from dashboard projection"
+  | Some row ->
+    let receipt = row |> member "dispatch_receipt" in
+    check string "receipt recognized" "recognized"
+      (receipt |> member "projection_status" |> to_string);
+    check string "receipt kind" "masc.keeper_wake.enqueued"
+      (receipt |> member "kind" |> to_string);
+    check string "receipt queue" "keeper_event_queue"
+      (receipt |> member "queue" |> to_string);
+    check string "receipt stimulus" "schedule_due"
+      (receipt |> member "stimulus" |> to_string);
+    check string "receipt keeper" "schedule-keeper"
+      (receipt |> member "keeper_name" |> to_string);
+    check string "receipt schedule" request.schedule_id
+      (receipt |> member "schedule_id" |> to_string);
+    check string "receipt urgency" "immediate"
+      (receipt |> member "urgency" |> to_string);
+    check string "receipt post id" "schedule-due:keeper-wake-sched-1"
+      (receipt |> member "post_id" |> to_string)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -320,7 +320,122 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
     check string "receipt urgency" "immediate"
       (receipt |> member "urgency" |> to_string);
     check string "receipt post id" "schedule-due:keeper-wake-sched-1"
-      (receipt |> member "post_id" |> to_string)
+      (receipt |> member "post_id" |> to_string);
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "queue evidence matched" "matched_pending"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check string "queue evidence source" "durable_event_queue_snapshot"
+      (queue_evidence |> member "source" |> to_string);
+    check string "queue evidence keeper" "schedule-keeper"
+      (queue_evidence |> member "keeper_name" |> to_string);
+    check string "queue evidence stimulus" "schedule_due"
+      (queue_evidence |> member "stimulus" |> to_string);
+    check string "queue evidence matched bucket" "pending"
+      (queue_evidence |> member "matched_bucket" |> to_string);
+    check string "queue evidence matched payload" "schedule_due"
+      (queue_evidence |> member "matched_payload_kind" |> to_string);
+    check string "queue evidence matched schedule" request.schedule_id
+      (queue_evidence |> member "matched_schedule_id" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check (float 0.001) "queue evidence matched due_at" request.due_at
+      (queue_evidence |> member "matched_due_at" |> to_float);
+    check string "queue evidence matched digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "matched_payload_digest" |> to_string);
+    check int "queue evidence pending count" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int);
+    check int "queue evidence read errors" 0
+      (queue_evidence |> member "read_errors" |> to_list |> List.length)
+;;
+
+let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let request = create_pending_keeper_wake_schedule config in
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  ignore (tick_ok config ~now:201.0 : Schedule_runner.tick_result);
+  let expected_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at
+    ; payload_digest = Schedule_domain.payload_digest request.payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run the scheduled maintenance lane now."
+    }
+  in
+  let post_id = Keeper_event_queue.schedule_due_post_id expected_wake in
+  (match Keeper_registry_event_queue.drop_by_post_id ~base_path keeper_name ~post_id with
+   | Error message -> fail ("drop failed: " ^ message)
+   | Ok removed -> check int "removed current occurrence" 1 (List.length removed));
+  let stale_payload_json =
+    `Assoc
+      [ "kind", `String "masc.keeper_wake"
+      ; "schema_version", `Int 1
+      ; ( "body"
+        , `Assoc
+            [ "keeper_name", `String keeper_name
+            ; "title", `String "Scheduled lane wake"
+            ; "message", `String "Run a different scheduled occurrence."
+            ; "urgency", `String "immediate"
+            ] )
+      ]
+  in
+  let stale_payload =
+    match Schedule_domain.payload_of_yojson stale_payload_json with
+    | Ok payload -> payload
+    | Error message -> fail ("stale payload parse failed: " ^ message)
+  in
+  let stale_wake : Keeper_event_queue.scheduled_wake =
+    { schedule_id = request.schedule_id
+    ; due_at = request.due_at +. 60.0
+    ; payload_digest = Schedule_domain.payload_digest stale_payload
+    ; title = Some "Scheduled lane wake"
+    ; message = "Run a different scheduled occurrence."
+    }
+  in
+  let stale_stimulus : Keeper_event_queue.stimulus =
+    { post_id = Keeper_event_queue.schedule_due_post_id stale_wake
+    ; urgency = Keeper_event_queue.Immediate
+    ; arrived_at = request.due_at +. 61.0
+    ; payload = Keeper_event_queue.Schedule_due stale_wake
+    }
+  in
+  Keeper_registry_event_queue.enqueue ~base_path keeper_name stale_stimulus;
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  match row with
+  | None -> fail "keeper wake schedule missing from dashboard projection"
+  | Some row ->
+    let queue_evidence = row |> member "keeper_queue_evidence" in
+    check string "stale occurrence does not match" "not_found"
+      (queue_evidence |> member "projection_status" |> to_string);
+    check (float 0.001) "queue evidence execution due_at" request.due_at
+      (queue_evidence |> member "execution_due_at" |> to_float);
+    check string "queue evidence execution digest"
+      (Schedule_domain.payload_digest request.payload)
+      (queue_evidence |> member "execution_payload_digest" |> to_string);
+    check int "stale occurrence still visible as pending" 1
+      (queue_evidence |> member "pending_count" |> to_int);
+    check int "queue evidence inflight count" 0
+      (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
@@ -394,6 +509,8 @@ let () =
             test_board_post_consumer_rejects_read_only_risk
         ; test_case "keeper wake enqueues typed stimulus" `Quick
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
+        ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
+            test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -48,6 +48,34 @@ let automated id : Schedule_domain.actor =
   { id; kind = Schedule_domain.Automated_actor; display_name = None }
 ;;
 
+let keeper_meta_for_name keeper_name =
+  match
+    Keeper_meta_json_parse.meta_of_json
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String keeper_name
+        ; "trace_id", `String ("trace-" ^ keeper_name)
+        ; "last_model_used", `String "llama:auto"
+        ; "tool_access", `List []
+        ])
+  with
+  | Ok meta -> meta
+  | Error msg -> fail ("keeper meta parse failed: " ^ msg)
+;;
+
+let dashboard_schedule_row_exn dashboard ~schedule_id =
+  let open Yojson.Safe.Util in
+  match
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find_opt (fun row ->
+      String.equal (row |> member "schedule_id" |> to_string) schedule_id)
+  with
+  | Some row -> row
+  | None -> fail ("schedule missing from dashboard projection: " ^ schedule_id)
+;;
+
 let board_post_payload =
   `Assoc
     [ "kind", `String "masc.board_post"
@@ -292,18 +320,7 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
     Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
   in
   let open Yojson.Safe.Util in
-  let row =
-    dashboard
-    |> member "requests"
-    |> to_list
-    |> List.find_opt (fun row ->
-      String.equal
-        (row |> member "schedule_id" |> to_string)
-        request.schedule_id)
-  in
-  match row with
-  | None -> fail "keeper wake schedule missing from dashboard projection"
-  | Some row ->
+  let row = dashboard_schedule_row_exn dashboard ~schedule_id:request.schedule_id in
     let receipt = row |> member "dispatch_receipt" in
     check string "receipt recognized" "recognized"
       (receipt |> member "projection_status" |> to_string);
@@ -438,6 +455,77 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
       (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
+let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let meta = keeper_meta_for_name keeper_name in
+  let (_entry : Keeper_registry.registry_entry) =
+    Keeper_registry.register ~base_path:config.Workspace_utils.base_path keeper_name meta
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.unregister ~base_path:config.Workspace_utils.base_path keeper_name)
+    (fun () ->
+      let request = create_pending_keeper_wake_schedule config in
+      ignore (approve_schedule config request : Schedule_domain.schedule_request);
+      let result = tick_ok config ~now:201.0 in
+      check int "one dispatch" 1 (List.length result.dispatches);
+      check string "dispatch status" "succeeded"
+        (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+      let pending_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let open Yojson.Safe.Util in
+      let pending_evidence = pending_row |> member "keeper_queue_evidence" in
+      check string "pending evidence matched" "matched_pending"
+        (pending_evidence |> member "projection_status" |> to_string);
+      check string "pending matched bucket" "pending"
+        (pending_evidence |> member "matched_bucket" |> to_string);
+      check int "pending count before lease" 1
+        (pending_evidence |> member "pending_count" |> to_int);
+      check int "inflight count before lease" 0
+        (pending_evidence |> member "inflight_count" |> to_int);
+      let leased =
+        match
+          Keeper_registry_event_queue.dequeue
+            ~base_path:config.Workspace_utils.base_path
+            keeper_name
+        with
+        | Some stimulus -> stimulus
+        | None -> fail "registered keeper should lease the scheduled wake"
+      in
+      check string "leased post id" "schedule-due:keeper-wake-sched-1" leased.post_id;
+      (match leased.payload with
+       | Keeper_event_queue.Schedule_due wake ->
+         check string "leased schedule id" request.schedule_id wake.schedule_id
+       | _ -> fail "registered keeper leased a non-schedule payload");
+      let inflight_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let inflight_evidence = inflight_row |> member "keeper_queue_evidence" in
+      check string "inflight evidence matched" "matched_inflight"
+        (inflight_evidence |> member "projection_status" |> to_string);
+      check string "inflight source" "durable_event_queue_snapshot"
+        (inflight_evidence |> member "source" |> to_string);
+      check string "inflight matched bucket" "inflight"
+        (inflight_evidence |> member "matched_bucket" |> to_string);
+      check string "inflight matched payload" "schedule_due"
+        (inflight_evidence |> member "matched_payload_kind" |> to_string);
+      check string "inflight matched schedule" request.schedule_id
+        (inflight_evidence |> member "matched_schedule_id" |> to_string);
+      check int "pending count after lease" 0
+        (inflight_evidence |> member "pending_count" |> to_int);
+      check int "inflight count after lease" 1
+        (inflight_evidence |> member "inflight_count" |> to_int);
+      Keeper_registry_event_queue.ack_consumed
+        ~base_path:config.Workspace_utils.base_path
+        keeper_name
+        [ leased ])
+;;
+
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
   with_workspace
   @@ fun config ->
@@ -511,6 +599,8 @@ let () =
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
+        ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
+            test_keeper_wake_dashboard_tracks_runtime_inflight_lease
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -119,6 +119,14 @@ let keeper_wake_payload =
     ]
 ;;
 
+let unsupported_payload =
+  `Assoc
+    [ "kind", `String "legacy.unsupported_scheduler_payload"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "message", `String "This payload is not in the schedule consumer catalog." ]
+    ]
+;;
+
 let create_pending_board_schedule config =
   match
     Schedule_service.create config ~schedule_id:"board-sched-1"
@@ -138,6 +146,19 @@ let create_pending_keeper_wake_schedule config =
       ~requested_at:100.0 ~requested_by:(human "operator")
       ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
       ~payload:keeper_wake_payload ~risk_class:Schedule_domain.Workspace_write
+      ~source:Schedule_domain.Operator_request ()
+  with
+  | Ok request -> request
+  | Error err ->
+    fail ("create failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let create_pending_unsupported_schedule config =
+  match
+    Schedule_service.create config ~schedule_id:"unsupported-live-sched"
+      ~requested_at:100.0 ~requested_by:(human "operator")
+      ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
+      ~payload:unsupported_payload ~risk_class:Schedule_domain.Read_only
       ~source:Schedule_domain.Operator_request ()
   with
   | Ok request -> request
@@ -470,6 +491,54 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
       (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
+let test_dashboard_live_supported_non_terminal_evidence_matches_supported_request () =
+  with_workspace
+  @@ fun config ->
+  let request = create_pending_keeper_wake_schedule config in
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let evidence = dashboard |> member "live_supported_non_terminal_evidence" in
+  check string "live supported evidence matched" "matched_supported_non_terminal"
+    (evidence |> member "projection_status" |> to_string);
+  check string "live supported evidence source" "schedule_store"
+    (evidence |> member "source" |> to_string);
+  check int "one supported request" 1
+    (evidence |> member "supported_request_count" |> to_int);
+  check int "one supported non-terminal request" 1
+    (evidence |> member "supported_non_terminal_count" |> to_int);
+  check int "one supported live request" 1
+    (evidence |> member "supported_live_count" |> to_int);
+  check int "no unsupported requests" 0
+    (evidence |> member "unsupported_request_count" |> to_int);
+  check (list string) "matched schedule ids" [ request.schedule_id ]
+    (evidence |> member "matched_schedule_ids" |> to_list |> List.map to_string)
+;;
+
+let test_dashboard_live_supported_non_terminal_evidence_reports_absent_supported_payloads
+      ()
+  =
+  with_workspace
+  @@ fun config ->
+  ignore (create_pending_unsupported_schedule config : Schedule_domain.schedule_request);
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let evidence = dashboard |> member "live_supported_non_terminal_evidence" in
+  check string "live supported evidence absent" "no_supported_payload_rows"
+    (evidence |> member "projection_status" |> to_string);
+  check int "no supported requests" 0
+    (evidence |> member "supported_request_count" |> to_int);
+  check int "no supported live requests" 0
+    (evidence |> member "supported_live_count" |> to_int);
+  check int "one unsupported request" 1
+    (evidence |> member "unsupported_request_count" |> to_int);
+  check int "no matched schedule ids" 0
+    (evidence |> member "matched_schedule_ids" |> to_list |> List.length)
+;;
+
 let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
   with_workspace
   @@ fun config ->
@@ -570,10 +639,37 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (reaction_evidence |> member "turn_started_seen" |> to_bool);
       check int "two matched ledger rows after turn" 2
         (reaction_evidence |> member "matched_record_count" |> to_int);
-      Keeper_registry_event_queue.ack_consumed
+      (match
+         Keeper_registry_event_queue.ack_consumed_result
+           ~base_path:config.Workspace_utils.base_path
+           keeper_name
+           [ leased ]
+       with
+       | Ok () -> ()
+       | Error msg -> fail ("scheduled wake ack failed: " ^ msg));
+      Keeper_reaction_ledger.record_event_queue_reaction
         ~base_path:config.Workspace_utils.base_path
-        keeper_name
-        [ leased ])
+        ~keeper_name
+        ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+        leased;
+      let acked_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let acked_queue_evidence = acked_row |> member "keeper_queue_evidence" in
+      check string "acked queue evidence drained" "not_found"
+        (acked_queue_evidence |> member "projection_status" |> to_string);
+      check int "pending count after ack" 0
+        (acked_queue_evidence |> member "pending_count" |> to_int);
+      check int "inflight count after ack" 0
+        (acked_queue_evidence |> member "inflight_count" |> to_int);
+      let acked_reaction_evidence = acked_row |> member "keeper_reaction_evidence" in
+      check string "reaction evidence matched ack" "matched_consumed_ack"
+        (acked_reaction_evidence |> member "projection_status" |> to_string);
+      check bool "reaction evidence event queue acked" true
+        (acked_reaction_evidence |> member "event_queue_ack_seen" |> to_bool);
+      check int "three matched ledger rows after ack" 3
+        (acked_reaction_evidence |> member "matched_record_count" |> to_int))
 ;;
 
 let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
@@ -695,6 +791,12 @@ let () =
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
+        ; test_case "dashboard live supported non-terminal evidence matches supported request"
+            `Quick
+            test_dashboard_live_supported_non_terminal_evidence_matches_supported_request
+        ; test_case "dashboard live supported non-terminal evidence reports absent supported payloads"
+            `Quick
+            test_dashboard_live_supported_non_terminal_evidence_reports_absent_supported_payloads
         ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
             test_keeper_wake_dashboard_tracks_runtime_inflight_lease
         ; test_case "keeper wake ledger failure keeps dispatch success visible" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -878,7 +878,13 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check string "last execution status" "succeeded"
       (row |> member "last_execution" |> member "status" |> to_string);
     check string "last execution detail" "test.exec"
-      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string)
+      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string);
+    check string "unrecognized dispatch receipt status" "unrecognized_detail"
+      (row |> member "dispatch_receipt" |> member "projection_status" |> to_string);
+    check bool "unrecognized dispatch receipt reason" true
+      (String_util.contains_substring
+         (row |> member "dispatch_receipt" |> member "reason" |> to_string)
+         "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 
 let test_dashboard_projection_surfaces_schedule_runner_signals () =

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -884,6 +884,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check bool "unrecognized dispatch receipt reason" true
       (String_util.contains_substring
          (row |> member "dispatch_receipt" |> member "reason" |> to_string)
+         "unsupported schedule dispatch receipt kind: test.exec");
+    check string "unrecognized queue evidence status" "unrecognized_receipt"
+      (row |> member "keeper_queue_evidence" |> member "projection_status" |> to_string);
+    check bool "unrecognized queue evidence reason" true
+      (String_util.contains_substring
+         (row |> member "keeper_queue_evidence" |> member "reason" |> to_string)
          "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 


### PR DESCRIPTION
## Summary
- add an OCaml regression that drives `masc.keeper_wake` through `Schedule_runner.tick`, registers the target keeper, leases the wake through `Keeper_registry_event_queue.dequeue`, and verifies the dashboard row changes from `matched_pending` to `matched_inflight` using the durable queue snapshot
- extend the scheduled automation panel test so v2 renders `matched_inflight` keeper queue evidence, not only pending queue evidence

## Validation
- `ocamlformat --check test/test_schedule_consumer_dispatch.ml`
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `env GITHUB_BASE_REF=codex/scheduler-wake-queue-e2e-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`

Local Dune build was not run; scheduler/OCaml compilation remains CI authority per repo workflow.