### PR TITLE
[codex] Fix activity route syntax

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -755,6 +755,7 @@ let add_routes ~sw ~clock router =
                    Http.Response.json_value ~status:`Not_found
                      (`Assoc [("error", `String (Board_tool.board_error_to_string e))])
                      reqd)))
+         )
          request reqd)
 
   |> Http.Router.prefix_put "/api/v1/board/sub-boards/" (fun request reqd ->


### PR DESCRIPTION
## Summary

- Close the `with_tool_auth` callback in the board sub-board delete route.
- Restores parsing for `lib/server/server_routes_http_routes_activity.ml` after the identity-enforcement wrapper added in `#23489`.

## Root Cause

The `prefix_delete "/api/v1/board/sub-boards/"` route wrapped its handler with `with_tool_auth`, but the callback was not closed before passing `request reqd`. OCaml therefore treated the route registration as an unmatched `(` and reported the syntax error at EOF.

## Validation

- `ocamlc -stop-after parsing -c lib/server/server_routes_http_routes_activity.ml`
- `git diff --check -- lib/server/server_routes_http_routes_activity.ml`

` scripts/dune-local.sh build bin/main_eio.exe` was attempted, but the wrapper refused because live bare Dune processes were already running outside `scripts/dune-local.sh`.