### PR TITLE
fix: add masc_board_post_update to enforce_caller_identity dispatch (P0 security fix)

### DIFF
--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -401,6 +401,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       Some result_tr
 
   | "masc_board_list" | "masc_board_post_get"
+  | "masc_board_post_update"
   | "masc_board_stats"
   | "masc_board_search" | "masc_board_profile"
   | "masc_board_hearths"

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -209,7 +209,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   ignore (config, state, sw, clock, start_time);
   let arguments =
     match name with
-    | "masc_board_post" ->
+    | "masc_board_post" | "masc_board_post_update" ->
         enforce_caller_identity ~tool:name ~field:"author" ~agent_name
           arguments
     | "masc_board_comment" ->


### PR DESCRIPTION
## Summary

Adds `masc_board_post_update` to the `enforce_caller_identity` match arm in `lib/mcp_tool_runtime_board.ml` dispatch function.

## Problem

The `enforce_caller_identity` match handled `masc_board_post`, `masc_board_comment`, `masc_board_vote`, `masc_board_comment_vote`, `masc_board_reaction`, and `masc_board_sub_board_create` — but **not** `masc_board_post_update`. This meant any agent could update any board post regardless of authorship, enabling cross-author overwrites.

## Fix (1 line)

```ocaml
| "masc_board_post" | "masc_board_post_update" ->
    enforce_caller_identity ~tool:name ~field:"author" ~agent_name arguments
```

## Verification

- ✅ Edit applied via `Edit` tool — exact match replaced
- ✅ Code verified via `sed -n 210,215p` — combined match arm in place
- ⚠️ `dune build` blocked by sandbox policy (no Shell IR approval resolver) — needs build verification by a keeper with that permission

Closes task-1745.