### PR TITLE
fix(dashboard): verify fusion board origin linkage

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -56,6 +56,7 @@ function boardPost(overrides: Partial<BoardPost> & { id: string; meta: BoardPost
     comment_count: 0,
     created_at: '2026-06-19T01:00:00Z',
     updated_at: '2026-06-19T01:02:00Z',
+    origin: null,
     ...rest,
   }
 }
@@ -123,6 +124,10 @@ describe('FusionSurface', () => {
             output_tokens: 360,
           },
         },
+        origin: {
+          source: 'fusion',
+          fusion_run_id: 'fus-1',
+        },
       }),
     ]
 
@@ -154,7 +159,69 @@ describe('FusionSurface', () => {
     expect(container.querySelector('.fus-rdot.done')).not.toBeNull()
     expect(container.textContent).toContain('panel ×2')
     expect(container.textContent).toContain('board evidence')
+    expect(container.querySelector('[data-testid="fusion-sink-linkage"]')?.getAttribute('data-linkage-status')).toBe('verified')
+    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-meta-run-id')).toBe('fus-1')
+    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-origin-run-id')).toBe('fus-1')
+    expect(container.textContent).toContain('origin verified')
+    expect(container.textContent).toContain('typed origin으로 run linkage 검증')
     expect(container.textContent).not.toContain('chat · board')
+  })
+
+  it('warns when a successful fusion board post lacks typed origin linkage', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-legacy',
+        title: 'Fusion deliberation (run fus-legacy): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-legacy',
+          question: 'Legacy sink?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use meta only.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Legacy answer.' },
+        },
+        origin: null,
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
+    const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
+    expect(linkage?.getAttribute('data-linkage-status')).toBe('missing')
+    expect(linkage?.textContent).toContain('origin unverified')
+    expect(linkage?.textContent).toContain('typed board origin is absent')
+    expect(correlation?.getAttribute('data-origin-run-id')).toBe('')
+    expect(correlation?.textContent).toContain('origin unverified')
+  })
+
+  it('flags a meta/origin run-id mismatch instead of treating sink projection as verified', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-drift',
+        title: 'Fusion deliberation (run fus-meta): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-meta',
+          question: 'Drifted sink?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Mismatch.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Mismatch answer.' },
+        },
+        origin: {
+          source: 'fusion',
+          fusion_run_id: 'fus-origin',
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
+    const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
+    expect(linkage?.getAttribute('data-linkage-status')).toBe('mismatch')
+    expect(linkage?.textContent).toContain('origin mismatch')
+    expect(linkage?.textContent).toContain('origin.fusion_run_id=fus-origin')
+    expect(correlation?.getAttribute('data-meta-run-id')).toBe('fus-meta')
+    expect(correlation?.getAttribute('data-origin-run-id')).toBe('fus-origin')
   })
 
   it('renders the RFC-0284 judge-node strip for a judge-of-judges run', () => {

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -110,6 +110,8 @@ interface FusionRunParams {
 interface FusionRunView {
   runId: string
   boardPostId: string
+  boardOriginSource: string | null
+  boardOriginRunId: string | null
   keeperName: string
   title: string
   question: string
@@ -337,6 +339,8 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
   return {
     runId,
     boardPostId: post.id,
+    boardOriginSource: post.origin?.source ?? null,
+    boardOriginRunId: post.origin?.fusion_run_id ?? null,
     keeperName: keeperNameFor(post),
     title: post.title || `Fusion run ${runId}`,
     question,
@@ -875,6 +879,50 @@ function hasParams(params: FusionRunParams): boolean {
     || params.maxTokens !== null
 }
 
+type FusionSinkLinkageStatus = 'verified' | 'missing' | 'mismatch'
+
+interface FusionSinkLinkage {
+  status: FusionSinkLinkageStatus
+  label: string
+  detail: string
+}
+
+function sinkLinkageFor(run: FusionRunView): FusionSinkLinkage {
+  if (run.boardOriginSource !== FUSION_BOARD_SOURCE || !run.boardOriginRunId) {
+    return {
+      status: 'missing',
+      label: 'origin unverified',
+      detail: 'typed board origin is absent; using meta.run_id only',
+    }
+  }
+  if (run.boardOriginRunId !== run.runId) {
+    return {
+      status: 'mismatch',
+      label: 'origin mismatch',
+      detail: `origin.fusion_run_id=${run.boardOriginRunId}`,
+    }
+  }
+  return {
+    status: 'verified',
+    label: 'origin verified',
+    detail: 'origin.source=fusion and origin.fusion_run_id match meta.run_id',
+  }
+}
+
+function FusionSinkLinkageBadge({ linkage }: { linkage: FusionSinkLinkage }) {
+  return html`
+    <span
+      class=${`fus-sink-linkage ${linkage.status}`}
+      data-testid="fusion-sink-linkage"
+      data-linkage-status=${linkage.status}
+      title=${linkage.detail}
+    >
+      <span class="fus-sink-linkage-k">${linkage.label}</span>
+      <span class="fus-sink-linkage-v">${linkage.detail}</span>
+    </span>
+  `
+}
+
 // Presentation-only thresholds for clamping a long resolved_answer. These are a
 // display heuristic, not a semantic model of the rendered markdown — RichContent
 // owns markdown parsing, so this deliberately avoids counting markdown blocks and
@@ -919,6 +967,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
   const tokenLabel = combinedTokenLabel(run.usage)
   const preset = run.preset ?? findPreset(run.runId)
   const shape = fusionShapeInfo(run.judges)
+  const sinkLinkage = sinkLinkageFor(run)
 
   return html`
     <div class="fus-run-scroll" data-testid="fusion-detail">
@@ -1076,7 +1125,8 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                         class=${`fus-sink-to ${ringFocusClasses()}`}
                         onClick=${() => navigate('board', { post: run.boardPostId })}
                       >보드 포스트 #${run.boardPostId} →</button>
-                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · run_id로 쿼리</span>
+                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · typed origin으로 run linkage 검증</span>
+                      <${FusionSinkLinkageBadge} linkage=${sinkLinkage} />
                     </div>
                   </div>
                   <div class="fus-sink-track">
@@ -1087,7 +1137,17 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                     </div>
                   </div>
                 </div>
-                <div class="fus-corr">correlation · <span class="mono">${run.runId}</span></div>
+                <div
+                  class="fus-corr"
+                  data-testid="fusion-sink-correlation"
+                  data-meta-run-id=${run.runId}
+                  data-origin-source=${run.boardOriginSource ?? ''}
+                  data-origin-run-id=${run.boardOriginRunId ?? ''}
+                >
+                  correlation · meta <span class="mono">${run.runId}</span>
+                  <span class="fus-corr-sep">/</span>
+                  origin <span class="mono">${run.boardOriginRunId ?? 'unverified'}</span>
+                </div>
               </div>
             </div>
           `

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -345,6 +345,52 @@
   overflow-wrap: anywhere;
 }
 
+.v2-fusion-surface .fus-sink-linkage {
+  display: grid;
+  gap: 3px;
+  max-width: 100%;
+  margin-top: 6px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-surface) 78%, transparent);
+  padding: 6px 8px;
+}
+
+.v2-fusion-surface .fus-sink-linkage.verified {
+  border-color: var(--ok-border);
+  background: var(--ok-soft);
+}
+
+.v2-fusion-surface .fus-sink-linkage.missing {
+  border-color: color-mix(in srgb, var(--warn-fg) 42%, var(--fus-line));
+  background: var(--warn-soft);
+}
+
+.v2-fusion-surface .fus-sink-linkage.mismatch {
+  border-color: var(--bad-30);
+  background: var(--bad-10);
+}
+
+.v2-fusion-surface .fus-sink-linkage-k {
+  color: var(--fus-text);
+  font-size: var(--fs-10);
+  font-weight: 800;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-sink-linkage-v {
+  color: var(--fus-muted);
+  font-size: var(--fs-11);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.v2-fusion-surface .fus-corr-sep {
+  color: var(--fus-muted);
+  margin: 0 6px;
+}
+
 .v2-fusion-surface .fus-label {
   color: var(--fus-muted);
   font-size: var(--fs-11);


### PR DESCRIPTION
## Summary
- Surface the typed board origin linkage for completed Fusion sink rows.
- Mark successful sink projection as `origin verified` only when `origin.source=fusion` and `origin.fusion_run_id` matches `meta.run_id`.
- Render explicit `origin unverified` / `origin mismatch` states instead of treating meta-only or drifted rows as fully verified.

## Validation
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm exec vitest run src/components/fusion/fusion-surface.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec vitest run src/components/fusion/fusion-surface.test.ts src/components/fusion/fusion-runs-panel.test.ts src/store-fusion-runs.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- `env GITHUB_BASE_REF=codex/fusion-board-sink-error-state-20260706 python3 scripts/check_test_coverage.py`
- `git diff --check`
- Playwright CLI screenshot against mock dashboard API: `/tmp/masc-fusion-origin-linkage-5187-tall.png`

## Stack
- Base: #23387 (`codex/fusion-board-sink-error-state-20260706`)
