### PR TITLE
fix(keeper): supervisor honors Pause_keeper verdict for turn-failure streaks (#23439)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -337,9 +337,27 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
        | Some Keeper_registry.Turn_overflow_pause
        | Some Keeper_registry.Turn_livelock_pause ->
          { acc with to_unregister = entry :: acc.to_unregister }
+       | Some (Keeper_registry.Turn_consecutive_failures count) ->
+         (* #23439: policy returns [Pause_keeper] for a turn-failure streak
+            (keeper_failure_policy.ml [Turn_failure_streak]).  This reason
+            previously fell through to [queue_standard_restart], discarding the
+            verdict; the restart then zeroed the streak evidence
+            (keeper_registry_setup.ml [turn_consecutive_failures = 0]) so the
+            identical "Keeper turn failed N consecutive cycle(s)" blocker
+            regenerated every sweep.  Honor the verdict via the shared
+            crash-auto-pause path, with the same fail-closed unregister rule as
+            the stale-storm / provider-timeout arms above. *)
+         (match handle_turn_failure_streak_pause ctx entry ~count with
+          | Ok () -> { acc with to_unregister = entry :: acc.to_unregister }
+          | Error err ->
+            Log.Keeper.warn
+              "%s: turn_failure_streak pause not committed (%s); keeping \
+               registry entry so the pause retries next sweep"
+              entry.name
+              err;
+            acc)
        | Some
            ( Keeper_registry.Heartbeat_consecutive_failures _
-           | Keeper_registry.Turn_consecutive_failures _
            | Keeper_registry.Stale_turn_timeout _
            | Keeper_registry.Stale_fleet_batch _
            | Keeper_registry.Provider_runtime_error _

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -697,5 +697,9 @@ let handle_provider_timeout_pause ctx entry =
   Pause_policy.handle_provider_timeout_pause ~publish_phase_lifecycle ctx entry
 ;;
 
+let handle_turn_failure_streak_pause ctx entry =
+  Pause_policy.handle_turn_failure_streak_pause ~publish_phase_lifecycle ctx entry
+;;
+
 let failure_reason_policy_decision = Pause_policy.failure_reason_policy_decision
 let failure_reason_policy_decision_for_test = failure_reason_policy_decision

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -383,6 +383,46 @@ let handle_provider_timeout_pause
          count)
 ;;
 
+let handle_turn_failure_streak_pause
+      ~publish_phase_lifecycle
+      (ctx : _ context)
+      (entry : Keeper_registry.registry_entry)
+      ~count
+  =
+  (* #23439: [Keeper_failure_policy] returns a typed [Pause_keeper] verdict
+     for a [Turn_failure_streak] (keeper_failure_policy.ml).  Route it to the
+     same crash-auto-pause path the stale-storm / provider-timeout arms use
+     instead of restarting.  [No_progress_loop] is the accurate blocker class
+     (the keeper keeps running turns but none complete), and unlike a
+     provider timeout the failures are not a slow-provider blip, so pausing
+     surfaces the streak to operators as [Paused].  Auto-resume with
+     exponential back-off (same policy as the provider-timeout turn-level
+     pause): a transient cause self-heals after the back-off, while a
+     persistent cause re-pauses with a doubled delay rather than restarting
+     every sweep.  The blocker can still recur after an auto-resume cycle
+     because resume clears the streak evidence (see #23439 RFC half — latched
+     typed failure episode); this arm only stops the restart-driven
+     regeneration by honoring the pause verdict. *)
+  handle_crash_auto_pause
+    ~publish_phase_lifecycle
+    ctx
+    entry
+    ~reason_tag:"turn_failure_streak"
+    ~metric_name:Keeper_metrics.(to_string TurnFailureStreakPaused)
+    ~lifecycle_detail:(Printf.sprintf "turn_failure_streak count=%d" count)
+    ~blocker_class:(Some No_progress_loop)
+    ~resume_policy:Auto_resume_with_backoff
+    ~log_message:
+      (Printf.sprintf
+         "TURN FAILURE STREAK AUTO-PAUSED (count=%d consecutive turn failures). \
+          Supervisor honors the failure-policy Pause_keeper verdict instead of \
+          restarting; auto-resume with exponential back-off (see \
+          MASC_KEEPER_AUTO_RESUME_INITIAL_SEC) retries once the back-off delay \
+          elapses. Operator may inspect the keeper's turn failures and resume \
+          manually via masc_keeper_up. See issue #23439."
+         count)
+;;
+
 let failure_reason_policy_decision
       (reason : Keeper_registry.failure_reason option)
   : Keeper_failure_policy.decision option

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -81,6 +81,22 @@ val handle_provider_timeout_pause
   -> count:int
   -> (unit, string) result
 
+(** [handle_turn_failure_streak_pause ~publish_phase_lifecycle ctx entry
+      ~count] pauses [entry] because the keeper's turns failed [count]
+    consecutive cycles ([Keeper_registry.Turn_consecutive_failures], which
+    [failure_reason_policy_decision] maps to a [Pause_keeper] verdict).
+    Blocker class [No_progress_loop]; auto-resume with exponential back-off
+    (same policy as [handle_provider_timeout_pause]). Fail-closed like
+    [handle_crash_auto_pause]. Added for #23439 so the supervisor honors the
+    typed pause verdict instead of restarting the keeper. *)
+val handle_turn_failure_streak_pause
+  :  publish_phase_lifecycle:
+       (phase:Keeper_state_machine.phase -> string -> string -> unit -> unit)
+  -> _ context
+  -> Keeper_registry.registry_entry
+  -> count:int
+  -> (unit, string) result
+
 (** [handle_auto_pause_from_meta ~config ~meta ~reason_tag
       ?metric_name ~lifecycle_detail ~log_message ~blocker_class
       ~resume_policy] is the turn-context SSOT for pausing a keeper.

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -137,10 +137,11 @@ val reconcile_persisted_auto_pause_task_release
 
 (** [failure_reason_policy_decision reason] maps a persisted
     [Keeper_registry.failure_reason] back to a
-    [Keeper_failure_policy.decision]. Returns [None] for non-policy
-    reasons (heartbeat / turn consecutive failures, fleet batch,
-    provider runtime error, fiber unresolved, exception) and [None]
-    when [reason] itself is [None]. *)
+    [Keeper_failure_policy.decision]. Policy-backed reasons include
+    provider timeout, stale termination storms, and turn consecutive
+    failures. Returns [None] for non-policy reasons (heartbeat, fleet
+    batch, provider runtime error, fiber unresolved, exception) and
+    [None] when [reason] itself is [None]. *)
 val failure_reason_policy_decision
   :  Keeper_registry.failure_reason option
   -> Keeper_failure_policy.decision option

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -120,6 +120,7 @@ type t =
   | SelfPreservationUniversal
   | StaleStormPaused
   | ProviderTimeoutLoopPaused
+  | TurnFailureStreakPaused
   | CycleExceptions
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
@@ -380,6 +381,7 @@ let to_string = function
   | SelfPreservationUniversal -> "masc_keeper_self_preservation_universal_total"
   | StaleStormPaused -> "masc_keeper_stale_storm_paused_total"
   | ProviderTimeoutLoopPaused -> "masc_keeper_provider_timeout_loop_paused_total"
+  | TurnFailureStreakPaused -> "masc_keeper_turn_failure_streak_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
   | StateSnapshotSkippedNoState ->
@@ -569,6 +571,7 @@ let all : t list =
     ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
     ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
     PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
+    TurnFailureStreakPaused;
     CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; StateSnapshotInvalidGoal; PromptUnknownToolTokens;
     PromptTokenStripped;
     ProgressUpdatedLineFailures;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -111,6 +111,7 @@ type t =
   | SelfPreservationUniversal
   | StaleStormPaused
   | ProviderTimeoutLoopPaused
+  | TurnFailureStreakPaused
   | CycleExceptions
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2241,6 +2241,102 @@ let test_provider_timeout_loop_pause_skips_restart () =
       check bool "registry entry unregistered after provider timeout loop pause"
         false (Reg.is_registered ~base_path:config.base_path name))
 
+(* ── #23439: turn-failure-streak auto-pause ──────────────────────── *)
+
+(* [Keeper_failure_policy] returns a typed [Pause_keeper] verdict for a
+   [Turn_failure_streak] (keeper_failure_policy.ml).  Before #23439 the
+   supervisor re-matched [failure_reason] and routed
+   [Turn_consecutive_failures] into [queue_standard_restart], discarding the
+   verdict; the restart then zeroed [turn_consecutive_failures]
+   (keeper_registry_setup.ml) so the identical "Keeper turn failed N
+   consecutive cycle(s)" blocker regenerated every sweep.  sweep_and_recover
+   must now:
+   1. Skip the [to_restart] enqueue (no RestartAttempts for this keeper).
+   2. Persist [meta.paused = true] on disk.
+   3. Enable auto-resume with back-off ([auto_resume_after_sec = Some _],
+      unlike the stale-storm manual pause which leaves it [None]).
+   4. Increment [masc_keeper_turn_failure_streak_paused_total].
+   5. Not mark the keeper dead. *)
+let test_turn_failure_streak_pause_skips_restart () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+      let name = "turn-failure-streak-keeper" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      resolve_done_for_test reg (`Crashed "synthetic turn failure streak");
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Turn_consecutive_failures 3));
+      let attempt_labels = [ ("keeper", name) ] in
+      let baseline_pause =
+        Masc.Otel_metric_store.metric_total
+          "masc_keeper_turn_failure_streak_paused_total"
+      in
+      let baseline_dead =
+        Masc.Otel_metric_store.metric_total
+          Keeper_metrics.(to_string DeadTotal)
+      in
+      let baseline_restart_attempts =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string RestartAttempts)
+          ~labels:attempt_labels ()
+      in
+      let ctx : _ Keeper_types_profile.context =
+        {
+          config;
+          agent_name = supervisor_agent_name;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      sweep_and_recover_no_materialize ctx;
+      let after_pause =
+        Masc.Otel_metric_store.metric_total
+          "masc_keeper_turn_failure_streak_paused_total"
+      in
+      let after_dead =
+        Masc.Otel_metric_store.metric_total
+          Keeper_metrics.(to_string DeadTotal)
+      in
+      let after_restart_attempts =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string RestartAttempts)
+          ~labels:attempt_labels ()
+      in
+      check (float 0.001) "turn_failure_streak_paused counter incremented by 1"
+        (baseline_pause +. 1.0) after_pause;
+      check (float 0.001)
+        "restart attempt NOT incremented (Pause_keeper verdict honored)"
+        baseline_restart_attempts after_restart_attempts;
+      check (float 0.001) "dead counter NOT incremented (streak is a pause)"
+        baseline_dead after_dead;
+      (match Keeper_meta_store.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused = true after turn failure streak pause"
+             true m.paused;
+           check bool "turn failure streak pause enables auto-resume back-off"
+             true (Option.is_some m.auto_resume_after_sec)
+       | Ok None -> fail "meta missing after turn failure streak pause"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "registry entry unregistered after turn failure streak pause"
+        false (Reg.is_registered ~base_path:config.base_path name))
+
 (* Fail-closed pause commit: when [paused=true] cannot be persisted (here:
    meta missing on disk), the pause must not commit — no pause counter, no
    Paused publish, and the registry entry must stay registered so the pause
@@ -3581,6 +3677,8 @@ let () =
         test_legacy_stale_fleet_batch_routes_to_restart_budget;
       test_case "Provider timeout loop skips restart, persists paused, increments counter" `Quick
         test_provider_timeout_loop_pause_skips_restart;
+      test_case "Turn failure streak honors Pause_keeper verdict, skips restart (#23439)" `Quick
+        test_turn_failure_streak_pause_skips_restart;
       test_case "storm pause persist failure keeps entry registered (fail-closed)" `Quick
         test_stale_storm_pause_persist_failure_keeps_entry_registered;
       test_case "terminal-state launch reject does not announce Running" `Quick


### PR DESCRIPTION
## 무엇 / 왜

`Keeper_failure_policy`는 3연속 turn 실패(`Turn_failure_streak`)에 대해 typed `Pause_keeper` verdict를 반환합니다(`lib/keeper_failure_policy/keeper_failure_policy.ml:398-405`). 그러나 supervisor의 `sweep_and_recover`는 이 verdict를 소비하지 않고, persist된 `failure_reason`을 스스로 재매칭해 `Turn_consecutive_failures`를 `queue_standard_restart`로 흘려보냈습니다(`lib/keeper/keeper_supervisor.ml:341-352`). restart 경로는 실패 증거를 0으로 지우기 때문에(`lib/keeper/keeper_registry_setup.ml:460-461`, `turn_consecutive_failures = 0`), 동일한 `"Keeper turn failed 3 consecutive cycle(s)"` blocker가 **매 sweep마다 무한 재생성**됐습니다.

### 운영 임팩트
- **이전**: 3연속 실패 키퍼 → restart → 증거 0으로 리셋 → 다시 3연속 실패 → restart … 동일 blocker가 매 sweep/poll 재공지. 운영자에게 actionable하지 않은 반복 노이즈.
- **이후**: 3연속 실패 키퍼는 policy verdict대로 **pause**됩니다(`paused=true`). pause된 키퍼는 turn을 돌리지 않으므로, restart로 인한 blocker 재생성 루프가 끊깁니다. 키퍼는 `Paused` 상태 + `No_progress_loop` blocker로 운영자에게 노출됩니다.

## 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_supervisor.ml` | inner match의 `Turn_consecutive_failures`를 restart 그룹에서 분리해 pause 경로로 라우팅 (fail-closed unregister 규칙은 stale-storm / provider-timeout arm과 동일) |
| `lib/keeper/keeper_supervisor_pause_policy.ml` | `handle_turn_failure_streak_pause` 신규 wrapper (기존 `handle_crash_auto_pause` 재사용, 신규 pause 머신러리 없음) |
| `lib/keeper/keeper_supervisor_pause_policy.mli` | wrapper 시그니처 노출 |
| `lib/keeper/keeper_supervisor_launch.ml` | `publish_phase_lifecycle` 주입 재수출 |
| `lib/keeper_metrics/keeper_metrics.{ml,mli}` | `TurnFailureStreakPaused` → `masc_keeper_turn_failure_streak_paused_total` |
| `test/test_keeper_supervisor.ml` | 회귀 방지 테스트 |

### 설계 선택
- **blocker class = `No_progress_loop`**: 키퍼가 turn을 계속 돌리지만 하나도 완료하지 못하는 상태를 정확히 표현. timeout이 아니므로 `Turn_timeout`이 아님. (기존 두 wrapper는 `Turn_timeout`을 쓰지만 그건 실제 timeout 원인일 때 정확한 것.) `No_progress_loop`은 pause 시 owned task도 release함(`blocker_class_releases_owned_tasks_on_pause`).
- **resume policy = `Auto_resume_with_backoff`**: turn-level pause 선례(provider-timeout)와 동일. 일시적 원인은 back-off 후 self-heal, 지속적 원인은 back-off가 배가되며 재-pause(매 sweep restart보다 완화). fleet-level인 stale-storm의 `Manual_resume_required`와 대비.

## 로컬 검증

`dune build --root . @check` PASS (전체 프로젝트, EXIT=0). touched 파일 7종 `ocamlformat --check` 모두 PASS.

신규 테스트 (`stale_storm_phase2` 그룹, case 3) + 그룹 전체 10 case PASS:
```
[OK]  stale_storm_phase2  0  Stale_termination_storm skips restart...
[OK]  stale_storm_phase2  2  Provider timeout loop skips restart...
[OK]  stale_storm_phase2  3  Turn failure streak honors Pause_keeper verdict, skips restart (#23439)
[OK]  stale_storm_phase2  9  non-storm Crashed still routes to restart (regression guard)
Test Successful in 0.211s. 10 tests run.
```
(`#9` 회귀 가드가 green — pause가 아닌 실패 원인은 여전히 restart로 감을 확인.)

테스트가 검증하는 것:
1. `masc_keeper_turn_failure_streak_paused_total` +1
2. `RestartAttempts`(해당 키퍼 라벨) **미증가** — standard restart 미enqueue
3. `DeadTotal` 미증가
4. `meta.paused = true` (디스크 persist)
5. `auto_resume_after_sec = Some _` (auto-resume back-off 활성 — resume policy 선택 고정)
6. registry entry unregister

### Revert 실증 (회귀 방지 증명)
`Turn_consecutive_failures` arm을 임시로 옛 `queue_standard_restart`로 되돌린 뒤 재빌드/실행 → 테스트 실패:
```
File "test/test_keeper_supervisor.ml", line 2322:
FAIL turn_failure_streak_paused counter incremented by 1
   Expected: `1'  Received: `0'
[ERROR] [Keeper] turn-failure-streak-keeper: cannot read meta for restart, removing
1 failure! in 0.016s.
```
로그의 `cannot read meta for restart`가 옛 restart 경로 재진입을 보여줌. arm 복원 후 재실행 → PASS.

## 미검증 / 스코프 밖 (RFC 절반)

- **latched typed failure episode (이슈 제안 #2)는 구현하지 않음.** restart 증거 zeroing(`keeper_supervisor.ml:879`, `keeper_supervisor_resume_reconcile_gate.ml:85`)과 auto-resume 로직은 **건드리지 않았습니다**.
- **정직한 재발 가능성**: auto-resume이 발동하면(back-off 경과 후) resume 경로가 streak 증거를 리셋합니다 — `keeper_supervisor_resume_reconcile_gate.ml:85`가 `reset_turn_failures`를 호출하고, relaunch 시 새 registry entry는 `turn_consecutive_failures = 0`. 따라서 원인이 지속되면 키퍼는 재-pause되고 blocker가 **다시 발생할 수 있습니다**. 다만 재발 주기는 exponential back-off(초기 1h, 최대 24h로 배가)로 억제됩니다. 완전 제거는 RFC의 latched episode(cause fingerprint + first_observed_ts, resume이 지울 수 없고 해제에 증명 필요)의 몫입니다.
- 이 PR의 주장은 **"policy verdict를 존중한다(restart 대신 pause)"**이지 "blocker spam을 완전히 없앤다"가 아닙니다. 11개 stateless projection surface의 재계산 재공지도 RFC 스코프입니다.

### exhaustive match에서 드러난 다른 미소비 verdict (이 PR에서 배선하지 않음)
`failure_reason_policy_decision`가 생산하지만 `queue_standard_restart`로 가는 나머지 lifecycle_effect:
- `Ambiguous_partial_commit` → `Pause_current_work`
- `Provider_runtime_error{reason=Some, non-retryable}` → `Runtime_exhausted{retryable=false}` → `Pause_current_work`

이들은 모두 **`Pause_current_work`**(Turn_scope, "현재 turn 작업 중단")입니다. `Pause_keeper`(키퍼 자체 pause)와 달리, crash-sweep 시점엔 이미 turn이 종료됐으므로 restart로 매핑되는 것이 명백한 버그인지 애매합니다. 이 PR에서는 배선하지 않고 목록만 남깁니다. (그 외 `Stale_turn_timeout`→`Restart_keeper`, `None` 계열은 restart가 의도된 동작으로 discard 아님.)

## 안티패턴 아님

이 변경은 기존 typed verdict(`Pause_keeper`)를 **존중**하는 것으로, 워크어라운드 시그니처의 정반대입니다. string 분류기 추가 없음, cap/cooldown/dedup 없음, telemetry-as-fix 아님(metric은 관측 보조일 뿐 fix는 pause 라우팅 자체). exhaustive match(no `_ ->` catch-all)를 유지합니다.

## RFC gate

이 파일 세트는 masc RFC gate 대상 경로(credential / operator_control / sandbox / hooks / workflow) 어디에도 해당하지 않습니다. `RFC-WAIVED: not an RFC-gated subsystem (keeper supervisor pause-verdict consumption only)`.

Refs #23439 #23438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
