### PR TITLE
[codex] Record board attention candidates

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1,0 +1,360 @@
+(* See .mli. *)
+
+type signal_kind =
+  | Post_created
+  | Comment_added
+  | Reaction_changed
+
+type attention_authority =
+  | Llm_judge_required
+
+type wake_authority =
+  | No_direct_wake
+
+type candidate = {
+  candidate_id : string;
+  dedupe_key : string;
+  keeper_name : string;
+  post_id : string;
+  signal_kind : signal_kind;
+  author : string;
+  title : string;
+  content_preview : string;
+  hearth : string option;
+  updated_at : float option;
+  recorded_at : float;
+  attention_authority : attention_authority;
+  wake_authority : wake_authority;
+}
+
+type record_result =
+  [ `Recorded
+  | `Duplicate of candidate
+  | `Error of string
+  ]
+
+let candidate_dir base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "board_attention_candidates"
+
+let candidate_path ~base_path ~keeper_name =
+  Filename.concat
+    (candidate_dir base_path)
+    (Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name ^ ".jsonl")
+
+let ensure_candidate_dir ~base_path =
+  let (_ : string) = Keeper_fs.ensure_dir (candidate_dir base_path) in
+  ()
+
+let signal_kind_to_string = function
+  | Post_created -> "post_created"
+  | Comment_added -> "comment_added"
+  | Reaction_changed -> "reaction_changed"
+
+let signal_kind_of_string = function
+  | "post_created" -> Some Post_created
+  | "comment_added" -> Some Comment_added
+  | "reaction_changed" -> Some Reaction_changed
+  | _ -> None
+
+let attention_authority_to_string = function
+  | Llm_judge_required -> "llm_judge_required"
+
+let attention_authority_of_string = function
+  | "llm_judge_required" -> Some Llm_judge_required
+  | _ -> None
+
+let wake_authority_to_string = function
+  | No_direct_wake -> "no_direct_wake"
+
+let wake_authority_of_string = function
+  | "no_direct_wake" -> Some No_direct_wake
+  | _ -> None
+
+let candidate_id_of_dedupe_key key =
+  Digestif.SHA256.(digest_string key |> to_hex)
+
+let signal_kind_of_board_signal_kind = function
+  | Board_dispatch.Board_post_created -> Post_created
+  | Board_dispatch.Board_comment_added -> Comment_added
+  | Board_dispatch.Board_reaction_changed _ -> Reaction_changed
+
+let content_preview_max_bytes = 240
+
+let short_preview ~max_len text =
+  let text = String.trim text in
+  if String.length text <= max_len then text else String.sub text 0 max_len
+
+let updated_at_dedupe_segment = function
+  | Some ts -> Printf.sprintf "%.6f" ts
+  | None -> "none"
+
+let bool_segment value = if value then "true" else "false"
+
+let signal_payload_fingerprint (signal : Board_dispatch.board_signal) =
+  let kind = signal_kind_of_board_signal_kind signal.kind in
+  let reaction_segments =
+    match signal.kind with
+    | Board_dispatch.Board_post_created | Board_dispatch.Board_comment_added -> []
+    | Board_dispatch.Board_reaction_changed reaction ->
+      [ Board.reaction_target_type_to_string reaction.target_type
+      ; reaction.target_id
+      ; reaction.user_id
+      ; reaction.emoji
+      ; bool_segment reaction.reacted
+      ]
+  in
+  let hearth_segment =
+    match signal.hearth with
+    | Some value -> value
+    | None -> ""
+  in
+  let payload =
+    String.concat "\031"
+      ([ signal_kind_to_string kind
+       ; signal.post_id
+       ; signal.author
+       ; signal.title
+       ; signal.content
+       ; hearth_segment
+       ; updated_at_dedupe_segment signal.updated_at
+       ]
+       @ reaction_segments)
+  in
+  candidate_id_of_dedupe_key payload
+
+let dedupe_key ~keeper_name ~(signal : Board_dispatch.board_signal) =
+  let kind = signal_kind_of_board_signal_kind signal.kind in
+  String.concat ":"
+    [
+      "board_attention_candidate";
+      keeper_name;
+      signal.post_id;
+      signal_kind_to_string kind;
+      signal_payload_fingerprint signal;
+    ]
+
+let of_board_signal ~keeper_name ~recorded_at signal =
+  let signal_kind = signal_kind_of_board_signal_kind signal.kind in
+  let dedupe_key = dedupe_key ~keeper_name ~signal in
+  {
+    candidate_id = candidate_id_of_dedupe_key dedupe_key;
+    dedupe_key;
+    keeper_name;
+    post_id = signal.post_id;
+    signal_kind;
+    author = signal.author;
+    title = signal.title;
+    content_preview = short_preview ~max_len:content_preview_max_bytes signal.content;
+    hearth = signal.hearth;
+    updated_at = signal.updated_at;
+    recorded_at;
+    attention_authority = Llm_judge_required;
+    wake_authority = No_direct_wake;
+  }
+
+let opt_string_field key = function
+  | None -> []
+  | Some value -> [ (key, `String value) ]
+
+let opt_float_field key = function
+  | None -> []
+  | Some value -> [ (key, `Float value) ]
+
+let candidate_to_json c =
+  `Assoc
+    ([ ("candidate_id", `String c.candidate_id);
+       ("dedupe_key", `String c.dedupe_key);
+       ("keeper_name", `String c.keeper_name);
+       ("post_id", `String c.post_id);
+       ("signal_kind", `String (signal_kind_to_string c.signal_kind));
+       ("author", `String c.author);
+       ("title", `String c.title);
+       ("content_preview", `String c.content_preview);
+       ("recorded_at", `Float c.recorded_at);
+       ( "attention_authority",
+         `String (attention_authority_to_string c.attention_authority) );
+       ("wake_authority", `String (wake_authority_to_string c.wake_authority));
+     ]
+     @ opt_string_field "hearth" c.hearth
+     @ opt_float_field "updated_at" c.updated_at)
+
+let ( let* ) = Result.bind
+
+let required_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Ok value
+      | _ -> Error (Printf.sprintf "missing string field %s" key))
+  | _ -> Error "expected object"
+
+let required_float key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Float value) -> Ok value
+      | Some (`Int value) -> Ok (float_of_int value)
+      | _ -> Error (Printf.sprintf "missing float field %s" key))
+  | _ -> Error "expected object"
+
+let optional_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | Some (`String _) | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let optional_float key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Float value) -> Some value
+      | Some (`Int value) -> Some (float_of_int value)
+      | Some `Null | None -> None
+      | Some _ -> None)
+  | _ -> None
+
+let candidate_of_json json =
+  let* candidate_id = required_string "candidate_id" json in
+  let* dedupe_key = required_string "dedupe_key" json in
+  let* keeper_name = required_string "keeper_name" json in
+  let* post_id = required_string "post_id" json in
+  let* signal_kind_label = required_string "signal_kind" json in
+  let* signal_kind =
+    match signal_kind_of_string signal_kind_label with
+    | Some kind -> Ok kind
+    | None -> Error (Printf.sprintf "unknown signal_kind %S" signal_kind_label)
+  in
+  let* author = required_string "author" json in
+  let* title = required_string "title" json in
+  let* content_preview = required_string "content_preview" json in
+  let* recorded_at = required_float "recorded_at" json in
+  let* attention_authority_label = required_string "attention_authority" json in
+  let* attention_authority =
+    match attention_authority_of_string attention_authority_label with
+    | Some authority -> Ok authority
+    | None ->
+      Error
+        (Printf.sprintf
+           "unknown attention_authority %S"
+           attention_authority_label)
+  in
+  let* wake_authority_label = required_string "wake_authority" json in
+  let* wake_authority =
+    match wake_authority_of_string wake_authority_label with
+    | Some authority -> Ok authority
+    | None -> Error (Printf.sprintf "unknown wake_authority %S" wake_authority_label)
+  in
+  Ok
+    {
+      candidate_id;
+      dedupe_key;
+      keeper_name;
+      post_id;
+      signal_kind;
+      author;
+      title;
+      content_preview;
+      hearth = optional_string "hearth" json;
+      updated_at = optional_float "updated_at" json;
+      recorded_at;
+      attention_authority;
+      wake_authority;
+    }
+
+let parse_line ~file_path line =
+  try
+    match Yojson.Safe.from_string line |> candidate_of_json with
+    | Ok candidate -> Some candidate
+    | Error detail ->
+      Log.Keeper.warn
+        "keeper_board_attention_candidate: parse failed path=%s detail=%s"
+        file_path
+        detail;
+      None
+  with
+  | Yojson.Json_error detail ->
+    Log.Keeper.warn
+      "keeper_board_attention_candidate: invalid json path=%s detail=%s"
+      file_path
+      detail;
+    None
+
+let load_candidates ~base_path ~keeper_name =
+  let path = candidate_path ~base_path ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else
+    try
+      let candidates_rev, _boundary =
+        Fs_compat.fold_appended_lines ~path ~from:0 ~init:[]
+          ~f:(fun acc line ->
+            let line = String.trim line in
+            if String.equal line "" then acc
+            else
+              match parse_line ~file_path:path line with
+              | Some candidate -> candidate :: acc
+              | None -> acc)
+      in
+      List.rev candidates_rev
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.warn
+        "keeper_board_attention_candidate: load failed keeper=%s detail=%s"
+        (Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name)
+        (Printexc.to_string exn);
+      []
+
+let recent_dedup_window_bytes = Keeper_external_attention.dedup_window_bytes
+
+let load_recent_candidates ~base_path ~keeper_name =
+  let path = candidate_path ~base_path ~keeper_name in
+  match Fs_compat.file_size path with
+  | None -> []
+  | Some size when size <= recent_dedup_window_bytes ->
+    load_candidates ~base_path ~keeper_name
+  | Some size ->
+    let from = size - recent_dedup_window_bytes in
+    let slice =
+      Fs_compat.read_slice ~path ~from ~len:recent_dedup_window_bytes
+    in
+    (match String.index_opt slice '\n', String.rindex_opt slice '\n' with
+     | Some i, Some j when j > i ->
+       String.sub slice (i + 1) (j - i - 1)
+       |> String.split_on_char '\n'
+       |> List.filter_map (fun line ->
+              let line = String.trim line in
+              if String.equal line "" then None else parse_line ~file_path:path line)
+     | _ -> [])
+
+let candidate_by_id candidates candidate_id =
+  List.find_opt
+    (fun candidate -> String.equal candidate.candidate_id candidate_id)
+    candidates
+
+let append_candidate ~base_path candidate =
+  try
+    ensure_candidate_dir ~base_path;
+    let path = candidate_path ~base_path ~keeper_name:candidate.keeper_name in
+    Fs_compat.append_file path (Yojson.Safe.to_string (candidate_to_json candidate) ^ "\n");
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    let detail = Printexc.to_string exn in
+    Log.Keeper.warn
+      "keeper_board_attention_candidate: append failed keeper=%s detail=%s"
+      (Workspace_utils_backend_setup.sanitize_namespace_segment candidate.keeper_name)
+      detail;
+    Error detail
+
+let record ~base_path candidate =
+  let recent =
+    load_recent_candidates ~base_path ~keeper_name:candidate.keeper_name
+  in
+  match candidate_by_id recent candidate.candidate_id with
+  | Some existing -> `Duplicate existing
+  | None -> (
+      match append_candidate ~base_path candidate with
+      | Ok () -> `Recorded
+      | Error detail -> `Error detail)

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -1,0 +1,62 @@
+(** Durable evidence for board signals that reached the reactive pipeline but
+    had no deterministic keeper wake reason.
+
+    This ledger is intentionally not a wake queue. A recorded candidate means
+    "this board signal requires an LLM/Judge attention boundary before it can
+    become control flow"; it does not wake a keeper and does not authorize
+    substring/keyword matching as a fallback. *)
+
+type signal_kind =
+  | Post_created
+  | Comment_added
+  | Reaction_changed
+
+type attention_authority =
+  | Llm_judge_required
+
+type wake_authority =
+  | No_direct_wake
+
+type candidate = {
+  candidate_id : string;
+  dedupe_key : string;
+  keeper_name : string;
+  post_id : string;
+  signal_kind : signal_kind;
+  author : string;
+  title : string;
+  content_preview : string;
+  hearth : string option;
+  updated_at : float option;
+  recorded_at : float;
+  attention_authority : attention_authority;
+  wake_authority : wake_authority;
+}
+
+type record_result =
+  [ `Recorded
+  | `Duplicate of candidate
+  | `Error of string
+  ]
+
+val signal_kind_to_string : signal_kind -> string
+val signal_kind_of_string : string -> signal_kind option
+val attention_authority_to_string : attention_authority -> string
+val attention_authority_of_string : string -> attention_authority option
+val wake_authority_to_string : wake_authority -> string
+val wake_authority_of_string : string -> wake_authority option
+
+val candidate_id_of_dedupe_key : string -> string
+
+val of_board_signal :
+  keeper_name:string ->
+  recorded_at:float ->
+  Board_dispatch.board_signal ->
+  candidate
+
+val candidate_to_json : candidate -> Yojson.Safe.t
+val candidate_of_json : Yojson.Safe.t -> (candidate, string) result
+
+val record : base_path:string -> candidate -> record_result
+
+val load_candidates : base_path:string -> keeper_name:string -> candidate list

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -506,6 +506,46 @@ let board_signal_entry_is_wakeup_candidate (entry : Keeper_registry.registry_ent
   | _ -> false
 ;;
 
+let record_board_attention_candidate
+      ~(config : Workspace.config)
+      ~(signal_kind_label : string)
+      ~(meta : keeper_meta)
+      (signal : Board_dispatch.board_signal)
+  =
+  let candidate =
+    Keeper_board_attention_candidate.of_board_signal
+      ~keeper_name:meta.name
+      ~recorded_at:(Time_compat.now ())
+      signal
+  in
+  match Keeper_board_attention_candidate.record ~base_path:config.base_path candidate with
+  | `Recorded ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string BoardSignalAttentionCandidateTotal)
+      ~labels:
+        [ ("keeper", meta.name)
+        ; ("kind", signal_kind_label)
+        ; ( "attention_authority"
+          , Keeper_board_attention_candidate.attention_authority_to_string
+              candidate.attention_authority )
+        ; ( "wake_authority"
+          , Keeper_board_attention_candidate.wake_authority_to_string
+              candidate.wake_authority )
+        ]
+      ()
+  | `Duplicate _ -> ()
+  | `Error err ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string KeepaliveSignalFailures)
+      ~labels:[ ("keeper", meta.name); ("phase", "board_attention_candidate_record") ]
+      ();
+    Log.Keeper.warn
+      "board attention candidate record failed: keeper=%s post=%s error=%s"
+      meta.name
+      signal.post_id
+      err
+;;
+
 let paused_meta_allows_board_auto_resume (meta : keeper_meta) =
   meta.paused
   && Option.is_some
@@ -607,7 +647,8 @@ let wakeup_relevant_keeper_for_board_signal
                  ("keeper", meta.name);
                  ("kind", signal_kind_label);
                ]
-               ()
+               ();
+             record_board_attention_candidate ~config ~signal_kind_label ~meta signal
            | None, _ | Some _, _ -> ());
           (match entry.phase, wake_reason with
            | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -78,6 +78,7 @@ type t =
   | KeepaliveSignalFailures
   | BoardSignalWakeupCappedTotal
   | BoardSignalNoWakeTotal
+  | BoardSignalAttentionCandidateTotal
   | MetaJsonFailures
   | ToolsOasFailures
   | ToolsOasDeterministicFailures
@@ -334,6 +335,8 @@ let to_string = function
   | KeepaliveSignalFailures -> "masc_keeper_keepalive_signal_failures_total"
   | BoardSignalWakeupCappedTotal -> "masc_keeper_board_signal_wakeup_capped_total"
   | BoardSignalNoWakeTotal -> "masc_keeper_board_signal_no_wake_total"
+  | BoardSignalAttentionCandidateTotal ->
+    "masc_keeper_board_signal_attention_candidate_total"
   | MetaJsonFailures -> "masc_keeper_meta_json_failures_total"
   | ToolsOasFailures -> "masc_keeper_tools_oas_failures_total"
   | ToolsOasDeterministicFailures ->

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -69,6 +69,7 @@ type t =
   | KeepaliveSignalFailures
   | BoardSignalWakeupCappedTotal
   | BoardSignalNoWakeTotal
+  | BoardSignalAttentionCandidateTotal
   | MetaJsonFailures
   | ToolsOasFailures
   | ToolsOasDeterministicFailures

--- a/test/dune
+++ b/test/dune
@@ -192,6 +192,7 @@
   test_keeper_chat_blocks
   test_keeper_chat_media_store
   test_keeper_external_attention
+  test_keeper_board_attention_candidate
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -1,0 +1,143 @@
+module A = Masc.Keeper_board_attention_candidate
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path
+    then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let with_temp_base name f =
+  let base_path = temp_base_path name in
+  match f base_path with
+  | result ->
+    (try remove_tree base_path with _ -> ());
+    result
+  | exception exn ->
+    (try remove_tree base_path with _ -> ());
+    raise exn
+
+let signal ?(kind = Masc.Board_dispatch.Board_post_created)
+    ?(post_id = "post-1") ?(updated_at = Some 42.0)
+    ?(content = "goal-adjacent board text") () :
+    Masc.Board_dispatch.board_signal =
+  {
+    kind;
+    post_id;
+    author = "external-author";
+    title = "Board update";
+    content;
+    hearth = Some "hearth-1";
+    updated_at;
+  }
+
+let expect_recorded = function
+  | `Recorded -> ()
+  | `Duplicate _ -> Alcotest.fail "expected first record to append"
+  | `Error detail -> Alcotest.failf "record failed: %s" detail
+
+let test_candidate_roundtrip_and_authority () =
+  let candidate =
+    A.of_board_signal
+      ~keeper_name:"sangsu"
+      ~recorded_at:100.0
+      (signal ())
+  in
+  Alcotest.(check string)
+    "attention authority"
+    "llm_judge_required"
+    (A.attention_authority_to_string candidate.A.attention_authority);
+  Alcotest.(check string)
+    "wake authority"
+    "no_direct_wake"
+    (A.wake_authority_to_string candidate.A.wake_authority);
+  match A.candidate_of_json (A.candidate_to_json candidate) with
+  | Ok decoded -> Alcotest.(check bool) "roundtrip" true (decoded = candidate)
+  | Error detail -> Alcotest.failf "decode failed: %s" detail
+
+let test_record_dedupes_by_keeper_signal_identity () =
+  with_temp_base "keeper-board-attention-candidate" @@ fun base_path ->
+  let first =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:100.0 (signal ())
+  in
+  let duplicate =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:101.0 (signal ())
+  in
+  Alcotest.(check string)
+    "same signal identity produces stable candidate id"
+    first.A.candidate_id
+    duplicate.A.candidate_id;
+  expect_recorded (A.record ~base_path first);
+  (match A.record ~base_path duplicate with
+   | `Duplicate existing ->
+     Alcotest.(check string)
+       "duplicate returns existing candidate"
+       first.A.candidate_id
+       existing.A.candidate_id
+   | `Recorded -> Alcotest.fail "duplicate appended"
+   | `Error detail -> Alcotest.failf "duplicate record failed: %s" detail);
+  match A.load_candidates ~base_path ~keeper_name:"sangsu" with
+  | [ loaded ] ->
+    Alcotest.(check string) "loaded id" first.A.candidate_id loaded.A.candidate_id
+  | loaded ->
+    Alcotest.failf "expected one loaded candidate, got %d" (List.length loaded)
+
+let test_distinct_signal_identity_changes_candidate_id () =
+  let a =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:100.0
+      (signal ~post_id:"post-1" ())
+  in
+  let b =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:100.0
+      (signal ~post_id:"post-2" ())
+  in
+  Alcotest.(check bool)
+    "distinct post id changes candidate id"
+    true
+    (not (String.equal a.A.candidate_id b.A.candidate_id))
+
+let test_distinct_payload_on_same_post_changes_candidate_id () =
+  let a =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:100.0
+      (signal ~post_id:"post-1" ~content:"first comment" ())
+  in
+  let b =
+    A.of_board_signal ~keeper_name:"sangsu" ~recorded_at:100.0
+      (signal ~post_id:"post-1" ~content:"second comment" ())
+  in
+  Alcotest.(check bool)
+    "distinct payload changes candidate id"
+    true
+    (not (String.equal a.A.candidate_id b.A.candidate_id))
+
+let () =
+  Alcotest.run
+    "keeper_board_attention_candidate"
+    [
+      ( "candidate"
+      , [ Alcotest.test_case
+            "roundtrip and authority labels"
+            `Quick
+            test_candidate_roundtrip_and_authority
+        ; Alcotest.test_case
+            "record dedupes by keeper signal identity"
+            `Quick
+            test_record_dedupes_by_keeper_signal_identity
+        ; Alcotest.test_case
+            "distinct signal identity changes candidate id"
+            `Quick
+            test_distinct_signal_identity_changes_candidate_id
+        ; Alcotest.test_case
+            "distinct payload on same post changes candidate id"
+            `Quick
+            test_distinct_payload_on_same_post_changes_candidate_id
+        ] );
+    ]


### PR DESCRIPTION
## Summary

G-REACT follow-up for the keeper audit matrix.

Current `main` already removed the stale substring/keyword wake authority: board signals only wake from typed deterministic reasons (`explicit_mention`, thread reply after self comment, reaction after self activity). This PR fills the remaining observability gap by recording durable `board_attention_candidate` evidence whenever a running keeper sees a board signal but has no deterministic wake reason.

Key behavior:

- add `Keeper_board_attention_candidate`, an append-only per-keeper JSONL ledger under `.masc/board_attention_candidates/`
- mark each candidate with typed authority fields:
  - `attention_authority = llm_judge_required`
  - `wake_authority = no_direct_wake`
- record candidates from `wakeup_relevant_keeper_for_board_signal` only for `wake_reason = None` on running keepers
- keep wake selection unchanged: candidates are evidence only and do not enqueue/wake a keeper
- add `masc_keeper_board_signal_attention_candidate_total` for recorded candidates
- pin JSON round-trip, dedupe, and payload-identity behavior in `test_keeper_board_attention_candidate`

This intentionally does not fake an LLM judge. It creates the durable typed boundary/evidence so a real judge integration can consume candidates later without reintroducing substring or keyword authority.

## Validation

- `ocamlformat --check lib/keeper/keeper_board_attention_candidate.ml lib/keeper/keeper_board_attention_candidate.mli lib/keeper/keeper_keepalive_signal.ml lib/keeper_metrics/keeper_metrics.ml lib/keeper_metrics/keeper_metrics.mli test/test_keeper_board_attention_candidate.ml test/dune`
- `git diff --check origin/main..HEAD`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
  - PASS for new debt; advisory warnings are existing files outside this diff.

Blocked locally:

- `scripts/dune-local.sh build test/test_keeper_board_attention_candidate.exe test/test_smart_heartbeat_keepalive.exe`
  - refused because an unrelated bare `dune build .` process is live: PID 38238, PPID 63224.
  - Per project direction, CI remains the dune build authority.
