### PR TITLE
fix(runtime): adapt to agent_sdk Chat_template_token payload — main red repair (#23460 follow-up)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -169,6 +169,7 @@ streaming = true
 # choice. Do not re-enable without a serializer path + model-side proof.
 supports-tool-choice = false
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 supports-native-streaming = true
 supports-top-k = true
 supports-seed = true
@@ -190,6 +191,7 @@ streaming = true
 # `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`.
 supports-tool-choice = false
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 supports-native-streaming = true
 supports-top-k = true
 supports-seed = true

--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -37,7 +37,7 @@ Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) tri
 | `api_format` | `Messages_api \| Chat_completions_api \| Ollama_api` | `runtime_api_format` |
 | `transport` | `Http of string \| Cli of string` | `runtime_transport` |
 | `credential` | `Env of string \| File of string \| Inline of string` | `runtime_credential` |
-| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
+| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_adaptive`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token of string`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
 | `capabilities` | 10-field provider 행동 record + `capabilities_default` | `runtime_capabilities` |
 | `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `runtime_model_capabilities` |
 | `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `runtime_provider` |

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -84,7 +84,7 @@ type thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -71,7 +71,7 @@ type thinking_control_format =
   | Thinking_object_adaptive
   | Thinking_object_only
   | Chat_template_kwargs
-  | Chat_template_token
+  | Chat_template_token of string
   | Ollama_think
   | Reasoning_effort
   | Enable_thinking

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -404,20 +404,55 @@ let parse_providers (toml : Otoml.t)
 
 (* --- Layer 2: Models --- *)
 
-let parse_thinking_control_format ~(path : string) (raw : string)
+let parse_thinking_control_format ~(path : string) ~(token : string option) (raw : string)
   : (Runtime_schema.thinking_control_format, parse_error list) result
   =
+  (* Mirrors the OAS catalog contract (oas#2484): [Chat_template_token]
+     carries its token, so a chat-template-token declaration without a
+     [thinking-control-token] key — or a blank/padded token, or a token on a
+     non-token format — fails the load instead of detonating per request. *)
+  let reject_orphan_token format =
+    match token with
+    | None -> Ok format
+    | Some _ ->
+      Error
+        (error
+           (path ^ ".thinking-control-token")
+           (Printf.sprintf
+              "thinking-control-token is only valid with \
+               thinking-control-format = \"chat-template-token\" (got %S)"
+              raw))
+  in
   match String.lowercase_ascii (String.trim raw) with
   | "" | "none" | "no-thinking-control" | "no_thinking_control" ->
-    Ok Runtime_schema.No_thinking_control
-  | "thinking-object" | "thinking_object" -> Ok Runtime_schema.Thinking_object
+    reject_orphan_token Runtime_schema.No_thinking_control
+  | "thinking-object" | "thinking_object" ->
+    reject_orphan_token Runtime_schema.Thinking_object
   | "thinking-object-only" | "thinking_object_only" ->
-    Ok Runtime_schema.Thinking_object_only
-  | "chat-template-kwargs" | "chat_template_kwargs" -> Ok Runtime_schema.Chat_template_kwargs
-  | "chat-template-token" | "chat_template_token" -> Ok Runtime_schema.Chat_template_token
-  | "ollama-think" | "ollama_think" -> Ok Runtime_schema.Ollama_think
-  | "reasoning-effort" | "reasoning_effort" -> Ok Runtime_schema.Reasoning_effort
-  | "enable-thinking" | "enable_thinking" -> Ok Runtime_schema.Enable_thinking
+    reject_orphan_token Runtime_schema.Thinking_object_only
+  | "chat-template-kwargs" | "chat_template_kwargs" ->
+    reject_orphan_token Runtime_schema.Chat_template_kwargs
+  | "chat-template-token" | "chat_template_token" ->
+    (match token with
+     | Some t when String.trim t = t && t <> "" ->
+       Ok (Runtime_schema.Chat_template_token t)
+     | Some _ ->
+       Error
+         (error
+            (path ^ ".thinking-control-token")
+            "thinking-control-token must be a non-empty string without \
+             leading or trailing whitespace")
+     | None ->
+       Error
+         (error
+            (path ^ ".thinking-control-format")
+            "chat-template-token requires a thinking-control-token key \
+             naming the template token (e.g. \"<|think|>\")"))
+  | "ollama-think" | "ollama_think" -> reject_orphan_token Runtime_schema.Ollama_think
+  | "reasoning-effort" | "reasoning_effort" ->
+    reject_orphan_token Runtime_schema.Reasoning_effort
+  | "enable-thinking" | "enable_thinking" ->
+    reject_orphan_token Runtime_schema.Enable_thinking
   | other ->
     (* Unknown enum members fail the load, mirroring how this parser already
        rejects unknown protocols / credential types. A silent downgrade to
@@ -449,9 +484,18 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       None
   in
   let thinking_control_format_result =
+    let token = Otoml.find_opt tbl Otoml.get_string [ "thinking-control-token" ] in
     match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
-    | None -> Ok Runtime_schema.No_thinking_control
-    | Some raw -> parse_thinking_control_format ~path raw
+    | None ->
+      (match token with
+       | None -> Ok Runtime_schema.No_thinking_control
+       | Some _ ->
+         Error
+           (error
+              (path ^ ".thinking-control-token")
+              "thinking-control-token requires thinking-control-format = \
+               \"chat-template-token\""))
+    | Some raw -> parse_thinking_control_format ~path ~token raw
   in
   Result.map
     (fun thinking_control_format ->

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -404,6 +404,21 @@ let parse_providers (toml : Otoml.t)
 
 (* --- Layer 2: Models --- *)
 
+let thinking_control_token_key = "thinking-control-token"
+
+let exact_non_empty_string_opt_field ~(path : string) (tbl : Otoml.t) (key : string)
+  : (string option, parse_error list) result
+  =
+  match typed_find "string" path tbl key Otoml.get_string with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some value) when String.trim value = "" ->
+    Error (error (path ^ "." ^ key) (key ^ " must be non-empty"))
+  | Ok (Some value) when value <> String.trim value ->
+    Error (error (path ^ "." ^ key) (key ^ " must not have leading or trailing whitespace"))
+  | Ok (Some value) -> Ok (Some value)
+;;
+
 let parse_thinking_control_format ~(path : string) ~(token : string option) (raw : string)
   : (Runtime_schema.thinking_control_format, parse_error list) result
   =
@@ -417,7 +432,7 @@ let parse_thinking_control_format ~(path : string) ~(token : string option) (raw
     | Some _ ->
       Error
         (error
-           (path ^ ".thinking-control-token")
+           (path ^ "." ^ thinking_control_token_key)
            (Printf.sprintf
               "thinking-control-token is only valid with \
                thinking-control-format = \"chat-template-token\" (got %S)"
@@ -439,7 +454,7 @@ let parse_thinking_control_format ~(path : string) ~(token : string option) (raw
      | Some _ ->
        Error
          (error
-            (path ^ ".thinking-control-token")
+            (path ^ "." ^ thinking_control_token_key)
             "thinking-control-token must be a non-empty string without \
              leading or trailing whitespace")
      | None ->
@@ -484,18 +499,21 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       None
   in
   let thinking_control_format_result =
-    let token = Otoml.find_opt tbl Otoml.get_string [ "thinking-control-token" ] in
-    match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
-    | None ->
+    match
+      ( typed_find "string" path tbl "thinking-control-format" Otoml.get_string
+      , exact_non_empty_string_opt_field ~path tbl thinking_control_token_key )
+    with
+    | Error errs, _ | _, Error errs -> Error errs
+    | Ok None, Ok token ->
       (match token with
        | None -> Ok Runtime_schema.No_thinking_control
        | Some _ ->
          Error
            (error
-              (path ^ ".thinking-control-token")
+              (path ^ "." ^ thinking_control_token_key)
               "thinking-control-token requires thinking-control-format = \
                \"chat-template-token\""))
-    | Some raw -> parse_thinking_control_format ~path ~token raw
+    | Ok (Some raw), Ok token -> parse_thinking_control_format ~path ~token raw
   in
   Result.map
     (fun thinking_control_format ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1441,7 +1441,7 @@ let thinking_control_format_wire : Runtime_schema.thinking_control_format -> str
   | Runtime_schema.Thinking_object_adaptive -> "thinking-object-adaptive"
   | Runtime_schema.Thinking_object_only -> "thinking-object-only"
   | Runtime_schema.Chat_template_kwargs -> "chat-template-kwargs"
-  | Runtime_schema.Chat_template_token -> "chat-template-token"
+  | Runtime_schema.Chat_template_token _ -> "chat-template-token"
   | Runtime_schema.Ollama_think -> "ollama-think"
   | Runtime_schema.Reasoning_effort -> "reasoning-effort"
   | Runtime_schema.Enable_thinking -> "enable-thinking"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -429,7 +429,7 @@ let test_repo_oas_model_catalog_covers_live_runpod_rtxa6000_gemma () =
     check bool "RunPod RTX A6000 Gemma seed" true caps.supports_seed;
     check bool "RunPod RTX A6000 Gemma chat-template token thinking" true
       (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_token))
+         caps.thinking_control_format = Chat_template_token "<|think|>"))
 
 let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
   with_repo_oas_model_catalog @@ fun catalog ->
@@ -451,7 +451,10 @@ let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
        (option string)
        (provider_model_id ^ " thinking token")
        (Some "<|think|>")
-       entry.thinking_control_token);
+       (match entry.thinking_control_format with
+        | Some (Llm_provider.Capabilities.Chat_template_token token) ->
+          Some token
+        | Some _ | None -> None));
   match
     Llm_provider.Capabilities.for_provider_model_id
       ~allow_bare_fallback:false
@@ -469,7 +472,7 @@ let test_repo_oas_model_catalog_covers_local_gemma4_e2b_qat () =
     check bool "Local Gemma4 E2B audio input" true caps.supports_audio_input;
     check bool "Local Gemma4 E2B chat-template token thinking" true
       (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_token));
+         caps.thinking_control_format = Chat_template_token "<|think|>"));
     check
       (option string)
       "Local Gemma4 E2B thinking token"
@@ -520,8 +523,10 @@ let test_repo_oas_model_catalog_preserve_axes_resolve () =
      | Some entry ->
        check (option string) (model_id ^ " native base") (Some "kimi")
          entry.base_label;
-       check (option string) (model_id ^ " no request thinking knob") (Some "none")
-         entry.thinking_control_format;
+       check bool (model_id ^ " no request thinking knob") true
+         (match entry.thinking_control_format with
+          | Some Llm_provider.Capabilities.No_thinking_control -> true
+          | Some _ | None -> false);
        check (option string) (model_id ^ " always preserved thinking")
          (Some "always_preserved")
          entry.preserve_thinking_control_format;
@@ -672,7 +677,7 @@ let test_repo_runtime_toml_loads () =
           check bool "Gemma4 chat-template-token thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Chat_template_token);
+               (Runtime_schema.Chat_template_token "<|think|>"));
           (* Native Ollama /api/chat never serializes tool_choice
              (oas backend_ollama.ml:24); declaring true here would override
              oas models.toml false while the transport drops forced tool
@@ -702,7 +707,7 @@ let test_repo_runtime_toml_loads () =
           check bool "Gemma4 E2B chat-template-token thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Chat_template_token);
+               (Runtime_schema.Chat_template_token "<|think|>"));
           check bool "Gemma4 E2B forced tool_choice disabled" false
             caps.supports_tool_choice;
           check bool "Gemma4 E2B image input" true caps.supports_image_input;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -658,6 +658,7 @@ streaming = true
 
 [models.gemma4.capabilities]
 thinking-control-format = "chat_template_token"
+thinking-control-token = "<|think|>"
 
 [ollama.gemma4]
 max-concurrent = 1
@@ -679,7 +680,8 @@ max-concurrent = 1
        (match model.capabilities with
         | Some caps ->
           check bool "chat template token parsed" true
-            (caps.thinking_control_format = Runtime_schema.Chat_template_token)
+            (caps.thinking_control_format
+             = Runtime_schema.Chat_template_token "<|think|>")
         | None -> fail "expected model capabilities")
      | models -> failf "expected one model, got %d" (List.length models))
 

--- a/test/test_thinking_control_format_unknown_error.ml
+++ b/test/test_thinking_control_format_unknown_error.ml
@@ -128,6 +128,19 @@ let test_orphan_token_fails () =
        (Runtime_toml.parse_string
           (toml_with_tcf_and_token "reasoning-effort" "<|think|>")))
 
+let test_non_string_token_fails_as_parse_error () =
+  let toml =
+    {|[models.m]
+max-context = 1000
+
+[models.m.capabilities]
+thinking-control-format = "chat-template-token"
+thinking-control-token = 123
+|}
+  in
+  check bool "non-string thinking-control-token fails as Error" true
+    (is_error (Runtime_toml.parse_string toml))
+
 let test_absent_capabilities_loads () =
   (* No capabilities table at all is fine — absence defaults to no control. *)
   check bool "model without a capabilities table loads" true
@@ -150,5 +163,7 @@ let () =
           test_case "blank/padded token fails" `Quick
             test_chat_template_token_padded_token_fails;
           test_case "orphan token fails" `Quick test_orphan_token_fails;
+          test_case "non-string token fails as parse error" `Quick
+            test_non_string_token_fails_as_parse_error;
         ] );
     ]

--- a/test/test_thinking_control_format_unknown_error.ml
+++ b/test/test_thinking_control_format_unknown_error.ml
@@ -55,8 +55,6 @@ let test_valid_values_load_and_map_to_oas_variants () =
       ; "thinking-object-only", Thinking_object_only
       ; "chat_template_kwargs", Chat_template_kwargs
       ; "chat-template-kwargs", Chat_template_kwargs
-      ; "chat_template_token", Chat_template_token
-      ; "chat-template-token", Chat_template_token
       ; "ollama_think", Ollama_think
       ; "ollama-think", Ollama_think
       ; "reasoning_effort", Reasoning_effort
@@ -77,6 +75,59 @@ let test_unknown_value_fails_load () =
   check bool "unknown thinking-control-format fails the load (Error)" true
     (is_error (Runtime_toml.parse_string (toml_with_tcf "bogus-format")))
 
+(* chat-template-token carries its token (mirrors oas#2484): the format
+   requires a thinking-control-token key, blank/padded tokens fail, and an
+   orphan token on another format fails. *)
+let toml_with_tcf_and_token tcf token =
+  Printf.sprintf
+    {|[models.m]
+max-context = 1000
+
+[models.m.capabilities]
+thinking-control-format = "%s"
+thinking-control-token = "%s"
+|}
+    tcf token
+
+let test_chat_template_token_roundtrip () =
+  List.iter
+    (fun raw ->
+      match Runtime_toml.parse_string (toml_with_tcf_and_token raw "<|think|>") with
+      | Error errs -> failf "expected %S to parse:\n%s" raw (render_errors errs)
+      | Ok cfg ->
+        (match cfg.Runtime_schema.models with
+         | [ model ] ->
+           (match model.Runtime_schema.capabilities with
+            | Some caps ->
+              check bool
+                ("thinking-control-token carried for " ^ raw)
+                true
+                (Runtime_schema.equal_thinking_control_format
+                   caps.Runtime_schema.thinking_control_format
+                   (Runtime_schema.Chat_template_token "<|think|>"))
+            | None -> failf "expected capabilities for %S" raw)
+         | models -> failf "expected one model, got %d" (List.length models)))
+    [ "chat_template_token"; "chat-template-token" ]
+
+let test_chat_template_token_without_token_fails () =
+  check bool "chat-template-token without token fails the load" true
+    (is_error (Runtime_toml.parse_string (toml_with_tcf "chat-template-token")))
+
+let test_chat_template_token_padded_token_fails () =
+  check bool "padded thinking-control-token fails the load" true
+    (is_error
+       (Runtime_toml.parse_string
+          (toml_with_tcf_and_token "chat-template-token" " <|think|> ")));
+  check bool "empty thinking-control-token fails the load" true
+    (is_error
+       (Runtime_toml.parse_string (toml_with_tcf_and_token "chat-template-token" "")))
+
+let test_orphan_token_fails () =
+  check bool "thinking-control-token on a non-token format fails the load" true
+    (is_error
+       (Runtime_toml.parse_string
+          (toml_with_tcf_and_token "reasoning-effort" "<|think|>")))
+
 let test_absent_capabilities_loads () =
   (* No capabilities table at all is fine — absence defaults to no control. *)
   check bool "model without a capabilities table loads" true
@@ -92,5 +143,12 @@ let () =
           test_case "unknown value fails load" `Quick test_unknown_value_fails_load;
           test_case "absent capabilities loads" `Quick
             test_absent_capabilities_loads;
+          test_case "chat-template-token carries the token" `Quick
+            test_chat_template_token_roundtrip;
+          test_case "chat-template-token without token fails" `Quick
+            test_chat_template_token_without_token_fails;
+          test_case "blank/padded token fails" `Quick
+            test_chat_template_token_padded_token_fails;
+          test_case "orphan token fails" `Quick test_orphan_token_fails;
         ] );
     ]


### PR DESCRIPTION
## 무엇/왜 — main red 복구

pin bump #23460이 required check FAILURE 상태로 머지되어(agent_sdk 0.208.20+oas#2484) main이 컴파일 불가입니다. 원인은 `runtime_schema.ml`의 **투명 re-export가 설계 의도대로 작동한 것**입니다: *"This re-exports the OAS capability enum so OAS variant changes break MASC compile instead of leaving a stale local mirror."* — oas#2484가 `Chat_template_token of string`으로 바꿨고, masc mirror가 컴파일 타임에 깨졌습니다.

## 변경

- `runtime_schema(.mli)`: `Chat_template_token of string` (OAS variant 정합)
- `runtime_toml`: `chat-template-token` format은 `thinking-control-token` 키 필수(정확·비공백·무패딩), 다른 format에 붙은 orphan token은 거부 — oas#2484 카탈로그 계약을 masc runtime.toml 로드에 미러링 (per-request 폭발 대신 로드 시점 fail-closed)
- seed `config/runtime.toml`: chat_template_token 항목 2곳에 `thinking-control-token = "<|think|>"` 추가
- dashboard wire label: payload 패턴 반영
- 테스트: token roundtrip/missing/padded/orphan 4케이스 신설, 카탈로그 entry 단언은 typed 생성자에서 token 추출로 갱신(upstream standalone 필드 삭제됨), 기존 단언은 `"<|think|>"` 값 검증으로 강화

## 로컬 검증

- `dune build --root . @check` clean
- `test_thinking_control_format_unknown_error` 7/7, `test_runtime_config_validity` 32/32 (repo seed+카탈로그 실파싱 포함), `test_runtime_provider_auth_headers` 37/37

## 운영 조치 (이미 수행)

live `~/.masc/config/runtime.toml`의 `chat_template_token` 항목(gemma4-26b-a4b-qat)에 token 키 선반영 + backup(`.bak-thinktoken-20260707`) — 이 코드가 배포될 때 서버 부팅 fail-closed로 막히지 않도록.

## 미검증

- 전체 `dune runtest`는 CI 위임

Refs #23460 #23443 jeong-sik/oas#2484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
