### PR TITLE
fix(keeper): extend HITL summary timeout default

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -411,12 +411,14 @@ let keeper_tool_search_top_k () : int =
 
 (* ── HITL context-summary worker policy ─────────────────────── *)
 
-(** Timeout for the HITL summary LLM call. Kept short because the summary
-    is advisory and must not block operator attention. *)
+(** Timeout for the HITL summary LLM call. The summary is advisory and must
+    stay bounded, but it should not use the same fast-local timeout class as
+    dashboard probes: slow providers should still get a usable window to
+    produce the operator briefing. *)
 let hitl_summary_timeout_sec_rp =
   _rp_float ~key:"keeper.hitl_summary.timeout_sec"
     ~default:(fun () -> float_of_env_default "MASC_KEEPER_HITL_SUMMARY_TIMEOUT_SEC"
-                          ~default:30.0 ~min_v:1.0 ~max_v:300.0)
+                          ~default:120.0 ~min_v:1.0 ~max_v:300.0)
     ~min_v:1.0 ~max_v:300.0
     ~description:"HITL context-summary LLM timeout (seconds)" ()
 let hitl_summary_timeout_sec () : float =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -477,6 +477,15 @@ let test_fallback_summary_is_redacted_and_uncertain () =
   check (float 0.0001) "fallback uncertainty" 0.85 summary.uncertainty
 ;;
 
+(* ── Policy defaults ───────────────────────────── *)
+
+let test_hitl_summary_timeout_default_is_operator_scale () =
+  check (float 0.0001)
+    "HITL summary timeout default should allow slow provider briefings"
+    120.0
+    (Keeper_config.hitl_summary_timeout_sec ())
+;;
+
 (* ── Runner ───────────────────────────────────── *)
 
 let () =
@@ -513,6 +522,10 @@ let () =
             test_plain_mode_error_outcomes_record_degradation
         ; test_case "fallback summary is redacted and uncertain" `Quick
             test_fallback_summary_is_redacted_and_uncertain
+        ] )
+    ; ( "policy"
+      , [ test_case "HITL summary timeout default is operator-scale" `Quick
+            test_hitl_summary_timeout_default_is_operator_scale
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Raise the default HITL context-summary LLM timeout from 30s to 120s.
- Keep the existing 300s ceiling and env/runtime-param override path intact.
- Add a regression test pinning the operator-scale default.

## Why
The HITL context summary is an operator briefing, not a fast dashboard probe. A 30s default caused slow providers to time out before producing useful approval context. Latest `main` already falls back deterministically on LLM failure; this PR gives the advisory LLM path a more realistic window before that fallback is needed.

## Validation
- `ocamlformat --check lib/keeper/keeper_config.ml test/test_hitl_summary_worker.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_hitl_summary_worker.exe` was not run to completion: the repo wrapper refused because a separate bare `dune build --root ... @test/runtest-test_dune_local_script` process was already active in another worktree. CI should be the build authority for this PR.