### PR TITLE
fix(exec): floor gh destructive ops behind leading global flags (#23390)

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -4188,11 +4188,19 @@ let rec parse subcmd act draft squash del_branch body title search state rest = 
                }))
      | None -> None)
   | arg :: args ->
-    (match subcmd with
-     | None -> parse (Some arg) act draft squash del_branch body title search state rest args
-     | Some _ when act = None && String.length arg > 0 && arg.[0] <> '-' ->
+    let is_flag = String.length arg > 0 && arg.[0] = '-' in
+    (match subcmd, act with
+     (* First non-flag token is the subcommand; the second is the action.
+        Flags — whether they appear BEFORE the subcommand (gh/Cobra accepts
+        global flags like [--repo o/r] ahead of the subcommand) or after it —
+        fall through to the flag handling below, which consumes value-taking
+        flags. Routing leading flags through the same handling keeps the real
+        subcommand from being shadowed by a flag or its value (issue #23390). *)
+     | None, _ when not is_flag ->
+       parse (Some arg) act draft squash del_branch body title search state rest args
+     | Some _, None when not is_flag ->
        parse subcmd (Some arg) draft squash del_branch body title search state rest args
-     | Some _ ->
+     | _ ->
        (match arg with
         | "--draft" -> parse subcmd act true squash del_branch body title search state rest args
         | "--squash" -> parse subcmd act draft true del_branch body title search state rest args

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -164,7 +164,22 @@ let repo_hosting_cli_is_floored (bin : Exec_program.t) (args : Shell_ir.arg list
   match Exec_program.known bin with
   | Some Exec_program.Gh ->
     let words = Exec_program.to_string bin :: List.map repo_hosting_arg_word args in
-    (match Shell_ir_risk.classify_repo_hosting_cli words with
+    (* Classify through [repo_hosting_cli_floor_risk], not the word-list
+       classifier alone: a leading value-taking global flag ([gh --repo o/r pr
+       merge]) shifts the subcommand out of the word-list's position-based
+       slot, so the naive classifier misses the destructive verb and the floor
+       never fires (issue #23390). The typed lowering consumes value-flags like
+       gh does, locating the real subcommand. *)
+    let simple : Shell_ir.simple =
+      { Shell_ir.bin
+      ; args
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Sandbox_target.host ()
+      }
+    in
+    (match Shell_ir_risk.repo_hosting_cli_floor_risk words simple with
      | R2_Irreversible | Destructive_protected -> true
      | R0_Read | R1_Reversible_mutation -> false)
   | Some _ | None -> false

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -478,6 +478,18 @@ let classify_repo_hosting_cli (words : string list) : risk_class =
     else if in_table repo_hosting_cli_reversible_mutations command sub then R1_Reversible_mutation
     else R0_Read
 
+(* Subcommand-table risk for a known gh family. Shared by [risk_of_gh_verb]
+   (typed opinion) and [repo_hosting_cli_floor_risk] (enforcement floor) so the
+   subcommand tables are the single risk source. A table-absent action is a
+   read (R0): most such actions in a known family are reads (view/list/status)
+   and we cannot distinguish them from a genuinely unknown action without a
+   reads table. *)
+let table_risk_of_gh_family (command : string) (action : string) : risk_class =
+  if in_table repo_hosting_cli_irreversible_ops command action then R2_Irreversible
+  else if in_table repo_hosting_cli_reversible_mutations command action then
+    R1_Reversible_mutation
+  else R0_Read
+
 (* RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
 
    [risk_of_gh_verb] is the closed-sum lens over [classify_repo_hosting_cli]:
@@ -521,13 +533,7 @@ let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
        default so the "no action" case is a decision, not a silent fold. *)
     (match v.Gh_verb.action with
      | None -> R0_Read
-     | Some action ->
-       let command = Gh_verb.family_token fam in
-       if in_table repo_hosting_cli_irreversible_ops command action then
-         R2_Irreversible
-       else if in_table repo_hosting_cli_reversible_mutations command action
-       then R1_Reversible_mutation
-       else R0_Read)
+     | Some action -> table_risk_of_gh_family (Gh_verb.family_token fam) action)
 
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)
@@ -946,6 +952,54 @@ let risk_rank = function
 ;;
 
 let max_risk a b = if risk_rank a >= risk_rank b then a else b
+
+(* Enforcement-floor risk for a gh command, robust to leading global flags.
+
+   [classify_repo_hosting_cli] locates the subcommand as the first non-flag
+   token after "gh", so a leading value-taking global flag ([gh --repo o/r pr
+   merge]) shifts the flag's value ("o/r") into the subcommand slot and the
+   destructive verb ("merge") is missed — the command classifies R0 and the
+   approval catastrophic floor never fires (issue #23390: gh accepts flags
+   before the subcommand via Cobra, so the op executes). This is the floor's
+   SSOT for gh risk, so the miss is an autonomous-keeper bypass.
+
+   Fix: combine two views with [max_risk].
+   - [words]: the existing word-list classifier — retains the string-borne
+     risk it alone sees ([gh api -X DELETE], graphql mutation bodies,
+     positional-token scans).
+   - [simple]: the typed lowering ([Shell_ir_typed.of_simple], whose gh parser
+     consumes value-flags exactly like gh) yields the correctly-located
+     subcommand; [table_risk_of_gh_family] then reads the same subcommand
+     tables. [Api]/[Other]/bare family stay R0 here — this fix restores correct
+     subcommand location WITHOUT changing the historical "unknown gh subcommand
+     is R0" floor semantics (fail-closing unknown gh is RFC-0309 W3, not this
+     bug fix). *)
+let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
+  : risk_class
+  =
+  let word_risk = classify_repo_hosting_cli words in
+  let typed_risk =
+    (* [@warning "-4"]: only the [Gh] constructor is of interest; every other
+       typed command (and the [Generic] escape hatch for non-literal argv) is
+       not a repo-hosting op, so it floors nothing here and the word-list path
+       above already covers it. Same find-first rationale as
+       [Approval_policy.find_destructive_repo_hosting_cli]. *)
+    match Shell_ir_typed.of_simple simple with
+    | Shell_ir_typed.W (Shell_ir_typed_types.Gh { subcommand; action; _ }) -> (
+      let v = Gh_verb.of_fields ~subcommand ~action in
+      match v.Gh_verb.family, v.Gh_verb.action with
+      | (Gh_verb.Api | Gh_verb.Other _), _ | _, None -> R0_Read
+      | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+          | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key
+          | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset
+          | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as
+        fam )
+      , Some action ->
+        table_risk_of_gh_family (Gh_verb.family_token fam) action)
+    | Shell_ir_typed.W _ -> R0_Read
+  in
+  max_risk word_risk typed_risk
+[@@warning "-4"]
 
 let redirect_risk = function
   | Redirect_scope.File { mode = (Redirect_scope.Write | Redirect_scope.Append); _ } ->

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -213,7 +213,38 @@ let gh_floor_words_of_simple (simple : Shell_ir.simple) =
          | None -> collect ("" :: acc) rest)
     in
     collect [] simple.args
-  | Some _ | None -> None
+  | Some
+      ( Exec_program.Ls | Exec_program.Cat | Exec_program.Pwd | Exec_program.Echo
+      | Exec_program.Head | Exec_program.Tail | Exec_program.Rg | Exec_program.Grep
+      | Exec_program.Find | Exec_program.Which | Exec_program.Test
+      | Exec_program.Basename | Exec_program.Dirname | Exec_program.Stat
+      | Exec_program.Du | Exec_program.Df | Exec_program.Sort | Exec_program.Uniq
+      | Exec_program.Wc | Exec_program.Cut | Exec_program.Tr | Exec_program.File
+      | Exec_program.Printf | Exec_program.Date | Exec_program.Env
+      | Exec_program.Printenv | Exec_program.Hostname | Exec_program.Whoami
+      | Exec_program.Uname | Exec_program.Ps | Exec_program.Tty | Exec_program.Cp
+      | Exec_program.Mv | Exec_program.Ln | Exec_program.Touch | Exec_program.Tee
+      | Exec_program.Awk | Exec_program.Xargs | Exec_program.Git
+      | Exec_program.Docker | Exec_program.Curl | Exec_program.Wget | Exec_program.Ssh
+      | Exec_program.Scp | Exec_program.Tar | Exec_program.Rsync | Exec_program.Make
+      | Exec_program.Cmake | Exec_program.Dune_local_sh | Exec_program.Diff
+      | Exec_program.Patch | Exec_program.Mkdir | Exec_program.Npm | Exec_program.Node
+      | Exec_program.Npx | Exec_program.Yarn | Exec_program.Pnpm | Exec_program.Pip
+      | Exec_program.Python | Exec_program.Python3 | Exec_program.Pytest
+      | Exec_program.Pyright | Exec_program.Ruff | Exec_program.Opam
+      | Exec_program.Ocamlfind | Exec_program.Tsc | Exec_program.Cargo
+      | Exec_program.Rustc | Exec_program.Go | Exec_program.Gofmt | Exec_program.Gradle
+      | Exec_program.Java | Exec_program.Javac | Exec_program.Mvn | Exec_program.Ninja
+      | Exec_program.Sed | Exec_program.Uv | Exec_program.Glab
+      | Exec_program.Terminal_notifier | Exec_program.Osascript | Exec_program.Play
+      | Exec_program.Rec | Exec_program.Ffplay | Exec_program.Mpg123 | Exec_program.Open
+      | Exec_program.Psql | Exec_program.Mysql | Exec_program.Mariadb
+      | Exec_program.Cockroach | Exec_program.Sudo | Exec_program.Su
+      | Exec_program.Chmod | Exec_program.Chown | Exec_program.Rm | Exec_program.Dd
+      | Exec_program.Mkfs | Exec_program.Shutdown | Exec_program.Reboot
+      | Exec_program.Halt | Exec_program.Poweroff ) ->
+    None
+  | None -> None
 ;;
 
 let normalize_command_words words =

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -166,6 +166,56 @@ let rec skip_gh_global_options = function
   | parts -> parts
 ;;
 
+let shell_arg_literal = function
+  | Shell_ir.Lit (s, _) -> Some s
+  | Shell_ir.Var _ | Shell_ir.Concat _ -> None
+;;
+
+let gh_global_value_option = function
+  | "--repo" | "-R" | "--hostname" | "--config" | "--git-protocol" -> true
+  | _ -> false
+;;
+
+let gh_global_bool_option = function
+  | "--help" | "-h" | "--version" | "--debug" | "--verbose" | "--no-color"
+  | "--paginate" ->
+    true
+  | _ -> false
+;;
+
+let gh_global_eq_value_option opt =
+  String.length opt > 1
+  && opt.[0] = '-'
+  && (String.starts_with ~prefix:"--repo=" opt
+      || String.starts_with ~prefix:"-R=" opt
+      || String.starts_with ~prefix:"--hostname=" opt
+      || String.starts_with ~prefix:"--config=" opt
+      || String.starts_with ~prefix:"--git-protocol=" opt)
+;;
+
+let gh_floor_words_of_simple (simple : Shell_ir.simple) =
+  match Exec_program.known simple.bin with
+  | Some Exec_program.Gh ->
+    let rec collect acc = function
+      | [] -> Some (Exec_program.to_string simple.bin :: List.rev acc)
+      | arg :: rest ->
+        (match shell_arg_literal arg with
+         | Some opt when gh_global_value_option opt ->
+           let rest =
+             match rest with
+             | [] -> []
+             | _value :: rest -> rest
+           in
+           collect acc rest
+         | Some opt when gh_global_bool_option opt || gh_global_eq_value_option opt ->
+           collect acc rest
+         | Some word -> collect (word :: acc) rest
+         | None -> collect ("" :: acc) rest)
+    in
+    collect [] simple.args
+  | Some _ | None -> None
+;;
+
 let normalize_command_words words =
   match strip_env_prefix words with
   | "git" :: rest -> "git" :: skip_git_global_options rest
@@ -963,10 +1013,13 @@ let max_risk a b = if risk_rank a >= risk_rank b then a else b
    before the subcommand via Cobra, so the op executes). This is the floor's
    SSOT for gh risk, so the miss is an autonomous-keeper bypass.
 
-   Fix: combine two views with [max_risk].
+   Fix: combine three views with [max_risk].
    - [words]: the existing word-list classifier — retains the string-borne
      risk it alone sees ([gh api -X DELETE], graphql mutation bodies,
-     positional-token scans).
+     positional-token scans) when argv is all literal.
+   - [simple] arg words: an enforcement-only view that consumes known gh global
+     value flags directly from [Shell_ir.arg], so dynamic flag values cannot
+     shadow the real family/action slot.
    - [simple]: the typed lowering ([Shell_ir_typed.of_simple], whose gh parser
      consumes value-flags exactly like gh) yields the correctly-located
      subcommand; [table_risk_of_gh_family] then reads the same subcommand
@@ -978,6 +1031,11 @@ let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
   : risk_class
   =
   let word_risk = classify_repo_hosting_cli words in
+  let arg_word_risk =
+    match gh_floor_words_of_simple simple with
+    | Some words -> classify_repo_hosting_cli words
+    | None -> R0_Read
+  in
   let typed_risk =
     (* [@warning "-4"]: only the [Gh] constructor is of interest; every other
        typed command (and the [Generic] escape hatch for non-literal argv) is
@@ -998,7 +1056,7 @@ let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
         table_risk_of_gh_family (Gh_verb.family_token fam) action)
     | Shell_ir_typed.W _ -> R0_Read
   in
-  max_risk word_risk typed_risk
+  max_risk word_risk (max_risk arg_word_risk typed_risk)
 [@@warning "-4"]
 
 let redirect_risk = function

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -93,9 +93,11 @@ val classify_repo_hosting_cli : string list -> risk_class
 val repo_hosting_cli_floor_risk : string list -> Shell_ir.simple -> risk_class
 (** Enforcement-floor risk for a gh command, robust to leading global flags
     (issue #23390). [max] of [classify_repo_hosting_cli words] (string-borne
-    risk: [gh api -X DELETE], graphql bodies) and the typed lowering of
-    [simple] (whose gh parser consumes value-flags like gh, so the subcommand
-    is located correctly even after [gh --repo o/r pr merge]). Keeps the
+    risk: [gh api -X DELETE], graphql bodies), an enforcement-only [simple]
+    arg view that consumes known gh global value flags even when their values
+    are dynamic, and the typed lowering of [simple] (whose gh parser consumes
+    literal value-flags like gh, so the subcommand is located correctly even
+    after [gh --repo o/r pr merge]). Keeps the
     historical floor semantics — unrecognized gh subcommand / [Api] / bare
     family stay [R0_Read]; fail-closing unknown gh is RFC-0309 W3, not here.
     Used by [Approval_policy.repo_hosting_cli_is_floored]. *)

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -90,6 +90,16 @@ val classify_repo_hosting_cli : string list -> risk_class
     The current command literal is ["gh"], but the API is named for the
     Shell-IR capability boundary rather than a product-level GH helper family. *)
 
+val repo_hosting_cli_floor_risk : string list -> Shell_ir.simple -> risk_class
+(** Enforcement-floor risk for a gh command, robust to leading global flags
+    (issue #23390). [max] of [classify_repo_hosting_cli words] (string-borne
+    risk: [gh api -X DELETE], graphql bodies) and the typed lowering of
+    [simple] (whose gh parser consumes value-flags like gh, so the subcommand
+    is located correctly even after [gh --repo o/r pr merge]). Keeps the
+    historical floor semantics — unrecognized gh subcommand / [Api] / bare
+    family stay [R0_Read]; fail-closing unknown gh is RFC-0309 W3, not here.
+    Used by [Approval_policy.repo_hosting_cli_is_floored]. *)
+
 val risk_of_gh_verb : Gh_verb.t -> risk_class
 (** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
     Reads the same subcommand tables as [classify_repo_hosting_cli] for known

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -393,6 +393,48 @@ let test_gh_reversible_repo_hosting_ops_allowed_under_autonomous () =
   | Verdict.Allow t -> assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
   | _ -> Alcotest.fail "gh pr create should remain allowed under autonomous"
 
+(* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
+   pr merge]) must not slip the destructive op past the floor. gh (Cobra)
+   accepts flags before the subcommand and consumes their values, so the
+   word-list classifier's position-based subcommand slot is wrong; the typed
+   lowering locates the real subcommand. *)
+let test_gh_leading_flag_destructive_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: leading-flag destructive op must be floored" label)
+    [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
+    ; "gh --repo o/r pr ready", [ "--repo"; "o/r"; "pr"; "ready"; "123" ]
+    ; "gh --repo o/r repo delete"
+      , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
+    ]
+
+(* Control: a leading global flag on a READ must NOT be over-blocked — the fix
+   restores correct subcommand location without flooring reads. *)
+let test_gh_leading_flag_read_not_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
+         Alcotest.failf "%s: leading-flag read must not be floored" label
+       | _ -> ())
+    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
+    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    ]
+
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
    common force-delete-untracked form) is destructive and hits the floor.
    Probe finding 2026-06-18: [git clean -fd] was graded as plain audited git
@@ -502,6 +544,8 @@ let () =
   test_gh_irreversible_repo_hosting_ops_denied_under_autonomous ();
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
+  test_gh_leading_flag_destructive_floored_under_autonomous ();
+  test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -417,12 +417,35 @@ let test_gh_leading_flag_destructive_floored_under_autonomous () =
       , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
     ]
 
+let test_gh_leading_dynamic_flag_destructive_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: dynamic leading-flag destructive op must be floored" label)
+    [ ( "gh --repo $REPO pr merge"
+      , [ lit "--repo"; var "REPO"; lit "pr"; lit "merge"; lit "5" ] )
+    ; ( "gh --repo o/r pr merge $PR_NUMBER"
+      , [ lit "--repo"; lit "o/r"; lit "pr"; lit "merge"; var "PR_NUMBER" ] )
+    ; ( "gh --hostname $HOST api -X DELETE"
+      , [ lit "--hostname"; var "HOST"; lit "api"; lit "-X"; lit "DELETE"
+        ; lit "/repos/owner/repo"
+        ] )
+    ]
+
 (* Control: a leading global flag on a READ must NOT be over-blocked — the fix
    restores correct subcommand location without flooring reads. *)
 let test_gh_leading_flag_read_not_floored_under_autonomous () =
   List.iter
     (fun (label, args) ->
-       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let s = simple (bin_ok "gh") ~args in
        let caps = Capability_check.of_simple s in
        match
          Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
@@ -431,8 +454,10 @@ let test_gh_leading_flag_read_not_floored_under_autonomous () =
        | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
          Alcotest.failf "%s: leading-flag read must not be floored" label
        | _ -> ())
-    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
-    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    [ "gh --repo o/r pr view", [ lit "--repo"; lit "o/r"; lit "pr"; lit "view"; lit "123" ]
+    ; "gh --repo o/r pr list", [ lit "--repo"; lit "o/r"; lit "pr"; lit "list" ]
+    ; ( "gh --repo $REPO pr view $PR_NUMBER"
+      , [ lit "--repo"; var "REPO"; lit "pr"; lit "view"; var "PR_NUMBER" ] )
     ]
 
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
@@ -545,6 +570,7 @@ let () =
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
   test_gh_leading_flag_destructive_floored_under_autonomous ();
+  test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)


### PR DESCRIPTION
## What

승인 catastrophic floor의 gh bypass 수정 (issue #23390).

- `bin/gen_shell_ir_walkers.ml` (gh `parse_body`): leading flag를 subcommand 확정 전에 **post-subcommand와 동일한 flag 처리**로 라우팅(value-taking flag는 값까지 소비). subcommand/action은 non-flag 토큰에만 할당. → `of_simple`이 global flag 뒤의 진짜 subcommand를 정확히 찾음.
- `lib/exec/shell_ir_risk.ml`: `repo_hosting_cli_floor_risk = max(word-list 분류기, typed subcommand 테이블 조회)`. 공유 헬퍼 `table_risk_of_gh_family`로 `risk_of_gh_verb`와 테이블 SSOT 공유.
- `lib/exec/approval_policy.ml`: `repo_hosting_cli_is_floored`가 위 함수 사용.

## Why (실측 확인된 exploit)

gh는 Cobra 기반이라 subcommand 앞 global flag를 허용하고 값을 소비합니다. `gh --repo cli/cli pr list`가 **실제 실행됨(exit 0)** 을 확인했고, 따라서 `gh --repo o/r pr merge`도 실행됩니다.

문제: word-list 분류기(`classify_repo_hosting_cli`)와 typed 파서(`parse_body`) **둘 다** "gh 다음 첫 토큰 = subcommand"로 가정. `gh --repo o/r pr merge`에서 `--repo`의 값 `o/r`이 subcommand 슬롯을 먹어 destructive verb `merge`를 놓침 → R0으로 분류 → `repo_hosting_cli_is_floored`(R2/Destructive에서만 floor) 미발화 → autonomous overlay Observe → **무승인 merge 실행**.

실측 (`test_approval_policy.ml` 통과 전 probe):
```
--repo o/r pr merge 5      => floor=R0  (fix 후 R2)
--repo o/r repo delete o/r => floor=R0  (fix 후 R2)
```

## 근본 수정 방향

- **parse_body(SSOT)에서 leading flag skip** — value-flag 목록이 이미 거기 있으므로 중복 없이 근본 수정. `of_simple`/`risk_of_typed`(RFC-0309 W1) 전체가 leading-flag에 정확해지는 부수 효과.
- floor는 word-list(gh api -X/graphql string-borne risk 보존) ⊔ typed subcommand의 max. **floor 의미 불변**: unrecognized subcommand / api / bare family는 R0 유지 — unknown gh를 fail-close하는 건 RFC-0309 W3, 이 버그 fix 아님. read 과다차단 없음(control 테스트로 증명).

## 검증

- `test_approval_policy`: leading-flag pr merge / pr ready / repo delete = **Denied**; leading-flag pr view / pr list = **not floored**(read 보존). all tests passed.
- 전체 `@lib/exec/test/runtest` green (differential/oracle/typed/e2e — parse_body 변경 회귀 0).
- top-level `test/test_shell_ir_risk` 10/10, keeper + main_eio 빌드 green.
- 전체 meta bug-class gate 로컬 PASS. lib-regression 0(failwith/List.hd/Option.value~default/`| _ -> Some` 추가 없음). ocamlformat clean.

## RFC

RFC-0254 (approval catastrophic floor / verdict). 기존 floor 동작의 버그 수정(신규 capability 아님). Refs #23390. RFC-0309(typed gh) W1의 typed 파서를 정확하게 만드는 후속.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
