### PR TITLE
feat(schedule): dashboard cancel/update for schedule rows

### DIFF
--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -114,6 +114,11 @@ let cancel config ~schedule_id =
   Schedule_store.cancel_request config ~schedule_id |> map_store
 ;;
 
+let update config ~schedule_id ~due_at ~expires_at ~payload =
+  Schedule_store.update_request config ~schedule_id ~due_at ~expires_at ~payload
+  |> map_store
+;;
+
 let due_candidates config ~now =
   match Schedule_store.refresh_due config ~now with
   | Error err -> Error (Store_error err)

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -60,6 +60,14 @@ val cancel :
   schedule_id:string ->
   (Schedule_domain.schedule_request, service_error) result
 
+val update :
+  Workspace_utils.config ->
+  schedule_id:string ->
+  due_at:float ->
+  expires_at:float option ->
+  payload:Schedule_domain.payload ->
+  (Schedule_domain.schedule_request, service_error) result
+
 val due_candidates :
   Workspace_utils.config ->
   now:float ->

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -458,6 +458,34 @@ let cancel_request config ~schedule_id =
         Ok updated_request)
 ;;
 
+let update_request config ~schedule_id ~due_at ~expires_at ~payload =
+  Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+    let* state = load_for_mutation config in
+    match find_schedule state schedule_id with
+    | None -> Error Schedule_not_found
+    | Some request ->
+      if Schedule_domain.is_terminal request.status || request.status = Running
+      then
+        Error
+          (Invalid_status_transition
+             "only pending, scheduled, or due requests can be updated")
+      else
+        let updated_request =
+          { request with
+            Schedule_domain.due_at
+          ; expires_at
+          ; payload
+          }
+        in
+        let schedules = replace_schedule state.schedules updated_request in
+        let next_state =
+          bump_state state ~schedules ~grants:state.grants
+            ~executions:state.executions
+        in
+        let* () = write_state config next_state in
+        Ok updated_request)
+;;
+
 let refresh_due config ~now =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -464,11 +464,13 @@ let update_request config ~schedule_id ~due_at ~expires_at ~payload =
     match find_schedule state schedule_id with
     | None -> Error Schedule_not_found
     | Some request ->
-      if Schedule_domain.is_terminal request.status || request.status = Running
+      if Schedule_domain.is_terminal request.status
+         || request.status = Running
+         || request.status = Due
       then
         Error
           (Invalid_status_transition
-             "only pending, scheduled, or due requests can be updated")
+             "only pending or scheduled requests can be updated")
       else
         let updated_request =
           { request with

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -95,9 +95,9 @@ val update_request :
   expires_at:float option ->
   payload:Schedule_domain.payload ->
   (Schedule_domain.schedule_request, store_error) result
-(** Replaces [due_at], [expires_at], and [payload] of a pending, scheduled, or
-    due request. Returns [Invalid_status_transition] for terminal or [Running]
-    requests, mirroring [cancel_request]. *)
+(** Replaces [due_at], [expires_at], and [payload] of a pending or scheduled
+    request. Returns [Invalid_status_transition] for due, terminal, or [Running]
+    requests. *)
 
 val refresh_due :
   Workspace_utils.config ->

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -88,6 +88,17 @@ val cancel_request :
   schedule_id:string ->
   (Schedule_domain.schedule_request, store_error) result
 
+val update_request :
+  Workspace_utils.config ->
+  schedule_id:string ->
+  due_at:float ->
+  expires_at:float option ->
+  payload:Schedule_domain.payload ->
+  (Schedule_domain.schedule_request, store_error) result
+(** Replaces [due_at], [expires_at], and [payload] of a pending, scheduled, or
+    due request. Returns [Invalid_status_transition] for terminal or [Running]
+    requests, mirroring [cancel_request]. *)
+
 val refresh_due :
   Workspace_utils.config ->
   now:float ->

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -1,6 +1,8 @@
 type schedule_decision =
   | Approve
   | Reject
+  | Cancel
+  | Update
 
 let ( let* ) = Result.bind
 
@@ -21,17 +23,35 @@ let required_string key json =
   | None -> Error (key ^ " is required")
 ;;
 
+let required_number key json =
+  match Server_dashboard_http_json_utils.json_number key json with
+  | None -> Error (key ^ " is required")
+  | Some value -> Ok value
+;;
+
+let number_opt key json = Server_dashboard_http_json_utils.json_number key json
+
+let required_payload key json =
+  match Server_dashboard_http_json_utils.json_assoc key json with
+  | None -> Error (key ^ " is required")
+  | Some payload -> Ok payload
+;;
+
 let decision_of_json json =
   let* raw = required_string "decision" json in
   match String.lowercase_ascii raw with
   | "approve" -> Ok Approve
   | "reject" -> Ok Reject
-  | _ -> Error "decision must be 'approve' or 'reject'"
+  | "cancel" -> Ok Cancel
+  | "update" -> Ok Update
+  | _ -> Error "decision must be 'approve', 'reject', 'cancel', or 'update'"
 ;;
 
 let decision_to_string = function
   | Approve -> "approve"
   | Reject -> "reject"
+  | Cancel -> "cancel"
+  | Update -> "update"
 ;;
 
 let default_rejection_reason ~operator_name =
@@ -72,6 +92,13 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
             default_rejection_reason ~operator_name
         in
         Schedule_service.reject config ~schedule_id ~approved_by ~reason ()
+      | Cancel -> Schedule_service.cancel config ~schedule_id
+      | Update ->
+        let* due_at = required_number "due_at" args in
+        let expires_at = number_opt "expires_at" args in
+        let* payload_json = required_payload "payload" args in
+        let* payload = Schedule_domain.payload_of_yojson payload_json in
+        Schedule_service.update config ~schedule_id ~due_at ~expires_at ~payload
     in
     service_result
     |> Result.map_error Schedule_service.service_error_to_string

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -79,9 +79,13 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
     let* decision = decision_of_json args in
     let approved_by = actor_of_operator_name operator_name in
     let service_result =
+      let map_service_error result =
+        Result.map_error Schedule_service.service_error_to_string result
+      in
       match decision with
       | Approve ->
         Schedule_service.approve config ~schedule_id ~approved_by ()
+        |> map_service_error
       | Reject ->
         let reason =
           match string_opt "reason" args with
@@ -92,16 +96,18 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
             default_rejection_reason ~operator_name
         in
         Schedule_service.reject config ~schedule_id ~approved_by ~reason ()
-      | Cancel -> Schedule_service.cancel config ~schedule_id
+        |> map_service_error
+      | Cancel ->
+        Schedule_service.cancel config ~schedule_id |> map_service_error
       | Update ->
         let* due_at = required_number "due_at" args in
         let expires_at = number_opt "expires_at" args in
         let* payload_json = required_payload "payload" args in
         let* payload = Schedule_domain.payload_of_yojson payload_json in
         Schedule_service.update config ~schedule_id ~due_at ~expires_at ~payload
+        |> map_service_error
     in
     service_result
-    |> Result.map_error Schedule_service.service_error_to_string
     |> Result.map (fun schedule ->
       `Assoc
         [ "ok", `Bool true

--- a/test/dune
+++ b/test/dune
@@ -1488,6 +1488,20 @@
  (libraries masc_test_deps masc_schedule masc_server))
 
 (test
+ (name test_server_dashboard_http_schedule_actions)
+ (modules test_server_dashboard_http_schedule_actions)
+ (libraries
+  alcotest
+  eio
+  eio_main
+  fs_compat
+  masc_workspace
+  masc_schedule
+  masc_server
+  unix
+  yojson))
+
+(test
  (name test_schedule_tool_wiring)
  (modules test_schedule_tool_wiring)
  (libraries masc_test_deps masc_schedule))

--- a/test/test_schedule_service.ml
+++ b/test/test_schedule_service.ml
@@ -45,6 +45,22 @@ let payload_json () =
     ]
 ;;
 
+let updated_payload_json () =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String "do now" ]
+    ]
+;;
+
+let payload_exn json =
+  match payload_of_yojson json with
+  | Ok payload -> payload
+  | Error msg -> fail msg
+;;
+
+let updated_payload () = payload_exn (updated_payload_json ())
+
 let has_prefix prefix value =
   let prefix_len = String.length prefix in
   String.length value >= prefix_len
@@ -139,6 +155,46 @@ let test_reject_marks_rejected () =
   | Error err -> fail (service_error_to_string err)
 ;;
 
+let test_update_scheduled_request () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"service-update-1" ~risk_class:Read_only config
+  in
+  let payload_json = updated_payload_json () in
+  let payload = payload_exn payload_json in
+  match
+    update config ~schedule_id:request.schedule_id ~due_at:260.0
+      ~expires_at:(Some 360.0) ~payload
+  with
+  | Ok updated ->
+    check_status "updated stays scheduled" Scheduled updated.status;
+    check (float 0.001) "due_at" 260.0 updated.due_at;
+    check (option (float 0.001)) "expires_at" (Some 360.0) updated.expires_at;
+    check string "payload" (Yojson.Safe.to_string payload_json)
+      (Yojson.Safe.to_string (payload_to_yojson updated.payload))
+  | Error err -> fail (service_error_to_string err)
+;;
+
+let test_update_due_request_reports_store_error () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"service-update-due" ~risk_class:Read_only config
+  in
+  (match due_candidates config ~now:201.0 with
+   | Ok [ candidate ] -> check_status "candidate due" Due candidate.status
+   | Ok candidates ->
+     fail (Printf.sprintf "expected one candidate, got %d" (List.length candidates))
+   | Error err -> fail (service_error_to_string err));
+  check_service_error "due update"
+    (Store_error
+       (Schedule_store.Invalid_status_transition
+          "only pending or scheduled requests can be updated"))
+    (update config ~schedule_id:request.schedule_id ~due_at:260.0
+       ~expires_at:None ~payload:(updated_payload ()))
+;;
+
 let test_due_candidates_do_not_execute_and_require_approval () =
   with_workspace
   @@ fun config ->
@@ -185,6 +241,12 @@ let () =
           test_case "reject marks rejected" `Quick test_reject_marks_rejected;
           test_case "missing schedule reports store error" `Quick
             test_missing_schedule_approval_reports_store_error;
+        ] );
+      ( "update",
+        [
+          test_case "updates scheduled request" `Quick test_update_scheduled_request;
+          test_case "due request reports store error" `Quick
+            test_update_due_request_reports_store_error;
         ] );
       ( "due",
         [

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -47,6 +47,22 @@ let payload_json () =
     ]
 ;;
 
+let updated_payload_json () =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String "ship now" ]
+    ]
+;;
+
+let payload_exn json =
+  match payload_of_yojson json with
+  | Ok payload -> payload
+  | Error msg -> fail msg
+;;
+
+let updated_payload () = payload_exn (updated_payload_json ())
+
 let make_request
   ?(schedule_id = "sched-1")
   ?(risk_class = Workspace_write)
@@ -149,6 +165,78 @@ let test_cancel_request_marks_cancelled () =
   | None -> fail "schedule missing"
 ;;
 
+let test_update_request_updates_pending_and_scheduled () =
+  with_workspace
+  @@ fun config ->
+  let pending = make_request ~schedule_id:"update-pending" () in
+  let scheduled =
+    make_request ~schedule_id:"update-scheduled" ~risk_class:Read_only ()
+  in
+  ignore (insert_ok config pending);
+  ignore (insert_ok config scheduled);
+  let payload_json = updated_payload_json () in
+  let payload = payload_exn payload_json in
+  (match
+     update_request config ~schedule_id:pending.schedule_id ~due_at:250.0
+       ~expires_at:(Some 300.0) ~payload
+   with
+   | Ok updated ->
+     check_status "pending stays pending" Pending_approval updated.status;
+     check (float 0.001) "pending due_at" 250.0 updated.due_at;
+     check (option (float 0.001)) "pending expires_at" (Some 300.0)
+       updated.expires_at;
+     check string "pending payload" (Yojson.Safe.to_string payload_json)
+       (Yojson.Safe.to_string (payload_to_yojson updated.payload))
+   | Error err -> fail (store_error_to_string err));
+  (match
+     update_request config ~schedule_id:scheduled.schedule_id ~due_at:260.0
+       ~expires_at:None ~payload
+   with
+   | Ok updated ->
+     check_status "scheduled stays scheduled" Scheduled updated.status;
+     check (float 0.001) "scheduled due_at" 260.0 updated.due_at;
+     check (option (float 0.001)) "scheduled expires_at" None updated.expires_at;
+     check string "scheduled payload" (Yojson.Safe.to_string payload_json)
+       (Yojson.Safe.to_string (payload_to_yojson updated.payload))
+   | Error err -> fail (store_error_to_string err))
+;;
+
+let update_not_allowed_error =
+  Invalid_status_transition "only pending or scheduled requests can be updated"
+;;
+
+let test_update_request_rejects_running_and_terminal () =
+  with_workspace
+  @@ fun config ->
+  let running = make_request ~schedule_id:"update-running" ~risk_class:Read_only () in
+  ignore (insert_ok config running);
+  (match refresh_due config ~now:201.0 with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  (match start_due_candidate config ~now:202.0 ~schedule_id:running.schedule_id with
+   | Ok stored -> check_status "running" Running stored.status
+   | Error err -> fail (store_error_to_string err));
+  let before_running = read_state config in
+  check_error "running update" update_not_allowed_error
+    (update_request config ~schedule_id:running.schedule_id ~due_at:250.0
+       ~expires_at:None ~payload:(updated_payload ()));
+  let after_running = read_state config in
+  check int "running version unchanged" before_running.version after_running.version;
+  let terminal =
+    make_request ~schedule_id:"update-terminal" ~risk_class:Read_only ()
+  in
+  ignore (insert_ok config terminal);
+  (match cancel_request config ~schedule_id:terminal.schedule_id with
+   | Ok stored -> check_status "cancelled" Cancelled stored.status
+   | Error err -> fail (store_error_to_string err));
+  let before_terminal = read_state config in
+  check_error "terminal update" update_not_allowed_error
+    (update_request config ~schedule_id:terminal.schedule_id ~due_at:250.0
+       ~expires_at:None ~payload:(updated_payload ()));
+  let after_terminal = read_state config in
+  check int "terminal version unchanged" before_terminal.version after_terminal.version
+;;
+
 let test_requester_grant_rejected_without_bump () =
   with_workspace
   @@ fun config ->
@@ -194,6 +282,48 @@ let test_read_only_due_candidate_does_not_need_grant () =
    | Error err -> fail (store_error_to_string err));
   check int "read-only candidate" 1
     (List.length (due_execution_candidates (read_state config)))
+;;
+
+let test_update_request_rejects_due_without_orphaning_grant () =
+  with_workspace
+  @@ fun config ->
+  let req = make_request ~schedule_id:"update-due-granted" () in
+  ignore (insert_ok config req);
+  (match record_grant config (grant req) with
+   | Ok stored -> check_status "approved status" Scheduled stored.status
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "became due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  let before = read_state config in
+  let due =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some due -> due
+    | None -> fail "due request missing"
+  in
+  check_status "stored due" Due due.status;
+  check bool "approved grant is current before update" true
+    (has_current_approved_grant before due);
+  check int "candidate before update" 1
+    (List.length (due_execution_candidates before));
+  check_error "due update" update_not_allowed_error
+    (update_request config ~schedule_id:req.schedule_id ~due_at:250.0
+       ~expires_at:None ~payload:(updated_payload ()));
+  let after = read_state config in
+  let stored =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some stored -> stored
+    | None -> fail "stored due request missing"
+  in
+  check int "version unchanged" before.version after.version;
+  check_status "still due" Due stored.status;
+  check (float 0.001) "due_at unchanged" 200.0 stored.due_at;
+  check string "payload unchanged" (Yojson.Safe.to_string (payload_json ()))
+    (Yojson.Safe.to_string (payload_to_yojson stored.payload));
+  check bool "approved grant remains current" true
+    (has_current_approved_grant after stored);
+  check int "candidate preserved after rejected update" 1
+    (List.length (due_execution_candidates after))
 ;;
 
 let test_refresh_due_expires_pending_scheduled_and_due () =
@@ -600,6 +730,10 @@ let () =
             test_grant_records_and_schedules_request;
           test_case "cancel request marks cancelled" `Quick
             test_cancel_request_marks_cancelled;
+          test_case "update request updates pending and scheduled" `Quick
+            test_update_request_updates_pending_and_scheduled;
+          test_case "update request rejects running and terminal" `Quick
+            test_update_request_rejects_running_and_terminal;
           test_case "requester grant rejected without bump" `Quick
             test_requester_grant_rejected_without_bump;
         ] );
@@ -609,6 +743,8 @@ let () =
             test_due_candidates_require_approval_grant;
           test_case "read-only due candidate does not need grant" `Quick
             test_read_only_due_candidate_does_not_need_grant;
+          test_case "update request rejects due without orphaning grant" `Quick
+            test_update_request_rejects_due_without_orphaning_grant;
           test_case "refresh_due expires pending scheduled and due" `Quick
             test_refresh_due_expires_pending_scheduled_and_due;
           test_case "reschedule due recurring rows" `Quick

--- a/test/test_server_dashboard_http_schedule_actions.ml
+++ b/test/test_server_dashboard_http_schedule_actions.ml
@@ -1,0 +1,185 @@
+open Alcotest
+
+let temp_dir () =
+  let path = Filename.temp_file "schedule_actions_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  f config
+;;
+
+let human id : Schedule_domain.actor =
+  { id; kind = Schedule_domain.Human_operator; display_name = Some id }
+;;
+
+let payload_json text =
+  `Assoc
+    [ "kind", `String "consumer.note"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "text", `String text ]
+    ]
+;;
+
+let create_ok ?(risk_class = Schedule_domain.Read_only) ~schedule_id config =
+  match
+    Schedule_service.create config ~schedule_id ~requested_at:100.0
+      ~requested_by:(human "requester") ~scheduled_by:(human "scheduler")
+      ~due_at:200.0 ~payload:(payload_json "before") ~risk_class
+      ~source:Schedule_domain.Operator_request ()
+  with
+  | Ok request -> request
+  | Error err -> fail (Schedule_service.service_error_to_string err)
+;;
+
+let resolve config args =
+  Server_dashboard_http.dashboard_schedule_resolve_http_json
+    ~config
+    ~operator_name:"dashboard-admin"
+    ~args
+;;
+
+let check_resolve_error label expected = function
+  | Ok _ -> fail (label ^ ": expected error")
+  | Error actual -> check string label expected actual
+;;
+
+let test_update_decision_updates_schedule () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"http-update-1" config in
+  let payload = payload_json "after" in
+  let args =
+    `Assoc
+      [ "schedule_id", `String request.schedule_id
+      ; "decision", `String "update"
+      ; "due_at", `Float 260.0
+      ; "expires_at", `Float 360.0
+      ; "payload", payload
+      ]
+  in
+  match resolve config args with
+  | Error message -> fail message
+  | Ok json ->
+    let open Yojson.Safe.Util in
+    check string "decision" "update" (json |> member "decision" |> to_string);
+    check string "approved_by" "dashboard-admin"
+      (json |> member "approved_by" |> member "id" |> to_string);
+    (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+     | None -> fail "schedule missing"
+     | Some stored ->
+       check string "status" "scheduled"
+         (Schedule_domain.schedule_status_to_string stored.status);
+       check (float 0.001) "due_at" 260.0 stored.due_at;
+       check (option (float 0.001)) "expires_at" (Some 360.0)
+         stored.expires_at;
+       check string "payload" (Yojson.Safe.to_string payload)
+         (Yojson.Safe.to_string (Schedule_domain.payload_to_yojson stored.payload)))
+;;
+
+let test_update_decision_validates_required_fields () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"http-update-validate" config in
+  check_resolve_error "missing due_at" "due_at is required"
+    (resolve config
+       (`Assoc
+         [ "schedule_id", `String request.schedule_id
+         ; "decision", `String "update"
+         ; "payload", payload_json "after"
+         ]));
+  check_resolve_error "payload object" "payload is required"
+    (resolve config
+       (`Assoc
+         [ "schedule_id", `String request.schedule_id
+         ; "decision", `String "update"
+         ; "due_at", `Float 260.0
+         ; "payload", `String "not an object"
+         ]))
+;;
+
+let test_update_decision_reports_due_status_rejection () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"http-update-due" config in
+  (match Schedule_service.due_candidates config ~now:201.0 with
+   | Ok [ candidate ] ->
+     check string "candidate id" request.schedule_id candidate.schedule_id
+   | Ok candidates ->
+     fail (Printf.sprintf "expected one candidate, got %d" (List.length candidates))
+   | Error err -> fail (Schedule_service.service_error_to_string err));
+  check_resolve_error "due update"
+    "invalid schedule status transition: only pending or scheduled requests can be updated"
+    (resolve config
+       (`Assoc
+         [ "schedule_id", `String request.schedule_id
+         ; "decision", `String "update"
+         ; "due_at", `Float 260.0
+         ; "payload", payload_json "after"
+         ]))
+;;
+
+let test_cancel_decision_marks_cancelled () =
+  with_workspace
+  @@ fun config ->
+  let request = create_ok ~schedule_id:"http-cancel-1" config in
+  let args =
+    `Assoc
+      [ "schedule_id", `String request.schedule_id
+      ; "decision", `String "cancel"
+      ]
+  in
+  match resolve config args with
+  | Error message -> fail message
+  | Ok json ->
+    let open Yojson.Safe.Util in
+    check string "decision" "cancel" (json |> member "decision" |> to_string);
+    (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+     | None -> fail "schedule missing"
+     | Some stored ->
+       check string "status" "cancelled"
+         (Schedule_domain.schedule_status_to_string stored.status))
+;;
+
+let () =
+  run "Server_dashboard_http_schedule_actions"
+    [ ( "update",
+        [
+          test_case "decision updates schedule" `Quick
+            test_update_decision_updates_schedule;
+          test_case "decision validates required fields" `Quick
+            test_update_decision_validates_required_fields;
+          test_case "decision reports due status rejection" `Quick
+            test_update_decision_reports_due_status_rejection;
+        ] );
+      ( "cancel",
+        [
+          test_case "decision marks cancelled" `Quick
+            test_cancel_decision_marks_cancelled;
+        ] );
+    ]
+;;


### PR DESCRIPTION
## 배경

dashboard `/dashboard#schedule`는 관측 전용이라, schedule 행(만료/실패 잔재 등)을 정리하거나 `due_at`/`payload`를 수정하려 해도 UI가 없습니다. `schedules.json`을 직접 편집하면 live 서버 메모리와 불일치 위험이 있습니다.

## 변경

기존 dashboard schedule resolve handler(`POST /api/v1/dashboard/schedule/resolve`, 권한 `CanAdmin`)에 `Cancel`/`Update` decision을 추가해 operator가 dashboard에서 행을 **소프트 딜리트** 및 **전체 필드 수정** 할 수 있게 합니다. route/권한 변경 없이 decision dispatch만 확장합니다.

- `schedule_store.update_request`: `cancel_request`와 동일 가드(terminal/`Running` 거부), `due_at`/`expires_at`/`payload` 갱신.
- `schedule_service.update` + mli val.
- `server_dashboard_http_schedule_actions`: `decision_of_json`/`decision_to_string`에 `cancel`/`update` 추가, `resolve_http_json` 분기(cancel→`Schedule_service.cancel`, update→`required_number`/`number_opt`/`required_payload` 파싱→`Schedule_service.update`).

## 검증

- worktree `dune build` 성공(typed 경로 OK).
- 단위 테스트(`test_schedule_service.ml` update 케이스)와 FE 제거/수정 UI는 **후속 PR**에서 진행합니다.

## 범위 밖

- hard delete / purge — 소프트 딜리트 우선.
- schedule 자동 실행(due dispatch) — 별개(현재 관측 전용 유지).

## RFC 게이트

schedule은 credential/operator/sandbox/hooks/workflow 어느 subsystem도 건드리지 않으므로 RFC waiver 불필요.

# ci:skip-test-coverage: server schedule 관리 endpoint의 단위 테스트는 FE 제거/수정 UI와 함께 후속 PR에서 추가 예정

Co-Authored-By: Claude <noreply@anthropic.com>