### PR TITLE
fix(build): unbreak main after #23353 (red-merge)

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -135,7 +135,7 @@ let dedupe_key ~keeper_name ~(signal : Board_dispatch.board_signal) =
       signal_payload_fingerprint signal;
     ]
 
-let of_board_signal ~keeper_name ~recorded_at signal =
+let of_board_signal ~keeper_name ~recorded_at (signal : Board_dispatch.board_signal) =
   let signal_kind = signal_kind_of_board_signal_kind signal.kind in
   let dedupe_key = dedupe_key ~keeper_name ~signal in
   {

--- a/test/dune
+++ b/test/dune
@@ -536,6 +536,7 @@
   test_keeper_chat_blocks
   test_keeper_chat_media_store
   test_keeper_external_attention
+  test_keeper_board_attention_candidate
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager


### PR DESCRIPTION
Main is broken by #23353 which merged with two compile errors (red-merge). This PR fixes both.

1. lib/keeper/keeper_board_attention_candidate.ml: of_board_signal was missing the `(signal : Board_dispatch.board_signal)` annotation that its sibling functions (lines 95, 127) already have -> `Unbound record field kind`.
2. test/dune: the `(tests)` stanza maintains `names` and `(modules)` lists in duplicate. #23353 added `test_keeper_board_attention_candidate` to `names` only -> `not listed in (modules)`.

Verified locally: `dune build test/test_keeper_board_attention_candidate.exe` -> EXIT 0.

Both are mechanical mistakes CI should have caught pre-merge — another instance of the red-merge pattern (cf #22871 -> #22938). Because main is broken, other open PRs (#23330, #23332) inherit the broken base until this lands. Suggest fast-track merge once CI is green.
