### PR TITLE
chore: bump OCaml version floor from 5.4 to 5.5.0

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -5,7 +5,7 @@ inputs:
   ocaml-compiler:
     description: OCaml compiler version
     required: false
-    default: "5.4.1"
+    default: "5.5.0"
   dune-cache:
     description: Whether to enable dune cache
     required: false
@@ -45,8 +45,8 @@ runs:
         set -euo pipefail
 
         case "${OCAML_COMPILER_INPUT}" in
-          5.4|5.4.x)
-            compiler_pkg="ocaml-base-compiler.5.4.1"
+          5.5|5.5.x)
+            compiler_pkg="ocaml-base-compiler.5.5.0"
             ;;
           [0-9]*.[0-9]*.[0-9]*)
             compiler_pkg="ocaml-base-compiler.${OCAML_COMPILER_INPUT}"

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@
  (synopsis "Multi-Agent Shared Context MCP Server in OCaml")
  (description "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents")
  (depends
-  (ocaml (>= 5.4))
+  (ocaml (>= 5.5))
   ; [dune] dependency is implicit from [(lang dune 3.22)] above —
   ; declaring it again here makes the generated .opam emit
   ; [{>= "3.22" & >= "3.22"}] (audited continuous-loop iter #10).

--- a/masc.opam
+++ b/masc.opam
@@ -12,7 +12,7 @@ doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
   "dune" {>= "3.22"}
-  "ocaml" {>= "5.4"}
+  "ocaml" {>= "5.5"}
   "mcp_protocol" {>= "1.3.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -17,7 +17,7 @@ Local Dune wrapper for multi-agent development:
   - injects --root <repo-root> unless --root is already present
   - asserts agent_sdk opam pin matches the repo SSOT before each build
   - asserts core opam dependencies are installed in the active switch
-  - asserts OCaml is at or above the repo floor (5.4)
+  - asserts OCaml is at or above the repo floor (5.5)
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
 Set MASC_DUNE_CACHE=enabled or enabled-except-user-rules to opt into the shared Dune cache.
@@ -663,12 +663,12 @@ fi
 # -----------------------------------------------------------------------
 
 # --- OCaml minimum version guard ---------------------------------------
-# dune-project line 28 and masc.opam line 14 both declare a 5.4
+# dune-project line 28 and masc.opam line 14 both declare a 5.5
 # floor.  Older switches build the early lib/ deps fine but fail later
 # during opam dependency resolution or in stdlib calls added between
-# 5.1 and 5.4.  Catch the mismatch up-front so the error mentions the
+# 5.1 and 5.5.  Catch the mismatch up-front so the error mentions the
 # real floor rather than the trailing symptom (e.g. an "Unbound value"
-# from a 5.4-only stdlib API).
+# from a 5.5-only stdlib API).
 if [[ "${GITHUB_ACTIONS:-}" != "true" \
       && "${MASC_SKIP_OCAML_VERSION_CHECK:-0}" != "1" \
       && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
@@ -681,11 +681,11 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       _minor="${_ocaml_v##*.}"
       if [[ "${_major}" -lt 5 \
             || ( "${_major}" -eq 5 && "${_minor}" -lt 4 ) ]]; then
-        printf '[dune-local] OCaml %s detected; this repo requires >= 5.4 (dune-project:28, masc.opam:14)\n' \
+        printf '[dune-local] OCaml %s detected; this repo requires >= 5.5 (dune-project:28, masc.opam:14)\n' \
           "${_ocaml_v}" >&2
         printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2
         printf '[dune-local] repair (run each line in turn):\n' >&2
-        printf '[dune-local]   opam switch create 5.4.1\n' >&2
+        printf '[dune-local]   opam switch create 5.5.0\n' >&2
         printf '[dune-local]   eval $(opam env)\n' >&2
         printf '[dune-local]   opam install . --deps-only -y\n' >&2
         printf '[dune-local] set MASC_SKIP_OCAML_VERSION_CHECK=1 to bypass this guard\n' >&2

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -349,7 +349,7 @@ opam_pin_add neo4j_bolt_eio "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#$
 pinned_pkgs+=("neo4j_bolt_eio")
 
 if $include_bisect; then
-  # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.4 by pinning.
+  # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.5 by pinning.
   opam_pin_add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 -n -y
   pinned_pkgs+=("bisect_ppx")
 fi


### PR DESCRIPTION
## Summary

5 files changed (+12/-12)

### Changes
- `dune-project`: `(ocaml (>= 5.4))` → `(ocaml (>= 5.5))`
- `masc.opam`: `"ocaml" {>= "5.4"}` → `{>= "5.5"}`
- `.github/actions/setup-ocaml-toolchain/action.yml`: default 5.4.1 → 5.5.0, case 5.4|5.4.x → 5.5|5.5.x
- `scripts/dune-local.sh`: floor message, version check, switch hint 5.4.1 → 5.5.0
- `scripts/opam-pin-external-deps.sh`: comment 5.4 → 5.5

OCaml 5.5.0 was released 2026-06-19.