### PR TITLE
chore: bump version to 0.19.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.19.56] - 2026-07-06
+
 ### Added
 - Interactive install wizard in `scripts/install.sh` with TTY detection,
   typed provider catalog selection, secure API key prompting, and writing
@@ -25,6 +27,17 @@
   copy-paste start command with `MASC_BASE_PATH`, `OAS_MODEL_CATALOG`, and
   `MASC_RUNTIME_EVENTS=0` wired for clean Linux/macOS installs.
 
+### Fixed
+- Stop keeper infinite rotation on `capacity_backpressure` (#23383, Phase A of
+  #23373). `degraded_reason_allows_candidate_cycle` now caps rotation for
+  `Capacity_backpressure`; the keeper pauses once when candidates are
+  exhausted instead of looping forever between two cooldown runtimes
+  (incidents 2026-05-21, 2026-07-06).
+- Expand rotation candidates to the full runtime catalog for transient
+  infrastructure errors (#23392, Phase B-1) so failover reaches healthy
+  runtimes outside the narrow `[base; default; phase_recovery]` set.
+- Unbreak main build after #23353 red-merge: add missing type annotation and
+  `(modules)` entry for `test_keeper_board_attention_candidate` (#23356).
 ## [0.19.55] - 2026-07-03
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc Roadmap
 
-> Current package version: v0.19.55
-> Latest changelog entry: v0.19.55 (2026-07-03)
+> Current package version: v0.19.56
+> Latest changelog entry: v0.19.56 (2026-07-06)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
 > Updated: 2026-07-03
 

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,8 +9,8 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.55
-> Latest changelog entry: v0.19.55 (2026-07-03)
+> Current package version: v0.19.56
+> Latest changelog entry: v0.19.56 (2026-07-06)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
 > Updated: 2026-07-03
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -11,7 +11,7 @@ code_refs:
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-07-03
-> Snapshot baseline: `dune-project` version `0.19.55`
+> Snapshot baseline: `dune-project` version `0.19.56`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 Keeper/MCP client가 동일 workspace에서 작업할 때 필요한 조율과 관찰성을 제공한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper turn, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc)
-(version 0.19.55)
+(version 0.19.56)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
Version bump 0.19.55 -> 0.19.56 (291 commits since v0.19.55). Aligns dune-project, ROADMAP, PRODUCT-OPERATING-PLAN, SPEC-INDEX, CHANGELOG. Major: Phase A (#23383) cap rotation on capacity_backpressure, Phase B-1 (#23392) catalog failover, main build repair (#23356). Tag v0.19.56 after merge.