### PR TITLE
fix(dashboard): surface fusion registry load errors

### DIFF
--- a/dashboard/src/components/fusion/fusion-runs-panel.test.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { parseFusionRunsResponse } from '../../api/dashboard'
-import { fusionRuns, fusionRunsLoading } from '../../store'
+import { fusionRuns, fusionRunsError, fusionRunsLoading } from '../../store'
 import {
   FusionRunsPanel,
   fusionRunPipelineSegments,
@@ -118,6 +118,7 @@ describe('FusionRunsPanel', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     fusionRuns.value = []
+    fusionRunsError.value = null
     fusionRunsLoading.value = false
   })
 
@@ -125,6 +126,7 @@ describe('FusionRunsPanel', () => {
     render(null, container)
     container.remove()
     fusionRuns.value = []
+    fusionRunsError.value = null
     fusionRunsLoading.value = false
   })
 
@@ -138,6 +140,44 @@ describe('FusionRunsPanel', () => {
     fusionRunsLoading.value = true
     render(html`<${FusionRunsPanel} />`, container)
     expect(container.textContent).toContain('Loading fusion runs')
+  })
+
+  it('renders a registry load error instead of the empty state', () => {
+    fusionRunsError.value = 'HTTP 503 registry unavailable'
+
+    render(html`<${FusionRunsPanel} />`, container)
+
+    const error = container.querySelector('[data-testid="fusion-runs-error"]')
+    expect(error).not.toBeNull()
+    expect(error?.getAttribute('data-registry-source')).toBe('/api/v1/dashboard/fusion-runs')
+    expect(error?.textContent).toContain('Registry load failed')
+    expect(error?.textContent).toContain('HTTP 503 registry unavailable')
+    expect(container.querySelector('[data-testid="fusion-runs-empty"]')).toBeNull()
+    expect(container.textContent).not.toContain('No active or recent fusion runs')
+  })
+
+  it('keeps cached registry rows visible while surfacing the refresh error', () => {
+    fusionRuns.value = [
+      {
+        runId: 'cached-failed',
+        keeper: 'analyst',
+        preset: 'trio',
+        startedAt: 1_783_106_656,
+        status: 'failed',
+        error: 'fusion aborted: 0 of 3 panels answered',
+        failureCode: 'panels_unavailable',
+      },
+    ]
+    fusionRunsError.value = 'network offline'
+
+    render(html`<${FusionRunsPanel} />`, container)
+
+    expect(container.querySelector('[data-testid="fusion-runs-error"]')?.textContent).toContain('network offline')
+    const cards = container.querySelectorAll('[data-testid="fusion-run-status-card"]')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.getAttribute('data-run-id')).toBe('cached-failed')
+    expect(cards[0]?.textContent).toContain('panels_unavailable')
+    expect(container.textContent).not.toContain('No active or recent fusion runs')
   })
 
   it('renders one card per run with its status and a running indicator', () => {

--- a/dashboard/src/components/fusion/fusion-runs-panel.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 import type { FusionRunRecord, FusionRunStatusLabel } from '../../api/dashboard'
-import { fusionRuns, fusionRunsLoading } from '../../store'
+import { fusionRuns, fusionRunsError, fusionRunsLoading } from '../../store'
 import { TimeAgo } from '../common/time-ago'
 
 type StatusTone = 'ok' | 'warn' | 'bad'
@@ -116,6 +116,7 @@ function FusionRunStatusCard({ run }: { run: FusionRunRecord }) {
 export function FusionRunsPanel() {
   const runs = fusionRuns.value
   const loading = fusionRunsLoading.value
+  const error = fusionRunsError.value
   const runningCount = runs.filter(run => run.status === 'running').length
 
   return html`
@@ -131,13 +132,26 @@ export function FusionRunsPanel() {
           <span class="fus-runs-count">${runs.length}</span>
         </div>
       </header>
-      ${runs.length === 0
-        ? html`<p class="fus-runs-empty" data-testid="fusion-runs-empty">
-            ${loading ? 'Loading fusion runs...' : 'No active or recent fusion runs.'}
-          </p>`
-        : html`<ul class="fus-runs-list" aria-live="polite">
+      ${error
+        ? html`<div
+            class="fus-runs-error"
+            data-testid="fusion-runs-error"
+            data-registry-source="/api/v1/dashboard/fusion-runs"
+            role="alert"
+          >
+            <span class="fus-runs-error-k">Registry load failed</span>
+            <span class="fus-runs-error-v">${error}</span>
+          </div>`
+        : null}
+      ${runs.length > 0
+        ? html`<ul class="fus-runs-list" aria-live="polite">
             ${runs.map(run => html`<${FusionRunStatusCard} key=${run.runId} run=${run} />`)}
-          </ul>`}
+          </ul>`
+        : error
+          ? null
+          : html`<p class="fus-runs-empty" data-testid="fusion-runs-empty">
+              ${loading ? 'Loading fusion runs...' : 'No active or recent fusion runs.'}
+            </p>`}
     </section>
   `
 }

--- a/dashboard/src/store-fusion-runs.test.ts
+++ b/dashboard/src/store-fusion-runs.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardFusionRunsResponse } from './api/dashboard-fusion'
+
+const fusionApiMocks = vi.hoisted(() => ({
+  fetchFusionRuns: vi.fn<() => Promise<DashboardFusionRunsResponse>>(),
+}))
+
+vi.mock('./api/dashboard-fusion', async importOriginal => {
+  const actual = await importOriginal<typeof import('./api/dashboard-fusion')>()
+  return {
+    ...actual,
+    fetchFusionRuns: fusionApiMocks.fetchFusionRuns,
+  }
+})
+
+vi.mock('./api/dashboard-hot', () => ({
+  fetchDashboardBootstrap: vi.fn(),
+  fetchDashboardShell: vi.fn(),
+}))
+
+vi.mock('./sse', () => ({
+  journal: {
+    log: vi.fn(),
+  },
+}))
+
+vi.mock('./components/common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import {
+  fusionRuns,
+  fusionRunsError,
+  fusionRunsLoading,
+  refreshFusionRuns,
+} from './store'
+
+beforeEach(() => {
+  fusionRuns.value = []
+  fusionRunsError.value = null
+  fusionRunsLoading.value = false
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  fusionRuns.value = []
+  fusionRunsError.value = null
+  fusionRunsLoading.value = false
+})
+
+describe('refreshFusionRuns', () => {
+  it('hydrates fusion run registry rows and clears a prior error', async () => {
+    fusionRunsError.value = 'previous registry error'
+    fusionApiMocks.fetchFusionRuns.mockResolvedValue({
+      generatedAt: '2026-07-06T04:10:00Z',
+      count: 1,
+      runs: [
+        {
+          runId: 'fus-ok',
+          keeper: 'analyst',
+          preset: 'trio',
+          startedAt: 1_783_106_656,
+          status: 'running',
+        },
+      ],
+    })
+
+    await refreshFusionRuns()
+
+    expect(fusionRunsError.value).toBeNull()
+    expect(fusionRuns.value).toHaveLength(1)
+    expect(fusionRuns.value[0]?.runId).toBe('fus-ok')
+    expect(fusionRunsLoading.value).toBe(false)
+  })
+
+  it('surfaces registry refresh failure without dropping cached rows', async () => {
+    fusionRuns.value = [
+      {
+        runId: 'fus-cached',
+        keeper: 'analyst',
+        preset: 'trio',
+        startedAt: 1_783_106_656,
+        status: 'failed',
+        error: 'fusion aborted: 0 of 3 panels answered',
+        failureCode: 'panels_unavailable',
+      },
+    ]
+    fusionApiMocks.fetchFusionRuns.mockRejectedValue(new Error('HTTP 503 registry unavailable'))
+
+    await refreshFusionRuns()
+
+    expect(fusionRunsError.value).toBe('HTTP 503 registry unavailable')
+    expect(fusionRuns.value).toHaveLength(1)
+    expect(fusionRuns.value[0]?.runId).toBe('fus-cached')
+    expect(fusionRunsLoading.value).toBe(false)
+  })
+})

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -330,6 +330,7 @@ export const fusionBoardPosts = signal<BoardPost[]>([])
 export const fusionBoardLoading = signal(false)
 export const fusionRuns = signal<FusionRunRecord[]>([])
 export const fusionRunsLoading = signal(false)
+export const fusionRunsError = signal<string | null>(null)
 
 // --- OAS monitoring state ---
 
@@ -1346,12 +1347,14 @@ export async function refreshFusionBoard(): Promise<void> {
 // event self-heals on the next fetch.
 export async function refreshFusionRuns(): Promise<void> {
   fusionRunsLoading.value = true
+  fusionRunsError.value = null
   try {
     const { fetchFusionRuns } = await import('./api/dashboard-fusion')
     const data = await fetchFusionRuns()
     fusionRuns.value = data.runs
   } catch (err) {
     console.warn('[Fusion] runs fetch error:', err)
+    fusionRunsError.value = errorMessageOr(err, 'Fusion run registry load failed')
   } finally {
     fusionRunsLoading.value = false
   }

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -849,6 +849,30 @@ button.fus-reconcile-row:hover {
   padding: 4px 0;
 }
 
+.v2-fusion-surface .fus-runs-error {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--bad-30);
+  border-radius: var(--r-1);
+  background: var(--bad-10);
+  color: var(--bad-light);
+  padding: 8px 10px;
+}
+
+.v2-fusion-surface .fus-runs-error-k {
+  font-size: var(--fs-10);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-runs-error-v {
+  color: var(--fus-text);
+  font-size: var(--fs-12);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .v2-fusion-surface .fus-runs-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add a first-class `fusionRunsError` signal for `/api/v1/dashboard/fusion-runs` refresh failures
- render a registry error banner in the Fusion run-status panel instead of collapsing failed loads into the empty state
- keep cached registry rows visible while marking the latest registry refresh as failed

## Live context
- Current root-main `/api/v1/dashboard/fusion-runs` returns one failed run with `failure_code=panels_unavailable`; this PR does not fabricate successful Fusion evidence. It only makes registry fetch failure visible if the endpoint cannot be read.

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm exec vitest run src/components/fusion/fusion-runs-panel.test.ts src/store-fusion-runs.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec vitest run src/components/fusion/fusion-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- `env GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py`
- `git diff --check`

Note: direct per-file ESLint on `src/store.ts` and the new store test is outside the current dashboard ESLint allowlist and reports ignored-file warnings; the configured `pnpm run lint` target passed.