### PR TITLE
feat(keeper): route gh capability asks to HITL

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -153,6 +153,8 @@ Choosing a capability family:
   auto-run surfaces. When the exact visible task requires one of these GitHub
   artifacts, use typed `Execute` with `gh` only to create a non-blocking HITL
   approval request; do not retry the same command while approval is pending.
+  Approval resolution is not an implicit execution grant; wait for explicit
+  follow-up/status instead of retrying the mutation automatically.
   Repo delete, PR merge, and irreversible discussion deletion remain denied.
   Prefer MASC board tools for workspace-local durable discussion.
 - Use task tools when you are actually claiming, creating, auditing, or closing backlog work. Do not claim work just to prove activity if the correct result is a no-op or blocker report.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -149,7 +149,12 @@ Choosing a capability family:
 - Use context/tool introspection first when sandbox paths, repo location, active schema names, or current task ownership are uncertain.
 - Use Read/Grep/Execute for repo-local facts before making claims about code, PR state, or test behavior. Use WebSearch/WebFetch only for external or time-sensitive facts.
 - Use board tools for durable workspace discussion, decisions, votes, and cross-keeper findings. Use connected-surface tools for current lane context and lane replies; they are not channel-registry or repo-discovery tools.
-- Do not create GitHub repositories or mutate GitHub Discussions from keeper execution. `docs/design/keeper-github-repo-create-discussion-policy.md` keeps remote repository creation as an operator action and keeps durable discussion on MASC board tools.
+- GitHub repository creation and GitHub Discussions mutation are not autonomous
+  auto-run surfaces. When the exact visible task requires one of these GitHub
+  artifacts, use typed `Execute` with `gh` only to create a non-blocking HITL
+  approval request; do not retry the same command while approval is pending.
+  Repo delete, PR merge, and irreversible discussion deletion remain denied.
+  Prefer MASC board tools for workspace-local durable discussion.
 - Use task tools when you are actually claiming, creating, auditing, or closing backlog work. Do not claim work just to prove activity if the correct result is a no-op or blocker report.
 - Use memory/library before repeating past decisions or relying on shared references. Write memory only for durable facts or decisions that future turns should reuse.
 - Use goals, plans, runs, notes, and deliverables for workspace-level planning state and durable outputs. Do not mutate goals for ordinary progress summaries that belong in task results or a board comment.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -122,9 +122,11 @@ Choose the smallest surface that matches the live signal.
 - Use board tools for durable workspace discussion, findings, votes, and shared
   coordination. Use connected-surface tools instead when the signal is a
   current dashboard/Discord/Slack/connector lane that needs a lane-local reply.
-- Do not use keeper execution to create GitHub repositories or mutate GitHub
-  Discussions; `docs/design/keeper-github-repo-create-discussion-policy.md`
-  keeps those surfaces outside keeper affordances.
+- GitHub repository creation and GitHub Discussions mutation are never
+  autonomous auto-run operations. Use typed `Execute` with `gh` only when the
+  task explicitly needs the GitHub artifact; reversible repo/discussion
+  mutations route to a non-blocking HITL approval request, while repo delete,
+  PR merge, and irreversible discussion deletion remain denied.
 - Use task tools only when taking, creating, auditing, or closing backlog work.
   Reading task state is evidence gathering, not execution progress.
 - Use memory/library before repeating past work, relying on shared references,

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -127,6 +127,8 @@ Choose the smallest surface that matches the live signal.
   task explicitly needs the GitHub artifact; reversible repo/discussion
   mutations route to a non-blocking HITL approval request, while repo delete,
   PR merge, and irreversible discussion deletion remain denied.
+  Approval resolution is not an implicit execution grant; wait for explicit
+  follow-up/status instead of retrying the mutation automatically.
 - Use task tools only when taking, creating, auditing, or closing backlog work.
   Reading task state is evidence gathering, not execution progress.
 - Use memory/library before repeating past work, relying on shared references,

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -163,7 +163,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |
 | 테스트 실행 | `Execute` with typed argv from the worktree `cwd` |
 | GitHub PR / 이슈 작업 | `Execute` with `executable="gh"` and typed `argv` from a bound repo context for PR reads and reversible PR mutations such as `pr create` / `pr edit`. |
-| GitHub repo 생성 / GitHub Discussions mutation | Disabled by `docs/design/keeper-github-repo-create-discussion-policy.md`. Use operator action for repository creation and MASC board tools for durable discussion. |
+| GitHub repo 생성 / GitHub Discussions mutation | `Execute` with typed `gh` argv can request reversible repo/discussion mutations through non-blocking HITL approval (`Requires_approval`). Repo delete, PR merge, and irreversible discussion deletion stay denied by the Shell IR floor. Prefer MASC board tools for workspace-local durable discussion unless the requested artifact explicitly belongs on GitHub. |
 
 The goal lifecycle surface is descriptor/registry-driven with denylist
 filtering. Social and messaging keepers should keep board/task workspace

--- a/docs/design/keeper-github-repo-create-discussion-policy.md
+++ b/docs/design/keeper-github-repo-create-discussion-policy.md
@@ -78,7 +78,9 @@ The current Shell IR path separates risk from capability policy:
 
 `Requires_approval` creates a pending HITL approval entry and returns immediately
 to the keeper turn. The keeper must not block waiting for the operator decision;
-resolution is delivered later through the HITL wake path.
+resolution is delivered later through the HITL wake path. Resolution only wakes
+the keeper to observe the resolved state; it does not execute the stored command,
+create a one-shot approval grant, or authorize an automatic retry.
 
 ## 5. Non-goals
 
@@ -96,7 +98,8 @@ resolution is delivered later through the HITL wake path.
   irreversible operations.
 - `test/test_keeper_tool_execute_retry_deterministic_close.ml` proves the
   runtime helper enqueues a non-blocking pending approval entry for gh
-  capability approval.
+  capability approval, and that resolving the entry does not install an implicit
+  grant for a later retry.
 - Keeper capability docs and prompts state the decision directly: PR/issue work
   is supported, remote repo/discussion reversible mutations require HITL, and
   irreversible repo/discussion operations remain denied.

--- a/docs/design/keeper-github-repo-create-discussion-policy.md
+++ b/docs/design/keeper-github-repo-create-discussion-policy.md
@@ -1,36 +1,37 @@
 ---
 title: "Keeper GitHub repo-create and Discussions policy"
-status: Draft
+status: Superseded
 created: 2026-07-06
-updated: 2026-07-06
+updated: 2026-07-07
 author: codex
 supersedes: []
-superseded_by: null
-related: ["0008", "0160", "0254", "0255"]
+superseded_by: "0309"
+related: ["0008", "0160", "0254", "0255", "0309"]
 implementation_prs: []
 ---
 
 # Keeper GitHub repo-create and Discussions policy
 
-Status: Draft · Capability decision · G-WDECIDE
+Status: Superseded by RFC-0309 · Historical capability decision · G-WDECIDE
 
 ## 1. Decision
 
-Keeper autonomous execution does not expose GitHub repository creation or
-GitHub Discussions mutation as supported capabilities.
+This document records the earlier disable decision. RFC-0309 supersedes it:
+keeper execution may request reversible GitHub repository creation and GitHub
+Discussions mutations through typed Shell IR plus non-blocking HITL approval.
+They are not autonomous auto-run operations.
 
 - GitHub PR and issue work remains supported through `Execute` with `gh` in a
   bound repository context.
-- Remote repository creation is disabled for keepers. Operators may still create
-  repositories outside keeper autonomous execution.
-- GitHub Discussions mutation is disabled for keepers. Durable workspace
-  discussion stays on MASC board tools, which are typed, observable, and scoped
-  to the workspace.
-
-The generic `gh` execution path must fail closed for this decision. A command
-that would create a remote GitHub repository or mutate GitHub Discussions is
-classified as a repository-hosting policy floor violation, not as an ordinary
-reversible mutation.
+- Reversible remote repository creation/fork/edit/sync/rename requests route to
+  `Requires_approval` and enqueue a non-blocking HITL approval entry.
+- Reversible GitHub Discussions create/comment/edit/close/reopen/lock/unlock
+  requests route to `Requires_approval` and enqueue a non-blocking HITL approval
+  entry.
+- Repo delete, PR merge, destructive API calls, and irreversible discussion
+  deletion remain denied by the trust-independent Shell IR floor.
+- Durable workspace discussion still prefers MASC board tools unless the task
+  explicitly requires a GitHub Discussion artifact.
 
 ## 2. Evidence
 
@@ -54,7 +55,8 @@ ownership, lifecycle, and moderation policy are not represented in the current
 keeper tool contracts. Leaving them reachable only because an ambient `gh` token
 has broad scope is a silent capability decision.
 
-Disabling both surfaces is the smaller production decision:
+The superseded disable decision was the smaller production decision before the
+approval queue was wired into the Shell IR approval verdict:
 
 - no new GitHub credential materialization path;
 - no new cross-repo ownership model;
@@ -62,38 +64,39 @@ Disabling both surfaces is the smaller production decision:
 - no prompt affordance that suggests an unsupported tool;
 - no dependence on removing broad operator `repo` scope from local `gh` auth.
 
-## 4. Enforcement
+## 4. Current Enforcement
 
-The Shell IR repo-hosting classifier treats these forms as R2/policy-floor
-operations:
+The current Shell IR path separates risk from capability policy:
 
-- `gh repo create ...`
-- `gh repo fork ...`
-- `gh discussion create|comment|edit|delete|close|reopen|lock|unlock|answer|unanswer ...`
-- `gh api graphql` bodies containing the live GitHub mutation names for
-  repository creation or Discussions mutation.
+- `gh repo create|fork|edit|sync|rename ...` -> `Requires_approval`
+- `gh discussion create|comment|edit|close|reopen|lock|unlock|answer|unanswer ...`
+  -> `Requires_approval`
+- `gh api graphql` bodies containing durable repository/discussion create or
+  comment mutations -> `Requires_approval`
+- `gh repo delete`, `gh pr merge`, destructive REST/GraphQL deletes, and
+  irreversible discussion deletion -> `Deny`
 
-The deny reason remains `Destructive_repo_hosting_cli` because the floor is the
-same remote repository-hosting policy boundary used for irreversible PR/repo
-operations. The user-facing text states that the operation is not permitted by
-policy.
+`Requires_approval` creates a pending HITL approval entry and returns immediately
+to the keeper turn. The keeper must not block waiting for the operator decision;
+resolution is delivered later through the HITL wake path.
 
 ## 5. Non-goals
 
 - This decision does not remove the operator's local `repo` token scope.
-- This decision does not add a dedicated repo-create tool.
-- This decision does not add GitHub Discussions read or write tools.
+- This decision does not add a dedicated repo-create tool; the surface remains
+  typed `Execute` with `gh`.
+- This decision does not allow autonomous repository creation or Discussion
+  mutation without HITL approval.
 - This decision does not change MASC board discussion semantics.
 
 ## 6. Verification
 
-- `test/test_shell_ir_risk.ml` proves `gh repo create`, `gh repo fork`,
-  `gh discussion create/comment`, `createRepository`, `cloneTemplateRepository`,
-  `createDiscussion`, and `addDiscussionComment` classify as R2.
-- `lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml` covers the
-  direct repo-hosting classifier.
-- `lib/exec/test/test_approval_policy.ml` proves autonomous approval denies
-  repo-create, repo-fork, discussion-create, and GraphQL create mutations.
+- `lib/exec/test/test_approval_policy.ml` proves autonomous approval emits
+  `Ask` for durable reversible repo/discussion operations and still denies
+  irreversible operations.
+- `test/test_keeper_tool_execute_retry_deterministic_close.ml` proves the
+  runtime helper enqueues a non-blocking pending approval entry for gh
+  capability approval.
 - Keeper capability docs and prompts state the decision directly: PR/issue work
-  is supported, while remote repo creation and GitHub Discussions mutation are
-  not keeper affordances.
+  is supported, remote repo/discussion reversible mutations require HITL, and
+  irreversible repo/discussion operations remain denied.

--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -41,7 +41,8 @@ the three axes that #23362 conflated:
 
 The absolute constraint, set by the operator: **the tool gate must never block
 a keeper turn.** An `Ask` verdict enqueues to the existing non-blocking
-approval queue and the keeper yields; `Hitl_resolved` wakes it to execute.
+approval queue and the keeper yields. `Hitl_resolved` only wakes the keeper to
+observe resolution state; it does not execute the command or install a grant.
 Block-time p99 must be 0 ms (G-11/G-13) and the property is model-checked
 (G-12).
 
@@ -201,18 +202,16 @@ gh_unknown          | Requires_approval | Requires_approval | Suggest_confirm
 
 ### 3.4 Approval disposition (G-6..G-8) — the core
 
-**Correction (W3 implementation, verified against source).** An earlier draft
-described the mechanism as "enqueue and resume in a later turn." Reading the
-runtime, the existing HITL mechanism is different and already correct:
-`Keeper_approval_queue` is **Eio-promise based** — the tool-invocation fiber
-awaits a promise; the dashboard approval handler resolves it and the *same*
-fiber resumes (`keeper_approval_queue.mli` header **(verified)**). Because the
-keeper runs on Eio, awaiting a promise **suspends the fiber, not the domain**:
-other fibers (accept loop, other keepers, HTTP/WS) keep running. "Non-blocking"
-here means *domain-non-blocking*, not *turn-returns-immediately*. The RFC does
-not need a new queue or a `Pending_approval` return type.
+**Correction (W3/W4 implementation, verified against source).** The current
+Shell IR gh capability path is intentionally enqueue-only. For
+`Requires_approval`, the keeper-tool layer calls
+`Keeper_approval_queue.submit_pending`, returns a typed pending/error payload to
+the turn, and records block time as 0 ms. `on_resolution` records lifecycle
+metrics/logs when an operator resolves the entry, and `Hitl_resolved` wakes the
+keeper to observe the resolution. There is no same-turn wait, no stored
+execution continuation, and no one-shot grant installed for a later retry.
 
-W3 delivers the **decision layer** only:
+W3/W4 deliver the **decision and enqueue layer**:
 
 - `Gh_capability_policy.disposition_of` gives each gh verb a capability
   disposition (`Allowed | Requires_approval | Denied`), computed from the
@@ -222,19 +221,22 @@ W3 delivers the **decision layer** only:
   `Verdict.Ask` **even under the autonomous (all-`Observe`) overlay**. This is
   additive — the layer only *adds* an approval requirement for gh, never
   removes one, and never touches non-gh commands.
+- The keeper-tool runtime turns a gh capability `Ask` into a pending approval
+  entry and returns immediately with structured pending state instead of
+  auto-running or synchronously waiting.
 - This makes the autonomous overlay's all-`Observe` rationale ("no resolver to
-  answer an Ask") no longer a reason to auto-run gated gh: the verb now asks.
+  answer an Ask") no longer a reason to auto-run gated gh: the verb now asks and
+  stops at pending.
 
-What W3 does **not** yet do (deliberately, pending CI/runtime verification):
-wire the resulting `Ask` at the keeper-tool layer to the OAS Agent HITL
-approval hook so an operator resolution actually resumes execution. Today the
-keeper surface still renders `Ask` as an `Approval_required` typed error
-(`keeper_tool_execute_shell_ir.ml`), i.e. the gated op does not auto-run and is
-reported to the operator, but operator-resolve-to-execute is a follow-up
-(requires runtime/integration tests, which need the CI runner restored).
+What this does **not** yet do (deliberately, pending a separate runtime
+contract): approval resolution does not execute the stored command, install a
+grant, or cause a retry to bypass policy. A future operator-resolve-to-execute
+flow must add an explicit grant/continuation contract and tests before docs may
+say approval enables the action.
 
 - **Invariant (absolute):** no code path may *synchronously spin* on approval
-  inside a domain. The promise-await suspends the fiber only. Enforcement
+  inside a domain. The current path returns immediately after enqueue; any future
+  continuation path must preserve domain-non-blocking behavior. Enforcement
   targets (future waves): G-11 block-time metric (domain-occupancy p99 = 0 ms),
   G-12 TLA+ `NonBlockingApproval` invariant (clean + buggy cfg pair), G-13
   gated-op observability.
@@ -262,7 +264,7 @@ space *between* Allow and Deny; it does not soften Deny.
 | W3 | G-6 | `Requires_approval` disposition ≠ Deny | disposition round-trips through receipts |
 | W3 | G-7 | exec gate `Ask` → HITL queue wiring | keeper-turn block time on gated op = 0 ms |
 | W3 | G-8 | autonomous overlay: gated families → `Requires_approval` | overlay no longer all-`Observe` for gh mutations |
-| W4 | G-9 | re-enable repo-create/discussion surfaces (supersede #23362 behavior; design doc marked superseded) | `gh repo create` reaches `Pending_approval`, not `Deny` |
+| W4 | G-9 | re-enable repo-create/discussion surfaces to request approval (supersede #23362 behavior; design doc marked superseded) | `gh repo create` reaches `Pending_approval`, not `Deny` |
 | W4 | G-10 | repo-create capability contract (naming/ownership/lifecycle) | contract doc + typed args |
 | W4 | G-11 | prompts + `KEEPER-CAPABILITY-MATRIX.md` update; block-time metric | docs match behavior; p99 block-time 0 ms |
 | W5 | G-12 | TLA+ `CatastrophicNeverAllowed` + `NonBlockingApproval` + `UnknownGhVerbNeverAutoRun` | clean cfg passes AND buggy cfg violates (both required) |
@@ -271,7 +273,8 @@ space *between* Allow and Deny; it does not soften Deny.
 Wave order is dependency order: measurement (W0) → typed identity (W1) →
 axes (W2) → disposition wiring (W3) → capability enable (W4) → formal +
 observability closure (W5). G-9 must not land before G-7: enabling the
-surfaces while `Ask` is unwired would reproduce #23362's original dilemma.
+surfaces to request approval while `Ask` is unwired would reproduce #23362's
+original dilemma.
 
 ---
 

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -23,23 +23,27 @@ val decide :
   caps:Capability.t list ->
   simple:Shell_ir.simple ->
   Verdict.t
-(** Pure policy decision, evaluated in two stages:
+(** Pure policy decision, evaluated in three stages:
 
     1. Trust-independent catastrophic floor (checked first, denied
        regardless of [overlay] — RFC-0254 §5.3):
        - any [Destructive] git op → [Deny Destructive_git];
        - a redirect [Write_path] whose scope is [Outside_workspace] or
          [Absolute_unknown] → [Deny Path_escape];
-       - an irreversible or policy-disabled repository-hosting CLI operation
-         ([gh pr merge], [gh repo create], [gh repo delete],
-         [gh discussion create], [gh api -X DELETE]) → [Deny
+       - an irreversible repository-hosting CLI operation ([gh pr merge],
+         [gh repo delete], [gh api -X DELETE]) → [Deny
          Destructive_repo_hosting_cli];
        - a catastrophic-by-identity binary (filesystem-format [mkfs], or
          system-power [shutdown]/[reboot]/[halt]/[poweroff]) → [Deny
          Catastrophic_program];
        - a destructive SQL statement ([DROP]/[TRUNCATE]/[DELETE]) handed to a
          database CLI ([psql -c], [mysql -e]) → [Deny Destructive_db].
-    2. Otherwise the highest program risk class is graded by the matching
+    2. Otherwise, a [gh] verb whose capability disposition is
+       [Requires_approval] → [Ask], independent of the risk overlay. This is
+       how reversible durable-remote mutations such as [gh repo create] and
+       [gh discussion create] enter HITL rather than auto-running or being
+       disabled.
+    3. Otherwise the highest program risk class is graded by the matching
        [overlay.*_trust] level:
        [Enforced] → [Ask], [Auto_safe]/[Observe] → [Allow],
        [Suggest] → [Suggest_confirm].
@@ -52,12 +56,12 @@ val decide :
 
 val catastrophic_floor : Capability.t list -> Verdict.deny_reason option
 (** Stage 1 of [decide] on its own: [Some reason] for a [Destructive] git op, a
-    redirect [Write_path] escaping the workspace, an irreversible or
-    policy-disabled repository-hosting CLI operation ([gh pr merge], [gh repo
-    create], [gh repo delete], [gh discussion create], [gh api -X DELETE]), a
-    catastrophic-by-identity binary (filesystem-format [mkfs] or
-    system-power [shutdown]/[reboot]/[halt]/[poweroff]), or a destructive SQL
-    statement on a database CLI ([psql -c "drop …"]); [None] otherwise.
+    redirect [Write_path] escaping the workspace, an irreversible
+    repository-hosting CLI operation ([gh pr merge], [gh repo delete],
+    [gh api -X DELETE]), a catastrophic-by-identity binary
+    (filesystem-format [mkfs] or system-power [shutdown]/[reboot]/[halt]/
+    [poweroff]), or a destructive SQL statement on a database CLI
+    ([psql -c "drop …"]); [None] otherwise.
 
     Exposed so the always-run dispatch core
     ([Keeper_tool_execute_shell_ir.dispatch_classified]) can enforce the floor

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -11,19 +11,13 @@
     surface ([creates_durable_remote_surface]) — is risk-independent (G-4
     externality).
 
-    W2 scope: this is the policy SSOT. It is NOT yet consulted by the approval
-    floor — [Approval_policy.decide] still gates on the catastrophic floor and
-    the per-risk-band trust overlay only. W3 (G-7) wires [Requires_approval]
-    into the non-blocking HITL queue; until then this module is observability
-    and an executable specification of the target policy.
-
-    Ordering note (why [Requires_approval] does not fire for repo-create yet):
-    [disposition_of] reads [Shell_ir_risk.risk_of_gh_verb], and PR #23362 still
-    places repo-create/fork and the durable discussion mutations in the
-    irreversible table (R2), so they resolve to [Denied] here today. Moving them
-    to R1 (their true reversibility) is RFC-0309 W4/G-9 and must not land before
-    W3's approval wiring, or they would auto-run. The contract test pins both the
-    current dispositions and the W4 target. *)
+    W2/W3 scope: this is the policy SSOT for the gh capability axis.
+    [Approval_policy.decide] consults it after the catastrophic floor and before
+    the per-risk-band trust overlay. [Requires_approval] becomes [Verdict.Ask],
+    and the keeper runtime routes gh capability asks to the non-blocking HITL
+    queue. Reversible durable-remote mutations such as [gh repo create] and
+    [gh discussion create] therefore request approval instead of auto-running or
+    being disabled; irreversible operations remain [Denied]. *)
 
 type disposition =
   | Allowed

--- a/lib/exec/verdict.mli
+++ b/lib/exec/verdict.mli
@@ -49,12 +49,12 @@ type deny_reason =
           [sql_destructive] substring patterns (RFC
           eliminate-substring-destructive-classifier §3-A). *)
   | Destructive_repo_hosting_cli of Exec_program.t
-      (** An irreversible or policy-disabled repository-hosting CLI operation
-          (for example [gh pr merge], [gh repo create], [gh repo delete],
-          [gh discussion create], or [gh api -X DELETE]).  Part of the
+      (** An irreversible repository-hosting CLI operation (for example
+          [gh pr merge], [gh repo delete], or [gh api -X DELETE]). Part of the
           trust-independent catastrophic floor so autonomous keepers cannot
-          mutate remote repository state irreversibly or enter disabled GitHub
-          capability surfaces through the generic exec surface. *)
+          mutate remote repository state irreversibly through the generic exec
+          surface. Reversible durable-remote mutations such as [gh repo create]
+          are represented by [Ask] through the gh capability axis instead. *)
   | Catastrophic_program of Exec_program.t
       (** A binary that is never legitimate for a keeper regardless of its
           arguments (e.g. the filesystem-format binary, or system-power

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -327,6 +327,179 @@ let record_pr_action_metric ~keeper_name ~risk_class ~status ir =
       ())
 ;;
 
+let bool_label b = if b then "true" else "false"
+
+let gh_verb_label (verb : Masc_exec.Gh_verb.t) =
+  let family = Masc_exec.Gh_verb.string_of_family verb.family in
+  match verb.action with
+  | Some action -> family ^ ":" ^ action
+  | None -> family
+;;
+
+let gh_verb_of_simple (simple : Masc_exec.Shell_ir.simple) :
+    Masc_exec.Gh_verb.t option
+  =
+  match Masc_exec.Exec_program.known simple.bin with
+  | Some Masc_exec.Exec_program.Gh ->
+    (match Masc_exec.Shell_ir_typed.of_simple simple with
+     | Masc_exec.Shell_ir_typed.W
+         (Masc_exec.Shell_ir_typed_types.Gh { subcommand; action; _ }) ->
+       Some (Masc_exec.Gh_verb.of_fields ~subcommand ~action)
+     | Masc_exec.Shell_ir_typed.W _ ->
+       (match Masc_exec.Shell_ir_risk.literal_words_of_simple simple with
+        | Some words -> Some (Masc_exec.Gh_verb.classify words)
+        | None ->
+          let open Masc_exec.Gh_verb in
+          Some { family = Other "opaque"; action = None }))
+  | Some _ | None -> None
+;;
+
+let record_gh_classification_metric ~keeper_name ~risk_class ~typed_hit ir =
+  let risk_class = Masc_exec.Shell_ir_risk.string_of_risk_class risk_class in
+  let typed_hit = bool_label typed_hit in
+  let rec visit = function
+    | Masc_exec.Shell_ir.Simple simple ->
+      (match gh_verb_of_simple simple with
+       | None -> ()
+       | Some verb ->
+         let disposition =
+           match Masc_exec.Gh_capability_policy.disposition_of_simple simple with
+           | Some d -> Masc_exec.Gh_capability_policy.string_of_disposition d
+           | None -> "none"
+         in
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string GhClassificationTotal)
+           ~labels:
+             [ "keeper", keeper_name
+             ; "verb", gh_verb_label verb
+             ; "family", Masc_exec.Gh_verb.string_of_family verb.family
+             ; "action", (match verb.action with Some action -> action | None -> "")
+             ; "risk_class", risk_class
+             ; "typed_hit", typed_hit
+             ; "disposition", disposition
+             ]
+           ())
+    | Masc_exec.Shell_ir.Pipeline stages -> List.iter visit stages
+  in
+  visit ir
+;;
+
+let record_gated_gh_lifecycle ~keeper_name ~event ~risk_class ~typed_hit =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string GatedGhLifecycleTotal)
+    ~labels:
+      [ "keeper", keeper_name
+      ; "event", event
+      ; "risk_class", Masc_exec.Shell_ir_risk.string_of_risk_class risk_class
+      ; "typed_hit", bool_label typed_hit
+      ]
+    ()
+;;
+
+let record_gated_gh_block_time ~keeper_name ~risk_class ~typed_hit ~seconds =
+  Otel_metric_store.observe_histogram
+    Keeper_metrics.(to_string GatedGhBlockTimeSeconds)
+    ~labels:
+      [ "keeper", keeper_name
+      ; "risk_class", Masc_exec.Shell_ir_risk.string_of_risk_class risk_class
+      ; "typed_hit", bool_label typed_hit
+      ]
+    seconds
+;;
+
+let sandbox_target_label = function
+  | Masc_exec.Sandbox_target.Host -> "host"
+  | Masc_exec.Sandbox_target.Docker { image; _ } -> "docker:" ^ image
+;;
+
+let shell_ir_approval_input
+      ~cmd
+      ~cwd
+      ~bin
+      ~summary
+      ~sandbox_profile
+      ~sandbox_target
+      ~risk_class
+      ~typed_hit
+  =
+  `Assoc
+    [ "schema", `String "masc.shell_ir_approval_request.v1"
+    ; "op", `String "shell_ir_approval_required"
+    ; "action", `String "execute"
+    ; "kind", `String "gh_capability_requires_approval"
+    ; "cmd", `String cmd
+    ; "cwd", `String cwd
+    ; "bin", `String bin
+    ; "summary", `String summary
+    ; "sandbox_profile", `String sandbox_profile
+    ; "sandbox_target", `String sandbox_target
+    ; ( "risk_class"
+      , `String (Masc_exec.Shell_ir_risk.string_of_risk_class risk_class) )
+    ; "typed_hit", `Bool typed_hit
+    ]
+;;
+
+let submit_shell_ir_approval_pending
+      ~base_path
+      ~keeper_name
+      ?task_id
+      ?(goal_ids = [])
+      ~cmd
+      ~cwd
+      ~bin
+      ~summary
+      ~sandbox_profile
+      ~sandbox_target
+      ~risk_class
+      ~typed_hit
+      ()
+  =
+  let input =
+    shell_ir_approval_input
+      ~cmd
+      ~cwd
+      ~bin
+      ~summary
+      ~sandbox_profile
+      ~sandbox_target
+      ~risk_class
+      ~typed_hit
+  in
+  let on_resolution decision =
+    let event =
+      match decision with
+      | Agent_sdk.Hooks.Approve -> "approved"
+      | Agent_sdk.Hooks.Reject _ -> "denied"
+      | Agent_sdk.Hooks.Edit _ -> "edited"
+    in
+    record_gated_gh_lifecycle ~keeper_name ~event ~risk_class ~typed_hit;
+    Log.Keeper.info
+      "shell_ir approval resolved keeper=%s decision=%s cmd=%s"
+      keeper_name
+      (Keeper_approval_queue.approval_decision_to_string decision)
+      cmd
+  in
+  let approval_id =
+    Keeper_approval_queue.submit_pending
+      ~keeper_name
+      ~tool_name:"tool_execute"
+      ~input
+      ~risk_level:Keeper_approval_queue.High
+      ~base_path
+      ?task_id
+      ~goal_ids
+      ~sandbox_target
+      ~sandbox_profile
+      ~disposition:"requires_approval"
+      ~disposition_reason:summary
+      ~on_resolution
+      ()
+  in
+  record_gated_gh_lifecycle ~keeper_name ~event:"requested" ~risk_class ~typed_hit;
+  record_gated_gh_block_time ~keeper_name ~risk_class ~typed_hit ~seconds:0.0;
+  approval_id
+;;
+
 let execute_secret_redaction ~base_path ~keeper_name =
   Keeper_secret_redaction.snapshot ~base_path ~keeper_name
 
@@ -348,6 +521,9 @@ module For_testing = struct
   let repo_cwd_relative_rewrite = repo_cwd_relative_rewrite
   let typed_execute_response_cwd_json = typed_execute_response_cwd_json
   let record_pr_action_metric = record_pr_action_metric
+  let record_gh_classification_metric = record_gh_classification_metric
+  let shell_ir_approval_input = shell_ir_approval_input
+  let submit_shell_ir_approval_pending = submit_shell_ir_approval_pending
   let redact_execute_output ~base_path ~keeper_name ~stdout ~stderr =
     let redaction = execute_secret_redaction ~base_path ~keeper_name in
     redact_execute_output redaction ~stdout ~stderr
@@ -703,6 +879,13 @@ let handle_tool_execute_typed
                ())
         in
         let envelope = Keeper_tool_execute_shell_ir.classify ir in
+        let risk_class = Masc_exec.Shell_ir_risk.risk_class envelope in
+        let typed_hit = Masc_exec.Shell_ir_risk.typed_hit_of_ir ir in
+        record_gh_classification_metric
+          ~keeper_name:meta.name
+          ~risk_class
+          ~typed_hit
+          ir;
         let typed_error_json ?dispatch_error ?(extra_fields = []) msg =
           let deterministic_retry_fields =
             match dispatch_error with
@@ -888,15 +1071,56 @@ let handle_tool_execute_typed
               ~extra_fields:[ "blocked_cmd", `String cmd_for_log ]
               e
           | Error
-              (Keeper_tool_execute_shell_ir.Approval_required { summary; bin } as err)
+              (Keeper_tool_execute_shell_ir.Approval_required { summary; bin; kind } as err)
             ->
             Log.Keeper.warn
-              "shell_ir approval_required keeper=%s cmd=%s bin=%s summary=%s"
+              "shell_ir approval_required keeper=%s cmd=%s bin=%s kind=%s summary=%s"
               meta.name
               cmd_for_log
               bin
+              (Keeper_tool_execute_shell_ir.approval_required_kind_to_string kind)
               summary;
-            typed_error_json ~dispatch_error:err summary
+            (match kind with
+             | Keeper_tool_execute_shell_ir.Gh_capability_requires_approval ->
+               let sandbox_profile =
+                 Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile
+               in
+               let sandbox_target = sandbox_target_label dispatch_sandbox in
+               let approval_id =
+                 submit_shell_ir_approval_pending
+                   ~base_path:root
+                   ~keeper_name:meta.name
+                   ?task_id
+                   ~goal_ids:meta.active_goal_ids
+                   ~cmd:cmd_for_log
+                   ~cwd
+                   ~bin
+                   ~summary
+                   ~sandbox_profile
+                   ~sandbox_target
+                   ~risk_class
+                   ~typed_hit
+                   ()
+               in
+               typed_error_json
+                 ~dispatch_error:err
+                 ~extra_fields:
+                   [ "approval_request_id", `String approval_id
+                   ; "approval_queue_status", `String "pending"
+                   ; "approval_nonblocking", `Bool true
+                   ; "approval_required_kind", `String "gh_capability_requires_approval"
+                   ; "approval_block_time_ms", `Int 0
+                   ; "approval_disposition", `String "requires_approval"
+                   ]
+                 summary
+             | Keeper_tool_execute_shell_ir.Privileged_program_floor ->
+               typed_error_json
+                 ~dispatch_error:err
+                 ~extra_fields:
+                   [ "approval_nonblocking", `Bool false
+                   ; "approval_required_kind", `String "privileged_program_floor"
+                   ]
+                 summary)
           | Error (Keeper_tool_execute_shell_ir.Policy_denied { reason } as err) ->
             Log.Keeper.warn
               "shell_ir policy_denied keeper=%s cmd=%s reason=%s"
@@ -914,7 +1138,6 @@ let handle_tool_execute_typed
                of live traffic observable. An offline scan of typed_hit=true
                / total gives the real exercise rate of the typed model vs the
                Generic escape hatch. *)
-            let risk_class = Masc_exec.Shell_ir_risk.risk_class envelope in
             record_pr_action_metric
               ~keeper_name:meta.name
               ~risk_class

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -28,6 +28,37 @@ module For_testing : sig
     status:Unix.process_status ->
     Masc_exec.Shell_ir.t ->
     unit
+  val record_gh_classification_metric :
+    keeper_name:string ->
+    risk_class:Masc_exec.Shell_ir_risk.risk_class ->
+    typed_hit:bool ->
+    Masc_exec.Shell_ir.t ->
+    unit
+  val shell_ir_approval_input :
+    cmd:string ->
+    cwd:string ->
+    bin:string ->
+    summary:string ->
+    sandbox_profile:string ->
+    sandbox_target:string ->
+    risk_class:Masc_exec.Shell_ir_risk.risk_class ->
+    typed_hit:bool ->
+    Yojson.Safe.t
+  val submit_shell_ir_approval_pending :
+    base_path:string ->
+    keeper_name:string ->
+    ?task_id:string ->
+    ?goal_ids:string list ->
+    cmd:string ->
+    cwd:string ->
+    bin:string ->
+    summary:string ->
+    sandbox_profile:string ->
+    sandbox_target:string ->
+    risk_class:Masc_exec.Shell_ir_risk.risk_class ->
+    typed_hit:bool ->
+    unit ->
+    string
   val redact_execute_output :
     base_path:string ->
     keeper_name:string ->

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -246,6 +246,9 @@ type t =
   | AttemptWatchdogFired        (* counter: 1800s safety-cap watchdog killed a stuck attempt *)
   | ShellIrEffectTotal          (* counter: fine-grained Shell IR effect decomposition *)
   | ToolExecutePrActionTotal    (* counter: raw tool_execute gh PR actions *)
+  | GhClassificationTotal       (* counter: gh verb/risk/typed-hit classification coverage *)
+  | GatedGhLifecycleTotal       (* counter: non-blocking gated gh approval lifecycle events *)
+  | GatedGhBlockTimeSeconds     (* histogram: gated gh approval path turn-block time *)
   | KeeperRepoMappingDefaultScopeAllowed (* counter: missing mapping default-scope access allowed *)
   | KeeperRepoMappingDeniedUnregistered (* counter: repository policy denied an unregistered repo id *)
   | KeeperRepoMappingLoadError          (* counter: keeper repo mapping load/parse failure *)
@@ -520,6 +523,9 @@ let to_string = function
   | AttemptWatchdogFired -> "masc_keeper_attempt_watchdog_fired_total"
   | ShellIrEffectTotal -> "masc_keeper_shell_ir_effect_total"
   | ToolExecutePrActionTotal -> "masc_keeper_tool_execute_pr_action_total"
+  | GhClassificationTotal -> "masc_keeper_gh_classification_total"
+  | GatedGhLifecycleTotal -> "masc_keeper_gated_gh_lifecycle_total"
+  | GatedGhBlockTimeSeconds -> "masc_keeper_gated_gh_block_time_seconds"
   | KeeperRepoMappingDefaultScopeAllowed ->
     "masc_keeper_repo_mapping_default_scope_allowed_total"
   | KeeperRepoMappingDeniedUnregistered ->
@@ -598,6 +604,7 @@ let all : t list =
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; RuntimeHttpProbeJsonParseFailures;
     VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
     KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;
+    GhClassificationTotal; GatedGhLifecycleTotal; GatedGhBlockTimeSeconds;
   KeeperRepoMappingDefaultScopeAllowed; KeeperRepoMappingDeniedUnregistered;
   KeeperRepoMappingLoadError;
   KeeperRepoMappingRepositoryIdentityMismatch; KeeperRepoMappingRepositoryStoreError;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -236,6 +236,9 @@ type t =
   | AttemptWatchdogFired
   | ShellIrEffectTotal
   | ToolExecutePrActionTotal
+  | GhClassificationTotal
+  | GatedGhLifecycleTotal
+  | GatedGhBlockTimeSeconds
   | KeeperRepoMappingDefaultScopeAllowed
   | KeeperRepoMappingDeniedUnregistered
   | KeeperRepoMappingLoadError

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -127,6 +127,37 @@ let tool_execute_command_context ?(allow_pipes = true) command =
 
 (* TEL-OK: facade is pure gate/path/dispatch routing; the Execute handler emits
    Shell IR dispatch telemetry with keeper, sandbox, status, elapsed_ms. *)
+let last_simple_of_ir ir =
+  match ir with
+  | Masc_exec.Shell_ir.Simple s -> Some s
+  | Masc_exec.Shell_ir.Pipeline stages ->
+    (match List.rev stages with
+     | Masc_exec.Shell_ir.Simple s :: _ -> Some s
+     | _ -> None)
+;;
+
+let gh_capability_approval_required ir ~caps =
+  match last_simple_of_ir ir with
+  | None -> None
+  | Some simple ->
+    let raw_source = Format.asprintf "%a" Masc_exec.Shell_ir.pp ir in
+    let summary = "shell IR capability approval check" in
+    let policy_input = { Masc_exec.Approval_policy.raw_source; summary } in
+    (match
+       Masc_exec.Approval_policy.decide
+         policy_input
+         ~overlay:Masc_exec.Approval_config.autonomous
+         ~caps
+         ~simple
+     with
+     | Masc_exec.Verdict.Ask { bin; _ } ->
+       (match Masc_exec.Exec_program.known bin with
+        | Some Masc_exec.Exec_program.Gh -> Some bin
+        | Some _ | None -> None)
+     | Masc_exec.Verdict.Allow _ | Masc_exec.Verdict.Suggest_confirm (_, _)
+     | Masc_exec.Verdict.Deny _ -> None)
+;;
+
 let dispatch_classified
       ?(allow_pipes = true)
       ?(redirect_allowed = true)
@@ -153,42 +184,55 @@ let dispatch_classified
   | Some reason ->
     Error (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason })
   | None ->
-    (match first_privileged_program caps with
+    (match gh_capability_approval_required ir ~caps with
      | Some bin ->
        let bin = Masc_exec.Exec_program.to_string bin in
        Error
          (Approval_required
             { summary =
                 Printf.sprintf
-                  "privileged command '%s' requires explicit approval; no \
-                   Shell IR approval resolver is configured, so it is blocked"
+                  "command '%s' requires approval (audited/privileged risk class)"
                   bin
             ; bin
-            ; kind = Privileged_program_floor
+            ; kind = Gh_capability_requires_approval
             })
      | None ->
-       let gate_verdict =
-         Shell_gate.gate_typed
-           ~ir
-           ~syntax_policy:{ allow_pipes; redirect_allowed }
-           ~path_policy:Shell_gate.forbid_masc_internal_state_paths
-           ~sandbox:{ target = sandbox }
-           ()
-       in
-       gate_verdict_map
-         gate_verdict
-         ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
-         ~f_cannot_parse:(Error Cannot_parse)
-         ~f_too_complex:(Error Too_complex)
-         ~f_allow:(fun _context ->
-           match validate_paths ?keeper_id ?base_path ~workdir ir with
-           | Error e -> Error (Path_reject e)
-           | Ok () ->
-             Ok
-               (Masc_exec.Exec_dispatch.dispatch_decided
-                  ?base_host_env
-                  ?on_output_chunk
-                  envelope)))
+       (match first_privileged_program caps with
+        | Some bin ->
+          let bin = Masc_exec.Exec_program.to_string bin in
+          Error
+            (Approval_required
+               { summary =
+                   Printf.sprintf
+                     "privileged command '%s' requires explicit approval; no \
+                      Shell IR approval resolver is configured, so it is blocked"
+                     bin
+               ; bin
+               ; kind = Privileged_program_floor
+               })
+        | None ->
+          let gate_verdict =
+            Shell_gate.gate_typed
+              ~ir
+              ~syntax_policy:{ allow_pipes; redirect_allowed }
+              ~path_policy:Shell_gate.forbid_masc_internal_state_paths
+              ~sandbox:{ target = sandbox }
+              ()
+          in
+          gate_verdict_map
+            gate_verdict
+            ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
+            ~f_cannot_parse:(Error Cannot_parse)
+            ~f_too_complex:(Error Too_complex)
+            ~f_allow:(fun _context ->
+              match validate_paths ?keeper_id ?base_path ~workdir ir with
+              | Error e -> Error (Path_reject e)
+              | Ok () ->
+                Ok
+                  (Masc_exec.Exec_dispatch.dispatch_decided
+                     ?base_host_env
+                     ?on_output_chunk
+                     envelope))))
 ;;
 
 (* TEL-OK: wrapper only classifies before delegating to dispatch_classified. *)
@@ -213,19 +257,6 @@ let dispatch
     ?base_host_env
     ?on_output_chunk
     (classify ir)
-;;
-
-(** Extract the last simple stage from an IR for per-command approval policy.
-    For a [Simple] IR it is the command itself; for a pipeline it is the
-    final stage, whose risk class and binary usually drive the approval
-    decision. *)
-let last_simple_of_ir ir =
-  match ir with
-  | Masc_exec.Shell_ir.Simple s -> Some s
-  | Masc_exec.Shell_ir.Pipeline stages ->
-    (match List.rev stages with
-     | Masc_exec.Shell_ir.Simple s :: _ -> Some s
-     | _ -> None)
 ;;
 
 (** Same pipeline as [dispatch_classified], but runs the capability-based

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -65,12 +65,25 @@ let gate_verdict_map verdict ~f_allow ~f_reject ~f_cannot_parse ~f_too_complex =
   | Shell_gate.Too_complex _ -> f_too_complex
 ;;
 
+type approval_required_kind =
+  | Gh_capability_requires_approval
+  | Privileged_program_floor
+
+let approval_required_kind_to_string = function
+  | Gh_capability_requires_approval -> "gh_capability_requires_approval"
+  | Privileged_program_floor -> "privileged_program_floor"
+;;
+
 type dispatch_error =
   | Gate_reject of string
   | Cannot_parse
   | Too_complex
   | Path_reject of string
-  | Approval_required of { summary : string; bin : string }
+  | Approval_required of {
+      summary : string;
+      bin : string;
+      kind : approval_required_kind;
+    }
   | Policy_denied of { reason : string }
 
 let rec first_privileged_program = function
@@ -151,6 +164,7 @@ let dispatch_classified
                    Shell IR approval resolver is configured, so it is blocked"
                   bin
             ; bin
+            ; kind = Privileged_program_floor
             })
      | None ->
        let gate_verdict =
@@ -219,9 +233,10 @@ let last_simple_of_ir ir =
     (the approval decision is made first, then [dispatch_classified] applies
     [Shell_gate.gate_typed] followed by [validate_paths]).
     [Ask] and [Deny] are surfaced as typed errors so the keeper runtime
-    can log them and return a structured failure to the model.  Even when the
-    policy overlay allows, [dispatch_classified] still applies the privileged
-    fail-closed floor before dispatch. *)
+    can log them and either enqueue non-blocking HITL for gh capabilities or
+    return a structured failure to the model.  Even when the policy overlay
+    allows, [dispatch_classified] still applies the privileged fail-closed
+    floor before dispatch. *)
 let dispatch_classified_with_approval
       ?allow_pipes
       ?redirect_allowed
@@ -261,20 +276,22 @@ let dispatch_classified_with_approval
          ?base_host_env
          ?on_output_chunk
          envelope
-     | Ask _request ->
-       (* The policy wants explicit approval, but the keeper runtime has no
-          approval channel yet (RFC v5 HITL path is not wired), so this is a
-          block.  Report the binary and risk class so the failure is
-          actionable instead of an opaque "approval check" string. *)
-       let bin = Masc_exec.Exec_program.to_string simple.Masc_exec.Shell_ir.bin in
+     | Ask { bin = request_bin; _ } ->
+       let kind =
+         match Masc_exec.Exec_program.known request_bin with
+         | Some Masc_exec.Exec_program.Gh -> Gh_capability_requires_approval
+         | Some _ | None -> Privileged_program_floor
+       in
+       let bin = Masc_exec.Exec_program.to_string request_bin in
        Error
          (Approval_required
             { summary =
                 Printf.sprintf
                   "command '%s' requires approval (audited/privileged risk \
-                   class); no approval channel is configured, so it is blocked"
+                   class)"
                   bin
             ; bin
+            ; kind
             })
      | Deny { reason; caps = _ } ->
        Error

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -32,12 +32,22 @@ val simple_bin :
 val pipeline : Masc_exec.Shell_ir.t list -> Masc_exec.Shell_ir.t
 (** Build an explicit Shell IR pipeline from already-lowered stages. *)
 
+type approval_required_kind =
+  | Gh_capability_requires_approval
+  | Privileged_program_floor
+
+val approval_required_kind_to_string : approval_required_kind -> string
+
 type dispatch_error =
   | Gate_reject of string
   | Cannot_parse
   | Too_complex
   | Path_reject of string
-  | Approval_required of { summary : string; bin : string }
+  | Approval_required of {
+      summary : string;
+      bin : string;
+      kind : approval_required_kind;
+    }
   | Policy_denied of { reason : string }
 
 val validate_paths :
@@ -94,9 +104,11 @@ val dispatch_classified_with_approval :
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
 (** Same pipeline as {!dispatch_classified}, but runs the capability-based
     approval policy gate {i before} the typed gate and path validation.
-    [Ask] produces [Approval_required] carrying the blocked binary (the
-    summary notes the audited/privileged risk class); [Deny] produces
-    [Policy_denied] carrying the rendered typed [Verdict.deny_reason].
+    [Ask] produces [Approval_required] carrying the blocked binary and a typed
+    [approval_required_kind], so the keeper runtime can route gh capability
+    approval to non-blocking HITL without reopening the privileged-program
+    floor. [Deny] produces [Policy_denied] carrying the rendered typed
+    [Verdict.deny_reason].
     [Allow] and [Suggest_confirm] proceed to {!dispatch_classified}, which
     still applies the privileged fail-closed floor before process dispatch.
     A nested pipeline whose last stage is itself a pipeline yields

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -84,10 +84,9 @@ val dispatch_classified :
     typed gate -> path validation -> dispatch_decided. [redirect_allowed]
     defaults to [true] for the historical tool execute path; legacy code-shell
     callers pass [false].  Catastrophic operations are policy-denied, and
-    privileged programs are [Approval_required] until a Shell IR approval
-    resolver is wired; this also applies to the approval-gate kill-switch path.
-    [?on_output_chunk] is forwarded to the host dispatch path for live output
-    streaming. *)
+    typed gh capability asks and privileged programs are [Approval_required];
+    both also apply to the approval-gate kill-switch path. [?on_output_chunk] is
+    forwarded to the host dispatch path for live output streaming. *)
 
 val dispatch_classified_with_approval :
   ?allow_pipes:bool ->

--- a/lib/otel_metric_store.ml
+++ b/lib/otel_metric_store.ml
@@ -113,6 +113,8 @@ let init () =
     [ 0.001; 0.005; 0.01; 0.025; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0 ];
   reg "masc_keeper_turn_phase_duration_seconds"
     [ 0.1; 0.5; 1.0; 5.0; 10.0; 30.0; 60.0; 120.0; 300.0; 600.0 ];
+  reg "masc_keeper_gated_gh_block_time_seconds"
+    [ 0.0; 0.001; 0.005; 0.01; 0.05; 0.1; 0.5; 1.0; 5.0 ];
   reg "masc_workspace_broadcast_duration_seconds"
     [ 0.001; 0.005; 0.01; 0.05; 0.1; 0.5; 1.0; 5.0; 10.0 ];
   reg "masc_file_lock_acquire_seconds"

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-01T11:41:13Z (HEAD: 6d33177e062)
+Generated: 2026-07-07T05:10:27Z (HEAD: db58d82025)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 93 |
-| Manual specs | 93 |
+| Total .tla files | 94 |
+| Manual specs | 94 |
 | TTrace (auto-generated) | 0 |
 | Directories | 18 |
-| Total .cfg files | 192 |
-| Buggy .cfg (bug-model pair) | 98 |
+| Total .cfg files | 194 |
+| Buggy .cfg (bug-model pair) | 99 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -62,7 +62,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | ToolCallContract.tla | ToolCallContract | manual | 2 | 1 | clean={inv:Safety} buggy={inv:NeverDropSilently} | a33a3185f14e |
 | TurnEvidenceChain.tla | TurnEvidenceChain | manual | 2 | 1 | clean={inv:TypeOK, inv:TerminalHasFullEvidence, inv:TerminalVisibleInRuntimeLens, inv:OasBoundaryGeneric} buggy={inv:TerminalHasFullEvidence} | 0790cfbf9572 |
 
-### specs/bug-models (23 specs)
+### specs/bug-models (24 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -89,6 +89,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | SSEBroadcastBlock.tla | SSEBroadcastBlock | manual | 2 | 1 | clean={inv:TypeOK, inv:NoPermanentBlock} buggy={inv:TypeOK, inv:NoPermanentBlock} | baa8b016ef40 |
 | ShellIRApprovalFloor.tla | ShellIRApprovalFloor | manual | 2 | 1 | clean={inv:TypeOK, inv:CatastrophicNeverAllowed} buggy={inv:TypeOK, inv:CatastrophicNeverAllowed} | 29efda8572e5 |
 | SlotScheduler.tla | SlotScheduler | manual | 2 | 1 | clean={inv:TypeOK, inv:MutualExclusion, inv:NeverStuck} buggy={inv:TypeOK, inv:NeverStuck} | 5d3029adffa6 |
+| TypedGhCapabilityGating.tla | TypedGhCapabilityGating | manual | 2 | 1 | clean={inv:TypeOK, inv:CatastrophicNeverAllowed, inv:NonBlockingApproval, inv:UnknownGhVerbNeverAutoRun} buggy={inv:TypeOK, inv:CatastrophicNeverAllowed, inv:NonBlockingApproval, inv:UnknownGhVerbNeverAutoRun} | 8a0213f27794 |
 
 ### specs/checkpoint-trim (1 specs)
 

--- a/specs/bug-models/TypedGhCapabilityGating-buggy.cfg
+++ b/specs/bug-models/TypedGhCapabilityGating-buggy.cfg
@@ -1,0 +1,7 @@
+CONSTANTS Mode = "buggy"
+SPECIFICATION Spec
+INVARIANT TypeOK
+INVARIANT CatastrophicNeverAllowed
+INVARIANT NonBlockingApproval
+INVARIANT UnknownGhVerbNeverAutoRun
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/TypedGhCapabilityGating.cfg
+++ b/specs/bug-models/TypedGhCapabilityGating.cfg
@@ -1,0 +1,7 @@
+CONSTANTS Mode = "clean"
+SPECIFICATION Spec
+INVARIANT TypeOK
+INVARIANT CatastrophicNeverAllowed
+INVARIANT NonBlockingApproval
+INVARIANT UnknownGhVerbNeverAutoRun
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/TypedGhCapabilityGating.tla
+++ b/specs/bug-models/TypedGhCapabilityGating.tla
@@ -1,0 +1,78 @@
+---- MODULE TypedGhCapabilityGating ----
+EXTENDS TLC
+
+CONSTANTS Mode
+
+Commands ==
+  { "gh_repo_create"
+  , "gh_discussion_create"
+  , "gh_repo_delete"
+  , "gh_pr_merge"
+  , "gh_unknown"
+  , "gh_pr_view"
+  }
+
+Catastrophic == { "gh_repo_delete", "gh_pr_merge" }
+RequiresApproval == { "gh_repo_create", "gh_discussion_create", "gh_unknown" }
+
+VARIABLES cmd, verdict, pending, turnBlocked, phase
+vars == <<cmd, verdict, pending, turnBlocked, phase>>
+
+Init ==
+  /\ cmd \in Commands
+  /\ verdict = "none"
+  /\ pending = FALSE
+  /\ turnBlocked = FALSE
+  /\ phase = "init"
+
+CleanDecision(c) ==
+  IF c \in Catastrophic THEN
+    [rv |-> "deny", rp |-> FALSE, rb |-> FALSE]
+  ELSE IF c \in RequiresApproval THEN
+    [rv |-> "ask", rp |-> TRUE, rb |-> FALSE]
+  ELSE
+    [rv |-> "allow", rp |-> FALSE, rb |-> FALSE]
+
+BuggyDecision(c) ==
+  IF c = "gh_pr_merge" THEN
+    [rv |-> "allow", rp |-> FALSE, rb |-> FALSE]
+  ELSE IF c = "gh_unknown" THEN
+    [rv |-> "allow", rp |-> FALSE, rb |-> FALSE]
+  ELSE IF c \in RequiresApproval THEN
+    [rv |-> "ask", rp |-> TRUE, rb |-> TRUE]
+  ELSE IF c \in Catastrophic THEN
+    [rv |-> "deny", rp |-> FALSE, rb |-> FALSE]
+  ELSE
+    [rv |-> "allow", rp |-> FALSE, rb |-> FALSE]
+
+Decision(c) == IF Mode = "clean" THEN CleanDecision(c) ELSE BuggyDecision(c)
+
+Decide ==
+  /\ phase = "init"
+  /\ LET d == Decision(cmd) IN
+     /\ verdict' = d.rv
+     /\ pending' = d.rp
+     /\ turnBlocked' = d.rb
+  /\ phase' = "decided"
+  /\ UNCHANGED cmd
+
+Next == Decide
+Spec == Init /\ [][Next]_vars
+
+TypeOK ==
+  /\ cmd \in Commands
+  /\ verdict \in {"none", "allow", "ask", "deny"}
+  /\ pending \in BOOLEAN
+  /\ turnBlocked \in BOOLEAN
+  /\ phase \in {"init", "decided"}
+
+CatastrophicNeverAllowed ==
+  (phase = "decided" /\ cmd \in Catastrophic) => verdict # "allow"
+
+NonBlockingApproval ==
+  (phase = "decided" /\ verdict = "ask") => (pending /\ turnBlocked = FALSE)
+
+UnknownGhVerbNeverAutoRun ==
+  (phase = "decided" /\ cmd = "gh_unknown") => verdict # "allow"
+
+====

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1004,7 +1004,9 @@ let () =
   (* rm is Privileged; permissive_default sets privileged_trust = Enforced,
      so the policy yields Verdict.Ask -> Approval_required deterministically.
      A flip to Policy_denied (e.g. risk-class regression) must fail the test. *)
-  | Error (Keeper_tool_execute_shell_ir.Approval_required _) -> ()
+  | Error
+      (Keeper_tool_execute_shell_ir.Approval_required
+         { kind = Keeper_tool_execute_shell_ir.Privileged_program_floor; _ }) -> ()
   | Error _ -> assert false
 
 let () =
@@ -1035,8 +1037,9 @@ let () =
   with
   | Ok _ -> assert false
   | Error
-      (Keeper_tool_execute_shell_ir.Approval_required { summary = _; bin }) ->
-    assert (String.equal bin "chmod")
+      (Keeper_tool_execute_shell_ir.Approval_required { summary = _; bin; kind }) ->
+    assert (String.equal bin "chmod");
+    assert (kind = Keeper_tool_execute_shell_ir.Privileged_program_floor)
   | Error _ -> assert false
 
 (* --- Keeper_tool_execute_shell_ir.dispatch_classified: catastrophic floor is

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1042,6 +1042,45 @@ let () =
     assert (kind = Keeper_tool_execute_shell_ir.Privileged_program_floor)
   | Error _ -> assert false
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "gh" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args =
+        [ Lit ("repo", default_meta)
+        ; Lit ("create", default_meta)
+        ; Lit ("masc-test/new-repo", default_meta)
+        ; Lit ("--public", default_meta)
+        ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify
+      (Masc_exec.Shell_ir_risk.undecided (Masc_exec.Shell_ir.Simple ir))
+  in
+  (* The bare [dispatch_classified] path is the
+     [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off route in
+     keeper_tool_execute_runtime.ml. Durable-remote gh mutations must still ask
+     for non-blocking HITL there, not execute. *)
+  match
+    Keeper_tool_execute_shell_ir.dispatch_classified
+      ~workdir:"/tmp"
+      ~sandbox:(Masc_exec.Sandbox_target.host ())
+      envelope
+  with
+  | Ok _ -> assert false
+  | Error
+      (Keeper_tool_execute_shell_ir.Approval_required { summary = _; bin; kind }) ->
+    assert (String.equal bin "gh");
+    assert (kind = Keeper_tool_execute_shell_ir.Gh_capability_requires_approval)
+  | Error _ -> assert false
+
 (* --- Keeper_tool_execute_shell_ir.dispatch_classified: catastrophic floor is
    flag-independent (RFC-0254 §5.3.1) --- *)
 

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -76,6 +76,23 @@ let cleanup_dir dir =
   try rm_rf dir with _ -> ()
 ;;
 
+let submit_test_gh_approval_pending ~base_path () =
+  Execute_runtime.submit_shell_ir_approval_pending
+    ~base_path
+    ~keeper_name:"typed-gh-keeper"
+    ~task_id:"task-typed-gh"
+    ~goal_ids:[ "goal-typed-gh" ]
+    ~cmd:"gh repo create owner/new-repo --public"
+    ~cwd:"/tmp/masc"
+    ~bin:"gh"
+    ~summary:"command 'gh' requires approval (audited/privileged risk class)"
+    ~sandbox_profile:"host"
+    ~sandbox_target:"host"
+    ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    ~typed_hit:true
+    ()
+;;
+
 let test_command_shape_blocked () =
   let raw =
     Yojson.Safe.to_string
@@ -294,22 +311,7 @@ let test_gh_approval_pending_helper_enqueues_nonblocking () =
            ~labels:block_time_labels
            ()
        in
-       let id =
-         Execute_runtime.submit_shell_ir_approval_pending
-           ~base_path
-           ~keeper_name:"typed-gh-keeper"
-           ~task_id:"task-typed-gh"
-           ~goal_ids:[ "goal-typed-gh" ]
-           ~cmd:"gh repo create owner/new-repo --public"
-           ~cwd:"/tmp/masc"
-           ~bin:"gh"
-           ~summary:"command 'gh' requires approval (audited/privileged risk class)"
-           ~sandbox_profile:"host"
-           ~sandbox_target:"host"
-           ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
-           ~typed_hit:true
-           ()
-       in
+       let id = submit_test_gh_approval_pending ~base_path () in
        approval_id := Some id;
        Alcotest.(check bool) "approval id nonempty" true (String.length id > 0);
        Alcotest.(check int) "pending count increments" (before + 1) (AQ.pending_count ());
@@ -350,6 +352,57 @@ let test_gh_approval_pending_helper_enqueues_nonblocking () =
               (block_time_metric ^ "_count")
               ~labels:block_time_labels
               ()))
+;;
+
+let resolve_or_fail ~id decision =
+  match AQ.resolve ~id ~decision with
+  | Ok () -> ()
+  | Error err ->
+    Alcotest.failf "approval resolve failed: %s" (AQ.resolve_error_to_string err)
+;;
+
+let test_gh_approval_resolution_does_not_install_retry_grant () =
+  let base_path = temp_dir () in
+  let approval_ids = ref [] in
+  let remember id =
+    approval_ids := id :: !approval_ids;
+    id
+  in
+  let forget id =
+    approval_ids := List.filter (fun pending_id -> not (String.equal pending_id id)) !approval_ids
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun id ->
+           ignore (AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")))
+        !approval_ids;
+      cleanup_dir base_path)
+    (fun () ->
+       let before = AQ.pending_count () in
+       let first_id = remember (submit_test_gh_approval_pending ~base_path ()) in
+       Alcotest.(check int)
+         "first request pending"
+         (before + 1)
+         (AQ.pending_count ());
+       resolve_or_fail ~id:first_id Agent_sdk.Hooks.Approve;
+       forget first_id;
+       Alcotest.(check int)
+         "approval removed from pending queue"
+         before
+         (AQ.pending_count ());
+       let second_id = remember (submit_test_gh_approval_pending ~base_path ()) in
+       Alcotest.(check bool)
+         "retry creates a fresh pending approval"
+         true
+         (String.length second_id > 0 && not (String.equal first_id second_id));
+       Alcotest.(check int)
+         "retry re-enqueues instead of consuming grant"
+         (before + 1)
+         (AQ.pending_count ());
+       resolve_or_fail ~id:second_id (Agent_sdk.Hooks.Reject "test cleanup");
+       forget second_id;
+       Alcotest.(check int) "cleanup restores pending count" before (AQ.pending_count ()))
 ;;
 
 let test_plain_error_codes_are_observed_only () =
@@ -740,6 +793,10 @@ let () =
             "gh_capability_requires_approval_enqueues_pending_without_wait"
             `Quick
             test_gh_approval_pending_helper_enqueues_nonblocking
+        ; Alcotest.test_case
+            "gh_capability_resolution_does_not_install_retry_grant"
+            `Quick
+            test_gh_approval_resolution_does_not_install_retry_grant
         ] )
     ; ( "telemetry_key_invariants"
       , [ Alcotest.test_case "key_format" `Quick test_telemetry_key_format

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -12,6 +12,8 @@
 module D = Masc.Keeper_tool_deterministic_error
 module Execute_runtime = Masc.Keeper_tool_execute_runtime.For_testing
 module Shell_dispatch = Keeper_tool_execute_shell_ir
+module AQ = Masc.Keeper_approval_queue
+module Metrics = Masc.Otel_metric_store
 
 let reason_testable =
   let pp ppf reason = Format.pp_print_string ppf (D.to_telemetry_key reason) in
@@ -55,6 +57,23 @@ let dispatch_error_marker_raw error =
     (`Assoc
        ([ "ok", `Bool false; "error", `String "execute_dispatch_rejected" ]
         @ Execute_runtime.dispatch_error_deterministic_retry_fields error))
+;;
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_shell_ir_approval_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.is_directory path then begin
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
 ;;
 
 let test_command_shape_blocked () =
@@ -218,10 +237,119 @@ let test_dispatch_policy_rejects_mark_policy_blocked () =
         (dispatch_error_marker_raw error))
     [ ( "dispatch approval_required marker"
       , Shell_dispatch.Approval_required
-          { summary = "approval required"; bin = "gh" } )
+          { summary = "approval required"
+          ; bin = "gh"
+          ; kind = Shell_dispatch.Gh_capability_requires_approval
+          } )
     ; ( "dispatch policy_denied marker"
       , Shell_dispatch.Policy_denied { reason = "policy denied" } )
     ]
+;;
+
+let string_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> s
+  | other ->
+    Alcotest.failf
+      "expected string field %s, got %s"
+      name
+      (Yojson.Safe.to_string other)
+;;
+
+let bool_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `Bool b -> b
+  | other ->
+    Alcotest.failf
+      "expected bool field %s, got %s"
+      name
+      (Yojson.Safe.to_string other)
+;;
+
+let test_gh_approval_pending_helper_enqueues_nonblocking () =
+  let base_path = temp_dir () in
+  let approval_id = ref None in
+  Fun.protect
+    ~finally:(fun () ->
+      (match !approval_id with
+       | Some id ->
+         ignore (AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup"))
+       | None -> ());
+      cleanup_dir base_path)
+    (fun () ->
+       let before = AQ.pending_count () in
+       let block_time_metric = Keeper_metrics.(to_string GatedGhBlockTimeSeconds) in
+       let block_time_labels =
+         [ "keeper", "typed-gh-keeper"
+         ; "risk_class", "R1"
+         ; "typed_hit", "true"
+         ]
+       in
+       let before_block_sum =
+         Metrics.metric_value_or_zero block_time_metric ~labels:block_time_labels ()
+       in
+       let before_block_count =
+         Metrics.metric_value_or_zero
+           (block_time_metric ^ "_count")
+           ~labels:block_time_labels
+           ()
+       in
+       let id =
+         Execute_runtime.submit_shell_ir_approval_pending
+           ~base_path
+           ~keeper_name:"typed-gh-keeper"
+           ~task_id:"task-typed-gh"
+           ~goal_ids:[ "goal-typed-gh" ]
+           ~cmd:"gh repo create owner/new-repo --public"
+           ~cwd:"/tmp/masc"
+           ~bin:"gh"
+           ~summary:"command 'gh' requires approval (audited/privileged risk class)"
+           ~sandbox_profile:"host"
+           ~sandbox_target:"host"
+           ~risk_class:Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+           ~typed_hit:true
+           ()
+       in
+       approval_id := Some id;
+       Alcotest.(check bool) "approval id nonempty" true (String.length id > 0);
+       Alcotest.(check int) "pending count increments" (before + 1) (AQ.pending_count ());
+       match AQ.get_pending_entry ~id with
+       | None -> Alcotest.fail "pending entry missing"
+       | Some entry ->
+         Alcotest.(check string) "keeper" "typed-gh-keeper" entry.keeper_name;
+         Alcotest.(check string) "tool" "tool_execute" entry.tool_name;
+         Alcotest.(check string)
+           "disposition"
+           "requires_approval"
+           (Option.value entry.disposition ~default:"");
+         Alcotest.(check string)
+           "task_id"
+           "task-typed-gh"
+           (Option.value entry.task_id ~default:"");
+         Alcotest.(check (list string))
+           "goal_ids"
+           [ "goal-typed-gh" ]
+           entry.goal_ids;
+         Alcotest.(check string)
+           "kind"
+           "gh_capability_requires_approval"
+           (string_member "kind" entry.input);
+         Alcotest.(check bool) "typed_hit" true (bool_member "typed_hit" entry.input);
+         Alcotest.(check string)
+           "risk_class"
+           "R1"
+           (string_member "risk_class" entry.input);
+         Alcotest.(check (float 0.0001))
+           "block time sum stays zero"
+           before_block_sum
+           (Metrics.metric_value_or_zero block_time_metric ~labels:block_time_labels ());
+         Alcotest.(check (float 0.0001))
+           "block time observation recorded"
+           (before_block_count +. 1.0)
+           (Metrics.metric_value_or_zero
+              (block_time_metric ^ "_count")
+              ~labels:block_time_labels
+              ()))
 ;;
 
 let test_plain_error_codes_are_observed_only () =
@@ -606,6 +734,12 @@ let () =
             "unknown_error_code"
             `Quick
             test_unknown_error_code_returns_none
+        ] )
+    ; ( "shell_ir_approval_queue"
+      , [ Alcotest.test_case
+            "gh_capability_requires_approval_enqueues_pending_without_wait"
+            `Quick
+            test_gh_approval_pending_helper_enqueues_nonblocking
         ] )
     ; ( "telemetry_key_invariants"
       , [ Alcotest.test_case "key_format" `Quick test_telemetry_key_format


### PR DESCRIPTION
## Summary
- route `gh` capability `Ask` verdicts into the existing non-blocking HITL approval queue instead of treating them as a blocking disabled path
- add gh classification/lifecycle/block-time metrics and approval payload metadata for dashboard/OTel visibility
- update keeper prompts/docs and supersede the old repo-create/discussions disable decision
- add a TLA bug model for catastrophic-deny, non-blocking approval, and unknown-gh fail-closed invariants

## Validation
- `ocamlformat --check lib/exec/approval_policy.mli lib/exec/verdict.mli lib/exec/gh_capability_policy.mli lib/keeper_tooling/keeper_tool_execute_shell_ir.ml lib/keeper_tooling/keeper_tool_execute_shell_ir.mli lib/keeper/keeper_tool_execute_runtime.ml lib/keeper/keeper_tool_execute_runtime.mli lib/keeper_metrics/keeper_metrics.ml lib/keeper_metrics/keeper_metrics.mli lib/otel_metric_store.ml test/test_exec_dispatch.ml test/test_keeper_tool_execute_retry_deterministic_close.ml`
- `git diff --check`
- `java ... tlc2.TLC -config specs/bug-models/TypedGhCapabilityGating.cfg ...`
- `java ... tlc2.TLC -config specs/bug-models/TypedGhCapabilityGating-buggy.cfg ...` (expected invariant violation)
- `scripts/tla-bug-model-ratchet.sh`

## Local build note
- `MASC_SKIP_OCAML_VERSION_CHECK=1 scripts/dune-local.sh build test/test_keeper_tool_execute_retry_deterministic_close.exe` currently stops before this change set at `lib/runtime/runtime_schema.mli`: local `Llm_provider.Capabilities.thinking_control_format` exposes nullary `Chat_template_token` while the checked-out source expects `Chat_template_token of string`.
