### PR TITLE
feat(tool): expose keeper waiting inventory

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -103,6 +103,17 @@ let masc_dashboard_spec : tool_spec =
   }
 ;;
 
+let masc_keeper_waiting_inventory_spec : tool_spec =
+  { name = "masc_keeper_waiting_inventory"
+  ; description =
+      "Return the canonical keeper waiting inventory read model: what each keeper is \
+       waiting on, source counts, global waiting rows, and supported state labels."
+  ; parameters = []
+  ; additional_properties = false
+  ; behavior_contract = []
+  }
+;;
+
 let masc_gc_spec : tool_spec =
   { name = "masc_gc"
   ; description =
@@ -380,6 +391,7 @@ let phase6_specs : tool_spec list =
   [ masc_config_spec
   ; masc_tool_help_spec
   ; masc_dashboard_spec
+  ; masc_keeper_waiting_inventory_spec
   ; masc_gc_spec
   ; masc_tool_stats_spec
   ; masc_cleanup_zombies_spec

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1695,6 +1695,8 @@ let internal_descriptors : t list =
       "Read workspace configuration." ~readonly:true
   ; masc_misc_descriptor "dashboard" "masc_dashboard"
       "Read workspace dashboard summary." ~readonly:true
+  ; masc_misc_descriptor "keeper_waiting_inventory" "masc_keeper_waiting_inventory"
+      "Read keeper waiting inventory." ~readonly:true
   ; masc_misc_descriptor "cleanup_zombies" "masc_cleanup_zombies"
       "Reap orphan / zombie workspace state." ~readonly:false
   ; masc_misc_descriptor "tool_stats" "masc_tool_stats"

--- a/lib/otel_metric_store/otel_metric_names.ml
+++ b/lib/otel_metric_store/otel_metric_names.ml
@@ -142,6 +142,14 @@ let metric_backend_mutex_held_sec = "masc_backend_mutex_held_sec"
 let metric_tool_metrics_persist_dropped =
   Otel_metric_store_core.declare_counter "masc_tool_metrics_persist_dropped_total"
 
+(* Schedule unsupported payload counter. Labels:
+   - [phase] in {creation, dispatch}
+   - [risk_class] in [Schedule_domain.risk_class_to_string] labels.
+   Raw payload kinds are intentionally not labels; they remain in typed
+   errors/projections to avoid unbounded metric cardinality. *)
+let metric_schedule_payload_unsupported_total =
+  Otel_metric_store_core.declare_counter "masc_schedule_payload_unsupported_total"
+
 let metric_tool_bind_required_guard =
   Otel_metric_store_core.declare_counter "masc_tool_bind_required_guard_total"
 

--- a/lib/otel_metric_store/otel_metric_names.mli
+++ b/lib/otel_metric_store/otel_metric_names.mli
@@ -113,6 +113,13 @@ val metric_backend_mutex_held_sec : string
 (** Counter for [tool_metrics_persist] write-queue overflow drops. No labels. *)
 val metric_tool_metrics_persist_dropped : string
 
+(** Schedule unsupported payload counter. Labels: [phase] in
+    {[creation | dispatch]} and [risk_class] in
+    [Schedule_domain.risk_class_to_string] labels. Raw payload kinds are not
+    labels; they remain in typed errors/projections to avoid unbounded metric
+    cardinality. *)
+val metric_schedule_payload_unsupported_total : string
+
 (** Counter for bind-required guard rejects. Labels: [tool],
     [agent_name], and [reason]. *)
 val metric_tool_bind_required_guard : string

--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -1,6 +1,89 @@
+(* TEL-OK: pure schedule payload projection/validation. Runtime telemetry for
+   unsupported creation/dispatch lives at the tool/server caller boundaries. *)
+
+type known_kind =
+  | Board_post
+  | Keeper_wake
+
+type support_status =
+  | Supported
+  | Unsupported
+  | Unknown
+
+type creation_rejection =
+  | Creation_invalid_payload of string
+  | Creation_invalid_supported_payload of known_kind * string
+  | Creation_unsupported_side_effecting_kind of string
+
+type dispatch_rejection =
+  | Dispatch_invalid_payload of string
+  | Dispatch_invalid_supported_payload of known_kind * string
+  | Dispatch_unsupported_kind of string
+
+type payload_view =
+  { raw_kind : string
+  ; schema_version : int
+  ; body : (string * Yojson.Safe.t) list
+  }
+
+type unsupported_kind_count =
+  { raw_kind : string
+  ; count : int
+  }
+
+type support_summary =
+  { supported_kinds : string list
+  ; unsupported_request_count : int
+  ; unsupported_kinds : unsupported_kind_count list
+  ; unknown_request_count : int
+  }
+
+let ( let* ) = Result.bind
+
 let trim_nonempty value =
   let trimmed = String.trim value in
   if String.equal trimmed "" then None else Some trimmed
+;;
+
+let known_kind_to_string = function
+  | Board_post -> Schedule_supported_kinds.board_post
+  | Keeper_wake -> Schedule_supported_kinds.keeper_wake
+;;
+
+let dispatch_tool_name = function
+  | Board_post -> Tool_name.Board_name.(to_string Board_post)
+  | Keeper_wake -> Schedule_supported_kinds.keeper_wake
+;;
+
+let known_kinds = [ Board_post; Keeper_wake ]
+let supported_payload_kinds = List.map known_kind_to_string known_kinds
+let board_post_kind = known_kind_to_string Board_post
+let keeper_wake_kind = known_kind_to_string Keeper_wake
+
+let support_status_to_string = function
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Unknown -> "unknown"
+;;
+
+let creation_rejection_message = function
+  | Creation_invalid_payload msg -> msg
+  | Creation_invalid_supported_payload (_, msg) -> msg
+  | Creation_unsupported_side_effecting_kind raw_kind ->
+    Schedule_supported_kinds.unsupported_error raw_kind
+;;
+
+let dispatch_rejection_message = function
+  | Dispatch_invalid_payload msg -> msg
+  | Dispatch_invalid_supported_payload (_, msg) -> msg
+  | Dispatch_unsupported_kind raw_kind ->
+    "unsupported schedule payload kind: " ^ raw_kind
+;;
+
+let classify_kind = function
+  | kind when String.equal kind (known_kind_to_string Board_post) -> Some Board_post
+  | kind when String.equal kind (known_kind_to_string Keeper_wake) -> Some Keeper_wake
+  | _ -> None
 ;;
 
 let assoc_string key fields =
@@ -9,23 +92,393 @@ let assoc_string key fields =
   | _ -> None
 ;;
 
-let payload_fields payload =
-  match Schedule_domain.payload_to_yojson payload with
-  | `Assoc fields -> Some fields
-  | _ -> None
+let required_string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) ->
+    (match trim_nonempty value with
+     | Some value -> Ok value
+     | None -> Error (name ^ " must be non-empty"))
+  | Some _ -> Error ("expected string field: " ^ name)
+  | None -> Error ("missing field: " ^ name)
 ;;
 
-let kind_of_payload payload =
-  Option.bind (payload_fields payload) (assoc_string "kind")
+let optional_string_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (trim_nonempty value)
+  | Some _ -> Error ("expected string field: " ^ name)
 ;;
 
-let body_fields payload =
-  match payload_fields payload with
-  | Some fields ->
-    (match List.assoc_opt "body" fields with
-     | Some (`Assoc body) -> Some body
-     | _ -> None)
-  | None -> None
+let optional_int_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ -> Error ("expected int field: " ^ name)
+;;
+
+let optional_assoc_field name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Assoc _ as value) -> Ok (Some value)
+  | Some _ -> Error ("expected object field: " ^ name)
+;;
+
+let payload_view_of_json payload =
+  match payload with
+  | `Assoc fields ->
+    let* raw_kind = required_string_field "kind" fields in
+    let* schema_version =
+      match List.assoc_opt "schema_version" fields with
+      | Some (`Int value) -> Ok value
+      | Some _ -> Error "expected int field: schema_version"
+      | None -> Error "missing field: schema_version"
+    in
+    let* body =
+      match List.assoc_opt "body" fields with
+      | Some (`Assoc body) -> Ok body
+      | Some _ -> Error "payload.body must be an object"
+      | None -> Error "missing field: body"
+    in
+    Ok { raw_kind; schema_version; body }
+  | _ -> Error "payload must be a JSON object"
+;;
+
+let payload_view (request : Schedule_domain.schedule_request) =
+  Schedule_domain.payload_to_yojson request.payload |> payload_view_of_json
+;;
+
+let kind_of_json_result payload =
+  let* view = payload_view_of_json payload in
+  Ok view.raw_kind
+;;
+
+let board_schema_version_error ~creation schema_version =
+  if schema_version = 1
+  then Ok ()
+  else if creation
+  then Error (board_post_kind ^ " only supports payload_schema_version=1")
+  else Error (board_post_kind ^ " only supports schema_version=1")
+;;
+
+let validate_board_post_common ~content_error view =
+  let* _content =
+    match assoc_string "content" view.body with
+    | Some content -> Ok content
+    | None -> Error content_error
+  in
+  let* ttl_hours = optional_int_field "ttl_hours" view.body in
+  match ttl_hours with
+  | Some ttl when ttl < 0 -> Error "ttl_hours must be non-negative"
+  | _ -> Ok ()
+;;
+
+let validate_board_post_for_creation ~risk_class view =
+  let* () = board_schema_version_error ~creation:true view.schema_version in
+  if not (Schedule_domain.is_side_effecting risk_class)
+  then
+    Error
+      (board_post_kind
+       ^ " requires a side-effecting risk_class such as workspace_write")
+  else
+    validate_board_post_common
+      ~content_error:
+        (board_post_kind
+         ^ " payload requires non-empty body.content; use board_content for board schedules")
+      view
+;;
+
+let validate_board_post_for_dispatch request view =
+  let* () = board_schema_version_error ~creation:false view.schema_version in
+  if not (Schedule_domain.is_side_effecting request.Schedule_domain.risk_class)
+  then Error (board_post_kind ^ " requires a side-effecting risk_class")
+  else
+    validate_board_post_common
+      ~content_error:"missing field: content"
+      view
+;;
+
+let keeper_wake_schema_version_error ~creation schema_version =
+  if schema_version = 1
+  then Ok ()
+  else if creation
+  then Error (keeper_wake_kind ^ " only supports payload_schema_version=1")
+  else Error (keeper_wake_kind ^ " only supports schema_version=1")
+;;
+
+let validate_keeper_wake_body body =
+  match assoc_string "keeper_name" body, assoc_string "message" body with
+  | None, _ -> Error (keeper_wake_kind ^ " payload requires non-empty body.keeper_name")
+  | _, None -> Error (keeper_wake_kind ^ " payload requires non-empty body.message")
+  | Some keeper_name, Some _
+    when not (Schedule_supported_kinds.valid_keeper_wake_target_name keeper_name) ->
+    Error
+      (Schedule_supported_kinds.keeper_wake_target_name_error
+         ~field:(keeper_wake_kind ^ " payload body.keeper_name"))
+  | Some _, Some _ ->
+    (match optional_string_field "urgency" body with
+     | Error msg -> Error msg
+     | Ok None -> Ok ()
+     | Ok (Some raw) ->
+       Schedule_supported_kinds.keeper_wake_urgency_of_string raw
+       |> Result.map (fun _ -> ()))
+;;
+
+let validate_keeper_wake_for_creation ~risk_class view =
+  let* () = keeper_wake_schema_version_error ~creation:true view.schema_version in
+  if not (Schedule_domain.is_side_effecting risk_class)
+  then
+    Error
+      (keeper_wake_kind
+       ^ " requires a side-effecting risk_class such as workspace_write")
+  else validate_keeper_wake_body view.body
+;;
+
+let validate_keeper_wake_for_dispatch request view =
+  let* () = keeper_wake_schema_version_error ~creation:false view.schema_version in
+  if not (Schedule_domain.is_side_effecting request.Schedule_domain.risk_class)
+  then Error (keeper_wake_kind ^ " requires a side-effecting risk_class")
+  else validate_keeper_wake_body view.body
+;;
+
+let validate_request_payload_for_creation_detailed ~payload ~risk_class =
+  match payload with
+  | `Assoc fields ->
+    (match assoc_string "kind" fields with
+     | Some raw_kind ->
+       (match classify_kind raw_kind with
+        | Some Board_post ->
+          let* schema_version =
+            match List.assoc_opt "schema_version" fields with
+            | Some (`Int value) -> Ok value
+            | Some _ ->
+              Error
+                (Creation_invalid_supported_payload
+                   ( Board_post
+                   , board_post_kind ^ " payload.schema_version must be an integer" ))
+            | None ->
+              Error
+                (Creation_invalid_supported_payload
+                   (Board_post, board_post_kind ^ " payload requires schema_version=1"))
+          in
+          let* body =
+            match List.assoc_opt "body" fields with
+            | Some (`Assoc body) -> Ok body
+            | Some _ ->
+              Error
+                (Creation_invalid_supported_payload
+                   (Board_post, board_post_kind ^ " payload.body must be an object"))
+            | None ->
+              Error
+                (Creation_invalid_supported_payload
+                   ( Board_post
+                   , board_post_kind
+                     ^ " payload requires object body with non-empty content; use board_content for board schedules"
+                   ))
+          in
+          validate_board_post_for_creation ~risk_class
+            { raw_kind; schema_version; body }
+          |> Result.map_error (fun msg ->
+            Creation_invalid_supported_payload (Board_post, msg))
+        | Some Keeper_wake ->
+          let* schema_version =
+            match List.assoc_opt "schema_version" fields with
+            | Some (`Int value) -> Ok value
+            | Some _ ->
+              Error
+                (Creation_invalid_supported_payload
+                   ( Keeper_wake
+                   , keeper_wake_kind ^ " payload.schema_version must be an integer" ))
+            | None ->
+              Error
+                (Creation_invalid_supported_payload
+                   (Keeper_wake, keeper_wake_kind ^ " payload requires schema_version=1"))
+          in
+          let* body =
+            match List.assoc_opt "body" fields with
+            | Some (`Assoc body) -> Ok body
+            | Some _ ->
+              Error
+                (Creation_invalid_supported_payload
+                   (Keeper_wake, keeper_wake_kind ^ " payload.body must be an object"))
+            | None ->
+              Error
+                (Creation_invalid_supported_payload
+                   (Keeper_wake, keeper_wake_kind ^ " payload requires object body"))
+          in
+          validate_keeper_wake_for_creation ~risk_class
+            { raw_kind; schema_version; body }
+          |> Result.map_error (fun msg ->
+            Creation_invalid_supported_payload (Keeper_wake, msg))
+        | None when Schedule_domain.is_side_effecting risk_class ->
+          Error (Creation_unsupported_side_effecting_kind raw_kind)
+        | None -> Ok ())
+     | None -> Error (Creation_invalid_payload "payload.kind is required"))
+  | _ -> Error (Creation_invalid_payload "payload must be a JSON object")
+;;
+
+let validate_request_payload_for_creation ~payload ~risk_class =
+  validate_request_payload_for_creation_detailed ~payload ~risk_class
+  |> Result.map_error creation_rejection_message
+;;
+
+let dispatch_view_detailed request =
+  let* view =
+    payload_view request |> Result.map_error (fun msg -> Dispatch_invalid_payload msg)
+  in
+  match classify_kind view.raw_kind with
+  | Some Board_post ->
+    let* () =
+      validate_board_post_for_dispatch request view
+      |> Result.map_error (fun msg ->
+        Dispatch_invalid_supported_payload (Board_post, msg))
+    in
+    Ok (Board_post, view)
+  | Some Keeper_wake ->
+    let* () =
+      validate_keeper_wake_for_dispatch request view
+      |> Result.map_error (fun msg ->
+        Dispatch_invalid_supported_payload (Keeper_wake, msg))
+    in
+    Ok (Keeper_wake, view)
+  | None -> Error (Dispatch_unsupported_kind view.raw_kind)
+;;
+
+let dispatch_view request =
+  dispatch_view_detailed request |> Result.map_error dispatch_rejection_message
+;;
+
+let log_projection_error (request : Schedule_domain.schedule_request) ~surface message =
+  Log.Misc.warn
+    "schedule_payload_projection.%s failed schedule_id=%s: %s"
+    surface
+    request.schedule_id
+    message
+;;
+
+let support_status_result request =
+  match payload_view request with
+  | Error msg -> Error msg
+  | Ok view ->
+    (match classify_kind view.raw_kind with
+     | Some _ -> Ok Supported
+     | None -> Ok Unsupported)
+;;
+
+let support_status request =
+  match support_status_result request with
+  | Ok status -> status
+  | Error msg ->
+    log_projection_error request ~surface:"support_status" msg;
+    Unknown
+;;
+
+let kind_result (request : Schedule_domain.schedule_request) =
+  Schedule_domain.payload_to_yojson request.payload |> kind_of_json_result
+;;
+
+let kind request =
+  match kind_result request with
+  | Ok raw_kind -> Some raw_kind
+  | Error msg ->
+    log_projection_error request ~surface:"kind" msg;
+    None
+;;
+
+let dispatch_tool_for_request_result request =
+  match dispatch_view_detailed request with
+  | Ok (kind, _) -> Ok (dispatch_tool_name kind)
+  | Error err -> Error err
+;;
+
+let dispatch_tool_for_request request =
+  match dispatch_tool_for_request_result request with
+  | Ok tool_name -> Some tool_name
+  | Error err ->
+    log_projection_error
+      request
+      ~surface:"dispatch_tool_for_request"
+      (dispatch_rejection_message err);
+    None
+;;
+
+let known_kind_contract_to_yojson kind =
+  match kind with
+  | Board_post | Keeper_wake ->
+    `Assoc
+      [ "kind", `String (known_kind_to_string kind)
+      ; "schema_versions", `List [ `Int 1 ]
+      ; "dispatch_tool", `String (dispatch_tool_name kind)
+      ; "side_effecting_risk_required", `Bool true
+      ; "creation_contract", `String "per_kind_validator_required"
+      ; "dispatch_contract", `String "consumer_supported"
+      ]
+;;
+
+let supported_contracts_to_yojson () =
+  `List (List.map known_kind_contract_to_yojson known_kinds)
+;;
+
+let support_summary schedules =
+  let bump kind counts =
+    let rec loop acc = function
+      | [] -> List.rev ((kind, 1) :: acc)
+      | (existing, count) :: rest when String.equal existing kind ->
+        List.rev_append acc ((existing, count + 1) :: rest)
+      | item :: rest -> loop (item :: acc) rest
+    in
+    loop [] counts
+  in
+  let unsupported_request_count, unknown_request_count, unsupported_kinds =
+    List.fold_left
+      (fun (unsupported_count, unknown_count, kind_counts)
+        (request : Schedule_domain.schedule_request) ->
+         match support_status request with
+         | Supported -> unsupported_count, unknown_count, kind_counts
+         | Unsupported ->
+           (match kind request with
+            | Some raw_kind ->
+              unsupported_count + 1, unknown_count, bump raw_kind kind_counts
+            | None -> unsupported_count, unknown_count + 1, kind_counts)
+         | Unknown -> unsupported_count, unknown_count + 1, kind_counts)
+      (0, 0, [])
+      schedules
+  in
+  let unsupported_kinds =
+    unsupported_kinds
+    |> List.sort (fun (left_kind, left_count) (right_kind, right_count) ->
+      match compare right_count left_count with
+      | 0 -> String.compare left_kind right_kind
+      | order -> order)
+    |> List.map (fun (raw_kind, count) -> { raw_kind; count })
+  in
+  let supported_kinds = List.sort_uniq String.compare supported_payload_kinds in
+  { supported_kinds
+  ; unsupported_request_count
+  ; unsupported_kinds
+  ; unknown_request_count
+  }
+;;
+
+let support_summary_yojson summary =
+  `Assoc
+    [ ( "supported_kinds"
+      , `List
+          (List.map (fun raw_kind -> `String raw_kind) summary.supported_kinds)
+      )
+    ; "supported_contracts", supported_contracts_to_yojson ()
+    ; "unsupported_request_count", `Int summary.unsupported_request_count
+    ; ( "unsupported_kinds"
+      , `List
+          (List.map
+             (fun { raw_kind; count } ->
+                `Assoc [ "kind", `String raw_kind; "count", `Int count ])
+             summary.unsupported_kinds) )
+    ; "unknown_request_count", `Int summary.unknown_request_count
+    ]
+;;
+
+let support_summary_to_yojson schedules =
+  schedules |> support_summary |> support_summary_yojson
 ;;
 
 let board_target body =
@@ -61,19 +514,27 @@ let keeper_wake_summary body =
   | None, None -> None
 ;;
 
-let target_summary_of_payload payload =
-  match kind_of_payload payload, body_fields payload with
-  | Some kind, Some body when String.equal kind Schedule_supported_kinds.board_post ->
-    board_target body, board_summary body
-  | Some kind, Some body when String.equal kind Schedule_supported_kinds.keeper_wake ->
-    keeper_wake_target body, keeper_wake_summary body
-  | _ -> None, None
+let target_summary_result (request : Schedule_domain.schedule_request) =
+  match payload_view request with
+  | Error msg -> Error msg
+  | Ok view ->
+    (match classify_kind view.raw_kind with
+     | Some Board_post -> Ok (board_target view.body, board_summary view.body)
+     | Some Keeper_wake -> Ok (keeper_wake_target view.body, keeper_wake_summary view.body)
+     | None -> Ok (None, None))
 ;;
 
-let kind (request : Schedule_domain.schedule_request) =
-  kind_of_payload request.payload
+let target_summary request =
+  match target_summary_result request with
+  | Ok summary -> summary
+  | Error msg ->
+    log_projection_error request ~surface:"target_summary" msg;
+    None, None
 ;;
 
-let target_summary (request : Schedule_domain.schedule_request) =
-  target_summary_of_payload request.payload
-;;
+let view_kind (view : payload_view) = view.raw_kind
+let view_schema_version (view : payload_view) = view.schema_version
+let body_required_string view name = required_string_field name view.body
+let body_optional_string view name = optional_string_field name view.body
+let body_optional_int view name = optional_int_field name view.body
+let body_optional_assoc view name = optional_assoc_field name view.body

--- a/lib/schedule_payload_projection.mli
+++ b/lib/schedule_payload_projection.mli
@@ -1,0 +1,94 @@
+(** Typed projection and registry for schedule payload envelopes.
+
+    The schedule domain keeps payloads opaque. This module is the boundary that
+    names the payload kinds MASC can understand, validates side-effecting
+    creation requests, and returns typed views for production dispatch. *)
+
+type known_kind =
+  | Board_post
+  | Keeper_wake
+
+type support_status =
+  | Supported
+  | Unsupported
+  | Unknown
+
+type creation_rejection =
+  | Creation_invalid_payload of string
+  | Creation_invalid_supported_payload of known_kind * string
+  | Creation_unsupported_side_effecting_kind of string
+
+type dispatch_rejection =
+  | Dispatch_invalid_payload of string
+  | Dispatch_invalid_supported_payload of known_kind * string
+  | Dispatch_unsupported_kind of string
+
+type payload_view
+
+type unsupported_kind_count =
+  { raw_kind : string
+  ; count : int
+  }
+
+type support_summary =
+  { supported_kinds : string list
+  ; unsupported_request_count : int
+  ; unsupported_kinds : unsupported_kind_count list
+  ; unknown_request_count : int
+  }
+
+val known_kind_to_string : known_kind -> string
+val dispatch_tool_name : known_kind -> string
+val supported_payload_kinds : string list
+val support_status_to_string : support_status -> string
+val creation_rejection_message : creation_rejection -> string
+val dispatch_rejection_message : dispatch_rejection -> string
+val supported_contracts_to_yojson : unit -> Yojson.Safe.t
+val support_summary : Schedule_domain.schedule_request list -> support_summary
+val support_summary_yojson : support_summary -> Yojson.Safe.t
+val support_summary_to_yojson : Schedule_domain.schedule_request list -> Yojson.Safe.t
+val kind_of_json_result : Yojson.Safe.t -> (string, string) result
+
+val validate_request_payload_for_creation_detailed
+  :  payload:Yojson.Safe.t
+  -> risk_class:Schedule_domain.risk_class
+  -> (unit, creation_rejection) result
+
+val validate_request_payload_for_creation
+  :  payload:Yojson.Safe.t
+  -> risk_class:Schedule_domain.risk_class
+  -> (unit, string) result
+
+val dispatch_view_detailed
+  :  Schedule_domain.schedule_request
+  -> (known_kind * payload_view, dispatch_rejection) result
+
+val dispatch_view
+  :  Schedule_domain.schedule_request
+  -> (known_kind * payload_view, string) result
+
+val support_status_result
+  :  Schedule_domain.schedule_request
+  -> (support_status, string) result
+
+val support_status : Schedule_domain.schedule_request -> support_status
+val kind_result : Schedule_domain.schedule_request -> (string, string) result
+val kind : Schedule_domain.schedule_request -> string option
+
+val dispatch_tool_for_request_result
+  :  Schedule_domain.schedule_request
+  -> (string, dispatch_rejection) result
+
+val dispatch_tool_for_request : Schedule_domain.schedule_request -> string option
+val target_summary_result
+  :  Schedule_domain.schedule_request
+  -> (string option * string option, string) result
+
+val target_summary : Schedule_domain.schedule_request -> string option * string option
+
+val view_kind : payload_view -> string
+val view_schema_version : payload_view -> int
+val body_required_string : payload_view -> string -> (string, string) result
+val body_optional_string : payload_view -> string -> (string option, string) result
+val body_optional_int : payload_view -> string -> (int option, string) result
+val body_optional_assoc : payload_view -> string -> (Yojson.Safe.t option, string) result

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -2,7 +2,7 @@
    [Schedule_runner] and persisted as execution records; the server maintenance
    loop logs aggregate dispatch counts for runtime telemetry. *)
 
-let supported_payload_kinds = Schedule_supported_kinds.supported
+let supported_payload_kinds = Schedule_payload_projection.supported_payload_kinds
 let board_post_created_kind = "masc.board_post.created"
 let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
 let keeper_event_queue_label = "keeper_event_queue"
@@ -10,6 +10,23 @@ let reaction_ledger_recorded_label = "recorded"
 let reaction_ledger_record_failed_label = "record_failed"
 
 let ( let* ) = Result.bind
+
+let unsupported_payload_labels ~phase (request : Schedule_domain.schedule_request) =
+  [ "phase", phase
+  ; "risk_class", Schedule_domain.risk_class_to_string request.risk_class
+  ]
+;;
+
+let record_unsupported_payload_dispatch request rejection =
+  match rejection with
+  | Schedule_payload_projection.Dispatch_unsupported_kind _ ->
+    Otel_metric_store.inc_counter
+      Otel_metric_store.metric_schedule_payload_unsupported_total
+      ~labels:(unsupported_payload_labels ~phase:"dispatch" request)
+      ()
+  | Schedule_payload_projection.Dispatch_invalid_payload _
+  | Schedule_payload_projection.Dispatch_invalid_supported_payload _ -> ()
+;;
 
 let assoc_field name fields =
   match List.assoc_opt name fields with
@@ -34,13 +51,6 @@ let optional_string_field name fields =
   | Some _ -> Error ("expected string field: " ^ name)
 ;;
 
-let optional_int_field name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`Int value) -> Ok (Some value)
-  | Some _ -> Error ("expected int field: " ^ name)
-;;
-
 let optional_keeper_wake_urgency_field name fields =
   match List.assoc_opt name fields with
   | None | Some `Null -> Ok None
@@ -63,13 +73,6 @@ let keeper_queue_urgency_of_schedule_urgency = function
   | Schedule_supported_kinds.Keeper_wake_immediate -> Keeper_event_queue.Immediate
   | Schedule_supported_kinds.Keeper_wake_normal -> Keeper_event_queue.Normal
   | Schedule_supported_kinds.Keeper_wake_low -> Keeper_event_queue.Low
-;;
-
-let optional_assoc_field name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`Assoc _ as value) -> Ok (Some value)
-  | Some _ -> Error ("expected object field: " ^ name)
 ;;
 
 type keeper_wake_reaction_ledger_status =
@@ -185,7 +188,10 @@ let dispatch_receipt_to_yojson = function
       ([ "kind", `String keeper_wake_enqueued_kind
        ; "queue", `String queue
        ; "stimulus", `String stimulus
-       ; "stimulus_id", (match stimulus_id with None -> `Null | Some value -> `String value)
+       ; ( "stimulus_id"
+         , match stimulus_id with
+           | None -> `Null
+           | Some value -> `String value )
        ; "keeper_name", `String keeper_name
        ; "schedule_id", `String schedule_id
        ; "urgency", `String urgency
@@ -194,74 +200,19 @@ let dispatch_receipt_to_yojson = function
        @ keeper_wake_reaction_ledger_status_json_fields reaction_ledger_status)
 ;;
 
-type payload_view =
-  { kind : string
-  ; schema_version : int
-  ; body : (string * Yojson.Safe.t) list
-  }
-
-let payload_view (request : Schedule_domain.schedule_request) =
-  match Schedule_domain.payload_to_yojson request.payload with
-  | `Assoc fields ->
-    let* kind = string_field "kind" fields in
-    let* schema_version =
-      match List.assoc_opt "schema_version" fields with
-      | Some (`Int value) -> Ok value
-      | Some _ -> Error "expected int field: schema_version"
-      | None -> Error "missing field: schema_version"
-    in
-    let* body =
-      match List.assoc_opt "body" fields with
-      | Some (`Assoc fields) -> Ok fields
-      | Some _ -> Error "payload.body must be an object"
-      | None -> Error "missing field: body"
-    in
-    Ok { kind; schema_version; body }
-  | _ -> Error "payload must be an object"
-;;
-
-let accepts_board_post (request : Schedule_domain.schedule_request) payload =
-  if not (String.equal payload.kind Schedule_supported_kinds.board_post) then
-    Error ("unsupported schedule payload kind: " ^ payload.kind)
-  else if payload.schema_version <> 1 then
-    Error "masc.board_post only supports schema_version=1"
-  else if not (Schedule_domain.is_side_effecting request.risk_class) then
-    Error "masc.board_post requires a side-effecting risk_class"
-  else
-    let* _content = string_field "content" payload.body in
-    let* ttl_hours = optional_int_field "ttl_hours" payload.body in
-    match ttl_hours with
-    | Some ttl when ttl < 0 -> Error "ttl_hours must be non-negative"
-    | _ -> Ok ()
-;;
-
-let accepts_keeper_wake (request : Schedule_domain.schedule_request) payload =
-  if not (String.equal payload.kind Schedule_supported_kinds.keeper_wake) then
-    Error ("unsupported schedule payload kind: " ^ payload.kind)
-  else if payload.schema_version <> 1 then
-    Error "masc.keeper_wake only supports schema_version=1"
-  else if not (Schedule_domain.is_side_effecting request.risk_class) then
-    Error "masc.keeper_wake requires a side-effecting risk_class"
-  else
-    let* _keeper_name = keeper_name_field "keeper_name" payload.body in
-    let* _message = string_field "message" payload.body in
-    let* _title = optional_string_field "title" payload.body in
-    let* _urgency = optional_keeper_wake_urgency_field "urgency" payload.body in
-    Ok ()
-;;
-
 let accepts request =
-  let* payload = payload_view request in
-  if String.equal payload.kind Schedule_supported_kinds.board_post
-  then accepts_board_post request payload
-  else accepts_keeper_wake request payload
+  match Schedule_payload_projection.dispatch_view_detailed request with
+  | Ok (_kind, _payload) -> Ok ()
+  | Error rejection ->
+    record_unsupported_payload_dispatch request rejection;
+    Error (Schedule_payload_projection.dispatch_rejection_message rejection)
 ;;
 
 let schedule_meta_json (request : Schedule_domain.schedule_request) payload user_meta =
   let base =
     [ "source", `String "scheduled_automation"
     ; "schedule_id", `String request.schedule_id
-    ; "payload_kind", `String payload.kind
+    ; "payload_kind", `String (Schedule_payload_projection.view_kind payload)
     ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
     ; "requested_by", `String request.requested_by.id
     ; "scheduled_by", `String request.scheduled_by.id
@@ -275,13 +226,13 @@ let schedule_meta_json (request : Schedule_domain.schedule_request) payload user
 ;;
 
 let dispatch_board_post request payload =
-  let* content = string_field "content" payload.body in
-  let* title = optional_string_field "title" payload.body in
-  let* author = optional_string_field "author" payload.body in
-  let* hearth = optional_string_field "hearth" payload.body in
-  let* thread_id = optional_string_field "thread_id" payload.body in
-  let* ttl_hours = optional_int_field "ttl_hours" payload.body in
-  let* user_meta = optional_assoc_field "meta" payload.body in
+  let* content = Schedule_payload_projection.body_required_string payload "content" in
+  let* title = Schedule_payload_projection.body_optional_string payload "title" in
+  let* author = Schedule_payload_projection.body_optional_string payload "author" in
+  let* hearth = Schedule_payload_projection.body_optional_string payload "hearth" in
+  let* thread_id = Schedule_payload_projection.body_optional_string payload "thread_id" in
+  let* ttl_hours = Schedule_payload_projection.body_optional_int payload "ttl_hours" in
+  let* user_meta = Schedule_payload_projection.body_optional_assoc payload "meta" in
   let author =
     (* DET-OK: absent board-post author maps to the stable scheduled automation
        actor label for auditability. *)
@@ -291,8 +242,17 @@ let dispatch_board_post request payload =
   in
   let meta_json = schedule_meta_json request payload user_meta in
   match
-    Board_dispatch.create_post ~author ~content ?title ~post_kind:Board.System_post
-      ~meta_json ~visibility:Board.Internal ?ttl_hours ?hearth ?thread_id ()
+    Board_dispatch.create_post
+      ~author
+      ~content
+      ?title
+      ~post_kind:Board.System_post
+      ~meta_json
+      ~visibility:Board.Internal
+      ?ttl_hours
+      ?hearth
+      ?thread_id
+      ()
   with
   | Error err -> Error (Board_types.show_board_error err)
   | Ok post ->
@@ -309,6 +269,26 @@ let dispatch_board_post request payload =
         ])
 ;;
 
+let body_keeper_name payload =
+  let* keeper_name =
+    Schedule_payload_projection.body_required_string payload "keeper_name"
+  in
+  if Schedule_supported_kinds.valid_keeper_wake_target_name keeper_name
+  then Ok keeper_name
+  else
+    Error
+      (Schedule_supported_kinds.keeper_wake_target_name_error ~field:"keeper_name")
+;;
+
+let body_keeper_wake_urgency payload =
+  let* raw = Schedule_payload_projection.body_optional_string payload "urgency" in
+  match raw with
+  | None -> Ok None
+  | Some value ->
+    let* urgency = Schedule_supported_kinds.keeper_wake_urgency_of_string value in
+    Ok (Some urgency)
+;;
+
 let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
   try
     Keeper_reaction_ledger.record_event_queue_stimulus ~base_path ~keeper_name stimulus;
@@ -323,10 +303,10 @@ let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
 ;;
 
 let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request) payload =
-  let* keeper_name = keeper_name_field "keeper_name" payload.body in
-  let* message = string_field "message" payload.body in
-  let* title = optional_string_field "title" payload.body in
-  let* urgency = optional_keeper_wake_urgency_field "urgency" payload.body in
+  let* keeper_name = body_keeper_name payload in
+  let* message = Schedule_payload_projection.body_required_string payload "message" in
+  let* title = Schedule_payload_projection.body_optional_string payload "title" in
+  let* urgency = body_keeper_wake_urgency payload in
   let urgency =
     urgency
     (* DET-OK: absent masc.keeper_wake urgency is the schema-v1 default;
@@ -383,14 +363,14 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
 ;;
 
 let dispatch config ~now request =
-  let* payload = payload_view request in
-  if String.equal payload.kind Schedule_supported_kinds.board_post
-  then (
-    let* () = accepts_board_post request payload in
-    dispatch_board_post request payload)
-  else (
-    let* () = accepts_keeper_wake request payload in
-    dispatch_keeper_wake config ~now request payload)
+  match Schedule_payload_projection.dispatch_view_detailed request with
+  | Error rejection ->
+    Error (Schedule_payload_projection.dispatch_rejection_message rejection)
+  | Ok (kind, payload) ->
+    (match kind with
+     | Schedule_payload_projection.Board_post -> dispatch_board_post request payload
+     | Schedule_payload_projection.Keeper_wake ->
+       dispatch_keeper_wake config ~now request payload)
 ;;
 
 let consumer : Schedule_runner.consumer = { accepts; dispatch }

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -247,6 +247,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_plan_update", broadcast_tool);
     ("masc_keeper_list", read_state_tool);
     ("masc_keeper_status", read_state_tool);
+    ("masc_keeper_waiting_inventory", read_state_tool);
     ("masc_keeper_up", broadcast_tool);
     ( "masc_keeper_down",
       with_semantic_flags ~destructive:true ~effect_domain:Masc_workspace

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -36,6 +36,26 @@ let workspace_mutating_tool_names =
   [ "tool_edit_file"; "tool_write_file"; "create_text_file"; "edit_text_file"; "file_write" ]
 ;;
 
+let schedule_request_surface_tools =
+  [ "masc_schedule_create"
+  ; "masc_schedule_list"
+  ; "masc_schedule_get"
+  ; "masc_schedule_cancel"
+  ]
+;;
+
+let schedule_operator_decision_tools =
+  [ "masc_schedule_approve"; "masc_schedule_reject" ]
+;;
+
+let public_schedule_surface_tools = schedule_request_surface_tools
+let keeper_schedule_surface_tools = schedule_request_surface_tools
+(* TEL-OK: pure surface membership constants; tool-call telemetry is emitted by
+   the dispatch/runtime boundary. *)
+let spawned_agent_schedule_surface_tools = []
+let local_worker_schedule_surface_tools = []
+let schedule_surface_tools = schedule_request_surface_tools
+
 (* ================================================================ *)
 (* Curated tool-name lists                                          *)
 (* ================================================================ *)
@@ -86,7 +106,10 @@ let public_mcp_surface_tools =
   ; "masc_board_curation_read"
   ; "masc_board_curation_submit"
   ; "masc_board_reaction"
-  ; (* Agent discovery *)
+  ]
+  @ public_schedule_surface_tools
+  @
+  [ (* Agent discovery *)
     "masc_agent_card"
   ; (* Utility *)
     "masc_tool_help"
@@ -135,6 +158,7 @@ let spawned_agent_surface_tools =
   ; "masc_note_add"
   ; "masc_update_priority"
   ]
+  @ spawned_agent_schedule_surface_tools
 ;;
 
 let local_worker_surface_tools =
@@ -169,6 +193,7 @@ let local_worker_surface_tools =
   ; "masc_run_get"
   ; "masc_run_list"
   ]
+  @ local_worker_schedule_surface_tools
 ;;
 
 let session_min_surface_tools =

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -71,6 +71,7 @@ let public_mcp_surface_tools =
   ; (* Keeper runtime front door. *)
     "masc_keeper_list"
   ; "masc_keeper_status"
+  ; "masc_keeper_waiting_inventory"
   ; "masc_keeper_up"
   ; "masc_keeper_down"
   ; (* Persona authoring is operator-visible. *)

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.mli
@@ -14,6 +14,30 @@
 val public_mcp_surface_tools : string list
 (** Externally reachable MCP tools — the public surface. *)
 
+val schedule_request_surface_tools : string list
+(** Schedule request tools that read/create/cancel durable schedule rows. *)
+
+val schedule_operator_decision_tools : string list
+(** Human decision tools for approve/reject. These are not public MCP or
+    keeper-standard tools; dashboard/operator endpoints own those actions. *)
+
+val public_schedule_surface_tools : string list
+(** Schedule tools visible to external MCP clients. *)
+
+val keeper_schedule_surface_tools : string list
+(** Schedule tools visible to keeper-standard projections. *)
+
+val spawned_agent_schedule_surface_tools : string list
+(** Schedule tools visible to spawned managed agents. Empty by policy until
+    spawned agents have a lane ownership contract for reservations. *)
+
+val local_worker_schedule_surface_tools : string list
+(** Schedule tools visible to local worker containers. Empty by policy:
+    local workers execute bounded delegated work, not durable reservations. *)
+
+val schedule_surface_tools : string list
+(** Compatibility alias for {!schedule_request_surface_tools}. *)
+
 val spawned_agent_surface_tools : string list
 (** Tools visible to spawned worker agents. *)
 

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -71,6 +71,23 @@ let workflow_err ~tool_name ~start_time msg : Tool_result.result =
     ~start_time
     msg
 
+let expect_no_args ~tool_name ~start_time args =
+  match args with
+  | `Assoc [] -> Ok ()
+  | `Assoc fields ->
+      let names = fields |> List.map fst |> String.concat ", " in
+      Error
+        (workflow_err
+           ~tool_name
+           ~start_time
+           (Printf.sprintf "%s does not accept arguments: %s" tool_name names))
+  | _ ->
+      Error
+        (workflow_err
+           ~tool_name
+           ~start_time
+           (Printf.sprintf "%s arguments must be an object" tool_name))
+
 let dashboard_handler =
   ref (fun ~tool_name ~start_time:_ _ctx _args ->
     Tool_result.make_err
@@ -133,6 +150,16 @@ let handle_tool_stats ~tool_name ~start_time _ctx args : Tool_result.result =
   let report = Tool_registry.stats_report ~top_n ~all_tool_names in
   text_ok ~tool_name ~start_time (Yojson.Safe.to_string report)
 
+let handle_keeper_waiting_inventory ~tool_name ~start_time ctx args : Tool_result.result =
+  match expect_no_args ~tool_name ~start_time args with
+  | Error result -> result
+  | Ok () ->
+      Tool_result.make_ok
+        ~tool_name
+        ~start_time
+        ~data:(Server_keeper_waiting_inventory.dashboard_json ctx.config)
+        ()
+
 let strip_mcp_prefix name =
   let prefix = "mcp__masc__" in
   let plen = String.length prefix in
@@ -186,6 +213,8 @@ let dispatch ctx ~name ~args : Tool_result.result option =
       Some (Tool_misc_introspection.handle_config ~tool_name:name ~start_time:start args)
   | "masc_dashboard" ->
       Some (handle_dashboard ~tool_name:name ~start_time:start ctx args)
+  | "masc_keeper_waiting_inventory" ->
+      Some (handle_keeper_waiting_inventory ~tool_name:name ~start_time:start ctx args)
   | "masc_gc" -> Some (handle_gc ~tool_name:name ~start_time:start ctx args)
   | "masc_cleanup_zombies" ->
       Some (handle_cleanup_zombies ~tool_name:name ~start_time:start ctx args)
@@ -209,6 +238,7 @@ let tool_spec_read_only =
   [
     "masc_tool_help";
     "masc_dashboard";
+    "masc_keeper_waiting_inventory";
   ]
 
 let () =

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -41,9 +41,13 @@ let resolve_due_at ~requested_at recurrence args =
   match due_at with
   | Some due_at -> Ok due_at
   | None ->
-    (match Schedule_domain.first_due_after ~now:requested_at recurrence with
-     | Some due_at -> Ok due_at
-     | None ->
+    (match Schedule_domain.first_due_after_result ~now:requested_at recurrence with
+     | Error err ->
+       Error
+         ("recurrence due_at calculation failed: "
+          ^ Schedule_domain.due_calculation_error_to_string err)
+     | Ok (Some due_at) -> Ok due_at
+     | Ok None ->
        Error
          "one of due_at_unix or due_at_iso is required unless recurrence_kind is daily or cron")
 ;;
@@ -173,7 +177,7 @@ let board_post_payload_from_args args =
   let* content = required_string args "board_content" in
   let schema_version =
     (* DET-OK: board_* is a stable convenience projection for the existing
-       masc.board_post v1 consumer. *)
+       board-post v1 consumer. *)
     optional_int args "payload_schema_version" |> Option.value ~default:1
   in
   if schema_version <> 1
@@ -192,7 +196,7 @@ let board_post_payload_from_args args =
     let* fields = optional_body_object args ~arg:"board_meta" ~field:"meta" fields in
     Ok
       (`Assoc
-        [ "kind", `String "masc.board_post"
+        [ "kind", `String Schedule_supported_kinds.board_post
         ; "schema_version", `Int schema_version
         ; "body", `Assoc (List.rev fields)
         ])
@@ -235,102 +239,63 @@ let payload_from_args args =
            board_post_payload_from_args args
          | Some kind ->
            Error
-             ("board_* convenience fields require payload_kind omitted or masc.board_post, got "
+             ("board_* convenience fields require payload_kind omitted or "
+              ^ Schedule_supported_kinds.board_post
+              ^ ", got "
               ^ kind))
     else generic_payload_from_args args
 ;;
 
-let assoc_string_opt key fields =
-  match List.assoc_opt key fields with
-  | Some (`String value) -> trim_nonempty value
-  | _ -> None
+let schedule_payload_unsupported_labels ~phase ~risk_class =
+  [ "phase", phase
+  ; "risk_class", Schedule_domain.risk_class_to_string risk_class
+  ]
 ;;
 
-let validate_payload_schema_version ~kind fields =
-  match List.assoc_opt "schema_version" fields with
-  | Some (`Int 1) -> Ok ()
-  | Some (`Int _) -> Error (kind ^ " only supports payload_schema_version=1")
-  | Some _ -> Error (kind ^ " payload.schema_version must be an integer")
-  | None -> Error (kind ^ " payload requires schema_version=1")
-;;
-
-let body_object ~kind fields =
-  match List.assoc_opt "body" fields with
-  | Some (`Assoc body) -> Ok body
-  | Some _ -> Error (kind ^ " payload.body must be an object")
-  | None -> Error (kind ^ " payload requires object body")
-;;
-
-let validate_keeper_wake_body body =
-  match assoc_string_opt "keeper_name" body, assoc_string_opt "message" body with
-  | None, _ -> Error "masc.keeper_wake payload requires non-empty body.keeper_name"
-  | _, None -> Error "masc.keeper_wake payload requires non-empty body.message"
-  | Some keeper_name, Some _
-    when not (Schedule_supported_kinds.valid_keeper_wake_target_name keeper_name) ->
-    Error
-      (Schedule_supported_kinds.keeper_wake_target_name_error
-         ~field:"masc.keeper_wake payload body.keeper_name")
-  | Some _, Some _ ->
-    (match assoc_string_opt "urgency" body with
-     | None -> Ok ()
-     | Some raw ->
-       (match Schedule_supported_kinds.keeper_wake_urgency_of_string raw with
-        | Ok _ -> Ok ()
-        | Error msg -> Error msg))
+let record_unsupported_payload_creation ~risk_class rejection =
+  match rejection with
+  | Schedule_payload_projection.Creation_unsupported_side_effecting_kind _ ->
+    Otel_metric_store.inc_counter
+      Otel_metric_store.metric_schedule_payload_unsupported_total
+      ~labels:(schedule_payload_unsupported_labels ~phase:"creation" ~risk_class)
+      ()
+  | Schedule_payload_projection.Creation_invalid_payload _
+  | Schedule_payload_projection.Creation_invalid_supported_payload _ -> ()
 ;;
 
 let validate_known_payload_request ~payload ~risk_class =
-  match payload with
-  | `Assoc fields ->
-    (match assoc_string_opt "kind" fields with
-     | Some kind when String.equal kind Schedule_supported_kinds.board_post ->
-       let* () =
-         validate_payload_schema_version ~kind:Schedule_supported_kinds.board_post fields
-       in
-       if not (Schedule_domain.is_side_effecting risk_class)
-       then Error "masc.board_post requires a side-effecting risk_class such as workspace_write"
-       else (
-         match body_object ~kind:Schedule_supported_kinds.board_post fields with
-         | Ok body ->
-           (match assoc_string_opt "content" body with
-            | Some _ -> Ok ()
-            | None ->
-              Error
-                "masc.board_post payload requires non-empty body.content; use board_content for board schedules")
-         | Error _ ->
-           Error
-             "masc.board_post payload requires object body with non-empty content; use board_content for board schedules")
-     | Some kind when String.equal kind Schedule_supported_kinds.keeper_wake ->
-       let* () =
-         validate_payload_schema_version ~kind:Schedule_supported_kinds.keeper_wake fields
-       in
-       if not (Schedule_domain.is_side_effecting risk_class)
-       then
-         Error
-           "masc.keeper_wake requires a side-effecting risk_class such as workspace_write"
-       else
-         let* body = body_object ~kind:Schedule_supported_kinds.keeper_wake fields in
-         validate_keeper_wake_body body
-     | Some kind when Schedule_domain.is_side_effecting risk_class ->
-       (* Only side-effecting work needs a consumer adapter that can dispatch
-          it. Reject kinds the consumer cannot run so the queue is not filled
-          with work that dies at dispatch. Read-only/reminder kinds carry no
-          side effect, so their kind stays opaque to the schedule domain — a
-          consumer that does not recognize one records a visible failed
-          execution (fail_due_candidate), not a silent accept-then-die. *)
-       Error (Schedule_supported_kinds.unsupported_error kind)
-     | Some _ -> Ok ()
-     | None -> Error "payload.kind is required")
-  | _ -> Error "payload must be a JSON object"
+  match
+    Schedule_payload_projection.validate_request_payload_for_creation_detailed
+      ~payload
+      ~risk_class
+  with
+  | Ok () -> Ok ()
+  | Error rejection ->
+    record_unsupported_payload_creation ~risk_class rejection;
+    Error (Schedule_payload_projection.creation_rejection_message rejection)
 ;;
 
-let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
+let schedule_request_json
+      ?last_execution
+      ?lifecycle_audit
+      (request : Schedule_domain.schedule_request)
+  =
   let next_due_at =
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
   in
   let requires_grant = Schedule_domain.requires_separate_human_grant request in
   let payload_target, payload_summary =
     Schedule_payload_projection.target_summary request
+  in
+  let lifecycle_audit_fields =
+    match lifecycle_audit with
+    | None -> []
+    | Some audit ->
+      [ ( "lifecycle_audit"
+        , Schedule_audit_log.projection_to_yojson
+            ~limit:Schedule_audit_log.default_projection_limit
+            audit )
+      ]
   in
   match Schedule_domain.schedule_request_to_yojson request with
   | `Assoc fields ->
@@ -364,6 +329,15 @@ let schedule_request_json ?last_execution (request : Schedule_domain.schedule_re
            , match Schedule_payload_projection.kind request with
              | None -> `Null
              | Some kind -> `String kind )
+         ; ( "payload_support"
+           , `String
+               (request
+                |> Schedule_payload_projection.support_status
+                |> Schedule_payload_projection.support_status_to_string) )
+         ; ( "payload_dispatch_tool"
+           , match Schedule_payload_projection.dispatch_tool_for_request request with
+             | None -> `Null
+             | Some tool_name -> `String tool_name )
          ; ( "payload_target"
            , match payload_target with
              | None -> `Null
@@ -377,7 +351,8 @@ let schedule_request_json ?last_execution (request : Schedule_domain.schedule_re
              | None -> `Null
              | Some execution -> Schedule_domain.execution_record_to_yojson execution
            )
-         ])
+         ]
+       @ lifecycle_audit_fields)
   | other -> other
 ;;
 
@@ -401,6 +376,13 @@ let runtime_error ~tool_name ~start_time message =
     ~start_time
     ~data:(Tool_args.error_assoc [ "message", `String message ])
     message
+;;
+
+let schedule_read_runtime_error ~tool_name ~start_time err =
+  runtime_error
+    ~tool_name
+    ~start_time
+    ("schedule store read failed: " ^ Schedule_store.read_error_to_string err)
 ;;
 
 let request_result ~tool_name ~start_time = function
@@ -469,44 +451,75 @@ let handle_list ~tool_name ~start_time ctx args =
       optional_int args "limit" |> Option.value ~default:50
     in
     let limit = min 200 (max 1 raw_limit) in
-    let state = Schedule_store.read_state ctx.config in
-    let schedules =
-      (match status with
-       | None -> state.Schedule_store.schedules
-       | Some expected ->
-         List.filter
-           (fun (request : Schedule_domain.schedule_request) ->
-             request.status = expected)
-           state.schedules)
-      |> take limit
-      |> List.map (fun (request : Schedule_domain.schedule_request) ->
-        let last_execution =
-          Schedule_store.last_execution_for_schedule state
-            ~schedule_id:request.Schedule_domain.schedule_id
-        in
-        schedule_request_json ?last_execution request)
-    in
-    ok ~tool_name ~start_time
-      (`Assoc
-        [ "status", `String "ok"
-        ; "limit", `Int limit
-        ; "schedules", `List schedules
-        ])
+    (match Schedule_store.read_state_result ctx.config with
+     | Error err -> schedule_read_runtime_error ~tool_name ~start_time err
+     | Ok state ->
+       let audit_source = Schedule_audit_log.read_all ctx.config in
+       let request_rows =
+         (match status with
+          | None -> state.Schedule_store.schedules
+          | Some expected ->
+            List.filter
+              (fun (request : Schedule_domain.schedule_request) ->
+                 request.status = expected)
+              state.schedules)
+         |> take limit
+       in
+       let schedules =
+         request_rows
+         |> List.map (fun (request : Schedule_domain.schedule_request) ->
+           let last_execution =
+             Schedule_store.last_execution_for_schedule
+               state
+               ~schedule_id:request.Schedule_domain.schedule_id
+           in
+           let lifecycle_audit =
+             Schedule_audit_log.projection_for_schedule
+               audit_source
+               ~schedule_id:request.Schedule_domain.schedule_id
+               ~limit:Schedule_audit_log.default_projection_limit
+           in
+           schedule_request_json ?last_execution ~lifecycle_audit request)
+       in
+       ok ~tool_name ~start_time
+         (`Assoc
+           [ "status", `String "ok"
+           ; "limit", `Int limit
+           ; "payload_support"
+             , Schedule_payload_projection.support_summary_to_yojson request_rows
+           ; "schedules", `List schedules
+           ]))
 ;;
 
 let handle_get ~tool_name ~start_time ctx args =
   match required_string args "schedule_id" with
   | Error msg -> workflow_error ~tool_name ~start_time msg
   | Ok schedule_id ->
-    let state = Schedule_store.read_state ctx.config in
-    (match Schedule_service.get ctx.config ~schedule_id with
+    (match Schedule_store.read_state_result ctx.config with
+     | Error err -> schedule_read_runtime_error ~tool_name ~start_time err
+     | Ok state ->
+       match
+         List.find_opt
+           (fun (request : Schedule_domain.schedule_request) ->
+              String.equal request.schedule_id schedule_id)
+           state.schedules
+       with
      | None -> workflow_error ~tool_name ~start_time "schedule not found"
      | Some request ->
        let last_execution =
          Schedule_store.last_execution_for_schedule state
            ~schedule_id:request.Schedule_domain.schedule_id
        in
-       ok ~tool_name ~start_time (schedule_request_json ?last_execution request))
+       let lifecycle_audit =
+         Schedule_audit_log.read_recent_for_schedule
+           ctx.config
+           ~schedule_id:request.Schedule_domain.schedule_id
+           ~limit:Schedule_audit_log.default_projection_limit
+       in
+       ok
+         ~tool_name
+         ~start_time
+         (schedule_request_json ?last_execution ~lifecycle_audit request))
 ;;
 
 let handle_cancel ~tool_name ~start_time ctx args =
@@ -517,8 +530,11 @@ let handle_cancel ~tool_name ~start_time ctx args =
       actor_kind_of_arg args "cancelled_by_kind" Schedule_domain.Human_operator
     in
     let* reason = required_string args "reason" in
+    let cancelled_by : Schedule_domain.actor =
+      { id = cancelled_by_id; kind = cancelled_by_kind; display_name = None }
+    in
     let* request =
-      Schedule_service.cancel ctx.config ~schedule_id
+      Schedule_service.cancel ctx.config ~schedule_id ~cancelled_by ~reason
       |> Result.map_error Schedule_service.service_error_to_string
     in
     Ok (request, cancelled_by_id, cancelled_by_kind, reason)

--- a/lib/tool_surface/tool_resource_axis.ml
+++ b/lib/tool_surface/tool_resource_axis.ml
@@ -222,6 +222,7 @@ let classify_catalog_tool ~tool_name =
      | "masc_dashboard"
      | "masc_get_metrics"
      | "masc_goal_list"
+     | "masc_keeper_waiting_inventory"
      | "masc_messages"
      | "masc_operator_digest"
      | "masc_operator_snapshot"

--- a/scripts/keeper-waiting-inventory-proof-check.sh
+++ b/scripts/keeper-waiting-inventory-proof-check.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${REQUIRE_PASS:=0}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/keeper-waiting-inventory-proof-check.sh [--require-pass|--allow-fail] PROOF.json
+
+Validates proof emitted by scripts/keeper-waiting-inventory.sh --proof-out.
+Set REQUIRE_PASS=1 or pass --require-pass to reject fail proofs.
+USAGE
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_pass="$REQUIRE_PASS"
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --require-pass)
+    require_pass=1
+    shift
+    ;;
+  --allow-fail)
+    require_pass=0
+    shift
+    ;;
+esac
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+if truthy "$require_pass"; then
+  require_pass=1
+else
+  require_pass=0
+fi
+
+proof_path="$1"
+command -v jq >/dev/null || fail "jq is required"
+[[ -f "$proof_path" ]] || fail "proof file not found: ${proof_path}"
+
+report="$(
+  jq -ce \
+    --arg proof_path "$proof_path" \
+    --arg require_pass "$require_pass" \
+    '
+      def emit($condition; $message):
+        if $condition then [] else [$message] end;
+
+      def object_value($value):
+        ($value | type) == "object";
+
+      def nonempty_string($value):
+        ($value | type) == "string" and ($value | length > 0);
+
+      def string_array($value):
+        ($value | type) == "array"
+        and all($value[]; (type == "string") and (length > 0));
+
+      def error_array($value):
+        string_array($value);
+
+      def boolean_value($value):
+        ($value | type) == "boolean";
+
+      def number_value($value):
+        ($value | type) == "number";
+
+      def array_value($value):
+        ($value | type) == "array";
+
+      def integer_value($value):
+        number_value($value)
+        and $value >= 0
+        and $value == ($value | floor);
+
+      def nullable_number($value):
+        $value == null or number_value($value);
+
+      def nullable_string($value):
+        $value == null or (($value | type) == "string");
+
+      def waiting_row_shape($row):
+        object_value($row)
+        and ($row | has("keeper_name"))
+        and ($row.keeper_name == null or nonempty_string($row.keeper_name))
+        and nonempty_string($row.source)
+        and nonempty_string($row.waiting_on)
+        and nonempty_string($row.wake_producer)
+        and ($row | has("since"))
+        and nullable_number($row.since)
+        and ($row | has("since_iso"))
+        and nullable_string($row.since_iso)
+        and ($row | has("due_at"))
+        and nullable_number($row.due_at)
+        and ($row | has("due_at_iso"))
+        and nullable_string($row.due_at_iso)
+        and nonempty_string($row.next_action)
+        and ($row | has("detail"));
+
+      def keeper_shape($supported_states; $keeper):
+        object_value($keeper)
+        and nonempty_string($keeper.keeper_name)
+        and nonempty_string($keeper.state)
+        and array_value($supported_states)
+        and (($supported_states | index($keeper.state)) != null)
+        and array_value($keeper.waiting_on)
+        and integer_value($keeper.waiting_count)
+        and ($keeper.waiting_count == ($keeper.waiting_on | length))
+        and object_value($keeper.sources)
+        and ($keeper | has("since"))
+        and nullable_number($keeper.since)
+        and ($keeper | has("since_iso"))
+        and nullable_string($keeper.since_iso)
+        and ($keeper | has("due_at"))
+        and nullable_number($keeper.due_at)
+        and ($keeper | has("due_at_iso"))
+        and nullable_string($keeper.due_at_iso)
+        and ($keeper.next_action == null or nonempty_string($keeper.next_action))
+        and all($keeper.waiting_on[]; waiting_row_shape(.));
+
+      def keeper_row_total($keepers):
+        if array_value($keepers) then
+          ([$keepers[] | if array_value(.waiting_on) then (.waiting_on | length) else 0 end] | add // 0)
+        else
+          null
+        end;
+
+      def waiting_rows_shape($rows):
+        if array_value($rows) then
+          all($rows[]; waiting_row_shape(.))
+        else
+          false
+        end;
+
+      def inventory_projection_errors($projection; $label):
+        emit(object_value($projection); ($label + " must be an object"))
+        + if object_value($projection) then
+            emit(($projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                 ($label + " schema mismatch"))
+            + emit(($projection.source == "server_keeper_waiting_inventory");
+                   ($label + " source mismatch"))
+            + emit(string_array($projection.supported_states);
+                   ($label + ".supported_states must be a string array"))
+            + emit(integer_value($projection.keeper_count);
+                   ($label + ".keeper_count must be a non-negative integer"))
+            + emit(integer_value($projection.waiting_keeper_count);
+                   ($label + ".waiting_keeper_count must be a non-negative integer"))
+            + emit(integer_value($projection.row_count);
+                   ($label + ".row_count must be a non-negative integer"))
+            + emit(integer_value($projection.global_row_count);
+                   ($label + ".global_row_count must be a non-negative integer"))
+            + emit(array_value($projection.keepers);
+                   ($label + ".keepers must be an array"))
+            + emit(array_value($projection.global_waiting_on);
+                   ($label + ".global_waiting_on must be an array"))
+            + if integer_value($projection.keeper_count)
+                 and array_value($projection.keepers) then
+                emit(($projection.keeper_count == ($projection.keepers | length));
+                     ($label + ".keeper_count must match keepers length"))
+              else
+                []
+              end
+            + if integer_value($projection.waiting_keeper_count)
+                 and integer_value($projection.keeper_count) then
+                emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                     ($label + ".waiting_keeper_count must not exceed keeper_count"))
+              else
+                []
+              end
+            + if integer_value($projection.row_count)
+                 and array_value($projection.keepers) then
+                emit(($projection.row_count == keeper_row_total($projection.keepers));
+                     ($label + ".row_count must match keeper waiting rows"))
+              else
+                []
+              end
+            + if integer_value($projection.global_row_count)
+                 and array_value($projection.global_waiting_on) then
+                emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                     ($label + ".global_row_count must match global_waiting_on length"))
+              else
+                []
+              end
+            + if array_value($projection.keepers) then
+                emit(all($projection.keepers[]; keeper_shape($projection.supported_states; .));
+                     ($label + ".keepers rows must match schema"))
+              else
+                []
+              end
+            + if array_value($projection.global_waiting_on) then
+                emit(waiting_rows_shape($projection.global_waiting_on);
+                     ($label + ".global_waiting_on rows must match schema"))
+              else
+                []
+              end
+          else
+            []
+          end;
+
+      def inventory_parity_errors($dashboard; $mcp):
+        emit(($mcp.schema == $dashboard.schema);
+             "mcp_result.schema must match preflight waiting_projection.schema")
+        + emit(($mcp.source == $dashboard.source);
+               "mcp_result.source must match preflight waiting_projection.source")
+        + emit(($mcp.supported_states == $dashboard.supported_states);
+               "mcp_result.supported_states must match preflight waiting_projection.supported_states")
+        + emit(($mcp.keeper_count == $dashboard.keeper_count);
+               "mcp_result.keeper_count must match preflight waiting_projection.keeper_count")
+        + emit(($mcp.waiting_keeper_count == $dashboard.waiting_keeper_count);
+               "mcp_result.waiting_keeper_count must match preflight waiting_projection.waiting_keeper_count")
+        + emit(($mcp.row_count == $dashboard.row_count);
+               "mcp_result.row_count must match preflight waiting_projection.row_count")
+        + emit(($mcp.global_row_count == $dashboard.global_row_count);
+               "mcp_result.global_row_count must match preflight waiting_projection.global_row_count")
+        + emit(($mcp.global_pending_confirm_count == $dashboard.global_pending_confirm_count);
+               "mcp_result.global_pending_confirm_count must match preflight waiting_projection")
+        + emit(($mcp.source_counts == $dashboard.source_counts);
+               "mcp_result.source_counts must match preflight waiting_projection.source_counts")
+        + emit(($mcp.keepers == $dashboard.keepers);
+               "mcp_result.keepers must match preflight waiting_projection.keepers")
+        + emit(($mcp.global_waiting_on == $dashboard.global_waiting_on);
+               "mcp_result.global_waiting_on must match preflight waiting_projection.global_waiting_on");
+
+      def cli_failure_stage($value):
+        $value == "argument_parse"
+        or $value == "startup"
+        or $value == "token_load"
+        or $value == "dashboard_preflight"
+        or $value == "mcp_initialize"
+        or $value == "mcp_tool_call"
+        or $value == "proof_write"
+        or $value == "output";
+
+      def common_preflight_errors($require_pass):
+        emit((.schema == "masc.keeper_waiting_inventory_preflight.v1");
+             "schema must be masc.keeper_waiting_inventory_preflight.v1")
+        + emit((.status == "fail" or .status == "preflight_pass");
+               "status must be fail or preflight_pass")
+        + emit((($require_pass == "1") | not) or (.status == "preflight_pass");
+               "REQUIRE_PASS rejects fail proof")
+        + emit((.ok == (.status == "preflight_pass"));
+               "ok must match status")
+        + emit(nonempty_string(.dashboard_url); "dashboard_url must be a non-empty string")
+        + emit(nonempty_string(.mcp_url); "mcp_url must be a non-empty string")
+        + emit((.tool_name == "masc_keeper_waiting_inventory");
+               "tool_name must be masc_keeper_waiting_inventory")
+        + emit(error_array(.errors); "errors must be a string array")
+        + emit(object_value(.runtime_identity_gate);
+               "runtime_identity_gate must be an object")
+        + emit(boolean_value(.runtime_identity_gate.allow_diverged_runtime);
+               "runtime_identity_gate.allow_diverged_runtime must be boolean")
+        + emit(object_value(.runtime_identity_gate.runtime_resolution);
+               "runtime_identity_gate.runtime_resolution must be an object")
+        + emit(object_value(.waiting_tool_surface);
+               "waiting_tool_surface must be an object")
+        + emit((.waiting_tool_surface.required == "masc_keeper_waiting_inventory");
+               "waiting_tool_surface.required must be masc_keeper_waiting_inventory")
+        + emit(boolean_value(.waiting_tool_surface.present);
+               "waiting_tool_surface.present must be boolean")
+        + emit(object_value(.waiting_projection);
+               "waiting_projection must be an object")
+        + emit(boolean_value(.waiting_projection.present);
+               "waiting_projection.present must be boolean");
+
+      def successful_preflight_errors:
+        (.runtime_identity_gate.runtime_resolution // null) as $runtime
+        | (.waiting_tool_surface.tool // null) as $tool
+        | (.waiting_projection // null) as $projection
+        | emit((.errors | length) == 0; "preflight_pass errors must be empty")
+          + emit(($runtime.deployment_state.status == "current");
+                 "runtime deployment_state.status must be current")
+          + emit(nonempty_string($runtime.runtime_binary_git_commit);
+                 "runtime_binary_git_commit must be non-empty")
+          + emit(($runtime.source_mismatch == false);
+                 "source_mismatch must be false")
+          + emit(($runtime.server_workspace_mismatch == false);
+                 "server_workspace_mismatch must be false")
+          + emit((.waiting_tool_surface.present == true);
+                 "waiting_tool_surface.present must be true")
+          + emit(object_value($tool); "waiting_tool_surface.tool must be an object")
+          + emit((($tool.surfaces // []) | index("public_mcp")) != null;
+                 "tool must expose public_mcp surface")
+          + emit(($tool.registered_schema == true);
+                 "tool registered_schema must be true")
+          + emit(($tool.dispatch_registered == true);
+                 "tool dispatch_registered must be true")
+          + emit(($tool.direct_call_allowed == true);
+                 "tool direct_call_allowed must be true")
+          + emit(($tool.effectDomain == "read_only");
+                 "tool effectDomain must be read_only")
+          + emit(($tool.implementationStatus == "real");
+                 "tool implementationStatus must be real")
+          + emit((.waiting_projection.present == true);
+                 "waiting_projection.present must be true")
+          + emit((.waiting_projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                 "waiting_projection schema mismatch")
+          + emit((.waiting_projection.source == "server_keeper_waiting_inventory");
+                 "waiting_projection source mismatch")
+          + emit(string_array(.waiting_projection.supported_states);
+                 "waiting_projection.supported_states must be a string array")
+          + emit(integer_value(.waiting_projection.keeper_count);
+                 "waiting_projection.keeper_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.waiting_keeper_count);
+                 "waiting_projection.waiting_keeper_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.row_count);
+                 "waiting_projection.row_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.global_row_count);
+                 "waiting_projection.global_row_count must be a non-negative integer")
+          + emit(array_value(.waiting_projection.keepers);
+                 "waiting_projection.keepers must be an array")
+          + emit(array_value(.waiting_projection.global_waiting_on);
+                 "waiting_projection.global_waiting_on must be an array")
+          + if integer_value($projection.keeper_count)
+               and array_value($projection.keepers) then
+              emit(($projection.keeper_count == ($projection.keepers | length));
+                   "waiting_projection.keeper_count must match keepers length")
+            else
+              []
+            end
+          + if integer_value($projection.waiting_keeper_count)
+               and integer_value($projection.keeper_count) then
+              emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                   "waiting_projection.waiting_keeper_count must not exceed keeper_count")
+            else
+              []
+            end
+          + if integer_value($projection.row_count)
+               and array_value($projection.keepers) then
+              emit(($projection.row_count == keeper_row_total($projection.keepers));
+                   "waiting_projection.row_count must match keeper waiting rows")
+            else
+              []
+            end
+          + if integer_value($projection.global_row_count)
+               and array_value($projection.global_waiting_on) then
+              emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                   "waiting_projection.global_row_count must match global_waiting_on length")
+            else
+              []
+            end
+          + if array_value($projection.keepers) then
+              emit(all($projection.keepers[]; keeper_shape($projection.supported_states; .));
+                   "waiting_projection.keepers rows must match schema")
+            else
+              []
+            end
+          + if array_value($projection.global_waiting_on) then
+              emit(waiting_rows_shape($projection.global_waiting_on);
+                   "waiting_projection.global_waiting_on rows must match schema")
+            else
+              []
+            end;
+
+      def failed_preflight_errors:
+        emit((.errors | length) > 0; "fail proof must include at least one error");
+
+      def preflight_pass_errors_for($proof; $require_pass):
+        $proof
+        | common_preflight_errors($require_pass)
+          + successful_preflight_errors;
+
+      def cli_common_errors($require_pass):
+        emit((.schema == "masc.keeper_waiting_inventory_cli_proof.v1");
+             "schema must be masc.keeper_waiting_inventory_cli_proof.v1")
+        + emit((.status == "fail" or .status == "pass");
+               "CLI proof status must be fail or pass")
+        + emit((($require_pass == "1") | not) or (.status == "pass");
+               "REQUIRE_PASS rejects CLI fail proof")
+        + emit(nonempty_string(.dashboard_url); "dashboard_url must be a non-empty string")
+        + emit(nonempty_string(.mcp_url); "mcp_url must be a non-empty string")
+        + emit((.tool_name == "masc_keeper_waiting_inventory");
+               "tool_name must be masc_keeper_waiting_inventory");
+
+      def cli_failure_errors:
+        emit((.status == "fail"); "CLI proof status must be fail")
+        + emit(nonempty_string(.reason); "CLI fail proof reason must be non-empty")
+        + emit(nonempty_string(.failure_stage);
+               "CLI fail proof failure_stage must be non-empty")
+        + emit(cli_failure_stage(.failure_stage);
+               "CLI fail proof failure_stage is not recognized")
+        + emit((.preflight == null or object_value(.preflight));
+               "CLI fail proof preflight must be null or object");
+
+      def cli_success_errors($require_pass):
+        (.preflight // null) as $preflight
+        | (.mcp_result // null) as $mcp
+        | emit((.status == "pass"); "CLI success proof status must be pass")
+          + emit((.ok == true); "CLI success proof ok must be true")
+          + emit(object_value($preflight);
+                 "CLI success proof preflight must be an object")
+          + if object_value($preflight) then
+              preflight_pass_errors_for($preflight; "1")
+            else
+              []
+            end
+          + inventory_projection_errors($mcp; "mcp_result")
+          + if object_value($preflight) and object_value($mcp) then
+              inventory_parity_errors($preflight.waiting_projection; $mcp)
+            else
+              []
+            end;
+
+      (
+        if .schema == "masc.keeper_waiting_inventory_preflight.v1" then
+          common_preflight_errors($require_pass)
+          + if .status == "preflight_pass" then
+              successful_preflight_errors
+            elif .status == "fail" then
+              failed_preflight_errors
+            else
+              []
+            end
+        elif .schema == "masc.keeper_waiting_inventory_cli_proof.v1" then
+          cli_common_errors($require_pass)
+          + if .status == "pass" then
+              cli_success_errors($require_pass)
+            elif .status == "fail" then
+              cli_failure_errors
+            else
+              []
+            end
+        else
+          ["unsupported proof schema"]
+        end
+      ) as $errors
+      | {
+          ok:(($errors | length) == 0),
+          schema:(.schema // null),
+          status:(.status // null),
+          require_pass:($require_pass == "1"),
+          proof_path:$proof_path,
+          checked_contract:{
+            tool_name:"masc_keeper_waiting_inventory"
+          },
+          errors:$errors
+        }
+    ' "$proof_path"
+)" || fail "proof JSON is not parseable or validator failed: ${proof_path}"
+
+if ! printf '%s' "$report" | jq -e '.ok == true' >/dev/null; then
+  printf '%s\n' "$report" | jq . >&2
+  exit 1
+fi
+
+printf '%s\n' "$report"

--- a/scripts/keeper-waiting-inventory.sh
+++ b/scripts/keeper-waiting-inventory.sh
@@ -1,0 +1,656 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+: "${PORT:=8935}"
+: "${BASE_URL:=http://127.0.0.1:${PORT}}"
+BASE_URL="${BASE_URL%/}"
+: "${MCP_URL:=${BASE_URL}/mcp}"
+: "${CURL_TIMEOUT_SEC:=25}"
+: "${HTTP_TIMEOUT_SEC:=${CURL_TIMEOUT_SEC}}"
+: "${CURL_RETRY_COUNT:=4}"
+: "${CURL_RETRY_DELAY_SEC:=1}"
+: "${MCP_CLIENT_NAME:=keeper-waiting-inventory-cli}"
+: "${MCP_SESSION_ID:=}"
+: "${COMPACT:=0}"
+: "${PREFLIGHT_ONLY:=0}"
+: "${REQUIRE_CURRENT_RUNTIME:=0}"
+: "${ALLOW_DIVERGED_RUNTIME:=0}"
+: "${PROOF_OUT:=}"
+
+WAITING_TOOL_NAME="masc_keeper_waiting_inventory"
+PREFLIGHT_REPORT_JSON=""
+FAILURE_STAGE="argument_parse"
+
+# shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
+source "${REPO_ROOT}/scripts/harness/lib/mcp_jsonrpc.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/keeper-waiting-inventory.sh [options]
+
+Read the immutable keeper waiting inventory through the MCP tool
+masc_keeper_waiting_inventory and print the tool result JSON.
+
+Options:
+  --base-url URL      Dashboard/MCP base URL. Default: http://127.0.0.1:8935.
+  --mcp-url URL       MCP endpoint. Overrides --base-url-derived endpoint.
+  --base-path PATH    Base path used only to load .masc/auth/codex-mcp-client.token.
+  --preflight-only    Check runtime/tool/projection readiness and exit.
+  --require-current-runtime
+                      Run the same readiness gate before calling the MCP tool.
+  --allow-diverged-runtime
+                      Allow non-current runtime identity in the readiness gate.
+  --proof-out PATH    Write preflight pass/fail JSON proof to PATH.
+  --compact           Print compact JSON instead of pretty JSON.
+  -h, --help          Show this help.
+
+Environment:
+  MCP_TOKEN, MCP_AUTH_TOKEN, MASC_ADMIN_TOKEN are accepted by the shared MCP
+  helper. If none are set, the script tries BASE_PATH/.masc/auth/codex-mcp-client.token.
+USAGE
+}
+
+fail() {
+  write_failure_proof "$*" || true
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_proof_json() {
+  local payload="$1"
+  if [[ -z "$PROOF_OUT" ]]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$PROOF_OUT")"
+  printf '%s\n' "$payload" >"$PROOF_OUT"
+}
+
+write_failure_proof() {
+  local reason="$1"
+  if [[ -z "$PROOF_OUT" ]] || ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+  local preflight_json="null"
+  if [[ -n "$PREFLIGHT_REPORT_JSON" ]] \
+    && printf '%s' "$PREFLIGHT_REPORT_JSON" | jq -e . >/dev/null 2>&1; then
+    preflight_json="$PREFLIGHT_REPORT_JSON"
+  fi
+  local payload
+  payload="$(
+    jq -cn \
+      --arg reason "$reason" \
+	      --arg base_url "$BASE_URL" \
+	      --arg mcp_url "$MCP_URL" \
+	      --arg tool_name "$WAITING_TOOL_NAME" \
+	      --arg failure_stage "$FAILURE_STAGE" \
+	      --argjson preflight "$preflight_json" \
+	      '{
+	        schema:"masc.keeper_waiting_inventory_cli_proof.v1",
+	        status:"fail",
+	        reason:$reason,
+	        failure_stage:$failure_stage,
+	        dashboard_url:$base_url,
+	        mcp_url:$mcp_url,
+	        tool_name:$tool_name,
+        preflight:$preflight
+      }'
+  )" && write_proof_json "$payload"
+}
+
+write_cli_success_proof() {
+  local inventory_json="$1"
+  if [[ -z "$PROOF_OUT" ]]; then
+    return 0
+  fi
+  if [[ -z "$PREFLIGHT_REPORT_JSON" ]]; then
+    fail "--proof-out success proof requires preflight evidence"
+  fi
+  local payload
+  payload="$(
+    jq -cn \
+      --arg base_url "$BASE_URL" \
+      --arg mcp_url "$MCP_URL" \
+      --arg tool_name "$WAITING_TOOL_NAME" \
+      --argjson preflight "$PREFLIGHT_REPORT_JSON" \
+      --argjson inventory "$inventory_json" \
+      '{
+        schema:"masc.keeper_waiting_inventory_cli_proof.v1",
+        status:"pass",
+        ok:true,
+        dashboard_url:$base_url,
+        mcp_url:$mcp_url,
+        tool_name:$tool_name,
+        preflight:$preflight,
+        mcp_result:$inventory
+      }'
+  )" || fail "could not build keeper waiting inventory success proof"
+  write_proof_json "$payload"
+}
+
+base_path_default() {
+  if [[ -n "${BASE_PATH:-}" ]]; then
+    printf '%s\n' "$BASE_PATH"
+  elif [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
+
+BASE_PATH="$(base_path_default)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      BASE_URL="${2%/}"
+      MCP_URL="${BASE_URL}/mcp"
+      shift 2
+      ;;
+    --mcp-url)
+      MCP_URL="$2"
+      shift 2
+      ;;
+    --base-path)
+      BASE_PATH="$2"
+      shift 2
+      ;;
+    --compact)
+      COMPACT=1
+      shift
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY=1
+      REQUIRE_CURRENT_RUNTIME=1
+      shift
+      ;;
+    --require-current-runtime)
+      REQUIRE_CURRENT_RUNTIME=1
+      shift
+      ;;
+    --allow-diverged-runtime)
+      ALLOW_DIVERGED_RUNTIME=1
+      shift
+      ;;
+    --proof-out)
+      PROOF_OUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if truthy "$PREFLIGHT_ONLY"; then
+  PREFLIGHT_ONLY=1
+  REQUIRE_CURRENT_RUNTIME=1
+else
+  PREFLIGHT_ONLY=0
+fi
+
+if truthy "$REQUIRE_CURRENT_RUNTIME"; then
+  REQUIRE_CURRENT_RUNTIME=1
+else
+  REQUIRE_CURRENT_RUNTIME=0
+fi
+
+if truthy "$ALLOW_DIVERGED_RUNTIME"; then
+  ALLOW_DIVERGED_RUNTIME=1
+else
+  ALLOW_DIVERGED_RUNTIME=0
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+load_mcp_token() {
+  if [[ -n "${MCP_TOKEN:-}" || -n "${MCP_AUTH_TOKEN:-}" || -n "${MASC_ADMIN_TOKEN:-}" ]]; then
+    return 0
+  fi
+  local token_file="${BASE_PATH%/}/.masc/auth/codex-mcp-client.token"
+  if [[ -f "$token_file" ]]; then
+    MCP_TOKEN="$(tr -d '\n' <"$token_file")"
+    export MCP_TOKEN
+  fi
+}
+
+dashboard_tools_json() {
+  curl -fsS --max-time "$CURL_TIMEOUT_SEC" "${BASE_URL}/api/v1/dashboard/tools"
+}
+
+build_preflight_report() {
+  local dashboard_json allow_diverged
+  dashboard_json="$(dashboard_tools_json)" \
+    || fail "dashboard tools probe failed at ${BASE_URL}/api/v1/dashboard/tools"
+  allow_diverged="$ALLOW_DIVERGED_RUNTIME"
+  PREFLIGHT_REPORT_JSON="$(
+    printf '%s' "$dashboard_json" \
+      | jq -ce \
+          --arg dashboard_url "$BASE_URL" \
+          --arg mcp_url "$MCP_URL" \
+          --arg tool_name "$WAITING_TOOL_NAME" \
+          --arg allow_diverged_runtime "$allow_diverged" \
+          '
+            def emit($condition; $message):
+              if $condition then [] else [$message] end;
+
+            def object_value($value):
+              ($value | type) == "object";
+
+            def nonempty_string($value):
+              ($value | type) == "string" and ($value | length > 0);
+
+            def string_array($value):
+              ($value | type) == "array"
+              and all($value[]; (type == "string") and (length > 0));
+
+            def number_value($value):
+              ($value | type) == "number";
+
+            def array_value($value):
+              ($value | type) == "array";
+
+            def integer_value($value):
+              number_value($value)
+              and $value >= 0
+              and $value == ($value | floor);
+
+            def nullable_number($value):
+              $value == null or number_value($value);
+
+            def nullable_string($value):
+              $value == null or (($value | type) == "string");
+
+            def waiting_row_shape($row):
+              object_value($row)
+              and ($row | has("keeper_name"))
+              and ($row.keeper_name == null or nonempty_string($row.keeper_name))
+              and nonempty_string($row.source)
+              and nonempty_string($row.waiting_on)
+              and nonempty_string($row.wake_producer)
+              and ($row | has("since"))
+              and nullable_number($row.since)
+              and ($row | has("since_iso"))
+              and nullable_string($row.since_iso)
+              and ($row | has("due_at"))
+              and nullable_number($row.due_at)
+              and ($row | has("due_at_iso"))
+              and nullable_string($row.due_at_iso)
+              and nonempty_string($row.next_action)
+              and ($row | has("detail"));
+
+            def keeper_shape($supported_states; $keeper):
+              object_value($keeper)
+              and nonempty_string($keeper.keeper_name)
+              and nonempty_string($keeper.state)
+              and array_value($supported_states)
+              and (($supported_states | index($keeper.state)) != null)
+              and array_value($keeper.waiting_on)
+              and integer_value($keeper.waiting_count)
+              and ($keeper.waiting_count == ($keeper.waiting_on | length))
+              and object_value($keeper.sources)
+              and ($keeper | has("since"))
+              and nullable_number($keeper.since)
+              and ($keeper | has("since_iso"))
+              and nullable_string($keeper.since_iso)
+              and ($keeper | has("due_at"))
+              and nullable_number($keeper.due_at)
+              and ($keeper | has("due_at_iso"))
+              and nullable_string($keeper.due_at_iso)
+              and ($keeper.next_action == null or nonempty_string($keeper.next_action))
+              and all($keeper.waiting_on[]; waiting_row_shape(.));
+
+            def keeper_row_total($keepers):
+              if array_value($keepers) then
+                ([$keepers[] | if array_value(.waiting_on) then (.waiting_on | length) else 0 end] | add // 0)
+              else
+                null
+              end;
+
+            def waiting_rows_shape($rows):
+              if array_value($rows) then
+                all($rows[]; waiting_row_shape(.))
+              else
+                false
+              end;
+
+            (.runtime_resolution // null) as $runtime
+            | (.tool_inventory.tools // []) as $tools
+            | (first($tools[]? | select(.name == $tool_name)) // null) as $tool
+            | (.keeper_waiting_inventory // null) as $projection
+            | (
+                emit(object_value($runtime); "runtime_resolution must be an object")
+                + if ($allow_diverged_runtime == "1") then
+                    []
+                  else
+                    emit(($runtime.deployment_state.status == "current");
+                         "runtime deployment_state.status must be current")
+                    + emit(($runtime.source_mismatch == false);
+                           "runtime_resolution.source_mismatch must be false")
+                    + emit(($runtime.server_workspace_mismatch == false);
+                           "runtime_resolution.server_workspace_mismatch must be false")
+                    + emit(nonempty_string($runtime.runtime_binary_git_commit);
+                           "runtime_binary_git_commit must be a non-empty string")
+                  end
+                + emit(($tool != null);
+                       "tool_inventory.tools must contain masc_keeper_waiting_inventory")
+                + if ($tool == null) then
+                    []
+                  else
+                    emit((($tool.surfaces // []) | index("public_mcp")) != null;
+                         "masc_keeper_waiting_inventory must expose public_mcp surface")
+                    + emit(($tool.registered_schema == true);
+                           "masc_keeper_waiting_inventory registered_schema must be true")
+                    + emit(($tool.dispatch_registered == true);
+                           "masc_keeper_waiting_inventory dispatch_registered must be true")
+                    + emit(($tool.direct_call_allowed == true);
+                           "masc_keeper_waiting_inventory direct_call_allowed must be true")
+                    + emit(($tool.effectDomain == "read_only");
+                           "masc_keeper_waiting_inventory effectDomain must be read_only")
+                    + emit(($tool.implementationStatus == "real");
+                           "masc_keeper_waiting_inventory implementationStatus must be real")
+                  end
+                + emit(object_value($projection);
+                       "keeper_waiting_inventory projection must be an object")
+                + if object_value($projection) then
+                    emit(($projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                         "keeper_waiting_inventory schema mismatch")
+                    + emit(($projection.source == "server_keeper_waiting_inventory");
+                           "keeper_waiting_inventory source mismatch")
+                    + emit(string_array($projection.supported_states);
+                           "keeper_waiting_inventory.supported_states must be a string array")
+                    + emit(integer_value($projection.keeper_count);
+                           "keeper_waiting_inventory.keeper_count must be a non-negative integer")
+                    + emit(integer_value($projection.waiting_keeper_count);
+                           "keeper_waiting_inventory.waiting_keeper_count must be a non-negative integer")
+                    + emit(integer_value($projection.row_count);
+                           "keeper_waiting_inventory.row_count must be a non-negative integer")
+                    + emit(integer_value($projection.global_row_count);
+                           "keeper_waiting_inventory.global_row_count must be a non-negative integer")
+                    + emit(array_value($projection.keepers);
+                           "keeper_waiting_inventory.keepers must be an array")
+                    + emit(array_value($projection.global_waiting_on);
+                           "keeper_waiting_inventory.global_waiting_on must be an array")
+                    + if integer_value($projection.keeper_count)
+                         and array_value($projection.keepers) then
+                        emit(($projection.keeper_count == ($projection.keepers | length));
+                             "keeper_waiting_inventory.keeper_count must match keepers length")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.waiting_keeper_count)
+                         and integer_value($projection.keeper_count) then
+                        emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                             "keeper_waiting_inventory.waiting_keeper_count must not exceed keeper_count")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.row_count)
+                         and array_value($projection.keepers) then
+                        emit(($projection.row_count == keeper_row_total($projection.keepers));
+                             "keeper_waiting_inventory.row_count must match keeper waiting rows")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.global_row_count)
+                         and array_value($projection.global_waiting_on) then
+                        emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                             "keeper_waiting_inventory.global_row_count must match global_waiting_on length")
+                      else
+                        []
+                      end
+                    + if array_value($projection.keepers) then
+                        emit(all($projection.keepers[];
+                                 keeper_shape($projection.supported_states; .));
+                             "keeper_waiting_inventory.keepers rows must match schema")
+                      else
+                        []
+                      end
+                    + if array_value($projection.global_waiting_on) then
+                        emit(waiting_rows_shape($projection.global_waiting_on);
+                             "keeper_waiting_inventory.global_waiting_on rows must match schema")
+                      else
+                        []
+                      end
+                  else
+                    []
+                  end
+              ) as $errors
+            | {
+                status:($runtime.status // null),
+                deployment_state:{
+                  status:($runtime.deployment_state.status // null),
+                  operator_action_required:
+                    (if ($runtime.deployment_state | has("operator_action_required")) then
+                       $runtime.deployment_state.operator_action_required
+                     else
+                       null
+                     end),
+                  binary_commit_known:
+                    (if ($runtime.deployment_state | has("binary_commit_known")) then
+                       $runtime.deployment_state.binary_commit_known
+                     else
+                       null
+                     end),
+                  upstream:($runtime.deployment_state.upstream // null),
+                  deployed:($runtime.deployment_state.deployed // null),
+                  runtime_repo:($runtime.deployment_state.runtime_repo // null),
+                  workspace:($runtime.deployment_state.workspace // null)
+                },
+                server_repo_git_commit:($runtime.server_repo_git_commit // null),
+                runtime_binary_git_commit:($runtime.runtime_binary_git_commit // null),
+                runtime_repo_head_git_commit:
+                  ($runtime.runtime_repo_head_git_commit // null),
+                source_mismatch:
+                  (if ($runtime | has("source_mismatch")) then
+                     $runtime.source_mismatch
+                   else
+                     null
+                   end),
+                server_workspace_mismatch:
+                  (if ($runtime | has("server_workspace_mismatch")) then
+                     $runtime.server_workspace_mismatch
+                   else
+                     null
+                   end),
+                build:{
+                  commit:($runtime.build.commit // null),
+                  repo_root:($runtime.build.repo_root // null),
+                  executable_path:($runtime.build.executable_path // null),
+                  started_at:($runtime.build.started_at // null)
+                }
+              } as $runtime_summary
+            | {
+                schema:"masc.keeper_waiting_inventory_preflight.v1",
+                status:(if ($errors | length) == 0 then "preflight_pass" else "fail" end),
+                ok:(($errors | length) == 0),
+                dashboard_url:$dashboard_url,
+                mcp_url:$mcp_url,
+                tool_name:$tool_name,
+                runtime_identity_gate:{
+                  allow_diverged_runtime:($allow_diverged_runtime == "1"),
+                  runtime_resolution:$runtime_summary
+                },
+                waiting_tool_surface:{
+                  required:$tool_name,
+                  present:($tool != null),
+                  tool:$tool
+                },
+                waiting_projection:{
+                  present:object_value($projection),
+                  schema:($projection.schema // null),
+                  source:($projection.source // null),
+                  generated_at:($projection.generated_at // null),
+                  supported_states:($projection.supported_states // null),
+                  keeper_count:($projection.keeper_count // null),
+                  waiting_keeper_count:($projection.waiting_keeper_count // null),
+                  row_count:($projection.row_count // null),
+                  global_row_count:($projection.global_row_count // null),
+                  global_pending_confirm_count:($projection.global_pending_confirm_count // null),
+                  source_counts:($projection.source_counts // null),
+                  keepers:($projection.keepers // null),
+                  global_waiting_on:($projection.global_waiting_on // null)
+                },
+                errors:$errors
+              }
+          '
+  )" || fail "dashboard tools preflight report could not be parsed"
+}
+
+run_preflight_gate() {
+  build_preflight_report
+  write_proof_json "$PREFLIGHT_REPORT_JSON"
+  if ! printf '%s' "$PREFLIGHT_REPORT_JSON" | jq -e '.ok == true' >/dev/null; then
+    printf '%s\n' "$PREFLIGHT_REPORT_JSON" | jq . >&2
+    exit 1
+  fi
+}
+
+initialize_mcp_session() {
+  if [[ -n "${MCP_SESSION_ID:-}" ]]; then
+    export MCP_SESSION_ID
+    return 0
+  fi
+
+  local headers_file body_file auth_header_file init_body protocol_version
+  headers_file="$(mcp_mktemp_file "keeper-waiting-inventory-init" ".headers")"
+  body_file="$(mcp_mktemp_file "keeper-waiting-inventory-init" ".body")"
+  auth_header_file=""
+  if [[ -n "${MCP_TOKEN:-}" ]]; then
+    auth_header_file="$(_mcp_auth_header_file "$MCP_TOKEN")" || auth_header_file=""
+  fi
+  init_body="$(
+    jq -cn --arg client_name "$MCP_CLIENT_NAME" \
+      '{jsonrpc:"2.0", id:1, method:"initialize", params:{protocolVersion:"2025-11-25", clientInfo:{name:$client_name, version:"1.0"}, capabilities:{}}}'
+  )"
+
+  local -a init_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+  )
+  if [[ -n "$auth_header_file" ]]; then
+    init_headers+=( -H "@$auth_header_file" )
+  fi
+
+  if ! curl -sS --max-time "$CURL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" \
+    -X POST "$MCP_URL" "${init_headers[@]}" --data-binary "$init_body" >/dev/null; then
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
+    fail "MCP initialize failed at ${MCP_URL}"
+  fi
+
+  MCP_SESSION_ID="$(
+    awk '
+      tolower($0) ~ /^mcp-session-id:/ {
+        sub(/^[^:]+:[[:space:]]*/, "", $0)
+        sub(/\r$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$headers_file"
+  )"
+  protocol_version="$(
+    awk '
+      tolower($0) ~ /^mcp-protocol-version:/ {
+        sub(/^[^:]+:[[:space:]]*/, "", $0)
+        sub(/\r$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$headers_file"
+  )"
+
+  if [[ -z "$MCP_SESSION_ID" ]]; then
+    if jq -e . "$body_file" >/dev/null 2>&1; then
+      jq . "$body_file" >&2
+    else
+      cat "$body_file" >&2 || true
+    fi
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
+    fail "MCP initialize did not return Mcp-Session-Id"
+  fi
+
+  export MCP_SESSION_ID
+  if [[ -n "$protocol_version" ]]; then
+    MCP_PROTOCOL_VERSION="$protocol_version"
+    export MCP_PROTOCOL_VERSION
+  fi
+
+  local -a initialized_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+    -H "mcp-session-id: ${MCP_SESSION_ID}"
+  )
+  if [[ -n "$auth_header_file" ]]; then
+    initialized_headers+=( -H "@$auth_header_file" )
+  fi
+  curl -sS --max-time "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+    "${initialized_headers[@]}" \
+    --data-binary '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+    >/dev/null || true
+
+  rm -f "$headers_file" "$body_file" "$auth_header_file"
+}
+
+main() {
+  FAILURE_STAGE="startup"
+  require_cmd curl
+  require_cmd jq
+  FAILURE_STAGE="token_load"
+  load_mcp_token
+  if [[ "$REQUIRE_CURRENT_RUNTIME" == "1" || -n "$PROOF_OUT" ]]; then
+    FAILURE_STAGE="dashboard_preflight"
+    run_preflight_gate
+    if [[ "$PREFLIGHT_ONLY" == "1" ]]; then
+      FAILURE_STAGE="output"
+      if [[ "$COMPACT" == "1" ]]; then
+        printf '%s\n' "$PREFLIGHT_REPORT_JSON"
+      else
+        printf '%s\n' "$PREFLIGHT_REPORT_JSON" | jq .
+      fi
+      exit 0
+    fi
+  fi
+  FAILURE_STAGE="mcp_initialize"
+  initialize_mcp_session
+
+  local result
+  FAILURE_STAGE="mcp_tool_call"
+  result="$(
+    mcp_call_tool_result \
+      7001 \
+      "$WAITING_TOOL_NAME" \
+      '{}' \
+      "$MCP_SESSION_ID" \
+      "${MCP_TOKEN:-}" \
+      "$MCP_URL"
+  )" || fail "masc_keeper_waiting_inventory call failed"
+
+  if [[ -z "$result" ]]; then
+    fail "masc_keeper_waiting_inventory returned empty result"
+  fi
+  FAILURE_STAGE="proof_write"
+  write_cli_success_proof "$result"
+  FAILURE_STAGE="output"
+  if [[ "$COMPACT" == "1" ]]; then
+    printf '%s\n' "$result"
+  else
+    printf '%s\n' "$result" | jq .
+  fi
+}
+
+main "$@"

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -1,21 +1,40 @@
 open Alcotest
 open Masc
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+;;
+
 let with_config f =
   let path = Filename.temp_dir "schedule_tool_wiring_test" "" in
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () ->
+    f (Workspace.default_config path))
+;;
+
+let replace_path_with_directory path =
+  if Sys.file_exists path then rm_rf path;
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Unix.mkdir path 0o755
+;;
+
+let write_text path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
   Fun.protect
-    ~finally:(fun () ->
-      let rec rm path =
-        if Sys.file_exists path then
-          if Sys.is_directory path then begin
-            Sys.readdir path
-            |> Array.iter (fun entry -> rm (Filename.concat path entry));
-            Unix.rmdir path
-          end else
-            Sys.remove path
-      in
-      rm path)
-    (fun () -> f (Workspace.default_config path))
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let event_queue_snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
 ;;
 
 let payload =
@@ -60,6 +79,42 @@ let automated id : Schedule_domain.actor =
   { id; kind = Schedule_domain.Automated_actor; display_name = None }
 ;;
 
+let keeper_meta_for keeper_name trace_id =
+  match
+    Keeper_meta_json_parse.meta_of_json
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String keeper_name
+        ; "trace_id", `String trace_id
+        ; "last_model_used", `String "llama:auto"
+        ; "tool_access", `List []
+        ])
+  with
+  | Ok meta -> meta
+  | Error msg -> fail ("meta parse failed: " ^ msg)
+;;
+
+let payload_exn json =
+  match Schedule_domain.payload_of_yojson json with
+  | Ok payload -> payload
+  | Error msg -> fail msg
+;;
+
+let unsupported_payload_metric_labels ~phase ~risk_class =
+  [ "phase", phase
+  ; "risk_class", Schedule_domain.risk_class_to_string risk_class
+  ]
+;;
+
+let unsupported_payload_metric_value ~phase ~risk_class =
+  Otel_metric_store.metric_value_or_zero
+    Otel_metric_store.metric_schedule_payload_unsupported_total
+    ~labels:(unsupported_payload_metric_labels ~phase ~risk_class)
+    ()
+;;
+
+let metric_value name = Otel_metric_store.metric_value_or_zero name ()
+
 let create_args = `Assoc create_fields
 
 let schedule_definition action =
@@ -96,10 +151,26 @@ let operator_schedule_tool_name action =
   schema.name
 ;;
 
+let schedule_definition_names () =
+  Tool_schemas_schedule.definitions
+  |> List.map (fun (definition : Tool_schemas_schedule.definition) ->
+    let schema : Masc_domain.tool_schema = definition.schema in
+    schema.name)
+;;
+
+let json_string_list json =
+  json |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string
+;;
+
+let check_absent label names tool_name =
+  check bool label false (List.mem tool_name names)
+;;
+
 let test_schema_and_descriptor_exposed () =
   let create_name = schedule_tool_name Tool_schemas_schedule.Create_request in
   let approve_name = operator_schedule_tool_name Tool_schemas_schedule.Approve_request in
   let reject_name = operator_schedule_tool_name Tool_schemas_schedule.Reject_request in
+  let schedule_names = schedule_definition_names () in
   let approve_schema =
     (operator_schedule_definition Tool_schemas_schedule.Approve_request).schema
   in
@@ -113,6 +184,58 @@ let test_schema_and_descriptor_exposed () =
   check bool "raw schema has create" true (List.mem create_name schema_names);
   check bool "raw schema hides approve" false (List.mem approve_name schema_names);
   check bool "raw schema hides reject" false (List.mem reject_name schema_names);
+  check (list string) "schedule request tools match public definitions"
+    schedule_names
+    Tool_catalog_surfaces.schedule_request_surface_tools;
+  check (list string) "schedule compatibility alias matches request tools"
+    Tool_catalog_surfaces.schedule_request_surface_tools
+    Tool_catalog_surfaces.schedule_surface_tools;
+  check (list string) "public schedule policy"
+    schedule_names
+    Tool_catalog_surfaces.public_schedule_surface_tools;
+  check (list string) "keeper schedule policy"
+    schedule_names
+    Tool_catalog_surfaces.keeper_schedule_surface_tools;
+  check (list string) "spawned schedule policy intentionally empty"
+    []
+    Tool_catalog_surfaces.spawned_agent_schedule_surface_tools;
+  check (list string) "local worker schedule policy intentionally empty"
+    []
+    Tool_catalog_surfaces.local_worker_schedule_surface_tools;
+  check (list string) "operator schedule decision tools"
+    [ approve_name; reject_name ]
+    Tool_catalog_surfaces.schedule_operator_decision_tools;
+  List.iter
+    (fun name ->
+       check bool ("public MCP exposes " ^ name) true
+         (List.mem name Tool_catalog_surfaces.public_mcp_surface_tools))
+    schedule_names;
+  List.iter
+    (fun name ->
+       check_absent
+         ("spawned agent hides schedule tool " ^ name)
+         Tool_catalog_surfaces.spawned_agent_surface_tools
+         name;
+       check_absent
+         ("local worker hides schedule tool " ^ name)
+         Tool_catalog_surfaces.local_worker_surface_tools
+         name)
+    schedule_names;
+  List.iter
+    (fun name ->
+       check_absent
+         ("public MCP hides operator decision " ^ name)
+         Tool_catalog_surfaces.public_mcp_surface_tools
+         name;
+       check_absent
+         ("spawned agent hides operator decision " ^ name)
+         Tool_catalog_surfaces.spawned_agent_surface_tools
+         name;
+       check_absent
+         ("local worker hides operator decision " ^ name)
+         Tool_catalog_surfaces.local_worker_surface_tools
+         name)
+    Tool_catalog_surfaces.schedule_operator_decision_tools;
   check string "approve describes due grants"
     "Record a separate human execution grant for a pending or due scheduled request. Recurring side-effecting requests need a fresh grant for each due occurrence."
     approve_schema.description;
@@ -127,7 +250,51 @@ let test_schema_and_descriptor_exposed () =
   in
   check bool "descriptor has create" true (List.mem create_name descriptor_names);
   check bool "descriptor hides approve" false (List.mem approve_name descriptor_names);
-  check bool "descriptor hides reject" false (List.mem reject_name descriptor_names)
+  check bool "descriptor hides reject" false (List.mem reject_name descriptor_names);
+  let surface_snapshot = Capability_registry.surface_snapshot_json Config.raw_all_tool_schemas in
+  let member = Yojson.Safe.Util.member in
+  let public_names =
+    surface_snapshot
+    |> member "public_mcp"
+    |> member "tools"
+    |> json_string_list
+  in
+  let keeper_standard_names =
+    surface_snapshot
+    |> member "keeper_standard"
+    |> member "tools"
+    |> json_string_list
+  in
+  let spawned_names =
+    surface_snapshot
+    |> member "spawned_agent_mcp"
+    |> member "tools"
+    |> json_string_list
+  in
+  let local_worker_names =
+    surface_snapshot
+    |> member "local_worker"
+    |> member "tools"
+    |> json_string_list
+  in
+  List.iter
+    (fun name ->
+       check bool ("public snapshot includes " ^ name) true
+         (List.mem name public_names);
+       check bool ("keeper-standard snapshot includes " ^ name) true
+         (List.mem name keeper_standard_names))
+    schedule_names;
+  List.iter
+    (fun name ->
+       check_absent ("spawned snapshot hides schedule " ^ name) spawned_names name;
+       check_absent ("local-worker snapshot hides schedule " ^ name) local_worker_names name)
+    schedule_names;
+  List.iter
+    (fun name ->
+       check_absent ("keeper-standard hides operator decision " ^ name)
+         keeper_standard_names
+         name)
+    Tool_catalog_surfaces.schedule_operator_decision_tools
 ;;
 
 let schedule_ctx config : Tool_schedule.context =
@@ -145,11 +312,220 @@ let test_dispatch_create_persists_schedule () =
   | None -> fail "dispatch returned None"
   | Some result ->
     check bool "create succeeds" true (Tool_result.is_success result);
+    let open Yojson.Safe.Util in
+    check string "result payload support" "unsupported"
+      (Tool_result.data result |> member "payload_support" |> to_string);
     let state = Schedule_store.read_state config in
     check int "one schedule persisted" 1 (List.length state.schedules);
     let request = List.hd state.schedules in
     check string "status" "scheduled"
       (Schedule_domain.schedule_status_to_string request.status)
+;;
+
+let test_dispatch_get_surfaces_lifecycle_audit () =
+  with_config
+  @@ fun config ->
+  let ctx = schedule_ctx config in
+  let create_args =
+    `Assoc (("schedule_id", `String "sched-audit-tool") :: create_fields)
+  in
+  (match
+     Tool_schedule.dispatch ctx
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args:create_args
+   with
+   | Some result when Tool_result.is_success result -> ()
+   | Some result -> fail ("create failed: " ^ Tool_result.message result)
+   | None -> fail "create dispatch returned None");
+  match
+    Tool_schedule.dispatch ctx
+      ~name:(schedule_tool_name Tool_schemas_schedule.Get_request)
+      ~args:(`Assoc [ "schedule_id", `String "sched-audit-tool" ])
+  with
+  | None -> fail "get dispatch returned None"
+  | Some result ->
+    check bool "get succeeds" true (Tool_result.is_success result);
+    let open Yojson.Safe.Util in
+    let audit = Tool_result.data result |> member "lifecycle_audit" in
+    check string "payload support" "unsupported"
+      (Tool_result.data result |> member "payload_support" |> to_string);
+    check string "audit source" "schedule_lifecycle_audit_jsonl"
+      (audit |> member "source" |> to_string);
+    check string "audit status" "ok" (audit |> member "status" |> to_string);
+    check int "audit limit" Schedule_audit_log.default_projection_limit
+      (audit |> member "limit" |> to_int);
+    check int "audit event count" 1 (audit |> member "event_count" |> to_int);
+    check string "audit coverage" "events_recorded"
+      (audit |> member "coverage" |> to_string);
+    check string "audit backfill policy"
+      "not_synthesized_from_schedule_snapshot"
+      (audit |> member "backfill_policy" |> to_string);
+    let event =
+      match audit |> member "events" |> to_list with
+      | [ event ] -> event
+      | events -> failf "expected one audit event, got %d" (List.length events)
+    in
+    check string "audit action" "request_created"
+      (event |> member "action" |> to_string);
+    check string "audit schedule" "sched-audit-tool"
+      (event |> member "schedule_id" |> to_string);
+    check string "audit current status" "scheduled"
+      (event |> member "current_status" |> to_string)
+;;
+
+let test_dispatch_get_surfaces_pre_audit_no_events_policy () =
+  with_config
+  @@ fun config ->
+  let ctx = schedule_ctx config in
+  let request =
+    match
+      Schedule_domain.create_request
+        ~schedule_id:"sched-pre-audit"
+        ~requested_by:(human "operator")
+        ~scheduled_by:(human "scheduler")
+        ~requested_at:100.0
+        ~due_at:200.0
+        ~payload
+        ~risk_class:Schedule_domain.Read_only
+        ~approval_required:false
+        ~source:Schedule_domain.Operator_request
+        ()
+    with
+    | Ok request -> request
+    | Error msg -> fail msg
+  in
+  Workspace_utils.mkdir_p (Workspace_utils.masc_dir config);
+  Workspace_core.write_text
+    config
+    (Schedule_store.schedules_path config)
+    (Yojson.Safe.to_string
+       (Schedule_store.state_to_yojson
+          { (Schedule_store.default_state ()) with schedules = [ request ] }));
+  match
+    Tool_schedule.dispatch ctx
+      ~name:(schedule_tool_name Tool_schemas_schedule.Get_request)
+      ~args:(`Assoc [ "schedule_id", `String "sched-pre-audit" ])
+  with
+  | None -> fail "get dispatch returned None"
+  | Some result ->
+    check bool "get succeeds" true (Tool_result.is_success result);
+    let open Yojson.Safe.Util in
+    let audit = Tool_result.data result |> member "lifecycle_audit" in
+    check string "audit status" "ok" (audit |> member "status" |> to_string);
+    check int "audit event count" 0 (audit |> member "event_count" |> to_int);
+    check string "audit coverage" "no_lifecycle_events"
+      (audit |> member "coverage" |> to_string);
+    check string "audit backfill policy"
+      "not_synthesized_from_schedule_snapshot"
+      (audit |> member "backfill_policy" |> to_string);
+    check int "audit events empty" 0 (audit |> member "events" |> to_list |> List.length)
+;;
+
+let test_dispatch_list_surfaces_payload_support_summary () =
+  with_config
+  @@ fun config ->
+  let ctx = schedule_ctx config in
+  let create name args =
+    match Tool_schedule.dispatch ctx ~name ~args with
+    | Some result when Tool_result.is_success result -> ()
+    | Some result -> fail ("create failed: " ^ Tool_result.message result)
+    | None -> fail "create dispatch returned None"
+  in
+  create
+    (schedule_tool_name Tool_schemas_schedule.Create_request)
+    (`Assoc (("schedule_id", `String "sched-unsupported") :: create_fields));
+  create
+    (schedule_tool_name Tool_schemas_schedule.Create_request)
+    (`Assoc
+       [ "schedule_id", `String "sched-supported"
+       ; "due_at_unix", `Float 200.0
+       ; "risk_class", `String "workspace_write"
+       ; "board_content", `String "supported board post"
+       ; "requested_by_id", `String "operator"
+       ; "scheduled_by_id", `String "scheduler-agent"
+       ]);
+  match
+    Tool_schedule.dispatch ctx
+      ~name:(schedule_tool_name Tool_schemas_schedule.List_requests)
+      ~args:(`Assoc [ "limit", `Int 10 ])
+  with
+  | None -> fail "list dispatch returned None"
+  | Some result ->
+    check bool "list succeeds" true (Tool_result.is_success result);
+    let open Yojson.Safe.Util in
+    let data = Tool_result.data result in
+    let payload_support = data |> member "payload_support" in
+    check string "supported kind" Schedule_supported_kinds.board_post
+      (payload_support |> member "supported_kinds" |> to_list |> List.hd |> to_string);
+    let contract =
+      payload_support |> member "supported_contracts" |> to_list |> List.hd
+    in
+    check string "supported contract kind" Schedule_supported_kinds.board_post
+      (contract |> member "kind" |> to_string);
+    check string "supported contract dispatch tool"
+      (Schedule_payload_projection.dispatch_tool_name
+         Schedule_payload_projection.Board_post)
+      (contract |> member "dispatch_tool" |> to_string);
+    check bool "supported contract side-effecting risk" true
+      (contract |> member "side_effecting_risk_required" |> to_bool);
+    check int "one unsupported request"
+      1
+      (payload_support |> member "unsupported_request_count" |> to_int);
+    let schedules = data |> member "schedules" |> to_list in
+    check bool "supported row present" true
+      (List.exists
+         (fun row ->
+            String.equal "sched-supported" (row |> member "schedule_id" |> to_string)
+            && String.equal "supported" (row |> member "payload_support" |> to_string))
+         schedules);
+    check bool "unsupported row present" true
+      (List.exists
+         (fun row ->
+            String.equal "sched-unsupported" (row |> member "schedule_id" |> to_string)
+            && String.equal "unsupported" (row |> member "payload_support" |> to_string))
+         schedules)
+;;
+
+let test_dispatch_list_reports_schedule_store_read_error () =
+  with_config
+  @@ fun config ->
+  write_text (Schedule_store.schedules_path config) "{not-json";
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.List_requests)
+      ~args:(`Assoc [])
+  with
+  | None -> fail "list dispatch returned None"
+  | Some result ->
+    check bool "list fails" false (Tool_result.is_success result);
+    check (option string) "failure class" (Some "runtime_failure")
+      (Option.map Tool_result.tool_failure_class_to_string
+         (Tool_result.failure_class result));
+    check bool "error is explicit schedule store read failure" true
+      (String_util.contains_substring
+         (Tool_result.message result)
+         "schedule store read failed")
+;;
+
+let test_dispatch_get_reports_schedule_store_read_error () =
+  with_config
+  @@ fun config ->
+  write_text (Schedule_store.schedules_path config) "{not-json";
+  match
+    Tool_schedule.dispatch (schedule_ctx config)
+      ~name:(schedule_tool_name Tool_schemas_schedule.Get_request)
+      ~args:(`Assoc [ "schedule_id", `String "sched-corrupt" ])
+  with
+  | None -> fail "get dispatch returned None"
+  | Some result ->
+    check bool "get fails" false (Tool_result.is_success result);
+    check (option string) "failure class" (Some "runtime_failure")
+      (Option.map Tool_result.tool_failure_class_to_string
+         (Tool_result.failure_class result));
+    check bool "error is explicit schedule store read failure" true
+      (String_util.contains_substring
+         (Tool_result.message result)
+         "schedule store read failed")
 ;;
 
 let test_dispatch_operator_decisions_are_dashboard_only () =
@@ -276,10 +652,16 @@ let test_dispatch_create_board_post_convenience_payload () =
      let open Yojson.Safe.Util in
      check string "result payload kind" "masc.board_post"
        (data |> member "payload_kind" |> to_string);
+     check string "result payload dispatch tool"
+       (Schedule_payload_projection.dispatch_tool_name
+          Schedule_payload_projection.Board_post)
+       (data |> member "payload_dispatch_tool" |> to_string);
      check string "result payload target" "hearth:ops"
        (data |> member "payload_target" |> to_string);
      check string "result payload summary" "Scheduled check-in"
        (data |> member "payload_summary" |> to_string);
+     check string "result payload support" "supported"
+       (data |> member "payload_support" |> to_string);
      check bool "result separate grant" true
        (data |> member "requires_separate_human_grant" |> to_bool));
   (match Schedule_store.get_schedule config ~schedule_id:"sched-board-post" with
@@ -313,6 +695,10 @@ let test_dispatch_create_board_post_convenience_payload () =
   in
   check string "dashboard payload kind" "masc.board_post"
     (row |> member "payload_kind" |> to_string);
+  check string "dashboard payload dispatch tool"
+    (Schedule_payload_projection.dispatch_tool_name
+       Schedule_payload_projection.Board_post)
+    (row |> member "payload_dispatch_tool" |> to_string);
   check string "dashboard payload target" "hearth:ops"
     (row |> member "payload_target" |> to_string);
   check string "dashboard payload summary" "Scheduled check-in"
@@ -563,6 +949,8 @@ let test_dispatch_create_rejects_board_payload_without_content () =
 let test_dispatch_create_rejects_unsupported_side_effecting_kind () =
   with_config
   @@ fun config ->
+  let risk_class = Schedule_domain.Workspace_write in
+  let before = unsupported_payload_metric_value ~phase:"creation" ~risk_class in
   let args =
     `Assoc
       [ "schedule_id", `String "sched-unsupported-kind"
@@ -585,15 +973,131 @@ let test_dispatch_create_rejects_unsupported_side_effecting_kind () =
        (Tool_result.is_success result);
      check (option string) "failure class" (Some "workflow_rejection")
        (Option.map Tool_result.tool_failure_class_to_string
-          (Tool_result.failure_class result)));
+          (Tool_result.failure_class result));
+     check string "message"
+       (Schedule_supported_kinds.unsupported_error "orphan_auto_release")
+       (Tool_result.message result));
   let state = Schedule_store.read_state config in
   check int "no schedule persisted for unsupported kind" 0
-    (List.length state.schedules)
+    (List.length state.schedules);
+  let after = unsupported_payload_metric_value ~phase:"creation" ~risk_class in
+  check (float 0.000001) "unsupported creation metric increments" 1.0
+    (after -. before)
+;;
+
+let test_payload_registry_matches_supported_kind_ssot () =
+  check (list string) "registry uses supported-kind SSOT"
+    Schedule_supported_kinds.supported
+    Schedule_payload_projection.supported_payload_kinds;
+  check string "board-post variant string" Schedule_supported_kinds.board_post
+    (Schedule_payload_projection.known_kind_to_string
+       Schedule_payload_projection.Board_post);
+  (match
+     Schedule_payload_projection.supported_contracts_to_yojson ()
+     |> Yojson.Safe.Util.to_list
+   with
+   | contract :: _ ->
+     let open Yojson.Safe.Util in
+     check string "registry contract kind" Schedule_supported_kinds.board_post
+       (contract |> member "kind" |> to_string);
+     check string "registry contract dispatch tool"
+       (Schedule_payload_projection.dispatch_tool_name
+          Schedule_payload_projection.Board_post)
+       (contract |> member "dispatch_tool" |> to_string);
+     check int "registry contract schema version" 1
+       (contract |> member "schema_versions" |> to_list |> List.hd |> to_int);
+     check bool "registry contract side-effecting risk" true
+       (contract |> member "side_effecting_risk_required" |> to_bool)
+   | [] -> fail "expected at least one payload contract")
+;;
+
+let test_dispatch_tool_projection_requires_dispatchable_payload () =
+  let request : Schedule_domain.schedule_request =
+    { schedule_id = "sched-readonly-board"
+    ; requested_by = human "operator"
+    ; scheduled_by = automated "scheduler-agent"
+    ; requested_at = 100.0
+    ; due_at = 200.0
+    ; expires_at = None
+    ; payload = payload_exn board_post_payload
+    ; risk_class = Schedule_domain.Read_only
+    ; approval_required = false
+    ; status = Schedule_domain.Scheduled
+    ; source = Schedule_domain.System_request
+    ; recurrence = Schedule_domain.One_shot
+    }
+  in
+  check (option string) "read-only board payload has no dispatch tool" None
+    (Schedule_payload_projection.dispatch_tool_for_request request)
+;;
+
+let test_payload_projection_result_surfaces_invalid_payload () =
+  let request : Schedule_domain.schedule_request =
+    { schedule_id = "sched-invalid-payload"
+    ; requested_by = human "operator"
+    ; scheduled_by = automated "scheduler-agent"
+    ; requested_at = 100.0
+    ; due_at = 200.0
+    ; expires_at = None
+    ; payload =
+        payload_exn
+          (`Assoc [ "schema_version", `Int 1; "body", `Assoc [ "content", `String "x" ] ])
+    ; risk_class = Schedule_domain.Workspace_write
+    ; approval_required = false
+    ; status = Schedule_domain.Scheduled
+    ; source = Schedule_domain.System_request
+    ; recurrence = Schedule_domain.One_shot
+    }
+  in
+  (match Schedule_payload_projection.support_status_result request with
+   | Error msg -> check string "support status error" "missing field: kind" msg
+   | Ok status ->
+     fail
+       ("expected support status error, got "
+        ^ Schedule_payload_projection.support_status_to_string status));
+  check string "legacy support status" "unknown"
+    (Schedule_payload_projection.support_status_to_string
+       (Schedule_payload_projection.support_status request));
+  (match Schedule_payload_projection.kind_result request with
+   | Error msg -> check string "kind error" "missing field: kind" msg
+   | Ok kind -> fail ("expected kind error, got " ^ kind));
+  (match
+     Schedule_payload_projection.kind_of_json_result
+       (`Assoc
+         [ "kind", `String "test.raw"
+         ; "schema_version", `Int 1
+         ; "body", `Assoc []
+         ])
+   with
+   | Ok kind -> check string "raw payload kind" "test.raw" kind
+   | Error msg -> fail ("expected raw payload kind, got " ^ msg));
+  (match
+     Schedule_payload_projection.kind_of_json_result
+       (`Assoc [ "schema_version", `Int 1; "body", `Assoc [] ])
+   with
+   | Error msg -> check string "raw payload kind error" "missing field: kind" msg
+   | Ok kind -> fail ("expected raw payload kind error, got " ^ kind));
+  check (option string) "legacy kind projection" None
+    (Schedule_payload_projection.kind request);
+  (match Schedule_payload_projection.dispatch_tool_for_request_result request with
+   | Error err ->
+     check string "dispatch projection error" "missing field: kind"
+       (Schedule_payload_projection.dispatch_rejection_message err)
+   | Ok tool_name -> fail ("expected dispatch projection error, got " ^ tool_name));
+  check (option string) "legacy dispatch projection" None
+    (Schedule_payload_projection.dispatch_tool_for_request request);
+  (match Schedule_payload_projection.target_summary_result request with
+   | Error msg -> check string "target summary error" "missing field: kind" msg
+   | Ok _ -> fail "expected target summary error");
+  check (pair (option string) (option string)) "legacy target summary" (None, None)
+    (Schedule_payload_projection.target_summary request)
 ;;
 
 let test_dispatch_create_rejects_read_only_board_payload () =
   with_config
   @@ fun config ->
+  let risk_class = Schedule_domain.Read_only in
+  let before = unsupported_payload_metric_value ~phase:"creation" ~risk_class in
   let args =
     `Assoc
       [ "schedule_id", `String "sched-board-readonly"
@@ -617,7 +1121,10 @@ let test_dispatch_create_rejects_read_only_board_payload () =
        "masc.board_post requires a side-effecting risk_class such as workspace_write"
        (Tool_result.message result));
   let state = Schedule_store.read_state config in
-  check int "no schedule persisted" 0 (List.length state.schedules)
+  check int "no schedule persisted" 0 (List.length state.schedules);
+  let after = unsupported_payload_metric_value ~phase:"creation" ~risk_class in
+  check (float 0.000001) "invalid supported payload is not unsupported" 0.0
+    (after -. before)
 ;;
 
 let test_dispatch_cancel_persists_status () =
@@ -651,7 +1158,26 @@ let test_dispatch_cancel_persists_status () =
     | None -> fail "schedule missing"
     | Some request ->
       check string "status" "cancelled"
-        (Schedule_domain.schedule_status_to_string request.status)
+        (Schedule_domain.schedule_status_to_string request.status);
+      (match
+         Schedule_audit_log.read_recent_for_schedule config
+           ~schedule_id:"sched-cancel" ~limit:1
+       with
+       | Error msg -> fail msg
+       | Ok [ event ] ->
+         check string "cancel audit action" "request_cancelled"
+           (Schedule_audit_log.action_to_string event.action);
+         check string "cancel audit actor" "operator"
+           (match event.actor with
+            | Some actor -> actor.id
+            | None -> "");
+         (match event.detail with
+          | Some (`Assoc fields) ->
+            (match List.assoc_opt "reason" fields with
+             | Some (`String reason) -> check string "cancel audit reason" "test cleanup" reason
+             | _ -> fail "cancel audit reason missing")
+          | _ -> fail "cancel audit detail missing")
+       | Ok events -> failf "expected one cancel audit event, got %d" (List.length events))
 ;;
 
 let create_schedule_exn
@@ -674,6 +1200,206 @@ let create_schedule_exn
   | Ok request -> request
   | Error err ->
     fail ("schedule create failed: " ^ Schedule_service.service_error_to_string err)
+;;
+
+let test_schedule_signals_enqueue_keeper_owned_wake () =
+  with_config
+  @@ fun config ->
+  let base_path = config.Workspace.base_path in
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.clear ())
+    (fun () ->
+       Keeper_registry.clear ();
+       let keeper_name = "schedule-signal-keeper" in
+       let meta = keeper_meta_for keeper_name "trace-schedule-signal" in
+       let entry = Keeper_registry.register ~base_path keeper_name meta in
+       let enqueue_labels =
+         [ "keeper", keeper_name; "source", "schedule_signal"; "outcome", "queued" ]
+       in
+       let enqueue_before =
+         Otel_metric_store.metric_value_or_zero
+           Otel_metric_store.metric_keeper_wake_enqueue_total
+           ~labels:enqueue_labels
+           ()
+       in
+       ignore
+         (create_schedule_exn config ~schedule_id:"sched-owned-signal" ~due_at:200.0
+            ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+            ~scheduled_by:(automated keeper_name)
+            ()
+          : Schedule_domain.schedule_request);
+       ignore
+         (create_schedule_exn config ~schedule_id:"sched-orphan-signal" ~due_at:200.0
+            ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+            ~scheduled_by:(automated "unknown-scheduler")
+            ()
+          : Schedule_domain.schedule_request);
+       ignore
+         (create_schedule_exn config ~schedule_id:"sched-human-signal" ~due_at:200.0
+            ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+            ~scheduled_by:(human "operator")
+            ()
+          : Schedule_domain.schedule_request);
+       let signal schedule_id signal_id : Schedule_runner.wake_signal =
+         { signal_id
+         ; kind = Schedule_runner.Due_candidate
+         ; schedule_id
+         ; emitted_at = 201.0
+         ; due_at = 200.0
+         ; risk_class = Schedule_domain.Read_only
+         ; payload_digest = "sha256:" ^ schedule_id
+         ; payload = payload
+         }
+       in
+       check bool "wake flag starts false" false (Atomic.get entry.fiber_wakeup);
+       let wake_counts : Schedule_runner_status.wake_enqueue_counts =
+         Server_bootstrap_maintenance.For_testing.enqueue_schedule_signal_keeper_wakes
+           ~config
+           [ signal "sched-owned-signal" "sig-owned"
+           ; signal "sched-orphan-signal" "sig-orphan"
+           ; signal "sched-missing-signal" "sig-missing"
+           ; signal "sched-human-signal" "sig-human"
+           ]
+       in
+       check int "one wake enqueued" 1 wake_counts.wake_enqueued;
+       check int "three wakes skipped without keeper" 3
+         wake_counts.wake_skipped_no_keeper;
+       check int "one wake skipped missing schedule" 1
+         wake_counts.wake_skipped_missing_schedule;
+       check int "one wake skipped non-keeper actor" 1
+         wake_counts.wake_skipped_non_keeper_actor;
+       check int "one wake skipped unregistered keeper" 1
+         wake_counts.wake_skipped_unregistered_keeper;
+       check int "no wake enqueue failures" 0 wake_counts.wake_failed;
+       check bool "wake flag flips" true (Atomic.get entry.fiber_wakeup);
+       let queue = Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+       check int "one keeper-owned schedule signal enqueued" 1
+         (Keeper_event_queue.length queue);
+       (match Keeper_event_queue.dequeue queue with
+        | None -> fail "missing schedule signal stimulus"
+        | Some (stimulus, rest) ->
+          check bool "queue rest empty" true (Keeper_event_queue.is_empty rest);
+          check string "stimulus post id" "schedule-signal:sig-owned"
+            stimulus.post_id;
+          (match stimulus.payload with
+           | Keeper_event_queue.Schedule_signal signal ->
+             check string "schedule id" "sched-owned-signal" signal.schedule_id;
+             check string "signal id" "sig-owned" signal.schedule_signal_id;
+             check string "signal kind" "due_candidate"
+               (Keeper_event_queue.schedule_signal_kind_to_string
+                  signal.schedule_signal_kind)
+           | _ -> fail "expected Schedule_signal payload"));
+       let enqueue_after =
+         Otel_metric_store.metric_value_or_zero
+           Otel_metric_store.metric_keeper_wake_enqueue_total
+           ~labels:enqueue_labels
+           ()
+       in
+       check (float 0.000001) "schedule signal enqueue metric increments" 1.0
+         (enqueue_after -. enqueue_before))
+;;
+
+let test_schedule_signal_wake_counts_persist_failure () =
+  with_config
+  @@ fun config ->
+  let base_path = config.Workspace.base_path in
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.clear ())
+    (fun () ->
+       Keeper_registry.clear ();
+       let keeper_name = "schedule-signal-persist-failure-keeper" in
+       let meta = keeper_meta_for keeper_name "trace-schedule-signal-persist-failure" in
+       let entry = Keeper_registry.register ~base_path keeper_name meta in
+       let failed_labels =
+         [ "keeper", keeper_name; "source", "schedule_signal"; "outcome", "persist_failed" ]
+       in
+       let failed_before =
+         Otel_metric_store.metric_value_or_zero
+           Otel_metric_store.metric_keeper_wake_enqueue_total
+           ~labels:failed_labels
+           ()
+       in
+       ignore
+         (create_schedule_exn config ~schedule_id:"sched-persist-failed-signal"
+            ~due_at:200.0 ~risk_class:Schedule_domain.Read_only
+            ~requested_by:(human "operator") ~scheduled_by:(automated keeper_name)
+            ()
+          : Schedule_domain.schedule_request);
+       let signal : Schedule_runner.wake_signal =
+         { signal_id = "sig-persist-failed"
+         ; kind = Schedule_runner.Due_candidate
+         ; schedule_id = "sched-persist-failed-signal"
+         ; emitted_at = 201.0
+         ; due_at = 200.0
+         ; risk_class = Schedule_domain.Read_only
+         ; payload_digest = "sha256:sched-persist-failed-signal"
+         ; payload = payload
+         }
+       in
+       check bool "wake flag starts false" false (Atomic.get entry.fiber_wakeup);
+       replace_path_with_directory
+         (event_queue_snapshot_path ~base_path ~keeper_name);
+       let wake_counts : Schedule_runner_status.wake_enqueue_counts =
+         Server_bootstrap_maintenance.For_testing.enqueue_schedule_signal_keeper_wakes
+           ~config
+           [ signal ]
+       in
+       check int "persist failure does not count as wake enqueued" 0
+         wake_counts.wake_enqueued;
+       check int "no keeper skip on owned schedule" 0
+         wake_counts.wake_skipped_no_keeper;
+       check int "persist failure counts as wake failed" 1 wake_counts.wake_failed;
+       check bool "wake hint stays false when event layer persist fails" false
+         (Atomic.get entry.fiber_wakeup);
+       let failed_after =
+         Otel_metric_store.metric_value_or_zero
+           Otel_metric_store.metric_keeper_wake_enqueue_total
+           ~labels:failed_labels
+           ()
+       in
+       check (float 0.000001) "schedule signal persist failure metric increments" 1.0
+         (failed_after -. failed_before))
+;;
+
+let test_schedule_signal_wake_counts_store_read_failure () =
+  with_config
+  @@ fun config ->
+  let base_path = config.Workspace.base_path in
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.clear ())
+    (fun () ->
+       Keeper_registry.clear ();
+       let keeper_name = "schedule-signal-store-read-failure-keeper" in
+       let meta = keeper_meta_for keeper_name "trace-schedule-signal-store-read-failure" in
+       let entry = Keeper_registry.register ~base_path keeper_name meta in
+       write_text (Schedule_store.schedules_path config) "{not-json";
+       let signal : Schedule_runner.wake_signal =
+         { signal_id = "sig-store-read-failed"
+         ; kind = Schedule_runner.Due_candidate
+         ; schedule_id = "sched-store-read-failed-signal"
+         ; emitted_at = 201.0
+         ; due_at = 200.0
+         ; risk_class = Schedule_domain.Read_only
+         ; payload_digest = "sha256:sched-store-read-failed-signal"
+         ; payload = payload
+         }
+       in
+       check bool "wake flag starts false" false (Atomic.get entry.fiber_wakeup);
+       let wake_counts : Schedule_runner_status.wake_enqueue_counts =
+         Server_bootstrap_maintenance.For_testing.enqueue_schedule_signal_keeper_wakes
+           ~config
+           [ signal ]
+       in
+       check int "store read failure does not count as wake enqueued" 0
+         wake_counts.wake_enqueued;
+       check int "store read failure is not a keeper ownership skip" 0
+         wake_counts.wake_skipped_no_keeper;
+       check int "store read failure counts as wake failed" 1 wake_counts.wake_failed;
+       check bool "wake hint stays false on unreadable schedule store" false
+         (Atomic.get entry.fiber_wakeup);
+       let queue = Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+       check int "no schedule signal stimulus is enqueued" 0
+         (Keeper_event_queue.length queue))
 ;;
 
 let test_dashboard_projection_surfaces_schedule_fsm () =
@@ -751,6 +1477,10 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (json |> member "derived_counts" |> member "due_effective" |> to_int);
   check int "blocked approval count" 1
     (json |> member "derived_counts" |> member "blocked_approval" |> to_int);
+  check (float 0.000001) "approval blocked count gauge" 1.0
+    (metric_value Otel_metric_store.metric_schedule_approval_blocked_count);
+  check bool "approval wait gauge is positive" true
+    (metric_value Otel_metric_store.metric_schedule_approval_wait_seconds > 0.0);
   check int "due execution ready count" 0
     (json |> member "derived_counts" |> member "due_execution_ready" |> to_int);
   check int "expired effective count" 1
@@ -766,6 +1496,14 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
   check string "supported payload kind" "masc.board_post"
     (json |> member "payload_support" |> member "supported_kinds" |> to_list
      |> List.hd |> to_string);
+  let payload_contract =
+    json |> member "payload_support" |> member "supported_contracts" |> to_list
+    |> List.hd
+  in
+  check string "supported payload contract dispatch tool"
+    (Schedule_payload_projection.dispatch_tool_name
+       Schedule_payload_projection.Board_post)
+    (payload_contract |> member "dispatch_tool" |> to_string);
   (match json |> member "payload_support" |> member "unsupported_kinds" |> to_list with
    | unsupported :: _ ->
      check string "unsupported payload kind" "test.reminder"
@@ -818,8 +1556,15 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (due_tool_status |> member "direct_call_allowed" |> to_bool);
   check string "due keeper next tool default visibility" "default"
     (due_tool_status |> member "visibility" |> to_string);
-  check int "due keeper next tool has no surface projection" 0
-    (due_tool_status |> member "surface_count" |> to_int);
+  let due_tool_surfaces =
+    due_tool_status |> member "surfaces" |> json_string_list
+  in
+  check bool "due keeper next tool public surface" true
+    (List.mem "public_mcp" due_tool_surfaces);
+  check bool "due keeper next tool keeper surface" true
+    (List.mem "keeper_standard" due_tool_surfaces);
+  check bool "due keeper next tool has surface projection" true
+    ((due_tool_status |> member "surface_count" |> to_int) >= 2);
   check string "due keeper next tool read-only domain" "read_only"
     (due_tool_status |> member "effect_domain" |> to_string);
   check bool "due keeper action mentions runner tick" true
@@ -875,12 +1620,26 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
       (row |> member "effective_status" |> to_string);
     check string "terminal readiness" "terminal"
       (row |> member "execution_readiness" |> to_string);
-    check string "last execution status" "succeeded"
-      (row |> member "last_execution" |> member "status" |> to_string);
-    check string "last execution detail" "test.exec"
-      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string);
-    check string "unrecognized dispatch receipt status" "unrecognized_detail"
-      (row |> member "dispatch_receipt" |> member "projection_status" |> to_string);
+	    check string "last execution status" "succeeded"
+	      (row |> member "last_execution" |> member "status" |> to_string);
+	    check string "last execution detail" "test.exec"
+	      (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string);
+	    let lifecycle_audit = row |> member "lifecycle_audit" in
+	    check string "lifecycle audit source" "schedule_lifecycle_audit_jsonl"
+      (lifecycle_audit |> member "source" |> to_string);
+    check string "lifecycle audit status" "ok"
+      (lifecycle_audit |> member "status" |> to_string);
+    let latest_event =
+      match lifecycle_audit |> member "events" |> to_list with
+      | event :: _ -> event
+      | [] -> fail "expected lifecycle audit event"
+    in
+    check string "latest lifecycle action" "execution_succeeded"
+	      (latest_event |> member "action" |> to_string);
+	    check string "latest lifecycle current status" "succeeded"
+	      (latest_event |> member "current_status" |> to_string);
+	    check string "unrecognized dispatch receipt status" "unrecognized_detail"
+	      (row |> member "dispatch_receipt" |> member "projection_status" |> to_string);
     check bool "unrecognized dispatch receipt reason" true
       (String_util.contains_substring
          (row |> member "dispatch_receipt" |> member "reason" |> to_string)
@@ -888,9 +1647,9 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     check string "unrecognized queue evidence status" "unrecognized_receipt"
       (row |> member "keeper_queue_evidence" |> member "projection_status" |> to_string);
     check bool "unrecognized queue evidence reason" true
-      (String_util.contains_substring
-         (row |> member "keeper_queue_evidence" |> member "reason" |> to_string)
-         "unsupported schedule dispatch receipt kind: test.exec")
+	      (String_util.contains_substring
+	         (row |> member "keeper_queue_evidence" |> member "reason" |> to_string)
+	         "unsupported schedule dispatch receipt kind: test.exec")
 ;;
 
 let test_dashboard_projection_surfaces_schedule_runner_signals () =
@@ -916,7 +1675,9 @@ let test_dashboard_projection_surfaces_schedule_runner_signals () =
   check string "signal source" "schedule_runner_signals"
     (json |> member "signal_source" |> to_string);
   check int "signal count" 1 (json |> member "signal_count" |> to_int);
+  check int "signal error count" 0 (json |> member "signal_error_count" |> to_int);
   check int "signal limit" 20 (json |> member "signal_limit" |> to_int);
+  check int "signal errors" 0 (List.length (json |> member "signal_errors" |> to_list));
   let signal =
     match json |> member "signals" |> to_list with
     | [ signal ] -> signal
@@ -940,6 +1701,79 @@ let test_dashboard_projection_surfaces_schedule_runner_signals () =
     (signal |> member "payload_kind" |> to_string);
   check string "signal payload digest" emitted.payload_digest
     (signal |> member "payload_digest" |> to_string)
+;;
+
+let test_dashboard_projection_surfaces_schedule_runner_signal_decode_errors () =
+  with_config
+  @@ fun config ->
+  let store =
+    Dated_jsonl.create ~base_dir:(Schedule_runner.signals_dir config) ()
+  in
+  Dated_jsonl.append
+    store
+    (`Assoc
+      [ "event_type", `String "schedule.due_candidate"
+      ; "signal_id", `String "malformed-signal"
+      ]);
+  let json =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  check int "no decoded signals" 0 (json |> member "signal_count" |> to_int);
+  check int "one signal decode error" 1
+    (json |> member "signal_error_count" |> to_int);
+  let error =
+    match json |> member "signal_errors" |> to_list with
+    | [ error ] -> error
+    | errors -> failf "expected one signal error, got %d" (List.length errors)
+  in
+  check int "error ordinal" 0 (error |> member "ordinal" |> to_int);
+  check bool "error message visible" true
+    (String.length (error |> member "error" |> to_string) > 0)
+;;
+
+let test_dashboard_projection_reports_schedule_store_read_error () =
+  with_config
+  @@ fun config ->
+  write_text (Schedule_store.schedules_path config) "{not-json";
+  let json =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  check string "schema" "masc.dashboard.scheduled_automation.v1"
+    (json |> member "schema" |> to_string);
+  check string "status" "unknown" (json |> member "status" |> to_string);
+  check bool "schedule store known" false
+    (json |> member "schedule_store_known" |> to_bool);
+  check bool "read error present" true
+    (String.length (json |> member "schedule_store_read_error" |> to_string) > 0);
+  check bool "request count unknown" true
+    (json |> member "request_count" = `Null);
+  check bool "counts unknown" true (json |> member "counts" = `Null);
+  check bool "fsm active count unknown" true
+    (json |> member "fsm" |> member "active_count" = `Null);
+  check int "requests empty for unreadable store" 0
+    (List.length (json |> member "requests" |> to_list))
+;;
+
+let test_keeper_observation_reports_schedule_store_read_error () =
+  with_config
+  @@ fun config ->
+  write_text (Schedule_store.schedules_path config) "{not-json";
+  let observation =
+    Keeper_world_observation.read_scheduled_automation_observation
+      ~config
+      ~now:1_000.0
+  in
+  check bool "schedule counts unknown" false
+    (Keeper_world_observation.scheduled_automation_counts_known observation);
+  (match Keeper_world_observation.scheduled_automation_read_error observation with
+   | None -> fail "expected schedule read error"
+   | Some error ->
+     check bool "read error is visible" true (String.length error > 0));
+  check int "compat active count remains zero" 0 observation.active_count;
+  check int "compat due-ready count remains zero" 0 observation.due_ready_count;
+  check int "no attention items on unreadable store" 0 (List.length observation.items)
 ;;
 
 let test_keeper_observation_surfaces_schedule_attention () =
@@ -995,6 +1829,55 @@ let test_keeper_observation_surfaces_schedule_attention () =
    | _ -> fail "expected blocked and ready attention rows")
 ;;
 
+let test_keeper_observation_filters_schedule_attention_by_owner () =
+  with_config
+  @@ fun config ->
+  let now = 2_000.0 in
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-owned-ready" ~due_at:(now -. 10.0)
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-other-ready" ~due_at:(now -. 20.0)
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "other-keeper")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-human-ready" ~due_at:(now -. 30.0)
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(human "operator")
+       ()
+      : Schedule_domain.schedule_request);
+  (match Schedule_store.refresh_due config ~now with
+   | Ok _ -> ()
+   | Error err -> fail (Schedule_store.store_error_to_string err));
+  let global =
+    Keeper_world_observation.read_scheduled_automation_observation ~config ~now
+  in
+  check int "global sees all due-ready schedules" 3 global.due_ready_count;
+  let owned =
+    Keeper_world_observation.read_scheduled_automation_observation
+      ~config
+      ~keeper_name:"scheduler-agent"
+      ~now
+  in
+  check int "keeper sees only owned due-ready schedule" 1 owned.due_ready_count;
+  (match owned.items with
+   | [ item ] -> check string "owned schedule id" "sched-owned-ready" item.schedule_id
+   | items -> failf "expected one owned item, got %d" (List.length items));
+  let other =
+    Keeper_world_observation.read_scheduled_automation_observation
+      ~config
+      ~keeper_name:"missing-keeper"
+      ~now
+  in
+  check int "unknown keeper sees no schedule attention" 0 other.due_ready_count;
+  check int "unknown keeper has no schedule attention items" 0 (List.length other.items)
+;;
+
 let () =
   run "Schedule_tool_wiring"
     [ ( "wiring"
@@ -1002,6 +1885,16 @@ let () =
             test_schema_and_descriptor_exposed
         ; test_case "dispatch create persists schedule" `Quick
             test_dispatch_create_persists_schedule
+        ; test_case "dispatch get surfaces lifecycle audit" `Quick
+            test_dispatch_get_surfaces_lifecycle_audit
+        ; test_case "dispatch get surfaces pre-audit no-events policy" `Quick
+            test_dispatch_get_surfaces_pre_audit_no_events_policy
+        ; test_case "dispatch list surfaces payload support summary" `Quick
+            test_dispatch_list_surfaces_payload_support_summary
+        ; test_case "dispatch list reports schedule store read error" `Quick
+            test_dispatch_list_reports_schedule_store_read_error
+        ; test_case "dispatch get reports schedule store read error" `Quick
+            test_dispatch_get_reports_schedule_store_read_error
         ; test_case "operator decisions are dashboard-only" `Quick
             test_dispatch_operator_decisions_are_dashboard_only
         ; test_case "dispatch create persists recurrence" `Quick
@@ -1026,14 +1919,34 @@ let () =
             test_dispatch_create_rejects_read_only_board_payload
         ; test_case "dispatch create rejects unsupported side-effecting kind" `Quick
             test_dispatch_create_rejects_unsupported_side_effecting_kind
+        ; test_case "payload registry matches supported-kind SSOT" `Quick
+            test_payload_registry_matches_supported_kind_ssot
+        ; test_case "dispatch tool projection requires dispatchable payload" `Quick
+            test_dispatch_tool_projection_requires_dispatchable_payload
+        ; test_case "payload projection result surfaces invalid payload" `Quick
+            test_payload_projection_result_surfaces_invalid_payload
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
+        ; test_case "schedule signals enqueue keeper-owned wake" `Quick
+            test_schedule_signals_enqueue_keeper_owned_wake
+        ; test_case "schedule signal wake counts durable enqueue failure" `Quick
+            test_schedule_signal_wake_counts_persist_failure
+        ; test_case "schedule signal wake counts store read failure" `Quick
+            test_schedule_signal_wake_counts_store_read_failure
         ; test_case "dashboard projection surfaces schedule FSM" `Quick
             test_dashboard_projection_surfaces_schedule_fsm
         ; test_case "dashboard projection surfaces schedule runner signals" `Quick
             test_dashboard_projection_surfaces_schedule_runner_signals
+        ; test_case "dashboard projection surfaces schedule runner signal decode errors" `Quick
+            test_dashboard_projection_surfaces_schedule_runner_signal_decode_errors
+        ; test_case "dashboard projection reports schedule store read error" `Quick
+            test_dashboard_projection_reports_schedule_store_read_error
+        ; test_case "keeper observation reports schedule store read error" `Quick
+            test_keeper_observation_reports_schedule_store_read_error
         ; test_case "keeper observation surfaces schedule attention" `Quick
             test_keeper_observation_surfaces_schedule_attention
+        ; test_case "keeper observation filters schedule attention by owner" `Quick
+            test_keeper_observation_filters_schedule_attention_by_owner
         ] )
     ]
 ;;

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -126,6 +126,43 @@ let test_masc_dashboard_input_schema_matches () =
     gen.input_schema
 ;;
 
+let test_masc_keeper_waiting_inventory_name_matches () =
+  let gen =
+    find_by_name "masc_keeper_waiting_inventory" Tool_descriptors_gen.schemas
+  in
+  let hand =
+    find_by_name "masc_keeper_waiting_inventory" Tool_schemas_misc.schemas
+  in
+  Alcotest.(check string) "masc_keeper_waiting_inventory name" hand.name gen.name
+;;
+
+let test_masc_keeper_waiting_inventory_description_matches () =
+  let gen =
+    find_by_name "masc_keeper_waiting_inventory" Tool_descriptors_gen.schemas
+  in
+  let hand =
+    find_by_name "masc_keeper_waiting_inventory" Tool_schemas_misc.schemas
+  in
+  Alcotest.(check string)
+    "masc_keeper_waiting_inventory description"
+    hand.description
+    gen.description
+;;
+
+let test_masc_keeper_waiting_inventory_input_schema_matches () =
+  let gen =
+    find_by_name "masc_keeper_waiting_inventory" Tool_descriptors_gen.schemas
+  in
+  let hand =
+    find_by_name "masc_keeper_waiting_inventory" Tool_schemas_misc.schemas
+  in
+  Alcotest.check
+    yojson_testable
+    "masc_keeper_waiting_inventory input_schema (Yojson.Safe.equal)"
+    hand.input_schema
+    gen.input_schema
+;;
+
 let test_masc_gc_name_matches () =
   let gen = find_by_name "masc_gc" Tool_descriptors_gen.schemas in
   let hand = find_by_name "masc_gc" Tool_schemas_misc.schemas in
@@ -313,6 +350,20 @@ let () =
             "input_schema"
             `Quick
             test_masc_dashboard_input_schema_matches
+        ] )
+    ; ( "masc_keeper_waiting_inventory field-by-field"
+      , [ Alcotest.test_case
+            "name"
+            `Quick
+            test_masc_keeper_waiting_inventory_name_matches
+        ; Alcotest.test_case
+            "description"
+            `Quick
+            test_masc_keeper_waiting_inventory_description_matches
+        ; Alcotest.test_case
+            "input_schema"
+            `Quick
+            test_masc_keeper_waiting_inventory_input_schema_matches
         ] )
     ; ( "masc_gc field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_gc_name_matches

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -24,6 +24,14 @@ let parse_json s =
   try Yojson.Safe.from_string s
   with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
 
+let json_string_member key = function
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`String value) -> value
+       | Some _ -> failwith ("json field is not a string: " ^ key)
+       | None -> failwith ("missing json field: " ^ key))
+  | _ -> failwith "expected json object"
+
 let with_env name value_opt f =
   let original = Sys.getenv_opt name in
   let restore () =
@@ -139,6 +147,38 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
+)
+
+let () = test "dispatch_keeper_waiting_inventory" (fun () ->
+  let ctx = make_test_ctx () in
+  Workspace.ensure_workspace_bootstrap ctx.config;
+  let args = `Assoc [] in
+  match Tool_misc.dispatch ctx ~name:"masc_keeper_waiting_inventory" ~args with
+  | Some result ->
+      assert (Tool_result.is_success result);
+      let data = Tool_result.data result in
+      assert
+        (String.equal
+           (json_string_member "schema" data)
+           "masc.dashboard.keeper_waiting_inventory.v1");
+      assert
+        (String.equal
+           (json_string_member "source" data)
+           "server_keeper_waiting_inventory")
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_keeper_waiting_inventory_rejects_unexpected_args" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [ ("scope", `String "current") ] in
+  match Tool_misc.dispatch ctx ~name:"masc_keeper_waiting_inventory" ~args with
+  | Some result ->
+      assert (not (Tool_result.is_success result));
+      assert (Tool_result.failure_class result = Some Tool_result.Workflow_rejection);
+      assert
+        (Tool_result.message result
+         = "masc_keeper_waiting_inventory does not accept arguments: scope")
+  | None -> failwith "dispatch returned None"
 )
 
 let () = test "dispatch_dashboard_invalid_scope" (fun () ->

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -718,6 +718,18 @@ let test_masc_dashboard_schema () =
   | None -> Alcotest.fail "masc_dashboard not found"
   | Some _ -> ()
 
+let test_masc_keeper_waiting_inventory_schema () =
+  match find_registered_tool "masc_keeper_waiting_inventory" with
+  | None -> Alcotest.fail "masc_keeper_waiting_inventory not found"
+  | Some schema ->
+      (match get_json_assoc "properties" schema.input_schema with
+       | Some props ->
+           Alcotest.(check int)
+             "masc_keeper_waiting_inventory has no parameters"
+             0
+             (List.length props)
+       | None -> Alcotest.fail "masc_keeper_waiting_inventory missing properties")
+
 let test_masc_agent_fitness_schema () =
   match find_registered_tool "masc_agent_fitness" with
   | None -> Alcotest.fail "masc_agent_fitness not found"
@@ -870,6 +882,8 @@ let () =
     ];
     "dashboard_tools", [
       Alcotest.test_case "dashboard" `Quick test_masc_dashboard_schema;
+      Alcotest.test_case "keeper_waiting_inventory" `Quick
+        test_masc_keeper_waiting_inventory_schema;
       Alcotest.test_case "agent_fitness" `Quick test_masc_agent_fitness_schema;
       Alcotest.test_case "get_metrics" `Quick test_masc_get_metrics_schema;
       Alcotest.test_case "agent_card" `Quick test_masc_agent_card_schema;


### PR DESCRIPTION
Stacked on #23408. Extracted from the superseded #23393 bundle.

Scope:
- Adds the generated misc tool descriptor for `masc_keeper_waiting_inventory`.
- Registers the keeper waiting inventory as read-only metadata and on the public MCP surface.
- Dispatches the tool through `Tool_misc` with explicit no-argument validation.
- Classifies the tool as read-state/resource-safe.
- Adds focused tests for descriptor parity, dispatch success/error, and registered schema presence.

Out of scope for this slice:
- CLI wrappers and proof scripts.
- Legacy `config/tool_policy.toml`; it is currently marked as a non-runtime legacy marker, so this slice avoids treating it as an SSOT.

Validation performed locally:
- `opam exec -- ocamlformat --inplace ...` for touched OCaml files.
- `git diff --cached --check`
- conflict-marker scan over changed files.

Notes:
- No local Dune build/test result is claimed; Dune validation remains CI-owned per project direction.