### PR TITLE
fix(keeper): remove effective_core_tools shadowed definition — code tools restored to per-turn core (#23440)

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -96,8 +96,13 @@ let core_discovery_tools =
   @ Keeper_tool_descriptor.public_names ()
 ;;
 
-let effective_core_tools () = core_discovery_tools
-;;
+(* [effective_core_tools] is defined below (see "Universe-aware effective core
+   tools"), after the injected-schema state it reads. The earlier static
+   definition here returned [core_discovery_tools] unconditionally and was dead:
+   the later universe-aware definition shadowed it, so every caller resolved to
+   the later one. Removed in #23440 so the guard tests assert against the single
+   live definition. [core_discovery_tools] itself is retained — it is still used
+   by [Keeper_tool_affinity.pre_populate_from_history]. *)
 
 let core_always_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length core_always_tools) in
@@ -312,7 +317,26 @@ let effective_core_tools () =
   in
   let descriptor_publics =
     Keeper_tool_descriptor.public_descriptors
-    |> List.filter (fun d -> Set_util.StringSet.mem d.Keeper_tool_descriptor.internal_name universe_set)
+    |> List.filter (fun d ->
+      (* Native-executor descriptors (Execute/Grep via [Shell_ir]; Read/Edit/
+         Write via [Filesystem]) reach the in-process execution gates directly
+         and are available regardless of the injected masc_* universe, so they
+         stay in the always-visible core. [In_process] descriptors (WebSearch/
+         WebFetch) are backed by masc dispatch and remain universe-gated, which
+         preserves the #20455 WARN-spam control (validate_allow_list prunes a
+         descriptor public whose backend schema was never injected). The
+         [executor] variant is the typed availability discriminator — no masc_
+         string-prefix test, and a new [executor] constructor fails this match
+         at compile time. Without the native-executor arm the code tools were
+         structurally excluded from the per-turn core surface, re-creating the
+         #19864/#20060 split-brain (#23440). *)
+      match d.Keeper_tool_descriptor.executor with
+      | Keeper_tool_descriptor.Shell_ir | Keeper_tool_descriptor.Filesystem ->
+        true
+      | Keeper_tool_descriptor.In_process ->
+        Set_util.StringSet.mem
+          d.Keeper_tool_descriptor.internal_name
+          universe_set)
     |> List.concat_map Keeper_tool_descriptor.public_names_of_descriptor
   in
   base_core_tools @ descriptor_publics

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1045,26 +1045,48 @@ let test_effective_core_tools_is_subset_of_discovery () =
     effective
 ;;
 
-let test_effective_core_tools_without_universe_has_no_descriptor_publics () =
-  (* Establish the empty-universe precondition explicitly: descriptor public
-     names must NOT appear in effective_core_tools when their internal_name is
-     absent from the universe. Mcp_server_eio's module-load bootstrap injects
-     the full schema universe when it is linked into this executable, so the
-     universe cannot be assumed to start empty.
+let test_effective_core_tools_without_universe_keeps_only_native_executor_publics () =
+  (* With an empty masc universe, effective_core_tools must still expose the
+     native-executor code tools (Execute/Grep/Read/Edit/Write): they run through
+     the in-process execution gates and do not depend on masc schema injection.
+     Regression guard for #23440 (the shadowed universe-only definition
+     structurally excluded them from the per-turn core surface). In_process
+     descriptors (WebSearch/WebFetch) are masc-backed and must be pruned when
+     their backend schema is not injected, preserving #20455 universe-awareness.
 
-     Earlier tests may also mutate the schema universe, so bracket this
-     assertion with a save/reset to keep following tests isolated. *)
+     Partition by the typed [executor] variant so the assertion mirrors the
+     production discriminator rather than a hardcoded name list.
+
+     Mcp_server_eio's module-load bootstrap can inject the full schema universe
+     when linked into this executable, and earlier tests may mutate it, so
+     bracket the assertion with a save/reset to keep following tests isolated. *)
   with_masc_schemas [] (fun () ->
     let effective = Registry.effective_core_tools () in
-    let descriptor_publics = Descriptor.public_names () in
     List.iter
-      (fun name ->
-         if List.mem name effective
-         then
-           Alcotest.failf
-             "effective_core_tools contains descriptor public %S when universe is empty"
-             name)
-      descriptor_publics)
+      (fun (d : Descriptor.t) ->
+         let public_names = Descriptor.public_names_of_descriptor d in
+         match d.Descriptor.executor with
+         | Descriptor.Shell_ir | Descriptor.Filesystem ->
+           List.iter
+             (fun name ->
+                if not (List.mem name effective)
+                then
+                  Alcotest.failf
+                    "native-executor public %S missing from effective_core_tools \
+                     with empty universe"
+                    name)
+             public_names
+         | Descriptor.In_process ->
+           List.iter
+             (fun name ->
+                if List.mem name effective
+                then
+                  Alcotest.failf
+                    "in-process (masc-backed) public %S present in \
+                     effective_core_tools when universe is empty"
+                    name)
+             public_names)
+      Descriptor.public_descriptors)
 ;;
 
 let test_effective_core_tools_with_full_universe_matches_discovery () =
@@ -1209,9 +1231,9 @@ let () =
             `Quick
             test_effective_core_tools_is_subset_of_discovery
         ; test_case
-            "effective_core_tools without universe has no descriptor publics"
+            "effective_core_tools without universe keeps only native-executor publics"
             `Quick
-            test_effective_core_tools_without_universe_has_no_descriptor_publics
+            test_effective_core_tools_without_universe_keeps_only_native_executor_publics
         ; test_case
             "effective_core_tools with full universe matches discovery"
             `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -1,7 +1,8 @@
 (** Harness tests for WARN root cause fixes.
 
-    1. Tool access discovery: core_discovery_tools stay candidate-visible
-       across narrow tool_access lists and are hidden by denylist
+    1. Tool access discovery: the per-turn core surface
+       (effective_core_tools) stays visible across narrow tool_access lists
+       and is hidden by denylist
     2. Atomic agent JSON writes: no empty-file race condition *)
 
 open Alcotest
@@ -72,12 +73,17 @@ let build_policy_allowed_tool_set (meta : Keeper_meta_contract.keeper_meta) =
     (Keeper_tool_policy.StringSet.union internal_set public_set)
     (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
 
-(** Filter core_discovery_tools through the current policy-visible set. *)
+(** Filter the PRODUCTION per-turn core surface through the current
+    policy-visible set. [effective_core_tools ()] is the exact function the
+    keeper turn loop uses to build the always-visible core (see
+    [Keeper_run_tools_setup.compute_tool_surface]); asserting against it — not
+    the static [core_discovery_tools] discovery pool — is what makes the #23440
+    shadowing/exclusion regression fail CI. *)
 let filter_core_by_tool_access (meta : Keeper_meta_contract.keeper_meta) =
   let policy_allowed_tool_set = build_policy_allowed_tool_set meta in
   List.filter
     (fun name -> Keeper_tool_policy.StringSet.mem name policy_allowed_tool_set)
-    Keeper_tool_registry.core_discovery_tools
+    (Keeper_tool_dispatch_runtime.effective_core_tools ())
 
 let write_tools = [ "Edit" ]
 
@@ -94,10 +100,13 @@ let test_core_tools_visible_with_empty_tool_access () =
       tool_access = [];
       tool_denylist = [] }
   in
-  (* Precondition: descriptor-backed public tools are in unfiltered core. *)
+  (* Precondition: the native-executor code tools are in the unfiltered
+     production core surface, so a filtered-out result below is the policy
+     filter's doing rather than an absent base entry. *)
+  let unfiltered_core = Keeper_tool_dispatch_runtime.effective_core_tools () in
   List.iter (fun t ->
-    if not (List.mem t Keeper_tool_registry.core_discovery_tools) then
-      fail (Printf.sprintf "precondition: %s missing from core_discovery_tools" t)
+    if not (List.mem t unfiltered_core) then
+      fail (Printf.sprintf "precondition: %s missing from effective_core_tools" t)
   ) (write_tools @ read_alias_tools);
   let filtered = filter_core_by_tool_access meta in
   List.iter (fun t ->


### PR DESCRIPTION
## 무엇을

키퍼의 per-turn always-visible core tool surface에서 코드 도구(`Execute`/`Grep`/`Read`/`Edit`/`Write`)가 구조적으로 배제되던 문제를 고칩니다.

`keeper_tool_registry.ml`에는 `effective_core_tools ()` 정의가 두 개 있었습니다.

- 첫 번째(`:99`, dead): `core_discovery_tools`를 무조건 반환.
- 두 번째(`:306`, production): descriptor public을 `mem d.internal_name universe_set`로 게이팅. `universe_set`은 `injected_masc_tool_names ()` — `keeper_tool_policy.keeper_supported_masc_schemas`가 `String.starts_with ~prefix:"masc_"`로 필터링하므로 **오직 `masc_*` 스키마만** 담깁니다.

코드 도구 descriptor의 internal_name은 `tool_execute`/`tool_search_files`/`tool_read_file`/`tool_edit_file`/`tool_write_file`로 `masc_` prefix가 없어 universe에 절대 들어가지 않고, 두 번째 정의의 필터에서 항상 탈락합니다. 결과적으로 키퍼는 도구가 광고되는 것은 보지만 core surface에는 없어, 코드 작업에서 파일 0건 쓰고 tool call만 소진하는 fleet-wide 증상("constraint-58")이 발생했습니다.

## 왜 (히스토리 조사 — 의도적 게이팅 + collateral 배제)

`git log -S effective_core_tools`로 확인:

- **`bb9ec9fc25` (#20455, 2026-06-08)** 가 두 번째 universe-aware 정의를 도입. 커밋 메시지: 이전엔 `effective_core_tools`가 `core_discovery_tools`를 정적으로 반환해 `validate_allow_list`가 매 턴 non-universe 이름을 prune → WARN spam. universe 멤버십 필터는 이를 막기 위한 **의도적** 설계입니다.
- **`f7f270d675` (#5375)** 가 최초 도입.

즉 universe-awareness는 의도적이지만, **코드 도구 배제는 collateral**입니다. 게이트가 "모든 public descriptor는 masc_* 백엔드"라고 암묵적으로 가정했는데, native-executor 코드 도구에는 거짓입니다. `config.ml`이 이미 동일 클래스 버그(`#19864/#20060` split-brain)를 WebSearch/WebFetch에 대해 문서화하고 있으며, 그건 `masc_web_*`를 universe에 projection하는 방식으로 우회했습니다 — 코드 도구는 internal_name이 `masc_*`가 아니라 이 우회로를 쓸 수 없습니다.

## 변경

- `lib/keeper/keeper_tool_registry.ml`
  - production `effective_core_tools ()`의 필터를 **typed `executor` variant** 기준으로 변경. `Shell_ir`/`Filesystem`(native executor = 인프로세스 실행 게이트, 주입 무관)은 무조건 admit, `In_process`(masc dispatch 백엔드 = WebSearch/WebFetch)는 기존대로 universe-gated 유지 → #20455 WARN-spam 통제 보존. `masc_` 문자열 prefix 분류기 없음, catch-all 없음 — 새 `executor` 생성자는 컴파일 타임에 이 match를 깨뜨립니다.
  - dead 첫 번째 정의(`:99`) 제거(shadowed, 모든 caller가 두 번째로 resolve). `core_discovery_tools` 값 자체는 `Keeper_tool_affinity.pre_populate_from_history`가 쓰므로 유지.
- `test/test_warn_root_causes.ml`
  - `filter_core_by_tool_access`의 base를 `core_discovery_tools`(정적 discovery pool) → 프로덕션 `effective_core_tools ()`(키퍼가 매 턴 쓰는 바로 그 함수)로 retarget. precondition도 동일하게 조정.
- `test/test_keeper_tool_descriptor_registry_integrity.ml`
  - `without_universe` 가드를 새 invariant로 재작성: 빈 universe에서 native-executor public은 core에 **있어야** 하고, In_process(masc-backed) public은 **없어야** 함. `public_descriptors`를 typed `executor`로 파티션해 프로덕션 discriminator를 그대로 미러링.

## 로컬 검증

- `dune build --root . lib/` clean, `dune build --root . @check` exit 0 (전체 worktree 타입체크).
- 통과: `test_keeper_tool_descriptor_registry_integrity`(32), `test_warn_root_causes`(14), `test_keeper_topk_llm`(25), `test_keeper_agent_isolation`(24), `test_tool_descriptors_gen`(24), `test_keeper_tool_policy_masc_surface`(2), `test_keeper_tool_policy_paths`, `test_keeper_tool_resolution`(16), `test_tool_registry_consistency`(6), `test_keeper_run_tools_hooks`(11), `test_keeper_tool_matrix`(142).
- **회귀 가드 실증(버그 모델)**: universe-only 게이트로 임시 revert 시 `test_warn_root_causes` 3건 + `test_keeper_tool_descriptor_registry_integrity` 1건 FAIL(`native-executor public "Execute" missing from effective_core_tools with empty universe`) → fix 복원 시 전부 통과.
- 편집한 3개 `.ml` 파일은 `@fmt` clean(변경하지 않은 일부 `dune` 파일의 포맷 드리프트는 base 상태이며 이 PR 범위 밖).

## Enforcement 불변 (approval/ACL은 downstream 유지)

이 PR은 **core surface에 어떤 도구가 보이는지**만 바꿉니다. 키퍼가 **실제 호출 가능한지**는 그대로입니다.

- 실행 도달성은 `can_execute`(`lib/keeper/keeper_tool_policy.ml:287`)가 결정 — `candidate_set`(코드 도구는 `descriptor_candidate_tool_names ()`로 이미 포함) − `deny_set` 기준이며 `effective_core_tools`와 무관.
- `compute_tool_surface`(`lib/keeper/keeper_run_tools_setup.ml:471-475`)는 `effective_core_tools ()`를 `policy_allowed_tool_set`와 교집합. `policy_allowed_tool_set`는 public 이름을 그 descriptor의 internal target이 `keeper_allowed_tool_names`(candidate − deny)에 있을 때만 포함(`:323-326`). 따라서 코드 도구를 deny한 키퍼는 이 fix 후에도 여전히 core에서 보이지 않습니다.

## 미검증

- fleet 런타임에서의 실제 "burn N calls, write 0 files" 감소 지표(코드 경로/테스트로는 core surface 노출을 증명; 라이브 키퍼 재현은 미측정).
- 무관한 `dune` 파일 포맷 드리프트(로컬 ocamlformat/dune 버전 차이 추정)는 손대지 않음.

RFC 게이트 대상 subsystem(credential/identity/operator control/keeper sandbox/hooks/workflow) 아님 — `keeper_tool_registry`는 해당 없음. workaround signature 아님(문자열 분류기를 **추가**가 아니라 typed match로 **대체**).

Refs #23440 #21836

🤖 Generated with [Claude Code](https://claude.com/claude-code)
