### PR TITLE
fix(runtime): carry chat template token through OAS pin

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -169,6 +169,7 @@ streaming = true
 # choice. Do not re-enable without a serializer path + model-side proof.
 supports-tool-choice = false
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 supports-native-streaming = true
 supports-top-k = true
 supports-seed = true
@@ -190,6 +191,7 @@ streaming = true
 # `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`.
 supports-tool-choice = false
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 supports-native-streaming = true
 supports-top-k = true
 supports-seed = true

--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -37,7 +37,7 @@ Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) tri
 | `api_format` | `Messages_api \| Chat_completions_api \| Ollama_api` | `runtime_api_format` |
 | `transport` | `Http of string \| Cli of string` | `runtime_transport` |
 | `credential` | `Env of string \| File of string \| Inline of string` | `runtime_credential` |
-| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
+| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_adaptive`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token of string`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
 | `capabilities` | 10-field provider 행동 record + `capabilities_default` | `runtime_capabilities` |
 | `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `runtime_model_capabilities` |
 | `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `runtime_provider` |

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -84,7 +84,7 @@ type thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -71,7 +71,7 @@ type thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -404,20 +404,98 @@ let parse_providers (toml : Otoml.t)
 
 (* --- Layer 2: Models --- *)
 
-let parse_thinking_control_format ~(path : string) (raw : string)
+let thinking_control_token_key = "thinking-control-token"
+
+let exact_non_empty_string_opt_field ~(path : string) (tbl : Otoml.t) (key : string)
+  : (string option, parse_error list) result
+  =
+  match typed_find "string" path tbl key Otoml.get_string with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when String.trim value = "" ->
+    Error (error (path ^ "." ^ key) (key ^ " must be non-empty"))
+  | Ok (Some value) when value <> String.trim value ->
+    Error (error (path ^ "." ^ key) (key ^ " must not have leading or trailing whitespace"))
+  | Ok (Some value) -> Ok (Some value)
+;;
+
+let require_no_thinking_control_token
+      ~(path : string)
+      ~(thinking_control_format : string)
+      (thinking_control_token : string option)
+      (format : Runtime_schema.thinking_control_format)
+  : (Runtime_schema.thinking_control_format, parse_error list) result
+  =
+  match thinking_control_token with
+  | None -> Ok format
+  | Some _ ->
+    Error
+      (error
+         (path ^ "." ^ thinking_control_token_key)
+         (Printf.sprintf
+            "thinking-control-token is only valid when thinking-control-format \
+             is \"chat_template_token\"; got %S"
+            thinking_control_format))
+;;
+
+let parse_thinking_control_format
+      ~(path : string)
+      ~(thinking_control_token : string option)
+      (raw : string)
   : (Runtime_schema.thinking_control_format, parse_error list) result
   =
   match String.lowercase_ascii (String.trim raw) with
   | "" | "none" | "no-thinking-control" | "no_thinking_control" ->
-    Ok Runtime_schema.No_thinking_control
-  | "thinking-object" | "thinking_object" -> Ok Runtime_schema.Thinking_object
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"none"
+      thinking_control_token
+      Runtime_schema.No_thinking_control
+  | "thinking-object" | "thinking_object" ->
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"thinking_object"
+      thinking_control_token
+      Runtime_schema.Thinking_object
   | "thinking-object-only" | "thinking_object_only" ->
-    Ok Runtime_schema.Thinking_object_only
-  | "chat-template-kwargs" | "chat_template_kwargs" -> Ok Runtime_schema.Chat_template_kwargs
-  | "chat-template-token" | "chat_template_token" -> Ok Runtime_schema.Chat_template_token
-  | "ollama-think" | "ollama_think" -> Ok Runtime_schema.Ollama_think
-  | "reasoning-effort" | "reasoning_effort" -> Ok Runtime_schema.Reasoning_effort
-  | "enable-thinking" | "enable_thinking" -> Ok Runtime_schema.Enable_thinking
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"thinking_object_only"
+      thinking_control_token
+      Runtime_schema.Thinking_object_only
+  | "chat-template-kwargs" | "chat_template_kwargs" ->
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"chat_template_kwargs"
+      thinking_control_token
+      Runtime_schema.Chat_template_kwargs
+  | "chat-template-token" | "chat_template_token" ->
+    (match thinking_control_token with
+     | Some token -> Ok (Runtime_schema.Chat_template_token token)
+     | None ->
+       Error
+         (error
+            (path ^ "." ^ thinking_control_token_key)
+            "thinking-control-token is required when thinking-control-format is \
+             \"chat_template_token\""))
+  | "ollama-think" | "ollama_think" ->
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"ollama_think"
+      thinking_control_token
+      Runtime_schema.Ollama_think
+  | "reasoning-effort" | "reasoning_effort" ->
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"reasoning_effort"
+      thinking_control_token
+      Runtime_schema.Reasoning_effort
+  | "enable-thinking" | "enable_thinking" ->
+    require_no_thinking_control_token
+      ~path
+      ~thinking_control_format:"enable_thinking"
+      thinking_control_token
+      Runtime_schema.Enable_thinking
   | other ->
     (* Unknown enum members fail the load, mirroring how this parser already
        rejects unknown protocols / credential types. A silent downgrade to
@@ -449,9 +527,20 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       None
   in
   let thinking_control_format_result =
-    match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
-    | None -> Ok Runtime_schema.No_thinking_control
-    | Some raw -> parse_thinking_control_format ~path raw
+    match
+      ( typed_find "string" path tbl "thinking-control-format" Otoml.get_string
+      , exact_non_empty_string_opt_field ~path tbl thinking_control_token_key )
+    with
+    | Error errs, _ | _, Error errs -> Error errs
+    | Ok None, Ok None -> Ok Runtime_schema.No_thinking_control
+    | Ok None, Ok (Some token) ->
+      require_no_thinking_control_token
+        ~path
+        ~thinking_control_format:"none"
+        (Some token)
+        Runtime_schema.No_thinking_control
+    | Ok (Some raw), Ok thinking_control_token ->
+      parse_thinking_control_format ~path ~thinking_control_token raw
   in
   Result.map
     (fun thinking_control_format ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1431,17 +1431,18 @@ let runtime_default_runtime_id () =
   Runtime.get_default_runtime () |> Option.map (fun (rt : Runtime.t) -> rt.id)
 ;;
 
-(* Canonical wire strings for the thinking-control-format capability, matching
-   the forms lib/runtime/runtime_toml.ml's parser accepts so the projection
-   round-trips. Exhaustive by construction — a new variant fails to compile
-   here rather than silently emitting a stale label. *)
+(* Canonical wire labels for the thinking-control-format capability, matching
+   the forms lib/runtime/runtime_toml.ml's parser accepts. Token-bearing
+   formats still project their label here; the token remains config/catalog
+   data. Exhaustive by construction — a new variant fails to compile here rather
+   than silently emitting a stale label. *)
 let thinking_control_format_wire : Runtime_schema.thinking_control_format -> string = function
   | Runtime_schema.No_thinking_control -> "none"
   | Runtime_schema.Thinking_object -> "thinking-object"
   | Runtime_schema.Thinking_object_adaptive -> "thinking-object-adaptive"
   | Runtime_schema.Thinking_object_only -> "thinking-object-only"
   | Runtime_schema.Chat_template_kwargs -> "chat-template-kwargs"
-  | Runtime_schema.Chat_template_token -> "chat-template-token"
+  | Runtime_schema.Chat_template_token _ -> "chat-template-token"
   | Runtime_schema.Ollama_think -> "ollama-think"
   | Runtime_schema.Reasoning_effort -> "reasoning-effort"
   | Runtime_schema.Enable_thinking -> "enable-thinking"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -429,7 +429,7 @@ let test_repo_oas_model_catalog_covers_live_runpod_rtxa6000_gemma () =
     check bool "RunPod RTX A6000 Gemma seed" true caps.supports_seed;
     check bool "RunPod RTX A6000 Gemma chat-template token thinking" true
       (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_token))
+         caps.thinking_control_format = Chat_template_token "<|think|>"))
 
 let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
   with_repo_oas_model_catalog @@ fun catalog ->
@@ -447,11 +447,9 @@ let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
        (provider_model_id ^ " audio input")
        (Some true)
        entry.supports_audio_input;
-     check
-       (option string)
-       (provider_model_id ^ " thinking token")
-       (Some "<|think|>")
-       entry.thinking_control_token);
+     check bool (provider_model_id ^ " thinking token carried by format") true
+       (Llm_provider.Capabilities.(
+          entry.thinking_control_format = Some (Chat_template_token "<|think|>"))));
   match
     Llm_provider.Capabilities.for_provider_model_id
       ~allow_bare_fallback:false
@@ -469,7 +467,7 @@ let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
     check bool "Local Gemma4 E2B audio input" true caps.supports_audio_input;
     check bool "Local Gemma4 E2B chat-template token thinking" true
       (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_token));
+         caps.thinking_control_format = Chat_template_token "<|think|>"));
     check
       (option string)
       "Local Gemma4 E2B thinking token"
@@ -520,8 +518,9 @@ let test_repo_oas_model_catalog_preserve_axes_resolve () =
      | Some entry ->
        check (option string) (model_id ^ " native base") (Some "kimi")
          entry.base_label;
-       check (option string) (model_id ^ " no request thinking knob") (Some "none")
-         entry.thinking_control_format;
+       check bool (model_id ^ " no request thinking knob") true
+         (Llm_provider.Capabilities.(
+            entry.thinking_control_format = Some No_thinking_control));
        check (option string) (model_id ^ " always preserved thinking")
          (Some "always_preserved")
          entry.preserve_thinking_control_format;
@@ -672,7 +671,7 @@ let test_repo_runtime_toml_loads () =
           check bool "Gemma4 chat-template-token thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Chat_template_token);
+               (Runtime_schema.Chat_template_token "<|think|>"));
           (* Native Ollama /api/chat never serializes tool_choice
              (oas backend_ollama.ml:24); declaring true here would override
              oas models.toml false while the transport drops forced tool
@@ -702,7 +701,7 @@ let test_repo_runtime_toml_loads () =
           check bool "Gemma4 E2B chat-template-token thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Chat_template_token);
+               (Runtime_schema.Chat_template_token "<|think|>"));
           check bool "Gemma4 E2B forced tool_choice disabled" false
             caps.supports_tool_choice;
           check bool "Gemma4 E2B image input" true caps.supports_image_input;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -658,6 +658,7 @@ streaming = true
 
 [models.gemma4.capabilities]
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 
 [ollama.gemma4]
 max-concurrent = 1
@@ -679,7 +680,8 @@ max-concurrent = 1
        (match model.capabilities with
         | Some caps ->
           check bool "chat template token parsed" true
-            (caps.thinking_control_format = Runtime_schema.Chat_template_token)
+            (caps.thinking_control_format
+             = Runtime_schema.Chat_template_token "<|think|>")
         | None -> fail "expected model capabilities")
      | models -> failf "expected one model, got %d" (List.length models))
 

--- a/test/test_thinking_control_format_unknown_error.ml
+++ b/test/test_thinking_control_format_unknown_error.ml
@@ -10,19 +10,36 @@
 
 open Alcotest
 
-let toml_with_tcf tcf =
+let toml_with_tcf ?thinking_control_token tcf =
+  let token_line =
+    match thinking_control_token with
+    | None -> ""
+    | Some token -> Printf.sprintf "thinking-control-token = \"%s\"\n" token
+  in
   Printf.sprintf
     {|[models.m]
 max-context = 1000
 
 [models.m.capabilities]
 thinking-control-format = "%s"
+%s
 |}
     tcf
+    token_line
 
 let model_without_capabilities = {|[models.m]
 max-context = 1000
 |}
+
+let toml_with_token_without_tcf token =
+  Printf.sprintf
+    {|[models.m]
+max-context = 1000
+
+[models.m.capabilities]
+thinking-control-token = "%s"
+|}
+    token
 
 let is_error = function Ok _ -> false | Error _ -> true
 let is_ok = function Ok _ -> true | Error _ -> false
@@ -33,8 +50,8 @@ let render_errors errs =
     Printf.sprintf "%s: %s" err.path err.message)
   |> String.concat "\n"
 
-let parsed_thinking_control_format raw =
-  match Runtime_toml.parse_string (toml_with_tcf raw) with
+let parsed_thinking_control_format ?thinking_control_token raw =
+  match Runtime_toml.parse_string (toml_with_tcf ?thinking_control_token raw) with
   | Error errs -> failf "expected %S to parse:\n%s" raw (render_errors errs)
   | Ok cfg ->
     (match cfg.Runtime_schema.models with
@@ -55,8 +72,6 @@ let test_valid_values_load_and_map_to_oas_variants () =
       ; "thinking-object-only", Thinking_object_only
       ; "chat_template_kwargs", Chat_template_kwargs
       ; "chat-template-kwargs", Chat_template_kwargs
-      ; "chat_template_token", Chat_template_token
-      ; "chat-template-token", Chat_template_token
       ; "ollama_think", Ollama_think
       ; "ollama-think", Ollama_think
       ; "reasoning_effort", Reasoning_effort
@@ -71,11 +86,37 @@ let test_valid_values_load_and_map_to_oas_variants () =
          (Runtime_schema.equal_thinking_control_format
             (parsed_thinking_control_format raw)
             expected))
-    cases
+    cases;
+  List.iter
+    (fun raw ->
+       check bool ("thinking-control-format " ^ raw) true
+         (Runtime_schema.equal_thinking_control_format
+            (parsed_thinking_control_format
+               ~thinking_control_token:"<|think|>"
+               raw)
+            (Runtime_schema.Chat_template_token "<|think|>")))
+    [ "chat_template_token"; "chat-template-token" ]
 
 let test_unknown_value_fails_load () =
   check bool "unknown thinking-control-format fails the load (Error)" true
     (is_error (Runtime_toml.parse_string (toml_with_tcf "bogus-format")))
+
+let test_tokenless_chat_template_token_fails_load () =
+  check bool "tokenless chat-template-token fails the load (Error)" true
+    (is_error (Runtime_toml.parse_string (toml_with_tcf "chat_template_token")))
+
+let test_orphan_thinking_control_token_fails_load () =
+  check bool "orphan thinking-control-token fails the load (Error)" true
+    (is_error
+       (Runtime_toml.parse_string (toml_with_token_without_tcf "<|think|>")))
+
+let test_padded_thinking_control_token_fails_load () =
+  check bool "padded thinking-control-token fails the load (Error)" true
+    (is_error
+       (Runtime_toml.parse_string
+          (toml_with_tcf
+             ~thinking_control_token:" <|think|> "
+             "chat_template_token")))
 
 let test_absent_capabilities_loads () =
   (* No capabilities table at all is fine — absence defaults to no control. *)
@@ -90,6 +131,12 @@ let () =
           test_case "valid values map to OAS variants" `Quick
             test_valid_values_load_and_map_to_oas_variants;
           test_case "unknown value fails load" `Quick test_unknown_value_fails_load;
+          test_case "tokenless chat-template-token fails load" `Quick
+            test_tokenless_chat_template_token_fails_load;
+          test_case "orphan token fails load" `Quick
+            test_orphan_thinking_control_token_fails_load;
+          test_case "padded token fails load" `Quick
+            test_padded_thinking_control_token_fails_load;
           test_case "absent capabilities loads" `Quick
             test_absent_capabilities_loads;
         ] );


### PR DESCRIPTION
Follow-up to #23460, which merged the abfffbd8 OAS pin while CI was still failing on the typed `Chat_template_token of string` contract.

## What changed
- Updates the MASC OAS re-export mirror to `Chat_template_token of string`.
- Parses `thinking-control-token` beside `thinking-control-format` in runtime TOML and rejects tokenless/orphan/padded declarations.
- Adds explicit Gemma `<|think|>` tokens to `config/runtime.toml`.
- Updates focused tests and RFC docs for the token-bearing constructor.

## Verification
- `git diff --check`
- `ocamlformat --check lib/runtime/runtime_schema.ml lib/runtime/runtime_schema.mli lib/runtime/runtime_toml.ml lib/server/server_dashboard_http_runtime_info.ml test/test_runtime_config_validity.ml test/test_runtime_provider_auth_headers.ml test/test_thinking_control_format_unknown_error.ml`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/check-toml-syntax.sh`

No local Dune build was run; CI remains the build authority for this queue.