### PR TITLE
feat(exec): close known-family unknown-action gap in gh capability gating

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -36,21 +36,30 @@ let creates_durable_remote_surface (v : Gh_verb.t) : bool =
 ;;
 
 let disposition_of (v : Gh_verb.t) : disposition =
-  match v.Gh_verb.family with
-  (* Unrecognized area: a human adjudicates. Never silently allowed. This is
-     the capability-axis counterpart of risk_of_gh_verb's Other -> R2
-     fail-close: on the risk axis Other floors, on the capability axis it asks. *)
-  | Gh_verb.Other _ -> Requires_approval
-  | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
-  | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
-  | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run
-  | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Api ->
+  match Shell_ir_risk.classify_gh_verb v with
+  (* Unrecognized top-level area: a human adjudicates. Never silently allowed. *)
+  | Shell_ir_risk.Gh_unrecognized_family -> Requires_approval
+  (* Known mutating-capable family with an action that is neither a known read
+     nor a table mutation (e.g. [gh repo upsert-magic]). Closing this is the
+     point of the fix: instead of auto-running as an R0 read, it asks. *)
+  | Shell_ir_risk.Gh_unrecognized_action -> Requires_approval
+  (* Reads and bare invocations: allowed. *)
+  | Shell_ir_risk.Gh_read -> Allowed
+  (* Irreversible mutations are also risk-floored (R2/Destructive): denied. *)
+  | Shell_ir_risk.Gh_irreversible_mutation -> Denied
+  (* Reversible mutation: approval only when it touches a durable remote
+     surface (repo/discussion mutating action); otherwise allowed. *)
+  | Shell_ir_risk.Gh_reversible_mutation ->
+    if creates_durable_remote_surface v then Requires_approval else Allowed
+  (* [gh api]: the capability axis defers to risk (string-borne). A read-shaped
+     api call is Allowed; a destructive -X/graphql is R2 and denied by the floor
+     and by risk_of_gh_verb via the word-list, handled in the risk projection. *)
+  | Shell_ir_risk.Gh_string_borne ->
     (match Shell_ir_risk.risk_of_gh_verb v with
      | Shell_ir_risk.R2_Irreversible | Shell_ir_risk.Destructive_protected ->
        Denied
-     | Shell_ir_risk.R0_Read -> Allowed
-     | Shell_ir_risk.R1_Reversible_mutation ->
-       if creates_durable_remote_surface v then Requires_approval else Allowed)
+     | Shell_ir_risk.R1_Reversible_mutation -> Requires_approval
+     | Shell_ir_risk.R0_Read -> Allowed)
 ;;
 
 (* Body-aware disposition. [disposition_of] keys on the typed [Gh_verb.t] alone,

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -619,6 +619,55 @@ let table_risk_of_gh_family (command : string) (action : string) : risk_class =
     R1_Reversible_mutation
   else R0_Read
 
+(* Well-known gh read actions shared across families ([gh pr view], [gh repo
+   list], [gh run view], [gh pr diff], [gh pr checks], ...). Kept deliberately
+   TIGHT: an action wrongly omitted here is only over-gated to non-blocking
+   approval (safe), whereas an action wrongly included would let an unrecognized
+   mutation auto-run as a read. *)
+let gh_read_actions =
+  [ "view"; "list"; "status"; "diff"; "checks"; "browse"; "download" ]
+;;
+
+let gh_action_is_known_read (action : string) : bool =
+  List.mem (String.lowercase_ascii action) gh_read_actions
+;;
+
+(* Typed classification of a gh verb, shared by [risk_of_gh_verb] (risk axis)
+   and [Gh_capability_policy.disposition_of] (capability axis) so both read one
+   source. This closes the known-family-unknown-action gap: an action on a
+   mutating-capable family that is neither a table mutation nor a known read is
+   [Gh_unrecognized_action] — the risk axis keeps it R0 (its reversibility is
+   genuinely unknown; fabricating R1/R2 would be the #23362 policy-as-risk
+   mistake), while the capability axis routes it to non-blocking approval rather
+   than auto-running it as a read. *)
+type gh_verb_class =
+  | Gh_read (* known read action, or a bare family invocation *)
+  | Gh_reversible_mutation (* action in the reversible table *)
+  | Gh_irreversible_mutation (* action in the irreversible table *)
+  | Gh_unrecognized_action
+      (* known mutating-capable family, action neither a mutation nor a read *)
+  | Gh_string_borne (* [gh api]: risk is the -X method / graphql body (floor) *)
+  | Gh_unrecognized_family (* [Gh_verb.Other] *)
+
+let classify_gh_verb (v : Gh_verb.t) : gh_verb_class =
+  match v.Gh_verb.family with
+  | Gh_verb.Api -> Gh_string_borne
+  | Gh_verb.Other _ -> Gh_unrecognized_family
+  | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+    | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+    | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
+    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as fam ->
+    (match v.Gh_verb.action with
+     | None -> Gh_read (* bare family: a read *)
+     | Some action ->
+       let command = Gh_verb.family_token fam in
+       if in_table repo_hosting_cli_irreversible_ops command action then
+         Gh_irreversible_mutation
+       else if in_table repo_hosting_cli_reversible_mutations command action then
+         Gh_reversible_mutation
+       else if gh_action_is_known_read action then Gh_read
+       else Gh_unrecognized_action)
+
 (* RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
 
    [risk_of_gh_verb] is the closed-sum lens over [classify_repo_hosting_cli]:
@@ -636,33 +685,29 @@ let table_risk_of_gh_family (command : string) (action : string) : risk_class =
      floor ([classify]'s [max_risk] with [classify_repo_hosting_cli]) own it,
      exactly as RFC-0208 requires.
    - a known family with a table-absent action ([gh pr view], [gh repo list]):
-     table-absent actions in a known family are overwhelmingly reads, and we
-     cannot distinguish a read from an unknown action without a reads table.
-     Fail-closing them would over-block reads, so they stay [R0_Read]. The
-     residual "known-family unknown-action" case (e.g. [gh repo upsert-magic])
-     is therefore NOT fail-closed by W1; it is deferred to W3, where an unknown
-     action routes to non-blocking approval instead of a read or a hard deny.
+     a KNOWN read stays [R0_Read]. An UNRECOGNIZED action
+     ([Gh_unrecognized_action], e.g. [gh repo upsert-magic]) also stays
+     [R0_Read] on the RISK axis — its reversibility is genuinely unknown, and
+     fabricating R1/R2 here would repeat #23362's policy-as-risk mistake. The
+     gating of unrecognized actions is a CAPABILITY decision
+     ([Gh_capability_policy.disposition_of] -> [Requires_approval]), not a risk
+     claim; both read [classify_gh_verb] so they cannot disagree.
 
    This function is the capability-identity substrate for W2 (per-keeper policy)
    and W3 (approval routing). It never returns [Destructive_protected]: gh ops
    are R0/R1/R2 only, and [Destructive_protected] is the one class the dispatch
    layer special-cases. *)
 let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
-  match v.Gh_verb.family with
+  match classify_gh_verb v with
   (* string-borne: -X METHOD / graphql body owned by the word-list floor. *)
-  | Gh_verb.Api -> R0_Read
+  | Gh_string_borne -> R0_Read
   (* fail-closed: unrecognized gh area is not a known read shape. *)
-  | Gh_verb.Other _ -> R2_Irreversible
-  | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
-    | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
-    | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
-    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as fam ->
-    (* [None] is a bare family invocation ([gh repo]) — a read, not a hidden
-       default. Matched explicitly rather than collapsed to an empty-string
-       default so the "no action" case is a decision, not a silent fold. *)
-    (match v.Gh_verb.action with
-     | None -> R0_Read
-     | Some action -> table_risk_of_gh_family (Gh_verb.family_token fam) action)
+  | Gh_unrecognized_family -> R2_Irreversible
+  | Gh_read -> R0_Read
+  | Gh_reversible_mutation -> R1_Reversible_mutation
+  | Gh_irreversible_mutation -> R2_Irreversible
+  (* Risk genuinely unknown; capability axis gates it. Not fabricated to R1/R2. *)
+  | Gh_unrecognized_action -> R0_Read
 
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -102,17 +102,41 @@ val repo_hosting_cli_floor_risk : string list -> Shell_ir.simple -> risk_class
     family stay [R0_Read]; fail-closing unknown gh is RFC-0309 W3, not here.
     Used by [Approval_policy.repo_hosting_cli_is_floored]. *)
 
+type gh_verb_class =
+  | Gh_read
+  | Gh_reversible_mutation
+  | Gh_irreversible_mutation
+  | Gh_unrecognized_action
+  | Gh_string_borne
+  | Gh_unrecognized_family
+      (** Typed classification of a gh verb, the single source both the risk
+          axis ([risk_of_gh_verb]) and the capability axis
+          ([Gh_capability_policy.disposition_of]) read.
+          - [Gh_read]: a known read action ([view]/[list]/[status]/...) or a
+            bare family invocation ([gh repo]).
+          - [Gh_reversible_mutation] / [Gh_irreversible_mutation]: the action is
+            in the reversible / irreversible subcommand table.
+          - [Gh_unrecognized_action]: a known mutating-capable family with an
+            action that is neither a table mutation nor a known read
+            (e.g. [gh repo upsert-magic]). The capability axis routes this to
+            approval; the risk axis keeps it [R0_Read] because its reversibility
+            is genuinely unknown.
+          - [Gh_string_borne]: [gh api] — risk is the -X method / graphql body,
+            owned by the word-list floor (RFC-0208).
+          - [Gh_unrecognized_family]: [Gh_verb.Other]. *)
+
+val classify_gh_verb : Gh_verb.t -> gh_verb_class
+(** Classify a gh verb. See {!gh_verb_class}. *)
+
 val risk_of_gh_verb : Gh_verb.t -> risk_class
-(** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command.
-    Reads the same subcommand tables as [classify_repo_hosting_cli] for known
-    families (so the two agree for every recognized [family/action] pair) and
-    differs only for [Gh_verb.Other] (an unrecognized top-level area), which is
-    fail-closed to [R2_Irreversible] rather than the word-list [R0_Read]
-    fall-through. [Gh_verb.Api] returns [R0_Read] — its risk is string-borne
-    (HTTP method / graphql body) and owned by the word-list floor. Known
-    families with a table-absent action stay [R0_Read] (treated as reads).
-    Never returns [Destructive_protected]. Capability-identity substrate for
-    W2 (per-keeper policy) and W3 (non-blocking approval routing). *)
+(** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command,
+    projected from [classify_gh_verb]. Reads the same subcommand tables as
+    [classify_repo_hosting_cli] for known families (so the two agree for every
+    recognized [family/action] pair). [Gh_verb.Other] is fail-closed to
+    [R2_Irreversible]; [Gh_verb.Api] returns [R0_Read] (string-borne, floor);
+    a known read and an unrecognized action both stay [R0_Read] on the RISK
+    axis (an unrecognized action's reversibility is genuinely unknown — the
+    capability axis, not risk, gates it). Never returns [Destructive_protected]. *)
 
 val gh_api_graphql_creates_durable_remote : string list -> bool
 (** True when [words] is a [gh api graphql ...] invocation whose (comment-

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -492,7 +492,11 @@ let test_gh_durable_remote_asks_under_autonomous () =
     ; "gh repo edit", [ "repo"; "edit"; "--description"; "d" ]
     ; "gh repo sync", [ "repo"; "sync" ]
     ; "gh repo set-default", [ "repo"; "set-default"; "o/r" ]
-    ; "gh frobnicate (unknown -> Requires_approval)", [ "frobnicate"; "now" ]
+    ; "gh frobnicate (unknown family -> Requires_approval)", [ "frobnicate"; "now" ]
+    (* Gap fix: an unrecognized ACTION on a known mutating family no longer
+       auto-runs as a read — it Asks under autonomous. *)
+    ; "gh repo upsert-magic (unknown action)", [ "repo"; "upsert-magic"; "o/r" ]
+    ; "gh pr teleport (unknown action)", [ "pr"; "teleport"; "123" ]
     ]
 
 (* RFC-0309 W4 axis-symmetry regression: the string-borne GraphQL form of a

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -98,12 +98,21 @@ let test_current_dispositions () =
      work. *)
   check "repo clone (local -> Allowed)" (verb ~sub:"repo" ~act:"clone" ())
     Pol.Allowed;
-  (* unrecognized area: a human adjudicates *)
+  (* unrecognized top-level area: a human adjudicates *)
   check "unknown verb" (verb ~sub:"frobnicate" ~act:"now" ()) Pol.Requires_approval;
-  check "unknown action in known family"
-    (verb ~sub:"repo" ~act:"upsert-magic" ()) Pol.Allowed
-    (* known family + table-absent action -> R0 (read) -> Allowed; the
-       unknown-action gap is deferred to W3, same as the risk axis. *)
+  (* GAP CLOSED: an unrecognized action on a known mutating-capable family no
+     longer auto-runs as a read — it asks. (Was Allowed while the gap was open.) *)
+  check "unknown action in known family -> Requires_approval"
+    (verb ~sub:"repo" ~act:"upsert-magic" ()) Pol.Requires_approval;
+  check "unknown action under pr -> Requires_approval"
+    (verb ~sub:"pr" ~act:"teleport" ()) Pol.Requires_approval;
+  (* Known reads on the same families stay Allowed — no over-block of routine
+     work. This is the reads-set guard that keeps the gap fix from flooring
+     legitimate reads. *)
+  check "repo view (known read)" (verb ~sub:"repo" ~act:"view" ()) Pol.Allowed;
+  check "pr diff (known read)" (verb ~sub:"pr" ~act:"diff" ()) Pol.Allowed;
+  check "pr checks (known read)" (verb ~sub:"pr" ~act:"checks" ()) Pol.Allowed;
+  check "run list (known read)" (verb ~sub:"run" ~act:"list" ()) Pol.Allowed
 ;;
 
 (* --- W4 axis symmetry: string-borne graphql vs typed (disposition_of_words) --

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -161,8 +161,14 @@ let corpus : (string * string * expectation) list =
        read ("gh repo view") without a reads table, so fail-closing here
        would over-block reads. Stays R0; deferred to W3, where an unknown
        action routes to non-blocking approval instead of auto-run. -------- *)
+    (* Known-family unknown-action: the RISK axis keeps this R0 (its
+       reversibility is genuinely unknown — not fabricated). The
+       auto-run GAP is now CLOSED on the CAPABILITY axis
+       (Gh_capability_policy.disposition_of -> Requires_approval), proven in
+       test_gh_capability_policy and test_approval_policy. So this is no longer
+       a permissive DEFECT on the risk axis; it is the intended honest R0. *)
     ("unknown-repo-action", "gh repo upsert-magic owner/repo",
-     Defect_unknown_permissive Shell_ir_risk.R0_Read);
+     Stable Shell_ir_risk.R0_Read);
   ]
 ;;
 
@@ -267,7 +273,10 @@ let test_ledger () =
   Alcotest.(check int) "R2 count" 11 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
   Alcotest.(check int) "defect: policy-as-risk (CLOSED by W4)" 0 policy_as_risk;
-  Alcotest.(check int) "defect: unknown-permissive (residual)" 1
+  (* Was 1 (unknown-repo-action). CLOSED: the auto-run gap moved to the
+     capability axis (Requires_approval); the risk R0 is now intended, so the
+     corpus carries zero permissive defects. *)
+  Alcotest.(check int) "defect: unknown-permissive (CLOSED, capability-gated)" 0
     unknown_permissive;
   Alcotest.(check int) "W1: fail-closed opinion" 3 fail_closed_opinion
 ;;


### PR DESCRIPTION
## What

Shell IR gh 게이팅의 **known-family unknown-action R0 fail-open 갭**을 닫습니다. 적대적 진단(5-lens 워크플로)이 최우선 개선으로 지목한 항목.

> **Base**: W4(#23424) 스택 위. RFC-0309 W1~W4의 잔여 결함 해소.

- `lib/exec/shell_ir_risk.ml`: `classify_gh_verb : Gh_verb.t -> gh_verb_class` 도입 — `Gh_read | Gh_reversible_mutation | Gh_irreversible_mutation | Gh_unrecognized_action | Gh_string_borne | Gh_unrecognized_family`. **risk 축(`risk_of_gh_verb`)과 capability 축(`Gh_capability_policy.disposition_of`) 둘 다 이걸 읽어 불일치 불가**(SSOT).
- `lib/exec/gh_capability_policy.ml`: `disposition_of`가 `classify_gh_verb` 소비 → `Gh_unrecognized_action → Requires_approval`.

## Why (실측된 갭)

진단이 확인: `gh repo upsert-magic owner/repo`는 command="repo", action="upsert-magic"가 두 mutation 테이블 어디에도 없어 **R0 → autonomous overlay에서 무승인 auto-run**(shell_ir_risk.ml 478-479, risk_of_gh_verb). RFC-0309 baseline이 `Defect_unknown_permissive`로 pin해둔 잔여 결함이자, W1~W3에서 "W3로 이연"이라 남긴 항목.

## 축 분리를 지킨 fix

- **risk 축은 정직 유지**: unknown action의 가역성은 **genuinely 모름** → R0 유지. R1/R2로 날조하면 #23362의 policy-as-risk 실수 반복. floor(monotone)도 불변.
- **capability 축이 게이팅**: `Gh_unrecognized_action → Requires_approval → Verdict.Ask`(W3 decide 경로). "미인식 action을 read로 auto-run" 대신 승인 요청.
- **read 과다차단 방지**: 좁은 `gh_read_actions` set(view/list/status/diff/checks/browse/download). target이 Deny가 아니라 non-blocking Ask라, read를 빠뜨려도 과다 gating(안전)일 뿐 silent auto-run 아님. 반대로 잘못 포함하면 mutation이 read로 새므로 **의도적으로 tight**.

## 검증

- `test_gh_capability_policy`: `repo upsert-magic`/`pr teleport` → Requires_approval; `repo view`/`pr diff`/`pr checks`/`run list` → Allowed(read 보존).
- `test_approval_policy`: unknown action이 autonomous에서 **Ask로 격리**됨을 end-to-end 증명.
- baseline harness: **unknown-permissive defect count 1→0**(마지막 permissive 결함 닫힘), risk R0는 의도된 값으로 Stable.
- 전체 `@lib/exec/test/runtest` green, top-level `test_shell_ir_risk` PASS, keeper+main_eio 빌드 green, meta bug-class gate 로컬 PASS, lib-regression 0, ocamlformat clean.
- ⚠️ CI: repo Build and Test가 self-hosted 러너 **디스크 풀**로 repo-wide 다운. CI Gate red 예상, 코드 무관 — 로컬 전체 검증으로 대체.

## RFC

RFC-0309 §3.1 잔여 결함(known-family unknown-action) 해소. W1(#23391)/W2(#23413)/W3(#23416)/W4(#23424) 스택 위. 진단 워크플로가 5-lens 중 word-list 렌즈 severity=medium으로 최우선 지목.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
