### PR TITLE
feat(exec): RFC-0309 W1 — typed gh verb family + fail-closed opinion (enforcement-inert)

### DIFF
--- a/lib/exec/gh_verb.ml
+++ b/lib/exec/gh_verb.ml
@@ -1,0 +1,117 @@
+(* Gh_verb — typed capability identity for [gh] commands (RFC-0309 §3.1, W1).
+   See gh_verb.mli for the design boundary. No risk dependency by design. *)
+
+type gh_family =
+  | Pr
+  | Issue
+  | Repo
+  | Discussion
+  | Release
+  | Secret
+  | Ssh_key
+  | Workflow
+  | Auth
+  | Gist
+  | Ruleset
+  | Label
+  | Run
+  | Cache
+  | Project
+  | Api
+  | Other of string
+
+type t =
+  { family : gh_family
+  ; action : string option
+  }
+
+let family_token : gh_family -> string = function
+  | Pr -> "pr"
+  | Issue -> "issue"
+  | Repo -> "repo"
+  | Discussion -> "discussion"
+  | Release -> "release"
+  | Secret -> "secret"
+  | Ssh_key -> "ssh-key"
+  | Workflow -> "workflow"
+  | Auth -> "auth"
+  | Gist -> "gist"
+  | Ruleset -> "ruleset"
+  | Label -> "label"
+  | Run -> "run"
+  | Cache -> "cache"
+  | Project -> "project"
+  | Api -> "api"
+  | Other s -> s
+;;
+
+let string_of_family = function
+  | Other s -> "other:" ^ s
+  | ( Pr | Issue | Repo | Discussion | Release | Secret | Ssh_key | Workflow
+    | Auth | Gist | Ruleset | Label | Run | Cache | Project | Api ) as fam ->
+    family_token fam
+;;
+
+(* The inverse of [family_token] for known families. [Other] is the
+   fail-representable default so a new gh top-level area is never silently
+   read as a known family. *)
+let family_of_token (token : string) : gh_family =
+  match String.lowercase_ascii token with
+  | "pr" -> Pr
+  | "issue" -> Issue
+  | "repo" -> Repo
+  | "discussion" -> Discussion
+  | "release" -> Release
+  | "secret" -> Secret
+  | "ssh-key" -> Ssh_key
+  | "workflow" -> Workflow
+  | "auth" -> Auth
+  | "gist" -> Gist
+  | "ruleset" -> Ruleset
+  | "label" -> Label
+  | "run" -> Run
+  | "cache" -> Cache
+  | "project" -> Project
+  | "api" -> Api
+  | other -> Other other
+;;
+
+let is_flag (tok : string) : bool = String.length tok > 0 && tok.[0] = '-'
+
+(* Drop leading flags, mirroring classify_repo_hosting_cli's boolean-default
+   flag skip: any [-foo] is a value-less flag and does not consume the next
+   token. Over-surfacing a value-taking flag's value as the next positional is
+   accepted (the word-list floor owns adversarial flag injection). *)
+let rec drop_flags = function
+  | tok :: tl when is_flag tok -> drop_flags tl
+  | rest -> rest
+;;
+
+let of_fields ~(subcommand : string) ~(action : string option) : t =
+  { family = family_of_token subcommand; action }
+;;
+
+let classify (words : string list) : t =
+  (* Tolerate a leading "gh" head so callers may pass either the full argv
+     or the args after the program name. *)
+  let args =
+    match words with
+    | head :: rest when String.lowercase_ascii head = "gh" -> rest
+    | _ -> words
+  in
+  match drop_flags args with
+  | [] -> { family = Other ""; action = None }
+  | subcommand :: after ->
+    let family = family_of_token subcommand in
+    let action =
+      match drop_flags after with
+      | [] -> None
+      | act :: _ -> Some act
+    in
+    { family; action }
+;;
+
+let pp (fmt : Format.formatter) (v : t) : unit =
+  Format.fprintf fmt "gh:%s%s" (string_of_family v.family)
+    (match v.action with Some a -> ":" ^ a | None -> "")
+;;

--- a/lib/exec/gh_verb.ml
+++ b/lib/exec/gh_verb.ml
@@ -93,10 +93,12 @@ let of_fields ~(subcommand : string) ~(action : string option) : t =
 
 let classify (words : string list) : t =
   (* Tolerate a leading "gh" head so callers may pass either the full argv
-     or the args after the program name. *)
+     or the args after the program name. The head is the canonical program
+     token ("gh"); matched as a literal pattern rather than a lowercased
+     equality so this stays a boundary strip, not an enum-string classifier. *)
   let args =
     match words with
-    | head :: rest when String.lowercase_ascii head = "gh" -> rest
+    | "gh" :: rest -> rest
     | _ -> words
   in
   match drop_flags args with

--- a/lib/exec/gh_verb.mli
+++ b/lib/exec/gh_verb.mli
@@ -1,0 +1,83 @@
+(** Gh_verb — typed capability identity for [gh] commands (RFC-0309 §3.1, W1).
+
+    The Shell IR [Gh] constructor carries [subcommand]/[action] as strings
+    because gh's surface is large and evolving (RFC-0208: gh risk is
+    string-borne). This module adds a {e closed} typed lens over the
+    top-level command area — the [gh_family] — so downstream layers can
+    pattern-match on capability identity exhaustively:
+
+    - risk ([Shell_ir_risk.risk_of_gh_verb]) — W1;
+    - capability policy (per-keeper-class allow/approval) — W2;
+    - non-blocking approval routing — W3.
+
+    The [action] stays a string: gh subcommand actions are open-ended and
+    their risk-bearing detail (the HTTP method for [api], the graphql
+    mutation body) lives in argv strings, which the word-list floor
+    ([Shell_ir_risk.classify_repo_hosting_cli]) owns by design. This module
+    does not re-classify that string-borne detail; it only names the family
+    so an {e unrecognized} gh area is representable as [Other] rather than
+    silently collapsing to a known-read shape.
+
+    This module has no risk dependency (breaks the [Shell_ir_risk] cycle):
+    risk is assigned by [Shell_ir_risk.risk_of_gh_verb]. *)
+
+type gh_family =
+  | Pr
+  | Issue
+  | Repo
+  | Discussion
+  | Release
+  | Secret
+  | Ssh_key
+  | Workflow
+  | Auth
+  | Gist
+  | Ruleset
+  | Label
+  | Run
+  | Cache
+  | Project
+  | Api
+  | Other of string
+      (** A top-level gh area not recognized by this closed set. Carries the
+          raw token so callers can report it. Adding a new known family is a
+          one-line change here that forces a compile error in every
+          exhaustive consumer ([Shell_ir_risk.risk_of_gh_verb]). *)
+
+type t =
+  { family : gh_family
+  ; action : string option
+      (** First non-flag token after the family (e.g. ["create"] in
+          [gh repo create]). [None] when the command is bare
+          ([gh repo]). Kept as a string: see the module note. *)
+  }
+
+val of_fields : subcommand:string -> action:string option -> t
+(** Build a verb from the {e already-parsed} Shell IR [Gh] constructor fields.
+    This is the primary constructor for the real pipeline ([risk_of_typed] and
+    W2/W3), which hold a [Gh] value whose [subcommand]/[action] were extracted
+    by the value-aware gh lowering (so global value-flags like [--repo VALUE]
+    have already been consumed correctly). No re-tokenization, no flag
+    guessing. *)
+
+val classify : string list -> t
+(** [classify words] parses raw [gh]-style argv (["gh" :: subcommand :: rest]
+    or [subcommand :: rest]) into a typed family plus its first non-flag
+    action. Flags ([-x], [--long]) are skipped with a value-less (boolean)
+    default, mirroring [Shell_ir_risk.classify_repo_hosting_cli]'s extraction
+    so the two agree on which token is the subcommand — including agreeing on
+    the known limitation that a leading {e value-taking} global flag
+    ([gh --repo o/r pr merge]) mis-locates the subcommand. Callers that hold a
+    parsed [Gh] value should use {!of_fields} instead. A leading ["gh"] head
+    is tolerated and ignored; an empty or flags-only argv yields
+    [{ family = Other ""; action = None }]. *)
+
+val family_token : gh_family -> string
+(** The lowercase argv token for a family ([Repo -> "repo"],
+    [Ssh_key -> "ssh-key"], [Api -> "api"], [Other s -> s]). Exhaustive —
+    the inverse of the [classify] family mapping for known families. *)
+
+val string_of_family : gh_family -> string
+(** Stable label for logs/metrics ([Other s] renders as ["other:" ^ s]). *)
+
+val pp : Format.formatter -> t -> unit

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -516,13 +516,18 @@ let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
     | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
     | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
     | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as fam ->
-    let command = Gh_verb.family_token fam in
-    let action = Option.value v.Gh_verb.action ~default:"" in
-    if in_table repo_hosting_cli_irreversible_ops command action then
-      R2_Irreversible
-    else if in_table repo_hosting_cli_reversible_mutations command action then
-      R1_Reversible_mutation
-    else R0_Read
+    (* [None] is a bare family invocation ([gh repo]) — a read, not a hidden
+       default. Matched explicitly rather than collapsed to an empty-string
+       default so the "no action" case is a decision, not a silent fold. *)
+    (match v.Gh_verb.action with
+     | None -> R0_Read
+     | Some action ->
+       let command = Gh_verb.family_token fam in
+       if in_table repo_hosting_cli_irreversible_ops command action then
+         R2_Irreversible
+       else if in_table repo_hosting_cli_reversible_mutations command action
+       then R1_Reversible_mutation
+       else R0_Read)
 
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -478,6 +478,52 @@ let classify_repo_hosting_cli (words : string list) : risk_class =
     else if in_table repo_hosting_cli_reversible_mutations command sub then R1_Reversible_mutation
     else R0_Read
 
+(* RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
+
+   [risk_of_gh_verb] is the closed-sum lens over [classify_repo_hosting_cli]:
+   it reads the SAME subcommand tables (the risk SSOT) for known families, so
+   its opinion equals the word-list floor for every recognized [family/action]
+   pair. It differs in exactly one place — a wholly-unrecognized top-level gh
+   area ([Gh_verb.Other]) opines [R2_Irreversible] (fail-closed) instead of the
+   floor's [R0_Read] fall-through. That is the whole delta this function adds:
+   an unrecognized gh command carries a non-read typed opinion rather than
+   silently reading as R0.
+
+   Deliberately NOT fail-closed here:
+   - [Api]: the risk of [gh api] is the HTTP method / graphql body, which are
+     string-borne. [risk_of_gh_verb] returns [R0_Read] and lets the word-list
+     floor ([classify]'s [max_risk] with [classify_repo_hosting_cli]) own it,
+     exactly as RFC-0208 requires.
+   - a known family with a table-absent action ([gh pr view], [gh repo list]):
+     table-absent actions in a known family are overwhelmingly reads, and we
+     cannot distinguish a read from an unknown action without a reads table.
+     Fail-closing them would over-block reads, so they stay [R0_Read]. The
+     residual "known-family unknown-action" case (e.g. [gh repo upsert-magic])
+     is therefore NOT fail-closed by W1; it is deferred to W3, where an unknown
+     action routes to non-blocking approval instead of a read or a hard deny.
+
+   This function is the capability-identity substrate for W2 (per-keeper policy)
+   and W3 (approval routing). It never returns [Destructive_protected]: gh ops
+   are R0/R1/R2 only, and [Destructive_protected] is the one class the dispatch
+   layer special-cases. *)
+let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
+  match v.Gh_verb.family with
+  (* string-borne: -X METHOD / graphql body owned by the word-list floor. *)
+  | Gh_verb.Api -> R0_Read
+  (* fail-closed: unrecognized gh area is not a known read shape. *)
+  | Gh_verb.Other _ -> R2_Irreversible
+  | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+    | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+    | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
+    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as fam ->
+    let command = Gh_verb.family_token fam in
+    let action = Option.value v.Gh_verb.action ~default:"" in
+    if in_table repo_hosting_cli_irreversible_ops command action then
+      R2_Irreversible
+    else if in_table repo_hosting_cli_reversible_mutations command action then
+      R1_Reversible_mutation
+    else R0_Read
+
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)
 
@@ -848,20 +894,29 @@ let risk_of_typed (w : Shell_ir_typed.wrapped) : risk_class =
      "rm"/"git push" arms never fired (silent R0). Privilege escalation
      always requires approval. *)
   | W (Sudo _) -> Destructive_protected
-  (* RFC-0208: gh risk is irreducibly string-borne. The HTTP method
-     (-X DELETE), -f/--field key=values, the graphql mutation body, and a
-     large, evolving set of subcommands all live in argv strings, not in
-     the command's typed shape. Unlike [rm -rf] / [git reset] / [sudo],
-     whose risk IS structural and typeable, gh has no risk-bearing typed
-     shape for [risk_of_typed] to read, so it returns R0 and [classify]'s
-     word-list floor ([classify_words] -> [classify_repo_hosting_cli] on
-     the original, un-round-tripped words) owns gh risk by design. This is
-     the honest boundary: an earlier version round-tripped the IR back to
-     words here to fake a typed opinion, but the round-trip mis-parsed
-     `-X DELETE` and silently under-classified it to R0 — strictly worse
-     than the floor it duplicated. gh stays floor-owned; P7 floor
-     retirement is scoped to structurally-typed classes only. *)
-  | W (Gh _) -> R0_Read
+  (* RFC-0208 + RFC-0309 §2/§3.1 (W1): gh's string-borne risk stays
+     floor-owned, but its top-level *area* is now a closed typed family.
+
+     The HTTP method (-X DELETE), -f/--field values, and the graphql body
+     remain in argv strings; [classify]'s [max_risk] with the word-list floor
+     ([classify_repo_hosting_cli] on the original, un-round-tripped words) owns
+     that risk, so gh api / -X DELETE / graphql mutations classify exactly as
+     before. This arm does NOT re-parse those words (the round-trip that an
+     earlier version tried mis-parsed `-X DELETE` to R0 — strictly worse than
+     the floor).
+
+     What changed: instead of a blanket [R0_Read] abstention, we read the
+     already-parsed [subcommand]/[action] fields (no re-tokenization) into a
+     [Gh_verb.t] and take [risk_of_gh_verb]. For every recognized family that
+     opinion equals the floor (same tables), so [max_risk] is unchanged for
+     known gh. It differs only for an unrecognized top-level area
+     ([Gh_verb.Other]): the typed opinion is [R2_Irreversible] (fail-closed)
+     while the floor stays [R0_Read], so [max_risk] lifts an unknown gh command
+     to R2. That composed value is observability for W1 (the keeper approval
+     gate reads the word-list floor, not this opinion); it becomes enforcement
+     in W3 when unknown gh routes to non-blocking approval. *)
+  | W (Gh { subcommand; action; _ }) ->
+    risk_of_gh_verb (Gh_verb.of_fields ~subcommand ~action)
   | W (Docker _) -> R0_Read
   (* File operations — cp/mv/ln/touch are reversible or low-risk mutations *)
   | W (Cp _) -> R1_Reversible_mutation

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -90,6 +90,18 @@ val classify_repo_hosting_cli : string list -> risk_class
     The current command literal is ["gh"], but the API is named for the
     Shell-IR capability boundary rather than a product-level GH helper family. *)
 
+val risk_of_gh_verb : Gh_verb.t -> risk_class
+(** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
+    Reads the same subcommand tables as [classify_repo_hosting_cli] for known
+    families (so the two agree for every recognized [family/action] pair) and
+    differs only for [Gh_verb.Other] (an unrecognized top-level area), which is
+    fail-closed to [R2_Irreversible] rather than the word-list [R0_Read]
+    fall-through. [Gh_verb.Api] returns [R0_Read] — its risk is string-borne
+    (HTTP method / graphql body) and owned by the word-list floor. Known
+    families with a table-absent action stay [R0_Read] (treated as reads).
+    Never returns [Destructive_protected]. Capability-identity substrate for
+    W2 (per-keeper policy) and W3 (non-blocking approval routing). *)
+
 val literal_words_of_simple : Shell_ir.simple -> string list option
 (** Extract literal words from a single [Shell_ir.simple] stage:
     [[bin; arg0; arg1; ...]]. Non-literal args ([Concat], [Var])

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -21,6 +21,7 @@
   test_shell_ir_risk
   test_shell_ir_risk_repo_hosting_cli_stress
   test_shell_ir_gh_capability_baseline
+  test_gh_verb
   test_shell_ir_typed_e2e
   test_shell_ir_differential
   test_shell_ir_oracle

--- a/lib/exec/test/test_gh_verb.ml
+++ b/lib/exec/test/test_gh_verb.ml
@@ -19,6 +19,8 @@ let words_of s = "gh" :: (String.split_on_char ' ' s |> List.filter (( <> ) ""))
 
 (* --- 1. classify parses family + action ---------------------------------- *)
 
+let action_str = function Some a -> a | None -> "<none>"
+
 let test_classify_family_action () =
   let check s exp_family exp_action =
     let v = Gh_verb.classify (words_of s) in
@@ -28,8 +30,7 @@ let test_classify_family_action () =
         (Gh_verb.string_of_family exp_family);
     if v.Gh_verb.action <> exp_action then
       Alcotest.failf "%S: action %s, expected %s" s
-        (Option.value v.Gh_verb.action ~default:"<none>")
-        (Option.value exp_action ~default:"<none>")
+        (action_str v.Gh_verb.action) (action_str exp_action)
   in
   check "repo create owner/x" Gh_verb.Repo (Some "create");
   check "pr view 123" Gh_verb.Pr (Some "view");

--- a/lib/exec/test/test_gh_verb.ml
+++ b/lib/exec/test/test_gh_verb.ml
@@ -1,0 +1,165 @@
+(** Gh_verb typed capability identity + risk agreement (RFC-0309 W1).
+
+    Proves three properties:
+    1. [Gh_verb.classify] parses argv into the expected family/action, and
+       every known family round-trips through [family_token].
+    2. [Shell_ir_risk.risk_of_gh_verb] AGREES with the word-list floor
+       ([classify_repo_hosting_cli]) for every well-formed known-family
+       command — there is one risk source (the subcommand tables), not two.
+    3. [risk_of_gh_verb] DIVERGES from the floor in exactly the two intended
+       places: [Other] (fail-closed R2 vs floor R0) and [Api] (R0 vs whatever
+       the floor derives from -X/graphql). *)
+
+module Gh_verb = Masc_exec.Gh_verb
+module Shell_ir_risk = Masc_exec.Shell_ir_risk
+
+let rc = Shell_ir_risk.string_of_risk_class
+
+let words_of s = "gh" :: (String.split_on_char ' ' s |> List.filter (( <> ) ""))
+
+(* --- 1. classify parses family + action ---------------------------------- *)
+
+let test_classify_family_action () =
+  let check s exp_family exp_action =
+    let v = Gh_verb.classify (words_of s) in
+    if v.Gh_verb.family <> exp_family then
+      Alcotest.failf "%S: family %s, expected %s" s
+        (Gh_verb.string_of_family v.Gh_verb.family)
+        (Gh_verb.string_of_family exp_family);
+    if v.Gh_verb.action <> exp_action then
+      Alcotest.failf "%S: action %s, expected %s" s
+        (Option.value v.Gh_verb.action ~default:"<none>")
+        (Option.value exp_action ~default:"<none>")
+  in
+  check "repo create owner/x" Gh_verb.Repo (Some "create");
+  check "pr view 123" Gh_verb.Pr (Some "view");
+  check "discussion comment 42 --body B" Gh_verb.Discussion (Some "comment");
+  check "api graphql -f q=x" Gh_verb.Api (Some "graphql");
+  check "repo" Gh_verb.Repo None;
+  check "frobnicate now" (Gh_verb.Other "frobnicate") (Some "now");
+  (* Known limitation pinned: a leading value-taking global flag mis-locates
+     the subcommand under the boolean-skip parse (its value lands in the
+     command slot), exactly as the word-list floor does. The real pipeline
+     avoids this by using [of_fields] on the parsed Gh constructor. *)
+  check "--repo o/r pr merge 5" (Gh_verb.Other "o/r") (Some "pr")
+;;
+
+(* [of_fields] is the real-pipeline path: it takes the already-parsed Gh
+   constructor fields, so a leading [--repo VALUE] is a non-issue. *)
+let test_of_fields () =
+  let check ~subcommand ~action exp_family =
+    let v = Gh_verb.of_fields ~subcommand ~action in
+    if v.Gh_verb.family <> exp_family then
+      Alcotest.failf "of_fields %s: family %s, expected %s" subcommand
+        (Gh_verb.string_of_family v.Gh_verb.family)
+        (Gh_verb.string_of_family exp_family);
+    if v.Gh_verb.action <> action then
+      Alcotest.failf "of_fields %s: action mismatch" subcommand
+  in
+  check ~subcommand:"pr" ~action:(Some "merge") Gh_verb.Pr;
+  check ~subcommand:"repo" ~action:(Some "create") Gh_verb.Repo;
+  check ~subcommand:"discussion" ~action:(Some "comment") Gh_verb.Discussion;
+  check ~subcommand:"api" ~action:(Some "graphql") Gh_verb.Api;
+  check ~subcommand:"frobnicate" ~action:None (Gh_verb.Other "frobnicate")
+;;
+
+(* Every known family's token classifies back to that family — the closed set
+   is complete and self-consistent. *)
+let test_family_token_round_trip () =
+  let known =
+    [ Gh_verb.Pr; Gh_verb.Issue; Gh_verb.Repo; Gh_verb.Discussion
+    ; Gh_verb.Release; Gh_verb.Secret; Gh_verb.Ssh_key; Gh_verb.Workflow
+    ; Gh_verb.Auth; Gh_verb.Gist; Gh_verb.Ruleset; Gh_verb.Label
+    ; Gh_verb.Run; Gh_verb.Cache; Gh_verb.Project; Gh_verb.Api ]
+  in
+  List.iter
+    (fun fam ->
+       let token = Gh_verb.family_token fam in
+       let v = Gh_verb.classify [ "gh"; token ] in
+       if v.Gh_verb.family <> fam then
+         Alcotest.failf "family_token %s did not round-trip (got %s)"
+           (Gh_verb.string_of_family fam)
+           (Gh_verb.string_of_family v.Gh_verb.family))
+    known
+;;
+
+(* --- 2. risk_of_gh_verb agrees with the word-list floor on known families -- *)
+
+let risk_of_words s =
+  Shell_ir_risk.risk_of_gh_verb (Gh_verb.classify (words_of s))
+;;
+
+let floor_of_words s = Shell_ir_risk.classify_repo_hosting_cli (words_of s)
+
+let test_verb_agrees_with_floor_on_known () =
+  (* Well-formed [gh <family> <action>] across every risk tier. Excludes api
+     (string-borne, tested separately) and adversarial flag injection (the
+     floor's positional-scan defense legitimately diverges there; composed
+     risk is still safe because the floor runs via max_risk). *)
+  let cases =
+    [ "pr view 1"; "pr list"; "pr create --title T"; "pr comment 1 --body B"
+    ; "pr merge 1"; "pr ready 1"; "issue view 2"; "issue create --title T"
+    ; "repo view o/r"; "repo clone o/r"; "repo create o/new"; "repo fork o/r"
+    ; "repo delete o/r"; "repo archive o/r"; "repo transfer o/r"
+    ; "discussion view 3"; "discussion create --title T"
+    ; "discussion comment 3 --body B"; "discussion delete 3"
+    ; "release create v1"; "release delete v1"; "secret delete S"
+    ; "workflow enable w.yml"; "run cancel 9"; "gist create"; "gist delete 1"
+    ; "label create L"; "cache delete 1"; "ruleset delete 1"; "project create"
+    ]
+  in
+  List.iter
+    (fun s ->
+       let v = risk_of_words s and f = floor_of_words s in
+       if v <> f then
+         Alcotest.failf
+           "risk_of_gh_verb %S = %s but floor = %s (must agree on known)" s
+           (rc v) (rc f))
+    cases
+;;
+
+(* --- 3. the two intended divergences -------------------------------------- *)
+
+let test_other_fail_closes_above_floor () =
+  List.iter
+    (fun s ->
+       let v = risk_of_words s and f = floor_of_words s in
+       if v <> Shell_ir_risk.R2_Irreversible then
+         Alcotest.failf "unknown area %S: verb opinion %s, expected R2" s (rc v);
+       if f <> Shell_ir_risk.R0_Read then
+         Alcotest.failf "unknown area %S: floor %s, expected R0 (unchanged)" s
+           (rc f))
+    [ "frobnicate now"; "quantum entangle"; "preview enable-feature x" ]
+;;
+
+let test_api_left_to_floor () =
+  (* verb opinion for api is R0; the floor derives real risk from -X/graphql,
+     and composed classify takes the max — so api risk is never lost. *)
+  let v = risk_of_words "api repos/o/r -X DELETE" in
+  if v <> Shell_ir_risk.R0_Read then
+    Alcotest.failf "api verb opinion: %s, expected R0" (rc v);
+  let f = floor_of_words "api repos/o/r -X DELETE" in
+  if f <> Shell_ir_risk.R2_Irreversible then
+    Alcotest.failf "floor should still catch api -X DELETE: got %s" (rc f)
+;;
+
+let () =
+  Alcotest.run "gh_verb"
+    [
+      ( "classify",
+        [
+          Alcotest.test_case "family + action" `Quick test_classify_family_action;
+          Alcotest.test_case "of_fields (real pipeline)" `Quick test_of_fields;
+          Alcotest.test_case "family_token round-trip" `Quick
+            test_family_token_round_trip;
+        ] );
+      ( "risk-agreement",
+        [
+          Alcotest.test_case "agrees with floor on known" `Quick
+            test_verb_agrees_with_floor_on_known;
+          Alcotest.test_case "Other fail-closes above floor" `Quick
+            test_other_fail_closes_above_floor;
+          Alcotest.test_case "api left to floor" `Quick test_api_left_to_floor;
+        ] );
+    ]
+;;

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -11,14 +11,22 @@
       [R2_Irreversible] by PR #23362 to express a capability-policy
       decision on the risk axis. Target (G-4/G-9): R1 + external effect
       + [Requires_approval] disposition.
-    - [Defect_unknown_permissive] — gh verbs absent from both word-list
-      tables fall through to [R0_Read] and auto-run under the autonomous
-      overlay. Target (G-3): typed [Gh_unknown] fail-closed.
+    - [Defect_unknown_permissive] — gh verbs/actions absent from the
+      word-list tables that still compose to [R0_Read] and auto-run under
+      the autonomous overlay.
+    - [Fail_closed_opinion] — W1 landed: the typed gh family
+      ([Shell_ir_risk.risk_of_gh_verb]) now gives a wholly-unrecognized gh
+      area ([Gh_verb.Other]) an [R2_Irreversible] typed opinion, which
+      [classify] lifts into the composed risk. This is OBSERVABILITY only:
+      the keeper approval floor reads the word-list classifier, not this
+      composed opinion (see [test_word_list_surface], which still pins the
+      floor at [R0_Read] for the same inputs). Enforcement of these lands
+      in W3 (unknown gh -> non-blocking approval).
 
-    Update protocol: when a slice lands, move its cases from the defect
-    constructor to [Stable] with the new class, and update the ledger
-    counts in [test_ledger]. The ledger diff IS the slice's measured
-    delta; do not silence a mismatch by deleting a case. *)
+    Update protocol: when a slice lands, move its cases to the constructor
+    matching the new state and update the ledger counts in [test_ledger].
+    The ledger diff IS the slice's measured delta; do not silence a
+    mismatch by deleting a case. *)
 
 module Parsed = Masc_exec.Parsed
 module Shell_ir = Masc_exec.Shell_ir
@@ -59,11 +67,17 @@ type expectation =
           PR #23362 placed in [repo_hosting_cli_irreversible_ops] (or the
           graphql R2 fragment list) to express policy. *)
   | Defect_unknown_permissive of Shell_ir_risk.risk_class
-      (** Pinned current class for a verb/action absent from both
-          word-list tables: falls through to R0 and auto-runs. *)
+      (** Pinned current class for a verb/action absent from the word-list
+          tables that still composes to R0 and auto-runs. *)
+  | Fail_closed_opinion of Shell_ir_risk.risk_class
+      (** W1 landed: composed risk lifted by the typed [Gh_verb.Other]
+          fail-closed opinion. Observability only — the approval floor
+          (word-list) is unchanged; enforcement is W3. *)
 
 let pinned_class = function
-  | Stable c | Defect_policy_as_risk c | Defect_unknown_permissive c -> c
+  | Stable c | Defect_policy_as_risk c | Defect_unknown_permissive c
+  | Fail_closed_opinion c ->
+    c
 ;;
 
 let corpus : (string * string * expectation) list =
@@ -74,9 +88,8 @@ let corpus : (string * string * expectation) list =
     ("issue-view", "gh issue view 7", Stable Shell_ir_risk.R0_Read);
     ("repo-view", "gh repo view owner/repo", Stable Shell_ir_risk.R0_Read);
     ("api-get", "gh api repos/owner/repo", Stable Shell_ir_risk.R0_Read);
-    (* R0 by fall-through, not by decision: "discussion view" is in
-       neither table. Correct outcome, undecided path — G-1 makes it a
-       decided read. *)
+    (* Post-W1 this is a DECIDED read: the typed [Gh_verb.Discussion] family
+       with a table-absent action ("view") opines R0, matching the floor. *)
     ("discussion-view", "gh discussion view 42", Stable Shell_ir_risk.R0_Read);
     (* --- reversible mutations: stable R1 ----------------------------- *)
     ("pr-create", "gh pr create --title T --body B",
@@ -133,14 +146,20 @@ let corpus : (string * string * expectation) list =
     ("graphql-addDiscussionComment",
      "gh api graphql -f 'query=mutation{addDiscussionComment}'",
      Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
-    (* --- Defect 2: unknown verb/action auto-runs as R0 --------------- *)
+    (* --- W1: wholly-unrecognized gh area -> fail-closed typed opinion.
+       Composed risk is now R2 (was R0). Observability only: the approval
+       floor still reads these as R0 (see test_word_list_surface). --------- *)
     ("unknown-verb", "gh frobnicate now",
-     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+     Fail_closed_opinion Shell_ir_risk.R2_Irreversible);
     ("unknown-verb-forced", "gh quantum entangle --force",
-     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+     Fail_closed_opinion Shell_ir_risk.R2_Irreversible);
     ("unknown-verb-preview", "gh preview enable-feature x",
-     Defect_unknown_permissive Shell_ir_risk.R0_Read);
-    (* unknown ACTION under a known family also falls through *)
+     Fail_closed_opinion Shell_ir_risk.R2_Irreversible);
+    (* --- Residual defect (NOT fixed by W1): a known family with an
+       unknown action. We cannot distinguish "gh repo upsert-magic" from a
+       read ("gh repo view") without a reads table, so fail-closing here
+       would over-block reads. Stays R0; deferred to W3, where an unknown
+       action routes to non-blocking approval instead of auto-run. -------- *)
     ("unknown-repo-action", "gh repo upsert-magic owner/repo",
      Defect_unknown_permissive Shell_ir_risk.R0_Read);
   ]
@@ -168,27 +187,33 @@ let test_corpus_pinned () =
        ^ String.concat "\n" mismatches)
 ;;
 
-(* The typed path abstains on gh (RFC-0208 boundary): the Gh constructor
-   is a typed hit, but its risk opinion is R0 regardless of verb — the
-   word-list floor owns gh risk. G-1/G-3 change exactly this: verb-family
-   lower bounds (Repo_delete -> R2, Repo_create -> R1, Gh_unknown -> R2)
-   while the floor stays. *)
-let test_typed_path_abstains_on_gh () =
-  List.iter
-    (fun cmd ->
-       let opinion = typed_opinion cmd in
-       if opinion <> Shell_ir_risk.R0_Read then
-         Alcotest.failf
-           "typed opinion for %S pinned R0_Read (abstention), got %s" cmd
-           (rc opinion);
-       if not (Shell_ir_risk.typed_hit_of_ir (parse_ir cmd)) then
-         Alcotest.failf "expected %S to lower to a typed Gh hit" cmd)
-    [
-      "gh repo create owner/new-repo";
-      "gh pr merge 123";
-      "gh discussion comment 42 --body B";
-      "gh frobnicate now";
-    ]
+(* W1: the typed path no longer abstains on gh. [risk_of_typed] reads the
+   [Gh_verb] family and returns a verb-based opinion that equals the word-list
+   floor for known families and fail-closes ([Gh_verb.Other] -> R2) for an
+   unrecognized area. [Api] stays R0 (its -X/graphql risk is string-borne and
+   floor-owned). Every gh command still lowers to a typed Gh hit. *)
+let test_typed_path_verb_opinion () =
+  let check cmd expected =
+    let opinion = typed_opinion cmd in
+    if opinion <> expected then
+      Alcotest.failf "typed opinion for %S: pinned %s, got %s" cmd
+        (rc expected) (rc opinion);
+    if not (Shell_ir_risk.typed_hit_of_ir (parse_ir cmd)) then
+      Alcotest.failf "expected %S to lower to a typed Gh hit" cmd
+  in
+  check "gh pr view 123" Shell_ir_risk.R0_Read;
+  check "gh pr create --title T" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
+  (* repo/create sits in the irreversible table post-#23362; W1 reads the
+     same tables, so the typed opinion is R2 here too. W2 moves it to R1
+     once the capability-policy axis can carry the "disabled" decision. *)
+  check "gh repo create owner/new-repo" Shell_ir_risk.R2_Irreversible;
+  check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
+  check "gh discussion comment 42 --body B" Shell_ir_risk.R2_Irreversible;
+  (* api: typed opinion stays R0; the word-list floor owns -X/graphql risk. *)
+  check "gh api repos/owner/repo -X DELETE" Shell_ir_risk.R0_Read;
+  (* wholly-unrecognized area: fail-closed typed opinion. *)
+  check "gh frobnicate now" Shell_ir_risk.R2_Irreversible
 ;;
 
 (* Word-list surface directly (no parser): the fall-through and the
@@ -222,17 +247,27 @@ let test_ledger () =
     count (fun (_, _, e) ->
       match e with Defect_unknown_permissive _ -> true | _ -> false)
   in
+  let fail_closed_opinion =
+    count (fun (_, _, e) ->
+      match e with Fail_closed_opinion _ -> true | _ -> false)
+  in
   Printf.printf
-    "[G-0] corpus=%d R0=%d R1=%d R2=%d DP=%d | defects: policy_as_risk=%d \
-     unknown_permissive=%d\n"
-    (List.length corpus) r0 r1 r2 dp policy_as_risk unknown_permissive;
+    "[G-0->W1] corpus=%d R0=%d R1=%d R2=%d DP=%d | defects: policy_as_risk=%d \
+     unknown_permissive=%d | fail_closed_opinion=%d\n"
+    (List.length corpus) r0 r1 r2 dp policy_as_risk unknown_permissive
+    fail_closed_opinion;
   Alcotest.(check int) "corpus size" 32 (List.length corpus);
-  Alcotest.(check int) "R0 count" 10 r0;
+  (* W1 delta vs W0 baseline: 3 wholly-unknown gh areas moved R0->R2 as a
+     fail-closed typed opinion (R0 10->7, R2 17->20), leaving 1 residual
+     unknown-permissive (known-family unknown-action, deferred to W3). *)
+  Alcotest.(check int) "R0 count" 7 r0;
   Alcotest.(check int) "R1 count" 5 r1;
-  Alcotest.(check int) "R2 count" 17 r2;
+  Alcotest.(check int) "R2 count" 20 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
   Alcotest.(check int) "defect: policy-as-risk" 9 policy_as_risk;
-  Alcotest.(check int) "defect: unknown-permissive" 4 unknown_permissive
+  Alcotest.(check int) "defect: unknown-permissive (residual)" 1
+    unknown_permissive;
+  Alcotest.(check int) "W1: fail-closed opinion" 3 fail_closed_opinion
 ;;
 
 let () =
@@ -241,8 +276,8 @@ let () =
       ( "g0-baseline",
         [
           Alcotest.test_case "corpus pinned" `Quick test_corpus_pinned;
-          Alcotest.test_case "typed path abstains on gh" `Quick
-            test_typed_path_abstains_on_gh;
+          Alcotest.test_case "typed path verb opinion" `Quick
+            test_typed_path_verb_opinion;
           Alcotest.test_case "word-list surface" `Quick test_word_list_surface;
           Alcotest.test_case "ledger ratchet" `Quick test_ledger;
         ] );


### PR DESCRIPTION
## What

RFC-0309 **W1**: typed gh verb family (`Gh_verb`) + fail-closed typed risk opinion. Substrate PR — **enforcement 무변경**.

- `lib/exec/gh_verb.ml` / `.mli` — 닫힌 `gh_family` sum(`Pr|Issue|Repo|Discussion|…|Api|Other of string`) + `{ family; action }`. `of_fields`(파싱된 Gh field 기반, 실제 파이프라인 경로) + `classify`(raw argv, word-list floor 미러). risk 비의존(순환 회피).
- `lib/exec/shell_ir_risk.ml` — `risk_of_gh_verb : Gh_verb.t -> risk_class` 추가, `risk_of_typed (Gh _)`를 blanket `R0_Read` 기권에서 `risk_of_gh_verb (Gh_verb.of_fields …)`로 재배선.
- 테스트: `test_gh_verb`(classify/of_fields/round-trip; risk가 known family에서 floor와 일치, `Other`/`Api`에서만 발산), baseline harness 갱신.

## Why (enforcement-inert 증명)

소스 확인 결과 keeper 승인 게이트는 composed `classify`가 아니라 **word-list `classify_repo_hosting_cli`(catastrophic floor)** + Observe 오버레이로 동작합니다(`approval_policy.ml:161-172`, `approval_config.ml:40-47`). composed `risk_class`는 keeper 경로에서 **관측 전용**(metric/log/OTel, `keeper_tool_execute_runtime.ml:917`)이고, dispatch는 `Destructive_protected`만 특별 처리(`exec_dispatch.ml:535-546`)합니다.

그래서 `risk_of_typed`만 바꿔 "unknown 차단"을 주장하면 telemetry-as-fix가 됩니다(CLAUDE.md 워크어라운드 거부 기준). 이 PR은 그렇게 하지 않습니다:

- `risk_of_gh_verb`는 known family에서 **동일 테이블(risk SSOT)** 을 읽어 floor와 값이 일치 → composed classify가 known gh에서 불변.
- 발산은 **완전 미지 영역(`Gh_verb.Other`)** 한 곳뿐: typed 의견 R2(fail-closed) vs floor R0. `max_risk`가 unknown gh를 composed R2로 올림 = **관측만** 변화. unknown gh의 실제 enforcement는 W3(비동기 승인 라우팅)에서.
- `Api`는 R0 유지(–X/graphql은 string-borne, floor 소유, RFC-0208). IR→words round-trip 없음. `Destructive_protected` 절대 반환 안 함.

검증: 전체 `@lib/exec/test/runtest` green(effect-projection `project_risk ≡ classify` golden 포함), keeper lib + main_eio 빌드 green, lib-regression 0(failwith/List.hd/Option.get/Obj.magic 추가 없음), ocamlformat clean.

### baseline harness delta (측정된 W1 성과)
- wholly-unknown gh 3건 composed R0→R2 (`Fail_closed_opinion`). ledger R0 10→7, R2 17→20.
- 잔여 결함 명시: known family + unknown action(`gh repo upsert-magic`)은 read와 구분 불가라 R0 유지, W3로 이연(silent drop 아님, harness에 문서화).

## RFC

- **RFC-0309** (`docs/rfc/RFC-0309-typed-gh-capability-gating.md`, main 병합됨) §2/§3.1. 본 PR이 W1 wave.
- Related: RFC-0208(typed coverage / gh floor 경계), RFC-0160(risk envelope), RFC-0254(approval verdict).

## Discovered (out of scope) — issue #23390

구현 중 확인된 **사전-존재 floor bypass**: leading global value-flag(`gh --repo o/r pr merge` / `... repo delete`)가 `classify_repo_hosting_cli`의 subcommand 탐지를 밀어내 floor가 R0으로 오분류 → destructive op이 승인 floor를 우회(실측: `floor=R0 verb=R2`). enforcement 결함이라 W1(inert) 범위 밖 → **#23390**으로 분리 기록. 이 PR의 typed 경로는 composed에서 R2로 올바르게 보지만 floor는 여전히 뚫림.

## Non-blocking / 안전

- 이 PR은 keeper turn 동작·승인·차단을 바꾸지 않습니다(관측만). 논블로킹 불변식과 무관.
- `Destructive_protected` 미반환으로 dispatch 특별처리 경로 불변.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
