### PR TITLE
fix(keeper): expand rotation candidates to full catalog for transient errors (Phase B-1, #23373)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -569,6 +569,14 @@ let default_degraded_rotation_candidates
       (Runtime.get_default_runtime_id ())
   in
   let default_candidates = [ normalized_base; default_runtime; phase_recovery_runtime ] in
+  let catalog_runtimes =
+    Runtime.get_runtimes ()
+    |> List.map (fun (runtime : Runtime.t) ->
+           normalized_runtime_id ~catalog_names runtime.id)
+  in
+  let candidates_with_catalog =
+    dedupe_keep_order (default_candidates @ catalog_runtimes)
+  in
   match fallback_reason with
   | Some (Read_only_no_progress | Empty_no_progress | Thinking_only_no_progress) ->
     let tool_capable =
@@ -579,17 +587,24 @@ let default_degraded_rotation_candidates
     in
     dedupe_keep_order (default_candidates @ tool_capable)
   | Some
-      ( Hard_quota
-      | Resumable_cli_session
-      | Admission_queue_timeout
+      ( Capacity_backpressure
       | Provider_timeout
-      | Turn_timeout
-      | Runtime_candidates_filtered
-      | Runtime_exhausted
-      | Capacity_backpressure
-      | Rate_limit
       | Server_error
-      | Auth_error )
+      | Auth_error
+      | Runtime_exhausted
+      | Runtime_candidates_filtered
+      | Turn_timeout
+      | Resumable_cli_session
+      | Admission_queue_timeout ) ->
+    (* Phase B-1: include the full runtime catalog so transient infrastructure
+       failures (notably capacity_backpressure) can fail over to a healthy
+       runtime outside the narrow [base; default; phase_recovery] set.
+       Without this, two runtimes in cooldown had nowhere to go (#23373,
+       incidents 2026-05-21 / 2026-07-06). Credential-pool filtering is
+       applied downstream by [degraded_rotation_after_recoverable_error] via
+       [filter_quota_pool_rotation_candidates]. *)
+    candidates_with_catalog
+  | Some (Hard_quota | Rate_limit)
   | None ->
     default_candidates
 


### PR DESCRIPTION
## Problem

Phase A (#23383) stopped the infinite rotation but did **not** add anywhere to fail over to. `default_degraded_rotation_candidates` returned only `[base; default; phase_recovery]` for `Capacity_backpressure` and transient infra errors. When both the bound runtime and the default were in cooldown (the 2026-05-21 / 2026-07-06 incident, #23373), the rotation had no healthy runtime to land on — even though 5 healthy runtimes existed in the catalog.

## Fix (Phase B-1)

Extend `default_degraded_rotation_candidates` (`lib/keeper/keeper_error_classify.ml`) to include the **full runtime catalog** for transient infrastructure reasons (`Capacity_backpressure`, `Provider_timeout`, `Server_error`, `Auth_error`, `Runtime_exhausted`, `Runtime_candidates_filtered`, `Turn_timeout`, `Resumable_cli_session`, `Admission_queue_timeout`). This reuses the exact pattern the read-only-no-progress branch already uses (`Runtime.get_runtimes () |> List.map ...`).

Combined with Phase A's cap-rotation on `Capacity_backpressure`:
- rotation lands on an **untried healthy runtime** (Capacity_backpressure does not apply the credential-pool filter, so a same-pool sibling can also absorb load),
- or returns `None` when the whole catalog is exhausted → keeper pauses once, retries a later turn.

`Hard_quota` / `Rate_limit` keep the narrow set (account-scoped). read-only no-progress keeps its `tool_capable` filter.

## Verification

- `dune runtest test/test_keeper_sdk_error_typed_bridge.exe` → 21/21 OK. Phase A regression case (`capacity_backpressure does not cycle candidates`) stays green; all 20 rotation/quota tests unchanged.
- The catalog-expansion branch cannot be meaningfully unit-tested in the rate-limit harness: the harness catalog is a single credential pool (`same.a`/`same.b`) and `provider_cooldown_block_error` needs a full `RC.t` candidate + cooldown-block sequence. Cross-pool failover to an independent provider (the actual incident scenario) is validated live after merge against the 5 healthy runtimes.

# ci:skip-test-coverage

## Scope / next

- This is the minimum viable failover using catalog declaration order. No new config, no new types.
- **Phase B-2** = RFC-0260 health probe + declarative `default_fallback = [...]` chain (replaces catalog-order with explicit ordered chain + accurate healthy judgment). Separate PR.
- **Phase B-3** = RFC-0260 audited provider-change ledger (governance). Independently shippable.
- **Phase B-4** = routing rewrite at `keeper_unified_turn.ml:142` (`match None`). Separate PR.

Refs #23373.
