### PR TITLE
[codex] Add task snapshots to catchup digest

### DIFF
--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -39,6 +39,8 @@ let crash_scan_max = 500
 let audit_dirname = "audit" (* Audit_log store *)
 let activity_events_dirname = "activity-events" (* Activity_graph store *)
 let transition_audit_dirname = "transition-audit" (* Keeper_transition_audit durable store *)
+let tasks_dirname = "tasks" (* Workspace_utils_paths_backend.tasks_dir *)
+let backlog_filename = "backlog.json" (* Workspace_utils_paths_backend.backlog_path basename *)
 
 (* keeper.* activity-event kinds are still raw strings pending the #8455
    Event_kind migration; the board.* kinds below come from the typed
@@ -54,10 +56,24 @@ let operator_resume_event = "operator_resume"
 
 (* ── Types (mirror the .mli) ─────────────────────────────────────── *)
 
+type task_snapshot =
+  { title : string
+  ; status : string
+  ; assignee : string option
+  ; phase : string option
+  ; verifier : string option
+  ; submitted_at : string option
+  ; verification_id : string option
+  ; handoff_summary : string option
+  ; handoff_next_step : string option
+  ; handoff_evidence_refs : string list
+  }
+
 type task_item =
   { task_id : string
   ; transition : string
   ; ts : float
+  ; current_task : task_snapshot option
   }
 
 type lifecycle_item =
@@ -163,11 +179,92 @@ let json_num_field name json =
   | _ -> None
 ;;
 
+let string_opt_to_json = function
+  | Some s -> `String s
+  | None -> `Null
+;;
+
 (* ── Fail-visible day-partitioned reader ─────────────────────────── *)
 
 (* A parse or IO failure is appended to [errs] (fail-visible), never
    silently dropped. The list is bounded by {!read_errors_cap}. *)
 let bounded_add errs msg = if List.length !errs < read_errors_cap then errs := msg :: !errs
+
+let non_empty_string_opt value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+;;
+
+let non_empty_opt = function
+  | Some value -> non_empty_string_opt value
+  | None -> None
+;;
+
+let task_status_snapshot_fields (status : Masc_domain.task_status) =
+  match status with
+  | Masc_domain.Todo -> None, None, None, None, None
+  | Masc_domain.Claimed { assignee; _ }
+  | Masc_domain.InProgress { assignee; _ } ->
+    Some assignee, None, None, None, None
+  | Masc_domain.AwaitingVerification { assignee; submitted_at; verification_id; phase } ->
+    let phase, verifier =
+      match phase with
+      | Masc_domain.Awaiting_verifier -> Some "awaiting_verifier", None
+      | Masc_domain.Verifier_assigned { verifier } -> Some "verifier_assigned", Some verifier
+    in
+    Some assignee, phase, verifier, Some submitted_at, Some verification_id
+  | Masc_domain.Done { assignee; _ } -> Some assignee, None, None, None, None
+  | Masc_domain.Cancelled { cancelled_by; _ } -> Some cancelled_by, None, None, None, None
+;;
+
+let task_snapshot_of_task (task : Masc_domain.task) =
+  let assignee, phase, verifier, submitted_at, verification_id =
+    task_status_snapshot_fields task.task_status
+  in
+  let handoff_summary, handoff_next_step, handoff_evidence_refs =
+    match task.handoff_context with
+    | None -> None, None, []
+    | Some ({ summary; next_step; evidence_refs; _ } : Masc_domain.task_handoff_context) ->
+      non_empty_string_opt summary, non_empty_opt next_step, evidence_refs
+  in
+  { title = task.title
+  ; status = Masc_domain.task_status_to_string task.task_status
+  ; assignee
+  ; phase
+  ; verifier
+  ; submitted_at
+  ; verification_id
+  ; handoff_summary
+  ; handoff_next_step
+  ; handoff_evidence_refs
+  }
+;;
+
+let read_task_snapshot_index ~errs ~masc_dir =
+  let table : (string, task_snapshot) Hashtbl.t = Hashtbl.create 64 in
+  let backlog_path =
+    Filename.concat (Filename.concat masc_dir tasks_dirname) backlog_filename
+  in
+  if Sys.file_exists backlog_path
+  then (
+    match Safe_ops.read_json_file_safe backlog_path with
+    | Error msg ->
+      bounded_add errs (Printf.sprintf "backlog: %s: %s" backlog_path msg)
+    | Ok json ->
+      (match Masc_domain.backlog_of_yojson json with
+       | Error msg ->
+         bounded_add errs (Printf.sprintf "backlog: %s: %s" backlog_path msg)
+       | Ok backlog ->
+         List.iter
+           (fun (task : Masc_domain.task) ->
+             Hashtbl.replace table task.id (task_snapshot_of_task task))
+           backlog.tasks));
+  table
+;;
+
+let attach_current_task task_snapshot_by_id (item : task_item) =
+  { item with current_task = Hashtbl.find_opt task_snapshot_by_id item.task_id }
+;;
 
 let task_id_of_audit_details ~errs details =
   match Safe_ops.json_string_opt "task_id" details with
@@ -435,7 +532,9 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
             let record transition =
               match task_id_of_audit_details ~errs details with
               | Some task_id ->
-                task_items := { task_id; transition; ts = timestamp } :: !task_items
+                task_items
+                  := { task_id; transition; ts = timestamp; current_task = None }
+                     :: !task_items
               | None -> ()
             in
             match action with
@@ -512,6 +611,10 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       bounded_add errs (Printf.sprintf "keeper-meta: %s: %s" meta_path e);
       false
   in
+  let task_snapshot_by_id = read_task_snapshot_index ~errs ~masc_dir in
+  let task_items_with_current =
+    !task_items |> List.map (attach_current_task task_snapshot_by_id)
+  in
   let coverage =
     let source causes = { lower_bound = causes <> []; causes } in
     { chat =
@@ -540,7 +643,7 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
       ; done_ = !done_
       ; released = !released
       ; cancelled = !cancelled
-      ; items = cap_task_items !task_items
+      ; items = cap_task_items task_items_with_current
       }
   ; board = { posted = !posted; commented = !commented; voted = !voted }
   ; lifecycle =
@@ -561,11 +664,30 @@ let float_opt_to_json = function
   | None -> `Null
 ;;
 
+let task_snapshot_to_json (s : task_snapshot) =
+  `Assoc
+    [ "title", `String s.title
+    ; "status", `String s.status
+    ; "assignee", string_opt_to_json s.assignee
+    ; "phase", string_opt_to_json s.phase
+    ; "verifier", string_opt_to_json s.verifier
+    ; "submitted_at", string_opt_to_json s.submitted_at
+    ; "verification_id", string_opt_to_json s.verification_id
+    ; "handoff_summary", string_opt_to_json s.handoff_summary
+    ; "handoff_next_step", string_opt_to_json s.handoff_next_step
+    ; "handoff_evidence_refs", `List (List.map (fun ref_ -> `String ref_) s.handoff_evidence_refs)
+    ]
+;;
+
 let task_item_to_json (i : task_item) =
   `Assoc
     [ "task_id", `String i.task_id
     ; "transition", `String i.transition
     ; "ts", `Float i.ts
+    ; ( "current_task"
+      , match i.current_task with
+        | Some current_task -> task_snapshot_to_json current_task
+        | None -> `Null )
     ]
 ;;
 

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -18,10 +18,24 @@ val digest_items_cap : int
 (** Upper bound on each [items] array ([tasks], [lifecycle]). The sibling
     count fields stay full counts, independent of this cap. *)
 
+type task_snapshot =
+  { title : string
+  ; status : string
+  ; assignee : string option
+  ; phase : string option
+  ; verifier : string option
+  ; submitted_at : string option
+  ; verification_id : string option
+  ; handoff_summary : string option
+  ; handoff_next_step : string option
+  ; handoff_evidence_refs : string list
+  }
+
 type task_item =
   { task_id : string
   ; transition : string
   ; ts : float
+  ; current_task : task_snapshot option
   }
 
 type lifecycle_item =

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -59,6 +59,24 @@ let str_contains ~needle haystack =
 
 let has_cause cause coverage = List.exists (( = ) cause) coverage.D.causes
 
+let json_assoc_fields = function
+  | `Assoc fields -> fields
+  | _ -> []
+;;
+
+let json_string_field key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Some value
+  | Some `Null | None -> None
+  | Some _ -> None
+;;
+
+let json_list_field key fields =
+  match List.assoc_opt key fields with
+  | Some (`List items) -> items
+  | _ -> []
+;;
+
 (* ── store paths (mirror Common.*_from_base_path) ────────────────── *)
 
 let masc base = Filename.concat base ".masc"
@@ -71,10 +89,49 @@ let activity_dir base = Filename.concat (masc base) "activity-events"
 let transition_dir base = Filename.concat (masc base) "transition-audit"
 let chat_file base = Filename.concat (Filename.concat (masc base) "keeper_chat") (keeper ^ ".jsonl")
 let meta_file base = Filename.concat (keepers base) (keeper ^ ".json")
+let backlog_file base = Filename.concat (Filename.concat (masc base) "tasks") "backlog.json"
 
 (* ── fixture row builders ────────────────────────────────────────── *)
 
 let json_line j = Yojson.Safe.to_string j
+
+let handoff_context ?next_step ?(evidence_refs = []) summary
+  : Masc_domain.task_handoff_context
+  =
+  { summary
+  ; reason = None
+  ; next_step
+  ; failure_mode = None
+  ; reclaim_policy = None
+  ; evidence_refs
+  ; updated_at = Some "2026-07-02T00:00:00Z"
+  ; updated_by = Some "digest-test"
+  }
+;;
+
+let task ?handoff_context ~id ~title ~status () : Masc_domain.task =
+  { id
+  ; title
+  ; description = "fixture task"
+  ; task_status = status
+  ; priority = 2
+  ; files = []
+  ; created_at = "2026-07-02T00:00:00Z"
+  ; created_by = Some "digest-test"
+  ; contract = None
+  ; handoff_context
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+let write_backlog base tasks =
+  let backlog : Masc_domain.backlog =
+    { tasks; last_updated = "2026-07-02T00:00:00Z"; version = 1 }
+  in
+  write_file (backlog_file base) (json_line (Masc_domain.backlog_to_yojson backlog))
+;;
 
 let chat_row ?id ?kind ?(content = "x") ~role ~ts () =
   let base = [ "role", `String role; "content", `String content; "ts", `Float ts ] in
@@ -186,6 +243,35 @@ let write_rich_fixture base =
   append_line (af (since_unix +. 400.)) (audit_row ~ts:(since_unix +. 400.) ~agent_id:("keeper:" ^ keeper) ~action:"release_task" ~transition:"release" ~task_id:"task-3");
   append_line (af (since_unix +. 500.)) (audit_row ~ts:(since_unix +. 500.) ~agent_id:"other" ~action:"claim_task" ~transition:"claim" ~task_id:"task-4");
   append_line (af (since_unix -. 200.)) (audit_row ~ts:(since_unix -. 200.) ~agent_id:keeper ~action:"claim_task" ~transition:"claim" ~task_id:"task-5");
+  write_backlog
+    base
+    [ task
+        ~id:"task-1"
+        ~title:"Implement visible-text feedback guard"
+        ~status:
+          (Masc_domain.AwaitingVerification
+             { assignee = keeper
+             ; submitted_at = "2026-07-02T00:10:00Z"
+             ; verification_id = "vrf-task-1"
+             ; phase = Masc_domain.Awaiting_verifier
+             })
+        ~handoff_context:
+          (handoff_context
+             ~next_step:"cross-agent review"
+             ~evidence_refs:[ "PR#23399"; "commit:f2678ed43" ]
+             "PR is open and waiting for verification")
+        ()
+    ; task
+        ~id:"task-2"
+        ~title:"Complete dashboard follow-up"
+        ~status:
+          (Masc_domain.Done
+             { assignee = "keeper-" ^ keeper ^ "-agent"
+             ; completed_at = "2026-07-02T00:20:00Z"
+             ; notes = Some "done"
+             })
+        ()
+    ];
   (* activity-events board.* + keeper.turn_failed for the keeper; a foreign
      board row and a pre-since board row that must be excluded. *)
   let acd = activity_dir base in
@@ -267,6 +353,30 @@ let test_counts_and_boundary () =
     Alcotest.(check int) "tasks.released (keeper: prefix form)" 1 released;
     Alcotest.(check int) "tasks.cancelled" 0 cancelled;
     Alcotest.(check int) "task items (foreign + pre-since excluded)" 3 (List.length task_items);
+    (match List.find_opt (fun item -> String.equal item.D.task_id "task-1") task_items with
+     | Some { D.current_task = Some current; _ } ->
+       Alcotest.(check string)
+         "task-1 current status"
+         "awaiting_verification"
+         current.D.status;
+       Alcotest.(check (option string))
+         "task-1 submitted_at"
+         (Some "2026-07-02T00:10:00Z")
+         current.D.submitted_at;
+       Alcotest.(check (option string))
+         "task-1 handoff summary"
+         (Some "PR is open and waiting for verification")
+         current.D.handoff_summary;
+       Alcotest.(check (list string))
+         "task-1 evidence refs"
+         [ "PR#23399"; "commit:f2678ed43" ]
+         current.D.handoff_evidence_refs
+     | Some { D.current_task = None; _ } -> Alcotest.fail "task-1 must include current_task"
+     | None -> Alcotest.fail "expected task-1 item");
+    (match List.find_opt (fun item -> String.equal item.D.task_id "task-3") task_items with
+     | Some { D.current_task = None; _ } -> ()
+     | Some { D.current_task = Some _; _ } -> Alcotest.fail "task-3 should not have a current_task"
+     | None -> Alcotest.fail "expected task-3 item");
     (* board *)
     Alcotest.(check int) "board.posted" 1 posted;
     Alcotest.(check int) "board.commented" 1 commented;
@@ -469,6 +579,38 @@ let test_to_json_shape () =
               (List.mem_assoc "causes" chat_fields)
           | _ -> Alcotest.fail "coverage.chat must be an object")
        | _ -> Alcotest.fail "coverage must be an object")
+      ;
+      (match List.assoc_opt "tasks" fields with
+       | Some (`Assoc task_fields) ->
+         let item_for_task_1 =
+           json_list_field "items" task_fields
+           |> List.find_opt (fun item ->
+             String.equal
+               (Option.value
+                  (json_string_field "task_id" (json_assoc_fields item))
+                  ~default:"")
+               "task-1")
+         in
+         (match item_for_task_1 with
+          | Some item ->
+            (match List.assoc_opt "current_task" (json_assoc_fields item) with
+             | Some (`Assoc current_fields) ->
+               Alcotest.(check (option string))
+                 "current_task.status serialised"
+                 (Some "awaiting_verification")
+                 (json_string_field "status" current_fields);
+               Alcotest.(check (option string))
+                 "current_task.handoff_next_step serialised"
+                 (Some "cross-agent review")
+                 (json_string_field "handoff_next_step" current_fields);
+               Alcotest.(check int)
+                 "current_task.handoff_evidence_refs serialised"
+                 2
+                 (List.length (json_list_field "handoff_evidence_refs" current_fields))
+             | Some `Null -> Alcotest.fail "task-1 current_task must not be null"
+             | _ -> Alcotest.fail "task-1 current_task must be an object")
+          | None -> Alcotest.fail "expected task-1 JSON item")
+       | _ -> Alcotest.fail "tasks must be an object")
     | _ -> Alcotest.fail "to_json must be a JSON object")
 ;;
 


### PR DESCRIPTION
## Summary

- Add a current task snapshot to each keeper catch-up digest task item when the task still exists in backlog.
- Include status, assignee, verification phase/id, submitted timestamp, and handoff summary/evidence in the JSON payload.
- Extend `test_keeper_catchup_digest` fixtures/assertions so fusion-style task transitions carry current backlog context.

## Root Cause

Fusion catch-up judge prompts only received task transition facts (`task_id`, `transition`, `ts`). For runs like `fus-0547de4e5830742a5adb302f6cb721c1`, the prompt could see `task-1838` was claimed/started but could not see the current backlog state (`awaiting_verification`) or handoff evidence (`PR#23399`, `commit:f2678ed43`). That made panel/judge answers look like there was less progress than the durable task state actually showed.

## Validation

- `git diff --cached --check`
- `MASC_SKIP_OCAML_VERSION_CHECK=1 scripts/dune-local.sh build test/test_keeper_catchup_digest.exe`
- `./_build/default/test/test_keeper_catchup_digest.exe`

Note: the regular local wrapper stops on this machine because the active opam switch is OCaml 5.4.1 while `dune-project` requires OCaml >= 5.5. The targeted build above used the repo wrapper with only the version guard bypassed.
