### PR TITLE
rfc: RFC-0309 typed gh capability gating — draft + G-0 baseline harness (W0)

### DIFF
--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -1,0 +1,289 @@
+---
+rfc: "0309"
+title: "Typed gh capability gating — active repo/discussion surfaces behind non-blocking HITL approval"
+status: Draft
+created: 2026-07-06
+updated: 2026-07-06
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0254", "0255", "0304", "0303", "0160", "0208"]
+implementation_prs: []
+---
+
+# RFC-0309: Typed gh capability gating
+
+Status: Draft · Capability-plane redesign · Supersedes the behavior decision of
+`docs/design/keeper-github-repo-create-discussion-policy.md` (PR #23362)
+Drafted by: Claude (goal-matrix design session 2026-07-06), pending owner review.
+
+> Anchors marked **(verified)** were read against `origin/main` @ `051506d8a7`
+> on 2026-07-06. The G-0 baseline harness
+> (`lib/exec/test/test_shell_ir_gh_capability_baseline.ml`, this RFC's W0 PR)
+> pins every classification claim in §1 as an executable characterization test.
+
+---
+
+## §0 Summary
+
+Keepers should be able to **actively** create GitHub repositories, open
+Discussions, and comment on them — gated by an **asynchronous, non-blocking**
+human approval step, not disabled. PR #23362 achieved safety by disabling both
+surfaces and encoding that policy decision into the *risk* axis (factually
+reversible operations were re-labeled `R2_Irreversible`). This RFC separates
+the three axes that #23362 conflated:
+
+| Axis | Question it answers | Owner after this RFC |
+|------|--------------------|---------------------|
+| **Risk** | Is this operation factually reversible? | `Shell_ir_risk` (typed verb family + word-list floor) |
+| **Capability policy** | May *this keeper class* perform this verb family? | New `keeper_capability` policy table (G-5) |
+| **Disposition** | Run / ask a human asynchronously / refuse? | `Verdict.t` incl. `Ask`, wired to the non-blocking HITL queue (G-6/G-7) |
+
+The absolute constraint, set by the operator: **the tool gate must never block
+a keeper turn.** An `Ask` verdict enqueues to the existing non-blocking
+approval queue and the keeper yields; `Hitl_resolved` wakes it to execute.
+Block-time p99 must be 0 ms (G-11/G-13) and the property is model-checked
+(G-12).
+
+---
+
+## §1 Problem — three defects, one root
+
+### Defect 1 — policy encoded as risk (#23362)
+
+`repo_hosting_cli_irreversible_ops` now contains `("repo", ["create"; …;
+"fork"])` and the entire `discussion` family (`lib/exec/shell_ir_risk.ml:284-296`
+**(verified)**). `gh repo create` is factually reversible (a created repo can
+be deleted); `gh discussion comment` is editable and deletable. Labeling them
+`R2_Irreversible` makes the risk taxonomy assert falsehoods. The deny message
+was reworded in the same PR to "repository-hosting CLI operation not permitted
+**by policy**" (`lib/exec/verdict.ml:80-84` **(verified)**) — an in-code
+admission that the axis being expressed is policy, not risk.
+
+Why it matters beyond taste: every downstream consumer of `risk_class`
+(receipts, dashboards, differential harness, future policy layers) now reads
+"irreversible" for operations that are not. The next capability decision will
+have to either pile onto the same lie or contradict it.
+
+### Defect 2 — unknown gh verb auto-runs (Unknown → Permissive)
+
+`classify_repo_hosting_cli` falls through to `R0_Read` when a subcommand
+matches neither hand-maintained table (`lib/exec/shell_ir_risk.ml:478-479`
+**(verified)**: `else if in_table … reversible … then R1 … else R0_Read`).
+Under the autonomous overlay every risk class maps to `Observe` (auto-allow)
+(`lib/exec/approval_config.ml:40-47` **(verified)**), so **a gh verb the word
+lists have never heard of executes silently**. GitHub ships new verbs; each one
+is fail-open until someone hand-edits a string list. This is the
+Unknown→Permissive-Default anti-pattern the workspace guidelines name
+explicitly.
+
+### Defect 3 — binary disposition forces policy into risk
+
+The approval floor only fires for `R2_Irreversible`/`Destructive_protected`
+(`lib/exec/approval_policy.ml:161-171` **(verified)**), and the autonomous
+overlay auto-allows everything else because — quoting the code — *"there is no
+human or resolver in the loop to answer an [Ask]"*
+(`lib/exec/approval_config.ml:40-47` **(verified)**). So the only lever
+available to #23362 for "keeper must not do this unsupervised" was to relabel
+the op R2. Meanwhile `Verdict.t` already has a 4-way disposition including
+`Ask` (`lib/exec/verdict.mli:67-72` **(verified)**), and the keeper HITL
+approval queue is already **non-blocking with a `Hitl_resolved` wake**
+(`lib/keeper/keeper_approval_queue.ml:730, 841` **(verified)**). The resolver
+the comment says doesn't exist *does* exist — it is simply not wired to the
+exec gate. Wiring it is simultaneously the capability enabler and the
+non-blocking guarantee.
+
+**Root cause common to all three:** the system has one axis (risk) where it
+needs three (risk × capability policy × disposition).
+
+---
+
+## §2 Boundary with RFC-0208 — what stays string-owned, and why
+
+`risk_of_typed` deliberately abstains on `Gh` (`W (Gh _) -> R0_Read`,
+`lib/exec/shell_ir_risk.ml:852-864` **(verified)**) with a documented
+rationale: gh risk is *string-borne* — the HTTP method (`-X DELETE`), graphql
+mutation bodies, and an evolving subcommand set live in argv strings, and an
+earlier attempt to fake a typed opinion by round-tripping the IR mis-parsed
+`-X DELETE` into a silent R0. That argument is correct **for risk**, and this
+RFC does not reverse it:
+
+- The word-list floor (`classify_words` → `classify_repo_hosting_cli`)
+  **remains the owner of string-borne risk**: HTTP methods, graphql mutation
+  fragments, positional-token sweeps.
+- `classify` composes opinions with `max_risk (redirect) (max typed floor)`
+  (`lib/exec/shell_ir_risk.ml:916-922` **(verified)**). A typed opinion can
+  only *raise* the decision above the floor, never lower it. The
+  under-classification hazard RFC-0208 fixed cannot re-enter through this RFC.
+- What the typed layer takes over is **capability identity**, not risk
+  arithmetic: *which verb family is this?* (`Pr`, `Issue`, `Repo`,
+  `Discussion`, `Release`, `Api`, `Unknown of string`). That set is small,
+  closed, and enumerable — exactly what GADTs are for — and it is the input
+  the capability-policy axis needs. The `Unknown` constructor is the
+  fail-closed replacement for today's `else R0_Read`.
+
+**Delta vs. the 2026-07-06 goal-matrix document:** the matrix's pass criterion
+"word-list membership 0" is narrowed here to: *capability-relevant gh verb
+decisions are typed and exhaustive; unknown verbs are fail-closed; the
+word-list floor for string-borne risk (methods, graphql bodies) is retained by
+design.* The original criterion would have re-introduced the round-trip defect
+RFC-0208 documents.
+
+---
+
+## §3 Design
+
+### 3.1 Typed gh verb family (G-1..G-3)
+
+Extend the existing `Gh` constructor's payload (or lower beside it) with a
+parsed verb family:
+
+```ocaml
+(* Shell_ir_typed_types — sketch, final shape in W1 PR *)
+type gh_repo_action =
+  | Repo_view | Repo_list | Repo_clone
+  | Repo_create | Repo_fork              (* reversible, external *)
+  | Repo_edit | Repo_sync | Repo_set_default
+  | Repo_delete | Repo_archive | Repo_transfer | Repo_rename  (* irreversible *)
+
+type gh_discussion_action =
+  | Discussion_create | Discussion_comment | Discussion_edit
+  | Discussion_close | Discussion_reopen | Discussion_answer
+  | Discussion_unanswer | Discussion_lock | Discussion_unlock
+  | Discussion_delete                     (* irreversible *)
+
+type gh_verb =
+  | Gh_pr of gh_pr_action
+  | Gh_issue of gh_issue_action
+  | Gh_repo of gh_repo_action
+  | Gh_discussion of gh_discussion_action
+  | Gh_release of gh_release_action
+  | Gh_api                                (* risk stays floor-owned *)
+  | Gh_unknown of string                  (* fail-closed *)
+```
+
+Rules:
+
+- Lowering is **from original argv at parse time** — no IR→words round-trip
+  (the RFC-0208 hazard).
+- `risk_of_typed` gives a **lower-bound** opinion from the verb
+  (`Repo_delete → R2`, `Repo_create → R1`, `Gh_unknown → R2` fail-closed);
+  the word-list floor still applies via `max_risk`, so `gh api -X DELETE`
+  stays R2 regardless of the typed opinion.
+- Walker/codegen coverage via `gen_shell_ir_walkers` (G-2) so new verbs force
+  compile-time decisions everywhere.
+- Exhaustive match in `risk_of_typed` — adding a verb without classifying it
+  is a compile error, not a silent R0 (G-3).
+
+### 3.2 Externality axis (G-4)
+
+`Exec_effect.External_mutation` already exists but is coarse. Add a
+reversibility-aware external effect so `Repo_create` carries
+"external, reversible, durable-remote-surface" — the fact pattern the
+capability policy keys on. Risk answers *can it be undone*; externality
+answers *who can see it before it is undone*.
+
+### 3.3 Capability policy axis (G-5)
+
+A per-keeper-class table, orthogonal to risk:
+
+```
+capability          | autonomous keeper | supervised keeper | operator session
+--------------------|-------------------|-------------------|------------------
+gh_pr (create/edit) | Allow             | Allow             | Allow
+gh_repo_create      | Requires_approval | Requires_approval | Allow
+gh_discussion (mut) | Requires_approval | Allow             | Allow
+gh_repo_delete etc. | Deny (floor)      | Deny (floor)      | Suggest_confirm
+gh_unknown          | Requires_approval | Requires_approval | Suggest_confirm
+```
+
+(Values illustrative; the W2 PR fixes the table with the operator.)
+
+### 3.4 Non-blocking approval disposition (G-6..G-8) — the core
+
+- `Requires_approval` disposition resolves to `Verdict.Ask`, which the exec
+  gate translates into an **enqueue** on `keeper_approval_queue` — the same
+  non-blocking queue HITL already uses (`keeper_approval_queue.ml:730`
+  **(verified)** non-blocking update; `:841` **(verified)**
+  `wake_keeper_on_approval_resolution`).
+- The keeper turn **does not wait**: the tool call returns immediately with a
+  typed `Pending_approval { ticket }` result the keeper can report, plan
+  around, or park. On operator resolution, `Hitl_resolved` wakes the keeper
+  (stimulus-gated wake, RFC-0303) and the approved command executes in the
+  resumed turn.
+- The autonomous overlay's all-`Observe` rationale ("no resolver") becomes
+  false by construction, so the overlay maps gated verb families to
+  `Requires_approval` instead (G-8).
+- **Invariant (absolute):** no code path introduced by this RFC may
+  synchronously wait on approval resolution inside a keeper turn.
+  Enforcement: G-11 block-time metric (p99 = 0 ms), G-12 TLA+
+  `NonBlockingApproval` invariant (clean + buggy cfg pair), G-13 gated-op
+  observability (100% of gated ops emit queue/resolution/wake events).
+
+### 3.5 What #23362 got right and keeps
+
+The genuine irreversibles stay floored exactly as before: `pr merge/ready`,
+`repo delete/archive/transfer/rename`, `release delete`, `secret delete`,
+`gh api -X DELETE`, `delete*` graphql mutations, `discussion delete`. The
+catastrophic floor (`Deny`) remains trust-independent. This RFC widens the
+space *between* Allow and Deny; it does not soften Deny.
+
+---
+
+## §4 Goal matrix (G-0..G-13, six waves)
+
+| Wave | Goal | Deliverable | Quantitative pass |
+|------|------|-------------|-------------------|
+| W0 | G-0 | Baseline harness `test_shell_ir_gh_capability_baseline.ml` + this RFC | corpus pinned; defect ledger counts asserted (delta-ratchet) |
+| W1 | G-1 | typed gh verb family in `Shell_ir_typed_types` | verbs in §3.1 lower from argv; 0 IR→words round-trips |
+| W1 | G-2 | `gen_shell_ir_walkers` coverage | walkers compile-fail on unhandled verb |
+| W1 | G-3 | `risk_of_typed` exhaustive over verbs; `Gh_unknown → R2` fail-closed | unknown-verb auto-run count 0 (baseline: 4 pinned cases, incl. unknown action under a known family) |
+| W2 | G-4 | reversible-external effect axis | `Repo_create` carries external+reversible effect |
+| W2 | G-5 | `keeper_capability` policy table | policy decision readable without consulting risk |
+| W3 | G-6 | `Requires_approval` disposition ≠ Deny | disposition round-trips through receipts |
+| W3 | G-7 | exec gate `Ask` → HITL queue wiring | keeper-turn block time on gated op = 0 ms |
+| W3 | G-8 | autonomous overlay: gated families → `Requires_approval` | overlay no longer all-`Observe` for gh mutations |
+| W4 | G-9 | re-enable repo-create/discussion surfaces (supersede #23362 behavior; design doc marked superseded) | `gh repo create` reaches `Pending_approval`, not `Deny` |
+| W4 | G-10 | repo-create capability contract (naming/ownership/lifecycle) | contract doc + typed args |
+| W4 | G-11 | prompts + `KEEPER-CAPABILITY-MATRIX.md` update; block-time metric | docs match behavior; p99 block-time 0 ms |
+| W5 | G-12 | TLA+ `CatastrophicNeverAllowed` + `NonBlockingApproval` + `UnknownGhVerbNeverAutoRun` | clean cfg passes AND buggy cfg violates (both required) |
+| W5 | G-13 | gated-op observability | 100% gated ops emit enqueue/resolve/wake events |
+
+Wave order is dependency order: measurement (W0) → typed identity (W1) →
+axes (W2) → disposition wiring (W3) → capability enable (W4) → formal +
+observability closure (W5). G-9 must not land before G-7: enabling the
+surfaces while `Ask` is unwired would reproduce #23362's original dilemma.
+
+---
+
+## §5 Supersession of #23362
+
+- `docs/design/keeper-github-repo-create-discussion-policy.md` remains the
+  live decision **until G-9 lands**. The W4 PR flips its front-matter to
+  `superseded_by: RFC-0309` in the same commit that changes behavior — docs
+  and behavior never disagree.
+- The #23362 word-list entries for `repo create/fork` and the reversible
+  `discussion` mutations move out of `repo_hosting_cli_irreversible_ops` in
+  W2/W4 (after the capability axis exists to receive them). Until then the
+  baseline harness pins them as `DEFECT(policy-as-risk)` — deliberately
+  failing loudly if anyone "fixes" them before the policy axis exists.
+- Prompt lines added by #23362 ("Do not create GitHub repositories …") are
+  replaced in G-11 with the approval-flow description.
+
+## §6 Non-goals
+
+- No removal of the word-list floor for string-borne risk (methods, graphql
+  bodies, action-flags) — RFC-0208's boundary stands.
+- No new GitHub credential materialization path; RFC-0008's retirement of the
+  keeper-side credential provider is untouched.
+- No synchronous approval waits anywhere, including "just this once" paths.
+- No GitHub Discussions *read* tooling (separate decision).
+- No change to MASC board semantics — the board remains the primary durable
+  discussion plane; GitHub Discussions is for external-facing threads.
+
+## §7 Rollback
+
+Each wave is independently revertable. G-9 (behavior flip) is a single PR
+whose revert restores #23362 semantics exactly; the axes and wiring beneath
+it (W1–W3) are inert without it — they add typed structure and an unused
+disposition, both of which fail closed.

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -20,6 +20,7 @@
   test_shell_ir_walkers_gen
   test_shell_ir_risk
   test_shell_ir_risk_repo_hosting_cli_stress
+  test_shell_ir_gh_capability_baseline
   test_shell_ir_typed_e2e
   test_shell_ir_differential
   test_shell_ir_oracle

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -1,0 +1,250 @@
+(** G-0 baseline harness — RFC-0309 typed gh capability gating.
+
+    Characterization corpus: pins the CURRENT classification of the gh
+    capability surface, including known defects, so that each RFC-0309
+    slice produces a measurable, reviewable delta in this file.
+
+    This file asserts what the classifier DOES, not what it SHOULD do.
+    Defect-tagged cases pin behavior RFC-0309 will change:
+
+    - [Defect_policy_as_risk] — factually reversible operations labeled
+      [R2_Irreversible] by PR #23362 to express a capability-policy
+      decision on the risk axis. Target (G-4/G-9): R1 + external effect
+      + [Requires_approval] disposition.
+    - [Defect_unknown_permissive] — gh verbs absent from both word-list
+      tables fall through to [R0_Read] and auto-run under the autonomous
+      overlay. Target (G-3): typed [Gh_unknown] fail-closed.
+
+    Update protocol: when a slice lands, move its cases from the defect
+    constructor to [Stable] with the new class, and update the ledger
+    counts in [test_ledger]. The ledger diff IS the slice's measured
+    delta; do not silence a mismatch by deleting a case. *)
+
+module Parsed = Masc_exec.Parsed
+module Shell_ir = Masc_exec.Shell_ir
+module Shell_ir_risk = Masc_exec.Shell_ir_risk
+module Shell_ir_typed = Masc_exec.Shell_ir_typed
+module Bash = Masc_exec_bash_parser.Bash
+
+let parse_ir cmd =
+  match Bash.parse_string cmd with
+  | Parsed.Parsed ir -> ir
+  | Parsed.Parse_error _ | Parsed.Parse_aborted _ | Parsed.Too_complex _ ->
+    failwith (Printf.sprintf "failed to parse: %s" cmd)
+;;
+
+(* Full production pipeline: parser -> classify (typed opinion max-merged
+   with the word-list floor and redirect floor). *)
+let classify_cmd cmd =
+  Shell_ir_risk.risk_class
+    (Shell_ir_risk.classify (Shell_ir_risk.undecided (parse_ir cmd)))
+;;
+
+(* Typed-path opinion alone, before the word-list floor merges in. *)
+let typed_opinion cmd =
+  match parse_ir cmd with
+  | Shell_ir.Simple s ->
+    Shell_ir_risk.risk_of_typed (Shell_ir_typed.of_simple s)
+  | Shell_ir.Pipeline _ ->
+    failwith (Printf.sprintf "expected a simple command: %s" cmd)
+;;
+
+let rc = Shell_ir_risk.string_of_risk_class
+
+type expectation =
+  | Stable of Shell_ir_risk.risk_class
+      (** Current class = RFC-0309 target class. No change expected. *)
+  | Defect_policy_as_risk of Shell_ir_risk.risk_class
+      (** Pinned current class for a factually reversible operation that
+          PR #23362 placed in [repo_hosting_cli_irreversible_ops] (or the
+          graphql R2 fragment list) to express policy. *)
+  | Defect_unknown_permissive of Shell_ir_risk.risk_class
+      (** Pinned current class for a verb/action absent from both
+          word-list tables: falls through to R0 and auto-runs. *)
+
+let pinned_class = function
+  | Stable c | Defect_policy_as_risk c | Defect_unknown_permissive c -> c
+;;
+
+let corpus : (string * string * expectation) list =
+  [
+    (* --- reads: stable R0 ------------------------------------------- *)
+    ("pr-view", "gh pr view 123", Stable Shell_ir_risk.R0_Read);
+    ("pr-list", "gh pr list --state open", Stable Shell_ir_risk.R0_Read);
+    ("issue-view", "gh issue view 7", Stable Shell_ir_risk.R0_Read);
+    ("repo-view", "gh repo view owner/repo", Stable Shell_ir_risk.R0_Read);
+    ("api-get", "gh api repos/owner/repo", Stable Shell_ir_risk.R0_Read);
+    (* R0 by fall-through, not by decision: "discussion view" is in
+       neither table. Correct outcome, undecided path — G-1 makes it a
+       decided read. *)
+    ("discussion-view", "gh discussion view 42", Stable Shell_ir_risk.R0_Read);
+    (* --- reversible mutations: stable R1 ----------------------------- *)
+    ("pr-create", "gh pr create --title T --body B",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
+    ("pr-comment", "gh pr comment 123 --body B",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
+    ("issue-create", "gh issue create --title T",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
+    ("issue-edit", "gh issue edit 123",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
+    ("release-create", "gh release create v1.0.0",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
+    (* --- genuinely irreversible: stable R2 (floor stands, RFC-0309
+       does not soften Deny) ------------------------------------------- *)
+    ("pr-merge", "gh pr merge 123 --squash", Stable Shell_ir_risk.R2_Irreversible);
+    (* pre-existing floor: `pr ready --undo` exists, but ready triggers
+       external side-effects (CI, notifications). Revisit under the G-4
+       externality axis; out of W0 scope. *)
+    ("pr-ready", "gh pr ready 123", Stable Shell_ir_risk.R2_Irreversible);
+    ("repo-delete", "gh repo delete owner/repo --yes",
+     Stable Shell_ir_risk.R2_Irreversible);
+    ("repo-archive", "gh repo archive owner/repo",
+     Stable Shell_ir_risk.R2_Irreversible);
+    ("repo-transfer", "gh repo transfer owner/repo",
+     Stable Shell_ir_risk.R2_Irreversible);
+    ("api-delete", "gh api repos/owner/repo -X DELETE",
+     Stable Shell_ir_risk.R2_Irreversible);
+    ("graphql-deleteDiscussion",
+     "gh api graphql -f 'query=mutation{deleteDiscussion}'",
+     Stable Shell_ir_risk.R2_Irreversible);
+    ("discussion-delete", "gh discussion delete 42",
+     Stable Shell_ir_risk.R2_Irreversible);
+    (* --- Defect 1: policy encoded as risk (PR #23362) ---------------- *)
+    ("repo-create", "gh repo create owner/new-repo",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("repo-fork", "gh repo fork owner/repo",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("discussion-create", "gh discussion create --title T --body B",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("discussion-comment", "gh discussion comment 42 --body B",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("discussion-edit", "gh discussion edit 42 --body B",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    (* close/reopen are a reversible round-trip pair; both sit in the
+       irreversible table. *)
+    ("discussion-close", "gh discussion close 42",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("graphql-createRepository",
+     "gh api graphql -f 'query=mutation{createRepository}'",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("graphql-createDiscussion",
+     "gh api graphql -f 'query=mutation{createDiscussion}'",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    ("graphql-addDiscussionComment",
+     "gh api graphql -f 'query=mutation{addDiscussionComment}'",
+     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+    (* --- Defect 2: unknown verb/action auto-runs as R0 --------------- *)
+    ("unknown-verb", "gh frobnicate now",
+     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+    ("unknown-verb-forced", "gh quantum entangle --force",
+     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+    ("unknown-verb-preview", "gh preview enable-feature x",
+     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+    (* unknown ACTION under a known family also falls through *)
+    ("unknown-repo-action", "gh repo upsert-magic owner/repo",
+     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+  ]
+;;
+
+(* Every corpus case classifies to its pinned class. A mismatch means the
+   classifier changed: update the case per the header protocol so the
+   diff records the delta. *)
+let test_corpus_pinned () =
+  let mismatches =
+    List.filter_map
+      (fun (label, cmd, exp) ->
+         let actual = classify_cmd cmd in
+         let expected = pinned_class exp in
+         if actual = expected then None
+         else
+           Some
+             (Printf.sprintf "%s: %S pinned %s, got %s" label cmd
+                (rc expected) (rc actual)))
+      corpus
+  in
+  if mismatches <> [] then
+    Alcotest.fail
+      ("classifier drifted from G-0 baseline:\n"
+       ^ String.concat "\n" mismatches)
+;;
+
+(* The typed path abstains on gh (RFC-0208 boundary): the Gh constructor
+   is a typed hit, but its risk opinion is R0 regardless of verb — the
+   word-list floor owns gh risk. G-1/G-3 change exactly this: verb-family
+   lower bounds (Repo_delete -> R2, Repo_create -> R1, Gh_unknown -> R2)
+   while the floor stays. *)
+let test_typed_path_abstains_on_gh () =
+  List.iter
+    (fun cmd ->
+       let opinion = typed_opinion cmd in
+       if opinion <> Shell_ir_risk.R0_Read then
+         Alcotest.failf
+           "typed opinion for %S pinned R0_Read (abstention), got %s" cmd
+           (rc opinion);
+       if not (Shell_ir_risk.typed_hit_of_ir (parse_ir cmd)) then
+         Alcotest.failf "expected %S to lower to a typed Gh hit" cmd)
+    [
+      "gh repo create owner/new-repo";
+      "gh pr merge 123";
+      "gh discussion comment 42 --body B";
+      "gh frobnicate now";
+    ]
+;;
+
+(* Word-list surface directly (no parser): the fall-through and the
+   policy conflation are properties of this table, not of the parser. *)
+let test_word_list_surface () =
+  let check words expected =
+    let actual = Shell_ir_risk.classify_repo_hosting_cli words in
+    if actual <> expected then
+      Alcotest.failf "classify_repo_hosting_cli [%s]: pinned %s, got %s"
+        (String.concat "; " words) (rc expected) (rc actual)
+  in
+  check [ "gh"; "frobnicate"; "now" ] Shell_ir_risk.R0_Read;
+  check [ "gh"; "repo"; "upsert-magic"; "owner/repo" ] Shell_ir_risk.R0_Read;
+  check [ "gh"; "discussion"; "close"; "42" ] Shell_ir_risk.R2_Irreversible
+;;
+
+(* Ledger ratchet: exact distribution over the corpus. A slice that fixes
+   a defect must update these counts — the diff is the measured delta. *)
+let test_ledger () =
+  let count pred = List.length (List.filter pred corpus) in
+  let by_class c = count (fun (_, _, e) -> pinned_class e = c) in
+  let r0 = by_class Shell_ir_risk.R0_Read in
+  let r1 = by_class Shell_ir_risk.R1_Reversible_mutation in
+  let r2 = by_class Shell_ir_risk.R2_Irreversible in
+  let dp = by_class Shell_ir_risk.Destructive_protected in
+  let policy_as_risk =
+    count (fun (_, _, e) ->
+      match e with Defect_policy_as_risk _ -> true | _ -> false)
+  in
+  let unknown_permissive =
+    count (fun (_, _, e) ->
+      match e with Defect_unknown_permissive _ -> true | _ -> false)
+  in
+  Printf.printf
+    "[G-0] corpus=%d R0=%d R1=%d R2=%d DP=%d | defects: policy_as_risk=%d \
+     unknown_permissive=%d\n"
+    (List.length corpus) r0 r1 r2 dp policy_as_risk unknown_permissive;
+  Alcotest.(check int) "corpus size" 32 (List.length corpus);
+  Alcotest.(check int) "R0 count" 10 r0;
+  Alcotest.(check int) "R1 count" 5 r1;
+  Alcotest.(check int) "R2 count" 17 r2;
+  Alcotest.(check int) "Destructive count" 0 dp;
+  Alcotest.(check int) "defect: policy-as-risk" 9 policy_as_risk;
+  Alcotest.(check int) "defect: unknown-permissive" 4 unknown_permissive
+;;
+
+let () =
+  Alcotest.run "shell_ir_gh_capability_baseline"
+    [
+      ( "g0-baseline",
+        [
+          Alcotest.test_case "corpus pinned" `Quick test_corpus_pinned;
+          Alcotest.test_case "typed path abstains on gh" `Quick
+            test_typed_path_abstains_on_gh;
+          Alcotest.test_case "word-list surface" `Quick test_word_list_surface;
+          Alcotest.test_case "ledger ratchet" `Quick test_ledger;
+        ] );
+    ]
+;;

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -30,7 +30,7 @@ let parse_ir cmd =
   match Bash.parse_string cmd with
   | Parsed.Parsed ir -> ir
   | Parsed.Parse_error _ | Parsed.Parse_aborted _ | Parsed.Too_complex _ ->
-    failwith (Printf.sprintf "failed to parse: %s" cmd)
+    Alcotest.failf "failed to parse: %s" cmd
 ;;
 
 (* Full production pipeline: parser -> classify (typed opinion max-merged
@@ -46,7 +46,7 @@ let typed_opinion cmd =
   | Shell_ir.Simple s ->
     Shell_ir_risk.risk_of_typed (Shell_ir_typed.of_simple s)
   | Shell_ir.Pipeline _ ->
-    failwith (Printf.sprintf "expected a simple command: %s" cmd)
+    Alcotest.failf "expected a simple command: %s" cmd
 ;;
 
 let rc = Shell_ir_risk.string_of_risk_class


### PR DESCRIPTION
## What

RFC-0309 W0 (첫 wave): RFC 초안 + G-0 분류 baseline harness. **동작 변경 없음** — 문서 1건 + characterization 테스트 1건.

- `docs/rfc/RFC-0309-typed-gh-capability-gating.md` — typed gh capability gating 설계. #23362가 하나의 축(risk)에 뭉친 세 축을 분리: **risk**(사실적 가역성) × **capability policy**(keeper class별 허용 동사) × **disposition**(Allow / Requires_approval / Deny). `Verdict.Ask`를 이미 존재하는 non-blocking HITL 승인 큐(`keeper_approval_queue.ml:730,841`)에 배선해, repo-create/discussion을 **비활성화 대신 비동기 승인 뒤에서 활성화**한다. G-0..G-13, 6 wave.
- `lib/exec/test/test_shell_ir_gh_capability_baseline.ml` — G-0 harness. 32-case corpus가 현재 분류를 pin: policy-as-risk 9건(#23362가 가역 op를 R2로 라벨), unknown verb/action R0 fall-through 4건, typed-path 기권(`risk_of_typed(Gh)→R0`), ledger ratchet(분포 카운트 assert). 이후 각 slice는 이 파일의 diff로 delta가 드러난다.

## Why

#23362는 keeper의 repo 생성/Discussion을 disable하면서 그 정책 결정을 risk 분류기에 인코딩했다. 결과:

1. **policy-as-risk**: `gh repo create`(삭제 가능), `gh discussion comment`(수정/삭제 가능), `discussion close/reopen`(가역 왕복쌍)이 전부 `R2_Irreversible` — risk taxonomy가 사실을 진술하지 않게 됨. deny 메시지가 "not permitted **by policy**"로 바뀐 것이 in-code 자인.
2. **Unknown→Permissive**: 두 word-list 테이블에 없는 gh 동사는 `R0_Read` fall-through → autonomous overlay(all-Observe)에서 **무승인 자동 실행**. 미지의 action(`gh repo upsert-magic`)도 동일.
3. **이진 disposition**: 승인 floor가 R2/Destructive에서만 발화하고 overlay는 "no resolver to answer Ask"를 이유로 전부 자동 허용 — 그런데 non-blocking resolver(HITL 큐 + `Hitl_resolved` wake)는 이미 존재하며 배선만 안 됨. 그래서 #23362가 쓸 수 있는 유일한 레버가 "R2로 재라벨"이었다.

RFC-0208의 "gh risk는 string-borne"(method/-X, graphql body) 경계는 **유지**한다 — typed 패밀리는 risk 소유가 아니라 capability 동사 식별을 맡고, `classify`는 `max_risk(typed, floor)`(`shell_ir_risk.ml:916-922`)라 typed 의견이 floor를 하향시킬 수 없다.

## RFC

- **RFC-0309** — `docs/rfc/RFC-0309-typed-gh-capability-gating.md` (본 PR에 포함).
- Related: RFC-0254 (approval verdict), RFC-0255, RFC-0303 (stimulus-gated wake), RFC-0304 (HITL escalation), RFC-0160 (risk envelope), RFC-0208 (typed coverage / gh floor boundary).
- Supersedes(동작은 G-9 wave에서): `docs/design/keeper-github-repo-create-discussion-policy.md` (#23362) — 그 시점까지 해당 design doc이 유효하며, G-9 PR이 front-matter를 함께 뒤집는다.

## Verification

- `dune build --root . lib/exec/test/test_shell_ir_gh_capability_baseline.exe` — clean.
- 로컬 4/4 pass (`corpus pinned` / `typed path abstains on gh` / `word-list surface` / `ledger ratchet`).
- ocamlformat `@lib/exec/test/fmt` — no diff.
- 동작 변경 없음: lib 코드 무수정, 테스트는 현재 동작을 assert.

## Non-blocking invariant (절대 제약)

이 RFC의 어떤 wave도 keeper turn 내부에서 승인 해소를 동기 대기하지 않는다. `Requires_approval` → 큐 enqueue + turn 즉시 반환(`Pending_approval` typed result) → `Hitl_resolved` wake로 재개. G-11(block-time p99=0ms metric), G-12(TLA+ `NonBlockingApproval` clean+buggy 쌍), G-13(gated op 관측 100%)이 이를 고정한다.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
