### PR TITLE
dashboard: prove scheduler wake keeper reaction

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -82,6 +82,8 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   queue?: string
   stimulus?: string
   stimulus_id?: string | null
+  reaction_ledger_status?: string | null
+  reaction_ledger_error?: string | null
   keeper_name?: string
   schedule_id?: string
   urgency?: string

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -81,12 +81,40 @@ export interface DashboardScheduledAutomationDispatchReceipt {
   kind?: string
   queue?: string
   stimulus?: string
+  stimulus_id?: string | null
   keeper_name?: string
   schedule_id?: string
   urgency?: string
   post_id?: string
   author?: string
   hearth?: string | null
+  reason?: string
+}
+
+export interface DashboardScheduledAutomationKeeperReactionEvidence {
+  projection_status:
+    | 'matched_turn_started'
+    | 'matched_stimulus'
+    | 'not_found'
+    | 'missing_stimulus_id'
+    | 'unrecognized_receipt'
+  source?: string
+  keeper_name?: string
+  schedule_id?: string
+  post_id?: string
+  stimulus?: string
+  stimulus_id?: string
+  stimulus_kind?: string
+  reaction_kind?: string
+  stimulus_seen?: boolean
+  turn_started_seen?: boolean
+  matched_record_count?: number
+  stimulus_recorded_at?: number | null
+  stimulus_recorded_at_iso?: string | null
+  turn_started_recorded_at?: number | null
+  turn_started_recorded_at_iso?: string | null
+  latest_recorded_at?: number | null
+  latest_recorded_at_iso?: string | null
   reason?: string
 }
 
@@ -187,6 +215,7 @@ export interface DashboardScheduledAutomationRequest {
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
   keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null
+  keeper_reaction_evidence?: DashboardScheduledAutomationKeeperReactionEvidence | null
 }
 
 export interface DashboardScheduledAutomationPayloadSupport {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -188,6 +188,7 @@ export type {
   DashboardScheduledAutomationFsm,
   DashboardScheduledAutomationExecution,
   DashboardScheduledAutomationDispatchReceipt,
+  DashboardScheduledAutomationKeeperReactionEvidence,
   DashboardScheduledAutomationKeeperQueueEvidence,
   DashboardScheduledAutomationKeeperToolStatus,
   DashboardScheduledAutomationActor,

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -595,6 +595,7 @@ describe('ScheduledAutomationPanel', () => {
             kind: 'masc.keeper_wake.enqueued',
             queue: 'keeper_event_queue',
             stimulus: 'schedule_due',
+            stimulus_id: 'stimulus:keeper-wake-digest',
             keeper_name: 'schedule-keeper',
             schedule_id: 'sched-keeper-wake',
             urgency: 'immediate',
@@ -606,6 +607,7 @@ describe('ScheduledAutomationPanel', () => {
           kind: 'masc.keeper_wake.enqueued',
           queue: 'keeper_event_queue',
           stimulus: 'schedule_due',
+          stimulus_id: 'stimulus:keeper-wake-digest',
           keeper_name: 'schedule-keeper',
           schedule_id: 'sched-keeper-wake',
           urgency: 'immediate',
@@ -630,6 +632,24 @@ describe('ScheduledAutomationPanel', () => {
           matched_age_seconds: 0,
           read_errors: [],
         },
+        keeper_reaction_evidence: {
+          projection_status: 'matched_stimulus',
+          source: 'keeper_reaction_ledger',
+          keeper_name: 'schedule-keeper',
+          schedule_id: 'sched-keeper-wake',
+          post_id: 'schedule-due:sched-keeper-wake',
+          stimulus: 'schedule_due',
+          stimulus_id: 'stimulus:keeper-wake-digest',
+          stimulus_kind: 'schedule_due',
+          reaction_kind: 'turn_started',
+          stimulus_seen: true,
+          turn_started_seen: false,
+          matched_record_count: 1,
+          stimulus_recorded_at: 201,
+          stimulus_recorded_at_iso: '2026-06-21T00:03:21Z',
+          latest_recorded_at: 201,
+          latest_recorded_at_iso: '2026-06-21T00:03:21Z',
+        },
       }),
     ])
 
@@ -640,6 +660,7 @@ describe('ScheduledAutomationPanel', () => {
     expect(receipt?.getAttribute('data-schedule-dispatch-receipt-kind')).toBe('masc.keeper_wake.enqueued')
     expect(container.querySelector('[data-dispatch-receipt-row="queue"]')?.textContent).toContain('keeper_event_queue')
     expect(container.querySelector('[data-dispatch-receipt-row="stimulus"]')?.textContent).toContain('schedule_due')
+    expect(container.querySelector('[data-dispatch-receipt-row="stimulus_id"]')?.textContent).toContain('stimulus:keeper-wake-digest')
     expect(container.querySelector('[data-dispatch-receipt-row="keeper"]')?.textContent).toContain('schedule-keeper')
     expect(container.querySelector('[data-dispatch-receipt-row="post_id"]')?.textContent).toContain('schedule-due:sched-keeper-wake')
     const queueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="matched_pending"]')
@@ -648,6 +669,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-keeper-queue-evidence-row="matched_bucket"]')?.textContent).toContain('pending')
     expect(container.querySelector('[data-keeper-queue-evidence-row="pending_count"]')?.textContent).toContain('1')
     expect(container.querySelector('[data-keeper-queue-evidence-row="matched_payload_kind"]')?.textContent).toContain('schedule_due')
+    const reactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_stimulus"]')
+    expect(reactionEvidence).not.toBeNull()
+    expect(reactionEvidence?.getAttribute('data-schedule-keeper-reaction-evidence-source')).toBe('keeper_reaction_ledger')
+    expect(container.querySelector('[data-keeper-reaction-evidence-row="stimulus_id"]')?.textContent).toContain('stimulus:keeper-wake-digest')
+    expect(container.querySelector('[data-keeper-reaction-evidence-row="turn_started_seen"]')?.textContent).toContain('false')
 
     render(null, container)
     render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
@@ -670,6 +696,10 @@ describe('ScheduledAutomationPanel', () => {
     expect(v2QueueEvidence?.textContent).toContain('durable_event_queue_snapshot')
     expect(v2QueueEvidence?.textContent).toContain('matched pending')
     expect(v2QueueEvidence?.textContent).toContain('schedule_due')
+    const v2ReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_stimulus"]')
+    expect(v2ReactionEvidence).not.toBeNull()
+    expect(v2ReactionEvidence?.textContent).toContain('keeper_reaction_ledger')
+    expect(v2ReactionEvidence?.textContent).toContain('matched stimulus')
 
     const wakeRequest = auto.requests[0]!
     const inflightAuto = automation([
@@ -682,6 +712,16 @@ describe('ScheduledAutomationPanel', () => {
           pending_count: 0,
           inflight_count: 1,
           matched_bucket: 'inflight',
+        },
+        keeper_reaction_evidence: {
+          ...wakeRequest.keeper_reaction_evidence!,
+          projection_status: 'matched_turn_started',
+          turn_started_seen: true,
+          matched_record_count: 2,
+          turn_started_recorded_at: 202,
+          turn_started_recorded_at_iso: '2026-06-21T00:03:22Z',
+          latest_recorded_at: 202,
+          latest_recorded_at_iso: '2026-06-21T00:03:22Z',
         },
       },
     ])
@@ -703,6 +743,11 @@ describe('ScheduledAutomationPanel', () => {
     expect(inflightQueueEvidence?.textContent).toContain('inflight_count')
     expect(inflightQueueEvidence?.textContent).toContain('1')
     expect(inflightQueueEvidence?.textContent).toContain('inflight')
+    const turnReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_turn_started"]')
+    expect(turnReactionEvidence).not.toBeNull()
+    expect(turnReactionEvidence?.textContent).toContain('matched turn started')
+    expect(turnReactionEvidence?.textContent).toContain('turn_started')
+    expect(turnReactionEvidence?.textContent).toContain('true')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -414,6 +414,8 @@ function dispatchReceiptRows(
     { label: 'queue', value: receipt.queue },
     { label: 'stimulus', value: receipt.stimulus },
     { label: 'stimulus_id', value: receipt.stimulus_id },
+    { label: 'reaction_ledger_status', value: receipt.reaction_ledger_status },
+    { label: 'reaction_ledger_error', value: receipt.reaction_ledger_error },
     { label: 'keeper', value: receipt.keeper_name },
     { label: 'schedule', value: receipt.schedule_id },
     { label: 'urgency', value: receipt.urgency },

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -6,6 +6,7 @@ import {
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
+  type DashboardScheduledAutomationKeeperReactionEvidence,
   type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
   type DashboardScheduledAutomationRequest,
@@ -412,6 +413,7 @@ function dispatchReceiptRows(
     { label: 'kind', value: receipt.kind },
     { label: 'queue', value: receipt.queue },
     { label: 'stimulus', value: receipt.stimulus },
+    { label: 'stimulus_id', value: receipt.stimulus_id },
     { label: 'keeper', value: receipt.keeper_name },
     { label: 'schedule', value: receipt.schedule_id },
     { label: 'urgency', value: receipt.urgency },
@@ -531,6 +533,82 @@ function QueueEvidenceBlock({
       </div>
       ${rows.map(row => html`
         <div class=${compact ? 'sch-kv' : 'grid grid-cols-[7.5rem_minmax(0,1fr)] gap-2'} data-keeper-queue-evidence-row=${row.label}>
+          <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
+          <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function reactionEvidenceTone(
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
+): StatusChipTone {
+  if (!evidence) return 'neutral'
+  if (evidence.projection_status === 'matched_turn_started') return 'ok'
+  if (
+    evidence.projection_status === 'matched_stimulus' ||
+    evidence.projection_status === 'not_found' ||
+    evidence.projection_status === 'missing_stimulus_id'
+  ) return 'warn'
+  return 'bad'
+}
+
+function reactionEvidenceRows(
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
+): Array<{ label: string; value: string }> {
+  if (!evidence) return []
+  const rows: Array<{ label: string; value: string | number | boolean | null | undefined }> = [
+    { label: 'source', value: evidence.source },
+    { label: 'keeper', value: evidence.keeper_name },
+    { label: 'schedule', value: evidence.schedule_id },
+    { label: 'post_id', value: evidence.post_id },
+    { label: 'stimulus', value: evidence.stimulus },
+    { label: 'stimulus_id', value: evidence.stimulus_id },
+    { label: 'stimulus_kind', value: evidence.stimulus_kind },
+    { label: 'reaction_kind', value: evidence.reaction_kind },
+    { label: 'stimulus_seen', value: evidence.stimulus_seen },
+    { label: 'turn_started_seen', value: evidence.turn_started_seen },
+    { label: 'matched_record_count', value: evidence.matched_record_count },
+    { label: 'stimulus_recorded_at', value: evidence.stimulus_recorded_at_iso },
+    { label: 'turn_started_recorded_at', value: evidence.turn_started_recorded_at_iso },
+    { label: 'latest_recorded_at', value: evidence.latest_recorded_at_iso },
+    { label: 'reason', value: evidence.reason },
+  ]
+  return rows
+    .map(row => ({ label: row.label, value: row.value == null ? '' : String(row.value) }))
+    .filter(row => row.value.trim() !== '')
+}
+
+function ReactionEvidenceBlock({
+  evidence,
+  compact = false,
+}: {
+  evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
+  compact?: boolean
+}) {
+  if (!evidence) return null
+  const rows = reactionEvidenceRows(evidence)
+  return html`
+    <div
+      class=${compact
+        ? 'sch-kvs'
+        : 'grid gap-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2'}
+      data-schedule-keeper-reaction-evidence=${evidence.projection_status}
+      data-schedule-keeper-reaction-evidence-source=${evidence.source ?? ''}
+    >
+      <div class=${compact ? 'sch-kv' : 'flex flex-wrap items-center gap-2'}>
+        ${compact
+          ? html`<span class="k">keeper_reaction_evidence</span>`
+          : html`<span class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">keeper reaction evidence</span>`}
+        <span class=${compact ? 'v mono' : ''}>
+          <${StatusChip} tone=${reactionEvidenceTone(evidence)} uppercase=${false}>
+            ${enumLabel(evidence.projection_status)}
+          <//>
+        </span>
+      </div>
+      ${rows.map(row => html`
+        <div class=${compact ? 'sch-kv' : 'grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2'} data-keeper-reaction-evidence-row=${row.label}>
           <span class=${compact ? 'k' : 'truncate text-[var(--color-fg-disabled)]'} title=${row.label}>${row.label}</span>
           <span class=${compact ? 'v mono' : 'truncate font-mono text-[var(--color-fg-secondary)]'} title=${row.value}>${row.value}</span>
         </div>
@@ -802,10 +880,12 @@ function LastExecutionBlock({
   execution,
   dispatchReceipt,
   queueEvidence,
+  reactionEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
   queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  reactionEvidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="mt-1 text-xs text-[var(--color-fg-muted)]">-</div>`
@@ -847,6 +927,7 @@ function LastExecutionBlock({
         : null}
       <${DispatchReceiptBlock} receipt=${dispatchReceipt} />
       <${QueueEvidenceBlock} evidence=${queueEvidence} />
+      <${ReactionEvidenceBlock} evidence=${reactionEvidence} />
     </div>
   `
 }
@@ -939,6 +1020,7 @@ function ScheduleDetailPanel({
             execution=${execution}
             dispatchReceipt=${request.dispatch_receipt ?? null}
             queueEvidence=${request.keeper_queue_evidence ?? null}
+            reactionEvidence=${request.keeper_reaction_evidence ?? null}
           />
         </div>
       </div>
@@ -1503,6 +1585,7 @@ function SchDetail({
               execution=${execution}
               dispatchReceipt=${request.dispatch_receipt ?? null}
               queueEvidence=${request.keeper_queue_evidence ?? null}
+              reactionEvidence=${request.keeper_reaction_evidence ?? null}
             />
           </div>
 
@@ -1517,10 +1600,12 @@ function SchExecution({
   execution,
   dispatchReceipt,
   queueEvidence,
+  reactionEvidence,
 }: {
   execution: DashboardScheduledAutomationExecution | null | undefined
   dispatchReceipt: DashboardScheduledAutomationDispatchReceipt | null | undefined
   queueEvidence: DashboardScheduledAutomationKeeperQueueEvidence | null | undefined
+  reactionEvidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined
 }) {
   if (!execution) {
     return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
@@ -1537,6 +1622,7 @@ function SchExecution({
     </div>
     <${DispatchReceiptBlock} receipt=${dispatchReceipt} compact=${true} />
     <${QueueEvidenceBlock} evidence=${queueEvidence} compact=${true} />
+    <${ReactionEvidenceBlock} evidence=${reactionEvidence} compact=${true} />
     ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
   `
 }

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -49,6 +49,10 @@ let record_recovery_stimulus_turn_started =
   Stimulus_intake.record_recovery_stimulus_turn_started
 ;;
 
+let record_event_queue_stimulus_turn_started =
+  Stimulus_intake.record_event_queue_stimulus_turn_started
+;;
+
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
@@ -150,6 +154,23 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Hitl_resolved _
       | Keeper_event_queue.Goal_verification_failed _ ->
         None)
+    stimuli
+;;
+
+let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
+  List.iter
+    (fun (stimulus : Keeper_event_queue.stimulus) ->
+       match stimulus.payload with
+       | Keeper_event_queue.Schedule_due _ ->
+         record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.No_progress_recovery
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Goal_verification_failed _ -> ())
     stimuli
 ;;
 
@@ -406,6 +427,10 @@ let run_keepalive_unified_turn
              admitted. The four prior inline pressure gates here were removed: they
              ran AFTER intake had already consumed the stimulus, forcing a
              consume/requeue churn loop, and logged only at DEBUG (a silent skip). *)
+          record_schedule_due_turn_started_reactions
+            ~ctx
+            ~keeper_name:meta_after_triage.name
+            !consumed_stimuli;
           let event_bus = Keeper_event_bus.get () in
           let meta_after_cycle =
             run_keeper_cycle

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -29,7 +29,7 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
     stim
 ;;
 
-let record_recovery_stimulus_turn_started
+let record_event_queue_stimulus_turn_started
       ~(ctx : _ context)
       ~keeper_name
       (stimulus : Keeper_event_queue.stimulus)
@@ -44,11 +44,15 @@ let record_recovery_stimulus_turn_started
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.error
-      "turn entry: failed to persist recovery stimulus reaction post_id=%s \
+      "turn entry: failed to persist event queue stimulus reaction post_id=%s \
        (keeper=%s): %s"
       stimulus.post_id
       keeper_name
       (Printexc.to_string exn)
+;;
+
+let record_recovery_stimulus_turn_started ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
 ;;
 
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -30,6 +30,16 @@ val record_recovery_stimulus_turn_started
   -> Keeper_event_queue.stimulus
   -> unit
 
+(** [record_event_queue_stimulus_turn_started ~ctx ~keeper_name stim] writes
+    a generic [Turn_started] reaction for an event-queue stimulus after the
+    heartbeat scheduler has admitted a real keeper turn. Logs and swallows
+    errors except [Eio.Cancel.Cancelled]. *)
+val record_event_queue_stimulus_turn_started
+  :  ctx:_ context
+  -> keeper_name:string
+  -> Keeper_event_queue.stimulus
+  -> unit
+
 (** Result of one heartbeat intake — accumulated pending board events
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -427,6 +427,79 @@ let bool_field name json =
   | _ -> false
 ;;
 
+type event_queue_reaction_evidence =
+  { keeper_name : string
+  ; stimulus_id : string
+  ; stimulus_seen : bool
+  ; turn_started_seen : bool
+  ; stimulus_recorded_at : float option
+  ; turn_started_recorded_at : float option
+  ; latest_recorded_at : float option
+  ; matched_record_count : int
+  }
+
+let max_recorded_at current candidate =
+  match current, candidate with
+  | None, None -> None
+  | Some value, None | None, Some value -> Some value
+  | Some left, Some right -> Some (Float.max left right)
+;;
+
+let reaction_kind_field row =
+  match assoc_field "reaction" row with
+  | Some reaction ->
+    (match string_field "kind" reaction with
+     | None -> None
+     | Some kind -> Some (reaction_kind_of_string kind))
+  | None -> None
+;;
+
+let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
+  let stimulus_seen = ref false in
+  let turn_started_seen = ref false in
+  let stimulus_recorded_at = ref None in
+  let turn_started_recorded_at = ref None in
+  let latest_recorded_at = ref None in
+  let matched_record_count = ref 0 in
+  let store = store_for_base_path ~base_path ~keeper_name in
+  Dated_jsonl.iter_all store (fun row ->
+    match string_field "stimulus_id" row with
+    | Some row_stimulus_id when String.equal row_stimulus_id stimulus_id ->
+      incr matched_record_count;
+      let recorded_at = float_field "recorded_at_unix" row in
+      latest_recorded_at := max_recorded_at !latest_recorded_at recorded_at;
+      (match string_field "record_kind" row with
+       | Some record_kind when String.equal record_kind "stimulus" ->
+         stimulus_seen := true;
+         stimulus_recorded_at := max_recorded_at !stimulus_recorded_at recorded_at
+       | Some record_kind when String.equal record_kind "reaction" ->
+         (match reaction_kind_field row with
+          | Some Turn_started ->
+            turn_started_seen := true;
+            turn_started_recorded_at
+              := max_recorded_at !turn_started_recorded_at recorded_at
+          | Some Execution_receipt
+          | Some Terminal_reason
+          | Some Cursor_ack
+          | Some Operator_escalation
+          | Some Supervisor_recovery_requested
+          | Some (Unknown_reaction _)
+          | None -> ())
+       | Some _
+       | None -> ())
+    | Some _
+    | None -> ());
+  { keeper_name
+  ; stimulus_id
+  ; stimulus_seen = !stimulus_seen
+  ; turn_started_seen = !turn_started_seen
+  ; stimulus_recorded_at = !stimulus_recorded_at
+  ; turn_started_recorded_at = !turn_started_recorded_at
+  ; latest_recorded_at = !latest_recorded_at
+  ; matched_record_count = !matched_record_count
+  }
+;;
+
 let string_list_field name json =
   list_field name json
   |> List.filter_map (function

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -63,6 +63,23 @@ val record_event_queue_reaction :
   unit
 (** Append a [record_kind="reaction"] row tied to an event queue stimulus. *)
 
+type event_queue_reaction_evidence =
+  { keeper_name : string
+  ; stimulus_id : string
+  ; stimulus_seen : bool
+  ; turn_started_seen : bool
+  ; stimulus_recorded_at : float option
+  ; turn_started_recorded_at : float option
+  ; latest_recorded_at : float option
+  ; matched_record_count : int
+  }
+
+val event_queue_reaction_evidence :
+  base_path:string -> keeper_name:string -> stimulus_id:string -> event_queue_reaction_evidence
+(** Stream the durable reaction ledger for exact rows sharing [stimulus_id].
+    This intentionally does not use a "recent rows" limit, because dashboards
+    use it to prove a specific queue stimulus was observed by the keeper. *)
+
 val record_board_cursor_ack :
   base_path:string ->
   keeper_name:string ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2814,6 +2814,7 @@ let schedule_keeper_queue_evidence_dashboard_json
               ; queue
               ; stimulus
               ; stimulus_id = _
+              ; reaction_ledger_status = _
               }) ->
           let due_at = execution.Schedule_domain.due_at in
           let payload_digest = execution.Schedule_domain.payload_digest in
@@ -2891,6 +2892,7 @@ let schedule_keeper_reaction_evidence_dashboard_json
               ; queue = _
               ; stimulus
               ; stimulus_id
+              ; reaction_ledger_status = _
               }) ->
           let base_fields =
             [ "source", `String "keeper_reaction_ledger"

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2807,7 +2807,14 @@ let schedule_keeper_queue_evidence_dashboard_json
         | Ok Server_schedule_consumers.Board_post_created _ -> `Null
         | Ok
             (Server_schedule_consumers.Keeper_wake_enqueued
-              { keeper_name; schedule_id; urgency = _; post_id; queue; stimulus }) ->
+              { keeper_name
+              ; schedule_id
+              ; urgency = _
+              ; post_id
+              ; queue
+              ; stimulus
+              ; stimulus_id = _
+              }) ->
           let due_at = execution.Schedule_domain.due_at in
           let payload_digest = execution.Schedule_domain.payload_digest in
           let snapshot =
@@ -2856,6 +2863,97 @@ let schedule_keeper_queue_evidence_dashboard_json
              `Assoc (("projection_status", `String "read_error") :: base_fields)
            | None, None, [] ->
              `Assoc (("projection_status", `String "not_found") :: base_fields))))
+;;
+
+let schedule_keeper_reaction_evidence_dashboard_json
+  (config : Workspace.config)
+  (execution : Schedule_domain.execution_record option)
+  =
+  match execution with
+  | None -> `Null
+  | Some execution ->
+    (match execution.Schedule_domain.detail with
+     | None -> `Null
+     | Some detail ->
+       (match Server_schedule_consumers.dispatch_receipt_of_detail detail with
+        | Error reason ->
+          `Assoc
+            [ "projection_status", `String "unrecognized_receipt"
+            ; "reason", `String reason
+            ]
+        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
+        | Ok
+            (Server_schedule_consumers.Keeper_wake_enqueued
+              { keeper_name
+              ; schedule_id
+              ; urgency = _
+              ; post_id
+              ; queue = _
+              ; stimulus
+              ; stimulus_id
+              }) ->
+          let base_fields =
+            [ "source", `String "keeper_reaction_ledger"
+            ; "keeper_name", `String keeper_name
+            ; "schedule_id", `String schedule_id
+            ; "post_id", `String post_id
+            ; "stimulus", `String stimulus
+            ; ( "reaction_kind"
+              , `String
+                  (Keeper_reaction_ledger.reaction_kind_to_string
+                     Keeper_reaction_ledger.Turn_started) )
+            ; ( "stimulus_kind"
+              , `String
+                  (Keeper_reaction_ledger.stimulus_kind_to_string
+                     Keeper_reaction_ledger.Schedule_due) )
+            ]
+          in
+          (match stimulus_id with
+           | None ->
+             `Assoc
+               (("projection_status", `String "missing_stimulus_id")
+                :: ("reason", `String "dispatch receipt predates stimulus_id projection")
+                :: base_fields)
+           | Some stimulus_id ->
+             let evidence =
+               Keeper_reaction_ledger.event_queue_reaction_evidence
+                 ~base_path:config.Workspace_utils.base_path
+                 ~keeper_name
+                 ~stimulus_id
+             in
+             let projection_status =
+               if evidence.turn_started_seen
+               then "matched_turn_started"
+               else if evidence.stimulus_seen
+               then "matched_stimulus"
+               else "not_found"
+             in
+             `Assoc
+               (("projection_status", `String projection_status)
+                :: base_fields
+                @ [ "stimulus_id", `String stimulus_id
+                  ; "stimulus_seen", `Bool evidence.stimulus_seen
+                  ; "turn_started_seen", `Bool evidence.turn_started_seen
+                  ; "matched_record_count", `Int evidence.matched_record_count
+                  ; ( "stimulus_recorded_at"
+                    , match evidence.stimulus_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "stimulus_recorded_at_iso"
+                    , unix_iso_option_json evidence.stimulus_recorded_at )
+                  ; ( "turn_started_recorded_at"
+                    , match evidence.turn_started_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "turn_started_recorded_at_iso"
+                    , unix_iso_option_json evidence.turn_started_recorded_at )
+                  ; ( "latest_recorded_at"
+                    , match evidence.latest_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "latest_recorded_at_iso"
+                    , unix_iso_option_json evidence.latest_recorded_at )
+                  ]))))
 ;;
 
 let schedule_signal_projection_limit = 20
@@ -2962,6 +3060,8 @@ let schedule_request_dashboard_json
         | Some execution -> execution_record_dashboard_json execution )
     ; "dispatch_receipt", schedule_dispatch_receipt_dashboard_json last_execution
     ; "keeper_queue_evidence", schedule_keeper_queue_evidence_dashboard_json ~now config last_execution
+    ; ( "keeper_reaction_evidence"
+      , schedule_keeper_reaction_evidence_dashboard_json config last_execution )
     ]
 ;;
 

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -6,6 +6,8 @@ let supported_payload_kinds = Schedule_supported_kinds.supported
 let board_post_created_kind = "masc.board_post.created"
 let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
 let keeper_event_queue_label = "keeper_event_queue"
+let reaction_ledger_recorded_label = "recorded"
+let reaction_ledger_record_failed_label = "record_failed"
 
 let ( let* ) = Result.bind
 
@@ -70,6 +72,44 @@ let optional_assoc_field name fields =
   | Some _ -> Error ("expected object field: " ^ name)
 ;;
 
+type keeper_wake_reaction_ledger_status =
+  | Keeper_wake_reaction_ledger_recorded
+  | Keeper_wake_reaction_ledger_record_failed of string
+
+let keeper_wake_reaction_ledger_status_to_string = function
+  | Keeper_wake_reaction_ledger_recorded -> reaction_ledger_recorded_label
+  | Keeper_wake_reaction_ledger_record_failed _ -> reaction_ledger_record_failed_label
+;;
+
+let keeper_wake_reaction_ledger_error = function
+  | Keeper_wake_reaction_ledger_recorded -> None
+  | Keeper_wake_reaction_ledger_record_failed reason -> Some reason
+;;
+
+let keeper_wake_reaction_ledger_status_of_fields fields =
+  match optional_string_field "reaction_ledger_status" fields with
+  | Error reason -> Error reason
+  | Ok None -> Ok None
+  | Ok (Some value) when String.equal value reaction_ledger_recorded_label ->
+    Ok (Some Keeper_wake_reaction_ledger_recorded)
+  | Ok (Some value) when String.equal value reaction_ledger_record_failed_label ->
+    let* reason = string_field "reaction_ledger_error" fields in
+    Ok (Some (Keeper_wake_reaction_ledger_record_failed reason))
+  | Ok (Some value) -> Error ("unsupported reaction_ledger_status: " ^ value)
+;;
+
+let keeper_wake_reaction_ledger_status_json_fields = function
+  | None -> [ "reaction_ledger_status", `Null; "reaction_ledger_error", `Null ]
+  | Some status ->
+    [ "reaction_ledger_status"
+    , `String (keeper_wake_reaction_ledger_status_to_string status)
+    ; ( "reaction_ledger_error"
+      , match keeper_wake_reaction_ledger_error status with
+        | None -> `Null
+        | Some reason -> `String reason )
+    ]
+;;
+
 type dispatch_receipt =
   | Board_post_created of
       { post_id : string
@@ -84,6 +124,7 @@ type dispatch_receipt =
       ; queue : string
       ; stimulus : string
       ; stimulus_id : string option
+      ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
       }
 
 let dispatch_receipt_of_detail = function
@@ -104,9 +145,20 @@ let dispatch_receipt_of_detail = function
       let* queue = string_field "queue" fields in
       let* stimulus = string_field "stimulus" fields in
       let* stimulus_id = optional_string_field "stimulus_id" fields in
+      let* reaction_ledger_status =
+        keeper_wake_reaction_ledger_status_of_fields fields
+      in
       Ok
         (Keeper_wake_enqueued
-           { keeper_name; schedule_id; urgency; post_id; queue; stimulus; stimulus_id })
+           { keeper_name
+           ; schedule_id
+           ; urgency
+           ; post_id
+           ; queue
+           ; stimulus
+           ; stimulus_id
+           ; reaction_ledger_status
+           })
     else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
   | _ -> Error "schedule dispatch receipt detail must be an object"
 ;;
@@ -120,17 +172,26 @@ let dispatch_receipt_to_yojson = function
       ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
       ]
   | Keeper_wake_enqueued
-      { keeper_name; schedule_id; urgency; post_id; queue; stimulus; stimulus_id } ->
+      { keeper_name
+      ; schedule_id
+      ; urgency
+      ; post_id
+      ; queue
+      ; stimulus
+      ; stimulus_id
+      ; reaction_ledger_status
+      } ->
     `Assoc
-      [ "kind", `String keeper_wake_enqueued_kind
-      ; "queue", `String queue
-      ; "stimulus", `String stimulus
-      ; "stimulus_id", (match stimulus_id with None -> `Null | Some value -> `String value)
-      ; "keeper_name", `String keeper_name
-      ; "schedule_id", `String schedule_id
-      ; "urgency", `String urgency
-      ; "post_id", `String post_id
-      ]
+      ([ "kind", `String keeper_wake_enqueued_kind
+       ; "queue", `String queue
+       ; "stimulus", `String stimulus
+       ; "stimulus_id", (match stimulus_id with None -> `Null | Some value -> `String value)
+       ; "keeper_name", `String keeper_name
+       ; "schedule_id", `String schedule_id
+       ; "urgency", `String urgency
+       ; "post_id", `String post_id
+       ]
+       @ keeper_wake_reaction_ledger_status_json_fields reaction_ledger_status)
 ;;
 
 type payload_view =
@@ -251,11 +312,11 @@ let dispatch_board_post request payload =
 let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
   try
     Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name stimulus;
-    Ok ()
+    Keeper_wake_reaction_ledger_recorded
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    Error
+    Keeper_wake_reaction_ledger_record_failed
       (Printf.sprintf
          "failed to persist keeper reaction ledger stimulus: %s"
          (Printexc.to_string exn))
@@ -293,23 +354,32 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     ~base_path:config.Workspace_utils.base_path
     keeper_name
     stimulus;
-  let* () =
+  let reaction_ledger_status =
     record_keeper_wake_stimulus
       ~base_path:config.Workspace_utils.base_path
       ~keeper_name
       stimulus
   in
+  (match reaction_ledger_status with
+   | Keeper_wake_reaction_ledger_recorded -> ()
+   | Keeper_wake_reaction_ledger_record_failed reason ->
+     Log.Keeper.warn
+       "schedule keeper wake reaction ledger append failed schedule_id=%s keeper=%s: %s"
+       request.schedule_id
+       keeper_name
+       reason);
   Ok
     (`Assoc
-      [ "kind", `String keeper_wake_enqueued_kind
-      ; "queue", `String keeper_event_queue_label
-      ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
-      ; "stimulus_id", `String stimulus_id
-      ; "keeper_name", `String keeper_name
-      ; "schedule_id", `String request.schedule_id
-      ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)
-      ; "post_id", `String stimulus.post_id
-      ])
+      ([ "kind", `String keeper_wake_enqueued_kind
+       ; "queue", `String keeper_event_queue_label
+       ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+       ; "stimulus_id", `String stimulus_id
+       ; "keeper_name", `String keeper_name
+       ; "schedule_id", `String request.schedule_id
+       ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)
+       ; "post_id", `String stimulus.post_id
+       ]
+       @ keeper_wake_reaction_ledger_status_json_fields (Some reaction_ledger_status)))
 ;;
 
 let dispatch config ~now request =

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -83,6 +83,7 @@ type dispatch_receipt =
       ; post_id : string
       ; queue : string
       ; stimulus : string
+      ; stimulus_id : string option
       }
 
 let dispatch_receipt_of_detail = function
@@ -102,7 +103,10 @@ let dispatch_receipt_of_detail = function
       let* post_id = string_field "post_id" fields in
       let* queue = string_field "queue" fields in
       let* stimulus = string_field "stimulus" fields in
-      Ok (Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus })
+      let* stimulus_id = optional_string_field "stimulus_id" fields in
+      Ok
+        (Keeper_wake_enqueued
+           { keeper_name; schedule_id; urgency; post_id; queue; stimulus; stimulus_id })
     else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
   | _ -> Error "schedule dispatch receipt detail must be an object"
 ;;
@@ -115,11 +119,13 @@ let dispatch_receipt_to_yojson = function
       ; "author", `String author
       ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
       ]
-  | Keeper_wake_enqueued { keeper_name; schedule_id; urgency; post_id; queue; stimulus } ->
+  | Keeper_wake_enqueued
+      { keeper_name; schedule_id; urgency; post_id; queue; stimulus; stimulus_id } ->
     `Assoc
       [ "kind", `String keeper_wake_enqueued_kind
       ; "queue", `String queue
       ; "stimulus", `String stimulus
+      ; "stimulus_id", (match stimulus_id with None -> `Null | Some value -> `String value)
       ; "keeper_name", `String keeper_name
       ; "schedule_id", `String schedule_id
       ; "urgency", `String urgency
@@ -242,6 +248,19 @@ let dispatch_board_post request payload =
         ])
 ;;
 
+let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
+  try
+    Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name stimulus;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "failed to persist keeper reaction ledger stimulus: %s"
+         (Printexc.to_string exn))
+;;
+
 let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request) payload =
   let* keeper_name = keeper_name_field "keeper_name" payload.body in
   let* message = string_field "message" payload.body in
@@ -269,15 +288,23 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     ; payload = Keeper_event_queue.Schedule_due wake
     }
   in
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
   Keeper_registry_event_queue.enqueue
     ~base_path:config.Workspace_utils.base_path
     keeper_name
     stimulus;
+  let* () =
+    record_keeper_wake_stimulus
+      ~base_path:config.Workspace_utils.base_path
+      ~keeper_name
+      stimulus
+  in
   Ok
     (`Assoc
       [ "kind", `String keeper_wake_enqueued_kind
       ; "queue", `String keeper_event_queue_label
       ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+      ; "stimulus_id", `String stimulus_id
       ; "keeper_name", `String keeper_name
       ; "schedule_id", `String request.schedule_id
       ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -13,6 +13,7 @@ type dispatch_receipt =
       ; post_id : string
       ; queue : string
       ; stimulus : string
+      ; stimulus_id : string option
       }
 
 val dispatch_receipt_of_detail :

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -1,5 +1,9 @@
 val supported_payload_kinds : string list
 
+type keeper_wake_reaction_ledger_status =
+  | Keeper_wake_reaction_ledger_recorded
+  | Keeper_wake_reaction_ledger_record_failed of string
+
 type dispatch_receipt =
   | Board_post_created of
       { post_id : string
@@ -14,6 +18,7 @@ type dispatch_receipt =
       ; queue : string
       ; stimulus : string
       ; stimulus_id : string option
+      ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
       }
 
 val dispatch_receipt_of_detail :

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -54,6 +54,23 @@ let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
   }
 ;;
 
+let schedule_due_stimulus ?(schedule_id = "sched-ledger-1") () :
+  Keeper_event_queue.stimulus
+  =
+  { post_id = "schedule-due:" ^ schedule_id
+  ; urgency = Keeper_event_queue.Immediate
+  ; arrived_at = 1234.5
+  ; payload =
+      Keeper_event_queue.Schedule_due
+        { schedule_id
+        ; due_at = 1200.0
+        ; payload_digest = "payload-digest"
+        ; title = Some "Wake"
+        ; message = "Scheduled lane wake"
+        }
+  }
+;;
+
 let check_member_string label expected key json =
   check string label expected (json |> member key |> to_string)
 ;;
@@ -125,6 +142,54 @@ let test_event_queue_stimulus_and_turn_reaction () =
     "turn_started"
     "kind"
     (reaction_row |> member "reaction")
+;;
+
+let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "ledger-schedule-keeper" in
+  let stimulus = schedule_due_stimulus () in
+  let unrelated = schedule_due_stimulus ~schedule_id:"sched-ledger-other" () in
+  let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    stimulus;
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    unrelated;
+  let stimulus_only =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "exact stimulus seen" true stimulus_only.stimulus_seen;
+  check bool "turn reaction absent" false stimulus_only.turn_started_seen;
+  check int "one exact row before reaction" 1 stimulus_only.matched_record_count;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus;
+  let reacted =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "exact stimulus still seen" true reacted.stimulus_seen;
+  check bool "turn reaction seen" true reacted.turn_started_seen;
+  check int "two exact rows after reaction" 2 reacted.matched_record_count;
+  let missing =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id:"stimulus:missing"
+  in
+  check bool "missing stimulus absent" false missing.stimulus_seen;
+  check bool "missing reaction absent" false missing.turn_started_seen;
+  check int "missing exact rows" 0 missing.matched_record_count
 ;;
 
 let test_cursor_ack_is_replayable_state_entry () =
@@ -1225,6 +1290,10 @@ let () =
             "event queue stimulus and turn reaction are durable"
             `Quick
             test_event_queue_stimulus_and_turn_reaction
+        ; test_case
+            "event queue reaction evidence matches exact stimulus id"
+            `Quick
+            test_event_queue_reaction_evidence_matches_exact_stimulus_id
         ; test_case
             "cursor ack is replayable state entry"
             `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -487,6 +487,25 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (pending_evidence |> member "pending_count" |> to_int);
       check int "inflight count before lease" 0
         (pending_evidence |> member "inflight_count" |> to_int);
+      let pending_receipt = pending_row |> member "dispatch_receipt" in
+      let stimulus_id = pending_receipt |> member "stimulus_id" |> to_string in
+      check bool "dispatch receipt includes stimulus id" true
+        (String.starts_with ~prefix:"stimulus:" stimulus_id);
+      let pending_reaction_evidence =
+        pending_row |> member "keeper_reaction_evidence"
+      in
+      check string "reaction evidence sees queued stimulus" "matched_stimulus"
+        (pending_reaction_evidence |> member "projection_status" |> to_string);
+      check string "reaction evidence source" "keeper_reaction_ledger"
+        (pending_reaction_evidence |> member "source" |> to_string);
+      check string "reaction evidence stimulus id" stimulus_id
+        (pending_reaction_evidence |> member "stimulus_id" |> to_string);
+      check bool "reaction evidence stimulus seen" true
+        (pending_reaction_evidence |> member "stimulus_seen" |> to_bool);
+      check bool "reaction evidence turn not started yet" false
+        (pending_reaction_evidence |> member "turn_started_seen" |> to_bool);
+      check int "one matched ledger row before turn" 1
+        (pending_reaction_evidence |> member "matched_record_count" |> to_int);
       let leased =
         match
           Keeper_registry_event_queue.dequeue
@@ -520,6 +539,22 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (inflight_evidence |> member "pending_count" |> to_int);
       check int "inflight count after lease" 1
         (inflight_evidence |> member "inflight_count" |> to_int);
+      Keeper_reaction_ledger.record_event_queue_reaction
+        ~base_path:config.Workspace_utils.base_path
+        ~keeper_name
+        ~reaction_kind:Keeper_reaction_ledger.Turn_started
+        leased;
+      let reacted_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let reaction_evidence = reacted_row |> member "keeper_reaction_evidence" in
+      check string "reaction evidence matched turn" "matched_turn_started"
+        (reaction_evidence |> member "projection_status" |> to_string);
+      check bool "reaction evidence turn started" true
+        (reaction_evidence |> member "turn_started_seen" |> to_bool);
+      check int "two matched ledger rows after turn" 2
+        (reaction_evidence |> member "matched_record_count" |> to_int);
       Keeper_registry_event_queue.ack_consumed
         ~base_path:config.Workspace_utils.base_path
         keeper_name

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -23,6 +23,19 @@ let rm_rf dir =
   | _ -> ()
 ;;
 
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_empty_file path =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> ())
+;;
+
 let with_workspace f =
   Eio_main.run
   @@ fun env ->
@@ -338,6 +351,8 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (receipt |> member "urgency" |> to_string);
     check string "receipt post id" "schedule-due:keeper-wake-sched-1"
       (receipt |> member "post_id" |> to_string);
+    check string "receipt reaction ledger recorded" "recorded"
+      (receipt |> member "reaction_ledger_status" |> to_string);
     let queue_evidence = row |> member "keeper_queue_evidence" in
     check string "queue evidence matched" "matched_pending"
       (queue_evidence |> member "projection_status" |> to_string);
@@ -561,6 +576,52 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         [ leased ])
 ;;
 
+let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_dir =
+    Filename.concat
+      (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
+      keeper_name
+  in
+  mkdir_p keeper_dir;
+  write_empty_file (Filename.concat keeper_dir "reaction-ledger");
+  let request = create_pending_keeper_wake_schedule config in
+  ignore (approve_schedule config request : Schedule_domain.schedule_request);
+  let result = tick_ok config ~now:201.0 in
+  check int "one dispatch" 1 (List.length result.dispatches);
+  check string "dispatch status stays succeeded" "succeeded"
+    (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing"
+   | Some stored ->
+     check string "schedule succeeded" "succeeded"
+       (Schedule_domain.schedule_status_to_string stored.status));
+  check int "wake remains durably queued" 1
+    (Keeper_event_queue.length
+       (Keeper_registry_event_queue.snapshot ~base_path keeper_name));
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row = dashboard_schedule_row_exn dashboard ~schedule_id:request.schedule_id in
+  let receipt = row |> member "dispatch_receipt" in
+  check string "receipt recognized" "recognized"
+    (receipt |> member "projection_status" |> to_string);
+  check string "ledger failure visible" "record_failed"
+    (receipt |> member "reaction_ledger_status" |> to_string);
+  check bool "ledger failure reason visible" true
+    (String.length (receipt |> member "reaction_ledger_error" |> to_string) > 0);
+  let queue_evidence = row |> member "keeper_queue_evidence" in
+  check string "queue evidence still matched" "matched_pending"
+    (queue_evidence |> member "projection_status" |> to_string);
+  let reaction_evidence = row |> member "keeper_reaction_evidence" in
+  check string "reaction ledger miss visible" "not_found"
+    (reaction_evidence |> member "projection_status" |> to_string)
+;;
+
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
   with_workspace
   @@ fun config ->
@@ -636,6 +697,8 @@ let () =
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
             test_keeper_wake_dashboard_tracks_runtime_inflight_lease
+        ; test_case "keeper wake ledger failure keeps dispatch success visible" `Quick
+            test_keeper_wake_ledger_failure_keeps_dispatch_success_visible
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ; test_case "dashboard resolve uses authenticated operator" `Quick


### PR DESCRIPTION
## Summary
- add `stimulus_id` to `masc.keeper_wake` dispatch receipts and persist the corresponding keeper reaction-ledger stimulus row
- add exact `stimulus_id` reaction-ledger lookup for scheduler dashboard rows, surfacing `matched_stimulus` vs `matched_turn_started`
- render `keeper_reaction_evidence` beside dispatch receipt and durable queue evidence in the scheduled automation panel

## Validation
- `ocamlformat --check lib/server/server_schedule_consumers.ml lib/server/server_schedule_consumers.mli lib/keeper/keeper_reaction_ledger.ml lib/keeper/keeper_reaction_ledger.mli lib/keeper/keeper_heartbeat_stimulus_intake.ml lib/keeper/keeper_heartbeat_stimulus_intake.mli lib/keeper/keeper_heartbeat_loop.ml lib/server/server_dashboard_http_runtime_info.ml test/test_schedule_consumer_dispatch.ml test/test_keeper_reaction_ledger.ml`
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`
- `env GITHUB_BASE_REF=codex/scheduler-wake-runtime-evidence-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`
- risk grep for `failwith`, `assert false`, `Sys.command`, `Obj.magic`

Local Dune build intentionally not run; CI remains the Dune build authority for this stack.
