### PR TITLE
fix(keeper): fall back HITL summaries on LLM failure

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -30,9 +30,12 @@ let () =
       "Total HITL context-summary worker outcomes classified by [outcome]. \
        Labels: [outcome] (ok_summary | parse_error | provider_error | timeout | \
        no_provider_config | no_net | slot_unavailable | crashed | \
-       degraded_plain_json), [risk_level]. [degraded_plain_json] is emitted \
-       alongside the terminal outcome when the judge endpoint could not serve \
-       native structured output and the plain-text JSON path was used."
+       degraded_plain_json | fallback_summary), [risk_level]. \
+       [degraded_plain_json] is emitted alongside the terminal outcome when \
+       the judge endpoint could not serve native structured output and the \
+       plain-text JSON path was used. [fallback_summary] means the operator \
+       received deterministic request metadata because the advisory LLM summary \
+       was unavailable."
     ()
 ;;
 
@@ -236,6 +239,110 @@ let build_context_bundle ~(entry : pending_approval) : Yojson.Safe.t =
     ; "partial_context", `Bool partial_context
     ; "context_notes", `List (List.rev_map (fun s -> `String s) context_notes)
     ]
+;;
+
+(* ── Deterministic fallback ────────────────────── *)
+
+let fallback_model_run_id = "deterministic-fallback"
+
+let preview_text ~max_bytes text =
+  text
+  |> Observability_redact.redact_preview ~max_len:max_bytes
+  |> String_util.utf8_prefix ~max_bytes
+;;
+
+let fallback_reason_preview reason = preview_text ~max_bytes:180 reason
+
+let input_preview_of_entry (entry : pending_approval) =
+  match Observability_redact.redact_tool_input ~tool_name:entry.tool_name entry.input with
+  | Some preview -> preview_text ~max_bytes:320 preview
+  | None -> "input preview withheld by observability redaction policy"
+;;
+
+let context_bundle_partial context_bundle =
+  match Json_util.assoc_member_opt "partial_context" context_bundle with
+  | Some (`Bool value) -> value
+  | _ -> false
+;;
+
+let id_part label = function
+  | Some value when String.trim value <> "" -> [ Printf.sprintf "%s=%s" label value ]
+  | _ -> []
+;;
+
+let turn_part = function
+  | Some turn_id -> [ Printf.sprintf "turn=%d" turn_id ]
+  | None -> []
+;;
+
+let fallback_relation (entry : pending_approval) =
+  let parts =
+    turn_part entry.turn_id
+    @ id_part "task" entry.task_id
+    @ id_part "goal" entry.goal_id
+    @ List.map (Printf.sprintf "goal=%s") entry.goal_ids
+  in
+  match List.filter (fun value -> String.trim value <> "") parts with
+  | [] -> "no linked turn/task/goal metadata"
+  | values -> String.concat ", " values
+;;
+
+let fallback_summary ~generated_at ~(entry : pending_approval) ~context_bundle ~reason =
+  let reason = fallback_reason_preview reason in
+  let risk = risk_level_to_string entry.risk_level in
+  let partial_context = context_bundle_partial context_bundle in
+  let context_summary =
+    Printf.sprintf
+      "LLM context summary unavailable (%s). Deterministic fallback: keeper %s \
+       requests %s (%s risk) in %s; %s. Raw input preview: %s"
+      reason
+      entry.keeper_name
+      entry.tool_name
+      risk
+      entry.sandbox_target
+      (fallback_relation entry)
+      (input_preview_of_entry entry)
+  in
+  let key_questions =
+    [ "Does the raw input match the current task, goal, and recent keeper context?"
+    ; "Is the requested tool action scoped, reversible, and expected for this keeper?"
+    ; "Could the request be based on stale, deprecated, or unverified information?"
+    ]
+  in
+  let suggested_options =
+    [ { label = "approve"
+      ; rationale =
+          "Approve only if the raw payload is current, scoped, and expected for \
+           the active work."
+      ; estimated_risk_delta = None
+      }
+    ; { label = "reject"
+      ; rationale =
+          "Reject when the payload is stale, too broad, or not tied to the \
+           visible task/goal context."
+      ; estimated_risk_delta = None
+      }
+    ]
+  in
+  { summary_version
+  ; generated_at
+  ; model_run_id = fallback_model_run_id
+  ; context_summary
+  ; key_questions
+  ; suggested_options
+  ; risk_rationale =
+      Some
+        (Printf.sprintf
+           "Deterministic fallback generated after advisory HITL summary LLM \
+            failure: %s. It does not verify external state or keeper claims."
+           reason)
+  ; uncertainty = if partial_context then 0.95 else 0.85
+  }
+;;
+
+let emit_fallback_summary ~generated_at ~entry ~context_bundle ~reason ~on_summary =
+  record_outcome ~risk_level:entry.risk_level "fallback_summary";
+  on_summary (fallback_summary ~generated_at ~entry ~context_bundle ~reason)
 ;;
 
 (* ── LLM call ───────────────────────────────────── *)
@@ -443,16 +550,24 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
   match provider_config with
   | None ->
     record_outcome ~risk_level:entry.risk_level "no_provider_config";
-    on_failure ~reason:"HITL summary: no provider config available" ~retryable:false
+    emit_fallback_summary
+      ~generated_at
+      ~entry
+      ~context_bundle:(build_context_bundle ~entry)
+      ~reason:"HITL summary: no provider config available"
+      ~on_summary
   | Some provider_config ->
     Eio.Fiber.fork ~sw (fun () ->
       try
         with_summary_slot (fun sw ->
           let context_bundle = build_context_bundle ~entry in
+          let emit_fallback ~reason =
+            emit_fallback_summary ~generated_at ~entry ~context_bundle ~reason ~on_summary
+          in
           match Eio_context.get_net_opt () with
           | None ->
             record_outcome ~risk_level:entry.risk_level "no_net";
-            on_failure ~reason:"HITL summary worker: Eio net unavailable" ~retryable:true
+            emit_fallback ~reason:"HITL summary worker: Eio net unavailable"
           | Some net ->
             (match call_summary_llm ~sw ~net ~provider_config ~context_bundle () with
              | Ok (response, mode) ->
@@ -469,17 +584,17 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
                   on_summary summary
                 | Error reason ->
                   record_outcome ~risk_level:entry.risk_level "parse_error";
-                  on_failure ~reason ~retryable:true)
+                  emit_fallback ~reason)
              | Error { mode; error = (Agent_sdk.Error.Api (Timeout _) as error) } ->
                List.iter
                  (record_outcome ~risk_level:entry.risk_level)
                  (summary_llm_error_outcomes ~mode error);
-               on_failure ~reason:"HITL summary LLM call timed out" ~retryable:true
+               emit_fallback ~reason:"HITL summary LLM call timed out"
              | Error { mode; error } ->
                List.iter
                  (record_outcome ~risk_level:entry.risk_level)
                  (summary_llm_error_outcomes ~mode error);
-               on_failure ~reason:(Agent_sdk.Error.to_string error) ~retryable:true))
+               emit_fallback ~reason:(Agent_sdk.Error.to_string error)))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
@@ -497,6 +612,7 @@ module For_testing = struct
     | Plain_json_text
 
   let build_context_bundle = build_context_bundle
+  let fallback_summary = fallback_summary
   let parse_summary = parse_summary
   let summary_of_response = summary_of_response
   let provider_config_for_summary = provider_config_for_summary

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -1,8 +1,10 @@
 (** Spawn an asynchronous HITL context-summary worker.
-    The worker is fire-and-forget: it calls [on_summary] or [on_failure] on
-    the calling fiber, and the caller is responsible for writing the result
-    back to the approval entry (e.g. via [Keeper_approval_queue.update_pending_entry]).
-    This keeps the worker decoupled from the queue and avoids a module cycle. *)
+    The worker is fire-and-forget: it calls [on_summary] with either the LLM
+    summary or a deterministic request-metadata fallback. [on_failure] is
+    reserved for unexpected worker failures where even fallback generation did
+    not run. The caller is responsible for writing the result back to the
+    approval entry (e.g. via [Keeper_approval_queue.update_pending_entry]). This
+    keeps the worker decoupled from the queue and avoids a module cycle. *)
 val spawn
   :  sw:Eio.Switch.t
   -> ?provider_config:Llm_provider.Provider_config.t
@@ -22,6 +24,13 @@ module For_testing : sig
 
   val build_context_bundle
     : entry:Keeper_approval_queue_rules_types.pending_approval -> Yojson.Safe.t
+
+  val fallback_summary
+    :  generated_at:float
+    -> entry:Keeper_approval_queue_rules_types.pending_approval
+    -> context_bundle:Yojson.Safe.t
+    -> reason:string
+    -> Keeper_approval_queue_rules_types.hitl_context_summary
 
   val parse_summary
     :  generated_at:float

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -60,6 +60,7 @@ let dummy_pending_approval
     ?(goal_id = "goal-1")
     ?(turn_id = 42)
     ?(audit_base_path = "")
+    ?(input = `Assoc [ "arg", `String "value" ])
     ()
     : Q.pending_approval
   =
@@ -71,7 +72,7 @@ let dummy_pending_approval
   ; sandbox_target = "local"
   ; sandbox_profile = None
   ; backend = None
-  ; input = `Assoc [ "arg", `String "value" ]
+  ; input
   ; risk_level = Q.Medium
   ; requested_at = 1780587600.0
   ; turn_id = Some turn_id
@@ -227,21 +228,28 @@ let test_hitl_summary_schema_excludes_server_owned_fields () =
 
 (* ── spawn / bundle tests ───────────────────────── *)
 
-let test_spawn_no_provider_config_calls_on_failure () =
+let test_spawn_no_provider_config_uses_fallback_summary () =
   Eio.Switch.run (fun sw ->
-    let called = ref false in
-    let reason_ref = ref "" in
-    let on_summary _ = fail "on_summary should not be called" in
+    let failure_called = ref false in
+    let summary_ref = ref None in
+    let on_summary summary = summary_ref := Some summary in
     let on_failure ~reason ~retryable =
-      called := true;
-      reason_ref := reason;
+      failure_called := true;
+      ignore reason;
       ignore retryable
     in
     H.spawn ~sw ~entry:(dummy_pending_approval ()) ?provider_config:None
       ~on_summary ~on_failure ();
-    check bool "on_failure called" true !called;
-    check bool "reason mentions no provider config" true
-      (Astring.String.is_infix ~affix:"no provider config" !reason_ref))
+    check bool "on_failure not called" false !failure_called;
+    match !summary_ref with
+    | None -> fail "expected fallback summary"
+    | Some summary ->
+      check string "fallback model_run_id" "deterministic-fallback" summary.model_run_id;
+      check bool "context explains missing LLM summary" true
+        (Astring.String.is_infix ~affix:"LLM context summary unavailable"
+           summary.context_summary);
+      check int "fallback questions" 3 (List.length summary.key_questions);
+      check int "fallback options" 2 (List.length summary.suggested_options))
 ;;
 
 let test_build_context_bundle_includes_ids_and_partial_context () =
@@ -437,6 +445,38 @@ let test_plain_mode_error_outcomes_record_degradation () =
        provider_error)
 ;;
 
+let test_fallback_summary_is_redacted_and_uncertain () =
+  let entry =
+    dummy_pending_approval
+      ~input:
+        (`Assoc
+            [ "api_key", `String "sk-test-secret"
+            ; "path", `String "/tmp/example"
+            ; "content", `String "write this file"
+            ])
+      ()
+  in
+  let summary =
+    H.For_testing.fallback_summary
+      ~generated_at:1234567890.0
+      ~entry
+      ~context_bundle:(`Assoc [ "partial_context", `Bool false ])
+      ~reason:"Internal error: HTTP 429: rate limit reached"
+  in
+  check string "fallback model_run_id" "deterministic-fallback" summary.model_run_id;
+  check bool "mentions fallback reason" true
+    (Astring.String.is_infix ~affix:"HTTP 429" summary.context_summary);
+  check bool "redacts raw secret" false
+    (Astring.String.is_infix ~affix:"sk-test-secret" summary.context_summary);
+  check bool "keeps redaction marker" true
+    (Astring.String.is_infix ~affix:"[REDACTED]" summary.context_summary);
+  check bool "risk rationale present" true
+    (match summary.risk_rationale with
+     | Some text -> Astring.String.is_infix ~affix:"does not verify external state" text
+     | None -> false);
+  check (float 0.0001) "fallback uncertainty" 0.85 summary.uncertainty
+;;
+
 (* ── Runner ───────────────────────────────────── *)
 
 let () =
@@ -455,8 +495,8 @@ let () =
             test_hitl_summary_schema_excludes_server_owned_fields
         ] )
     ; ( "worker"
-      , [ test_case "spawn with no provider config calls on_failure" `Quick
-            (with_eio test_spawn_no_provider_config_calls_on_failure)
+      , [ test_case "spawn with no provider config uses fallback summary" `Quick
+            (with_eio test_spawn_no_provider_config_uses_fallback_summary)
         ; test_case "build_context_bundle includes IDs and partial_context" `Quick
             test_build_context_bundle_includes_ids_and_partial_context
         ; test_case "build_context_bundle with real workspace is not partial" `Quick
@@ -471,6 +511,8 @@ let () =
             test_summary_of_response_plain_json_text_parses_prose_wrapped
         ; test_case "plain-mode errors keep degradation observable" `Quick
             test_plain_mode_error_outcomes_record_degradation
+        ; test_case "fallback summary is redacted and uncertain" `Quick
+            test_fallback_summary_is_redacted_and_uncertain
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a deterministic request-metadata fallback for HITL context summaries when the advisory LLM call fails
- route no-provider, no-net, parse, timeout, and provider-error paths to `on_summary` with an explicit fallback instead of leaving the approval card in `failed`
- keep observability via `fallback_summary` metrics and preserve redacted input previews in the fallback text

## Why
The approvals surface should not block on advisory LLM summaries. If the judge hits timeout, rate limit, or malformed JSON, operators should still get a useful low-confidence briefing from the pending approval payload instead of a red failure banner.

## Validation
- `scripts/dune-local.sh build test/test_hitl_summary_worker.exe`
- `./_build/default/test/test_hitl_summary_worker.exe` (14 tests)

## Notes
- No provider/model hardcoding; this keeps existing runtime routing intact.
- Full Dune build/test remains CI-owned.
