### PR TITLE
ci: avoid dune re-entry in public tool sweep

### DIFF
--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -90,9 +90,15 @@ cleanup_contract_task() {
 }
 trap 'cleanup_contract_task' EXIT
 
+public_tool_manifest_exe="${PUBLIC_TOOL_MANIFEST_EXE:-${ROOT_DIR}/_build/default/bin/public_tool_manifest.exe}"
+if [[ ! -x "$public_tool_manifest_exe" ]]; then
+  echo "FAIL: public tool manifest executable not found: ${public_tool_manifest_exe}" >&2
+  echo "Build ./bin/public_tool_manifest.exe before running the contract harness." >&2
+  exit 1
+fi
+
 manifest_json="$(
-  env -u DUNE_RPC \
-    opam exec -- dune exec --root "$ROOT_DIR" bin/public_tool_manifest.exe \
+  "$public_tool_manifest_exe" \
     | awk 'BEGIN { printing = 0 } /^\{/ { printing = 1 } printing { print }'
 )"
 expected_public_tools="$(printf '%s\n' "$manifest_json" | jq -c '.public_tool_names | sort')"


### PR DESCRIPTION
## Summary
- Stop `public_tool_live_sweep.sh` from invoking `opam exec -- dune exec` inside the contract harness.
- Use the already-built `PUBLIC_TOOL_MANIFEST_EXE` or `_build/default/bin/public_tool_manifest.exe` instead.
- Fail fast with a clear message if the manifest executable is missing.

## Context
- #23394 Build and Test hit the contract harness failure: `Another Dune instance is currently running. Aborting...` while `public_tool_live_sweep.sh` was trying to run `dune exec`.
- This keeps the harness from starting a second Dune process after the CI Build step has already materialized targets.

## Verification
- `bash -n scripts/harness/contract/public_tool_live_sweep.sh`
- `shellcheck -e SC1091 scripts/harness/contract/public_tool_live_sweep.sh`
- `git diff --check`

Local Dune build/test intentionally not run; PR CI is the build authority.