### PR TITLE
feat(gate): drop magic-token default contract (RFC-0311 Phase 1a)

### DIFF
--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -197,7 +197,19 @@ let empty_task_contract =
   }
 ;;
 
-let default_verification_evidence_refs = [ "completion_notes"; "reviewable_evidence_ref" ]
+(* RFC-0311 §8: the default verification contract requires no *specific*
+   evidence entries. The prior default
+   [ "completion_notes"; "reviewable_evidence_ref" ] could be satisfied only by
+   pasting those two literal tokens into the completion notes (the gate matched
+   them as substrings). That single mechanism simultaneously (a) over-blocked
+   keepers who did not know the tokens and (b) let any completion be faked by
+   pasting the labels. With no required entries the gate accepts a completion
+   backed by substantive notes OR any trusted typed Evidence_ref (PR / commit /
+   URL / trace id) — one flexible bar across code and non-code tasks. A task
+   that needs stricter, kind-specific evidence sets an explicit contract at
+   creation (masc_add_task takes a full typed contract). Requiring a trusted
+   ref unconditionally and typed-kind binding are deferred to Phase 2/3. *)
+let default_verification_evidence_refs = []
 
 let first_line text =
   match String.index_opt text '\n' with

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -657,10 +657,11 @@ let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
       | Some contract ->
           assert (not contract.strict);
           assert (contract.completion_contract <> []);
-          assert (List.mem "completion_notes" contract.required_evidence);
-          assert (List.mem "reviewable_evidence_ref" contract.required_evidence);
-          assert (List.mem "completion_notes" contract.verify_gate_evidence);
-          assert (List.mem "reviewable_evidence_ref" contract.verify_gate_evidence);
+          (* RFC-0311 §8: the default contract no longer carries magic-token
+             required_evidence. Completion is gated on substantive evidence
+             (notes or a trusted ref), not verbatim token mentions. *)
+          assert (contract.required_evidence = []);
+          assert (contract.verify_gate_evidence = []);
           assert (str_contains (List.hd contract.completion_contract)
                     "Default verification task")
       | None -> failwith "expected default verification contract")
@@ -688,8 +689,12 @@ let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (f
     (fun (task : Masc_domain.task) ->
        match task.contract with
        | Some contract ->
+           (* Default verification contract is injected (completion_contract
+              present); RFC-0311 §8: it no longer carries magic-token
+              required/verify evidence. *)
            assert (contract.completion_contract <> []);
-           assert (contract.verify_gate_evidence <> [])
+           assert (contract.required_evidence = []);
+           assert (contract.verify_gate_evidence = [])
        | None -> failwith "expected default verification contract for batch task")
     tasks
 )

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1333,7 +1333,7 @@ let () = test "handle_transition_done_no_contract_passes_real_cdal_gate" (fun ()
               (Masc_domain.task_status_to_string other)))
 )
 
-let () = test "handle_transition_done_default_contract_accepts_default_evidence_tokens" (fun () ->
+let () = test "handle_transition_done_default_contract_accepts_substantive_notes" (fun () ->
   let ctx = make_test_ctx () in
   let add_result =
     Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
@@ -1354,10 +1354,9 @@ let () = test "handle_transition_done_default_contract_accepts_default_evidence_
           ("action", `String "done");
           ( "notes",
             `String
-              "completion_notes: contract harness completed the live workflow. \
+              "Contract harness completed the live workflow with reviewer-visible notes. \
                Task scope satisfied: Default contract Done task - Mirrors \
-               contract harness task completion. \
-               reviewable_evidence_ref: contract-harness transcript." );
+               contract harness task completion." );
         ])
   in
   if not (Tool_result.is_success result) then


### PR DESCRIPTION
## 무엇 / 왜 (RFC-0311 Phase 1a)

task-completion evidence gate의 매직토큰 default를 제거합니다. #23499(decap 리네임)에 이어지는 행동 변경 1커밋.

`default_verification_evidence_refs`가 `["completion_notes"; "reviewable_evidence_ref"]`였습니다. 이 두 리터럴 토큰을 완료 notes에 붙여넣어야만 충족되는 substring 매칭이 **하나의 메커니즘으로 과잉차단과 누수를 동시에** 만들었습니다:
- 토큰을 모르는 키퍼 → 결정론적 거부 (관측된 gate 거부 **142/142가 이 contracted 경로**, #23330 no-contract 규칙은 0/142)
- 아는 키퍼 → 라벨 붙여넣기로 fake-done

## 변경

default `required_evidence`를 **비웁니다(`[]`)**. 기본 task는 이제 **substantive notes 또는 임의 trusted typed Evidence_ref(PR/commit/URL/trace id)** 로 완료 — code·non-code 통틀어 하나의 유연한 bar. 게이트는 유지(placeholder는 여전히 거부).

- `lib/workspace/workspace_task_classify.ml` — default 토큰 → `[]` (+ 근거 주석)
- `test/test_tool_task_coverage.ml` — default-content assertion 2곳 갱신

## 심플 / 유연

- **심플**: 핵심은 default를 비우는 1줄. gate 로직·explicit-contract 테스트 ~15개는 **손대지 않음**.
- **유연**: 완료 증거로 notes / PR / commit / URL / trace 중 아무거나 수용. 더 엄격한 검증이 필요하면 생성 시 explicit typed contract 지정(masc_add_task가 이미 수용). Explicit contract(non-empty required_evidence)는 **불변**.

## 이 PR에 없는 것 (RFC-0311 Phase 2/3)

- trusted ref **무조건 요구**(notes dual-accept 제거) + typed-kind 계약 binding → substring/notes 경로 완전 은퇴
- **Layer 2 = LLM substantiveness 판단**(fail-closed). **완전한 fake-done 차단은 여기서 완성**. Layer 1(typed 존재)만으로는 stall과 leak을 동시에 못 막음.

## 검증

- gate의 empty-required 동작(substantive notes 또는 trusted ref로 통과)은 `test_task_completion_gate` 176/185가 이미 잠금. 이 변경은 default가 그런 계약을 생성하게 함.
- 로컬 full `dune build`/`runtest`는 CI 위임(대형 OCaml, 로컬 5분 타임아웃). 컴파일/전체 스위트는 required checks에 위임.

## 관련

RFC-0311 (Accepted, §8). 선행 #23499(decap). Refs #18840. 후속: Phase 2/3.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
