### PR TITLE
feat(keeper): RFC-0313 W1 — pure pacing module + observe-only shadow

### DIFF
--- a/lib/keeper/keeper_pacing.ml
+++ b/lib/keeper/keeper_pacing.ml
@@ -1,0 +1,63 @@
+(* RFC-0313 W1 — pure per-runtime revisit pacing. See keeper_pacing.mli. *)
+
+type policy =
+  { base_sec : float
+  ; multiplier : float
+  ; cap_sec : float
+  }
+
+let default_policy = { base_sec = 30.0; multiplier = 2.0; cap_sec = 3600.0 }
+
+type revisit =
+  { eligible_at : float
+  ; consecutive : int
+  }
+
+(* Sorted-by-key unique assoc list; catalogs are small (tens of
+   runtimes), so linear operations dominate any tree structure. *)
+type t = (string * revisit) list
+
+let empty = []
+
+let by_key (a, _) (b, _) = String.compare a b
+
+let computed_delay ~policy ~consecutive =
+  let raw =
+    policy.base_sec *. (policy.multiplier ** float_of_int (consecutive - 1))
+  in
+  Float.min policy.cap_sec raw
+
+let on_failure ~policy ~runtime_id ~retry_after ~now t =
+  let consecutive =
+    match List.assoc_opt runtime_id t with
+    | Some r -> r.consecutive + 1
+    | None -> 1
+  in
+  let delay =
+    match retry_after with
+    | Some ra -> Float.min policy.cap_sec (Float.max 0.0 ra)
+    | None -> computed_delay ~policy ~consecutive
+  in
+  let entry = { eligible_at = now +. delay; consecutive } in
+  List.sort by_key ((runtime_id, entry) :: List.remove_assoc runtime_id t)
+
+let on_success ~runtime_id t = List.remove_assoc runtime_id t
+
+let revisit_of ~runtime_id t = List.assoc_opt runtime_id t
+
+let next_turn_due ~catalog ~now t =
+  match catalog with
+  | [] -> now
+  | _ ->
+    List.fold_left
+      (fun acc runtime_id ->
+         let due =
+           match List.assoc_opt runtime_id t with
+           | None -> now
+           | Some r -> Float.max now r.eligible_at
+         in
+         Float.min acc due)
+      infinity
+      catalog
+
+let to_summary t = t

--- a/lib/keeper/keeper_pacing.mli
+++ b/lib/keeper/keeper_pacing.mli
@@ -1,0 +1,69 @@
+(** RFC-0313 W1 — pure per-runtime revisit pacing.
+
+    A turn failure may change WHEN a runtime is next tried (the revisit
+    deadline) and WHERE the next turn runs (whichever runtime is due
+    first), never WHETHER the keeper exists. This module is the pure
+    state for the "when": an immutable per-runtime map of revisit
+    deadlines. It has no dependencies beyond the stdlib and performs no
+    I/O; the shadow store ([Keeper_pacing_shadow]) owns process state
+    and telemetry.
+
+    Verified shape: specs/keeper-state-machine/KeeperPacing.tla —
+    [on_failure] maps to [TurnFailure] (widening bounded by
+    [policy.cap_sec], the [PacingBounded] invariant), [on_success] to
+    [TurnSuccess], [next_turn_due] to the min-eligible scheduling rule
+    (a keeper always has a finite next turn). *)
+
+type policy =
+  { base_sec : float (** first revisit delay after a failure *)
+  ; multiplier : float (** widening factor per consecutive failure *)
+  ; cap_sec : float (** hard bound: no revisit exceeds now + cap_sec *)
+  }
+
+val default_policy : policy
+(** base 30s, x2 per consecutive failure, cap 3600s. Single named
+    site for the shadow phase; RFC-0313 W3 moves the policy to
+    config/runtime.toml [pacing] when pacing becomes enforcing. With
+    these values the 2026-07-06 storm fixture window (300s) admits at
+    most ~7 attempts per runtime vs the 1,002 recorded
+    (test/fixtures/pacing_storm_20260706/). *)
+
+type revisit =
+  { eligible_at : float (** unix seconds; runtime may be tried at/after this *)
+  ; consecutive : int
+    (** consecutive failures on this runtime since its last success.
+        Observability only — never compared against a threshold. *)
+  }
+
+type t
+(** Pacing state for one keeper. Immutable. A runtime with no entry is
+    eligible immediately. *)
+
+val empty : t
+
+val on_failure
+  :  policy:policy
+  -> runtime_id:string
+  -> retry_after:float option
+  -> now:float
+  -> t
+  -> t
+(** Widen [runtime_id]'s revisit: delay = min(cap_sec,
+    base_sec * multiplier^(consecutive-1)); a provider-supplied
+    [retry_after] (clamped to [0, cap_sec]) replaces the computed
+    delay. Never touches other runtimes. *)
+
+val on_success : runtime_id:string -> t -> t
+(** Clear [runtime_id]'s revisit (eligible immediately, consecutive
+    reset). Other runtimes keep their deadlines. *)
+
+val revisit_of : runtime_id:string -> t -> revisit option
+
+val next_turn_due : catalog:string list -> now:float -> t -> float
+(** Earliest time any runtime in [catalog] is eligible: [now] when some
+    runtime has no entry or an expired deadline, otherwise the minimum
+    [eligible_at]. An empty [catalog] yields [now] — the keeper always
+    has a next turn. *)
+
+val to_summary : t -> (string * revisit) list
+(** Observability projection, sorted by runtime id. *)

--- a/lib/keeper/keeper_pacing_shadow.ml
+++ b/lib/keeper/keeper_pacing_shadow.ml
@@ -1,0 +1,57 @@
+(* RFC-0313 W1 — observe-only pacing shadow. See keeper_pacing_shadow.mli. *)
+
+let mu = Eio.Mutex.create ()
+let table : (string, Keeper_pacing.t) Hashtbl.t = Hashtbl.create 64
+
+let catalog_runtime_ids () =
+  match Runtime.get_runtime_ids () with
+  | [] -> []
+  | ids -> ids
+
+let emit_telemetry ~keeper_name ~runtime_id ~kind ~state ~now =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string PacingShadowEvents)
+    ~labels:[ "keeper", keeper_name; "runtime", runtime_id; "kind", kind ]
+    ();
+  match catalog_runtime_ids () with
+  | [] -> ()
+  | catalog ->
+    let due = Keeper_pacing.next_turn_due ~catalog ~now state in
+    Otel_metric_store.set_gauge
+      Keeper_metrics.(to_string PacingShadowNextDueSec)
+      ~labels:[ "keeper", keeper_name ]
+      (Float.max 0.0 (due -. now))
+
+let update ~keeper_name ~runtime_id ~kind f =
+  let now = Time_compat.now () in
+  let state =
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+      let prev =
+        match Hashtbl.find_opt table keeper_name with
+        | Some state -> state
+        | None -> Keeper_pacing.empty
+      in
+      let next = f ~now prev in
+      Hashtbl.replace table keeper_name next;
+      next)
+  in
+  emit_telemetry ~keeper_name ~runtime_id ~kind ~state ~now
+
+let observe_failure ~keeper_name ~runtime_id ~retry_after =
+  update ~keeper_name ~runtime_id ~kind:"failure" (fun ~now state ->
+    Keeper_pacing.on_failure
+      ~policy:Keeper_pacing.default_policy
+      ~runtime_id
+      ~retry_after
+      ~now
+      state)
+
+let observe_success ~keeper_name ~runtime_id =
+  update ~keeper_name ~runtime_id ~kind:"success" (fun ~now:_ state ->
+    Keeper_pacing.on_success ~runtime_id state)
+
+let snapshot ~keeper_name =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    match Hashtbl.find_opt table keeper_name with
+    | Some state -> Keeper_pacing.to_summary state
+    | None -> [])

--- a/lib/keeper/keeper_pacing_shadow.mli
+++ b/lib/keeper/keeper_pacing_shadow.mli
@@ -1,0 +1,32 @@
+(** RFC-0313 W1 — observe-only pacing shadow.
+
+    Computes what [Keeper_pacing] WOULD schedule for each keeper and
+    emits telemetry; changes no behavior. Consumers flip to reading
+    this state in RFC-0313 W3, after the storm-replay harness pins the
+    schedule against test/fixtures/pacing_storm_20260706/.
+
+    Telemetry per observation:
+    - counter [Keeper_metrics.PacingShadowEvents]
+      labels keeper / runtime / kind (failure | success)
+    - gauge [Keeper_metrics.PacingShadowNextDueSec]
+      labels keeper — seconds until the keeper's next turn would be due
+      under pacing (0 when some runtime is eligible now), computed over
+      the live runtime catalog.
+
+    [retry_after] is the provider hint when the caller has one in hand;
+    W1 call sites pass [None] (the hint is threaded through routing in
+    RFC-0313 W2). *)
+
+val observe_failure
+  :  keeper_name:string
+  -> runtime_id:string
+  -> retry_after:float option
+  -> unit
+
+val observe_success : keeper_name:string -> runtime_id:string -> unit
+
+val snapshot : keeper_name:string -> (string * Keeper_pacing.revisit) list
+(** Current shadow schedule for one keeper, sorted by runtime id.
+    Empty when nothing has been observed. State is keyed by keeper
+    name, so tests isolate by using distinct names — no reset surface
+    is exposed. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -916,6 +916,13 @@ dominant source of the observed CAS race exhaustion after
                       (String.concat ", " committed_tools)
                       turn_event_summary.event_count
                       (String.concat ", " turn_event_summary.payload_kinds));
+                  (* RFC-0313 W1 shadow: record what pacing would schedule.
+                     Placed before the escalate call, which may raise
+                     [Keeper_fiber_crash] and must not skip the observation. *)
+                  Keeper_pacing_shadow.observe_failure
+                    ~keeper_name:meta.name
+                    ~runtime_id:final_execution.runtime_id
+                    ~retry_after:None;
                   Keeper_unified_turn_failure.record_failure_and_maybe_escalate
                     ~config
                     ~meta
@@ -945,6 +952,11 @@ dominant source of the observed CAS race exhaustion after
                        ~keeper_name:meta.name
                        trajectory_acc
                        Trajectory.Completed;
+                  (* RFC-0313 W1 shadow: a success clears this runtime's
+                     shadow revisit. *)
+                  Keeper_pacing_shadow.observe_success
+                    ~keeper_name:meta.name
+                    ~runtime_id:final_execution.runtime_id;
                   (* SSOT: success-path terminal FSM transitions
                      (Streaming -> Completing -> Done) are emitted once inside
                      [Keeper_unified_turn_success.handle]. Do not duplicate them

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -19,6 +19,8 @@ type t =
   | TotalCostUsd
   | TurnScheduled
   | TurnCompleted
+  | PacingShadowEvents
+  | PacingShadowNextDueSec
   | IdleSeconds
   | ContractViolations
   | MetricEmitDropped
@@ -275,6 +277,8 @@ let to_string = function
   | TotalCostUsd -> "masc_keeper_total_cost_usd"
   | TurnScheduled -> "masc_keeper_turn_scheduled_total"
   | TurnCompleted -> "masc_keeper_turn_completed_total"
+  | PacingShadowEvents -> "masc_keeper_pacing_shadow_events_total"
+  | PacingShadowNextDueSec -> "masc_keeper_pacing_shadow_next_due_sec"
   | IdleSeconds -> "masc_keeper_idle_seconds"
   | ContractViolations -> "masc_keeper_contract_violations_total"
   | MetricEmitDropped -> "masc_keeper_metric_emit_dropped_total"
@@ -550,7 +554,7 @@ let to_string = function
 let all : t list =
   [ Turns; InputTokens; OutputTokens; CacheCreationTokens;
     CacheReadTokens; UsageAnomalies; TotalCostUsd; TurnScheduled;
-    TurnCompleted; IdleSeconds; ContractViolations; MetricEmitDropped;
+    TurnCompleted; PacingShadowEvents; PacingShadowNextDueSec; IdleSeconds; ContractViolations; MetricEmitDropped;
     ContextMaxObserved; TurnStarts; TurnReattempts; TurnRegressions;
     TurnLivelockBlocks; TurnLivelockBlocksRepeated; TurnLivelockBlocksThresholdPark; TurnLatencyBucket;
     TurnLatencyByModelBucket; ProviderCooldownSkip; ProviderCooldownRemainingSec; ProviderBlockDurationSec;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -10,6 +10,8 @@ type t =
   | TotalCostUsd
   | TurnScheduled
   | TurnCompleted
+  | PacingShadowEvents
+  | PacingShadowNextDueSec
   | IdleSeconds
   | ContractViolations
   | MetricEmitDropped

--- a/test/dune
+++ b/test/dune
@@ -234,6 +234,7 @@
   test_workspace_telemetry_drop_non_eio
   test_keeper_contract_classifier_pure
   test_keeper_compact_policy_pure
+  test_keeper_pacing
   test_heartbeat_smart
   test_keeper_allowed_paths
   test_playground_repo_readiness
@@ -584,6 +585,7 @@
   test_workspace_telemetry_drop_non_eio
   test_keeper_contract_classifier_pure
   test_keeper_compact_policy_pure
+  test_keeper_pacing
   test_heartbeat_smart
   test_keeper_allowed_paths
   test_playground_repo_readiness

--- a/test/test_keeper_pacing.ml
+++ b/test/test_keeper_pacing.ml
@@ -1,0 +1,101 @@
+(** Pure-function unit tests for [Keeper_pacing] (RFC-0313 W1).
+
+    Pins the schedule semantics the TLA+ spec
+    (specs/keeper-state-machine/KeeperPacing.tla) verifies in the
+    abstract: failure widens one runtime's revisit (bounded by the
+    policy cap), success clears it, and a keeper always has a finite
+    next-turn due time. *)
+
+open Masc
+module KP = Keeper_pacing
+
+let policy = KP.default_policy
+let feq = Alcotest.(check (float 1e-6))
+
+let revisit_exn t runtime_id =
+  match KP.revisit_of ~runtime_id t with
+  | Some r -> r
+  | None -> Alcotest.failf "expected revisit entry for %s" runtime_id
+
+let test_failure_widens_exponentially () =
+  let t = KP.empty in
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:100.0 t in
+  feq "first failure: base delay" 130.0 (revisit_exn t "a").eligible_at;
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:130.0 t in
+  feq "second failure: doubled" 190.0 (revisit_exn t "a").eligible_at;
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:190.0 t in
+  feq "third failure: doubled again" 310.0 (revisit_exn t "a").eligible_at;
+  Alcotest.(check int) "consecutive tracked" 3 (revisit_exn t "a").consecutive
+
+let test_delay_never_exceeds_cap () =
+  let t =
+    List.fold_left
+      (fun t now -> KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now t)
+      KP.empty
+      [ 0.0; 1.0; 2.0; 3.0; 4.0; 5.0; 6.0; 7.0; 8.0; 9.0; 10.0 ]
+  in
+  let r = revisit_exn t "a" in
+  Alcotest.(check bool)
+    "eligible_at bounded by now + cap"
+    true
+    (r.eligible_at <= 10.0 +. policy.cap_sec)
+
+let test_retry_after_wins_and_is_clamped () =
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:(Some 300.0) ~now:0.0 KP.empty in
+  feq "provider hint replaces computed delay" 300.0 (revisit_exn t "a").eligible_at;
+  let t = KP.on_failure ~policy ~runtime_id:"b" ~retry_after:(Some 999999.0) ~now:0.0 KP.empty in
+  feq "hint clamped to cap" policy.cap_sec (revisit_exn t "b").eligible_at;
+  let t = KP.on_failure ~policy ~runtime_id:"c" ~retry_after:(Some (-5.0)) ~now:0.0 KP.empty in
+  feq "negative hint clamped to zero" 0.0 (revisit_exn t "c").eligible_at
+
+let test_failure_touches_only_that_runtime () =
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:0.0 KP.empty in
+  Alcotest.(check bool) "other runtime has no entry" true (KP.revisit_of ~runtime_id:"b" t = None)
+
+let test_success_clears_runtime () =
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:0.0 KP.empty in
+  let t = KP.on_failure ~policy ~runtime_id:"b" ~retry_after:None ~now:0.0 t in
+  let t = KP.on_success ~runtime_id:"a" t in
+  Alcotest.(check bool) "cleared runtime eligible now" true (KP.revisit_of ~runtime_id:"a" t = None);
+  Alcotest.(check bool) "other runtime keeps its revisit" true (KP.revisit_of ~runtime_id:"b" t <> None)
+
+let test_next_turn_due_prefers_eligible_runtime () =
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:None ~now:0.0 KP.empty in
+  feq "unpaced catalog runtime is due now" 5.0 (KP.next_turn_due ~catalog:[ "a"; "b" ] ~now:5.0 t)
+
+let test_next_turn_due_min_when_all_paced () =
+  let t = KP.on_failure ~policy ~runtime_id:"a" ~retry_after:(Some 100.0) ~now:0.0 KP.empty in
+  let t = KP.on_failure ~policy ~runtime_id:"b" ~retry_after:(Some 40.0) ~now:0.0 t in
+  feq "min eligible_at wins" 40.0 (KP.next_turn_due ~catalog:[ "a"; "b" ] ~now:5.0 t);
+  feq "expired deadline is due now" 45.0 (KP.next_turn_due ~catalog:[ "a"; "b" ] ~now:45.0 t)
+
+let test_next_turn_due_always_finite () =
+  feq "empty catalog is due now" 7.0 (KP.next_turn_due ~catalog:[] ~now:7.0 KP.empty);
+  feq "empty state is due now" 7.0 (KP.next_turn_due ~catalog:[ "a" ] ~now:7.0 KP.empty)
+
+let test_shadow_snapshot_isolated_by_keeper () =
+  let keeper_name = "test-keeper-pacing-shadow-isolated" in
+  Alcotest.(check int)
+    "unknown keeper snapshot is empty"
+    0
+    (List.length (Keeper_pacing_shadow.snapshot ~keeper_name))
+
+let () =
+  Alcotest.run
+    "keeper_pacing"
+    [ ( "on_failure"
+      , [ Alcotest.test_case "widens exponentially" `Quick test_failure_widens_exponentially
+        ; Alcotest.test_case "delay capped" `Quick test_delay_never_exceeds_cap
+        ; Alcotest.test_case "retry_after wins, clamped" `Quick test_retry_after_wins_and_is_clamped
+        ; Alcotest.test_case "touches only that runtime" `Quick test_failure_touches_only_that_runtime
+        ] )
+    ; ( "on_success"
+      , [ Alcotest.test_case "clears runtime" `Quick test_success_clears_runtime ] )
+    ; ( "next_turn_due"
+      , [ Alcotest.test_case "prefers eligible runtime" `Quick test_next_turn_due_prefers_eligible_runtime
+        ; Alcotest.test_case "min when all paced" `Quick test_next_turn_due_min_when_all_paced
+        ; Alcotest.test_case "always finite" `Quick test_next_turn_due_always_finite
+        ] )
+    ; ( "shadow"
+      , [ Alcotest.test_case "snapshot isolated by keeper" `Quick test_shadow_snapshot_isolated_by_keeper ] )
+    ]


### PR DESCRIPTION
## 목적

RFC-0313 (Keeper Existence Invariance, #23481) **W1**: 순수 pacing 모듈 + observe-only shadow. 실패가 존재(pause/dead)가 아니라 "다음 방문 시각"만 바꾸는 스케줄을 계산해 텔레메트리로만 노출합니다. **행동 변화 0** — 소비자 flip은 W3(스톰 replay 하네스 통과 후).

## 변경

- `lib/keeper/keeper_pacing.{ml,mli}` — 불변 per-runtime revisit 맵 (stdlib-only, 순수). `on_failure`: base 30s ×2, cap 3600s, provider `retry_after`가 계산값을 대체(0..cap 클램프). `on_success`: 해당 runtime 엔트리 제거. `next_turn_due`: 카탈로그 min-eligible — keeper는 정의상 항상 유한한 다음 턴을 가짐. 형태는 `specs/keeper-state-machine/KeeperPacing.tla`(#23481 W0, 로컬 TLC clean 810 states/buggy 2종 violated)와 일치.
- `lib/keeper/keeper_pacing_shadow.{ml,mli}` — Eio.Mutex 보호 프로세스 상태 + 텔레메트리: counter `masc_keeper_pacing_shadow_events_total`(keeper/runtime/kind), gauge `masc_keeper_pacing_shadow_next_due_sec`(keeper). test backdoor 없음(테스트는 keeper 이름 격리).
- `lib/keeper/keeper_unified_turn.ml` — 배선 2곳: 실패(escalate 호출 **전** — `Keeper_fiber_crash` raise로 관측이 스킵되지 않도록), 성공. 둘 다 `final_execution.runtime_id` 스코프 내.
- `lib/keeper_metrics/` — enum 4사이트(type/.mli/to_string/all)에 constructor 2개 추가. 외부 exhaustive match 소비자 없음 확인(`to_string` 경유만).
- `test/test_keeper_pacing.ml` — widening(30→60→120)/cap/retry_after 클램프(음수 포함)/성공 리셋/min-due/빈 카탈로그 유한성 9케이스.

## 정책 상수에 대해

`default_policy`(30s/×2/3600s)는 shadow 단계의 단일 명명 사이트입니다. W3(enforce 전환) 때 `config/runtime.toml [pacing]`으로 이동 — RFC-0313 §Migration에 명시된 순서이며, 이 값으로 07-06 스톰 fixture 창(300s)은 runtime당 최대 ~7회 시도로 바운드됩니다(실측 1,002회 대비).

## 검증

- 순수 모듈: 독립 ocamlc 타입체크 + 시맨틱 스모크(widening 30/60/120, cap 클램프, min-due, success 리셋 — 전부 기대값 일치).
- retry_after는 W1 호출부에서 `None`(provider 힌트 배선은 W2 라우팅에서). mli에 명시.
- dune 빌드/테스트는 CI에서 확인.

RFC-0313 (#23481) W1. 상세 설계와 마이그레이션 웨이브는 RFC 본문 참조.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
