### PR TITLE
dashboard: back state diagram runtime labels

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -727,6 +727,8 @@ export interface KeeperStateDiagramResponse {
   recovery_floor_count?: number
   runtime_models?: string[]
   last_provider_result?: string | null
+  runtime_models_source?: string
+  last_provider_result_source?: string
   memory_kind_usage?: MemoryKindUsageEntry[]
   /** RFC-0149 §3.1 — sibling field carrying the typed memory-bank
    *  read failure class (`yojson_parse_error | io_error | type_error

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -56,6 +56,100 @@ let json_time_iso_opt = function
   | None -> `Null
 ;;
 
+type state_diagram_runtime_projection =
+  { runtime_models : string list
+  ; last_provider_result : string option
+  ; runtime_models_source : string
+  ; last_provider_result_source : string
+  ; effective_runtime_reason : string option
+  }
+
+let public_runtime_model_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+;;
+
+let state_diagram_runtime_projection
+    (meta : Keeper_meta_contract.keeper_meta option)
+  =
+  match meta with
+  | None ->
+    { runtime_models = []
+    ; last_provider_result = None
+    ; runtime_models_source = "missing_keeper_meta"
+    ; last_provider_result_source = "missing_keeper_meta"
+    ; effective_runtime_reason = None
+    }
+  | Some m ->
+    let last_runtime_attempt =
+      match m.runtime.last_runtime_attempt with
+      | Some attempt
+        when String.trim attempt.Keeper_meta_contract.provider_id <> "" ->
+        Some attempt
+      | Some _ | None -> None
+    in
+    let runtime_projection_evidence, runtime_projection_source =
+      try
+        let runtime_id = Keeper_meta_contract.runtime_id_of_meta m in
+        let has_evidence =
+          Provider_runtime_projection.default_execution_model_strings runtime_id
+          |> List.exists (fun label -> String.trim label <> "")
+        in
+        ( has_evidence
+        , if has_evidence
+          then "provider_runtime_projection.default_execution_model_strings"
+          else "provider_runtime_projection.empty" )
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | _ -> false, "provider_runtime_projection.unavailable"
+    in
+    let runtime_model_evidence =
+      Option.is_some last_runtime_attempt || runtime_projection_evidence
+    in
+    let runtime_models =
+      if runtime_model_evidence then [ public_runtime_model_label ] else []
+    in
+    let last_provider_result, last_provider_result_source =
+      match last_runtime_attempt, runtime_models with
+      | Some _, _ :: _ ->
+        Some public_runtime_model_label, "keeper_meta.runtime.last_runtime_attempt"
+      | Some _, [] ->
+        None, "keeper_meta.runtime.last_runtime_attempt_without_model_evidence"
+      | None, _ -> None, "missing_keeper_meta.runtime.last_runtime_attempt"
+    in
+    { runtime_models
+    ; last_provider_result
+    ; runtime_models_source =
+        (match last_runtime_attempt with
+         | Some _ -> "keeper_meta.runtime.last_runtime_attempt"
+         | None -> runtime_projection_source)
+    ; last_provider_result_source
+    ; effective_runtime_reason =
+        (if runtime_model_evidence then Some "keeper_meta.runtime_evidence" else None)
+    }
+;;
+
+let state_diagram_runtime_projection_json
+    (projection : state_diagram_runtime_projection)
+  =
+  `Assoc
+    [ "runtime_models", Json_util.json_string_list projection.runtime_models
+    ; "last_provider_result", Json_util.string_opt_to_json projection.last_provider_result
+    ; "runtime_models_source", `String projection.runtime_models_source
+    ; "last_provider_result_source", `String projection.last_provider_result_source
+    ]
+;;
+
+let state_diagram_runtime_fsm_mermaid
+    (projection : state_diagram_runtime_projection)
+  =
+  Keeper_decision_audit.runtime_fsm_to_mermaid
+    ~provider_health:[]
+    ?effective_runtime_reason:projection.effective_runtime_reason
+    ~models:projection.runtime_models
+    ~last_provider_result:projection.last_provider_result
+    ()
+;;
+
 let memory_os_fact_is_current ~now (fact : Keeper_memory_os_types.fact) =
   match fact.valid_until with
   | None -> true
@@ -1769,21 +1863,15 @@ let handle_keeper_get_subroutes state req request reqd =
           ~thompson_beta:stats.beta
           ()
       in
-      let runtime_fsm_mermaid =
-        match meta with
-        | Ok (Some m) ->
-          let models = [ "candidate" ] in
-          let provider_health = [] in
-          Keeper_decision_audit.runtime_fsm_to_mermaid
-            ~provider_health
-            ~effective_runtime_reason:"runtime"
-            ~models ~last_provider_result:None ()
-        | _ ->
-          Keeper_decision_audit.runtime_fsm_to_mermaid
-            ~models:[] ~last_provider_result:None ()
+      let runtime_projection =
+        state_diagram_runtime_projection
+          (match meta with
+           | Ok meta -> meta
+           | Error _ -> None)
       in
-      let runtime_models = [] in
-      let last_provider = `Null in
+      let runtime_fsm_mermaid =
+        state_diagram_runtime_fsm_mermaid runtime_projection
+      in
       (* Memory tier usage: join kind_caps (policy) with kind_counts (bank
          summary). Each kind reports used / cap so the dashboard tier
          panel can render saturation without re-reading the memory file.
@@ -1845,20 +1933,27 @@ let handle_keeper_get_subroutes state req request reqd =
           `String (Buffer.contents b)
         | _ -> `Null
       in
-      let json = `Assoc [
-        "keeper", `String name;
-        "current_phase", `String phase_str;
-        "mermaid", `String mermaid;
-        "decision_pipeline_mermaid", `String decision_pipeline_mermaid;
-        "runtime_fsm_mermaid", `String runtime_fsm_mermaid;
-        "compaction_submachine_mermaid", compaction_submachine_mermaid;
-        "thompson_alpha", `Float stats.alpha;
-        "thompson_beta", `Float stats.beta;
-        "runtime_models", `List (List.map (fun s -> `String s) runtime_models);
-        "last_provider_result", last_provider;
-        "memory_kind_usage", memory_kind_usage;
-        "memory_kind_usage_error_class", memory_kind_usage_error_class_json;
-      ] in
+      let runtime_projection_fields =
+        match state_diagram_runtime_projection_json runtime_projection with
+        | `Assoc fields -> fields
+        | _ -> []
+      in
+      let json =
+        `Assoc
+          ([ "keeper", `String name
+           ; "current_phase", `String phase_str
+           ; "mermaid", `String mermaid
+           ; "decision_pipeline_mermaid", `String decision_pipeline_mermaid
+           ; "runtime_fsm_mermaid", `String runtime_fsm_mermaid
+           ; "compaction_submachine_mermaid", compaction_submachine_mermaid
+           ; "thompson_alpha", `Float stats.alpha
+           ; "thompson_beta", `Float stats.beta
+           ]
+           @ runtime_projection_fields
+           @ [ "memory_kind_usage", memory_kind_usage
+             ; "memory_kind_usage_error_class", memory_kind_usage_error_class_json
+             ])
+      in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if req_path = prefix ^ "composite" then
     (* LT-16a: fleet-wide composite snapshot. Enumerates every

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -118,6 +118,29 @@ val offline_keeper_composite_json :
 (** Offline/paused composite fallback for keepers missing from the live
     registry. Exposed so dashboard tests can pin the JSON shape. *)
 
+(** {1 Keeper state diagram runtime projection} *)
+
+type state_diagram_runtime_projection =
+  { runtime_models : string list
+  ; last_provider_result : string option
+  ; runtime_models_source : string
+  ; last_provider_result_source : string
+  ; effective_runtime_reason : string option
+  }
+
+val state_diagram_runtime_projection :
+  Keeper_meta_contract.keeper_meta option -> state_diagram_runtime_projection
+(** Redacted runtime/provider projection for [GET /state-diagram].
+    It never exposes concrete OAS provider or model identifiers. *)
+
+val state_diagram_runtime_projection_json :
+  state_diagram_runtime_projection -> Yojson.Safe.t
+(** JSON fields embedded in the [GET /state-diagram] response. *)
+
+val state_diagram_runtime_fsm_mermaid :
+  state_diagram_runtime_projection -> string
+(** Runtime FSM Mermaid rendered from the redacted projection. *)
+
 val handle_keeper_checkpoints_post :
   Mcp_server.server_state ->
   Httpun.Request.t -> Httpun.Reqd.t -> string -> unit

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1221,6 +1221,112 @@ let test_offline_keeper_composite_exposes_secret_projection () =
     false
     (contains_substring (Yojson.Safe.to_string json) sentinel)
 
+let keeper_state_diagram_meta ?last_runtime_attempt_provider name =
+  let runtime_attempt_fields =
+    match last_runtime_attempt_provider with
+    | None -> []
+    | Some provider_id ->
+      [ ( "last_runtime_attempt"
+        , `Assoc
+            [ "provider_id", `String provider_id
+            ; "http_status", `Int 200
+            ; "outcome", `Assoc [ "kind", `String "success" ]
+            ; "timestamp", `Float 1_720_000_000.0
+            ] )
+      ]
+  in
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         ([ "name", `String name
+          ; "agent_name", `String (name ^ "-agent")
+          ; "trace_id", `String ("trace-" ^ name)
+          ]
+          @ runtime_attempt_fields))
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.failf "state diagram meta fixture failed: %s" err
+
+let test_state_diagram_runtime_projection_redacts_live_runtime_evidence () =
+  let raw_provider = "openai:gpt-5-secret" in
+  let projection =
+    Server_dashboard_http_keeper_api.state_diagram_runtime_projection
+      (Some
+         (keeper_state_diagram_meta
+            ~last_runtime_attempt_provider:raw_provider
+            "state-diagram-runtime"))
+  in
+  Alcotest.(check (list string))
+    "runtime model labels are public redaction labels"
+    [ "runtime" ]
+    projection.runtime_models;
+  Alcotest.(check (option string))
+    "last provider result is redacted to the public runtime label"
+    (Some "runtime")
+    projection.last_provider_result;
+  Alcotest.(check string)
+    "runtime model source records keeper meta provenance"
+    "keeper_meta.runtime.last_runtime_attempt"
+    projection.runtime_models_source;
+  Alcotest.(check string)
+    "last provider source records keeper meta provenance"
+    "keeper_meta.runtime.last_runtime_attempt"
+    projection.last_provider_result_source;
+  let json =
+    Server_dashboard_http_keeper_api.state_diagram_runtime_projection_json
+      projection
+    |> Yojson.Safe.to_string
+  in
+  Alcotest.(check bool)
+    "projection JSON does not leak raw provider id"
+    false
+    (contains_substring json raw_provider);
+  let mermaid =
+    Server_dashboard_http_keeper_api.state_diagram_runtime_fsm_mermaid
+      projection
+  in
+  Alcotest.(check bool)
+    "runtime FSM contains the redacted runtime node"
+    true
+    (contains_substring mermaid {|state "runtime" as P0|});
+  Alcotest.(check bool)
+    "runtime FSM no longer renders fake candidate node"
+    false
+    (contains_substring mermaid "candidate");
+  Alcotest.(check bool)
+    "runtime FSM does not leak raw provider id"
+    false
+    (contains_substring mermaid raw_provider)
+
+let test_state_diagram_runtime_projection_missing_meta_stays_empty () =
+  let projection =
+    Server_dashboard_http_keeper_api.state_diagram_runtime_projection None
+  in
+  Alcotest.(check (list string))
+    "missing meta exposes no runtime model labels"
+    []
+    projection.runtime_models;
+  Alcotest.(check (option string))
+    "missing meta has no last provider result"
+    None
+    projection.last_provider_result;
+  Alcotest.(check string)
+    "missing meta source is explicit"
+    "missing_keeper_meta"
+    projection.runtime_models_source;
+  let mermaid =
+    Server_dashboard_http_keeper_api.state_diagram_runtime_fsm_mermaid
+      projection
+  in
+  Alcotest.(check bool)
+    "missing meta FSM reports zero models"
+    true
+    (contains_substring mermaid "Models: 0");
+  Alcotest.(check bool)
+    "missing meta FSM has no fake candidate node"
+    false
+    (contains_substring mermaid "candidate")
+
 let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   ignore (Workspace.init config ~agent_name:None);
@@ -1662,6 +1768,10 @@ let () =
             test_dashboard_fleet_composite_envelope_is_cached;
           test_case "offline keeper composite exposes secret projection" `Quick
             test_offline_keeper_composite_exposes_secret_projection;
+          test_case "state diagram runtime projection redacts live evidence" `Quick
+            test_state_diagram_runtime_projection_redacts_live_runtime_evidence;
+          test_case "state diagram runtime projection stays empty without meta" `Quick
+            test_state_diagram_runtime_projection_missing_meta_stays_empty;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick


### PR DESCRIPTION
## Summary
- Replace the state-diagram route's fake `candidate` runtime FSM node with a redacted live-backed projection.
- Emit `runtime_models_source` and `last_provider_result_source` so the dashboard can distinguish missing meta/projection data from observed runtime evidence.
- Add focused tests covering raw provider redaction, no fake candidate node, and missing-meta empty state.

## Validation
- `opam exec -- ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/server/server_dashboard_http_keeper_api.mli test/test_dashboard_http_core.ml`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- `scripts/dune-local.sh exec test/test_dashboard_http_core.exe` (49 tests)
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `git diff --check`

## Task 1823 Scope
This is slice 3 for task-1823. It removes the state-diagram placeholder runtime label. Remaining task scope still includes bootstrap synthetic-empty metadata and broader server-side provenance gaps.