### PR TITLE
dashboard: stop fabricating missing runtime provenance

### DIFF
--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -176,6 +176,10 @@ val runtime_provider_label : public_label
 val runtime_model_label : public_label
 (** The redaction label used for *model_id* on external surfaces. *)
 
+val unknown_model_label : public_label
+(** The label used for *model_id* on external surfaces when no model evidence
+    exists. *)
+
 val to_string : public_label -> string
 (** Project a redaction label into a plain string at the emit boundary. *)
 ```
@@ -187,6 +191,7 @@ type public_label = string
 
 let runtime_provider_label = "runtime"
 let runtime_model_label = "runtime"
+let unknown_model_label = "unknown_model"
 let to_string s = s
 ```
 
@@ -266,6 +271,7 @@ Once PR-3 is merged, any future PR that adds an inline `"runtime"` literal at an
 | Phase | Verification |
 |---|---|
 | PR-1 | Alcotest: `runtime_provider_label \|> to_string = "runtime"` and `runtime_model_label \|> to_string = "runtime"`. Compile-time: attempting `let x : Boundary_redaction.public_label = "foo"` outside the module fails the build. |
+| 2026-07-06 extension | Alcotest: `unknown_model_label \|> to_string = "unknown_model"` and the value is distinct from `runtime_model_label`. Governance dashboard model classification routes missing model evidence through this typed label instead of a local string. |
 | PR-2 | For each of the 23 sites: dashboard SSE / OAS bridge / keeper telemetry output byte-equality regression test. The boundary-emit byte stream must be identical to pre-codemod main. Regression count target: 0. |
 | PR-3 | Adding a test fixture that places `let _ = "runtime"` at `lib/runtime/foo.ml` causes a build failure with the lint rule error message. Removing the fixture restores the build. |
 | Overall | After PR-3 merge, `rg -n '"runtime"' lib/runtime/ lib/keeper/` should return only: (a) `boundary_redaction.ml` source, (b) `keeper_status_runtime.ml:219` allow-listed heuristic, (c) `.mli` doc comments. Total expected hits: ≤ 4. |

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -381,6 +381,11 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                          then "warn"
                          else "ok"
                        in
+                       let receipt_runtime_summary =
+                         match receipt_runtime_id receipt with
+                         | Some runtime_id -> runtime_id
+                         | None -> "<missing receipt.runtime.name>"
+                       in
                        Some
                          (timeline_event_json ~ts:ended_at ~kind:"keeper_receipt"
                             ~lane:("keeper:" ^ detail.meta.name)
@@ -388,8 +393,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                             ~summary:
                               (Printf.sprintf "%s · %s"
                                  outcome
-                                 (receipt_runtime_id receipt
-                                  |> Option.value ~default:(Keeper_meta_contract.runtime_id_of_meta detail.meta)))
+                                 receipt_runtime_summary)
                             ~severity)))
   in
   let goal_events = List.map goal_event_timeline_json goal_events in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -124,7 +124,8 @@ let governance_model_source_to_string = function
 let redacted_runtime_model_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
-let unknown_model_label = "unknown_model"
+let unknown_model_label =
+  Boundary_redaction.to_string Boundary_redaction.unknown_model_label
 
 let resolve_governance_model_used ~raw_model ~canonical_model_id =
   if String.trim raw_model <> "" then redacted_runtime_model_label, Response_model

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -121,15 +121,20 @@ let governance_model_source_to_string = function
   | Telemetry_resolved -> "telemetry_resolved"
   | Unknown_source -> "unknown_source"
 
+let redacted_runtime_model_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+
+let unknown_model_label = "unknown_model"
+
 let resolve_governance_model_used ~raw_model ~canonical_model_id =
-  if String.trim raw_model <> "" then "runtime", Response_model
+  if String.trim raw_model <> "" then redacted_runtime_model_label, Response_model
   else
     match canonical_model_id with
     | Some id ->
         let trimmed = String.trim id in
-        if trimmed <> "" then "runtime", Telemetry_resolved
-        else "runtime", Unknown_source
-    | None -> "runtime", Unknown_source
+        if trimmed <> "" then redacted_runtime_model_label, Telemetry_resolved
+        else unknown_model_label, Unknown_source
+    | None -> unknown_model_label, Unknown_source
 
 let governance_dir base_path =
   Filename.concat

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -236,8 +236,9 @@ val resolve_governance_model_used :
 (** Picks the internal model id for empty-model diagnostics.
     [raw_model] (trimmed non-empty) wins for classification; otherwise
     falls back to [canonical_model_id], otherwise the unknown source branch.
-    The returned id is always the neutral [runtime] lane so dashboard state does
-    not expose concrete provider/model identity. *)
+    Evidence-backed model ids are projected to the neutral [runtime] lane so
+    dashboard state does not expose concrete provider/model identity. Missing
+    evidence returns ["unknown_model"] instead of fabricating runtime evidence. *)
 
 type governance_response_parse_failure =
   | Structural_error of string

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -238,7 +238,8 @@ val resolve_governance_model_used :
     falls back to [canonical_model_id], otherwise the unknown source branch.
     Evidence-backed model ids are projected to the neutral [runtime] lane so
     dashboard state does not expose concrete provider/model identity. Missing
-    evidence returns ["unknown_model"] instead of fabricating runtime evidence. *)
+    evidence returns [Boundary_redaction.unknown_model_label] instead of
+    fabricating runtime evidence. *)
 
 type governance_response_parse_failure =
   | Structural_error of string

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -121,6 +121,8 @@ let classify_failure_output (output : string) : string =
 let bucket_key record field ~default =
   Safe_ops.json_string_opt field record |> Option.value ~default
 
+let unknown_runtime_profile_bucket = "unknown_runtime_profile"
+
 let runtime_bucket_key record =
   match Safe_ops.json_string_opt "runtime_profile" record with
   | Some value when String.trim value <> "" -> value
@@ -128,7 +130,7 @@ let runtime_bucket_key record =
     let runtime_contract = Option.value ~default:`Null (Json_util.assoc_member_opt "runtime_contract" record) in
     (match Safe_ops.json_string_opt "runtime_profile" runtime_contract with
      | Some value when String.trim value <> "" -> value
-     | _ -> "unknown_runtime_profile")
+     | _ -> unknown_runtime_profile_bucket)
 
 (* Split the two failure modes that previously collapsed to the
    bare "unknown" bucket so a non-zero count on either tells the

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -128,7 +128,7 @@ let runtime_bucket_key record =
     let runtime_contract = Option.value ~default:`Null (Json_util.assoc_member_opt "runtime_contract" record) in
     (match Safe_ops.json_string_opt "runtime_profile" runtime_contract with
      | Some value when String.trim value <> "" -> value
-     | _ -> "runtime")
+     | _ -> "unknown_runtime_profile")
 
 (* Split the two failure modes that previously collapsed to the
    bare "unknown" bucket so a non-zero count on either tells the

--- a/lib/dashboard/dashboard_http_tool_quality.mli
+++ b/lib/dashboard/dashboard_http_tool_quality.mli
@@ -22,6 +22,11 @@ val classify_failure_output : string -> string
     normalised free-text classification or to ["parse_error"] /
     ["unknown_error"] / ["empty_output"] when nothing matches. *)
 
+val unknown_runtime_profile_bucket : string
+(** Bucket emitted by {!aggregate} when a tool-call record carries no
+    [runtime_profile] evidence at either the top level or in
+    [runtime_contract]. *)
+
 val aggregate :
   ?n:int -> ?window_hours:float -> unit -> Yojson.Safe.t
 (** Build the dashboard payload from the most recent [n] keeper

--- a/lib/types_boundary/boundary_redaction.ml
+++ b/lib/types_boundary/boundary_redaction.ml
@@ -4,6 +4,7 @@ type public_label = string
 
 let runtime_provider_label : public_label = "runtime"
 let runtime_model_label : public_label = "runtime"
+let unknown_model_label : public_label = "unknown_model"
 
 let to_string (label : public_label) : string = label
 

--- a/lib/types_boundary/boundary_redaction.mli
+++ b/lib/types_boundary/boundary_redaction.mli
@@ -27,6 +27,12 @@ val runtime_model_label : public_label
     [runtime_provider_label], while preserving the source field's meaning at
     call sites. *)
 
+val unknown_model_label : public_label
+(** Label for external model fields where no model evidence exists. This is
+    distinct from {!runtime_model_label}: ["runtime"] means model identity was
+    present and redacted, while ["unknown_model"] means there was no evidence to
+    redact. *)
+
 val to_string : public_label -> string
 
 (** Redacted lane label for external observability metric labels

--- a/test/stanzas/test_governance_response_model_empty_9880.inc
+++ b/test/stanzas/test_governance_response_model_empty_9880.inc
@@ -1,4 +1,4 @@
 (test
  (name test_governance_response_model_empty_9880)
  (modules test_governance_response_model_empty_9880)
-  (libraries masc masc.dashboard alcotest unix))
+  (libraries masc masc.dashboard masc.types_boundary alcotest unix))

--- a/test/test_boundary_redaction_runtime_lane.ml
+++ b/test/test_boundary_redaction_runtime_lane.ml
@@ -9,6 +9,14 @@ let test_runtime_lane_derives_from_model_label () =
     (Boundary.to_string Boundary.runtime_model_label)
     runtime_lane_string
 
+let test_unknown_model_label_is_distinct_from_runtime_redaction () =
+  let unknown_model = Boundary.to_string Boundary.unknown_model_label in
+  Alcotest.(check string) "unknown model label" "unknown_model" unknown_model;
+  Alcotest.(check bool)
+    "unknown model is not the redacted runtime lane"
+    false
+    (String.equal runtime_lane_string unknown_model)
+
 let test_runtime_lane_public_surfaces_use_boundary_ssot () =
   Alcotest.(check string)
     "keeper hooks use boundary lane SSOT"
@@ -31,6 +39,10 @@ let () =
             "runtime lane derives from typed model label"
             `Quick
             test_runtime_lane_derives_from_model_label
+        ; Alcotest.test_case
+            "unknown model label is a typed boundary label"
+            `Quick
+            test_unknown_model_label_is_distinct_from_runtime_redaction
         ; Alcotest.test_case
             "public surfaces serialize boundary lane"
             `Quick

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -37,6 +37,7 @@ let make_goal ?metric ?target_value id title =
 
 module A = Dashboard_goals_types_attainment
 module Acc = Dashboard_goals_types_accessor
+module Timeline = Dashboard_goals_types_timeline
 module MD = Masc_domain
 
 let json_str j key = Yojson.Safe.Util.(j |> member key |> to_string)
@@ -85,6 +86,19 @@ let make_node ?(tasks = []) goal : Acc.tree_node =
     activity_observation = "none";
     stagnation_status = "fresh";
   }
+
+let make_keeper_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ ("name", `String name)
+        ; ("agent_name", `String ("agent-" ^ name))
+        ; ("trace_id", `String ("trace-" ^ name))
+        ; ("goal", `String "goal timeline test")
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("make_keeper_meta: " ^ err)
 
 (* (a) A goal that declares a metric is exposed as typed "unevaluated". *)
 let test_declared_metric_is_unevaluated () =
@@ -167,6 +181,33 @@ let test_unevaluated_metric_does_not_enable_completion_ready () =
   check string "task-derived attainment is not completion-ready" "in_progress"
     (json_str json "state")
 
+let test_keeper_receipt_timeline_missing_runtime_stays_missing () =
+  let goal = make_goal "g7" "timeline" in
+  let meta = make_keeper_meta "timeline-keeper" in
+  let receipt =
+    `Assoc
+      [ ("outcome", `String "ok")
+      ; ("ended_at", `String "2026-07-06T02:00:00Z")
+      ]
+  in
+  let detail =
+    Acc.
+      { meta
+      ; latest_receipt = Some receipt
+      ; runtime_trust = `Assoc []
+      }
+  in
+  let events = Timeline.build_goal_timeline (make_node goal) [ detail ] [] [] in
+  let receipt_event =
+    List.find
+      (fun event -> String.equal (json_str event "kind") "keeper_receipt")
+      events
+  in
+  check string
+    "receipt without runtime does not borrow configured runtime"
+    "ok · <missing receipt.runtime.name>"
+    (json_str receipt_event "summary")
+
 let () =
   run "goal metric unevaluated"
     [
@@ -182,5 +223,7 @@ let () =
           test_case "absent metric in json" `Quick test_absent_metric_in_json;
           test_case "unevaluated metric does not enable completion ready" `Quick
             test_unevaluated_metric_does_not_enable_completion_ready;
+          test_case "receipt timeline does not fabricate runtime" `Quick
+            test_keeper_receipt_timeline_missing_runtime_stays_missing;
         ] );
     ]

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -23,6 +23,8 @@ module Metrics = Masc.Otel_metric_store
 module Judge = Dashboard_governance_judge
 
 let metric_name = "masc_governance_response_model_empty_total"
+let unknown_model_label =
+  Boundary_redaction.to_string Boundary_redaction.unknown_model_label
 
 let count_for ~source =
   Metrics.metric_value_or_zero metric_name ~labels:[ "source", source ] ()
@@ -119,7 +121,7 @@ let test_empty_everywhere_uses_unknown_source () =
     ~msg:"unknown source"
     ~raw_model:""
     ~canonical_model_id:None
-    ~expected_model:"unknown_model"
+    ~expected_model:unknown_model_label
     ~expected_source:"unknown_source"
 ;;
 
@@ -128,7 +130,7 @@ let test_empty_canonical_id_uses_unknown_source () =
     ~msg:"empty canonical"
     ~raw_model:""
     ~canonical_model_id:(Some "")
-    ~expected_model:"unknown_model"
+    ~expected_model:unknown_model_label
     ~expected_source:"unknown_source"
 ;;
 

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -5,8 +5,8 @@
     visibility.
 
     The fallback resolver is tested directly so this cannot
-    degrade into a metric-only smoke test that never proves
-    [model_used] is actually filled. *)
+    degrade into a metric-only smoke test that fabricates a runtime
+    model when no model evidence exists. *)
 
 open Masc
 
@@ -53,10 +53,10 @@ let test_telemetry_resolved_branch () =
 ;;
 
 (* When neither [response.model] nor telemetry resolves the model, the writer
-   still projects the neutral runtime lane and counts under
-   [unknown_source]. Distinct rows let dashboards separate "transport leaked
-   but recovered" from "transport leaked and no recovery available" without
-   exposing concrete provider/model identity. *)
+   records an explicit unknown-model marker and counts under [unknown_source].
+   Distinct rows let dashboards separate "transport leaked but recovered" from
+   "transport leaked and no recovery available" without exposing concrete
+   provider/model identity. *)
 let test_unknown_source_branch () =
   let before = count_for ~source:"unknown_source" in
   Metrics.inc_counter metric_name ~labels:[ "source", "unknown_source" ] ();
@@ -119,7 +119,7 @@ let test_empty_everywhere_uses_unknown_source () =
     ~msg:"unknown source"
     ~raw_model:""
     ~canonical_model_id:None
-    ~expected_model:"runtime"
+    ~expected_model:"unknown_model"
     ~expected_source:"unknown_source"
 ;;
 
@@ -128,7 +128,7 @@ let test_empty_canonical_id_uses_unknown_source () =
     ~msg:"empty canonical"
     ~raw_model:""
     ~canonical_model_id:(Some "")
-    ~expected_model:"runtime"
+    ~expected_model:"unknown_model"
     ~expected_source:"unknown_source"
 ;;
 

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -903,7 +903,9 @@ let test_dashboard_aggregate_missing_runtime_profile_is_unknown () =
       ();
     let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
     let by_runtime = Yojson.Safe.Util.member "by_runtime" summary in
-    let unknown_bucket = find_bucket "unknown_runtime_profile" by_runtime in
+    let unknown_bucket =
+      find_bucket Dashboard_http_tool_quality.unknown_runtime_profile_bucket by_runtime
+    in
     Alcotest.(check int)
       "missing runtime profile goes to unknown bucket"
       1

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -891,6 +891,24 @@ let test_dashboard_aggregate_groups_runtime_fields () =
     Alcotest.(check int) "auto tool_choice calls" 2
       (Safe_ops.json_int ~default:0 "calls" auto_bucket))
 
+let test_dashboard_aggregate_missing_runtime_profile_is_unknown () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k-missing-runtime"
+      ~tool_name:"masc_status"
+      ~input:(`Assoc [])
+      ~output_text:"ok"
+      ~success:true
+      ~duration_ms:1.0
+      ();
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    let by_runtime = Yojson.Safe.Util.member "by_runtime" summary in
+    let unknown_bucket = find_bucket "unknown_runtime_profile" by_runtime in
+    Alcotest.(check int)
+      "missing runtime profile goes to unknown bucket"
+      1
+      (Safe_ops.json_int ~default:0 "calls" unknown_bucket))
+
 let test_dashboard_hourly_trend_numeric_ts () =
   with_tmp_log_dir (fun dir ->
     let store =
@@ -1287,6 +1305,8 @@ let () =
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"
             test_dashboard_aggregate_groups_runtime_fields
+        ; eio_test "dashboard aggregate marks missing runtime profile unknown"
+            test_dashboard_aggregate_missing_runtime_profile_is_unknown
         ; eio_test "dashboard hourly trend buckets numeric ts"
             test_dashboard_hourly_trend_numeric_ts
         ; eio_test "dashboard aggregate window hours"


### PR DESCRIPTION
## Summary
- Redact evidence-backed governance model ids through `Boundary_redaction.runtime_model_label`, but emit `unknown_model` when no model evidence exists.
- Bucket missing tool-quality runtime profile as `unknown_runtime_profile` instead of the fabricated `runtime` bucket.
- Keep goal timeline receipt summaries tied to receipt evidence; missing `receipt.runtime.name` now surfaces as `<missing receipt.runtime.name>` instead of borrowing keeper runtime metadata.

## Validation
- PASS: `scripts/dune-local.sh build test/test_goal_metric_unevaluated.exe test/test_governance_response_model_empty_9880.exe test/test_keeper_tool_call_log.exe`
- PASS: `scripts/dune-local.sh exec test/test_goal_metric_unevaluated.exe`
- PASS: `scripts/dune-local.sh exec test/test_governance_response_model_empty_9880.exe`
- PASS: `scripts/dune-local.sh exec test/test_keeper_tool_call_log.exe`
- PASS: `opam exec -- ocamlformat --check lib/dashboard/dashboard_goals_types_timeline.ml lib/dashboard/dashboard_governance_judge.ml lib/dashboard/dashboard_governance_judge.mli lib/dashboard/dashboard_http_tool_quality.ml test/test_goal_metric_unevaluated.ml test/test_governance_response_model_empty_9880.ml test/test_keeper_tool_call_log.ml`
- PASS: `git diff --check origin/main...HEAD`
- PASS: `bash scripts/ci/check-determinism-contract.sh`
- PASS: `bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed`