### PR TITLE
fix(ci): classify runner disk warnings as disk exhaustion

### DIFF
--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -36,6 +36,9 @@ CI_TEST_RPC_RETRY_DONE=0
 CI_TEST_ALLOW_FLAKY_RETRY="${CI_TEST_ALLOW_FLAKY_RETRY:-1}"
 CI_TEST_FLAKY_RETRY_DONE=0
 CI_TEST_DISK_FULL_GUIDANCE_DONE=0
+CI_TEST_DISK_PRESSURE_DONE=0
+CI_TEST_DISK_MIN_AVAILABLE_MB="${CI_TEST_DISK_MIN_AVAILABLE_MB:-1024}"
+CI_TEST_DISK_CHECK_SEC="${CI_TEST_DISK_CHECK_SEC:-10}"
 CI_TEST_ISOLATED_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR:-.ci_build}"
 CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-0}"
 CI_CONTRACT_HARNESS_CMD="${CI_CONTRACT_HARNESS_CMD:-scripts/harness/contract/run_all.sh}"
@@ -135,6 +138,39 @@ fi
 if [[ -z "${HEARTBEAT_SEC}" || "${HEARTBEAT_SEC}" -le 0 ]]; then
   HEARTBEAT_SEC=30
 fi
+if [[ -z "${CI_TEST_DISK_MIN_AVAILABLE_MB}" || "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -lt 0 ]]; then
+  CI_TEST_DISK_MIN_AVAILABLE_MB=1024
+fi
+if [[ -z "${CI_TEST_DISK_CHECK_SEC}" || "${CI_TEST_DISK_CHECK_SEC}" -le 0 ]]; then
+  CI_TEST_DISK_CHECK_SEC=10
+fi
+
+disk_available_mb() {
+  local path="${1:-${DUNE_SOURCEROOT}}"
+  df -Pm "${path}" 2>/dev/null \
+    | awk 'NR == 2 { print $4; found=1 } END { if (!found) print "" }'
+}
+
+disk_pressure_detected() {
+  [[ "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -gt 0 ]] || return 1
+
+  local avail_mb=""
+  avail_mb="$(disk_available_mb "${DUNE_SOURCEROOT}")"
+  [[ "${avail_mb}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${avail_mb}" -le "${CI_TEST_DISK_MIN_AVAILABLE_MB}" ]]
+}
+
+disk_pressure_detail() {
+  local avail_mb=""
+  avail_mb="$(disk_available_mb "${DUNE_SOURCEROOT}")"
+  if [[ "${avail_mb}" =~ ^[0-9]+$ ]]; then
+    printf 'path=%s available_mb=%s min_available_mb=%s' \
+      "${DUNE_SOURCEROOT}" "${avail_mb}" "${CI_TEST_DISK_MIN_AVAILABLE_MB}"
+  else
+    printf 'path=%s available_mb=unknown min_available_mb=%s' \
+      "${DUNE_SOURCEROOT}" "${CI_TEST_DISK_MIN_AVAILABLE_MB}"
+  fi
+}
 
 diag_dump() {
   local reason="${1:-unknown}"
@@ -269,24 +305,31 @@ agent_sdk_interface_mismatch_detected() {
     "${TEST_LOG_FILE}"
 }
 
-disk_full_detected() {
+filtered_test_log_contains() {
+  local pattern="${1}"
+  local filtered_log=""
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
+  filtered_log="$(mktemp_ci_log)"
   grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    | grep -Eiq \
-      -e 'No space left on device|dune_trace_write[(][)]|ENOSPC' \
-      -e '##\[warning\].*(You are running out of disk space|Free space left:[[:space:]]*[0-9]+[[:space:]]*(MB|MiB))'
+    > "${filtered_log}" || true
+  grep -Eiq "${pattern}" "${filtered_log}"
+  local status=$?
+  rm -f "${filtered_log}"
+  return "${status}"
+}
+
+disk_full_detected() {
+  filtered_test_log_contains \
+    'No space left on device|dune_trace_write[(][)]|ENOSPC|##\[warning\].*(You are running out of disk space|Free space left:[[:space:]]*[0-9]+[[:space:]]*(MB|MiB))'
 }
 
 deterministic_test_failure_detected() {
-  [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    | grep -Eiq '\[FAIL\]|[[:digit:]]+ failure!|Test Failed|ASSERT '
+  filtered_test_log_contains '\[FAIL\]|[[:digit:]]+ failure!|Test Failed|ASSERT '
 }
 
 native_link_failure_detected() {
-  [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    | grep -Eiq 'collect2: error: ld returned 1 exit status|Error: Error during linking [(]exit code [[:digit:]]+[)]|/usr/bin/ld: final link failed'
+  filtered_test_log_contains \
+    'collect2: error: ld returned 1 exit status|Error: Error during linking [(]exit code [[:digit:]]+[)]|/usr/bin/ld: final link failed'
 }
 
 log_disk_full_guidance() {
@@ -334,6 +377,8 @@ run_with_timeout() {
   local deadline=0
   local status=0
   local kill_grace_sec=5
+  local next_disk_check
+  next_disk_check=$(( $(date +%s) + CI_TEST_DISK_CHECK_SEC ))
 
   ACTIVE_CMD_PID=""
   ACTIVE_CMD_PGID=""
@@ -355,6 +400,8 @@ run_with_timeout() {
   fi
 
   while kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; do
+    local now_epoch
+    now_epoch="$(date +%s)"
     if [[ "${deadline}" -gt 0 ]] && [[ "$(date +%s)" -ge "${deadline}" ]]; then
       CI_LAST_TIMEOUT_DIAG_DONE=1
       diag_dump "timeout"
@@ -372,6 +419,29 @@ run_with_timeout() {
       ACTIVE_CMD_PGID=""
       ACTIVE_LOG_TAIL_PID=""
       return 124
+    fi
+    if [[ "${now_epoch}" -ge "${next_disk_check}" ]]; then
+      next_disk_check=$((now_epoch + CI_TEST_DISK_CHECK_SEC))
+      if disk_pressure_detected; then
+        CI_TEST_DISK_PRESSURE_DONE=1
+        log_line "[ci-run] ERROR: disk pressure while running test command: $(disk_pressure_detail)"
+        log_disk_full_guidance
+        diag_dump "disk_pressure"
+        kill_active_cmd_tree TERM
+        sleep "${kill_grace_sec}"
+        if kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
+          kill_active_cmd_tree KILL
+        fi
+        wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
+        if [[ -n "${ACTIVE_LOG_TAIL_PID}" ]]; then
+          kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
+          wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
+        fi
+        ACTIVE_CMD_PID=""
+        ACTIVE_CMD_PGID=""
+        ACTIVE_LOG_TAIL_PID=""
+        return 75
+      fi
     fi
     sleep 1
   done
@@ -418,6 +488,7 @@ if test_cmd_needs_dune_sanitization; then
   log_line "[ci-run] sanitized_command: $(effective_test_cmd)"
 fi
 log_line "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
+log_line "[ci-run] disk_min_available_mb=${CI_TEST_DISK_MIN_AVAILABLE_MB} disk_check_sec=${CI_TEST_DISK_CHECK_SEC}"
 log_line "[ci-run] started_at=$(iso_now)"
 log_line "[ci-run] log_file=${TEST_LOG_FILE}"
 log_line "[ci-run] source_root=${DUNE_SOURCEROOT}"
@@ -436,10 +507,14 @@ set -e
 if [[ "${status}" -ne 0 ]] && disk_full_detected; then
   log_disk_full_guidance
 fi
+if [[ "${status}" -ne 0 ]] && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 1 ]]; then
+  log_disk_full_guidance
+fi
 
 if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_ALLOW_RPC_RETRY}" = "1" ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
+  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && ! test_cmd_has_explicit_build_dir \
   && rpc_server_not_running_detected; then
@@ -458,6 +533,7 @@ fi
 if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && agent_sdk_interface_mismatch_detected; then
   run_agent_sdk_clean_retry
@@ -481,6 +557,7 @@ if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && deterministic_test_failure_detected \
   && ! disk_full_detected; then
@@ -492,6 +569,7 @@ if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && native_link_failure_detected \
   && ! disk_full_detected; then
@@ -503,6 +581,7 @@ if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
   && test_cmd_needs_dune_sanitization \
   && ! deterministic_test_failure_detected \
   && ! native_link_failure_detected \
@@ -532,7 +611,7 @@ if [[ "${status}" -ne 0 ]] \
 fi
 
 if [[ "${status}" -ne 0 ]]; then
-  if disk_full_detected; then
+  if [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 1 ]] || disk_full_detected; then
     log_disk_full_guidance
   fi
   diag_dump "nonzero_exit_${status}"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -272,7 +272,9 @@ agent_sdk_interface_mismatch_detected() {
 disk_full_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
   grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    | grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC'
+    | grep -Eiq \
+      -e 'No space left on device|dune_trace_write[(][)]|ENOSPC' \
+      -e '##\[warning\].*(You are running out of disk space|Free space left:[[:space:]]*[0-9]+[[:space:]]*(MB|MiB))'
 }
 
 deterministic_test_failure_detected() {

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -248,6 +248,31 @@ exit 1
   Unix.chmod dune_path 0o755;
   bin_dir
 
+let make_fake_dune_github_disk_warning dir =
+  let bin_dir = Filename.concat dir "bin-github-disk-warning" in
+  Unix.mkdir bin_dir 0o755;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
+if [ "${1:-}" = "--version" ]; then
+  printf '3.21.0\n'
+  exit 0
+fi
+if [ "${1:-}" = "clean" ]; then
+  exit 0
+fi
+printf 'collect2: error: ld returned 1 exit status\n' >&2
+printf 'Error: Error during linking (exit code 1)\n' >&2
+printf '##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 14 MB\n' >&2
+exit 1
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  bin_dir
+
 let test_rpc_retry_uses_isolated_build_dir () =
   with_temp_dir "ci-run-tests-retry" (fun dir ->
       let cwd = Unix.realpath dir in
@@ -530,6 +555,59 @@ let test_disk_full_failure_skips_flaky_retry () =
           failf "expected exactly one dune invocation, got:\n%s"
             (String.concat "\n" log_lines))
 
+let test_github_disk_warning_skips_flaky_retry () =
+  with_temp_dir "ci-run-tests-gh-disk-warning" (fun dir ->
+      let cwd = Unix.realpath dir in
+      let repo_dir = Filename.concat dir "repo" in
+      Unix.mkdir repo_dir 0o755;
+      let fake_log = Filename.concat dir "fake-dune.log" in
+      let ci_log = Filename.concat dir "ci-run-tests.log" in
+      let fake_bin = make_fake_dune_github_disk_warning dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("DUNE_BUILD_DIR", "");
+          ("FAKE_DUNE_LOG", fake_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_TEST_LOG_FILE", ci_log);
+          ("CI_CONTRACT_HARNESS_ENABLED", "0");
+          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
+        ]
+      in
+      let code, stdout, stderr =
+        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
+      in
+      check int "github disk warning exit code" 1 code;
+      let ci_log_contents = read_file ci_log in
+      let observed_output =
+        String.concat "\n" [ ci_log_contents; stdout; stderr ]
+      in
+      check bool "disk guidance present" true
+        (contains_substring observed_output
+           "detected disk exhaustion during dune build");
+      check bool "github runner warning preserved" true
+        (contains_substring observed_output "Free space left: 14 MB");
+      check bool "flaky retry skipped" false
+        (contains_substring observed_output "flaky-test mitigation");
+      let log_lines =
+        read_file fake_log
+        |> String.split_on_char '\n'
+        |> List.filter (fun line -> String.trim line <> "")
+      in
+      match log_lines with
+      | [ first ] ->
+          check string "single attempt uses repo cwd"
+            (Printf.sprintf "test||%s" cwd)
+            first
+      | _ ->
+          failf "expected exactly one dune invocation, got:\n%s"
+            (String.concat "\n" log_lines))
+
 let test_timeout_diagnostics_capture_active_process_group () =
   with_temp_dir "ci-run-tests-timeout" (fun dir ->
       let ci_log = Filename.concat dir "ci-run-tests.log" in
@@ -579,6 +657,8 @@ let () =
             test_agent_sdk_artifact_failure_after_flaky_retry_disables_cache;
           test_case "disk full failure skips flaky retry" `Quick
             test_disk_full_failure_skips_flaky_retry;
+          test_case "github disk warning skips flaky retry" `Quick
+            test_github_disk_warning_skips_flaky_retry;
           test_case "timeout diagnostics capture active process group" `Quick
             test_timeout_diagnostics_capture_active_process_group;
         ] );

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -217,6 +217,11 @@ fi
 printf '  [FAIL]        module-init          3   keeper all complete.\n' >&2
 printf 'ASSERT Keeper_metrics.all covers every constructor\n' >&2
 printf '1 failure! in 0.000s. 6 tests run.\n' >&2
+i=0
+while [ "$i" -lt 5000 ]; do
+  printf 'deterministic failure context %s\n' "$i" >&2
+  i=$((i + 1))
+done
 exit 1
 |}
   ;
@@ -271,6 +276,49 @@ exit 1
 |}
   ;
   Unix.chmod dune_path 0o755;
+  bin_dir
+
+let make_fake_dune_with_low_disk_df dir =
+  let bin_dir = Filename.concat dir "bin-low-disk-df" in
+  Unix.mkdir bin_dir 0o755;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
+if [ "${1:-}" = "--version" ]; then
+  printf '3.21.0\n'
+  exit 0
+fi
+if [ "${1:-}" = "clean" ]; then
+  exit 0
+fi
+trap 'exit 143' TERM
+sleep 10
+exit 0
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  let df_path = Filename.concat bin_dir "df" in
+  write_file df_path
+    {|#!/bin/sh
+case "${1:-}" in
+  -Pm)
+    printf 'Filesystem 1048576-blocks Used Available Capacity Mounted on\n'
+    printf '/dev/root 100 99 14 99%% /\n'
+    ;;
+  -h)
+    printf 'Filesystem Size Used Avail Use%% Mounted on\n'
+    printf '/dev/root 100G 99G 14M 99%% /\n'
+    ;;
+  *)
+    /bin/df "$@"
+    ;;
+esac
+|}
+  ;
+  Unix.chmod df_path 0o755;
   bin_dir
 
 let test_rpc_retry_uses_isolated_build_dir () =
@@ -608,6 +656,64 @@ let test_github_disk_warning_skips_flaky_retry () =
           failf "expected exactly one dune invocation, got:\n%s"
             (String.concat "\n" log_lines))
 
+let test_low_disk_df_stops_before_flaky_retry () =
+  with_temp_dir "ci-run-tests-low-disk-df" (fun dir ->
+      let cwd = Unix.realpath dir in
+      let repo_dir = Filename.concat dir "repo" in
+      Unix.mkdir repo_dir 0o755;
+      let fake_log = Filename.concat dir "fake-dune.log" in
+      let ci_log = Filename.concat dir "ci-run-tests.log" in
+      let fake_bin = make_fake_dune_with_low_disk_df dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("DUNE_BUILD_DIR", "");
+          ("FAKE_DUNE_LOG", fake_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_TEST_DISK_CHECK_SEC", "1");
+          ("CI_TEST_DISK_MIN_AVAILABLE_MB", "1024");
+          ("CI_TEST_LOG_FILE", ci_log);
+          ("CI_CONTRACT_HARNESS_ENABLED", "0");
+          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
+        ]
+      in
+      let code, stdout, stderr =
+        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
+      in
+      check int "low disk pressure exit code" 75 code;
+      let ci_log_contents = read_file ci_log in
+      let observed_output =
+        String.concat "\n" [ ci_log_contents; stdout; stderr ]
+      in
+      check bool "disk pressure detail present" true
+        (contains_substring observed_output
+           "available_mb=14 min_available_mb=1024");
+      check bool "disk diagnostics present" true
+        (contains_substring observed_output "[ci-diag] reason=disk_pressure");
+      check bool "disk guidance present" true
+        (contains_substring observed_output
+           "detected disk exhaustion during dune build");
+      check bool "flaky retry skipped" false
+        (contains_substring observed_output "flaky-test mitigation");
+      let log_lines =
+        read_file fake_log
+        |> String.split_on_char '\n'
+        |> List.filter (fun line -> String.trim line <> "")
+      in
+      match log_lines with
+      | [ first ] ->
+          check string "single attempt uses repo cwd"
+            (Printf.sprintf "test||%s" cwd)
+            first
+      | _ ->
+          failf "expected exactly one dune invocation, got:\n%s"
+            (String.concat "\n" log_lines))
+
 let test_timeout_diagnostics_capture_active_process_group () =
   with_temp_dir "ci-run-tests-timeout" (fun dir ->
       let ci_log = Filename.concat dir "ci-run-tests.log" in
@@ -659,6 +765,8 @@ let () =
             test_disk_full_failure_skips_flaky_retry;
           test_case "github disk warning skips flaky retry" `Quick
             test_github_disk_warning_skips_flaky_retry;
+          test_case "low disk df stops before flaky retry" `Quick
+            test_low_disk_df_stops_before_flaky_retry;
           test_case "timeout diagnostics capture active process group" `Quick
             test_timeout_diagnostics_capture_active_process_group;
         ] );


### PR DESCRIPTION
## Summary
- Treat GitHub Actions low-disk warning lines as disk exhaustion in `scripts/ci-run-tests.sh`.
- Keep matching scoped to the Actions warning line while preserving existing `ENOSPC` / `dune_trace_write()` detection.
- Add `ci-run-tests` unit coverage with a fake `dune` that proves the warning skips the flaky retry path.

## Why
Several current PRs have `Build and Test` failing or cancelling after `ci-run-tests.sh` enters `.ci_build_flaky`. The logs show Actions low-space warnings during native linking and repeated linker failures. Retrying another full native-link build amplifies runner disk pressure.

This PR does not fix runner capacity by itself; it stops classifying low-disk as a flaky-test retry and prints the existing disk-repair guidance instead.

## Validation
- `bash -n scripts/ci-run-tests.sh`
- `ocamlformat --check test/test_ci_run_tests_script.ml`
- `git diff --check origin/main...HEAD`
- `GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py`
- Direct fake-dune smoke test: `status=1`, `fake_dune_invocations=1`, disk exhaustion guidance present, no `flaky-test mitigation`

## Notes
- `shellcheck scripts/ci-run-tests.sh` still reports pre-existing SC2009 / SC2012 / SC2235 only; no new shellcheck issue was introduced by this diff.
- I did not complete the focused Dune unit test locally because `scripts/dune-local.sh build @test/runtest-test_ci_run_tests_script` stayed behind the existing `/tmp/me-dune-local.lock` holder; CI remains the build authority for Dune.