### PR TITLE
fix(test): repair three quick-suite reds on main (pacing shadow Eio ctx, metrics tripwire 249, ide scope message)

### DIFF
--- a/test/test_keeper_pacing.ml
+++ b/test/test_keeper_pacing.ml
@@ -74,6 +74,12 @@ let test_next_turn_due_always_finite () =
   feq "empty state is due now" 7.0 (KP.next_turn_due ~catalog:[ "a" ] ~now:7.0 KP.empty)
 
 let test_shadow_snapshot_isolated_by_keeper () =
+  (* Keeper_pacing_shadow guards its table with Eio.Mutex.use_rw
+     ~protect:true, which needs a fiber context even when uncontended —
+     without Eio_main.run this raised
+     Effect.Unhandled(Cancel.Get_context) on main (2026-07-07). *)
+  Eio_main.run
+  @@ fun _env ->
   let keeper_name = "test-keeper-pacing-shadow-isolated" in
   Alcotest.(check int)
     "unknown keeper snapshot is empty"

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 247
+  check int "Keeper_metrics.all covers every constructor" 249
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -554,7 +554,7 @@ let test_read_annotations_rejects_missing_scope () =
     check
       string
       "missing scope error"
-      "IDE scope is required; pass repo_id or canonical_url"
+      "IDE scope is required; pass repo_id, canonical_url, or keeper_lane"
       (error_message_of_response response);
     check
       string


### PR DESCRIPTION
fix(test): repair three quick-suite reds on main

Build and Test on main (912c41fc1e) fails three tests from two merges:

1. keeper_pacing shadow (W1 #23487): Keeper_pacing_shadow uses
   Eio.Mutex.use_rw ~protect:true, which needs a fiber context even
   uncontended; the test called snapshot outside Eio and raised
   Effect.Unhandled(Cancel.Get_context). Wrap it in Eio_main.run
   (masc_test_deps re-exports eio_main; precedent:
   test_keeper_supervisor).
2. otel_zero_fill module-init (W1 #23487): the documented drift
   tripwire literal was not bumped when PacingShadowEvents/
   PacingShadowNextDueSec joined Keeper_metrics.all — 247 -> 249.
3. server_ide_http scope_contract (#23461): the missing-scope error
   gained keeper_lane in server_ide_http.ml:106 but one test literal
   kept the old two-scope message.

The PR-side quick suite does not run these binaries, so both regressions
surfaced only on the main run — same single-job hostage shape as #23426,
hence one PR for all three.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)