### PR TITLE
fix(board): retire repo capability residue

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -41,6 +41,7 @@ When a tool call fails:
    - switch to a different tool/approach and say WHY in your next message, or
    - ask the operator via keeper_broadcast (include the tool name, error class, and what you tried).
 4. Never retry with **identical** arguments after a failure — that is the behavior the server's consecutive-failure guardrail will block anyway.
+5. Do not reuse old board capacity/blocker wording as current truth. For file-write blockers, separate active schema visibility from approval policy: if Write/Edit is visible but a call times out or is denied, report the exact visible tool name, latest error class, and server hint from the failed call. If no fresh failed call exists, retry once or state that current evidence is missing.
 
 Short form: hint → fix args → retry once → if still stuck, judgment request. Do NOT end a turn on a silent tool error.
 

--- a/lib/board_tool_adapter/board_tool.mli
+++ b/lib/board_tool_adapter/board_tool.mli
@@ -10,9 +10,9 @@
       through {!handle_tool} (one entry per
       [masc_board_*] tool name),
     - the {b tools} list advertised to MCP clients
-      (13 schemas: post, list, get, comment, vote, stats,
-      search, comment_vote, reaction, profile, hearth_list,
-      curation_read, delete),
+      (post/list/get, comments, votes, reactions, stats,
+      search, profile, hearths, curation, cleanup/delete,
+      and sub-board operations),
     - the {b truncated-markdown detector}
       ({!detect_truncated_markdown_with_reason}) used by
       the post-create path to flag chat-suffix paste

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -123,6 +123,13 @@ let tool_spec_read_only =
   ]
 ;;
 
+let destructive_board_tool_names =
+  let open Tool_name.Board_name in
+  [ to_string Board_delete; to_string Board_cleanup ]
+;;
+
+let is_destructive_board_tool name = List.mem name destructive_board_tool_names
+
 let register () =
   let handler ~name ~args = Some (handle_tool name args) in
   let make_spec (s : Masc_domain.tool_schema) =
@@ -135,7 +142,7 @@ let register () =
       ~handler_binding:(Shared handler)
       ~is_read_only:ro
       ~is_idempotent:ro
-      ~is_destructive:(String.equal s.name "masc_board_delete")
+      ~is_destructive:(is_destructive_board_tool s.name)
       ()
   in
   Tool_spec.register_all (List.map make_spec Board_tool_registry.tools)

--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -49,27 +49,49 @@ let is_agent name =
   | None -> false
 ;;
 
-let resolve_board_post_kind ~author (raw_kind : string option)
+let normalized_identity_candidate value =
+  let value = String.lowercase_ascii (String.trim value) in
+  if String.equal value "" || String.equal value "anonymous" then None else Some value
+;;
+
+let registered_agent_author ~author ?author_raw_agent_name () =
+  let candidates =
+    [ Some author; author_raw_agent_name ]
+    |> List.filter_map (function
+      | Some value -> normalized_identity_candidate value
+      | None -> None)
+    |> List.sort_uniq String.compare
+  in
+  match Atomic.get agent_lookup_hook with
+  | None -> false
+  | Some lookup -> List.exists lookup candidates
+;;
+
+let resolve_board_post_kind ~author ?author_raw_agent_name (raw_kind : string option)
   : (Board.post_kind, string) Stdlib.result
   =
+  let author_lc = String.lowercase_ascii (String.trim author) in
+  let author_is_registered_agent =
+    registered_agent_author ~author ?author_raw_agent_name ()
+  in
   match raw_kind with
   | Some raw ->
     (match Board.post_kind_of_string (String.lowercase_ascii (String.trim raw)) with
      | Some Board.System_post ->
        Error "system posts are reserved for platform/internal surfaces"
+     | Some Board.Human_post when author_is_registered_agent ->
+       Error "registered agent authors cannot create direct board posts; use automation or omit post_kind"
      | Some kind -> Ok kind
      | None -> Error (Printf.sprintf "unknown post_kind: %s" raw))
   | None ->
-    let author_lc = String.lowercase_ascii (String.trim author) in
     if String.equal author_lc "" || String.equal author_lc "anonymous"
     then
       (* Missing or default author is never direct/manual — classify as
          automation to prevent misleading direct-attributed posts (#4604). *)
       Ok Board.Automation_post
-    else (
-      match Atomic.get agent_lookup_hook with
-      | Some _ when is_agent author_lc -> Ok Board.Automation_post
-      | _ -> Ok Board.Human_post)
+    else if author_is_registered_agent
+    then Ok Board.Automation_post
+    else Ok Board.Human_post
 ;;
 
 (** {1 SOUL Evolution callback} *)
@@ -525,16 +547,20 @@ let handle_board_cleanup ~tool_name ~start_time args : Tool_result.result =
          | Eio.Cancel.Cancelled _ as e -> raise e
          | _exn -> Stdlib.incr failed)
       targets;
-    Tool_result.make_ok
-      ~tool_name
-      ~start_time
-      ~data:
-        (`String
-           (Printf.sprintf
-              "Cleanup done: %d deleted, %d failed (scanned %d, age>%dh)"
-              !deleted
-              !failed
-              (List.length all_posts)
-              max_age_hours))
-      ())
+    let message =
+      Printf.sprintf
+        "Cleanup done: %d deleted, %d failed (scanned %d, age>%dh)"
+        !deleted
+        !failed
+        (List.length all_posts)
+        max_age_hours
+    in
+    if !failed > 0
+    then
+      Tool_result.make_err
+        ~tool_name
+        ~class_:Tool_result.Runtime_failure
+        ~start_time
+        message
+    else Tool_result.make_ok ~tool_name ~start_time ~data:(`String message) ())
 ;;

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -29,6 +29,16 @@ open Tool_args
 (* RFC-0189 PR-1b.2 — handlers in this module return the typed
    [Tool_result.result] variant directly. *)
 
+let meta_string_field name = function
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt name fields with
+     | Some (`String value) ->
+       let value = String.trim value in
+       if String.equal value "" then None else Some value
+     | _ -> None)
+  | Some _ | None -> None
+;;
+
 let handle_post_create ~tool_name ~start_time args : Tool_result.result =
   let title = get_string_opt args "title" in
   (* Reject empty or whitespace-only titles. *)
@@ -130,7 +140,15 @@ let handle_post_create ~tool_name ~start_time args : Tool_result.result =
         | Some v -> v
         | None -> Board.Internal
       in
-      match Board_tool_handlers.resolve_board_post_kind ~author raw_post_kind with
+      let author_raw_agent_name =
+        meta_string_field "author_raw_agent_name" meta_json
+      in
+      match
+        Board_tool_handlers.resolve_board_post_kind
+          ~author
+          ?author_raw_agent_name
+          raw_post_kind
+      with
       | Error msg ->
         Tool_result.make_err
           ~tool_name

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -188,6 +188,7 @@ let tools =
   ; board_tool_curation_read
   ; board_tool_curation_submit
   ; tool_delete
+  ; board_tool_cleanup
   ; Board_tool_schemas.tool_sub_board_create
   ; Board_tool_schemas.tool_sub_board_list
   ; Board_tool_schemas.tool_sub_board_get

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -68,6 +68,7 @@ let masc_board_tools_with_keeper_wrappers =
   [
     "masc_board_comment";
     "masc_board_curation_submit";
+    "masc_board_cleanup";
     "masc_board_post";
     "masc_board_vote";
     "masc_board_delete";

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -284,6 +284,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_board_sub_board_create", broadcast_tool);
     ("masc_board_sub_board_update", broadcast_tool);
     ("masc_board_sub_board_delete", broadcast_tool);
+    ("masc_board_cleanup", destructive_tool);
     ("masc_board_delete", destructive_tool);
     ("masc_tool_stats", read_state_tool);
     ("masc_pause", broadcast_tool);

--- a/test/test_keeper_tool_policy_masc_surface.ml
+++ b/test/test_keeper_tool_policy_masc_surface.ml
@@ -7,6 +7,10 @@ let names_from_board_registry () =
 let check_member label name expected names =
   check bool label expected (List.mem name names)
 
+let test_board_registry_advertises_cleanup_tool () =
+  let names = List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) Board_tool_registry.tools in
+  check_member "board cleanup advertised" "masc_board_cleanup" true names
+
 let test_raw_board_wrappers_filtered_without_hiding_read_tools () =
   let names = names_from_board_registry () in
   check_member "raw board post filtered" "masc_board_post" false names;
@@ -17,6 +21,7 @@ let test_raw_board_wrappers_filtered_without_hiding_read_tools () =
     "masc_board_curation_submit"
     false
     names;
+  check_member "raw board cleanup filtered" "masc_board_cleanup" false names;
   check_member "raw board delete filtered" "masc_board_delete" false names;
   check_member "board list remains visible" "masc_board_list" true names;
   check_member "board post get remains visible" "masc_board_post_get" true names;
@@ -27,6 +32,8 @@ let () =
     [
       ( "board wrapper filter",
         [
+          test_case "advertises board cleanup tool" `Quick
+            test_board_registry_advertises_cleanup_tool;
           test_case
             "filters raw board write tools with keeper wrappers"
             `Quick

--- a/test/test_persona_tool_reachability.ml
+++ b/test/test_persona_tool_reachability.ml
@@ -59,7 +59,7 @@ let assert_tool_in_line ~group ~tool line =
     true
     (String_util.contains_substring line needle)
 
-let test_repo_capability_groups_present () =
+let test_tool_access_groups_present () =
   let path = locate_tool_policy_toml () in
   let content = read_file path in
   List.iter
@@ -70,7 +70,7 @@ let test_repo_capability_groups_present () =
         (String_util.contains_substring content ("[groups." ^ group ^ "]")))
     [ "filesystem"; "workspace_write"; "search_files"; "execute" ]
 
-let test_repo_capability_groups_include_expected_tools () =
+let test_tool_access_groups_include_expected_tools () =
   let path = locate_tool_policy_toml () in
   let content = read_file path in
   let check_group group tools =
@@ -88,9 +88,9 @@ let () =
     [
       ( "tool_access_groups",
         [
-          Alcotest.test_case "repo capability groups present" `Quick
-            test_repo_capability_groups_present;
-          Alcotest.test_case "repo capability groups include expected tools" `Quick
-            test_repo_capability_groups_include_expected_tools;
+          Alcotest.test_case "tool access groups present" `Quick
+            test_tool_access_groups_present;
+          Alcotest.test_case "tool access groups include expected tools" `Quick
+            test_tool_access_groups_include_expected_tools;
         ] );
     ]

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1853,7 +1853,12 @@ let test_tools_count () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "20 tool schemas" 20 (List.length Board_tool.tools)
+  let names = List.map (fun (t : Masc_domain.tool_schema) -> t.name) Board_tool.tools in
+  Alcotest.(check int) "21 tool schemas" 21 (List.length names);
+  Alcotest.(check bool)
+    "cleanup schema advertised"
+    true
+    (List.mem "masc_board_cleanup" names)
 
 let test_tools_names_unique () =
   with_eio @@ fun env ->
@@ -2253,6 +2258,85 @@ let () =
             Alcotest.(check string) "classified as automation" "automation"
               Yojson.Safe.Util.(
                 parse_create_response_json msg |> member "post_kind" |> to_string));
+          Alcotest.test_case
+            "with hook: agent direct post_kind rejected"
+            `Quick
+            (fun () ->
+               with_eio @@ fun env ->
+               Fs_compat.set_fs (Eio.Stdenv.fs env);
+               cleanup ();
+               Board_tool.set_agent_lookup (fun name -> name = "claude-agent");
+               let ok, msg =
+                 dispatch
+                   "masc_board_post"
+                   (make_args
+                      [ "title", `String "test"
+                      ; "content", `String "hello"
+                      ; "author", `String "claude-agent"
+                      ; "post_kind", `String "direct"
+                      ])
+               in
+               Alcotest.(check bool) "post rejected" false ok;
+               Alcotest.(check bool)
+                 "agent direct rejection surfaced"
+                 true
+               (contains_substring
+                  msg
+                  "registered agent authors cannot create direct board posts"));
+          Alcotest.test_case
+            "with hook: raw agent meta classifies canonical keeper as automation"
+            `Quick
+            (fun () ->
+               with_eio @@ fun env ->
+               Fs_compat.set_fs (Eio.Stdenv.fs env);
+               cleanup ();
+               Board_tool.set_agent_lookup (fun name -> name = "claude-agent");
+               let ok, msg =
+                 dispatch
+                   "masc_board_post"
+                   (make_args
+                      [ "title", `String "test"
+                      ; "content", `String "hello"
+                      ; "author", `String "keeper-canonical"
+                      ; ( "meta"
+                        , `Assoc
+                            [ "author_raw_agent_name", `String "claude-agent" ] )
+                      ])
+               in
+               Alcotest.(check bool) "post created" true ok;
+               Alcotest.(check string)
+                 "classified as automation"
+                 "automation"
+                 Yojson.Safe.Util.(
+                   parse_create_response_json msg |> member "post_kind" |> to_string));
+          Alcotest.test_case
+            "with hook: raw agent meta direct post_kind rejected"
+            `Quick
+            (fun () ->
+               with_eio @@ fun env ->
+               Fs_compat.set_fs (Eio.Stdenv.fs env);
+               cleanup ();
+               Board_tool.set_agent_lookup (fun name -> name = "claude-agent");
+               let ok, msg =
+                 dispatch
+                   "masc_board_post"
+                   (make_args
+                      [ "title", `String "test"
+                      ; "content", `String "hello"
+                      ; "author", `String "keeper-canonical"
+                      ; "post_kind", `String "direct"
+                      ; ( "meta"
+                        , `Assoc
+                            [ "author_raw_agent_name", `String "claude-agent" ] )
+                      ])
+               in
+               Alcotest.(check bool) "post rejected" false ok;
+               Alcotest.(check bool)
+                 "agent direct rejection surfaced"
+                 true
+                 (contains_substring
+                    msg
+                    "registered agent authors cannot create direct board posts"));
           Alcotest.test_case "with hook: non-agent stays direct" `Quick (fun () ->
             with_eio @@ fun env ->
             Fs_compat.set_fs (Eio.Stdenv.fs env);

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -140,6 +140,9 @@ let () =
               check bool "masc_board_delete -> Mod_inline" true
                 (Tool_dispatch.lookup_tag "masc_board_delete"
                  = Some Tool_dispatch.Mod_inline);
+              check bool "masc_board_cleanup -> Mod_inline" true
+                (Tool_dispatch.lookup_tag "masc_board_cleanup"
+                 = Some Tool_dispatch.Mod_inline);
               check bool "masc_status -> Mod_state" true
                 (Tool_dispatch.lookup_tag "masc_status"
                  = Some Tool_dispatch.Mod_state);

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1638,7 +1638,15 @@ let test_keeper_tool_hint_contracts_match_required_fields () =
   assert_not_contains
     "board get hint avoids retired name"
     capabilities
-    "keeper_board_get"
+    "keeper_board_get";
+  assert_contains
+    "keeper capabilities separates schema visibility from approval policy"
+    capabilities
+    "separate active schema visibility from approval policy";
+  assert_not_contains
+    "keeper capabilities avoids retired capacity token"
+    capabilities
+    ("repo" ^ "_cap")
 
 let test_orchestrator_prompt_pins_start_transition () =
   let prompt = read_source_file "config/prompts/system.orchestrator.md" in


### PR DESCRIPTION
## Summary
- remove retired repo-capability wording from persona reachability tests
- advertise `masc_board_cleanup` through the board registry/catalog and mark it destructive
- keep raw board cleanup filtered from keeper-facing wrapper policy
- add keeper prompt guidance to avoid reusing stale board blocker wording as current approval truth
- reject `post_kind=direct` when the author or preserved raw runtime author resolves to a registered agent, so agent-authored status/blocker posts cannot bypass automation TTL as human/direct posts
- return explicit cleanup failure when destructive cleanup has any failed delete, instead of reporting partial failure as a successful tool result

## Why
Live board state still contains old permanent posts about a retired capacity blocker, so keepers can re-read stale board context and repeat it as if it were current. The deeper cause is that agent-authored board posts could be explicitly written as `direct`, which made them human posts and allowed permanent retention instead of the automation TTL path.

The review found one remaining identity gap: HTTP/MCP board write paths can canonicalize a runtime agent name to a keeper author while preserving the raw runtime agent in `meta.author_raw_agent_name`. Post-kind classification now considers both the canonical author and that preserved raw runtime author.

The code path also had a cleanup handler but no advertised cleanup schema, which made official cleanup harder to reach.

## Verification
- `ocamlformat --check lib/board_tool_adapter/board_tool.mli lib/board_tool_adapter/board_tool_dispatch.ml test/test_tool_board_coverage.ml test/test_keeper_tool_policy_masc_surface.ml test/test_persona_tool_reachability.ml test/test_tool_dispatch.ml test/test_tool_input_validation.ml`
- `scripts/dune-local.sh build test/test_persona_tool_reachability.exe test/test_keeper_tool_policy_masc_surface.exe test/test_tool_dispatch.exe test/test_tool_input_validation.exe test/test_tool_board_coverage.exe`
- `./_build/default/test/test_persona_tool_reachability.exe`
- `./_build/default/test/test_keeper_tool_policy_masc_surface.exe`
- `./_build/default/test/test_tool_dispatch.exe`
- `./_build/default/test/test_tool_input_validation.exe`
- `./_build/default/test/test_tool_board_coverage.exe`
- review-response focused rerun: `ocamlformat --check lib/board_tool_adapter/board_tool_handlers.ml lib/board_tool_adapter/board_tool_post.ml test/test_tool_board_coverage.ml`
- review-response focused rerun: `scripts/dune-local.sh build test/test_tool_board_coverage.exe`
- review-response focused rerun: `./_build/default/test/test_tool_board_coverage.exe` (98 tests)
- `rg -n "repo_cap|repo capability|repo_capability|repository-capacity|repository capacity" lib test config scripts -S` returned no matches
- `git diff --check`
