### PR TITLE
[codex] Preserve gate source context in keeper chat

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -242,6 +242,53 @@ describe('ChatTranscript', () => {
     )
     const surfaceLink = bubble.querySelector('a[href="https://discord.com/channels/guild-1/thread-1"]')
     expect(surfaceLink?.textContent).toContain('Discord Thread')
+    expect(surfaceLink?.getAttribute('title')).toContain('guild_id=guild-1')
+    expect(surfaceLink?.getAttribute('title')).toContain('thread_id=thread-1')
+  })
+
+  it('renders connector speaker and route context for gate history rows', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'gate-user',
+            text: 'hello from discord',
+            speakerId: '98791450001',
+            speakerName: 'Minsu',
+            speakerAuthority: 'external',
+            conversationId: 'discord:guild-1:channel:1514586257706061834',
+            externalMessageId: '1498985300729172039',
+            surface: {
+              kind: 'gate',
+              label: 'discord',
+              address: {
+                connector: 'discord',
+                workspace_id: '1514586257706061834',
+                external_message_id: '1498985300729172039',
+              },
+            },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-entry-id="gate-user"]') as HTMLElement
+    expect(bubble.getAttribute('data-chat-surface-kind')).toBe('gate')
+    expect(bubble.getAttribute('data-chat-speaker-id')).toBe('98791450001')
+    expect(bubble.getAttribute('data-chat-speaker-name')).toBe('Minsu')
+    expect(bubble.getAttribute('data-chat-conversation-id')).toBe(
+      'discord:guild-1:channel:1514586257706061834',
+    )
+    expect(bubble.getAttribute('data-chat-external-message-id')).toBe('1498985300729172039')
+    expect(bubble.textContent).toContain('Gate: discord')
+    expect(bubble.textContent).toContain('Minsu')
+    const chips = [...bubble.querySelectorAll('[data-chat-meta-chip]')]
+    expect(chips.some(chip => chip.getAttribute('title')?.includes('workspace_id=1514586257706061834'))).toBe(true)
+    expect(chips.some(chip => chip.getAttribute('title')?.includes('speaker_id=98791450001'))).toBe(true)
+    expect(chips.some(chip => chip.getAttribute('title')?.includes('external_message_id=1498985300729172039'))).toBe(true)
   })
 
   it('exposes interrupted stream reconciliation as a no-receipt contract gap', () => {
@@ -289,6 +336,13 @@ describe('ChatTranscript', () => {
         role: 'user',
         content: 'legacy row without turn ref',
         ts: 1_780_000_000,
+        source: 'discord',
+        surface: { kind: 'gate', label: 'discord', address: { workspace_id: 'chan-1' } },
+        conversation_id: 'discord:guild-1:channel:chan-1',
+        external_message_id: 'msg-1',
+        speaker_id: 'user-1',
+        speaker_name: 'Minsu',
+        speaker_authority: 'external',
         stream_contract: {
           source: 'keeper_chat_store',
           status: 'history_without_turn_ref',
@@ -333,7 +387,10 @@ describe('ChatTranscript', () => {
     expect(legacy.getAttribute('data-chat-stream-contract-status')).toBe('history_without_turn_ref')
     expect(legacy.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
     expect(legacy.getAttribute('data-chat-stream-contract-badge-state')).toBe('no-turn-ref')
-    expect(legacy.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('턴 연결 없음')
+    const noTurnBadge = legacy.querySelector('[data-chat-stream-contract-badge]')
+    expect(noTurnBadge?.textContent).toContain('턴 연결 없음')
+    expect(noTurnBadge?.getAttribute('title')).toContain('conversation_id=discord:guild-1:channel:chan-1')
+    expect(noTurnBadge?.getAttribute('title')).toContain('speaker_name=Minsu')
 
     const failure = container.querySelector('[data-chat-entry-id="smoke-error-assistant"]') as HTMLElement
     expect(failure).not.toBeNull()

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -177,37 +177,98 @@ export function ChatSuggestionChip({
   return html`<${SuggestionChip} pre=${pre} ...${rest}>${children}<//>`
 }
 
-function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string; icon: string } | null {
+type ChatMetaInfo = {
+  url?: string
+  label: string
+  icon: string
+  title: string
+  tone?: 'accent' | 'default'
+}
+
+function compactIdentifier(value?: string | null, head = 6, tail = 4): string | null {
+  const normalized = value?.trim()
+  if (!normalized) return null
+  if (normalized.length <= head + tail + 1) return normalized
+  return `${normalized.slice(0, head)}…${normalized.slice(-tail)}`
+}
+
+function compactKeyValues(fields: Array<[string, string | null | undefined]>): string {
+  return fields
+    .map(([key, value]) => {
+      const normalized = value?.trim()
+      return normalized ? `${key}=${normalized}` : null
+    })
+    .filter((value): value is string => value !== null)
+    .join(' · ')
+}
+
+function gateAddressValue(surface: SurfaceRef, ...keys: string[]): string | null {
+  const address = surface.address
+  if (!address) return null
+  for (const key of keys) {
+    const value = address[key]?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+function surfaceLink(surface?: SurfaceRef | null): ChatMetaInfo | null {
   if (!surface || !surface.kind) return null
   switch (surface.kind) {
     case 'discord':
       if (surface.channel_id) {
         const targetId = surface.thread_id || surface.channel_id
         const guild = surface.guild_id || '@me'
+        const labelTarget = compactIdentifier(targetId) ?? targetId
+        const title = compactKeyValues([
+          ['surface', surface.thread_id ? 'discord_thread' : 'discord_channel'],
+          ['guild_id', surface.guild_id || '@me'],
+          ['channel_id', surface.channel_id],
+          ['parent_channel_id', surface.parent_channel_id],
+          ['thread_id', surface.thread_id],
+        ])
         return {
           url: `https://discord.com/channels/${guild}/${targetId}`,
-          label: surface.thread_id ? 'Discord Thread' : 'Discord Channel',
+          label: `${surface.thread_id ? 'Discord Thread' : 'Discord Channel'} ${labelTarget}`,
           icon: '🎮',
+          title,
+          tone: 'accent',
         }
       }
       break
     case 'slack':
       if (surface.channel_id) {
         const team = surface.team_id ? `&team=${surface.team_id}` : ''
+        const labelTarget = compactIdentifier(surface.channel_id) ?? surface.channel_id
+        const title = compactKeyValues([
+          ['surface', 'slack_channel'],
+          ['team_id', surface.team_id],
+          ['channel_id', surface.channel_id],
+          ['thread_ts', surface.thread_ts],
+        ])
         return {
           url: `https://slack.com/app_redirect?channel=${surface.channel_id}${team}`,
-          label: 'Slack Channel',
+          label: `Slack Channel ${labelTarget}`,
           icon: '💬',
+          title,
+          tone: 'accent',
         }
       }
       break
     case 'github':
       if (surface.repo) {
         const path = surface.notification_id ? `/notifications/${surface.notification_id}` : ''
+        const title = compactKeyValues([
+          ['surface', 'github'],
+          ['repo', surface.repo],
+          ['notification_id', surface.notification_id],
+        ])
         return {
           url: `https://github.com/${surface.repo}${path}`,
           label: `GitHub: ${surface.repo}`,
           icon: '🐙',
+          title,
+          tone: 'accent',
         }
       }
       break
@@ -216,21 +277,106 @@ function surfaceLink(surface?: SurfaceRef | null): { url: string; label: string;
         url: '#',
         label: 'Dashboard',
         icon: '💻',
+        title: compactKeyValues([
+          ['surface', 'dashboard'],
+          ['session_id', surface.session_id],
+        ]),
       }
     case 'agent':
       return {
         url: '#',
         label: 'Agent (Self)',
         icon: '🤖',
+        title: 'surface=agent',
       }
     case 'gate':
-      return {
-        url: '#',
-        label: `Gate: ${surface.label || 'connector'}`,
-        icon: '⚡',
+      {
+        const label = surface.label || 'connector'
+        const workspace = gateAddressValue(surface, 'workspace_id', 'channel_workspace_id')
+        const labelSuffix = compactIdentifier(workspace)
+        const titleFields: Array<[string, string | null | undefined]> = [
+          ['surface', 'gate'],
+          ['label', label],
+        ]
+        if (surface.address) {
+          for (const [key, value] of Object.entries(surface.address)) {
+            titleFields.push([key, value])
+          }
+        }
+        return {
+          url: '#',
+          label: `Gate: ${label}${labelSuffix ? ` · ${labelSuffix}` : ''}`,
+          icon: '⚡',
+          title: compactKeyValues(titleFields),
+        }
       }
   }
   return null
+}
+
+function speakerMeta(entry: KeeperConversationEntry): ChatMetaInfo | null {
+  const speakerId = entry.speakerId?.trim()
+  const speakerName = entry.speakerName?.trim()
+  const authority = entry.speakerAuthority?.trim()
+  if (!speakerId && !speakerName && !authority) return null
+  const label = speakerName || compactIdentifier(speakerId) || authority || 'speaker'
+  return {
+    label,
+    icon: '👤',
+    title: compactKeyValues([
+      ['speaker_name', speakerName],
+      ['speaker_id', speakerId],
+      ['speaker_authority', authority],
+    ]),
+  }
+}
+
+function routeMeta(entry: KeeperConversationEntry): ChatMetaInfo | null {
+  const conversationId = entry.conversationId?.trim()
+  const externalMessageId = entry.externalMessageId?.trim()
+  if (!conversationId && !externalMessageId) return null
+  const labelId = compactIdentifier(externalMessageId || conversationId)
+  return {
+    label: labelId ? `ctx ${labelId}` : 'ctx',
+    icon: '⌁',
+    title: compactKeyValues([
+      ['conversation_id', conversationId],
+      ['external_message_id', externalMessageId],
+    ]),
+  }
+}
+
+function ChatMetaChip({ info, compact }: { info: ChatMetaInfo | null; compact: boolean }) {
+  if (!info) return null
+  const paddingClass = compact ? 'px-2 py-0.5' : 'px-2.5 py-1'
+  const toneClass = info.tone === 'accent'
+    ? `border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]`
+    : `border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]`
+  if (info.url && info.url !== '#') {
+    return html`
+      <a
+        href=${info.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class=${`inline-flex items-center gap-1 rounded-[var(--r-0)] border ${toneClass} ${paddingClass} text-2xs font-semibold hover:bg-[var(--accent-20)] ${CHAT_FOCUS_RING}`}
+        title=${info.title}
+        data-chat-meta-chip=${info.label}
+      >
+        <span>${info.icon}</span>
+        <span>${info.label}</span>
+      </a>
+    `
+  }
+  return html`
+    <span
+      class=${`inline-flex items-center gap-1 rounded-[var(--r-0)] border ${toneClass} ${paddingClass} text-2xs font-medium`}
+      title=${info.title}
+      data-chat-meta-chip=${info.label}
+    >
+      <span>${info.icon}</span>
+      <span>${info.label}</span>
+    </span>
+  `
 }
 
 type ChatTranscriptVariant = 'default' | 'messenger'
@@ -336,12 +482,20 @@ type StreamContractBadgeInfo = {
 function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContractBadgeInfo | null {
   const contract = entry.streamContract
   if (!contract) return null
+  const sourceContext = compactKeyValues([
+    ['surface_kind', entry.surface?.kind],
+    ['conversation_id', entry.conversationId],
+    ['external_message_id', entry.externalMessageId],
+    ['speaker_id', entry.speakerId],
+    ['speaker_name', entry.speakerName],
+  ])
   const title = [
     `source=${contract.source}`,
     `status=${contract.status}`,
     contract.eventName ? `event=${contract.eventName}` : null,
     contract.deliveryReceipt ? `receipt=${contract.deliveryReceipt}` : null,
     contract.reason ?? null,
+    sourceContext || null,
   ].filter((value): value is string => Boolean(value)).join(' · ')
   switch (contract.deliveryReceipt) {
     case 'server_lifecycle_replay_only':
@@ -2224,6 +2378,8 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     attachBlocks.length > 0 ? 'server_block' : null,
   ].filter((value): value is string => value !== null)
   const surfaceInfo = surfaceLink(entry.surface)
+  const speakerInfo = speakerMeta(entry)
+  const routeInfo = routeMeta(entry)
 
   return html`
     <article
@@ -2252,6 +2408,12 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-queue-seq=${entry.queueSeq ?? undefined}
       data-chat-queue-client-action-id=${entry.queueClientActionId ?? undefined}
       data-chat-surface-kind=${entry.surface?.kind ?? undefined}
+      data-chat-surface-address=${entry.surface?.address ? JSON.stringify(entry.surface.address) : undefined}
+      data-chat-conversation-id=${entry.conversationId ?? undefined}
+      data-chat-external-message-id=${entry.externalMessageId ?? undefined}
+      data-chat-speaker-id=${entry.speakerId ?? undefined}
+      data-chat-speaker-name=${entry.speakerName ?? undefined}
+      data-chat-speaker-authority=${entry.speakerAuthority ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
       data-chat-attachment-count=${attachments.length}
       data-chat-server-attach-block-count=${attachBlocks.length}
@@ -2291,30 +2453,9 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                         `
                       : null}
                     <${StreamContractBadge} badge=${streamContractBadge} compact=${true} />
-                    ${surfaceInfo && surfaceInfo.url !== '#'
-                      ? html`
-                          <a
-                            href=${surfaceInfo.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)] ${CHAT_FOCUS_RING}"
-                            title=${surfaceInfo.label}
-                          >
-                            <span>${surfaceInfo.icon}</span>
-                            <span>${surfaceInfo.label}</span>
-                          </a>
-                        `
-                      : surfaceInfo
-                      ? html`
-                          <span
-                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)]"
-                            title=${surfaceInfo.label}
-                          >
-                            <span>${surfaceInfo.icon}</span>
-                            <span>${surfaceInfo.label}</span>
-                          </span>
-                        `
-                      : null}
+                    <${ChatMetaChip} info=${surfaceInfo} compact=${true} />
+                    <${ChatMetaChip} info=${speakerInfo} compact=${true} />
+                    <${ChatMetaChip} info=${routeInfo} compact=${true} />
                   </div>
                 `
               : html`
@@ -2342,30 +2483,9 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                         `
                       : null}
                     <${StreamContractBadge} badge=${streamContractBadge} compact=${false} />
-                    ${surfaceInfo && surfaceInfo.url !== '#'
-                      ? html`
-                          <a
-                            href=${surfaceInfo.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-semibold text-[var(--color-accent-fg)] hover:bg-[var(--accent-20)] ${CHAT_FOCUS_RING}"
-                            title=${surfaceInfo.label}
-                          >
-                            <span>${surfaceInfo.icon}</span>
-                            <span>${surfaceInfo.label}</span>
-                          </a>
-                        `
-                      : surfaceInfo
-                      ? html`
-                          <span
-                            class="inline-flex items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]"
-                            title=${surfaceInfo.label}
-                          >
-                            <span>${surfaceInfo.icon}</span>
-                            <span>${surfaceInfo.label}</span>
-                          </span>
-                        `
-                      : null}
+                    <${ChatMetaChip} info=${surfaceInfo} compact=${false} />
+                    <${ChatMetaChip} info=${speakerInfo} compact=${false} />
+                    <${ChatMetaChip} info=${routeInfo} compact=${false} />
                   </div>
                   <div class="mt-2 truncate text-sm font-bold text-[var(--color-fg-primary)]">
                     ${avatarLabel(entry)}

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -331,6 +331,9 @@ describe('thread history merge & persistence', () => {
         content: 'state snapshot',
         ts: 1_780_000_000,
         surface: { kind: 'dashboard', session_id: 'sess-1' },
+        speaker_id: 'operator-1',
+        speaker_name: 'Operator',
+        speaker_authority: 'owner',
       },
       {
         role: 'assistant',
@@ -338,6 +341,8 @@ describe('thread history merge & persistence', () => {
         content: 'reply from channel context',
         ts: 1_780_000_001,
         turn_ref: 'trace-rest#7',
+        conversation_id: 'discord:guild-1:channel:channel-1',
+        external_message_id: 'message-1',
         surface: {
           kind: 'discord',
           guild_id: 'guild-1',
@@ -357,6 +362,11 @@ describe('thread history merge & persistence', () => {
       thread_id: 'thread-1',
     })
     expect(entries[1]?.turnRef).toBe('trace-rest#7')
+    expect(entries[0]?.speakerId).toBe('operator-1')
+    expect(entries[0]?.speakerName).toBe('Operator')
+    expect(entries[0]?.speakerAuthority).toBe('owner')
+    expect(entries[1]?.conversationId).toBe('discord:guild-1:channel:channel-1')
+    expect(entries[1]?.externalMessageId).toBe('message-1')
   })
 
   it('prefers backend stream contracts from REST chat history', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -860,6 +860,11 @@ function normalizeHistoryEntry(
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
+  const conversationId = asString(raw.conversation_id) ?? null
+  const externalMessageId = asString(raw.external_message_id) ?? null
+  const speakerId = asString(raw.speaker_id) ?? null
+  const speakerName = asString(raw.speaker_name) ?? null
+  const speakerAuthority = asString(raw.speaker_authority) ?? null
   // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
   // keeper_chat_store mints kind=transport_failure (row content is the
@@ -895,6 +900,11 @@ function normalizeHistoryEntry(
     streamContract,
     details: null,
     surface,
+    conversationId,
+    externalMessageId,
+    speakerId,
+    speakerName,
+    speakerAuthority,
     audio,
     attachments,
     blocks,
@@ -1402,6 +1412,11 @@ interface RestChatHistoryMessage {
   tool_call_name?: string
   source?: string
   surface?: SurfaceRef
+  conversation_id?: string
+  external_message_id?: string
+  speaker_id?: string
+  speaker_name?: string
+  speaker_authority?: string
   // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
   turn_ref?: string | null
   audio?: unknown
@@ -1447,6 +1462,11 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     }),
     details: null,
     surface: message.surface ?? null,
+    conversationId: asString(message.conversation_id) ?? null,
+    externalMessageId: asString(message.external_message_id) ?? null,
+    speakerId: asString(message.speaker_id) ?? null,
+    speakerName: asString(message.speaker_name) ?? null,
+    speakerAuthority: asString(message.speaker_authority) ?? null,
     // Tool rows share the same untrusted REST boundary; reject malformed
     // turn_ref values here too so this path matches normalizeHistoryEntry.
     turnRef: asString(message.turn_ref) ?? null,
@@ -1477,6 +1497,11 @@ export function chatHistoryEntriesFromRest(
         ts_unix: message.ts,
         source: message.source,
         surface: message.surface,
+        conversation_id: message.conversation_id,
+        external_message_id: message.external_message_id,
+        speaker_id: message.speaker_id,
+        speaker_name: message.speaker_name,
+        speaker_authority: message.speaker_authority,
         audio: message.audio,
         attachments: message.attachments,
         kind: message.kind,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -979,6 +979,11 @@ export interface KeeperConversationEntry {
   details?: KeeperConversationDetails | null
   error?: string | null
   surface?: SurfaceRef | null
+  conversationId?: string | null
+  externalMessageId?: string | null
+  speakerId?: string | null
+  speakerName?: string | null
+  speakerAuthority?: string | null
   audio?: KeeperConversationAudioClip | null
 }
 

--- a/lib/gate/channel_gate.ml
+++ b/lib/gate/channel_gate.ml
@@ -52,6 +52,7 @@ type dispatch_fn =
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -63,6 +64,7 @@ type streaming_dispatch_fn =
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -199,6 +201,7 @@ let handle_inbound_with ~dispatch (msg : inbound_message) =
           ~channel_user_name:msg.channel_user_name
           ~channel_workspace_id:msg.channel_workspace_id
           ~keeper_name:keeper
+          ~idempotency_key:msg.idempotency_key
           ~metadata:msg.metadata
           ~content:(String.trim msg.content)
       in

--- a/lib/gate/channel_gate.mli
+++ b/lib/gate/channel_gate.mli
@@ -97,6 +97,7 @@ type dispatch_fn =
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -108,6 +109,7 @@ type streaming_dispatch_fn =
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -291,13 +291,106 @@ let metadata_value key metadata =
       if value = "" then None else Some value
   | None -> None
 
-let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
+let metadata_value_any keys metadata =
+  List.find_map (fun key -> metadata_value key metadata) keys
+
+let assoc_string_if_present key value =
+  match non_empty_opt value with
+  | None -> []
+  | Some value -> [ (key, value) ]
+
+let opt_assoc_string_if_present key = function
+  | None -> []
+  | Some value -> assoc_string_if_present key value
+
+let gate_address ~channel ~channel_workspace_id ?conversation_id
+    ?external_message_id () =
+  assoc_string_if_present "connector" channel
+  @ assoc_string_if_present "workspace_id" channel_workspace_id
+  @ opt_assoc_string_if_present "conversation_id" conversation_id
+  @ opt_assoc_string_if_present "external_message_id" external_message_id
+
+let discord_channel_id ~channel_workspace_id ~metadata =
+  match metadata_value_any [ "discord.channel_id"; "discord_channel_id" ] metadata with
+  | Some channel_id -> channel_id
+  | None -> String.trim channel_workspace_id
+
+let discord_guild_id metadata =
+  metadata_value_any [ "discord.guild_id"; "discord_guild_id" ] metadata
+
+let surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
+    ~metadata ?conversation_id ?external_message_id () =
+  match connector_kind with
+  | Discord ->
+      Surface_ref.Discord
+        {
+          guild_id = discord_guild_id metadata;
+          channel_id = discord_channel_id ~channel_workspace_id ~metadata;
+          parent_channel_id =
+            metadata_value_any
+              [ "discord.parent_channel_id"; "discord_parent_channel_id" ]
+              metadata;
+          thread_id =
+            metadata_value_any [ "discord.thread_id"; "discord_thread_id" ] metadata;
+        }
+  | Generic ->
+      let label =
+        match non_empty_opt channel with
+        | Some lane -> lane
+        | None -> "gate"
+      in
+      Surface_ref.Gate
+        {
+          label;
+          address =
+            gate_address ~channel ~channel_workspace_id ?conversation_id
+              ?external_message_id ();
+        }
+
+let conversation_id_for_channel_context ~connector_kind ~channel
+    ~channel_workspace_id ~metadata =
+  match metadata_value "conversation_id" metadata with
+  | Some value -> Some value
+  | None -> (
+      match connector_kind with
+      | Discord ->
+          let channel_id = discord_channel_id ~channel_workspace_id ~metadata in
+          (match non_empty_opt channel_id with
+           | None -> None
+           | Some channel_id ->
+               let guild_label =
+                 match discord_guild_id metadata with
+                 | Some guild_id -> guild_id
+                 | None -> "dm"
+               in
+               Some (Printf.sprintf "discord:%s:channel:%s" guild_label channel_id))
+      | Generic ->
+          (match non_empty_opt channel, non_empty_opt channel_workspace_id with
+           | Some lane, Some workspace_id ->
+               Some (Printf.sprintf "gate:%s:workspace:%s" lane workspace_id)
+           | _ -> None))
+
+let external_message_id_for_channel_context ~idempotency_key ~metadata =
+  match metadata_value_any [ "external_message_id"; "discord.message_id" ] metadata with
+  | Some value -> Some value
+  | None -> non_empty_opt idempotency_key
+
+let ensure_metadata key value metadata =
+  match value with
+  | None -> metadata
+  | Some value ->
+      if Option.is_some (List.assoc_opt key metadata) then metadata
+      else metadata @ [ (key, value) ]
+
+let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
     ?conversation_id ?turn_ref ~reply () =
   let content = String.trim reply in
   if content <> "" then begin
-    (* RFC-0232 P5: the gate recorder knows the connector label only;
-       coordinates ride [conversation_id] as before. *)
-    let surface = Surface_ref.Gate { label = source; address = [] } in
+    let surface =
+      match surface with
+      | Some surface -> surface
+      | None -> Surface_ref.Gate { label = source; address = [] }
+    in
     (* RFC-0233 §7: [turn_ref] is the join key the keeper minted into the
        reply payload, carried onto this connector turn's assistant row. *)
     Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
@@ -312,7 +405,7 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source
 let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
     ~proc_mgr ~net ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~metadata ~content () =
+    ~keeper_name ~idempotency_key ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
   let redaction =
     Keeper_secret_redaction.snapshot
@@ -344,8 +437,22 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
      history. *)
   let lane = String.trim channel in
   let opt value = match String.trim value with "" -> None | v -> Some v in
-  let conversation_id = metadata_value "conversation_id" metadata in
-  let external_message_id = metadata_value "external_message_id" metadata in
+  let conversation_id =
+    conversation_id_for_channel_context ~connector_kind ~channel
+      ~channel_workspace_id ~metadata
+  in
+  let external_message_id =
+    external_message_id_for_channel_context ~idempotency_key ~metadata
+  in
+  let metadata =
+    metadata
+    |> ensure_metadata "conversation_id" conversation_id
+    |> ensure_metadata "external_message_id" external_message_id
+  in
+  let surface =
+    surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
+      ~metadata ?conversation_id ?external_message_id ()
+  in
   (* RFC-0232 §3.3: the connector decoded a structured mention of this
      channel's bound keeper (e.g. Discord <@snowflake>, invisible to
      the content token parser), so the recorder persists it as an
@@ -360,7 +467,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
     ~base_dir:config.Workspace.base_path
     ~keeper_name
     ~content:(String.trim content)
-    ~surface:(Surface_ref.Gate { label = lane; address = [] })
+    ~surface
     ?conversation_id
     ?external_message_id
     ~speaker:
@@ -387,6 +494,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
          of the generic "agent" source. Internal-only args, same class
          as [direct_reply] / [channel_session_key]. *)
       ("channel", `String channel);
+      ("channel_workspace_id", `String channel_workspace_id);
       ("channel_user_id", `String channel_user_id);
       ("channel_user_name", `String channel_user_name);
       ("channel_metadata", string_assoc_json metadata);
@@ -553,7 +661,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
       in
       persist_connector_assistant_reply
         ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
-        ?conversation_id ?turn_ref ~reply ();
+        ~surface ?conversation_id ?turn_ref ~reply ();
       Gate_protocol.Reply { content = reply; structured; stats; message_request = None }
   | `Async_ack (_, Some result) | `Streaming (Some result) ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
@@ -569,14 +677,14 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
    [Generic] default. *)
 let dispatch ~connector_kind ~sw ~clock ~proc_mgr ~net ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-    ~metadata ~content =
+    ~idempotency_key ~metadata ~content =
   dispatch_core ~connector_kind ~sw ~clock ~proc_mgr ~net ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-    ~metadata ~content ()
+    ~idempotency_key ~metadata ~content ()
 
 let dispatch_with_text_snapshot ~connector_kind ~on_text_snapshot ~sw ~clock
     ~proc_mgr ~net ~config ~channel ~channel_user_id ~channel_user_name
-    ~channel_workspace_id ~keeper_name ~metadata ~content =
+    ~channel_workspace_id ~keeper_name ~idempotency_key ~metadata ~content =
   dispatch_core ~connector_kind ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
     ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~metadata ~content ()
+    ~keeper_name ~idempotency_key ~metadata ~content ()

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -47,6 +47,7 @@ val dispatch :
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -75,6 +76,7 @@ val dispatch_with_text_snapshot :
   channel_user_name:string ->
   channel_workspace_id:string ->
   keeper_name:string ->
+  idempotency_key:string ->
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -107,6 +109,7 @@ val persist_connector_assistant_reply :
   base_dir:string ->
   keeper_name:string ->
   source:string ->
+  ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?turn_ref:Ids.Turn_ref.t ->
   reply:string ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -84,6 +84,14 @@ let has_connector_context (payload : keeper_chat_stream_request) =
 let has_external_speaker (payload : keeper_chat_stream_request) =
   has_connector_context payload && payload.channel_user_id <> ""
 
+let gate_address_of_request payload =
+  let field key value =
+    let value = String.trim value in
+    if value = "" then [] else [ (key, value) ]
+  in
+  field "connector" payload.channel
+  @ field "workspace_id" payload.channel_workspace_id
+
 let message_for_request payload =
   if has_external_speaker payload then
     Gate_keeper_backend.contextualize_message
@@ -98,7 +106,8 @@ let message_for_request payload =
 
 let chat_surface_of_request payload =
   if has_connector_context payload then
-    Surface_ref.Gate { label = payload.channel; address = [] }
+    Surface_ref.Gate
+      { label = payload.channel; address = gate_address_of_request payload }
   else Surface_ref.Dashboard { session_id = None }
 
 let chat_speaker_of_request payload =

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -144,7 +144,7 @@ let test_inbound_of_json_normalizes_channel_label () =
 (* ── Mock dispatch for handle_inbound tests ──────────────────── *)
 
 let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~channel_user_name:_
-    ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_ ~content:_ =
+    ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Reply {
     content = "mock reply";
     structured = None;
@@ -153,11 +153,11 @@ let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~channel_user_name:_
   }
 
 let mock_dispatch_error ~channel:_ ~channel_user_id:_ ~channel_user_name:_
-    ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_ ~content:_ =
+    ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Keeper_error_result "mock keeper error"
 
 let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~channel_user_name:_
-    ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_ ~content:_ =
+    ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Unavailable_result
 
 let queued_request : Gate_protocol.message_request =
@@ -174,7 +174,7 @@ let queued_request : Gate_protocol.message_request =
   }
 
 let mock_dispatch_queued ~channel:_ ~channel_user_id:_ ~channel_user_name:_
-    ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_ ~content:_ =
+    ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Reply
     { content = "luna is busy; your message is queued (request_id=req-queued)."
     ; structured = None
@@ -239,11 +239,11 @@ let test_handle_inbound_passes_channel_context_to_dispatch () =
   reset_dedup ();
   let seen = ref None in
   let dispatch ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-      ~keeper_name:_ ~metadata ~content:_ =
+      ~keeper_name:_ ~idempotency_key ~metadata ~content:_ =
     seen :=
       Some
         (channel, channel_user_id, channel_user_name, channel_workspace_id,
-         metadata);
+         idempotency_key, metadata);
     Gate_protocol.Reply {
       content = "ok";
       structured = None;
@@ -262,11 +262,12 @@ let test_handle_inbound_passes_channel_context_to_dispatch () =
   match Channel_gate.handle_inbound ~dispatch msg with
   | Ok _ -> (
       match !seen with
-      | Some (channel, user_id, user_name, workspace_id, metadata) ->
+      | Some (channel, user_id, user_name, workspace_id, idempotency_key, metadata) ->
           check string "channel" "discord" channel;
           check string "user id" "user-1" user_id;
           check string "user name" "Alice" user_name;
           check string "workspace id" "thread-7" workspace_id;
+          check string "idempotency key" msg.idempotency_key idempotency_key;
           check string "metadata" "guild-1"
             (List.assoc "discord.guild_id" metadata)
       | None -> fail "dispatch should receive connector context" )
@@ -276,7 +277,7 @@ let test_handle_inbound_passes_metadata_to_dispatch () =
   reset_dedup ();
   let seen = ref None in
   let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
-      ~channel_workspace_id:_ ~keeper_name:_ ~metadata ~content:_ =
+      ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata ~content:_ =
     seen := Some metadata;
     Gate_protocol.Reply
       { content = "ok"
@@ -310,8 +311,8 @@ let test_handle_inbound_streaming_forwards_snapshot_callback () =
   reset_dedup ();
   let snapshots = ref [] in
   let dispatch ~on_text_snapshot ~channel:_ ~channel_user_id:_
-      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_
-      ~content:_ =
+      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+      ~idempotency_key:_ ~metadata:_ ~content:_ =
     on_text_snapshot "partial";
     Gate_protocol.Reply
       { content = "ok"
@@ -338,8 +339,8 @@ let test_handle_inbound_streaming_validation_blocks_callback () =
   let dispatch_called = ref false in
   let snapshot_called = ref false in
   let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
-      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_ ~metadata:_
-      ~content:_ =
+      ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+      ~idempotency_key:_ ~metadata:_ ~content:_ =
     dispatch_called := true;
     Gate_protocol.Reply
       { content = "ok"

--- a/test/test_copilot_dock_channel_wiring.ml
+++ b/test/test_copilot_dock_channel_wiring.ml
@@ -67,7 +67,11 @@ let test_copilot_surface_is_gate_label () =
   in
   let chat_surface = Stream.For_testing.chat_surface_of_request payload in
   check surface "chat surface"
-    (Masc.Surface_ref.Gate { label = "copilot"; address = [] })
+    (Masc.Surface_ref.Gate
+       {
+         label = "copilot";
+         address = [ ("connector", "copilot"); ("workspace_id", "session-7") ];
+       })
     chat_surface;
   let speaker = Stream.For_testing.chat_speaker_of_request payload in
   check string "authority label" "owner"
@@ -137,7 +141,11 @@ let test_external_connector_still_contextualized () =
     (Stream.For_testing.has_external_speaker payload);
   let chat_surface = Stream.For_testing.chat_surface_of_request payload in
   check surface "surface"
-    (Masc.Surface_ref.Gate { label = "discord"; address = [] })
+    (Masc.Surface_ref.Gate
+       {
+         label = "discord";
+         address = [ ("connector", "discord"); ("workspace_id", "workspace-9") ];
+       })
     chat_surface;
   let speaker = Stream.For_testing.chat_speaker_of_request payload in
   check string "authority" "external"

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -145,12 +145,21 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
       let keeper_name = "discord-reply-keeper" in
+      let surface =
+        Masc.Surface_ref.Discord
+          {
+            guild_id = Some "guild-1";
+            channel_id = "chan-9";
+            parent_channel_id = None;
+            thread_id = None;
+          }
+      in
       K.append_user_message ~base_dir ~keeper_name
         ~content:"<@bot> factorio?"
-        ~surface:(Masc.Surface_ref.Gate { label = "discord"; address = [] })
+        ~surface
         ~conversation_id:"discord:guild-1:channel:chan-9" ();
       Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord"
+        ~keeper_name ~source:"discord" ~surface
         ~conversation_id:"discord:guild-1:channel:chan-9"
         ~reply:"already answered" ();
       match K.load ~base_dir ~keeper_name with
@@ -162,6 +171,10 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
           check string "assistant conversation id"
             "discord:guild-1:channel:chan-9"
             (Option.value assistant.K.conversation_id ~default:"");
+          check bool "assistant keeps typed surface" true
+            (match assistant.K.surface with
+             | Some actual -> Surface_ref.equal surface actual
+             | None -> false);
           check string "assistant content" "already answered" assistant.K.content
       | messages ->
           failf "expected 2 chat messages, got %d" (List.length messages))
@@ -2308,7 +2321,14 @@ let test_chat_surface_of_request_labels_copilot_gate () =
       attachments = [] }
   in
   let surface = Server_routes_http_keeper_stream.For_testing.chat_surface_of_request payload in
-  check string "copilot surface label" "copilot" (Surface_ref.lane_label surface)
+  check string "copilot surface label" "copilot" (Surface_ref.lane_label surface);
+  check bool "copilot surface keeps route address" true
+    (Surface_ref.equal surface
+       (Surface_ref.Gate
+          {
+            label = "copilot";
+            address = [ ("connector", "copilot"); ("workspace_id", "session-7") ];
+          }))
 
 let test_chat_speaker_of_request_copilot_is_owner () =
   let payload =

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -79,7 +79,8 @@ let test_busy_discord_enqueues () =
               ~sw ~clock ~proc_mgr:None ~net:None ~config
               ~channel:"discord" ~channel_user_id:"user-42"
               ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
-              ~keeper_name ~metadata:[] ~content:"are you there?")
+              ~keeper_name ~idempotency_key:"discord-msg-777"
+              ~metadata:[] ~content:"are you there?")
         in
         (* The connector receives a busy ACK now; the deferred reply arrives
            later via the consumer, so there is no async-poll request_id. *)


### PR DESCRIPTION
## Summary

This keeps connector-origin chat rows from losing their source identity at the gate boundary.

- Thread `idempotency_key` through `Channel_gate` into `Gate_keeper_backend` so inbound connector rows can retain a stable external message fallback.
- Persist Discord connector rows with typed `Surface_ref.Discord` instead of flattening them to `Gate { label = "discord"; address = [] }`.
- Populate generic `Gate.address` with connector/workspace/conversation/message coordinates when a connector cannot be represented by a typed surface.
- Surface speaker, conversation, and external message metadata in the dashboard transcript chips and in the `턴 연결 없음` badge title.

## Root Cause

The store already had fields for `surface`, `conversation_id`, `external_message_id`, and `speaker_*`, but the gate/backend path wrote Discord traffic as a generic empty-address gate surface. The dashboard also passed those REST fields through the schema but did not lift them into `KeeperConversationEntry`, so even preserved metadata could not be inspected in the bubble UI.

## Validation

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/keeper-state.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/chat/primitives.ts src/components/chat/primitives.test.ts`
- `git diff --check`
- `ocamlformat --check lib/gate/channel_gate.ml lib/gate/channel_gate.mli lib/gate_keeper_backend.ml lib/gate_keeper_backend.mli lib/server/server_routes_http_keeper_stream.ml test/test_channel_gate.ml test/test_copilot_dock_channel_wiring.ml test/test_gate_keeper_backend.ml test/test_keeper_busy_connector_deferred.ml`

Local OCaml focused build was attempted but blocked by the local switch, not by a compiler diagnostic from this diff:

```text
scripts/dune-local.sh build ./test/test_channel_gate.exe ./test/test_gate_keeper_backend.exe ./test/test_copilot_dock_channel_wiring.exe ./test/test_keeper_busy_connector_deferred.exe
[dune-local] OCaml 5.4 detected; this repo requires >= 5.5 (dune-project)
```
