### PR TITLE
dashboard: prove scheduler wake consumed ack

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -95,6 +95,7 @@ export interface DashboardScheduledAutomationDispatchReceipt {
 
 export interface DashboardScheduledAutomationKeeperReactionEvidence {
   projection_status:
+    | 'matched_consumed_ack'
     | 'matched_turn_started'
     | 'matched_stimulus'
     | 'not_found'
@@ -110,11 +111,14 @@ export interface DashboardScheduledAutomationKeeperReactionEvidence {
   reaction_kind?: string
   stimulus_seen?: boolean
   turn_started_seen?: boolean
+  event_queue_ack_seen?: boolean
   matched_record_count?: number
   stimulus_recorded_at?: number | null
   stimulus_recorded_at_iso?: string | null
   turn_started_recorded_at?: number | null
   turn_started_recorded_at_iso?: string | null
+  event_queue_ack_recorded_at?: number | null
+  event_queue_ack_recorded_at_iso?: string | null
   latest_recorded_at?: number | null
   latest_recorded_at_iso?: string | null
   reason?: string

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -231,6 +231,27 @@ export interface DashboardScheduledAutomationPayloadSupport {
   unknown_request_count?: number
 }
 
+export interface DashboardScheduledAutomationLiveSupportedNonTerminalEvidence {
+  schema?: string
+  source?: string
+  projection_status:
+    | 'matched_supported_non_terminal'
+    | 'no_supported_payload_rows'
+    | 'no_supported_non_terminal'
+  criteria?: string
+  reason?: string
+  request_count?: number
+  supported_request_count?: number
+  supported_non_terminal_count?: number
+  supported_live_count?: number
+  supported_terminal_or_expired_count?: number
+  unsupported_request_count?: number
+  unknown_request_count?: number
+  terminal_or_expired_count?: number
+  matched_schedule_ids?: string[]
+  matched_schedule_id_limit?: number
+}
+
 export interface DashboardScheduledAutomation {
   schema?: string
   source?: string
@@ -245,6 +266,7 @@ export interface DashboardScheduledAutomation {
   counts: Record<string, number>
   derived_counts?: Record<string, number>
   payload_support?: DashboardScheduledAutomationPayloadSupport
+  live_supported_non_terminal_evidence?: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence
   fsm: DashboardScheduledAutomationFsm
   requests: DashboardScheduledAutomationRequest[]
 }

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -195,6 +195,7 @@ export type {
   DashboardScheduledAutomationSignal,
   DashboardScheduledAutomationRequest,
   DashboardScheduledAutomationPayloadSupport,
+  DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
   DashboardScheduledAutomation,
   DashboardToolsResponse,
 } from './dashboard-tools-prompts'

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -748,6 +748,62 @@ describe('ScheduledAutomationPanel', () => {
     expect(turnReactionEvidence?.textContent).toContain('matched turn started')
     expect(turnReactionEvidence?.textContent).toContain('turn_started')
     expect(turnReactionEvidence?.textContent).toContain('true')
+
+    const ackedAuto = automation([
+      {
+        ...wakeRequest,
+        schedule_id: 'sched-keeper-wake',
+        keeper_queue_evidence: {
+          ...wakeRequest.keeper_queue_evidence!,
+          projection_status: 'not_found',
+          pending_count: 0,
+          inflight_count: 0,
+          matched_bucket: undefined,
+          matched_post_id: undefined,
+          matched_schedule_id: undefined,
+          matched_payload_kind: undefined,
+          matched_arrived_at: undefined,
+          matched_arrived_at_iso: undefined,
+          matched_age_seconds: undefined,
+        },
+        keeper_reaction_evidence: {
+          ...wakeRequest.keeper_reaction_evidence!,
+          projection_status: 'matched_consumed_ack',
+          turn_started_seen: true,
+          event_queue_ack_seen: true,
+          matched_record_count: 3,
+          turn_started_recorded_at: 202,
+          turn_started_recorded_at_iso: '2026-06-21T00:03:22Z',
+          event_queue_ack_recorded_at: 203,
+          event_queue_ack_recorded_at_iso: '2026-06-21T00:03:23Z',
+          latest_recorded_at: 203,
+          latest_recorded_at_iso: '2026-06-21T00:03:23Z',
+        },
+      },
+    ])
+
+    render(null, container)
+    render(html`<${ScheduledAutomationPanel} automation=${ackedAuto} variant="v2" />`, container)
+
+    const ackDoneFilter = container.querySelector('[data-schedule-filter="done"]') as HTMLButtonElement
+    ackDoneFilter.click()
+    await Promise.resolve()
+
+    const openAckDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
+    openAckDetail.click()
+    await Promise.resolve()
+
+    const ackQueueEvidence = container.querySelector('[data-schedule-keeper-queue-evidence="not_found"]')
+    expect(ackQueueEvidence).not.toBeNull()
+    expect(ackQueueEvidence?.textContent).toContain('not found')
+    expect(ackQueueEvidence?.textContent).toContain('pending_count')
+    expect(ackQueueEvidence?.textContent).toContain('0')
+    const ackReactionEvidence = container.querySelector('[data-schedule-keeper-reaction-evidence="matched_consumed_ack"]')
+    expect(ackReactionEvidence).not.toBeNull()
+    expect(ackReactionEvidence?.textContent).toContain('matched consumed ack')
+    expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_seen')
+    expect(ackReactionEvidence?.textContent).toContain('true')
+    expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_recorded_at')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1033,6 +1033,83 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.querySelector('[data-schedule-signal-id="sig-unknown-only"]')).toBeNull()
   })
 
+  it('renders explicit live supported non-terminal evidence absence', () => {
+    const auto = payloadSupportAutomation()
+    auto.live_supported_non_terminal_evidence = {
+      schema: 'masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1',
+      source: 'schedule_store',
+      projection_status: 'no_supported_payload_rows',
+      criteria: 'payload_support=supported && execution_readiness not in {terminal,expired}',
+      reason: 'current live schedule_store has no rows with a supported payload kind',
+      request_count: 3,
+      supported_request_count: 0,
+      supported_non_terminal_count: 0,
+      supported_live_count: 0,
+      supported_terminal_or_expired_count: 0,
+      unsupported_request_count: 2,
+      unknown_request_count: 1,
+      terminal_or_expired_count: 2,
+      matched_schedule_ids: [],
+      matched_schedule_id_limit: 8,
+    }
+
+    for (const variant of [undefined, 'v2'] as const) {
+      render(null, container)
+      render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
+
+      const evidence = container.querySelector('[data-schedule-live-supported-evidence="no_supported_payload_rows"]')
+      expect(evidence).not.toBeNull()
+      expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('0')
+      expect(evidence?.getAttribute('data-schedule-live-supported-source')).toBe('schedule_store')
+      expect(evidence?.textContent).toContain('no supported payload rows')
+      expect(evidence?.textContent).toContain('payload_support=supported')
+      expect(evidence?.textContent).toContain('unsupported/unknown')
+      expect(evidence?.textContent).toContain('3')
+    }
+  })
+
+  it('renders matched live supported non-terminal evidence and opens matched rows', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-supported-live',
+        next_due_at: 100,
+        next_due_at_iso: '2026-06-21T00:10:00Z',
+        execution_readiness: 'scheduled',
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+      }),
+    ])
+    auto.live_supported_non_terminal_evidence = {
+      schema: 'masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1',
+      source: 'schedule_store',
+      projection_status: 'matched_supported_non_terminal',
+      criteria: 'payload_support=supported && execution_readiness not in {terminal,expired}',
+      reason: 'live schedule_store contains supported rows whose readiness is not terminal or expired',
+      request_count: 1,
+      supported_request_count: 1,
+      supported_non_terminal_count: 1,
+      supported_live_count: 1,
+      supported_terminal_or_expired_count: 0,
+      unsupported_request_count: 0,
+      unknown_request_count: 0,
+      terminal_or_expired_count: 0,
+      matched_schedule_ids: ['sched-supported-live'],
+      matched_schedule_id_limit: 8,
+    }
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const evidence = container.querySelector('[data-schedule-live-supported-evidence="matched_supported_non_terminal"]')
+    expect(evidence).not.toBeNull()
+    expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('1')
+    expect(evidence?.textContent).toContain('matched supported non-terminal')
+    const open = container.querySelector('[data-schedule-live-supported-open="sched-supported-live"]') as HTMLButtonElement
+    expect(open).not.toBeNull()
+    open.click()
+    await Promise.resolve()
+    expect(container.querySelector('[data-schedule-detail-panel="sched-supported-live"]')).not.toBeNull()
+  })
+
   it('uses explicit ready and terminal status matching', async () => {
     const automation = sampleAutomation()
     automation.requests = [

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -9,6 +9,7 @@ import {
   type DashboardScheduledAutomationKeeperReactionEvidence,
   type DashboardScheduledAutomationKeeperQueueEvidence,
   type DashboardScheduledAutomationExecution,
+  type DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
   type DashboardScheduledAutomationRequest,
   type DashboardScheduledAutomationSignal,
 } from '../../api'
@@ -1357,6 +1358,105 @@ function SchPayloadSupportBanner({
   `
 }
 
+type LiveSupportedEvidenceStatus =
+  DashboardScheduledAutomationLiveSupportedNonTerminalEvidence['projection_status']
+
+function liveSupportedEvidenceLabel(status: LiveSupportedEvidenceStatus): string {
+  switch (status) {
+    case 'matched_supported_non_terminal':
+      return 'matched supported non-terminal'
+    case 'no_supported_payload_rows':
+      return 'no supported payload rows'
+    case 'no_supported_non_terminal':
+      return 'no supported non-terminal'
+    default:
+      return assertNever(status)
+  }
+}
+
+function liveSupportedEvidenceBannerClass(status: LiveSupportedEvidenceStatus): string {
+  switch (status) {
+    case 'matched_supported_non_terminal':
+      return 'approve'
+    case 'no_supported_payload_rows':
+      return 'payload bad'
+    case 'no_supported_non_terminal':
+      return 'payload warn'
+    default:
+      return assertNever(status)
+  }
+}
+
+function SchLiveSupportedEvidence({
+  evidence,
+  onOpen,
+}: {
+  evidence: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence | null | undefined
+  onOpen: (scheduleId: string) => void
+}) {
+  if (!evidence) return null
+  const matchedIds = evidence.matched_schedule_ids ?? []
+  const status = evidence.projection_status
+  return html`
+    <section
+      class=${`sch-banner ${liveSupportedEvidenceBannerClass(status)}`}
+      data-schedule-live-supported-evidence=${status}
+      data-schedule-live-supported-count=${evidence.supported_live_count ?? 0}
+      data-schedule-live-supported-source=${evidence.source ?? ''}
+    >
+      <span class="sch-banner-ico">${status === 'matched_supported_non_terminal' ? '✓' : '!'}</span>
+      <div class="sch-banner-txt">
+        <div>
+          <b>live supported scheduler evidence</b>
+          <span class="mono"> ${liveSupportedEvidenceLabel(status)}</span>
+        </div>
+        <div class="sch-banner-sub">
+          <span class="mono">${evidence.criteria ?? 'payload_support=supported && non-terminal'}</span>
+        </div>
+        <div class="sch-evidence-counts" aria-label="Live supported scheduler counts">
+          <span class="sch-evidence-count">
+            <span>requests</span>
+            <span class="mono">${(evidence.request_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>supported</span>
+            <span class="mono">${(evidence.supported_request_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>live</span>
+            <span class="mono">${(evidence.supported_live_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>terminal/expired</span>
+            <span class="mono">${(evidence.terminal_or_expired_count ?? 0).toLocaleString()}</span>
+          </span>
+          <span class="sch-evidence-count">
+            <span>unsupported/unknown</span>
+            <span class="mono">${((evidence.unsupported_request_count ?? 0) + (evidence.unknown_request_count ?? 0)).toLocaleString()}</span>
+          </span>
+        </div>
+        ${evidence.reason
+          ? html`<div class="sch-banner-sub">${evidence.reason}</div>`
+          : null}
+        ${matchedIds.length > 0
+          ? html`
+              <div class="sch-payload-rows" aria-label="Live supported schedule ids">
+                ${matchedIds.map(scheduleId => html`
+                  <button
+                    type="button"
+                    class="sch-payload-row mono"
+                    data-schedule-live-supported-open=${scheduleId}
+                    onClick=${() => { onOpen(scheduleId) }}
+                  >${scheduleId}</button>
+                `)}
+              </div>
+            `
+          : null}
+      </div>
+    </section>
+  `
+}
+
 // Card rail tone class. SCHED_STATUS specs only ever yield warn/info/ok/bad/dim
 // for statuses; .sch-card.st-volt is not defined, so clamp anything else to dim.
 const CARD_RAIL_TONES: ReadonlySet<string> = new Set(['ok', 'warn', 'bad', 'info', 'dim'])
@@ -1728,6 +1828,10 @@ function SchedulePrototypeSurface({
         summary=${payloadSummary}
         onOpen=${setSelectedScheduleId}
       />
+      <${SchLiveSupportedEvidence}
+        evidence=${automation.live_supported_non_terminal_evidence ?? null}
+        onOpen=${setSelectedScheduleId}
+      />
 
       <div class="sch-tabs" role="tablist" aria-label="예약 필터">
         ${SCH_TABS.map(definition => {
@@ -2078,6 +2182,11 @@ export function ScheduledAutomationPanel({
             </div>
           `
         : null}
+
+      <${SchLiveSupportedEvidence}
+        evidence=${automation.live_supported_non_terminal_evidence ?? null}
+        onOpen=${setSelectedScheduleId}
+      />
 
       <div class="flex flex-wrap gap-2">
         ${nonzeroCounts.length > 0

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -547,7 +547,10 @@ function reactionEvidenceTone(
   evidence: DashboardScheduledAutomationKeeperReactionEvidence | null | undefined,
 ): StatusChipTone {
   if (!evidence) return 'neutral'
-  if (evidence.projection_status === 'matched_turn_started') return 'ok'
+  if (
+    evidence.projection_status === 'matched_consumed_ack' ||
+    evidence.projection_status === 'matched_turn_started'
+  ) return 'ok'
   if (
     evidence.projection_status === 'matched_stimulus' ||
     evidence.projection_status === 'not_found' ||
@@ -571,9 +574,11 @@ function reactionEvidenceRows(
     { label: 'reaction_kind', value: evidence.reaction_kind },
     { label: 'stimulus_seen', value: evidence.stimulus_seen },
     { label: 'turn_started_seen', value: evidence.turn_started_seen },
+    { label: 'event_queue_ack_seen', value: evidence.event_queue_ack_seen },
     { label: 'matched_record_count', value: evidence.matched_record_count },
     { label: 'stimulus_recorded_at', value: evidence.stimulus_recorded_at_iso },
     { label: 'turn_started_recorded_at', value: evidence.turn_started_recorded_at_iso },
+    { label: 'event_queue_ack_recorded_at', value: evidence.event_queue_ack_recorded_at_iso },
     { label: 'latest_recorded_at', value: evidence.latest_recorded_at_iso },
     { label: 'reason', value: evidence.reason },
   ]

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -44,8 +44,9 @@
 .sch-banner-go:hover { border-color: var(--volt-dim); color: var(--volt); }
 .sch-banner-x { flex: none; background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: var(--fs-12); padding: 2px 4px; }
 .sch-banner-x:hover { color: var(--text-bright); }
-.sch-payload-kinds, .sch-payload-rows { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.sch-payload-kinds, .sch-payload-rows, .sch-evidence-counts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 .sch-payload-kind { display: inline-flex; align-items: center; gap: 6px; border: 1px solid color-mix(in oklab, var(--status-bad) 32%, transparent); border-radius: var(--radius-pill); padding: 2px 8px; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 7%, transparent); font-size: var(--fs-10); }
+.sch-evidence-count { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); padding: 2px 8px; color: var(--text-mid); background: var(--bg-sunken); font-size: var(--fs-10); }
 .sch-payload-row { border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-sunken); color: var(--text-mid); cursor: pointer; font-size: var(--fs-10); padding: 2px 8px; }
 .sch-payload-row:hover { border-color: var(--volt-dim); color: var(--volt); }
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -53,6 +53,10 @@ let record_event_queue_stimulus_turn_started =
   Stimulus_intake.record_event_queue_stimulus_turn_started
 ;;
 
+let record_event_queue_stimulus_ack =
+  Stimulus_intake.record_event_queue_stimulus_ack
+;;
+
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
@@ -163,6 +167,23 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
        match stimulus.payload with
        | Keeper_event_queue.Schedule_due _ ->
          record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
+       | Keeper_event_queue.Board_signal _
+       | Keeper_event_queue.Fusion_completed _
+       | Keeper_event_queue.Bg_completed _
+       | Keeper_event_queue.Bootstrap
+       | Keeper_event_queue.No_progress_recovery
+       | Keeper_event_queue.Connector_attention _
+       | Keeper_event_queue.Hitl_resolved _
+       | Keeper_event_queue.Goal_verification_failed _ -> ())
+    stimuli
+;;
+
+let record_schedule_due_event_queue_ack_reactions ~ctx ~keeper_name stimuli =
+  List.iter
+    (fun (stimulus : Keeper_event_queue.stimulus) ->
+       match stimulus.payload with
+       | Keeper_event_queue.Schedule_due _ ->
+         record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus
        | Keeper_event_queue.Board_signal _
        | Keeper_event_queue.Fusion_completed _
        | Keeper_event_queue.Bg_completed _
@@ -454,10 +475,27 @@ let run_keepalive_unified_turn
       then
         if !consumed_stimuli_turn_completed
         then (
-          Keeper_registry_event_queue.ack_consumed
-            ~base_path:ctx.config.base_path
-            meta_after_triage.name
-            !consumed_stimuli;
+          (match
+             Keeper_registry_event_queue.ack_consumed_result
+               ~base_path:ctx.config.base_path
+               meta_after_triage.name
+               !consumed_stimuli
+           with
+           | Ok () ->
+             record_schedule_due_event_queue_ack_reactions
+               ~ctx
+               ~keeper_name:meta_after_triage.name
+               !consumed_stimuli
+           | Error msg ->
+             Log.Keeper.warn
+               "registry: ack_consumed failed name=%s: %s"
+               meta_after_triage.name
+               msg);
+          (*
+             Connector post-turn handling preserves the existing behavior:
+             it is an external-attention lifecycle update, while
+             [event_queue_ack] evidence above is emitted only after durable
+             event-queue acknowledgement succeeds. *)
           mark_connector_attention_ignored_after_turn
             ~base_path:ctx.config.base_path
             ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -29,16 +29,17 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
     stim
 ;;
 
-let record_event_queue_stimulus_turn_started
+let record_event_queue_stimulus_reaction
       ~(ctx : _ context)
       ~keeper_name
+      ~reaction_kind
       (stimulus : Keeper_event_queue.stimulus)
   =
   try
     Keeper_reaction_ledger.record_event_queue_reaction
       ~base_path:ctx.config.base_path
       ~keeper_name
-      ~reaction_kind:Keeper_reaction_ledger.Turn_started
+      ~reaction_kind
       stimulus
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -49,6 +50,22 @@ let record_event_queue_stimulus_turn_started
       stimulus.post_id
       keeper_name
       (Printexc.to_string exn)
+;;
+
+let record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_reaction
+    ~ctx
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Turn_started
+    stimulus
+;;
+
+let record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus =
+  record_event_queue_stimulus_reaction
+    ~ctx
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+    stimulus
 ;;
 
 let record_recovery_stimulus_turn_started ~ctx ~keeper_name stimulus =

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -40,6 +40,16 @@ val record_event_queue_stimulus_turn_started
   -> Keeper_event_queue.stimulus
   -> unit
 
+(** [record_event_queue_stimulus_ack ~ctx ~keeper_name stim] writes a durable
+    [Event_queue_ack] reaction only after the caller has confirmed
+    [ack_consumed] persisted. Logs and swallows errors except
+    [Eio.Cancel.Cancelled]. *)
+val record_event_queue_stimulus_ack
+  :  ctx:_ context
+  -> keeper_name:string
+  -> Keeper_event_queue.stimulus
+  -> unit
+
 (** Result of one heartbeat intake — accumulated pending board events
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -18,6 +18,7 @@ type stimulus_kind =
 
 type reaction_kind =
   | Turn_started
+  | Event_queue_ack
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
@@ -58,6 +59,7 @@ let stimulus_kind_of_string = function
 
 let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
+  | Event_queue_ack -> "event_queue_ack"
   | Execution_receipt -> "execution_receipt"
   | Terminal_reason -> "terminal_reason"
   | Cursor_ack -> "cursor_ack"
@@ -72,6 +74,7 @@ let reaction_kind_to_string = function
    추가 시 컴파일러가 분류 누락을 강제한다(stimulus와 동일한 닫힌-합 안티패턴 방지). *)
 let reaction_kind_of_string = function
   | "turn_started" -> Turn_started
+  | "event_queue_ack" -> Event_queue_ack
   | "execution_receipt" -> Execution_receipt
   | "terminal_reason" -> Terminal_reason
   | "cursor_ack" -> Cursor_ack
@@ -432,8 +435,10 @@ type event_queue_reaction_evidence =
   ; stimulus_id : string
   ; stimulus_seen : bool
   ; turn_started_seen : bool
+  ; event_queue_ack_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
+  ; event_queue_ack_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   }
@@ -457,8 +462,10 @@ let reaction_kind_field row =
 let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   let stimulus_seen = ref false in
   let turn_started_seen = ref false in
+  let event_queue_ack_seen = ref false in
   let stimulus_recorded_at = ref None in
   let turn_started_recorded_at = ref None in
+  let event_queue_ack_recorded_at = ref None in
   let latest_recorded_at = ref None in
   let matched_record_count = ref 0 in
   let store = store_for_base_path ~base_path ~keeper_name in
@@ -478,6 +485,10 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
             turn_started_seen := true;
             turn_started_recorded_at
               := max_recorded_at !turn_started_recorded_at recorded_at
+          | Some Event_queue_ack ->
+            event_queue_ack_seen := true;
+            event_queue_ack_recorded_at
+              := max_recorded_at !event_queue_ack_recorded_at recorded_at
           | Some Execution_receipt
           | Some Terminal_reason
           | Some Cursor_ack
@@ -493,8 +504,10 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   ; stimulus_id
   ; stimulus_seen = !stimulus_seen
   ; turn_started_seen = !turn_started_seen
+  ; event_queue_ack_seen = !event_queue_ack_seen
   ; stimulus_recorded_at = !stimulus_recorded_at
   ; turn_started_recorded_at = !turn_started_recorded_at
+  ; event_queue_ack_recorded_at = !event_queue_ack_recorded_at
   ; latest_recorded_at = !latest_recorded_at
   ; matched_record_count = !matched_record_count
   }
@@ -768,6 +781,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let stimulus_count = ref 0 in
   let reaction_count = ref 0 in
   let turn_started_count = ref 0 in
+  let event_queue_ack_count = ref 0 in
   let cursor_ack_count = ref 0 in
   let execution_receipt_count = ref 0 in
   let terminal_reason_count = ref 0 in
@@ -858,6 +872,7 @@ let summarize_rows ~keeper_name ~limit rows =
     | Some raw ->
       (match reaction_kind_of_string raw with
        | Turn_started -> incr turn_started_count
+       | Event_queue_ack -> incr event_queue_ack_count
        | Cursor_ack -> incr cursor_ack_count
        | Execution_receipt -> incr execution_receipt_count
        | Terminal_reason -> incr terminal_reason_count
@@ -1036,6 +1051,7 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "stimulus_count", `Int !stimulus_count
     ; "reaction_count", `Int !reaction_count
     ; "turn_started_count", `Int !turn_started_count
+    ; "event_queue_ack_count", `Int !event_queue_ack_count
     ; "cursor_ack_count", `Int !cursor_ack_count
     ; "execution_receipt_count", `Int !execution_receipt_count
     ; "terminal_reason_count", `Int !terminal_reason_count
@@ -1407,6 +1423,7 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "stimulus_count", `Int (total_int "stimulus_count")
     ; "reaction_count", `Int (total_int "reaction_count")
     ; "turn_started_count", `Int (total_int "turn_started_count")
+    ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
     ; "cursor_ack_count", `Int (total_int "cursor_ack_count")
     ; "execution_receipt_count", `Int (total_int "execution_receipt_count")
     ; "terminal_reason_count", `Int (total_int "terminal_reason_count")

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -25,6 +25,7 @@ type stimulus_kind =
 
 type reaction_kind =
   | Turn_started
+  | Event_queue_ack
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
@@ -68,8 +69,10 @@ type event_queue_reaction_evidence =
   ; stimulus_id : string
   ; stimulus_seen : bool
   ; turn_started_seen : bool
+  ; event_queue_ack_seen : bool
   ; stimulus_recorded_at : float option
   ; turn_started_recorded_at : float option
+  ; event_queue_ack_recorded_at : float option
   ; latest_recorded_at : float option
   ; matched_record_count : int
   }

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -99,10 +99,12 @@ let requeue_front ~base_path name stimuli =
        loop ())
 ;;
 
+let ack_consumed_result ~base_path name stimuli =
+  Keeper_event_queue_persistence.ack_consumed ~base_path ~keeper_name:name stimuli
+;;
+
 let ack_consumed ~base_path name stimuli =
-  match
-    Keeper_event_queue_persistence.ack_consumed ~base_path ~keeper_name:name stimuli
-  with
+  match ack_consumed_result ~base_path name stimuli with
   | Ok () -> ()
   | Error msg ->
     Log.Keeper.warn "registry: ack_consumed failed name=%s: %s" name msg

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -31,6 +31,12 @@ val ack_consumed :
 (** Acknowledge consumed stimuli after a keepalive turn completes. Until this
     runs, a restart reloads the leased stimuli for at-least-once replay. *)
 
+val ack_consumed_result :
+  base_path:string -> string -> Keeper_event_queue.stimulus list -> (unit, string) result
+(** Result-returning variant of {!ack_consumed}. Callers that publish follow-on
+    evidence must use this so they do not claim an acknowledgement after durable
+    queue persistence failed. *)
+
 val drop_by_post_id :
   base_path:string
   -> string

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2419,11 +2419,26 @@ let schedule_payload_kind_supported kind =
   List.exists (String.equal kind) schedule_supported_payload_kinds
 ;;
 
-let schedule_payload_support_status (request : Schedule_domain.schedule_request) =
+type schedule_payload_support =
+  | Supported
+  | Unsupported
+  | Unknown
+
+let schedule_payload_support (request : Schedule_domain.schedule_request) =
   match Schedule_payload_projection.kind request with
-  | Some kind when schedule_payload_kind_supported kind -> "supported"
-  | Some _ -> "unsupported"
-  | None -> "unknown"
+  | Some kind when schedule_payload_kind_supported kind -> Supported
+  | Some _ -> Unsupported
+  | None -> Unknown
+;;
+
+let schedule_payload_support_to_string = function
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Unknown -> "unknown"
+;;
+
+let schedule_payload_support_status request =
+  schedule_payload_support request |> schedule_payload_support_to_string
 ;;
 
 let schedule_payload_support_json schedules =
@@ -2478,6 +2493,18 @@ let schedule_effectively_expired ~now (request : Schedule_domain.schedule_reques
 
 let schedule_request_effectively_active ~now request =
   schedule_request_active request && not (schedule_effectively_expired ~now request)
+;;
+
+let schedule_readiness_counts_as_live_supported = function
+  | Schedule_projection.Blocked_approval
+  | Schedule_projection.Awaiting_approval
+  | Schedule_projection.Due_pending_refresh
+  | Schedule_projection.Ready
+  | Schedule_projection.Approved
+  | Schedule_projection.Scheduled
+  | Schedule_projection.Running ->
+    true
+  | Schedule_projection.Expired | Schedule_projection.Terminal -> false
 ;;
 
 let schedule_effectively_due ~now (request : Schedule_domain.schedule_request) =
@@ -3076,6 +3103,127 @@ let schedule_request_dashboard_json
     ]
 ;;
 
+let live_supported_evidence_ids_limit = 8
+
+let schedule_live_supported_non_terminal_evidence_json ~now ~state schedules =
+  let
+    ( supported_request_count
+    , supported_non_terminal_count
+    , supported_live_count
+    , supported_terminal_or_expired_count
+    , unsupported_request_count
+    , unknown_request_count
+    , terminal_or_expired_count
+    , matched_ids )
+    =
+    List.fold_left
+      (fun
+        ( supported_count
+        , supported_non_terminal
+        , supported_live
+        , supported_terminal_or_expired
+        , unsupported_count
+        , unknown_count
+        , terminal_or_expired
+        , ids )
+        (request : Schedule_domain.schedule_request)
+       ->
+         let readiness = schedule_execution_readiness ~now state request in
+         let live_readiness =
+           schedule_readiness_counts_as_live_supported readiness
+         in
+         let terminal_or_expired_row = not live_readiness in
+         let terminal_or_expired =
+           if terminal_or_expired_row then terminal_or_expired + 1 else terminal_or_expired
+         in
+         match schedule_payload_support request with
+         | Supported ->
+           let non_terminal = not (Schedule_domain.is_terminal request.status) in
+           let supported_non_terminal =
+             if non_terminal then supported_non_terminal + 1 else supported_non_terminal
+           in
+           if live_readiness
+           then (
+             let ids =
+               if List.length ids < live_supported_evidence_ids_limit
+               then request.schedule_id :: ids
+               else ids
+             in
+             ( supported_count + 1
+             , supported_non_terminal
+             , supported_live + 1
+             , supported_terminal_or_expired
+             , unsupported_count
+             , unknown_count
+             , terminal_or_expired
+             , ids ))
+           else
+             ( supported_count + 1
+             , supported_non_terminal
+             , supported_live
+             , supported_terminal_or_expired + 1
+             , unsupported_count
+             , unknown_count
+             , terminal_or_expired
+             , ids )
+         | Unsupported ->
+           ( supported_count
+           , supported_non_terminal
+           , supported_live
+           , supported_terminal_or_expired
+           , unsupported_count + 1
+           , unknown_count
+           , terminal_or_expired
+           , ids )
+         | Unknown ->
+           ( supported_count
+           , supported_non_terminal
+           , supported_live
+           , supported_terminal_or_expired
+           , unsupported_count
+           , unknown_count + 1
+           , terminal_or_expired
+           , ids ))
+      (0, 0, 0, 0, 0, 0, 0, [])
+      schedules
+  in
+  let request_count = List.length schedules in
+  let projection_status =
+    if supported_live_count > 0
+    then "matched_supported_non_terminal"
+    else if supported_request_count = 0 && request_count > 0
+    then "no_supported_payload_rows"
+    else "no_supported_non_terminal"
+  in
+  let reason =
+    if supported_live_count > 0
+    then "live schedule_store contains supported rows whose readiness is not terminal or expired"
+    else if supported_request_count = 0 && request_count > 0
+    then "current live schedule_store has no rows with a supported payload kind"
+    else "supported rows are currently terminal or effectively expired"
+  in
+  `Assoc
+    [ "schema", `String "masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1"
+    ; "source", `String "schedule_store"
+    ; "projection_status", `String projection_status
+    ; ( "criteria"
+      , `String
+          "payload_support=supported && execution_readiness not in {terminal,expired}" )
+    ; "reason", `String reason
+    ; "request_count", `Int request_count
+    ; "supported_request_count", `Int supported_request_count
+    ; "supported_non_terminal_count", `Int supported_non_terminal_count
+    ; "supported_live_count", `Int supported_live_count
+    ; "supported_terminal_or_expired_count", `Int supported_terminal_or_expired_count
+    ; "unsupported_request_count", `Int unsupported_request_count
+    ; "unknown_request_count", `Int unknown_request_count
+    ; "terminal_or_expired_count", `Int terminal_or_expired_count
+    ; ( "matched_schedule_ids"
+      , `List (List.map (fun schedule_id -> `String schedule_id) (List.rev matched_ids)) )
+    ; "matched_schedule_id_limit", `Int live_supported_evidence_ids_limit
+    ]
+;;
+
 let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
   (* NDT-OK: dashboard read-model freshness clock; it derives display-only
      effective-due state and never mutates the schedule store or runs work. *)
@@ -3167,6 +3315,8 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
           ; "unknown_payload_kind", `Int unknown_payload_kind_count
           ] )
     ; "payload_support", payload_support
+    ; ( "live_supported_non_terminal_evidence"
+      , schedule_live_supported_non_terminal_evidence_json ~now ~state schedules )
     ; ( "fsm"
       , `Assoc
           [ "state", `String (schedule_fsm_state ~now state schedules)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2924,7 +2924,9 @@ let schedule_keeper_reaction_evidence_dashboard_json
                  ~stimulus_id
              in
              let projection_status =
-               if evidence.turn_started_seen
+               if evidence.event_queue_ack_seen
+               then "matched_consumed_ack"
+               else if evidence.turn_started_seen
                then "matched_turn_started"
                else if evidence.stimulus_seen
                then "matched_stimulus"
@@ -2936,6 +2938,7 @@ let schedule_keeper_reaction_evidence_dashboard_json
                 @ [ "stimulus_id", `String stimulus_id
                   ; "stimulus_seen", `Bool evidence.stimulus_seen
                   ; "turn_started_seen", `Bool evidence.turn_started_seen
+                  ; "event_queue_ack_seen", `Bool evidence.event_queue_ack_seen
                   ; "matched_record_count", `Int evidence.matched_record_count
                   ; ( "stimulus_recorded_at"
                     , match evidence.stimulus_recorded_at with
@@ -2949,6 +2952,12 @@ let schedule_keeper_reaction_evidence_dashboard_json
                       | Some ts -> `Float ts )
                   ; ( "turn_started_recorded_at_iso"
                     , unix_iso_option_json evidence.turn_started_recorded_at )
+                  ; ( "event_queue_ack_recorded_at"
+                    , match evidence.event_queue_ack_recorded_at with
+                      | None -> `Null
+                      | Some ts -> `Float ts )
+                  ; ( "event_queue_ack_recorded_at_iso"
+                    , unix_iso_option_json evidence.event_queue_ack_recorded_at )
                   ; ( "latest_recorded_at"
                     , match evidence.latest_recorded_at with
                       | None -> `Null

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -166,6 +166,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "exact stimulus seen" true stimulus_only.stimulus_seen;
   check bool "turn reaction absent" false stimulus_only.turn_started_seen;
+  check bool "event queue ack absent" false stimulus_only.event_queue_ack_seen;
   check int "one exact row before reaction" 1 stimulus_only.matched_record_count;
   Keeper_reaction_ledger.record_event_queue_reaction
     ~base_path
@@ -180,7 +181,28 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "exact stimulus still seen" true reacted.stimulus_seen;
   check bool "turn reaction seen" true reacted.turn_started_seen;
+  check bool "event queue ack still absent" false reacted.event_queue_ack_seen;
   check int "two exact rows after reaction" 2 reacted.matched_record_count;
+  Keeper_reaction_ledger.record_event_queue_reaction
+    ~base_path
+    ~keeper_name
+    ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+    stimulus;
+  let acknowledged =
+    Keeper_reaction_ledger.event_queue_reaction_evidence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+  in
+  check bool "event queue ack seen" true acknowledged.event_queue_ack_seen;
+  check int "three exact rows after ack" 3 acknowledged.matched_record_count;
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "summary counts event queue ack" 1
+    (summary |> member "event_queue_ack_count" |> to_int);
+  check int "event queue ack is not unknown" 0
+    (summary |> member "unknown_reaction_count" |> to_int);
   let missing =
     Keeper_reaction_ledger.event_queue_reaction_evidence
       ~base_path
@@ -189,6 +211,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   in
   check bool "missing stimulus absent" false missing.stimulus_seen;
   check bool "missing reaction absent" false missing.turn_started_seen;
+  check bool "missing ack absent" false missing.event_queue_ack_seen;
   check int "missing exact rows" 0 missing.matched_record_count
 ;;
 
@@ -1271,6 +1294,7 @@ let test_reaction_kind_string_roundtrip () =
     (fun k ->
       check bool "reaction_kind round-trips through string" true (roundtrips k))
     [ Keeper_reaction_ledger.Turn_started
+    ; Keeper_reaction_ledger.Event_queue_ack
     ; Keeper_reaction_ledger.Execution_receipt
     ; Keeper_reaction_ledger.Terminal_reason
     ; Keeper_reaction_ledger.Cursor_ack

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -119,6 +119,14 @@ let keeper_wake_payload =
     ]
 ;;
 
+let unsupported_payload =
+  `Assoc
+    [ "kind", `String "legacy.unsupported_scheduler_payload"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "message", `String "This payload is not in the schedule consumer catalog." ]
+    ]
+;;
+
 let create_pending_board_schedule config =
   match
     Schedule_service.create config ~schedule_id:"board-sched-1"
@@ -138,6 +146,19 @@ let create_pending_keeper_wake_schedule config =
       ~requested_at:100.0 ~requested_by:(human "operator")
       ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
       ~payload:keeper_wake_payload ~risk_class:Schedule_domain.Workspace_write
+      ~source:Schedule_domain.Operator_request ()
+  with
+  | Ok request -> request
+  | Error err ->
+    fail ("create failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let create_pending_unsupported_schedule config =
+  match
+    Schedule_service.create config ~schedule_id:"unsupported-live-sched"
+      ~requested_at:100.0 ~requested_by:(human "operator")
+      ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
+      ~payload:unsupported_payload ~risk_class:Schedule_domain.Read_only
       ~source:Schedule_domain.Operator_request ()
   with
   | Ok request -> request
@@ -470,6 +491,54 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
       (queue_evidence |> member "inflight_count" |> to_int)
 ;;
 
+let test_dashboard_live_supported_non_terminal_evidence_matches_supported_request () =
+  with_workspace
+  @@ fun config ->
+  let request = create_pending_keeper_wake_schedule config in
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let evidence = dashboard |> member "live_supported_non_terminal_evidence" in
+  check string "live supported evidence matched" "matched_supported_non_terminal"
+    (evidence |> member "projection_status" |> to_string);
+  check string "live supported evidence source" "schedule_store"
+    (evidence |> member "source" |> to_string);
+  check int "one supported request" 1
+    (evidence |> member "supported_request_count" |> to_int);
+  check int "one supported non-terminal request" 1
+    (evidence |> member "supported_non_terminal_count" |> to_int);
+  check int "one supported live request" 1
+    (evidence |> member "supported_live_count" |> to_int);
+  check int "no unsupported requests" 0
+    (evidence |> member "unsupported_request_count" |> to_int);
+  check (list string) "matched schedule ids" [ request.schedule_id ]
+    (evidence |> member "matched_schedule_ids" |> to_list |> List.map to_string)
+;;
+
+let test_dashboard_live_supported_non_terminal_evidence_reports_absent_supported_payloads
+      ()
+  =
+  with_workspace
+  @@ fun config ->
+  ignore (create_pending_unsupported_schedule config : Schedule_domain.schedule_request);
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let evidence = dashboard |> member "live_supported_non_terminal_evidence" in
+  check string "live supported evidence absent" "no_supported_payload_rows"
+    (evidence |> member "projection_status" |> to_string);
+  check int "no supported requests" 0
+    (evidence |> member "supported_request_count" |> to_int);
+  check int "no supported live requests" 0
+    (evidence |> member "supported_live_count" |> to_int);
+  check int "one unsupported request" 1
+    (evidence |> member "unsupported_request_count" |> to_int);
+  check int "no matched schedule ids" 0
+    (evidence |> member "matched_schedule_ids" |> to_list |> List.length)
+;;
+
 let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
   with_workspace
   @@ fun config ->
@@ -722,6 +791,12 @@ let () =
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
+        ; test_case "dashboard live supported non-terminal evidence matches supported request"
+            `Quick
+            test_dashboard_live_supported_non_terminal_evidence_matches_supported_request
+        ; test_case "dashboard live supported non-terminal evidence reports absent supported payloads"
+            `Quick
+            test_dashboard_live_supported_non_terminal_evidence_reports_absent_supported_payloads
         ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
             test_keeper_wake_dashboard_tracks_runtime_inflight_lease
         ; test_case "keeper wake ledger failure keeps dispatch success visible" `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -570,10 +570,37 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (reaction_evidence |> member "turn_started_seen" |> to_bool);
       check int "two matched ledger rows after turn" 2
         (reaction_evidence |> member "matched_record_count" |> to_int);
-      Keeper_registry_event_queue.ack_consumed
+      (match
+         Keeper_registry_event_queue.ack_consumed_result
+           ~base_path:config.Workspace_utils.base_path
+           keeper_name
+           [ leased ]
+       with
+       | Ok () -> ()
+       | Error msg -> fail ("scheduled wake ack failed: " ^ msg));
+      Keeper_reaction_ledger.record_event_queue_reaction
         ~base_path:config.Workspace_utils.base_path
-        keeper_name
-        [ leased ])
+        ~keeper_name
+        ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+        leased;
+      let acked_row =
+        Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+        |> dashboard_schedule_row_exn ~schedule_id:request.schedule_id
+      in
+      let acked_queue_evidence = acked_row |> member "keeper_queue_evidence" in
+      check string "acked queue evidence drained" "not_found"
+        (acked_queue_evidence |> member "projection_status" |> to_string);
+      check int "pending count after ack" 0
+        (acked_queue_evidence |> member "pending_count" |> to_int);
+      check int "inflight count after ack" 0
+        (acked_queue_evidence |> member "inflight_count" |> to_int);
+      let acked_reaction_evidence = acked_row |> member "keeper_reaction_evidence" in
+      check string "reaction evidence matched ack" "matched_consumed_ack"
+        (acked_reaction_evidence |> member "projection_status" |> to_string);
+      check bool "reaction evidence event queue acked" true
+        (acked_reaction_evidence |> member "event_queue_ack_seen" |> to_bool);
+      check int "three matched ledger rows after ack" 3
+        (acked_reaction_evidence |> member "matched_record_count" |> to_int))
 ;;
 
 let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =


### PR DESCRIPTION
## Summary
- Adds durable `event_queue_ack` reaction evidence for scheduler wake stimuli, emitted only after `ack_consumed_result` succeeds.
- Extends the dashboard scheduler projection/UI to show `matched_consumed_ack` instead of inferring completion from queue absence.
- Keeps existing `ack_consumed` behavior as a logging wrapper for callers that do not need proof.

## Validation
- `ocamlformat --check lib/keeper/keeper_registry_event_queue.ml lib/keeper/keeper_registry_event_queue.mli lib/keeper/keeper_reaction_ledger.ml lib/keeper/keeper_reaction_ledger.mli lib/keeper/keeper_heartbeat_stimulus_intake.ml lib/keeper/keeper_heartbeat_stimulus_intake.mli lib/keeper/keeper_heartbeat_loop.ml lib/server/server_dashboard_http_runtime_info.ml test/test_keeper_reaction_ledger.ml test/test_schedule_consumer_dispatch.ml`
- `env GITHUB_BASE_REF=codex/scheduler-wake-reaction-evidence-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`
- `rg "failwith|assert false|Sys\.command|Obj\.magic" <touched files>`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run build`

## Notes
- Local Dune build intentionally not run; CI remains the OCaml build authority for this stack.
- Build warning observed: existing Vite font resolution/chunk-size warnings only.