### PR TITLE
refactor(board): centralize raw author meta key

### DIFF
--- a/lib/board_tool_adapter/board_tool.mli
+++ b/lib/board_tool_adapter/board_tool.mli
@@ -87,6 +87,16 @@ val parse_sort_order : string -> (sort_order, string) Result.t
     a constructor automatically updates the user-facing
     catalogue. *)
 
+(** {1 Identity meta keys} *)
+
+val raw_agent_name_meta_key : field:string -> string
+(** Canonical board-post meta key for preserving the raw runtime
+    identity surface associated with [field]. *)
+
+val author_raw_agent_name_meta_key : string
+(** Canonical board-post meta key for the raw runtime author
+    identity preserved by HTTP/MCP identity enforcement. *)
+
 (** {1 Display formatting} *)
 
 val format_timestamp_relative : float -> string

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -53,6 +53,9 @@ let strip_state_blocks_text (s : string) : string =
 
 (** {1 Helpers} *)
 
+let raw_agent_name_meta_key ~field = field ^ "_raw_agent_name"
+let author_raw_agent_name_meta_key = raw_agent_name_meta_key ~field:"author"
+
 let format_timestamp_relative ts =
   let now = Time_compat.now () in
   let diff = now -. ts in

--- a/lib/board_tool_adapter/board_tool_format.mli
+++ b/lib/board_tool_adapter/board_tool_format.mli
@@ -17,6 +17,8 @@ type sort_order = Board_dispatch.sort_order =
   | Discussed
 
 val strip_state_blocks_text : string -> string
+val raw_agent_name_meta_key : field:string -> string
+val author_raw_agent_name_meta_key : string
 val format_timestamp_relative : float -> string
 val board_error_to_string : Board.board_error -> string
 val board_error_failure_class : Board.board_error -> Tool_result.tool_failure_class

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -141,7 +141,7 @@ let handle_post_create ~tool_name ~start_time args : Tool_result.result =
         | None -> Board.Internal
       in
       let author_raw_agent_name =
-        meta_string_field "author_raw_agent_name" meta_json
+        meta_string_field Board_tool_format.author_raw_agent_name_meta_key meta_json
       in
       match
         Board_tool_handlers.resolve_board_post_kind

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -104,7 +104,11 @@ let canonical_board_author raw =
 
 let record_identity_raw_surface field raw canonical fields =
   if String.equal raw "" || String.equal raw canonical then fields
-  else json_upsert_meta_string_field (field ^ "_raw_agent_name") raw fields
+  else
+    json_upsert_meta_string_field
+      (Board_tool_format.raw_agent_name_meta_key ~field)
+      raw
+      fields
 
 (** #10297: enforce that a board-tool caller cannot author / vote under
     a principal other than the runtime contract's [agent_name].  Pre-fix

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -860,7 +860,11 @@ let add_routes ~sw ~clock router =
              let* args = json_upsert_string_field "author" author args in
              let* args =
                if String.equal author (String.trim agent_name) then Ok args
-               else json_ensure_meta_string_field "author_raw_agent_name" agent_name args
+               else
+                 json_ensure_meta_string_field
+                   Board_tool.author_raw_agent_name_meta_key
+                   agent_name
+                   args
              in
              let* args = json_ensure_meta_source "dashboard_board_post" args in
              let result = Board_tool.handle_tool "masc_board_post" args in

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -540,7 +540,10 @@ let test_inline_board_post_author_rewrites_caller_claim () =
       normalized |> member "meta" |> member "author_caller_claim" |> to_string);
   Alcotest.(check string) "raw ctx agent preserved" "keeper-velvet-hammer-agent"
     Yojson.Safe.Util.(
-      normalized |> member "meta" |> member "author_raw_agent_name" |> to_string);
+      normalized
+      |> member "meta"
+      |> member Board_tool.author_raw_agent_name_meta_key
+      |> to_string);
   Alcotest.(check string) "existing meta preserved" "probe-10297"
     Yojson.Safe.Util.(normalized |> member "meta" |> member "trace" |> to_string)
 
@@ -2300,7 +2303,9 @@ let () =
                       ; "author", `String "keeper-canonical"
                       ; ( "meta"
                         , `Assoc
-                            [ "author_raw_agent_name", `String "claude-agent" ] )
+                            [ ( Board_tool.author_raw_agent_name_meta_key
+                              , `String "claude-agent" )
+                            ] )
                       ])
                in
                Alcotest.(check bool) "post created" true ok;
@@ -2327,7 +2332,9 @@ let () =
                       ; "post_kind", `String "direct"
                       ; ( "meta"
                         , `Assoc
-                            [ "author_raw_agent_name", `String "claude-agent" ] )
+                            [ ( Board_tool.author_raw_agent_name_meta_key
+                              , `String "claude-agent" )
+                            ] )
                       ])
                in
                Alcotest.(check bool) "post rejected" false ok;


### PR DESCRIPTION
## Summary
- centralize the board raw-agent identity meta key in the board tool facade
- use the shared key from MCP identity enforcement, HTTP board post writes, post-kind classification, and board coverage tests

## Why
PR #23380 fixed stale direct-post classification by using the preserved raw runtime author identity. This follow-up removes the remaining duplicated `author_raw_agent_name` string at call sites so the identity meta field has one SSOT.

## Verification
- `ocamlformat --check lib/board_tool_adapter/board_tool.mli lib/board_tool_adapter/board_tool_format.ml lib/board_tool_adapter/board_tool_format.mli lib/board_tool_adapter/board_tool_post.ml lib/mcp_tool_runtime_board.ml lib/server/server_routes_http_routes_activity.ml test/test_tool_board_coverage.ml`
- `git diff --check --cached`
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe`
- `./_build/default/test/test_tool_board_coverage.exe` (98 tests)
