### PR TITLE
chore: update bonsai-dashboard switch from ocaml-variants.5.2.0+ox to 5.5.0+options

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-12-ocaml-5.4 AS build
+FROM ocaml/opam:debian-12-ocaml-5.5 AS build
 
 WORKDIR /src
 

--- a/dashboard_bonsai/README.md
+++ b/dashboard_bonsai/README.md
@@ -25,7 +25,7 @@ Jane Street **Bonsai** (OCaml + js_of_ocaml) 기반 masc 대시보드 island.
 
 OxCaml 기반 OCaml 5.2 + Jane Street v0.18 preview 패키지.
 
-- 컴파일러: `ocaml-variants.5.2.0+ox`
+- 컴파일러: `ocaml-variants.5.5.0+options`
 - Bonsai: `v0.18~preview.130.83+317` (OxCaml repo)
 - stock OCaml 5.3/5.4 + janestreet-bleeding 조합은 macOS 26 SDK(`dispatch/base.h`
   `fallthrough` 매크로 충돌)와 충돌 — OxCaml만 동작.
@@ -33,7 +33,7 @@ OxCaml 기반 OCaml 5.2 + Jane Street v0.18 preview 패키지.
 ### 1회 switch 셋업
 
 ```bash
-opam switch create bonsai-dashboard 5.2.0+ox \
+opam switch create bonsai-dashboard 5.5.0+options \
     --repos ox=git+https://github.com/oxcaml/opam-repository.git,default \
     --no-install
 opam install --switch=bonsai-dashboard \

--- a/dashboard_bonsai/README.md
+++ b/dashboard_bonsai/README.md
@@ -23,17 +23,17 @@ Jane Street **Bonsai** (OCaml + js_of_ocaml) 기반 masc 대시보드 island.
 
 ## Toolchain
 
-OxCaml 기반 OCaml 5.2 + Jane Street v0.18 preview 패키지.
+OCaml 5.5.0+options + Jane Street v0.18 preview 패키지.
 
 - 컴파일러: `ocaml-variants.5.5.0+options`
 - Bonsai: `v0.18~preview.130.83+317` (OxCaml repo)
-- stock OCaml 5.3/5.4 + janestreet-bleeding 조합은 macOS 26 SDK(`dispatch/base.h`
-  `fallthrough` 매크로 충돌)와 충돌 — OxCaml만 동작.
+- 이전 stock OCaml 5.3/5.4 + janestreet-bleeding 조합은 macOS 26 SDK(`dispatch/base.h`
+  `fallthrough` 매크로 충돌)와 충돌했으므로 사용하지 않는다.
 
 ### 1회 switch 셋업
 
 ```bash
-opam switch create bonsai-dashboard 5.5.0+options \
+opam switch create bonsai-dashboard ocaml-variants.5.5.0+options \
     --repos ox=git+https://github.com/oxcaml/opam-repository.git,default \
     --no-install
 opam install --switch=bonsai-dashboard \

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -44,7 +44,7 @@ bonsai-dashboard-if-available:
 	  $(MAKE) bonsai-dashboard; \
 	else \
 	  echo "==> bonsai-dashboard switch not found — skipping Bonsai island."; \
-	  echo "    Run \`opam switch create bonsai-dashboard ocaml-variants.5.2.0+ox\`"; \
+	  echo "    Run \`opam switch create bonsai-dashboard ocaml-variants.5.5.0+options\`"; \
 	  echo "    (see docs/bonsai-migration/phase-0-report.md) to enable."; \
 	fi
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -680,7 +680,7 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
       _major="${_ocaml_v%%.*}"
       _minor="${_ocaml_v##*.}"
       if [[ "${_major}" -lt 5 \
-            || ( "${_major}" -eq 5 && "${_minor}" -lt 4 ) ]]; then
+            || ( "${_major}" -eq 5 && "${_minor}" -lt 5 ) ]]; then
         printf '[dune-local] OCaml %s detected; this repo requires >= 5.5 (dune-project:28, masc.opam:14)\n' \
           "${_ocaml_v}" >&2
         printf '[dune-local] symptom under older switch: opam dep resolution fails or stdlib API missing\n' >&2

--- a/test/Dockerfile.benchmark
+++ b/test/Dockerfile.benchmark
@@ -7,7 +7,7 @@
 # Run:
 #   docker run --rm masc-bench
 
-FROM ocaml/opam:ubuntu-24.04-ocaml-5.2 AS builder
+FROM ocaml/opam:ubuntu-24.04-ocaml-5.5 AS builder
 
 # Install system dependencies
 USER root
@@ -75,7 +75,7 @@ RUN echo '#!/bin/bash' > /home/opam/run_benchmarks.sh && \
     chmod +x /home/opam/run_benchmarks.sh
 
 # Runtime stage
-FROM ocaml/opam:ubuntu-24.04-ocaml-5.2
+FROM ocaml/opam:ubuntu-24.04-ocaml-5.5
 
 USER root
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

5 files changed.

- `Dockerfile.worker-runtime`: worker runtime image moved to OCaml 5.5.
- `scripts/dune-local.sh`: local/CI wrapper switch hint aligned with OCaml 5.5.
- `test/Dockerfile.benchmark`: benchmark image moved to OCaml 5.5.
- `mk/build.mk`: Bonsai dashboard switch hint updated from `ocaml-variants.5.2.0+ox` to `ocaml-variants.5.5.0+options`.
- `dashboard_bonsai/README.md`: compiler version and switch creation command updated to match the Makefile path.

## Queue Shape

This PR is the current aggregate OCaml 5.5 floor owner for the worker runtime, benchmark image, dune-local wrapper, and Bonsai dashboard switch docs.

Related narrower PRs:

- #23369 covers `Dockerfile.worker-runtime` and `scripts/dune-local.sh`.
- #23370 covers `Dockerfile.worker-runtime`, `scripts/dune-local.sh`, and `test/Dockerfile.benchmark`.

Merge order should be explicit:

- If this PR lands first, #23369 and #23370 are superseded by this aggregate PR and should be closed or rebased away.
- If #23369/#23370 land first, this PR must be rebased before review/merge so its diff returns to the Bonsai switch files only.

## Validation

CI is the build authority. Local validation used only focused non-Dune checks from the branch cleanup pass:

- `git diff origin/main...HEAD --check`
- `bash -n scripts/dune-local.sh`
- `make -n bonsai-dashboard-if-available`
- stale OCaml 5.2 grep over `dashboard_bonsai/README.md` and `mk/build.mk`

Part of the OCaml 5.5 migration: Bonsai dashboard switch plus currently aggregated floor-image/wrapper updates.
