### PR TITLE
chore: bump worker-runtime Docker image from ocaml-5.4 to ocaml-5.5

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+FROM ocaml/opam:debian-12-ocaml-5.5 AS build
 
 WORKDIR /src
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -680,7 +680,7 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       _major="${_ocaml_v%%.*}"
       _minor="${_ocaml_v##*.}"
       if [[ "${_major}" -lt 5 \
-            || ( "${_major}" -eq 5 && "${_minor}" -lt 4 ) ]]; then
+            || ( "${_major}" -eq 5 && "${_minor}" -lt 5 ) ]]; then
         printf '[dune-local] OCaml %s detected; this repo requires >= 5.5 (dune-project:28, masc.opam:14)\n' \
           "${_ocaml_v}" >&2
         printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2


### PR DESCRIPTION
## Summary

1 file changed (+1/-1)

- `Dockerfile.worker-runtime`: `FROM ocaml/opam:debian-12-ocaml-5.4` → `ocaml-5.5`

Part of the OCaml 5.5 migration (step 2: Dockerfiles).