### PR TITLE
Record PR duplicate search evidence

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -4140,7 +4140,9 @@ parse None false false false args|}
     }
   ; { name = "Gh"
     ; anon_pattern = "Gh _"
-    ; bind_pattern = "Gh { subcommand; action; draft; squash; delete_branch; body; title; rest }"
+    ; bind_pattern =
+        "Gh { subcommand; action; draft; squash; delete_branch; body; title; \
+         search; state; rest }"
     ; risk = "`Audited"
     ; sandbox = "`Host"
     ; to_simple_body =
@@ -4152,6 +4154,8 @@ parse None false false false args|}
       let args = if delete_branch then args @ [ "--delete-branch" ] else args in
       let args = match body with Some b -> args @ [ "--body"; b ] | None -> args in
       let args = match title with Some t -> args @ [ "--title"; t ] | None -> args in
+      let args = match search with Some q -> args @ [ "--search"; q ] | None -> args in
+      let args = match state with Some s -> args @ [ "--state"; s ] | None -> args in
       let args = args @ rest in
       { Shell_ir.bin = Exec_program.of_known Exec_program.Gh
       ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args
@@ -4164,7 +4168,7 @@ parse None false false false args|}
     ; parse_body =
         Some
           {|
-let rec parse subcmd act draft squash del_branch body title rest = function
+let rec parse subcmd act draft squash del_branch body title search state rest = function
   | [] ->
     (match subcmd with
      | Some s ->
@@ -4178,54 +4182,70 @@ let rec parse subcmd act draft squash del_branch body title rest = function
                ; delete_branch = del_branch
                ; body
                ; title
+               ; search
+               ; state
                ; rest = List.rev rest
                }))
      | None -> None)
   | arg :: args ->
     (match subcmd with
-     | None -> parse (Some arg) act draft squash del_branch body title rest args
+     | None -> parse (Some arg) act draft squash del_branch body title search state rest args
      | Some _ when act = None && String.length arg > 0 && arg.[0] <> '-' ->
-       parse subcmd (Some arg) draft squash del_branch body title rest args
+       parse subcmd (Some arg) draft squash del_branch body title search state rest args
      | Some _ ->
        (match arg with
-        | "--draft" -> parse subcmd act true squash del_branch body title rest args
-        | "--squash" -> parse subcmd act draft true del_branch body title rest args
-        | "--delete-branch" -> parse subcmd act draft squash true body title rest args
+        | "--draft" -> parse subcmd act true squash del_branch body title search state rest args
+        | "--squash" -> parse subcmd act draft true del_branch body title search state rest args
+        | "--delete-branch" -> parse subcmd act draft squash true body title search state rest args
         | "--body" ->
           (match args with
-           | v :: rest' -> parse subcmd act draft squash del_branch (Some v) title rest rest'
-           | [] -> parse subcmd act draft squash del_branch body title rest args)
+           | v :: rest' -> parse subcmd act draft squash del_branch (Some v) title search state rest rest'
+           | [] -> parse subcmd act draft squash del_branch body title search state rest args)
         | "--title" ->
           (match args with
-           | v :: rest' -> parse subcmd act draft squash del_branch body (Some v) rest rest'
-           | [] -> parse subcmd act draft squash del_branch body title rest args)
+           | v :: rest' -> parse subcmd act draft squash del_branch body (Some v) search state rest rest'
+           | [] -> parse subcmd act draft squash del_branch body title search state rest args)
+        | "--search" ->
+          (match args with
+           | v :: rest' -> parse subcmd act draft squash del_branch body title (Some v) state rest rest'
+           | [] -> parse subcmd act draft squash del_branch body title search state rest args)
+        | "--state" ->
+          (match args with
+           | v :: rest' -> parse subcmd act draft squash del_branch body title search (Some v) rest rest'
+           | [] -> parse subcmd act draft squash del_branch body title search state rest args)
         | arg when Shell_ir_typed_types.is_eq_form_flag arg ["--body"] ->
           let v = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--body"]) in
-          parse subcmd act draft squash del_branch (Some v) title rest args
+          parse subcmd act draft squash del_branch (Some v) title search state rest args
         | arg when Shell_ir_typed_types.is_eq_form_flag arg ["--title"] ->
           let v = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--title"]) in
-          parse subcmd act draft squash del_branch body (Some v) rest args
+          parse subcmd act draft squash del_branch body (Some v) search state rest args
+        | arg when Shell_ir_typed_types.is_eq_form_flag arg ["--search"] ->
+          let v = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--search"]) in
+          parse subcmd act draft squash del_branch body title (Some v) state rest args
+        | arg when Shell_ir_typed_types.is_eq_form_flag arg ["--state"] ->
+          let v = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--state"]) in
+          parse subcmd act draft squash del_branch body title search (Some v) rest args
         | "--repo" | "--assignee" | "--label" | "--milestone" | "--project"
         | "--reviewer" | "--base" | "--head" | "--editor" | "--hostname"
-        | "--jq" | "--template" | "--limit" | "--state"
+        | "--jq" | "--template" | "--limit"
         | "-R" | "-a" | "-l" | "-p" | "-r" | "-B" | "-H" ->
           (match args with
-           | _ :: rest' -> parse subcmd act draft squash del_branch body title rest rest'
-           | [] -> parse subcmd act draft squash del_branch body title rest args)
+           | _ :: rest' -> parse subcmd act draft squash del_branch body title search state rest rest'
+           | [] -> parse subcmd act draft squash del_branch body title search state rest args)
         | "--" ->
           (* POSIX end-of-options: remaining args go to rest *)
-          parse subcmd act draft squash del_branch body title (List.rev args @ rest) []
+          parse subcmd act draft squash del_branch body title search state (List.rev args @ rest) []
         | _ when String.length arg > 1 && arg.[0] = '-' && arg.[1] = '-' ->
           (match String.index_opt arg '=' with
-           | Some _ -> parse subcmd act draft squash del_branch body title rest args
+           | Some _ -> parse subcmd act draft squash del_branch body title search state rest args
            | None ->
              (match args with
               | v :: rest' when String.length v > 0 && v.[0] <> '-' ->
-                parse subcmd act draft squash del_branch body title rest rest'
-              | _ -> parse subcmd act draft squash del_branch body title rest args))
-        | _ -> parse subcmd act draft squash del_branch body title (arg :: rest) args))
+                parse subcmd act draft squash del_branch body title search state rest rest'
+              | _ -> parse subcmd act draft squash del_branch body title search state rest args))
+        | _ -> parse subcmd act draft squash del_branch body title search state (arg :: rest) args))
 in
-parse None None false false false None None [] args|}
+parse None None false false false None None None None [] args|}
     ; no_expand_combined = false
     }
   ; { name = "Chmod"

--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -1,7 +1,7 @@
 ---
 description: keeper unified turn intent block (prepended via "## Turn Intent" after unified.system render)
 category: keeper
-template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, task_create_guidance, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
+template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, task_create_guidance, board_post_guidance, board_curation_guidance, broadcast_guidance, pr_duplicate_search_guidance, state_block_instruction]
 ---
 
 Use the world state below as raw context.
@@ -12,7 +12,7 @@ Your checkpoint survives across cycles — focus on doing one meaningful unit of
 Your conversation history is preserved across cycles — use that context to avoid repeating the same actions.
 
 Act through tools, not declarations. Call the tool directly.
-{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{task_create_guidance}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
+{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{task_create_guidance}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}{{pr_duplicate_search_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
 - If continuity says there is nothing to do but this turn still has backlog, repo delta, or a scheduled autonomous trigger, treat that mismatch as actionable and investigate it before going silent.
 - Nothing genuinely actionable after checking? End your turn with the [STATE] block.
 

--- a/config/prompts/keeper.turn_intent.pr_duplicate_search_guidance.md
+++ b/config/prompts/keeper.turn_intent.pr_duplicate_search_guidance.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent PR duplicate search guidance bullet
+category: keeper
+---
+- Before opening a GitHub PR, run a live duplicate check with `gh pr list --search <branch-or-task-or-title> --state all` and use the result to update an existing PR when appropriate instead of creating a duplicate.

--- a/lib/command_descriptor/command_descriptor.ml
+++ b/lib/command_descriptor/command_descriptor.ml
@@ -1,5 +1,6 @@
 type t =
   | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_search of { query : string; state : string option }
   | Gh_pr_merge of { pr_number : int; squash : bool }
   | Gh_pr_comment of { pr_number : int; body : string }
   | Gh_pr_close of { pr_number : int }
@@ -20,6 +21,7 @@ type pr_action_surface =
 
 type pr_action =
   | Create
+  | Search
   | Merge
   | Comment
   | Close
@@ -39,6 +41,7 @@ let pr_action_surface_to_string = function
 
 let pr_action_to_string = function
   | Create -> "create"
+  | Search -> "search"
   | Merge -> "merge"
   | Comment -> "comment"
   | Close -> "close"
@@ -55,6 +58,13 @@ let to_json = function
       ; "title", `String title
       ; "base", `String base
       ; "draft", `Bool draft
+      ]
+  | Gh_pr_search { query; state } ->
+    `Assoc
+      [ "kind", `String "gh_pr_search"
+      ; "query", `String query
+      ; "state", (match state with Some s -> `String s | None -> `Null)
+      ; "duplicate_search", `Bool true
       ]
   | Gh_pr_merge { pr_number; squash } ->
     `Assoc
@@ -164,11 +174,15 @@ let pr_action_of_gh_action = function
 ;;
 
 let compute_typed : type i o r s. (i, o, r, s) Typed.command -> t = function
-  | Typed.Gh { subcommand; action; title; draft; squash; body; rest; _ } ->
+  | Typed.Gh { subcommand; action; title; draft; squash; body; search; state; rest; _ } ->
     (match subcommand, action with
      | "pr", Some "create" ->
        let base = extract_flag_from_rest rest ~flag:"--base" ~short:(Some "-b") ~default:"main" in
        Gh_pr_create { title = string_or "" title; base; draft }
+     | "pr", Some "list" ->
+       (match search with
+        | Some query -> Gh_pr_search { query; state }
+        | None -> Generic)
      | "pr", Some "merge" -> Gh_pr_merge { pr_number = extract_number_from_rest rest; squash }
      | "pr", Some "comment" ->
        Gh_pr_comment { pr_number = extract_number_from_rest rest; body = string_or "" body }
@@ -364,6 +378,7 @@ let rec compute ir =
              Pipe_chain { first_cmd; last_cmd; length }
            | (None, Some _) | (Some _, None) | (None, None) -> Generic)
         | ( Gh_pr_create _
+          | Gh_pr_search _
           | Gh_pr_merge _
           | Gh_pr_comment _
           | Gh_pr_close _
@@ -383,6 +398,10 @@ let rec compute ir =
 let pr_action_event_of_typed
   : type i o r s. (i, o, r, s) Typed.command -> pr_action_event option
   = function
+  | Typed.Gh { subcommand; action = Some "list"; search = Some _; _ }
+    when String.equal subcommand "pr" -> Some { surface = Gh_cli; action = Search }
+  | Typed.Gh { subcommand; action = Some "list"; search = None; _ }
+    when String.equal subcommand "pr" -> None
   | Typed.Gh { subcommand; action; _ } when String.equal subcommand "pr" ->
     Option.map (fun action -> { surface = Gh_cli; action }) (pr_action_of_gh_action action)
   | Typed.Gh _

--- a/lib/command_descriptor/command_descriptor.mli
+++ b/lib/command_descriptor/command_descriptor.mli
@@ -6,6 +6,7 @@
 
 type t =
   | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_search of { query : string; state : string option }
   | Gh_pr_merge of { pr_number : int; squash : bool }
   | Gh_pr_comment of { pr_number : int; body : string }
   | Gh_pr_close of { pr_number : int }
@@ -26,6 +27,7 @@ type pr_action_surface =
 
 type pr_action =
   | Create
+  | Search
   | Merge
   | Comment
   | Close

--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -487,7 +487,19 @@ let of_command = function
     let args = if race then args @ [ arg "-race" ] else args in
     let args = args @ List.map arg rest in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Go, args) ]
-  | Shell_ir_typed.W (Gh { subcommand; action; draft; squash; delete_branch; body; title; rest }) ->
+  | Shell_ir_typed.W
+      (Gh
+        { subcommand
+        ; action
+        ; draft
+        ; squash
+        ; delete_branch
+        ; body
+        ; title
+        ; search
+        ; state
+        ; rest
+        }) ->
     let args = [ arg subcommand ] in
     let args = match action with Some a -> args @ [ arg a ] | None -> args in
     let args = if draft then args @ [ arg "--draft" ] else args in
@@ -495,6 +507,8 @@ let of_command = function
     let args = if delete_branch then args @ [ arg "--delete-branch" ] else args in
     let args = match body with Some b -> args @ [ arg "--body"; arg b ] | None -> args in
     let args = match title with Some t -> args @ [ arg "--title"; arg t ] | None -> args in
+    let args = match search with Some q -> args @ [ arg "--search"; arg q ] | None -> args in
+    let args = match state with Some s -> args @ [ arg "--state"; arg s ] | None -> args in
     let args = args @ List.map arg rest in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Gh, args) ]
   | Shell_ir_typed.W (Chmod { mode; path; recursive }) ->

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -498,10 +498,10 @@ let pp fmt = function
   | W (Go { subcommand; verbose; race; rest }) ->
     Format.fprintf fmt "Go(sub=%s, v=%b, race=%b, rest=%a)" subcommand verbose race
       (Format.pp_print_list Format.pp_print_string) rest
-  | W (Gh { subcommand; action; draft; squash; delete_branch; body; title; rest }) ->
+  | W (Gh { subcommand; action; draft; squash; delete_branch; body; title; search; state; rest }) ->
     Format.fprintf
       fmt
-      "Gh(sub=%s, action=%a, draft=%b, squash=%b, del_br=%b, body=%a, title=%a, rest=%a)"
+      "Gh(sub=%s, action=%a, draft=%b, squash=%b, del_br=%b, body=%a, title=%a, search=%a, state=%a, rest=%a)"
       subcommand
       (Format.pp_print_option Format.pp_print_string)
       action
@@ -512,6 +512,10 @@ let pp fmt = function
       body
       (Format.pp_print_option Format.pp_print_string)
       title
+      (Format.pp_print_option Format.pp_print_string)
+      search
+      (Format.pp_print_option Format.pp_print_string)
+      state
       (Format.pp_print_list Format.pp_print_string)
       rest
   | W (Chmod { mode; path; recursive }) ->

--- a/lib/exec/shell_ir_typed_types.ml
+++ b/lib/exec/shell_ir_typed_types.ml
@@ -420,6 +420,8 @@ and (_, _, _, _) command =
       ; delete_branch : bool
       ; body : string option
       ; title : string option
+      ; search : string option
+      ; state : string option
       ; rest : string list
       }
       -> (unit, string, [ `Audited ], [ `Host ]) command

--- a/lib/exec/shell_ir_typed_types.mli
+++ b/lib/exec/shell_ir_typed_types.mli
@@ -410,6 +410,8 @@ and (_, _, _, _) command =
       ; delete_branch : bool
       ; body : string option
       ; title : string option
+      ; search : string option
+      ; state : string option
       ; rest : string list
       }
       -> (unit, string, [ `Audited ], [ `Host ]) command

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -92,7 +92,7 @@ let all_wrapped : Shell_ir_typed.wrapped list =
   ; W (Npm { subcommand = "install"; save_dev = true; global = false; force = false; rest = [] })
   ; W (Cargo { subcommand = "build"; release = true; verbose = false; features = None; rest = [] })
   ; W (Go { subcommand = "build"; verbose = false; race = false; rest = [ "./..." ] })
-  ; W (Gh { subcommand = "pr"; action = Some "list"; draft = false; squash = false; delete_branch = false; body = None; title = None; rest = [] })
+  ; W (Gh { subcommand = "pr"; action = Some "list"; draft = false; squash = false; delete_branch = false; body = None; title = None; search = None; state = None; rest = [] })
   ; W (Chmod { mode = "755"; path = "/tmp/x"; recursive = false })
   ; W (Chown { owner = "root"; path = "/tmp/x"; recursive = false })
   ; W (Docker { subcommand = "run"; rm = false; privileged = false; detach = true; name = None; network = None; volumes = []; publish = []; env_vars = []; workdir = None; platform = None; rest = [ "nginx" ] })
@@ -313,7 +313,7 @@ let test_of_simple_round_trip () =
     ; W (Npm { subcommand = "run"; save_dev = false; global = false; force = false; rest = [ "build" ] })
     ; W (Cargo { subcommand = "test"; release = false; verbose = false; features = None; rest = [ "--lib" ] })
     ; W (Go { subcommand = "run"; verbose = true; race = false; rest = [ "main.go" ] })
-    ; W (Gh { subcommand = "issue"; action = Some "create"; draft = false; squash = false; delete_branch = false; body = None; title = Some "bug"; rest = [] })
+    ; W (Gh { subcommand = "issue"; action = Some "create"; draft = false; squash = false; delete_branch = false; body = None; title = Some "bug"; search = None; state = None; rest = [] })
     ; W (Chmod { mode = "644"; path = "/etc/config"; recursive = true })
     ; W (Chown { owner = "user:group"; path = "/var/data"; recursive = true })
     ; W (Docker { subcommand = "build"; rm = false; privileged = false; detach = false; name = None; network = None; volumes = []; publish = []; env_vars = []; workdir = None; platform = None; rest = [ "myapp"; "." ] })
@@ -492,6 +492,24 @@ let test_flag_equals_parsing () =
    | W (Gh { subcommand = "pr"; action = Some "create"; body = Some "hello world"; title = Some "my pr"; draft = true; _ }) -> ()
    | w ->
      Alcotest.failf "Gh --flag=value: expected body/title parsed, got %a" pp w);
+  let gh_search =
+    of_simple
+      { (base "gh") with
+        args =
+          [ lit "pr"; lit "list"; lit "--search=task-1814"; lit "--state"; lit "all" ]
+      }
+  in
+  (match gh_search with
+   | W
+       (Gh
+          { subcommand = "pr"
+          ; action = Some "list"
+          ; search = Some "task-1814"
+          ; state = Some "all"
+          ; _
+          }) -> ()
+   | w ->
+     Alcotest.failf "Gh --search/--state: expected fields parsed, got %a" pp w);
   (* Curl: --request=POST --data=hello *)
   let curl =
     of_simple

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -552,6 +552,15 @@ let extract_descriptor_from_output (output_text : string) : Ide_event_types.comm
          let base = Yojson.Safe.Util.member "base" descriptor_json |> Yojson.Safe.Util.to_string in
          let draft = Yojson.Safe.Util.member "draft" descriptor_json |> Yojson.Safe.Util.to_bool in
          Some (Ide_event_types.Gh_pr_create { title; base; draft })
+       | "gh_pr_search" ->
+         let query = Yojson.Safe.Util.member "query" descriptor_json |> Yojson.Safe.Util.to_string in
+         let state =
+           match Yojson.Safe.Util.member "state" descriptor_json with
+           | `String value -> Some value
+           | `Null -> None
+           | _ -> None
+         in
+         Some (Ide_event_types.Gh_pr_search { query; state })
        | "gh_pr_merge" ->
          let pr_number = Yojson.Safe.Util.member "pr_number" descriptor_json |> Yojson.Safe.Util.to_int in
          let squash = Yojson.Safe.Util.member "squash" descriptor_json |> Yojson.Safe.Util.to_bool in
@@ -971,7 +980,7 @@ let ingest_pr_event_from_descriptor
         ~pr_state:"open" ~repo ~keeper_id ~turn_id
         ~comment_count:1 ~review_status:None
         ~timestamp_ms:(now_ms ())
-    | Some (Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
+    | Some (Ide_event_types.Gh_pr_search _ | Ide_event_types.Gh_issue_create _ | Ide_event_types.Gh_issue_close _ | Ide_event_types.Git_push _ | Ide_event_types.Git_commit _ | Ide_event_types.Pipe_chain _ | Ide_event_types.Generic)
     | None -> ()
 
 (** Ingest PR creation/update events from descriptor-backed tool output.

--- a/lib/ide/ide_event_types.ml
+++ b/lib/ide/ide_event_types.ml
@@ -4,6 +4,7 @@
     Kept as an IDE-facing alias for the neutral [Command_descriptor.t]. *)
 type command_descriptor = Command_descriptor.t =
   | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_search of { query : string; state : string option }
   | Gh_pr_merge of { pr_number : int; squash : bool }
   | Gh_pr_comment of { pr_number : int; body : string }
   | Gh_pr_close of { pr_number : int }

--- a/lib/ide/ide_event_types.mli
+++ b/lib/ide/ide_event_types.mli
@@ -4,6 +4,7 @@
     Kept as an IDE-facing alias for the neutral [Command_descriptor.t]. *)
 type command_descriptor = Command_descriptor.t =
   | Gh_pr_create of { title : string; base : string; draft : bool }
+  | Gh_pr_search of { query : string; state : string option }
   | Gh_pr_merge of { pr_number : int; squash : bool }
   | Gh_pr_comment of { pr_number : int; body : string }
   | Gh_pr_close of { pr_number : int }

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -724,6 +724,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       ~enabled:(tool_allowed "keeper_broadcast")
       Keeper_prompt_names.turn_intent_broadcast_guidance
   in
+  let pr_duplicate_search_guidance =
+    load_externalized_bullet
+      ~enabled:
+        (tool_allowed "tool_execute"
+         || tool_allowed "Execute"
+         || tool_allowed "execute")
+      Keeper_prompt_names.turn_intent_pr_duplicate_search_guidance
+  in
   let task_create_guidance =
     load_externalized_bullet
       ~enabled:show_task_create_guidance
@@ -748,6 +756,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       ("board_post_guidance", board_post_guidance);
       ("board_curation_guidance", board_curation_guidance);
       ("broadcast_guidance", broadcast_guidance);
+      ("pr_duplicate_search_guidance", pr_duplicate_search_guidance);
       ("state_block_instruction", state_block_instruction_text);
     ]
   in

--- a/lib/keeper_metrics/keeper_prompt_names.ml
+++ b/lib/keeper_metrics/keeper_prompt_names.ml
@@ -36,6 +36,8 @@ let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
 let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
 let turn_intent_task_create_guidance = "keeper.turn_intent.task_create_guidance"
+let turn_intent_pr_duplicate_search_guidance =
+  "keeper.turn_intent.pr_duplicate_search_guidance"
 
 (** User-prompt "Claimable Work" section body, emitted when a claimable backlog
     is visible and the keeper holds no task. *)

--- a/lib/keeper_metrics/keeper_prompt_names.mli
+++ b/lib/keeper_metrics/keeper_prompt_names.mli
@@ -32,6 +32,7 @@ val turn_intent_board_post_guidance : string
 val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
 val turn_intent_task_create_guidance : string
+val turn_intent_pr_duplicate_search_guidance : string
 
 (** User-prompt "Claimable Work" section template key. *)
 val immediate_task_move : string

--- a/test/test_command_descriptor.ml
+++ b/test/test_command_descriptor.ml
@@ -63,6 +63,30 @@ let test_gh_pr_create_base_short () =
   | other -> failf "expected Gh_pr_create, got %s" (Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json other))
 ;;
 
+let test_gh_pr_search () =
+  let ir = parse_ir "gh pr list --search 'task-1814' --state all" in
+  match Desc.compute ir with
+  | Ide_event_types.Gh_pr_search { query; state } ->
+    check string "query" "task-1814" query;
+    check (option string) "state" (Some "all") state
+  | other ->
+    failf
+      "expected Gh_pr_search, got %s"
+      (Yojson.Safe.to_string
+         (Ide_event_types.command_descriptor_to_json other))
+;;
+
+let test_gh_pr_list_without_search_is_generic () =
+  let ir = parse_ir "gh pr list --state all" in
+  match Desc.compute ir with
+  | Ide_event_types.Generic -> ()
+  | other ->
+    failf
+      "expected Generic, got %s"
+      (Yojson.Safe.to_string
+         (Ide_event_types.command_descriptor_to_json other))
+;;
+
 let test_gh_pr_merge () =
   let ir = parse_ir "gh pr merge 123 --squash" in
   match Desc.compute ir with
@@ -225,9 +249,19 @@ let test_pr_action_projection_uses_typed_gh_only () =
   in
   check string "pipeline surface" "gh_cli" pipeline_surface;
   check string "pipeline action" "comment" pipeline_action;
+  let search_surface, search_action =
+    parse_ir "gh pr list --search 'task-1814' --state all"
+    |> single_pr_action_labels
+  in
+  check string "search surface" "gh_cli" search_surface;
+  check string "search action" "search" search_action;
   let git_merge_ir = parse_ir "git merge feature-branch --squash" in
   check int "git merge is not gh PR action" 0
     (List.length (Desc.pr_action_events_of_ir git_merge_ir))
+  ;
+  let plain_list_ir = parse_ir "gh pr list --state all" in
+  check int "plain gh pr list is not duplicate-search evidence" 0
+    (List.length (Desc.pr_action_events_of_ir plain_list_ir))
 ;;
 
 let test_tool_execute_pr_action_metric_labels () =
@@ -271,6 +305,28 @@ let test_tool_execute_pr_action_metric_labels () =
   in
   check bool "failed attempt metric increments" true
     (failed_after >= failed_before +. 1.0);
+  let search_ir = parse_ir "gh pr list --search 'task-1814' --state all" in
+  let search_labels =
+    [ "keeper", keeper_name
+    ; "surface", "gh_cli"
+    ; "action", "search"
+    ; "status", "success"
+    ; "risk_class", "R0"
+    ]
+  in
+  let search_before =
+    Metrics.metric_value_or_zero metric ~labels:search_labels ()
+  in
+  Execute_runtime.record_pr_action_metric
+    ~keeper_name
+    ~risk_class:Masc_exec.Shell_ir_risk.R0_Read
+    ~status:(Unix.WEXITED 0)
+    search_ir;
+  let search_after =
+    Metrics.metric_value_or_zero metric ~labels:search_labels ()
+  in
+  check bool "search metric increments" true
+    (search_after >= search_before +. 1.0);
   let total_before = Metrics.metric_total metric in
   Execute_runtime.record_pr_action_metric
     ~keeper_name
@@ -347,6 +403,22 @@ let test_extract_descriptor_gh_pr_create () =
   | other -> failf "expected Gh_pr_create descriptor, got %s" (match other with Some d -> Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json d) | None -> "None")
 ;;
 
+let test_extract_descriptor_gh_pr_search () =
+  let output =
+    {|{"ok":true,"output":"[]","command_descriptor":{"kind":"gh_pr_search","query":"task-1814","state":"all","duplicate_search":true}}|}
+  in
+  match Ide_bridge.extract_descriptor_from_output output with
+  | Some (Ide_event_types.Gh_pr_search { query; state }) ->
+    check string "query" "task-1814" query;
+    check (option string) "state" (Some "all") state
+  | other ->
+    failf
+      "expected Gh_pr_search descriptor, got %s"
+      (match other with
+       | Some d -> Yojson.Safe.to_string (Ide_event_types.command_descriptor_to_json d)
+       | None -> "None")
+;;
+
 let test_descriptor_to_pr_event () =
   with_temp_dir (fun base_dir ->
     let output = {|{"ok":true,"output":"{\"number\":999,\"url\":\"https://github.com/jeong-sik/masc/pull/999\"}","command_descriptor":{"kind":"gh_pr_create","title":"test PR","base":"main","draft":false}}|} in
@@ -403,6 +475,8 @@ let () =
         ; test_case "create --draft" `Quick test_gh_pr_create_draft
         ; test_case "create --base=develop" `Quick test_gh_pr_create_base_eq
         ; test_case "create -b develop" `Quick test_gh_pr_create_base_short
+        ; test_case "search" `Quick test_gh_pr_search
+        ; test_case "plain list is generic" `Quick test_gh_pr_list_without_search_is_generic
         ; test_case "merge" `Quick test_gh_pr_merge
         ; test_case "comment" `Quick test_gh_pr_comment
         ; test_case "close" `Quick test_gh_pr_close
@@ -447,6 +521,7 @@ let () =
         ] )
     ; ( "bridge_integration"
       , [ test_case "extract descriptor" `Quick test_extract_descriptor_gh_pr_create
+        ; test_case "extract search descriptor" `Quick test_extract_descriptor_gh_pr_search
         ; test_case "descriptor to PR event" `Quick test_descriptor_to_pr_event
         ; test_case "descriptor merge event" `Quick test_descriptor_merge_event
         ] )

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -132,6 +132,7 @@ let turn_intent_bullet_keys =
     Keeper_prompt_names.turn_intent_board_curation_guidance;
     Keeper_prompt_names.turn_intent_broadcast_guidance;
     Keeper_prompt_names.turn_intent_task_create_guidance;
+    Keeper_prompt_names.turn_intent_pr_duplicate_search_guidance;
   ]
 
 let task_create_observation : WO.world_observation =


### PR DESCRIPTION
## Summary

- Preserve `gh pr list --search/--state` in typed Shell IR instead of dropping those flags.
- Record searched PR lists as `gh_pr_search` command descriptors and `search` PR action metrics; plain `gh pr list` remains generic.
- Add turn-intent guidance requiring a live duplicate PR search before opening a PR.

## Duplicate PR Search

- `gh -R jeong-sik/masc pr list --search "keeper-pr-duplicate-search-wave4-20260706 OR \"Record PR duplicate search evidence\"" --state all --json number,state,title,headRefName,url --limit 10`
- Result before PR creation: `[]`

## Verification

- `git diff --check origin/main..HEAD`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `scripts/dune-local.sh build test/test_command_descriptor.exe test/test_keeper_prompt_external.exe lib/exec/test/test_shell_ir_walkers_gen.exe`
- `./_build/default/test/test_command_descriptor.exe`
- `./_build/default/test/test_keeper_prompt_external.exe`
- `./_build/default/lib/exec/test/test_shell_ir_walkers_gen.exe`