### PR TITLE
fix(board): reclaim orphaned reactions and votes in sweep

### DIFF
--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -150,6 +150,28 @@ let with_persist_lock store f =
 ;;
 
 (** {1 Sweeper - Aggressive Cleanup} *)
+(* Extract [(target_kind, target_id)] from a vote_log key of the form
+   "post:<id>:<voter>" or "comment:<id>:<voter>".  Mirrors
+   [Board_votes.parse_vote_key], but lives in this lower module so [sweep] can
+   reclaim orphaned votes without an upward dependency on [Board_votes]. *)
+let vote_key_target key =
+  match String.index_opt key ':' with
+  | None -> None
+  | Some i1 ->
+    let kind = String.sub key 0 i1 in
+    let rest = String.sub key (i1 + 1) (String.length key - i1 - 1) in
+    (match String.index_opt rest ':' with
+     | None -> None
+     | Some i2 ->
+       let target_id = String.sub rest 0 i2 in
+       if String.equal target_id "" then None
+       else (
+         match kind with
+         | "post" -> Some (`Post, target_id)
+         | "comment" -> Some (`Comment, target_id)
+         | _ -> None))
+;;
+
 let sweep store =
   with_lock store (fun () ->
     let now = Time_compat.now () in
@@ -240,6 +262,50 @@ let sweep store =
                   Stdlib.incr cap_evicted)
                to_evict))
         author_posts);
+    (* Reclaim reactions and votes whose target post/comment no longer exists.
+       [sweep] removes posts/comments but historically left [store.reactions] and
+       [store.vote_log] resident: those two tables were pruned only by the
+       explicit [delete_post] path, not by the TTL lifecycle, so they grew for
+       the whole process lifetime and reloaded whole from disk on boot.  Pruning
+       by target existence reclaims new expirations AND boot-reloaded orphans
+       (whose targets are already gone, so a per-removal hook would never revisit
+       them).  Work is bounded per pass by [sweeper_batch_size] via [Seq.take],
+       so a large backlog drains across sweeps without a long lock hold; disk is
+       compacted by the next full snapshot flush, which dumps the pruned tables. *)
+    let orphan_reaction_keys =
+      Hashtbl.to_seq store.reactions
+      |> Seq.filter_map (fun (key, (reaction : reaction)) ->
+        let target_present =
+          match reaction.target_type with
+          | Reaction_post -> Hashtbl.mem store.posts reaction.target_id
+          | Reaction_comment -> Hashtbl.mem store.comments reaction.target_id
+        in
+        if target_present then None else Some key)
+      |> Seq.take Limits.sweeper_batch_size
+      |> List.of_seq
+    in
+    List.iter (Hashtbl.remove store.reactions) orphan_reaction_keys;
+    let orphan_vote_keys =
+      Hashtbl.to_seq store.vote_log
+      |> Seq.filter_map (fun (key, _) ->
+        match vote_key_target key with
+        | Some (`Post, target_id) when not (Hashtbl.mem store.posts target_id) ->
+          Some key
+        | Some (`Comment, target_id)
+          when not (Hashtbl.mem store.comments target_id) ->
+          Some key
+        | Some _ | None -> None)
+      |> Seq.take Limits.sweeper_batch_size
+      |> List.of_seq
+    in
+    List.iter (Hashtbl.remove store.vote_log) orphan_vote_keys;
+    let removed_reactions = List.length orphan_reaction_keys in
+    let removed_votes = List.length orphan_vote_keys in
+    if removed_reactions > 0 || removed_votes > 0 then
+      Log.BoardLog.debug
+        "sweep reclaimed %d orphaned reactions, %d orphaned votes"
+        removed_reactions
+        removed_votes;
     let window = Stdlib.Float.of_int Limits.comment_rate_window_sec in
     Board_comment_rate_limit.sweep_stale ~now ~window;
     if !removed_posts > 0 || !cap_evicted > 0 then invalidate_post_caches store;

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -111,6 +111,41 @@ let test_sweeper_skips_permanent () =
   let (removed_posts, _) = sweep store in
   Alcotest.(check int) "sweeper removed 0 permanent posts" 0 removed_posts
 
+let test_sweep_reclaims_orphaned_reactions_and_votes () =
+  let store = create_store () in
+  let post_id =
+    match
+      create_post store ~author:"test-agent"
+        ~content:"Post with a reaction and a vote" ~post_kind:Human_post
+        ~ttl_hours:1 ()
+    with
+    | Ok post -> Post_id.to_string post.id
+    | Error e -> Alcotest.fail (show_board_error e)
+  in
+  (match
+     toggle_reaction store ~target_type:Reaction_post ~target_id:post_id
+       ~user_id:"reactor-agent" ~emoji:"👍"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (show_board_error e));
+  (match vote store ~voter:"voter-agent" ~post_id ~direction:Up with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (show_board_error e));
+  Alcotest.(check bool) "reaction present before sweep" true
+    (Hashtbl.length store.reactions > 0);
+  Alcotest.(check bool) "vote present before sweep" true
+    (Hashtbl.length store.vote_log > 0);
+  (* Simulate the post already gone — expired and swept in an earlier pass, or
+     reloaded as an orphan on boot.  A per-removal hook could never revisit its
+     reactions/votes because the post is no longer in [store.posts]; the
+     existence-based reclaim in [sweep] must still collect them. *)
+  Hashtbl.remove store.posts post_id;
+  let _ = sweep store in
+  Alcotest.(check int) "orphaned reactions reclaimed" 0
+    (Hashtbl.length store.reactions);
+  Alcotest.(check int) "orphaned votes reclaimed" 0
+    (Hashtbl.length store.vote_log)
+
 let schedule_reset_timestamp_for_test = 0.0
 
 let reset_sweep_schedule_for_test =
@@ -305,6 +340,9 @@ let () =
             (with_eio test_expiring_post);
           Alcotest.test_case "sweeper skips permanent" `Quick
             (with_eio test_sweeper_skips_permanent);
+          Alcotest.test_case "sweep reclaims orphaned reactions and votes"
+            `Quick
+            (with_eio test_sweep_reclaims_orphaned_reactions_and_votes);
           Alcotest.test_case "maybe_sweep schedules once" `Quick
             (with_eio test_maybe_sweep_updates_schedule_once);
           Alcotest.test_case "maybe_sweep concurrent schedules once" `Quick


### PR DESCRIPTION
## Context
대시보드 개별 채팅을 여러 개(≈5+) 열거나 IDE를 켜면 서버 퍼포먼스가 급락하는 문제("하나가 멈추면 전부 멈춤")를 소스 5-렌즈 조사 + 적대 검증 + 라이브 런타임 측정으로 규명한 후속 작업입니다.

- 급성 원인(세션당 delta 재직렬화의 단일 도메인 독점)은 이미 **#23339**로 머지·배포됨.
- 남은 원인은 두 갈래로 확인됨: (1) diffuse minor-GC churn (JSON 파싱 + metric 인코딩, `bin/main_eio.ml:969-972`의 자체 프로파일링 주석이 지목), (2) 상시 live-heap retention(~1.2GB). 라이브 측정: `live_words` 1.0–1.3GB, minor GC ~66/s.

이 PR은 (2) retention의 **확인된 구성요소 하나**를 근본 수정합니다.

## Problem
`sweep`(`lib/board/board_core_persist.ml`)은 만료된 post/comment는 제거하지만 그 **reactions / vote_log 항목은 그대로 남깁니다**. 이 두 테이블은 명시적 `delete_post` 경로에서만 정리되고 TTL 라이프사이클에서는 정리되지 않아, 만료된 post의 reactions/votes가 프로세스 수명 내내 누적되고 부팅 시 disk에서 통째로 다시 로드됩니다(`load_persisted_reactions` / `load_persisted_votes`는 모든 행을 무조건 로드). 무한 in-memory 누수로, steady-state live-heap과 단일 이벤트 루프 도메인의 major-GC 압력에 기여합니다.

## Change
`sweep`에 **존재 기반(existence-based) reclaim pass** 추가:
- target post/comment가 `store.posts` / `store.comments`에 없는 reaction 제거.
- 파싱한 target이 사라진 `vote_log` 항목 제거(`vote_key_target` 헬퍼로 `kind:target_id:voter` 파싱, `Board_votes.parse_vote_key`와 동형이나 상위 의존을 피하려 하위 모듈에 인라인).
- **per-removal 훅이 아니라 존재 기반**이라, 부팅 시 재로드된 orphan(이미 target이 없어 per-removal 훅이 재방문 불가)까지 정리.
- pass당 작업량은 `Seq.take Limits.sweeper_batch_size`로 제한 → 대량 백로그가 긴 락 점유 없이 여러 sweep에 걸쳐 배수됨. disk 파일은 다음 full snapshot flush가 pruned in-memory 테이블을 덤프하며 compact.

## Impact
- 3 files: `lib/board/board_core_persist.ml`(+헬퍼/prune), `test/test_board_ttl.ml`(신규 테스트).
- 동작 변경 없음(만료된 post의 데드 데이터만 정리). 와이어 프로토콜·API 불변.
- 새 stall 유발 없음: bounded visit, sweep은 기존과 동일 주기(`sweeper_interval_sec`).

## Test
`test_board_ttl`에 `sweep reclaims orphaned reactions and votes` 추가: post에 reaction+vote를 달고, post를 직접 제거해 이미 사라진/부팅 재로드 orphan을 시뮬레이션한 뒤 sweep가 둘 다 reclaim하는지 검증. **board TTL 17/17 통과**. `dune build` lib/board + test 성공, ocamlformat clean.

## Scope / non-goals
- 이 PR은 retention의 **한 구성요소**(board reactions/vote_log 무한 누수) fix입니다. 규모는 fleet 활동에 비례하며 지배적 원인은 아닙니다. 남은 dominant 원인 두 가지는 별도 후속:
  - diffuse churn: metric 인코딩 hot path(`otel_metric_store_core`가 호출당 Buffer 2 + 문자열 2 할당) + Yojson 트리 빌드. 프로파일(`Gc.Memprof`) 기반 후속 PR 권장.
  - 나머지 ~1GB retention의 소스는 미확정(추가 조사 필요).
- 참고: 조사 중 발견한 main 빌드 파손(#23353 fallout)은 이미 **#23356 / #23358**로 복구됨(본 브랜치는 그 위에 rebase).

RFC-WAIVED: board persistence 정리 로직으로 credential/identity/operator/sandbox/hooks 경계 비해당(agent_delegation 목록 밖). 워크어라운드 시그니처 비해당 — 무한 누수의 근본 수정(sweep이 만료 target의 파생 데이터도 정리하도록 불변식 복원)이며 telemetry/string-classifier/N-of-M/cap 패턴 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
