### PR TITLE
keeper: stop fabricating runtime provenance

### DIFF
--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -271,7 +271,7 @@ Once PR-3 is merged, any future PR that adds an inline `"runtime"` literal at an
 | Phase | Verification |
 |---|---|
 | PR-1 | Alcotest: `runtime_provider_label \|> to_string = "runtime"` and `runtime_model_label \|> to_string = "runtime"`. Compile-time: attempting `let x : Boundary_redaction.public_label = "foo"` outside the module fails the build. |
-| 2026-07-06 extension | Alcotest: `unknown_model_label \|> to_string = "unknown_model"` and the value is distinct from `runtime_model_label`. Governance dashboard model classification routes missing model evidence through this typed label instead of a local string. |
+| 2026-07-06 extension | Alcotest: `unknown_model_label \|> to_string = "unknown_model"` and the value is distinct from `runtime_model_label`. Governance dashboard model classification and keeper status model labels route missing model evidence through this typed label instead of a local string. |
 | PR-2 | For each of the 23 sites: dashboard SSE / OAS bridge / keeper telemetry output byte-equality regression test. The boundary-emit byte stream must be identical to pre-codemod main. Regression count target: 0. |
 | PR-3 | Adding a test fixture that places `let _ = "runtime"` at `lib/runtime/foo.ml` causes a build failure with the lint rule error message. Removing the fixture restores the build. |
 | Overall | After PR-3 merge, `rg -n '"runtime"' lib/runtime/ lib/keeper/` should return only: (a) `boundary_redaction.ml` source, (b) `keeper_status_runtime.ml:219` allow-listed heuristic, (c) `.mli` doc comments. Total expected hits: ≤ 4. |

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -804,9 +804,10 @@ let append_memory_notes_from_reply
       (match parse_state_snapshot_from_reply reply with
     | Some s -> (s, "reply_state_block", false)
     | None ->
-        (* Deterministic fallback: use keeper meta fields as memory source.
-           This guarantees memory write regardless of LLM output format.
-           See RFC #3646 Section 3: Det/NonDet boundary principle. *)
+        (* Deterministic fallback: use keeper meta fields as a continuity
+           snapshot only. Because this snapshot is constructed rather than
+           model-authored, the candidate gate suppresses durable writes and
+           reports the suppression explicitly. *)
         ( {
             Keeper_memory_policy.priority = None;
             Keeper_memory_policy.goal =
@@ -825,6 +826,12 @@ let append_memory_notes_from_reply
     memory_candidates_from_snapshot_gated ~is_synthetic snapshot
   in
   let notes = selection.selected in
+  if selection.suppressed_synthetic_candidates > 0 then
+    Log.Keeper.info
+      ~keeper_name:meta.name
+      "memory_candidates suppressed source=%s synthetic_candidates=%d"
+      source
+      selection.suppressed_synthetic_candidates;
   if selection.dropped_by_total_cap > 0 || selection.dropped_by_kind <> [] then
     Log.Keeper.warn
       ~keeper_name:meta.name

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -787,8 +787,9 @@ let append_memory_notes_from_reply
   (* [source] is the per-note provenance written to the memory-bank JSONL — a
      separate vocabulary from the turn-cascade [state_snapshot_source]. The
      turn-cascade source (when present) is rendered to its wire string and carries
-     its typed synthetic-ness; the internal fallback labels are never synthetic.
-     RFC-0242 §3.2: the candidate gate now receives the [is_synthetic] bit, not a
+     its typed synthetic-ness. The meta-goal fallback is also constructed rather
+     than model-authored, so it is marked synthetic before candidate selection.
+     RFC-0242 §3.2: the candidate gate receives the [is_synthetic] bit, not a
      string to re-classify. *)
   let (snapshot, source, is_synthetic) =
     match snapshot with
@@ -818,7 +819,7 @@ let append_memory_notes_from_reply
             open_questions = [];
             constraints = [];
           },
-          "meta_goal_fallback", false ))
+          "meta_goal_fallback", true ))
   in
   let selection =
     memory_candidates_from_snapshot_gated ~is_synthetic snapshot

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -197,6 +197,9 @@ type candidate_selection_result = {
       (** Drops attributed to per-kind caps, by kind. *)
   dropped_by_total_cap : int;
       (** Drops attributed to the global [total_cap]. *)
+  suppressed_synthetic_candidates : int;
+      (** Otherwise valid candidates intentionally suppressed because the
+          snapshot was synthetic rather than model-authored. *)
 }
 (** Outcome of [select_memory_candidates]. *)
 
@@ -264,9 +267,11 @@ val memory_candidates_from_snapshot_gated :
   is_synthetic:bool ->
   keeper_state_snapshot ->
   candidate_selection_result
-(** Gated variant used by post-turn persistence. When [is_synthetic] (the
-    snapshot was fabricated from run metadata, not model-authored), no durable
-    memory candidates are produced — synthetic snapshots are resume aids only. *)
+  (** Gated variant used by post-turn persistence. When [is_synthetic] (the
+      snapshot was fabricated from run metadata, not model-authored), no durable
+      memory candidates are produced — synthetic snapshots are resume aids only.
+      [suppressed_synthetic_candidates] records how many otherwise valid
+      candidates were intentionally suppressed by this gate. *)
 
 (** {1 Bank wire format} *)
 

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -35,10 +35,16 @@ type candidate_selection_result = {
   selected: (string * string * int) list;
   dropped_by_kind: (string * int) list;
   dropped_by_total_cap: int;
+  suppressed_synthetic_candidates: int;
 }
 
 let empty_candidate_selection =
-  { selected = []; dropped_by_kind = []; dropped_by_total_cap = 0 }
+  {
+    selected = [];
+    dropped_by_kind = [];
+    dropped_by_total_cap = 0;
+    suppressed_synthetic_candidates = 0;
+  }
 
 let select_memory_candidates
     (rows : (string * string * int) list) : candidate_selection_result =
@@ -56,6 +62,7 @@ let select_memory_candidates
             |> List.of_seq
             |> List.sort (fun (a, _) (b, _) -> String.compare a b);
           dropped_by_total_cap = dropped_total;
+          suppressed_synthetic_candidates = 0;
         }
     | _ when List.length acc >= total_cap ->
         {
@@ -65,6 +72,7 @@ let select_memory_candidates
             |> List.of_seq
             |> List.sort (fun (a, _) (b, _) -> String.compare a b);
           dropped_by_total_cap = dropped_total + List.length rest;
+          suppressed_synthetic_candidates = 0;
         }
     | (kind, text, pr) :: rest' ->
         let cap = cap_for_kind kind_caps kind in
@@ -282,5 +290,17 @@ let memory_candidates_from_snapshot
 
 let memory_candidates_from_snapshot_gated ~is_synthetic snapshot =
   if is_synthetic
-  then empty_candidate_selection
+  then
+    let ungated = memory_candidates_from_snapshot snapshot in
+    let dropped_by_kind =
+      List.fold_left
+        (fun total (_, count) -> total + count)
+        0
+        ungated.dropped_by_kind
+    in
+    {
+      empty_candidate_selection with
+      suppressed_synthetic_candidates =
+        List.length ungated.selected + ungated.dropped_by_total_cap + dropped_by_kind;
+    }
   else memory_candidates_from_snapshot snapshot

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -170,6 +170,7 @@ type candidate_selection_result = {
   selected : (string * string * int) list;
   dropped_by_kind : (string * int) list;
   dropped_by_total_cap : int;
+  suppressed_synthetic_candidates : int;
 }
 val select_memory_candidates :
   (string * string * int) list -> candidate_selection_result
@@ -203,4 +204,6 @@ val memory_candidates_from_snapshot_gated :
   candidate_selection_result
   (** Gated variant used by post-turn persistence. When [is_synthetic] (the
       snapshot was fabricated from run metadata, not model-authored), no durable
-      memory candidates are produced — synthetic snapshots are resume aids only. *)
+      memory candidates are produced — synthetic snapshots are resume aids only.
+      [suppressed_synthetic_candidates] records how many otherwise valid
+      candidates were intentionally suppressed by this gate. *)

--- a/lib/keeper/keeper_status_detail_observability.ml
+++ b/lib/keeper/keeper_status_detail_observability.ml
@@ -62,28 +62,35 @@ let selected_model_of_runtime_trust runtime_trust =
            |> Option.map (fun model ->
              model, "runtime_trust.execution.provider_selected_model"))
 
-let lightweight_runtime_contract_json ~runtime_blocker_class ~selected_model =
-  let model, source =
+let lightweight_runtime_contract_json ~runtime_blocker_class ~selected_model
+    ~runtime_verified =
+  let source =
     match selected_model with
-    | Some (model, source) -> Some model, source
-    | None -> None, "none"
+    | Some (_, source) -> source
+    | None -> "none"
   in
   let proof_note =
-    match selected_model with
-    | Some _ ->
-        "Selected model was observed from runtime trust / receipt. Concrete \
-         provider identity remains OAS-owned."
-    | None ->
+    match runtime_verified, selected_model with
+    | true, Some _ ->
+        "Scoped runtime observation is present; selected model label remains \
+         OAS-owned."
+    | false, Some _ ->
+        "Selected model label is available, but no scoped runtime observation \
+         verified it. Concrete provider identity remains OAS-owned."
+    | true, None ->
+        "Scoped runtime observation is present. Provider/model identity is owned \
+         by OAS."
+    | false, None ->
         "Provider/model identity is owned by OAS. MASC status exposes only \
          control-plane signals."
   in
   `Assoc
     [ "source", `String source
-    ; "verified", `Bool (Option.is_some model)
+    ; "verified", `Bool runtime_verified
     ; "provider_scope", `Null
     ; "provider_reachable", `Null
     ; "healthy_runtime_count", `Null
-    ; "actual_model_id", Json_util.string_opt_to_json model
+    ; "actual_model_id", `Null
     ; "actual_slots", `Null
     ; "actual_ctx", `Null
     ; "chat_completion_compatible", `Null
@@ -163,6 +170,18 @@ let attempt_summary_json ?selected_model latest_runtime =
         ; "fallback_applied", `Bool fallback_applied
         ]
 
+type runtime_observation_scope =
+  | Runtime_observation_absent
+  | Runtime_observation_matched
+  | Runtime_observation_missing_runtime_id
+  | Runtime_observation_mismatched
+
+let runtime_observation_scope_to_string = function
+  | Runtime_observation_absent -> "absent"
+  | Runtime_observation_matched -> "matched"
+  | Runtime_observation_missing_runtime_id -> "missing_runtime_id"
+  | Runtime_observation_mismatched -> "mismatched_runtime_id"
+
 let latest_runtime_for_current_config ~current_runtime_id latest_metrics =
   let latest_runtime =
     match latest_metrics with
@@ -173,26 +192,30 @@ let latest_runtime_for_current_config ~current_runtime_id latest_metrics =
     | None -> None
   in
   match latest_runtime with
-  | None -> None
+  | None -> None, Runtime_observation_absent
   | Some runtime ->
       let runtime_id_matches =
-        let observed_runtime_id =
-          match Json_util.assoc_string_opt "runtime_id" runtime with
-          | Some value -> Some value
-          | None -> Json_util.assoc_string_opt "runtime_id" runtime
-        in
+        let observed_runtime_id = Json_util.assoc_string_opt "runtime_id" runtime in
         match observed_runtime_id with
         | Some observed_name -> String.equal observed_name current_runtime_id
-        | None -> true
+        | None -> false
       in
-      if runtime_id_matches then Some runtime else None
+      if runtime_id_matches then Some runtime, Runtime_observation_matched
+      else
+        let scope =
+          match Json_util.assoc_string_opt "runtime_id" runtime with
+          | Some _ -> Runtime_observation_mismatched
+          | None -> Runtime_observation_missing_runtime_id
+        in
+        None, scope
 
 let model_observability_json ~current_runtime_id ~runtime_blocker_fields
     ~runtime_trust latest_metrics =
-  let latest_runtime =
+  let latest_runtime, runtime_observation_scope =
     latest_runtime_for_current_config ~current_runtime_id latest_metrics
   in
   let selected_model = selected_model_of_runtime_trust runtime_trust in
+  let runtime_verified = Option.is_some latest_runtime in
   let runtime_blocker_class =
     assoc_string_opt "runtime_blocker_class" runtime_blocker_fields
   in
@@ -203,12 +226,15 @@ let model_observability_json ~current_runtime_id ~runtime_blocker_fields
     [ ( "runtime_id"
       , if runtime_id = "" then `Null else `String runtime_id )
     ; ( "recent_turn_observation"
-      , `Bool (Option.is_some latest_runtime || Option.is_some selected_model) )
+      , `Bool runtime_verified )
+    ; ( "runtime_observation_scope"
+      , `String (runtime_observation_scope_to_string runtime_observation_scope) )
     ; "configured_labels", `List []
     ; "resolved_candidates", `List []
     ; ( "selected_model"
       , Json_util.string_opt_to_json (Option.map fst selected_model) )
     ; "attempt_summary", attempt_summary_json ?selected_model latest_runtime
     ; ( "runtime_contract"
-      , lightweight_runtime_contract_json ~runtime_blocker_class ~selected_model )
+      , lightweight_runtime_contract_json ~runtime_blocker_class ~selected_model
+          ~runtime_verified )
     ]

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -12,21 +12,22 @@ open Keeper_types_profile
    and zombie/stale assessment. *)
 let agent_staleness_threshold_s = 120.0
 
+let unknown_model_label = "unknown_model"
+
 let active_model_of_meta (m : keeper_meta) : string =
   match m.runtime.last_runtime_attempt with
   | Some record when String.trim record.provider_id <> "" -> record.provider_id
-  | _ -> Keeper_meta_contract.runtime_id_of_meta m
+  | _ -> unknown_model_label
 
 let active_model_label_of_meta (m : keeper_meta) : string =
   (* RFC-0132 PR-2: the meta surface is external (status detail); the model
      label is redacted via SSOT ([Boundary_redaction.runtime_model_label]).
-     [meta.runtime.usage] carries only [last_input_tokens] — there is no
-     separate last-model-used field — so [last_model_used_label] at the emit
-     sites mirrors this same redacted value. Splitting the two would require
-     adding a model field to [usage_metrics] plus an RFC-0132 carve-out
-     (separate change). Intentionally identical to active by design. *)
-  let _ = m in
-  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+     Missing runtime-attempt evidence stays explicit instead of borrowing the
+     configured/default runtime. *)
+  match m.runtime.last_runtime_attempt with
+  | Some record when String.trim record.provider_id <> "" ->
+      Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+  | _ -> unknown_model_label
 
 let next_model_hint_of_meta (m : keeper_meta) : string option =
   (* NOT-YET-IMPLEMENTED (#22080 follow-up): meta carries no field recording the

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -12,7 +12,8 @@ open Keeper_types_profile
    and zombie/stale assessment. *)
 let agent_staleness_threshold_s = 120.0
 
-let unknown_model_label = "unknown_model"
+let unknown_model_label =
+  Boundary_redaction.to_string Boundary_redaction.unknown_model_label
 
 let active_model_of_meta (m : keeper_meta) : string =
   match m.runtime.last_runtime_attempt with

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -1292,8 +1292,8 @@ let test_old_ocaml_aborts_build () =
     check int "exits non-zero on old OCaml" 1 code;
     check bool "OCaml version message present" true
       (contains_substring stderr "OCaml 5.0 detected");
-    check bool "minimum 5.4 mentioned" true
-      (contains_substring stderr ">= 5.4");
+    check bool "minimum 5.5 mentioned" true
+      (contains_substring stderr ">= 5.5");
     check bool "skip hint present" true
       (contains_substring stderr "MASC_SKIP_OCAML_VERSION_CHECK=1");
     check bool "dune not invoked" false (Sys.file_exists dune_log))

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -47,7 +47,37 @@ let assert_ok ~kind result =
     Alcotest.failf
       "expected Memory_write_ok kind=%s, got Memory_write_invalid %s"
       kind
-      (Keeper_tool_memory_runtime.memory_write_error_kind_to_string r.error_kind)
+    (Keeper_tool_memory_runtime.memory_write_error_kind_to_string r.error_kind)
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let dir = Filename.temp_file "keeper-memory-write-" ".tmp" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o700;
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+;;
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "trace_id", `String ("trace-" ^ name)
+        ; "goal", `String "fallback goal"
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
 ;;
 
 (* --- snapshot mapping (kind -> populated field) -------------------- *)
@@ -192,6 +222,31 @@ let test_synthetic_snapshot_source_drops_memory_candidates () =
     0
     (List.length selection.Keeper_memory_bank.selected)
 
+let test_meta_goal_fallback_writes_no_durable_memory_candidates () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "meta-goal-fallback" in
+  let count, kinds =
+    Keeper_memory_bank.append_memory_notes_from_reply
+      config
+      meta
+      ~turn:1
+      ~reply:"plain response without a state block"
+      ()
+  in
+  Alcotest.(check int)
+    "meta_goal_fallback is synthetic and writes no durable notes"
+    0
+    count;
+  Alcotest.(check (list string)) "no fallback kinds" [] kinds;
+  let path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  Alcotest.(check bool)
+    "memory bank file is not created for meta_goal_fallback"
+    false
+    (Sys.file_exists path)
+;;
+
 (* --- constants ----------------------------------------------------- *)
 
 let test_max_title_chars_constant () =
@@ -256,6 +311,10 @@ let () =
             "synthetic snapshot source drops candidates"
             `Quick
             test_synthetic_snapshot_source_drops_memory_candidates
+        ; Alcotest.test_case
+            "meta_goal_fallback writes no durable memory candidates"
+            `Quick
+            test_meta_goal_fallback_writes_no_durable_memory_candidates
         ] )
     ; ( "constants"
       , [ Alcotest.test_case "max_title_chars = 120" `Quick test_max_title_chars_constant

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -220,7 +220,11 @@ let test_synthetic_snapshot_source_drops_memory_candidates () =
   Alcotest.(check int)
     "synthetic source writes no durable memory candidates"
     0
-    (List.length selection.Keeper_memory_bank.selected)
+    (List.length selection.Keeper_memory_bank.selected);
+  Alcotest.(check bool)
+    "synthetic suppression is observable"
+    true
+    (selection.Keeper_memory_bank.suppressed_synthetic_candidates > 0)
 
 let test_meta_goal_fallback_writes_no_durable_memory_candidates () =
   with_temp_dir
@@ -240,6 +244,15 @@ let test_meta_goal_fallback_writes_no_durable_memory_candidates () =
     0
     count;
   Alcotest.(check (list string)) "no fallback kinds" [] kinds;
+  let fallback_selection =
+    Keeper_memory_bank.memory_candidates_from_snapshot_gated
+      ~is_synthetic:true
+      { Keeper_memory_policy.empty_keeper_state_snapshot with goal = Some meta.goal }
+  in
+  Alcotest.(check int)
+    "meta_goal_fallback suppression count"
+    1
+    fallback_selection.Keeper_memory_bank.suppressed_synthetic_candidates;
   let path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
   Alcotest.(check bool)
     "memory bank file is not created for meta_goal_fallback"

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -93,7 +93,7 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 let test_active_model_missing_attempt_is_unknown () =
   let meta = make_meta "status-runtime-missing-attempt" in
   let unknown_model_label =
-    Masc.Boundary_redaction.to_string Masc.Boundary_redaction.unknown_model_label
+    Boundary_redaction.to_string Boundary_redaction.unknown_model_label
   in
   Alcotest.(check string)
     "missing runtime attempt is explicit unknown"

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -90,6 +90,18 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
 ;;
 
+let test_active_model_missing_attempt_is_unknown () =
+  let meta = make_meta "status-runtime-missing-attempt" in
+  Alcotest.(check string)
+    "missing runtime attempt is explicit unknown"
+    "unknown_model"
+    (Masc.Keeper_status_runtime.active_model_of_meta meta);
+  Alcotest.(check string)
+    "missing runtime attempt label is explicit unknown"
+    "unknown_model"
+    (Masc.Keeper_status_runtime.active_model_label_of_meta meta)
+;;
+
 let drop_value reason =
   P.metric_value_or_zero
     P.metric_persistence_read_drops
@@ -589,25 +601,25 @@ let test_model_observability_uses_runtime_trust_selected_model () =
   in
   let open Yojson.Safe.Util in
   Alcotest.(check bool)
-    "runtime-trust model counts as recent observation"
-    true
+    "runtime-trust model alone is not a scoped runtime observation"
+    false
     (json |> member "recent_turn_observation" |> to_bool);
   Alcotest.(check string)
     "selected model falls through to model_observability"
     "receipt-model"
     (json |> member "selected_model" |> to_string);
   Alcotest.(check bool)
-    "runtime contract marks selected model proof verified"
-    true
+    "runtime contract does not verify weak selected-model hint"
+    false
     (json |> member "runtime_contract" |> member "verified" |> to_bool);
   Alcotest.(check string)
     "runtime contract source records trust field"
     "runtime_trust.selected_model"
     (json |> member "runtime_contract" |> member "source" |> to_string);
-  Alcotest.(check string)
-    "runtime contract exposes observed selected model"
-    "receipt-model"
-    (json |> member "runtime_contract" |> member "actual_model_id" |> to_string)
+  Alcotest.(check bool)
+    "runtime contract does not expose selected model as actual model"
+    true
+    (json |> member "runtime_contract" |> member "actual_model_id" = `Null)
 ;;
 
 let test_model_observability_uses_runtime_trust_execution_selected_model () =
@@ -626,31 +638,109 @@ let test_model_observability_uses_runtime_trust_execution_selected_model () =
   in
   let open Yojson.Safe.Util in
   Alcotest.(check bool)
-    "runtime-trust execution model counts as recent observation"
-    true
+    "runtime-trust execution model alone is not a scoped runtime observation"
+    false
     (json |> member "recent_turn_observation" |> to_bool);
   Alcotest.(check string)
     "execution selected model falls through to model_observability"
     "execution-model"
     (json |> member "selected_model" |> to_string);
   Alcotest.(check bool)
-    "runtime contract marks execution selected model proof verified"
-    true
+    "runtime contract does not verify weak execution selected-model hint"
+    false
     (json |> member "runtime_contract" |> member "verified" |> to_bool);
   Alcotest.(check string)
     "runtime contract source records execution trust field"
     "runtime_trust.execution.provider_selected_model"
     (json |> member "runtime_contract" |> member "source" |> to_string);
+  Alcotest.(check bool)
+    "runtime contract does not expose execution hint as actual model"
+    true
+    (json |> member "runtime_contract" |> member "actual_model_id" = `Null)
+;;
+
+let test_model_observability_missing_runtime_id_is_unscoped () =
+  let latest_metrics =
+    Some
+      (`Assoc
+        [ ( "runtime"
+          , `Assoc
+              [ "attempts", `List [ `Assoc [ "status", `String "ok" ] ]
+              ; "selected_index", `Int 0
+              ] )
+        ])
+  in
+  let json =
+    O.model_observability_json
+      ~current_runtime_id:"runtime-test"
+      ~runtime_blocker_fields:[]
+      ~runtime_trust:(`Assoc [])
+      latest_metrics
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool)
+    "missing runtime_id is not current-runtime observation"
+    false
+    (json |> member "recent_turn_observation" |> to_bool);
   Alcotest.(check string)
-    "runtime contract exposes observed execution selected model"
-    "execution-model"
-    (json |> member "runtime_contract" |> member "actual_model_id" |> to_string)
+    "runtime observation scope is explicit"
+    "missing_runtime_id"
+    (json |> member "runtime_observation_scope" |> to_string);
+  Alcotest.(check bool)
+    "missing runtime_id does not verify runtime contract"
+    false
+    (json |> member "runtime_contract" |> member "verified" |> to_bool)
+;;
+
+let test_model_observability_runtime_match_does_not_promote_model_hint () =
+  let latest_metrics =
+    Some
+      (`Assoc
+        [ ( "runtime"
+          , `Assoc
+              [ "runtime_id", `String "runtime-test"
+              ; "attempts", `List [ `Assoc [ "status", `String "ok" ] ]
+              ; "selected_index", `Int 0
+              ] )
+        ])
+  in
+  let runtime_trust = `Assoc [ "selected_model", `String "receipt-model" ] in
+  let json =
+    O.model_observability_json
+      ~current_runtime_id:"runtime-test"
+      ~runtime_blocker_fields:[]
+      ~runtime_trust
+      latest_metrics
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool)
+    "matched runtime row is a scoped runtime observation"
+    true
+    (json |> member "recent_turn_observation" |> to_bool);
+  Alcotest.(check string)
+    "runtime observation scope is matched"
+    "matched"
+    (json |> member "runtime_observation_scope" |> to_string);
+  Alcotest.(check bool)
+    "runtime contract scope is verified"
+    true
+    (json |> member "runtime_contract" |> member "verified" |> to_bool);
+  Alcotest.(check bool)
+    "weak selected-model hint is not promoted to actual model"
+    true
+    (json |> member "runtime_contract" |> member "actual_model_id" = `Null)
 ;;
 
 let () =
   Alcotest.run
     "keeper_runtime_trust_snapshot"
-    [ ( "decision_log_read_drops"
+    [ ( "status_runtime_provenance"
+      , [ Alcotest.test_case
+            "missing runtime attempt does not fabricate active_model"
+            `Quick
+            test_active_model_missing_attempt_is_unknown
+        ] )
+    ; ( "decision_log_read_drops"
       , [ Alcotest.test_case
             "malformed decision rows increment drop metrics"
             `Quick
@@ -705,6 +795,14 @@ let () =
             "status model observability reuses runtime-trust execution selected model"
             `Quick
             test_model_observability_uses_runtime_trust_execution_selected_model
+        ; Alcotest.test_case
+            "status model observability treats missing runtime_id as unscoped"
+            `Quick
+            test_model_observability_missing_runtime_id_is_unscoped
+        ; Alcotest.test_case
+            "status model observability keeps matched weak model hint non-actual"
+            `Quick
+            test_model_observability_runtime_match_does_not_promote_model_hint
         ] )
     ]
 ;;

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -92,13 +92,16 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 
 let test_active_model_missing_attempt_is_unknown () =
   let meta = make_meta "status-runtime-missing-attempt" in
+  let unknown_model_label =
+    Masc.Boundary_redaction.to_string Masc.Boundary_redaction.unknown_model_label
+  in
   Alcotest.(check string)
     "missing runtime attempt is explicit unknown"
-    "unknown_model"
+    unknown_model_label
     (Masc.Keeper_status_runtime.active_model_of_meta meta);
   Alcotest.(check string)
     "missing runtime attempt label is explicit unknown"
-    "unknown_model"
+    unknown_model_label
     (Masc.Keeper_status_runtime.active_model_label_of_meta meta)
 ;;
 


### PR DESCRIPTION
## Summary
- keep missing runtime-attempt evidence explicit as `unknown_model` instead of falling back to configured runtime ids
- route the unknown model label through `Boundary_redaction.unknown_model_label` rather than a local string literal
- require scoped runtime metrics before marking status-detail runtime observations verified
- keep weak selected-model hints out of `runtime_contract.actual_model_id`
- mark meta-goal fallback memory snapshots synthetic so they do not create durable memory-bank notes
- rebase onto `origin/main` and align the `test_dune_local_script` old-OCaml guard expectation with the repo's OCaml 5.5 floor

## Validation
Local, non-Dune only:
- `opam exec -- ocamlformat --check ...changed OCaml files...`
- `git diff --check origin/main...HEAD`
- `bash scripts/ci/check-determinism-contract.sh`
- `bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed`

GitHub Actions at head `331eec60ce97eb187eb6c2fc4b99829f09fe40b8`:
- PASS: `Build and Test`
- PASS: `CI Gate`
- PASS: `Health`
- PASS: `Lint`
- PASS: `OCaml 5.5 Build Canary`
- PASS: `TLA+ Model Checking`
- FAIL: `Branch Protection Watchdog` only; log reports `enforce_admins.enabled=false; expected true` for repository branch protection config, with required context `CI Gate` present.

Local Dune build/tests intentionally not run per user instruction; Dune build authority is CI.

Fixes #23379
MASC: task-1833
