### PR TITLE
[codex] Clarify compaction snapshot evidence

### DIFF
--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -9,7 +9,11 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
-import { fetchKeeperCompactionSnapshots } from '../../api/dashboard'
+import {
+  fetchKeeperCompactionSnapshots,
+  fetchKeeperTurnRecords,
+  type TurnRecordRow,
+} from '../../api/dashboard'
 import {
   hydrateCompactionSnapshots,
   keeperCompactionSnapshots,
@@ -34,13 +38,33 @@ type CompactionSnapshotLoadState = {
   readonly scanTruncated: boolean
 }
 
+type PromptContextLoadState = {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly rows: readonly TurnRecordRow[]
+  readonly count: number | null
+  readonly health: string | null
+  readonly source: string | null
+  readonly producer: string | null
+}
+
 function isFiniteNumber(n: number | null | undefined): n is number {
   return typeof n === 'number' && Number.isFinite(n)
 }
 
 function fmtTok(n: number | null | undefined): string {
-  if (!isFiniteNumber(n)) return '미수신'
+  if (!isFiniteNumber(n)) return '계측 없음'
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+}
+
+function fmtBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`
+  if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`
+  return `${n}B`
+}
+
+function shortDigest(digest: string): string {
+  return digest.length > 12 ? digest.slice(0, 12) : digest
 }
 
 function CmpStat({
@@ -74,23 +98,6 @@ function CmpStat({
       </div>
     </div>
   `
-}
-
-function cmpFullCtx(ev: CompactionSnapshot, side: 'before' | 'after'): string {
-  const tok = side === 'before' ? ev.before.tok : ev.after.tok
-  const otherTok = side === 'before' ? ev.after.tok : ev.before.tok
-  const label = side === 'before' ? '압축 전' : '압축 후'
-  const lines = [
-    `## ${label} 컨텍스트`,
-    '',
-    `- 총 토큰: ${fmtTok(tok)}`,
-    `- 메시지 수: ${ev.before.msgs != null && ev.after.msgs != null ? String(side === 'before' ? ev.before.msgs : ev.after.msgs) : '미수신'}`,
-    `- trace 수: ${ev.before.traces != null && ev.after.traces != null ? String(side === 'before' ? ev.before.traces : ev.after.traces) : '미수신'}`,
-    `- 반대쪽: ${fmtTok(otherTok)}`,
-    '',
-    '전체 프롬프트 텍스트는 이 API에서 노출하지 않습니다.',
-  ]
-  return lines.join('\n')
 }
 
 function DataGapNote({ children }: { children: string }): VNode {
@@ -177,6 +184,85 @@ function CompactionEmptyState({
   `
 }
 
+function selectPromptContextRow(
+  rows: readonly TurnRecordRow[],
+  ev: CompactionSnapshot,
+): { row: TurnRecordRow | null; linked: boolean } {
+  const linked = rows.find((row) => {
+    if (!ev.traceId || row.record.trace_id !== ev.traceId) return false
+    return ev.keeperTurnId == null || row.record.absolute_turn === ev.keeperTurnId
+  })
+  if (linked) return { row: linked, linked: true }
+  return { row: rows.length > 0 ? rows[rows.length - 1]! : null, linked: false }
+}
+
+function PromptContextEvidence({
+  ev,
+  loadState,
+}: {
+  ev: CompactionSnapshot
+  loadState: PromptContextLoadState
+}): VNode {
+  if (loadState.loading) {
+    return html`<div class="mem-empty mem-disclosure">최근 turn-records prompt blocks 불러오는 중...</div>`
+  }
+  if (loadState.error) {
+    return html`<div class="mem-read-error" role="alert">turn-records 조회 실패 — ${loadState.error}</div>`
+  }
+  const { row, linked } = selectPromptContextRow(loadState.rows, ev)
+  if (!row) {
+    return html`<div class="mem-empty">최근 turn-records가 없어 주입 컨텍스트를 검산할 수 없습니다.</div>`
+  }
+  const blocks = row.record.blocks
+  const totalBytes = blocks.reduce((sum, block) => sum + block.bytes, 0)
+  const inputTok = row.record.input_tokens
+  const ctxWin = row.record.context_window
+  const pct = inputTok != null && ctxWin != null && ctxWin > 0
+    ? Math.round((inputTok / ctxWin) * 100)
+    : null
+  const diff = row.diff_vs_prev
+  return html`
+    <div class="mem-compo" data-testid="compaction-prompt-context">
+      <div class="mem-compo-head">
+        <span class="mono mem-compo-tot">${fmtBytes(totalBytes)}</span>
+        <span class="mem-compo-sub">
+          ${inputTok != null
+            ? html`${fmtTok(inputTok)} tok${ctxWin != null ? html` / ${fmtTok(ctxWin)} window` : null}${pct != null ? html` · ${pct}%` : null}`
+            : html`${blocks.length} blocks`}
+        </span>
+      </div>
+      <div class="mem-trust-sub mono">
+        ${linked ? 'snapshot-linked turn-record' : 'latest turn-record'}
+        · ${row.record.trace_id}#${row.record.absolute_turn}
+        · ${loadState.source ?? 'turn_record'}${loadState.health ? ` · ${loadState.health}` : ''}
+      </div>
+      <div class="mem-trust-sub mono">${loadState.producer ?? 'keeper_turn_record_writer'}</div>
+      ${!linked
+        ? html`<div class="mem-empty mem-disclosure">선택한 snapshot trace가 최근 ${loadState.count ?? blocks.length}개 turn-records 안에 없어 최신 턴의 prompt block 증거를 표시합니다.</div>`
+        : null}
+      <div class="mem-legend">
+        ${blocks.map((block) => html`
+          <div key=${`${block.block}-${block.digest}`} class="mem-leg">
+            <span class="mem-leg-sw" style=${{ background: 'var(--volt-dim)' }}></span>
+            <span class="mem-leg-lbl">${block.block}</span>
+            <span class="mem-leg-v mono">${fmtBytes(block.bytes)} · ${shortDigest(block.digest)}</span>
+          </div>
+        `)}
+      </div>
+      ${diff
+        ? html`
+          <div class="mem-prompt-foot">
+            이전 턴 대비 added ${diff.added.length} · removed ${diff.removed.length} · changed ${diff.changed.length}
+          </div>
+        `
+        : null}
+      <div class="mem-prompt-foot">
+        raw prompt text는 이 화면/API에서 노출하지 않습니다. 이 표는 실제 주입된 prompt block의 이름, 크기, digest 증거입니다.
+      </div>
+    </div>
+  `
+}
+
 export function CompactionInspectorOverlay({
   keeper,
   onClose,
@@ -192,7 +278,6 @@ export function CompactionInspectorOverlay({
   const hydratedEvents = hydratedState.keeperName === keeper.name ? hydratedState.events : []
   const events = globalEvents.length > 0 ? globalEvents : hydratedEvents
   const [idx, setIdx] = useState(0)
-  const [side, setSide] = useState<'before' | 'after'>('after')
   const [loadState, setLoadState] = useState<CompactionSnapshotLoadState>({
     loading: true,
     error: null,
@@ -204,6 +289,15 @@ export function CompactionInspectorOverlay({
     readErrorCount: 0,
     readErrors: [],
     scanTruncated: false,
+  })
+  const [promptContextState, setPromptContextState] = useState<PromptContextLoadState>({
+    loading: true,
+    error: null,
+    rows: [],
+    count: null,
+    health: null,
+    source: null,
+    producer: null,
   })
 
   useEffect(() => {
@@ -265,6 +359,50 @@ export function CompactionInspectorOverlay({
           readErrorCount: 0,
           readErrors: [],
           scanTruncated: false,
+        })
+      })
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [keeper.name])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let active = true
+    setPromptContextState({
+      loading: true,
+      error: null,
+      rows: [],
+      count: null,
+      health: null,
+      source: null,
+      producer: null,
+    })
+    void fetchKeeperTurnRecords(keeper.name, 12, { signal: controller.signal })
+      .then((payload) => {
+        if (!active) return
+        setPromptContextState({
+          loading: false,
+          error: null,
+          rows: payload.entries,
+          count: payload.count,
+          health: payload.health ?? null,
+          source: payload.source ?? null,
+          producer: payload.producer ?? null,
+        })
+      })
+      .catch((err: unknown) => {
+        if (!active) return
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setPromptContextState({
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+          rows: [],
+          count: null,
+          health: null,
+          source: null,
+          producer: null,
         })
       })
     return () => {
@@ -352,7 +490,7 @@ export function CompactionInspectorOverlay({
             </div>
             ${hasTokenPair
               ? html`<${CmpStat} label="토큰" a=${ev.before.tok} b=${ev.after.tok} unit="k" max=${Math.max(ev.before.tok, 1)} />`
-              : html`<${DataGapNote}>이 snapshot에는 before/after token count가 없습니다.</${DataGapNote}>`}
+              : html`<${DataGapNote}>이 snapshot은 compaction event는 확인하지만 before/after token count는 기록하지 않았습니다.</${DataGapNote}>`}
             ${ev.before.msgs != null && ev.after.msgs != null
               ? html`<${CmpStat} label="메시지" a=${ev.before.msgs} b=${ev.after.msgs} max=${Math.max(ev.before.msgs, 1)} />`
               : null}
@@ -364,7 +502,7 @@ export function CompactionInspectorOverlay({
           <div class="turn-sec">
             <h4>유지 · 요약 · 폐기</h4>
             ${ev.kept.length === 0 && ev.summarized.length === 0 && ev.dropped.length === 0
-              ? html`<${DataGapNote}>백엔드 API는 상세 분류(kept / summarized / dropped)와 raw prompt text를 노출하지 않습니다.</${DataGapNote}>`
+              ? html`<${DataGapNote}>현재 백엔드 projection은 kept / summarized / dropped 목록을 노출하지 않습니다. 이 snapshot은 "컴팩션 이벤트 발생"과 가능한 token 계측만 증명합니다.</${DataGapNote}>`
               : html`
                 <div class="cmp-diff">
                   <div class="cmp-col kept">
@@ -390,16 +528,8 @@ export function CompactionInspectorOverlay({
           </div>
 
           <div class="turn-sec">
-            <h4>전체 컨텍스트 (실제 프롬프트)</h4>
-            <div class="cmp-side-toggle">
-              <button type="button" class=${`cmp-side ${side === 'before' ? 'on' : ''}`} onClick=${() => setSide('before')}>
-                압축 전 · ${fmtTok(ev.before.tok)}
-              </button>
-              <button type="button" class=${`cmp-side ${side === 'after' ? 'on' : ''}`} onClick=${() => setSide('after')}>
-                압축 후 · ${fmtTok(ev.after.tok)}
-              </button>
-            </div>
-            <pre class="turn-pre cmp-ctx-pre">${cmpFullCtx(ev, side)}</pre>
+            <h4>최근 턴 주입 컨텍스트</h4>
+            <${PromptContextEvidence} ev=${ev} loadState=${promptContextState} />
           </div>
         </div>
       </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { shellAuthSummary, tasks } from '../../store'
 import { navigate } from '../../router'
 import { callMcpTool } from '../../api/mcp'
-import { fetchKeeperCompactionSnapshots, fetchRuntimeProviders } from '../../api/dashboard'
+import { fetchKeeperCompactionSnapshots, fetchKeeperTurnRecords, fetchRuntimeProviders } from '../../api/dashboard'
 import { requestConfirm } from '../common/confirm-dialog'
 import { KeeperWorkspaceRail, runtimeRawSpecOpen } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
@@ -30,6 +30,56 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
       entries: [],
     }),
     fetchRuntimeProviders: vi.fn().mockResolvedValue({ providers: [] }),
+    fetchKeeperTurnRecords: vi.fn().mockResolvedValue({
+      keeper: 'masc-improver',
+      count: 2,
+      skipped_rows: 0,
+      source: 'turn_record',
+      producer: 'keeper_agent_run.run_turn|keeper_turn_record_writer',
+      durable_store: '.masc/keepers/masc-improver/turn-records',
+      dashboard_surface: '/api/v1/keepers/:name/turn-records',
+      freshness_slo_s: 300,
+      latest_ts_unix: 1_782_444_590,
+      latest_ts_iso: '2026-06-26T03:03:10Z',
+      latest_age_s: 3,
+      health: 'ok',
+      stale_reason: null,
+      coverage_gaps: [],
+      memory_os: null,
+      user_model: null,
+      entries: [
+        {
+          record: {
+            execution_ids: ['exec-cmp'],
+            keeper: 'masc-improver',
+            trace_id: 'trace-cmp',
+            absolute_turn: 12,
+            blocks: [
+              { block: 'persona', bytes: 2048, digest: 'persona-digest-aaaaaaaa' },
+              { block: 'dynamic_context', bytes: 1024, digest: 'dynamic-digest-bbbbbbbb' },
+              { block: 'memory_os_recall', bytes: 512, digest: 'memory-digest-cccccccc' },
+            ],
+            runtime_profile: 'oas-seoul-1',
+            model: 'runtime',
+            finish_reason: 'completed',
+            input_tokens: 33000,
+            output_tokens: 120,
+            context_window: 200000,
+            ts: 1_782_444_590,
+          },
+          diff_vs_prev: {
+            added: [],
+            removed: [],
+            changed: [
+              {
+                prev: { block: 'dynamic_context', bytes: 900, digest: 'old-dynamic' },
+                next: { block: 'dynamic_context', bytes: 1024, digest: 'dynamic-digest-bbbbbbbb' },
+              },
+            ],
+          },
+        },
+      ],
+    }),
     fetchKeeperCompactionSnapshots: vi.fn().mockResolvedValue({
       schema: 'keeper.compaction_snapshots.v1',
       keeper: 'masc-improver',
@@ -663,6 +713,13 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('proactive(85%)')
     expect(container.textContent).toContain('runtime_manifest · observed')
     expect(container.textContent).toContain('trace-cmp#12')
+    const promptContext = await findByTestId('compaction-prompt-context')
+    expect(fetchKeeperTurnRecords).toHaveBeenCalledWith('masc-improver', 12, expect.any(Object))
+    expect(promptContext.textContent).toContain('snapshot-linked turn-record')
+    expect(promptContext.textContent).toContain('trace-cmp#12')
+    expect(promptContext.textContent).toContain('dynamic_context')
+    expect(promptContext.textContent).toContain('memory_os_recall')
+    expect(promptContext.textContent).toContain('raw prompt text는 이 화면/API에서 노출하지 않습니다')
   })
 
   it('renders live durable compaction snapshots even when token counts are missing', async () => {
@@ -717,7 +774,9 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('pre_dispatch_hygiene')
     expect(container.textContent).toContain('runtime_manifest · compacted')
     expect(container.textContent).toContain('trace-live')
-    expect(container.textContent).toContain('before/after token count가 없습니다')
+    expect(container.textContent).toContain('before/after token count는 기록하지 않았습니다')
+    expect(container.textContent).toContain('latest turn-record')
+    expect(container.textContent).toContain('선택한 snapshot trace가 최근 2개 turn-records 안에 없어')
     expect(container.textContent).not.toContain('아직 이 keeper에서 durable compaction snapshot이 없습니다.')
   })
 


### PR DESCRIPTION
## Summary

Clarifies the keeper compaction snapshot inspector so the panel no longer presents missing telemetry as if the dashboard simply failed to receive it.

## What changed

- Replaces the ambiguous missing-token label with `계측 없음`.
- Removes the misleading "actual prompt" before/after text block, because the backend API does not expose raw prompt text there.
- Adds recent turn-record prompt block evidence to the inspector, including block names, byte sizes, digests, input token/window usage, and whether the row is linked to the selected snapshot or is a latest-turn fallback.
- Updates tests for the new evidence flow and missing-token copy.

## Why

For old durable compaction snapshots, `before_tokens`, `after_tokens`, and detailed kept/summarized/dropped lists can be absent. The previous UI made that look like a mysterious dashboard receive failure. The panel now states what is actually proven: the compaction event exists, but token before/after telemetry may not have been recorded, and raw prompt text is not exposed by this surface.

## Validation

- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/components/keeper-workspace/compaction-inspector-overlay.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts`
- `git diff --check`
- `agent-browser` click-through on `http://127.0.0.1:5177/dashboard/#keepers?keeper=sangsu`, opening `컴팩션 스냅샷 before/after 보기` and confirming the rendered `계측 없음`, data-gap explanation, and recent prompt block evidence.

Screenshot artifact from the browser check: `/private/tmp/masc-compaction-pr-after.png`.