### PR TITLE
fix: verify scheduler live evidence rows

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1068,6 +1068,27 @@ describe('ScheduledAutomationPanel', () => {
     }
   })
 
+  it('renders an explicit contract gap when live supported evidence is absent', () => {
+    const auto = payloadSupportAutomation()
+    delete auto.live_supported_non_terminal_evidence
+
+    for (const variant of [undefined, 'v2'] as const) {
+      render(null, container)
+      render(html`<${ScheduledAutomationPanel} automation=${auto} variant=${variant} />`, container)
+
+      const evidence = container.querySelector('[data-schedule-live-supported-evidence="projection_contract_missing"]')
+      expect(evidence).not.toBeNull()
+      expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('0')
+      expect(evidence?.getAttribute('data-schedule-live-supported-source')).toBe('schedule_store')
+      expect(evidence?.getAttribute('data-schedule-live-supported-schema')).toBe('missing')
+      expect(evidence?.textContent).toContain('projection contract missing')
+      expect(evidence?.textContent).toContain('live_supported_non_terminal_evidence')
+      expect(evidence?.textContent).toContain('matched_supported_non_terminal')
+      expect(evidence?.textContent).toContain('unproven')
+      expect(evidence?.textContent).toContain('3')
+    }
+  })
+
   it('renders matched live supported non-terminal evidence and opens matched rows', async () => {
     const auto = automation([
       request({

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1124,11 +1124,58 @@ describe('ScheduledAutomationPanel', () => {
     expect(evidence).not.toBeNull()
     expect(evidence?.getAttribute('data-schedule-live-supported-count')).toBe('1')
     expect(evidence?.textContent).toContain('matched supported non-terminal')
+    const integrity = container.querySelector('[data-schedule-live-supported-row-integrity="matched_rows_verified"]')
+    expect(integrity).not.toBeNull()
+    expect(integrity?.getAttribute('data-schedule-live-supported-row-integrity-count')).toBe('1')
     const open = container.querySelector('[data-schedule-live-supported-open="sched-supported-live"]') as HTMLButtonElement
     expect(open).not.toBeNull()
     open.click()
     await Promise.resolve()
     expect(container.querySelector('[data-schedule-detail-panel="sched-supported-live"]')).not.toBeNull()
+  })
+
+  it('renders a mismatch when matched live evidence contradicts response rows', () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-unsupported-row',
+        execution_readiness: 'scheduled',
+        payload_kind: 'orphan_auto_release',
+        payload_support: 'unsupported',
+      }),
+      request({
+        schedule_id: 'sched-terminal-row',
+        execution_readiness: 'terminal',
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+      }),
+    ])
+    auto.live_supported_non_terminal_evidence = {
+      schema: 'masc.dashboard.scheduled_automation.live_supported_non_terminal_evidence.v1',
+      source: 'schedule_store',
+      projection_status: 'matched_supported_non_terminal',
+      criteria: 'payload_support=supported && execution_readiness not in {terminal,expired}',
+      reason: 'live schedule_store contains supported rows whose readiness is not terminal or expired',
+      request_count: 2,
+      supported_request_count: 1,
+      supported_non_terminal_count: 1,
+      supported_live_count: 1,
+      supported_terminal_or_expired_count: 1,
+      unsupported_request_count: 1,
+      unknown_request_count: 0,
+      terminal_or_expired_count: 1,
+      matched_schedule_ids: ['sched-unsupported-row', 'sched-terminal-row', 'sched-missing-row'],
+      matched_schedule_id_limit: 8,
+    }
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const mismatch = container.querySelector('[data-schedule-live-supported-row-integrity="matched_row_mismatch"]')
+    expect(mismatch).not.toBeNull()
+    expect(mismatch?.getAttribute('data-schedule-live-supported-row-integrity-count')).toBe('3')
+    expect(mismatch?.textContent).toContain('sched-unsupported-row:payload_support_not_supported')
+    expect(mismatch?.textContent).toContain('sched-terminal-row:execution_readiness_terminal_or_expired')
+    expect(mismatch?.textContent).toContain('sched-missing-row:missing_request_row')
+    expect(container.querySelector('[data-schedule-live-supported-row-integrity="matched_rows_verified"]')).toBeNull()
   })
 
   it('uses explicit ready and terminal status matching', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1388,13 +1388,49 @@ function liveSupportedEvidenceBannerClass(status: LiveSupportedEvidenceStatus): 
 }
 
 function SchLiveSupportedEvidence({
+  automation,
   evidence,
   onOpen,
 }: {
+  automation: DashboardScheduledAutomation
   evidence: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence | null | undefined
   onOpen: (scheduleId: string) => void
 }) {
-  if (!evidence) return null
+  if (!evidence) {
+    const requestCount = automation.request_count ?? automation.requests?.length ?? 0
+    return html`
+      <section
+        class="sch-banner payload warn"
+        data-schedule-live-supported-evidence="projection_contract_missing"
+        data-schedule-live-supported-count="0"
+        data-schedule-live-supported-source=${automation.source ?? 'dashboard_response'}
+        data-schedule-live-supported-schema="missing"
+      >
+        <span class="sch-banner-ico">!</span>
+        <div class="sch-banner-txt">
+          <div>
+            <b>live supported scheduler evidence</b>
+            <span class="mono"> projection contract missing</span>
+          </div>
+          <div class="sch-banner-sub">
+            <span class="mono">live_supported_non_terminal_evidence</span>
+            was absent from the dashboard response; production-base
+            <span class="mono">matched_supported_non_terminal</span> is unproven.
+          </div>
+          <div class="sch-evidence-counts" aria-label="Live supported scheduler contract gap counts">
+            <span class="sch-evidence-count">
+              <span>requests</span>
+              <span class="mono">${requestCount.toLocaleString()}</span>
+            </span>
+            <span class="sch-evidence-count">
+              <span>contract</span>
+              <span class="mono">missing</span>
+            </span>
+          </div>
+        </div>
+      </section>
+    `
+  }
   const matchedIds = evidence.matched_schedule_ids ?? []
   const status = evidence.projection_status
   return html`
@@ -1829,6 +1865,7 @@ function SchedulePrototypeSurface({
         onOpen=${setSelectedScheduleId}
       />
       <${SchLiveSupportedEvidence}
+        automation=${automation}
         evidence=${automation.live_supported_non_terminal_evidence ?? null}
         onOpen=${setSelectedScheduleId}
       />
@@ -2184,6 +2221,7 @@ export function ScheduledAutomationPanel({
         : null}
 
       <${SchLiveSupportedEvidence}
+        automation=${automation}
         evidence=${automation.live_supported_non_terminal_evidence ?? null}
         onOpen=${setSelectedScheduleId}
       />

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1387,6 +1387,51 @@ function liveSupportedEvidenceBannerClass(status: LiveSupportedEvidenceStatus): 
   }
 }
 
+type LiveSupportedMatchedRowIntegrity =
+  | { status: 'not_applicable' }
+  | { status: 'matched_rows_verified'; matchedCount: number }
+  | {
+      status: 'matched_row_mismatch'
+      mismatches: Array<{ scheduleId: string; reason: string }>
+    }
+
+function liveSupportedReadinessIsTerminalOrExpired(readiness: string | null | undefined): boolean {
+  return readiness === 'terminal' || readiness === 'expired'
+}
+
+function liveSupportedMatchedRowIntegrity(
+  evidence: DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
+  requests: DashboardScheduledAutomationRequest[],
+): LiveSupportedMatchedRowIntegrity {
+  if (evidence.projection_status !== 'matched_supported_non_terminal') {
+    return { status: 'not_applicable' }
+  }
+
+  const rowByScheduleId = new Map(requests.map(request => [request.schedule_id, request]))
+  const matchedIds = evidence.matched_schedule_ids ?? []
+  const mismatches =
+    matchedIds.length === 0
+      ? [{ scheduleId: '(none)', reason: 'missing_matched_schedule_ids' }]
+      : matchedIds.flatMap(scheduleId => {
+          const row = rowByScheduleId.get(scheduleId)
+          if (!row) {
+            return [{ scheduleId, reason: 'missing_request_row' }]
+          }
+          if (row.payload_support !== 'supported') {
+            return [{ scheduleId, reason: 'payload_support_not_supported' }]
+          }
+          if (liveSupportedReadinessIsTerminalOrExpired(row.execution_readiness)) {
+            return [{ scheduleId, reason: 'execution_readiness_terminal_or_expired' }]
+          }
+          return []
+        })
+
+  if (mismatches.length > 0) {
+    return { status: 'matched_row_mismatch', mismatches }
+  }
+  return { status: 'matched_rows_verified', matchedCount: matchedIds.length }
+}
+
 function SchLiveSupportedEvidence({
   automation,
   evidence,
@@ -1433,6 +1478,7 @@ function SchLiveSupportedEvidence({
   }
   const matchedIds = evidence.matched_schedule_ids ?? []
   const status = evidence.projection_status
+  const rowIntegrity = liveSupportedMatchedRowIntegrity(evidence, automation.requests ?? [])
   return html`
     <section
       class=${`sch-banner ${liveSupportedEvidenceBannerClass(status)}`}
@@ -1474,6 +1520,30 @@ function SchLiveSupportedEvidence({
         ${evidence.reason
           ? html`<div class="sch-banner-sub">${evidence.reason}</div>`
           : null}
+        ${rowIntegrity.status === 'matched_rows_verified'
+          ? html`
+              <div
+                class="sch-banner-sub"
+                data-schedule-live-supported-row-integrity="matched_rows_verified"
+                data-schedule-live-supported-row-integrity-count=${rowIntegrity.matchedCount}
+              >
+                matched schedule rows satisfy endpoint criteria in this response
+              </div>
+            `
+          : rowIntegrity.status === 'matched_row_mismatch'
+            ? html`
+                <div
+                  class="sch-banner-sub"
+                  data-schedule-live-supported-row-integrity="matched_row_mismatch"
+                  data-schedule-live-supported-row-integrity-count=${rowIntegrity.mismatches.length}
+                >
+                  matched row mismatch:
+                  <span class="mono">
+                    ${rowIntegrity.mismatches.map(item => `${item.scheduleId}:${item.reason}`).join(', ')}
+                  </span>
+                </div>
+              `
+            : null}
         ${matchedIds.length > 0
           ? html`
               <div class="sch-payload-rows" aria-label="Live supported schedule ids">


### PR DESCRIPTION
## Summary
- verify `matched_supported_non_terminal` evidence against the same response rows before displaying it as row-consistent
- surface explicit row-integrity mismatch reasons for missing rows, unsupported payload rows, and terminal/expired rows
- cover both verified and contradictory evidence cases in the scheduler automation panel tests

## Validation
- `pnpm vitest run src/components/tools/scheduled-automation-panel.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/components/tools/scheduled-automation-panel.ts src/components/tools/scheduled-automation-panel.test.ts`
- `env GITHUB_BASE_REF=codex/scheduler-production-live-truth-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check codex/scheduler-production-live-truth-20260706...HEAD`

## Stack
- Base: #23366 (`codex/scheduler-production-live-truth-20260706`)
