### PR TITLE
fix(work): reduce repeated Goal Store labels

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -306,9 +306,10 @@ describe('Work', () => {
 
       const kpis = screen.getByTestId('work-kpis')
       expect(kpis.textContent).toContain('활성 목표')
-      expect(kpis.textContent).toContain('전체 Task')
+      expect(kpis.textContent).toContain('전체 작업')
       expect(kpis.textContent).not.toContain('목표 TASK')
-      expect((kpis.textContent?.match(/Task/g) ?? []).length).toBe(1)
+      expect(kpis.textContent).not.toContain('Task')
+      expect(kpis.textContent).not.toContain('TASK')
 
       fireEvent.click(screen.getByTestId('work-view-kanban'))
 

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -293,7 +293,7 @@ describe('Work', () => {
       expect(screen.getByTestId('work-goal-list')).toBeTruthy()
     })
 
-    it('separates Goal KPI language from Task pipeline labels', () => {
+    it('avoids repeating Task scope labels across the KPI row and kanban columns', () => {
       goals.value = [
         { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
@@ -305,20 +305,19 @@ describe('Work', () => {
       render(html`<${Work} />`)
 
       const kpis = screen.getByTestId('work-kpis')
-      expect(kpis.textContent).toContain('GOAL')
-      expect(kpis.textContent).toContain('TASK')
-      expect(kpis.textContent).toContain('활성')
-      expect(kpis.textContent).toContain('전체')
+      expect(kpis.textContent).toContain('활성 목표')
+      expect(kpis.textContent).toContain('전체 Task')
       expect(kpis.textContent).not.toContain('목표 TASK')
+      expect((kpis.textContent?.match(/Task/g) ?? []).length).toBe(1)
 
       fireEvent.click(screen.getByTestId('work-view-kanban'))
 
       const todoCol = screen.getByTestId('kanban-col-todo')
       const claimedCol = screen.getByTestId('kanban-col-claimed')
-      expect(todoCol.querySelector('.wk-kcol-scope')?.textContent).toBe('TASK')
-      expect(todoCol.querySelector('.wk-kcol-label')?.textContent).toBe('미배정')
-      expect(claimedCol.querySelector('.wk-kcol-scope')?.textContent).toBe('TASK')
-      expect(claimedCol.querySelector('.wk-kcol-label')?.textContent).toBe('클레임됨')
+      expect(todoCol.querySelector('.wk-kcol-title')?.textContent).toBe('미배정')
+      expect(todoCol.textContent).not.toContain('TASK')
+      expect(claimedCol.querySelector('.wk-kcol-title')?.textContent).toBe('클레임됨')
+      expect(claimedCol.textContent).not.toContain('TASK')
 
       fireEvent.click(screen.getByTestId('work-view-list'))
       expect(screen.getByTestId('work-view-list').classList.contains('on')).toBe(true)

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -313,6 +313,10 @@ describe('Work', () => {
 
       fireEvent.click(screen.getByTestId('work-view-kanban'))
 
+      const section = screen.getByTestId('work-board-section')
+      expect(section.textContent).toContain('칸반 · 상태별')
+      expect(section.textContent).toContain('todo → claimed → in_progress → verify → done')
+
       const todoCol = screen.getByTestId('kanban-col-todo')
       const claimedCol = screen.getByTestId('kanban-col-claimed')
       expect(todoCol.querySelector('.wk-kcol-title')?.textContent).toBe('미배정')
@@ -972,6 +976,7 @@ describe('Work', () => {
         fireEvent.click(screen.getByTestId('work-view-kanban'))
 
         // Kanban board present; list view gone
+        expect(screen.getByTestId('work-board-section').textContent).toContain('칸반 · 상태별')
         const board = screen.getByTestId('work-kanban')
         expect(board).toBeTruthy()
         expect(screen.queryByTestId('work-goal-list')).toBeNull()

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1370,7 +1370,7 @@ function WorkSurfaceV2() {
               <div class="wk-kpi-v brass" data-testid="kpi-goals">${totals.goals}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k">전체 Task</div>
+              <div class="wk-kpi-k">전체 작업</div>
               <div class="wk-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
             </div>
             <div class="wk-kpi">
@@ -1438,7 +1438,7 @@ function WorkSurfaceV2() {
               />
             `}
 
-          <div class="wk-foot mono">목표 지표 · Task 상태 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 claim</div>
+          <div class="wk-foot mono">목표 지표 · 작업 상태 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 claim</div>
       </div>
       ${goalCreateOpen ? html`<${GoalCreateForm} />` : html`
         <${WorkAside}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -773,32 +773,45 @@ function KanbanView({
   onClaim: (id: string) => void
   onJumpGoal: (goalId: string) => void
 }) {
+  const total = kanbanTasks.length
   return html`
-    <div class="wk-kanban" data-testid="work-kanban">
-      ${KANBAN_COLUMNS.map(([status, label, cls]) => {
-        const col = kanbanTasks.filter(t => t.status === status)
-        return html`
-          <div key=${status} class=${`wk-kcol ${cls}`} data-testid=${`kanban-col-${status}`}>
-            <div class="wk-kcol-h">
-              <span class="wk-kcol-title">${label}</span>
-              <span class="wk-kcol-count">${col.length}</span>
-            </div>
-            <div class="wk-kcol-body">
-              ${col.length === 0
-                ? html`<div class="wk-kcol-empty mono">—</div>`
-                : col.map(t => html`
-                  <${KanbanCard}
-                    key=${t.id}
-                    task=${t}
-                    onClaim=${onClaim}
-                    onJumpGoal=${onJumpGoal}
-                  />
-                `)}
-            </div>
+    <section class="wk-board-section" data-testid="work-board-section">
+      <div class="wk-board-head">
+        <div>
+          <div class="wk-board-title">
+            <span class="wk-board-glyph" aria-hidden="true">▦</span>
+            칸반 · 상태별
+            <span class="wk-board-count mono">${total}</span>
           </div>
-        `
-      })}
-    </div>
+        </div>
+        <div class="wk-board-flow mono">todo → claimed → in_progress → verify → done</div>
+      </div>
+      <div class="wk-kanban" data-testid="work-kanban">
+        ${KANBAN_COLUMNS.map(([status, label, cls]) => {
+          const col = kanbanTasks.filter(t => t.status === status)
+          return html`
+            <div key=${status} class=${`wk-kcol ${cls}`} data-testid=${`kanban-col-${status}`}>
+              <div class="wk-kcol-h">
+                <span class="wk-kcol-title">${label}</span>
+                <span class="wk-kcol-count">${col.length}</span>
+              </div>
+              <div class="wk-kcol-body">
+                ${col.length === 0
+                  ? html`<div class="wk-kcol-empty mono">—</div>`
+                  : col.map(t => html`
+                    <${KanbanCard}
+                      key=${t.id}
+                      task=${t}
+                      onClaim=${onClaim}
+                      onJumpGoal=${onJumpGoal}
+                    />
+                  `)}
+              </div>
+            </div>
+          `
+        })}
+      </div>
+    </section>
   `
 }
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -47,18 +47,18 @@ type JobStateCls = 'done' | 'wip' | 'verify' | 'claimed' | 'cancelled' | 'todo'
 
 // ── Kanban view columns ─────────────────────────────────────────────────────
 // Closed tuple — cancelled is excluded by design (it has its own aside panel).
-// Each entry: [task.status value, scope label, Korean column label, CSS modifier cls].
+// Each entry: [task.status value, Korean column label, CSS modifier cls].
 // The cls values come directly from JobStateCls so KanbanCard can reuse the
 // same .wk-kcard.<cls> and .wk-kcol-dot.<cls> rules without extra mapping.
 type KanbanStatus = 'todo' | 'claimed' | 'in_progress' | 'awaiting_verification' | 'done'
-type KanbanColumn = readonly [status: KanbanStatus, scope: string, label: string, cls: JobStateCls]
+type KanbanColumn = readonly [status: KanbanStatus, label: string, cls: JobStateCls]
 
 const KANBAN_COLUMNS: ReadonlyArray<KanbanColumn> = [
-  ['todo',                  'TASK', '미배정',   'todo'],
-  ['claimed',               'TASK', '클레임됨', 'claimed'],
-  ['in_progress',           'TASK', '진행 중',  'wip'],
-  ['awaiting_verification', 'TASK', '검증 대기', 'verify'],
-  ['done',                  'TASK', '완료',     'done'],
+  ['todo',                  '미배정',   'todo'],
+  ['claimed',               '클레임됨', 'claimed'],
+  ['in_progress',           '진행 중',  'wip'],
+  ['awaiting_verification', '검증 대기', 'verify'],
+  ['done',                  '완료',     'done'],
 ] as const
 
 interface JobState {
@@ -775,15 +775,12 @@ function KanbanView({
 }) {
   return html`
     <div class="wk-kanban" data-testid="work-kanban">
-      ${KANBAN_COLUMNS.map(([status, scope, label, cls]) => {
+      ${KANBAN_COLUMNS.map(([status, label, cls]) => {
         const col = kanbanTasks.filter(t => t.status === status)
         return html`
           <div key=${status} class=${`wk-kcol ${cls}`} data-testid=${`kanban-col-${status}`}>
             <div class="wk-kcol-h">
-              <span class="wk-kcol-title">
-                <span class="wk-kcol-scope mono">${scope}</span>
-                <span class="wk-kcol-label">${label}</span>
-              </span>
+              <span class="wk-kcol-title">${label}</span>
               <span class="wk-kcol-count">${col.length}</span>
             </div>
             <div class="wk-kcol-body">
@@ -1369,23 +1366,23 @@ function WorkSurfaceV2() {
 
           <section class="wk-kpis" data-testid="work-kpis">
             <div class="wk-kpi primary">
-              <div class="wk-kpi-k"><span class="wk-kpi-scope">GOAL</span><span>활성</span></div>
+              <div class="wk-kpi-k">활성 목표</div>
               <div class="wk-kpi-v brass" data-testid="kpi-goals">${totals.goals}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k"><span class="wk-kpi-scope">TASK</span><span>전체</span></div>
+              <div class="wk-kpi-k">전체 Task</div>
               <div class="wk-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k"><span class="wk-kpi-scope">TASK</span><span>진행</span></div>
+              <div class="wk-kpi-k">진행 중</div>
               <div class=${`wk-kpi-v ${totals.wip > 0 ? 'volt' : ''}`} data-testid="kpi-wip">${totals.wip}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k"><span class="wk-kpi-scope">TASK</span><span>검증 대기</span></div>
+              <div class="wk-kpi-k">검증 대기</div>
               <div class=${`wk-kpi-v ${totals.verify > 0 ? 'volt' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k"><span class="wk-kpi-scope">TASK</span><span>미배정</span></div>
+              <div class="wk-kpi-k">미배정</div>
               <div class=${`wk-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
             </div>
           </section>
@@ -1441,7 +1438,7 @@ function WorkSurfaceV2() {
               />
             `}
 
-          <div class="wk-foot mono">GOAL 지표 · TASK 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 claim</div>
+          <div class="wk-foot mono">목표 지표 · Task 상태 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 claim</div>
       </div>
       ${goalCreateOpen ? html`<${GoalCreateForm} />` : html`
         <${WorkAside}

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -49,6 +49,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in oklab, var(--bg-panel) 70%, transparent);
   overflow: hidden;
+  margin-bottom: 24px;
 }
 
 .wk-kpi {
@@ -1431,6 +1432,46 @@
 
 /* ── Kanban board ────────────────────────────────────────────────────────── */
 
+.wk-board-section {
+  margin-top: 0;
+  padding-top: 18px;
+  border-top: 1px solid color-mix(in oklab, var(--color-border-default) 74%, transparent);
+}
+
+.wk-board-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 14px;
+}
+
+.wk-board-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-fg-primary);
+}
+
+.wk-board-glyph {
+  color: var(--color-accent-fg);
+  font-size: var(--text-xs);
+}
+
+.wk-board-count {
+  color: var(--color-accent-fg);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+
+.wk-board-flow {
+  color: var(--color-fg-muted);
+  font-size: var(--text-3xs);
+  text-align: right;
+}
+
 .wk-kanban {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -1439,6 +1480,16 @@
 }
 
 @media (max-width: 1100px) {
+  .wk-board-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .wk-board-flow {
+    text-align: left;
+  }
+
   .wk-kanban {
     grid-auto-flow: column;
     grid-auto-columns: minmax(244px, 1fr);

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -67,18 +67,10 @@
 }
 
 .wk-kpi-k {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 5px;
   font-size: 9.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
-}
-
-.wk-kpi-scope {
-  color: var(--color-accent-fg);
   font-weight: 700;
 }
 
@@ -1478,25 +1470,10 @@
 }
 
 .wk-kcol-title {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.125rem;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--color-fg-primary);
-  line-height: 1.1;
-}
-
-.wk-kcol-scope {
-  font-size: var(--text-3xs);
-  font-weight: 700;
-  color: var(--color-fg-muted);
-}
-
-.wk-kcol-label {
   font-size: var(--text-xs);
   font-weight: 700;
   color: var(--color-fg-primary);
+  line-height: 1.2;
 }
 
 .wk-kcol-count {


### PR DESCRIPTION
## Summary
- follow up #23453 by separating the Goal summary KPI strip from the kanban board section
- add a distinct kanban section header (칸반 · 상태별) plus spacing/border so KPI cells and board columns no longer read as one stacked matrix
- keep the KPI row readable as natural Korean summary labels: 활성 목표, 전체 작업, 진행 중, 검증 대기, 미배정
- keep kanban columns focused on status names only: 미배정, 클레임됨, 진행 중, 검증 대기, 완료

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/work.test.ts
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- git diff --check
- Python Playwright console/DOM check against local Vite server
- Playwright screenshots against local Vite server for desktop/mobile kanban