### PR TITLE
fix(exec): floor destructive git push refspecs (colon-delete, plus-force)

### DIFF
--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -96,6 +96,9 @@ let of_argv = function
              Ok (Destructive `Push_mirror)
            else if
              has_flag rest "--delete" || has_short_flag rest 'd'
+             (* [git push --prune] deletes remote refs that no longer exist
+                locally, so it belongs to the remote-ref deletion floor. *)
+             || has_long_flag rest "--prune"
              (* [:dst] (empty source) deletes the remote ref *)
              || has_leading_char_token ':' rest
            then

--- a/lib/exec/git_op.ml
+++ b/lib/exec/git_op.ml
@@ -32,6 +32,18 @@ let has_short_flag args ch =
       String.length arg >= 2 && arg.[0] = '-' && arg.[1] <> '-' && String.contains arg ch)
     args
 
+(* A [git push] refspec carries its danger in a POSITIONAL (non-flag) token, not
+   a flag: [:dst] (empty source) deletes the remote ref, and [+src[:dst]] (or a
+   bare [+ref]) force-overwrites it. The flag checks ([--delete]/[--force]/[-f])
+   never see these, so [git push origin :refs/heads/main] and
+   [git push origin +refs/heads/main] would grade as an ordinary [Mutating Push]
+   and auto-run. A leading '+' or ':' appears only on a refspec in push args (a
+   remote name or a flag never starts with them), so a leading-char scan is
+   exact. Same class as the leading-flag (#23390) and action-flag (find -delete)
+   bypasses: danger in a non-flag token. *)
+let has_leading_char_token ch args =
+  List.exists (fun arg -> String.length arg > 0 && arg.[0] = ch) args
+
 let rec strip_global_options = function
   | "-C" :: _path :: rest -> strip_global_options rest
   | "-c" :: _binding :: rest -> strip_global_options rest
@@ -76,11 +88,17 @@ let of_argv = function
            if has_flag rest "--force"
               || has_long_flag rest "--force-with-lease"
               || has_short_flag rest 'f'
+              (* [+src[:dst]] / [+ref] force-overwrites the remote ref *)
+              || has_leading_char_token '+' rest
            then
              Ok (Destructive `Push_force)
            else if has_flag rest "--mirror" then
              Ok (Destructive `Push_mirror)
-           else if has_flag rest "--delete" || has_short_flag rest 'd' then
+           else if
+             has_flag rest "--delete" || has_short_flag rest 'd'
+             (* [:dst] (empty source) deletes the remote ref *)
+             || has_leading_char_token ':' rest
+           then
              Ok (Destructive `Push_delete)
            else Ok (Mutating `Push)
        | "reset" when has_flag rest "--hard" ->

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -680,6 +680,20 @@ let test_push_mirror_floored_under_autonomous () =
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_mirror); _ } -> ()
   | _ -> assert false
 
+let test_push_prune_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "--prune"; lit "origin"; lit "main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+      ~caps ~simple:s
+  with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_delete); _ }
+    -> ()
+  | _ -> assert false
+
 (* Refspec-borne destructive push must hit the trust-independent floor under the
    autonomous overlay, exactly like the flag forms. [:dst] deletes the remote
    ref; [+ref] force-overwrites it. Without refspec parsing these auto-ran. *)
@@ -767,6 +781,7 @@ let () =
   test_push_delete_short_flag_floored_under_autonomous ();
   test_push_force_with_lease_floored_under_autonomous ();
   test_push_mirror_floored_under_autonomous ();
+  test_push_prune_floored_under_autonomous ();
   test_push_delete_refspec_floored_under_autonomous ();
   test_push_force_refspec_floored_under_autonomous ();
   test_worktree_remove_floored_under_autonomous ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -680,6 +680,37 @@ let test_push_mirror_floored_under_autonomous () =
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_mirror); _ } -> ()
   | _ -> assert false
 
+(* Refspec-borne destructive push must hit the trust-independent floor under the
+   autonomous overlay, exactly like the flag forms. [:dst] deletes the remote
+   ref; [+ref] force-overwrites it. Without refspec parsing these auto-ran. *)
+let test_push_delete_refspec_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "origin"; lit ":refs/heads/main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+      ~caps ~simple:s
+  with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_delete); _ }
+    -> ()
+  | _ -> assert false
+
+let test_push_force_refspec_floored_under_autonomous () =
+  let s =
+    simple (bin_ok "git")
+      ~args:[ lit "push"; lit "origin"; lit "+refs/heads/main" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+      ~caps ~simple:s
+  with
+  | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Push_force); _ }
+    -> ()
+  | _ -> assert false
+
 (* RFC-0255 §4.5: [worktree remove] is NOT recoverable (discards uncommitted
    worktree state and races concurrent keepers/the conveyor) — it STAYS in the
    floor and is [Deny] under every overlay including autonomous. *)
@@ -736,6 +767,8 @@ let () =
   test_push_delete_short_flag_floored_under_autonomous ();
   test_push_force_with_lease_floored_under_autonomous ();
   test_push_mirror_floored_under_autonomous ();
+  test_push_delete_refspec_floored_under_autonomous ();
+  test_push_force_refspec_floored_under_autonomous ();
   test_worktree_remove_floored_under_autonomous ();
   test_rm_root_allowed_at_policy_layer_jailed_downstream ();
   test_autonomous_allows_toolchain ();

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -95,6 +95,17 @@ let test_git_push_mirror_destructive () =
   | [ Capability.Git (Git_op.Destructive `Push_mirror) ] -> ()
   | _ -> assert false
 
+let test_git_push_prune_destructive () =
+  let ir =
+    Shell_ir.Simple
+      (simple
+         ~args:[ lit "push"; lit "--prune"; lit "origin"; lit "main" ]
+         (bin_ok "git"))
+  in
+  match Capability_check.of_ir ir with
+  | [ Capability.Git (Git_op.Destructive `Push_delete) ] -> ()
+  | _ -> assert false
+
 let test_git_with_var_falls_back_to_exec_bin () =
   (* git ${REMOTE} push — can't classify statically, falls back. *)
   let ir =
@@ -175,6 +186,7 @@ let () =
   test_git_push_delete_short_flag_destructive ();
   test_git_push_force_with_lease_destructive ();
   test_git_push_mirror_destructive ();
+  test_git_push_prune_destructive ();
   test_git_with_var_falls_back_to_exec_bin ();
   test_env_set_prefix_emitted_first ();
   test_redirect_write_becomes_write_path ();

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -124,6 +124,12 @@ let test_git_op_push_force_refspec () =
   | _ -> assert false
 ;;
 
+let test_git_op_push_prune_destructive () =
+  match Git_op.of_argv [ "git"; "push"; "--prune"; "origin"; "main" ] with
+  | Ok (Git_op.Destructive `Push_delete) -> ()
+  | _ -> assert false
+;;
+
 (* Guard against over-blocking: a plain [src:dst] refspec (no [+]/[:] marker)
    is an ordinary push, not destructive. *)
 let test_git_op_push_plain_refspec_not_destructive () =
@@ -255,6 +261,7 @@ let () =
   test_git_op_destructive_detection ();
   test_git_op_push_delete_refspec ();
   test_git_op_push_force_refspec ();
+  test_git_op_push_prune_destructive ();
   test_git_op_push_plain_refspec_not_destructive ();
   test_git_op_read ();
   test_git_op_read_with_cwd_flag ();

--- a/lib/exec/test/test_exec_types.ml
+++ b/lib/exec/test/test_exec_types.ml
@@ -109,6 +109,29 @@ let test_git_op_destructive_detection () =
   | Error _ -> assert false
 ;;
 
+(* Refspec-borne destructiveness: the danger is in a positional token, not a
+   flag. [:dst] (empty source) deletes the remote ref; [+ref] force-overwrites
+   it. Without refspec parsing these graded as an ordinary [Mutating Push]. *)
+let test_git_op_push_delete_refspec () =
+  match Git_op.of_argv [ "git"; "push"; "origin"; ":refs/heads/main" ] with
+  | Ok (Git_op.Destructive `Push_delete) -> ()
+  | _ -> assert false
+;;
+
+let test_git_op_push_force_refspec () =
+  match Git_op.of_argv [ "git"; "push"; "origin"; "+refs/heads/main" ] with
+  | Ok (Git_op.Destructive `Push_force) -> ()
+  | _ -> assert false
+;;
+
+(* Guard against over-blocking: a plain [src:dst] refspec (no [+]/[:] marker)
+   is an ordinary push, not destructive. *)
+let test_git_op_push_plain_refspec_not_destructive () =
+  match Git_op.of_argv [ "git"; "push"; "origin"; "main:main" ] with
+  | Ok (Git_op.Mutating `Push) -> ()
+  | _ -> assert false
+;;
+
 let test_git_op_read () =
   match Git_op.of_argv [ "git"; "status" ] with
   | Ok (Git_op.Read _) -> ()
@@ -230,6 +253,9 @@ let () =
   test_grep_is_known_safe_exec_program ();
   test_exec_program_empty_rejected ();
   test_git_op_destructive_detection ();
+  test_git_op_push_delete_refspec ();
+  test_git_op_push_force_refspec ();
+  test_git_op_push_plain_refspec_not_destructive ();
   test_git_op_read ();
   test_git_op_read_with_cwd_flag ();
   test_git_op_unknown ();


### PR DESCRIPTION
## What

`git push`의 파괴성은 flag뿐 아니라 **positional refspec 토큰**에도 실립니다. `Git_op.of_argv`의 push arm이 `--force`/`-f`/`--force-with-lease`/`--mirror`/`--delete`/`-d`만 검사해서, 동등한 refspec 형태가 평범한 `Mutating Push`로 분류되어 autonomous overlay에서 **무승인 auto-run**됐습니다.

- `:<dst>` refspec (빈 source) → 원격 ref **삭제**
- `+<ref>` refspec → 원격 ref **force-overwrite**

flag 형태(`--delete`/`--force`)는 catastrophic floor에서 Deny되는데, refspec 형태만 새던 비대칭입니다.

## Fix

push arm에서 positional refspec를 파싱:
- leading `+` (`+src[:dst]` / `+ref`) → `Push_force`
- leading `:` (`:dst`, 빈 source) → `Push_delete`

`+`/`:`로 시작하는 토큰은 push 인자에서 **refspec에만** 등장합니다 (remote명·flag는 이 문자로 시작 안 함) → leading-char 스캔이 정확. #23390(leading value-flag)·`find -delete`(action-flag)와 동일 계열: **비-flag 토큰에 실린 위험**.

## 검증

- `Git_op.of_argv`: colon-delete refspec → `Push_delete`, plus-force refspec → `Push_force`, 평범한 `main:main` → `Mutating Push`(과다차단 방지).
- end-to-end: 두 refspec 형태 모두 autonomous overlay에서 `Deny`(catastrophic floor).
- 전체 `@lib/exec/test/runtest` green, downstream keeper+keeper_tooling+bin green, STR/DET gate PASS, ocamlformat clean.

## 근거

RFC-0309 gh-gating 적대 감사(PR #23424/#23431 착지 후)에서 confirmed. gh capability 우회 2건은 #23449, 이건 git_op 서브시스템이라 별도. 남은 audit 항목: #23451(gh api method 파싱), #23445(curl egress).

base: main.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
