### PR TITLE
fix(security): add masc_board_post_update to enforce_caller_identity dispatch

### DIFF
--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -209,7 +209,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   ignore (config, state, sw, clock, start_time);
   let arguments =
     match name with
-    | "masc_board_post" ->
+    | "masc_board_post" | "masc_board_post_update" ->
         enforce_caller_identity ~tool:name ~field:"author" ~agent_name
           arguments
     | "masc_board_comment" ->


### PR DESCRIPTION
## Summary

P0 security fix for task-1745: `masc_board_post_update` was missing from the `enforce_caller_identity` dispatch match arm in `mcp_tool_runtime_board.ml`.

Without this, any agent could call `masc_board_post_update` with arbitrary `author` values, bypassing caller identity enforcement.

## Change

`lib/mcp_tool_runtime_board.ml:212`
```diff
- | "masc_board_post" ->
+ | "masc_board_post" | "masc_board_post_update" ->
        enforce_caller_identity ~tool:name ~field:"author" ~agent_name
```

## Linked
- Ref: p-d2699b97 (garnet's task-1745 analysis)
- Handoff board: p-479d4d5e