### PR TITLE
keeper: preserve replay snapshot provenance

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -165,6 +165,7 @@ let canonical_success_replay_checkpoint
       ~(session_id : string)
       ~(response_text : string)
       ~(state_snapshot : Keeper_memory_policy.keeper_state_snapshot option)
+      ~(state_snapshot_source : Keeper_memory_policy.state_snapshot_source)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   if messages_prefix_equal history_messages checkpoint.Agent_sdk.Checkpoint.messages
@@ -208,6 +209,7 @@ let canonical_success_replay_checkpoint
           ~session_id
           ~response_text
           ?snapshot:state_snapshot
+          ~snapshot_source:state_snapshot_source
     in
     Ok
       ( checkpoint
@@ -258,6 +260,7 @@ let checkpoint_for_replay_persistence
       ~session_id
       ~response_text
       ~state_snapshot
+      ~state_snapshot_source
       checkpoint
 ;;
 
@@ -404,6 +407,7 @@ let finalize
            ~metadata:
              [ ( Keeper_memory_policy.replay_metadata_key
                , Keeper_memory_policy.replay_metadata_of_snapshot
+                   ~state_snapshot_source
                    state_snapshot )
              ]
            [ Agent_sdk.Types.Text replay_response_text ])

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -820,12 +820,22 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     writes keep the checkpoint [working_context] empty. *)
 let patch_checkpoint_last_assistant
     ?snapshot
+    ?snapshot_source
     (cp : Agent_sdk.Checkpoint.t) ~session_id ~response_text
   : Agent_sdk.Checkpoint.t =
-  let snapshot =
+  let snapshot, snapshot_source =
     match snapshot with
-    | Some snapshot -> Some snapshot
-    | None -> Keeper_memory_policy.parse_state_snapshot_from_reply response_text
+    | Some snapshot -> Some snapshot, snapshot_source
+    | None ->
+        (match Keeper_memory_policy.parse_state_snapshot_from_reply response_text with
+         | Some snapshot ->
+             let snapshot_source =
+               match snapshot_source with
+               | Some source -> Some source
+               | None -> Some Keeper_memory_policy.State_block
+             in
+             Some snapshot, snapshot_source
+         | None -> None, None)
   in
   let visible_response_text =
     match snapshot with
@@ -838,7 +848,9 @@ let patch_checkpoint_last_assistant
       | Some snapshot ->
           [
             ( Keeper_memory_policy.replay_metadata_key,
-              Keeper_memory_policy.replay_metadata_of_snapshot snapshot );
+              Keeper_memory_policy.replay_metadata_of_snapshot
+                ?state_snapshot_source:snapshot_source
+                snapshot );
           ]
       | None -> []
     in

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -272,6 +272,7 @@ val load_context_from_checkpoint :
     text (state blocks stripped). *)
 val patch_checkpoint_last_assistant :
   ?snapshot:Keeper_memory_policy.keeper_state_snapshot ->
+  ?snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   Agent_sdk.Checkpoint.t ->
   session_id:string ->
   response_text:string ->

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -163,10 +163,14 @@ val keeper_state_snapshot_of_json :
   Yojson.Safe.t -> keeper_state_snapshot option
 val structured_working_context_of_snapshot :
   keeper_state_snapshot -> Yojson.Safe.t
-val replay_metadata_of_snapshot : keeper_state_snapshot -> Yojson.Safe.t
+val replay_metadata_of_snapshot :
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
+  keeper_state_snapshot ->
+  Yojson.Safe.t
 val snapshot_of_replay_metadata :
   Yojson.Safe.t -> keeper_state_snapshot option
 val with_snapshot_metadata :
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   Agent_sdk.Types.message ->
   keeper_state_snapshot -> Agent_sdk.Types.message
 val snapshot_of_message_metadata :

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -138,10 +138,14 @@ val keeper_state_snapshot_of_json :
   Yojson.Safe.t -> keeper_state_snapshot option
 val structured_working_context_of_snapshot :
   keeper_state_snapshot -> Yojson.Safe.t
-val replay_metadata_of_snapshot : keeper_state_snapshot -> Yojson.Safe.t
+val replay_metadata_of_snapshot :
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
+  keeper_state_snapshot ->
+  Yojson.Safe.t
 val snapshot_of_replay_metadata :
   Yojson.Safe.t -> keeper_state_snapshot option
 val with_snapshot_metadata :
+  ?state_snapshot_source:Keeper_memory_policy.state_snapshot_source ->
   Agent_sdk.Types.message -> keeper_state_snapshot -> Agent_sdk.Types.message
 val snapshot_of_message_metadata :
   Agent_sdk.Types.message -> keeper_state_snapshot option

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -712,13 +712,27 @@ let structured_working_context_of_snapshot
     ("state_snapshot", keeper_state_snapshot_to_json snapshot);
   ]
 
+let replay_metadata_provenance_fields = function
+  | None -> []
+  | Some state_snapshot_source ->
+      let synthetic = state_snapshot_source_is_synthetic state_snapshot_source in
+      [
+        ("state_snapshot_source", `String (state_snapshot_source_to_string state_snapshot_source));
+        ("state_snapshot_synthetic", `Bool synthetic);
+        ("state_snapshot_live_observation", `Bool (not synthetic));
+        ("state_snapshot_model_authored", `Bool (not synthetic));
+      ]
+
 let replay_metadata_of_snapshot
+    ?state_snapshot_source
     (snapshot : keeper_state_snapshot) : Yojson.Safe.t =
-  `Assoc [
-    ("kind", `String replay_metadata_kind);
-    ("version", `Int replay_metadata_version);
-    ("payload", keeper_state_snapshot_to_json snapshot);
-  ]
+  `Assoc
+    ([
+       ("kind", `String replay_metadata_kind);
+       ("version", `Int replay_metadata_version);
+       ("payload", keeper_state_snapshot_to_json snapshot);
+     ]
+     @ replay_metadata_provenance_fields state_snapshot_source)
 
 let snapshot_of_replay_metadata
     (json : Yojson.Safe.t) : keeper_state_snapshot option =
@@ -732,10 +746,12 @@ let snapshot_of_replay_metadata
   | _ -> None
 
 let with_snapshot_metadata
+    ?state_snapshot_source
     (msg : Agent_sdk.Types.message)
     (snapshot : keeper_state_snapshot) : Agent_sdk.Types.message =
   let metadata =
-    (replay_metadata_key, replay_metadata_of_snapshot snapshot)
+    ( replay_metadata_key,
+      replay_metadata_of_snapshot ?state_snapshot_source snapshot )
     :: List.remove_assoc replay_metadata_key msg.metadata
   in
   { msg with metadata }

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -316,15 +316,22 @@ val structured_working_context_of_snapshot :
   keeper_state_snapshot -> Yojson.Safe.t
 (** JSON shape consumed by the dashboard's working-context panel. *)
 
-val replay_metadata_of_snapshot : keeper_state_snapshot -> Yojson.Safe.t
+val replay_metadata_of_snapshot :
+  ?state_snapshot_source:state_snapshot_source ->
+  keeper_state_snapshot ->
+  Yojson.Safe.t
 (** JSON metadata blob attached to assistant messages so a fresh
-    keeper can hydrate the snapshot from message history. *)
+    keeper can hydrate the snapshot from message history. When the producer
+    knows the snapshot source, the metadata also carries explicit provenance
+    fields so synthetic snapshots cannot be mistaken for live model-authored
+    state. *)
 
 val snapshot_of_replay_metadata :
   Yojson.Safe.t -> keeper_state_snapshot option
 (** Inverse of [replay_metadata_of_snapshot]. *)
 
 val with_snapshot_metadata :
+  ?state_snapshot_source:state_snapshot_source ->
   Agent_sdk.Types.message ->
   keeper_state_snapshot -> Agent_sdk.Types.message
 (** Attach replay metadata to an assistant message. *)

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -27,6 +27,23 @@ let contains_substring text needle =
   in
   loop 0
 
+let json_string_field key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`String value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let json_bool_field key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`Bool value) -> Some value
+       | _ -> None)
+  | _ -> None
+
+let replay_metadata_of_message (msg : Agent_sdk.Types.message) =
+  List.assoc_opt KMP.replay_metadata_key msg.metadata
+
 (* ── Round-trip tests ────────────────────────────────────────────── *)
 
 let make_snapshot
@@ -123,6 +140,48 @@ let test_envelope_empty_snapshot_returns_none () =
   ] in
   let restored = KMP.snapshot_of_structured_working_context json in
   Alcotest.(check bool) "empty snapshot in envelope -> None" true (restored = None)
+
+let test_replay_metadata_marks_synthesized_snapshot_non_live () =
+  let snapshot =
+    make_snapshot
+      ~goal:(Some "Recover scheduler state")
+      ~progress:None
+      ~done_summary:None
+      ~next_summary:None
+      ~next_items:[]
+      ~decisions:[]
+      ~open_questions:[]
+      ~constraints:[]
+      ()
+  in
+  let metadata =
+    KMP.replay_metadata_of_snapshot
+      ~state_snapshot_source:KMP.Synthesized
+      snapshot
+  in
+  Alcotest.(check (option string))
+    "source"
+    (Some "synthesized")
+    (json_string_field "state_snapshot_source" metadata);
+  Alcotest.(check (option bool))
+    "synthetic"
+    (Some true)
+    (json_bool_field "state_snapshot_synthetic" metadata);
+  Alcotest.(check (option bool))
+    "live observation"
+    (Some false)
+    (json_bool_field "state_snapshot_live_observation" metadata);
+  Alcotest.(check (option bool))
+    "model authored"
+    (Some false)
+    (json_bool_field "state_snapshot_model_authored" metadata);
+  match KMP.snapshot_of_replay_metadata metadata with
+  | None -> Alcotest.fail "metadata payload no longer hydrates"
+  | Some hydrated ->
+      Alcotest.(check (option string))
+        "payload still hydrates"
+        snapshot.goal
+        hydrated.goal
 
 let test_structured_state_schema_parse_raw_snapshot_json () =
   let json =
@@ -373,6 +432,25 @@ let test_patch_stores_replay_metadata_and_clears_working_context () =
   match List.rev patched.messages with
   | [] -> Alcotest.fail "patched checkpoint has no messages"
   | last :: _ ->
+      (match replay_metadata_of_message last with
+       | None -> Alcotest.fail "assistant message missing raw replay metadata"
+       | Some metadata ->
+           Alcotest.(check (option string))
+             "metadata source"
+             (Some "model_state_block")
+             (json_string_field "state_snapshot_source" metadata);
+           Alcotest.(check (option bool))
+             "metadata synthetic"
+             (Some false)
+             (json_bool_field "state_snapshot_synthetic" metadata);
+           Alcotest.(check (option bool))
+             "metadata live observation"
+             (Some true)
+             (json_bool_field "state_snapshot_live_observation" metadata);
+           Alcotest.(check (option bool))
+             "metadata model authored"
+             (Some true)
+             (json_bool_field "state_snapshot_model_authored" metadata));
       (match KMP.snapshot_of_message_metadata last with
        | None -> Alcotest.fail "assistant message metadata missing replay snapshot"
        | Some snap ->
@@ -1295,6 +1373,10 @@ let () =
             "schema parses raw snapshot json"
             `Quick
             test_structured_state_schema_parse_raw_snapshot_json;
+          Alcotest.test_case
+            "replay metadata marks synthesized non-live"
+            `Quick
+            test_replay_metadata_marks_synthesized_snapshot_non_live;
           Alcotest.test_case
             "reply parser accepts fenced envelope"
             `Quick


### PR DESCRIPTION
## Summary

- add typed replay snapshot provenance fields when a producer knows the snapshot source
- pass snapshot source through checkpoint patching and finalizer replay metadata
- cover synthesized snapshots as non-live/non-model-authored metadata while keeping payload hydration backward-compatible

## Validation

- `opam exec -- ocamlformat --check lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_policy.mli lib/keeper/keeper_memory_bank.mli lib/keeper/keeper_memory_bank_selection.mli lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core.mli lib/keeper/keeper_agent_run_finalize_response.ml test/test_keeper_state_snapshot_json.ml`
- `scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe`
- `scripts/dune-local.sh exec test/test_keeper_state_snapshot_json.exe` (45 tests)
- `git diff --check origin/main..HEAD`

Part of #23309 / task-1823.
