### PR TITLE
Avoid shared websocket payload string copies

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -272,13 +272,14 @@ let record_pong session =
   Atomic.set session.last_pong_at (Unix.gettimeofday ())
 (* NDT-OK: wall-clock used only for liveness, not deterministic output. *)
 
-(** Send a pre-allocated frame to a WebSocket client.
+(** Send a pre-encoded text payload to a WebSocket client.
 
-    The caller owns the [bytes] buffer; this function only reads it.  In
-    server mode ws-direct does not mask (RFC 6455 §5.3), and the payload is
-    copied into the faraday writer synchronously, so the same [bytes] value can
-    safely be passed to multiple sessions in one broadcast. *)
-let send_frame_bytes session bytes ~len =
+    The caller owns the [payload] bigstring and must treat it as immutable after
+    passing it here.  ws-direct owns RFC 6455 framing and role-specific masking;
+    server-mode fanout can therefore reuse one immutable payload across
+    sessions without allocating a per-session payload string. *)
+let send_text_bigstring session payload =
+  let len = Bigstringaf.length payload in
   if is_session_closed session then begin
     Atomic.set session.closed true;
     false
@@ -287,7 +288,7 @@ let send_frame_bytes session bytes ~len =
       if is_session_closed session then false
       else begin
         try
-          Ws_wsd.send_text session.wsd (Bytes.sub_string bytes 0 len);
+          Ws_wsd.send_text_bigstring session.wsd payload;
           Transport_metrics.inc_ws_bytes_sent ~bytes:len;
           Transport_metrics.observe_ws_message_bytes_sent len;
           true
@@ -308,42 +309,50 @@ let websocket_text_payload text =
   Inference_utils.sanitize_text_utf8 text
 
 (** Send a text frame to a WebSocket client.
-    Allocates [Bytes.t] per call — fine for single-destination sends.
+    Allocates a [Bigstringaf.t] per call — fine for single-destination sends.
     Multicast paths should go through [send_text_shared] instead so the
-    bytes allocation is paid once per broadcast, not once per session. *)
+    payload allocation is paid once per broadcast, not once per session. *)
 let send_text session text =
-  let bytes = Bytes.of_string (websocket_text_payload text) in
-  send_frame_bytes session bytes ~len:(Bytes.length bytes)
+  let payload_text = websocket_text_payload text in
+  let payload =
+    Bigstringaf.of_string payload_text ~off:0 ~len:(String.length payload_text)
+  in
+  send_text_bigstring session payload
 
-(** Module-local cache of the last [Bytes.of_string sse_event] result.
+(** Module-local cache of the last [Bigstringaf.of_string sse_event] result.
 
     [Sse.notify_external_subscribers] delivers the same [event: string]
     reference to every subscribed WS session in sequence.  Before this
-    cache, every session ran [Bytes.of_string] independently in the
-    raw-SSE-forward path, producing O(sessions) identical allocations.
+    cache, every session encoded the same payload independently in the
+    raw-SSE-forward path, producing O(sessions) identical allocations and
+    copies at the WebSocket API boundary.
     Keyed by physical equality so a fresh broadcast invalidates it. *)
-let bytes_cache : (string * Bytes.t) Atomic.t =
-  Atomic.make ("", Bytes.empty)
+let bigstring_cache : (string * Bigstringaf.t) Atomic.t =
+  Atomic.make ("", Bigstringaf.empty)
 
-let bytes_of_shared_text text =
-  let cached_str, cached_bytes = Atomic.get bytes_cache in
+let bigstring_of_shared_text text =
+  let cached_str, cached_payload = Atomic.get bigstring_cache in
   if cached_str == text then begin
     Transport_metrics.inc_ws_bytes_cache_hit ();
-    cached_bytes
+    cached_payload
   end
   else begin
     Transport_metrics.inc_ws_bytes_cache_miss ();
-    let bytes = Bytes.of_string (websocket_text_payload text) in
-    Atomic.set bytes_cache (text, bytes);
-    bytes
+    let payload_text = websocket_text_payload text in
+    let payload =
+      Bigstringaf.of_string payload_text ~off:0
+        ~len:(String.length payload_text)
+    in
+    Atomic.set bigstring_cache (text, payload);
+    payload
   end
 
 (** Send a text frame that will also be sent to other sessions in this
-    broadcast.  Allocates [Bytes.of_string text] once per unique string
-    reference; subsequent sessions in the same fanout reuse the bytes. *)
+    broadcast.  Encodes [text] to [Bigstringaf.t] once per unique string
+    reference; subsequent sessions in the same fanout reuse that payload. *)
 let send_text_shared session text =
-  let bytes = bytes_of_shared_text text in
-  send_frame_bytes session bytes ~len:(Bytes.length bytes)
+  let payload = bigstring_of_shared_text text in
+  send_text_bigstring session payload
 
 let send_text_checked ~context session text =
   let sent = send_text session text in
@@ -980,7 +989,7 @@ let send_dashboard_or_raw_sse session sse_event =
         else
           (* Same event string is forwarded verbatim to every session that
              does not match a subscribed dashboard slice; the shared cache
-             collapses N identical [Bytes.of_string] allocations into 1. *)
+             collapses N identical payload encodings into 1. *)
           send_text_shared_checked ~context:"sse-forward" session sse_event
   end
   else begin

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -41,9 +41,9 @@
     ([sha1], [sessions_mutex], [slice_index] +
     [slice_index_*] family, [__test_*] hooks,
     [inbound_message_handler],
-    [log_ws_delivery_dropped], [send_frame_bytes] /
+    [log_ws_delivery_dropped], [send_text_bigstring] /
     [websocket_text_payload] / [send_text] /
-    [bytes_cache] / [bytes_of_shared_text] /
+    [bigstring_cache] / [bigstring_of_shared_text] /
     [send_text_shared] / [send_text_*_checked] /
     [send_json_checked], [jsonrpc_notification],
     [next_dashboard_seq], [valid_dashboard_slice] /
@@ -458,8 +458,8 @@ val slice_index_subscribers : string -> string list
 (** Session ids subscribed to [slice].  Returns [\[\]]
     when [slice] is unknown or has no subscribers. *)
 
-val bytes_of_shared_text : string -> Bytes.t
-(** Returns the WebSocket frame bytes for [text],
+val bigstring_of_shared_text : string -> Bigstringaf.t
+(** Returns the WebSocket text payload for [text],
     re-using a single-entry physical-equality cache so
     the per-broadcast fanout collapses to one encoding
     pass. *)

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -56,7 +56,7 @@ fi
 # --- Pin SHAs (bump these when upstream changes are needed) ---
 readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
 readonly GRPC_DIRECT_SHA="d7269ebebf9e4688486cc6591c66e794607e7b0f"
-readonly WS_DIRECT_SHA="88f325956e8d03e5d68838145ada08a19e221c42"
+readonly WS_DIRECT_SHA="05e01cf008d4a5024474d13cee35cda42e2bea09"
 readonly NEO4J_BOLT_SHA="a1ca30c1247db5c58934e99306fe330419f7b21a"
 
 include_bisect=false

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -429,28 +429,28 @@ let test_parse_cache_counters () =
   Alcotest.(check (float 0.001)) "fresh allocation forces miss"
     1.0 (misses2 -. misses1)
 
-(* ====== Bytes cache for broadcast fanout ====== *)
+(* ====== Bigstring cache for broadcast fanout ====== *)
 
 (* Sse.notify_external_subscribers delivers the same event string reference
-   to every WS session.  The bytes cache collapses N identical
-   [Bytes.of_string] allocations into one per unique string reference. *)
+   to every WS session.  The bigstring cache collapses N identical payload
+   encodings into one per unique string reference. *)
 
-let test_bytes_of_shared_text_reuses_same_ref () =
+let test_bigstring_of_shared_text_reuses_same_ref () =
   let text = String.make 32 'x' in
-  let b1 = Ws.bytes_of_shared_text text in
-  let b2 = Ws.bytes_of_shared_text text in
+  let b1 = Ws.bigstring_of_shared_text text in
+  let b2 = Ws.bigstring_of_shared_text text in
   (* Physical equality: the same reference returns the exact same
-     [Bytes.t] (not just equal content), proving no re-allocation. *)
-  Alcotest.(check bool) "same string ref returns same Bytes"
+     [Bigstringaf.t] (not just equal content), proving no re-allocation. *)
+  Alcotest.(check bool) "same string ref returns same Bigstringaf.t"
     true (b1 == b2)
 
-let test_bytes_of_shared_text_content_matches () =
+let test_bigstring_of_shared_text_content_matches () =
   let text = "{\"type\":\"execution_snapshot\",\"payload\":{\"n\":1}}" in
-  let bytes = Ws.bytes_of_shared_text text in
+  let payload = Ws.bigstring_of_shared_text text in
   Alcotest.(check int) "length matches" (String.length text)
-    (Bytes.length bytes);
+    (Bigstringaf.length payload);
   Alcotest.(check string) "content round-trips" text
-    (Bytes.to_string bytes)
+    (Bigstringaf.to_string payload)
 
 let contains_substring haystack needle =
   let hlen = String.length haystack in
@@ -461,33 +461,54 @@ let contains_substring haystack needle =
   in
   nlen = 0 || loop 0
 
-let test_bytes_of_shared_text_repairs_invalid_utf8_for_text_frames () =
+let test_bigstring_of_shared_text_repairs_invalid_utf8_for_text_frames () =
   let text =
     "id: 42\nevent: message\ndata: {\"type\":\"transport_health_snapshot\",\
      \"payload\":\"bad\xC3\"}\n\n"
   in
-  let bytes = Ws.bytes_of_shared_text text in
-  let wire = Bytes.to_string bytes in
+  let payload = Ws.bigstring_of_shared_text text in
+  let wire = Bigstringaf.to_string payload in
   Alcotest.(check bool) "wire payload is valid UTF-8"
     true (String.is_valid_utf_8 wire);
   Alcotest.(check bool) "invalid byte is replaced"
     true (contains_substring wire "\xEF\xBF\xBD")
 
-let test_bytes_of_shared_text_invalidates_on_new_ref () =
+let test_bigstring_of_shared_text_invalidates_on_new_ref () =
   (* Force two distinct string allocations so physical equality differs
      even though content is the same.  The cache must re-allocate rather
-     than return the prior bytes. *)
+     than return the prior payload. *)
   let a = String.concat "" ["hello"; "-world"] in
   let b = String.concat "" ["hello"; "-world"] in
   assert (not (a == b));
-  let ba = Ws.bytes_of_shared_text a in
-  let bb = Ws.bytes_of_shared_text b in
-  Alcotest.(check bool) "distinct refs get distinct bytes"
+  let ba = Ws.bigstring_of_shared_text a in
+  let bb = Ws.bigstring_of_shared_text b in
+  Alcotest.(check bool) "distinct refs get distinct payloads"
     true (not (ba == bb));
   Alcotest.(check string) "content still correct for A"
-    a (Bytes.to_string ba);
+    a (Bigstringaf.to_string ba);
   Alcotest.(check string) "content still correct for B"
-    b (Bytes.to_string bb)
+    b (Bigstringaf.to_string bb)
+
+let test_shared_send_avoids_per_session_payload_string_copy () =
+  let source = read_source_file "lib/server/server_mcp_transport_ws.ml" in
+  let send_span =
+    substring_between source
+      ~start_marker:"let send_text_bigstring"
+      ~end_marker:"let websocket_text_payload"
+  in
+  let cache_span =
+    substring_between source
+      ~start_marker:"let bigstring_of_shared_text"
+      ~end_marker:"let send_text_checked"
+  in
+  Alcotest.(check bool) "send path uses ws-direct bigstring API" true
+    (contains_substring send_span "Ws_wsd.send_text_bigstring");
+  Alcotest.(check bool) "send path avoids payload string copy" false
+    (contains_substring send_span "Bytes.sub_string");
+  Alcotest.(check bool) "shared cache encodes to bigstring" true
+    (contains_substring cache_span "Bigstringaf.of_string");
+  Alcotest.(check bool) "shared cache avoids bytes payload copy" false
+    (contains_substring cache_span "Bytes.of_string")
 
 (* Observability: the Otel_metric_store counters must account exactly for the
    traffic the cache absorbs — hits for reuse, misses for fresh
@@ -501,9 +522,9 @@ let test_bytes_cache_counters () =
   let hits0 = read_counter hits_name in
   let misses0 = read_counter misses_name in
   let text = String.make 16 'z' in
-  let _ = Ws.bytes_of_shared_text text in   (* miss: first time *)
-  let _ = Ws.bytes_of_shared_text text in   (* hit *)
-  let _ = Ws.bytes_of_shared_text text in   (* hit *)
+  let _ = Ws.bigstring_of_shared_text text in   (* miss: first time *)
+  let _ = Ws.bigstring_of_shared_text text in   (* hit *)
+  let _ = Ws.bigstring_of_shared_text text in   (* hit *)
   Alcotest.(check (float 0.001)) "two hits observed"
     2.0 (read_counter hits_name -. hits0);
   Alcotest.(check (float 0.001)) "one miss observed"
@@ -513,7 +534,7 @@ let test_bytes_cache_counters () =
      level too. *)
   let text' = String.concat "" [String.make 8 'z'; String.make 8 'z'] in
   assert (not (text == text'));
-  let _ = Ws.bytes_of_shared_text text' in
+  let _ = Ws.bigstring_of_shared_text text' in
   Alcotest.(check (float 0.001)) "fresh allocation forces another miss"
     2.0 (read_counter misses_name -. misses0)
 
@@ -1227,14 +1248,16 @@ let () =
         test_parse_cache_counters;
     ]);
     ("bytes_cache", [
-      Alcotest.test_case "same string ref returns same Bytes" `Quick
-        test_bytes_of_shared_text_reuses_same_ref;
+      Alcotest.test_case "same string ref returns same Bigstringaf.t" `Quick
+        test_bigstring_of_shared_text_reuses_same_ref;
       Alcotest.test_case "content round-trips through cache" `Quick
-        test_bytes_of_shared_text_content_matches;
+        test_bigstring_of_shared_text_content_matches;
       Alcotest.test_case "invalid UTF-8 is repaired before text frames" `Quick
-        test_bytes_of_shared_text_repairs_invalid_utf8_for_text_frames;
+        test_bigstring_of_shared_text_repairs_invalid_utf8_for_text_frames;
       Alcotest.test_case "distinct refs force re-allocation" `Quick
-        test_bytes_of_shared_text_invalidates_on_new_ref;
+        test_bigstring_of_shared_text_invalidates_on_new_ref;
+      Alcotest.test_case "shared send avoids payload string copy" `Quick
+        test_shared_send_avoids_per_session_payload_string_copy;
       Alcotest.test_case "hit/miss counters track reuse" `Quick
         test_bytes_cache_counters;
       Alcotest.test_case "dashboard delta shared payload excludes seq" `Quick


### PR DESCRIPTION
## Summary
- switch shared WebSocket fan-out payload caching from `Bytes.t` to `Bigstringaf.t`
- send cached payloads through `Ws_wsd.send_text_bigstring` so dashboard/raw SSE fan-out no longer allocates a full payload string per session
- bump `WS_DIRECT_SHA` to jeong-sik/ws-direct@05e01cf008d4a5024474d13cee35cda42e2bea09, which exposes the bigstring text-send API in https://github.com/jeong-sik/ws-direct/pull/4
- add a source ratchet proving the shared send path uses the bigstring API and does not regress to `Bytes.sub_string` / `Bytes.of_string`

## Why
The previous dashboard delta split removed per-session JSON serialization, but the shared send path still converted the cached payload back through `Bytes.sub_string` and the public ws-direct string API for every recipient. That preserved an O(sessions * payload_bytes) copy at the WebSocket API boundary.

The new path keeps one shared `Bigstringaf.t` per physical broadcast string and sends that payload directly through ws-direct's frame serializer. The payload is treated as immutable after construction; ws-direct's server send path does not mutate it.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/ws-direct/.worktrees/ws-direct-bigstring-send-20260706 @install`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/ws-direct/.worktrees/ws-direct-bigstring-send-20260706 @test/runtest-test_endpoint`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/ws-direct/.worktrees/ws-direct-bigstring-send-20260706`
- `bash scripts/opam-pin-external-deps.sh && opam install --yes ws-direct-core ws-direct-gluten ws-direct-eio`
- `opam exec -- ocamlformat --check lib/server/server_mcp_transport_ws.ml lib/server/server_mcp_transport_ws.mli test/test_ws_transport.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_ws_transport.exe && ./_build/default/test/test_ws_transport.exe` (68 tests)
- GitHub CI on head `764828604749c204761941c3e9ab7b281972fcfe`: `Build and Test`, `CI Gate`, `ocamlformat-check` all passed
