### PR TITLE
feat(exec): RFC-0309 W3 — route gh Requires_approval to Verdict/HITL (supersedes #23416)

### DIFF
--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -199,26 +199,45 @@ gh_unknown          | Requires_approval | Requires_approval | Suggest_confirm
 
 (Values illustrative; the W2 PR fixes the table with the operator.)
 
-### 3.4 Non-blocking approval disposition (G-6..G-8) — the core
+### 3.4 Approval disposition (G-6..G-8) — the core
 
-- `Requires_approval` disposition resolves to `Verdict.Ask`, which the exec
-  gate translates into an **enqueue** on `keeper_approval_queue` — the same
-  non-blocking queue HITL already uses (`keeper_approval_queue.ml:730`
-  **(verified)** non-blocking update; `:841` **(verified)**
-  `wake_keeper_on_approval_resolution`).
-- The keeper turn **does not wait**: the tool call returns immediately with a
-  typed `Pending_approval { ticket }` result the keeper can report, plan
-  around, or park. On operator resolution, `Hitl_resolved` wakes the keeper
-  (stimulus-gated wake, RFC-0303) and the approved command executes in the
-  resumed turn.
-- The autonomous overlay's all-`Observe` rationale ("no resolver") becomes
-  false by construction, so the overlay maps gated verb families to
-  `Requires_approval` instead (G-8).
-- **Invariant (absolute):** no code path introduced by this RFC may
-  synchronously wait on approval resolution inside a keeper turn.
-  Enforcement: G-11 block-time metric (p99 = 0 ms), G-12 TLA+
-  `NonBlockingApproval` invariant (clean + buggy cfg pair), G-13 gated-op
-  observability (100% of gated ops emit queue/resolution/wake events).
+**Correction (W3 implementation, verified against source).** An earlier draft
+described the mechanism as "enqueue and resume in a later turn." Reading the
+runtime, the existing HITL mechanism is different and already correct:
+`Keeper_approval_queue` is **Eio-promise based** — the tool-invocation fiber
+awaits a promise; the dashboard approval handler resolves it and the *same*
+fiber resumes (`keeper_approval_queue.mli` header **(verified)**). Because the
+keeper runs on Eio, awaiting a promise **suspends the fiber, not the domain**:
+other fibers (accept loop, other keepers, HTTP/WS) keep running. "Non-blocking"
+here means *domain-non-blocking*, not *turn-returns-immediately*. The RFC does
+not need a new queue or a `Pending_approval` return type.
+
+W3 delivers the **decision layer** only:
+
+- `Gh_capability_policy.disposition_of` gives each gh verb a capability
+  disposition (`Allowed | Requires_approval | Denied`), computed from the
+  typed verb identity and the risk axis, orthogonal to the trust overlay.
+- `Approval_policy.decide` consults it **between the catastrophic floor and the
+  risk-graded trust overlay**: a `Requires_approval` gh verb produces
+  `Verdict.Ask` **even under the autonomous (all-`Observe`) overlay**. This is
+  additive — the layer only *adds* an approval requirement for gh, never
+  removes one, and never touches non-gh commands.
+- This makes the autonomous overlay's all-`Observe` rationale ("no resolver to
+  answer an Ask") no longer a reason to auto-run gated gh: the verb now asks.
+
+What W3 does **not** yet do (deliberately, pending CI/runtime verification):
+wire the resulting `Ask` at the keeper-tool layer to the OAS Agent HITL
+approval hook so an operator resolution actually resumes execution. Today the
+keeper surface still renders `Ask` as an `Approval_required` typed error
+(`keeper_tool_execute_shell_ir.ml`), i.e. the gated op does not auto-run and is
+reported to the operator, but operator-resolve-to-execute is a follow-up
+(requires runtime/integration tests, which need the CI runner restored).
+
+- **Invariant (absolute):** no code path may *synchronously spin* on approval
+  inside a domain. The promise-await suspends the fiber only. Enforcement
+  targets (future waves): G-11 block-time metric (domain-occupancy p99 = 0 ms),
+  G-12 TLA+ `NonBlockingApproval` invariant (clean + buggy cfg pair), G-13
+  gated-op observability.
 
 ### 3.5 What #23362 got right and keeps
 

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -337,6 +337,27 @@ let ask_of policy ~caps ~bin : Verdict.t =
       raw_source = policy.raw_source;
     }
 
+(* RFC-0309 W3 (G-6/G-8): the capability axis, consulted between the
+   catastrophic floor and the risk-graded trust overlay. It is ORTHOGONAL to
+   risk and to the overlay: a gh verb whose [Gh_capability_policy.disposition]
+   is [Requires_approval] produces [Ask] even under the autonomous (all-Observe)
+   overlay, because the non-blocking HITL queue is the resolver the overlay
+   comment (approval_config.ml) said did not exist. [Allowed]/[Denied] verbs are
+   left to the existing risk grading ([Denied] verbs are R2/Destructive, already
+   floored or Ask-graded; [Allowed] verbs fall through to the overlay), so this
+   layer only ADDS an approval requirement, never removes one. Non-gh commands
+   are unaffected. *)
+let gh_verb_of_simple (simple : Shell_ir.simple) : Gh_verb.t option =
+  match Exec_program.known simple.Shell_ir.bin with
+  | Some Exec_program.Gh ->
+    let words =
+      Exec_program.to_string simple.Shell_ir.bin
+      :: List.map repo_hosting_arg_word simple.Shell_ir.args
+    in
+    Some (Gh_verb.classify words)
+  | Some _ | None -> None
+[@@warning "-4"]
+
 let trust_dispatch ~trust_level ~caps ~policy ~bin ~simple : Verdict.t =
   match trust_level with
   | Approval_config.Enforced -> ask_of policy ~caps ~bin
@@ -356,6 +377,16 @@ let decide (policy : t)
   | Some reason ->
     (* Trust-independent: denied regardless of [overlay] (RFC-0254 §5.3). *)
     Verdict.Deny { caps; reason }
+  | None when
+      (match gh_verb_of_simple simple with
+       | Some v ->
+         Gh_capability_policy.disposition_of v
+         = Gh_capability_policy.Requires_approval
+       | None -> false) ->
+    (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval] is
+       escalated to [Ask] regardless of overlay. Additive only — reached solely
+       for gh, and only to REQUIRE approval the risk grading would not. *)
+    ask_of policy ~caps ~bin:simple.bin
   | None ->
     (* Non-catastrophic: graded by the per-actor trust overlay.  Under the
        autonomous overlay every level is [Observe] => [Allow] + telemetry;

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -12,14 +12,27 @@ let string_of_disposition = function
   | Denied -> "denied"
 ;;
 
-(* G-4 externality axis, risk-independent. Exhaustive over gh_family so a new
-   family forces an explicit durable-remote decision here. *)
-let creates_durable_remote_surface : Gh_verb.gh_family -> bool = function
-  | Gh_verb.Repo | Gh_verb.Discussion -> true
-  | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Release | Gh_verb.Secret
-  | Gh_verb.Ssh_key | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist
-  | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache
-  | Gh_verb.Project | Gh_verb.Api | Gh_verb.Other _ -> false
+(* Actions on a durable-remote family that only read or act locally — they do
+   NOT touch the durable remote surface, so they are not a capability decision.
+   [clone] copies to local disk; [view]/[list] read. *)
+let local_or_read_repo_action = function
+  | "clone" | "view" | "list" -> true
+  | _ -> false
+;;
+
+(* G-4 externality axis, risk-independent. Keyed on the whole verb: only a
+   MUTATING action on a durable-remote family counts. *)
+let creates_durable_remote_surface (v : Gh_verb.t) : bool =
+  match v.Gh_verb.family, v.Gh_verb.action with
+  | (Gh_verb.Repo | Gh_verb.Discussion), Some action ->
+    not (local_or_read_repo_action action)
+  | (Gh_verb.Repo | Gh_verb.Discussion), None -> false
+  | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Release | Gh_verb.Secret
+      | Gh_verb.Ssh_key | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist
+      | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache
+      | Gh_verb.Project | Gh_verb.Api | Gh_verb.Other _ )
+    , _ ) ->
+    false
 ;;
 
 let disposition_of (v : Gh_verb.t) : disposition =
@@ -37,6 +50,5 @@ let disposition_of (v : Gh_verb.t) : disposition =
        Denied
      | Shell_ir_risk.R0_Read -> Allowed
      | Shell_ir_risk.R1_Reversible_mutation ->
-       if creates_durable_remote_surface v.Gh_verb.family then Requires_approval
-       else Allowed)
+       if creates_durable_remote_surface v then Requires_approval else Allowed)
 ;;

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -41,13 +41,19 @@ val string_of_disposition : disposition -> string
 (** Stable lowercase label for logs/metrics: "allowed" | "requires_approval" |
     "denied". *)
 
-val creates_durable_remote_surface : Gh_verb.gh_family -> bool
-(** G-4 externality axis (risk-independent): [true] for gh families that create
-    or mutate a durable remote surface whose ownership, lifecycle, and
-    moderation policy are not modeled in keeper tool contracts — [Repo] and
-    [Discussion]. [Pr]/[Issue]/[Release]/etc. act within an already-owned repo,
-    so [false]. This is the fact that makes repo-create/discussion a capability
-    decision rather than an ordinary reversible mutation. *)
+val creates_durable_remote_surface : Gh_verb.t -> bool
+(** G-4 externality axis (risk-independent): [true] when this gh verb creates or
+    mutates a durable remote surface whose ownership, lifecycle, and moderation
+    policy are not modeled in keeper tool contracts.
+
+    Keyed on the whole verb (family + action), not the family alone (W3
+    per-action refinement): a [Repo]/[Discussion] verb that is a local or
+    read-only action ([repo clone] copies to the local disk, [repo view] /
+    [repo list] read) does NOT touch a durable remote surface and is [false].
+    Only the mutating actions on those families ([repo create]/[fork]/[edit]/
+    [sync]/[set-default]/[rename]; every [discussion] mutation) are [true].
+    [Pr]/[Issue]/[Release]/etc. act within an already-owned repo, so [false].
+    A [None] action (bare [gh repo]) is a read, so [false]. *)
 
 val disposition_of : Gh_verb.t -> disposition
 (** The capability disposition for a gh verb. Reads

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -460,6 +460,85 @@ let test_gh_leading_flag_read_not_floored_under_autonomous () =
       , [ lit "--repo"; var "REPO"; lit "pr"; lit "view"; var "PR_NUMBER" ] )
     ]
 
+(* RFC-0309 W3 (G-6/G-8): the capability axis escalates a durable-remote gh
+   mutation to [Ask] even under the autonomous (all-Observe) overlay — the
+   non-blocking HITL queue is the resolver. This is the enable path: instead of
+   auto-running (old autonomous behavior) or being disabled (#23362), a
+   [Requires_approval] verb asks. *)
+let test_gh_durable_remote_asks_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } ->
+         assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: durable-remote gh op must Ask under autonomous"
+           label)
+    (* R1 durable-remote mutations that exist TODAY (repo reversible table).
+       discussion mutations and repo create/fork are R2 under #23362, so they
+       Deny (not Ask) until W4/G-9 moves them to R1 — asserted separately in
+       [test_gh_r2_durable_remote_denies_pending_w4]. *)
+    [ "gh repo edit", [ "repo"; "edit"; "--description"; "d" ]
+    ; "gh repo sync", [ "repo"; "sync" ]
+    ; "gh repo set-default", [ "repo"; "set-default"; "o/r" ]
+    ; "gh frobnicate (unknown -> Requires_approval)", [ "frobnicate"; "now" ]
+    ]
+
+(* #23362 keeps discussion mutations and repo create/fork at R2, so the
+   capability disposition is [Denied] and they take the floor Deny path, NOT
+   the W3 Ask path. Pinned here so W4/G-9 (R2 -> R1) produces a visible delta:
+   these flip from Deny to Ask. *)
+let test_gh_r2_durable_remote_denies_pending_w4 () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Destructive_repo_hosting_cli _; _ } -> ()
+       | _ ->
+         Alcotest.failf "%s: R2 durable-remote must Deny under autonomous (W4 -> Ask)"
+           label)
+    [ "gh discussion comment", [ "discussion"; "comment"; "42"; "--body"; "B" ]
+    ; "gh repo create", [ "repo"; "create"; "o/new" ]
+    ]
+
+(* Regression guard: the W3 capability layer is ADDITIVE. Reads and local /
+   in-repo reversible mutations stay [Allow] under autonomous — no over-block of
+   routine keeper work. *)
+let test_gh_reads_and_local_still_allowed_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Allow _ -> ()
+       | _ -> Alcotest.failf "%s: should stay Allow under autonomous" label)
+    [ "gh pr view", [ "pr"; "view"; "1" ]
+    ; "gh pr create", [ "pr"; "create"; "--title"; "T" ]
+    ; "gh issue comment", [ "issue"; "comment"; "5"; "--body"; "B" ]
+    ; "gh repo clone (local)", [ "repo"; "clone"; "o/r" ]
+    ; "gh repo view", [ "repo"; "view"; "o/r" ]
+    ]
+
+(* Non-gh commands are untouched by the capability layer. *)
+let test_non_gh_unaffected_by_capability_layer () =
+  let s = simple (bin_ok "ls") ~args:[ lit "-la" ] in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Allow _ -> ()
+  | _ -> Alcotest.fail "ls should stay Allow under autonomous"
+
 (* Floor completeness — [git clean] with a bundled force flag ([-fd], the
    common force-delete-untracked form) is destructive and hits the floor.
    Probe finding 2026-06-18: [git clean -fd] was graded as plain audited git
@@ -572,6 +651,10 @@ let () =
   test_gh_leading_flag_destructive_floored_under_autonomous ();
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
+  test_gh_durable_remote_asks_under_autonomous ();
+  test_gh_r2_durable_remote_denies_pending_w4 ();
+  test_gh_reads_and_local_still_allowed_under_autonomous ();
+  test_non_gh_unaffected_by_capability_layer ();
   test_git_clean_bundled_force_denied ();
   (* RFC-0255 §4.5 review response: no raw destructive-git demotion. *)
   test_reset_hard_floored_under_autonomous ();

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -26,26 +26,37 @@ let check label v expected =
       (dstr expected)
 ;;
 
-(* --- externality axis (G-4): exactly Repo + Discussion ------------------- *)
+(* --- externality axis (G-4): per-action durable-remote (W3 refinement) ---- *)
 let test_durable_remote_surface () =
-  let yes = [ Gh_verb.Repo; Gh_verb.Discussion ] in
+  (* mutating actions on a durable-remote family -> true *)
+  let yes =
+    [ ("repo", "create"); ("repo", "fork"); ("repo", "edit"); ("repo", "sync")
+    ; ("repo", "rename"); ("discussion", "create"); ("discussion", "comment")
+    ; ("discussion", "edit"); ("discussion", "delete") ]
+  in
+  (* local / read actions on the SAME families, and any non-durable family,
+     and bare invocations -> false *)
   let no =
-    [ Gh_verb.Pr; Gh_verb.Issue; Gh_verb.Release; Gh_verb.Secret
-    ; Gh_verb.Ssh_key; Gh_verb.Workflow; Gh_verb.Auth; Gh_verb.Gist
-    ; Gh_verb.Ruleset; Gh_verb.Label; Gh_verb.Run; Gh_verb.Cache
-    ; Gh_verb.Project; Gh_verb.Api; Gh_verb.Other "x" ]
+    [ ("repo", "clone"); ("repo", "view"); ("repo", "list")
+    ; ("discussion", "view"); ("discussion", "list")
+    ; ("pr", "merge"); ("issue", "create"); ("release", "create")
+    ; ("api", "graphql"); ("frobnicate", "now") ]
   in
   List.iter
-    (fun f ->
-       if not (Pol.creates_durable_remote_surface f) then
-         Alcotest.failf "%s should be durable-remote" (Gh_verb.string_of_family f))
+    (fun (sub, act) ->
+       let v = verb ~sub ~act () in
+       if not (Pol.creates_durable_remote_surface v) then
+         Alcotest.failf "gh %s %s should be durable-remote" sub act)
     yes;
   List.iter
-    (fun f ->
-       if Pol.creates_durable_remote_surface f then
-         Alcotest.failf "%s should NOT be durable-remote"
-           (Gh_verb.string_of_family f))
-    no
+    (fun (sub, act) ->
+       let v = verb ~sub ~act () in
+       if Pol.creates_durable_remote_surface v then
+         Alcotest.failf "gh %s %s should NOT be durable-remote" sub act)
+    no;
+  (* bare families (no action) are reads -> false *)
+  if Pol.creates_durable_remote_surface (verb ~sub:"repo" ()) then
+    Alcotest.fail "bare 'gh repo' should NOT be durable-remote"
 ;;
 
 (* --- current dispositions (with #23362 tables in force) ------------------- *)
@@ -72,13 +83,14 @@ let test_current_dispositions () =
     Pol.Denied;
   check "discussion create (W4->requires_approval)"
     (verb ~sub:"discussion" ~act:"create" ()) Pol.Denied;
-  (* durable-remote R1 that already exists today -> Requires_approval. NOTE
-     coarseness: this is family-level, so a local-only op like [repo clone]
-     (R1, Repo) also lands here. W3 refines the externality to per-action; for
-     an unenforced spec, conservative over-approval is safe. *)
+  (* durable-remote R1 mutation -> Requires_approval *)
   check "repo edit" (verb ~sub:"repo" ~act:"edit" ()) Pol.Requires_approval;
-  check "repo clone (coarse: local op, refine in W3)"
-    (verb ~sub:"repo" ~act:"clone" ()) Pol.Requires_approval;
+  check "repo sync" (verb ~sub:"repo" ~act:"sync" ()) Pol.Requires_approval;
+  (* W3 per-action refinement: repo clone is a LOCAL op (copies to disk), not a
+     durable-remote mutation, so it stays Allowed — no over-approval of routine
+     work. *)
+  check "repo clone (local -> Allowed)" (verb ~sub:"repo" ~act:"clone" ())
+    Pol.Allowed;
   (* unrecognized area: a human adjudicates *)
   check "unknown verb" (verb ~sub:"frobnicate" ~act:"now" ()) Pol.Requires_approval;
   check "unknown action in known family"


### PR DESCRIPTION
## What

RFC-0309 **W3 (decision layer)**: W2 capability 축을 승인 결정에 배선. autonomous overlay에서도 gated gh verb가 `Verdict.Ask`로 격상됩니다.

> **Base**: 이 PR은 W2(#23413) 위에 스택. W2 머지 후 리뷰/머지.

- `lib/exec/approval_policy.ml`: `decide`가 catastrophic floor 다음, risk-graded trust overlay 앞에서 `Gh_capability_policy.disposition_of`를 참조. disposition이 `Requires_approval`인 gh verb → `Verdict.Ask`(overlay 무관). **additive-only**: gh에만, 승인을 *추가*만(제거 안 함), non-gh 무영향.
- `lib/exec/gh_capability_policy.ml`: G-4 per-action 정밀화 — `creates_durable_remote_surface`가 family가 아니라 verb 전체(family+action) 기준. `repo clone/view/list`(로컬·read)는 false → Allowed 유지(routine 작업 과다차단 없음). mutating action(create/fork/edit/sync…, discussion mutation)만 true.
- `docs/rfc/RFC-0309-...md §3.4`: non-blocking framing 정정.

## Why (실제 메커니즘 확인 후 설계)

understanding으로 런타임을 읽어 RFC 전제를 정정했습니다: 기존 HITL(`Keeper_approval_queue`)은 **Eio-promise fiber-suspend**(tool fiber가 promise await, 대시보드가 resolve하면 같은 fiber resume)이지 "enqueue 후 나중 turn resume"이 아닙니다. Eio라 **fiber suspend = domain은 non-block**(accept loop·다른 keeper·HTTP/WS 계속). 따라서 새 큐/`Pending_approval` 타입 불필요.

`decide`는 floor(Deny) → risk band trust_dispatch만 했고 **gh verb별 capability 자리가 없었습니다**. 이 PR이 그 직교 축을 배선: `Requires_approval`이면 autonomous(all-Observe)에서도 Ask.

## Scope (decision layer만 — 정직한 경계)

**W3가 지금 하는 것**: `decide`가 gated gh를 Ask로 격상. keeper surface는 Ask를 아직 `Approval_required` typed error로 렌더 → gated op이 **auto-run 안 하고 운영자에게 보고**됨(#23362의 disable보다 나음, auto-run보다 안전).

**후속(별도, CI/런타임 복구 후)**: keeper-tool 레이어에서 Ask를 OAS Agent HITL hook에 통합 → 운영자 resolve→실행(진짜 능동 enable). 런타임/통합 테스트 필요(러너 down이라 이번엔 불가).

## W4 delta point (문서화)

`discussion` mutation·`repo create/fork`는 #23362 때문에 **오늘 R2 → Deny**(Ask 아님). 오늘 실제 Ask로 격상되는 durable-remote R1은 `repo edit/sync/set-default` + unknown gh(`Other`)뿐. 테스트가 R2 케이스를 "현재 Deny, W4에서 Ask"로 pin → W4/G-9(R2→R1)가 가시적 delta(Deny→Ask).

## 검증

- `test_approval_policy` all passed: durable-remote R1 + unknown → Ask; read/local/pr-create → Allow; non-gh(ls) 무영향; discussion/repo-create → Deny(W4 pending). `test_gh_capability_policy` 2/2 (per-action externality).
- 전체 `@lib/exec/test/runtest` green(회귀 0), keeper+main_eio 빌드 green.
- 전체 meta bug-class gate 로컬 PASS. lib-regression 0, ocamlformat clean.
- ⚠️ CI: repo Build and Test가 self-hosted 러너 **디스크 풀**(`No space left on device`)로 repo-wide 다운(#23400 참조) — CI Gate red 예상, 코드 무관. 로컬 전체 검증으로 대체.

## RFC

RFC-0309 §3.3/§3.4 (G-6/G-8 + G-4 per-action). W1(#23391)·W2(#23413) 위. G-9(repo/discussion 활성)은 이 Ask 배선 이후 W4.

Co-Authored-By: Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
#23416의 승계 PR입니다: W2(#23413) squash 머지 시 base 브랜치 삭제로 #23416이 auto-close되어 reopen이 불가능해 동일 브랜치(feature/rfc-0309-w3-ask-routing)에서 base=main으로 재개설. 리뷰 이력은 #23416 참조. diff는 W2 내용이 main과 동일해 W3 delta만 남습니다.
