### PR TITLE
test(fusion): prove successful sink projection

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -56,6 +56,7 @@ function boardPost(overrides: Partial<BoardPost> & { id: string; meta: BoardPost
     comment_count: 0,
     created_at: '2026-06-19T01:00:00Z',
     updated_at: '2026-06-19T01:02:00Z',
+    origin: null,
     ...rest,
   }
 }
@@ -123,6 +124,10 @@ describe('FusionSurface', () => {
             output_tokens: 360,
           },
         },
+        origin: {
+          source: 'fusion',
+          fusion_run_id: 'fus-1',
+        },
       }),
     ]
 
@@ -154,7 +159,69 @@ describe('FusionSurface', () => {
     expect(container.querySelector('.fus-rdot.done')).not.toBeNull()
     expect(container.textContent).toContain('panel ×2')
     expect(container.textContent).toContain('board evidence')
+    expect(container.querySelector('[data-testid="fusion-sink-linkage"]')?.getAttribute('data-linkage-status')).toBe('verified')
+    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-meta-run-id')).toBe('fus-1')
+    expect(container.querySelector('[data-testid="fusion-sink-correlation"]')?.getAttribute('data-origin-run-id')).toBe('fus-1')
+    expect(container.textContent).toContain('origin verified')
+    expect(container.textContent).toContain('typed origin으로 run linkage 검증')
     expect(container.textContent).not.toContain('chat · board')
+  })
+
+  it('warns when a successful fusion board post lacks typed origin linkage', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-legacy',
+        title: 'Fusion deliberation (run fus-legacy): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-legacy',
+          question: 'Legacy sink?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Use meta only.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Legacy answer.' },
+        },
+        origin: null,
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
+    const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
+    expect(linkage?.getAttribute('data-linkage-status')).toBe('missing')
+    expect(linkage?.textContent).toContain('origin unverified')
+    expect(linkage?.textContent).toContain('typed board origin is absent')
+    expect(correlation?.getAttribute('data-origin-run-id')).toBe('')
+    expect(correlation?.textContent).toContain('origin unverified')
+  })
+
+  it('flags a meta/origin run-id mismatch instead of treating sink projection as verified', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-drift',
+        title: 'Fusion deliberation (run fus-meta): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-meta',
+          question: 'Drifted sink?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Mismatch.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Mismatch answer.' },
+        },
+        origin: {
+          source: 'fusion',
+          fusion_run_id: 'fus-origin',
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const linkage = container.querySelector('[data-testid="fusion-sink-linkage"]')
+    const correlation = container.querySelector('[data-testid="fusion-sink-correlation"]')
+    expect(linkage?.getAttribute('data-linkage-status')).toBe('mismatch')
+    expect(linkage?.textContent).toContain('origin mismatch')
+    expect(linkage?.textContent).toContain('origin.fusion_run_id=fus-origin')
+    expect(correlation?.getAttribute('data-meta-run-id')).toBe('fus-meta')
+    expect(correlation?.getAttribute('data-origin-run-id')).toBe('fus-origin')
   })
 
   it('renders the RFC-0284 judge-node strip for a judge-of-judges run', () => {

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -110,6 +110,8 @@ interface FusionRunParams {
 interface FusionRunView {
   runId: string
   boardPostId: string
+  boardOriginSource: string | null
+  boardOriginRunId: string | null
   keeperName: string
   title: string
   question: string
@@ -337,6 +339,8 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
   return {
     runId,
     boardPostId: post.id,
+    boardOriginSource: post.origin?.source ?? null,
+    boardOriginRunId: post.origin?.fusion_run_id ?? null,
     keeperName: keeperNameFor(post),
     title: post.title || `Fusion run ${runId}`,
     question,
@@ -875,6 +879,50 @@ function hasParams(params: FusionRunParams): boolean {
     || params.maxTokens !== null
 }
 
+type FusionSinkLinkageStatus = 'verified' | 'missing' | 'mismatch'
+
+interface FusionSinkLinkage {
+  status: FusionSinkLinkageStatus
+  label: string
+  detail: string
+}
+
+function sinkLinkageFor(run: FusionRunView): FusionSinkLinkage {
+  if (run.boardOriginSource !== FUSION_BOARD_SOURCE || !run.boardOriginRunId) {
+    return {
+      status: 'missing',
+      label: 'origin unverified',
+      detail: 'typed board origin is absent; using meta.run_id only',
+    }
+  }
+  if (run.boardOriginRunId !== run.runId) {
+    return {
+      status: 'mismatch',
+      label: 'origin mismatch',
+      detail: `origin.fusion_run_id=${run.boardOriginRunId}`,
+    }
+  }
+  return {
+    status: 'verified',
+    label: 'origin verified',
+    detail: 'origin.source=fusion and origin.fusion_run_id match meta.run_id',
+  }
+}
+
+function FusionSinkLinkageBadge({ linkage }: { linkage: FusionSinkLinkage }) {
+  return html`
+    <span
+      class=${`fus-sink-linkage ${linkage.status}`}
+      data-testid="fusion-sink-linkage"
+      data-linkage-status=${linkage.status}
+      title=${linkage.detail}
+    >
+      <span class="fus-sink-linkage-k">${linkage.label}</span>
+      <span class="fus-sink-linkage-v">${linkage.detail}</span>
+    </span>
+  `
+}
+
 // Presentation-only thresholds for clamping a long resolved_answer. These are a
 // display heuristic, not a semantic model of the rendered markdown — RichContent
 // owns markdown parsing, so this deliberately avoids counting markdown blocks and
@@ -919,6 +967,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
   const tokenLabel = combinedTokenLabel(run.usage)
   const preset = run.preset ?? findPreset(run.runId)
   const shape = fusionShapeInfo(run.judges)
+  const sinkLinkage = sinkLinkageFor(run)
 
   return html`
     <div class="fus-run-scroll" data-testid="fusion-detail">
@@ -1076,7 +1125,8 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                         class=${`fus-sink-to ${ringFocusClasses()}`}
                         onClick=${() => navigate('board', { post: run.boardPostId })}
                       >보드 포스트 #${run.boardPostId} →</button>
-                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · run_id로 쿼리</span>
+                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · typed origin으로 run linkage 검증</span>
+                      <${FusionSinkLinkageBadge} linkage=${sinkLinkage} />
                     </div>
                   </div>
                   <div class="fus-sink-track">
@@ -1087,7 +1137,17 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
                     </div>
                   </div>
                 </div>
-                <div class="fus-corr">correlation · <span class="mono">${run.runId}</span></div>
+                <div
+                  class="fus-corr"
+                  data-testid="fusion-sink-correlation"
+                  data-meta-run-id=${run.runId}
+                  data-origin-source=${run.boardOriginSource ?? ''}
+                  data-origin-run-id=${run.boardOriginRunId ?? ''}
+                >
+                  correlation · meta <span class="mono">${run.runId}</span>
+                  <span class="fus-corr-sep">/</span>
+                  origin <span class="mono">${run.boardOriginRunId ?? 'unverified'}</span>
+                </div>
               </div>
             </div>
           `

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -345,6 +345,52 @@
   overflow-wrap: anywhere;
 }
 
+.v2-fusion-surface .fus-sink-linkage {
+  display: grid;
+  gap: 3px;
+  max-width: 100%;
+  margin-top: 6px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--color-bg-surface) 78%, transparent);
+  padding: 6px 8px;
+}
+
+.v2-fusion-surface .fus-sink-linkage.verified {
+  border-color: var(--ok-border);
+  background: var(--ok-soft);
+}
+
+.v2-fusion-surface .fus-sink-linkage.missing {
+  border-color: color-mix(in srgb, var(--warn-fg) 42%, var(--fus-line));
+  background: var(--warn-soft);
+}
+
+.v2-fusion-surface .fus-sink-linkage.mismatch {
+  border-color: var(--bad-30);
+  background: var(--bad-10);
+}
+
+.v2-fusion-surface .fus-sink-linkage-k {
+  color: var(--fus-text);
+  font-size: var(--fs-10);
+  font-weight: 800;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.v2-fusion-surface .fus-sink-linkage-v {
+  color: var(--fus-muted);
+  font-size: var(--fs-11);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.v2-fusion-surface .fus-corr-sep {
+  color: var(--fus-muted);
+  margin: 0 6px;
+}
+
 .v2-fusion-surface .fus-label {
   color: var(--fus-muted);
   font-size: var(--fs-11);

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -21,6 +21,47 @@ let contains ~needle haystack =
   nl = 0 || go 0
 ;;
 
+let assoc_fields label = function
+  | `Assoc fields -> fields
+  | json ->
+    fail
+      (Printf.sprintf "%s: expected JSON object, got %s" label
+         (Yojson.Safe.to_string json))
+;;
+
+let field label fields key =
+  match List.assoc_opt key fields with
+  | Some value -> value
+  | None -> fail (Printf.sprintf "%s: missing field %s" label key)
+;;
+
+let string_field label fields key =
+  match field label fields key with
+  | `String value -> value
+  | json ->
+    fail
+      (Printf.sprintf "%s.%s: expected string, got %s" label key
+         (Yojson.Safe.to_string json))
+;;
+
+let int_field label fields key =
+  match field label fields key with
+  | `Int value -> value
+  | json ->
+    fail
+      (Printf.sprintf "%s.%s: expected int, got %s" label key
+         (Yojson.Safe.to_string json))
+;;
+
+let list_field label fields key =
+  match field label fields key with
+  | `List values -> values
+  | json ->
+    fail
+      (Printf.sprintf "%s.%s: expected list, got %s" label key
+         (Yojson.Safe.to_string json))
+;;
+
 let temp_base_path prefix =
   Filename.concat
     (Filename.get_temp_dir_name ())
@@ -317,6 +358,132 @@ let test_missing_board_post_id_fallback () =
   check string "synthetic fallback post id" "fusion-run:fus-9" ev.post_id
 ;;
 
+let test_emit_success_projects_board_chat_and_registry () =
+  with_isolated_base_path "fusion-success-sink" (fun base_dir ->
+    let keeper = "fusion-keeper" in
+    let run_id = Printf.sprintf "fus-success-%d" (Random.bits ()) in
+    let question = "Which implementation should ship?" in
+    let resolved_answer = "Ship the typed-origin path." in
+    let panel_usage = { Fusion_types.input_tokens = 11; output_tokens = 13 } in
+    let judge_usage = { Fusion_types.input_tokens = 17; output_tokens = 19 } in
+    let synthesis = judge_synthesis resolved_answer in
+    let panel =
+      [ Fusion_types.Answered
+          { model = "skeptic (claude)"
+          ; answer = "typed origin keeps the dashboard honest"
+          ; usage = panel_usage
+          }
+      ]
+    in
+    let judges =
+      [ Fusion_types.Synthesized
+          { role = Fusion_types.Single; synthesis; usage = judge_usage }
+      ]
+    in
+    Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
+      ~preset:"unit-test" ~started_at:2.0;
+    let result =
+      Fusion_sink.emit ~base_dir ~keeper ~run_id ~question ~panel
+        ~judge:(Ok synthesis) ~judges ~judge_usage
+    in
+    check bool "emit succeeds" true (Result.is_ok result);
+    let post =
+      match Board.find_post_by_run_id (Board.global ()) ~run_id with
+      | Some post -> post
+      | None -> fail "fusion board post should be indexed by typed origin.fusion_run_id"
+    in
+    let post_id = Board.Post_id.to_string post.id in
+    (match post.origin with
+     | Some origin ->
+       check (option string) "origin.source" (Some "fusion") origin.source;
+       check (option string) "origin.fusion_run_id" (Some run_id) origin.fusion_run_id;
+       check bool "origin.turn_ref is not fabricated" true (Option.is_none origin.turn_ref)
+     | None -> fail "fusion board post should carry typed origin");
+    let meta =
+      match post.meta_json with
+      | Some json -> assoc_fields "board.meta" json
+      | None -> fail "fusion board post should carry meta_json"
+    in
+    check string "meta.source" "fusion" (string_field "board.meta" meta "source");
+    check string "meta.run_id" run_id (string_field "board.meta" meta "run_id");
+    check string "meta.question" question (string_field "board.meta" meta "question");
+    (match list_field "board.meta" meta "panel" with
+     | [ panel_json ] ->
+       let p = assoc_fields "board.meta.panel[0]" panel_json in
+       check string "panel model" "skeptic (claude)"
+         (string_field "board.meta.panel[0]" p "model");
+       check string "panel status" "answered"
+         (string_field "board.meta.panel[0]" p "status")
+     | other -> fail (Printf.sprintf "expected exactly one panel row, got %d" (List.length other)));
+    let judge = assoc_fields "board.meta.judge" (field "board.meta" meta "judge") in
+    check string "judge status" "synthesized"
+      (string_field "board.meta.judge" judge "status");
+    check string "judge resolved answer" resolved_answer
+      (string_field "board.meta.judge" judge "resolved_answer");
+    (match list_field "board.meta" meta "judges" with
+     | [ judge_json ] ->
+       let j = assoc_fields "board.meta.judges[0]" judge_json in
+       check string "judge node role" "single"
+         (string_field "board.meta.judges[0]" j "role");
+       check int "judge node input tokens" judge_usage.input_tokens
+         (int_field "board.meta.judges[0]" j "input_tokens")
+     | other ->
+       fail (Printf.sprintf "expected exactly one judge node, got %d" (List.length other)));
+    let observed_usage =
+      assoc_fields "board.meta.observed_usage" (field "board.meta" meta "observed_usage")
+    in
+    check int "observed input tokens" (panel_usage.input_tokens + judge_usage.input_tokens)
+      (int_field "board.meta.observed_usage" observed_usage "input_tokens");
+    check int "observed output tokens" (panel_usage.output_tokens + judge_usage.output_tokens)
+      (int_field "board.meta.observed_usage" observed_usage "output_tokens");
+    let dashboard_json =
+      Board_dispatch.post_to_yojson_with_karma post ~author_karma:0
+      |> assoc_fields "dashboard.post"
+    in
+    let dashboard_origin =
+      assoc_fields "dashboard.post.origin" (field "dashboard.post" dashboard_json "origin")
+    in
+    check string "dashboard origin source" "fusion"
+      (string_field "dashboard.post.origin" dashboard_origin "source");
+    check string "dashboard origin run id" run_id
+      (string_field "dashboard.post.origin" dashboard_origin "fusion_run_id");
+    let dashboard_meta =
+      assoc_fields "dashboard.post.meta" (field "dashboard.post" dashboard_json "meta")
+    in
+    check string "dashboard meta run id" run_id
+      (string_field "dashboard.post.meta" dashboard_meta "run_id");
+    let messages = Keeper_chat_store.load ~base_dir ~keeper_name:keeper in
+    let fusion_block =
+      List.find_map
+        (fun (m : Keeper_chat_store.chat_message) ->
+           if contains ~needle:resolved_answer m.content
+           then (
+             match m.blocks with
+             | Some blocks ->
+               List.find_map
+                 (function
+                   | Keeper_chat_blocks.Fusion { board_post_id; run_id } ->
+                     Some (board_post_id, run_id)
+                   | _ -> None)
+                 blocks
+             | None -> None)
+           else None)
+        messages
+    in
+    (match fusion_block with
+     | Some (block_post_id, block_run_id) ->
+       check string "chat fusion block post id" post_id block_post_id;
+       check string "chat fusion block run id" run_id block_run_id
+     | None -> fail "chat lane should carry a Fusion block for the board evidence");
+    match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
+    | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
+    | Some { Fusion_run_registry.status = Completed { ok = false; _ }; _ } ->
+      fail "fusion run should complete ok=true"
+    | Some { Fusion_run_registry.status = Running; _ } ->
+      fail "fusion run should not remain running"
+    | None -> fail "fusion run should remain visible")
+;;
+
 let test_emit_board_failure_is_best_effort () =
   with_isolated_base_path "fusion-board-best-effort" (fun base_dir ->
     let keeper = "bad/keeper" in
@@ -376,6 +543,10 @@ let () =
             "missing board_post_id falls back to fusion-run id"
             `Quick
             test_missing_board_post_id_fallback
+        ; test_case
+            "emit success projects board, chat block, and registry"
+            `Quick
+            test_emit_success_projects_board_chat_and_registry
         ; test_case
             "emit treats board post failure as best-effort"
             `Quick


### PR DESCRIPTION
## Summary

- add a focused `Fusion_sink.emit` success-path regression test
- prove one real sink execution writes a typed-origin board post, dashboard board JSON meta/origin, keeper chat `Fusion` block, and completed registry state
- keep this PR test-only and stacked on #23388

## Validation

- `scripts/dune-local.sh build test/test_fusion_wake.exe`
- `_build/default/test/test_fusion_wake.exe` (8 tests passed)
- `ocamlformat --check test/test_fusion_wake.ml`
- `git diff --check`

## Notes

The attempted wrapper `dune exec test/test_fusion_wake.exe` was stopped while waiting behind another long-running local `dune runtest` lock; the already-built focused binary was executed directly instead.
