### PR TITLE
fix: surface scheduler live evidence contract gap

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1068,6 +1068,27 @@ describe('ScheduledAutomationPanel', () => {
     }
   })
 
+  it('renders an explicit contract gap when live supported evidence is absent', () => {
+    const auto = payloadSupportAutomation()
+    delete auto.live_supported_non_terminal_evidence
+
+    for (const variant of [undefined, 'v2'] as const) {
+      render(null, container)
+      render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
+
+      const evidence = container.querySelector('[data-schedule-live-supported-evidence="projection_contract_missing"]')
+      expect(evidence).not.toBeNull()
+      expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('0')
+      expect(evidence?.getAttribute('data-schedule-live-supported-source')).toBe('schedule_store')
+      expect(evidence?.getAttribute('data-schedule-live-supported-schema')).toBe('missing')
+      expect(evidence?.textContent).toContain('projection contract missing')
+      expect(evidence?.textContent).toContain('live_supported_non_terminal_evidence')
+      expect(evidence?.textContent).toContain('matched_supported_non_terminal')
+      expect(evidence?.textContent).toContain('unproven')
+      expect(evidence?.textContent).toContain('3')
+    }
+  })
+
   it('renders matched live supported non-terminal evidence and opens matched rows', async () => {
     const auto = automation([
       request({

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1388,13 +1388,49 @@ function liveSupportedEvidenceBannerClass(status: LiveSupportedEvidenceStatus): 
 }
 
 function SchLiveSupportedEvidence({
+  automation,
   evidence,
   onOpen,
 }: {
+  automation: DashboardScheduledAutomation
   evidence: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence | null | undefined
   onOpen: (scheduleId: string) => void
 }) {
-  if (!evidence) return null
+  if (!evidence) {
+    const requestCount = automation.request_count ?? automation.requests?.length ?? 0
+    return html`
+      <section
+        class="sch-banner payload warn"
+        data-schedule-live-supported-evidence="projection_contract_missing"
+        data-schedule-live-supported-count="0"
+        data-schedule-live-supported-source=${automation.source ?? 'dashboard_response'}
+        data-schedule-live-supported-schema="missing"
+      >
+        <span class="sch-banner-ico">!</span>
+        <div class="sch-banner-txt">
+          <div>
+            <b>live supported scheduler evidence</b>
+            <span class="mono"> projection contract missing</span>
+          </div>
+          <div class="sch-banner-sub">
+            <span class="mono">live_supported_non_terminal_evidence</span>
+            was absent from the dashboard response; production-base
+            <span class="mono">matched_supported_non_terminal</span> is unproven.
+          </div>
+          <div class="sch-evidence-counts" aria-label="Live supported scheduler contract gap counts">
+            <span class="sch-evidence-count">
+              <span>requests</span>
+              <span class="mono">${requestCount.toLocaleString()}</span>
+            </span>
+            <span class="sch-evidence-count">
+              <span>contract</span>
+              <span class="mono">missing</span>
+            </span>
+          </div>
+        </div>
+      </section>
+    `
+  }
   const matchedIds = evidence.matched_schedule_ids ?? []
   const status = evidence.projection_status
   return html`
@@ -1829,6 +1865,7 @@ function SchedulePrototypeSurface({
         onOpen=${setSelectedScheduleId}
       />
       <${SchLiveSupportedEvidence}
+        automation=${automation}
         evidence=${automation.live_supported_non_terminal_evidence ?? null}
         onOpen=${setSelectedScheduleId}
       />
@@ -2184,6 +2221,7 @@ export function ScheduledAutomationPanel({
         : null}
 
       <${SchLiveSupportedEvidence}
+        automation=${automation}
         evidence=${automation.live_supported_non_terminal_evidence ?? null}
         onOpen=${setSelectedScheduleId}
       />


### PR DESCRIPTION
## Summary
- render an explicit scheduler live-supported evidence banner when `live_supported_non_terminal_evidence` is absent from the dashboard response
- mark production-base `matched_supported_non_terminal` as unproven instead of silently hiding the evidence panel
- add a regression for both classic and v2 scheduled automation panels

## Validation
- `pnpm install --frozen-lockfile` in `dashboard/`
- `pnpm vitest run src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/tools/scheduled-automation-panel.ts src/components/tools/scheduled-automation-panel.test.ts`
- `env GITHUB_BASE_REF=codex/scheduler-live-supported-contract-v2-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check codex/scheduler-live-supported-contract-v2-20260706...HEAD`