### PR TITLE
fix(metrics): add missing BoardSignalAttentionCandidateTotal to zero-fill + realign tripwire (main red)

### DIFF
--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -564,7 +564,7 @@ let all : t list =
     MetaReadFailures; ApprovalQueueFailures; GuardsFailures; ProfileLoadFailures;
     CompactAuditFailures; CompactAuditRetentionParse; CompactAuditDrainBatches; CompactAuditDrainBatchSizeBucket;
     FsFailures; CrashPersistenceFailures; GenerationLineageFailures; KeepaliveSignalFailures;
-    BoardSignalWakeupCappedTotal; BoardSignalNoWakeTotal; MetaJsonFailures; ToolsOasFailures;
+    BoardSignalWakeupCappedTotal; BoardSignalNoWakeTotal; BoardSignalAttentionCandidateTotal; MetaJsonFailures; ToolsOasFailures;
     ToolsOasDeterministicFailures; TurnUpUpdateFailures; AgentToolDispatchRuntimeFailures; CircuitBreakerTrips;
     PromptFailures; RunContextFailures; SearchFilesFailures; TagDispatchFailures;
     TraceEmitFailures; TransitionAuditFailures; ExecutionReceiptFailures; OperatorBroadcastSuppressed;

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 242
+  check int "Keeper_metrics.all covers every constructor" 247
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
## 무엇이 문제였나 (main red)

main의 `Build and Test`가 `test_otel_zero_fill.ml:60` "Keeper_metrics.all covers every constructor"에서 실패 중입니다 (기대 242 vs 실제).

원인은 2중이며, 하나는 **실제 zero-fill 결함**입니다:

1. **`all` 누락 (진짜 버그)**: #23353 (`255c434ab4`)이 `BoardSignalAttentionCandidateTotal` 생성자를 추가하면서 `all` 리스트에 넣지 않았습니다. `all`은 `register_zero_fill`의 입력이므로, 이 metric은 모듈 init 시 0으로 선등록되지 않습니다 — 첫 increment 전까지 scrape에서 부재. `keeper_keepalive_signal.ml:524`에서 실사용 중이라 dead 코드가 아닙니다. `all` 정의 주석("when you add a constructor... add the constructor to [all] in the same edit")의 명시 위반.
2. **tripwire 카운트 미갱신**: #23353(+1), #23452(`fcf1f69acb`, TurnFailureStreakPaused +1), #23476(`933316935b`, Gh* +3) 세 커밋이 생성자 총 5개를 추가하면서 아무도 기대값 242를 갱신하지 않았습니다. (#23452/#23476은 `all`에는 올바르게 추가함.)

## 무엇을 바꿨나

- `lib/keeper_metrics/keeper_metrics.ml`: `all`에 `BoardSignalAttentionCandidateTotal` 추가 (선언 순서 유지 — BoardSignalNoWakeTotal 다음).
- `test/test_otel_zero_fill.ml`: tripwire 242 → 247.

## 검증

variant 생성자 전수 스캔으로 parity 확인:

```
variant: 247 / all: 247
missing: NONE / extra: NONE / dupes in all: 0
```

(injectivity 체크는 기존 테스트 2번째 assertion이 CI에서 검증.)

## 재발 관찰

같은 tripwire 미갱신이 3커밋 연속 발생했습니다. 이 tripwire는 "생성자 추가 + `all` 추가"의 정상 편집에서도 실패하도록 설계돼 있어(카운트 하드코딩) 매 추가마다 수동 갱신이 필요합니다. enumerate ppx 부재가 근본 제약이라는 점은 코드 주석에 이미 명시돼 있습니다 — ppx 도입 여부는 별도 논의가 필요하면 이슈로 분리하겠습니다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
