### PR TITLE
feat(exec): RFC-0309 W4/G-9 — enable repo-create/discussion via R2->R1 + capability approval

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -347,14 +347,20 @@ let ask_of policy ~caps ~bin : Verdict.t =
    floored or Ask-graded; [Allowed] verbs fall through to the overlay), so this
    layer only ADDS an approval requirement, never removes one. Non-gh commands
    are unaffected. *)
-let gh_verb_of_simple (simple : Shell_ir.simple) : Gh_verb.t option =
+let gh_capability_of_simple (simple : Shell_ir.simple)
+  : Gh_capability_policy.disposition option
+  =
   match Exec_program.known simple.Shell_ir.bin with
   | Some Exec_program.Gh ->
     let words =
       Exec_program.to_string simple.Shell_ir.bin
       :: List.map repo_hosting_arg_word simple.Shell_ir.args
     in
-    Some (Gh_verb.classify words)
+    (* [disposition_of_words], not [disposition_of]: [gh api graphql ...] lowers
+       to the body-blind [Gh_verb.Api], so the words must be passed through for
+       the graphql-body durable-remote check (RFC-0309 W4 axis-symmetry fix). *)
+    Some
+      (Gh_capability_policy.disposition_of_words words (Gh_verb.classify words))
   | Some _ | None -> None
 [@@warning "-4"]
 
@@ -378,11 +384,10 @@ let decide (policy : t)
     (* Trust-independent: denied regardless of [overlay] (RFC-0254 §5.3). *)
     Verdict.Deny { caps; reason }
   | None when
-      (match gh_verb_of_simple simple with
-       | Some v ->
-         Gh_capability_policy.disposition_of v
-         = Gh_capability_policy.Requires_approval
-       | None -> false) ->
+      (match gh_capability_of_simple simple with
+       | Some Gh_capability_policy.Requires_approval -> true
+       | Some (Gh_capability_policy.Allowed | Gh_capability_policy.Denied) | None
+         -> false) ->
     (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval] is
        escalated to [Ask] regardless of overlay. Additive only — reached solely
        for gh, and only to REQUIRE approval the risk grading would not. *)

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -350,19 +350,10 @@ let ask_of policy ~caps ~bin : Verdict.t =
 let gh_capability_of_simple (simple : Shell_ir.simple)
   : Gh_capability_policy.disposition option
   =
-  match Exec_program.known simple.Shell_ir.bin with
-  | Some Exec_program.Gh ->
-    let words =
-      Exec_program.to_string simple.Shell_ir.bin
-      :: List.map repo_hosting_arg_word simple.Shell_ir.args
-    in
-    (* [disposition_of_words], not [disposition_of]: [gh api graphql ...] lowers
-       to the body-blind [Gh_verb.Api], so the words must be passed through for
-       the graphql-body durable-remote check (RFC-0309 W4 axis-symmetry fix). *)
-    Some
-      (Gh_capability_policy.disposition_of_words words (Gh_verb.classify words))
-  | Some _ | None -> None
-[@@warning "-4"]
+  (* [disposition_of_simple], not [disposition_of]: [gh api graphql ...] lowers
+     to the body-blind [Gh_verb.Api], so the capability axis must see both the
+     literal argv words and any Shell IR opacity in the graphql [query] body. *)
+  Gh_capability_policy.disposition_of_simple simple
 
 let trust_dispatch ~trust_level ~caps ~policy ~bin ~simple : Verdict.t =
   match trust_level with

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -52,3 +52,25 @@ let disposition_of (v : Gh_verb.t) : disposition =
      | Shell_ir_risk.R1_Reversible_mutation ->
        if creates_durable_remote_surface v then Requires_approval else Allowed)
 ;;
+
+(* Body-aware disposition. [disposition_of] keys on the typed [Gh_verb.t] alone,
+   but [Gh_verb.Api] (i.e. [gh api graphql ...]) is body-blind by design
+   (RFC-0208: graphql method/body risk is irreducibly string-borne). W4/G-9
+   demoted the durable-remote graphql create mutations (createRepository,
+   createDiscussion, addDiscussionComment, …) from the R2 deny floor to R1, so
+   the floor no longer denies them and the body-blind [Api] disposition would
+   wrongly [Allow] them — while the typed [gh repo create] form
+   [Requires_approval]. This entry point restores axis symmetry by inspecting the
+   parsed graphql body (owned by [Shell_ir_risk]) for those fragments. Every
+   other command delegates unchanged to [disposition_of]; the check is ADDITIVE
+   (it only turns [Allowed] into [Requires_approval], never the reverse). *)
+let disposition_of_words (words : string list) (v : Gh_verb.t) : disposition =
+  match v.Gh_verb.family with
+  | Gh_verb.Api when Shell_ir_risk.gh_api_graphql_creates_durable_remote words ->
+    Requires_approval
+  | Gh_verb.Api | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+  | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+  | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run
+  | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ ->
+    disposition_of v
+;;

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -74,3 +74,118 @@ let disposition_of_words (words : string list) (v : Gh_verb.t) : disposition =
   | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ ->
     disposition_of v
 ;;
+
+let rec arg_literal : Shell_ir.arg -> string option = function
+  | Shell_ir.Lit (s, _) -> Some s
+  | Shell_ir.Var _ -> None
+  | Shell_ir.Concat parts ->
+    let rec collect acc = function
+      | [] -> Some (String.concat "" (List.rev acc))
+      | Shell_ir.Lit (s, _) :: rest -> collect (s :: acc) rest
+      | Shell_ir.Var _ :: _ -> None
+      | Shell_ir.Concat nested :: rest ->
+        (match collect [] nested with
+         | Some s -> collect (s :: acc) rest
+         | None -> None)
+    in
+    collect [] parts
+;;
+
+let rec arg_leading_literal : Shell_ir.arg -> string option = function
+  | Shell_ir.Lit (s, _) -> Some s
+  | Shell_ir.Var _ -> None
+  | Shell_ir.Concat [] -> Some ""
+  | Shell_ir.Concat (first :: _) -> arg_leading_literal first
+;;
+
+let arg_word (arg : Shell_ir.arg) : string =
+  match arg_literal arg with
+  | Some s -> s
+  | None -> ""
+;;
+
+let is_graphql_api (v : Gh_verb.t) : bool =
+  match v.Gh_verb.family, v.Gh_verb.action with
+  | Gh_verb.Api, Some action -> String.equal (String.lowercase_ascii action) "graphql"
+  | Gh_verb.Api, None -> false
+  | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+    | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+    | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
+    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ )
+    , _ -> false
+;;
+
+let is_field_flag = function
+  | "-f" | "-F" | "--field" | "--raw-field" -> true
+  | _ -> false
+;;
+
+let strip_attached_field_flag tok =
+  let lower = String.lowercase_ascii tok in
+  let strip prefix =
+    let n = String.length prefix in
+    String.sub tok n (String.length tok - n)
+  in
+  if String.starts_with ~prefix:"--field=" lower then Some (strip "--field=")
+  else if String.starts_with ~prefix:"--raw-field=" lower then
+    Some (strip "--raw-field=")
+  else if String.starts_with ~prefix:"-f" tok && not (String.equal tok "-f") then
+    Some (strip "-f")
+  else if String.starts_with ~prefix:"-F" tok && not (String.equal tok "-F") then
+    Some (strip "-F")
+  else None
+;;
+
+let field_prefix_may_be_query field_prefix =
+  let lower = String.lowercase_ascii field_prefix in
+  String.starts_with ~prefix:"query=" lower || not (String.contains lower '=')
+;;
+
+let opaque_field_arg_may_be_query (arg : Shell_ir.arg) : bool =
+  match arg_literal arg with
+  | Some _ -> false
+  | None ->
+    (match arg_leading_literal arg with
+     | Some prefix -> field_prefix_may_be_query prefix
+     | None -> true)
+;;
+
+let attached_opaque_field_may_be_query (arg : Shell_ir.arg) : bool =
+  match arg_literal arg with
+  | Some _ -> false
+  | None ->
+    (match arg_leading_literal arg with
+     | Some prefix ->
+       (match strip_attached_field_flag prefix with
+        | Some field_prefix -> field_prefix_may_be_query field_prefix
+        | None -> false)
+     | None -> false)
+;;
+
+let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
+  let rec scan = function
+    | [] -> false
+    | arg :: rest ->
+      (match arg_literal arg with
+       | Some tok when is_field_flag tok ->
+         (match rest with
+          | value :: tail -> opaque_field_arg_may_be_query value || scan tail
+          | [] -> false)
+       | Some _ | None -> attached_opaque_field_may_be_query arg || scan rest)
+  in
+  scan args
+;;
+
+let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
+  match Exec_program.known simple.Shell_ir.bin with
+  | Some Exec_program.Gh ->
+    let words =
+      Exec_program.to_string simple.Shell_ir.bin
+      :: List.map arg_word simple.Shell_ir.args
+    in
+    let verb = Gh_verb.classify words in
+    if is_graphql_api verb && graphql_query_body_is_opaque simple.Shell_ir.args
+    then Some Requires_approval
+    else Some (disposition_of_words words verb)
+  | Some _ | None -> None
+[@@warning "-4"]

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -78,3 +78,15 @@ val disposition_of_words : string list -> Gh_verb.t -> disposition
     [Requires_approval] for such bodies. ADDITIVE: only ever upgrades [Allowed]
     to [Requires_approval], never the reverse. Callers with the raw argv words
     (e.g. [Approval_policy.decide]) should prefer this over [disposition_of]. *)
+
+val disposition_of_simple : Shell_ir.simple -> disposition option
+(** Capability disposition for a parsed Shell IR simple command. Returns [None]
+    for non-[gh] commands.
+
+    This is the approval-path entry point because it preserves argument opacity.
+    Literal [gh api graphql -f query=...] bodies are classified through
+    {!disposition_of_words}. If the GraphQL [query] field itself is non-literal
+    (for example [query=$MUTATION] or an opaque field token), the body cannot be
+    inspected for durable-remote mutations, so the capability axis fail-closes to
+    [Requires_approval]. Opaque non-query GraphQL variables such as
+    [owner=$OWNER] do not trigger this approval path. *)

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -65,3 +65,16 @@ val disposition_of : Gh_verb.t -> disposition
     - risk R0 -> [Allowed];
     - risk R1 -> [Requires_approval] if [creates_durable_remote_surface],
       else [Allowed]. *)
+
+val disposition_of_words : string list -> Gh_verb.t -> disposition
+(** Body-aware disposition. Identical to [disposition_of] for every command
+    except [gh api graphql ...]: the typed verb for [gh api] is [Gh_verb.Api],
+    which is body-blind by design (RFC-0208), yet W4/G-9 demoted durable-remote
+    graphql creates (createRepository/createDiscussion/addDiscussionComment) from
+    the R2 deny floor to R1. Without body inspection the disposition would
+    [Allow] them while the typed [gh repo create] form [Requires_approval] — an
+    axis-asymmetry bypass. This variant consults
+    [Shell_ir_risk.gh_api_graphql_creates_durable_remote words] and returns
+    [Requires_approval] for such bodies. ADDITIVE: only ever upgrades [Allowed]
+    to [Requires_approval], never the reverse. Callers with the raw argv words
+    (e.g. [Approval_policy.decide]) should prefer this over [disposition_of]. *)

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -492,12 +492,15 @@ let strip_graphql_comments s =
     s;
   Buffer.contents buf
 
-let body_contains_r2_mutation words =
-  let body =
-    String.concat " " words
-    |> String.lowercase_ascii
-    |> strip_graphql_comments
-  in
+let graphql_body_lower words =
+  String.concat " " words |> String.lowercase_ascii |> strip_graphql_comments
+
+(* Substring-scan the (comment-stripped, lowercased) graphql body for any of
+   [fragments]. Shared by the R2 deny-list and the durable-remote capability
+   list so both use one parser-owned body reader. *)
+let body_contains_fragment (fragments : string list) (words : string list) : bool
+  =
+  let body = graphql_body_lower words in
   let m = String.length body in
   List.exists
     (fun frag ->
@@ -510,7 +513,34 @@ let body_contains_r2_mutation words =
            else scan (i + 1)
          in
          scan 0)
-    repo_hosting_graphql_r2_fragments
+    fragments
+
+let body_contains_r2_mutation words =
+  body_contains_fragment repo_hosting_graphql_r2_fragments words
+
+(* GraphQL mutation fragments that establish or modify a durable REMOTE
+   repository/discussion surface and are reversible (R1). W4/G-9 moved these out
+   of [repo_hosting_graphql_r2_fragments] (they are reversible, so the risk floor
+   no longer denies them). The capability axis escalates them to Ask, mirroring
+   the typed [gh repo create] / [gh discussion create] path — without this the
+   string-borne graphql form would auto-run under the autonomous overlay while
+   the typed form asks (an axis-asymmetry bypass). Irreversible graphql mutations
+   (delete*/transfer/archive/purge) stay in [repo_hosting_graphql_r2_fragments]
+   and are denied by the floor, so they are deliberately absent here.
+   Over-inclusion only adds an approval prompt (safe); under-inclusion silently
+   auto-runs a durable-remote write (unsafe). *)
+let repo_hosting_graphql_durable_remote_fragments =
+  [ "createrepository"; "clonetemplaterepository"; "updaterepository";
+    "creatediscussion"; "updatediscussion"; "adddiscussioncomment";
+    "updatediscussioncomment"; "adddiscussionpollvote"; "closediscussion";
+    "reopendiscussion"; "markdiscussioncommentasanswer";
+    "unmarkdiscussioncommentasanswer" ]
+
+let gh_api_graphql_creates_durable_remote (words : string list) : bool =
+  (* Guard on the [graphql] endpoint token: a REST [gh api /path] call whose
+     path merely contains a mutation name must not be over-flagged. *)
+  List.mem "graphql" (List.map String.lowercase_ascii words)
+  && body_contains_fragment repo_hosting_graphql_durable_remote_fragments words
 
 let classify_repo_hosting_cli (words : string list) : risk_class =
   match words with

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -365,10 +365,17 @@ let classify_write_detail (words : string list) : risk_class option =
 let repo_hosting_cli_irreversible_ops =
   [
     ("pr", [ "merge"; "ready" ]);
-    ("repo", [ "create"; "delete"; "archive"; "transfer"; "rename"; "fork" ]);
-    ( "discussion",
-      [ "create"; "comment"; "edit"; "delete"; "close"; "reopen"; "lock";
-        "unlock"; "answer"; "unanswer" ] );
+    (* RFC-0309 W4/G-9: repo create/fork are factually REVERSIBLE (a created or
+       forked repo can be deleted), so they move to the reversible table below.
+       Only the genuinely irreversible repo ops stay here. This restores the
+       risk axis to state a fact; the "keeper may not create repos
+       unsupervised" decision now lives on the capability axis
+       ([Gh_capability_policy]) as [Requires_approval], superseding #23362's
+       policy-as-risk encoding. *)
+    ("repo", [ "delete"; "archive"; "transfer"; "rename" ]);
+    (* Only [delete] is irreversible; create/comment/edit/close/reopen/lock/
+       unlock/answer/unanswer are reversible discussion mutations (W4/G-9). *)
+    ("discussion", [ "delete" ]);
     ("release", [ "delete" ]);
     ("secret", [ "delete"; "remove" ]);
     ("ssh-key", [ "delete" ]);
@@ -392,8 +399,18 @@ let repo_hosting_cli_reversible_mutations =
     ("run", [ "cancel"; "rerun"; "watch" ]);
     ("cache", [ "delete" ]);
     ("gist", [ "create"; "edit"; "clone"; "rename" ]);
+    (* RFC-0309 W4/G-9: create/fork are reversible remote mutations. The
+       capability axis ([Gh_capability_policy]) routes create/fork/edit/sync to
+       [Requires_approval] because they touch a durable remote surface; the
+       risk axis only states they are reversible (R1). *)
     ("repo",
-     [ "clone"; "edit"; "sync"; "set-default" ]);
+     [ "clone"; "create"; "fork"; "edit"; "sync"; "set-default" ]);
+    (* RFC-0309 W4/G-9: reversible discussion mutations (delete stays R2 in the
+       irreversible table). The capability axis routes these to
+       [Requires_approval] via the Discussion durable-remote family. *)
+    ("discussion",
+     [ "create"; "comment"; "edit"; "close"; "reopen"; "lock"; "unlock";
+       "answer"; "unanswer" ]);
     ("project",
      [ "create"; "edit"; "close"; "copy"; "link"; "unlink"; "field-create";
        "field-delete"; "item-add"; "item-archive"; "item-delete"; "item-edit" ]);
@@ -452,12 +469,13 @@ let repo_hosting_graphql_r2_fragments =
   [ "deletepullrequest"; "deleteissue"; "deletebranch"; "deleteref";
     "deleteproject"; "deletebranchprotectionrule";
     "removeouterfromorganization"; "transferrepository";
-    "archiverepository"; "createrepository"; "clonetemplaterepository";
-    "creatediscussion"; "adddiscussioncomment"; "adddiscussionpollvote";
-    "closediscussion"; "deletediscussion"; "deletediscussioncomment";
-    "markdiscussioncommentasanswer"; "reopendiscussion";
-    "unmarkdiscussioncommentasanswer"; "updatediscussion";
-    "updatediscussioncomment";
+    "archiverepository";
+    (* RFC-0309 W4/G-9: only irreversible discussion graphql mutations stay R2.
+       createDiscussion/addDiscussionComment/closeDiscussion/updateDiscussion/
+       etc. are reversible and are gated by the capability axis, not the risk
+       floor (they were added to R2 by #23362's policy-as-risk encoding).
+       createRepository/cloneTemplateRepository are likewise reversible. *)
+    "deletediscussion"; "deletediscussioncomment";
     (* Forward-looking verb prefixes for mutations GitHub may introduce.
        Over-block here is acceptable — under-block (silent miss) is not. *)
     "purgerepository" ]

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -114,6 +114,19 @@ val risk_of_gh_verb : Gh_verb.t -> risk_class
     Never returns [Destructive_protected]. Capability-identity substrate for
     W2 (per-keeper policy) and W3 (non-blocking approval routing). *)
 
+val gh_api_graphql_creates_durable_remote : string list -> bool
+(** True when [words] is a [gh api graphql ...] invocation whose (comment-
+    stripped) body contains a durable-remote repository/discussion create/mutate
+    fragment that W4/G-9 demoted from the R2 deny floor to R1 (createRepository,
+    createDiscussion, addDiscussionComment, …). The capability axis
+    ([Gh_capability_policy.disposition_of_words]) consults this to escalate the
+    string-borne graphql form to [Requires_approval], matching the typed
+    [gh repo create] path — the typed verb for [gh api] is [Gh_verb.Api], which
+    is body-blind by design (RFC-0208), so the disposition would otherwise
+    [Allow] it. Guarded on the [graphql] endpoint token; a REST [gh api] path
+    that merely contains a mutation name returns [false]. Irreversible graphql
+    mutations stay R2-floored and are not reported here. *)
+
 val literal_words_of_simple : Shell_ir.simple -> string list option
 (** Extract literal words from a single [Shell_ir.simple] stage:
     [[bin; arg0; arg1; ...]]. Non-literal args ([Concat], [Var])

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -363,16 +363,16 @@ let test_gh_irreversible_repo_hosting_ops_denied_under_autonomous () =
        | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
          assert (Exec_program.to_string bin = "gh")
        | _ -> Alcotest.failf "%s: expected gh irreversible op to be denied" label)
+    (* W4/G-9: repo create/fork, discussion create, and graphql create* moved
+       to R1 (reversible) — they are no longer Deny; they Ask via the capability
+       axis (asserted in [test_gh_durable_remote_asks_under_autonomous]). Only
+       the genuinely irreversible ops remain Deny here. *)
     [ "gh pr merge", [ "pr"; "merge"; "123"; "--squash" ]
-    ; "gh repo create", [ "repo"; "create"; "owner/new-repo" ]
-    ; "gh repo fork", [ "repo"; "fork"; "owner/repo" ]
     ; "gh repo delete", [ "repo"; "delete"; "owner/repo"; "--yes" ]
-    ; "gh discussion create", [ "discussion"; "create"; "--title"; "T" ]
+    ; "gh discussion delete", [ "discussion"; "delete"; "42" ]
     ; "gh api delete", [ "api"; "-X"; "DELETE"; "/repos/owner/repo" ]
-    ; "gh graphql createRepository"
-      , [ "api"; "graphql"; "-f"; "query=mutation{createRepository}" ]
-    ; "gh graphql createDiscussion"
-      , [ "api"; "graphql"; "-f"; "query=mutation{createDiscussion}" ]
+    ; "gh graphql deleteDiscussion"
+      , [ "api"; "graphql"; "-f"; "query=mutation{deleteDiscussion}" ]
     ]
 
 let test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous () =
@@ -479,35 +479,19 @@ let test_gh_durable_remote_asks_under_autonomous () =
        | _ ->
          Alcotest.failf "%s: durable-remote gh op must Ask under autonomous"
            label)
-    (* R1 durable-remote mutations that exist TODAY (repo reversible table).
-       discussion mutations and repo create/fork are R2 under #23362, so they
-       Deny (not Ask) until W4/G-9 moves them to R1 — asserted separately in
-       [test_gh_r2_durable_remote_denies_pending_w4]. *)
-    [ "gh repo edit", [ "repo"; "edit"; "--description"; "d" ]
+    (* W4/G-9 ENABLED: repo create/fork and discussion mutations moved R2->R1,
+       so they now take the capability Ask path (durable-remote R1) instead of
+       the floor Deny path — the active-keeper enablement. Plus the R1
+       durable-remote ops that already existed (repo edit/sync/set-default) and
+       unknown gh. *)
+    [ "gh repo create", [ "repo"; "create"; "o/new" ]
+    ; "gh repo fork", [ "repo"; "fork"; "o/r" ]
+    ; "gh discussion create", [ "discussion"; "create"; "--title"; "T" ]
+    ; "gh discussion comment", [ "discussion"; "comment"; "42"; "--body"; "B" ]
+    ; "gh repo edit", [ "repo"; "edit"; "--description"; "d" ]
     ; "gh repo sync", [ "repo"; "sync" ]
     ; "gh repo set-default", [ "repo"; "set-default"; "o/r" ]
     ; "gh frobnicate (unknown -> Requires_approval)", [ "frobnicate"; "now" ]
-    ]
-
-(* #23362 keeps discussion mutations and repo create/fork at R2, so the
-   capability disposition is [Denied] and they take the floor Deny path, NOT
-   the W3 Ask path. Pinned here so W4/G-9 (R2 -> R1) produces a visible delta:
-   these flip from Deny to Ask. *)
-let test_gh_r2_durable_remote_denies_pending_w4 () =
-  List.iter
-    (fun (label, args) ->
-       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
-       let caps = Capability_check.of_simple s in
-       match
-         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
-           ~caps ~simple:s
-       with
-       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } -> ()
-       | _ ->
-         Alcotest.failf "%s: R2 durable-remote must Deny under autonomous (W4 -> Ask)"
-           label)
-    [ "gh discussion comment", [ "discussion"; "comment"; "42"; "--body"; "B" ]
-    ; "gh repo create", [ "repo"; "create"; "o/new" ]
     ]
 
 (* Regression guard: the W3 capability layer is ADDITIVE. Reads and local /
@@ -538,6 +522,48 @@ let test_non_gh_unaffected_by_capability_layer () =
   match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
   | Verdict.Allow _ -> ()
   | _ -> Alcotest.fail "ls should stay Allow under autonomous"
+
+(* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
+   pr merge]) must not slip the destructive op past the floor. gh (Cobra)
+   accepts flags before the subcommand and consumes their values, so the
+   word-list classifier's position-based subcommand slot is wrong; the typed
+   lowering locates the real subcommand. *)
+let test_gh_leading_flag_destructive_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: leading-flag destructive op must be floored" label)
+    [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
+    ; "gh --repo o/r pr ready", [ "--repo"; "o/r"; "pr"; "ready"; "123" ]
+    ; "gh --repo o/r repo delete"
+      , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
+    ]
+
+(* Control: a leading global flag on a READ must NOT be over-blocked — the fix
+   restores correct subcommand location without flooring reads. *)
+let test_gh_leading_flag_read_not_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
+         Alcotest.failf "%s: leading-flag read must not be floored" label
+       | _ -> ())
+    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
+    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    ]
 
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
    common force-delete-untracked form) is destructive and hits the floor.
@@ -652,9 +678,10 @@ let () =
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_gh_durable_remote_asks_under_autonomous ();
-  test_gh_r2_durable_remote_denies_pending_w4 ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();
   test_non_gh_unaffected_by_capability_layer ();
+  test_gh_leading_flag_destructive_floored_under_autonomous ();
+  test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -17,6 +17,7 @@ let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
 
 let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 let var s = Shell_ir.Var (s, Shell_ir.default_meta)
+let concat parts = Shell_ir.Concat parts
 
 let default_policy : Approval_policy.t =
   { raw_source = "(test)"; summary = "(test summary)" }
@@ -533,6 +534,49 @@ let test_gh_graphql_durable_remote_asks_under_autonomous () =
          \"b\"}) { comment { id } } }" )
     ]
 
+(* Opaque GraphQL [query] bodies are not inspectable by the durable-remote
+   fragment classifier. They must fail closed to the same non-blocking approval
+   route, while opaque non-query variables stay non-blocking. *)
+let test_gh_graphql_opaque_query_asks_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf
+           "%s: opaque graphql query body must Ask under autonomous" label)
+    [ ( "query=$MUTATION concat"
+      , [ lit "api"; lit "graphql"; lit "-f"; concat [ lit "query="; var "MUTATION" ] ]
+      )
+    ; "query field variable", [ lit "api"; lit "graphql"; lit "-f"; var "FIELD" ]
+    ; ( "attached --field=query=$MUTATION"
+      , [ lit "api"; lit "graphql"; concat [ lit "--field=query="; var "MUTATION" ] ]
+      )
+    ]
+
+let test_gh_graphql_non_query_opaque_field_allowed_under_autonomous () =
+  let s =
+    simple (bin_ok "gh")
+      ~args:
+        [ lit "api"
+        ; lit "graphql"
+        ; lit "-F"
+        ; concat [ lit "owner="; var "OWNER" ]
+        ; lit "-f"
+        ; lit "query=query { viewer { login } }"
+        ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Allow t ->
+    assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
+  | _ -> Alcotest.fail "opaque non-query graphql variables must not Ask"
+
 (* Regression guard: the W3 capability layer is ADDITIVE. Reads and local /
    in-repo reversible mutations stay [Allow] under autonomous — no over-block of
    routine keeper work. *)
@@ -676,6 +720,8 @@ let () =
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_gh_durable_remote_asks_under_autonomous ();
   test_gh_graphql_durable_remote_asks_under_autonomous ();
+  test_gh_graphql_opaque_query_asks_under_autonomous ();
+  test_gh_graphql_non_query_opaque_field_allowed_under_autonomous ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();
   test_non_gh_unaffected_by_capability_layer ();
   test_git_clean_bundled_force_denied ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -494,6 +494,45 @@ let test_gh_durable_remote_asks_under_autonomous () =
     ; "gh frobnicate (unknown -> Requires_approval)", [ "frobnicate"; "now" ]
     ]
 
+(* RFC-0309 W4 axis-symmetry regression: the string-borne GraphQL form of a
+   durable-remote create must Ask under autonomous exactly like the typed
+   [gh repo create] form. W4 demoted createRepository/createDiscussion/
+   addDiscussionComment from the R2 deny floor to R1 (they are reversible), so
+   the floor no longer catches them; the typed verb is [Gh_verb.Api] which is
+   body-blind by design (RFC-0208), so the body-blind capability disposition
+   would wrongly [Allow] them. The capability axis must inspect the graphql body
+   for durable-remote create fragments and escalate to Ask — otherwise the typed
+   path asks while the equivalent string path auto-runs (an axis-asymmetry
+   bypass). *)
+let test_gh_graphql_durable_remote_asks_under_autonomous () =
+  List.iter
+    (fun (label, body) ->
+       let s =
+         simple (bin_ok "gh")
+           ~args:[ lit "api"; lit "graphql"; lit "-f"; lit ("query=" ^ body) ]
+       in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf
+           "%s: string-borne graphql durable-remote create must Ask under \
+            autonomous"
+           label)
+    [ ( "createRepository"
+      , "mutation { createRepository(input: {name: \"x\"}) { repository { id } } }"
+      )
+    ; ( "createDiscussion"
+      , "mutation { createDiscussion(input: {repositoryId: \"r\", title: \"t\", \
+         body: \"b\", categoryId: \"c\"}) { discussion { id } } }" )
+    ; ( "addDiscussionComment"
+      , "mutation { addDiscussionComment(input: {discussionId: \"d\", body: \
+         \"b\"}) { comment { id } } }" )
+    ]
+
 (* Regression guard: the W3 capability layer is ADDITIVE. Reads and local /
    in-repo reversible mutations stay [Allow] under autonomous — no over-block of
    routine keeper work. *)
@@ -522,48 +561,6 @@ let test_non_gh_unaffected_by_capability_layer () =
   match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
   | Verdict.Allow _ -> ()
   | _ -> Alcotest.fail "ls should stay Allow under autonomous"
-
-(* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
-   pr merge]) must not slip the destructive op past the floor. gh (Cobra)
-   accepts flags before the subcommand and consumes their values, so the
-   word-list classifier's position-based subcommand slot is wrong; the typed
-   lowering locates the real subcommand. *)
-let test_gh_leading_flag_destructive_floored_under_autonomous () =
-  List.iter
-    (fun (label, args) ->
-       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
-       let caps = Capability_check.of_simple s in
-       match
-         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
-           ~caps ~simple:s
-       with
-       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
-         assert (Exec_program.to_string bin = "gh")
-       | _ ->
-         Alcotest.failf "%s: leading-flag destructive op must be floored" label)
-    [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
-    ; "gh --repo o/r pr ready", [ "--repo"; "o/r"; "pr"; "ready"; "123" ]
-    ; "gh --repo o/r repo delete"
-      , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
-    ]
-
-(* Control: a leading global flag on a READ must NOT be over-blocked — the fix
-   restores correct subcommand location without flooring reads. *)
-let test_gh_leading_flag_read_not_floored_under_autonomous () =
-  List.iter
-    (fun (label, args) ->
-       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
-       let caps = Capability_check.of_simple s in
-       match
-         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
-           ~caps ~simple:s
-       with
-       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
-         Alcotest.failf "%s: leading-flag read must not be floored" label
-       | _ -> ())
-    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
-    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
-    ]
 
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
    common force-delete-untracked form) is destructive and hits the floor.
@@ -678,10 +675,9 @@ let () =
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_gh_durable_remote_asks_under_autonomous ();
+  test_gh_graphql_durable_remote_asks_under_autonomous ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();
   test_non_gh_unaffected_by_capability_layer ();
-  test_gh_leading_flag_destructive_floored_under_autonomous ();
-  test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -103,6 +103,55 @@ let test_current_dispositions () =
        unknown-action gap is deferred to W3, same as the risk axis. *)
 ;;
 
+(* --- W4 axis symmetry: string-borne graphql vs typed (disposition_of_words) --
+   [gh api graphql ...] lowers to the body-blind [Gh_verb.Api]; [disposition_of]
+   alone would [Allow] a durable-remote create because it cannot see the body.
+   [disposition_of_words] inspects the parsed graphql body so the string form
+   matches the typed [gh repo create] -> Requires_approval decision. *)
+let graphql_words body =
+  [ "gh"; "api"; "graphql"; "-f"; "query=" ^ body ]
+
+let test_graphql_durable_remote_words () =
+  let ask =
+    [ ("createRepository", "mutation { createRepository(input:{name:\"x\"}){ repository { id } } }")
+    ; ("createDiscussion", "mutation { createDiscussion(input:{title:\"t\"}){ discussion { id } } }")
+    ; ("addDiscussionComment", "mutation { addDiscussionComment(input:{body:\"b\"}){ comment { id } } }")
+    ]
+  in
+  (* graphql reads and non-durable mutations must NOT be over-approved *)
+  let allow =
+    [ ("query repo", "query { repository(owner:\"o\", name:\"r\"){ id } }")
+    ; ("addComment (issue, not durable-remote)", "mutation { addComment(input:{body:\"b\"}){ clientMutationId } }")
+    ]
+  in
+  List.iter
+    (fun (label, body) ->
+       let words = graphql_words body in
+       let v = Gh_verb.classify words in
+       let d = Pol.disposition_of_words words v in
+       if d <> Pol.Requires_approval then
+         Alcotest.failf "graphql %s: %s, expected requires_approval" label
+           (dstr d))
+    ask;
+  List.iter
+    (fun (label, body) ->
+       let words = graphql_words body in
+       let v = Gh_verb.classify words in
+       let d = Pol.disposition_of_words words v in
+       if d = Pol.Requires_approval then
+         Alcotest.failf "graphql %s must not be over-approved (%s)" label (dstr d))
+    allow;
+  (* disposition_of_words agrees with disposition_of for every non-Api verb *)
+  List.iter
+    (fun (sub, act) ->
+       let v = verb ~sub ~act () in
+       let words = [ "gh"; sub; act ] in
+       if Pol.disposition_of_words words v <> Pol.disposition_of v then
+         Alcotest.failf "gh %s %s: disposition_of_words diverged from disposition_of"
+           sub act)
+    [ ("repo", "create"); ("repo", "view"); ("pr", "merge"); ("issue", "create") ]
+;;
+
 let () =
   Alcotest.run "gh_capability_policy"
     [
@@ -112,6 +161,8 @@ let () =
             test_durable_remote_surface;
           Alcotest.test_case "current dispositions" `Quick
             test_current_dispositions;
+          Alcotest.test_case "graphql durable-remote (words)" `Quick
+            test_graphql_durable_remote_words;
         ] );
     ]
 ;;

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -71,18 +71,22 @@ let test_current_dispositions () =
   check "pr comment" (verb ~sub:"pr" ~act:"comment" ()) Pol.Allowed;
   check "issue create" (verb ~sub:"issue" ~act:"create" ()) Pol.Allowed;
   check "release create" (verb ~sub:"release" ~act:"create" ()) Pol.Allowed;
-  (* irreversible (also risk-floored): Denied *)
+  (* genuinely irreversible (also risk-floored): Denied *)
   check "pr merge" (verb ~sub:"pr" ~act:"merge" ()) Pol.Denied;
   check "repo delete" (verb ~sub:"repo" ~act:"delete" ()) Pol.Denied;
   check "discussion delete" (verb ~sub:"discussion" ~act:"delete" ()) Pol.Denied;
-  (* W4 target divergence: repo-create / discussion-create are Denied TODAY
-     because #23362 keeps them in the irreversible risk table. W4/G-9 moves
-     them to R1, at which point (durable-remote + R1) -> Requires_approval.
-     Pinned as Denied here so the W4 table change produces a visible delta. *)
-  check "repo create (W4->requires_approval)" (verb ~sub:"repo" ~act:"create" ())
-    Pol.Denied;
-  check "discussion create (W4->requires_approval)"
-    (verb ~sub:"discussion" ~act:"create" ()) Pol.Denied;
+  (* W4/G-9 ENABLED: repo-create / discussion-create are now R1 (reversible) +
+     durable-remote -> Requires_approval. Was Denied under #23362; the risk axis
+     no longer lies about reversibility and the capability axis carries the
+     decision. This is the active-keeper enablement. *)
+  check "repo create -> Requires_approval" (verb ~sub:"repo" ~act:"create" ())
+    Pol.Requires_approval;
+  check "repo fork -> Requires_approval" (verb ~sub:"repo" ~act:"fork" ())
+    Pol.Requires_approval;
+  check "discussion create -> Requires_approval"
+    (verb ~sub:"discussion" ~act:"create" ()) Pol.Requires_approval;
+  check "discussion comment -> Requires_approval"
+    (verb ~sub:"discussion" ~act:"comment" ()) Pol.Requires_approval;
   (* durable-remote R1 mutation -> Requires_approval *)
   check "repo edit" (verb ~sub:"repo" ~act:"edit" ()) Pol.Requires_approval;
   check "repo sync" (verb ~sub:"repo" ~act:"sync" ()) Pol.Requires_approval;

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -14,6 +14,9 @@
 
 module Gh_verb = Masc_exec.Gh_verb
 module Pol = Masc_exec.Gh_capability_policy
+module Exec_program = Masc_exec.Exec_program
+module Sandbox_target = Masc_exec.Sandbox_target
+module Shell_ir = Masc_exec.Shell_ir
 
 let verb ~sub ?act () = Gh_verb.of_fields ~subcommand:sub ~action:act
 
@@ -111,6 +114,24 @@ let test_current_dispositions () =
 let graphql_words body =
   [ "gh"; "api"; "graphql"; "-f"; "query=" ^ body ]
 
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
+let var s = Shell_ir.Var (s, Shell_ir.default_meta)
+let concat parts = Shell_ir.Concat parts
+
+let gh_bin =
+  match Exec_program.of_string "gh" with
+  | Ok bin -> bin
+  | Error _ -> assert false
+
+let gh_simple args : Shell_ir.simple =
+  { bin = gh_bin
+  ; args
+  ; env = []
+  ; cwd = None
+  ; redirects = []
+  ; sandbox = Sandbox_target.host ()
+  }
+
 let test_graphql_durable_remote_words () =
   let ask =
     [ ("createRepository", "mutation { createRepository(input:{name:\"x\"}){ repository { id } } }")
@@ -152,6 +173,42 @@ let test_graphql_durable_remote_words () =
     [ ("repo", "create"); ("repo", "view"); ("pr", "merge"); ("issue", "create") ]
 ;;
 
+let test_graphql_opaque_query_simple () =
+  let ask =
+    [ ( "query=$MUTATION concat"
+      , [ lit "api"; lit "graphql"; lit "-f"; concat [ lit "query="; var "MUTATION" ] ]
+      )
+    ; "opaque field", [ lit "api"; lit "graphql"; lit "-f"; var "FIELD" ]
+    ; ( "attached query"
+      , [ lit "api"; lit "graphql"; concat [ lit "--raw-field=query="; var "MUTATION" ] ]
+      )
+    ]
+  in
+  List.iter
+    (fun (label, args) ->
+       match Pol.disposition_of_simple (gh_simple args) with
+       | Some Pol.Requires_approval -> ()
+       | Some d ->
+         Alcotest.failf "%s: expected requires_approval, got %s" label (dstr d)
+       | None -> Alcotest.failf "%s: expected gh disposition" label)
+    ask;
+  match
+    Pol.disposition_of_simple
+      (gh_simple
+         [ lit "api"
+         ; lit "graphql"
+         ; lit "-F"
+         ; concat [ lit "owner="; var "OWNER" ]
+         ; lit "-f"
+         ; lit "query=query { viewer { login } }"
+         ])
+  with
+  | Some Pol.Requires_approval ->
+    Alcotest.fail "opaque non-query graphql variables must not require approval"
+  | Some (Pol.Allowed | Pol.Denied) -> ()
+  | None -> Alcotest.fail "expected gh disposition"
+;;
+
 let () =
   Alcotest.run "gh_capability_policy"
     [
@@ -163,6 +220,8 @@ let () =
             test_current_dispositions;
           Alcotest.test_case "graphql durable-remote (words)" `Quick
             test_graphql_durable_remote_words;
+          Alcotest.test_case "graphql opaque query (simple)" `Quick
+            test_graphql_opaque_query_simple;
         ] );
     ]
 ;;

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -122,30 +122,31 @@ let corpus : (string * string * expectation) list =
      Stable Shell_ir_risk.R2_Irreversible);
     ("discussion-delete", "gh discussion delete 42",
      Stable Shell_ir_risk.R2_Irreversible);
-    (* --- Defect 1: policy encoded as risk (PR #23362) ---------------- *)
+    (* --- W4/G-9 FIXED: #23362's policy-as-risk closed. These reversible ops
+       now classify R1; the "keeper may not do this unsupervised" decision moved
+       to the capability axis ([Gh_capability_policy] -> Requires_approval).
+       Was [Defect_policy_as_risk R2]; now [Stable R1]. --------------------- *)
     ("repo-create", "gh repo create owner/new-repo",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("repo-fork", "gh repo fork owner/repo",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("discussion-create", "gh discussion create --title T --body B",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("discussion-comment", "gh discussion comment 42 --body B",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("discussion-edit", "gh discussion edit 42 --body B",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
-    (* close/reopen are a reversible round-trip pair; both sit in the
-       irreversible table. *)
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("discussion-close", "gh discussion close 42",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("graphql-createRepository",
      "gh api graphql -f 'query=mutation{createRepository}'",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("graphql-createDiscussion",
      "gh api graphql -f 'query=mutation{createDiscussion}'",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("graphql-addDiscussionComment",
      "gh api graphql -f 'query=mutation{addDiscussionComment}'",
-     Defect_policy_as_risk Shell_ir_risk.R2_Irreversible);
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     (* --- W1: wholly-unrecognized gh area -> fail-closed typed opinion.
        Composed risk is now R2 (was R0). Observability only: the approval
        floor still reads these as R0 (see test_word_list_surface). --------- *)
@@ -204,12 +205,11 @@ let test_typed_path_verb_opinion () =
   check "gh pr view 123" Shell_ir_risk.R0_Read;
   check "gh pr create --title T" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
-  (* repo/create sits in the irreversible table post-#23362; W1 reads the
-     same tables, so the typed opinion is R2 here too. W2 moves it to R1
-     once the capability-policy axis can carry the "disabled" decision. *)
-  check "gh repo create owner/new-repo" Shell_ir_risk.R2_Irreversible;
+  (* W4/G-9: repo create is reversible (R1); the capability axis carries the
+     "requires approval" decision. Was R2 under #23362. *)
+  check "gh repo create owner/new-repo" Shell_ir_risk.R1_Reversible_mutation;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
-  check "gh discussion comment 42 --body B" Shell_ir_risk.R2_Irreversible;
+  check "gh discussion comment 42 --body B" Shell_ir_risk.R1_Reversible_mutation;
   (* api: typed opinion stays R0; the word-list floor owns -X/graphql risk. *)
   check "gh api repos/owner/repo -X DELETE" Shell_ir_risk.R0_Read;
   (* wholly-unrecognized area: fail-closed typed opinion. *)
@@ -227,7 +227,9 @@ let test_word_list_surface () =
   in
   check [ "gh"; "frobnicate"; "now" ] Shell_ir_risk.R0_Read;
   check [ "gh"; "repo"; "upsert-magic"; "owner/repo" ] Shell_ir_risk.R0_Read;
-  check [ "gh"; "discussion"; "close"; "42" ] Shell_ir_risk.R2_Irreversible
+  (* W4/G-9: discussion close is reversible (R1); discussion delete stays R2. *)
+  check [ "gh"; "discussion"; "close"; "42" ] Shell_ir_risk.R1_Reversible_mutation;
+  check [ "gh"; "discussion"; "delete"; "42" ] Shell_ir_risk.R2_Irreversible
 ;;
 
 (* Ledger ratchet: exact distribution over the corpus. A slice that fixes
@@ -257,14 +259,14 @@ let test_ledger () =
     (List.length corpus) r0 r1 r2 dp policy_as_risk unknown_permissive
     fail_closed_opinion;
   Alcotest.(check int) "corpus size" 32 (List.length corpus);
-  (* W1 delta vs W0 baseline: 3 wholly-unknown gh areas moved R0->R2 as a
-     fail-closed typed opinion (R0 10->7, R2 17->20), leaving 1 residual
-     unknown-permissive (known-family unknown-action, deferred to W3). *)
+  (* W4/G-9 delta vs W1: the 9 policy-as-risk cases moved R2->R1 (repo
+     create/fork, discussion create/comment/edit/close, graphql create x3), so
+     R1 5->14, R2 20->11, and policy_as_risk 9->0 — the #23362 defect is closed. *)
   Alcotest.(check int) "R0 count" 7 r0;
-  Alcotest.(check int) "R1 count" 5 r1;
-  Alcotest.(check int) "R2 count" 20 r2;
+  Alcotest.(check int) "R1 count" 14 r1;
+  Alcotest.(check int) "R2 count" 11 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
-  Alcotest.(check int) "defect: policy-as-risk" 9 policy_as_risk;
+  Alcotest.(check int) "defect: policy-as-risk (CLOSED by W4)" 0 policy_as_risk;
   Alcotest.(check int) "defect: unknown-permissive (residual)" 1
     unknown_permissive;
   Alcotest.(check int) "W1: fail-closed opinion" 3 fail_closed_opinion

--- a/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
+++ b/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
@@ -19,10 +19,10 @@ let cases : case list = [
   { label = "baseline-pr-list";          input = "pr list --state open";          expected = E_R0 };
   { label = "baseline-pr-create";        input = "pr create --title T";            expected = E_R1 };
   { label = "baseline-pr-merge";         input = "pr merge 123";                   expected = E_R2 };
-  { label = "baseline-repo-create";      input = "repo create owner/new-repo";      expected = E_R2 };
-  { label = "baseline-repo-fork";        input = "repo fork owner/repo";            expected = E_R2 };
+  { label = "baseline-repo-create";      input = "repo create owner/new-repo";      expected = E_R1 };  (* W4/G-9: reversible; capability axis gates *)
+  { label = "baseline-repo-fork";        input = "repo fork owner/repo";            expected = E_R1 };  (* W4/G-9 *)
   { label = "baseline-repo-delete";      input = "repo delete o/r --yes";          expected = E_R2 };
-  { label = "baseline-discussion-create";input = "discussion create --title T";     expected = E_R2 };
+  { label = "baseline-discussion-create";input = "discussion create --title T";     expected = E_R1 };  (* W4/G-9 *)
 
   { label = "flag-no-space-XDELETE";     input = "api -XDELETE /repos/o/r";        expected = E_R2 };
   { label = "flag-equals-method";        input = "api --method=DELETE /repos/o/r"; expected = E_R2 };
@@ -35,8 +35,8 @@ let cases : case list = [
 
   { label = "graphql-deletePR";          input = "api graphql -f query=mutation{deletePullRequest}"; expected = E_R2 };
   { label = "graphql-purgeRepository";   input = "api graphql -f query=mutation{purgeRepository}";   expected = E_R2 };
-  { label = "graphql-createRepository";  input = "api graphql -f query=mutation{createRepository}";  expected = E_R2 };
-  { label = "graphql-createDiscussion";  input = "api graphql -f query=mutation{createDiscussion}";  expected = E_R2 };
+  { label = "graphql-createRepository";  input = "api graphql -f query=mutation{createRepository}";  expected = E_R1 };  (* W4/G-9: reversible *)
+  { label = "graphql-createDiscussion";  input = "api graphql -f query=mutation{createDiscussion}";  expected = E_R1 };  (* W4/G-9: reversible *)
 
   { label = "double-spaces-merge";       input = "pr  merge  123";                 expected = E_R2 };
   { label = "case-upper-cmd";            input = "PR LIST";                        expected = E_R0 };

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -228,6 +228,20 @@ let test_gh_r1_reversible () =
   check "gh pr reopen 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue create" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue edit 123" Shell_ir_risk.R1_Reversible_mutation;
+  (* RFC-0309 W4/G-9: repo create/fork and discussion mutations are reversible
+     (R1). The "keeper may not do this unsupervised" decision lives on the
+     capability axis (Requires_approval), not the risk floor. *)
+  check "gh repo create repo-name" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh repo fork owner/repo" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh discussion create --repo owner/repo --title T --body B"
+    Shell_ir_risk.R1_Reversible_mutation;
+  check "gh discussion comment 123 --body B" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh api graphql -f 'query=mutation{createRepository}'"
+    Shell_ir_risk.R1_Reversible_mutation;
+  check "gh api graphql -f 'query=mutation{createDiscussion}'"
+    Shell_ir_risk.R1_Reversible_mutation;
+  check "gh api graphql -f 'query=mutation{addDiscussionComment}'"
+    Shell_ir_risk.R1_Reversible_mutation;
   check "gh release create v1.0.0" Shell_ir_risk.R1_Reversible_mutation;
   check "gh release upload v1.0.0 file.tgz" Shell_ir_risk.R1_Reversible_mutation;
   check "gh run cancel 123" Shell_ir_risk.R1_Reversible_mutation;
@@ -252,14 +266,10 @@ let test_gh_r1_reversible () =
 let test_gh_r2_irreversible () =
   check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
   check "gh pr ready 123" Shell_ir_risk.R2_Irreversible;
-  check "gh repo create repo-name" Shell_ir_risk.R2_Irreversible;
-  check "gh repo fork owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo archive owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo transfer owner/repo" Shell_ir_risk.R2_Irreversible;
-  check "gh discussion create --repo owner/repo --title T --body B"
-    Shell_ir_risk.R2_Irreversible;
-  check "gh discussion comment 123 --body B" Shell_ir_risk.R2_Irreversible;
+  check "gh discussion delete 123" Shell_ir_risk.R2_Irreversible;
   check "gh release delete v1.0.0" Shell_ir_risk.R2_Irreversible;
   check "gh secret delete SECRET" Shell_ir_risk.R2_Irreversible;
   check "gh secret remove SECRET" Shell_ir_risk.R2_Irreversible;
@@ -271,12 +281,7 @@ let test_gh_r2_irreversible () =
   check "gh ruleset delete 123" Shell_ir_risk.R2_Irreversible;
   check "gh api repos/owner/repo -X DELETE" Shell_ir_risk.R2_Irreversible;
   check "gh api repos/owner/repo --method DELETE" Shell_ir_risk.R2_Irreversible;
-  check "gh api graphql -f 'query=mutation{createRepository}'" Shell_ir_risk.R2_Irreversible;
-  check "gh api graphql -f 'query=mutation{cloneTemplateRepository}'"
-    Shell_ir_risk.R2_Irreversible;
-  check "gh api graphql -f 'query=mutation{createDiscussion}'"
-    Shell_ir_risk.R2_Irreversible;
-  check "gh api graphql -f 'query=mutation{addDiscussionComment}'"
+  check "gh api graphql -f 'query=mutation{deleteDiscussion}'"
     Shell_ir_risk.R2_Irreversible
 ;;
 


### PR DESCRIPTION
## What

RFC-0309 **W4/G-9**: 키퍼의 repo 생성·Discussion을 **능동적으로 활성화**. #23362의 policy-as-risk 인코딩을 supersede.

> **Base**: W3(#23416) 스택. W3 머지 후 리뷰/머지. #23390 fix를 stack coherence를 위해 cherry-pick 포함.

- `lib/exec/shell_ir_risk.ml`: `repo create/fork`, 가역 discussion mutation(`create/comment/edit/close/reopen/lock/unlock/answer/unanswer`), graphql `create*`를 irreversible 테이블(R2)→reversible(R1)로 이동. 진짜 비가역만 R2 유지(`repo delete/archive/transfer/rename`, `discussion delete`, graphql `delete*`).
- 결과: risk 축이 사실을 진술(이들은 가역=R1), "무승인 금지" 결정은 capability 축(W2/W3)이 담당 → `Requires_approval → Verdict.Ask`. **autonomous 키퍼의 repo 생성/discussion이 auto-run(pre-#23362)도 disable(#23362)도 아닌 "승인 요청"으로** 흐름.

## Why (원 요구의 완성)

사용자 요구: "당연히 능동성을 원합니다." #23362는 안전을 위해 repo/discussion을 **비활성화**하면서 그 정책을 risk 분류기에 인코딩했습니다(가역 op를 R2로 라벨 — risk taxonomy가 사실을 진술하지 않게 됨). W0~W3가 세 축(risk × capability × disposition)을 분리하고 Ask 배선을 완성했으므로, 이제 W4가 #23362를 안전하게 되돌립니다:

- risk R2→R1: 사실 복원(created repo는 삭제 가능=가역).
- capability disposition: repo/discussion 가역 mutation은 durable-remote이므로 `Requires_approval`.
- decide(W3): `Requires_approval` → `Verdict.Ask` (autonomous overlay에서도).

**순서 안전성 충족**: G-9(활성)은 G-7(Ask 배선, W3) 이후 — RFC가 명시한 제약을 지킴. Ask 없이 활성화하면 auto-run 위험이었으나, W3가 선행 완료됨.

## Stack coherence — #23390 cherry-pick

구현 중 `gh --repo o/r pr view`가 R2로 오분류되는 실패를 만났습니다. 원인: W1의 fail-close(`Gh_verb.Other → R2`)가 leading-flag misparse(`--repo`를 subcommand로 오인, #23390 버그)와 결합. **W4 결함이 아니라 스택에 #23390이 빠진 것**이 원인이라, #23390 fix(PR #23400)를 cherry-pick해 정합성을 맞췄습니다(parse가 leading flag skip → read는 R0 유지). 최종 통합 순서상 어차피 필요합니다.

## 검증

- `test_approval_policy` all passed: repo/discussion create/fork → Ask(autonomous), 진짜 irreversible만 Deny, #23390 leading-flag regression 유지.
- baseline harness 4/4: **policy-as-risk 결함 count 9→0**(닫힘), R1 5→14, R2 20→11 (measured delta).
- capability policy 2/2(repo/discussion create → Requires_approval), top-level `test_shell_ir_risk` 10/10, differential/oracle PASS, 전체 `@lib/exec/test/runtest` green.
- keeper + main_eio 빌드 green. meta bug-class gate 로컬 PASS. lib-regression 0, ocamlformat clean.
- ⚠️ CI: repo Build and Test가 self-hosted 러너 **디스크 풀**로 repo-wide 다운(#23400 참조). CI Gate red 예상, 코드 무관 — 로컬 전체 검증으로 대체.

## 남은 것 (별도 후속)

이 PR은 **분류/정책 레이어**를 완성합니다. 진짜 end-to-end 능동 enable의 마지막 조각은 keeper-tool 레이어에서 `Ask`를 OAS Agent HITL hook에 배선(운영자 resolve→실행)하는 것 — 런타임/통합 테스트 필요(러너 복구 전제)로 별도 PR입니다. 그 전까지 gated op은 auto-run 안 하고 운영자에게 `Approval_required`로 보고됩니다.

## RFC

RFC-0309 §3.5 supersession + §4 G-9. `docs/design/keeper-github-repo-create-discussion-policy.md`(#23362)의 동작 결정을 supersede. W1(#23391)·W2(#23413)·W3(#23416) 위. 관련 #23390(#23400).

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update (`cc4f4b86c1`): graphql axis-symmetry P0 fixed

리뷰(#23424 adversarial)가 지적한 P0를 코드로 재현·수정했습니다. W4가 graphql `createRepository`/`createDiscussion`/`addDiscussionComment`를 R2→R1로 내리면서, body-blind `Gh_verb.Api`(RFC-0208)를 보는 capability 축이 `Allowed`를 반환 → typed `gh repo create`는 Ask하는데 동등한 `gh api graphql 'mutation{createRepository}'`는 autonomous에서 auto-run되던 비대칭 bypass.

- `Shell_ir_risk.gh_api_graphql_creates_durable_remote` (parser-owned body 스캔, graphql 토큰 가드)
- `Gh_capability_policy.disposition_of_words` (body-aware, additive: Allowed→Requires_approval만)
- `Approval_policy.decide`가 argv words 전달
- end-to-end `decide … autonomous = Ask` 회귀 테스트 3종 + capability 대칭 unit test
- risk 축 불변(createRepository=R1 유지), baseline 4/4

부수: #23390 leading-flag 테스트 중복(shadowing, 약한 사본) 제거 → 강한 원본 복원.

남은 REST POST durable-remote(`gh api -X POST /user/repos`)는 pre-existing gap으로 별도 이슈 #23445 기록.
