### PR TITLE
fix(keeper): cap rotation on capacity_backpressure to stop infinite cycle (#23373 Phase A)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -676,6 +676,12 @@ let is_completion_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
 let degraded_reason_allows_candidate_cycle = function
   | Hard_quota
   | Rate_limit
+  (* Capacity_backpressure: provider retry_after is minutes-long, so cycling
+     the same candidate pool at the turn retry cadence just hammers the
+     provider and loops forever (incidents 2026-05-21, 2026-07-06, #23373).
+     Cap rotation here; the keeper pauses after candidates are exhausted and
+     retries on a later turn once the provider actually recovers. *)
+  | Capacity_backpressure
   | Read_only_no_progress
   | Empty_no_progress
   | Thinking_only_no_progress -> false
@@ -685,7 +691,6 @@ let degraded_reason_allows_candidate_cycle = function
   | Turn_timeout
   | Runtime_candidates_filtered
   | Runtime_exhausted
-  | Capacity_backpressure
   | Server_error
   | Auth_error -> true
 

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -182,11 +182,13 @@ val degraded_retry_after_recoverable_error :
     are excluded before attempt filtering, preserving independent-provider
     failover while avoiding same-account fan-out. If no pool function is
     supplied, no credential-pool filtering is applied. Non-contract transient
-    infrastructure errors (provider timeout, server error, capacity
-    backpressure) allow cycling through candidates again when all are exhausted,
-    because the same runtime may succeed on a subsequent attempt. Contract
-    violations, read-only no-progress accept rejections, and quota/rate-limit
-    classes cap rotation after the candidate set is exhausted.
+    infrastructure errors (provider timeout, server error) allow cycling
+    through candidates again when all are exhausted, because the same runtime
+    may succeed on a subsequent attempt. [Capacity_backpressure] caps rotation:
+    its provider retry_after is minutes-long, so cycling the same pool is
+    futile and previously looped forever (2026-05-21, 2026-07-06, #23373).
+    Contract violations, read-only no-progress accept rejections, and
+    quota/rate-limit classes cap rotation after the candidate set is exhausted.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?credential_pool_of_runtime_id:(string -> string option) ->
@@ -196,6 +198,12 @@ val degraded_rotation_after_recoverable_error :
   attempted_runtimes:string list ->
   Agent_sdk.Error.sdk_error ->
   degraded_retry option
+
+(** [true] when [reason] permits re-cycling the candidate pool after every
+    candidate has been attempted. [Capacity_backpressure] returns [false]
+    (see {!degraded_rotation_after_recoverable_error}). *)
+val degraded_reason_allows_candidate_cycle :
+  degraded_retry_reason -> bool
 
 val max_transient_retries : unit -> int
 

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -821,6 +821,16 @@ let test_read_only_no_progress_default_runtime_uses_tool_capable_candidate () =
     Alcotest.fail "expected read-only no-progress to rotate to a tool-capable runtime"
 ;;
 
+let test_capacity_backpressure_does_not_cycle_candidates () =
+  (* Regression: capacity_backpressure must cap rotation rather than cycle.
+     When this reason allowed candidate cycling, two runtimes that were both
+     in capacity cooldown looped forever (2026-05-21, 2026-07-06, #23373). *)
+  Alcotest.(check bool)
+    "capacity_backpressure does not allow candidate cycle"
+    false
+    (EC.degraded_reason_allows_candidate_cycle EC.Capacity_backpressure)
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -913,6 +923,10 @@ let () =
             "default runtime read-only no-progress uses tool-capable candidate"
             `Quick
             test_read_only_no_progress_default_runtime_uses_tool_capable_candidate
+        ; Alcotest.test_case
+            "capacity_backpressure does not cycle candidates"
+            `Quick
+            test_capacity_backpressure_does_not_cycle_candidates
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

Keeper entered infinite rotation between two runtimes (`glm-coding.glm-5-turbo` ↔ `runpod_rtxa6000.gemma4-coder-fable5-q4km`) that were both in `capacity_backpressure` cooldown (~59 min retry_after). `degraded_rotation_after_recoverable_error` cycled `first_candidate` at every turn retry (~1s), emitting `pause_human` broadcasts with seq climbing (108439+). Recurred on 2026-05-21 and 2026-07-06. Tracked in #23373.

## Root cause

`lib/keeper/keeper_error_classify.ml` — `degraded_reason_allows_candidate_cycle` returned `true` for `Capacity_backpressure`. When every candidate was already attempted, the `None when ... allows_cycle` branch restarted from `first_candidate` (lines ~735-752). Provider `retry_after` is minutes-long, so the same-pool cycle never made progress — it just hammered the provider and looped forever. No max-rotation counter on this path.

## Fix

Move `Capacity_backpressure` from the cycle group to the cap-rotation group (alongside `Hard_quota` / `Rate_limit`). After candidates are exhausted, `degraded_rotation_after_recoverable_error` returns `None` → `No_degraded_retry` → the keeper pauses once and retries on a later turn once the provider actually recovers.

This is the rotation-level termination invariant that was missing — `keeper_failure_policy` only labels capacity, and `keeper_failure_circuit_breaker` is scoped to tool-call failures, so nothing was stopping the cycle.

## Verification

- `dune runtest test/test_keeper_sdk_error_typed_bridge.exe` → 21/21 OK, including a new regression case `capacity_backpressure does not cycle candidates`.
- The 20 existing rotation/quota tests stay green — other transient classes (`Provider_timeout`, `Server_error`, etc.) keep cycling as before.

## Scope / what this is NOT

- Does **not** add healthy-global-pool failover (the candidate set is still bound runtime + default + fallback hints). That's Phase B — RFC-0207 Part B (persona `runtime_failover = [...]`) and RFC-0260 (provider health gate + audited failover chain). This PR stops the infinite loop; Phase B makes failover actually reach the 5 healthy runtimes.
- Does not touch `keeper_unified_turn.ml:142` `match None` (routing rewrite) — also Phase B.

WORKAROUND-WAIVED: this is a root rotation-termination invariant (not a symptom suppressor), and the deferred alternative is explicitly RFC-0207 Part B + RFC-0260. The `cap` keyword here is about ending the cycle, not a cap/cooldown symptom patch.

Closes #23373 (Phase A).
