### PR TITLE
fix(board): fail closed on claim rollup persist errors

### DIFF
--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -425,16 +425,17 @@ let posts_jsonl_unlocked store =
     store.posts;
   Buffer.contents buf
 ;;
-let save_posts_jsonl content =
+let save_posts_jsonl_result content =
   try
     ensure_masc_dir ();
     let path = persist_path () in
     match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg -> record_persist_error ~where:"rewrite_posts" msg
+    | Ok () -> Ok ()
+    | Error msg -> persist_io_error ~where:"rewrite_posts" msg
   with
-  | Sys_error msg -> record_persist_error ~where:"rewrite_posts" msg
+  | Sys_error msg -> persist_io_error ~where:"rewrite_posts" msg
 ;;
+let save_posts_jsonl content = ignore (save_posts_jsonl_result content)
 let rewrite_posts store =
   let content = with_lock store (fun () -> posts_jsonl_unlocked store) in
   with_persist_lock store (fun () -> save_posts_jsonl content)
@@ -535,8 +536,9 @@ let rollback_rolled_up_post store ~(previous : post) ~(rolled_up : post) =
   match rollback with
   | Error _ as e -> e
   | Ok posts_jsonl ->
-    with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
-    Ok ()
+    (match with_persist_lock store (fun () -> save_posts_jsonl_result posts_jsonl) with
+     | Ok () -> Ok ()
+     | Error e -> Error (Board_types.show_board_error e))
 ;;
 
 let sub_board_access_to_string = Board_sub_board_json.sub_board_access_to_string
@@ -805,20 +807,30 @@ let create_post_with_outcome
            rollback_fresh_post store post;
            Error e)
       | Ok (`Rolled_up (previous, post, posts_jsonl)) ->
-        with_persist_lock store (fun () -> save_posts_jsonl posts_jsonl);
-        (match after_rollup_persist with
-         | None -> Ok (Rolled_up_post post)
-         | Some hook ->
-           (match hook post with
-            | Ok () -> Ok (Rolled_up_post post)
-            | Error msg ->
-              let message = "status-rollup post-persist hook failed: " ^ msg in
-              (match rollback_rolled_up_post store ~previous ~rolled_up:post with
-               | Ok () -> Error (Validation_error message)
-               | Error rollback ->
-                 Error
-                   (Validation_error
-                      (message ^ "; rollback failed: " ^ rollback)))))
+        (match with_persist_lock store (fun () -> save_posts_jsonl_result posts_jsonl) with
+         | Error persist_error ->
+           let message =
+             "status-rollup persist failed: " ^ Board_types.show_board_error persist_error
+           in
+           (match rollback_rolled_up_post store ~previous ~rolled_up:post with
+            | Ok () -> Error persist_error
+            | Error rollback ->
+              Error
+                (Validation_error (message ^ "; rollback failed: " ^ rollback)))
+         | Ok () ->
+           (match after_rollup_persist with
+            | None -> Ok (Rolled_up_post post)
+            | Some hook ->
+              (match hook post with
+               | Ok () -> Ok (Rolled_up_post post)
+               | Error msg ->
+                 let message = "status-rollup post-persist hook failed: " ^ msg in
+                 (match rollback_rolled_up_post store ~previous ~rolled_up:post with
+                  | Ok () -> Error (Validation_error message)
+                  | Error rollback ->
+                    Error
+                      (Validation_error
+                         (message ^ "; rollback failed: " ^ rollback))))))
       | Ok (`Dedup_hit existing) -> Ok (Dedup_hit existing)
       | Error _ as e -> e)
 ;;

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -58,6 +58,7 @@ val max_jsonl_bytes : int
 val rotate_if_needed : string -> unit
 
 val posts_jsonl_unlocked : store -> string
+val save_posts_jsonl_result : string -> (unit, board_error) result
 val save_posts_jsonl : string -> unit
 val rewrite_posts : store -> unit
 val rewrite_comments : store -> unit

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1774,6 +1774,8 @@ let claim_gate_sidecar_path () =
     (Filename.concat _test_base_path Common.masc_dirname)
     "board_claim_evidence.jsonl"
 
+let claim_gate_posts_path () = Board.persist_path ()
+
 let create_claim_gate_source_post () =
   let correction =
     "Correction: I did not create the PoC claimed here. \
@@ -2057,6 +2059,69 @@ let test_post_create_claim_gate_rolls_back_rollup_sidecar_failure () =
     Yojson.Safe.Util.(post |> member "body" |> to_string);
   Alcotest.(check string)
     "rolled-up meta restored"
+    "first"
+    Yojson.Safe.Util.(post |> member "meta" |> member "rollup_marker" |> to_string)
+
+let test_post_create_claim_gate_skips_sidecar_when_rollup_persist_fails () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let task_id = "task-claim-persist" in
+  let make_rollup_args ~content ~marker =
+    make_args
+      [ "content", `String content
+      ; "author", `String "ramarama"
+      ; "post_kind", `String "automation"
+      ; "meta", `Assoc [ "task_id", `String task_id; "rollup_marker", `String marker ]
+      ; "claims", `List [ `String "artifact_missing" ]
+      ; "artifact_refs", `List [ `String "repos/masc/scratch/task-1746-poc.ml" ]
+      ]
+  in
+  let ok, body =
+    dispatch
+      "masc_board_post"
+      (make_rollup_args
+         ~content:"task-claim-persist checking artifact status"
+         ~marker:"first")
+  in
+  Alcotest.(check bool) "initial claim-gated status post accepted" true ok;
+  let post_id =
+    parse_create_response_json body
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string
+  in
+  let sidecar = claim_gate_sidecar_path () in
+  let sidecar_before = In_channel.with_open_text sidecar In_channel.input_all in
+  let posts_path = claim_gate_posts_path () in
+  Sys.remove posts_path;
+  Unix.mkdir posts_path 0o755;
+  let result =
+    dispatch_result
+      "masc_board_post"
+      (make_rollup_args
+         ~content:"task-claim-persist continuing artifact status"
+         ~marker:"second")
+  in
+  Alcotest.(check bool) "rollup fails when board persist fails" false
+    (Tool_result.is_success result);
+  Alcotest.(check bool) "board persist failure is explicit" true
+    (contains_substring (Tool_result.message result) "rewrite_posts");
+  let sidecar_after = In_channel.with_open_text sidecar In_channel.input_all in
+  Alcotest.(check string)
+    "failed rollup did not append claim evidence"
+    sidecar_before
+    sidecar_after;
+  let post =
+    match Board_dispatch.get_post ~post_id with
+    | Ok post -> Board.post_to_yojson post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  Alcotest.(check string)
+    "failed persist restored body"
+    "task-claim-persist checking artifact status"
+    Yojson.Safe.Util.(post |> member "body" |> to_string);
+  Alcotest.(check string)
+    "failed persist restored meta"
     "first"
     Yojson.Safe.Util.(post |> member "meta" |> member "rollup_marker" |> to_string)
 
@@ -2605,6 +2670,8 @@ let () =
             test_post_create_claim_gate_rolls_back_on_sidecar_failure;
           Alcotest.test_case "claim gate rolls back rollup sidecar failure" `Quick
             test_post_create_claim_gate_rolls_back_rollup_sidecar_failure;
+          Alcotest.test_case "claim gate skips sidecar on rollup persist failure" `Quick
+            test_post_create_claim_gate_skips_sidecar_when_rollup_persist_fails;
           Alcotest.test_case "claim gate projects dashboard evidence state" `Quick
             test_board_dashboard_json_embeds_claim_evidence_projection;
           Alcotest.test_case "claim gate rejects unknown claim kind" `Quick


### PR DESCRIPTION
## Summary
- make the board posts rewrite path result-bearing for status-rollup creates
- prevent claim-evidence sidecar recording unless the rollup snapshot write succeeds
- add a regression that failed rollup persistence restores the post and leaves the sidecar unchanged

## Why
Follow-up to #23486. The merged rollup-hook fix still treated `save_posts_jsonl` as durable even though it logged rewrite failures and returned `unit`. That allowed a failed `board_posts.jsonl` rewrite to be followed by a successful claim-evidence sidecar append and successful tool result.

## Validation
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/board/board_core_persist.ml lib/board/board_core_persist.mli test/test_tool_board_coverage.ml`
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe` blocked locally: repo wrapper refused because multiple bare Dune processes are already running outside `scripts/dune-local.sh`. CI is the build authority for this branch.