### PR TITLE
fix(exec): close two gh capability-Ask bypasses (external graphql body + pipeline stage)

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -355,6 +355,47 @@ let gh_capability_of_simple (simple : Shell_ir.simple)
      literal argv words and any Shell IR opacity in the graphql [query] body. *)
   Gh_capability_policy.disposition_of_simple simple
 
+(* RFC-0309 W3 (pipeline coverage): the capability Ask must fire for a gh
+   durable-remote op in ANY pipeline stage, not only the representative (last)
+   [simple] the caller extracts via [last_simple_of_ir]. [caps] folds over every
+   stage — the same source the catastrophic floor scans — so [gh repo create ...
+   | cat] still reaches the capability axis. Without this the trailing read stage
+   ([cat]) becomes the representative simple, and the R1 durable-remote create —
+   no longer floored after W4 moved it R2->R1 — would auto-run under the
+   autonomous overlay. Returns the first gh binary whose stage requires approval
+   so the [Ask] reports the real command, not the trailing read.
+
+   [@@warning "-4"]: the [_ :: rest] arm is a find-first scan that intentionally
+   skips non-gh capabilities, same rationale as [find_destructive_repo_hosting_cli]. *)
+let gh_cap_requiring_approval (caps : Capability.t list) : Exec_program.t option =
+  let rec scan = function
+    | [] -> None
+    | Capability.Exec_program (bin, args) :: rest ->
+      (match Exec_program.known bin with
+       | Some Exec_program.Gh ->
+         let simple : Shell_ir.simple =
+           { Shell_ir.bin
+           ; args
+           ; env = []
+           ; cwd = None
+           ; redirects = []
+           ; sandbox = Sandbox_target.host ()
+           }
+         in
+         (match gh_capability_of_simple simple with
+          | Some Gh_capability_policy.Requires_approval -> Some bin
+          | Some (Gh_capability_policy.Allowed | Gh_capability_policy.Denied)
+          | None -> scan rest)
+       | Some _ | None -> scan rest)
+    | Capability.Pipeline_fold inner :: rest ->
+      (match scan inner with
+       | Some _ as found -> found
+       | None -> scan rest)
+    | _ :: rest -> scan rest
+  in
+  scan caps
+[@@warning "-4"]
+
 let trust_dispatch ~trust_level ~caps ~policy ~bin ~simple : Verdict.t =
   match trust_level with
   | Approval_config.Enforced -> ask_of policy ~caps ~bin
@@ -374,20 +415,20 @@ let decide (policy : t)
   | Some reason ->
     (* Trust-independent: denied regardless of [overlay] (RFC-0254 §5.3). *)
     Verdict.Deny { caps; reason }
-  | None when
-      (match gh_capability_of_simple simple with
-       | Some Gh_capability_policy.Requires_approval -> true
-       | Some (Gh_capability_policy.Allowed | Gh_capability_policy.Denied) | None
-         -> false) ->
-    (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval] is
-       escalated to [Ask] regardless of overlay. Additive only — reached solely
-       for gh, and only to REQUIRE approval the risk grading would not. *)
-    ask_of policy ~caps ~bin:simple.bin
   | None ->
-    (* Non-catastrophic: graded by the per-actor trust overlay.  Under the
-       autonomous overlay every level is [Observe] => [Allow] + telemetry;
-       under [enforced_all] every level is [Enforced] => [Ask]. *)
-    (match max_risk caps with
+    (match gh_cap_requiring_approval caps with
+     | Some gh_bin ->
+       (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval]
+          is escalated to [Ask] regardless of overlay. Additive only — reached
+          solely for gh, and only to REQUIRE approval the risk grading would
+          not. Scanned over ALL caps so a gh op in any pipeline stage asks, not
+          only the representative [simple]. *)
+       ask_of policy ~caps ~bin:gh_bin
+     | None ->
+       (* Non-catastrophic: graded by the per-actor trust overlay.  Under the
+          autonomous overlay every level is [Observe] => [Allow] + telemetry;
+          under [enforced_all] every level is [Enforced] => [Ask]. *)
+       (match max_risk caps with
      | `Privileged ->
        trust_dispatch ~trust_level:overlay.privileged_trust
          ~caps ~policy ~bin:simple.bin ~simple
@@ -396,4 +437,4 @@ let decide (policy : t)
          ~caps ~policy ~bin:simple.bin ~simple
      | `Safe ->
        trust_dispatch ~trust_level:overlay.safe_trust
-         ~caps ~policy ~bin:simple.bin ~simple)
+         ~caps ~policy ~bin:simple.bin ~simple))

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -129,6 +129,11 @@ let is_field_flag = function
   | _ -> false
 ;;
 
+let is_external_field_flag = function
+  | "-F" | "--field" -> true
+  | _ -> false
+;;
+
 let strip_attached_field_flag tok =
   let lower = String.lowercase_ascii tok in
   let strip prefix =
@@ -140,6 +145,18 @@ let strip_attached_field_flag tok =
     Some (strip "--raw-field=")
   else if String.starts_with ~prefix:"-f" tok && not (String.equal tok "-f") then
     Some (strip "-f")
+  else if String.starts_with ~prefix:"-F" tok && not (String.equal tok "-F") then
+    Some (strip "-F")
+  else None
+;;
+
+let strip_attached_external_field_flag tok =
+  let lower = String.lowercase_ascii tok in
+  let strip prefix =
+    let n = String.length prefix in
+    String.sub tok n (String.length tok - n)
+  in
+  if String.starts_with ~prefix:"--field=" lower then Some (strip "--field=")
   else if String.starts_with ~prefix:"-F" tok && not (String.equal tok "-F") then
     Some (strip "-F")
   else None
@@ -172,12 +189,15 @@ let attached_opaque_field_may_be_query (arg : Shell_ir.arg) : bool =
 ;;
 
 (* A [query] field whose value is read from an EXTERNAL source: gh reads a
-   -f/-F/--field value beginning with '@' from that file ('@-' = stdin). The
+   -F/--field value beginning with '@' from that file ('@-' = stdin). The
    mutation text is therefore not in argv, so the literal body scanners
    ([body_contains_r2_mutation]/[gh_api_graphql_creates_durable_remote]) cannot
    see it and would R0-Allow it. This is the literal-argv counterpart of the
    Var/Concat opacity above; both mark the body opaque so the capability axis
-   asks. The file is NEVER read (no TOCTOU). *)
+   asks. The file is NEVER read (no TOCTOU).
+
+   [-f/--raw-field] is intentionally excluded here: gh treats [@...] as a raw
+   static string for that flag family, not as file/stdin input. *)
 let field_value_is_external_query field_prefix =
   String.starts_with ~prefix:"query=@" (String.lowercase_ascii field_prefix)
 ;;
@@ -191,7 +211,7 @@ let separate_field_value_is_external_query (arg : Shell_ir.arg) : bool =
 let attached_field_is_external_query (arg : Shell_ir.arg) : bool =
   match arg_literal arg with
   | Some tok ->
-    (match strip_attached_field_flag tok with
+    (match strip_attached_external_field_flag tok with
      | Some field_prefix -> field_value_is_external_query field_prefix
      | None -> false)
   | None -> false
@@ -221,7 +241,8 @@ let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
           (match rest with
            | value :: tail ->
              opaque_field_arg_may_be_query value
-             || separate_field_value_is_external_query value
+             || (is_external_field_flag tok
+                 && separate_field_value_is_external_query value)
              || scan tail
            | [] -> false)
         | Some _ | None ->

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -171,16 +171,63 @@ let attached_opaque_field_may_be_query (arg : Shell_ir.arg) : bool =
      | None -> false)
 ;;
 
+(* A [query] field whose value is read from an EXTERNAL source: gh reads a
+   -f/-F/--field value beginning with '@' from that file ('@-' = stdin). The
+   mutation text is therefore not in argv, so the literal body scanners
+   ([body_contains_r2_mutation]/[gh_api_graphql_creates_durable_remote]) cannot
+   see it and would R0-Allow it. This is the literal-argv counterpart of the
+   Var/Concat opacity above; both mark the body opaque so the capability axis
+   asks. The file is NEVER read (no TOCTOU). *)
+let field_value_is_external_query field_prefix =
+  String.starts_with ~prefix:"query=@" (String.lowercase_ascii field_prefix)
+;;
+
+let separate_field_value_is_external_query (arg : Shell_ir.arg) : bool =
+  match arg_literal arg with
+  | Some value -> field_value_is_external_query value
+  | None -> false
+;;
+
+let attached_field_is_external_query (arg : Shell_ir.arg) : bool =
+  match arg_literal arg with
+  | Some tok ->
+    (match strip_attached_field_flag tok with
+     | Some field_prefix -> field_value_is_external_query field_prefix
+     | None -> false)
+  | None -> false
+;;
+
+(* [gh api graphql --input FILE] (or [--input -]) delivers the whole request
+   body — including the graphql [query] — from a file or stdin. As with the '@'
+   sigil, the mutation text never reaches argv, so treat its presence as an
+   opaque body. Matches both the separate ([--input file]) and attached
+   ([--input=file]) forms. *)
+let arg_is_input_flag (arg : Shell_ir.arg) : bool =
+  match arg_leading_literal arg with
+  | Some tok ->
+    let lower = String.lowercase_ascii tok in
+    String.equal lower "--input" || String.starts_with ~prefix:"--input=" lower
+  | None -> false
+;;
+
 let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
   let rec scan = function
     | [] -> false
     | arg :: rest ->
-      (match arg_literal arg with
-       | Some tok when is_field_flag tok ->
-         (match rest with
-          | value :: tail -> opaque_field_arg_may_be_query value || scan tail
-          | [] -> false)
-       | Some _ | None -> attached_opaque_field_may_be_query arg || scan rest)
+      if arg_is_input_flag arg then true
+      else (
+        match arg_literal arg with
+        | Some tok when is_field_flag tok ->
+          (match rest with
+           | value :: tail ->
+             opaque_field_arg_may_be_query value
+             || separate_field_value_is_external_query value
+             || scan tail
+           | [] -> false)
+        | Some _ | None ->
+          attached_opaque_field_may_be_query arg
+          || attached_field_is_external_query arg
+          || scan rest)
   in
   scan args
 ;;

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -581,6 +581,82 @@ let test_gh_graphql_non_query_opaque_field_allowed_under_autonomous () =
     assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
   | _ -> Alcotest.fail "opaque non-query graphql variables must not Ask"
 
+(* External-body graphql: gh reads a [-f/-F/--field] value starting with '@'
+   from a file ('@-' = stdin), and [--input FILE] reads the whole body
+   externally. The mutation text is therefore not in argv, so the LITERAL body
+   scanners cannot see it. These forms are literal (no Shell_ir Var/Concat), so
+   the earlier $VAR opacity check does not fire; they must still Ask. *)
+let test_gh_graphql_external_body_asks_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s: external graphql body must Ask under autonomous"
+           label)
+    [ ("-F query=@file", [ "api"; "graphql"; "-F"; "query=@mutation.graphql" ])
+    ; ("-f query=@- (stdin)", [ "api"; "graphql"; "-f"; "query=@-" ])
+    ; ("--input file", [ "api"; "graphql"; "--input"; "body.json" ])
+    ; ("attached -Fquery=@file", [ "api"; "graphql"; "-Fquery=@mutation.graphql" ])
+    ; ("--input=file attached", [ "api"; "graphql"; "--input=body.json" ])
+    ]
+
+(* Regression guard for the external-body fix: an '@'-file on a NON-query field
+   (a graphql variable) combined with an inline READ query must NOT be
+   over-blocked. Only the query body being external is a capability concern. *)
+let test_gh_graphql_external_non_query_field_allowed () =
+  let s =
+    simple (bin_ok "gh")
+      ~args:
+        (List.map lit
+           [ "api"; "graphql"; "-F"; "owner=@owner.txt"; "-f"
+           ; "query=query { viewer { login } }" ])
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+      ~caps ~simple:s
+  with
+  | Verdict.Allow _ -> ()
+  | _ ->
+    Alcotest.fail
+      "external @-file on a non-query field with an inline read query must not \
+       Ask"
+
+(* RFC-0309 W3 pipeline coverage: a gh durable-remote op in a NON-final pipeline
+   stage must still Ask. [gh repo create ... | cat] shifts the representative
+   (last) simple to [cat]; the capability axis folds over ALL caps so the create
+   is still seen. Without the fold this auto-runs (R1, no longer floored after
+   W4 moved repo/discussion create R2->R1). The caller hands [decide] the last
+   stage as [~simple], mirroring [last_simple_of_ir]. *)
+let test_gh_durable_remote_in_pipeline_asks_under_autonomous () =
+  let cat_stage = simple (bin_ok "cat") in
+  List.iter
+    (fun (label, gh_args) ->
+       let gh_stage = simple (bin_ok "gh") ~args:(List.map lit gh_args) in
+       let ir =
+         Shell_ir.Pipeline
+           [ Shell_ir.Simple gh_stage; Shell_ir.Simple cat_stage ]
+       in
+       let caps = Capability_check.of_ir ir in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:cat_stage
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | _ ->
+         Alcotest.failf "%s | cat must still Ask under autonomous" label)
+    [ ("gh repo create", [ "repo"; "create"; "o/new" ])
+    ; ("gh discussion create", [ "discussion"; "create"; "--title"; "T" ])
+    ; ( "gh api graphql -F query=@file (composed with pipeline)"
+      , [ "api"; "graphql"; "-F"; "query=@mutation.graphql" ] )
+    ]
+
 (* Regression guard: the W3 capability layer is ADDITIVE. Reads and local /
    in-repo reversible mutations stay [Allow] under autonomous — no over-block of
    routine keeper work. *)
@@ -726,6 +802,9 @@ let () =
   test_gh_graphql_durable_remote_asks_under_autonomous ();
   test_gh_graphql_opaque_query_asks_under_autonomous ();
   test_gh_graphql_non_query_opaque_field_allowed_under_autonomous ();
+  test_gh_graphql_external_body_asks_under_autonomous ();
+  test_gh_graphql_external_non_query_field_allowed ();
+  test_gh_durable_remote_in_pipeline_asks_under_autonomous ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();
   test_non_gh_unaffected_by_capability_layer ();
   test_git_clean_bundled_force_denied ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -581,7 +581,7 @@ let test_gh_graphql_non_query_opaque_field_allowed_under_autonomous () =
     assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
   | _ -> Alcotest.fail "opaque non-query graphql variables must not Ask"
 
-(* External-body graphql: gh reads a [-f/-F/--field] value starting with '@'
+(* External-body graphql: gh reads a [-F/--field] value starting with '@'
    from a file ('@-' = stdin), and [--input FILE] reads the whole body
    externally. The mutation text is therefore not in argv, so the LITERAL body
    scanners cannot see it. These forms are literal (no Shell_ir Var/Concat), so
@@ -600,10 +600,37 @@ let test_gh_graphql_external_body_asks_under_autonomous () =
          Alcotest.failf "%s: external graphql body must Ask under autonomous"
            label)
     [ ("-F query=@file", [ "api"; "graphql"; "-F"; "query=@mutation.graphql" ])
-    ; ("-f query=@- (stdin)", [ "api"; "graphql"; "-f"; "query=@-" ])
+    ; ("-F query=@- (stdin)", [ "api"; "graphql"; "-F"; "query=@-" ])
+    ; ( "--field=query=@file"
+      , [ "api"; "graphql"; "--field=query=@mutation.graphql" ] )
     ; ("--input file", [ "api"; "graphql"; "--input"; "body.json" ])
     ; ("attached -Fquery=@file", [ "api"; "graphql"; "-Fquery=@mutation.graphql" ])
     ; ("--input=file attached", [ "api"; "graphql"; "--input=body.json" ])
+    ]
+
+(* [-f/--raw-field] is a static string parameter in gh; [query=@...] is not a
+   file/stdin-backed external body. It can still Ask when the value is Shell IR
+   opaque (Var/Concat), but a literal raw-field [@...] must not be documented or
+   tested as an external body. *)
+let test_gh_graphql_raw_field_at_literal_allowed () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Allow _ -> ()
+       | _ ->
+         Alcotest.failf
+           "%s: raw-field literal @ value is not an external graphql body" label)
+    [ ("-f query=@-", [ "api"; "graphql"; "-f"; "query=@-" ])
+    ; ( "--raw-field query=@file"
+      , [ "api"; "graphql"; "--raw-field"; "query=@mutation.graphql" ] )
+    ; ("attached -fquery=@file", [ "api"; "graphql"; "-fquery=@mutation.graphql" ])
+    ; ( "--raw-field=query=@file"
+      , [ "api"; "graphql"; "--raw-field=query=@mutation.graphql" ] )
     ]
 
 (* Regression guard for the external-body fix: an '@'-file on a NON-query field
@@ -803,6 +830,7 @@ let () =
   test_gh_graphql_opaque_query_asks_under_autonomous ();
   test_gh_graphql_non_query_opaque_field_allowed_under_autonomous ();
   test_gh_graphql_external_body_asks_under_autonomous ();
+  test_gh_graphql_raw_field_at_literal_allowed ();
   test_gh_graphql_external_non_query_field_allowed ();
   test_gh_durable_remote_in_pipeline_asks_under_autonomous ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();


### PR DESCRIPTION
## What

착지된 RFC-0309 gh capability gating을 **적대적으로 감사**(6-렌즈 workflow)한 결과, gh durable-remote op이 autonomous overlay에서 `Verdict.Allow`(무승인 auto-run)로 떨어지는 **2개의 capability-Ask 우회**를 닫습니다. typed/inline 형태는 올바르게 Ask하는데 동등한 우회 경로만 새던 비대칭입니다.

## 우회 1 — 외부 graphql body

`gh api graphql -F query=@mutation.graphql` (및 `-f query=@-` stdin, `--input FILE`)는 mutation을 **파일/stdin**에서 읽어 argv에 없습니다. 값 토큰이 완전한 `Shell_ir.Lit`이라 `$VAR` opacity 체크(fix d)를 건너뛰고, literal fragment 스캐너(`gh_api_graphql_creates_durable_remote`/`body_contains_r2_mutation`)도 `createRepository`/`deleteRef`를 못 봐 → R0/R1 → **Allowed**. deleteRef 같은 irreversible도 같은 경로로 샙니다.

- **fix**: `graphql_query_body_is_opaque`가 `query=@...` 필드 값과 `--input`을 opaque로 인식 → `Requires_approval`. `$VAR` 경로와 대칭. **파일은 절대 읽지 않음**(TOCTOU 회피).

## 우회 2 — 파이프라인 stage

capability 가드는 `last_simple_of_ir`가 decide에 넘기는 **대표(마지막) simple**만 봤는데, catastrophic floor는 모든 stage(`caps`)를 fold합니다. `gh repo create ... | cat`은 대표 simple을 `cat`으로 밀어 → capability 가드 무발동 → R1 durable-remote create(W4에서 R2→R1로 floor 벗어남)가 auto-run. **`| cat` 하나로 W4 능동성 게이팅 전체가 우회됩니다.**

- **fix**: `decide`가 모든 caps를 스캔(`gh_cap_requiring_approval`)해 `Requires_approval`인 gh stage가 하나라도 있으면 Ask. Ask는 trailing read가 아니라 실제 gh 바이너리를 보고.

## 축 분리 유지

두 fix 모두: risk floor는 가역성 사실만 진술, Ask는 capability 축이 담당, body/path 파싱은 `Shell_ir_risk`/parser 소관.

## 검증

- `test_approval_policy`: 외부-body(`@file`/`@-`/`--input`/attached) → autonomous Ask; **non-query 필드의 `@-file` + inline read query는 Allow 유지**(과다차단 방지); `gh repo/discussion create`·`gh api graphql -F query=@file`를 `cat`에 파이프해도 Ask.
- 전체 `@lib/exec/test/runtest` green, downstream keeper+keeper_tooling+bin green, STR/DET meta gate PASS, ocamlformat clean.

## 근거 / 남은 것

적대 감사(16 후보 중 10 confirmed)에서 나온 2건. 나머지 confirmed 우회는 별도 서브시스템이라 이슈로 분리:
- gh api method 파싱(`gh -XDELETE api`, `gh api -X $METHOD`) — DELETE floor 우회
- git push refspec(`git push origin :refs/heads/main` 삭제, `+refs/heads/main` force) — git_op
- `curl -X POST api.github.com/user/repos` — egress 모델 필요 (#23445 계열)

RFC-0309 §3 W3 확장. base: main (#23424/#23431 착지 후).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
