### PR TITLE
fix(work): align backlog language with sample aside

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -289,7 +289,7 @@ describe('Work', () => {
       expect(screen.getByTestId('kpi-backlog').textContent).toBe('2')
       // Five KPI summary cells
       expect(screen.getByTestId('work-kpis').children.length).toBe(5)
-      expect(screen.getByText(/미배정 task는 claim/).textContent).toContain('claim')
+      expect(screen.getByText(/미배정 task는 백로그에서 claim/).textContent).toContain('claim')
       expect(screen.getByTestId('work-goal-list')).toBeTruthy()
     })
 
@@ -307,6 +307,7 @@ describe('Work', () => {
       const kpis = screen.getByTestId('work-kpis')
       expect(kpis.textContent).toContain('활성 목표')
       expect(kpis.textContent).toContain('전체 작업')
+      expect(kpis.textContent).toContain('백로그')
       expect(kpis.textContent).not.toContain('목표 TASK')
       expect(kpis.textContent).not.toContain('Task')
       expect(kpis.textContent).not.toContain('TASK')
@@ -448,7 +449,7 @@ describe('Work', () => {
 
       const backlog = screen.getByTestId('work-backlog')
       expect(backlog).toBeTruthy()
-      expect(backlog.textContent).toContain('미배정 Task')
+      expect(backlog.textContent).toContain('클레임 가능 백로그')
       expect(backlog.textContent).toContain('2')
       expect(backlog.querySelectorAll('.wk-task-claim').length).toBe(2)
       expect(screen.getByText('Orphan job')).toBeTruthy()
@@ -724,6 +725,7 @@ describe('Work', () => {
         render(html`<${Work} />`)
 
         const aside = screen.getByTestId('work-aside')
+        expect(aside.querySelector('.wka-hud')?.textContent).toContain('백로그')
         // "지금 상황" calm state
         expect(aside.querySelector('[data-testid="wka-flagged-calm"]')?.textContent).toContain('주의 목표 없음')
         // "해야 할 일" calm state
@@ -791,6 +793,7 @@ describe('Work', () => {
         const aside = screen.getByTestId('work-aside')
         const approvalItems = aside.querySelectorAll('[data-testid="wka-approval-item"]')
         expect(approvalItems.length).toBe(1)
+        expect(approvalItems[0]?.classList.contains('approve')).toBe(true)
         expect(approvalItems[0]?.textContent).toContain('Approval Goal')
         expect(approvalItems[0]?.textContent).toContain('lead-keeper')
       })
@@ -817,6 +820,7 @@ describe('Work', () => {
         const aside = screen.getByTestId('work-aside')
         const verifyItems = aside.querySelectorAll('[data-testid="wka-verify-item"]')
         expect(verifyItems.length).toBe(1)
+        expect(verifyItems[0]?.classList.contains('verify')).toBe(true)
         expect(verifyItems[0]?.textContent).toContain('Verify Me')
         // 1 unsatisfied gate (done=blocked, inspect=ready → 1 open)
         expect(verifyItems[0]?.textContent).toContain('1 미충족')
@@ -841,6 +845,7 @@ describe('Work', () => {
         const aside = screen.getByTestId('work-aside')
         const blockerItems = aside.querySelectorAll('[data-testid="wka-blocker-item"]')
         expect(blockerItems.length).toBe(1)
+        expect(blockerItems[0]?.classList.contains('block')).toBe(true)
         expect(blockerItems[0]?.textContent).toContain('Blocked Task')
         expect(blockerItems[0]?.textContent).toContain('dependency unavailable')
       })
@@ -860,6 +865,7 @@ describe('Work', () => {
         const aside = screen.getByTestId('work-aside')
         const backlogItem = aside.querySelector('[data-testid="wka-backlog-item"]')
         expect(backlogItem).toBeTruthy()
+        expect(backlogItem?.classList.contains('claim')).toBe(true)
         expect(backlogItem?.textContent).toContain('미배정 task 2건')
       })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -939,7 +939,7 @@ function WorkAside({
           <span class=${`wka-hud-v ${counts.verify ? 'volt' : ''}`}>${counts.verify}</span>
         </div>
         <div class="wka-hud-c">
-          <span class="wka-hud-k">미배정</span>
+          <span class="wka-hud-k">백로그</span>
           <span class=${`wka-hud-v ${counts.backlog ? 'warn' : ''}`}>${counts.backlog}</span>
         </div>
         <div class="wka-hud-c">
@@ -1392,7 +1392,7 @@ function WorkSurfaceV2() {
               <div class=${`wk-kpi-v ${totals.verify > 0 ? 'volt' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
             </div>
             <div class="wk-kpi">
-              <div class="wk-kpi-k">미배정</div>
+              <div class="wk-kpi-k">백로그</div>
               <div class=${`wk-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
             </div>
           </section>
@@ -1401,7 +1401,7 @@ function WorkSurfaceV2() {
             <section class="wk-backlog" data-testid="work-backlog">
               <div class="wk-backlog-h">
                 <span class="wk-backlog-glyph" aria-hidden="true">⊕</span>
-                미배정 Task
+                클레임 가능 백로그
                 <span class="n">${backlogTasks.length}</span>
                 <span class="wk-backlog-sub mono">keeper_task_claim — 미배정 task</span>
               </div>
@@ -1448,7 +1448,7 @@ function WorkSurfaceV2() {
               />
             `}
 
-          <div class="wk-foot mono">목표 지표 · 작업 상태 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 claim</div>
+          <div class="wk-foot mono">목표 지표 · 작업 상태 흐름 · keeper 배정 · done은 gate 증거 후 완료 · 미배정 task는 백로그에서 claim</div>
       </div>
       ${goalCreateOpen ? html`<${GoalCreateForm} />` : html`
         <${WorkAside}

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1083,11 +1083,31 @@
   gap: 3px 9px;
   padding: 8px 11px;
   border: 1px solid var(--color-border-subtle);
+  border-left-width: 2px;
   border-radius: var(--radius-sm, 4px);
   background: var(--color-bg-surface);
   cursor: pointer;
   transition: border-color 0.16s ease, background 0.16s ease;
   width: 100%;
+}
+
+.wka-todo.approve {
+  border-left-color: var(--color-volt-strong, var(--color-accent));
+  background: color-mix(in oklab, var(--color-volt-wash, var(--color-accent-soft)) 18%, var(--color-bg-surface));
+}
+
+.wka-todo.verify {
+  border-left-color: var(--color-status-info, var(--color-info));
+}
+
+.wka-todo.block {
+  border-left-color: var(--color-status-bad);
+  background: color-mix(in oklab, var(--color-status-bad) 7%, var(--color-bg-surface));
+}
+
+.wka-todo.claim {
+  border-left-color: var(--color-status-warn);
+  background: color-mix(in oklab, var(--color-status-warn) 6%, var(--color-bg-surface));
 }
 
 .wka-todo:hover,


### PR DESCRIPTION
## Summary
- align Work KPI/aside/backlog copy with the v2 sample
- rename unassigned board language to backlog where the UI represents claimable backlog
- add type rails/tints for WorkAside todo cards so approval/verify/block/claim items scan separately

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/work.test.ts
- bash scripts/lint/no-raw-font-size-px.sh
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- Playwright capture against /Users/dancer/Downloads/v2 (29): desktop/mobile no overlay or page errors

Follow-up to #23480; #23480 was already merged before this sample-polish diff was pushed.