### PR TITLE
Clarify dashboard IDE status and rails

### DIFF
--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -166,8 +166,27 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
       repositories: () => [repo('masc', 'masc')],
     }), container)
 
-    expect(container.textContent).toContain('EXPLORER · masc')
-    expect(container.textContent).not.toContain('EXPLORER · project')
+    expect(container.querySelector('[data-testid="ide-explorer-source"]')?.textContent).toBe('masc')
+    expect(container.querySelector('[data-testid="ide-explorer-source"]')?.getAttribute('title'))
+      .toBe('Workspace source: masc')
+  })
+
+  it('labels loaded visible files distinctly from filtered results', () => {
+    const store = createFileTreeStore()
+    store.seed(SAMPLE)
+    render(h(IdeExplorer, { fileTreeStore: store }), container)
+
+    const count = container.querySelector<HTMLElement>('[data-testid="ide-explorer-file-count"]')
+    expect(count?.textContent).toBe('2 VISIBLE')
+    expect(count?.getAttribute('title')).toContain('currently loaded in the visible tree')
+
+    const search = container.querySelector<HTMLInputElement>('[role="searchbox"]')
+    expect(search).not.toBeNull()
+    search!.value = 'package'
+    fireEvent.input(search!)
+
+    expect(container.querySelector('[data-testid="ide-explorer-file-count"]')?.textContent)
+      .toBe('1/2 VISIBLE')
   })
 
   it('keeps header controls outside the scrollable tree body', () => {

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -69,6 +69,16 @@ export function explorerScopeLabel(
   }
 }
 
+export function explorerFileCountLabel(
+  visibleFileCount: number,
+  filteredFileCount: number,
+  filtering: boolean,
+): string {
+  return filtering
+    ? `${filteredFileCount}/${visibleFileCount} VISIBLE`
+    : `${visibleFileCount} VISIBLE`
+}
+
 export function IdeExplorer({
   fileTreeStore: store,
   workspaceSource,
@@ -149,7 +159,10 @@ export function IdeExplorer({
     if (needle === '') return visible
     return visible.filter(n => n.label.toLowerCase().includes(needle))
   }, [visible, filter])
-  const fileCount = filtered.filter(n => !n.hasChildren).length
+  const filtering = filter.trim() !== ''
+  const visibleFileCount = visible.filter(n => !n.hasChildren).length
+  const filteredFileCount = filtered.filter(n => !n.hasChildren).length
+  const fileCountLabel = explorerFileCountLabel(visibleFileCount, filteredFileCount, filtering)
   const diffSummary = useMemo(() => store.diffSummary(), [store, tick])
   const scopeLabel = explorerScopeLabel(source, keeperName, repoList)
 
@@ -170,7 +183,7 @@ export function IdeExplorer({
     <div
       class="ide-explorer"
       role="region"
-      aria-label="EXPLORER"
+      aria-label=${`EXPLORER ${scopeLabel.label}; ${fileCountLabel}`}
     >
       <header
         style=${{
@@ -182,14 +195,49 @@ export function IdeExplorer({
           borderBottom: '1px solid var(--color-border-divider)',
         }}
       >
-        <span>EXPLORER · <span
+        <span
+          style=${{
+            display: 'grid',
+            gap: 'var(--sp-1)',
+            minWidth: 0,
+            width: '100%',
+          }}
+        >
+          <span
+            style=${{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 'var(--sp-2)',
+              minWidth: 0,
+            }}
+          >
+            <span>EXPLORER</span>
+            <span
+              data-testid="ide-explorer-file-count"
+              title="Files currently loaded in the visible tree; unopened directories load when expanded."
+              aria-label=${fileCountLabel}
+              style=${{
+                flex: 'none',
+                letterSpacing: '0.08em',
+                whiteSpace: 'nowrap',
+              }}
+            >${fileCountLabel}</span>
+          </span>
+          <span
+            data-testid="ide-explorer-source"
+            title=${`Workspace source: ${scopeLabel.label}`}
             style=${{
               color: scopeLabel.tone === 'accent'
                 ? 'var(--color-accent-fg)'
                 : 'var(--color-fg-muted)',
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
-          >${scopeLabel.label}</span></span>
-        <span>${fileCount} FILES</span>
+          >${scopeLabel.label}</span>
+        </span>
       </header>
       ${diffSummary.changedFiles > 0 ? ExplorerDiffSummary(diffSummary) : null}
       ${repoList.length > 0 || onRepositoryScan ? html`

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -346,7 +346,7 @@ describe('IdeShell', () => {
     })
 
     expect(model.workspaceLabel).toBe('masc')
-    expect(model.connectionLabel).toBe('runtime · live')
+    expect(model.connectionLabel).toBe('dashboard · live')
     expect(model.connectionTone).toBe('ok')
     expect(model.chips.map(chip => chip.label)).toEqual([
       'SPLIT DIFF',
@@ -924,7 +924,13 @@ describe('IdeShell', () => {
     expect(contextStack).not.toBeNull()
     expect(primaryRail).not.toBeNull()
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
-    expect(buttonByText(container, 'Context').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, 'Run Activity').getAttribute('title'))
+      .toBe('Workspace and keeper activity linked to the active file and repository')
+    expect(buttonByText(container, 'Keeper Cursors').getAttribute('title'))
+      .toBe('Live keeper file focus and cursor stream status')
+    expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
+      .toContain('Dashboard event transport')
     expect(container.querySelector('.ide-plane-activity')).toBeNull()
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
   })
@@ -977,13 +983,13 @@ describe('IdeShell', () => {
       },
     }
 
-    fireEvent.click(buttonByText(container, 'Activity'))
-    expect(buttonByText(container, 'Activity').getAttribute('aria-selected')).toBe('true')
+    fireEvent.click(buttonByText(container, 'Run Activity'))
+    expect(buttonByText(container, 'Run Activity').getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
 
-    fireEvent.click(buttonByText(container, 'Cursors'))
-    expect(buttonByText(container, 'Cursors').getAttribute('aria-selected')).toBe('true')
+    fireEvent.click(buttonByText(container, 'Keeper Cursors'))
+    expect(buttonByText(container, 'Keeper Cursors').getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('.ide-plane-activity')).toBeNull()
     expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
     const cursorRail = container.querySelector('[data-testid="ide-cursor-rail"]')

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,6 +1,5 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { ConnectionStatus } from '../dashboard-shell'
 import { useSignalValue, useSubscribedSnapshot, useSubscribedValue } from './use-signal-value'
 import {
   activeIdeFile,
@@ -65,6 +64,12 @@ type IdeRightRailTab = 'context' | 'activity' | 'cursors'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok' | 'warn'
 type IdeConnectionTone = 'ok' | 'warn'
 
+interface IdeRightRailTabDescriptor {
+  readonly id: IdeRightRailTab
+  readonly label: string
+  readonly title: string
+}
+
 export interface IdeStatusbarChip {
   readonly id: string
   readonly label: string
@@ -104,10 +109,22 @@ const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
   'split-diff': 'SPLIT DIFF',
   blame: 'BLAME',
 }
-const IDE_RIGHT_RAIL_TABS: ReadonlyArray<{ readonly id: IdeRightRailTab; readonly label: string }> = [
-  { id: 'context', label: 'Context' },
-  { id: 'activity', label: 'Activity' },
-  { id: 'cursors', label: 'Cursors' },
+const IDE_RIGHT_RAIL_TABS: ReadonlyArray<IdeRightRailTabDescriptor> = [
+  {
+    id: 'context',
+    label: 'Work Context',
+    title: 'Keeper work, persistence, memory, and chat scoped to the active IDE context',
+  },
+  {
+    id: 'activity',
+    label: 'Run Activity',
+    title: 'Workspace and keeper activity linked to the active file and repository',
+  },
+  {
+    id: 'cursors',
+    label: 'Keeper Cursors',
+    title: 'Live keeper file focus and cursor stream status',
+  },
 ]
 
 export function normalizeIdeTreeWidth(value: unknown): number {
@@ -325,18 +342,18 @@ function disconnectionReasonLabel(): string {
   const bootstrap = devTokenBootstrapStatus.value
 
   if (!hasToken && bootstrap === 'no_endpoint') {
-    return 'runtime · auth required'
+    return 'dashboard · auth required'
   }
   if (!hasToken && bootstrap === 'network') {
-    return 'runtime · server unreachable'
+    return 'dashboard · server unreachable'
   }
   if (!hasToken && bootstrap === 'fetching') {
-    return 'runtime · bootstrapping...'
+    return 'dashboard · bootstrapping...'
   }
   if (!hasToken) {
-    return 'runtime · no token'
+    return 'dashboard · no token'
   }
-  return 'runtime · reconnecting'
+  return 'dashboard · reconnecting'
 }
 
 function statusbarLayerLabel(activeLayers: ReadonlySet<string>): string | null {
@@ -548,10 +565,30 @@ export function deriveIdeStatusbarModel({
     workspaceBasePath,
     chips,
     connectionLabel: dashboardConnected
-      ? 'runtime · live'
+      ? 'dashboard · live'
       : disconnectionReasonLabel(),
     connectionTone: dashboardConnected ? 'ok' : 'warn',
   }
+}
+
+function IdeDashboardConnectionChip({
+  label,
+  tone,
+}: {
+  readonly label: string
+  readonly tone: IdeConnectionTone
+}) {
+  const title = tone === 'ok'
+    ? 'Dashboard event transport is live. Repository tree loads, LSP, and keeper cursor streams report separate status.'
+    : 'Dashboard event transport is not live. Repository tree loads, LSP, and keeper cursor streams report separate status.'
+  return html`
+    <span
+      class=${`chip sm is-${tone}`}
+      data-testid="ide-dashboard-connection"
+      title=${title}
+      aria-label=${`${label}; ${title}`}
+    >${label}</span>
+  `
 }
 
 function paramsWithLayers(
@@ -1162,7 +1199,10 @@ export function IdeShell() {
             `)}
           </div>
           <${IdePresenceStrip} />
-          <${ConnectionStatus} />
+          <${IdeDashboardConnectionChip}
+            label=${statusbar.connectionLabel}
+            tone=${statusbar.connectionTone}
+          />
         </header>
         <${IdeToolbar}
           activeView=${activeView}
@@ -1238,6 +1278,8 @@ export function IdeShell() {
                     type="button"
                     role="tab"
                     aria-selected=${rightRailTab === tab.id ? 'true' : 'false'}
+                    aria-label=${tab.title}
+                    title=${tab.title}
                     class=${`ide-v2-rail-tab ide-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
                     onClick=${() => setRightRailTab(tab.id)}
                   >${tab.label}</button>

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -22,6 +22,12 @@
   color: var(--text-primary);
 }
 
+.ide-v2-surface > .ide-interject-bar {
+  flex: none;
+  position: relative;
+  z-index: var(--z-base);
+}
+
 .ide-v2-surface[data-terminal-open="true"] .ide-v2-body {
   /* Terminal drawer lives below the body and steals vertical space. */
 }
@@ -241,10 +247,15 @@
 }
 
 .ide-v2-tree .ide-explorer {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  min-height: 0;
+  min-width: 0;
   padding: 10px 8px;
   border-right: 0;
   background: transparent;
+  overflow: hidden;
 }
 
 .ide-v2-tree .ide-explorer > header {
@@ -258,7 +269,12 @@
 }
 
 .ide-v2-tree .ide-explorer-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
   padding: 0 2px;
+  overscroll-behavior: contain;
 }
 
 .ide-v2-tree .ide-explorer-row {
@@ -365,20 +381,27 @@
 .ide-v2-rail-tabs {
   flex: none;
   display: flex;
+  flex-wrap: wrap;
   gap: 2px;
   padding: 10px 10px 0;
   border-bottom: 1px solid var(--border-soft);
 }
 
 .ide-v2-rail-tab {
+  flex: 1 1 0;
+  min-width: 0;
   font-family: var(--font-ui);
-  font-size: var(--fs-11);
-  padding: 6px 12px;
+  font-size: var(--fs-10);
+  line-height: 1.2;
+  padding: 6px 8px;
   border: 0;
   background: none;
   color: var(--text-dim);
   cursor: pointer;
   border-bottom: 2px solid transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
 }
 
 .ide-v2-rail-tab.on {


### PR DESCRIPTION
## Summary
- Replace the generic dashboard `Connected` badge inside the IDE statusbar with an IDE-scoped dashboard transport chip.
- Rename the right rail tabs to `Work Context`, `Run Activity`, and `Keeper Cursors` with accessible titles so their boundaries are explicit.
- Make the explorer header show workspace source separately from loaded visible file counts, and keep the v2 explorer/interject/rail layout scroll-safe.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/ide/ide-shell.test.ts src/components/ide/ide-explorer.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- Playwright screenshots: desktop 1920x1080 and mobile 390x844 against Vite dev server.

## Notes
- Dune build not run locally; dashboard-only change, CI remains the build authority.