### PR TITLE
fix(keeper): cooldown gate preserves the arming cause — deterministic failures escalate instead of oscillating (#23438)

### DIFF
--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -78,6 +78,31 @@ type outcome =
   | Soft_rate_limited
   | Capacity_backpressure
 
+(* Public mirror of [outcome].  Defined here (rather than beside
+   [recent_outcome_count] where it originated) so [build_info_locked] can expose
+   the cooldown-arming outcome on [provider_info] without leaking the internal
+   [outcome] type.  See [outcome_matches] for the paired exhaustive match that
+   guards against the two types drifting. *)
+type outcome_kind =
+  | Outcome_success
+  | Outcome_failure
+  | Outcome_rejected
+  | Outcome_hard_quota
+  | Outcome_terminal_failure
+  | Outcome_server_error
+  | Outcome_soft_rate_limited
+  | Outcome_capacity_backpressure
+
+let outcome_kind_of_outcome = function
+  | Success -> Outcome_success
+  | Failure -> Outcome_failure
+  | Rejected -> Outcome_rejected
+  | Hard_quota -> Outcome_hard_quota
+  | Terminal_failure -> Outcome_terminal_failure
+  | Server_error -> Outcome_server_error
+  | Soft_rate_limited -> Outcome_soft_rate_limited
+  | Capacity_backpressure -> Outcome_capacity_backpressure
+
 type event = {
   time: float;  (* Unix timestamp *)
   outcome: outcome;
@@ -87,6 +112,13 @@ type provider_state = {
   mutable events: event list;  (* newest first *)
   mutable consecutive_failures: int;
   mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+  mutable cooldown_cause: outcome option;
+  (* The outcome that armed the current cooldown window (set wherever
+     [cooldown_until] is advanced, cleared on success/expiry).  [None] when
+     not in cooldown, or for a cooldown restored from persistence (the cause is
+     not persisted; it is re-armed on the next real failure).  Read by the
+     pre-dispatch cooldown gate so a deterministic arming cause escalates
+     instead of oscillating.  #23438. *)
   fingerprint_counts: (string, int) Hashtbl.t;
   (* Per-fingerprint cumulative counter (lifetime, no rolling decay).
      Phase 0 observability anchor for "which error keeps recurring".
@@ -178,6 +210,7 @@ let get_or_create_state t key =
       events = [];
       consecutive_failures = 0;
       cooldown_until = 0.0;
+      cooldown_cause = None;
       fingerprint_counts = Hashtbl.create 4;
       last_failure_at = 0.0;
       latency_ring = None;
@@ -244,6 +277,9 @@ let restore_providers t providers =
           <- (match finite_positive row.restore_cooldown_until with
               | Some ts when ts > now -> ts
               | _ -> 0.0);
+          (* The arming cause is not persisted; a restored cooldown reports no
+             cause until the next real failure re-arms it.  #23438. *)
+          state.cooldown_cause <- None;
           state.last_failure_at
           <- (match finite_positive row.restore_last_failure_at with
               | Some ts -> ts
@@ -380,6 +416,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       state.consecutive_failures <- 0;
       (* Clear cooldown on success — provider recovered *)
       state.cooldown_until <- 0.0;
+      state.cooldown_cause <- None;
       (* Append latency sample when caller provided one.  Non-success
          outcomes don't contribute to the percentile — a 200ms timeout
          and a 200ms successful response are not the same signal. *)
@@ -406,6 +443,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
         let new_until = now +. cooldown_dur in
         if new_until > state.cooldown_until then begin
           state.cooldown_until <- new_until;
+          state.cooldown_cause <- Some outcome;
           Runtime_metrics.on_provider_cooldown
             ~provider:provider_key ~reason:"failure_threshold";
           Otel_metric_store.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
@@ -433,6 +471,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. cooldown_dur in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
+        state.cooldown_cause <- Some outcome;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"soft_rate_limit";
         Otel_metric_store.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
@@ -453,6 +492,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. cooldown_dur in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
+        state.cooldown_cause <- Some outcome;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"capacity_backpressure";
         Otel_metric_store.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
@@ -470,6 +510,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. hard_quota_cooldown_sec in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
+        state.cooldown_cause <- Some outcome;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"hard_quota";
         Otel_metric_store.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
@@ -488,6 +529,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. terminal_failure_cooldown_sec in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
+        state.cooldown_cause <- Some outcome;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"terminal_failure";
         Otel_metric_store.observe_histogram
@@ -505,6 +547,7 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       let new_until = now +. server_error_cooldown_sec in
       if new_until > state.cooldown_until then begin
         state.cooldown_until <- new_until;
+        state.cooldown_cause <- Some outcome;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"server_error";
         Otel_metric_store.observe_histogram
@@ -582,6 +625,7 @@ let is_in_cooldown t ~provider_key =
         (* Expired cooldown — clear it *)
         if state.cooldown_until > 0.0 then
           state.cooldown_until <- 0.0;
+        state.cooldown_cause <- None;
         false
       end)
 
@@ -617,6 +661,7 @@ let check_circuit_breaker t ~provider_key =
       else begin
         if state.cooldown_until > 0.0 then
           state.cooldown_until <- 0.0;
+        state.cooldown_cause <- None;
         Ok ()
       end)
 
@@ -657,6 +702,7 @@ type provider_info = {
   consecutive_failures : int;
   in_cooldown : bool;
   cooldown_expires_at : float option;
+  cooldown_cause : outcome_kind option;
   events_in_window : int;
   rejected_in_window : int;
   top_fingerprints : (string * int) list;
@@ -819,6 +865,10 @@ let build_info_locked ~now ~key state =
     consecutive_failures = state.consecutive_failures;
     in_cooldown = in_cd;
     cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
+    cooldown_cause =
+      (if in_cd
+       then Option.map outcome_kind_of_outcome state.cooldown_cause
+       else None);
     events_in_window = total;
     rejected_in_window = rejected;
     top_fingerprints;
@@ -876,15 +926,8 @@ let all_providers t =
 
 (* ── Outcome window queries ────────────────────── *)
 
-type outcome_kind =
-  | Outcome_success
-  | Outcome_failure
-  | Outcome_rejected
-  | Outcome_hard_quota
-  | Outcome_terminal_failure
-  | Outcome_server_error
-  | Outcome_soft_rate_limited
-  | Outcome_capacity_backpressure
+(* [type outcome_kind] and [outcome_kind_of_outcome] are defined near [type
+   outcome] so [build_info_locked] can use them. *)
 
 let outcome_matches kind ev =
   (* Enumerate every [outcome_kind] x [outcome] pair so the compiler

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -338,6 +338,22 @@ val effective_weight : t -> provider_key:string -> config_weight:int -> int
 (** Human-readable summary for debugging/telemetry. *)
 val provider_summary : t -> provider_key:string -> string
 
+(** Outcome variant exposed for {!recent_outcome_count} window queries and the
+    [cooldown_cause] field of {!provider_info}.  Mirrors the internal
+    classification — the internal [outcome] type is kept abstract elsewhere to
+    keep the recording surface narrow.
+
+    @since 0.183.0 *)
+type outcome_kind =
+  | Outcome_success
+  | Outcome_failure
+  | Outcome_rejected
+  | Outcome_hard_quota
+  | Outcome_terminal_failure
+  | Outcome_server_error
+  | Outcome_soft_rate_limited
+  | Outcome_capacity_backpressure
+
 (** Structured summary for telemetry/dashboard consumption.
 
     @since 0.139.0 *)
@@ -347,6 +363,12 @@ type provider_info = {
   consecutive_failures : int;
   in_cooldown : bool;
   cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
+  cooldown_cause : outcome_kind option;
+  (** The outcome that armed the active cooldown window, [Some] iff
+      [in_cooldown] and the arming cause is known (a cooldown restored from
+      persistence reports [None] until re-armed).  The pre-dispatch cooldown
+      gate uses this to distinguish deterministic causes (which escalate) from
+      transient ones (which stay auto-recoverable).  #23438. *)
   events_in_window : int;             (** Events retained in rolling window *)
   rejected_in_window : int;           (** Subset of [events_in_window] whose outcome was [Rejected]. @since 0.160.0 *)
   top_fingerprints : (string * int) list;
@@ -409,21 +431,6 @@ val provider_info : t -> provider_key:string -> provider_info option
     Useful for dashboards and telemetry endpoints.
     @since 0.139.0 *)
 val all_providers : t -> provider_info list
-
-(** Outcome variant exposed for {!recent_outcome_count} window queries.
-    Mirrors the internal classification — kept abstract elsewhere to
-    keep the recording surface narrow.
-
-    @since 0.183.0 *)
-type outcome_kind =
-  | Outcome_success
-  | Outcome_failure
-  | Outcome_rejected
-  | Outcome_hard_quota
-  | Outcome_terminal_failure
-  | Outcome_server_error
-  | Outcome_soft_rate_limited
-  | Outcome_capacity_backpressure
 
 (** [recent_outcome_count t ~provider_key ~outcome ~window_s] returns the
     number of events of [outcome] recorded for [provider_key] within the

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -190,8 +190,18 @@ let is_auto_recoverable_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error
       (Keeper_turn_driver.Runtime_exhausted
          { reason = Keeper_turn_driver.Capacity_exhausted; _ }) ->
       true
-  | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-      true
+  | Some (Keeper_turn_driver.Capacity_backpressure { cooldown_cause; _ }) ->
+      (* A pre-dispatch provider-health cooldown block carries the failure that
+         armed the cooldown.  Deterministic causes (config/build error, depleted
+         balance, structural provider failure) re-fail on the next tick, so they
+         must NOT be auto-recoverable: returning [false] makes [counts_toward_crash]
+         true so the existing failure-streak policy escalates instead of the
+         keeper oscillating (#23438).  Genuine upstream capacity backpressure
+         ([None]) and transient causes stay auto-recoverable. *)
+      (match cooldown_cause with
+       | Some cause ->
+         not (Keeper_turn_driver.provider_cooldown_cause_is_deterministic cause)
+       | None -> true)
   | Some (Keeper_turn_driver.Runtime_exhausted _) ->
       false
   | Some (Keeper_turn_driver.Accept_rejected _)

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -258,8 +258,8 @@ let enrich_sdk_error ~runtime_id ~(provider_cfg : Llm_provider.Provider_config.t
 let message_looks_like_cli_wrapped_hard_quota =
   Keeper_turn_driver_provider_attempt.message_looks_like_cli_wrapped_hard_quota
 
-let message_looks_like_capacity_backpressure =
-  Keeper_turn_driver_provider_attempt.message_looks_like_capacity_backpressure
+(* [message_looks_like_capacity_backpressure] alias removed with the substring
+   classifier it re-exported (#23438). *)
 
 let sdk_error_is_hard_quota =
   Keeper_turn_driver_provider_attempt.sdk_error_is_hard_quota

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -30,13 +30,13 @@ include
       Keeper_internal_error.accept_response_shape
      and type tool_progress_effect =
       Keeper_internal_error.tool_progress_effect
+     and type provider_cooldown_cause =
+      Keeper_internal_error.provider_cooldown_cause
      and type masc_internal_error = Keeper_internal_error.masc_internal_error
 
 (** {1 Provider error helpers} *)
 
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
-
-val message_looks_like_capacity_backpressure : string -> bool
 
 val sdk_error_is_terminal_provider_runtime_failure :
   Agent_sdk.Error.sdk_error -> bool

--- a/lib/keeper/keeper_turn_driver_backpressure.ml
+++ b/lib/keeper/keeper_turn_driver_backpressure.ml
@@ -64,6 +64,9 @@ let capacity_backpressure_of_http_error ?source ~runtime_id last_err =
                 log_synthetic_backoff ~synthetic_sec:syn_sec
                   ~source:"Provider_capacity" ~detail:message;
                 Synthetic_default syn_sec);
+           (* Genuine upstream capacity exhaustion, not a pre-dispatch health
+              cooldown block — no arming cause to carry.  #23438. *)
+           cooldown_cause = None;
          })
   | Some
       (Llm_provider.Http_client.NetworkError
@@ -78,10 +81,11 @@ let capacity_backpressure_of_http_error ?source ~runtime_id last_err =
            source = Option.value source ~default:Runtime_slot;
            detail = message;
            retry_after =
-               let syn_sec = synthetic_retry_after_sec in
-               log_synthetic_backoff ~synthetic_sec:syn_sec
-                 ~source:"Runtime_slot" ~detail:message;
-               Synthetic_default syn_sec;
+             (let syn_sec = synthetic_retry_after_sec in
+              log_synthetic_backoff ~synthetic_sec:syn_sec
+                ~source:"Runtime_slot" ~detail:message;
+              Synthetic_default syn_sec);
+           cooldown_cause = None;
          })
   | Some
       (Llm_provider.Http_client.HttpError _
@@ -102,55 +106,14 @@ let capacity_backpressure_of_pending ~runtime_id = function
            source;
            detail;
            retry_after;
+           cooldown_cause = None;
          })
   | None -> None
 
-let capacity_backpressure_of_sdk_error
-    ~runtime_id
-    ~message_looks_like_capacity_backpressure
-    ~sdk_error_of_masc_internal_error
-    sdk_err =
-  match sdk_err with
-  | Agent_sdk.Error.Provider
-      (Llm_provider.Error.CapacityExhausted { retry_after; detail; _ }) ->
-    Some
-      (sdk_error_of_masc_internal_error
-         (Capacity_backpressure
-            {
-              runtime_id;
-              source = Provider_capacity;
-              detail;
-              retry_after =
-                (match retry_after with
-                 | Some s -> Explicit s
-                 | None ->
-                   let syn_sec = synthetic_retry_after_sec in
-                   log_synthetic_backoff ~synthetic_sec:syn_sec
-                     ~source:"Provider_capacity" ~detail;
-                   Synthetic_default syn_sec);
-            }))
-  | Agent_sdk.Error.Internal msg
-    when message_looks_like_capacity_backpressure msg ->
-    Some
-      (sdk_error_of_masc_internal_error
-         (Capacity_backpressure
-            {
-              runtime_id;
-              source = Provider_capacity;
-              detail = msg;
-              retry_after =
-                let syn_sec = synthetic_retry_after_sec in
-                log_synthetic_backoff ~synthetic_sec:syn_sec
-                  ~source:"Provider_capacity" ~detail:msg;
-                Synthetic_default syn_sec;
-            }))
-  | Agent_sdk.Error.Api _
-  | Agent_sdk.Error.Provider _
-  | Agent_sdk.Error.Agent _
-  | Agent_sdk.Error.Mcp _
-  | Agent_sdk.Error.Config _
-  | Agent_sdk.Error.Serialization _
-  | Agent_sdk.Error.Io _
-  | Agent_sdk.Error.Orchestration _
-  | Agent_sdk.Error.Internal _ ->
-    None
+(* [capacity_backpressure_of_sdk_error] was removed (#23438).  It classified an
+   [Agent_sdk.Error.Internal msg] into [Capacity_backpressure] via a substring
+   match ([message_looks_like_capacity_backpressure]) — a string classifier that
+   laundered opaque internal errors into the permanently-transient (auto-
+   recoverable, not-counting-toward-crash) class, the same failure mode that
+   made deterministic cooldowns oscillate.  The typed [cooldown_cause] on the
+   pre-dispatch gate replaces it; the function had no live callers. *)

--- a/lib/keeper/keeper_turn_driver_backpressure.mli
+++ b/lib/keeper/keeper_turn_driver_backpressure.mli
@@ -29,13 +29,7 @@ val capacity_backpressure_of_pending :
    * Keeper_internal_error.capacity_retry_after) option ->
   Keeper_internal_error.masc_internal_error option
 
-(** Classify an SDK error into a capacity-backpressure error,
-    when the error indicates provider capacity exhaustion or a
-    backpressure-like internal message. *)
-val capacity_backpressure_of_sdk_error :
-  runtime_id:string ->
-  message_looks_like_capacity_backpressure:(string -> bool) ->
-  sdk_error_of_masc_internal_error:(Keeper_internal_error.masc_internal_error ->
-                                    Agent_sdk.Error.sdk_error) ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error option
+(* [capacity_backpressure_of_sdk_error] was removed (#23438): a dead substring
+   classifier that laundered opaque [Internal] errors into the auto-recoverable
+   capacity-backpressure class.  The typed [cooldown_cause] on the pre-dispatch
+   cooldown gate replaces it. *)

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -186,10 +186,15 @@ let provider_cooldown_cause_of_outcome_kind
    cause that may recover.  Only when every blocker's cause is deterministic
    does the block escalate — hence "any transient wins".  #23438. *)
 let aggregate_cooldown_cause provider_infos =
-  let causes =
+  let cause_options =
     provider_infos
-    |> List.filter_map (fun (_, info) -> info.Keeper_binding_health.cooldown_cause)
-    |> List.filter_map provider_cooldown_cause_of_outcome_kind
+    |> List.map (fun (_, info) ->
+      match info.Keeper_binding_health.cooldown_cause with
+      | Some kind -> provider_cooldown_cause_of_outcome_kind kind
+      | None -> None)
+  in
+  let causes =
+    cause_options |> List.filter_map (fun cause -> cause)
   in
   match
     List.find_opt
@@ -198,7 +203,10 @@ let aggregate_cooldown_cause provider_infos =
       causes
   with
   | Some transient -> Some transient
-  | None -> (match causes with [] -> None | c :: _ -> Some c)
+  | None ->
+    if List.exists Option.is_none cause_options
+    then None
+    else (match causes with [] -> None | c :: _ -> Some c)
 
 let cooldown_remaining_sec_of_info info =
   match info.Keeper_binding_health.cooldown_expires_at with

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -154,7 +154,51 @@ let credential_pool_health_keys ~keeper_name candidate =
 type provider_cooldown_block =
   { blocked_provider_keys : string list
   ; cooldown_remaining_sec : int
+  ; cooldown_cause : Keeper_internal_error.provider_cooldown_cause option
   }
+
+(* Map the health tracker's public outcome-kind mirror to the typed cooldown
+   cause carried on the pre-dispatch backpressure envelope.  [Outcome_success]
+   never arms a cooldown, so it has no cause.  #23438. *)
+let provider_cooldown_cause_of_outcome_kind
+    (kind : Keeper_binding_health.outcome_kind)
+  : Keeper_internal_error.provider_cooldown_cause option =
+  match kind with
+  | Keeper_binding_health.Outcome_capacity_backpressure ->
+    Some Keeper_internal_error.Cooldown_provider_capacity
+  | Keeper_binding_health.Outcome_soft_rate_limited ->
+    Some Keeper_internal_error.Cooldown_soft_rate_limited
+  | Keeper_binding_health.Outcome_server_error ->
+    Some Keeper_internal_error.Cooldown_server_error
+  | Keeper_binding_health.Outcome_hard_quota ->
+    Some Keeper_internal_error.Cooldown_hard_quota
+  | Keeper_binding_health.Outcome_terminal_failure ->
+    Some Keeper_internal_error.Cooldown_terminal_failure
+  | Keeper_binding_health.Outcome_failure ->
+    Some Keeper_internal_error.Cooldown_provider_error
+  | Keeper_binding_health.Outcome_rejected ->
+    Some Keeper_internal_error.Cooldown_rejected
+  | Keeper_binding_health.Outcome_success -> None
+
+(* Aggregate the arming cause across every provider blocking this turn.  The
+   turn is blocked because all candidate providers are in cooldown; it remains
+   auto-recoverable as long as at least one blocker has a transient (or unknown)
+   cause that may recover.  Only when every blocker's cause is deterministic
+   does the block escalate — hence "any transient wins".  #23438. *)
+let aggregate_cooldown_cause provider_infos =
+  let causes =
+    provider_infos
+    |> List.filter_map (fun (_, info) -> info.Keeper_binding_health.cooldown_cause)
+    |> List.filter_map provider_cooldown_cause_of_outcome_kind
+  in
+  match
+    List.find_opt
+      (fun c ->
+        not (Keeper_internal_error.provider_cooldown_cause_is_deterministic c))
+      causes
+  with
+  | Some transient -> Some transient
+  | None -> (match causes with [] -> None | c :: _ -> Some c)
 
 let cooldown_remaining_sec_of_info info =
   match info.Keeper_binding_health.cooldown_expires_at with
@@ -197,15 +241,23 @@ let provider_cooldown_block ~keeper_name candidate =
         | first :: rest -> List.fold_left min first rest
       in
       let blocked_provider_keys = List.map fst provider_infos in
-      Some { blocked_provider_keys; cooldown_remaining_sec }
+      let cooldown_cause = aggregate_cooldown_cause provider_infos in
+      Some { blocked_provider_keys; cooldown_remaining_sec; cooldown_cause }
 
 let provider_cooldown_block_decision block =
+  let cooldown_cause_json =
+    match block.cooldown_cause with
+    | Some cause ->
+      `String (Keeper_internal_error.provider_cooldown_cause_to_string cause)
+    | None -> `Null
+  in
   `Assoc
     [ "blocker", `String "provider_cooldown"
     ; "provider_attempt_started", `Bool false
     ; ( "blocked_provider_keys"
       , `List (List.map (fun key -> `String key) block.blocked_provider_keys) )
     ; "cooldown_remaining_sec", `Int block.cooldown_remaining_sec
+    ; "cooldown_cause", cooldown_cause_json
     ; "retry_after_source", `String "provider_health_cooldown"
     ]
 
@@ -217,12 +269,23 @@ let provider_cooldown_block_error ~runtime_id block =
         (float_of_int block.cooldown_remaining_sec)
     else Keeper_internal_error.No_retry_hint
   in
+  let cause_label =
+    match block.cooldown_cause with
+    | Some cause -> Keeper_internal_error.provider_cooldown_cause_to_string cause
+    | None -> "provider_capacity"
+  in
+  let detail =
+    Printf.sprintf
+      "provider health cooldown active before dispatch (cause=%s)"
+      cause_label
+  in
   Keeper_internal_error.sdk_error_of_masc_internal_error
     (Keeper_internal_error.Capacity_backpressure
        { runtime_id
        ; source = Keeper_internal_error.Provider_capacity
-       ; detail = "provider health cooldown active before dispatch"
+       ; detail
        ; retry_after
+       ; cooldown_cause = block.cooldown_cause
        })
 
 let record_candidate_health_success ~keeper_name candidate ~latency_ms =
@@ -304,16 +367,10 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.Internal _ -> false
 
-let capacity_backpressure_indicators = [
-  "client capacity";
-  "capacity exhausted";
-  "local_resource_exhaustion";
-  "slot full";
-]
-
-let message_looks_like_capacity_backpressure (message : string) : bool =
-  let contains needle = String_util.contains_substring_ci message needle in
-  List.exists contains capacity_backpressure_indicators
+(* [capacity_backpressure_indicators] / [message_looks_like_capacity_backpressure]
+   were removed (#23438): a substring classifier whose only consumer was the
+   deleted [capacity_backpressure_of_sdk_error].  The typed [cooldown_cause] on
+   the pre-dispatch cooldown gate replaces string-based capacity detection. *)
 
 let message_looks_like_terminal_provider_runtime_failure message =
   let contains needle = String_util.contains_substring_ci message needle in

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -5,7 +5,6 @@
     provider-error classification, not runtime-specific. *)
 
 val message_looks_like_cli_wrapped_hard_quota : string -> bool
-val message_looks_like_capacity_backpressure : string -> bool
 val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 val sdk_error_is_terminal_provider_runtime_failure :
   Agent_sdk.Error.sdk_error -> bool
@@ -71,6 +70,10 @@ val health_error_kind : string -> Keeper_binding_health.error_kind
 type provider_cooldown_block =
   { blocked_provider_keys : string list
   ; cooldown_remaining_sec : int
+  ; cooldown_cause : Keeper_internal_error.provider_cooldown_cause option
+    (** Aggregate arming cause across all blocking providers ([None] when
+        unknown); deterministic only when every blocker is deterministic.
+        #23438. *)
   }
 
 val provider_cooldown_block :

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -49,6 +49,56 @@ type capacity_retry_after =
   | Synthetic_default of float
   | No_retry_hint
 
+(** The failure that armed the provider-health cooldown blocking a turn before
+    dispatch.  Mirrors {!Keeper_binding_health.outcome_kind} across the
+    keeper_runtime -> keeper module boundary (keeper_runtime cannot depend on
+    keeper_binding_health).  Carried on {!Capacity_backpressure} so the
+    pre-dispatch cooldown gate reports WHY the provider is cooling instead of
+    unconditionally claiming provider capacity.  #23438. *)
+type provider_cooldown_cause =
+  | Cooldown_provider_capacity
+  | Cooldown_soft_rate_limited
+  | Cooldown_server_error
+  | Cooldown_hard_quota
+  | Cooldown_terminal_failure
+  | Cooldown_provider_error
+  | Cooldown_rejected
+
+let provider_cooldown_cause_to_string = function
+  | Cooldown_provider_capacity -> "provider_capacity"
+  | Cooldown_soft_rate_limited -> "soft_rate_limited"
+  | Cooldown_server_error -> "server_error"
+  | Cooldown_hard_quota -> "hard_quota"
+  | Cooldown_terminal_failure -> "terminal_failure"
+  | Cooldown_provider_error -> "provider_error"
+  | Cooldown_rejected -> "rejected"
+
+let provider_cooldown_cause_of_string = function
+  | "provider_capacity" -> Some Cooldown_provider_capacity
+  | "soft_rate_limited" -> Some Cooldown_soft_rate_limited
+  | "server_error" -> Some Cooldown_server_error
+  | "hard_quota" -> Some Cooldown_hard_quota
+  | "terminal_failure" -> Some Cooldown_terminal_failure
+  | "provider_error" -> Some Cooldown_provider_error
+  | "rejected" -> Some Cooldown_rejected
+  | _ -> None
+
+(** [true] when waiting out the cooldown cannot resolve the cause: the next
+    attempt hits the same deterministic condition (config/build error, depleted
+    balance, structural provider failure, rejected output).  Transient causes
+    (provider capacity, HTTP 429, HTTP 5xx) are expected to recover, so a
+    cooldown block armed by them stays auto-recoverable.  A deterministic cause
+    must instead flow into the crash/pause escalation path so the keeper stops
+    oscillating.  #23438. *)
+let provider_cooldown_cause_is_deterministic = function
+  | Cooldown_hard_quota
+  | Cooldown_terminal_failure
+  | Cooldown_provider_error
+  | Cooldown_rejected -> true
+  | Cooldown_provider_capacity
+  | Cooldown_soft_rate_limited
+  | Cooldown_server_error -> false
+
 type runtime_exhaustion_reason =
   | Connection_refused
   | Dns_failure
@@ -215,6 +265,10 @@ type masc_internal_error =
       source : capacity_backpressure_source;
       detail : string;
       retry_after : capacity_retry_after;
+      cooldown_cause : provider_cooldown_cause option;
+      (* [Some cause] iff this is a pre-dispatch provider-health cooldown block
+         (the arming failure's cause).  [None] for genuine capacity backpressure
+         surfaced from an upstream capacity-exhaustion signal.  #23438. *)
     }
   | Resumable_cli_session of {
       runtime_id : string;
@@ -386,7 +440,7 @@ let masc_internal_error_to_json = function
         ("runtime_id", `String runtime_id);
         ("reason", runtime_exhaustion_reason_to_json reason);
       ]
-  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
+  | Capacity_backpressure { runtime_id; source; detail; retry_after; cooldown_cause } ->
     let runtime_id = runtime_id_to_string runtime_id in
     let retry_after_fields =
       match retry_after with
@@ -396,6 +450,12 @@ let masc_internal_error_to_json = function
         [ ("retry_after_sec", `Float s); ("retry_after_synthetic", `Bool true) ]
       | No_retry_hint -> [ ("retry_after_sec", `Null) ]
     in
+    let cooldown_cause_fields =
+      match cooldown_cause with
+      | Some cause ->
+        [ ("cooldown_cause", `String (provider_cooldown_cause_to_string cause)) ]
+      | None -> []
+    in
     `Assoc
       ([
          ("kind", `String "capacity_backpressure");
@@ -403,7 +463,8 @@ let masc_internal_error_to_json = function
          ("source", `String (capacity_backpressure_source_to_string source));
          ("detail", `String detail);
        ]
-      @ retry_after_fields)
+      @ retry_after_fields
+      @ cooldown_cause_fields)
   | Resumable_cli_session { runtime_id; detail; exit_code } ->
     let runtime_id = runtime_id_to_string runtime_id in
     `Assoc
@@ -594,7 +655,7 @@ let accept_rejection_is_read_only_no_progress
   && tool_effects_seen <> []
 
 let summary_of_masc_internal_error = function
-  | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
+  | Capacity_backpressure { runtime_id; source; detail; retry_after; cooldown_cause } ->
       let retry_after_suffix =
         match retry_after with
         | Explicit value -> Printf.sprintf "; retry_after=%.1fs" value
@@ -602,13 +663,21 @@ let summary_of_masc_internal_error = function
           Printf.sprintf "; retry_after=%.1fs (synthetic)" value
         | No_retry_hint -> ""
       in
+      let cooldown_cause_suffix =
+        match cooldown_cause with
+        | Some cause ->
+          Printf.sprintf "; cooldown_cause=%s"
+            (provider_cooldown_cause_to_string cause)
+        | None -> ""
+      in
       Some
         (Printf.sprintf
-           "Capacity backpressure blocked runtime %s; source=%s; detail=%s%s"
+           "Capacity backpressure blocked runtime %s; source=%s; detail=%s%s%s"
            (runtime_id_to_string runtime_id)
            (capacity_backpressure_source_to_string source)
            detail
-           retry_after_suffix)
+           retry_after_suffix
+           cooldown_cause_suffix)
   | Provider_timeout
       {
         budget_sec;
@@ -921,9 +990,14 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                  | Some s when retry_after_synthetic -> Synthetic_default s
                  | Some s -> Explicit s
                in
+               let cooldown_cause =
+                 match string_opt_of_assoc "cooldown_cause" json with
+                 | Some raw -> provider_cooldown_cause_of_string raw
+                 | None -> None
+               in
                Some
                  (Capacity_backpressure
-                    { runtime_id; source; detail; retry_after })
+                    { runtime_id; source; detail; retry_after; cooldown_cause })
              | None -> None)
           | _ -> None)
       | Some (`String "resumable_cli_session") -> (

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -22,6 +22,29 @@ type capacity_retry_after =
   | Synthetic_default of float
   | No_retry_hint
 
+(** The failure that armed a provider-health cooldown blocking a turn before
+    dispatch.  Mirrors {!Keeper_binding_health.outcome_kind} across the module
+    boundary; carried on {!Capacity_backpressure} so the pre-dispatch cooldown
+    gate reports the true cause instead of unconditionally claiming provider
+    capacity.  #23438. *)
+type provider_cooldown_cause =
+  | Cooldown_provider_capacity
+  | Cooldown_soft_rate_limited
+  | Cooldown_server_error
+  | Cooldown_hard_quota
+  | Cooldown_terminal_failure
+  | Cooldown_provider_error
+  | Cooldown_rejected
+
+val provider_cooldown_cause_to_string : provider_cooldown_cause -> string
+val provider_cooldown_cause_of_string : string -> provider_cooldown_cause option
+
+(** [true] when waiting out the cooldown cannot resolve the cause (deterministic
+    config/build/credential/quota/structural failure); [false] for transient
+    causes expected to recover (capacity, HTTP 429, HTTP 5xx).  Drives whether a
+    cooldown-block turn error is auto-recoverable or escalates.  #23438. *)
+val provider_cooldown_cause_is_deterministic : provider_cooldown_cause -> bool
+
 type runtime_exhaustion_reason =
   | Connection_refused
   | Dns_failure
@@ -81,6 +104,9 @@ type masc_internal_error =
       source : capacity_backpressure_source;
       detail : string;
       retry_after : capacity_retry_after;
+      cooldown_cause : provider_cooldown_cause option;
+      (** [Some cause] iff this is a pre-dispatch provider-health cooldown block;
+          [None] for genuine upstream capacity backpressure.  #23438. *)
     }
   | Resumable_cli_session of {
       runtime_id : string;

--- a/test/dune
+++ b/test/dune
@@ -27,6 +27,7 @@
 
 (tests
  (names
+  test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
   test_keeper_memory_os_io_fd
@@ -374,6 +375,7 @@
   test_board_rest_routes
   test_board_context_inference_resolution)
  (modules
+  test_keeper_cooldown_cause_23438
   test_keeper_lifecycle_gate
   test_keeper_lifecycle_global_gate
   test_keeper_memory_os_io_fd
@@ -727,11 +729,7 @@
   test_keeper_wire_capture
   test_board_rest_routes
   test_board_context_inference_resolution)
- (libraries
-  masc_test_deps
-  masc_schedule
-  multimodal
-  bigstringaf))
+ (libraries masc_test_deps masc_schedule multimodal bigstringaf))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.
 

--- a/test/test_keeper_cooldown_cause_23438.ml
+++ b/test/test_keeper_cooldown_cause_23438.ml
@@ -1,0 +1,225 @@
+(* test/test_keeper_cooldown_cause_23438.ml
+
+   #23438: the pre-dispatch provider-health cooldown gate must carry the
+   failure that armed the cooldown instead of erasing it into an
+   unconditional provider_capacity claim. On 2026-07-06 that erasure let
+   ~25 deterministic provider errors oscillate into 1,041 blocked turns:
+   Capacity_backpressure was always auto-recoverable, so no escalation
+   path could ever fire.
+
+   Pinned invariants:
+   1. [provider_cooldown_cause_is_deterministic] truth table: hard_quota /
+      terminal_failure / provider_error / rejected are deterministic;
+      provider_capacity / soft_rate_limited / server_error are transient.
+   2. to_string/of_string is a total roundtrip over every constructor.
+   3. sdk_error embed -> classify roundtrip preserves [cooldown_cause]
+      (Some and None) through the JSON wire payload.
+   4. [summary_of_masc_internal_error] names the true cause; a cause-less
+      block renders without the suffix (legacy shape preserved).
+   5. Classification: deterministic cause -> NOT auto-recoverable (feeds
+      counts_toward_crash so the failure-streak policy escalates);
+      transient cause and None -> auto-recoverable (today's behaviour). *)
+
+module KIE = Keeper_internal_error
+module EC = Masc.Keeper_error_classify
+module KTD = Masc.Keeper_turn_driver
+
+let all_causes =
+  [ KIE.Cooldown_provider_capacity
+  ; KIE.Cooldown_soft_rate_limited
+  ; KIE.Cooldown_server_error
+  ; KIE.Cooldown_hard_quota
+  ; KIE.Cooldown_terminal_failure
+  ; KIE.Cooldown_provider_error
+  ; KIE.Cooldown_rejected
+  ]
+
+let deterministic_causes =
+  [ KIE.Cooldown_hard_quota
+  ; KIE.Cooldown_terminal_failure
+  ; KIE.Cooldown_provider_error
+  ; KIE.Cooldown_rejected
+  ]
+
+let transient_causes =
+  [ KIE.Cooldown_provider_capacity
+  ; KIE.Cooldown_soft_rate_limited
+  ; KIE.Cooldown_server_error
+  ]
+
+let backpressure_error ?cooldown_cause () =
+  KIE.Capacity_backpressure
+    { runtime_id = "runpod_rtxa6000.gemma4-coder-fable5-q4km"
+    ; source = KIE.Provider_capacity
+    ; detail = "provider health cooldown active before dispatch"
+    ; retry_after = KIE.Synthetic_default 29.0
+    ; cooldown_cause
+    }
+
+let test_deterministic_truth_table () =
+  List.iter
+    (fun cause ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s is deterministic"
+           (KIE.provider_cooldown_cause_to_string cause))
+        true
+        (KIE.provider_cooldown_cause_is_deterministic cause))
+    deterministic_causes;
+  List.iter
+    (fun cause ->
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "%s is transient"
+           (KIE.provider_cooldown_cause_to_string cause))
+        false
+        (KIE.provider_cooldown_cause_is_deterministic cause))
+    transient_causes
+
+let test_cause_string_roundtrip () =
+  List.iter
+    (fun cause ->
+      let raw = KIE.provider_cooldown_cause_to_string cause in
+      match KIE.provider_cooldown_cause_of_string raw with
+      | Some decoded ->
+          Alcotest.(check bool)
+            (Printf.sprintf "roundtrip %s" raw)
+            true
+            (decoded = cause)
+      | None -> Alcotest.failf "of_string rejected canonical label %S" raw)
+    all_causes;
+  Alcotest.(check bool)
+    "unknown label decodes to None"
+    true
+    (KIE.provider_cooldown_cause_of_string "definitely_not_a_cause" = None)
+
+let embed_and_classify err =
+  KTD.classify_masc_internal_error (KTD.sdk_error_of_masc_internal_error err)
+
+let test_sdk_error_roundtrip_preserves_cause () =
+  List.iter
+    (fun cause ->
+      let original = backpressure_error ~cooldown_cause:cause () in
+      match embed_and_classify original with
+      | Some
+          (KIE.Capacity_backpressure { cooldown_cause = Some decoded; _ }) ->
+          Alcotest.(check bool)
+            (Printf.sprintf
+               "cause %s survives the wire"
+               (KIE.provider_cooldown_cause_to_string cause))
+            true
+            (decoded = cause)
+      | Some (KIE.Capacity_backpressure { cooldown_cause = None; _ }) ->
+          Alcotest.fail "cooldown_cause dropped by the JSON roundtrip"
+      | Some other ->
+          Alcotest.failf
+            "reclassified as %s"
+            (KIE.kind_of_masc_internal_error other)
+      | None -> Alcotest.fail "classify_masc_internal_error returned None")
+    all_causes
+
+let test_sdk_error_roundtrip_none_cause () =
+  match embed_and_classify (backpressure_error ()) with
+  | Some (KIE.Capacity_backpressure { cooldown_cause = None; _ }) -> ()
+  | Some (KIE.Capacity_backpressure { cooldown_cause = Some cause; _ }) ->
+      Alcotest.failf
+        "cause invented from nothing: %s"
+        (KIE.provider_cooldown_cause_to_string cause)
+  | Some other ->
+      Alcotest.failf
+        "reclassified as %s"
+        (KIE.kind_of_masc_internal_error other)
+  | None -> Alcotest.fail "classify_masc_internal_error returned None"
+
+let contains ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec scan i = i + nlen <= hlen
+    && (String.sub haystack i nlen = needle || scan (i + 1))
+  in
+  nlen = 0 || scan 0
+
+let summary_exn err =
+  match KIE.summary_of_masc_internal_error err with
+  | Some summary -> summary
+  | None -> Alcotest.fail "summary_of_masc_internal_error returned None"
+
+let test_summary_names_the_cause () =
+  let summary =
+    summary_exn (backpressure_error ~cooldown_cause:KIE.Cooldown_hard_quota ())
+  in
+  Alcotest.(check bool)
+    "summary carries cooldown_cause=hard_quota"
+    true
+    (contains ~needle:"cooldown_cause=hard_quota" summary);
+  let legacy = summary_exn (backpressure_error ()) in
+  Alcotest.(check bool)
+    "cause-less summary keeps the legacy shape"
+    false
+    (contains ~needle:"cooldown_cause=" legacy)
+
+let test_classification_escalates_deterministic_causes () =
+  List.iter
+    (fun cause ->
+      let sdk_error =
+        KTD.sdk_error_of_masc_internal_error
+          (backpressure_error ~cooldown_cause:cause ())
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "deterministic %s is not auto-recoverable"
+           (KIE.provider_cooldown_cause_to_string cause))
+        false
+        (EC.is_auto_recoverable_turn_error sdk_error))
+    deterministic_causes;
+  List.iter
+    (fun cause ->
+      let sdk_error =
+        KTD.sdk_error_of_masc_internal_error
+          (backpressure_error ~cooldown_cause:cause ())
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf
+           "transient %s stays auto-recoverable"
+           (KIE.provider_cooldown_cause_to_string cause))
+        true
+        (EC.is_auto_recoverable_turn_error sdk_error))
+    transient_causes;
+  let cause_less =
+    KTD.sdk_error_of_masc_internal_error (backpressure_error ())
+  in
+  Alcotest.(check bool)
+    "cause-less block stays auto-recoverable (legacy behaviour)"
+    true
+    (EC.is_auto_recoverable_turn_error cause_less)
+
+let () =
+  Alcotest.run
+    "keeper_cooldown_cause_23438"
+    [ ( "cooldown_cause"
+      , [ Alcotest.test_case
+            "deterministic truth table"
+            `Quick
+            test_deterministic_truth_table
+        ; Alcotest.test_case
+            "to_string/of_string roundtrip"
+            `Quick
+            test_cause_string_roundtrip
+        ; Alcotest.test_case
+            "sdk-error JSON roundtrip preserves cause"
+            `Quick
+            test_sdk_error_roundtrip_preserves_cause
+        ; Alcotest.test_case
+            "sdk-error JSON roundtrip preserves None"
+            `Quick
+            test_sdk_error_roundtrip_none_cause
+        ; Alcotest.test_case
+            "summary names the true cause"
+            `Quick
+            test_summary_names_the_cause
+        ; Alcotest.test_case
+            "deterministic causes escalate, transient stay recoverable"
+            `Quick
+            test_classification_escalates_deterministic_causes
+        ] )
+    ]

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -754,16 +754,29 @@ let test_soft_rate_limit_cooldown_blocks_candidate_before_dispatch () =
          { source = KTD.Provider_capacity
          ; retry_after = KTD.Synthetic_default retry_after
          ; detail
+         ; cooldown_cause
          ; _
          }) ->
     Alcotest.(check string)
-      "detail is explicit"
-      "provider health cooldown active before dispatch"
+      "detail names the true cooldown cause"
+      "provider health cooldown active before dispatch (cause=soft_rate_limited)"
       detail;
     Alcotest.(check bool)
       "synthetic retry-after preserves cooldown"
       true
-      (retry_after > 0.0)
+      (retry_after > 0.0);
+    (* Soft rate limit is transient — the cooldown block must carry the cause
+       and stay auto-recoverable so today's behavior is preserved. *)
+    Alcotest.(check bool)
+      "soft rate limit cooldown carries transient cause"
+      true
+      (match cooldown_cause with
+       | Some KTD.Cooldown_soft_rate_limited -> true
+       | _ -> false);
+    Alcotest.(check bool)
+      "transient cooldown block stays auto-recoverable"
+      true
+      (EC.is_auto_recoverable_turn_error mapped)
   | Some other ->
     Alcotest.failf
       "expected capacity_backpressure, got %s"

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -73,6 +73,7 @@ let provider_cooldown_backpressure_error runtime_id =
        ; source = Driver.Provider_capacity
        ; detail = "provider health cooldown active before dispatch"
        ; retry_after = Driver.Synthetic_default 30.0
+       ; cooldown_cause = None
        })
 
 let accept_empty_no_progress_error scope =


### PR DESCRIPTION
## 무엇/왜

pre-dispatch cooldown 게이트가 cooldown을 장전한 원인과 무관하게 `source=Provider_capacity` 하드코딩 + synthetic retry_after로 `Capacity_backpressure`를 방출해 **typed cause를 소거**했습니다. `Capacity_backpressure`는 무조건 auto-recoverable(`counts_toward_crash=false`)이라 결정론적 원인(config/build 오류, 쿼터 고갈, 구조적 provider 실패)도 무한 진동했습니다 — **07-06 실측: 실제 하드 오류 ~25건이 1,041 blocked turns로 증폭(~40×), 런타임 7종 동시 cooldown** (#23438).

## 설계 선택

- **payload 확장** (새 variant 대신 `Capacity_backpressure`에 `cooldown_cause : provider_cooldown_cause option` 필드): JSON codec이 하위호환(필드 부재→`None`)이고 대시보드 렌더링 경로가 유지됩니다.
- **cause 매핑**: `Keeper_binding_health.outcome_kind` → `provider_cooldown_cause` 7종 (keeper_runtime이 keeper_binding_health에 의존 불가하므로 mirror 타입, exhaustive match로 컴파일 타임 동기화).
- **결정론 판정**: `hard_quota`/`terminal_failure`/`provider_error`/`rejected` = deterministic → auto-recoverable 아님 → `counts_toward_crash=true`로 **기존** failure-streak 정책이 에스컬레이션 (#23452의 Pause_keeper 경로와 합류). `provider_capacity`/`soft_rate_limited`/`server_error` 및 cause-less(`None`)는 오늘 동작 유지.
- **집계는 any-transient-wins**: 턴을 막는 모든 provider의 cause가 결정론적일 때만 에스컬레이션 — transient 하나라도 있으면 회복 가능성이 있으므로 보수적으로 auto-recoverable 유지.
- **substring 분류기 삭제**: `message_looks_like_capacity_backpressure` (ml+mli 완전 제거) — 워크어라운드 시그니처(string 분류기)를 **추가가 아니라 삭제**하고 typed cause로 대체.

## 변경 파일 (15)

lib: `keeper_binding_health(.mli)`, `keeper_turn_driver_provider_attempt(.mli)`, `keeper_turn_driver_backpressure(.mli)`, `keeper_turn_driver.mli`, `keeper_error_classify`, `keeper_runtime_attempt`, `keeper_internal_error(.mli)` / test: 신규 `test_keeper_cooldown_cause_23438` + `test_keeper_sdk_error_typed_bridge`, `test_keeper_turn_driver_failover`, `test/dune`

## 로컬 검증

- `dune build --root . @check` 전체 clean
- 신규 `test_keeper_cooldown_cause_23438` **6/6 PASS**: 결정론 truth table(7종), to/of_string roundtrip, sdk_error embed→classify JSON roundtrip(cause Some/None 보존), summary가 `cooldown_cause=hard_quota` 명명 + cause-less는 legacy 형태 유지, 분류(deterministic→not auto-recoverable / transient·None→auto-recoverable)
- `test_keeper_turn_driver_failover` 16/16, `test_keeper_sdk_error_typed_bridge` 21/21 PASS (기존 단언은 cause 명명 메시지로 의도적 갱신)
- `dune fmt` 적용 (무관한 `test/fusion_core/dune` 드리프트는 revert, 범위 밖)

## 작업 경위 (투명성)

구현 대부분은 background agent 작업물이며, agent가 세션 한도로 중단된 뒤 operator 세션이 인수해 완성: 컴파일 오류 2건 수정(record 필드 값의 sequence 괄호 누락, `include module type of`의 `provider_cooldown_cause` 타입 제약 누락), 누락된 신규 테스트 파일 작성, dune modules 등록, 검증/커밋. 전체 `dune runtest`는 로컬 미실행(라이브 테스트 + 부하) — full gate는 CI.

## 미검증

- reactive-wake cooldown 게이팅(#23438 제안 3)과 RFC-0058 failover, latched failure episode는 범위 밖 (별도 트랙)
- fleet 런타임에서의 실제 escalate 빈도(코드/테스트로 분류 변화를 증명, 라이브 재현 미측정)

RFC 게이트 대상 subsystem 아님 (credential/operator_control/sandbox/hooks/workflow 무관).

Refs #23438 #23439 #23452 jeong-sik/masc#27914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
