### PR TITLE
[codex] split scheduler runner status surface

### DIFF
--- a/lib/otel_metric_store/otel_runtime_metric_names.ml
+++ b/lib/otel_metric_store/otel_runtime_metric_names.ml
@@ -13,6 +13,12 @@ let metric_inference_queue_rejected = Otel_metric_store_core.declare_counter "ma
 let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
 let metric_agent_heartbeat_age_seconds = "masc_agent_heartbeat_age_seconds"
 let metric_agent_stale_total = Otel_metric_store_core.declare_counter "masc_agent_stale_total"
+
+(* Scheduler runner loop liveness. Incremented once per tick completion by the
+   server maintenance fiber. Labels: [outcome] in {ok, error, crash}. *)
+let metric_schedule_runner_tick_outcomes =
+  Otel_metric_store_core.declare_counter "masc_schedule_runner_tick_outcomes_total"
+
 let metric_gc_minor_words = "masc_gc_minor_words"
 let metric_gc_major_words = "masc_gc_major_words"
 let metric_gc_heap_words = "masc_gc_heap_words"

--- a/lib/otel_metric_store/otel_runtime_metric_names.mli
+++ b/lib/otel_metric_store/otel_runtime_metric_names.mli
@@ -28,6 +28,10 @@ val metric_inference_queue_max_concurrent : string
 val metric_agent_heartbeat_age_seconds : string
 val metric_agent_stale_total : string
 
+(** Scheduler runner loop completions. Labels: [outcome] in
+    {[ok | error | crash]}. *)
+val metric_schedule_runner_tick_outcomes : string
+
 (** {1 OCaml GC sampler gauges}
 
     Populated by {!module:Gc_sampler} once per sampling interval from

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -13,5 +13,6 @@
   schedule_supported_kinds
   schedule_store
   schedule_service
-  schedule_runner)
+  schedule_runner
+  schedule_runner_status)
  (libraries digestif masc_workspace dated_jsonl masc_log masc_core unix yojson))

--- a/lib/schedule/schedule_runner_status.ml
+++ b/lib/schedule/schedule_runner_status.ml
@@ -1,0 +1,271 @@
+type tick_counts =
+  { due_changed : int
+  ; emitted : int
+  ; rescheduled : int
+  ; dispatch_succeeded : int
+  ; dispatch_failed : int
+  ; dispatch_unsupported : int
+  ; dispatch_start_rejected : int
+  ; wake_enqueued : int
+  ; wake_skipped_no_keeper : int
+  ; wake_skipped_missing_schedule : int
+  ; wake_skipped_non_keeper_actor : int
+  ; wake_skipped_unregistered_keeper : int
+  ; wake_failed : int
+  }
+
+type wake_enqueue_counts =
+  { wake_enqueued : int
+  ; wake_skipped_no_keeper : int
+  ; wake_skipped_missing_schedule : int
+  ; wake_skipped_non_keeper_actor : int
+  ; wake_skipped_unregistered_keeper : int
+  ; wake_failed : int
+  }
+
+let empty_wake_enqueue_counts =
+  { wake_enqueued = 0
+  ; wake_skipped_no_keeper = 0
+  ; wake_skipped_missing_schedule = 0
+  ; wake_skipped_non_keeper_actor = 0
+  ; wake_skipped_unregistered_keeper = 0
+  ; wake_failed = 0
+  }
+;;
+
+type snapshot =
+  { tick_in_flight : bool
+  ; tick_count : int
+  ; success_count : int
+  ; failure_count : int
+  ; crash_count : int
+  ; last_tick_started_at : float option
+  ; last_tick_finished_at : float option
+  ; last_success_at : float option
+  ; last_error_at : float option
+  ; last_error : string option
+  ; last_duration_sec : float option
+  ; last_counts : tick_counts option
+  }
+
+let empty =
+  { tick_in_flight = false
+  ; tick_count = 0
+  ; success_count = 0
+  ; failure_count = 0
+  ; crash_count = 0
+  ; last_tick_started_at = None
+  ; last_tick_finished_at = None
+  ; last_success_at = None
+  ; last_error_at = None
+  ; last_error = None
+  ; last_duration_sec = None
+  ; last_counts = None
+  }
+;;
+
+let state = ref empty
+let state_mu = Stdlib.Mutex.create ()
+
+let with_lock f = Stdlib.Mutex.protect state_mu f
+
+let reset_for_test () =
+  with_lock (fun () -> state := empty)
+;;
+
+let record_tick_started ~now =
+  with_lock (fun () ->
+    state := { !state with tick_in_flight = true; last_tick_started_at = Some now })
+;;
+
+let tick_counts_of_result
+      ~(wake_enqueue_counts : wake_enqueue_counts)
+      (result : Schedule_runner.tick_result)
+  =
+  let dispatch_succeeded, dispatch_failed, dispatch_unsupported, dispatch_start_rejected =
+    List.fold_left
+      (fun (succeeded, failed, unsupported, start_rejected)
+        (dispatch : Schedule_runner.dispatch_result) ->
+         match dispatch.status with
+         | Dispatch_succeeded -> succeeded + 1, failed, unsupported, start_rejected
+         | Dispatch_failed -> succeeded, failed + 1, unsupported, start_rejected
+         | Dispatch_unsupported -> succeeded, failed, unsupported + 1, start_rejected
+         | Dispatch_start_rejected -> succeeded, failed, unsupported, start_rejected + 1)
+      (0, 0, 0, 0)
+      result.dispatches
+  in
+  { due_changed = result.due_changed
+  ; emitted = List.length result.emitted
+  ; rescheduled = result.rescheduled
+  ; dispatch_succeeded
+  ; dispatch_failed
+  ; dispatch_unsupported
+  ; dispatch_start_rejected
+  ; wake_enqueued = wake_enqueue_counts.wake_enqueued
+  ; wake_skipped_no_keeper = wake_enqueue_counts.wake_skipped_no_keeper
+  ; wake_skipped_missing_schedule =
+      wake_enqueue_counts.wake_skipped_missing_schedule
+  ; wake_skipped_non_keeper_actor =
+      wake_enqueue_counts.wake_skipped_non_keeper_actor
+  ; wake_skipped_unregistered_keeper =
+      wake_enqueue_counts.wake_skipped_unregistered_keeper
+  ; wake_failed = wake_enqueue_counts.wake_failed
+  }
+;;
+
+let duration ~started_at ~finished_at = max 0.0 (finished_at -. started_at)
+
+let record_tick_ok
+      ?(wake_enqueue_counts = empty_wake_enqueue_counts)
+      ~started_at
+      ~finished_at
+      result
+  =
+  let counts = tick_counts_of_result ~wake_enqueue_counts result in
+  with_lock (fun () ->
+    let current = !state in
+    state :=
+      { current with
+        tick_in_flight = false
+      ; tick_count = current.tick_count + 1
+      ; success_count = current.success_count + 1
+      ; last_tick_started_at = Some started_at
+      ; last_tick_finished_at = Some finished_at
+      ; last_success_at = Some finished_at
+      ; last_duration_sec = Some (duration ~started_at ~finished_at)
+      ; last_counts = Some counts
+      })
+;;
+
+let record_failure ~crashed ~started_at ~finished_at error =
+  with_lock (fun () ->
+    let current = !state in
+    state :=
+      { current with
+        tick_in_flight = false
+      ; tick_count = current.tick_count + 1
+      ; failure_count = current.failure_count + 1
+      ; crash_count = current.crash_count + if crashed then 1 else 0
+      ; last_tick_started_at = Some started_at
+      ; last_tick_finished_at = Some finished_at
+      ; last_error_at = Some finished_at
+      ; last_error = Some error
+      ; last_duration_sec = Some (duration ~started_at ~finished_at)
+      })
+;;
+
+let record_tick_error ~started_at ~finished_at error =
+  record_failure ~crashed:false ~started_at ~finished_at error
+;;
+
+let record_tick_crash ~started_at ~finished_at error =
+  record_failure ~crashed:true ~started_at ~finished_at error
+;;
+
+let snapshot () = with_lock (fun () -> !state)
+
+let option_float_json = function
+  | None -> `Null
+  | Some value -> `Float value
+;;
+
+let option_int_counts_json = function
+  | None -> `Null
+  | Some counts ->
+    `Assoc
+      [ "due_changed", `Int counts.due_changed
+      ; "emitted", `Int counts.emitted
+      ; "rescheduled", `Int counts.rescheduled
+      ; "dispatch_succeeded", `Int counts.dispatch_succeeded
+      ; "dispatch_failed", `Int counts.dispatch_failed
+      ; "dispatch_unsupported", `Int counts.dispatch_unsupported
+      ; "dispatch_start_rejected", `Int counts.dispatch_start_rejected
+      ; "wake_enqueued", `Int counts.wake_enqueued
+      ; "wake_skipped_no_keeper", `Int counts.wake_skipped_no_keeper
+      ; "wake_skipped_missing_schedule", `Int counts.wake_skipped_missing_schedule
+      ; "wake_skipped_non_keeper_actor", `Int counts.wake_skipped_non_keeper_actor
+      ; "wake_skipped_unregistered_keeper", `Int counts.wake_skipped_unregistered_keeper
+      ; "wake_failed", `Int counts.wake_failed
+      ]
+;;
+
+let option_age ~now = function
+  | None -> None
+  | Some ts -> Some (max 0.0 (now -. ts))
+;;
+
+let latest_error_is_newer snapshot =
+  match snapshot.last_error_at, snapshot.last_success_at with
+  | Some _, None -> true
+  | Some error_at, Some success_at -> error_at >= success_at
+  | None, _ -> false
+;;
+
+let latest_tick_has_wake_failure snapshot =
+  match snapshot.last_counts with
+  | Some counts -> counts.wake_failed > 0
+  | None -> false
+;;
+
+let latest_tick_has_dispatch_failure snapshot =
+  match snapshot.last_counts with
+  | Some counts ->
+    counts.dispatch_failed > 0
+    || counts.dispatch_unsupported > 0
+    || counts.dispatch_start_rejected > 0
+  | None -> false
+;;
+
+let status ?now ?stale_after_sec snapshot =
+  let stale =
+    match now, stale_after_sec, snapshot.last_tick_finished_at with
+    | Some now, Some stale_after_sec, Some finished_at ->
+      now -. finished_at > stale_after_sec
+    | _ -> false
+  in
+  if snapshot.tick_in_flight
+  then "running"
+  else if snapshot.tick_count = 0
+  then "not_started"
+  else if stale
+  then "stale"
+  else if latest_error_is_newer snapshot
+          || latest_tick_has_dispatch_failure snapshot
+          || latest_tick_has_wake_failure snapshot
+  then "degraded"
+  else "ok"
+;;
+
+let snapshot_to_yojson ?now ?stale_after_sec snapshot =
+  let age_field name timestamp =
+    match now with
+    | None -> name, `Null
+    | Some now -> name, option_float_json (option_age ~now timestamp)
+  in
+  `Assoc
+    [ "schema", `String "masc.schedule.runner_status.v1"
+    ; "status", `String (status ?now ?stale_after_sec snapshot)
+    ; "tick_in_flight", `Bool snapshot.tick_in_flight
+    ; "tick_count", `Int snapshot.tick_count
+    ; "success_count", `Int snapshot.success_count
+    ; "failure_count", `Int snapshot.failure_count
+    ; "crash_count", `Int snapshot.crash_count
+    ; "last_tick_started_at", option_float_json snapshot.last_tick_started_at
+    ; "last_tick_finished_at", option_float_json snapshot.last_tick_finished_at
+    ; "last_success_at", option_float_json snapshot.last_success_at
+    ; "last_error_at", option_float_json snapshot.last_error_at
+    ; ( "last_error"
+      , match snapshot.last_error with
+        | None -> `Null
+        | Some error -> `String error )
+    ; "last_duration_sec", option_float_json snapshot.last_duration_sec
+    ; "last_counts", option_int_counts_json snapshot.last_counts
+    ; ( "stale_after_sec"
+      , match stale_after_sec with
+        | None -> `Null
+        | Some value -> `Float value )
+    ; age_field "last_tick_age_sec" snapshot.last_tick_finished_at
+    ; age_field "last_success_age_sec" snapshot.last_success_at
+    ; age_field "last_error_age_sec" snapshot.last_error_at
+    ]
+;;

--- a/lib/schedule/schedule_runner_status.ml
+++ b/lib/schedule/schedule_runner_status.ml
@@ -78,6 +78,10 @@ let record_tick_started ~now =
     state := { !state with tick_in_flight = true; last_tick_started_at = Some now })
 ;;
 
+(* TEL-OK: this module is a pure process-local projection over
+   [Schedule_runner.tick_result]. The server maintenance loop owns concrete Log
+   and Otel_metric_store emission at the same tick record call sites, while
+   [/health?full=1] reads this snapshot for the structured health surface. *)
 let tick_counts_of_result
       ~(wake_enqueue_counts : wake_enqueue_counts)
       (result : Schedule_runner.tick_result)

--- a/lib/schedule/schedule_runner_status.mli
+++ b/lib/schedule/schedule_runner_status.mli
@@ -1,0 +1,68 @@
+(** Process-local schedule runner status.
+
+    The scheduler domain/store remain durable SSOTs for scheduled work. This
+    module only tracks the currently running process' runner loop liveness so
+    health/dashboard surfaces can answer whether the production caller has been
+    ticking recently. *)
+
+type tick_counts =
+  { due_changed : int
+  ; emitted : int
+  ; rescheduled : int
+  ; dispatch_succeeded : int
+  ; dispatch_failed : int
+  ; dispatch_unsupported : int
+  ; dispatch_start_rejected : int
+  ; wake_enqueued : int
+  ; wake_skipped_no_keeper : int
+  ; wake_skipped_missing_schedule : int
+  ; wake_skipped_non_keeper_actor : int
+  ; wake_skipped_unregistered_keeper : int
+  ; wake_failed : int
+  }
+
+type wake_enqueue_counts =
+  { wake_enqueued : int
+  ; wake_skipped_no_keeper : int
+  ; wake_skipped_missing_schedule : int
+  ; wake_skipped_non_keeper_actor : int
+  ; wake_skipped_unregistered_keeper : int
+  ; wake_failed : int
+  }
+
+type snapshot =
+  { tick_in_flight : bool
+  ; tick_count : int
+  ; success_count : int
+  ; failure_count : int
+  ; crash_count : int
+  ; last_tick_started_at : float option
+  ; last_tick_finished_at : float option
+  ; last_success_at : float option
+  ; last_error_at : float option
+  ; last_error : string option
+  ; last_duration_sec : float option
+  ; last_counts : tick_counts option
+  }
+
+val reset_for_test : unit -> unit
+
+val record_tick_started : now:float -> unit
+val empty_wake_enqueue_counts : wake_enqueue_counts
+val record_tick_ok :
+  ?wake_enqueue_counts:wake_enqueue_counts ->
+  started_at:float ->
+  finished_at:float ->
+  Schedule_runner.tick_result ->
+  unit
+val record_tick_error :
+  started_at:float -> finished_at:float -> string -> unit
+val record_tick_crash :
+  started_at:float -> finished_at:float -> string -> unit
+
+val snapshot : unit -> snapshot
+
+val snapshot_to_yojson :
+  ?now:float -> ?stale_after_sec:float -> snapshot -> Yojson.Safe.t
+(** Render a stable JSON status. [stale_after_sec] is supplied by the caller
+    that owns the runner cadence; this module does not guess runtime policy. *)

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -6,7 +6,8 @@
  (wrapped false)
  (private_modules
   keeper_grpc_heartbeat
-  server_dashboard_http_schedule_actions)
+  server_dashboard_http_schedule_actions
+  server_schedule_runner_policy)
  (flags :standard -open Masc)
  (libraries
   masc

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -8,6 +8,13 @@ let log_server_fiber_crash =
 
 let schedule_runner_interval_sec = Server_schedule_runner_policy.interval_sec
 
+let record_schedule_runner_tick_outcome outcome =
+  Otel_metric_store.inc_counter
+    Otel_metric_store.metric_schedule_runner_tick_outcomes
+    ~labels:[ "outcome", outcome ]
+    ()
+;;
+
 (* Resolve the provider config for the Memory OS per-keeper consolidation pass.
    Env var takes precedence; otherwise inherit the librarian runtime so the
    consolidation LLM uses the same JSON-capable model the librarian uses.
@@ -208,6 +215,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                ~started_at
                ~finished_at
                result;
+             record_schedule_runner_tick_outcome "ok";
              if result.Schedule_runner.emitted <> []
                 || result.rescheduled > 0
                 || result.dispatches <> []
@@ -222,6 +230,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              let finished_at = Time_compat.now () in
              let error = Schedule_runner.runner_error_to_string err in
              Schedule_runner_status.record_tick_error ~started_at ~finished_at error;
+             record_schedule_runner_tick_outcome "error";
              Log.Server.warn "schedule_runner: tick failed: %s" error
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
@@ -229,6 +238,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            let finished_at = Time_compat.now () in
            let error = Printexc.to_string exn in
            Schedule_runner_status.record_tick_crash ~started_at ~finished_at error;
+           record_schedule_runner_tick_outcome "crash";
            Log.Server.warn "schedule_runner: tick crashed: %s" error);
         Eio.Time.sleep clock schedule_runner_interval_sec;
         loop ()

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -6,6 +6,8 @@ let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
 let log_server_fiber_crash =
   Server_bootstrap_loops_fiber.log_server_fiber_crash
 
+let schedule_runner_interval_sec = Server_schedule_runner_policy.interval_sec
+
 (* Resolve the provider config for the Memory OS per-keeper consolidation pass.
    Env var takes precedence; otherwise inherit the librarian runtime so the
    consolidation LLM uses the same JSON-capable model the librarian uses.
@@ -190,16 +192,22 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~sw
     ~on_error:(log_server_fiber_crash "schedule_runner")
     (fun () ->
-      let interval = 15.0 in
       let rec loop () =
+        let started_at = Time_compat.now () in
+        Schedule_runner_status.record_tick_started ~now:started_at;
         (try
            match
              Schedule_runner.tick
                ~consumer:Server_schedule_consumers.consumer
                (Mcp_server.workspace_config state)
-               ~now:(Time_compat.now ())
+               ~now:started_at
            with
            | Ok result ->
+             let finished_at = Time_compat.now () in
+             Schedule_runner_status.record_tick_ok
+               ~started_at
+               ~finished_at
+               result;
              if result.Schedule_runner.emitted <> []
                 || result.rescheduled > 0
                 || result.dispatches <> []
@@ -211,16 +219,18 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                  result.rescheduled
                  (List.length result.dispatches)
            | Error err ->
-             Log.Server.warn
-               "schedule_runner: tick failed: %s"
-               (Schedule_runner.runner_error_to_string err)
+             let finished_at = Time_compat.now () in
+             let error = Schedule_runner.runner_error_to_string err in
+             Schedule_runner_status.record_tick_error ~started_at ~finished_at error;
+             Log.Server.warn "schedule_runner: tick failed: %s" error
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-           Log.Server.warn
-             "schedule_runner: tick crashed: %s"
-             (Printexc.to_string exn));
-        Eio.Time.sleep clock interval;
+           let finished_at = Time_compat.now () in
+           let error = Printexc.to_string exn in
+           Schedule_runner_status.record_tick_crash ~started_at ~finished_at error;
+           Log.Server.warn "schedule_runner: tick crashed: %s" error);
+        Eio.Time.sleep clock schedule_runner_interval_sec;
         loop ()
       in
       loop ());

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -15,6 +15,36 @@ let record_schedule_runner_tick_outcome outcome =
     ()
 ;;
 
+let wake_enqueue_counts_of_dispatches dispatches =
+  let module Consumers = Server_schedule_consumers in
+  let bump_wake_failed
+        (counts : Schedule_runner_status.wake_enqueue_counts)
+    =
+    { counts with wake_failed = counts.wake_failed + 1 }
+  in
+  let bump_wake_enqueued
+        (counts : Schedule_runner_status.wake_enqueue_counts)
+    =
+    { counts with wake_enqueued = counts.wake_enqueued + 1 }
+  in
+  List.fold_left
+    (fun counts (dispatch : Schedule_runner.dispatch_result) ->
+       match dispatch.detail with
+       | None -> counts
+       | Some detail ->
+         (match Consumers.dispatch_receipt_of_detail detail with
+          | Error _ | Ok (Consumers.Board_post_created _) -> counts
+          | Ok (Consumers.Keeper_wake_enqueued { reaction_ledger_status; _ }) ->
+            let counts = bump_wake_enqueued counts in
+            (match reaction_ledger_status with
+             | Some (Consumers.Keeper_wake_reaction_ledger_record_failed _) ->
+               bump_wake_failed counts
+             | None | Some Consumers.Keeper_wake_reaction_ledger_recorded ->
+               counts)))
+    Schedule_runner_status.empty_wake_enqueue_counts
+    dispatches
+;;
+
 (* Resolve the provider config for the Memory OS per-keeper consolidation pass.
    Env var takes precedence; otherwise inherit the librarian runtime so the
    consolidation LLM uses the same JSON-capable model the librarian uses.
@@ -211,7 +241,11 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            with
            | Ok result ->
              let finished_at = Time_compat.now () in
+             let wake_enqueue_counts =
+               wake_enqueue_counts_of_dispatches result.dispatches
+             in
              Schedule_runner_status.record_tick_ok
+               ~wake_enqueue_counts
                ~started_at
                ~finished_at
                result;

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -16,6 +16,10 @@ val run_memory_os_consolidation_tick :
   unit ->
   unit
 
+val wake_enqueue_counts_of_dispatches :
+  Schedule_runner.dispatch_result list -> Schedule_runner_status.wake_enqueue_counts
+(** Derive keeper-wake delivery counts from typed production consumer receipts. *)
+
 val start_background_maintenance :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -316,6 +316,13 @@ let otel_health_json () =
     ]
 ;;
 
+let schedule_runner_status_json () =
+  Schedule_runner_status.snapshot ()
+  |> Schedule_runner_status.snapshot_to_yojson
+       ~now:(Time_compat.now ())
+       ~stale_after_sec:Server_schedule_runner_policy.stale_after_sec
+;;
+
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
     ?(health_detail = "probe") request =
   let uptime_secs = health_uptime_secs () in
@@ -345,6 +352,7 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("uptime", `String (health_uptime_string uptime_secs));
       ("sse_clients", `Int (Sse.client_count ()));
       ("startup", Server_startup_state.to_yojson ());
+      ("schedule_runner", schedule_runner_status_json ());
       ("runtime_startup_degradation",
        Runtime.startup_degradation_to_yojson (Runtime.startup_degradation ()));
       ("subsystems", Subsystem_health.to_yojson ());

--- a/lib/server/server_schedule_runner_policy.ml
+++ b/lib/server/server_schedule_runner_policy.ml
@@ -1,0 +1,6 @@
+let interval_sec = 15.0
+
+(* Four missed runner cadences means the production caller has failed to
+   observe three complete due windows after the last successful tick. The value
+   is surfaced in JSON and does not affect scheduling behavior. *)
+let stale_after_sec = interval_sec *. 4.0

--- a/lib/server/server_schedule_runner_policy.mli
+++ b/lib/server/server_schedule_runner_policy.mli
@@ -1,0 +1,8 @@
+(** Server-owned policy constants for the RFC-0234 schedule runner loop. *)
+
+val interval_sec : float
+(** Production runner cadence in seconds. *)
+
+val stale_after_sec : float
+(** Liveness warning threshold in seconds. This only affects health/dashboard
+    projection; it never changes scheduling behavior. *)

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -208,6 +208,20 @@ let tick_ok config ~now =
   | Error err -> fail (Schedule_runner.runner_error_to_string err)
 ;;
 
+let runner_status_json_after_dispatches result =
+  Schedule_runner_status.reset_for_test ();
+  let wake_enqueue_counts =
+    Server_bootstrap_maintenance.wake_enqueue_counts_of_dispatches result.dispatches
+  in
+  Schedule_runner_status.record_tick_ok
+    ~wake_enqueue_counts
+    ~started_at:201.0
+    ~finished_at:201.25
+    result;
+  Schedule_runner_status.snapshot ()
+  |> Schedule_runner_status.snapshot_to_yojson ~now:201.5 ~stale_after_sec:10.0
+;;
+
 let test_board_post_consumer_creates_post_and_succeeds_schedule () =
   with_workspace
   @@ fun config ->
@@ -303,6 +317,16 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
   check int "one dispatch" 1 (List.length result.dispatches);
   check string "dispatch status" "succeeded"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  let runner_status = runner_status_json_after_dispatches result in
+  let runner_counts =
+    Yojson.Safe.Util.(runner_status |> member "last_counts")
+  in
+  check string "runner health stays ok" "ok"
+    Yojson.Safe.Util.(runner_status |> member "status" |> to_string);
+  check int "runner wake enqueued from production receipt" 1
+    Yojson.Safe.Util.(runner_counts |> member "wake_enqueued" |> to_int);
+  check int "runner wake failed stays zero" 0
+    Yojson.Safe.Util.(runner_counts |> member "wake_failed" |> to_int);
   (match
      Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
        ~schedule_id:request.schedule_id
@@ -690,6 +714,16 @@ let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
   check int "one dispatch" 1 (List.length result.dispatches);
   check string "dispatch status stays succeeded" "succeeded"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
+  let runner_status = runner_status_json_after_dispatches result in
+  let runner_counts =
+    Yojson.Safe.Util.(runner_status |> member "last_counts")
+  in
+  check string "ledger failure degrades runner health" "degraded"
+    Yojson.Safe.Util.(runner_status |> member "status" |> to_string);
+  check int "ledger failure still counts wake enqueue" 1
+    Yojson.Safe.Util.(runner_counts |> member "wake_enqueued" |> to_int);
+  check int "ledger failure increments wake failure" 1
+    Yojson.Safe.Util.(runner_counts |> member "wake_failed" |> to_int);
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing"
    | Some stored ->

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -208,7 +208,7 @@ let tick_ok config ~now =
   | Error err -> fail (Schedule_runner.runner_error_to_string err)
 ;;
 
-let runner_status_json_after_dispatches result =
+let runner_status_json_after_dispatches (result : Schedule_runner.tick_result) =
   Schedule_runner_status.reset_for_test ();
   let wake_enqueue_counts =
     Server_bootstrap_maintenance.wake_enqueue_counts_of_dispatches result.dispatches

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -77,6 +77,33 @@ let check_dispatch_status label expected actual =
   check string label (dispatch_status_to_string expected) (dispatch_status_to_string actual)
 ;;
 
+let json_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let json_string key json =
+  match json_field key json with
+  | Some (`String value) -> value
+  | Some other -> failf "field %s expected string, got %s" key (Yojson.Safe.to_string other)
+  | None -> failf "missing string field %s" key
+;;
+
+let json_int key json =
+  match json_field key json with
+  | Some (`Int value) -> value
+  | Some other -> failf "field %s expected int, got %s" key (Yojson.Safe.to_string other)
+  | None -> failf "missing int field %s" key
+;;
+
+let json_float key json =
+  match json_field key json with
+  | Some (`Float value) -> value
+  | Some (`Int value) -> float_of_int value
+  | Some other -> failf "field %s expected float, got %s" key (Yojson.Safe.to_string other)
+  | None -> failf "missing float field %s" key
+;;
+
 let accepting_consumer ?(accept = Ok ()) ?dispatch_result calls =
   let dispatch_result =
     Option.value
@@ -335,6 +362,131 @@ let test_tick_marks_dispatch_failure_failed () =
        execution.error)
 ;;
 
+let test_runner_status_snapshot_tracks_liveness () =
+  Schedule_runner_status.reset_for_test ();
+  let render ?(now = 0.0) ?(stale_after_sec = 10.0) () =
+    Schedule_runner_status.snapshot ()
+    |> Schedule_runner_status.snapshot_to_yojson ~now ~stale_after_sec
+  in
+  check string "initial status" "not_started" (json_string "status" (render ()));
+  Schedule_runner_status.record_tick_started ~now:1.0;
+  check string "running status" "running"
+    (json_string "status" (render ~now:1.5 ()));
+  let ok_result =
+    { due_changed = 1
+    ; emitted = []
+    ; rescheduled = 2
+    ; dispatches =
+        [ { schedule_id = "status-1"
+          ; status = Dispatch_succeeded
+          ; detail = Some (`Assoc [ "ok", `Bool true ])
+          ; error = None
+          }
+        ]
+    }
+  in
+  Schedule_runner_status.record_tick_ok ~started_at:1.0 ~finished_at:1.25 ok_result;
+  let ok = render ~now:2.25 () in
+  check string "ok status" "ok" (json_string "status" ok);
+  check int "tick count" 1 (json_int "tick_count" ok);
+  check int "success count" 1 (json_int "success_count" ok);
+  check (float 0.000001) "last duration" 0.25
+    (json_float "last_duration_sec" ok);
+  check (float 0.000001) "last tick age" 1.0
+    (json_float "last_tick_age_sec" ok);
+  let counts =
+    match json_field "last_counts" ok with
+    | Some counts -> counts
+    | None -> fail "missing last_counts"
+  in
+  check int "last due count" 1 (json_int "due_changed" counts);
+  check int "last reschedule count" 2 (json_int "rescheduled" counts);
+  check int "last success dispatch count" 1 (json_int "dispatch_succeeded" counts);
+  check int "last failed dispatch count" 0 (json_int "dispatch_failed" counts);
+  check int "last unsupported dispatch count" 0 (json_int "dispatch_unsupported" counts);
+  check int "last start-rejected dispatch count" 0
+    (json_int "dispatch_start_rejected" counts);
+  let dispatch_failure_result =
+    { due_changed = 3
+    ; emitted = []
+    ; rescheduled = 0
+    ; dispatches =
+        [ { schedule_id = "status-dispatch-failed"
+          ; status = Dispatch_failed
+          ; detail = None
+          ; error = Some "dispatch failed"
+          }
+        ; { schedule_id = "status-dispatch-unsupported"
+          ; status = Dispatch_unsupported
+          ; detail = None
+          ; error = Some "unsupported"
+          }
+        ; { schedule_id = "status-dispatch-start-rejected"
+          ; status = Dispatch_start_rejected
+          ; detail = None
+          ; error = Some "start rejected"
+          }
+        ]
+    }
+  in
+  Schedule_runner_status.record_tick_ok
+    ~started_at:2.0
+    ~finished_at:2.125
+    dispatch_failure_result;
+  let dispatch_degraded = render ~now:2.25 () in
+  check string "dispatch failure degrades status" "degraded"
+    (json_string "status" dispatch_degraded);
+  let dispatch_counts =
+    match json_field "last_counts" dispatch_degraded with
+    | Some counts -> counts
+    | None -> fail "missing dispatch failure last_counts"
+  in
+  check int "failed dispatch count" 1 (json_int "dispatch_failed" dispatch_counts);
+  check int "unsupported dispatch count" 1
+    (json_int "dispatch_unsupported" dispatch_counts);
+  check int "start-rejected dispatch count" 1
+    (json_int "dispatch_start_rejected" dispatch_counts);
+  let wake_enqueue_counts : Schedule_runner_status.wake_enqueue_counts =
+    { wake_enqueued = 2
+    ; wake_skipped_no_keeper = 3
+    ; wake_skipped_missing_schedule = 1
+    ; wake_skipped_non_keeper_actor = 1
+    ; wake_skipped_unregistered_keeper = 1
+    ; wake_failed = 1
+    }
+  in
+  Schedule_runner_status.record_tick_ok
+    ~wake_enqueue_counts
+    ~started_at:2.5
+    ~finished_at:2.75
+    ok_result;
+  let wake_degraded = render ~now:3.0 () in
+  check string "wake failure degrades status" "degraded"
+    (json_string "status" wake_degraded);
+  let wake_counts =
+    match json_field "last_counts" wake_degraded with
+    | Some counts -> counts
+    | None -> fail "missing wake failure last_counts"
+  in
+  check int "wake enqueued count" 2 (json_int "wake_enqueued" wake_counts);
+  check int "wake skipped count" 3 (json_int "wake_skipped_no_keeper" wake_counts);
+  check int "wake missing schedule count" 1
+    (json_int "wake_skipped_missing_schedule" wake_counts);
+  check int "wake non-keeper actor count" 1
+    (json_int "wake_skipped_non_keeper_actor" wake_counts);
+  check int "wake unregistered keeper count" 1
+    (json_int "wake_skipped_unregistered_keeper" wake_counts);
+  check int "wake failed count" 1 (json_int "wake_failed" wake_counts);
+  Schedule_runner_status.record_tick_error ~started_at:3.0 ~finished_at:3.5 "boom";
+  let degraded = render ~now:4.0 () in
+  check string "degraded status" "degraded" (json_string "status" degraded);
+  check int "failure count" 1 (json_int "failure_count" degraded);
+  Schedule_runner_status.record_tick_crash ~started_at:5.0 ~finished_at:5.5 "crash";
+  let stale = render ~now:20.0 () in
+  check string "stale status" "stale" (json_string "status" stale);
+  check int "crash count" 1 (json_int "crash_count" stale)
+;;
+
 let () =
   run "Schedule_runner"
     [ ( "tick",
@@ -354,6 +506,10 @@ let () =
             test_tick_blocks_recurring_side_effect_until_fresh_grant
         ; test_case "marks dispatch failure failed" `Quick
             test_tick_marks_dispatch_failure_failed
+        ] )
+    ; ( "status",
+        [ test_case "tracks liveness snapshot" `Quick
+            test_runner_status_snapshot_tracks_liveness
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- split the scheduler runner status/audit slice out of #23393 into a small rebase-clean PR
- add a typed Schedule_runner_status snapshot for tick lifecycle, counts, timing, and degraded/crash state
- expose schedule_runner in full health output and record tick ok/error/crash outcomes from the maintenance loop

## Scope
- first split only; #23393 remains open and was not force-pushed
- dashboard wiring, keeper waiting inventory, broad fallback refactors, and generated report artifacts stay out of this PR

## Validation
- `opam exec -- ocamlformat --check lib/schedule/schedule_runner_status.ml lib/schedule/schedule_runner_status.mli lib/server/server_schedule_runner_policy.ml lib/server/server_schedule_runner_policy.mli lib/server/server_bootstrap_maintenance.ml lib/server/server_routes_http_runtime.ml test/test_schedule_runner.ml`
- `git diff --check`
- no local dune build; dune validation is left to CI per repo workflow