### PR TITLE
Fix pre-dispatch receipt boundary

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -211,6 +211,7 @@ let clock_lane_of_event = function
   | Turn_finished ->
     "keeper"
   | Runtime_routed
+  | Runtime_execution_built
   | Runtime_completed
   | Runtime_failed
   | Provider_lane_resolved ->
@@ -381,6 +382,7 @@ let decision_public_allowlist =
     ; "context_compact_started_count"; "context_compacted_count"
     ; "last_compaction"; "active_open_loop_count"
     ; "routing_action"; "routing_reason"; "degraded_runtime_id"
+    ; "runtime_execution_built"
     ; "media_dropped_total"; "media_dropped_counts"
     ; "clock_refs"
     ]

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -3,6 +3,7 @@ type event_kind =
     Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_execution_built
   | Runtime_completed
   | Runtime_failed
   | Pre_dispatch_blocked

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -202,17 +202,22 @@ let run_keeper_cycle
               (Keeper_turn_fsm.Failed failure_reason);
             Error err, turn_state
           | Ok initial_execution ->
-            record_pre_dispatch_terminal_observation
-              ~config
-              ~meta
-              ~generation
-              ~runtime_id:effective_runtime_runtime_name
-              ~outcome:`Ok
-              ~terminal_reason_code:"pre_dispatch_success"
-              ~activity_kind:"keeper.turn_pre_dispatch_ok"
-              ~trajectory_outcome:Trajectory.Completed
-              ~keeper_turn_id
-              ();
+            let turn_state =
+              Keeper_unified_turn_manifest.append_manifest
+                ~config
+                ~runtime_manifest_context
+                ~turn_start
+                ~turn_state
+                ~site:"runtime_execution_built"
+                ~runtime_id:effective_runtime_runtime_name
+                ~decision:
+                  (`Assoc
+                    [ "runtime_execution_built", `Bool true
+                    ; "routing_action", `String "runtime_execution_built"
+                    ; "routing_reason", `String "pre_dispatch_success"
+                    ])
+                Keeper_runtime_manifest.Runtime_execution_built
+            in
             Keeper_event_publisher.publish_runtime_execution_built
               ~keeper_name:meta.name
               ~runtime_id:initial_execution.runtime_id

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -9,6 +9,7 @@ type event_kind =
   | Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_execution_built
   | Runtime_completed
   | Runtime_failed
   | Pre_dispatch_blocked
@@ -30,6 +31,7 @@ let all_event_kinds =
     Turn_started;
     Phase_gate_decided;
     Runtime_routed;
+    Runtime_execution_built;
     Runtime_completed;
     Runtime_failed;
     Pre_dispatch_blocked;
@@ -51,6 +53,7 @@ let event_kind_to_string = function
   | Turn_started -> "turn_started"
   | Phase_gate_decided -> "phase_gate_decided"
   | Runtime_routed -> "runtime_routed"
+  | Runtime_execution_built -> "runtime_execution_built"
   | Runtime_completed -> "runtime_completed"
   | Runtime_failed -> "runtime_failed"
   | Pre_dispatch_blocked -> "pre_dispatch_blocked"
@@ -71,6 +74,7 @@ let event_kind_of_string = function
   | "turn_started" -> Some Turn_started
   | "phase_gate_decided" -> Some Phase_gate_decided
   | "runtime_routed" -> Some Runtime_routed
+  | "runtime_execution_built" -> Some Runtime_execution_built
   | "runtime_completed" -> Some Runtime_completed
   | "runtime_failed" -> Some Runtime_failed
   | "pre_dispatch_blocked" -> Some Pre_dispatch_blocked
@@ -113,6 +117,7 @@ let classify_compaction_snapshot_typed_event = function
   | Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_execution_built
   | Runtime_completed
   | Runtime_failed
   | Pre_dispatch_blocked

--- a/lib/keeper_registry/keeper_runtime_manifest_types.mli
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.mli
@@ -2,6 +2,7 @@ type event_kind =
     Turn_started
   | Phase_gate_decided
   | Runtime_routed
+  | Runtime_execution_built
   | Runtime_completed
   | Runtime_failed
   | Pre_dispatch_blocked

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -84,6 +84,7 @@ let event_started_at row =
   | Keeper_runtime_manifest.Turn_started
   | Keeper_runtime_manifest.Phase_gate_decided
   | Keeper_runtime_manifest.Runtime_routed
+  | Keeper_runtime_manifest.Runtime_execution_built
   | Keeper_runtime_manifest.Provider_lane_resolved
   | Keeper_runtime_manifest.Provider_attempt_started
   | Keeper_runtime_manifest.Context_injected
@@ -117,6 +118,7 @@ let event_finished_at row =
   | Keeper_runtime_manifest.Turn_started
   | Keeper_runtime_manifest.Phase_gate_decided
   | Keeper_runtime_manifest.Runtime_routed
+  | Keeper_runtime_manifest.Runtime_execution_built
   | Keeper_runtime_manifest.Provider_lane_resolved
   | Keeper_runtime_manifest.Provider_attempt_started
   | Keeper_runtime_manifest.Context_injected

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -145,6 +145,7 @@ let event_lane = function
   | Keeper_runtime_manifest.Turn_finished ->
     "keeper"
   | Keeper_runtime_manifest.Runtime_routed
+  | Keeper_runtime_manifest.Runtime_execution_built
   | Keeper_runtime_manifest.Runtime_completed
   | Keeper_runtime_manifest.Runtime_failed
   | Keeper_runtime_manifest.Provider_lane_resolved ->

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -5304,6 +5304,7 @@ let expected_compaction_snapshot_event_class = function
   | Runtime_manifest.Turn_started
   | Runtime_manifest.Phase_gate_decided
   | Runtime_manifest.Runtime_routed
+  | Runtime_manifest.Runtime_execution_built
   | Runtime_manifest.Runtime_completed
   | Runtime_manifest.Runtime_failed
   | Runtime_manifest.Pre_dispatch_blocked

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -61,15 +61,28 @@ let test_is_finished_turn () =
     [ manifest ~event:M.Turn_started
         ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
         ~links:(links ())
+    ; manifest ~event:M.Runtime_execution_built
+        ~decision:(clock_refs [ ("edge_id", `String "e2"); ("lane", `String "L1") ])
+        ~links:(links ())
     ; manifest ~event:M.Turn_finished
-        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~decision:(clock_refs [ ("edge_id", `String "e3"); ("lane", `String "L1") ])
         ~links:(links ())
     ]
   in
   Alcotest.(check bool) "turn with Turn_finished is finished" true
     (M.is_finished_turn manifests);
-  Alcotest.(check bool) "turn without Turn_finished is not finished" false
-    (M.is_finished_turn [ List.hd manifests ])
+  let pre_dispatch_ready =
+    [ manifest ~event:M.Turn_started
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ())
+    ; manifest ~event:M.Runtime_execution_built
+        ~decision:(clock_refs [ ("edge_id", `String "e2"); ("lane", `String "L1") ])
+        ~links:(links ())
+    ]
+  in
+  Alcotest.(check bool)
+    "runtime execution built is not a terminal turn" false
+    (M.is_finished_turn pre_dispatch_ready)
 
 let test_is_complete_turn () =
   let finished_only =


### PR DESCRIPTION
## Summary
- stop writing successful pre-dispatch readiness as a terminal execution receipt
- add typed `Runtime_execution_built` manifest event for the successful runtime execution build boundary
- keep real early-terminal paths (`pre_dispatch_*` failures, phase gate, livelock) on the existing terminal receipt path

## Live Evidence
- `taskmaster` wrote `pre_dispatch_success` / `receipt_appended` / `turn_finished` at 2026-07-06T01:29:37Z for keeper_turn_id=1733
- the same turn continued producing runtime manifest `context_injected` events through 2026-07-06T01:48:34Z, oas_turn_count=7821
- raw trace kept updating while the execution receipt file stayed at the pre-dispatch timestamp

## Validation
- `ocamlformat --check lib/keeper_registry/keeper_runtime_manifest_types.ml lib/keeper_registry/keeper_runtime_manifest_types.mli lib/keeper/keeper_runtime_manifest.ml lib/keeper/keeper_runtime_manifest_housekeeping.mli lib/keeper/keeper_unified_turn.ml lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml test/test_keeper_memory_os.ml test/test_keeper_runtime_manifest_completeness.ml`
- `git diff --check`
- `gtimeout 240 scripts/dune-local.sh build test/test_keeper_runtime_manifest_completeness.exe test/test_keeper_memory_os.exe`
- `gtimeout 120 _build/default/test/test_keeper_runtime_manifest_completeness.exe`