### PR TITLE
[codex] Fix board attention candidate build

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -135,7 +135,7 @@ let dedupe_key ~keeper_name ~(signal : Board_dispatch.board_signal) =
       signal_payload_fingerprint signal;
     ]
 
-let of_board_signal ~keeper_name ~recorded_at signal =
+let of_board_signal ~keeper_name ~recorded_at (signal : Board_dispatch.board_signal) =
   let signal_kind = signal_kind_of_board_signal_kind signal.kind in
   let dedupe_key = dedupe_key ~keeper_name ~signal in
   {

--- a/test/dune
+++ b/test/dune
@@ -536,6 +536,7 @@
   test_keeper_chat_blocks
   test_keeper_chat_media_store
   test_keeper_external_attention
+  test_keeper_board_attention_candidate
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager


### PR DESCRIPTION
## Summary

- Fixes the merged #23353 build break by typing `of_board_signal` as `Board_dispatch.board_signal`.
- Adds `test_keeper_board_attention_candidate` to the matching `test/dune` modules list.

## Verification

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_board_attention_candidate.exe test/test_smart_heartbeat_keepalive.exe`
- `./_build/default/test/test_keeper_board_attention_candidate.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe`
