### PR TITLE
fix(keeper): count read-error rows as waiting

### DIFF
--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -538,6 +538,11 @@ let test_corrupt_external_attention_is_read_error () =
     Otel_metric_store.metric_keeper_waiting_count
     ~labels:[ "scope", "keeper"; "source", "read_error" ]
     1.0;
+  check_metric_float "keeper read-error state metric"
+    Otel_metric_store.metric_keeper_waiting_keeper_count
+    ~labels:[ "state", "waiting" ]
+    1.0;
+  check int "one waiting keeper" 1 (json_int_member "waiting_keeper_count" json);
   check int "one keeper read error row" 1 (json_int_member "row_count" json);
   match find_keeper json keeper_name with
   | None -> fail "keeper row missing"


### PR DESCRIPTION
## Summary
- Treat read-error-only keeper rows as `waiting` instead of `idle`.
- Pin the regression with `waiting_keeper_count` and keeper state metric assertions for corrupt external attention reads.

## Context
- The keeper waiting inventory stack exposes keeper-scoped read errors as repair rows, but `row_state` classified read-error-only rows as `idle`.
- That hides an actionable repair condition from `waiting_keeper_count` and per-state metrics.

## Verification
- `opam exec -- ocamlformat --check lib/server/server_keeper_waiting_inventory.ml test/test_keeper_waiting_inventory.ml`
- `git diff --check`

Local Dune build/test intentionally not run; PR CI is the build authority.