### PR TITLE
feat(repo-sync): advance managed clone working tree after fetch (RFC-0210)

### DIFF
--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -123,6 +123,45 @@ let get_origin_url ~local_path =
   | Ok [] -> Error "git remote get-url origin returned no output"
   | Error msg -> Error msg
 
+let inspect_timeout_sec = status_summary_timeout_sec
+
+let current_branch ~repository =
+  match
+    run_git ~cwd:repository.local_path ~env:read_only_git_env
+      ~timeout_sec:inspect_timeout_sec
+      [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
+  with
+  | Ok (name :: _) -> Ok name
+  | Ok [] -> Error "git rev-parse --abbrev-ref HEAD returned no output"
+  | Error msg -> Error msg
+
+let ahead_behind ~repository ~target_ref =
+  match
+    run_git ~cwd:repository.local_path ~env:read_only_git_env
+      ~timeout_sec:inspect_timeout_sec
+      [ "rev-list"; "--left-right"; "--count"; target_ref ^ "...HEAD" ]
+  with
+  | Error msg -> Error msg
+  | Ok [] -> Error "git rev-list --left-right --count returned no output"
+  | Ok (line :: _) -> (
+      match String.split_on_char '\t' (String.trim line) with
+      | [ behind; ahead ] -> (
+          match
+            ( int_of_string_opt (String.trim behind),
+              int_of_string_opt (String.trim ahead) )
+          with
+          | Some behind, Some ahead -> Ok (behind, ahead)
+          | _ ->
+              Error
+                (Printf.sprintf
+                   "git rev-list --left-right --count returned non-numeric output: %S"
+                   line))
+      | _ ->
+          Error
+            (Printf.sprintf
+               "git rev-list --left-right --count returned malformed output: %S"
+               line))
+
 let get_recent_commits ~repository ~branch ~limit =
   match
     run_git ~cwd:repository.local_path

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -150,14 +150,14 @@ let ahead_behind ~repository ~target_ref =
             ( int_of_string_opt (String.trim behind),
               int_of_string_opt (String.trim ahead) )
           with
-          | Some behind, Some ahead -> Ok (behind, ahead)
+          | Some behind, Some ahead -> Stdlib.Ok (behind, ahead)
           | _ ->
-              Error
+              Stdlib.Error
                 (Printf.sprintf
                    "git rev-list --left-right --count returned non-numeric output: %S"
                    line))
       | _ ->
-          Error
+          Stdlib.Error
             (Printf.sprintf
                "git rev-list --left-right --count returned malformed output: %S"
                line))

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -142,9 +142,9 @@ let ahead_behind ~repository ~target_ref : (int * int, string) result =
       ~timeout_sec:inspect_timeout_sec
       [ "rev-list"; "--left-right"; "--count"; target_ref ^ "...HEAD" ]
   with
-  | Error msg -> Error msg
-  | Ok [] -> Error "git rev-list --left-right --count returned no output"
-  | Ok (line :: _) -> (
+  | Stdlib.Error msg -> Stdlib.Error msg
+  | Stdlib.Ok [] -> Stdlib.Error "git rev-list --left-right --count returned no output"
+  | Stdlib.Ok (line :: _) -> (
       match String.split_on_char '\t' (String.trim line) with
       | [ behind; ahead ] -> (
           match

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -104,7 +104,8 @@ let fetch ~repository : (string list, string) result =
    merge is local; the ref must already be fetched). *)
 let fast_forward ~repository ~target_ref : (unit, string) result =
   match
-    run_git ~cwd:repository.local_path [ "merge"; "--ff-only"; target_ref ]
+    run_git ~cwd:repository.local_path
+      [ "-c"; "core.hooksPath=/dev/null"; "merge"; "--ff-only"; target_ref ]
   with
   | Ok _ -> Ok ()
   | Error msg -> Error msg
@@ -135,7 +136,7 @@ let current_branch ~repository =
   | Ok [] -> Error "git rev-parse --abbrev-ref HEAD returned no output"
   | Error msg -> Error msg
 
-let ahead_behind ~repository ~target_ref =
+let ahead_behind ~repository ~target_ref : (int * int, string) result =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
       ~timeout_sec:inspect_timeout_sec

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -41,6 +41,19 @@ val get_origin_url : local_path:string -> (string, string) result
 (** [get_origin_url ~local_path] returns the configured [origin] remote URL
     for the repository at [local_path]. *)
 
+val current_branch : repository:repository -> (string, string) result
+(** [current_branch ~repository] returns the short name of the checked-out
+    branch via [git rev-parse --abbrev-ref HEAD]. A detached HEAD returns
+    ["HEAD"]. Read-only ([GIT_OPTIONAL_LOCKS=0]) with a bounded timeout. *)
+
+val ahead_behind :
+  repository:repository -> target_ref:string -> (int * int, string) result
+(** [ahead_behind ~repository ~target_ref] returns [(behind, ahead)]:
+    [behind] counts commits reachable from [target_ref] but not from HEAD,
+    [ahead] the reverse, via
+    [git rev-list --left-right --count <target_ref>...HEAD]. The target ref
+    must already be fetched. Read-only with a bounded timeout. *)
+
 val get_recent_commits :
   repository:repository -> branch:string -> limit:int -> (string list, string) result
 (** [get_recent_commits ~repository ~branch ~limit] returns the most recent

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -29,9 +29,10 @@ val fetch : repository:repository -> (string list, string) result
 val fast_forward :
   repository:repository -> target_ref:string -> (unit, string) result
 (** [fast_forward ~repository ~target_ref] advances the current branch to
-    [target_ref] with [git merge --ff-only]. Returns [Error] (without mutating
-    history) when the move is not a pure fast-forward, so a divergent working
-    tree is never overwritten. The target ref must already be fetched. *)
+    [target_ref] with a hook-suppressed [git merge --ff-only]. Returns [Error]
+    (without mutating history) when the move is not a pure fast-forward, so a
+    divergent working tree is never overwritten. The target ref must already be
+    fetched. *)
 
 val get_branches :
   repository:repository -> (string list, string) result

--- a/lib/repo_manager/repo_sync.ml
+++ b/lib/repo_manager/repo_sync.ml
@@ -2,7 +2,63 @@ open Repo_manager_types
 
 let ( let* ) = Result.bind
 
-let sync_repository ~base_path repo : (unit, string) result =
+type advance_outcome =
+  | Advanced of { behind : int }
+  | Already_current
+  | Skipped_dirty of { staged : int; unstaged : int; conflicted : int }
+  | Skipped_not_on_default_branch of { current : string }
+  | Fast_forward_refused of { behind : int; reason : string }
+  | Advance_inspect_failed of { reason : string }
+
+let advance_outcome_label = function
+  | Advanced _ -> "advanced"
+  | Already_current -> "already_current"
+  | Skipped_dirty _ -> "skipped_dirty"
+  | Skipped_not_on_default_branch _ -> "skipped_not_on_default_branch"
+  | Fast_forward_refused _ -> "fast_forward_refused"
+  | Advance_inspect_failed _ -> "advance_inspect_failed"
+
+(* RFC-0210 (Keeper Playground Repo Currency): a fetch alone never moves the
+   working tree, so managed clones drift arbitrarily far behind their remote
+   while reporting a clean "변경 없음" state to every reader (IDE workspace
+   tree/file/diff/blame). After a successful fetch we advance the checked-out
+   default branch to the fetched remote ref — work-preserving:
+
+   - tracked local modifications (staged/unstaged/conflicted) skip the move;
+   - a non-default checkout (feature branch, detached HEAD) skips the move;
+   - [git merge --ff-only] refuses divergence instead of rewriting history.
+
+   Every skip is a typed outcome the caller must consume; none of them is an
+   [Error] because the fetch itself succeeded and refs are current. *)
+let advance_working_tree ~repository : advance_outcome =
+  let target_ref = "origin/" ^ repository.default_branch in
+  match Repo_git.ahead_behind ~repository ~target_ref with
+  | Error reason -> Advance_inspect_failed { reason }
+  | Ok (0, _ahead) -> Already_current
+  | Ok (behind, _ahead) -> (
+      match Repo_git.current_branch ~repository with
+      | Error reason -> Advance_inspect_failed { reason }
+      | Ok current when not (String.equal current repository.default_branch) ->
+          Skipped_not_on_default_branch { current }
+      | Ok _default -> (
+          match Repo_git.status_summary ~repository with
+          | Error reason -> Advance_inspect_failed { reason }
+          | Ok summary
+            when summary.Repo_git.staged_files > 0
+                 || summary.Repo_git.unstaged_files > 0
+                 || summary.Repo_git.conflicted_files > 0 ->
+              Skipped_dirty
+                {
+                  staged = summary.Repo_git.staged_files;
+                  unstaged = summary.Repo_git.unstaged_files;
+                  conflicted = summary.Repo_git.conflicted_files;
+                }
+          | Ok _clean -> (
+              match Repo_git.fast_forward ~repository ~target_ref with
+              | Ok () -> Advanced { behind }
+              | Error reason -> Fast_forward_refused { behind; reason })))
+
+let sync_repository ~base_path repo : (advance_outcome, string) result =
   let local_path = Repo_store.local_path ~base_path repo in
   let repo_with_path = { repo with local_path } in
   let* () = Repo_store.update_status ~base_path repo.id Cloning in
@@ -19,8 +75,9 @@ let sync_repository ~base_path repo : (unit, string) result =
       let* () = Repo_store.update_status ~base_path repo.id (Error msg) in
       Error msg
   | Ok _branches ->
+      let outcome = advance_working_tree ~repository:repo_with_path in
       let* () = Repo_store.update_status ~base_path repo.id Active in
-      Ok ()
+      Ok outcome
 
 let should_sync repo ~now =
   if not repo.auto_sync then false
@@ -28,7 +85,8 @@ let should_sync repo ~now =
     let elapsed = Int64.sub now repo.updated_at in
     Int64.to_int elapsed >= repo.sync_interval
 
-let sync_all ~base_path ~now : (repository list, string) result =
+let sync_all ~base_path ~now :
+    ((repository * advance_outcome) list, string) result =
   let* repos = Repo_store.load_all ~base_path in
   let due = List.filter (fun r -> should_sync r ~now) repos in
   let rec loop synced = function
@@ -36,6 +94,6 @@ let sync_all ~base_path ~now : (repository list, string) result =
     | repo :: rest -> (
         match sync_repository ~base_path repo with
         | Error _ -> loop synced rest
-        | Ok () -> loop (repo :: synced) rest)
+        | Ok outcome -> loop ((repo, outcome) :: synced) rest)
   in
   loop [] due

--- a/lib/repo_manager/repo_sync.mli
+++ b/lib/repo_manager/repo_sync.mli
@@ -1,15 +1,44 @@
 open Repo_manager_types
 
-val sync_repository : base_path:string -> repository -> (unit, string) result
-(** [sync_repository ~base_path repo] fetches the repository and updates its
-    status to [Active] on success or [Error msg] on failure. *)
+type advance_outcome =
+  | Advanced of { behind : int }
+      (** Working tree fast-forwarded onto [origin/<default_branch>];
+          [behind] is the commit count covered by the move. *)
+  | Already_current
+      (** HEAD already contains [origin/<default_branch>]. *)
+  | Skipped_dirty of { staged : int; unstaged : int; conflicted : int }
+      (** Tracked local modifications present — the move was skipped to
+          preserve them (RFC-0210 work-preserving rule). *)
+  | Skipped_not_on_default_branch of { current : string }
+      (** The clone has a non-default branch (or detached HEAD, reported as
+          ["HEAD"]) checked out — the move was skipped. *)
+  | Fast_forward_refused of { behind : int; reason : string }
+      (** [git merge --ff-only] declined the move (divergent history or an
+          untracked file would be overwritten); the tree is unchanged. *)
+  | Advance_inspect_failed of { reason : string }
+      (** A read-only git inspection (rev-list / rev-parse / status) failed;
+          the tree is unchanged. *)
+
+val advance_outcome_label : advance_outcome -> string
+(** Stable wire/log label for each [advance_outcome] constructor. *)
+
+val sync_repository :
+  base_path:string -> repository -> (advance_outcome, string) result
+(** [sync_repository ~base_path repo] fetches the repository, then advances
+    the checked-out default branch to [origin/<default_branch>]
+    (work-preserving; see {!advance_outcome}). Status becomes [Active] on
+    fetch success and [Error msg] on fetch/clone failure. Advance-stage
+    skips and refusals are typed outcomes, not errors, because the refs are
+    current after a successful fetch. *)
 
 val should_sync : repository -> now:int64 -> bool
 (** [should_sync repo ~now] returns [true] if [repo.auto_sync] is enabled and
     [now - repo.updated_at] exceeds [repo.sync_interval] seconds. *)
 
 val sync_all :
-  base_path:string -> now:int64 -> (repository list, string) result
+  base_path:string ->
+  now:int64 ->
+  ((repository * advance_outcome) list, string) result
 (** [sync_all ~base_path ~now] loads all repositories, filters those that
-    should_sync, fetches each one, and returns the list of successfully synced
-    repositories. *)
+    should_sync, syncs each one, and returns the successfully synced
+    repositories paired with their working-tree advance outcome. *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -663,9 +663,33 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       try
         let now = Int64.of_float (Eio.Time.now clock) in
         match Repo_sync.sync_all ~base_path:(Mcp_server.workspace_config state).base_path ~now with
-        | Ok repos ->
-          if repos <> []
-          then Log.Server.info "repo_sync: synced %d repositories" (List.length repos)
+        | Ok synced ->
+          List.iter
+            (fun ((repo : Repo_manager_types.repository), outcome) ->
+              match outcome with
+              | Repo_sync.Already_current -> ()
+              | Repo_sync.Advanced { behind } ->
+                Log.Server.info
+                  "repo_sync: %s advanced %d commit(s) to origin/%s"
+                  repo.id behind repo.default_branch
+              | Repo_sync.Skipped_dirty { staged; unstaged; conflicted } ->
+                Log.Server.warn
+                  "repo_sync: %s not advanced (dirty tree: staged=%d unstaged=%d conflicted=%d)"
+                  repo.id staged unstaged conflicted
+              | Repo_sync.Skipped_not_on_default_branch { current } ->
+                Log.Server.warn
+                  "repo_sync: %s not advanced (checked out %s, default %s)"
+                  repo.id current repo.default_branch
+              | Repo_sync.Fast_forward_refused { behind; reason } ->
+                Log.Server.warn
+                  "repo_sync: %s is %d commit(s) behind but fast-forward was refused: %s"
+                  repo.id behind reason
+              | Repo_sync.Advance_inspect_failed { reason } ->
+                Log.Server.warn
+                  "repo_sync: %s advance inspection failed: %s" repo.id reason)
+            synced;
+          if synced <> []
+          then Log.Server.info "repo_sync: synced %d repositories" (List.length synced)
         | Error msg -> Log.Server.warn "repo_sync: sync_all failed: %s" msg
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -65,6 +65,31 @@ let git_status_json ~base_path (repo : Repo_manager_types.repository) =
           ("error", `String msg);
         ]
 
+(* Currency of the managed clone versus its fetched remote default branch.
+   [behind > 0] means readers of this repository (IDE workspace tree, file,
+   diff, blame) are looking at an out-of-date working tree — surfaced here so
+   the dashboard can render staleness instead of implying "no changes". *)
+let sync_currency_json ~base_path (repo : Repo_manager_types.repository) =
+  let abs_local_path = Repo_store.local_path ~base_path repo in
+  let repo_for_git = { repo with local_path = abs_local_path } in
+  let target_ref = "origin/" ^ repo.default_branch in
+  match Repo_git.ahead_behind ~repository:repo_for_git ~target_ref with
+  | Ok (behind, ahead) ->
+      `Assoc
+        [
+          ("state", `String "available");
+          ("target_ref", `String target_ref);
+          ("behind", `Int behind);
+          ("ahead", `Int ahead);
+        ]
+  | Error msg ->
+      `Assoc
+        [
+          ("state", `String "unavailable");
+          ("target_ref", `String target_ref);
+          ("error", `String msg);
+        ]
+
 let repository_json ~base_path (repo : Repo_manager_types.repository) =
   let status, error = status_json repo.status in
   let fields =
@@ -82,6 +107,7 @@ let repository_json ~base_path (repo : Repo_manager_types.repository) =
       ("created_at", timestamp_json repo.created_at);
       ("updated_at", timestamp_json repo.updated_at);
       ("git_status", git_status_json ~base_path repo);
+      ("sync_currency", sync_currency_json ~base_path repo);
     ]
   in
   let fields =
@@ -370,7 +396,29 @@ let handle_sync_repository state _agent_name req reqd =
           | Error msg ->
               json_response ~status:`Internal_server_error req reqd
                 (json_error msg)
-          | Ok () ->
+          | Ok outcome ->
+              let advance_fields =
+                match outcome with
+                | Repo_sync.Advanced { behind } -> [ ("behind", `Int behind) ]
+                | Repo_sync.Already_current -> []
+                | Repo_sync.Skipped_dirty { staged; unstaged; conflicted } ->
+                    [
+                      ("staged", `Int staged);
+                      ("unstaged", `Int unstaged);
+                      ("conflicted", `Int conflicted);
+                    ]
+                | Repo_sync.Skipped_not_on_default_branch { current } ->
+                    [ ("current_branch", `String current) ]
+                | Repo_sync.Fast_forward_refused { behind; reason } ->
+                    [ ("behind", `Int behind); ("reason", `String reason) ]
+                | Repo_sync.Advance_inspect_failed { reason } ->
+                    [ ("reason", `String reason) ]
+              in
+              let advance_json =
+                `Assoc
+                  (("state", `String (Repo_sync.advance_outcome_label outcome))
+                   :: advance_fields)
+              in
               let branches =
                 match Repo_store.list_branches ~base_path id with
                 | Ok branches ->
@@ -385,6 +433,7 @@ let handle_sync_repository state _agent_name req reqd =
                   [
                     ("id", `String id);
                     ("status", `String "active");
+                    ("advance", advance_json);
                     ("branches", branches);
                   ]
               in

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -95,6 +95,164 @@ let test_sync_all_no_due_repos () =
           | Ok synced -> Alcotest.(check int) "no due repos" 0 (List.length synced)
           | Error e -> Alcotest.fail ("sync_all failed: " ^ e)))
 
+(* --- RFC-0210 working-tree advance: real-git fixtures --- *)
+
+let run_cmd ~cwd argv =
+  let prev = Sys.getcwd () in
+  Sys.chdir cwd;
+  Fun.protect
+    ~finally:(fun () -> Sys.chdir prev)
+    (fun () ->
+       let pid =
+         Unix.create_process_env
+           (List.hd argv)
+           (Array.of_list argv)
+           (Unix.environment ())
+           Unix.stdin Unix.stdout Unix.stderr
+       in
+       match Unix.waitpid [] pid with
+       | _, Unix.WEXITED 0 -> Ok ()
+       | _, Unix.WEXITED code -> Error (Printf.sprintf "exit %d" code)
+       | _, Unix.WSIGNALED s -> Error (Printf.sprintf "signal %d" s)
+       | _, Unix.WSTOPPED s -> Error (Printf.sprintf "stopped %d" s))
+
+let git ~cwd args =
+  match run_cmd ~cwd ("git" :: args) with
+  | Ok () -> ()
+  | Error e ->
+      failwith (Printf.sprintf "git %s failed: %s" (String.concat " " args) e)
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let init_origin path =
+  Unix.mkdir path 0o755;
+  git ~cwd:path [ "init"; "-b"; "main" ];
+  git ~cwd:path [ "config"; "user.email"; "test@example.com" ];
+  git ~cwd:path [ "config"; "user.name"; "Test User" ];
+  write_file (Filename.concat path "file.txt") "one\n";
+  git ~cwd:path [ "add"; "file.txt" ];
+  git ~cwd:path [ "commit"; "-m"; "initial" ]
+
+let commit_origin path content message =
+  write_file (Filename.concat path "file.txt") content;
+  git ~cwd:path [ "add"; "file.txt" ];
+  git ~cwd:path [ "commit"; "-m"; message ]
+
+let fixture_repo ~origin ~clone id =
+  {
+    id;
+    name = id;
+    url = origin;
+    local_path = clone;
+    aliases = [];
+    default_branch = "main";
+    keepers = [];
+    status = Active;
+    auto_sync = true;
+    sync_interval = 300;
+    created_at = Int64.of_int 1700000000;
+    updated_at = Int64.of_int 1700000000;
+  }
+
+(* Creates origin + clone under [base_path], persists the repository record
+   (sync_repository updates status through Repo_store), and hands the record
+   to [f]. *)
+let with_advance_fixture base_path f =
+  let origin = Filename.concat base_path "origin" in
+  let clone = Filename.concat base_path "clone" in
+  init_origin origin;
+  git ~cwd:base_path [ "clone"; origin; clone ];
+  git ~cwd:clone [ "config"; "user.email"; "test@example.com" ];
+  git ~cwd:clone [ "config"; "user.name"; "Test User" ];
+  let repo = fixture_repo ~origin ~clone "r1" in
+  (match Repo_store.save_all ~base_path [ repo ] with
+   | Ok () -> ()
+   | Error e -> Alcotest.fail ("save_all failed: " ^ e));
+  f ~origin ~clone repo
+
+let check_outcome expected actual =
+  Alcotest.(check string)
+    "advance outcome"
+    expected
+    (Repo_sync.advance_outcome_label actual)
+
+let sync_ok ~base_path repo =
+  match Repo_sync.sync_repository ~base_path repo with
+  | Ok outcome -> outcome
+  | Error e -> Alcotest.fail ("sync_repository failed: " ^ e)
+
+let test_sync_advances_clean_clone () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin ~clone repo ->
+          commit_origin origin "two\n" "second";
+          (match sync_ok ~base_path repo with
+           | Repo_sync.Advanced { behind } ->
+               Alcotest.(check int) "advanced over one commit" 1 behind
+           | other -> check_outcome "advanced" other);
+          (match
+             Repo_git.ahead_behind ~repository:repo ~target_ref:"origin/main"
+           with
+           | Ok (behind, ahead) ->
+               Alcotest.(check (pair int int))
+                 "clone current after advance" (0, 0) (behind, ahead)
+           | Error e -> Alcotest.fail e);
+          Alcotest.(check string)
+            "working tree file advanced" "two\n"
+            (read_file (Filename.concat clone "file.txt"))))
+
+let test_sync_already_current () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin:_ ~clone:_ repo ->
+          check_outcome "already_current" (sync_ok ~base_path repo)))
+
+let test_sync_preserves_dirty_tree () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin ~clone repo ->
+          commit_origin origin "two\n" "second";
+          write_file (Filename.concat clone "file.txt") "local edit\n";
+          (match sync_ok ~base_path repo with
+           | Repo_sync.Skipped_dirty { unstaged; _ } ->
+               Alcotest.(check bool) "unstaged edit counted" true (unstaged > 0)
+           | other -> check_outcome "skipped_dirty" other);
+          Alcotest.(check string)
+            "local edit preserved" "local edit\n"
+            (read_file (Filename.concat clone "file.txt"))))
+
+let test_sync_refuses_diverged_clone () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin ~clone repo ->
+          commit_origin origin "two\n" "second";
+          write_file (Filename.concat clone "file.txt") "local commit\n";
+          git ~cwd:clone [ "add"; "file.txt" ];
+          git ~cwd:clone [ "commit"; "-m"; "local divergence" ];
+          (match sync_ok ~base_path repo with
+           | Repo_sync.Fast_forward_refused { behind; _ } ->
+               Alcotest.(check int) "behind counted" 1 behind
+           | other -> check_outcome "fast_forward_refused" other);
+          Alcotest.(check string)
+            "diverged commit preserved" "local commit\n"
+            (read_file (Filename.concat clone "file.txt"))))
+
+let test_sync_skips_non_default_branch () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin ~clone repo ->
+          commit_origin origin "two\n" "second";
+          git ~cwd:clone [ "checkout"; "-b"; "feature" ];
+          match sync_ok ~base_path repo with
+          | Repo_sync.Skipped_not_on_default_branch { current } ->
+              Alcotest.(check string) "reports checked-out branch" "feature" current
+          | other -> check_outcome "skipped_not_on_default_branch" other))
+
 let () =
   Alcotest.run "Repo_sync"
     [
@@ -112,5 +270,13 @@ let () =
         [
           Alcotest.test_case "empty repos" `Quick test_sync_all_empty_repos;
           Alcotest.test_case "no due repos" `Quick test_sync_all_no_due_repos;
+        ] );
+      ( "advance_working_tree",
+        [
+          Alcotest.test_case "advances clean clone" `Quick test_sync_advances_clean_clone;
+          Alcotest.test_case "already current" `Quick test_sync_already_current;
+          Alcotest.test_case "preserves dirty tree" `Quick test_sync_preserves_dirty_tree;
+          Alcotest.test_case "refuses diverged clone" `Quick test_sync_refuses_diverged_clone;
+          Alcotest.test_case "skips non-default branch" `Quick test_sync_skips_non_default_branch;
         ] );
     ]

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -117,7 +117,7 @@ let run_cmd ~cwd argv =
        | _, Unix.WSTOPPED s -> Error (Printf.sprintf "stopped %d" s))
 
 let git ~cwd args =
-  match run_cmd ~cwd ("git" :: args) with
+  match run_cmd ~cwd ("git" :: "-c" :: "core.hooksPath=/dev/null" :: args) with
   | Ok () -> ()
   | Error e ->
       failwith (Printf.sprintf "git %s failed: %s" (String.concat " " args) e)
@@ -210,6 +210,24 @@ let test_sync_advances_clean_clone () =
             "working tree file advanced" "two\n"
             (read_file (Filename.concat clone "file.txt"))))
 
+let test_sync_fast_forward_suppresses_post_merge_hook () =
+  with_temp_base_path (fun base_path ->
+      with_advance_fixture base_path (fun ~origin ~clone repo ->
+          let marker = Filename.concat clone ".git/post-merge-ran" in
+          let hook = Filename.concat clone ".git/hooks/post-merge" in
+          write_file hook "#!/bin/sh\nprintf ran > .git/post-merge-ran\n";
+          Unix.chmod hook 0o755;
+          commit_origin origin "two\n" "second";
+          (match sync_ok ~base_path repo with
+           | Repo_sync.Advanced { behind } ->
+               Alcotest.(check int) "advanced over one commit" 1 behind
+           | other -> check_outcome "advanced" other);
+          Alcotest.(check string)
+            "working tree file advanced" "two\n"
+            (read_file (Filename.concat clone "file.txt"));
+          Alcotest.(check bool)
+            "post-merge hook did not run" false (Sys.file_exists marker)))
+
 let test_sync_already_current () =
   with_temp_base_path (fun base_path ->
       with_advance_fixture base_path (fun ~origin:_ ~clone:_ repo ->
@@ -274,6 +292,8 @@ let () =
       ( "advance_working_tree",
         [
           Alcotest.test_case "advances clean clone" `Quick test_sync_advances_clean_clone;
+          Alcotest.test_case "suppresses post-merge hook" `Quick
+            test_sync_fast_forward_suppresses_post_merge_hook;
           Alcotest.test_case "already current" `Quick test_sync_already_current;
           Alcotest.test_case "preserves dirty tree" `Quick test_sync_preserves_dirty_tree;
           Alcotest.test_case "refuses diverged clone" `Quick test_sync_refuses_diverged_clone;


### PR DESCRIPTION
## 무엇이 문제였나

IDE 화면(workspace tree/file/diff/blame)은 서버 관리 클론(`.masc/repos/<id>`)을 서빙하는데, `repo_sync`는 `git fetch`만 수행하고 워킹트리를 전진시키지 않습니다. 실측(2026-07-07): `.masc/repos/masc`가 `origin/main` 대비 **240 커밋 behind**인 상태로 IDE에 "main · 변경 없음"으로 표시되었습니다. 운영자는 3일 전 코드를 현재 상태로 믿게 됩니다.

RFC-0210 (Keeper Playground Repo Currency)이 지목한 바로 그 결함입니다: fetch는 ref만 갱신하고, advance 능력이 없으며, staleness가 마스킹됩니다.

## 무엇을 바꿨나

- `Repo_git.current_branch` / `Repo_git.ahead_behind` 추가 — read-only(`GIT_OPTIONAL_LOCKS=0`), bounded timeout.
- `Repo_sync.sync_repository`: fetch 성공 후 checked-out default branch를 `origin/<default_branch>`로 **fast-forward**. work-preserving 규칙(RFC-0210):
  - tracked 변경(staged/unstaged/conflicted) 있으면 skip (`Skipped_dirty`)
  - default 브랜치가 아니면 skip (`Skipped_not_on_default_branch`, detached HEAD 포함)
  - divergence는 `git merge --ff-only`가 거부 (`Fast_forward_refused`) — 히스토리 재작성 없음
- 결과는 closed variant `advance_outcome` 6종으로 반환 — silent failure 없음, 호출자(부트스트랩 루프, sync 라우트)가 전부 exhaustive match로 소비.
- `POST /api/v1/repositories/<id>/sync` 응답에 `advance` 객체 추가 (additive).
- `GET /api/v1/repositories` 응답에 `sync_currency` (behind/ahead vs `origin/<default_branch>`) 추가 (additive) — IDE가 stale 클론을 "변경 없음"으로 위장하지 않도록 대시보드가 렌더 가능.

## 검증

- `test/test_repo_sync.ml`에 real-git 픽스처 5케이스 추가: clean advance / already current / dirty preserve / diverged refuse / non-default-branch skip. 각 케이스는 워킹트리 파일 내용까지 검증.
- dune 빌드/테스트는 CI에서 수행.

## RFC

- RFC-0210: Keeper Playground Repo Currency (fetch + fast-forward, work-preserving) — 본 PR은 §Problem 1(No advance capability), §3(No sync trigger의 advance 부재)을 managed clone 경로에서 해소.
- 관련: RFC-0104 (keeper-task-repo-binding)

## 영향 범위

- `lib/repo_manager/` (RFC 게이트 대상): repo_git, repo_sync
- `lib/server/`: bootstrap 루프 로그, repositories 라우트 JSON (additive)
- FE는 normalize 방식 파서라 additive 필드 무해 (`dashboard/src/api/repositories.ts:120-137` normalizeRepository)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
