### PR TITLE
fix(blame): keep porcelain headers authoritative

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -665,9 +665,11 @@ let parse_blame_porcelain lines =
     | [] -> List.rev acc
     | hd :: tl -> (
       match parse_blame_header hd with
-      | Some (sha, final_line, group_size) ->
-        let lines = List.init group_size (fun i -> final_line + i, sha) in
-        collect (Some sha) (lines @ acc) tl
+      | Some (sha, final_line, _group_size) ->
+        (* Porcelain still emits a header for every final line. The counted
+           first header only scopes the following metadata block; expanding it
+           would duplicate the later bare headers and corrupt attribution. *)
+        collect (Some sha) ((final_line, sha) :: acc) tl
       | None ->
         (match cur_sha with
          | Some sha when String.starts_with ~prefix:"author " hd ->

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -666,8 +666,7 @@ let parse_blame_porcelain lines =
     | hd :: tl -> (
       match parse_blame_header hd with
       | Some (sha, final_line, group_size) ->
-        let start_line = final_line - group_size + 1 in
-        let lines = List.init group_size (fun i -> start_line + i, sha) in
+        let lines = List.init group_size (fun i -> final_line + i, sha) in
         collect (Some sha) (lines @ acc) tl
       | None ->
         (match cur_sha with

--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -636,10 +636,15 @@ let is_hex_digit = function '0' .. '9' | 'a' .. 'f' -> true | _ -> false
 
 let parse_blame_header line =
   match String.split_on_char ' ' line with
-  | sha :: _orig_line :: final_line :: _rest
+  | sha :: _orig_line :: final_line :: rest
     when String.length sha = 40 && String.for_all is_hex_digit sha -> (
       match int_of_string_opt final_line with
-      | Some n when n > 0 -> Some (sha, n)
+      | Some n when n > 0 ->
+        let group_size = match rest with
+          | gs :: _ -> (match int_of_string_opt gs with Some g when g > 0 -> g | _ -> 1)
+          | [] -> 1
+        in
+        Some (sha, n, group_size)
       | Some _ | None -> None)
   | _ -> None
 
@@ -660,7 +665,10 @@ let parse_blame_porcelain lines =
     | [] -> List.rev acc
     | hd :: tl -> (
       match parse_blame_header hd with
-      | Some (sha, final_line) -> collect (Some sha) ((final_line, sha) :: acc) tl
+      | Some (sha, final_line, group_size) ->
+        let start_line = final_line - group_size + 1 in
+        let lines = List.init group_size (fun i -> start_line + i, sha) in
+        collect (Some sha) (lines @ acc) tl
       | None ->
         (match cur_sha with
          | Some sha when String.starts_with ~prefix:"author " hd ->

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -170,7 +170,7 @@ module For_testing_blame : sig
 
   (** [parse_blame_header line] returns [(sha, final_line)] when [line] is a
       porcelain group header ["<40-hex sha> <orig> <final>[ <count>]"]. *)
-  val parse_blame_header : string -> (string * int) option
+  val parse_blame_header : string -> (string * int * int) option
 
   (** [parse_blame_porcelain lines] joins per-line headers with each sha's
       metadata block (which git emits only on the sha's first group). Lines

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -168,8 +168,9 @@ module For_testing_blame : sig
 
   type entry = { bl_line : int; bl_author : string; bl_time : int64 }
 
-  (** [parse_blame_header line] returns [(sha, final_line)] when [line] is a
-      porcelain group header ["<40-hex sha> <orig> <final>[ <count>]"]. *)
+  (** [parse_blame_header line] returns [(sha, final_line, group_size)] when
+      [line] is a porcelain group header
+      ["<40-hex sha> <orig> <final>[ <count>]"]. *)
   val parse_blame_header : string -> (string * int * int) option
 
   (** [parse_blame_porcelain lines] joins per-line headers with each sha's

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -572,9 +572,9 @@ let sha_a = "4f03f7437bab0d9926bf5f373d7e39259a663a8a"
 let sha_b = "9b2c33d4e5f60718293a4b5c6d7e8f9012345678"
 
 (* Two commits interleaved: sha_a owns lines 1-2 and 4, sha_b owns line 3.
-   git emits sha_a's metadata block only once (first group); line 4 repeats
-   the bare header, arriving AFTER sha_b's metadata — the regression case
-   where sequential state tracking would attribute line 4 to sha_b. *)
+   git emits sha_a's metadata block only once (first counted header); line 2
+   and line 4 repeat bare headers. Line 4 arrives AFTER sha_b's metadata: the
+   regression case where sequential state tracking would attribute it to sha_b. *)
 let porcelain_fixture =
   [ sha_a ^ " 1 1 2"
   ; "author Alice"
@@ -585,6 +585,7 @@ let porcelain_fixture =
   ; "summary first commit"
   ; "filename file.txt"
   ; "\tline one"
+  ; sha_a ^ " 2 2"
   ; "\tline two"
   ; sha_b ^ " 3 3 1"
   ; "author Bob"
@@ -629,7 +630,7 @@ let test_blame_porcelain_sha_join () =
   Alcotest.(check int) "all four lines attributed" 4 (List.length entries);
   let by_line n = List.find (fun e -> e.B.bl_line = n) entries in
   Alcotest.(check string) "line 1 author" "Alice" (by_line 1).B.bl_author;
-  Alcotest.(check string) "line 2 author from group size" "Alice"
+  Alcotest.(check string) "line 2 author from repeated bare header" "Alice"
     (by_line 2).B.bl_author;
   Alcotest.(check string) "line 3 author" "Bob" (by_line 3).B.bl_author;
   Alcotest.(check int64) "line 1 time" 1700000100L (by_line 1).B.bl_time;

--- a/test/test_workspace_routes_keeper.ml
+++ b/test/test_workspace_routes_keeper.ml
@@ -585,7 +585,6 @@ let porcelain_fixture =
   ; "summary first commit"
   ; "filename file.txt"
   ; "\tline one"
-  ; sha_a ^ " 2 2"
   ; "\tline two"
   ; sha_b ^ " 3 3 1"
   ; "author Bob"
@@ -598,21 +597,21 @@ let porcelain_fixture =
   ]
 
 let test_blame_header_with_count () =
-  Alcotest.(check (option (pair string int)))
+  Alcotest.(check (option (triple string int int)))
     "header with group size parses final line"
-    (Some (sha_a, 1))
+    (Some (sha_a, 1, 2))
     (B.parse_blame_header (sha_a ^ " 1 1 2"))
 
 let test_blame_header_without_count () =
-  Alcotest.(check (option (pair string int)))
+  Alcotest.(check (option (triple string int int)))
     "bare repeated header parses final line"
-    (Some (sha_a, 2))
+    (Some (sha_a, 2, 1))
     (B.parse_blame_header (sha_a ^ " 2 2"))
 
 let test_blame_header_rejects_non_headers () =
   List.iter
     (fun line ->
-      Alcotest.(check (option (pair string int)))
+      Alcotest.(check (option (triple string int int)))
         (Printf.sprintf "non-header rejected: %S" line)
         None
         (B.parse_blame_header line))
@@ -630,6 +629,8 @@ let test_blame_porcelain_sha_join () =
   Alcotest.(check int) "all four lines attributed" 4 (List.length entries);
   let by_line n = List.find (fun e -> e.B.bl_line = n) entries in
   Alcotest.(check string) "line 1 author" "Alice" (by_line 1).B.bl_author;
+  Alcotest.(check string) "line 2 author from group size" "Alice"
+    (by_line 2).B.bl_author;
   Alcotest.(check string) "line 3 author" "Bob" (by_line 3).B.bl_author;
   Alcotest.(check int64) "line 1 time" 1700000100L (by_line 1).B.bl_time;
   Alcotest.(check int64) "line 3 time" 1700000200L (by_line 3).B.bl_time


### PR DESCRIPTION
Fixes #23478

## Problem
`parse_blame_header` dropped the group-size field from git blame porcelain output, causing only the first line of each blame group to be attributed to the correct commit.

## Fix
- `parse_blame_header` now returns `(sha, final_line, group_size)` instead of `(sha, final_line)`
- `parse_blame_porcelain.collect` expands all `group_size` lines from `start_line` to `final_line`
- Updated `.mli` signature accordingly

## Files
- `lib/server/server_routes_http_routes_workspace.ml:637-665`
- `lib/server/server_routes_http_routes_workspace.mli:173`