### PR TITLE
fix(keeper): RFC-0313 W2a route projection — auth/no-progress rotate, not escalate

### DIFF
--- a/lib/keeper/keeper_failure_route.ml
+++ b/lib/keeper/keeper_failure_route.ml
@@ -30,15 +30,30 @@ let of_degraded_retry_reason (reason : Keeper_error_classify.degraded_retry_reas
   | Keeper_error_classify.Admission_queue_timeout
   | Keeper_error_classify.Runtime_exhausted
   | Keeper_error_classify.Resumable_cli_session -> Retry_after_pacing
-  (* Provider-bound with candidates left to try: rotate on this turn. *)
-  | Keeper_error_classify.Runtime_candidates_filtered -> Rotate_now
-  (* Deterministic: retrying cannot help. Auth is a config/credential
-     fact; the three no-progress accept-rejections are model-behavior
-     facts. Both become stimuli for an LLM-boundary verdict, not retries. *)
+  (* Runtime-dependent failures: a DIFFERENT runtime (other credentials or
+     model) may succeed, so rotate — never escalate. This matches the
+     current production behavior: [recoverable_runtime_failure_reason]
+     returns a [Some] reason for exactly these (they are the rotation-
+     recoverable set), and the credential-pool candidate filter already
+     rotates auth/no-progress. Auth = this runtime's credential is invalid
+     (a different runtime's is not); no-progress = this model made no
+     progress on this input (a different model may). Correction: these were
+     mis-routed to [Escalate_judgment] in the first W2a landing — a
+     [degraded_retry_reason] is by construction rotation-recoverable, so
+     none of them is a judgment stimulus. *)
+  | Keeper_error_classify.Runtime_candidates_filtered
   | Keeper_error_classify.Auth_error
   | Keeper_error_classify.Read_only_no_progress
   | Keeper_error_classify.Empty_no_progress
-  | Keeper_error_classify.Thinking_only_no_progress -> Escalate_judgment
+  | Keeper_error_classify.Thinking_only_no_progress -> Rotate_now
+(* [Escalate_judgment] is intentionally unreachable from this projection:
+   every [degraded_retry_reason] is rotation-recoverable. Deterministic
+   errors that warrant a judgment stimulus (config / schema / contract /
+   Mcp / catalog illegal-state) are the ones [recoverable_runtime_failure_
+   reason] maps to [None] — i.e. they never become a [degraded_retry_reason]
+   at all, and are routed by the sdk-error-level total router, not here. The
+   [Escalate_judgment] constructor stays in the [route] type for that
+   caller. *)
 
 let is_deterministic = function
   | Escalate_judgment -> true

--- a/lib/keeper/keeper_failure_route.mli
+++ b/lib/keeper/keeper_failure_route.mli
@@ -35,10 +35,15 @@ type route =
 val route_to_string : route -> string
 
 val of_degraded_retry_reason : Keeper_error_classify.degraded_retry_reason -> route
-(** Total, exhaustive map. Deterministic reasons (auth, the three
-    no-progress accept-rejections) route to [Escalate_judgment]; every
-    transient/capacity/timeout reason routes to [Retry_after_pacing];
-    runtime-candidate filtering routes to [Rotate_now]. *)
+(** Total, exhaustive map. Every [degraded_retry_reason] is by construction
+    rotation-recoverable ([recoverable_runtime_failure_reason] returns
+    [Some] only for the recoverable set), so this projection produces only
+    [Retry_after_pacing] (transient / capacity / timeout / quota) and
+    [Rotate_now] (candidate filtering, auth, the three no-progress
+    accept-rejections — all runtime-dependent: a different credential or
+    model may succeed). [Escalate_judgment] is unreachable here; deterministic
+    errors that warrant a judgment stimulus are the [None] family, routed at
+    the sdk-error level, not projected from a [degraded_retry_reason]. *)
 
 val is_deterministic : route -> bool
 (** [true] for [Escalate_judgment]. Convenience for callers deciding

--- a/test/test_keeper_failure_route.ml
+++ b/test/test_keeper_failure_route.ml
@@ -42,10 +42,13 @@ let expected : (EC.degraded_retry_reason * R.route) list =
   ; EC.Capacity_backpressure, R.Retry_after_pacing
   ; EC.Rate_limit, R.Retry_after_pacing
   ; EC.Server_error, R.Retry_after_pacing
-  ; EC.Auth_error, R.Escalate_judgment
-  ; EC.Read_only_no_progress, R.Escalate_judgment
-  ; EC.Empty_no_progress, R.Escalate_judgment
-  ; EC.Thinking_only_no_progress, R.Escalate_judgment
+  (* Runtime-dependent → rotate (a different credential/model may succeed).
+     Matches current production behavior and codex #23495; the earlier W2a
+     landing mis-routed these to Escalate_judgment. *)
+  ; EC.Auth_error, R.Rotate_now
+  ; EC.Read_only_no_progress, R.Rotate_now
+  ; EC.Empty_no_progress, R.Rotate_now
+  ; EC.Thinking_only_no_progress, R.Rotate_now
   ]
 
 (* Every reason maps to the RFC-0313 §2 route the table assigns it. *)


### PR DESCRIPTION
## What

W2a(#23491)가 착지시킨 `Keeper_failure_route.of_degraded_retry_reason`에서 **`Auth_error` + no-progress 3종을 `Escalate_judgment`로 잘못 라우팅**한 것을 `Rotate_now`로 정정합니다.

## 왜 틀렸나

`degraded_retry_reason`은 **정의상 rotation-recoverable** — `recoverable_runtime_failure_reason`이 recoverable set에만 `Some`을 반환합니다. 따라서 이 14-variant 중 judgment stimulus(escalate)는 **하나도 없습니다**. auth·no-progress는 runtime-의존적:
- **auth**: 이 runtime의 credential이 무효 → 다른 credential runtime은 성공 가능 → rotate.
- **no-progress**: 이 model이 이 입력에 진전 없음 → 다른 model은 진전 가능 → rotate.

이는 **현행 프로덕션 동작**(credential-pool candidate filter가 이미 auth/no-progress를 rotate)과 **codex #23495**(같은 4종을 `rotate`)와 정합합니다. W2a의 첫 착지가 escalate로 단정한 게 오류였습니다(제 적대 검증 #23495 코멘트에서 자기발견).

## 결과

`Escalate_judgment`는 이 projection에서 **도달 불가(unreachable)** 가 되고, 주석으로 명시합니다: judgment stimulus 대상(config/schema/contract/Mcp/catalog-illegal)은 `degraded_retry_reason`이 되지 않는 `None` family이며 sdk-error 레벨 라우터 소관입니다. 생성자는 그 caller를 위해 `route` 타입에 유지.

## 안전성

- **소비자 0** (observe-only 모듈, main에 consumer 없음) → behavior change 0. main SSOT 매핑만 정정.
- **divergence 제거**: 내 W2a와 codex #23495가 이제 auth/no-progress에서 동일 → 두 route 모듈의 SSOT 통합(별도 진행)이 합의에서 출발.

## 검증
`test_keeper_failure_route` 3 tests green(4종 기대값 Rotate_now로 갱신), keeper+bin build green, STR/DET gate PASS, ocamlformat clean, RFC gate PASS.

RFC-0313 §2. #23491(W2a) 정정, #23495(codex W2)와 정합.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
