### PR TITLE
refactor(gate): rename Cdal_evidence_gate → Task_completion_gate (RFC-0311 decap)

### DIFF
--- a/docs/rfc/RFC-0311-typed-evidence-gate.md
+++ b/docs/rfc/RFC-0311-typed-evidence-gate.md
@@ -1,13 +1,13 @@
 ---
 rfc: "0311"
 title: "Typed evidence gate — retire the substring incantation, judgment to the LLM boundary"
-status: Draft
+status: Accepted
 created: 2026-07-06
-updated: 2026-07-06
+updated: 2026-07-07
 author: vincent
 supersedes: []
 superseded_by: null
-related: ["0042", "0088", "0189", "0310"]
+related: ["0042", "0088", "0109", "0189", "0199", "0310"]
 implementation_prs: []
 ---
 
@@ -73,3 +73,29 @@ done 판정의 결정론 층이 substring 주문(incantation)으로 구현되어
 - Phase 1: `evidence_refs` typed 필드 추가 + 이중 수용 (typed 또는 legacy substring 통과 — 전환 기간, WARN 관측).
 - Phase 2: LLM fail-closed 배선 + force 감사 이벤트.
 - Phase 3 (removal): `placeholder_note_bodies`, 20자 임계값, `evidence_entry_satisfied` substring 매처, `default_verification_evidence_refs`, 하네스 매직 토큰. — #18840이 스코프한 잔존 안티패턴의 청산 지점.
+
+## 8. 구현 착수 (2026-07-07): 진단 확정 + 운영자 결정
+
+4-agent read-only 진단 워크플로(over-block / leak / current-gate 트랙 + spec)로 §1 문제를 실측 검증했다. Draft → Accepted.
+
+### 8.1 진단 확정 — 과잉차단과 누수는 같은 한 줄
+
+- [근거] `keepers/*.decisions.jsonl` error_preview 142건 중 **142/142가 contracted 경로**(`required_evidence` n_unsat 2/3/4), #23330 no-contract 규칙(`contract_required:false`)은 **0/142**. 원래 지목된 no-contract typed-ref 규칙은 실측 거부가 0건 — 지배적 과잉차단 원인이 아니다.
+- [근거] 모든 task는 생성 시 무조건 계약을 받는다: `workspace_task_create.ml:161` → `ensure_task_contract_for_verification`. 계약 없이 생성해도 `required_evidence` 기본값이 `["completion_notes"; "reviewable_evidence_ref"]`(`workspace_task_classify.ml:200`) 두 메타 토큰으로 채워진다.
+- [근거] 이 기본 토큰을 만족하는 유일한 방법은 리터럴 문자열을 notes에 붙여넣는 substring 매칭(`task_completion_gate.ml:40-56`)이다. trusted-ref 대안은 `evidence_ref_is_gate_trusted ref_ && r = entry_lower`(`:74-78`)로 ref 문자열이 메타 필드명과 **정확히 일치**해야 하는데 어떤 실제 `Evidence_ref`도 그 이름이 될 수 없다. 따라서 한 줄이 동시에 **누수**(라벨 붙여넣기 = fake-done)이자 **과잉차단**(토큰을 모르는 키퍼는 결정론적 거부: nick0cave task-1831 4회 거부 후 포기, sangsu 트레이스 "required_evidence 항목을 verbatim으로 다 써야 하는데 그게 뭔지 모른다").
+- [근거] non-code task의 구조적 블로커: trusted 형태(Url/Trace_ref)를 원리상 생산할 수 있어도 제출 채널 `handoff_context.evidence_refs`가 `action='release'` 전용(`tool_task_schemas.ml:256`, `tool_task_args.ml:143-145`)이라 keeper가 "keeper_task_done 스키마에 노출 안 됨"으로 제출 불가.
+
+### 8.2 운영자 결정 (2026-07-07 ratified)
+
+**제약(최우선)**: 어떤 계약 모델이든 **keeper가 완료 경로에서 멈추면 안 된다**. 이 제약이 아래 설계를 결정한다 — 판단은 task를 붙잡되(AwaitingVerification) keeper lane은 붙잡지 않는다(§3.2).
+
+1. **계약 부여**: 생성 시 필수(마찰↑, 예측 불가)나 분류기(CLAUDE.md/RFC-0042 금지 안티패턴)가 아니라, **항상 부여 + 기본값을 universal typed-ref 요구**(`{Pr, Commit, Url, Trace_ref} 중 임의 trusted ref ≥1`)로. 모든 turn이 산출하는 Trace_ref로 default 충족 가능 → Layer 1 항상 통과 가능(anti-stall). 생성/클레임 시 더 엄격한 kind로 정제 가능(`tool_task_handlers.ml:266`이 이미 typed 계약 인자 수용).
+2. **non-code trusted evidence**: `Url`(발행 링크) + `Trace_ref`(turn:/trace:/receipt:) + 작성 산출물용 `Artifact_exists` 클레임(RFC-0199, `file_bytes` probe로 결정론 검증). raw `File_path`/`File_uri`는 비신뢰 유지(base-path 미해결 = 검토 불가; `task_completion_gate.ml:32-37`의 fail-closed 근거 타당).
+3. **제출 채널 enabler(필수)**: `evidence_refs`를 Done/Submit 경로에 직접 수용 — release 전용 non-empty-summary 결합에서 분리. §8.1의 구조적 블로커 해소.
+
+### 8.3 구현 순서
+
+- **PR-A (본 PR, behavior-preserving decap)**: 게이트 모듈 리네임 `Cdal_evidence_gate` → `Task_completion_gate`(`lib/task_completion_gate.{ml,mli}`), Atomic `cdal_evidence_gate_decide_fn` → `task_completion_gate_decide_fn`, 로그 문자열. rule_id `"cdal_evidence_incomplete"`는 PR-B에서 §5 typed reason으로 교체될 때까지 유지. 행동 변화 0. CDAL 브랜드가 게이트에서 사라지는 지점(생산자 측 `lib/cdal/`·`lib/cdal_runtime/`는 라이브이므로 무관, 별도 정리).
+- **PR-B (behavioral Phase 1+3)**: §3.1 Layer 1 typed 충족 + §8.2 결정 1·2·3. `default_verification_evidence_refs` 매직 토큰 → universal typed-ref, `ref==entry` 동등성 → typed-kind 매칭, enabler, substring 매처 제거(§7 Phase 3), 하네스 매직 토큰 마이그레이션(§4). tripwire 테스트(§6).
+- **PR-C (Phase 2)**: §3.2 LLM fail-closed 판단 + §3.3 force 감사.
+- 영속 계약 마이그레이션: `required_evidence : string list`(문자열 SSOT) → typed kind. 레거시 문자열 계약은 compat read 필요(`types_core.ml:519-540` 주석이 이미 "legacy 문자열 파싱 migration" 경로를 지시).

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -518,7 +518,7 @@ let finalize
   | Error e -> Error e
   | Ok saved_checkpoint ->
     (* Contract-verification proof evaluation / verdict-ledger persistence removed: task/goal
-       completion is verified by [Cdal_evidence_gate] (evidence-substantiveness),
+       completion is verified by [Task_completion_gate] (evidence-substantiveness),
        not by an internal proof/verdict pipeline. *)
     let librarian_messages =
       match saved_checkpoint with

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -2,7 +2,7 @@
 
     Extracted from keeper_agent_run.ml as part of #5732 god-module split.
     Contract-verification proof / contract-verdict / friction logging helpers were removed
-    when verification collapsed to [Cdal_evidence_gate]; only memory-bank
+    when verification collapsed to [Task_completion_gate]; only memory-bank
     write logging remains. *)
 
 let log_keeper_memory_write

--- a/lib/keeper/keeper_turn_telemetry.mli
+++ b/lib/keeper/keeper_turn_telemetry.mli
@@ -2,7 +2,7 @@
 
     Extracted from keeper_agent_run.ml as part of #5732 god-module split.
     Contract-verification proof / contract-verdict / friction logging helpers were removed
-    when verification collapsed to [Cdal_evidence_gate]; only memory-bank
+    when verification collapsed to [Task_completion_gate]; only memory-bank
     write logging remains. *)
 
 (** Log a memory-bank write summary. Promoted to info level when

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -457,7 +457,7 @@ and handle_transition ~tool_name ~start_time ctx args =
     in
     if not needs_gate then Workspace_hooks.Pass
     else
-      (Atomic.get Workspace_hooks.cdal_evidence_gate_decide_fn)
+      (Atomic.get Workspace_hooks.task_completion_gate_decide_fn)
         ~task_id
         ~task_opt
         ~notes

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -114,7 +114,7 @@ let clean_evidence_refs refs =
 (* Typed concat for the verifier request output (observability only).
    Phase E (RFC-0109 closeout) replaced the substring-classifier filter
    with placeholder-only filtering. Gating decisions belong to
-   [Cdal_evidence_gate]. *)
+   [Task_completion_gate]. *)
 let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
     ?submitted_evidence_refs
     (task : Masc_domain.task) =

--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -63,7 +63,7 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
               "task %s is awaiting verification by %s; approve or reject before marking done"
               task_id assignee)))
 
-(* Verification is owned solely by [Cdal_evidence_gate], applied upstream in
+(* Verification is owned solely by [Task_completion_gate], applied upstream in
    [Tool_task.handle_transition]. This per-action layer formerly ran a second
    gate against the contract-verdict ledger; that ledger no longer exists, so this
    layer never rejects. Kept as a typed seam so the transition control flow is

--- a/lib/task_completion_gate.ml
+++ b/lib/task_completion_gate.ml
@@ -189,13 +189,13 @@ let decide ~task_id ~task_opt ~notes ~handoff_context () =
     in
     if evidence_sufficient
     then begin
-      Log.Task.info "cdal_evidence_gate PASS task=%s notes_len=%d handoff_refs=%d"
+      Log.Task.info "task_completion_gate PASS task=%s notes_len=%d handoff_refs=%d"
         task_id (String.length (String.trim notes))
         (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs);
       Pass
     end
     else begin
-      Log.Task.warn "cdal_evidence_gate REJECT task=%s unsatisfied=%d notes_len=%d handoff_refs=%d rule=%s"
+      Log.Task.warn "task_completion_gate REJECT task=%s unsatisfied=%d notes_len=%d handoff_refs=%d rule=%s"
         task_id (List.length unsatisfied) (String.length (String.trim notes))
         (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs)
         rule_id_evidence_incomplete;

--- a/lib/task_completion_gate.mli
+++ b/lib/task_completion_gate.mli
@@ -1,4 +1,4 @@
-(** Cdal_evidence_gate — explicit task verification evidence surface.
+(** Task_completion_gate — explicit task verification evidence surface.
 
     The evidence gate for [submit_for_verification].
     Normal [Done_action] completion is LLM-reviewed by

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -517,7 +517,7 @@ type task_execution_links = {
 (** Task contract - persisted deterministic gate inputs.
 
     [required_evidence : string list] is the live source of truth: the contract
-    evidence gate ([Cdal_evidence_gate]) substring-matches each entry against
+    evidence gate ([Task_completion_gate]) substring-matches each entry against
     task-completion notes / handoff refs to decide whether a contracted task
     may complete.
 

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -424,7 +424,7 @@ type evidence_gate_verdict =
   | Pass
   | Reject of { reason : string; rule_id : string; hint : string; payload_json : Yojson.Safe.t }
 
-let cdal_evidence_gate_decide_fn
+let task_completion_gate_decide_fn
   : (task_id:string ->
      task_opt:Masc_domain.task option ->
      notes:string ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -194,7 +194,7 @@ type evidence_gate_verdict =
   | Pass
   | Reject of { reason : string; rule_id : string; hint : string; payload_json : Yojson.Safe.t }
 
-val cdal_evidence_gate_decide_fn :
+val task_completion_gate_decide_fn :
   (task_id:string ->
    task_opt:Masc_domain.task option ->
    notes:string ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -238,7 +238,7 @@ let transition_task_outcome_r
             , _
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
             , prepare_opt ) ->
-            (* RFC-0109 Phase E: gating is owned by Cdal_evidence_gate (called
+            (* RFC-0109 Phase E: gating is owned by Task_completion_gate (called
                from tool_task.ml before transition_task_r). Here we only
                collect typed evidence refs as observability metadata for
                the verifier request output. Empty list is valid for

--- a/lib/workspace/workspace_task_verification.ml
+++ b/lib/workspace/workspace_task_verification.ml
@@ -2,7 +2,7 @@
     extracted from task_state.ml.
 
     Phase D (RFC-0109 #18715) routed contracted submissions through the
-    typed [Cdal_evidence_gate] decision. Phase E (this module rewrite)
+    typed [Task_completion_gate] decision. Phase E (this module rewrite)
     retires the legacy substring-classifier predicates that used to
     reject empty/analysis-only submissions at the transition layer.
 
@@ -10,7 +10,7 @@
     metadata, handoff context, and a non-empty/non-placeholder notes
     string. They are forwarded to [Verification_protocol.create_submit_request]
     as observability metadata only — the gating decision lives in
-    [Cdal_evidence_gate]. *)
+    [Task_completion_gate]. *)
 
 open Masc_domain
 include Workspace_state

--- a/lib/workspace/workspace_task_verification.mli
+++ b/lib/workspace/workspace_task_verification.mli
@@ -5,7 +5,7 @@
     [evidence_ref_has_verification_artifact_ref] /
     [notes_have_verification_artifact_ref] /
     [verification_evidence_error_message] are gone — gating decisions
-    live in [Cdal_evidence_gate] only. *)
+    live in [Task_completion_gate] only. *)
 
 val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
 

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -642,11 +642,11 @@ let install () =
         ()
       : Workspace_hooks.evidence_gate_verdict
     =
-    match Cdal_evidence_gate.decide ~task_id ~task_opt ~notes ~handoff_context:handoff () with
-    | Cdal_evidence_gate.Pass -> Workspace_hooks.Pass
-    | Cdal_evidence_gate.Reject { reason; rule_id; hint; payload_json } ->
+    match Task_completion_gate.decide ~task_id ~task_opt ~notes ~handoff_context:handoff () with
+    | Task_completion_gate.Pass -> Workspace_hooks.Pass
+    | Task_completion_gate.Reject { reason; rule_id; hint; payload_json } ->
       Workspace_hooks.Reject { reason; rule_id; hint; payload_json }
   in
-  Atomic.set Workspace_hooks.cdal_evidence_gate_decide_fn decide_hook;
+  Atomic.set Workspace_hooks.task_completion_gate_decide_fn decide_hook;
   ()
 ;;

--- a/test/dune
+++ b/test/dune
@@ -306,7 +306,7 @@
   test_keeper_sandbox_read_backend
   test_keeper_path_ssot
   test_tool_input_validation
-  test_cdal_evidence_gate
+  test_task_completion_gate
   test_ocaml_north_star_task_lifecycle
   test_tool_blob_store
   test_tool_bridge_externalize
@@ -658,7 +658,7 @@
   test_tool_input_validation
   ; test_contract_risk removed (team session cleanup)
   ; test_contract_composer removed (team session cleanup)
-  test_cdal_evidence_gate
+  test_task_completion_gate
   test_ocaml_north_star_task_lifecycle
   ; test_risk_digest removed (team session cleanup)
   test_tool_blob_store

--- a/test/test_task_completion_gate.ml
+++ b/test/test_task_completion_gate.ml
@@ -1,4 +1,4 @@
-(** Cdal_evidence_gate — evidence-substantiveness decision tests.
+(** Task_completion_gate — evidence-substantiveness decision tests.
 
     The gate verifies explicit verification submissions by the presence of
     evidence a reviewer can inspect downstream: substantive notes plus the
@@ -8,7 +8,7 @@
 open Alcotest
 open Masc
 
-module Gate = Cdal_evidence_gate
+module Gate = Task_completion_gate
 
 let make_task
       ?(id = "task-1")
@@ -499,7 +499,7 @@ let test_rule_id_constant_stable () =
 
 let () =
   Alcotest.run
-    "cdal_evidence_gate"
+    "task_completion_gate"
     [ ( "evidence-substantiveness"
       , [ test_case "no contract without handoff refs → Reject" `Quick
             test_no_contract_without_handoff_refs_rejects

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -198,22 +198,22 @@ let start_task_001 ctx =
   in
   if not (Tool_result.is_success start) then failwith (Tool_result.message start)
 
-let with_cdal_evidence_gate_decide decide f =
-  let previous = Atomic.get Workspace_hooks.cdal_evidence_gate_decide_fn in
+let with_task_completion_gate_decide decide f =
+  let previous = Atomic.get Workspace_hooks.task_completion_gate_decide_fn in
   Fun.protect
     ~finally:(fun () ->
-      Atomic.set Workspace_hooks.cdal_evidence_gate_decide_fn previous)
+      Atomic.set Workspace_hooks.task_completion_gate_decide_fn previous)
     (fun () ->
-       Atomic.set Workspace_hooks.cdal_evidence_gate_decide_fn decide;
+       Atomic.set Workspace_hooks.task_completion_gate_decide_fn decide;
        f ())
 
 let workspace_evidence_verdict_of_cdal = function
-  | Cdal_evidence_gate.Pass -> Workspace_hooks.Pass
-  | Cdal_evidence_gate.Reject { reason; rule_id; hint; payload_json } ->
+  | Task_completion_gate.Pass -> Workspace_hooks.Pass
+  | Task_completion_gate.Reject { reason; rule_id; hint; payload_json } ->
       Workspace_hooks.Reject { reason; rule_id; hint; payload_json }
 
-let real_cdal_evidence_gate ~task_id ~task_opt ~notes ~handoff () =
-  Cdal_evidence_gate.decide
+let real_task_completion_gate ~task_id ~task_opt ~notes ~handoff () =
+  Task_completion_gate.decide
     ~task_id
     ~task_opt
     ~notes
@@ -1217,7 +1217,7 @@ let () = test "handle_transition_done_prefers_ownership_error_over_cdal_gate" (f
   assert (not (str_contains (Tool_result.message result) "contract verdict"))
 )
 
-let () = test "handle_transition_done_rejects_cdal_evidence_gate_failure" (fun () ->
+let () = test "handle_transition_done_rejects_task_completion_gate_failure" (fun () ->
   let ctx = make_test_ctx () in
   let add_result =
     Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -1240,7 +1240,7 @@ let () = test "handle_transition_done_rejects_cdal_evidence_gate_failure" (fun (
           ()));
   start_task_001 ctx;
   let gate_calls = ref 0 in
-  with_cdal_evidence_gate_decide
+  with_task_completion_gate_decide
     (fun ~task_id ~task_opt ~notes ~handoff:_ () ->
        incr gate_calls;
        assert (String.equal task_id "task-001");
@@ -1289,7 +1289,7 @@ let () = test "handle_transition_done_no_contract_passes_real_cdal_gate" (fun ()
   set_only_task_contract ctx None;
   start_task_001 ctx;
   let gate_calls = ref 0 in
-  with_cdal_evidence_gate_decide
+  with_task_completion_gate_decide
     (fun ~task_id ~task_opt ~notes ~handoff () ->
        incr gate_calls;
        assert (String.equal task_id "task-001");
@@ -1297,7 +1297,7 @@ let () = test "handle_transition_done_no_contract_passes_real_cdal_gate" (fun ()
        (match task_opt with
         | Some { Masc_domain.contract = None; _ } -> ()
         | _ -> failwith "expected analysis-only task with no contract");
-       real_cdal_evidence_gate ~task_id ~task_opt ~notes ~handoff ())
+       real_task_completion_gate ~task_id ~task_opt ~notes ~handoff ())
     (fun () ->
        let result =
          Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -1397,10 +1397,10 @@ let () = test "handle_transition_force_done_still_rejects_cdal_evidence_incomple
          (fun ~base_path:_ ~agent_name ->
             String.equal agent_name "admin-agent");
        let gate_calls = ref 0 in
-       with_cdal_evidence_gate_decide
+       with_task_completion_gate_decide
          (fun ~task_id ~task_opt ~notes ~handoff () ->
             incr gate_calls;
-            real_cdal_evidence_gate ~task_id ~task_opt ~notes ~handoff ())
+            real_task_completion_gate ~task_id ~task_opt ~notes ~handoff ())
          (fun () ->
             let result =
               Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -2041,7 +2041,7 @@ let () = test "transition_missing_task_clears_stale_current_task" (fun () ->
    removes.  Phase E semantics is now pinned by
    [test/test_task_state_verification_phase_e.ml] (5 cases) and by
    the typed contract verdict consultation in
-   [test/test_cdal_evidence_gate.ml] (10 cases).  See issue #18830
+   [test/test_task_completion_gate.ml] (10 cases).  See issue #18830
    Cluster A.1 for the triage record. *)
 
 let task_submit_evidence_notes =
@@ -2114,7 +2114,7 @@ let () = test "transition_pr_url_top_level_is_retired" (fun () ->
    assertion was the third lock-in of the retired behaviour and has
    been removed.  The remaining intent — contracted-task submit
    rejection when no contract verdict and no substantive evidence — is
-   covered by [test/test_cdal_evidence_gate.ml]'s missing-verdict
+   covered by [test/test_task_completion_gate.ml]'s missing-verdict
    arm. See issue #18830 Cluster A.1. *)
 
 let () = test "transition_claim_clears_legacy_cycle_do_not_reclaim_reason" (fun () ->

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -276,7 +276,7 @@ let test_submit_phase_e_no_substring_reject_at_transition () =
   (* RFC-0109 Phase E (2026-05-27): the transition layer no longer
      applies a substring classifier to reject submissions with
      "placeholder-only" notes. Gating for contracted tasks lives in
-     [Cdal_evidence_gate.decide] (see test/test_cdal_evidence_gate.ml).
+     [Task_completion_gate.decide] (see test/test_task_completion_gate.ml).
      transition_task_r called directly forwards typed evidence refs as
      observability metadata and lets the verifier protocol observe what
      the keeper actually wrote. *)


### PR DESCRIPTION
## 무엇 / 왜

task-completion evidence gate에서 CDAL 브랜드를 제거하는 **behavior-preserving 리네임**입니다. 판정 로직은 한 줄도 바꾸지 않습니다 — substring satisfier, 기본 계약, `rule_id` 문자열은 그대로 두고, 행동 변경(typed evidence로 전환)은 후속 PR-B(RFC-0311 Phase 1+3)에서 다룹니다.

이 게이트는 `lib/task/tool_task.ml:460`에서 `Submit_for_verification | Done_action`에만 호출되는 fake-done 안전 불변식입니다. 이름만 정리하고 리뷰 가능한 작은 diff로 분리해, 후속 행동 변경 PR이 깨끗한 base 위에서 검토되게 합니다.

## 변경

- `lib/cdal_evidence_gate.{ml,mli}` → `lib/task_completion_gate.{ml,mli}` (git mv)
- 모듈 참조 `Cdal_evidence_gate` → `Task_completion_gate` (14파일)
- Atomic `Workspace_hooks.cdal_evidence_gate_decide_fn` → `task_completion_gate_decide_fn` (5사이트)
- 로그 문자열 `"cdal_evidence_gate PASS/REJECT"` → `"task_completion_gate ..."`
- `test/test_cdal_evidence_gate.ml` → `test/test_task_completion_gate.ml` (+ `test/dune` 2줄)
- RFC-0311 Draft → Accepted: 확정 진단(142/142 거부가 contracted 경로, 과잉차단+누수가 같은 한 줄) + 운영자 결정 3건 기록

## 건드리지 않은 것

- **판정 로직 무변경**: `evidence_entry_satisfied` substring 매처, `notes_are_substantive` 20자 임계값, `default_verification_evidence_refs`, `ref==entry` 동등성 — 전부 그대로. PR-B에서 typed evidence로 교체.
- **rule_id 문자열** `"cdal_evidence_incomplete"` 유지 — PR-B에서 §5 typed reason(`Rejected_unparseable_ref` 등)으로 교체될 때 함께 마이그레이션. 텔레메트리 소비자 0건 확인(dashboard/scripts에서 참조 없음).
- **생산자 측 CDAL 라이브러리** `lib/cdal/`(Adversarial_eval, keeper 도구가 소비) · `lib/cdal_runtime/`(Autonomy_exec fd-guard, Direct_evidence)는 **라이브** — 게이트와 무관, 이 PR에서 안 건드림.
- 역사적 RFC(0109/0199/0262/0299/0308)의 옛 경로 참조는 역사적 기록으로 유지.

## 로컬 검증

- `dune build --root .` clean
- `test_task_completion_gate` / `test_tool_task_coverage` / `test_verification_fsm` green

## 관련

RFC-0311 (Accepted). Refs #18840. 후속: PR-B(Phase 1+3 typed gate), PR-C(Phase 2 LLM fail-closed).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
