### PR TITLE
[codex] Make passive-only completion observable

### DIFF
--- a/lib/keeper/keeper_completion_contract_result_label.ml
+++ b/lib/keeper/keeper_completion_contract_result_label.ml
@@ -48,11 +48,11 @@ let requires_attention = function
   | Surface_mismatch
   | No_capable_provider
   | Claim_only_after_owned_task
-  | Needs_execution_progress
-  | Passive_only ->
+  | Needs_execution_progress ->
     true
   | Unknown
   | Not_dispatched
+  | Passive_only
   | Satisfied_completion
   | Satisfied_execution ->
     false

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -180,12 +180,12 @@ let completion_contract_satisfied = function
 let completion_contract_unsatisfied = function
   | Contract_violated
   | Contract_claim_only_after_owned_task
-  | Contract_needs_execution_progress
-  | Contract_passive_only -> true
+  | Contract_needs_execution_progress -> true
   | Contract_unknown
   | Contract_not_dispatched
   | Contract_surface_mismatch
   | Contract_no_capable_provider
+  | Contract_passive_only
   | Contract_satisfied_completion
   | Contract_satisfied_execution -> false
 ;;

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -541,28 +541,6 @@ let reaction_receipt_field name row =
   | None -> None
 ;;
 
-let reaction_field name row =
-  match assoc_field "reaction" row with
-  | Some reaction -> assoc_field name reaction
-  | None -> None
-;;
-
-let reaction_current_task_id row =
-  match reaction_field "current_task_id" row with
-  | Some (`String value) when String.trim value <> "" -> Some value
-  | _ -> None
-;;
-
-let reaction_goal_ids row =
-  match assoc_field "reaction" row with
-  | Some reaction -> string_list_field "goal_ids" reaction
-  | None -> []
-;;
-
-let passive_only_without_work_scope row =
-  Option.is_none (reaction_current_task_id row) && reaction_goal_ids row = []
-;;
-
 let summary_schema = "keeper.reaction_ledger.summary.v1"
 let fleet_summary_schema = "keeper.reaction_ledger.fleet_summary.v1"
 
@@ -882,9 +860,11 @@ let summarize_rows ~keeper_name ~limit rows =
   in
   let note_contract_attention_label ~result ~label =
     incr completion_contract_attention_count;
+    latest_completion_contract_attention := Some label
+  in
+  let note_contract_result_label ~result ~label =
     (match result with
-     | Receipt_result.Passive_only ->
-       incr completion_contract_passive_only_count
+     | Receipt_result.Passive_only -> incr completion_contract_passive_only_count
      | Receipt_result.Violated
      | Receipt_result.Surface_mismatch
      | Receipt_result.No_capable_provider
@@ -893,19 +873,17 @@ let summarize_rows ~keeper_name ~limit rows =
      | Receipt_result.Unknown
      | Receipt_result.Not_dispatched
      | Receipt_result.Satisfied_completion
-     | Receipt_result.Satisfied_execution ->
-       ());
+     | Receipt_result.Satisfied_execution -> ());
     increment_count completion_contract_result_counts label;
-    latest_completion_contract_attention := Some label
   in
-  let note_completion_contract_attention row =
+  let note_completion_contract_result row =
     match reaction_receipt_field "completion_contract_result" row with
     | Some result ->
       (match Receipt_result.of_string result with
        | Some typed ->
+         let label = Receipt_result.to_string typed in
+         note_contract_result_label ~result:typed ~label;
          (match contract_result_attention_of_typed typed with
-          | Contract_attention { result = Receipt_result.Passive_only; _ }
-            when passive_only_without_work_scope row -> ()
           | Contract_attention { result; label } ->
             note_contract_attention_label ~result ~label
           | Contract_no_attention -> ())
@@ -963,7 +941,7 @@ let summarize_rows ~keeper_name ~limit rows =
         incr reaction_count;
         note_reaction_time id (float_field "recorded_at_unix" row);
         note_reaction_kind (nested_string_field "reaction" "kind" row);
-        note_completion_contract_attention row;
+        note_completion_contract_result row;
         mark_reacted id
       | Some "cursor_ack", Some _id ->
         incr reaction_count;
@@ -978,7 +956,7 @@ let summarize_rows ~keeper_name ~limit rows =
       | Some "reaction", None ->
         incr reaction_count;
         note_reaction_kind (nested_string_field "reaction" "kind" row);
-        note_completion_contract_attention row
+        note_completion_contract_result row
       | Some "cursor_ack", None ->
         incr reaction_count;
         incr cursor_ack_count;

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -74,16 +74,6 @@ let terminal_reason_from_decision json =
           Keeper_turn_terminal.of_code ~source:"decision_log" code)
         (json_string_opt_member "terminal_reason_code" json)
 
-let receipt_passive_only_without_work_scope receipt =
-  match
-    json_string_opt_member "completion_contract_result" receipt
-    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
-  with
-  | Some "passive_only" ->
-      Option.is_none (json_string_opt_member "current_task_id" receipt)
-      && goal_ids_of_json receipt = []
-  | Some _ | None -> false
-
 let terminal_reason_from_receipt receipt =
   let terminal_reason_code = json_string_opt_member "terminal_reason_code" receipt in
   let operator_disposition_reason =
@@ -94,8 +84,6 @@ let terminal_reason_from_receipt receipt =
   let receipt_requires_tool_attention =
     match operator_disposition_reason, completion_contract_result with
     | Some "tool_route_recoverable_failure", _ -> true
-    | _, Some Completion_contract_result.Passive_only ->
-      not (receipt_passive_only_without_work_scope receipt)
     | _, Some result -> Completion_contract_result.requires_attention result
     | _ -> false
   in
@@ -127,14 +115,10 @@ let receipt_contract_attention_reason receipt =
     "completion_contract_result:" ^ Completion_contract_result.to_string result
   in
   match completion_contract_result with
-  | Some Completion_contract_result.Passive_only
-    when receipt_passive_only_without_work_scope receipt ->
-      None
   | Some
       ( Completion_contract_result.Violated
       | Completion_contract_result.Claim_only_after_owned_task
-      | Completion_contract_result.Needs_execution_progress
-      | Completion_contract_result.Passive_only as result ) ->
+      | Completion_contract_result.Needs_execution_progress as result ) ->
       Some (attention_reason result)
   | Some
       ( Completion_contract_result.Unknown

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -75,6 +75,16 @@ let check_member_string label expected key json =
   check string label expected (json |> member key |> to_string)
 ;;
 
+let result_count_by_label json label =
+  json
+  |> member "completion_contract_result_counts"
+  |> to_list
+  |> List.find_opt (fun item ->
+    match item |> member "result" with
+    | `String value -> String.equal value label
+    | _ -> false)
+;;
+
 let check_list_has_string label expected json =
   check bool label true
     (json
@@ -280,7 +290,7 @@ let test_execution_receipt_links_to_reaction_ledger () =
     (reaction |> member "receipt")
 ;;
 
-let test_summary_counts_completion_contract_attention_receipts () =
+let test_summary_observes_passive_only_without_attention () =
   with_temp_base @@ fun base_path ->
   let config = Workspace.default_config base_path in
   let keeper_name = "contract-attention-keeper" in
@@ -324,21 +334,25 @@ let test_summary_counts_completion_contract_attention_receipts () =
     ~current_task_id:"task-satisfied"
     ~completion_contract_result:"satisfied_execution"
     ();
+  record
+    ~trace_id:"trace-violated"
+    ~current_task_id:"task-violated"
+    ~completion_contract_result:"violated"
+    ();
   let summary =
     Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
   in
   check_member_string "contract summary remains mechanically ok" "ok" "status" summary;
-  check int "completion contract attention count" 2
+  check int "completion contract attention count" 1
     (summary |> member "completion_contract_attention_count" |> to_int);
-  check int "passive-only count" 2
+  check int "passive-only observation count" 2
     (summary |> member "completion_contract_passive_only_count" |> to_int);
-  check string "latest contract attention" "passive_only"
+  check string "latest contract attention" "violated"
     (summary |> member "latest_completion_contract_attention" |> to_string);
   let result_count =
-    summary
-    |> member "completion_contract_result_counts"
-    |> to_list
-    |> List.hd
+    match result_count_by_label summary "passive_only" with
+    | Some value -> value
+    | None -> fail "passive_only observation count missing"
   in
   check_member_string "contract result label" "passive_only" "result" result_count;
   check int "contract result count" 2 (result_count |> member "count" |> to_int);
@@ -348,9 +362,9 @@ let test_summary_counts_completion_contract_attention_receipts () =
       ~keeper_names:[ keeper_name ]
       ~limit_per_keeper:10
   in
-  check int "fleet contract attention count" 2
+  check int "fleet contract attention count" 1
     (fleet |> member "completion_contract_attention_count" |> to_int);
-  check int "fleet passive-only count" 2
+  check int "fleet passive-only observation count" 2
     (fleet |> member "completion_contract_passive_only_count" |> to_int);
   let keeper_attention =
     fleet
@@ -363,7 +377,7 @@ let test_summary_counts_completion_contract_attention_receipts () =
     keeper_name
     "keeper_name"
     keeper_attention;
-  check int "fleet keeper contract attention count" 2
+  check int "fleet keeper contract attention count" 1
     (keeper_attention |> member "completion_contract_attention_count" |> to_int)
 ;;
 
@@ -463,7 +477,7 @@ let test_completion_contract_result_canonical_roundtrip () =
     ; Receipt.Contract_no_capable_provider, true
     ; Receipt.Contract_claim_only_after_owned_task, true
     ; Receipt.Contract_needs_execution_progress, true
-    ; Receipt.Contract_passive_only, true
+    ; Receipt.Contract_passive_only, false
     ; Receipt.Contract_satisfied_completion, false
     ; Receipt.Contract_satisfied_execution, false
     ]
@@ -494,7 +508,7 @@ let test_completion_contract_result_canonical_roundtrip () =
      |> Option.map Receipt.completion_contract_result_to_string)
 ;;
 
-let test_summary_ignores_passive_only_without_work_scope () =
+let test_summary_observes_passive_only_without_work_scope_attention () =
   with_temp_base @@ fun base_path ->
   let config = Workspace.default_config base_path in
   let keeper_name = "passive-no-work-keeper" in
@@ -525,7 +539,7 @@ let test_summary_ignores_passive_only_without_work_scope () =
   in
   check int "passive-only no-work attention not counted" 0
     (summary |> member "completion_contract_attention_count" |> to_int);
-  check int "passive-only no-work passive count not counted" 0
+  check int "passive-only no-work observation counted" 1
     (summary |> member "completion_contract_passive_only_count" |> to_int);
   check
     string
@@ -540,7 +554,7 @@ let test_summary_ignores_passive_only_without_work_scope () =
   in
   check int "fleet passive-only no-work attention not counted" 0
     (fleet |> member "completion_contract_attention_count" |> to_int);
-  check int "fleet passive-only no-work passive count not counted" 0
+  check int "fleet passive-only no-work observation counted" 1
     (fleet |> member "completion_contract_passive_only_count" |> to_int)
 ;;
 
@@ -822,7 +836,7 @@ let test_no_progress_recovery_cursor_ack_does_not_clear_pending () =
     (cursor_only_summary |> member "cursor_swept_stimulus_count" |> to_int)
 ;;
 
-let test_summary_links_passive_only_attention_to_pending_recovery () =
+let test_summary_links_passive_only_observation_to_pending_recovery () =
   with_temp_base @@ fun base_path ->
   let config = Workspace.default_config base_path in
   let keeper_name = "passive-recovery-keeper" in
@@ -855,8 +869,10 @@ let test_summary_links_passive_only_attention_to_pending_recovery () =
   let summary =
     Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
   in
-  check int "passive-only attention counted" 1
+  check int "passive-only observation counted" 1
     (summary |> member "completion_contract_passive_only_count" |> to_int);
+  check int "passive-only does not count as attention" 0
+    (summary |> member "completion_contract_attention_count" |> to_int);
   check int "pending no-progress recovery counted" 1
     (summary |> member "pending_no_progress_recovery_count" |> to_int);
   let fleet =
@@ -865,8 +881,10 @@ let test_summary_links_passive_only_attention_to_pending_recovery () =
       ~keeper_names:[ keeper_name ]
       ~limit_per_keeper:10
   in
-  check int "fleet passive-only attention counted" 1
+  check int "fleet passive-only observation counted" 1
     (fleet |> member "completion_contract_passive_only_count" |> to_int);
+  check int "fleet passive-only does not count as attention" 0
+    (fleet |> member "completion_contract_attention_count" |> to_int);
   check int "fleet pending no-progress recovery counted" 1
     (fleet |> member "pending_no_progress_recovery_count" |> to_int);
   let recovery_keeper =
@@ -1327,9 +1345,9 @@ let () =
             `Quick
             test_execution_receipt_links_to_reaction_ledger
         ; test_case
-            "summary counts completion-contract attention receipts"
+            "summary observes passive-only without attention"
             `Quick
-            test_summary_counts_completion_contract_attention_receipts
+            test_summary_observes_passive_only_without_attention
         ; test_case
             "summary degrades unknown completion-contract result"
             `Quick
@@ -1339,9 +1357,9 @@ let () =
             `Quick
             test_completion_contract_result_canonical_roundtrip
         ; test_case
-            "summary ignores passive-only receipts without work scope"
+            "summary observes passive-only without work-scope attention"
             `Quick
-            test_summary_ignores_passive_only_without_work_scope
+            test_summary_observes_passive_only_without_work_scope_attention
         ; test_case
             "summary marks unreacted and reacted stimuli"
             `Quick
@@ -1371,9 +1389,9 @@ let () =
             `Quick
             test_no_progress_recovery_cursor_ack_does_not_clear_pending
         ; test_case
-            "summary links passive-only attention to pending recovery"
+            "summary links passive-only observation to pending recovery"
             `Quick
-            test_summary_links_passive_only_attention_to_pending_recovery
+            test_summary_links_passive_only_observation_to_pending_recovery
         ; test_case
             "fleet summary surfaces durable event queue backlog"
             `Quick

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -421,6 +421,56 @@ let test_passive_only_no_work_receipt_does_not_mark_attention () =
           | _ -> false))
 ;;
 
+let test_passive_only_active_receipt_does_not_mark_attention () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       init_runtime_default_for_tests ();
+       let keeper_name = "runtime-trust-passive-only-active-task" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "passive_no_action"
+             ; "terminal_reason_code", `String "completed"
+             ; "completion_contract_result", `String "passive_only"
+             ; "current_task_id", `String "task-1844"
+             ; "goal_ids", `List [ `String "goal-pm-flow" ]
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "display disposition"
+         "Pass"
+         (snapshot |> member "disposition" |> to_string);
+       Alcotest.(check string)
+         "display reason"
+         "healthy"
+         (snapshot |> member "disposition_reason" |> to_string);
+       Alcotest.(check bool)
+         "needs attention"
+         false
+         (snapshot |> member "needs_attention" |> to_bool);
+       Alcotest.(check bool)
+         "attention reason omitted"
+         true
+         (match snapshot |> member "attention_reason" with
+          | `Null -> true
+          | _ -> false))
+;;
+
 let test_completion_blocker_supersedes_passive_only_receipt () =
   Eio_main.run
   @@ fun env ->
@@ -770,6 +820,10 @@ let () =
             "passive-only no-work receipt does not mark attention"
             `Quick
             test_passive_only_no_work_receipt_does_not_mark_attention
+        ; Alcotest.test_case
+            "passive-only active receipt does not mark attention"
+            `Quick
+            test_passive_only_active_receipt_does_not_mark_attention
         ; Alcotest.test_case
             "runtime blocker supersedes passive-only receipt"
             `Quick

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -698,7 +698,7 @@ let test_attention_checkpoint_prunes_current_turn_suffix () =
     .checkpoint_for_replay_persistence
       ~history_messages:[ old_user; old_assistant ]
       ~pre_turn_working_context
-      ~completion_contract_result:Receipt.Contract_passive_only
+      ~completion_contract_result:Receipt.Contract_violated
       ~session_id:"new-session"
       ~response_text:"synthetic no-progress"
       ~state_snapshot_source:KMP.State_block
@@ -735,7 +735,7 @@ let test_attention_checkpoint_refuses_mismatched_history_prefix () =
     .checkpoint_for_replay_persistence
       ~history_messages:[ expected_old_user; old_assistant ]
       ~pre_turn_working_context:(Some (`Assoc [ "pre_turn", `Bool true ]))
-      ~completion_contract_result:Receipt.Contract_passive_only
+      ~completion_contract_result:Receipt.Contract_violated
       ~session_id:"new-session"
       ~response_text:"synthetic no-progress"
       ~state_snapshot_source:KMP.State_block
@@ -1019,7 +1019,7 @@ let test_attention_contract_does_not_resume_working_state_digest () =
       ~pre_dispatch_compacted:false
       ~state_snapshot_source:KMP.Synthesized
       ~stop_reason:Runtime_agent.Completed
-      ~completion_contract_result:Receipt.Contract_passive_only
+      ~completion_contract_result:Receipt.Contract_violated
   in
   Alcotest.(check bool)
     "attention contract does not restore prior prompt-digest loops"
@@ -1036,6 +1036,19 @@ let test_attention_contract_does_not_resume_working_state_digest () =
     "budget checkpoint still resumes prior prompt-digest loops"
     true
     budget_resume
+
+let test_passive_only_contract_resumes_working_state_digest () =
+  let passive_resume =
+    Finalize.should_resume_merge
+      ~pre_dispatch_compacted:false
+      ~state_snapshot_source:KMP.Synthesized
+      ~stop_reason:Runtime_agent.Completed
+      ~completion_contract_result:Receipt.Contract_passive_only
+  in
+  Alcotest.(check bool)
+    "passive-only does not block working-state resume"
+    true
+    passive_resume
 
 let test_synthetic_finalizer_preserves_generated_response_text () =
   let raw_response_text =
@@ -1089,7 +1102,7 @@ let test_contract_attention_finalizer_drops_raw_response_text () =
       ~keeper_name:"albini"
       ~goal:"PM flow"
       ~actual_keeper_tool_names:["keeper_context_status"]
-      ~completion_contract_result:Receipt.Contract_passive_only
+      ~completion_contract_result:Receipt.Contract_violated
       ~stop_reason:Runtime_agent.Completed
       ~raw_response_text
       ()
@@ -1451,6 +1464,10 @@ let () =
             "attention result does not resume working-state digest"
             `Quick
             test_attention_contract_does_not_resume_working_state_digest;
+          Alcotest.test_case
+            "passive-only result resumes working-state digest"
+            `Quick
+            test_passive_only_contract_resumes_working_state_digest;
           Alcotest.test_case
             "synthetic finalizer preserves generated response text"
             `Quick


### PR DESCRIPTION
## What changed

- Reclassifies `completion_contract_result=passive_only` as observable telemetry rather than an attention-required completion-contract result.
- Stops runtime trust snapshots from converting passive-only receipts into `completion_contract_result:passive_only` attention reasons, even when a task or goal scope is present.
- Keeps passive-only visible in reaction-ledger observation counts while excluding it from completion-contract attention counts.
- Updates checkpoint/finalizer tests so true attention examples use `violated`, while passive-only is covered as non-blocking.

## Why

`passive_only` means a turn only produced passive/status evidence. That is useful to observe, but it should not itself block, page, prune replay, or become operator-facing attention. Repeated lack of useful progress should be handled by no-progress detection instead.

## Validation

- `MASC_SKIP_OCAML_VERSION_CHECK=1 scripts/dune-local.sh build test/test_keeper_reaction_ledger.exe test/test_keeper_runtime_trust_snapshot.exe test/test_keeper_state_snapshot_json.exe test/test_keeper_terminal_reason_typed.exe`
- `./_build/default/test/test_keeper_reaction_ledger.exe`
- `./_build/default/test/test_keeper_runtime_trust_snapshot.exe`
- `./_build/default/test/test_keeper_state_snapshot_json.exe`
- `./_build/default/test/test_keeper_terminal_reason_typed.exe`
- `git diff --check HEAD~1..HEAD`
- `git diff --name-only -z HEAD~1..HEAD -- '*.ml' '*.mli' | xargs -0 -I{} opam exec -- ocamlformat --check {}`