### PR TITLE
ci: compile @check in Build step — block test-compile breakage before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,7 +679,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          opam exec -- dune build --root . &
+          # @default alone does not compile test dirs outside the executed
+          # runtest subset, so a PR that breaks test compilation can land
+          # green (#23196/#23211/#23353 landed that way on 2026-07-04~06).
+          # @check compiles every library/executable/test without running.
+          opam exec -- dune build --root . @default @check &
           build_pid=$!
 
           (


### PR DESCRIPTION
## Summary
- Build and Test job의 컴파일 단계를 `dune build --root .`(=`@default`)에서 `@default @check`로 확장

## Why
`@default`는 실행되는 runtest 부분집합 밖의 test 디렉토리를 **컴파일조차 하지 않습니다.** 2026-07-04~06 48h 감사에서 main-broken 9건 중 test-compile 계열이 이 구멍으로 green 통과했습니다:
- #23211 → `test/test_dashboard_http_core.ml` Unbound module `Client_registry_eio` (fix: #23231)
- #23353 → 타입 주석 누락 + `(modules)` 미등재 컴파일 실패 2건 (fix: #23356, #23358)

`@check`는 모든 library/executable/test를 링크 없이 컴파일하므로 위 클래스가 머지 전에 차단됩니다. Build 실패는 기존대로 CI Gate aggregate를 통해 required를 fail시킵니다.

상세 진단: https://github.com/jeong-sik/masc/issues/21757#issuecomment-4894016675 (구멍 3개 중 in-repo로 고칠 수 있는 1개가 이 PR. `enforce_admins`/merge queue는 운영자 결정 대기)

## Trade-off
- Build 시간 증가 (DUNE_JOBS=1 환경에서 test 전체 컴파일 추가). 대신 test-compile 깨짐의 main 착지 비용(48h 내 2건, 복구 41m~1h02m + 중복 fix 경합)을 제거
- `@check`는 실행이 아니라 컴파일만이므로 flaky 표면은 늘지 않음

## Validation
- 워크플로 YAML 문법: 로컬 파싱 확인
- 실제 효과는 이 PR의 CI 런 자체가 증명 (Build step이 test 컴파일 포함으로 돎)
