### PR TITLE
[codex] Add HITL repo claim path for keepers

### DIFF
--- a/docs/superpowers/plans/2026-07-06-repo-claim-hitl-plan.html
+++ b/docs/superpowers/plans/2026-07-06-repo-claim-hitl-plan.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Keeper Repository Claim HITL Plan</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --ink: #1d2433;
+      --muted: #667085;
+      --line: #d8dde7;
+      --accent: #1f7a5a;
+      --warn: #a15c00;
+      --danger: #b42318;
+      --code: #eef2f6;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+    }
+
+    h1, h2, h3 { line-height: 1.2; margin: 0; }
+    h1 { font-size: 30px; letter-spacing: 0; }
+    h2 { font-size: 20px; margin-top: 32px; }
+    h3 { font-size: 16px; margin-top: 18px; }
+
+    p { margin: 10px 0 0; }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+    }
+
+    .pill {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 999px;
+      padding: 5px 10px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    section {
+      margin-top: 18px;
+      padding: 20px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    ul { margin: 12px 0 0; padding-left: 20px; }
+    li { margin: 7px 0; }
+
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 14px;
+    }
+
+    .tile {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfe;
+      min-height: 128px;
+    }
+
+    .ok { color: var(--accent); font-weight: 650; }
+    .warn { color: var(--warn); font-weight: 650; }
+    .danger { color: var(--danger); font-weight: 650; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 14px;
+    }
+
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th { background: #f0f4f8; }
+
+    @media (max-width: 820px) {
+      main { padding: 24px 16px 40px; }
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Keeper Repository Claim HITL Plan</h1>
+    <p>
+      Unknown keeper repository access should not silently become authority, but
+      it should also not dead-end as a plain reject when the repository identity
+      is known and the only missing fact is operator authorization.
+    </p>
+    <div class="meta">
+      <span class="pill">Date: 2026-07-06</span>
+      <span class="pill">Repo: jeong-sik/masc</span>
+      <span class="pill">Boundary: MASC only</span>
+      <span class="pill">OAS impact: none</span>
+    </div>
+
+    <section>
+      <h2>Decision</h2>
+      <p>
+        Keep the strict repo access gate as the default authority. Add an
+        explicit HITL claim path for the narrow case where a repository is
+        registered and identity-validated, but the keeper's selected mapping
+        does not include it.
+      </p>
+      <div class="grid">
+        <div class="tile">
+          <h3 class="ok">Allowed</h3>
+          <p>
+            Existing mapping permits the repository, or the current default
+            registered-repository scope applies.
+          </p>
+        </div>
+        <div class="tile">
+          <h3 class="warn">HITL Pending</h3>
+          <p>
+            Repository identity is valid, but the keeper mapping excludes it.
+            Queue an approval request and do not block the keeper fiber.
+          </p>
+        </div>
+        <div class="tile">
+          <h3 class="danger">Denied</h3>
+          <p>
+            Repository is unregistered, mapping file is malformed, repository
+            store load failed, or identity mismatched. No claim request is made.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Implementation Slice</h2>
+      <ul>
+        <li>Add a typed access decision in <code>Keeper_repo_mapping</code> so callers can distinguish not-in-mapping from load/store/identity errors.</li>
+        <li>Add a keeper-side HITL bridge that calls <code>Keeper_approval_queue.submit_pending</code> for repository-claim requests.</li>
+        <li>On operator approve, update <code>keeper_repo_mappings.toml</code> through the existing <code>save_mapping</code> SSOT.</li>
+        <li>On reject or edit, persist no mapping change and emit an explicit log path.</li>
+        <li>Wire read/write filesystem paths to return a structured <code>approval_pending</code> response instead of a plain policy reject for the claimable case.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Non Goals</h2>
+      <ul>
+        <li>No OAS API or provider behavior change.</li>
+        <li>No automatic repo registration for unregistered or identity-mismatched paths.</li>
+        <li>No heuristic matching from free text, branch names, or command strings.</li>
+        <li>No background mutation without an approval decision.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Validation</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Expected Result</th>
+            <th>Check</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Keeper mapping excludes registered repo</td>
+            <td>HITL pending approval is created</td>
+            <td>Focused Alcotest for repo claim bridge</td>
+          </tr>
+          <tr>
+            <td>Operator approves claim</td>
+            <td>Mapping file gains the repository id through <code>save_mapping</code></td>
+            <td>Resolve pending approval and reload mapping</td>
+          </tr>
+          <tr>
+            <td>Unregistered repo id</td>
+            <td>Fail closed; no HITL request</td>
+            <td>Repo mapping decision test</td>
+          </tr>
+          <tr>
+            <td>Malformed mapping or repository store</td>
+            <td>Fail closed with explicit diagnostic</td>
+            <td>Existing fail-closed tests remain unchanged</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -1,0 +1,162 @@
+type access_result =
+  | Access_allowed
+  | Access_pending_approval of
+      { approval_id : string
+      ; repository_id : Repo_manager_types.repository_id
+      }
+  | Access_denied of string
+
+let repository_claim_tool_name = "keeper_repo_claim_request"
+let repository_claim_request_type = "keeper_repository_scope_claim"
+
+let claim_denial_label = function
+  | Keeper_repo_mapping.Access_denied_not_in_mapping _ -> "not_in_mapping"
+  | Keeper_repo_mapping.Access_denied_unregistered_repository _ ->
+    "unregistered_repository"
+  | Keeper_repo_mapping.Access_denied_load_error _ -> "mapping_load_error"
+  | Keeper_repo_mapping.Access_denied_repository_store_error _ ->
+    "repository_store_error"
+;;
+
+let repository_claim_input ~keeper_id ~repository_id denial =
+  `Assoc
+    [ "request_type", `String repository_claim_request_type
+    ; "keeper_id", `String keeper_id
+    ; "repository_id", `String repository_id
+    ; "denial", `String (claim_denial_label denial)
+    ; "mapping_source", `String Keeper_repo_mapping.mappings_toml_basename
+    ]
+;;
+
+let repository_ids_with_claim repository_ids repository_id =
+  if List.exists (String.equal repository_id) repository_ids
+  then repository_ids
+  else repository_ids @ [ repository_id ]
+;;
+
+let grant_repository_access ~base_path ~keeper_id ~repository_id =
+  match Keeper_repo_mapping.lookup_mapping ~base_path ~keeper_id with
+  | Keeper_repo_mapping.Mapping_found mapping ->
+    let repository_ids =
+      repository_ids_with_claim mapping.repository_ids repository_id
+    in
+    Keeper_repo_mapping.save_mapping
+      ~base_path
+      (Repo_manager_types.make_keeper_repo_mapping ~keeper_id ~repository_ids)
+  | Keeper_repo_mapping.Mapping_missing _ ->
+    Keeper_repo_mapping.save_mapping
+      ~base_path
+      (Repo_manager_types.make_keeper_repo_mapping
+         ~keeper_id
+         ~repository_ids:[ repository_id ])
+  | Keeper_repo_mapping.Mapping_load_error detail -> Error detail
+;;
+
+let on_resolution ~base_path ~keeper_id ~repository_id = function
+  | Agent_sdk.Hooks.Approve -> (
+    match grant_repository_access ~base_path ~keeper_id ~repository_id with
+    | Ok () ->
+      Log.Keeper.info
+        ~keeper_name:keeper_id
+        "repo claim approved keeper=%s repository=%s"
+        keeper_id
+        repository_id
+    | Error detail ->
+      Log.Keeper.warn
+        ~keeper_name:keeper_id
+        "repo claim approval could not update mapping keeper=%s repository=%s \
+         detail=%s"
+        keeper_id
+        repository_id
+        detail)
+  | Agent_sdk.Hooks.Reject reason ->
+    Log.Keeper.info
+      ~keeper_name:keeper_id
+      "repo claim rejected keeper=%s repository=%s reason=%s"
+      keeper_id
+      repository_id
+      reason
+  | Agent_sdk.Hooks.Edit _ ->
+    Log.Keeper.warn
+      ~keeper_name:keeper_id
+      "repo claim edit decision ignored keeper=%s repository=%s"
+      keeper_id
+      repository_id
+;;
+
+let submit_claim_request ~base_path ~keeper_id ~repository_id denial =
+  Keeper_approval_queue.submit_pending
+    ~keeper_name:keeper_id
+    ~tool_name:repository_claim_tool_name
+    ~input:(repository_claim_input ~keeper_id ~repository_id denial)
+    ~risk_level:Keeper_approval_queue.High
+    ~base_path
+    ~sandbox_target:repository_id
+    ~disposition:"repo_claim_pending"
+    ~disposition_reason:"keeper repository mapping requires operator approval"
+    ~on_resolution:(on_resolution ~base_path ~keeper_id ~repository_id)
+    ()
+;;
+
+let request_repository_access ~keeper_id ~base_path ~repository_id =
+  match Keeper_repo_mapping.access_decision ~keeper_id ~repository_id ~base_path with
+  | Keeper_repo_mapping.Access_allowed -> Access_allowed
+  | Keeper_repo_mapping.Access_denied
+      (Keeper_repo_mapping.Access_denied_not_in_mapping _ as denial) ->
+    let approval_id =
+      submit_claim_request ~base_path ~keeper_id ~repository_id denial
+    in
+    Access_pending_approval { approval_id; repository_id }
+  | Keeper_repo_mapping.Access_denied denial ->
+    Access_denied (Keeper_repo_mapping.access_denial_to_string denial)
+;;
+
+let request_path_access ~keeper_id ~base_path ~path =
+  match Keeper_repo_mapping.repository_resolution_of_path ~base_path ~path with
+  | Keeper_repo_mapping.No_repository -> Access_allowed
+  | Keeper_repo_mapping.Repository repository_id ->
+    request_repository_access ~keeper_id ~base_path ~repository_id
+  | Keeper_repo_mapping.Repository_identity_mismatch mismatch ->
+    Access_denied (Keeper_repo_mapping.repository_identity_mismatch_message mismatch)
+  | Keeper_repo_mapping.Repository_store_error detail ->
+    Access_denied
+      (Printf.sprintf
+         "Repository store load failed while validating keeper %s path %s: %s"
+         keeper_id
+         path
+         detail)
+;;
+
+let tool_response_json ~path = function
+  | Access_allowed ->
+    `Assoc [ "ok", `Bool true; "path", `String path ]
+  | Access_pending_approval { approval_id; repository_id } ->
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String "repository access requires operator approval"
+      ; "path", `String path
+      ; "repository_id", `String repository_id
+      ; "approval_id", `String approval_id
+      ; ( "hitl"
+        , `Assoc
+            [ "status", `String "pending"
+            ; "request_type", `String repository_claim_request_type
+            ] )
+      ; ( "deterministic_retry"
+        , `Assoc
+            [ "reason", `String "approval_pending"
+            ; "retry_same_args", `Bool false
+            ] )
+      ]
+  | Access_denied detail ->
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String detail
+      ; "path", `String path
+      ; ( "deterministic_retry"
+        , `Assoc
+            [ "reason", `String "policy_blocked"
+            ; "retry_same_args", `Bool false
+            ] )
+      ]
+;;

--- a/lib/keeper/keeper_repo_claim_hitl.mli
+++ b/lib/keeper/keeper_repo_claim_hitl.mli
@@ -1,0 +1,35 @@
+(** Keeper-side HITL bridge for repository-scope claim requests.
+
+    [Keeper_repo_mapping] remains a pure policy/enforcement module and does
+    not depend on the keeper approval queue. This module is the composition
+    layer that turns a claimable selected-scope denial into a non-blocking HITL
+    request and applies the mapping mutation only after operator approval. *)
+
+type access_result =
+  | Access_allowed
+  | Access_pending_approval of
+      { approval_id : string
+      ; repository_id : Repo_manager_types.repository_id
+      }
+  | Access_denied of string
+
+val repository_claim_tool_name : string
+val repository_claim_request_type : string
+
+val request_repository_access :
+  keeper_id:string ->
+  base_path:string ->
+  repository_id:Repo_manager_types.repository_id ->
+  access_result
+(** Request access to a registered repository. Returns
+    [Access_pending_approval] only for the selected-scope miss that an operator
+    can resolve by adding [repository_id] to the keeper mapping. Hard
+    fail-closed cases return [Access_denied]. *)
+
+val request_path_access :
+  keeper_id:string -> base_path:string -> path:string -> access_result
+(** Resolve [path] through the repository catalog and request HITL access for
+    claimable repository-scope misses. *)
+
+val tool_response_json : path:string -> access_result -> Yojson.Safe.t
+(** Render a tool-facing policy response for non-[Access_allowed] results. *)

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -67,6 +67,15 @@ let string_opt_nonempty name json =
     if trimmed = "" then None else Some trimmed
 ;;
 
+let repo_access_tool_response ~keeper_id ~base_path ~path =
+  match Keeper_repo_claim_hitl.request_path_access ~keeper_id ~base_path ~path with
+  | Keeper_repo_claim_hitl.Access_allowed -> None
+  | access_result ->
+    Some
+      (Yojson.Safe.to_string
+         (Keeper_repo_claim_hitl.tool_response_json ~path access_result))
+;;
+
 let relative_path_has_segment_prefix prefix raw =
   String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
 ;;
@@ -227,24 +236,13 @@ let handle_read_file
        deterministic policy block so the supervisor does not retry the
        same failing path. *)
     (match
-       Keeper_repo_mapping.validate_path_access
+       repo_access_tool_response
          ~keeper_id:meta.name
          ~base_path:(Keeper_alerting_path.project_root_of_config config)
          ~path:target
      with
-     | Error msg ->
-       Yojson.Safe.to_string
-         (`Assoc
-            [ "ok", `Bool false
-            ; "error", `String msg
-            ; "path", `String target
-            ; ( "deterministic_retry"
-              , `Assoc
-                  [ "reason", `String "policy_blocked"
-                  ; "retry_same_args", `Bool false
-                  ] )
-            ])
-     | Ok () ->
+     | Some response -> response
+     | None ->
        let run_read () =
          (* RFC-0006 Phase B-1: Docker keepers are always contained to their
             playground bundle on the host before any read-side I/O proceeds.
@@ -601,82 +599,84 @@ let handle_file_write
             | Ok () ->
               let run () =
                 let* () = check_invariant_sandbox_isolation ~turn_sandbox_factory ~target in
-                let* () =
-                  Keeper_repo_mapping.validate_path_access
+                match
+                  repo_access_tool_response
                     ~keeper_id:meta.name
                     ~base_path:(Keeper_alerting_path.project_root_of_config config)
                     ~path:target
-                in
-                try
-                  let current =
-                    try Fs_compat.load_file target with
-                    | Eio.Cancel.Cancelled _ as e -> raise e
-                    | _ -> ""
-                  in
-                  if current = ""
-                  then
-                    Ok
-                      (error_json
-                         ~fields:[ "path", `String target ]
-                         "patch target file does not exist or is empty. Use \
-                          mode=overwrite to create.")
-                  else
-                    let* updated, occurrences =
-                      apply_patch ~old_string ~new_string ~replace_all current
-                    in
-                    let* () =
-                      match
-                        Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd:target
-                      with
-                      | Runtime runtime ->
-                        Keeper_turn_sandbox_runtime.overwrite_file
-                          runtime
-                          ~host_path:target
-                          ~content:updated
-                          ~timeout_sec:
-                            (Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Io ())
-                          ()
-                      | No_factory | Local_profile -> Keeper_fs.save_atomic target updated
-                    in
-                    Log.Keeper.info
-                      "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
-                       replace_all=%b occurrences=%d bytes=%d"
-                      meta.name
-                      target
-                      replace_all
-                      occurrences
-                      (String.length updated);
-                    (* IDE: record code region after successful patch write *)
-                    let ide_observation_error =
-                      track_write_region
-                        ~config
-                        ~keeper_name:meta.name
-                        ~file_path:target
-                        ~content:updated
-                        ~mode_raw:"patch"
-                        ~old_string
-                        ~new_string
-                        ()
-                    in
-                    Ok
-                      (Yojson.Safe.to_string
-                         (`Assoc
-                             ([ "ok", `Bool true
-                              ; "path", `String target
-                              ; "mode", `String "patch"
-                              ; "replace_all", `Bool replace_all
-                              ; "occurrences", `Int occurrences
-                              ; "bytes_written", `Int (String.length updated)
-                              ]
-                              @ ide_observation_failure_fields ide_observation_error
-                              @ via_field)))
                 with
-                | Fs_edit_error json -> Ok json
-                | Invalid_argument e ->
-                  Ok (error_json ~fields:[ "path", `String target ] e)
-                | Sys_error e -> Ok (error_json ~fields:[ "path", `String target ] e)
-                | Unix.Unix_error (err, _, _) ->
-                  Ok (error_json ~fields:[ "path", `String target ] (Unix.error_message err))
+                | Some response -> Ok response
+                | None -> (
+                  try
+                    let current =
+                      try Fs_compat.load_file target with
+                      | Eio.Cancel.Cancelled _ as e -> raise e
+                      | _ -> ""
+                    in
+                    if current = ""
+                    then
+                      Ok
+                        (error_json
+                           ~fields:[ "path", `String target ]
+                           "patch target file does not exist or is empty. Use \
+                            mode=overwrite to create.")
+                    else
+                      let* updated, occurrences =
+                        apply_patch ~old_string ~new_string ~replace_all current
+                      in
+                      let* () =
+                        match
+                          Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd:target
+                        with
+                        | Runtime runtime ->
+                          Keeper_turn_sandbox_runtime.overwrite_file
+                            runtime
+                            ~host_path:target
+                            ~content:updated
+                            ~timeout_sec:
+                              (Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Io ())
+                            ()
+                        | No_factory | Local_profile -> Keeper_fs.save_atomic target updated
+                      in
+                      Log.Keeper.info
+                        "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
+                         replace_all=%b occurrences=%d bytes=%d"
+                        meta.name
+                        target
+                        replace_all
+                        occurrences
+                        (String.length updated);
+                      (* IDE: record code region after successful patch write *)
+                      let ide_observation_error =
+                        track_write_region
+                          ~config
+                          ~keeper_name:meta.name
+                          ~file_path:target
+                          ~content:updated
+                          ~mode_raw:"patch"
+                          ~old_string
+                          ~new_string
+                          ()
+                      in
+                      Ok
+                        (Yojson.Safe.to_string
+                           (`Assoc
+                               ([ "ok", `Bool true
+                                ; "path", `String target
+                                ; "mode", `String "patch"
+                                ; "replace_all", `Bool replace_all
+                                ; "occurrences", `Int occurrences
+                                ; "bytes_written", `Int (String.length updated)
+                                ]
+                                @ ide_observation_failure_fields ide_observation_error
+                                @ via_field)))
+                  with
+                  | Fs_edit_error json -> Ok json
+                  | Invalid_argument e ->
+                    Ok (error_json ~fields:[ "path", `String target ] e)
+                  | Sys_error e -> Ok (error_json ~fields:[ "path", `String target ] e)
+                  | Unix.Unix_error (err, _, _) ->
+                    Ok (error_json ~fields:[ "path", `String target ] (Unix.error_message err)))
               in
               (match run () with
                | Ok json -> json
@@ -696,12 +696,14 @@ let handle_file_write
             | Ok () ->
               let run () =
              let* () = check_invariant_sandbox_isolation ~turn_sandbox_factory ~target in
-             let* () =
-               Keeper_repo_mapping.validate_path_access
+             match
+               repo_access_tool_response
                  ~keeper_id:meta.name
                  ~base_path:(Keeper_alerting_path.project_root_of_config config)
                  ~path:target
-             in
+             with
+             | Some response -> Ok response
+             | None -> (
              try
                let* () =
                  match
@@ -770,7 +772,7 @@ let handle_file_write
                Ok (error_json ~fields:[ "path", `String target ] e)
              | Sys_error e -> Ok (error_json ~fields:[ "path", `String target ] e)
              | Unix.Unix_error (err, _, _) ->
-               Ok (error_json ~fields:[ "path", `String target ] (Unix.error_message err))
+               Ok (error_json ~fields:[ "path", `String target ] (Unix.error_message err)))
            in
            (match run () with
             | Ok json -> json

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -334,6 +334,22 @@ let log_mapping_load_error_if_new ~keeper_id msg =
   mark ()
 ;;
 
+type access_denial =
+  | Access_denied_unregistered_repository of repository_id
+  | Access_denied_not_in_mapping of
+      { keeper_id : string
+      ; repository_id : repository_id
+      }
+  | Access_denied_load_error of string
+  | Access_denied_repository_store_error of
+      { repository_id : repository_id
+      ; detail : string
+      }
+
+type access_decision =
+  | Access_allowed
+  | Access_denied of access_denial
+
 type policy_decision =
   | Policy_decision_default_scope_allowed
   | Policy_decision_unregistered_repository
@@ -379,38 +395,62 @@ let record_policy_decision ~keeper_id ?repository_id decision =
     ()
 ;;
 
-let is_allowed ~keeper_id ~repository_id ~base_path =
+let access_denial_to_string = function
+  | Access_denied_unregistered_repository repository_id ->
+    Printf.sprintf
+      "Repository %s is not registered; access not allowed"
+      repository_id
+  | Access_denied_not_in_mapping { keeper_id; repository_id } ->
+    Printf.sprintf
+      "Keeper %s is not allowed to access repository %s"
+      keeper_id
+      repository_id
+  | Access_denied_load_error detail -> detail
+  | Access_denied_repository_store_error { repository_id; detail } ->
+    Printf.sprintf
+      "Repository store load failed while validating repository %s: %s"
+      repository_id
+      detail
+;;
+
+let access_decision ~keeper_id ~repository_id ~base_path =
   match repository_registered ~base_path ~repository_id with
-  | Stdlib.Error _ ->
+  | Stdlib.Error detail ->
     record_policy_decision ~keeper_id ~repository_id
       Policy_decision_repository_store_error;
-    false
+    Access_denied
+      (Access_denied_repository_store_error { repository_id; detail })
   | Stdlib.Ok false ->
     record_policy_decision ~keeper_id ~repository_id
       Policy_decision_unregistered_repository;
-    false
+    Access_denied (Access_denied_unregistered_repository repository_id)
   | Stdlib.Ok true -> (
     match lookup_mapping ~base_path ~keeper_id with
     | Mapping_missing _ ->
       record_policy_decision ~keeper_id ~repository_id
         Policy_decision_default_scope_allowed;
-      true
+      Access_allowed
     | Mapping_load_error msg ->
       log_mapping_load_error_if_new ~keeper_id msg;
       record_policy_decision ~keeper_id Policy_decision_load_error;
-      false
+      Access_denied (Access_denied_load_error msg)
     | Mapping_found mapping ->
-      if mapping_allows_repository mapping ~repository_id then true
+      if mapping_allows_repository mapping ~repository_id then Access_allowed
       else (
         record_policy_decision ~keeper_id ~repository_id Policy_decision_not_in_mapping;
-        false))
+        Access_denied
+          (Access_denied_not_in_mapping { keeper_id; repository_id })))
+;;
+
+let is_allowed ~keeper_id ~repository_id ~base_path =
+  match access_decision ~keeper_id ~repository_id ~base_path with
+  | Access_allowed -> true
+  | Access_denied _ -> false
 
 let validate_access ~keeper_id ~repository_id ~base_path =
-  if is_allowed ~keeper_id ~repository_id ~base_path then Ok ()
-  else
-    Error
-      (Printf.sprintf "Keeper %s is not allowed to access repository %s"
-         keeper_id repository_id)
+  match access_decision ~keeper_id ~repository_id ~base_path with
+  | Access_allowed -> Ok ()
+  | Access_denied denial -> Error (access_denial_to_string denial)
 
 let save_all ~base_path mappings =
   let path = mappings_toml_path base_path in

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -55,6 +55,33 @@ val log_mapping_load_error_if_new : keeper_id:string -> string -> unit
     corruption/misconfiguration even on display-only paths that do not call
     {!is_allowed}. *)
 
+type access_denial =
+  | Access_denied_unregistered_repository of repository_id
+  | Access_denied_not_in_mapping of
+      { keeper_id : string
+      ; repository_id : repository_id
+      }
+  | Access_denied_load_error of string
+  | Access_denied_repository_store_error of
+      { repository_id : repository_id
+      ; detail : string
+      }
+
+type access_decision =
+  | Access_allowed
+  | Access_denied of access_denial
+
+val access_denial_to_string : access_denial -> string
+
+val access_decision :
+  keeper_id:string ->
+  repository_id:repository_id ->
+  base_path:string ->
+  access_decision
+(** [access_decision ~keeper_id ~repository_id ~base_path] is the typed
+    repository access gate. Use it when a caller needs to distinguish a
+    claimable selected-scope miss from hard fail-closed cases. *)
+
 type policy_decision =
   | Policy_decision_default_scope_allowed
   | Policy_decision_unregistered_repository
@@ -97,6 +124,8 @@ val apply_mapping :
     Mapping load failures still return no repositories. *)
 
 type repository_identity_mismatch
+
+val repository_identity_mismatch_message : repository_identity_mismatch -> string
 
 type repository_resolution =
   | No_repository

--- a/test/dune
+++ b/test/dune
@@ -193,6 +193,7 @@
   test_keeper_chat_media_store
   test_keeper_external_attention
   test_keeper_board_attention_candidate
+  test_keeper_repo_claim_hitl
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager
@@ -537,6 +538,7 @@
   test_keeper_chat_media_store
   test_keeper_external_attention
   test_keeper_board_attention_candidate
+  test_keeper_repo_claim_hitl
   test_keeper_runtime_trust_snapshot
   test_keeper_tool_audit_snapshot
   test_lsp_process_manager

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -1,0 +1,189 @@
+module Claim = Masc.Keeper_repo_claim_hitl
+module AQ = Masc.Keeper_approval_queue
+
+open Repo_manager_types
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+;;
+
+let is_directory_no_follow path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } -> true
+  | _ -> false
+  | exception Unix.Unix_error _ -> false
+;;
+
+let path_exists_no_follow path =
+  match Unix.lstat path with
+  | _ -> true
+  | exception Unix.Unix_error _ -> false
+;;
+
+let rec remove_tree path =
+  if path_exists_no_follow path then
+    if is_directory_no_follow path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+;;
+
+let ensure_dir path =
+  let rec loop path =
+    if path = "" || path = "." || path = "/" || Sys.file_exists path then ()
+    else begin
+      let parent = Filename.dirname path in
+      if parent <> path then loop parent;
+      Unix.mkdir path 0o755
+    end
+  in
+  loop path
+;;
+
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let with_temp_base_path f =
+  let dir = Filename.temp_file "repo_claim_hitl" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+;;
+
+let sample_repo ~base_path id =
+  let local_path = Filename.concat base_path ("repo-" ^ id) in
+  ensure_dir local_path;
+  { id
+  ; name = id
+  ; url = "https://github.com/test/" ^ id
+  ; local_path
+  ; aliases = []
+  ; default_branch = "main"
+  ; keepers = []
+  ; status = Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = Int64.zero
+  ; updated_at = Int64.zero
+  }
+;;
+
+let write_repositories base_path repos =
+  let repo_block (repo : repository) =
+    Printf.sprintf
+      "[repository.%s]\nname = \"%s\"\nurl = \"%s\"\nlocal_path = \"%s\"\n\
+       default_branch = \"%s\"\nkeepers = []\nstatus = \"Active\"\nauto_sync = false\n\
+       sync_interval = 0\n"
+      repo.id
+      repo.name
+      repo.url
+      repo.local_path
+      repo.default_branch
+  in
+  write_file
+    (Filename.concat base_path ".masc/config/repositories.toml")
+    (String.concat "\n" (List.map repo_block repos))
+;;
+
+let write_mapping base_path keeper_id repo_ids =
+  let mapping = make_keeper_repo_mapping ~keeper_id ~repository_ids:repo_ids in
+  match Keeper_repo_mapping.save_mapping ~base_path mapping with
+  | Ok () -> ()
+  | Error detail -> Alcotest.fail ("save_mapping failed: " ^ detail)
+;;
+
+let test_not_in_mapping_requests_hitl_and_approval_grants_repo () =
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+  with_temp_base_path @@ fun base_path ->
+  let keeper_id = "keeper-repo-claim-hitl" in
+  let repo_a = sample_repo ~base_path "repo-a" in
+  let repo_b = sample_repo ~base_path "repo-b" in
+  write_repositories base_path [ repo_a; repo_b ];
+  write_mapping base_path keeper_id [ repo_a.id ];
+  let pending_before = AQ.pending_count () in
+  let result =
+    Claim.request_path_access
+      ~keeper_id
+      ~base_path
+      ~path:(Filename.concat repo_b.local_path "README.md")
+  in
+  let approval_id, repository_id =
+    match result with
+    | Claim.Access_pending_approval { approval_id; repository_id } ->
+      approval_id, repository_id
+    | Claim.Access_allowed -> Alcotest.fail "expected HITL request, got allowed"
+    | Claim.Access_denied detail ->
+      Alcotest.fail ("expected HITL request, got denial: " ^ detail)
+  in
+  Alcotest.(check string) "pending repository id" repo_b.id repository_id;
+  Alcotest.(check int) "pending count increments" (pending_before + 1) (AQ.pending_count ());
+  (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error err ->
+     Alcotest.fail ("approval resolve failed: " ^ AQ.resolve_error_to_string err));
+  Alcotest.(check int) "pending count restored" pending_before (AQ.pending_count ());
+  match
+    Keeper_repo_mapping.validate_access
+      ~keeper_id
+      ~base_path
+      ~repository_id:repo_b.id
+  with
+  | Ok () -> ()
+  | Error detail ->
+    Alcotest.fail ("approved repo claim did not update mapping: " ^ detail)
+;;
+
+let test_unregistered_repository_does_not_request_hitl () =
+  with_temp_base_path @@ fun base_path ->
+  let keeper_id = "keeper-repo-claim-unregistered" in
+  let repo_a = sample_repo ~base_path "repo-a" in
+  write_repositories base_path [ repo_a ];
+  write_mapping base_path keeper_id [ repo_a.id ];
+  let pending_before = AQ.pending_count () in
+  let result =
+    Claim.request_repository_access
+      ~keeper_id
+      ~base_path
+      ~repository_id:"not-registered"
+  in
+  (match result with
+   | Claim.Access_denied detail ->
+     Alcotest.(check bool)
+       "denial mentions unregistered repository"
+       true
+       (contains_substring detail "not-registered")
+   | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
+   | Claim.Access_pending_approval _ ->
+     Alcotest.fail "unregistered repositories must not request HITL");
+  Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
+;;
+
+let () =
+  Alcotest.run
+    "Keeper_repo_claim_hitl"
+    [ ( "repo claim"
+      , [ Alcotest.test_case
+            "not-in-mapping queues HITL and approval grants repo"
+            `Quick
+            test_not_in_mapping_requests_hitl_and_approval_grants_repo
+        ; Alcotest.test_case
+            "unregistered repository remains fail-closed"
+            `Quick
+            test_unregistered_repository_does_not_request_hitl
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- Adds a typed repo access decision so selected-scope misses are distinguishable from hard fail-closed errors.
- Adds a keeper-side HITL bridge that queues repository claim approvals without blocking the keeper.
- Applies approved claims through the existing keeper_repo_mappings.toml save path.
- Wires filesystem read/write policy responses to return approval_pending for claimable repo-scope misses.
- Adds a browser-openable implementation plan at docs/superpowers/plans/2026-07-06-repo-claim-hitl-plan.html.

## Boundaries
- MASC-only change; OAS remains unaware of keeper repo territory and HITL policy.
- Unregistered repositories, repository-store load failures, and identity mismatches still fail closed and do not create claims.
- Existing strict validate_access / validate_path_access APIs remain available for callers that must not mutate or queue HITL.

## Validation
- opam exec -- ocamlformat --check lib/repo_manager/keeper_repo_mapping.ml lib/repo_manager/keeper_repo_mapping.mli lib/keeper/keeper_repo_claim_hitl.ml lib/keeper/keeper_repo_claim_hitl.mli lib/keeper/keeper_tool_filesystem_runtime.ml test/test_keeper_repo_claim_hitl.ml test/test_keeper_repo_mapping.ml
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build test/test_keeper_repo_claim_hitl.exe test/test_keeper_repo_mapping.exe
- ./_build/default/test/test_keeper_repo_claim_hitl.exe
- ./_build/default/test/test_keeper_repo_mapping.exe
