### PR TITLE
feat(exec): RFC-0309 W2 — gh capability policy axis (enforcement-inert)

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -1,0 +1,42 @@
+(* Gh_capability_policy — capability axis for gh verbs (RFC-0309 §3.3, W2).
+   See gh_capability_policy.mli for the axis boundary and ordering notes. *)
+
+type disposition =
+  | Allowed
+  | Requires_approval
+  | Denied
+
+let string_of_disposition = function
+  | Allowed -> "allowed"
+  | Requires_approval -> "requires_approval"
+  | Denied -> "denied"
+;;
+
+(* G-4 externality axis, risk-independent. Exhaustive over gh_family so a new
+   family forces an explicit durable-remote decision here. *)
+let creates_durable_remote_surface : Gh_verb.gh_family -> bool = function
+  | Gh_verb.Repo | Gh_verb.Discussion -> true
+  | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Release | Gh_verb.Secret
+  | Gh_verb.Ssh_key | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist
+  | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache
+  | Gh_verb.Project | Gh_verb.Api | Gh_verb.Other _ -> false
+;;
+
+let disposition_of (v : Gh_verb.t) : disposition =
+  match v.Gh_verb.family with
+  (* Unrecognized area: a human adjudicates. Never silently allowed. This is
+     the capability-axis counterpart of risk_of_gh_verb's Other -> R2
+     fail-close: on the risk axis Other floors, on the capability axis it asks. *)
+  | Gh_verb.Other _ -> Requires_approval
+  | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+  | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+  | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run
+  | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Api ->
+    (match Shell_ir_risk.risk_of_gh_verb v with
+     | Shell_ir_risk.R2_Irreversible | Shell_ir_risk.Destructive_protected ->
+       Denied
+     | Shell_ir_risk.R0_Read -> Allowed
+     | Shell_ir_risk.R1_Reversible_mutation ->
+       if creates_durable_remote_surface v.Gh_verb.family then Requires_approval
+       else Allowed)
+;;

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -1,0 +1,61 @@
+(** Gh_capability_policy — the capability axis for gh verbs (RFC-0309 §3.3, W2).
+
+    RFC-0309 separates three axes that PR #23362 conflated:
+    - risk ([Shell_ir_risk]) — is the operation factually reversible?
+    - capability policy (THIS module) — may a keeper perform this verb family?
+    - disposition wiring (W3) — run / ask a human asynchronously / refuse?
+
+    This module owns the middle axis. It answers "may a keeper do this?" with a
+    typed [disposition], distinct from (not overloaded onto) the risk class.
+    The defining input of the axis — whether the verb touches a durable remote
+    surface ([creates_durable_remote_surface]) — is risk-independent (G-4
+    externality).
+
+    W2 scope: this is the policy SSOT. It is NOT yet consulted by the approval
+    floor — [Approval_policy.decide] still gates on the catastrophic floor and
+    the per-risk-band trust overlay only. W3 (G-7) wires [Requires_approval]
+    into the non-blocking HITL queue; until then this module is observability
+    and an executable specification of the target policy.
+
+    Ordering note (why [Requires_approval] does not fire for repo-create yet):
+    [disposition_of] reads [Shell_ir_risk.risk_of_gh_verb], and PR #23362 still
+    places repo-create/fork and the durable discussion mutations in the
+    irreversible table (R2), so they resolve to [Denied] here today. Moving them
+    to R1 (their true reversibility) is RFC-0309 W4/G-9 and must not land before
+    W3's approval wiring, or they would auto-run. The contract test pins both the
+    current dispositions and the W4 target. *)
+
+type disposition =
+  | Allowed
+      (** The keeper may run this autonomously (reads, local reversible
+          mutations within an existing repo). *)
+  | Requires_approval
+      (** The keeper must route this to non-blocking human approval (W3).
+          Reserved for reversible mutations that create/mutate a durable remote
+          surface, and for unrecognized verbs a human should adjudicate. *)
+  | Denied
+      (** Never permitted for a keeper. These are also floored on the risk axis
+          (R2/Destructive); the capability axis records the policy intent. *)
+
+val string_of_disposition : disposition -> string
+(** Stable lowercase label for logs/metrics: "allowed" | "requires_approval" |
+    "denied". *)
+
+val creates_durable_remote_surface : Gh_verb.gh_family -> bool
+(** G-4 externality axis (risk-independent): [true] for gh families that create
+    or mutate a durable remote surface whose ownership, lifecycle, and
+    moderation policy are not modeled in keeper tool contracts — [Repo] and
+    [Discussion]. [Pr]/[Issue]/[Release]/etc. act within an already-owned repo,
+    so [false]. This is the fact that makes repo-create/discussion a capability
+    decision rather than an ordinary reversible mutation. *)
+
+val disposition_of : Gh_verb.t -> disposition
+(** The capability disposition for a gh verb. Reads
+    [Shell_ir_risk.risk_of_gh_verb] as an input (a distinct axis may still
+    consult risk):
+    - [Gh_verb.Other] (unrecognized area) -> [Requires_approval] (a human
+      decides; never silently allowed — the W3 fail-safe);
+    - risk R2/Destructive -> [Denied];
+    - risk R0 -> [Allowed];
+    - risk R1 -> [Requires_approval] if [creates_durable_remote_surface],
+      else [Allowed]. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -22,6 +22,7 @@
   test_shell_ir_risk_repo_hosting_cli_stress
   test_shell_ir_gh_capability_baseline
   test_gh_verb
+  test_gh_capability_policy
   test_shell_ir_typed_e2e
   test_shell_ir_differential
   test_shell_ir_oracle

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -1,0 +1,101 @@
+(** Gh_capability_policy contract (RFC-0309 §3.3, W2).
+
+    Pins the capability disposition for representative gh verbs. This is the
+    executable specification W3 (approval routing) and W4 (repo-create/discussion
+    enablement) implement against. It records BOTH the current disposition and,
+    in comments, the W4 target where the two differ because PR #23362 still
+    places repo-create/discussion in the irreversible risk table.
+
+    Two properties an inert spec must keep honest:
+    - the externality axis ([creates_durable_remote_surface]) is exactly
+      {Repo, Discussion};
+    - no verb is silently [Allowed] that the RFC intends to gate — unrecognized
+      verbs are [Requires_approval]. *)
+
+module Gh_verb = Masc_exec.Gh_verb
+module Pol = Masc_exec.Gh_capability_policy
+
+let verb ~sub ?act () = Gh_verb.of_fields ~subcommand:sub ~action:act
+
+let dstr = Pol.string_of_disposition
+
+let check label v expected =
+  let actual = Pol.disposition_of v in
+  if actual <> expected then
+    Alcotest.failf "%s: disposition %s, expected %s" label (dstr actual)
+      (dstr expected)
+;;
+
+(* --- externality axis (G-4): exactly Repo + Discussion ------------------- *)
+let test_durable_remote_surface () =
+  let yes = [ Gh_verb.Repo; Gh_verb.Discussion ] in
+  let no =
+    [ Gh_verb.Pr; Gh_verb.Issue; Gh_verb.Release; Gh_verb.Secret
+    ; Gh_verb.Ssh_key; Gh_verb.Workflow; Gh_verb.Auth; Gh_verb.Gist
+    ; Gh_verb.Ruleset; Gh_verb.Label; Gh_verb.Run; Gh_verb.Cache
+    ; Gh_verb.Project; Gh_verb.Api; Gh_verb.Other "x" ]
+  in
+  List.iter
+    (fun f ->
+       if not (Pol.creates_durable_remote_surface f) then
+         Alcotest.failf "%s should be durable-remote" (Gh_verb.string_of_family f))
+    yes;
+  List.iter
+    (fun f ->
+       if Pol.creates_durable_remote_surface f then
+         Alcotest.failf "%s should NOT be durable-remote"
+           (Gh_verb.string_of_family f))
+    no
+;;
+
+(* --- current dispositions (with #23362 tables in force) ------------------- *)
+let test_current_dispositions () =
+  (* reads: Allowed *)
+  check "pr view" (verb ~sub:"pr" ~act:"view" ()) Pol.Allowed;
+  check "repo view" (verb ~sub:"repo" ~act:"view" ()) Pol.Allowed;
+  check "discussion view" (verb ~sub:"discussion" ~act:"view" ()) Pol.Allowed;
+  check "api graphql" (verb ~sub:"api" ~act:"graphql" ()) Pol.Allowed;
+  (* local / in-repo reversible mutations: Allowed *)
+  check "pr create" (verb ~sub:"pr" ~act:"create" ()) Pol.Allowed;
+  check "pr comment" (verb ~sub:"pr" ~act:"comment" ()) Pol.Allowed;
+  check "issue create" (verb ~sub:"issue" ~act:"create" ()) Pol.Allowed;
+  check "release create" (verb ~sub:"release" ~act:"create" ()) Pol.Allowed;
+  (* irreversible (also risk-floored): Denied *)
+  check "pr merge" (verb ~sub:"pr" ~act:"merge" ()) Pol.Denied;
+  check "repo delete" (verb ~sub:"repo" ~act:"delete" ()) Pol.Denied;
+  check "discussion delete" (verb ~sub:"discussion" ~act:"delete" ()) Pol.Denied;
+  (* W4 target divergence: repo-create / discussion-create are Denied TODAY
+     because #23362 keeps them in the irreversible risk table. W4/G-9 moves
+     them to R1, at which point (durable-remote + R1) -> Requires_approval.
+     Pinned as Denied here so the W4 table change produces a visible delta. *)
+  check "repo create (W4->requires_approval)" (verb ~sub:"repo" ~act:"create" ())
+    Pol.Denied;
+  check "discussion create (W4->requires_approval)"
+    (verb ~sub:"discussion" ~act:"create" ()) Pol.Denied;
+  (* durable-remote R1 that already exists today -> Requires_approval. NOTE
+     coarseness: this is family-level, so a local-only op like [repo clone]
+     (R1, Repo) also lands here. W3 refines the externality to per-action; for
+     an unenforced spec, conservative over-approval is safe. *)
+  check "repo edit" (verb ~sub:"repo" ~act:"edit" ()) Pol.Requires_approval;
+  check "repo clone (coarse: local op, refine in W3)"
+    (verb ~sub:"repo" ~act:"clone" ()) Pol.Requires_approval;
+  (* unrecognized area: a human adjudicates *)
+  check "unknown verb" (verb ~sub:"frobnicate" ~act:"now" ()) Pol.Requires_approval;
+  check "unknown action in known family"
+    (verb ~sub:"repo" ~act:"upsert-magic" ()) Pol.Allowed
+    (* known family + table-absent action -> R0 (read) -> Allowed; the
+       unknown-action gap is deferred to W3, same as the risk axis. *)
+;;
+
+let () =
+  Alcotest.run "gh_capability_policy"
+    [
+      ( "capability",
+        [
+          Alcotest.test_case "durable-remote surface axis" `Quick
+            test_durable_remote_surface;
+          Alcotest.test_case "current dispositions" `Quick
+            test_current_dispositions;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## What

RFC-0309 **W2**: capability policy 축(risk와 직교). **enforcement-inert** substrate — W1과 동일하게 동작 변경 없음.

- `lib/exec/gh_capability_policy.ml`/`.mli` — `disposition = Allowed | Requires_approval | Denied`, gh verb 정체성 기준. risk_class에 오버로드하지 않는 별도 축.
  - `creates_durable_remote_surface`(G-4 externality, risk-무관): mutation이 keeper tool 계약에 없는 durable remote surface를 건드리는 family = `{Repo, Discussion}`.
  - `disposition_of`: `Other`→Requires_approval(미지 verb는 사람이 판단); R2/Destructive→Denied; R0→Allowed; R1→durable-remote면 Requires_approval 아니면 Allowed.
- `test_gh_capability_policy.ml` — 계약 테스트(현재 disposition pin + W4 목표 문서화).

## Why

RFC-0309은 #23362가 뭉친 세 축을 분리합니다: risk(가역성) / **capability policy(이 모듈: 이 keeper가 이 verb family를 해도 되는가)** / disposition wiring(W3). 이 모듈이 중간 축을 소유합니다.

understanding 워크플로로 확인한 현재 모델: `Approval_policy.decide`는 catastrophic_floor(→Deny) 다음 `Exec_program.risk_class` band(gh=`Audited`)로 trust_dispatch만 하고, **gh verb family별 capability 결정은 자리가 없습니다**(keeper-class 타입도 코드에 없음 — 전부 하드코딩 autonomous=all-Observe). 이 PR이 그 신규 축을 typed로 도입합니다.

## Enforcement-inert (W1과 동일 패턴)

- `Approval_policy.decide`/floor는 아직 이 모듈을 참조하지 않습니다. W3(G-7)이 `Requires_approval`을 non-blocking HITL 큐에 배선합니다.
- exec_effect risk projection도 건드리지 않아 golden invariant `project_risk = risk`(checked_shell_ir.mli) 안전. externality는 risk projection 변경이 아니라 capability 모듈의 술어로 표현.

## W4 target divergence (정직한 현재 상태)

`repo create`/`discussion create`는 **오늘 Denied**입니다 — #23362가 이들을 irreversible risk 테이블에 두어 risk_of_gh_verb=R2이기 때문. W4/G-9가 R1으로 옮기면 (durable-remote + R1) → Requires_approval로 바뀝니다. 계약 테스트가 현재(Denied)를 pin하고 코멘트로 W4 목표를 기록 → W4 테이블 변경이 가시적 delta로 드러남. **G-9는 W3의 Ask 배선 이후에만**(순서 위반 시 auto-run).

Coarseness 명시: family-level externality라 `repo clone`(로컬 R1 Repo op)도 현재 Requires_approval에 매핑됩니다. W3이 per-action으로 정밀화. unenforced spec이므로 conservative over-approval은 안전.

## 검증

- `test_gh_capability_policy` 2/2, 전체 `@lib/exec/test/runtest` green, keeper+main_eio 빌드 green.
- 전체 meta bug-class gate 로컬 PASS(actor-consumer 게이트가 미사용 모듈을 flag하지 않음 — 의도된 W3 substrate API). lib-regression 0, ocamlformat clean.
- **CI 주의**: 현재 repo CI(Build and Test)가 self-hosted 러너 디스크 풀(`No space left on device`)로 repo-wide 다운(#23400 참조). 이 PR의 CI Gate도 동일 이유로 red일 수 있으나 코드와 무관 — 로컬 전체 검증으로 대체.

## RFC

RFC-0309 §3.3 (G-4/G-5). W1(#23391, typed gh verb family)의 후속. W3(Ask 배선)이 이 모듈을 소비.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
