### PR TITLE
feat(exec): require repo-create contract before HITL

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -153,6 +153,9 @@ Choosing a capability family:
   auto-run surfaces. When the exact visible task requires one of these GitHub
   artifacts, use typed `Execute` with `gh` only to create a non-blocking HITL
   approval request; do not retry the same command while approval is pending.
+  For `gh repo create`, provide an explicit `OWNER/NAME` target plus exactly one
+  visibility flag (`--public`, `--private`, or `--internal`); missing or ambient
+  ownership/visibility is denied before HITL.
   Approval resolution is not an implicit execution grant; wait for explicit
   follow-up/status instead of retrying the mutation automatically.
   Repo delete, PR merge, and irreversible discussion deletion remain denied.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -127,6 +127,9 @@ Choose the smallest surface that matches the live signal.
   task explicitly needs the GitHub artifact; reversible repo/discussion
   mutations route to a non-blocking HITL approval request, while repo delete,
   PR merge, and irreversible discussion deletion remain denied.
+  For `gh repo create`, use explicit `OWNER/NAME` plus exactly one visibility
+  flag (`--public`, `--private`, or `--internal`); missing contract metadata is
+  denied before HITL.
   Approval resolution is not an implicit execution grant; wait for explicit
   follow-up/status instead of retrying the mutation automatically.
 - Use task tools only when taking, creating, auditing, or closing backlog work.

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -163,7 +163,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |
 | 테스트 실행 | `Execute` with typed argv from the worktree `cwd` |
 | GitHub PR / 이슈 작업 | `Execute` with `executable="gh"` and typed `argv` from a bound repo context for PR reads and reversible PR mutations such as `pr create` / `pr edit`. |
-| GitHub repo 생성 / GitHub Discussions mutation | `Execute` with typed `gh` argv can request reversible repo/discussion mutations through non-blocking HITL approval (`Requires_approval`). Repo delete, PR merge, and irreversible discussion deletion stay denied by the Shell IR floor. Prefer MASC board tools for workspace-local durable discussion unless the requested artifact explicitly belongs on GitHub. |
+| GitHub repo 생성 / GitHub Discussions mutation | `Execute` with typed `gh` argv can request reversible repo/discussion mutations through non-blocking HITL approval (`Requires_approval`). `gh repo create` requires explicit `OWNER/NAME` plus exactly one visibility flag before HITL. Repo delete, PR merge, and irreversible discussion deletion stay denied by the Shell IR floor. Prefer MASC board tools for workspace-local durable discussion unless the requested artifact explicitly belongs on GitHub. |
 
 The goal lifecycle surface is descriptor/registry-driven with denylist
 filtering. Social and messaging keepers should keep board/task workspace

--- a/docs/design/keeper-github-repo-create-discussion-policy.md
+++ b/docs/design/keeper-github-repo-create-discussion-policy.md
@@ -68,7 +68,11 @@ approval queue was wired into the Shell IR approval verdict:
 
 The current Shell IR path separates risk from capability policy:
 
-- `gh repo create|fork|edit|sync|rename ...` -> `Requires_approval`
+- `gh repo create OWNER/NAME --public|--private|--internal ...` with a
+  literal target and exactly one visibility flag -> `Requires_approval`; missing
+  owner, missing/ambiguous visibility, or opaque repo target -> `Deny` before
+  HITL.
+- `gh repo fork|edit|sync|rename ...` -> `Requires_approval`
 - `gh discussion create|comment|edit|close|reopen|lock|unlock|answer|unanswer ...`
   -> `Requires_approval`
 - `gh api graphql` bodies containing durable repository/discussion create or
@@ -81,6 +85,10 @@ to the keeper turn. The keeper must not block waiting for the operator decision;
 resolution is delivered later through the HITL wake path. Resolution only wakes
 the keeper to observe the resolved state; it does not execute the stored command,
 create a one-shot approval grant, or authorize an automatic retry.
+For repo creation, the pending approval input includes the structured
+`repo_create_contract` (`owner`, `name`, `visibility`, and lifecycle flags such
+as `source`, `template`, `remote`, `clone`, `push`, and `add_readme`) so the
+operator is judging explicit metadata rather than ambient `gh` defaults.
 
 ## 5. Non-goals
 

--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -264,8 +264,8 @@ space *between* Allow and Deny; it does not soften Deny.
 | W3 | G-6 | `Requires_approval` disposition ≠ Deny | disposition round-trips through receipts |
 | W3 | G-7 | exec gate `Ask` → HITL queue wiring | keeper-turn block time on gated op = 0 ms |
 | W3 | G-8 | autonomous overlay: gated families → `Requires_approval` | overlay no longer all-`Observe` for gh mutations |
-| W4 | G-9 | re-enable repo-create/discussion surfaces to request approval (supersede #23362 behavior; design doc marked superseded) | `gh repo create` reaches `Pending_approval`, not `Deny` |
-| W4 | G-10 | repo-create capability contract (naming/ownership/lifecycle) | contract doc + typed args |
+| W4 | G-9 | re-enable repo-create/discussion surfaces to request approval (supersede #23362 behavior; design doc marked superseded) | contract-valid `gh repo create OWNER/NAME --public\|--private\|--internal` reaches `Pending_approval`, not `Deny` |
+| W4 | G-10 | repo-create capability contract (naming/ownership/lifecycle) | missing `OWNER/NAME`, missing/ambiguous visibility, or opaque repo target denies before HITL; valid requests carry structured contract metadata in the approval input |
 | W4 | G-11 | prompts + `KEEPER-CAPABILITY-MATRIX.md` update; block-time metric | docs match behavior; p99 block-time 0 ms |
 | W5 | G-12 | TLA+ `CatastrophicNeverAllowed` + `NonBlockingApproval` + `UnknownGhVerbNeverAutoRun` | clean cfg passes AND buggy cfg violates (both required) |
 | W5 | G-13 | gated-op observability | 100% gated ops emit enqueue/resolve/wake events |

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -355,6 +355,39 @@ let gh_capability_of_simple (simple : Shell_ir.simple)
      literal argv words and any Shell IR opacity in the graphql [query] body. *)
   Gh_capability_policy.disposition_of_simple simple
 
+let gh_capability_policy_deny_rule_of_simple (simple : Shell_ir.simple)
+  : string option
+  =
+  Gh_capability_policy.repo_create_contract_rule_of_simple simple
+
+let gh_capability_policy_deny_rule (caps : Capability.t list) : string option =
+  let rec scan = function
+    | [] -> None
+    | Capability.Exec_program (bin, args) :: rest ->
+      (match Exec_program.known bin with
+       | Some Exec_program.Gh ->
+         let simple : Shell_ir.simple =
+           { Shell_ir.bin
+           ; args
+           ; env = []
+           ; cwd = None
+           ; redirects = []
+           ; sandbox = Sandbox_target.host ()
+           }
+         in
+         (match gh_capability_policy_deny_rule_of_simple simple with
+          | Some _ as found -> found
+          | None -> scan rest)
+       | Some _ | None -> scan rest)
+    | Capability.Pipeline_fold inner :: rest ->
+      (match scan inner with
+       | Some _ as found -> found
+       | None -> scan rest)
+    | _ :: rest -> scan rest
+  in
+  scan caps
+[@@warning "-4"]
+
 (* RFC-0309 W3 (pipeline coverage): the capability Ask must fire for a gh
    durable-remote op in ANY pipeline stage, not only the representative (last)
    [simple] the caller extracts via [last_simple_of_ir]. [caps] folds over every
@@ -416,6 +449,9 @@ let decide (policy : t)
     (* Trust-independent: denied regardless of [overlay] (RFC-0254 §5.3). *)
     Verdict.Deny { caps; reason }
   | None ->
+    (match gh_capability_policy_deny_rule caps with
+     | Some rule -> Verdict.Deny { caps; reason = Verdict.Policy_deny { rule } }
+     | None ->
     (match gh_cap_requiring_approval caps with
      | Some gh_bin ->
        (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval]
@@ -437,4 +473,4 @@ let decide (policy : t)
          ~caps ~policy ~bin:simple.bin ~simple
      | `Safe ->
        trust_dispatch ~trust_level:overlay.safe_trust
-         ~caps ~policy ~bin:simple.bin ~simple))
+         ~caps ~policy ~bin:simple.bin ~simple)))

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -38,12 +38,17 @@ val decide :
          Catastrophic_program];
        - a destructive SQL statement ([DROP]/[TRUNCATE]/[DELETE]) handed to a
          database CLI ([psql -c], [mysql -e]) → [Deny Destructive_db].
-    2. Otherwise, a [gh] verb whose capability disposition is
+    2. Otherwise, a [gh repo create] request that lacks the G-10 contract
+       ([OWNER/NAME] plus exactly one visibility flag) → [Deny
+       (Policy_deny ...)]. Invalid repo-create requests must be corrected before
+       HITL; the approval queue only receives explicit ownership/visibility
+       metadata.
+    3. Otherwise, a [gh] verb whose capability disposition is
        [Requires_approval] → [Ask], independent of the risk overlay. This is
        how reversible durable-remote mutations such as [gh repo create] and
        [gh discussion create] enter HITL rather than auto-running or being
        disabled.
-    3. Otherwise the highest program risk class is graded by the matching
+    4. Otherwise the highest program risk class is graded by the matching
        [overlay.*_trust] level:
        [Enforced] → [Ask], [Auto_safe]/[Observe] → [Allow],
        [Suggest] → [Suggest_confirm].

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -6,6 +6,27 @@ type disposition =
   | Requires_approval
   | Denied
 
+type repo_create_visibility =
+  | Public
+  | Private
+  | Internal
+
+type repo_create_lifecycle =
+  { add_readme : bool
+  ; clone : bool
+  ; push : bool
+  ; source : string option
+  ; remote : string option
+  ; template : string option
+  }
+
+type repo_create_contract =
+  { owner : string
+  ; name : string
+  ; visibility : repo_create_visibility
+  ; lifecycle : repo_create_lifecycle
+  }
+
 let string_of_disposition = function
   | Allowed -> "allowed"
   | Requires_approval -> "requires_approval"
@@ -111,6 +132,275 @@ let arg_word (arg : Shell_ir.arg) : string =
   match arg_literal arg with
   | Some s -> s
   | None -> ""
+;;
+
+let literal_arg_words (args : Shell_ir.arg list) : (string list, string list) result =
+  let rec collect acc = function
+    | [] -> Ok (List.rev acc)
+    | arg :: rest ->
+      (match arg_literal arg with
+       | Some s -> collect (s :: acc) rest
+       | None -> Error [ "nonliteral_args" ])
+  in
+  collect [] args
+;;
+
+let is_flag tok = String.length tok > 0 && tok.[0] = '-'
+
+let split_eq tok =
+  match String.index_opt tok '=' with
+  | None -> None
+  | Some idx ->
+    let key = String.sub tok 0 idx in
+    let value = String.sub tok (idx + 1) (String.length tok - idx - 1) in
+    Some (key, value)
+;;
+
+let gh_global_value_flags = [ "--repo"; "-R"; "--hostname"; "-H" ]
+let gh_global_bool_flags = [ "--help" ]
+
+let rec next_gh_positional = function
+  | [] -> None
+  | tok :: rest when List.mem tok gh_global_value_flags ->
+    (match rest with _ :: tail -> next_gh_positional tail | [] -> None)
+  | tok :: rest
+    when (match split_eq tok with
+          | Some (key, _) -> List.mem key gh_global_value_flags
+          | None -> false) ->
+    next_gh_positional rest
+  | tok :: rest when List.mem tok gh_global_bool_flags -> next_gh_positional rest
+  | tok :: rest when is_flag tok -> next_gh_positional rest
+  | tok :: rest -> Some (tok, rest)
+;;
+
+let repo_create_tail words =
+  match next_gh_positional words with
+  | Some (family, after_family) when String.equal (String.lowercase_ascii family) "repo" ->
+    (match next_gh_positional after_family with
+     | Some (action, after_action)
+       when String.equal (String.lowercase_ascii action) "create" -> Some after_action
+     | Some _ | None -> None)
+  | Some _ | None -> None
+;;
+
+let repo_create_value_flags =
+  [ "--description", "description"
+  ; "-d", "description"
+  ; "--gitignore", "gitignore"
+  ; "-g", "gitignore"
+  ; "--homepage", "homepage"
+  ; "-h", "homepage"
+  ; "--license", "license"
+  ; "-l", "license"
+  ; "--remote", "remote"
+  ; "-r", "remote"
+  ; "--source", "source"
+  ; "-s", "source"
+  ; "--team", "team"
+  ; "-t", "team"
+  ; "--template", "template"
+  ; "-p", "template"
+  ]
+;;
+
+let repo_create_bool_flags =
+  [ "--add-readme"
+  ; "--clone"
+  ; "-c"
+  ; "--disable-issues"
+  ; "--disable-wiki"
+  ; "--include-all-branches"
+  ; "--push"
+  ]
+;;
+
+let visibility_of_flag = function
+  | "--public" -> Some Public
+  | "--private" -> Some Private
+  | "--internal" -> Some Internal
+  | _ -> None
+;;
+
+type repo_create_parse_acc =
+  { repo_name_arg : string option
+  ; visibility_flags : repo_create_visibility list
+  ; add_readme : bool
+  ; clone : bool
+  ; push : bool
+  ; source : string option
+  ; remote : string option
+  ; template : string option
+  ; errors : string list
+  }
+
+let empty_repo_create_acc =
+  { repo_name_arg = None
+  ; visibility_flags = []
+  ; add_readme = false
+  ; clone = false
+  ; push = false
+  ; source = None
+  ; remote = None
+  ; template = None
+  ; errors = []
+  }
+;;
+
+let record_repo_value acc field value =
+  match field with
+  | "source" -> { acc with source = Some value }
+  | "remote" -> { acc with remote = Some value }
+  | "template" -> { acc with template = Some value }
+  | "description" | "gitignore" | "homepage" | "license" | "team" -> acc
+  | _ -> acc
+;;
+
+let add_error acc err = { acc with errors = err :: acc.errors }
+
+let rec parse_repo_create_tail acc = function
+  | [] -> acc
+  | "--" :: rest ->
+    List.fold_left
+      (fun acc tok ->
+         match acc.repo_name_arg with
+         | None -> { acc with repo_name_arg = Some tok }
+         | Some _ -> add_error acc ("extra_positional:" ^ tok))
+      acc
+      rest
+  | tok :: rest ->
+    (match visibility_of_flag tok with
+     | Some visibility ->
+       parse_repo_create_tail
+         { acc with visibility_flags = visibility :: acc.visibility_flags }
+         rest
+     | None ->
+       if List.mem tok repo_create_bool_flags then
+         let acc =
+           match tok with
+           | "--add-readme" -> { acc with add_readme = true }
+           | "--clone" | "-c" -> { acc with clone = true }
+           | "--push" -> { acc with push = true }
+           | "--disable-issues" | "--disable-wiki" | "--include-all-branches" ->
+             acc
+           | _ -> acc
+         in
+         parse_repo_create_tail acc rest
+       else (
+         match List.assoc_opt tok repo_create_value_flags with
+         | Some field ->
+           (match rest with
+            | value :: tail ->
+              parse_repo_create_tail (record_repo_value acc field value) tail
+            | [] ->
+              parse_repo_create_tail
+                (add_error acc ("missing_flag_value:" ^ tok))
+                [])
+         | None ->
+           (match split_eq tok with
+            | Some (key, value) ->
+              (match List.assoc_opt key repo_create_value_flags with
+               | Some field ->
+                 parse_repo_create_tail (record_repo_value acc field value) rest
+               | None ->
+                 if is_flag tok
+                 then
+                   parse_repo_create_tail
+                     (add_error acc ("unknown_flag:" ^ key))
+                     rest
+                 else parse_repo_create_tail (add_error acc ("invalid_name:" ^ tok)) rest)
+            | None ->
+              if is_flag tok
+              then
+                parse_repo_create_tail (add_error acc ("unknown_flag:" ^ tok)) rest
+              else (
+                match acc.repo_name_arg with
+                | None ->
+                  parse_repo_create_tail { acc with repo_name_arg = Some tok } rest
+                | Some _ ->
+                  parse_repo_create_tail
+                    (add_error acc ("extra_positional:" ^ tok))
+                    rest))))
+;;
+
+let valid_repo_component s =
+  let valid_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '-' | '_' | '.' -> true
+    | _ -> false
+  in
+  String.length s > 0
+  && not (String.equal s "." || String.equal s "..")
+  && String.for_all valid_char s
+;;
+
+let unique_visibility flags =
+  let add acc v = if List.mem v acc then acc else v :: acc in
+  List.rev (List.fold_left add [] flags)
+;;
+
+let contract_from_acc acc : (repo_create_contract, string list) result =
+  let errors = List.rev acc.errors in
+  let errors, owner, name =
+    match acc.repo_name_arg with
+    | None -> "missing_name" :: "missing_owner" :: errors, None, None
+    | Some repo_name ->
+      (match String.split_on_char '/' repo_name with
+       | [ owner; name ] ->
+         let errors =
+           (if valid_repo_component owner then errors else "invalid_owner" :: errors)
+         in
+         let errors =
+           if valid_repo_component name then errors else "invalid_name" :: errors
+         in
+         errors, Some owner, Some name
+       | [ _name_without_owner ] -> "missing_owner" :: errors, None, None
+       | _ -> "invalid_name" :: errors, None, None)
+  in
+  let visibility_flags = unique_visibility acc.visibility_flags in
+  let errors, visibility =
+    match visibility_flags with
+    | [] -> "missing_visibility" :: errors, None
+    | [ visibility ] -> errors, Some visibility
+    | _ -> "ambiguous_visibility" :: errors, None
+  in
+  match errors, owner, name, visibility with
+  | [], Some owner, Some name, Some visibility ->
+    Ok
+      { owner
+      ; name
+      ; visibility
+      ; lifecycle =
+          { add_readme = acc.add_readme
+          ; clone = acc.clone
+          ; push = acc.push
+          ; source = acc.source
+          ; remote = acc.remote
+          ; template = acc.template
+          }
+      }
+  | errors, _, _, _ -> Error errors
+;;
+
+let repo_create_contract_of_simple simple =
+  match Exec_program.known simple.Shell_ir.bin with
+  | Some Exec_program.Gh ->
+    (match literal_arg_words simple.Shell_ir.args with
+     | Error errors ->
+       if repo_create_tail (List.map arg_word simple.Shell_ir.args) = None
+       then None
+       else Some (Error errors)
+     | Ok words ->
+       (match repo_create_tail words with
+        | None -> None
+        | Some tail ->
+          Some (contract_from_acc (parse_repo_create_tail empty_repo_create_acc tail))))
+  | Some _ | None -> None
+;;
+
+let repo_create_contract_rule_of_simple simple =
+  match repo_create_contract_of_simple simple with
+  | Some (Error errors) ->
+    Some ("gh_repo_create_contract:" ^ String.concat "," errors)
+  | Some (Ok _) | None -> None
 ;;
 
 let is_graphql_api (v : Gh_verb.t) : bool =
@@ -256,6 +546,9 @@ let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
 let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
   match Exec_program.known simple.Shell_ir.bin with
   | Some Exec_program.Gh ->
+    (match repo_create_contract_rule_of_simple simple with
+     | Some _ -> Some Denied
+     | None ->
     let words =
       Exec_program.to_string simple.Shell_ir.bin
       :: List.map arg_word simple.Shell_ir.args
@@ -263,6 +556,6 @@ let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
     let verb = Gh_verb.classify words in
     if is_graphql_api verb && graphql_query_body_is_opaque simple.Shell_ir.args
     then Some Requires_approval
-    else Some (disposition_of_words words verb)
+    else Some (disposition_of_words words verb))
   | Some _ | None -> None
 [@@warning "-4"]

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -380,20 +380,127 @@ let contract_from_acc acc : (repo_create_contract, string list) result =
   | errors, _, _, _ -> Error errors
 ;;
 
+let repo_create_contract_of_gh_simple simple =
+  match literal_arg_words simple.Shell_ir.args with
+  | Error errors ->
+    if repo_create_tail (List.map arg_word simple.Shell_ir.args) = None
+    then None
+    else Some (Error errors)
+  | Ok words ->
+    (match repo_create_tail words with
+     | None -> None
+     | Some tail ->
+       Some (contract_from_acc (parse_repo_create_tail empty_repo_create_acc tail)))
+;;
+
+let repo_create_contract_of_known simple = function
+  | Exec_program.Gh -> repo_create_contract_of_gh_simple simple
+  | Exec_program.Ls
+  | Exec_program.Cat
+  | Exec_program.Pwd
+  | Exec_program.Echo
+  | Exec_program.Head
+  | Exec_program.Tail
+  | Exec_program.Rg
+  | Exec_program.Grep
+  | Exec_program.Find
+  | Exec_program.Which
+  | Exec_program.Test
+  | Exec_program.Basename
+  | Exec_program.Dirname
+  | Exec_program.Stat
+  | Exec_program.Du
+  | Exec_program.Df
+  | Exec_program.Sort
+  | Exec_program.Uniq
+  | Exec_program.Wc
+  | Exec_program.Cut
+  | Exec_program.Tr
+  | Exec_program.File
+  | Exec_program.Printf
+  | Exec_program.Date
+  | Exec_program.Env
+  | Exec_program.Printenv
+  | Exec_program.Hostname
+  | Exec_program.Whoami
+  | Exec_program.Uname
+  | Exec_program.Ps
+  | Exec_program.Tty
+  | Exec_program.Cp
+  | Exec_program.Mv
+  | Exec_program.Ln
+  | Exec_program.Touch
+  | Exec_program.Tee
+  | Exec_program.Awk
+  | Exec_program.Xargs
+  | Exec_program.Git
+  | Exec_program.Docker
+  | Exec_program.Curl
+  | Exec_program.Wget
+  | Exec_program.Ssh
+  | Exec_program.Scp
+  | Exec_program.Tar
+  | Exec_program.Rsync
+  | Exec_program.Make
+  | Exec_program.Cmake
+  | Exec_program.Dune_local_sh
+  | Exec_program.Diff
+  | Exec_program.Patch
+  | Exec_program.Mkdir
+  | Exec_program.Npm
+  | Exec_program.Node
+  | Exec_program.Npx
+  | Exec_program.Yarn
+  | Exec_program.Pnpm
+  | Exec_program.Pip
+  | Exec_program.Python
+  | Exec_program.Python3
+  | Exec_program.Pytest
+  | Exec_program.Pyright
+  | Exec_program.Ruff
+  | Exec_program.Opam
+  | Exec_program.Ocamlfind
+  | Exec_program.Tsc
+  | Exec_program.Cargo
+  | Exec_program.Rustc
+  | Exec_program.Go
+  | Exec_program.Gofmt
+  | Exec_program.Gradle
+  | Exec_program.Java
+  | Exec_program.Javac
+  | Exec_program.Mvn
+  | Exec_program.Ninja
+  | Exec_program.Sed
+  | Exec_program.Uv
+  | Exec_program.Glab
+  | Exec_program.Terminal_notifier
+  | Exec_program.Osascript
+  | Exec_program.Play
+  | Exec_program.Rec
+  | Exec_program.Ffplay
+  | Exec_program.Mpg123
+  | Exec_program.Open
+  | Exec_program.Psql
+  | Exec_program.Mysql
+  | Exec_program.Mariadb
+  | Exec_program.Cockroach
+  | Exec_program.Sudo
+  | Exec_program.Su
+  | Exec_program.Chmod
+  | Exec_program.Chown
+  | Exec_program.Rm
+  | Exec_program.Dd
+  | Exec_program.Mkfs
+  | Exec_program.Shutdown
+  | Exec_program.Reboot
+  | Exec_program.Halt
+  | Exec_program.Poweroff -> None
+;;
+
 let repo_create_contract_of_simple simple =
   match Exec_program.known simple.Shell_ir.bin with
-  | Some Exec_program.Gh ->
-    (match literal_arg_words simple.Shell_ir.args with
-     | Error errors ->
-       if repo_create_tail (List.map arg_word simple.Shell_ir.args) = None
-       then None
-       else Some (Error errors)
-     | Ok words ->
-       (match repo_create_tail words with
-        | None -> None
-        | Some tail ->
-          Some (contract_from_acc (parse_repo_create_tail empty_repo_create_acc tail))))
-  | Some _ | None -> None
+  | None -> None
+  | Some known -> repo_create_contract_of_known simple known
 ;;
 
 let repo_create_contract_rule_of_simple simple =

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -31,9 +31,53 @@ type disposition =
       (** Never permitted for a keeper. These are also floored on the risk axis
           (R2/Destructive); the capability axis records the policy intent. *)
 
+type repo_create_visibility =
+  | Public
+  | Private
+  | Internal
+
+type repo_create_lifecycle =
+  { add_readme : bool
+  ; clone : bool
+  ; push : bool
+  ; source : string option
+  ; remote : string option
+  ; template : string option
+  }
+
+type repo_create_contract =
+  { owner : string
+  ; name : string
+  ; visibility : repo_create_visibility
+  ; lifecycle : repo_create_lifecycle
+  }
+(** G-10 repo-create capability contract extracted from literal
+    [gh repo create OWNER/NAME --public|--private|--internal ...] argv.
+    The owner segment must be explicit so ambient authenticated-user defaults
+    cannot decide ownership invisibly. [lifecycle] records the visible creation
+    mode flags that shape post-create state; these values are metadata for the
+    approval request and future lifecycle policy, not an execution grant. *)
+
 val string_of_disposition : disposition -> string
 (** Stable lowercase label for logs/metrics: "allowed" | "requires_approval" |
     "denied". *)
+
+val repo_create_contract_of_simple :
+  Shell_ir.simple -> (repo_create_contract, string list) result option
+(** [Some (Ok contract)] for a literal [gh repo create] command that satisfies
+    the G-10 contract, [Some (Error fields)] when the command is repo-create but
+    lacks required metadata or has unverifiable args, and [None] for non
+    repo-create commands. Required fields are:
+    - explicit [OWNER/NAME] repo target;
+    - exactly one visibility flag: [--public], [--private], or [--internal].
+
+    Missing or opaque contract fields are policy failures, not approval asks:
+    the keeper must provide the contract before a human can approve the remote
+    repository creation. *)
+
+val repo_create_contract_rule_of_simple : Shell_ir.simple -> string option
+(** Render a stable [Verdict.Policy_deny] rule for a repo-create command that
+    violates {!repo_create_contract_of_simple}. *)
 
 val creates_durable_remote_surface : Gh_verb.t -> bool
 (** G-4 externality axis (risk-independent): [true] when this gh verb creates or

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -485,7 +485,7 @@ let test_gh_durable_remote_asks_under_autonomous () =
        the floor Deny path — the active-keeper enablement. Plus the R1
        durable-remote ops that already existed (repo edit/sync/set-default) and
        unknown gh. *)
-    [ "gh repo create", [ "repo"; "create"; "o/new" ]
+    [ "gh repo create", [ "repo"; "create"; "o/new"; "--private" ]
     ; "gh repo fork", [ "repo"; "fork"; "o/r" ]
     ; "gh discussion create", [ "discussion"; "create"; "--title"; "T" ]
     ; "gh discussion comment", [ "discussion"; "comment"; "42"; "--body"; "B" ]
@@ -497,6 +497,32 @@ let test_gh_durable_remote_asks_under_autonomous () =
        auto-runs as a read — it Asks under autonomous. *)
     ; "gh repo upsert-magic (unknown action)", [ "repo"; "upsert-magic"; "o/r" ]
     ; "gh pr teleport (unknown action)", [ "pr"; "teleport"; "123" ]
+    ]
+
+let test_gh_repo_create_contract_denies_under_autonomous () =
+  List.iter
+    (fun (label, args, expected_rule) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Policy_deny { rule }; _ } ->
+         Alcotest.(check string) label expected_rule rule
+       | Verdict.Ask _ ->
+         Alcotest.failf "%s: invalid repo-create contract must Deny, not Ask" label
+       | Verdict.Allow _ | Verdict.Suggest_confirm _ | Verdict.Deny _ ->
+         Alcotest.failf "%s: expected Policy_deny for repo-create contract" label)
+    [ ( "missing visibility"
+      , [ "repo"; "create"; "o/new" ]
+      , "gh_repo_create_contract:missing_visibility" )
+    ; ( "missing owner"
+      , [ "repo"; "create"; "new"; "--private" ]
+      , "gh_repo_create_contract:missing_owner" )
+    ; ( "ambiguous visibility"
+      , [ "repo"; "create"; "o/new"; "--private"; "--public" ]
+      , "gh_repo_create_contract:ambiguous_visibility" )
     ]
 
 (* RFC-0309 W4 axis-symmetry regression: the string-borne GraphQL form of a
@@ -678,7 +704,7 @@ let test_gh_durable_remote_in_pipeline_asks_under_autonomous () =
        | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
        | _ ->
          Alcotest.failf "%s | cat must still Ask under autonomous" label)
-    [ ("gh repo create", [ "repo"; "create"; "o/new" ])
+    [ ("gh repo create", [ "repo"; "create"; "o/new"; "--private" ])
     ; ("gh discussion create", [ "discussion"; "create"; "--title"; "T" ])
     ; ( "gh api graphql -F query=@file (composed with pipeline)"
       , [ "api"; "graphql"; "-F"; "query=@mutation.graphql" ] )
@@ -871,6 +897,7 @@ let () =
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_gh_durable_remote_asks_under_autonomous ();
+  test_gh_repo_create_contract_denies_under_autonomous ();
   test_gh_graphql_durable_remote_asks_under_autonomous ();
   test_gh_graphql_opaque_query_asks_under_autonomous ();
   test_gh_graphql_non_query_opaque_field_allowed_under_autonomous ();

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -141,6 +141,58 @@ let gh_simple args : Shell_ir.simple =
   ; sandbox = Sandbox_target.host ()
   }
 
+let gh_simple_words words = gh_simple (List.map lit words)
+
+let test_repo_create_contract () =
+  let contract words =
+    Pol.repo_create_contract_of_simple (gh_simple_words words)
+  in
+  (match contract [ "repo"; "create"; "org/new-repo"; "--private" ] with
+   | Some (Ok c) ->
+     Alcotest.(check string) "owner" "org" c.owner;
+     Alcotest.(check string) "name" "new-repo" c.name;
+     Alcotest.(check string)
+       "visibility"
+       "private"
+       (match c.visibility with
+        | Pol.Public -> "public"
+        | Pol.Private -> "private"
+        | Pol.Internal -> "internal")
+   | Some (Error errors) ->
+     Alcotest.failf "expected valid contract, got %s" (String.concat "," errors)
+   | None -> Alcotest.fail "expected repo-create contract");
+  let expect_errors label words expected =
+    match contract words with
+    | Some (Error errors) ->
+      Alcotest.(check (list string)) label expected errors
+    | Some (Ok _) -> Alcotest.failf "%s: expected contract error" label
+    | None -> Alcotest.failf "%s: expected repo-create contract" label
+  in
+  expect_errors "missing owner"
+    [ "repo"; "create"; "new-repo"; "--private" ]
+    [ "missing_owner" ];
+  expect_errors "missing visibility"
+    [ "repo"; "create"; "org/new-repo" ]
+    [ "missing_visibility" ];
+  expect_errors "ambiguous visibility"
+    [ "repo"; "create"; "org/new-repo"; "--private"; "--public" ]
+    [ "ambiguous_visibility" ];
+  (match
+     Pol.repo_create_contract_of_simple
+       (gh_simple [ lit "repo"; lit "create"; var "REPO"; lit "--private" ])
+   with
+   | Some (Error [ "nonliteral_args" ]) -> ()
+   | Some (Error errors) ->
+     Alcotest.failf "opaque repo target errors: %s" (String.concat "," errors)
+   | Some (Ok _) -> Alcotest.fail "opaque repo target must not validate"
+   | None -> Alcotest.fail "expected opaque repo-create contract result");
+  (match
+     Pol.repo_create_contract_rule_of_simple (gh_simple_words [ "repo"; "view"; "org/repo" ])
+   with
+   | None -> ()
+   | Some rule -> Alcotest.failf "non-create should not emit rule: %s" rule)
+;;
+
 let test_graphql_durable_remote_words () =
   let ask =
     [ ("createRepository", "mutation { createRepository(input:{name:\"x\"}){ repository { id } } }")
@@ -227,6 +279,8 @@ let () =
             test_durable_remote_surface;
           Alcotest.test_case "current dispositions" `Quick
             test_current_dispositions;
+          Alcotest.test_case "repo-create contract" `Quick
+            test_repo_create_contract;
           Alcotest.test_case "graphql durable-remote (words)" `Quick
             test_graphql_durable_remote_words;
           Alcotest.test_case "graphql opaque query (simple)" `Quick

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -412,6 +412,48 @@ let sandbox_target_label = function
   | Masc_exec.Sandbox_target.Docker { image; _ } -> "docker:" ^ image
 ;;
 
+let json_opt_string name = function
+  | Some value -> [ name, `String value ]
+  | None -> []
+;;
+
+let repo_create_visibility_label = function
+  | Masc_exec.Gh_capability_policy.Public -> "public"
+  | Masc_exec.Gh_capability_policy.Private -> "private"
+  | Masc_exec.Gh_capability_policy.Internal -> "internal"
+;;
+
+let repo_create_contract_json
+      (contract : Masc_exec.Gh_capability_policy.repo_create_contract)
+  =
+  let lifecycle = contract.lifecycle in
+  `Assoc
+    ([ "owner", `String contract.owner
+     ; "name", `String contract.name
+     ; "visibility", `String (repo_create_visibility_label contract.visibility)
+     ; ( "lifecycle"
+       , `Assoc
+           ([ "add_readme", `Bool lifecycle.add_readme
+            ; "clone", `Bool lifecycle.clone
+            ; "push", `Bool lifecycle.push
+            ]
+            @ json_opt_string "source" lifecycle.source
+            @ json_opt_string "remote" lifecycle.remote
+            @ json_opt_string "template" lifecycle.template) )
+     ])
+;;
+
+let repo_create_contract_json_of_ir ir =
+  let rec scan = function
+    | Masc_exec.Shell_ir.Simple simple ->
+      (match Masc_exec.Gh_capability_policy.repo_create_contract_of_simple simple with
+       | Some (Ok contract) -> Some (repo_create_contract_json contract)
+       | Some (Error _) | None -> None)
+    | Masc_exec.Shell_ir.Pipeline stages -> List.find_map scan stages
+  in
+  scan ir
+;;
+
 let shell_ir_approval_input
       ~cmd
       ~cwd
@@ -421,8 +463,10 @@ let shell_ir_approval_input
       ~sandbox_target
       ~risk_class
       ~typed_hit
-  =
-  `Assoc
+      ?repo_create_contract
+      ()
+      =
+  let fields =
     [ "schema", `String "masc.shell_ir_approval_request.v1"
     ; "op", `String "shell_ir_approval_required"
     ; "action", `String "execute"
@@ -437,6 +481,13 @@ let shell_ir_approval_input
       , `String (Masc_exec.Shell_ir_risk.string_of_risk_class risk_class) )
     ; "typed_hit", `Bool typed_hit
     ]
+  in
+  `Assoc
+    (fields
+     @
+     match repo_create_contract with
+     | Some contract -> [ "repo_create_contract", contract ]
+     | None -> [])
 ;;
 
 let submit_shell_ir_approval_pending
@@ -452,6 +503,7 @@ let submit_shell_ir_approval_pending
       ~sandbox_target
       ~risk_class
       ~typed_hit
+      ?repo_create_contract
       ()
   =
   let input =
@@ -464,6 +516,8 @@ let submit_shell_ir_approval_pending
       ~sandbox_target
       ~risk_class
       ~typed_hit
+      ?repo_create_contract
+      ()
   in
   let on_resolution decision =
     let event =
@@ -1086,6 +1140,7 @@ let handle_tool_execute_typed
                  Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile
                in
                let sandbox_target = sandbox_target_label dispatch_sandbox in
+               let repo_create_contract = repo_create_contract_json_of_ir ir in
                let approval_id =
                  submit_shell_ir_approval_pending
                    ~base_path:root
@@ -1100,6 +1155,7 @@ let handle_tool_execute_typed
                    ~sandbox_target
                    ~risk_class
                    ~typed_hit
+                   ?repo_create_contract
                    ()
                in
                typed_error_json

--- a/lib/keeper/keeper_tool_execute_runtime.mli
+++ b/lib/keeper/keeper_tool_execute_runtime.mli
@@ -43,6 +43,8 @@ module For_testing : sig
     sandbox_target:string ->
     risk_class:Masc_exec.Shell_ir_risk.risk_class ->
     typed_hit:bool ->
+    ?repo_create_contract:Yojson.Safe.t ->
+    unit ->
     Yojson.Safe.t
   val submit_shell_ir_approval_pending :
     base_path:string ->
@@ -57,6 +59,7 @@ module For_testing : sig
     sandbox_target:string ->
     risk_class:Masc_exec.Shell_ir_risk.risk_class ->
     typed_hit:bool ->
+    ?repo_create_contract:Yojson.Safe.t ->
     unit ->
     string
   val redact_execute_output :

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -159,7 +159,8 @@ let gh_capability_policy_result ir ~caps =
        (match Masc_exec.Exec_program.known bin with
         | Some Masc_exec.Exec_program.Gh -> Gh_policy_approval_required bin
         | Some _ | None -> Gh_policy_noop)
-     | Masc_exec.Verdict.Allow _ | Masc_exec.Verdict.Suggest_confirm (_, _)
+     | Masc_exec.Verdict.Allow _ | Masc_exec.Verdict.Suggest_confirm (_, _) ->
+       Gh_policy_noop
      | Masc_exec.Verdict.Deny { reason; _ } ->
        Gh_policy_denied (Masc_exec.Verdict.deny_reason_to_string reason))
 ;;

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -136,9 +136,14 @@ let last_simple_of_ir ir =
      | _ -> None)
 ;;
 
-let gh_capability_approval_required ir ~caps =
+type gh_capability_policy_result =
+  | Gh_policy_noop
+  | Gh_policy_approval_required of Masc_exec.Exec_program.t
+  | Gh_policy_denied of string
+
+let gh_capability_policy_result ir ~caps =
   match last_simple_of_ir ir with
-  | None -> None
+  | None -> Gh_policy_noop
   | Some simple ->
     let raw_source = Format.asprintf "%a" Masc_exec.Shell_ir.pp ir in
     let summary = "shell IR capability approval check" in
@@ -152,10 +157,11 @@ let gh_capability_approval_required ir ~caps =
      with
      | Masc_exec.Verdict.Ask { bin; _ } ->
        (match Masc_exec.Exec_program.known bin with
-        | Some Masc_exec.Exec_program.Gh -> Some bin
-        | Some _ | None -> None)
+        | Some Masc_exec.Exec_program.Gh -> Gh_policy_approval_required bin
+        | Some _ | None -> Gh_policy_noop)
      | Masc_exec.Verdict.Allow _ | Masc_exec.Verdict.Suggest_confirm (_, _)
-     | Masc_exec.Verdict.Deny _ -> None)
+     | Masc_exec.Verdict.Deny { reason; _ } ->
+       Gh_policy_denied (Masc_exec.Verdict.deny_reason_to_string reason))
 ;;
 
 let dispatch_classified
@@ -184,8 +190,9 @@ let dispatch_classified
   | Some reason ->
     Error (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason })
   | None ->
-    (match gh_capability_approval_required ir ~caps with
-     | Some bin ->
+    (match gh_capability_policy_result ir ~caps with
+     | Gh_policy_denied reason -> Error (Policy_denied { reason })
+     | Gh_policy_approval_required bin ->
        let bin = Masc_exec.Exec_program.to_string bin in
        Error
          (Approval_required
@@ -196,7 +203,7 @@ let dispatch_classified
             ; bin
             ; kind = Gh_capability_requires_approval
             })
-     | None ->
+     | Gh_policy_noop ->
        (match first_privileged_program caps with
         | Some bin ->
           let bin = Masc_exec.Exec_program.to_string bin in

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1081,6 +1081,43 @@ let () =
     assert (kind = Keeper_tool_execute_shell_ir.Gh_capability_requires_approval)
   | Error _ -> assert false
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "gh" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args =
+        [ Lit ("repo", default_meta)
+        ; Lit ("create", default_meta)
+        ; Lit ("masc-test/new-repo", default_meta)
+        ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify
+      (Masc_exec.Shell_ir_risk.undecided (Masc_exec.Shell_ir.Simple ir))
+  in
+  (* G-10: a repo-create request missing required contract metadata is denied
+     before approval routing, including on the flag-off dispatch path. *)
+  match
+    Keeper_tool_execute_shell_ir.dispatch_classified
+      ~workdir:"/tmp"
+      ~sandbox:(Masc_exec.Sandbox_target.host ())
+      envelope
+  with
+  | Ok _ -> assert false
+  | Error (Keeper_tool_execute_shell_ir.Policy_denied { reason }) ->
+    assert (
+      String.equal
+        reason
+        "policy rule denied: gh_repo_create_contract:missing_visibility")
+  | Error _ -> assert false
+
 (* --- Keeper_tool_execute_shell_ir.dispatch_classified: catastrophic floor is
    flag-independent (RFC-0254 §5.3.1) --- *)
 


### PR DESCRIPTION
## Summary
- add a G-10 repo-create contract for `gh repo create`: explicit `OWNER/NAME` plus exactly one visibility flag before HITL
- deny invalid repo-create contracts as `Policy_deny` before approval routing, including the flag-off dispatch path
- attach structured `repo_create_contract` metadata to non-blocking HITL approval input for valid repo-create requests
- update RFC/design/prompt/capability docs to match the contract

## Validation
- `ocamlformat --check lib/exec/gh_capability_policy.ml lib/exec/gh_capability_policy.mli lib/exec/approval_policy.ml lib/exec/approval_policy.mli lib/keeper_tooling/keeper_tool_execute_shell_ir.ml lib/exec/test/test_gh_capability_policy.ml lib/exec/test/test_approval_policy.ml test/test_exec_dispatch.ml lib/keeper/keeper_tool_execute_runtime.ml`
- `ocamlc -stop-after parsing lib/exec/gh_capability_policy.ml lib/exec/gh_capability_policy.mli lib/exec/approval_policy.ml lib/exec/approval_policy.mli lib/keeper_tooling/keeper_tool_execute_shell_ir.ml lib/exec/test/test_gh_capability_policy.ml lib/exec/test/test_approval_policy.ml test/test_exec_dispatch.ml lib/keeper/keeper_tool_execute_runtime.ml`
- `git diff --check`

Local `dune` intentionally not run; CI is the build authority for this branch.