### PR TITLE
fix(keeper): stop scanning typed transient Overloaded for hard-quota indicators

### DIFF
--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -324,7 +324,16 @@ let api_error_message_for_quota_scan (api_err : Llm_provider.Retry.api_error)
   | Llm_provider.Retry.RateLimited { message; _ } -> Some message
   | Llm_provider.Retry.PaymentRequired { message } -> Some message
   | Llm_provider.Retry.NetworkError { message; _ } -> Some message
-  | Llm_provider.Retry.Overloaded { message } -> Some message
+  (* Overloaded is the typed transient 529/CapacityExhausted signal; OAS
+     [Retry.is_hard_quota (Overloaded _) = false] and [is_retryable = true]. Do
+     NOT scan its message for hard-quota indicators: a transient 529 whose prose
+     coincidentally contains an indicator (e.g. "exhausted your capacity on this
+     model") would be reclassified permanent -> immediate pool-wide 1h
+     Cooldown_hard_quota, stealing it from the transient bucket. Every genuine
+     permanent quota routes to PaymentRequired/RateLimited (caught by the typed
+     [is_hard_quota] tried first), never Overloaded. Full retire of the substring
+     scan is deferred to RFC (typed SDK-boundary parse). *)
+  | Llm_provider.Retry.Overloaded _ -> None
   | Llm_provider.Retry.ServerError { message; _ } -> Some message
   | Llm_provider.Retry.InvalidRequest { message; _ } -> Some message
   | Llm_provider.Retry.AuthError _
@@ -344,7 +353,10 @@ let cli_wrapped_hard_quota_indicators = [
   "org's monthly usage limit";
   "session usage limit";
   "add extra usage";
-  "resets apr ";
+  (* NB: no month-literal indicators — a "resets apr " string matched only April
+     and was a silent dead branch the other 11 months. The month-agnostic
+     "you've hit your limit" / "monthly usage limit" indicators carry the real
+     signal; absolute reset-time parsing is deferred to the typed-root RFC. *)
   "reached your specified api usage limits";
   "you will regain access on";
 ]

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -309,6 +309,38 @@ let test_payment_required_is_hard_quota () =
   | None -> Alcotest.fail "expected hard_quota recoverable reason"
 ;;
 
+(* Regression: a transient Overloaded (529/CapacityExhausted) whose prose
+   coincidentally contains a hard-quota indicator must NOT be classified as hard
+   quota. The typed variant already says transient; the message scan previously
+   overrode it to permanent (immediate pool-wide 1h cooldown). Fails PRE-fix
+   (true), passes POST-fix (false). *)
+let test_overloaded_with_quota_prose_is_not_hard_quota () =
+  let message =
+    "You have exhausted your capacity on this model. Your quota will reset after \
+     4h41m7s. reason=QUOTA_EXHAUSTED"
+  in
+  let err = SdkE.Api (Retry.Overloaded { message }) in
+  Alcotest.(check bool)
+    "transient overload with quota prose is not hard quota"
+    false
+    (KTD.sdk_error_is_hard_quota err)
+;;
+
+(* Deleting the month-hardcoded "resets apr " indicator loses no coverage: the
+   real signal is carried by the month-agnostic "you've hit your limit" /
+   "monthly usage limit" indicators. This also fixes the 11-months-of-the-year
+   false negative the April literal caused. *)
+let test_hit_your_limit_is_month_agnostic_hard_quota () =
+  List.iter
+    (fun month_variant ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s is hard quota (month-agnostic)" month_variant)
+         true
+         (KTD.message_looks_like_cli_wrapped_hard_quota
+            (Printf.sprintf "You've hit your limit \194\183 %s" month_variant)))
+    [ "resets Apr 24 at 4am"; "resets May 3 at 4am"; "resets Dec 31 at 4am" ]
+;;
+
 let test_soft_rate_limit_classifies_as_rate_limit () =
   let api_err =
     SdkE.Api
@@ -888,6 +920,14 @@ let () =
             "payment required is classified as hard quota"
             `Quick
             test_payment_required_is_hard_quota
+        ; Alcotest.test_case
+            "transient overload with quota prose is not hard quota"
+            `Quick
+            test_overloaded_with_quota_prose_is_not_hard_quota
+        ; Alcotest.test_case
+            "hit-your-limit hard quota is month-agnostic"
+            `Quick
+            test_hit_your_limit_is_month_agnostic_hard_quota
         ; Alcotest.test_case
             "soft rate limits skip same credential-pool candidates"
             `Quick


### PR DESCRIPTION
## What

`sdk_error_is_hard_quota`가 typed `Llm_provider.Retry.is_hard_quota`를 먼저 시도하고, 실패 시 에러 메시지 substring 스캔으로 fallback합니다. `api_error_message_for_quota_scan`가 **typed `Overloaded`(transient 529/CapacityExhausted)** 의 메시지를 그 스캔에 넘겨서, "exhausted your capacity on this model" 같은 문구를 우연히 담은 transient 529가 **permanent hard_quota로 오분류**됐습니다.

- `record_hard_quota` → **전 credential pool에 즉시 1시간 cooldown** (3-threshold 우회).
- 529는 보통 pool-wide → 전 candidate lane 동시 cooldown → aggregate deterministic → crash 카운트 → 3연속 keeper **auto-pause**, 10에 fiber crash.
- **초 단위 회복할 blip이 1시간 pool 블랙아웃 + 키퍼 정지로 증폭**.

## Fix (subtractive — classifier surface 축소)

1. `api_error_message_for_quota_scan`의 `Overloaded` arm을 `Some message` → `None`. OAS가 Overloaded를 만장일치 transient로 타입핑(`is_hard_quota (Overloaded _)=false`, `is_retryable=true`; HTTP 529/"overloaded_error"/CapacityExhausted에서만 생성). 진짜 permanent 쿼터는 전부 PaymentRequired(402)/RateLimited(429)로 가고 typed `is_hard_quota`(먼저 호출)가 잡음 → **false-negative 0**.
2. 월-하드코딩 `"resets apr "` 삭제 — 4월만 매칭, 나머지 11개월은 silent dead branch. month-agnostic `"you've hit your limit"`/`"monthly usage limit"`가 실 신호 담당.

`#23438`(capacity_backpressure_indicators 제거)과 같은 궤적: **typed variant를 string override보다 우선**.

## Self-review (Best Programmer)
- **목표**: transient overload가 permanent hard_quota cooldown을 유발하던 오분류 제거.
- **검증**: `test_keeper_sdk_error_typed_bridge` 23 tests green — transient Overloaded+quota prose→false(핵심), RateLimited/PaymentRequired hard-quota→true 유지(무회귀), "you've hit your limit"가 Apr/May/Dec 매칭(April 삭제 무손실). keeper+bin build green, STR/DET gate PASS, ocamlformat clean, RFC gate PASS.
- **Self-critique**: `Overloaded _ -> None`은 exhaustive match 유지(wildcard 추가 아님). false-negative 유일 실현 조건 = "어떤 프로바이더가 permanent hard-quota를 오직 typed Overloaded로만(402/429/api_error_status 신호 없이) 전달" — 알려진 프로바이더 중 없음(OAS 생성 사이트 전부 transient). residual = 미지의 미래 프로바이더 → typed-root RFC 소관.
- **남은 미검증**: CI Build and Test pending. 근본(typed-root)은 별도 RFC.

## Deferred to RFC (typed-root)

SDK 경계에서 `api_error_status`/`error.type` 파싱 → typed 라우팅, `QuotaExhausted { kind; reset_at }` 타입 + rolling-window vs billing-hard cooldown 분리, classifier 전체 제거, pool-wide blast-radius 정책. masc↔oas 경계 + credential-pool cooldown이라 surgical PR 범위 초과. → 이슈로 분리.

RFC-WAIVED: net subtractive classifier 정리 + 버그 fix, credential_*/keeper_gh_*/host_config_* 파일 무변경. typed-root retire는 후속 RFC.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
