### PR TITLE
Decode JSON-string composite tool args

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -243,9 +243,83 @@ let normalize_execute_args_envelope ?schema ~name args =
   | _ -> args
 ;;
 
+let schema_type_includes schema expected =
+  match Json_util.assoc_member_opt "type" schema with
+  | Some (`String actual) -> String.equal actual expected
+  | Some (`List values) ->
+    List.exists
+      (function
+        | `String actual -> String.equal actual expected
+        | _ -> false)
+      values
+  | _ -> false
+;;
+
+let schema_expects_array schema =
+  schema_type_includes schema "array"
+  || Option.is_some (Json_util.assoc_member_opt "items" schema)
+;;
+
+let schema_expects_object schema =
+  schema_type_includes schema "object"
+  || Option.is_some (Json_util.assoc_member_opt "properties" schema)
+  || Option.is_some (Json_util.assoc_member_opt "additionalProperties" schema)
+;;
+
+let schema_accepts_composite_value schema = function
+  | `List _ -> schema_expects_array schema
+  | `Assoc _ -> schema_expects_object schema
+  | _ -> false
+;;
+
+let schema_property_schema schema key =
+  match Json_util.assoc_member_opt "properties" schema with
+  | Some (`Assoc properties) -> List.assoc_opt key properties
+  | _ -> None
+;;
+
+let schema_items_schema schema =
+  Json_util.assoc_member_opt "items" schema
+;;
+
+let rec normalize_schema_json_string_composites ~schema value =
+  match value with
+  | `String raw when schema_expects_array schema || schema_expects_object schema ->
+    (match
+       try Some (Yojson.Safe.from_string raw) with
+       | Yojson.Json_error _ -> None
+     with
+     | Some parsed when schema_accepts_composite_value schema parsed ->
+       normalize_schema_json_string_composites ~schema parsed
+     | _ -> value)
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (key, field_value) ->
+            match schema_property_schema schema key with
+            | None -> key, field_value
+            | Some field_schema ->
+              key, normalize_schema_json_string_composites ~schema:field_schema field_value)
+         fields)
+  | `List values ->
+    (match schema_items_schema schema with
+     | None -> value
+     | Some item_schema ->
+       `List
+         (List.map
+            (fun item -> normalize_schema_json_string_composites ~schema:item_schema item)
+            values))
+  | _ -> value
+;;
+
 let prepare_args ?schema ~name args =
   let args = strip_internal_marker_args args in
   let args = normalize_execute_args_envelope ?schema ~name args in
+  let args =
+    match schema with
+    | None -> args
+    | Some schema -> normalize_schema_json_string_composites ~schema args
+  in
   normalize_blank_optional_enum_args ?schema args
 ;;
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -843,6 +843,38 @@ let test_validate_args_tool_execute_accepts_typed_exec () =
       "expected typed tool_execute exec to pass validation, got %s"
       (Yojson.Safe.to_string (Tool_result.data result))
 
+let test_validate_args_tool_execute_decodes_json_string_argv () =
+  let expected =
+    `Assoc
+      [ "executable", `String "git"
+      ; "argv", `List [ `String "status"; `String "--short" ]
+      ; "cwd", `String "/tmp"
+      ]
+  in
+  let args =
+    `Assoc
+      [ "executable", `String "git"
+      ; "argv", `String "[\"status\",\"--short\"]"
+      ; "cwd", `String "/tmp"
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"tool_execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool)
+      "json-string argv decoded to typed array"
+      true
+      (Yojson.Safe.equal expected forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected json-string argv to be decoded, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
 let test_validate_args_tool_execute_accepts_typed_pipeline () =
   let args =
     `Assoc
@@ -872,6 +904,42 @@ let test_validate_args_tool_execute_accepts_typed_pipeline () =
   | Error result ->
     Alcotest.failf
       "expected typed tool_execute pipeline to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+let test_validate_args_masc_transition_decodes_json_string_handoff_context () =
+  let expected_handoff =
+    `Assoc
+      [ "summary", `String "task-1823 edits applied"
+      ; "evidence_refs", `List [ `String "board:task-1823" ]
+      ]
+  in
+  let args =
+    `Assoc
+      [ "agent_name", `String "codex-local-admin"
+      ; "task_id", `String "task-1823"
+      ; "action", `String "release"
+      ; ( "handoff_context"
+        , `String
+            "{\"summary\":\"task-1823 edits applied\",\"evidence_refs\":[\"board:task-1823\"]}"
+        )
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:masc_transition_schema
+      ~name:"masc_transition"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool)
+      "json-string handoff_context decoded to typed object"
+      true
+      (Yojson.Safe.equal expected_handoff
+         (Yojson.Safe.Util.member "handoff_context" forwarded))
+  | Error result ->
+    Alcotest.failf
+      "expected json-string handoff_context to be decoded, got %s"
       (Yojson.Safe.to_string (Tool_result.data result))
 
 let test_validate_args_execute_unwraps_args_object_envelope () =
@@ -2176,8 +2244,12 @@ let () =
         test_validate_args_tool_execute_rejects_async_lifecycle_fields;
       Alcotest.test_case "tool_execute accepts typed exec" `Quick
         test_validate_args_tool_execute_accepts_typed_exec;
+      Alcotest.test_case "tool_execute decodes json-string argv" `Quick
+        test_validate_args_tool_execute_decodes_json_string_argv;
       Alcotest.test_case "tool_execute accepts typed pipeline" `Quick
         test_validate_args_tool_execute_accepts_typed_pipeline;
+      Alcotest.test_case "masc_transition decodes json-string handoff" `Quick
+        test_validate_args_masc_transition_decodes_json_string_handoff_context;
       Alcotest.test_case "Execute unwraps args object envelope" `Quick
         test_validate_args_execute_unwraps_args_object_envelope;
       Alcotest.test_case "tool_execute unwraps args object envelope" `Quick


### PR DESCRIPTION
## Summary
- decode JSON-stringified composite tool arguments before OAS schema validation when the registered schema expects an array or object
- fixes `Execute.argv` arriving as a string like `"[\"status\", \"--short\"]"` by restoring it to a typed JSON array before validation
- fixes the same boundary for object fields such as `masc_transition.handoff_context`
- keep ordinary strings strict: non-JSON strings such as `"--files lib"` still fail against array/object schemas

## Why
The tool schema for `Execute.argv` is already correct: `argv` must be an array and `executable` is separate. The live failure shows the boundary sometimes receives a composite value that was serialized one layer too far, so validation sees a string instead of the typed JSON value:

```text
"argv": wrong type — expected: array, got: string("[\"status\", \"--short\"...)
```

The same shape explains `masc_transition` failures when `handoff_context` is sent as a JSON object string.

This patch keeps the fix at the pre-dispatch validation boundary and makes it schema-driven rather than special-casing `argv` or `handoff_context` by name.

## Validation
- `opam exec -- ocamlformat --check lib/tool_input_validation.ml test/test_tool_input_validation.ml`
- `git diff --check`

Dune build/test is left to CI per project workflow.
