### PR TITLE
[codex] Stabilize keeper dashboard CI checks

### DIFF
--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -67,6 +67,42 @@ sandbox_profile = "local"
 goal = "Dashboard keeper fixture"
 |}
 
+let test_runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let init_runtime_default_for_tests dir =
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path test_runtime_toml;
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> failf "Runtime.init_default failed: %s" e
+
+let with_runtime_default_for_tests dir f =
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+      init_runtime_default_for_tests dir;
+      f ())
+
 let save_jsonl path entries =
   let body =
     entries
@@ -294,6 +330,7 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
     (fun () ->
       with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
       write_keeper_toml ~keepers_dir ~name:"sangsu";
+      with_runtime_default_for_tests dir @@ fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
@@ -338,6 +375,7 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
     (fun () ->
       with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
       write_keeper_toml ~keepers_dir ~name:"sangsu";
+      with_runtime_default_for_tests dir @@ fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 242
+  check int "Keeper_metrics.all covers every constructor" 243
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
## Summary
- Update `test_otel_zero_fill` expected Keeper_metrics.all size from 242 to 243.
- Initialize a minimal runtime.toml in namespace-truth keeper fixture tests so fixture keepalive stays Running before count assertions.

## Context
- Post-merge CI run `28746655690` attempt 3 failed first because `test_otel_zero_fill.ml` expected 242 but current `Keeper_metrics.all` has 243 entries.
- PR run `28753963845` proved that fix, then failed next in `test_dashboard_namespace_truth.ml`: keeper heartbeat crashed because `Runtime.init_default` had not run, so `counts.keepers` read 0.
- Both CI runs later hit retry/build disk exhaustion, but this PR targets the deterministic failures before retry.

## Validation
- `git diff --check`
- `ocamlformat --check test/test_dashboard_namespace_truth.ml`
- `ocamlformat --check test/test_otel_zero_fill.ml`
- `scripts/dune-local.sh build test/test_dashboard_namespace_truth.exe test/test_otel_zero_fill.exe`
- `./_build/default/test/test_dashboard_namespace_truth.exe`
- `./_build/default/test/test_otel_zero_fill.exe`

## Best Programmer Self-Review
- Scope: test-only CI unblock for stale metric tripwire and startup-realistic keeper fixture.
- Risk: low; no production code path changed.
- Source of truth check: `counts.keepers` is explicitly sourced from runtime keepalive, and keeper heartbeat now gets the same minimal runtime initialization pattern used by other keeper tests.