### PR TITLE
fix(dashboard): extend SnapshotBadge tone type to include warn/bad

### DIFF
--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -21,7 +21,7 @@ import { PanelCard } from './common/panel-card'
 import { SectionHeader } from './common/section-header'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 
-function SnapshotBadge({ tone, children }: { tone: 'accent' | 'neutral' | 'ok'; children: unknown }) {
+function SnapshotBadge({ tone, children }: { tone: 'accent' | 'neutral' | 'ok' | 'warn' | 'bad'; children: unknown }) {
   const chipTone: StatusChipTone = tone === 'accent' ? 'info' : tone
   return html`<${StatusChip} tone=${chipTone} uppercase=${false} class="font-semibold">${children}</${StatusChip}>`
 }


### PR DESCRIPTION
## Summary

Extends `SnapshotBadge` tone type from `'accent' | 'neutral' | 'ok'` to include `'warn'` and `'bad'` so warning/error states can be displayed on checkpoint snapshots.

## Change

**`dashboard/src/components/keeper-detail-history.ts`** — Line 24: Added `'warn' | 'bad'` to the `SnapshotBadge` tone union type.

## Why

`StatusChipTone` already supports `'warn'` and `'bad'`, but `SnapshotBadge`'s type was a strict subset, causing TypeScript errors when trying to pass warning/error tones.

## Verification

- Type-only change — no runtime behavior change
- `StatusChipTone` already handles `'warn'` and `'bad'` tones with appropriate styling
- The `'accent' → 'info'` mapping in the function body is unchanged

Part of task-1846 (Dashboard UX audit).

Closes #23493 (replaces dirty PR with leaked mcp_tool_runtime_board.ml changes).