### PR TITLE
feat(cli): add keeper waiting inventory proof wrapper

### DIFF
--- a/scripts/keeper-waiting-inventory-proof-check.sh
+++ b/scripts/keeper-waiting-inventory-proof-check.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${REQUIRE_PASS:=0}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/keeper-waiting-inventory-proof-check.sh [--require-pass|--allow-fail] PROOF.json
+
+Validates proof emitted by scripts/keeper-waiting-inventory.sh --proof-out.
+Set REQUIRE_PASS=1 or pass --require-pass to reject fail proofs.
+USAGE
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_pass="$REQUIRE_PASS"
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --require-pass)
+    require_pass=1
+    shift
+    ;;
+  --allow-fail)
+    require_pass=0
+    shift
+    ;;
+esac
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+if truthy "$require_pass"; then
+  require_pass=1
+else
+  require_pass=0
+fi
+
+proof_path="$1"
+command -v jq >/dev/null || fail "jq is required"
+[[ -f "$proof_path" ]] || fail "proof file not found: ${proof_path}"
+
+report="$(
+  jq -ce \
+    --arg proof_path "$proof_path" \
+    --arg require_pass "$require_pass" \
+    '
+      def emit($condition; $message):
+        if $condition then [] else [$message] end;
+
+      def object_value($value):
+        ($value | type) == "object";
+
+      def nonempty_string($value):
+        ($value | type) == "string" and ($value | length > 0);
+
+      def string_array($value):
+        ($value | type) == "array"
+        and all($value[]; (type == "string") and (length > 0));
+
+      def error_array($value):
+        string_array($value);
+
+      def boolean_value($value):
+        ($value | type) == "boolean";
+
+      def number_value($value):
+        ($value | type) == "number";
+
+      def array_value($value):
+        ($value | type) == "array";
+
+      def integer_value($value):
+        number_value($value)
+        and $value >= 0
+        and $value == ($value | floor);
+
+      def nullable_number($value):
+        $value == null or number_value($value);
+
+      def nullable_string($value):
+        $value == null or (($value | type) == "string");
+
+      def waiting_row_shape($row):
+        object_value($row)
+        and ($row | has("keeper_name"))
+        and ($row.keeper_name == null or nonempty_string($row.keeper_name))
+        and nonempty_string($row.source)
+        and nonempty_string($row.waiting_on)
+        and nonempty_string($row.wake_producer)
+        and ($row | has("since"))
+        and nullable_number($row.since)
+        and ($row | has("since_iso"))
+        and nullable_string($row.since_iso)
+        and ($row | has("due_at"))
+        and nullable_number($row.due_at)
+        and ($row | has("due_at_iso"))
+        and nullable_string($row.due_at_iso)
+        and nonempty_string($row.next_action)
+        and ($row | has("detail"));
+
+      def keeper_shape($supported_states; $keeper):
+        object_value($keeper)
+        and nonempty_string($keeper.keeper_name)
+        and nonempty_string($keeper.state)
+        and array_value($supported_states)
+        and (($supported_states | index($keeper.state)) != null)
+        and array_value($keeper.waiting_on)
+        and integer_value($keeper.waiting_count)
+        and ($keeper.waiting_count == ($keeper.waiting_on | length))
+        and object_value($keeper.sources)
+        and ($keeper | has("since"))
+        and nullable_number($keeper.since)
+        and ($keeper | has("since_iso"))
+        and nullable_string($keeper.since_iso)
+        and ($keeper | has("due_at"))
+        and nullable_number($keeper.due_at)
+        and ($keeper | has("due_at_iso"))
+        and nullable_string($keeper.due_at_iso)
+        and ($keeper.next_action == null or nonempty_string($keeper.next_action))
+        and all($keeper.waiting_on[]; waiting_row_shape(.));
+
+      def keeper_row_total($keepers):
+        if array_value($keepers) then
+          ([$keepers[] | if array_value(.waiting_on) then (.waiting_on | length) else 0 end] | add // 0)
+        else
+          null
+        end;
+
+      def waiting_rows_shape($rows):
+        if array_value($rows) then
+          all($rows[]; waiting_row_shape(.))
+        else
+          false
+        end;
+
+      def inventory_projection_errors($projection; $label):
+        emit(object_value($projection); ($label + " must be an object"))
+        + if object_value($projection) then
+            emit(($projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                 ($label + " schema mismatch"))
+            + emit(($projection.source == "server_keeper_waiting_inventory");
+                   ($label + " source mismatch"))
+            + emit(string_array($projection.supported_states);
+                   ($label + ".supported_states must be a string array"))
+            + emit(integer_value($projection.keeper_count);
+                   ($label + ".keeper_count must be a non-negative integer"))
+            + emit(integer_value($projection.waiting_keeper_count);
+                   ($label + ".waiting_keeper_count must be a non-negative integer"))
+            + emit(integer_value($projection.row_count);
+                   ($label + ".row_count must be a non-negative integer"))
+            + emit(integer_value($projection.global_row_count);
+                   ($label + ".global_row_count must be a non-negative integer"))
+            + emit(array_value($projection.keepers);
+                   ($label + ".keepers must be an array"))
+            + emit(array_value($projection.global_waiting_on);
+                   ($label + ".global_waiting_on must be an array"))
+            + if integer_value($projection.keeper_count)
+                 and array_value($projection.keepers) then
+                emit(($projection.keeper_count == ($projection.keepers | length));
+                     ($label + ".keeper_count must match keepers length"))
+              else
+                []
+              end
+            + if integer_value($projection.waiting_keeper_count)
+                 and integer_value($projection.keeper_count) then
+                emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                     ($label + ".waiting_keeper_count must not exceed keeper_count"))
+              else
+                []
+              end
+            + if integer_value($projection.row_count)
+                 and array_value($projection.keepers) then
+                emit(($projection.row_count == keeper_row_total($projection.keepers));
+                     ($label + ".row_count must match keeper waiting rows"))
+              else
+                []
+              end
+            + if integer_value($projection.global_row_count)
+                 and array_value($projection.global_waiting_on) then
+                emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                     ($label + ".global_row_count must match global_waiting_on length"))
+              else
+                []
+              end
+            + if array_value($projection.keepers) then
+                emit(all($projection.keepers[]; keeper_shape($projection.supported_states; .));
+                     ($label + ".keepers rows must match schema"))
+              else
+                []
+              end
+            + if array_value($projection.global_waiting_on) then
+                emit(waiting_rows_shape($projection.global_waiting_on);
+                     ($label + ".global_waiting_on rows must match schema"))
+              else
+                []
+              end
+          else
+            []
+          end;
+
+      def inventory_parity_errors($dashboard; $mcp):
+        emit(($mcp.schema == $dashboard.schema);
+             "mcp_result.schema must match preflight waiting_projection.schema")
+        + emit(($mcp.source == $dashboard.source);
+               "mcp_result.source must match preflight waiting_projection.source")
+        + emit(($mcp.supported_states == $dashboard.supported_states);
+               "mcp_result.supported_states must match preflight waiting_projection.supported_states")
+        + emit(($mcp.keeper_count == $dashboard.keeper_count);
+               "mcp_result.keeper_count must match preflight waiting_projection.keeper_count")
+        + emit(($mcp.waiting_keeper_count == $dashboard.waiting_keeper_count);
+               "mcp_result.waiting_keeper_count must match preflight waiting_projection.waiting_keeper_count")
+        + emit(($mcp.row_count == $dashboard.row_count);
+               "mcp_result.row_count must match preflight waiting_projection.row_count")
+        + emit(($mcp.global_row_count == $dashboard.global_row_count);
+               "mcp_result.global_row_count must match preflight waiting_projection.global_row_count")
+        + emit(($mcp.global_pending_confirm_count == $dashboard.global_pending_confirm_count);
+               "mcp_result.global_pending_confirm_count must match preflight waiting_projection")
+        + emit(($mcp.source_counts == $dashboard.source_counts);
+               "mcp_result.source_counts must match preflight waiting_projection.source_counts")
+        + emit(($mcp.keepers == $dashboard.keepers);
+               "mcp_result.keepers must match preflight waiting_projection.keepers")
+        + emit(($mcp.global_waiting_on == $dashboard.global_waiting_on);
+               "mcp_result.global_waiting_on must match preflight waiting_projection.global_waiting_on");
+
+      def cli_failure_stage($value):
+        $value == "argument_parse"
+        or $value == "startup"
+        or $value == "token_load"
+        or $value == "dashboard_preflight"
+        or $value == "mcp_initialize"
+        or $value == "mcp_tool_call"
+        or $value == "proof_write"
+        or $value == "output";
+
+      def common_preflight_errors($require_pass):
+        emit((.schema == "masc.keeper_waiting_inventory_preflight.v1");
+             "schema must be masc.keeper_waiting_inventory_preflight.v1")
+        + emit((.status == "fail" or .status == "preflight_pass");
+               "status must be fail or preflight_pass")
+        + emit((($require_pass == "1") | not) or (.status == "preflight_pass");
+               "REQUIRE_PASS rejects fail proof")
+        + emit((.ok == (.status == "preflight_pass"));
+               "ok must match status")
+        + emit(nonempty_string(.dashboard_url); "dashboard_url must be a non-empty string")
+        + emit(nonempty_string(.mcp_url); "mcp_url must be a non-empty string")
+        + emit((.tool_name == "masc_keeper_waiting_inventory");
+               "tool_name must be masc_keeper_waiting_inventory")
+        + emit(error_array(.errors); "errors must be a string array")
+        + emit(object_value(.runtime_identity_gate);
+               "runtime_identity_gate must be an object")
+        + emit(boolean_value(.runtime_identity_gate.allow_diverged_runtime);
+               "runtime_identity_gate.allow_diverged_runtime must be boolean")
+        + emit(object_value(.runtime_identity_gate.runtime_resolution);
+               "runtime_identity_gate.runtime_resolution must be an object")
+        + emit(object_value(.waiting_tool_surface);
+               "waiting_tool_surface must be an object")
+        + emit((.waiting_tool_surface.required == "masc_keeper_waiting_inventory");
+               "waiting_tool_surface.required must be masc_keeper_waiting_inventory")
+        + emit(boolean_value(.waiting_tool_surface.present);
+               "waiting_tool_surface.present must be boolean")
+        + emit(object_value(.waiting_projection);
+               "waiting_projection must be an object")
+        + emit(boolean_value(.waiting_projection.present);
+               "waiting_projection.present must be boolean");
+
+      def successful_preflight_errors:
+        (.runtime_identity_gate.runtime_resolution // null) as $runtime
+        | (.waiting_tool_surface.tool // null) as $tool
+        | (.waiting_projection // null) as $projection
+        | emit((.errors | length) == 0; "preflight_pass errors must be empty")
+          + emit(($runtime.deployment_state.status == "current");
+                 "runtime deployment_state.status must be current")
+          + emit(nonempty_string($runtime.runtime_binary_git_commit);
+                 "runtime_binary_git_commit must be non-empty")
+          + emit(($runtime.source_mismatch == false);
+                 "source_mismatch must be false")
+          + emit(($runtime.server_workspace_mismatch == false);
+                 "server_workspace_mismatch must be false")
+          + emit((.waiting_tool_surface.present == true);
+                 "waiting_tool_surface.present must be true")
+          + emit(object_value($tool); "waiting_tool_surface.tool must be an object")
+          + emit((($tool.surfaces // []) | index("public_mcp")) != null;
+                 "tool must expose public_mcp surface")
+          + emit(($tool.registered_schema == true);
+                 "tool registered_schema must be true")
+          + emit(($tool.dispatch_registered == true);
+                 "tool dispatch_registered must be true")
+          + emit(($tool.direct_call_allowed == true);
+                 "tool direct_call_allowed must be true")
+          + emit(($tool.effectDomain == "read_only");
+                 "tool effectDomain must be read_only")
+          + emit(($tool.implementationStatus == "real");
+                 "tool implementationStatus must be real")
+          + emit((.waiting_projection.present == true);
+                 "waiting_projection.present must be true")
+          + emit((.waiting_projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                 "waiting_projection schema mismatch")
+          + emit((.waiting_projection.source == "server_keeper_waiting_inventory");
+                 "waiting_projection source mismatch")
+          + emit(string_array(.waiting_projection.supported_states);
+                 "waiting_projection.supported_states must be a string array")
+          + emit(integer_value(.waiting_projection.keeper_count);
+                 "waiting_projection.keeper_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.waiting_keeper_count);
+                 "waiting_projection.waiting_keeper_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.row_count);
+                 "waiting_projection.row_count must be a non-negative integer")
+          + emit(integer_value(.waiting_projection.global_row_count);
+                 "waiting_projection.global_row_count must be a non-negative integer")
+          + emit(array_value(.waiting_projection.keepers);
+                 "waiting_projection.keepers must be an array")
+          + emit(array_value(.waiting_projection.global_waiting_on);
+                 "waiting_projection.global_waiting_on must be an array")
+          + if integer_value($projection.keeper_count)
+               and array_value($projection.keepers) then
+              emit(($projection.keeper_count == ($projection.keepers | length));
+                   "waiting_projection.keeper_count must match keepers length")
+            else
+              []
+            end
+          + if integer_value($projection.waiting_keeper_count)
+               and integer_value($projection.keeper_count) then
+              emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                   "waiting_projection.waiting_keeper_count must not exceed keeper_count")
+            else
+              []
+            end
+          + if integer_value($projection.row_count)
+               and array_value($projection.keepers) then
+              emit(($projection.row_count == keeper_row_total($projection.keepers));
+                   "waiting_projection.row_count must match keeper waiting rows")
+            else
+              []
+            end
+          + if integer_value($projection.global_row_count)
+               and array_value($projection.global_waiting_on) then
+              emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                   "waiting_projection.global_row_count must match global_waiting_on length")
+            else
+              []
+            end
+          + if array_value($projection.keepers) then
+              emit(all($projection.keepers[]; keeper_shape($projection.supported_states; .));
+                   "waiting_projection.keepers rows must match schema")
+            else
+              []
+            end
+          + if array_value($projection.global_waiting_on) then
+              emit(waiting_rows_shape($projection.global_waiting_on);
+                   "waiting_projection.global_waiting_on rows must match schema")
+            else
+              []
+            end;
+
+      def failed_preflight_errors:
+        emit((.errors | length) > 0; "fail proof must include at least one error");
+
+      def preflight_pass_errors_for($proof; $require_pass):
+        $proof
+        | common_preflight_errors($require_pass)
+          + successful_preflight_errors;
+
+      def cli_common_errors($require_pass):
+        emit((.schema == "masc.keeper_waiting_inventory_cli_proof.v1");
+             "schema must be masc.keeper_waiting_inventory_cli_proof.v1")
+        + emit((.status == "fail" or .status == "pass");
+               "CLI proof status must be fail or pass")
+        + emit((($require_pass == "1") | not) or (.status == "pass");
+               "REQUIRE_PASS rejects CLI fail proof")
+        + emit(nonempty_string(.dashboard_url); "dashboard_url must be a non-empty string")
+        + emit(nonempty_string(.mcp_url); "mcp_url must be a non-empty string")
+        + emit((.tool_name == "masc_keeper_waiting_inventory");
+               "tool_name must be masc_keeper_waiting_inventory");
+
+      def cli_failure_errors:
+        emit((.status == "fail"); "CLI proof status must be fail")
+        + emit(nonempty_string(.reason); "CLI fail proof reason must be non-empty")
+        + emit(nonempty_string(.failure_stage);
+               "CLI fail proof failure_stage must be non-empty")
+        + emit(cli_failure_stage(.failure_stage);
+               "CLI fail proof failure_stage is not recognized")
+        + emit((.preflight == null or object_value(.preflight));
+               "CLI fail proof preflight must be null or object");
+
+      def cli_success_errors($require_pass):
+        (.preflight // null) as $preflight
+        | (.mcp_result // null) as $mcp
+        | emit((.status == "pass"); "CLI success proof status must be pass")
+          + emit((.ok == true); "CLI success proof ok must be true")
+          + emit(object_value($preflight);
+                 "CLI success proof preflight must be an object")
+          + if object_value($preflight) then
+              preflight_pass_errors_for($preflight; "1")
+            else
+              []
+            end
+          + inventory_projection_errors($mcp; "mcp_result")
+          + if object_value($preflight) and object_value($mcp) then
+              inventory_parity_errors($preflight.waiting_projection; $mcp)
+            else
+              []
+            end;
+
+      (
+        if .schema == "masc.keeper_waiting_inventory_preflight.v1" then
+          common_preflight_errors($require_pass)
+          + if .status == "preflight_pass" then
+              successful_preflight_errors
+            elif .status == "fail" then
+              failed_preflight_errors
+            else
+              []
+            end
+        elif .schema == "masc.keeper_waiting_inventory_cli_proof.v1" then
+          cli_common_errors($require_pass)
+          + if .status == "pass" then
+              cli_success_errors($require_pass)
+            elif .status == "fail" then
+              cli_failure_errors
+            else
+              []
+            end
+        else
+          ["unsupported proof schema"]
+        end
+      ) as $errors
+      | {
+          ok:(($errors | length) == 0),
+          schema:(.schema // null),
+          status:(.status // null),
+          require_pass:($require_pass == "1"),
+          proof_path:$proof_path,
+          checked_contract:{
+            tool_name:"masc_keeper_waiting_inventory"
+          },
+          errors:$errors
+        }
+    ' "$proof_path"
+)" || fail "proof JSON is not parseable or validator failed: ${proof_path}"
+
+if ! printf '%s' "$report" | jq -e '.ok == true' >/dev/null; then
+  printf '%s\n' "$report" | jq . >&2
+  exit 1
+fi
+
+printf '%s\n' "$report"

--- a/scripts/keeper-waiting-inventory.sh
+++ b/scripts/keeper-waiting-inventory.sh
@@ -1,0 +1,656 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+: "${PORT:=8935}"
+: "${BASE_URL:=http://127.0.0.1:${PORT}}"
+BASE_URL="${BASE_URL%/}"
+: "${MCP_URL:=${BASE_URL}/mcp}"
+: "${CURL_TIMEOUT_SEC:=25}"
+: "${HTTP_TIMEOUT_SEC:=${CURL_TIMEOUT_SEC}}"
+: "${CURL_RETRY_COUNT:=4}"
+: "${CURL_RETRY_DELAY_SEC:=1}"
+: "${MCP_CLIENT_NAME:=keeper-waiting-inventory-cli}"
+: "${MCP_SESSION_ID:=}"
+: "${COMPACT:=0}"
+: "${PREFLIGHT_ONLY:=0}"
+: "${REQUIRE_CURRENT_RUNTIME:=0}"
+: "${ALLOW_DIVERGED_RUNTIME:=0}"
+: "${PROOF_OUT:=}"
+
+WAITING_TOOL_NAME="masc_keeper_waiting_inventory"
+PREFLIGHT_REPORT_JSON=""
+FAILURE_STAGE="argument_parse"
+
+# shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
+source "${REPO_ROOT}/scripts/harness/lib/mcp_jsonrpc.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/keeper-waiting-inventory.sh [options]
+
+Read the immutable keeper waiting inventory through the MCP tool
+masc_keeper_waiting_inventory and print the tool result JSON.
+
+Options:
+  --base-url URL      Dashboard/MCP base URL. Default: http://127.0.0.1:8935.
+  --mcp-url URL       MCP endpoint. Overrides --base-url-derived endpoint.
+  --base-path PATH    Base path used only to load .masc/auth/codex-mcp-client.token.
+  --preflight-only    Check runtime/tool/projection readiness and exit.
+  --require-current-runtime
+                      Run the same readiness gate before calling the MCP tool.
+  --allow-diverged-runtime
+                      Allow non-current runtime identity in the readiness gate.
+  --proof-out PATH    Write preflight pass/fail JSON proof to PATH.
+  --compact           Print compact JSON instead of pretty JSON.
+  -h, --help          Show this help.
+
+Environment:
+  MCP_TOKEN, MCP_AUTH_TOKEN, MASC_ADMIN_TOKEN are accepted by the shared MCP
+  helper. If none are set, the script tries BASE_PATH/.masc/auth/codex-mcp-client.token.
+USAGE
+}
+
+fail() {
+  write_failure_proof "$*" || true
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+write_proof_json() {
+  local payload="$1"
+  if [[ -z "$PROOF_OUT" ]]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$PROOF_OUT")"
+  printf '%s\n' "$payload" >"$PROOF_OUT"
+}
+
+write_failure_proof() {
+  local reason="$1"
+  if [[ -z "$PROOF_OUT" ]] || ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+  local preflight_json="null"
+  if [[ -n "$PREFLIGHT_REPORT_JSON" ]] \
+    && printf '%s' "$PREFLIGHT_REPORT_JSON" | jq -e . >/dev/null 2>&1; then
+    preflight_json="$PREFLIGHT_REPORT_JSON"
+  fi
+  local payload
+  payload="$(
+    jq -cn \
+      --arg reason "$reason" \
+	      --arg base_url "$BASE_URL" \
+	      --arg mcp_url "$MCP_URL" \
+	      --arg tool_name "$WAITING_TOOL_NAME" \
+	      --arg failure_stage "$FAILURE_STAGE" \
+	      --argjson preflight "$preflight_json" \
+	      '{
+	        schema:"masc.keeper_waiting_inventory_cli_proof.v1",
+	        status:"fail",
+	        reason:$reason,
+	        failure_stage:$failure_stage,
+	        dashboard_url:$base_url,
+	        mcp_url:$mcp_url,
+	        tool_name:$tool_name,
+        preflight:$preflight
+      }'
+  )" && write_proof_json "$payload"
+}
+
+write_cli_success_proof() {
+  local inventory_json="$1"
+  if [[ -z "$PROOF_OUT" ]]; then
+    return 0
+  fi
+  if [[ -z "$PREFLIGHT_REPORT_JSON" ]]; then
+    fail "--proof-out success proof requires preflight evidence"
+  fi
+  local payload
+  payload="$(
+    jq -cn \
+      --arg base_url "$BASE_URL" \
+      --arg mcp_url "$MCP_URL" \
+      --arg tool_name "$WAITING_TOOL_NAME" \
+      --argjson preflight "$PREFLIGHT_REPORT_JSON" \
+      --argjson inventory "$inventory_json" \
+      '{
+        schema:"masc.keeper_waiting_inventory_cli_proof.v1",
+        status:"pass",
+        ok:true,
+        dashboard_url:$base_url,
+        mcp_url:$mcp_url,
+        tool_name:$tool_name,
+        preflight:$preflight,
+        mcp_result:$inventory
+      }'
+  )" || fail "could not build keeper waiting inventory success proof"
+  write_proof_json "$payload"
+}
+
+base_path_default() {
+  if [[ -n "${BASE_PATH:-}" ]]; then
+    printf '%s\n' "$BASE_PATH"
+  elif [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+  else
+    printf '%s\n' "$REPO_ROOT"
+  fi
+}
+
+BASE_PATH="$(base_path_default)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      BASE_URL="${2%/}"
+      MCP_URL="${BASE_URL}/mcp"
+      shift 2
+      ;;
+    --mcp-url)
+      MCP_URL="$2"
+      shift 2
+      ;;
+    --base-path)
+      BASE_PATH="$2"
+      shift 2
+      ;;
+    --compact)
+      COMPACT=1
+      shift
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY=1
+      REQUIRE_CURRENT_RUNTIME=1
+      shift
+      ;;
+    --require-current-runtime)
+      REQUIRE_CURRENT_RUNTIME=1
+      shift
+      ;;
+    --allow-diverged-runtime)
+      ALLOW_DIVERGED_RUNTIME=1
+      shift
+      ;;
+    --proof-out)
+      PROOF_OUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if truthy "$PREFLIGHT_ONLY"; then
+  PREFLIGHT_ONLY=1
+  REQUIRE_CURRENT_RUNTIME=1
+else
+  PREFLIGHT_ONLY=0
+fi
+
+if truthy "$REQUIRE_CURRENT_RUNTIME"; then
+  REQUIRE_CURRENT_RUNTIME=1
+else
+  REQUIRE_CURRENT_RUNTIME=0
+fi
+
+if truthy "$ALLOW_DIVERGED_RUNTIME"; then
+  ALLOW_DIVERGED_RUNTIME=1
+else
+  ALLOW_DIVERGED_RUNTIME=0
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+load_mcp_token() {
+  if [[ -n "${MCP_TOKEN:-}" || -n "${MCP_AUTH_TOKEN:-}" || -n "${MASC_ADMIN_TOKEN:-}" ]]; then
+    return 0
+  fi
+  local token_file="${BASE_PATH%/}/.masc/auth/codex-mcp-client.token"
+  if [[ -f "$token_file" ]]; then
+    MCP_TOKEN="$(tr -d '\n' <"$token_file")"
+    export MCP_TOKEN
+  fi
+}
+
+dashboard_tools_json() {
+  curl -fsS --max-time "$CURL_TIMEOUT_SEC" "${BASE_URL}/api/v1/dashboard/tools"
+}
+
+build_preflight_report() {
+  local dashboard_json allow_diverged
+  dashboard_json="$(dashboard_tools_json)" \
+    || fail "dashboard tools probe failed at ${BASE_URL}/api/v1/dashboard/tools"
+  allow_diverged="$ALLOW_DIVERGED_RUNTIME"
+  PREFLIGHT_REPORT_JSON="$(
+    printf '%s' "$dashboard_json" \
+      | jq -ce \
+          --arg dashboard_url "$BASE_URL" \
+          --arg mcp_url "$MCP_URL" \
+          --arg tool_name "$WAITING_TOOL_NAME" \
+          --arg allow_diverged_runtime "$allow_diverged" \
+          '
+            def emit($condition; $message):
+              if $condition then [] else [$message] end;
+
+            def object_value($value):
+              ($value | type) == "object";
+
+            def nonempty_string($value):
+              ($value | type) == "string" and ($value | length > 0);
+
+            def string_array($value):
+              ($value | type) == "array"
+              and all($value[]; (type == "string") and (length > 0));
+
+            def number_value($value):
+              ($value | type) == "number";
+
+            def array_value($value):
+              ($value | type) == "array";
+
+            def integer_value($value):
+              number_value($value)
+              and $value >= 0
+              and $value == ($value | floor);
+
+            def nullable_number($value):
+              $value == null or number_value($value);
+
+            def nullable_string($value):
+              $value == null or (($value | type) == "string");
+
+            def waiting_row_shape($row):
+              object_value($row)
+              and ($row | has("keeper_name"))
+              and ($row.keeper_name == null or nonempty_string($row.keeper_name))
+              and nonempty_string($row.source)
+              and nonempty_string($row.waiting_on)
+              and nonempty_string($row.wake_producer)
+              and ($row | has("since"))
+              and nullable_number($row.since)
+              and ($row | has("since_iso"))
+              and nullable_string($row.since_iso)
+              and ($row | has("due_at"))
+              and nullable_number($row.due_at)
+              and ($row | has("due_at_iso"))
+              and nullable_string($row.due_at_iso)
+              and nonempty_string($row.next_action)
+              and ($row | has("detail"));
+
+            def keeper_shape($supported_states; $keeper):
+              object_value($keeper)
+              and nonempty_string($keeper.keeper_name)
+              and nonempty_string($keeper.state)
+              and array_value($supported_states)
+              and (($supported_states | index($keeper.state)) != null)
+              and array_value($keeper.waiting_on)
+              and integer_value($keeper.waiting_count)
+              and ($keeper.waiting_count == ($keeper.waiting_on | length))
+              and object_value($keeper.sources)
+              and ($keeper | has("since"))
+              and nullable_number($keeper.since)
+              and ($keeper | has("since_iso"))
+              and nullable_string($keeper.since_iso)
+              and ($keeper | has("due_at"))
+              and nullable_number($keeper.due_at)
+              and ($keeper | has("due_at_iso"))
+              and nullable_string($keeper.due_at_iso)
+              and ($keeper.next_action == null or nonempty_string($keeper.next_action))
+              and all($keeper.waiting_on[]; waiting_row_shape(.));
+
+            def keeper_row_total($keepers):
+              if array_value($keepers) then
+                ([$keepers[] | if array_value(.waiting_on) then (.waiting_on | length) else 0 end] | add // 0)
+              else
+                null
+              end;
+
+            def waiting_rows_shape($rows):
+              if array_value($rows) then
+                all($rows[]; waiting_row_shape(.))
+              else
+                false
+              end;
+
+            (.runtime_resolution // null) as $runtime
+            | (.tool_inventory.tools // []) as $tools
+            | (first($tools[]? | select(.name == $tool_name)) // null) as $tool
+            | (.keeper_waiting_inventory // null) as $projection
+            | (
+                emit(object_value($runtime); "runtime_resolution must be an object")
+                + if ($allow_diverged_runtime == "1") then
+                    []
+                  else
+                    emit(($runtime.deployment_state.status == "current");
+                         "runtime deployment_state.status must be current")
+                    + emit(($runtime.source_mismatch == false);
+                           "runtime_resolution.source_mismatch must be false")
+                    + emit(($runtime.server_workspace_mismatch == false);
+                           "runtime_resolution.server_workspace_mismatch must be false")
+                    + emit(nonempty_string($runtime.runtime_binary_git_commit);
+                           "runtime_binary_git_commit must be a non-empty string")
+                  end
+                + emit(($tool != null);
+                       "tool_inventory.tools must contain masc_keeper_waiting_inventory")
+                + if ($tool == null) then
+                    []
+                  else
+                    emit((($tool.surfaces // []) | index("public_mcp")) != null;
+                         "masc_keeper_waiting_inventory must expose public_mcp surface")
+                    + emit(($tool.registered_schema == true);
+                           "masc_keeper_waiting_inventory registered_schema must be true")
+                    + emit(($tool.dispatch_registered == true);
+                           "masc_keeper_waiting_inventory dispatch_registered must be true")
+                    + emit(($tool.direct_call_allowed == true);
+                           "masc_keeper_waiting_inventory direct_call_allowed must be true")
+                    + emit(($tool.effectDomain == "read_only");
+                           "masc_keeper_waiting_inventory effectDomain must be read_only")
+                    + emit(($tool.implementationStatus == "real");
+                           "masc_keeper_waiting_inventory implementationStatus must be real")
+                  end
+                + emit(object_value($projection);
+                       "keeper_waiting_inventory projection must be an object")
+                + if object_value($projection) then
+                    emit(($projection.schema == "masc.dashboard.keeper_waiting_inventory.v1");
+                         "keeper_waiting_inventory schema mismatch")
+                    + emit(($projection.source == "server_keeper_waiting_inventory");
+                           "keeper_waiting_inventory source mismatch")
+                    + emit(string_array($projection.supported_states);
+                           "keeper_waiting_inventory.supported_states must be a string array")
+                    + emit(integer_value($projection.keeper_count);
+                           "keeper_waiting_inventory.keeper_count must be a non-negative integer")
+                    + emit(integer_value($projection.waiting_keeper_count);
+                           "keeper_waiting_inventory.waiting_keeper_count must be a non-negative integer")
+                    + emit(integer_value($projection.row_count);
+                           "keeper_waiting_inventory.row_count must be a non-negative integer")
+                    + emit(integer_value($projection.global_row_count);
+                           "keeper_waiting_inventory.global_row_count must be a non-negative integer")
+                    + emit(array_value($projection.keepers);
+                           "keeper_waiting_inventory.keepers must be an array")
+                    + emit(array_value($projection.global_waiting_on);
+                           "keeper_waiting_inventory.global_waiting_on must be an array")
+                    + if integer_value($projection.keeper_count)
+                         and array_value($projection.keepers) then
+                        emit(($projection.keeper_count == ($projection.keepers | length));
+                             "keeper_waiting_inventory.keeper_count must match keepers length")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.waiting_keeper_count)
+                         and integer_value($projection.keeper_count) then
+                        emit(($projection.waiting_keeper_count <= $projection.keeper_count);
+                             "keeper_waiting_inventory.waiting_keeper_count must not exceed keeper_count")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.row_count)
+                         and array_value($projection.keepers) then
+                        emit(($projection.row_count == keeper_row_total($projection.keepers));
+                             "keeper_waiting_inventory.row_count must match keeper waiting rows")
+                      else
+                        []
+                      end
+                    + if integer_value($projection.global_row_count)
+                         and array_value($projection.global_waiting_on) then
+                        emit(($projection.global_row_count == ($projection.global_waiting_on | length));
+                             "keeper_waiting_inventory.global_row_count must match global_waiting_on length")
+                      else
+                        []
+                      end
+                    + if array_value($projection.keepers) then
+                        emit(all($projection.keepers[];
+                                 keeper_shape($projection.supported_states; .));
+                             "keeper_waiting_inventory.keepers rows must match schema")
+                      else
+                        []
+                      end
+                    + if array_value($projection.global_waiting_on) then
+                        emit(waiting_rows_shape($projection.global_waiting_on);
+                             "keeper_waiting_inventory.global_waiting_on rows must match schema")
+                      else
+                        []
+                      end
+                  else
+                    []
+                  end
+              ) as $errors
+            | {
+                status:($runtime.status // null),
+                deployment_state:{
+                  status:($runtime.deployment_state.status // null),
+                  operator_action_required:
+                    (if ($runtime.deployment_state | has("operator_action_required")) then
+                       $runtime.deployment_state.operator_action_required
+                     else
+                       null
+                     end),
+                  binary_commit_known:
+                    (if ($runtime.deployment_state | has("binary_commit_known")) then
+                       $runtime.deployment_state.binary_commit_known
+                     else
+                       null
+                     end),
+                  upstream:($runtime.deployment_state.upstream // null),
+                  deployed:($runtime.deployment_state.deployed // null),
+                  runtime_repo:($runtime.deployment_state.runtime_repo // null),
+                  workspace:($runtime.deployment_state.workspace // null)
+                },
+                server_repo_git_commit:($runtime.server_repo_git_commit // null),
+                runtime_binary_git_commit:($runtime.runtime_binary_git_commit // null),
+                runtime_repo_head_git_commit:
+                  ($runtime.runtime_repo_head_git_commit // null),
+                source_mismatch:
+                  (if ($runtime | has("source_mismatch")) then
+                     $runtime.source_mismatch
+                   else
+                     null
+                   end),
+                server_workspace_mismatch:
+                  (if ($runtime | has("server_workspace_mismatch")) then
+                     $runtime.server_workspace_mismatch
+                   else
+                     null
+                   end),
+                build:{
+                  commit:($runtime.build.commit // null),
+                  repo_root:($runtime.build.repo_root // null),
+                  executable_path:($runtime.build.executable_path // null),
+                  started_at:($runtime.build.started_at // null)
+                }
+              } as $runtime_summary
+            | {
+                schema:"masc.keeper_waiting_inventory_preflight.v1",
+                status:(if ($errors | length) == 0 then "preflight_pass" else "fail" end),
+                ok:(($errors | length) == 0),
+                dashboard_url:$dashboard_url,
+                mcp_url:$mcp_url,
+                tool_name:$tool_name,
+                runtime_identity_gate:{
+                  allow_diverged_runtime:($allow_diverged_runtime == "1"),
+                  runtime_resolution:$runtime_summary
+                },
+                waiting_tool_surface:{
+                  required:$tool_name,
+                  present:($tool != null),
+                  tool:$tool
+                },
+                waiting_projection:{
+                  present:object_value($projection),
+                  schema:($projection.schema // null),
+                  source:($projection.source // null),
+                  generated_at:($projection.generated_at // null),
+                  supported_states:($projection.supported_states // null),
+                  keeper_count:($projection.keeper_count // null),
+                  waiting_keeper_count:($projection.waiting_keeper_count // null),
+                  row_count:($projection.row_count // null),
+                  global_row_count:($projection.global_row_count // null),
+                  global_pending_confirm_count:($projection.global_pending_confirm_count // null),
+                  source_counts:($projection.source_counts // null),
+                  keepers:($projection.keepers // null),
+                  global_waiting_on:($projection.global_waiting_on // null)
+                },
+                errors:$errors
+              }
+          '
+  )" || fail "dashboard tools preflight report could not be parsed"
+}
+
+run_preflight_gate() {
+  build_preflight_report
+  write_proof_json "$PREFLIGHT_REPORT_JSON"
+  if ! printf '%s' "$PREFLIGHT_REPORT_JSON" | jq -e '.ok == true' >/dev/null; then
+    printf '%s\n' "$PREFLIGHT_REPORT_JSON" | jq . >&2
+    exit 1
+  fi
+}
+
+initialize_mcp_session() {
+  if [[ -n "${MCP_SESSION_ID:-}" ]]; then
+    export MCP_SESSION_ID
+    return 0
+  fi
+
+  local headers_file body_file auth_header_file init_body protocol_version
+  headers_file="$(mcp_mktemp_file "keeper-waiting-inventory-init" ".headers")"
+  body_file="$(mcp_mktemp_file "keeper-waiting-inventory-init" ".body")"
+  auth_header_file=""
+  if [[ -n "${MCP_TOKEN:-}" ]]; then
+    auth_header_file="$(_mcp_auth_header_file "$MCP_TOKEN")" || auth_header_file=""
+  fi
+  init_body="$(
+    jq -cn --arg client_name "$MCP_CLIENT_NAME" \
+      '{jsonrpc:"2.0", id:1, method:"initialize", params:{protocolVersion:"2025-11-25", clientInfo:{name:$client_name, version:"1.0"}, capabilities:{}}}'
+  )"
+
+  local -a init_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+  )
+  if [[ -n "$auth_header_file" ]]; then
+    init_headers+=( -H "@$auth_header_file" )
+  fi
+
+  if ! curl -sS --max-time "$CURL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" \
+    -X POST "$MCP_URL" "${init_headers[@]}" --data-binary "$init_body" >/dev/null; then
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
+    fail "MCP initialize failed at ${MCP_URL}"
+  fi
+
+  MCP_SESSION_ID="$(
+    awk '
+      tolower($0) ~ /^mcp-session-id:/ {
+        sub(/^[^:]+:[[:space:]]*/, "", $0)
+        sub(/\r$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$headers_file"
+  )"
+  protocol_version="$(
+    awk '
+      tolower($0) ~ /^mcp-protocol-version:/ {
+        sub(/^[^:]+:[[:space:]]*/, "", $0)
+        sub(/\r$/, "", $0)
+        print $0
+        exit
+      }
+    ' "$headers_file"
+  )"
+
+  if [[ -z "$MCP_SESSION_ID" ]]; then
+    if jq -e . "$body_file" >/dev/null 2>&1; then
+      jq . "$body_file" >&2
+    else
+      cat "$body_file" >&2 || true
+    fi
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
+    fail "MCP initialize did not return Mcp-Session-Id"
+  fi
+
+  export MCP_SESSION_ID
+  if [[ -n "$protocol_version" ]]; then
+    MCP_PROTOCOL_VERSION="$protocol_version"
+    export MCP_PROTOCOL_VERSION
+  fi
+
+  local -a initialized_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+    -H "mcp-session-id: ${MCP_SESSION_ID}"
+  )
+  if [[ -n "$auth_header_file" ]]; then
+    initialized_headers+=( -H "@$auth_header_file" )
+  fi
+  curl -sS --max-time "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+    "${initialized_headers[@]}" \
+    --data-binary '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+    >/dev/null || true
+
+  rm -f "$headers_file" "$body_file" "$auth_header_file"
+}
+
+main() {
+  FAILURE_STAGE="startup"
+  require_cmd curl
+  require_cmd jq
+  FAILURE_STAGE="token_load"
+  load_mcp_token
+  if [[ "$REQUIRE_CURRENT_RUNTIME" == "1" || -n "$PROOF_OUT" ]]; then
+    FAILURE_STAGE="dashboard_preflight"
+    run_preflight_gate
+    if [[ "$PREFLIGHT_ONLY" == "1" ]]; then
+      FAILURE_STAGE="output"
+      if [[ "$COMPACT" == "1" ]]; then
+        printf '%s\n' "$PREFLIGHT_REPORT_JSON"
+      else
+        printf '%s\n' "$PREFLIGHT_REPORT_JSON" | jq .
+      fi
+      exit 0
+    fi
+  fi
+  FAILURE_STAGE="mcp_initialize"
+  initialize_mcp_session
+
+  local result
+  FAILURE_STAGE="mcp_tool_call"
+  result="$(
+    mcp_call_tool_result \
+      7001 \
+      "$WAITING_TOOL_NAME" \
+      '{}' \
+      "$MCP_SESSION_ID" \
+      "${MCP_TOKEN:-}" \
+      "$MCP_URL"
+  )" || fail "masc_keeper_waiting_inventory call failed"
+
+  if [[ -z "$result" ]]; then
+    fail "masc_keeper_waiting_inventory returned empty result"
+  fi
+  FAILURE_STAGE="proof_write"
+  write_cli_success_proof "$result"
+  FAILURE_STAGE="output"
+  if [[ "$COMPACT" == "1" ]]; then
+    printf '%s\n' "$result"
+  else
+    printf '%s\n' "$result" | jq .
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Stacked on #23410. Extracted from the superseded #23393 bundle.

Scope:
- Adds `scripts/keeper-waiting-inventory.sh`, a read-only MCP wrapper for `masc_keeper_waiting_inventory`.
- Adds dashboard preflight gating for runtime identity, tool surface registration, and waiting-inventory projection shape.
- Adds `--proof-out` support for typed pass/fail CLI proof JSON.
- Adds `scripts/keeper-waiting-inventory-proof-check.sh` to validate preflight and CLI proof files, with `--require-pass` support.

Validation performed locally:
- `bash -n scripts/keeper-waiting-inventory.sh scripts/keeper-waiting-inventory-proof-check.sh`
- `shellcheck -x scripts/keeper-waiting-inventory.sh scripts/keeper-waiting-inventory-proof-check.sh`
- proof checker sample fail proof: `--allow-fail` accepted and `--require-pass` rejected.
- `scripts/keeper-waiting-inventory.sh --help`
- `scripts/keeper-waiting-inventory-proof-check.sh --help`
- `git diff --cached --check`
- conflict-marker scan over changed files.

Notes:
- No live MCP call is claimed here; the wrapper requires a running deployed/runtime-compatible server and auth token.
- No local Dune build/test result is claimed; Dune validation remains CI-owned per project direction.