### PR TITLE
Disable keeper repo-create discussion surfaces

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -148,6 +148,7 @@ Choosing a capability family:
 - Use context/tool introspection first when sandbox paths, repo location, active schema names, or current task ownership are uncertain.
 - Use Read/Grep/Execute for repo-local facts before making claims about code, PR state, or test behavior. Use WebSearch/WebFetch only for external or time-sensitive facts.
 - Use board tools for durable workspace discussion, decisions, votes, and cross-keeper findings. Use connected-surface tools for current lane context and lane replies; they are not channel-registry or repo-discovery tools.
+- Do not create GitHub repositories or mutate GitHub Discussions from keeper execution. `docs/design/keeper-github-repo-create-discussion-policy.md` keeps remote repository creation as an operator action and keeps durable discussion on MASC board tools.
 - Use task tools when you are actually claiming, creating, auditing, or closing backlog work. Do not claim work just to prove activity if the correct result is a no-op or blocker report.
 - Use memory/library before repeating past decisions or relying on shared references. Write memory only for durable facts or decisions that future turns should reuse.
 - Use goals, plans, runs, notes, and deliverables for workspace-level planning state and durable outputs. Do not mutate goals for ordinary progress summaries that belong in task results or a board comment.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -122,6 +122,9 @@ Choose the smallest surface that matches the live signal.
 - Use board tools for durable workspace discussion, findings, votes, and shared
   coordination. Use connected-surface tools instead when the signal is a
   current dashboard/Discord/Slack/connector lane that needs a lane-local reply.
+- Do not use keeper execution to create GitHub repositories or mutate GitHub
+  Discussions; `docs/design/keeper-github-repo-create-discussion-policy.md`
+  keeps those surfaces outside keeper affordances.
 - Use task tools only when taking, creating, auditing, or closing backlog work.
   Reading task state is evidence gathering, not execution progress.
 - Use memory/library before repeating past work, relying on shared references,

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -163,6 +163,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |
 | 테스트 실행 | `Execute` with typed argv from the worktree `cwd` |
 | GitHub PR / 이슈 작업 | `Execute` with `executable="gh"` and typed `argv` from a bound repo context for PR reads and reversible PR mutations such as `pr create` / `pr edit`. |
+| GitHub repo 생성 / GitHub Discussions mutation | Disabled by `docs/design/keeper-github-repo-create-discussion-policy.md`. Use operator action for repository creation and MASC board tools for durable discussion. |
 
 The goal lifecycle surface is descriptor/registry-driven with denylist
 filtering. Social and messaging keepers should keep board/task workspace

--- a/docs/design/keeper-github-repo-create-discussion-policy.md
+++ b/docs/design/keeper-github-repo-create-discussion-policy.md
@@ -1,0 +1,99 @@
+---
+title: "Keeper GitHub repo-create and Discussions policy"
+status: Draft
+created: 2026-07-06
+updated: 2026-07-06
+author: codex
+supersedes: []
+superseded_by: null
+related: ["0008", "0160", "0254", "0255"]
+implementation_prs: []
+---
+
+# Keeper GitHub repo-create and Discussions policy
+
+Status: Draft · Capability decision · G-WDECIDE
+
+## 1. Decision
+
+Keeper autonomous execution does not expose GitHub repository creation or
+GitHub Discussions mutation as supported capabilities.
+
+- GitHub PR and issue work remains supported through `Execute` with `gh` in a
+  bound repository context.
+- Remote repository creation is disabled for keepers. Operators may still create
+  repositories outside keeper autonomous execution.
+- GitHub Discussions mutation is disabled for keepers. Durable workspace
+  discussion stays on MASC board tools, which are typed, observable, and scoped
+  to the workspace.
+
+The generic `gh` execution path must fail closed for this decision. A command
+that would create a remote GitHub repository or mutate GitHub Discussions is
+classified as a repository-hosting policy floor violation, not as an ordinary
+reversible mutation.
+
+## 2. Evidence
+
+- [근거] `gh auth status --hostname github.com` on 2026-07-06T10:29:25+09:00,
+  confidence High: the active operator account currently has `repo` scope. Scope
+  availability is therefore not enough to define keeper capability.
+- [근거] `gh api graphql -f query='{__schema{mutationType{fields{name}}}}'` on
+  2026-07-06T10:29:25+09:00, confidence High: the live GitHub GraphQL schema
+  includes `createRepository`, `cloneTemplateRepository`, `createDiscussion`,
+  `addDiscussionComment`, `updateDiscussion`, `deleteDiscussion`, and related
+  discussion mutations.
+- [근거] Source inspection on 2026-07-06T10:29:25+09:00, confidence High:
+  `docs/KEEPER-CAPABILITY-MATRIX.md` documents PR/issue work through `gh`, board
+  tools already own durable workspace discussion, and `RFC-0008` retired the
+  keeper-side GitHub credential provider.
+
+## 3. Rationale
+
+Repository creation and GitHub Discussions create durable remote surfaces whose
+ownership, lifecycle, and moderation policy are not represented in the current
+keeper tool contracts. Leaving them reachable only because an ambient `gh` token
+has broad scope is a silent capability decision.
+
+Disabling both surfaces is the smaller production decision:
+
+- no new GitHub credential materialization path;
+- no new cross-repo ownership model;
+- no duplicate discussion plane beside MASC board;
+- no prompt affordance that suggests an unsupported tool;
+- no dependence on removing broad operator `repo` scope from local `gh` auth.
+
+## 4. Enforcement
+
+The Shell IR repo-hosting classifier treats these forms as R2/policy-floor
+operations:
+
+- `gh repo create ...`
+- `gh repo fork ...`
+- `gh discussion create|comment|edit|delete|close|reopen|lock|unlock|answer|unanswer ...`
+- `gh api graphql` bodies containing the live GitHub mutation names for
+  repository creation or Discussions mutation.
+
+The deny reason remains `Destructive_repo_hosting_cli` because the floor is the
+same remote repository-hosting policy boundary used for irreversible PR/repo
+operations. The user-facing text states that the operation is not permitted by
+policy.
+
+## 5. Non-goals
+
+- This decision does not remove the operator's local `repo` token scope.
+- This decision does not add a dedicated repo-create tool.
+- This decision does not add GitHub Discussions read or write tools.
+- This decision does not change MASC board discussion semantics.
+
+## 6. Verification
+
+- `test/test_shell_ir_risk.ml` proves `gh repo create`, `gh repo fork`,
+  `gh discussion create/comment`, `createRepository`, `cloneTemplateRepository`,
+  `createDiscussion`, and `addDiscussionComment` classify as R2.
+- `lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml` covers the
+  direct repo-hosting classifier.
+- `lib/exec/test/test_approval_policy.ml` proves autonomous approval denies
+  repo-create, repo-fork, discussion-create, and GraphQL create mutations.
+- Keeper capability docs and prompts state the decision directly: PR/issue work
+  is supported, while remote repo creation and GitHub Discussions mutation are
+  not keeper affordances.

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -30,8 +30,9 @@ val decide :
        - any [Destructive] git op → [Deny Destructive_git];
        - a redirect [Write_path] whose scope is [Outside_workspace] or
          [Absolute_unknown] → [Deny Path_escape];
-       - an irreversible repository-hosting CLI operation ([gh pr merge],
-         [gh repo delete], [gh api -X DELETE]) → [Deny
+       - an irreversible or policy-disabled repository-hosting CLI operation
+         ([gh pr merge], [gh repo create], [gh repo delete],
+         [gh discussion create], [gh api -X DELETE]) → [Deny
          Destructive_repo_hosting_cli];
        - a catastrophic-by-identity binary (filesystem-format [mkfs], or
          system-power [shutdown]/[reboot]/[halt]/[poweroff]) → [Deny
@@ -51,9 +52,10 @@ val decide :
 
 val catastrophic_floor : Capability.t list -> Verdict.deny_reason option
 (** Stage 1 of [decide] on its own: [Some reason] for a [Destructive] git op, a
-    redirect [Write_path] escaping the workspace, an irreversible
-    repository-hosting CLI operation ([gh pr merge], [gh repo delete], [gh api
-    -X DELETE]), a catastrophic-by-identity binary (filesystem-format [mkfs] or
+    redirect [Write_path] escaping the workspace, an irreversible or
+    policy-disabled repository-hosting CLI operation ([gh pr merge], [gh repo
+    create], [gh repo delete], [gh discussion create], [gh api -X DELETE]), a
+    catastrophic-by-identity binary (filesystem-format [mkfs] or
     system-power [shutdown]/[reboot]/[halt]/[poweroff]), or a destructive SQL
     statement on a database CLI ([psql -c "drop …"]); [None] otherwise.
 

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -284,7 +284,10 @@ let classify_write_detail (words : string list) : risk_class option =
 let repo_hosting_cli_irreversible_ops =
   [
     ("pr", [ "merge"; "ready" ]);
-    ("repo", [ "delete"; "archive"; "transfer"; "rename" ]);
+    ("repo", [ "create"; "delete"; "archive"; "transfer"; "rename"; "fork" ]);
+    ( "discussion",
+      [ "create"; "comment"; "edit"; "delete"; "close"; "reopen"; "lock";
+        "unlock"; "answer"; "unanswer" ] );
     ("release", [ "delete" ]);
     ("secret", [ "delete"; "remove" ]);
     ("ssh-key", [ "delete" ]);
@@ -309,7 +312,7 @@ let repo_hosting_cli_reversible_mutations =
     ("cache", [ "delete" ]);
     ("gist", [ "create"; "edit"; "clone"; "rename" ]);
     ("repo",
-     [ "create"; "clone"; "fork"; "edit"; "sync"; "set-default" ]);
+     [ "clone"; "edit"; "sync"; "set-default" ]);
     ("project",
      [ "create"; "edit"; "close"; "copy"; "link"; "unlink"; "field-create";
        "field-delete"; "item-add"; "item-archive"; "item-delete"; "item-edit" ]);
@@ -368,7 +371,12 @@ let repo_hosting_graphql_r2_fragments =
   [ "deletepullrequest"; "deleteissue"; "deletebranch"; "deleteref";
     "deleteproject"; "deletebranchprotectionrule";
     "removeouterfromorganization"; "transferrepository";
-    "archiverepository";
+    "archiverepository"; "createrepository"; "clonetemplaterepository";
+    "creatediscussion"; "adddiscussioncomment"; "adddiscussionpollvote";
+    "closediscussion"; "deletediscussion"; "deletediscussioncomment";
+    "markdiscussioncommentasanswer"; "reopendiscussion";
+    "unmarkdiscussioncommentasanswer"; "updatediscussion";
+    "updatediscussioncomment";
     (* Forward-looking verb prefixes for mutations GitHub may introduce.
        Over-block here is acceptable — under-block (silent miss) is not. *)
     "purgerepository" ]

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -364,8 +364,15 @@ let test_gh_irreversible_repo_hosting_ops_denied_under_autonomous () =
          assert (Exec_program.to_string bin = "gh")
        | _ -> Alcotest.failf "%s: expected gh irreversible op to be denied" label)
     [ "gh pr merge", [ "pr"; "merge"; "123"; "--squash" ]
+    ; "gh repo create", [ "repo"; "create"; "owner/new-repo" ]
+    ; "gh repo fork", [ "repo"; "fork"; "owner/repo" ]
     ; "gh repo delete", [ "repo"; "delete"; "owner/repo"; "--yes" ]
+    ; "gh discussion create", [ "discussion"; "create"; "--title"; "T" ]
     ; "gh api delete", [ "api"; "-X"; "DELETE"; "/repos/owner/repo" ]
+    ; "gh graphql createRepository"
+      , [ "api"; "graphql"; "-f"; "query=mutation{createRepository}" ]
+    ; "gh graphql createDiscussion"
+      , [ "api"; "graphql"; "-f"; "query=mutation{createDiscussion}" ]
     ]
 
 let test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous () =

--- a/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
+++ b/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
@@ -19,7 +19,10 @@ let cases : case list = [
   { label = "baseline-pr-list";          input = "pr list --state open";          expected = E_R0 };
   { label = "baseline-pr-create";        input = "pr create --title T";            expected = E_R1 };
   { label = "baseline-pr-merge";         input = "pr merge 123";                   expected = E_R2 };
+  { label = "baseline-repo-create";      input = "repo create owner/new-repo";      expected = E_R2 };
+  { label = "baseline-repo-fork";        input = "repo fork owner/repo";            expected = E_R2 };
   { label = "baseline-repo-delete";      input = "repo delete o/r --yes";          expected = E_R2 };
+  { label = "baseline-discussion-create";input = "discussion create --title T";     expected = E_R2 };
 
   { label = "flag-no-space-XDELETE";     input = "api -XDELETE /repos/o/r";        expected = E_R2 };
   { label = "flag-equals-method";        input = "api --method=DELETE /repos/o/r"; expected = E_R2 };
@@ -32,6 +35,8 @@ let cases : case list = [
 
   { label = "graphql-deletePR";          input = "api graphql -f query=mutation{deletePullRequest}"; expected = E_R2 };
   { label = "graphql-purgeRepository";   input = "api graphql -f query=mutation{purgeRepository}";   expected = E_R2 };
+  { label = "graphql-createRepository";  input = "api graphql -f query=mutation{createRepository}";  expected = E_R2 };
+  { label = "graphql-createDiscussion";  input = "api graphql -f query=mutation{createDiscussion}";  expected = E_R2 };
 
   { label = "double-spaces-merge";       input = "pr  merge  123";                 expected = E_R2 };
   { label = "case-upper-cmd";            input = "PR LIST";                        expected = E_R0 };

--- a/lib/exec/verdict.ml
+++ b/lib/exec/verdict.ml
@@ -80,7 +80,7 @@ let deny_reason_to_string : deny_reason -> string = function
     Format.asprintf "destructive database operation: %a" Db_op.pp op
   | Destructive_repo_hosting_cli bin ->
     Printf.sprintf
-      "destructive repository-hosting CLI operation not permitted: %s"
+      "repository-hosting CLI operation not permitted by policy: %s"
       (Exec_program.to_string bin)
   | Catastrophic_program bin ->
     Printf.sprintf "catastrophic program not permitted: %s"

--- a/lib/exec/verdict.mli
+++ b/lib/exec/verdict.mli
@@ -49,11 +49,12 @@ type deny_reason =
           [sql_destructive] substring patterns (RFC
           eliminate-substring-destructive-classifier §3-A). *)
   | Destructive_repo_hosting_cli of Exec_program.t
-      (** An irreversible repository-hosting CLI operation (for example
-          [gh pr merge], [gh repo delete], or [gh api -X DELETE]).  Part of the
+      (** An irreversible or policy-disabled repository-hosting CLI operation
+          (for example [gh pr merge], [gh repo create], [gh repo delete],
+          [gh discussion create], or [gh api -X DELETE]).  Part of the
           trust-independent catastrophic floor so autonomous keepers cannot
-          mutate remote repository state irreversibly through the generic exec
-          surface. *)
+          mutate remote repository state irreversibly or enter disabled GitHub
+          capability surfaces through the generic exec surface. *)
   | Catastrophic_program of Exec_program.t
       (** A binary that is never legitimate for a keeper regardless of its
           arguments (e.g. the filesystem-format binary, or system-power

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -230,8 +230,6 @@ let test_gh_r1_reversible () =
   check "gh issue edit 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh release create v1.0.0" Shell_ir_risk.R1_Reversible_mutation;
   check "gh release upload v1.0.0 file.tgz" Shell_ir_risk.R1_Reversible_mutation;
-  check "gh repo fork owner/repo" Shell_ir_risk.R1_Reversible_mutation;
-  check "gh repo create repo-name" Shell_ir_risk.R1_Reversible_mutation;
   check "gh run cancel 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh run rerun 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh workflow enable workflow.yml" Shell_ir_risk.R1_Reversible_mutation;
@@ -254,9 +252,14 @@ let test_gh_r1_reversible () =
 let test_gh_r2_irreversible () =
   check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
   check "gh pr ready 123" Shell_ir_risk.R2_Irreversible;
+  check "gh repo create repo-name" Shell_ir_risk.R2_Irreversible;
+  check "gh repo fork owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo archive owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo transfer owner/repo" Shell_ir_risk.R2_Irreversible;
+  check "gh discussion create --repo owner/repo --title T --body B"
+    Shell_ir_risk.R2_Irreversible;
+  check "gh discussion comment 123 --body B" Shell_ir_risk.R2_Irreversible;
   check "gh release delete v1.0.0" Shell_ir_risk.R2_Irreversible;
   check "gh secret delete SECRET" Shell_ir_risk.R2_Irreversible;
   check "gh secret remove SECRET" Shell_ir_risk.R2_Irreversible;
@@ -267,7 +270,14 @@ let test_gh_r2_irreversible () =
   check "gh gist delete 123" Shell_ir_risk.R2_Irreversible;
   check "gh ruleset delete 123" Shell_ir_risk.R2_Irreversible;
   check "gh api repos/owner/repo -X DELETE" Shell_ir_risk.R2_Irreversible;
-  check "gh api repos/owner/repo --method DELETE" Shell_ir_risk.R2_Irreversible
+  check "gh api repos/owner/repo --method DELETE" Shell_ir_risk.R2_Irreversible;
+  check "gh api graphql -f 'query=mutation{createRepository}'" Shell_ir_risk.R2_Irreversible;
+  check "gh api graphql -f 'query=mutation{cloneTemplateRepository}'"
+    Shell_ir_risk.R2_Irreversible;
+  check "gh api graphql -f 'query=mutation{createDiscussion}'"
+    Shell_ir_risk.R2_Irreversible;
+  check "gh api graphql -f 'query=mutation{addDiscussionComment}'"
+    Shell_ir_risk.R2_Irreversible
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- Add a G-WDECIDE decision doc disabling keeper GitHub repo creation and GitHub Discussions mutation.
- Keep GitHub PR/issue work as the supported keeper GitHub affordance, while durable discussion stays on MASC board tools.
- Move `gh repo create/fork`, `gh discussion ...`, and GitHub GraphQL repo/discussion creation mutations into the repo-hosting policy floor.

## Evidence

- `gh auth status --hostname github.com` showed the active operator token still has broad `repo` scope, so scope presence is not the keeper capability decision.
- `gh api graphql -f query='{__schema{mutationType{fields{name}}}}'` confirmed live mutation names including `createRepository`, `cloneTemplateRepository`, `createDiscussion`, and `addDiscussionComment`.
- Duplicate PR search before creation: `gh -R jeong-sik/masc pr list --search "keeper-gh-scope-policy-wave4-20260706 OR \"Disable keeper repo-create discussion surfaces\"" --state all --json number,state,title,headRefName,url --limit 10` -> `[]`.

## Verification

- `ocamlformat --check lib/exec/shell_ir_risk.ml lib/exec/test/test_approval_policy.ml lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml lib/exec/verdict.ml lib/exec/verdict.mli lib/exec/approval_policy.mli test/test_shell_ir_risk.ml`
- `scripts/dune-local.sh build test/test_shell_ir_risk.exe lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.exe lib/exec/test/test_approval_policy.exe`
- `./_build/default/test/test_shell_ir_risk.exe`
- `./_build/default/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.exe`
- `./_build/default/lib/exec/test/test_approval_policy.exe`
- `scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`
- `scripts/dune-local.sh build test/test_keeper_prompt_external.exe`
- `./_build/default/test/test_keeper_prompt_external.exe`
- `git diff --check origin/main..HEAD`