### PR TITLE
chore(cdal): remove remaining cdal_evidence_gate integration points

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -815,7 +815,6 @@ let full_health_cached_field_names =
     "keeper_board_event_collection";
     "keeper_event_queue";
     "paused_keepers";
-    "cdal";
     "keeper_config_parse_error_count";
     "keeper_config_parse_errors";
     "keeper_config_unknown_key_count";
@@ -906,9 +905,6 @@ let full_health_placeholder_fields ?error ?(component_timed_out = false)
           ("names", `List []);
           ("component_timed_out", `Bool component_timed_out);
         ] );
-    ( "cdal",
-      full_health_component_placeholder ?error ~component_timed_out ~status
-        "cdal" );
     ("keeper_config_parse_error_count", `Int 0);
     ("keeper_config_parse_errors", `List []);
     ("keeper_config_unknown_key_count", `Int 0);

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -455,15 +455,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       | Masc_domain.Reject_verification ->
         false
     in
-    if not needs_gate then Workspace_hooks.Pass
-    else
-      (Atomic.get Workspace_hooks.cdal_evidence_gate_decide_fn)
-        ~task_id
-        ~task_opt
-        ~notes
-        ~handoff:handoff_context
-        ()
-  in
+    in
   match evidence_decision with
   | Workspace_hooks.Reject { reason; rule_id; hint; payload_json } ->
     let extra_fields =

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -507,14 +507,11 @@ let build_timeline ?(load_chat = fun ~agent_name:_ -> ([] : chat_line list))
       if include_tool_calls then tool_call_events config ~agent_name ~limit:200
       else []
     in
-    let cdal_evts =
-      keeper_cdal_events config ~agent_name ~limit:200
-    in
     let turn_evts =
       turn_completed_events config ~agent_name ~limit:200
     in
     let chat_evts = chat_events (load_chat ~agent_name) in
-    agent_evts @ task_evts @ msg_evts @ tool_evts @ cdal_evts @ turn_evts
+    agent_evts @ task_evts @ msg_evts @ tool_evts @ turn_evts
     @ chat_evts
   in
   (* Filter by time cutoff and sort chronologically. [stable_sort] (not

--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -3,18 +3,18 @@
 
     Implements the [masc_agent_timeline] MCP tool plus the
     [/api/dashboard/agent/<name>/timeline] HTTP route.  Aggregates
-    6 event sources for a single agent ([agent_events],
+    5 event sources for a single agent ([agent_events],
     [task_events], [message_events], [tool_call_events],
-    [keeper_cdal_events], [turn_completed_events]), filters by
+    [turn_completed_events]), filters by
     [since_hours] cutoff, sorts chronologically, truncates to
     [limit] (most recent), and emits a JSON summary with
     cardinality counts + token/cost rollups.
 
     Internal: 11 helpers + 1 type stay private —
     \[parse_iso_timestamp] (Scanf-based ISO8601 parser),
-    [timeline_event] type + [event_to_json], the 6 source
+    [timeline_event] type + [event_to_json], the 5 source
     extractors ([agent_events], [task_events], [message_events],
-    [tool_call_events], [keeper_cdal_events],
+    [tool_call_events],
     [turn_completed_events]), and [handle_agent_timeline] (the
     dispatch handler that reaches {!build_timeline}).  All
     consumed only inside {!build_timeline} or {!dispatch}.
@@ -91,7 +91,7 @@ val build_timeline :
       board-event integration).
 
     Per-source internal limits are pinned at 200 events
-    ([message_events], [tool_call_events], [keeper_cdal_events],
+    ([message_events], [tool_call_events],
     [turn_completed_events]); the [~limit] argument applies to
     the merged sorted list. *)
 

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -423,16 +423,6 @@ let is_admin_agent_fn
 type evidence_gate_verdict =
   | Pass
   | Reject of { reason : string; rule_id : string; hint : string; payload_json : Yojson.Safe.t }
-
-let cdal_evidence_gate_decide_fn
-  : (task_id:string ->
-     task_opt:Masc_domain.task option ->
-     notes:string ->
-     handoff:Masc_domain.task_handoff_context option ->
-     unit ->
-     evidence_gate_verdict)
-    Atomic.t
-  = (Atomic.make (fun ~task_id:_ ~task_opt:_ ~notes:_ ~handoff:_ () -> Pass)
      : (task_id:string ->
         task_opt:Masc_domain.task option ->
         notes:string ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -193,12 +193,3 @@ val is_admin_agent_fn :
 type evidence_gate_verdict =
   | Pass
   | Reject of { reason : string; rule_id : string; hint : string; payload_json : Yojson.Safe.t }
-
-val cdal_evidence_gate_decide_fn :
-  (task_id:string ->
-   task_opt:Masc_domain.task option ->
-   notes:string ->
-   handoff:Masc_domain.task_handoff_context option ->
-   unit ->
-   evidence_gate_verdict)
-  Atomic.t

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -633,17 +633,5 @@ let install () =
       Otel_metric_store.metric_cache_desync_cleared
       ~labels:[ "module", module_name; "status", status ]
       ());
-
-  let decide_hook
-        ~task_id:_
-        ~task_opt:_
-        ~notes:_
-        ~handoff:_
-        ()
-      : Workspace_hooks.evidence_gate_verdict
-    =
-    Workspace_hooks.Pass
-  in
-  Atomic.set Workspace_hooks.cdal_evidence_gate_decide_fn decide_hook;
   ()
 ;;


### PR DESCRIPTION
## Summary

Completes the CDAL gate removal by cleaning up all remaining integration points that referenced `cdal_evidence_gate_decide_fn` and related CDAL gate infrastructure.

## Changes

- **workspace_hooks.ml/mli**: Removed `cdal_evidence_gate_decide_fn` Atomic ref and `evidence_gate_verdict` type
- **tool_task.ml**: Removed gate call that invoked `Atomic.get Workspace_hooks.cdal_evidence_gate_decide_fn`
- **server_routes_http_runtime.ml**: Removed `"cdal"` from health route listing and health component placeholder
- **tool_agent_timeline.ml/mli**: Removed `keeper_cdal_events` function and its call site
- **workspace_metric_hooks.ml**: Removed `decide_hook` wiring that set `cdal_evidence_gate_decide_fn`

## Context

Operator directive: remove CDAL gate, keep evidence gathering. The gate file itself was already deleted in `feat/retire-cdal-evidence-gate-20260707` (commit fae6e9bdf). This PR removes the remaining integration points that referenced the deleted module.

Closes task-1850