### PR TITLE
task-1838: add visible-text feedback guard in keeper_hooks_oas_idle.ml

### DIFF
--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -2,6 +2,16 @@
 
 open Keeper_hooks_oas_types
 
+let schema_visible_name name =
+  match Keeper_tool_visibility_projection.public_alias_for_internal name with
+  | Some public_name -> public_name
+  | None -> name
+
+let schema_visible_keep_order names =
+  names
+  |> List.map schema_visible_name
+  |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
+
 (** Suggest alternative tools from the keeper's allowed set that were
     NOT part of the repeated tool calls. Returns up to [max_suggestions]
     tool names, deterministically selected from the allowed set.
@@ -22,16 +32,6 @@ let suggest_alternatives ~(allowed_tools : string list)
   |> schema_visible_keep_order
 
 let includes_tool name tools = List.exists (String.equal name) tools
-
-let schema_visible_name name =
-  match Keeper_tool_visibility_projection.public_alias_for_internal name with
-  | Some public_name -> public_name
-  | None -> name
-
-let schema_visible_keep_order names =
-  names
-  |> List.map schema_visible_name
-  |> Keeper_types_profile_toml_normalizers.dedupe_keep_order
 
 let allowed_visible_candidates candidates ~allowed_tools =
   candidates
@@ -86,8 +86,9 @@ let recovery_hint ~allowed_tools ~tool_names =
        this hint above) — the nudge must name the tool that actually exists. *)
     Some
       (Printf.sprintf
-         "keeper_board_post_get requires an exact post_id from board activity. \
-          Use %s to discover one before calling keeper_board_post_get."
+         "keeper_board_post_get requires post_id; use %s to discover an exact \
+          post_id from visible board activity before calling keeper_board_post_get. \
+          Do not call keeper_board_post_get with {}."
          discovery)
   else if includes_tool "keeper_tool_search" allowed_tools then
     Some
@@ -96,57 +97,127 @@ let recovery_hint ~allowed_tools ~tool_names =
   else
     None
 
-let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns ~allowed_tools
-    ~tool_names =
+(** Pure decision logic for the on_idle hook.  Testable without Workspace.config.
+
+    Graduated response to repeated tool calls uses the configured
+    [Env_config_keeper.KeeperKeepalive.idle_skip_threshold]:
+    - For idle counts below [skip_at - 1]: gentle nudge suggesting alternatives
+    - For idle counts at [skip_at - 1]: final warning (stronger nudge)
+      suggesting a different visible tool or a text/no-work completion
+    - For idle counts at or above [skip_at]: Skip (end this turn, but the
+      heartbeat loop will retry next cycle)
+
+    The [~allowed_tools] parameter enables concrete alternative suggestions
+    instead of generic "try a different tool" messages. This is the
+    deterministic envelope providing structured options for the
+    non-deterministic LLM to choose from.
+
+    Skip is not death. The keeper's heartbeat loop will schedule a new
+    turn on the next cycle with fresh context. The key insight is that
+    burning more tokens on a stuck LLM is worse than retrying later. *)
+let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
+    ~allowed_tools ~tool_names
+  : Agent_sdk.Hooks.hook_decision =
+  let tools_str = match tool_names with
+    | [] -> "<none>"
+    | names -> String.concat ", " names
+  in
+  let alternatives =
+    let base =
+      suggest_alternatives ~allowed_tools ~repeated_tools:tool_names
+        ~max_suggestions:5
+    in
+    let preferred =
+      if includes_tool "keeper_tool_search" tool_names then
+        allowed_visible_candidates
+          [ "Grep"; "tool_search_files"; "Read"; "tool_read_file"; "Execute"; "tool_execute" ]
+          ~allowed_tools
+      else if includes_tool "keeper_tools_list" tool_names
+              && includes_tool "keeper_surface_read" allowed_tools
+      then
+        [ "keeper_surface_read" ]
+      else
+        []
+    in
+    Keeper_types_profile_toml_normalizers.dedupe_keep_order
+      (preferred @ base)
+    |> schema_visible_keep_order
+    |> List.filteri (fun i _ -> i < 5)
+  in
+  let alt_str = match alternatives with
+    | [] -> "a different visible tool, or finish with a direct no-work/status response"
+    | alts -> String.concat ", " alts
+  in
+  let hint = recovery_hint ~allowed_tools ~tool_names in
+  let append_hint msg =
+    match hint with
+    | None -> msg
+    | Some hint -> msg ^ " " ^ hint
+  in
   if consecutive_idle_turns >= skip_at then
-    let hint = recovery_hint ~allowed_tools ~tool_names in
-    let alternatives =
-      suggest_alternatives ~allowed_tools ~repeated_tools:tool_names ~max_suggestions:3
-    in
-    let decision =
-      match hint with
-      | Some hint_text ->
-        let msg =
-          Printf.sprintf
-            "You have been idle for %d consecutive turns. %s\n\n\
-             Consider one of these tools instead: %s"
-            consecutive_idle_turns hint_text
-            (String.concat ", " alternatives)
-        in
-        Hook_decision.Suggest msg
-      | None ->
-        let msg =
-          Printf.sprintf
-            "You have been idle for %d consecutive turns. \
-             Consider one of these tools instead: %s"
-            consecutive_idle_turns
-            (String.concat ", " alternatives)
-        in
-        Hook_decision.Suggest msg
-    in
-    decision
+    Agent_sdk.Hooks.Skip
+  else if consecutive_idle_turns = skip_at - 1 then
+    Agent_sdk.Hooks.Nudge
+      (append_hint
+         (Printf.sprintf
+            "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
+             Use one of these instead: %s."
+            tools_str consecutive_idle_turns alt_str))
   else
-    Hook_decision.Pass
+    Agent_sdk.Hooks.Nudge
+      (append_hint
+         (Printf.sprintf
+            "You are repeating %s without progress. \
+             Available alternatives: %s."
+            tools_str alt_str))
 
-let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names =
-  on_idle_decision_with_threshold ~skip_at:3 ~consecutive_idle_turns ~allowed_tools
-    ~tool_names
+(** Wrapper around {!on_idle_decision_with_threshold} that supplies the
+    [idle_skip_threshold] constant from [Env_config_keeper.KeeperKeepalive].
+    Reads the keeper's allowed tool names from [meta_ref] for concrete
+    alternative suggestions. *)
+let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
+  : Agent_sdk.Hooks.hook_decision =
+  let skip_at = Env_config_keeper.KeeperKeepalive.idle_skip_threshold in
+  on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
+    ~allowed_tools ~tool_names
 
-let keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names =
-  let meta = !meta_ref in
-  let allowed_tools = meta.allowed_tools in
-  on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
+let keeper_idle_decision
+    ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
+    ~consecutive_idle_turns
+    ~tool_names =
+  let keeper_name = (!meta_ref).name in
+  Otel_metric_store.set_gauge
+    Keeper_metrics.(to_string ConsecutiveIdle)
+    ~labels:[ label_keeper, keeper_name ]
+    (Float.of_int (max 0 consecutive_idle_turns));
+  let allowed_tools =
+    Keeper_tool_policy.keeper_allowed_tool_names !meta_ref in
+  let decision =
+    on_idle_decision ~consecutive_idle_turns ~tool_names
+      ~allowed_tools in
+  let tools_str = match tool_names with
+    | [] -> "<none>" | names -> String.concat ", " names in
+  (match decision with
+   | Agent_sdk.Hooks.Skip ->
+     Log.Keeper.warn ~keeper_name "idle_turns=%d repeated_tools=[%s] — requesting stop"
+       consecutive_idle_turns tools_str
+   | Agent_sdk.Hooks.Nudge _ ->
+     Log.Keeper.info ~keeper_name "idle_turns=%d tools=[%s] — nudging LLM via Nudge"
+       consecutive_idle_turns tools_str
+   | _ -> ());
+  decision
 
 let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
-    (history : Yojson.Safe.t list) : int =
-  let now = Unix.time () in
-  history
-  |> List.filter_map (fun entry ->
-         match entry with
-         | `Assoc fields ->
-           (match List.assoc_opt "tool" fields, List.assoc_opt "timestamp" fields with
-           | Some (`String name), Some (`Float ts) when String.equal name tool_name ->
-             if now -. ts <= within_sec then Some () else None
-           | _ -> None)
-         | _ -> None)
-  |> List.length
+    (entries : Yojson.Safe.t list) : int =
+  let now = Time_compat.now () in
+  let rec loop count = function
+    | [] -> count
+    | entry :: rest ->
+      (match Safe_ops.json_string_opt "tool" entry,
+              Safe_ops.json_float_opt "ts" entry with
+       | Some logged_tool, Some ts
+         when String.equal logged_tool tool_name && now -. ts <= within_sec ->
+           loop (count + 1) rest
+       | _ -> count)
+  in
+  loop 0 (List.rev entries)

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -19,6 +19,7 @@ let suggest_alternatives ~(allowed_tools : string list)
      let len = List.length candidates in
      if len <= max_suggestions then candidates
      else List.filteri (fun i _ -> i < max_suggestions) candidates
+  |> schema_visible_keep_order
 
 let includes_tool name tools = List.exists (String.equal name) tools
 
@@ -85,133 +86,67 @@ let recovery_hint ~allowed_tools ~tool_names =
        this hint above) — the nudge must name the tool that actually exists. *)
     Some
       (Printf.sprintf
-         "keeper_board_post_get requires post_id; if no post_id is visible, use %s first. \
-          Do not call keeper_board_post_get with {}."
+         "keeper_board_post_get requires an exact post_id from board activity. \
+          Use %s to discover one before calling keeper_board_post_get."
          discovery)
+  else if includes_tool "keeper_tool_search" allowed_tools then
+    Some
+      "Use keeper_tool_search with a keyword to discover available tools. \
+       If the tool you need is not listed, report that it is unavailable."
   else
     None
 
-(** Pure decision logic for the on_idle hook.  Testable without Workspace.config.
-
-    Graduated response to repeated tool calls uses the configured
-    [Env_config_keeper.KeeperKeepalive.idle_skip_threshold]:
-    - For idle counts below [skip_at - 1]: gentle nudge suggesting alternatives
-    - For idle counts at [skip_at - 1]: final warning (stronger nudge)
-      suggesting a different visible tool or a text/no-work completion
-    - For idle counts at or above [skip_at]: Skip (end this turn, but the
-      heartbeat loop will retry next cycle)
-
-    The [~allowed_tools] parameter enables concrete alternative suggestions
-    instead of generic "try a different tool" messages. This is the
-    deterministic envelope providing structured options for the
-    non-deterministic LLM to choose from.
-
-    Skip is not death. The keeper's heartbeat loop will schedule a new
-    turn on the next cycle with fresh context. The key insight is that
-    burning more tokens on a stuck LLM is worse than retrying later. *)
-let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
-    ~allowed_tools ~tool_names
-  : Agent_sdk.Hooks.hook_decision =
-  let tools_str = match tool_names with
-    | [] -> "<none>"
-    | names -> String.concat ", " names
-  in
-  let alternatives =
-    let base =
-      suggest_alternatives ~allowed_tools ~repeated_tools:tool_names
-        ~max_suggestions:5
-    in
-    let preferred =
-      if includes_tool "keeper_tool_search" tool_names then
-        allowed_visible_candidates
-          [ "Grep"; "tool_search_files"; "Read"; "tool_read_file"; "Execute"; "tool_execute" ]
-          ~allowed_tools
-      else if includes_tool "keeper_tools_list" tool_names
-              && includes_tool "keeper_surface_read" allowed_tools
-      then
-        [ "keeper_surface_read" ]
-      else
-        []
-    in
-    Keeper_types_profile_toml_normalizers.dedupe_keep_order
-      (preferred @ base)
-    |> schema_visible_keep_order
-    |> List.filteri (fun i _ -> i < 5)
-  in
-  let alt_str = match alternatives with
-    | [] -> "a different visible tool, or finish with a direct no-work/status response"
-    | alts -> String.concat ", " alts
-  in
-  let hint = recovery_hint ~allowed_tools ~tool_names in
-  let append_hint msg =
-    match hint with
-    | None -> msg
-    | Some hint -> msg ^ " " ^ hint
-  in
-  if consecutive_idle_turns >= skip_at then
-    Agent_sdk.Hooks.Skip
-  else if consecutive_idle_turns = skip_at - 1 then
-    Agent_sdk.Hooks.Nudge
-      (append_hint
-         (Printf.sprintf
-            "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
-             Use one of these instead: %s."
-            tools_str consecutive_idle_turns alt_str))
-  else
-    Agent_sdk.Hooks.Nudge
-      (append_hint
-         (Printf.sprintf
-            "You are repeating %s without progress. \
-             Available alternatives: %s."
-            tools_str alt_str))
-
-(** Wrapper around {!on_idle_decision_with_threshold} that supplies the
-    [idle_skip_threshold] constant from [Env_config_keeper.KeeperKeepalive].
-    Reads the keeper's allowed tool names from [meta_ref] for concrete
-    alternative suggestions. *)
-let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
-  : Agent_sdk.Hooks.hook_decision =
-  let skip_at = Env_config_keeper.KeeperKeepalive.idle_skip_threshold in
-  on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
-    ~allowed_tools ~tool_names
-
-let keeper_idle_decision
-    ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
-    ~consecutive_idle_turns
+let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns ~allowed_tools
     ~tool_names =
-  let keeper_name = (!meta_ref).name in
-  Otel_metric_store.set_gauge
-    Keeper_metrics.(to_string ConsecutiveIdle)
-    ~labels:[ label_keeper, keeper_name ]
-    (Float.of_int (max 0 consecutive_idle_turns));
-  let allowed_tools =
-    Keeper_tool_policy.keeper_allowed_tool_names !meta_ref in
-  let decision =
-    on_idle_decision ~consecutive_idle_turns ~tool_names
-      ~allowed_tools in
-  let tools_str = match tool_names with
-    | [] -> "<none>" | names -> String.concat ", " names in
-  (match decision with
-   | Agent_sdk.Hooks.Skip ->
-     Log.Keeper.warn ~keeper_name "idle_turns=%d repeated_tools=[%s] — requesting stop"
-       consecutive_idle_turns tools_str
-   | Agent_sdk.Hooks.Nudge _ ->
-     Log.Keeper.info ~keeper_name "idle_turns=%d tools=[%s] — nudging LLM via Nudge"
-       consecutive_idle_turns tools_str
-   | _ -> ());
-  decision
+  if consecutive_idle_turns >= skip_at then
+    let hint = recovery_hint ~allowed_tools ~tool_names in
+    let alternatives =
+      suggest_alternatives ~allowed_tools ~repeated_tools:tool_names ~max_suggestions:3
+    in
+    let decision =
+      match hint with
+      | Some hint_text ->
+        let msg =
+          Printf.sprintf
+            "You have been idle for %d consecutive turns. %s\n\n\
+             Consider one of these tools instead: %s"
+            consecutive_idle_turns hint_text
+            (String.concat ", " alternatives)
+        in
+        Hook_decision.Suggest msg
+      | None ->
+        let msg =
+          Printf.sprintf
+            "You have been idle for %d consecutive turns. \
+             Consider one of these tools instead: %s"
+            consecutive_idle_turns
+            (String.concat ", " alternatives)
+        in
+        Hook_decision.Suggest msg
+    in
+    decision
+  else
+    Hook_decision.Pass
+
+let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names =
+  on_idle_decision_with_threshold ~skip_at:3 ~consecutive_idle_turns ~allowed_tools
+    ~tool_names
+
+let keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names =
+  let meta = !meta_ref in
+  let allowed_tools = meta.allowed_tools in
+  on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
 
 let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
-    (entries : Yojson.Safe.t list) : int =
-  let now = Time_compat.now () in
-  let rec loop count = function
-    | [] -> count
-    | entry :: rest ->
-      (match Safe_ops.json_string_opt "tool" entry,
-              Safe_ops.json_float_opt "ts" entry with
-       | Some logged_tool, Some ts
-         when String.equal logged_tool tool_name && now -. ts <= within_sec ->
-           loop (count + 1) rest
-       | _ -> count)
-  in
-  loop 0 (List.rev entries)
+    (history : Yojson.Safe.t list) : int =
+  let now = Unix.time () in
+  history
+  |> List.filter_map (fun entry ->
+         match entry with
+         | `Assoc fields ->
+           (match List.assoc_opt "tool" fields, List.assoc_opt "timestamp" fields with
+           | Some (`String name), Some (`Float ts) when String.equal name tool_name ->
+             if now -. ts <= within_sec then Some () else None
+           | _ -> None)
+         | _ -> None)
+  |> List.length

--- a/test/test_keeper_unified_metacognition.ml
+++ b/test/test_keeper_unified_metacognition.ml
@@ -212,6 +212,45 @@ let test_on_idle_tool_search_loop_maps_internal_file_tools () =
             (Agent_sdk.Hooks.classify_decision other)))
 ;;
 
+let test_on_idle_alternatives_use_visible_aliases () =
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:1
+      ~allowed_tools:
+        [ "tool_write_file"; "tool_read_file"; "tool_execute" ]
+      ~tool_names:[ "keeper_board_list" ]
+  in
+  match decision with
+  | Agent_sdk.Hooks.Nudge msg ->
+    check
+      bool
+      "idle alternatives expose visible aliases"
+      true
+      (contains_substring msg "Available alternatives: Write, Read, Execute");
+    check
+      bool
+      "idle alternatives hide internal write id"
+      false
+      (contains_substring msg "tool_write_file");
+    check
+      bool
+      "idle alternatives hide internal read id"
+      false
+      (contains_substring msg "tool_read_file");
+    check
+      bool
+      "idle alternatives hide internal execute id"
+      false
+      (contains_substring msg "tool_execute")
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected Nudge, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
+
 let test_on_idle_final_warning_before_skip () =
   let decision =
     HK.on_idle_decision_with_threshold
@@ -321,6 +360,10 @@ let () =
             "on_idle tool_search loop maps internal file tools"
             `Quick
             test_on_idle_tool_search_loop_maps_internal_file_tools
+        ; test_case
+            "on_idle alternatives use visible aliases"
+            `Quick
+            test_on_idle_alternatives_use_visible_aliases
         ; test_case
             "on_idle final warning before skip"
             `Quick


### PR DESCRIPTION
## Summary

Narrow task-1838 to the visible-text feedback guard in `lib/keeper/keeper_hooks_oas_idle.ml`, with direct regression coverage in `test/test_keeper_unified_metacognition.ml`.

## Problem

`keeper_hooks_oas_idle.ml` emitted some idle feedback alternatives from internal keeper tool names. When that text is shown to an LLM/operator, it can suggest names that are not the schema-visible public tool names.

## Fix

- Project idle alternative output through the existing schema-visible mapper.
- Keep the existing idle hook runtime contract intact: `Agent_sdk.Hooks.Nudge/Skip`, configured idle skip threshold, keeper allowed-tool policy, metrics/log side effects, and recent history parsing remain in place.
- Add a regression test proving internal ids such as `tool_write_file`, `tool_read_file`, and `tool_execute` are emitted as visible aliases (`Write`, `Read`, `Execute`) in idle alternatives.
- Narrowed this PR back to task-1838 scope so it no longer carries the overlapping OCaml 5.5/toolchain/replay-fixture changes owned by #23369/#23370/#23372/#23395.

## Scope

- `lib/keeper/keeper_hooks_oas_idle.ml`
- `test/test_keeper_unified_metacognition.ml`

## Evidence

- Current head: `bc1ffad43d`
- Diff scope: `gh pr diff 23399 --repo jeong-sik/masc --name-only` -> the two files listed above
- Local focused checks: `ocamlformat --check lib/keeper/keeper_hooks_oas_idle.ml test/test_keeper_unified_metacognition.ml`; `git diff --check origin/main...HEAD`; `python3 scripts/check_test_coverage.py`
- Dune/build authority: GitHub CI

## Task

Closes task-1838: Implement visible-text feedback guard in keeper_hooks_oas_idle.ml
