### PR TITLE
chore: bump benchmark Docker image from ocaml-5.2 to ocaml-5.5

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+FROM ocaml/opam:debian-12-ocaml-5.5 AS build
 
 WORKDIR /src
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -680,7 +680,7 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       _major="${_ocaml_v%%.*}"
       _minor="${_ocaml_v##*.}"
       if [[ "${_major}" -lt 5 \
-            || ( "${_major}" -eq 5 && "${_minor}" -lt 4 ) ]]; then
+            || ( "${_major}" -eq 5 && "${_minor}" -lt 5 ) ]]; then
         printf '[dune-local] OCaml %s detected; this repo requires >= 5.5 (dune-project:28, masc.opam:14)\n' \
           "${_ocaml_v}" >&2
         printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2

--- a/test/Dockerfile.benchmark
+++ b/test/Dockerfile.benchmark
@@ -7,7 +7,7 @@
 # Run:
 #   docker run --rm masc-bench
 
-FROM ocaml/opam:ubuntu-24.04-ocaml-5.2 AS builder
+FROM ocaml/opam:ubuntu-24.04-ocaml-5.5 AS builder
 
 # Install system dependencies
 USER root
@@ -75,7 +75,7 @@ RUN echo '#!/bin/bash' > /home/opam/run_benchmarks.sh && \
     chmod +x /home/opam/run_benchmarks.sh
 
 # Runtime stage
-FROM ocaml/opam:ubuntu-24.04-ocaml-5.2
+FROM ocaml/opam:ubuntu-24.04-ocaml-5.5
 
 USER root
 RUN apt-get update && apt-get install -y \

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -1292,8 +1292,8 @@ let test_old_ocaml_aborts_build () =
     check int "exits non-zero on old OCaml" 1 code;
     check bool "OCaml version message present" true
       (contains_substring stderr "OCaml 5.0 detected");
-    check bool "minimum 5.4 mentioned" true
-      (contains_substring stderr ">= 5.4");
+    check bool "minimum 5.5 mentioned" true
+      (contains_substring stderr ">= 5.5");
     check bool "skip hint present" true
       (contains_substring stderr "MASC_SKIP_OCAML_VERSION_CHECK=1");
     check bool "dune not invoked" false (Sys.file_exists dune_log))


### PR DESCRIPTION
## Summary

1 file changed (+2/-2)

- `test/Dockerfile.benchmark`: both builder and runtime stages updated from `ocaml/opam:ubuntu-24.04-ocaml-5.2` to `ocaml/opam:ubuntu-24.04-ocaml-5.5`

Part of the OCaml 5.5 migration (step 2: Dockerfiles).