### PR TITLE
fix: restore main Build and Test — memory-os horizon/identity SSOT, gh floor (#23400 absorbed), hermetic installer test

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -4188,11 +4188,19 @@ let rec parse subcmd act draft squash del_branch body title search state rest = 
                }))
      | None -> None)
   | arg :: args ->
-    (match subcmd with
-     | None -> parse (Some arg) act draft squash del_branch body title search state rest args
-     | Some _ when act = None && String.length arg > 0 && arg.[0] <> '-' ->
+    let is_flag = String.length arg > 0 && arg.[0] = '-' in
+    (match subcmd, act with
+     (* First non-flag token is the subcommand; the second is the action.
+        Flags — whether they appear BEFORE the subcommand (gh/Cobra accepts
+        global flags like [--repo o/r] ahead of the subcommand) or after it —
+        fall through to the flag handling below, which consumes value-taking
+        flags. Routing leading flags through the same handling keeps the real
+        subcommand from being shadowed by a flag or its value (issue #23390). *)
+     | None, _ when not is_flag ->
+       parse (Some arg) act draft squash del_branch body title search state rest args
+     | Some _, None when not is_flag ->
        parse subcmd (Some arg) draft squash del_branch body title search state rest args
-     | Some _ ->
+     | _ ->
        (match arg with
         | "--draft" -> parse subcmd act true squash del_branch body title search state rest args
         | "--squash" -> parse subcmd act draft true del_branch body title search state rest args

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -164,7 +164,22 @@ let repo_hosting_cli_is_floored (bin : Exec_program.t) (args : Shell_ir.arg list
   match Exec_program.known bin with
   | Some Exec_program.Gh ->
     let words = Exec_program.to_string bin :: List.map repo_hosting_arg_word args in
-    (match Shell_ir_risk.classify_repo_hosting_cli words with
+    (* Classify through [repo_hosting_cli_floor_risk], not the word-list
+       classifier alone: a leading value-taking global flag ([gh --repo o/r pr
+       merge]) shifts the subcommand out of the word-list's position-based
+       slot, so the naive classifier misses the destructive verb and the floor
+       never fires (issue #23390). The typed lowering consumes value-flags like
+       gh does, locating the real subcommand. *)
+    let simple : Shell_ir.simple =
+      { Shell_ir.bin
+      ; args
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Sandbox_target.host ()
+      }
+    in
+    (match Shell_ir_risk.repo_hosting_cli_floor_risk words simple with
      | R2_Irreversible | Destructive_protected -> true
      | R0_Read | R1_Reversible_mutation -> false)
   | Some _ | None -> false

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -478,6 +478,18 @@ let classify_repo_hosting_cli (words : string list) : risk_class =
     else if in_table repo_hosting_cli_reversible_mutations command sub then R1_Reversible_mutation
     else R0_Read
 
+(* Subcommand-table risk for a known gh family. Shared by [risk_of_gh_verb]
+   (typed opinion) and [repo_hosting_cli_floor_risk] (enforcement floor) so the
+   subcommand tables are the single risk source. A table-absent action is a
+   read (R0): most such actions in a known family are reads (view/list/status)
+   and we cannot distinguish them from a genuinely unknown action without a
+   reads table. *)
+let table_risk_of_gh_family (command : string) (action : string) : risk_class =
+  if in_table repo_hosting_cli_irreversible_ops command action then R2_Irreversible
+  else if in_table repo_hosting_cli_reversible_mutations command action then
+    R1_Reversible_mutation
+  else R0_Read
+
 (* RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
 
    [risk_of_gh_verb] is the closed-sum lens over [classify_repo_hosting_cli]:
@@ -521,13 +533,7 @@ let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
        default so the "no action" case is a decision, not a silent fold. *)
     (match v.Gh_verb.action with
      | None -> R0_Read
-     | Some action ->
-       let command = Gh_verb.family_token fam in
-       if in_table repo_hosting_cli_irreversible_ops command action then
-         R2_Irreversible
-       else if in_table repo_hosting_cli_reversible_mutations command action
-       then R1_Reversible_mutation
-       else R0_Read)
+     | Some action -> table_risk_of_gh_family (Gh_verb.family_token fam) action)
 
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)
@@ -946,6 +952,54 @@ let risk_rank = function
 ;;
 
 let max_risk a b = if risk_rank a >= risk_rank b then a else b
+
+(* Enforcement-floor risk for a gh command, robust to leading global flags.
+
+   [classify_repo_hosting_cli] locates the subcommand as the first non-flag
+   token after "gh", so a leading value-taking global flag ([gh --repo o/r pr
+   merge]) shifts the flag's value ("o/r") into the subcommand slot and the
+   destructive verb ("merge") is missed — the command classifies R0 and the
+   approval catastrophic floor never fires (issue #23390: gh accepts flags
+   before the subcommand via Cobra, so the op executes). This is the floor's
+   SSOT for gh risk, so the miss is an autonomous-keeper bypass.
+
+   Fix: combine two views with [max_risk].
+   - [words]: the existing word-list classifier — retains the string-borne
+     risk it alone sees ([gh api -X DELETE], graphql mutation bodies,
+     positional-token scans).
+   - [simple]: the typed lowering ([Shell_ir_typed.of_simple], whose gh parser
+     consumes value-flags exactly like gh) yields the correctly-located
+     subcommand; [table_risk_of_gh_family] then reads the same subcommand
+     tables. [Api]/[Other]/bare family stay R0 here — this fix restores correct
+     subcommand location WITHOUT changing the historical "unknown gh subcommand
+     is R0" floor semantics (fail-closing unknown gh is RFC-0309 W3, not this
+     bug fix). *)
+let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
+  : risk_class
+  =
+  let word_risk = classify_repo_hosting_cli words in
+  let typed_risk =
+    (* [@warning "-4"]: only the [Gh] constructor is of interest; every other
+       typed command (and the [Generic] escape hatch for non-literal argv) is
+       not a repo-hosting op, so it floors nothing here and the word-list path
+       above already covers it. Same find-first rationale as
+       [Approval_policy.find_destructive_repo_hosting_cli]. *)
+    match Shell_ir_typed.of_simple simple with
+    | Shell_ir_typed.W (Shell_ir_typed_types.Gh { subcommand; action; _ }) -> (
+      let v = Gh_verb.of_fields ~subcommand ~action in
+      match v.Gh_verb.family, v.Gh_verb.action with
+      | (Gh_verb.Api | Gh_verb.Other _), _ | _, None -> R0_Read
+      | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+          | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key
+          | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset
+          | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as
+        fam )
+      , Some action ->
+        table_risk_of_gh_family (Gh_verb.family_token fam) action)
+    | Shell_ir_typed.W _ -> R0_Read
+  in
+  max_risk word_risk typed_risk
+[@@warning "-4"]
 
 let redirect_risk = function
   | Redirect_scope.File { mode = (Redirect_scope.Write | Redirect_scope.Append); _ } ->

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -213,7 +213,38 @@ let gh_floor_words_of_simple (simple : Shell_ir.simple) =
          | None -> collect ("" :: acc) rest)
     in
     collect [] simple.args
-  | Some _ | None -> None
+  | Some
+      ( Exec_program.Ls | Exec_program.Cat | Exec_program.Pwd | Exec_program.Echo
+      | Exec_program.Head | Exec_program.Tail | Exec_program.Rg | Exec_program.Grep
+      | Exec_program.Find | Exec_program.Which | Exec_program.Test
+      | Exec_program.Basename | Exec_program.Dirname | Exec_program.Stat
+      | Exec_program.Du | Exec_program.Df | Exec_program.Sort | Exec_program.Uniq
+      | Exec_program.Wc | Exec_program.Cut | Exec_program.Tr | Exec_program.File
+      | Exec_program.Printf | Exec_program.Date | Exec_program.Env
+      | Exec_program.Printenv | Exec_program.Hostname | Exec_program.Whoami
+      | Exec_program.Uname | Exec_program.Ps | Exec_program.Tty | Exec_program.Cp
+      | Exec_program.Mv | Exec_program.Ln | Exec_program.Touch | Exec_program.Tee
+      | Exec_program.Awk | Exec_program.Xargs | Exec_program.Git
+      | Exec_program.Docker | Exec_program.Curl | Exec_program.Wget | Exec_program.Ssh
+      | Exec_program.Scp | Exec_program.Tar | Exec_program.Rsync | Exec_program.Make
+      | Exec_program.Cmake | Exec_program.Dune_local_sh | Exec_program.Diff
+      | Exec_program.Patch | Exec_program.Mkdir | Exec_program.Npm | Exec_program.Node
+      | Exec_program.Npx | Exec_program.Yarn | Exec_program.Pnpm | Exec_program.Pip
+      | Exec_program.Python | Exec_program.Python3 | Exec_program.Pytest
+      | Exec_program.Pyright | Exec_program.Ruff | Exec_program.Opam
+      | Exec_program.Ocamlfind | Exec_program.Tsc | Exec_program.Cargo
+      | Exec_program.Rustc | Exec_program.Go | Exec_program.Gofmt | Exec_program.Gradle
+      | Exec_program.Java | Exec_program.Javac | Exec_program.Mvn | Exec_program.Ninja
+      | Exec_program.Sed | Exec_program.Uv | Exec_program.Glab
+      | Exec_program.Terminal_notifier | Exec_program.Osascript | Exec_program.Play
+      | Exec_program.Rec | Exec_program.Ffplay | Exec_program.Mpg123 | Exec_program.Open
+      | Exec_program.Psql | Exec_program.Mysql | Exec_program.Mariadb
+      | Exec_program.Cockroach | Exec_program.Sudo | Exec_program.Su
+      | Exec_program.Chmod | Exec_program.Chown | Exec_program.Rm | Exec_program.Dd
+      | Exec_program.Mkfs | Exec_program.Shutdown | Exec_program.Reboot
+      | Exec_program.Halt | Exec_program.Poweroff ) ->
+    None
+  | None -> None
 ;;
 
 let normalize_command_words words =

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -166,6 +166,56 @@ let rec skip_gh_global_options = function
   | parts -> parts
 ;;
 
+let shell_arg_literal = function
+  | Shell_ir.Lit (s, _) -> Some s
+  | Shell_ir.Var _ | Shell_ir.Concat _ -> None
+;;
+
+let gh_global_value_option = function
+  | "--repo" | "-R" | "--hostname" | "--config" | "--git-protocol" -> true
+  | _ -> false
+;;
+
+let gh_global_bool_option = function
+  | "--help" | "-h" | "--version" | "--debug" | "--verbose" | "--no-color"
+  | "--paginate" ->
+    true
+  | _ -> false
+;;
+
+let gh_global_eq_value_option opt =
+  String.length opt > 1
+  && opt.[0] = '-'
+  && (String.starts_with ~prefix:"--repo=" opt
+      || String.starts_with ~prefix:"-R=" opt
+      || String.starts_with ~prefix:"--hostname=" opt
+      || String.starts_with ~prefix:"--config=" opt
+      || String.starts_with ~prefix:"--git-protocol=" opt)
+;;
+
+let gh_floor_words_of_simple (simple : Shell_ir.simple) =
+  match Exec_program.known simple.bin with
+  | Some Exec_program.Gh ->
+    let rec collect acc = function
+      | [] -> Some (Exec_program.to_string simple.bin :: List.rev acc)
+      | arg :: rest ->
+        (match shell_arg_literal arg with
+         | Some opt when gh_global_value_option opt ->
+           let rest =
+             match rest with
+             | [] -> []
+             | _value :: rest -> rest
+           in
+           collect acc rest
+         | Some opt when gh_global_bool_option opt || gh_global_eq_value_option opt ->
+           collect acc rest
+         | Some word -> collect (word :: acc) rest
+         | None -> collect ("" :: acc) rest)
+    in
+    collect [] simple.args
+  | Some _ | None -> None
+;;
+
 let normalize_command_words words =
   match strip_env_prefix words with
   | "git" :: rest -> "git" :: skip_git_global_options rest
@@ -963,10 +1013,13 @@ let max_risk a b = if risk_rank a >= risk_rank b then a else b
    before the subcommand via Cobra, so the op executes). This is the floor's
    SSOT for gh risk, so the miss is an autonomous-keeper bypass.
 
-   Fix: combine two views with [max_risk].
+   Fix: combine three views with [max_risk].
    - [words]: the existing word-list classifier — retains the string-borne
      risk it alone sees ([gh api -X DELETE], graphql mutation bodies,
-     positional-token scans).
+     positional-token scans) when argv is all literal.
+   - [simple] arg words: an enforcement-only view that consumes known gh global
+     value flags directly from [Shell_ir.arg], so dynamic flag values cannot
+     shadow the real family/action slot.
    - [simple]: the typed lowering ([Shell_ir_typed.of_simple], whose gh parser
      consumes value-flags exactly like gh) yields the correctly-located
      subcommand; [table_risk_of_gh_family] then reads the same subcommand
@@ -978,6 +1031,11 @@ let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
   : risk_class
   =
   let word_risk = classify_repo_hosting_cli words in
+  let arg_word_risk =
+    match gh_floor_words_of_simple simple with
+    | Some words -> classify_repo_hosting_cli words
+    | None -> R0_Read
+  in
   let typed_risk =
     (* [@warning "-4"]: only the [Gh] constructor is of interest; every other
        typed command (and the [Generic] escape hatch for non-literal argv) is
@@ -998,7 +1056,7 @@ let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
         table_risk_of_gh_family (Gh_verb.family_token fam) action)
     | Shell_ir_typed.W _ -> R0_Read
   in
-  max_risk word_risk typed_risk
+  max_risk word_risk (max_risk arg_word_risk typed_risk)
 [@@warning "-4"]
 
 let redirect_risk = function

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -93,9 +93,11 @@ val classify_repo_hosting_cli : string list -> risk_class
 val repo_hosting_cli_floor_risk : string list -> Shell_ir.simple -> risk_class
 (** Enforcement-floor risk for a gh command, robust to leading global flags
     (issue #23390). [max] of [classify_repo_hosting_cli words] (string-borne
-    risk: [gh api -X DELETE], graphql bodies) and the typed lowering of
-    [simple] (whose gh parser consumes value-flags like gh, so the subcommand
-    is located correctly even after [gh --repo o/r pr merge]). Keeps the
+    risk: [gh api -X DELETE], graphql bodies), an enforcement-only [simple]
+    arg view that consumes known gh global value flags even when their values
+    are dynamic, and the typed lowering of [simple] (whose gh parser consumes
+    literal value-flags like gh, so the subcommand is located correctly even
+    after [gh --repo o/r pr merge]). Keeps the
     historical floor semantics — unrecognized gh subcommand / [Api] / bare
     family stay [R0_Read]; fail-closing unknown gh is RFC-0309 W3, not here.
     Used by [Approval_policy.repo_hosting_cli_is_floored]. *)

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -90,6 +90,16 @@ val classify_repo_hosting_cli : string list -> risk_class
     The current command literal is ["gh"], but the API is named for the
     Shell-IR capability boundary rather than a product-level GH helper family. *)
 
+val repo_hosting_cli_floor_risk : string list -> Shell_ir.simple -> risk_class
+(** Enforcement-floor risk for a gh command, robust to leading global flags
+    (issue #23390). [max] of [classify_repo_hosting_cli words] (string-borne
+    risk: [gh api -X DELETE], graphql bodies) and the typed lowering of
+    [simple] (whose gh parser consumes value-flags like gh, so the subcommand
+    is located correctly even after [gh --repo o/r pr merge]). Keeps the
+    historical floor semantics — unrecognized gh subcommand / [Api] / bare
+    family stay [R0_Read]; fail-closing unknown gh is RFC-0309 W3, not here.
+    Used by [Approval_policy.repo_hosting_cli_is_floored]. *)
+
 val risk_of_gh_verb : Gh_verb.t -> risk_class
 (** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
     Reads the same subcommand tables as [classify_repo_hosting_cli] for known

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -393,6 +393,48 @@ let test_gh_reversible_repo_hosting_ops_allowed_under_autonomous () =
   | Verdict.Allow t -> assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
   | _ -> Alcotest.fail "gh pr create should remain allowed under autonomous"
 
+(* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
+   pr merge]) must not slip the destructive op past the floor. gh (Cobra)
+   accepts flags before the subcommand and consumes their values, so the
+   word-list classifier's position-based subcommand slot is wrong; the typed
+   lowering locates the real subcommand. *)
+let test_gh_leading_flag_destructive_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: leading-flag destructive op must be floored" label)
+    [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
+    ; "gh --repo o/r pr ready", [ "--repo"; "o/r"; "pr"; "ready"; "123" ]
+    ; "gh --repo o/r repo delete"
+      , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
+    ]
+
+(* Control: a leading global flag on a READ must NOT be over-blocked — the fix
+   restores correct subcommand location without flooring reads. *)
+let test_gh_leading_flag_read_not_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
+         Alcotest.failf "%s: leading-flag read must not be floored" label
+       | _ -> ())
+    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
+    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    ]
+
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
    common force-delete-untracked form) is destructive and hits the floor.
    Probe finding 2026-06-18: [git clean -fd] was graded as plain audited git
@@ -502,6 +544,8 @@ let () =
   test_gh_irreversible_repo_hosting_ops_denied_under_autonomous ();
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
+  test_gh_leading_flag_destructive_floored_under_autonomous ();
+  test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -417,12 +417,35 @@ let test_gh_leading_flag_destructive_floored_under_autonomous () =
       , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
     ]
 
+let test_gh_leading_dynamic_flag_destructive_floored_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: dynamic leading-flag destructive op must be floored" label)
+    [ ( "gh --repo $REPO pr merge"
+      , [ lit "--repo"; var "REPO"; lit "pr"; lit "merge"; lit "5" ] )
+    ; ( "gh --repo o/r pr merge $PR_NUMBER"
+      , [ lit "--repo"; lit "o/r"; lit "pr"; lit "merge"; var "PR_NUMBER" ] )
+    ; ( "gh --hostname $HOST api -X DELETE"
+      , [ lit "--hostname"; var "HOST"; lit "api"; lit "-X"; lit "DELETE"
+        ; lit "/repos/owner/repo"
+        ] )
+    ]
+
 (* Control: a leading global flag on a READ must NOT be over-blocked — the fix
    restores correct subcommand location without flooring reads. *)
 let test_gh_leading_flag_read_not_floored_under_autonomous () =
   List.iter
     (fun (label, args) ->
-       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let s = simple (bin_ok "gh") ~args in
        let caps = Capability_check.of_simple s in
        match
          Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
@@ -431,8 +454,10 @@ let test_gh_leading_flag_read_not_floored_under_autonomous () =
        | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } ->
          Alcotest.failf "%s: leading-flag read must not be floored" label
        | _ -> ())
-    [ "gh --repo o/r pr view", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
-    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    [ "gh --repo o/r pr view", [ lit "--repo"; lit "o/r"; lit "pr"; lit "view"; lit "123" ]
+    ; "gh --repo o/r pr list", [ lit "--repo"; lit "o/r"; lit "pr"; lit "list" ]
+    ; ( "gh --repo $REPO pr view $PR_NUMBER"
+      , [ lit "--repo"; var "REPO"; lit "pr"; lit "view"; var "PR_NUMBER" ] )
     ]
 
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
@@ -545,6 +570,7 @@ let () =
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
   test_gh_leading_flag_destructive_floored_under_autonomous ();
+  test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -24,11 +24,14 @@ type indexed_fact =
   ; fact : fact
   }
 
-let ttl_expired ~now (fact : fact) =
-  match fact.valid_until with
-  | None -> false
-  | Some ts -> now > ts
-;;
+(* Retention boundary SSOT: the writer cap ([partition_expired]) and recall
+   both expire through [fact_is_current], whose [fact_effective_valid_until]
+   also derives the RFC-0259 P7 horizon for legacy [External_state] facts with
+   no explicit [valid_until]. Matching raw [fact.valid_until] here left GC
+   blind to that horizon — the memory-os sanity sweep asserts GC and sweep
+   agree, which broke main on 2026-07-06 (#23384). Same boundary at equality:
+   [ts >= now] current ⇔ [now > ts] expired. *)
+let ttl_expired ~now (fact : fact) = not (fact_is_current ~now fact)
 
 let bump_count key counts =
   let current =
@@ -107,8 +110,9 @@ let dedup_by_claim items =
 ;;
 
 (* RFC-0247 (purge): GC is now two structural passes only — hard-expire facts
-   past their [valid_until] horizon (a typed decision: Ephemeral TTL or
-   self-observation TTL), then dedup duplicate claims keeping the most-recently-verified.
+   past their effective horizon ([fact_effective_valid_until]: explicit
+   [valid_until], or the RFC-0259 P7 legacy [External_state] horizon), then
+   dedup duplicate claims keeping the most-recently-verified.
    The score-threshold
    discard ([decide_retention] on [score_fact <= 0.02]) was removed: a fact's
    value is not a number GC can threshold. Forgetting is the librarian's

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -15,10 +15,15 @@ type gc_report =
 
 exception Fact_store_corrupt of string
 
+(** [ttl_expired ~now fact] is [not (fact_is_current ~now fact)]: expiry runs
+    on the same effective horizon ([fact_effective_valid_until] — explicit
+    [valid_until], or the RFC-0259 P7 legacy [External_state] horizon) that the
+    writer cap ([partition_expired]) and recall use, so cap, recall, and GC
+    cannot disagree on what is expired. *)
 val ttl_expired : now:float -> fact -> bool
 
 (** Run the deterministic forgetting sweep for one keeper: hard-expire facts past
-    their Ephemeral TTL, then dedup duplicate claims keeping the
+    their effective horizon, then dedup duplicate claims keeping the
     most-recently-verified, and (unless [dry_run]) rewrite the store atomically.
 
     The whole read-modify-rewrite runs under [File_lock_eio.with_lock] on the

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -566,9 +566,10 @@ let read_facts_for_rewrite ~keeper_id =
 let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
   let path = facts_path ~keeper_id in
   let all = read_facts_for_rewrite ~keeper_id in
-  (* RFC-0259 §3.6 (P5): drop [valid_until]-expired rows before the trigger gate
+  (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows before the trigger gate
      and before ranking, so an under-cap store does not retain expired rows on
-     disk until the off-by-default GC sweep. Durable facts are never expired. *)
+     disk until the off-by-default GC sweep. Facts with no effective horizon
+     ([Keeper_memory_os_types.fact_effective_valid_until]) are never expired. *)
   let live, expired = partition_expired ~now all in
   let total = List.length live in
   if expired = [] && total <= trigger
@@ -647,11 +648,11 @@ let merge_episode_facts ~merge ~existing ~incoming =
 let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
   let existing = read_facts_for_rewrite ~keeper_id in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
-  (* RFC-0259 §3.6 (P5): drop [valid_until]-expired rows on the same boundary the
+  (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
      does not retain expired rows on disk. Expired rows are counted in [dropped]
-     alongside rank evictions. Durable facts ([valid_until = None]) are never
-     expired, so durable knowledge is never evicted here. *)
+     alongside rank evictions. Facts with no effective horizon (see
+     [Keeper_memory_os_types.fact_effective_valid_until]) are never expired, so durable knowledge is never evicted here. *)
   let live, expired = partition_expired ~now merged_list in
   let total = List.length live in
   let no_incoming = match incoming with [] -> true | _ :: _ -> false in

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -393,13 +393,15 @@ let fact_prompt_recallable (fact : fact) =
 ;;
 
 (* RFC-0259 §3.6 (P5): split a fact list into (live, expired-at-[now]) on the
-   typed [valid_until] boundary. The cap path ([Keeper_memory_os_io.cap_facts] /
-   [merge_and_cap_facts]) calls this so it drops expired rows on the SAME
+   effective-horizon boundary ([fact_is_current], i.e.
+   [fact_effective_valid_until]). The cap path ([Keeper_memory_os_io.cap_facts]
+   / [merge_and_cap_facts]) calls this so it drops expired rows on the SAME
    boundary the GC sweep uses ([Keeper_memory_os_gc.ttl_expired]), instead of
    leaving them on disk until the off-by-default 600s sweep happens to run.
-   Durable facts ([valid_until = None]) are always live, so this never evicts
-   durable knowledge. This is retention-path determinism (cap and GC agree on
-   what [valid_until] means), not a new read-side filter — recall already drops
+   Facts with no effective horizon ([valid_until = None] and not a legacy
+   [External_state] claim, RFC-0259 P7) are always live, so durable knowledge
+   is never evicted here. This is retention-path determinism (cap and GC agree
+   on the expiry boundary), not a new read-side filter — recall already drops
    expired rows via [fact_is_current]. *)
 let partition_expired ~now (facts : fact list) =
   List.partition (fact_is_current ~now) facts

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,6 +28,9 @@
 #   MASC_REPO      Override repo (default: jeong-sik/masc)
 #   MASC_PORT      Port used in the post-install local-start hint (default: 8935)
 #   MASC_ALLOW_UNVERIFIED=1  Same as --allow-unverified
+#   MASC_RELEASE_BASE_URL  Override the release asset base URL (mirror or
+#                  air-gapped install; file:// works). Defaults to
+#                  https://github.com/<repo>/releases/download
 #   OAS_MODEL_CATALOG  Override model catalog path; defaults to seeded
 #                  <base-path>/.masc/config/oas-models.toml when present.
 #   MASC_RUNTIME_EVENTS=0/1  Override OCaml Runtime_events. When unset, the
@@ -40,6 +43,7 @@
 set -euo pipefail
 
 REPO="${MASC_REPO:-jeong-sik/masc}"
+RELEASE_BASE_URL="${MASC_RELEASE_BASE_URL:-https://github.com/$REPO/releases/download}"
 VERSION="${MASC_VERSION:-}"
 PREFIX="${MASC_PREFIX:-$HOME/.local/bin}"
 MASC_PORT="${MASC_PORT:-8935}"
@@ -731,7 +735,7 @@ cleanup_install_temp_files() {
 trap cleanup_install_temp_files EXIT
 CHECKSUMS_AVAILABLE=0
 CHECKSUMS_FETCHED=0
-CHECKSUMS_URL="https://github.com/$REPO/releases/download/$VERSION/SHA256SUMS"
+CHECKSUMS_URL="$RELEASE_BASE_URL/$VERSION/SHA256SUMS"
 fetch_release_checksums() {
   [ "$CHECKSUMS_FETCHED" -eq 0 ] || return 0
   CHECKSUMS_FETCHED=1
@@ -755,7 +759,7 @@ fetch_release_checksums() {
 }
 
 # --- 3. download binary -------------------------------------------------------
-URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+URL="$RELEASE_BASE_URL/$VERSION/$ASSET"
 DEST="$PREFIX/masc"
 
 model_catalog_env_value() {

--- a/test/test_install_script.ml
+++ b/test/test_install_script.ml
@@ -292,17 +292,50 @@ let assert_not_contains label text needle =
   check bool label false (string_contains text needle)
 ;;
 
+(* Mirror install.sh's detect_asset so the staged release names the asset the
+   script will request for this platform. *)
+let platform_release_asset () =
+  let uname flag =
+    let ic = Unix.open_process_in ("uname " ^ flag) in
+    let line = try String.trim (input_line ic) with End_of_file -> "" in
+    ignore (Unix.close_process_in ic);
+    line
+  in
+  match uname "-s", uname "-m" with
+  | "Darwin", "arm64" -> "masc-macos-arm64"
+  | "Linux", "x86_64" -> "masc-linux-x64"
+  | os, arch -> failf "unsupported test platform for release asset: %s/%s" os arch
+;;
+
+(* Stage a file:// release mirror under [base_path] so install paths that
+   download (e.g. the --force refresh) exercise the real curl+install flow
+   hermetically instead of depending on a published GitHub release for the
+   HEAD version — the forced-wizard tests broke on exactly that 404 when
+   dune-project moved past the latest published release. SHA256SUMS is
+   deliberately absent: the harness passes --allow-unverified, which
+   downgrades missing checksums to a warning. *)
+let stage_release_mirror base_path =
+  let dir = Filename.concat base_path (Filename.concat ".release" (release_tag ())) in
+  ignore (Sys.command ("mkdir -p " ^ Filename.quote dir));
+  let asset = Filename.concat dir (platform_release_asset ()) in
+  unlink_if_exists asset;
+  Unix.symlink (Unix.realpath (real_masc_binary ())) asset;
+  "file://" ^ Filename.concat base_path ".release"
+;;
+
 let run_install_status ?(extra_env = "") args base_path =
   let root = source_root () in
   let script = Filename.concat root "scripts/install.sh" in
   let prefix = Filename.concat base_path ".local" in
   install_real_masc_binary prefix;
+  let release_base_url = stage_release_mirror base_path in
   let quoted_args = String.concat " " (List.map Filename.quote args) in
   let cmd =
     Printf.sprintf
-      "%s%sMASC_PREFIX=%s MASC_VERSION=%s MASC_BASE_PATH=%s bash %s --allow-unverified --no-seed --base-path %s %s 2>&1"
+      "%s%sMASC_RELEASE_BASE_URL=%s MASC_PREFIX=%s MASC_VERSION=%s MASC_BASE_PATH=%s bash %s --allow-unverified --no-seed --base-path %s %s 2>&1"
       extra_env
       (if String.equal extra_env "" then "" else " ")
+      (Filename.quote release_base_url)
       (Filename.quote prefix)
       (Filename.quote (release_tag ()))
       (Filename.quote base_path)
@@ -326,11 +359,14 @@ let run_install_status_with_stdin stdin args base_path =
   let script = Filename.concat root "scripts/install.sh" in
   let prefix = Filename.concat base_path ".local" in
   install_real_masc_binary prefix;
+  let release_base_url = stage_release_mirror base_path in
   let quoted_args = String.concat " " (List.map Filename.quote args) in
   let cmd =
     Printf.sprintf
-      "printf '%%s\\n' %s | MASC_PREFIX=%s MASC_VERSION=%s MASC_BASE_PATH=%s bash %s --allow-unverified --no-seed --base-path %s %s 2>&1"
+      "printf '%%s\\n' %s | MASC_RELEASE_BASE_URL=%s MASC_PREFIX=%s MASC_VERSION=%s \
+       MASC_BASE_PATH=%s bash %s --allow-unverified --no-seed --base-path %s %s 2>&1"
       (Filename.quote stdin)
+      (Filename.quote release_base_url)
       (Filename.quote prefix)
       (Filename.quote (release_tag ()))
       (Filename.quote base_path)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3057,6 +3057,54 @@ let test_partition_expired_splits_on_valid_until () =
     (List.map (fun f -> f.Types.claim) gone)
 ;;
 
+let test_gc_ttl_expired_uses_external_state_effective_horizon () =
+  let now = 1_000_000.0 in
+  let base = fact_fixture ~now () in
+  let expired_external =
+    { base with
+      Types.claim = "legacy external state expired"
+    ; Types.claim_kind = Some Types.External_state
+    ; Types.first_seen = now -. Types.external_state_ttl_seconds -. 1.0
+    ; Types.valid_until = None
+    }
+  in
+  let current_external =
+    { expired_external with
+      Types.claim = "legacy external state current"
+    ; Types.first_seen = now -. Types.external_state_ttl_seconds +. 1.0
+    }
+  in
+  let durable =
+    { expired_external with
+      Types.claim = "durable legacy row"
+    ; Types.claim_kind = None
+    }
+  in
+  Alcotest.(check bool)
+    "GC expires legacy external_state via effective horizon"
+    true
+    (GC.ttl_expired ~now expired_external);
+  Alcotest.(check bool)
+    "GC keeps current legacy external_state"
+    false
+    (GC.ttl_expired ~now current_external);
+  Alcotest.(check bool)
+    "GC keeps durable no-horizon fact"
+    false
+    (GC.ttl_expired ~now durable);
+  let live, gone =
+    Types.partition_expired ~now [ expired_external; current_external; durable ]
+  in
+  Alcotest.(check (list string))
+    "partition_expired shares GC effective horizon"
+    [ "legacy external state expired" ]
+    (List.map (fun f -> f.Types.claim) gone);
+  Alcotest.(check (list string))
+    "live keeps current external + durable"
+    [ "legacy external state current"; "durable legacy row" ]
+    (List.map (fun f -> f.Types.claim) live)
+;;
+
 (* RFC-0259 §3.6 (P5): cap_facts evicts an expired row even when the store is far
    below [trigger] (the disk-leak the off-by-default GC sweep would otherwise
    miss), and never evicts a durable row. Re-running is a no-op once clean. *)
@@ -5988,6 +6036,10 @@ let () =
             "partition_expired splits on valid_until (RFC-0259 P5)"
             `Quick
             test_partition_expired_splits_on_valid_until
+        ; Alcotest.test_case
+            "GC ttl_expired uses external_state effective horizon"
+            `Quick
+            test_gc_ttl_expired_uses_external_state_effective_horizon
         ; Alcotest.test_case
             "cap_facts drops expired below trigger (RFC-0259 P5)"
             `Quick

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -224,6 +224,34 @@ let test_mixed_results_keep_ok_totals_and_errors () =
       Alcotest.(check int) "ok ttl only" 1 report.ttl_expired))
 ;;
 
+(* The two expiry corners the External_state coverage in test_keeper_memory_os
+   does not pin: the boundary equality ([ts >= now] is current, so [now > ts] is
+   expired — explicit [valid_until] behavior is unchanged by the SSOT switch in
+   #23426), and explicit [valid_until] taking precedence over the legacy
+   [External_state] first_seen horizon in [fact_effective_valid_until]. *)
+let test_ttl_expired_matches_explicit_horizon_boundary () =
+  let now = 1_000_000.0 in
+  let base = fact_fixture ~now ~claim:"horizon boundary fixture" in
+  Alcotest.(check bool)
+    "past explicit horizon expires"
+    true
+    (GC.ttl_expired ~now { base with Types.valid_until = Some (now -. 1.0) });
+  Alcotest.(check bool)
+    "boundary ts = now stays live (ts >= now is current)"
+    false
+    (GC.ttl_expired ~now { base with Types.valid_until = Some now });
+  Alcotest.(check bool)
+    "explicit valid_until overrides the legacy External_state horizon"
+    false
+    (GC.ttl_expired
+       ~now
+       { base with
+         Types.claim_kind = Some Types.External_state
+       ; Types.first_seen = now -. Types.external_state_ttl_seconds -. 1.0
+       ; Types.valid_until = Some (now +. 60.0)
+       })
+;;
+
 let test_empty_scan_is_empty_report () =
   with_eio (fun () ->
     with_temp_keepers_dir (fun keepers_dir ->
@@ -261,6 +289,12 @@ let () =
             "empty scan is empty report"
             `Quick
             test_empty_scan_is_empty_report
+        ] )
+    ; ( "ttl boundary"
+      , [ Alcotest.test_case
+            "expiry matches explicit horizon boundary"
+            `Quick
+            test_ttl_expired_matches_explicit_horizon_boundary
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_sanity_sweep.ml
+++ b/test/test_keeper_memory_os_sanity_sweep.ml
@@ -79,9 +79,12 @@ let test_sweep_projects_typed_memory_state_without_rewrite () =
         Alcotest.(check int) "row gc written" 2 row.gc_preview.written;
         (match row.duplicate_groups with
          | [ group ] ->
+           (* [claim_identity] keys are namespaced by construction ("id:" /
+              "claim:", RFC-0259 §3.7): producer-id keys and normalized-prose
+              keys stay disjoint so equal text cannot over-merge across them. *)
            Alcotest.(check string)
              "claim identity from claim_id"
-             "same-conclusion"
+             "id:same-conclusion"
              group.claim_identity;
            Alcotest.(check (list int)) "duplicate indices" [ 0; 1 ] group.member_indices
          | groups ->
@@ -129,7 +132,10 @@ let test_duplicate_groups_follow_claim_identity_only () =
   Alcotest.(check int) "only exact claim identity groups" 1 (List.length groups);
   match groups with
   | [ group ] ->
-    Alcotest.(check string) "normalized prose identity" "exact same" group.claim_identity;
+    Alcotest.(check string)
+      "normalized prose identity"
+      "claim:exact same"
+      group.claim_identity;
     Alcotest.(check (list int)) "members" [ 2; 3 ] group.member_indices
   | _ -> Alcotest.fail "unexpected duplicate group shape"
 ;;


### PR DESCRIPTION
## Why — main Build and Test 복구 (4계열 전부)

main Build and Test가 2026-07-06 10:21 UTC부터 red. 조사 결과 **서로 독립적인 red-merge 부채 4계열**이 겹쳐 있고, Build and Test는 단일 job이라 4계열을 전부 고치기 전에는 어떤 PR도 green이 될 수 없는 인질 구조입니다. 원칙("CI에 집착 말고 모아서 해결")대로 이 PR이 4계열을 한 번에 닫습니다.

| 계열 | 도입 | 옳은 쪽 | 이 PR의 fix |
|---|---|---|---|
| ① GC ttl 만료 판정 | #23384 (red-merge) | 테스트 | `Keeper_memory_os_gc.ttl_expired = not (fact_is_current ~now fact)` — writer cap/recall과 동일한 effective-horizon SSOT |
| ② sanity claim-identity 리터럴 | #23384 (red-merge) | 코드 | 테스트 기대값을 SSOT의 네임스페이스 키(`id:`/`claim:`, RFC-0259 §3.7)로 정렬. 그룹핑 의미론 단언은 그대로 |
| ③ gh risk 분류 (R0/R1→R2) | #23391 W1 (CANCELLED-merge)이 한 달 된 green 테스트 4건을 깨뜨림 | 테스트 | **#23400 흡수** (fe06f179cd + 6ac8784c98 cherry-pick, 원저자 보존): leading global value-flag를 값-인지 skip 후 subcommand 결합 → `gh --repo o/r pr view`=R0, `pr close`=R1 복원. #23390의 무승인 destructive 우회도 함께 폐쇄 (floor = max(word-list, typed table), 단조 상승만) |
| ④ install.sh --force 404 | #23060 (red-merge) | 코드 | `MASC_RELEASE_BASE_URL` 주입점 추가(기본값 불변, mirror/air-gap 겸용) + 테스트가 file:// mirror를 스테이징해 --force 다운로드 경로를 hermetic하게 실주행. 근본 원인: 최신 릴리즈 v0.19.51 vs dune-project 0.19.56 → HEAD 버전 asset 404 |

②의 GC 경계 등호는 동치(`ts >= now` current ⇔ `now > ts` expired)라 explicit `valid_until` fact의 동작 불변. ①+② 이후 sanity sweep 케이스 0/1의 나머지 단언은 구성상 통과합니다.

## 행동 변화 범위
- legacy `External_state` fact(explicit `valid_until` 없음)가 `first_seen + 6h` horizon 초과 시 GC 대상 — recall/writer cap과의 합의 복원 (RFC-0259 P7 원래 의도)
- `gh` leading global value-flag 명령의 risk가 subcommand 기준으로 복원 (RFC-0309 W1의 fail-closed Other→R2는 진짜 unknown에 대해 유지)
- 설치 스크립트 기본 동작 불변 (`MASC_RELEASE_BASE_URL` 미설정 시 기존 URL)

## 프로세스 노트
4계열 모두 required check가 실패/취소 상태로 머지된 부채입니다 (#23384 FAILURE-merge, #23391 CANCELLED-merge, #23060 FAILURE-merge). enforce_admins:false 구멍의 실측 사례 4건 — 별도 운영자 결정 대기 중.

#23400은 이 PR에 흡수됨 (author 커밋 보존). 이 PR 머지 후 #23400은 rebase 시 empty가 되므로 close 예정. 후속 이슈: `Gh_verb.classify`(test-only lens)의 leading-flag 오파싱 정렬, v0.19.52+ GitHub release 미발행(실사용자 `--force` 설치도 404).

RFC: RFC-0309 (gh capability gating, W1 유지), RFC-0259 P6/P7 (memory-os identity/horizon SSOT).

## Validation
- `ocamlformat --check` 전체 수정 OCaml 파일 PASS, `bash -n install.sh` PASS
- 컴파일/테스트는 CI에서 — 이 PR의 Build and Test green이 main 복구의 증명
