### PR TITLE
[codex] Add Memory OS sanity sweep

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -913,9 +913,9 @@ let init_cmd =
   let info = Cmd.info "init" ~doc in
   Cmd.v info Term.(const init_cmd_exit $ base_path $ init_force)
 
-let memory_os_gc_keeper =
+let memory_os_keeper =
   let doc =
-    "Only dry-run the given keeper id. Repeatable. When omitted, all existing \
+    "Only scan the given keeper id. Repeatable. When omitted, all existing \
      non-shared keeper fact stores are scanned."
   in
   Arg.(value & opt_all string [] & info ["keeper"] ~docv:"KEEPER" ~doc)
@@ -962,7 +962,47 @@ let memory_os_gc_dry_run_cmd =
   let info = Cmd.info "memory-os-gc-dry-run" ~doc in
   Cmd.v info
     Term.(
-      const memory_os_gc_dry_run_cmd_exit $ base_path $ memory_os_gc_keeper
+      const memory_os_gc_dry_run_cmd_exit $ base_path $ memory_os_keeper
+      $ memory_os_gc_json)
+
+let memory_os_sanity_sweep_cmd_exit base_path keeper_ids as_json =
+  let base_path = Env_config.normalize_masc_base_path_input base_path in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
+  let report =
+    Eio_main.run
+    @@ fun env ->
+    let now = Eio.Time.now (Eio.Stdenv.clock env) in
+    match keeper_ids with
+    | [] ->
+      Masc.Keeper_memory_os_sanity_sweep.run_for_keepers_dir
+        ~keepers_dir
+        ~now
+        ()
+    | ids ->
+      Masc.Keeper_memory_os_sanity_sweep.run_for_keepers_dir
+        ~keepers_dir
+        ~keeper_ids:ids
+        ~now
+        ()
+  in
+  if as_json
+  then
+    print_endline
+      (Yojson.Safe.pretty_to_string
+         (Masc.Keeper_memory_os_sanity_sweep.to_json report))
+  else print_string (Masc.Keeper_memory_os_sanity_sweep.render_text report);
+  if report.error_count > 0 then 1 else 0
+
+let memory_os_sanity_sweep_cmd =
+  let doc =
+    "Build a read-only Memory OS sanity review packet: typed current/expired \
+     fact rows, duplicate claim identities, and deterministic GC preview. It \
+     never rewrites stores and never infers obsolete facts from claim prose."
+  in
+  let info = Cmd.info "memory-os-sanity-sweep" ~doc in
+  Cmd.v info
+    Term.(
+      const memory_os_sanity_sweep_cmd_exit $ base_path $ memory_os_keeper
       $ memory_os_gc_json)
 
 let setup_gc () =
@@ -985,7 +1025,13 @@ let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc" ~version:Masc.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ run_base_path)
-    info [ init_cmd; start_cmd; login_cmd; memory_os_gc_dry_run_cmd ]
+    info
+    [ init_cmd
+    ; start_cmd
+    ; login_cmd
+    ; memory_os_gc_dry_run_cmd
+    ; memory_os_sanity_sweep_cmd
+    ]
 
 let () =
   setup_gc ();

--- a/lib/keeper/keeper_memory_os_sanity_sweep.ml
+++ b/lib/keeper/keeper_memory_os_sanity_sweep.ml
@@ -1,0 +1,440 @@
+(** Read-only Memory OS sanity sweep. *)
+
+module Types = Keeper_memory_os_types
+module Io = Keeper_memory_os_io
+module GC = Keeper_memory_os_gc
+module String_map = Map.Make (String)
+
+type keeper_error =
+  | Missing_fact_store of { facts_path : string }
+  | Corrupt_fact_store of { message : string }
+  | Fact_store_access_error of { message : string }
+  | Fact_store_locked of
+      { caller : string
+      ; lock_path : string
+      ; attempts : int
+      }
+
+type fact_row =
+  { index : int
+  ; claim : string
+  ; claim_identity : string
+  ; category : string
+  ; claim_kind : string option
+  ; first_seen : float
+  ; valid_until : float option
+  ; effective_valid_until : float option
+  ; last_verified_at : float option
+  ; reference_time : float
+  ; current : bool
+  ; prompt_recallable : bool
+  }
+
+type duplicate_group =
+  { claim_identity : string
+  ; member_indices : int list
+  }
+
+type deterministic_gc_preview =
+  { total_input : int
+  ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
+  ; dedup_removed : int
+  ; written : int
+  }
+
+type keeper_result =
+  | Keeper_ok of
+      { keeper_id : string
+      ; facts_path : string
+      ; total_facts : int
+      ; current_facts : int
+      ; expired_facts : int
+      ; prompt_recallable_current_facts : int
+      ; duplicate_groups : duplicate_group list
+      ; facts : fact_row list
+      ; gc_preview : deterministic_gc_preview
+      }
+  | Keeper_error of
+      { keeper_id : string
+      ; error : keeper_error
+      }
+
+type t =
+  { keepers_dir : string
+  ; results : keeper_result list
+  ; total_facts : int
+  ; current_facts : int
+  ; expired_facts : int
+  ; prompt_recallable_current_facts : int
+  ; duplicate_group_count : int
+  ; deterministic_ttl_expired : int
+  ; deterministic_dedup_removed : int
+  ; deterministic_written : int
+  ; error_count : int
+  }
+
+let unique_sorted xs =
+  xs
+  |> List.filter_map (fun s ->
+    let s = String.trim s in
+    if String.equal s "" then None else Some s)
+  |> List.sort_uniq String.compare
+;;
+
+let fact_store_missing_error ~keepers_dir ~keeper_id =
+  let facts_path = Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  Keeper_error { keeper_id; error = Missing_fact_store { facts_path } }
+;;
+
+let access_error_message = function
+  | Sys_error message -> Some message
+  | Unix.Unix_error (error, fn, arg) ->
+    Some (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message error))
+  | _ -> None
+;;
+
+let keeper_error_message = function
+  | Missing_fact_store { facts_path } -> Printf.sprintf "fact store not found: %s" facts_path
+  | Corrupt_fact_store { message } | Fact_store_access_error { message } -> message
+  | Fact_store_locked { caller; lock_path; attempts } ->
+    Printf.sprintf
+      "fact store lock timeout: caller=%s lock_path=%s attempts=%d"
+      caller
+      lock_path
+      attempts
+;;
+
+let keeper_error_code = function
+  | Missing_fact_store _ -> "fact_store_missing"
+  | Corrupt_fact_store _ -> "fact_store_corrupt"
+  | Fact_store_access_error _ -> "fact_store_access_error"
+  | Fact_store_locked _ -> "fact_store_locked"
+;;
+
+let string_opt_to_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let float_opt_to_json = function
+  | None -> `Null
+  | Some value -> `Float value
+;;
+
+let category_counts_to_json rows =
+  `Assoc (List.map (fun (category, count) -> category, `Int count) rows)
+;;
+
+let row_of_fact ~now ~index (fact : Types.fact) =
+  let current = Types.fact_is_current ~now fact in
+  { index
+  ; claim = fact.claim
+  ; claim_identity = Types.claim_identity fact
+  ; category = Types.category_to_string fact.category
+  ; claim_kind = Option.map Types.claim_kind_to_string fact.claim_kind
+  ; first_seen = fact.first_seen
+  ; valid_until = fact.valid_until
+  ; effective_valid_until = Types.fact_effective_valid_until fact
+  ; last_verified_at = fact.last_verified_at
+  ; reference_time = Types.reference_time fact
+  ; current
+  ; prompt_recallable = current && Types.fact_prompt_recallable fact
+  }
+;;
+
+let duplicate_groups rows =
+  let by_identity =
+    List.fold_left
+      (fun acc row ->
+         if row.current
+         then (
+           let indices =
+             match String_map.find_opt row.claim_identity acc with
+             | Some indices -> indices
+             | None -> []
+           in
+           String_map.add row.claim_identity (row.index :: indices) acc)
+         else acc)
+      String_map.empty
+      rows
+  in
+  by_identity
+  |> String_map.bindings
+  |> List.filter_map (fun (claim_identity, indices) ->
+    match List.sort compare indices with
+    | [] | [ _ ] -> None
+    | member_indices -> Some { claim_identity; member_indices })
+;;
+
+let gc_preview_of_report (report : GC.gc_report) =
+  { total_input = report.total_input
+  ; ttl_expired = report.ttl_expired
+  ; ttl_expired_ephemeral = report.ttl_expired_ephemeral
+  ; ttl_expired_non_ephemeral = report.ttl_expired_non_ephemeral
+  ; ttl_expired_by_category = report.ttl_expired_by_category
+  ; dedup_removed = report.dedup_removed
+  ; written = report.written
+  }
+;;
+
+let run_gc_preview ~keepers_dir ~keeper_id ~now =
+  GC.run_gc_for_keepers_dir ~keepers_dir ~dry_run:true ~keeper_id ~now ()
+  |> gc_preview_of_report
+;;
+
+let run_one ~keepers_dir ~explicit ~keeper_id ~now =
+  let facts_path = Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  if explicit && not (Sys.file_exists facts_path)
+  then fact_store_missing_error ~keepers_dir ~keeper_id
+  else (
+    try
+      match Io.read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id with
+      | Error message -> Keeper_error { keeper_id; error = Corrupt_fact_store { message } }
+      | Ok facts ->
+        let rows = List.mapi (fun index fact -> row_of_fact ~now ~index fact) facts in
+        let current_facts = List.length (List.filter (fun row -> row.current) rows) in
+        let expired_facts = List.length rows - current_facts in
+        let prompt_recallable_current_facts =
+          List.length (List.filter (fun row -> row.prompt_recallable) rows)
+        in
+        let duplicate_groups = duplicate_groups rows in
+        let gc_preview = run_gc_preview ~keepers_dir ~keeper_id ~now in
+        Keeper_ok
+          { keeper_id
+          ; facts_path
+          ; total_facts = List.length rows
+          ; current_facts
+          ; expired_facts
+          ; prompt_recallable_current_facts
+          ; duplicate_groups
+          ; facts = rows
+          ; gc_preview
+          }
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | File_lock_eio.Flock_timeout { caller; path; attempts } ->
+      Keeper_error
+        { keeper_id; error = Fact_store_locked { caller; lock_path = path; attempts } }
+    | GC.Fact_store_corrupt message ->
+      Keeper_error { keeper_id; error = Corrupt_fact_store { message } }
+    | exn ->
+      (match access_error_message exn with
+       | Some message -> Keeper_error { keeper_id; error = Fact_store_access_error { message } }
+       | None -> raise exn))
+;;
+
+let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
+  let explicit, keeper_ids =
+    match keeper_ids with
+    | Some ids -> true, unique_sorted ids
+    | None -> false, Io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir
+  in
+  let results =
+    List.map (fun keeper_id -> run_one ~keepers_dir ~explicit ~keeper_id ~now) keeper_ids
+  in
+  let
+    ( total_facts
+    , current_facts
+    , expired_facts
+    , prompt_recallable_current_facts
+    , duplicate_group_count
+    , deterministic_ttl_expired
+    , deterministic_dedup_removed
+    , deterministic_written
+    , error_count )
+    =
+    List.fold_left
+      (fun
+        ( total_facts
+        , current_facts
+        , expired_facts
+        , prompt_recallable_current_facts
+        , duplicate_group_count
+        , deterministic_ttl_expired
+        , deterministic_dedup_removed
+        , deterministic_written
+        , error_count )
+        -> function
+         | Keeper_ok row ->
+           ( total_facts + row.total_facts
+           , current_facts + row.current_facts
+           , expired_facts + row.expired_facts
+           , prompt_recallable_current_facts + row.prompt_recallable_current_facts
+           , duplicate_group_count + List.length row.duplicate_groups
+           , deterministic_ttl_expired + row.gc_preview.ttl_expired
+           , deterministic_dedup_removed + row.gc_preview.dedup_removed
+           , deterministic_written + row.gc_preview.written
+           , error_count )
+         | Keeper_error _ ->
+           ( total_facts
+           , current_facts
+           , expired_facts
+           , prompt_recallable_current_facts
+           , duplicate_group_count
+           , deterministic_ttl_expired
+           , deterministic_dedup_removed
+           , deterministic_written
+           , error_count + 1 ))
+      (0, 0, 0, 0, 0, 0, 0, 0, 0)
+      results
+  in
+  { keepers_dir
+  ; results
+  ; total_facts
+  ; current_facts
+  ; expired_facts
+  ; prompt_recallable_current_facts
+  ; duplicate_group_count
+  ; deterministic_ttl_expired
+  ; deterministic_dedup_removed
+  ; deterministic_written
+  ; error_count
+  }
+;;
+
+module For_testing = struct
+  let row_of_fact = row_of_fact
+  let duplicate_groups = duplicate_groups
+end
+
+let fact_row_to_json row =
+  `Assoc
+    [ "index", `Int row.index
+    ; "claim", `String row.claim
+    ; "claim_identity", `String row.claim_identity
+    ; "category", `String row.category
+    ; "claim_kind", string_opt_to_json row.claim_kind
+    ; "first_seen", `Float row.first_seen
+    ; "valid_until", float_opt_to_json row.valid_until
+    ; "effective_valid_until", float_opt_to_json row.effective_valid_until
+    ; "last_verified_at", float_opt_to_json row.last_verified_at
+    ; "reference_time", `Float row.reference_time
+    ; "current", `Bool row.current
+    ; "prompt_recallable", `Bool row.prompt_recallable
+    ]
+;;
+
+let duplicate_group_to_json group =
+  `Assoc
+    [ "claim_identity", `String group.claim_identity
+    ; "member_indices", `List (List.map (fun index -> `Int index) group.member_indices)
+    ]
+;;
+
+let gc_preview_to_json preview =
+  `Assoc
+    [ "dry_run", `Bool true
+    ; "total_input", `Int preview.total_input
+    ; "ttl_expired", `Int preview.ttl_expired
+    ; "ttl_expired_ephemeral", `Int preview.ttl_expired_ephemeral
+    ; "ttl_expired_non_ephemeral", `Int preview.ttl_expired_non_ephemeral
+    ; "ttl_expired_by_category", category_counts_to_json preview.ttl_expired_by_category
+    ; "dedup_removed", `Int preview.dedup_removed
+    ; "written", `Int preview.written
+    ]
+;;
+
+let result_to_json = function
+  | Keeper_ok row ->
+    Tool_args.ok_assoc
+      [ "keeper_id", `String row.keeper_id
+      ; "facts_path", `String row.facts_path
+      ; "total_facts", `Int row.total_facts
+      ; "current_facts", `Int row.current_facts
+      ; "expired_facts", `Int row.expired_facts
+      ; "prompt_recallable_current_facts", `Int row.prompt_recallable_current_facts
+      ; ( "duplicate_groups"
+        , `List (List.map duplicate_group_to_json row.duplicate_groups) )
+      ; "facts", `List (List.map fact_row_to_json row.facts)
+      ; "gc_preview", gc_preview_to_json row.gc_preview
+      ]
+  | Keeper_error row ->
+    Tool_args.error_assoc
+      [ "keeper_id", `String row.keeper_id
+      ; "error_code", `String (keeper_error_code row.error)
+      ; "message", `String (keeper_error_message row.error)
+      ]
+;;
+
+let to_json report =
+  Tool_args.ok_assoc
+    [ "schema", `String "masc.memory_os.sanity_sweep.v1"
+    ; "mode", `String "read_only_dry_run"
+    ; "decision_policy", `String "typed_state_only_no_prose_inference"
+    ; "keepers_dir", `String report.keepers_dir
+    ; "keeper_count", `Int (List.length report.results)
+    ; "total_facts", `Int report.total_facts
+    ; "current_facts", `Int report.current_facts
+    ; "expired_facts", `Int report.expired_facts
+    ; "prompt_recallable_current_facts", `Int report.prompt_recallable_current_facts
+    ; "duplicate_group_count", `Int report.duplicate_group_count
+    ; "deterministic_ttl_expired", `Int report.deterministic_ttl_expired
+    ; "deterministic_dedup_removed", `Int report.deterministic_dedup_removed
+    ; "deterministic_written", `Int report.deterministic_written
+    ; "error_count", `Int report.error_count
+    ; "keepers", `List (List.map result_to_json report.results)
+    ]
+;;
+
+let render_duplicate_group group =
+  Printf.sprintf
+    "    - identity=%s indices=[%s]\n"
+    group.claim_identity
+    (group.member_indices |> List.map string_of_int |> String.concat ",")
+;;
+
+let render_keeper_result = function
+  | Keeper_error row ->
+    Printf.sprintf
+      "- %s: ERROR %s (%s)\n"
+      row.keeper_id
+      (keeper_error_code row.error)
+      (keeper_error_message row.error)
+  | Keeper_ok row ->
+    let duplicate_text =
+      match row.duplicate_groups with
+      | [] -> ""
+      | groups ->
+        "  duplicate claim groups:\n"
+        ^ (groups |> List.map render_duplicate_group |> String.concat "")
+    in
+    Printf.sprintf
+      "- %s: facts=%d current=%d expired=%d prompt_recallable_current=%d \
+       gc_ttl_expired=%d gc_dedup_removed=%d gc_written=%d\n%s"
+      row.keeper_id
+      row.total_facts
+      row.current_facts
+      row.expired_facts
+      row.prompt_recallable_current_facts
+      row.gc_preview.ttl_expired
+      row.gc_preview.dedup_removed
+      row.gc_preview.written
+      duplicate_text
+;;
+
+let render_text report =
+  let header =
+    Printf.sprintf
+      "Memory OS sanity sweep (read-only dry-run)\n\
+       policy: typed_state_only_no_prose_inference\n\
+       keepers_dir: %s\n\
+       keepers=%d total_facts=%d current=%d expired=%d \
+       prompt_recallable_current=%d duplicate_groups=%d errors=%d\n\
+       deterministic_gc: ttl_expired=%d dedup_removed=%d written=%d\n\n"
+      report.keepers_dir
+      (List.length report.results)
+      report.total_facts
+      report.current_facts
+      report.expired_facts
+      report.prompt_recallable_current_facts
+      report.duplicate_group_count
+      report.error_count
+      report.deterministic_ttl_expired
+      report.deterministic_dedup_removed
+      report.deterministic_written
+  in
+  header ^ (report.results |> List.map render_keeper_result |> String.concat "")
+;;

--- a/lib/keeper/keeper_memory_os_sanity_sweep.mli
+++ b/lib/keeper/keeper_memory_os_sanity_sweep.mli
@@ -1,0 +1,100 @@
+(** Read-only Memory OS sanity sweep.
+
+    This is an operator review packet, not an automatic belief invalidator. The
+    code only projects typed Memory OS state: current-vs-expired facts from the
+    stored [valid_until] boundary, duplicate claim identities from the Memory OS
+    SSOT, and prompt-recall eligibility from the typed fact schema. It does not
+    string-match claim prose or infer external truth. Obsolete/superseded
+    decisions remain HITL/model-judgement work through the existing
+    consolidation-plan index contract. *)
+
+type keeper_error =
+  | Missing_fact_store of { facts_path : string }
+  | Corrupt_fact_store of { message : string }
+  | Fact_store_access_error of { message : string }
+  | Fact_store_locked of
+      { caller : string
+      ; lock_path : string
+      ; attempts : int
+      }
+
+type fact_row =
+  { index : int
+  ; claim : string
+  ; claim_identity : string
+  ; category : string
+  ; claim_kind : string option
+  ; first_seen : float
+  ; valid_until : float option
+  ; effective_valid_until : float option
+  ; last_verified_at : float option
+  ; reference_time : float
+  ; current : bool
+  ; prompt_recallable : bool
+  }
+
+type duplicate_group =
+  { claim_identity : string
+  ; member_indices : int list
+  }
+
+type deterministic_gc_preview =
+  { total_input : int
+  ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
+  ; dedup_removed : int
+  ; written : int
+  }
+
+type keeper_result =
+  | Keeper_ok of
+      { keeper_id : string
+      ; facts_path : string
+      ; total_facts : int
+      ; current_facts : int
+      ; expired_facts : int
+      ; prompt_recallable_current_facts : int
+      ; duplicate_groups : duplicate_group list
+      ; facts : fact_row list
+      ; gc_preview : deterministic_gc_preview
+      }
+  | Keeper_error of
+      { keeper_id : string
+      ; error : keeper_error
+      }
+
+type t =
+  { keepers_dir : string
+  ; results : keeper_result list
+  ; total_facts : int
+  ; current_facts : int
+  ; expired_facts : int
+  ; prompt_recallable_current_facts : int
+  ; duplicate_group_count : int
+  ; deterministic_ttl_expired : int
+  ; deterministic_dedup_removed : int
+  ; deterministic_written : int
+  ; error_count : int
+  }
+
+val run_for_keepers_dir
+  :  keepers_dir:string
+  -> ?keeper_ids:string list
+  -> now:float
+  -> unit
+  -> t
+(** Build a read-only report for Memory OS fact stores. Must run inside an Eio
+    context because the deterministic GC preview takes the per-keeper fact-store
+    lock in dry-run mode. *)
+
+module For_testing : sig
+  val row_of_fact :
+    now:float -> index:int -> Keeper_memory_os_types.fact -> fact_row
+
+  val duplicate_groups : fact_row list -> duplicate_group list
+end
+
+val to_json : t -> Yojson.Safe.t
+val render_text : t -> string

--- a/test/dune
+++ b/test/dune
@@ -110,6 +110,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report
+  test_keeper_memory_os_sanity_sweep
   test_keeper_user_model
   test_keeper_recall_outcome_eval
   test_keeper_memory_os_consolidation
@@ -455,6 +456,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report
+  test_keeper_memory_os_sanity_sweep
   test_keeper_user_model
   test_keeper_recall_outcome_eval
   test_keeper_memory_os_consolidation

--- a/test/test_keeper_memory_os_sanity_sweep.ml
+++ b/test/test_keeper_memory_os_sanity_sweep.ml
@@ -1,0 +1,196 @@
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
+module Sweep = Masc.Keeper_memory_os_sanity_sweep
+
+let now = 10_000.0
+
+let fact
+      ?(category = Types.Fact)
+      ?(first_seen = now -. 60.0)
+      ?valid_until
+      ?last_verified_at
+      ?claim_id
+      ?(claim_kind = None)
+      claim
+  =
+  { Types.claim
+  ; category
+  ; external_ref = None
+  ; claim_kind
+  ; source = { Types.trace_id = "trace-sanity"; turn = 1; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen
+  ; valid_until
+  ; last_verified_at
+  ; schema_version = Types.schema_version
+  ; claim_id
+  }
+;;
+
+let with_temp_keepers_dir f =
+  let marker = Filename.temp_file "keeper-memory-os-sanity-" ".tmp" in
+  Sys.remove marker;
+  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let with_eio f = Eio_main.run @@ fun _env -> f ()
+
+let result_for keeper_id report =
+  List.find_opt
+    (function
+      | Sweep.Keeper_ok row -> String.equal row.keeper_id keeper_id
+      | Sweep.Keeper_error row -> String.equal row.keeper_id keeper_id)
+    report.Sweep.results
+;;
+
+let test_sweep_projects_typed_memory_state_without_rewrite () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let old_external_first_seen =
+        now -. Types.external_state_ttl_seconds -. 1.0
+      in
+      let rows =
+        [ fact ~claim_id:"same-conclusion" "first wording"
+        ; fact ~claim_id:"same-conclusion" "second wording"
+        ; fact
+            ~claim_kind:(Some Types.External_state)
+            ~first_seen:old_external_first_seen
+            "external state claim"
+        ; fact ~claim_kind:(Some Types.Diagnostic) "diagnostic evidence"
+        ]
+      in
+      List.iter (Memory_io.append_fact ~keeper_id:"alpha") rows;
+      let report = Sweep.run_for_keepers_dir ~keepers_dir ~keeper_ids:[ "alpha" ] ~now () in
+      Alcotest.(check int) "total facts" 4 report.total_facts;
+      Alcotest.(check int) "current facts" 3 report.current_facts;
+      Alcotest.(check int) "expired facts" 1 report.expired_facts;
+      Alcotest.(check int)
+        "diagnostic excluded from prompt recall"
+        2
+        report.prompt_recallable_current_facts;
+      Alcotest.(check int) "duplicate groups" 1 report.duplicate_group_count;
+      Alcotest.(check int) "gc ttl expired" 1 report.deterministic_ttl_expired;
+      Alcotest.(check int) "gc dedup removed" 1 report.deterministic_dedup_removed;
+      Alcotest.(check int) "dry-run does not rewrite" 4
+        (List.length (Memory_io.read_facts_all ~keeper_id:"alpha"));
+      match result_for "alpha" report with
+      | Some (Sweep.Keeper_ok row) ->
+        Alcotest.(check int) "row total" 4 row.total_facts;
+        Alcotest.(check int) "row gc written" 2 row.gc_preview.written;
+        (match row.duplicate_groups with
+         | [ group ] ->
+           Alcotest.(check string)
+             "claim identity from claim_id"
+             "same-conclusion"
+             group.claim_identity;
+           Alcotest.(check (list int)) "duplicate indices" [ 0; 1 ] group.member_indices
+         | groups ->
+           Alcotest.failf "expected one duplicate group, got %d" (List.length groups));
+        (match List.nth_opt row.facts 2 with
+         | Some expired ->
+           Alcotest.(check bool) "external state is expired by typed horizon" false expired.current;
+           Alcotest.(check bool)
+             "expired external state is not prompt recallable"
+             false
+             expired.prompt_recallable;
+           Alcotest.(check bool)
+             "legacy external state has effective horizon"
+             true
+             (Option.is_some expired.effective_valid_until)
+         | None -> Alcotest.fail "missing expired row");
+        (match List.nth_opt row.facts 3 with
+         | Some diagnostic ->
+           Alcotest.(check bool) "diagnostic current" true diagnostic.current;
+           Alcotest.(check bool)
+             "diagnostic excluded by claim_kind"
+             false
+             diagnostic.prompt_recallable
+         | None -> Alcotest.fail "missing diagnostic row")
+      | Some (Sweep.Keeper_error row) ->
+        Alcotest.failf "unexpected error for alpha: %s" row.keeper_id
+      | None -> Alcotest.fail "missing alpha result"))
+;;
+
+let test_duplicate_groups_follow_claim_identity_only () =
+  let rows =
+    [ Sweep.For_testing.row_of_fact
+        ~now
+        ~index:0
+        (fact ~claim_id:"first-identity" "same topic")
+    ; Sweep.For_testing.row_of_fact
+        ~now
+        ~index:1
+        (fact ~claim_id:"second-identity" "same topic")
+    ; Sweep.For_testing.row_of_fact ~now ~index:2 (fact "exact same")
+    ; Sweep.For_testing.row_of_fact ~now ~index:3 (fact " exact same ")
+    ]
+  in
+  let groups = Sweep.For_testing.duplicate_groups rows in
+  Alcotest.(check int) "only exact claim identity groups" 1 (List.length groups);
+  match groups with
+  | [ group ] ->
+    Alcotest.(check string) "normalized prose identity" "exact same" group.claim_identity;
+    Alcotest.(check (list int)) "members" [ 2; 3 ] group.member_indices
+  | _ -> Alcotest.fail "unexpected duplicate group shape"
+;;
+
+let test_explicit_missing_keeper_is_structured_error () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let report =
+        Sweep.run_for_keepers_dir ~keepers_dir ~keeper_ids:[ "missing" ] ~now ()
+      in
+      Alcotest.(check int) "error count" 1 report.error_count;
+      match result_for "missing" report with
+      | Some (Sweep.Keeper_error row) ->
+        (match row.error with
+         | Sweep.Missing_fact_store { facts_path } ->
+           Alcotest.(check string)
+             "missing path"
+             (Memory_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id:"missing")
+             facts_path
+         | Sweep.Corrupt_fact_store _
+         | Sweep.Fact_store_access_error _
+         | Sweep.Fact_store_locked _ ->
+           Alcotest.fail "expected missing fact store");
+        (match Sweep.to_json report with
+         | `Assoc fields ->
+           (match List.assoc_opt "keepers" fields with
+            | Some (`List [ `Assoc keeper_fields ]) ->
+              Alcotest.(check (option string))
+                "error status"
+                (Some "error")
+                (Option.bind
+                   (List.assoc_opt "status" keeper_fields)
+                   (function `String s -> Some s | _ -> None));
+              Alcotest.(check (option string))
+                "error code"
+                (Some "fact_store_missing")
+                (Option.bind
+                   (List.assoc_opt "error_code" keeper_fields)
+                   (function `String s -> Some s | _ -> None))
+            | Some _ | None -> Alcotest.fail "missing keeper JSON")
+         | _ -> Alcotest.fail "report JSON must be object")
+      | Some (Sweep.Keeper_ok _) -> Alcotest.fail "expected missing keeper error"
+      | None -> Alcotest.fail "missing result"))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os_sanity_sweep"
+    [ ( "sanity"
+      , [ Alcotest.test_case
+            "projects typed state without rewrite"
+            `Quick
+            test_sweep_projects_typed_memory_state_without_rewrite
+        ; Alcotest.test_case
+            "duplicate groups follow claim identity only"
+            `Quick
+            test_duplicate_groups_follow_claim_identity_only
+        ; Alcotest.test_case
+            "explicit missing keeper is structured error"
+            `Quick
+            test_explicit_missing_keeper_is_structured_error
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
Adds a read-only Memory OS sanity sweep operator report.

- adds a new `memory-os-sanity-sweep` CLI with `--keeper` and `--json`
- projects typed current/expired fact rows, duplicate claim identity groups, prompt-recallable current counts, and deterministic GC preview
- keeps cleanup non-mutating and non-blocking; no fact deletion or rewrite
- avoids prose inference: no PR/task/status/deprecated string parsing; decisions use `fact_is_current`, `fact_prompt_recallable`, `claim_identity`, and GC dry-run

## Validation
- `ocamlformat --check lib/keeper/keeper_memory_os_sanity_sweep.ml lib/keeper/keeper_memory_os_sanity_sweep.mli bin/main_eio.ml test/test_keeper_memory_os_sanity_sweep.ml test/dune`
- `git diff --check`
- no hardcoded/prose-inference pattern grep found in touched files
- Dune build/test intentionally deferred to CI per maintainer instruction
