### PR TITLE
[codex] Add manual catch-up activity judge

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -16,6 +16,7 @@ import {
   getStoredTokenMeta,
   isRemoteAccess,
   jsonHeaders,
+  post,
   runOperatorAction,
   fetchWithTimeout,
   DEFAULT_GET_TIMEOUT_MS,
@@ -702,6 +703,47 @@ export async function fetchKeeperCatchupDigest(
     throw new Error('fetchKeeperCatchupDigest: invalid digest payload')
   }
   return digest
+}
+
+export interface KeeperCatchupJudgmentResponse {
+  ok: true
+  status: 'fusion_started'
+  runId: string
+  ownerKeeper: string
+  fusionRoute: string
+  digest: KeeperCatchupDigest
+}
+
+export async function runKeeperCatchupJudgment(
+  keeperName: string,
+  sinceUnix: number,
+): Promise<KeeperCatchupJudgmentResponse> {
+  const raw = await post<unknown>(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/catchup-judge`,
+    { since_unix: sinceUnix },
+  )
+  if (!isRecord(raw) || raw.ok !== true) {
+    throw new Error('runKeeperCatchupJudgment: invalid response envelope')
+  }
+  const runId = asString(raw.run_id)
+  const ownerKeeper = asString(raw.owner_keeper)
+  const fusionRoute = asString(raw.fusion_route)
+  if (!runId || !ownerKeeper || !fusionRoute) {
+    throw new Error('runKeeperCatchupJudgment: missing run metadata')
+  }
+  const { parseKeeperCatchupDigest } = await import('./schemas/keeper-catchup-digest')
+  const digest = parseKeeperCatchupDigest(raw.digest)
+  if (!digest) {
+    throw new Error('runKeeperCatchupJudgment: invalid digest payload')
+  }
+  return {
+    ok: true,
+    status: 'fusion_started',
+    runId,
+    ownerKeeper,
+    fusionRoute,
+    digest,
+  }
 }
 
 // --- Keeper observability API ---

--- a/dashboard/src/components/keeper-catchup-digest-card.test.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.test.ts
@@ -1,0 +1,129 @@
+import { html } from 'htm/preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import {
+  KeeperCatchupDigestCard,
+  keeperCatchupDigestActivityCount,
+  shouldShowKeeperCatchupDigest,
+} from './keeper-catchup-digest-card'
+import { runKeeperCatchupJudgment } from '../api/keeper'
+import { navigate } from '../router'
+import type { KeeperCatchupDigest } from '../api/schemas/keeper-catchup-digest'
+
+vi.mock('../api/keeper', () => ({
+  runKeeperCatchupJudgment: vi.fn(),
+}))
+
+vi.mock('../router', () => ({
+  navigate: vi.fn(),
+}))
+
+const runKeeperCatchupJudgmentMock = vi.mocked(runKeeperCatchupJudgment)
+const navigateMock = vi.mocked(navigate)
+
+function makeDigest(overrides: Partial<KeeperCatchupDigest> = {}): KeeperCatchupDigest {
+  return {
+    keeper: 'idealist',
+    since_unix: 1_777_000_000,
+    generated_at_unix: 1_777_000_120,
+    chat: {
+      new_messages: 2,
+      first_new_ts: 1_777_000_030,
+      transport_failures: 0,
+    },
+    turns: {
+      completed: 10,
+      failed: 0,
+      crashes: 0,
+    },
+    tasks: {
+      claimed: 0,
+      done: 0,
+      released: 0,
+      cancelled: 0,
+      items: [],
+    },
+    board: {
+      posted: 3,
+      commented: 0,
+      voted: 0,
+    },
+    lifecycle: {
+      paused_now: false,
+      pause_events: 0,
+      resume_events: 0,
+      items: [],
+    },
+    coverage: {
+      chat: { lower_bound: false, causes: [] },
+      turns: { lower_bound: false, causes: [] },
+      tasks: { lower_bound: false, causes: [] },
+      board: { lower_bound: false, causes: [] },
+      lifecycle: { lower_bound: false, causes: [] },
+    },
+    read_errors: [],
+    ...overrides,
+  }
+}
+
+describe('KeeperCatchupDigestCard', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('summarizes the digest counts and remains visible above the minimum activity threshold', () => {
+    const digest = makeDigest()
+
+    expect(keeperCatchupDigestActivityCount(digest)).toBe(15)
+    expect(shouldShowKeeperCatchupDigest(digest)).toBe(true)
+
+    render(html`<${KeeperCatchupDigestCard} digest=${digest} />`)
+
+    expect(screen.getByText('그 사이 활동')).toBeInTheDocument()
+    expect(screen.getByText('이후 2개 메시지')).toBeInTheDocument()
+    expect(screen.getByText('메시지 2')).toBeInTheDocument()
+    expect(screen.getByText('턴 10회')).toBeInTheDocument()
+    expect(screen.getByText('보드 3')).toBeInTheDocument()
+    expect(screen.getByTestId('keeper-catchup-judge-run')).toHaveTextContent('판정 실행')
+  })
+
+  it('starts a manual catch-up judgment and links to the Fusion run', async () => {
+    const digest = makeDigest()
+    runKeeperCatchupJudgmentMock.mockResolvedValue({
+      ok: true,
+      status: 'fusion_started',
+      runId: 'fus-manual-1',
+      ownerKeeper: 'idealist',
+      fusionRoute: '/#fusion?run_id=fus-manual-1',
+      digest,
+    })
+
+    render(html`<${KeeperCatchupDigestCard} digest=${digest} />`)
+
+    fireEvent.click(screen.getByTestId('keeper-catchup-judge-run'))
+
+    await waitFor(() => {
+      expect(runKeeperCatchupJudgmentMock).toHaveBeenCalledWith('idealist', 1_777_000_000)
+    })
+    const openButton = await screen.findByTestId('keeper-catchup-judge-open')
+    expect(openButton).toHaveTextContent('결과 보기')
+
+    fireEvent.click(openButton)
+
+    expect(navigateMock).toHaveBeenCalledWith('fusion', { run_id: 'fus-manual-1' })
+  })
+
+  it('renders a failure inline when the judgment request fails', async () => {
+    const digest = makeDigest()
+    runKeeperCatchupJudgmentMock.mockRejectedValue(new Error('fusion disabled'))
+
+    render(html`<${KeeperCatchupDigestCard} digest=${digest} />`)
+
+    fireEvent.click(screen.getByTestId('keeper-catchup-judge-run'))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('fusion disabled')
+    expect(screen.queryByTestId('keeper-catchup-judge-open')).toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-catchup-digest-card.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.ts
@@ -1,9 +1,13 @@
 import { html } from 'htm/preact'
+import { ExternalLink, Scale } from 'lucide-preact'
+import { useState } from 'preact/hooks'
+import { runKeeperCatchupJudgment } from '../api/keeper'
 import type {
   KeeperCatchupDigest,
   KeeperCatchupDigestCoverageCause,
 } from '../api/schemas/keeper-catchup-digest'
 import { KEEPER_DIGEST_MIN_ACTIVITY } from '../config/constants'
+import { navigate } from '../router'
 
 // Total count of new activity across every category since the operator's
 // last-seen cursor. Drives the "is there anything worth showing" gate.
@@ -83,6 +87,8 @@ const CHIP_BASE =
 const CHIP_DEFAULT =
   'border-[var(--color-border-default)] bg-[var(--color-bg-page)] text-[var(--color-fg-secondary)]'
 const CHIP_WARN = 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
+const ACTION_BUTTON =
+  'inline-flex h-7 items-center gap-1.5 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 text-2xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-accent-muted)] hover:text-[var(--color-fg-default)] disabled:cursor-wait disabled:opacity-60'
 
 function digestChips(digest: KeeperCatchupDigest): DigestChip[] {
   const { chat, turns, tasks, board, lifecycle } = digest
@@ -109,6 +115,24 @@ function digestChips(digest: KeeperCatchupDigest): DigestChip[] {
 export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDigest }) {
   const chips = digestChips(digest)
   const coverageWarningItems = coverageWarnings(digest)
+  const [running, setRunning] = useState(false)
+  const [runId, setRunId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function runJudge() {
+    if (running) return
+    setRunning(true)
+    setError(null)
+    try {
+      const result = await runKeeperCatchupJudgment(digest.keeper, digest.since_unix)
+      setRunId(result.runId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '판정 실행에 실패했습니다.')
+    } finally {
+      setRunning(false)
+    }
+  }
+
   return html`
     <div
       data-keeper-catchup-digest
@@ -121,9 +145,36 @@ export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDiges
             ? html`<span class="text-2xs text-[var(--color-fg-secondary)]">이후 ${digest.chat.new_messages}개 메시지</span>`
             : null}
         </div>
-        ${digest.lifecycle.paused_now
-          ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-2xs font-medium text-[var(--warn-bright)]">일시정지됨</span>`
-          : null}
+        <div class="flex flex-wrap items-center gap-1.5">
+          ${digest.lifecycle.paused_now
+            ? html`<span class="inline-flex h-7 items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 text-2xs font-medium text-[var(--warn-bright)]">일시정지됨</span>`
+            : null}
+          ${runId
+            ? html`
+                <button
+                  type="button"
+                  class=${ACTION_BUTTON}
+                  title="Fusion 판정 결과 열기"
+                  data-testid="keeper-catchup-judge-open"
+                  onClick=${() => navigate('fusion', { run_id: runId })}
+                >
+                  <${ExternalLink} size=${12} aria-hidden="true" />
+                  결과 보기
+                </button>
+              `
+            : null}
+          <button
+            type="button"
+            class=${ACTION_BUTTON}
+            title="그 사이 활동을 엄격 판정자로 평가"
+            disabled=${running}
+            data-testid="keeper-catchup-judge-run"
+            onClick=${runJudge}
+          >
+            <${Scale} size=${12} aria-hidden="true" />
+            ${running ? '판정 중' : '판정 실행'}
+          </button>
+        </div>
       </div>
       ${chips.length > 0
         ? html`
@@ -136,6 +187,13 @@ export function KeeperCatchupDigestCard({ digest }: { digest: KeeperCatchupDiges
                   ${chip.text}
                 </span>
               `)}
+            </div>
+          `
+        : null}
+      ${error
+        ? html`
+            <div class="mt-2 rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-10)] px-2 py-1 text-2xs leading-relaxed text-[var(--bad-light)]" role="alert">
+              ${error}
             </div>
           `
         : null}

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -71,6 +71,12 @@ val handle_keeper_tools_post :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Handle [POST /tools] (tool-grant edits). *)
 
+val handle_keeper_catchup_judge_post :
+  Mcp_server.server_state ->
+  Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle [POST /catchup-judge] by recomputing the keeper catch-up digest
+    and starting an out-of-band Fusion judge run. *)
+
 (** {1 POST route classifier}
 
     keeper_post_route_kind ADT + classifier + path helpers live in

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -65,6 +65,122 @@ let error_json ?ok message =
 let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
   Http.Response.json_value ?request ~status (error_json ?ok message) reqd
 
+let keeper_catchup_judge_prompt ~keeper_name ~(digest : Keeper_catchup_digest.t) =
+  let digest_json = Keeper_catchup_digest.to_json digest in
+  Printf.sprintf
+    {|You are a strict MASC activity judge.
+
+Write the assessment in Korean. Judge only the activity digest below. Do not invent unseen messages, hidden intent, or external context.
+This assessment is advisory and non-blocking: do not claim it gates merge, keeper progress, task ownership, or user access. A FAIL verdict means immediate operator attention is recommended, not an automatic stop.
+
+Rubric:
+- Outcome quality: did the keeper make observable progress, or only produce motion?
+- Risk: are there failed turns, crashes, transport failures, read errors, or lower-bound coverage warnings?
+- Responsiveness: do the message/turn/board/task counts suggest useful engagement?
+- Improvement: name concrete next actions an operator or keeper should take.
+
+Return concise Markdown with these sections:
+1. Verdict: one of PASS, WATCH, or FAIL, with one sentence.
+2. Evidence: 3-5 bullets tied to exact digest fields.
+3. Improvement points: 2-4 concrete recommendations.
+4. Missing evidence: note any coverage/read limitations.
+
+Keeper: %s
+Digest JSON:
+```json
+%s
+```|}
+    keeper_name
+    (Yojson.Safe.pretty_to_string digest_json)
+;;
+
+let parse_fusion_result text =
+  try Yojson.Safe.from_string text with
+  | Yojson.Json_error _ -> `Assoc [ "ok", `Bool false; "error", `String text ]
+;;
+
+let is_finite_float value =
+  match classify_float value with
+  | FP_normal | FP_subnormal | FP_zero -> true
+  | FP_infinite | FP_nan -> false
+;;
+
+let handle_keeper_catchup_judge_post state req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_suffix req_path keeper_suffix_catchup_judge in
+  if name = "" then respond_error reqd "keeper name required"
+  else if not (Keeper_config.validate_name name) then
+    respond_error reqd (Printf.sprintf "invalid keeper name: %s" name)
+  else
+    try
+      let args = Yojson.Safe.from_string body_str in
+      let since_unix = Safe_ops.json_float_opt "since_unix" args in
+      match since_unix with
+      | None -> respond_error reqd "since_unix is required"
+      | Some since_unix when not (is_finite_float since_unix) ->
+        respond_error reqd "since_unix must be a finite unix-seconds float"
+      | Some since_unix when since_unix < 0.0 ->
+        respond_error reqd "since_unix must be non-negative"
+      | Some since_unix ->
+        let config = Mcp_server.workspace_config state in
+        let now_unix = Time_compat.now () in
+        let digest =
+          Keeper_catchup_digest.build ~base_path:config.base_path
+            ~keeper_name:name ~since_unix ~now_unix
+        in
+        let prompt = keeper_catchup_judge_prompt ~keeper_name:name ~digest in
+        (match Eio_context.get_root_switch_opt (), Eio_context.get_net_opt () with
+         | None, _ | _, None ->
+           respond_error reqd "fusion requires the server root switch + net (unavailable)"
+         | Some sw, Some net ->
+           (match Fusion_config_loader.load ~base_path:config.base_path with
+            | Error msg -> respond_error reqd msg
+            | Ok policy ->
+              let fusion_args =
+                `Assoc
+                  [ "prompt", `String prompt
+                  ; "web_tools", `Bool false
+                  ; "topology", `String "simple"
+                  ]
+              in
+              let run_id = Random_id.prefixed ~prefix:"fus-" ~bytes:16 in
+              let raw =
+                Fusion_tool.handle
+                  ~sw
+                  ~net
+                  ~base_dir:config.base_path
+                  ~keeper:name
+                  ~now_unix
+                  ~run_id
+                  ~policy
+                  ~args:fusion_args
+              in
+              let fusion_json = parse_fusion_result raw in
+              (match Json_util.assoc_member_opt "ok" fusion_json with
+               | Some (`Bool true) ->
+                 Http.Response.json_value ~compress:true ~request:req
+                   (`Assoc
+                      [ "ok", `Bool true
+                      ; "status", `String "fusion_started"
+                      ; "run_id", `String run_id
+                      ; "owner_keeper", `String name
+                      ; "fusion_route", `String ("/#fusion?run_id=" ^ run_id)
+                      ; "digest", Keeper_catchup_digest.to_json digest
+                      ])
+                   reqd
+               | _ ->
+                 let message =
+                   match Json_util.assoc_member_opt "error" fusion_json with
+                   | Some (`String msg) -> msg
+                   | _ -> Yojson.Safe.to_string fusion_json
+                 in
+                 respond_error reqd message)))
+    with
+    | Yojson.Json_error msg -> respond_error reqd ("invalid json: " ^ msg)
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> respond_error reqd (Printexc.to_string exn)
+;;
+
 (** Handle POST /api/v1/keepers/:name/tools.
     Extracted so it can be called from any prefix_post handler that
     catches POST /api/v1/keepers/* requests. *)

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -43,6 +43,9 @@ val respond_error :
 val handle_keeper_tools_post :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 
+val handle_keeper_catchup_judge_post :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+
 val stat_json_of_path : string -> Yojson.Safe.t
 val oas_checkpoint_summary_json :
   source_kind:string ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -14,6 +14,7 @@ let keeper_suffix_clear = "/clear"
 let keeper_suffix_checkpoints = "/checkpoints"
 let keeper_suffix_runtime_trace = "/runtime-trace"
 let keeper_suffix_directive = "/directive"
+let keeper_suffix_catchup_judge = "/catchup-judge"
 
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
@@ -65,6 +66,7 @@ type keeper_post_route_kind =
   | Keeper_post_clear
   | Keeper_post_checkpoints
   | Keeper_post_directive
+  | Keeper_post_catchup_judge
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -86,6 +88,7 @@ let classify_keeper_post_route req_path =
     else if ends_with keeper_suffix_clear then Keeper_post_clear
     else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
     else if ends_with keeper_suffix_directive then Keeper_post_directive
+    else if ends_with keeper_suffix_catchup_judge then Keeper_post_catchup_judge
     else Keeper_post_unknown
 
 let keeper_path_ends_with req_path suffix =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -22,6 +22,7 @@ val keeper_suffix_clear : string
 val keeper_suffix_checkpoints : string
 val keeper_suffix_runtime_trace : string
 val keeper_suffix_directive : string
+val keeper_suffix_catchup_judge : string
 
 (** {1 Dashboard cache keys} *)
 
@@ -60,6 +61,7 @@ type keeper_post_route_kind =
   | Keeper_post_clear
   | Keeper_post_checkpoints
   | Keeper_post_directive
+  | Keeper_post_catchup_judge
   | Keeper_post_unknown
 (** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1628,6 +1628,13 @@ let add_routes ~sw ~clock router =
                    ~sw ~clock state agent_name req reqd body_str
                )
              ) request reqd
+       | Keeper_api.Keeper_post_catchup_judge ->
+           with_tool_auth ~tool_name:"masc_fusion"
+             (fun state req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_catchup_judge_post state req reqd body_str
+               )
+             ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            respond_dashboard_error ~status:`Not_found reqd "not found")
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -140,6 +140,15 @@ let request target =
 let request_with_headers target headers =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) `GET target
 
+let test_keeper_post_route_classifies_catchup_judge () =
+  let path = "/api/v1/keepers/idealist/catchup-judge" in
+  check bool "catchup judge route kind" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route path
+     = Server_dashboard_http_keeper_api.Keeper_post_catchup_judge);
+  check string "keeper name extracted" "idealist"
+    (Server_dashboard_http_keeper_api.extract_keeper_name_for_suffix path
+       Server_dashboard_http_keeper_api.keeper_suffix_catchup_judge)
+
 let with_test_env f =
   let dir = test_dir () in
 	Fun.protect
@@ -1772,6 +1781,8 @@ let () =
             test_state_diagram_runtime_projection_redacts_live_runtime_evidence;
           test_case "state diagram runtime projection stays empty without meta" `Quick
             test_state_diagram_runtime_projection_missing_meta_stays_empty;
+          test_case "keeper catch-up judge route is classified" `Quick
+            test_keeper_post_route_classifies_catchup_judge;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick


### PR DESCRIPTION
## Summary

Adds a manual, advisory judge action to the keeper catch-up digest card.

- adds a `판정 실행` action on the "그 사이 활동" card
- posts to `POST /api/v1/keepers/:name/catchup-judge`, where the server recomputes the digest from `since_unix`
- starts a Fusion run with the digest as evidence and links back via `결과 보기`
- keeps the judgment explicitly non-blocking: it does not write gate state, block keeper progress, alter task ownership, or affect merge/readiness semantics

## Validation

- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-catchup-digest-card.test.ts --no-file-parallelism --maxWorkers=1`
- `ocamlformat --check lib/server/server_dashboard_http_keeper_api_types.ml lib/server/server_dashboard_http_keeper_api_types.mli lib/server/server_dashboard_http_keeper_api_post.ml lib/server/server_dashboard_http_keeper_api_post.mli lib/server/server_dashboard_http_keeper_api.mli lib/server/server_routes_http_routes_dashboard.ml test/test_dashboard_http_core.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_http_core.exe`