### PR TITLE
fix(ide): anchor keeper-relative observation paths at the playground sandbox root (#23469 OBS-2/4/5)

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -77,19 +77,41 @@ let non_empty_string_member name input =
   | _ -> None
 ;;
 
-let observation_file_path_from_tool_input ~base_path input =
+(* #23469 (task-1733 completion): keeper file tools resolve relative paths
+   against the keeper's playground sandbox root ([keeper_default_read_root]),
+   never against the server base path. The observation join mirrors that
+   contract, otherwise the emitted partition describes a file the tool never
+   touched: a sandbox-rooted [repos/<id>/…] edit used to be re-anchored at
+   the server base path and attributed through whichever repository happened
+   to be registered there, and a bare relative path with no [cwd] leaked
+   through unanchored for the resolver to join at the base path. Every
+   relative shape therefore anchors at [sandbox_root]; absolute paths pass
+   through untouched, and a pathless tool call stays a keeper-timeline fact
+   at [base_path]. *)
+let observation_file_path_from_tool_input ~base_path ~sandbox_root input =
+  let under_sandbox p = Filename.concat sandbox_root p in
   match Tool_input_path.tool_input_file_path input with
   | None -> base_path
-  | Some p when Filename.is_relative p && not (sandbox_rooted_relative_path p) ->
-    (match non_empty_string_member "cwd" input with
-     | Some cwd -> Filename.concat cwd p
-     | None -> p)
+  | Some p when Filename.is_relative p ->
+    if sandbox_rooted_relative_path p
+    then under_sandbox p
+    else (
+      match non_empty_string_member "cwd" input with
+      | Some cwd when Filename.is_relative cwd ->
+        under_sandbox (Filename.concat cwd p)
+      | Some cwd -> Filename.concat cwd p
+      | None -> under_sandbox p)
   | Some p -> p
 ;;
 
-let observation_partition_for_tool_input ~config ~kind input =
+let observation_partition_for_tool_input ~config ~meta ~kind input =
   let base_dir = Keeper_alerting_path.project_root_of_config config in
-  let file_path = observation_file_path_from_tool_input ~base_path:base_dir input in
+  let sandbox_root =
+    Keeper_tool_shared_runtime.keeper_observation_sandbox_root ~config ~meta
+  in
+  let file_path =
+    observation_file_path_from_tool_input ~base_path:base_dir ~sandbox_root input
+  in
   Keeper_tool_filesystem_runtime.resolve_partition_for_write
     ~base_dir
     ~kind
@@ -233,10 +255,13 @@ let assemble_hooks
            in
            (* task-1733: resolve the partition from the tool's actual edited
               file (input.path / input.file_path, with explicit cwd honoured
-              for relative paths), not from the [.masc] runtime root. *)
+              for relative paths), not from the [.masc] runtime root.
+              #23469: relative shapes anchor at this keeper's playground
+              sandbox root, matching the file tools' own resolution. *)
            let partition, _ =
              observation_partition_for_tool_input
                ~config
+               ~meta:acc.meta
                ~kind:"tool_event"
                input
            in

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -111,6 +111,9 @@ let observation_partition_for_tool_input ~config ~meta ~kind input =
   in
   let file_path =
     observation_file_path_from_tool_input ~base_path:base_dir ~sandbox_root input
+    |> Keeper_tool_shared_runtime.keeper_observation_host_path_of_visible_path
+         ~config
+         ~meta
   in
   Keeper_tool_filesystem_runtime.resolve_partition_for_write
     ~base_dir

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -55,12 +55,13 @@ let handle_ide_annotate
        (or worse, under whichever repository the base path happened to
        overlap), where repo-scoped IDE reads can never see it. *)
     let anchored_file_path =
-      if Filename.is_relative file_path
-      then
-        Filename.concat
-          (keeper_observation_sandbox_root ~config ~meta)
-          file_path
-      else file_path
+      (if Filename.is_relative file_path
+       then
+         Filename.concat
+           (keeper_observation_sandbox_root ~config ~meta)
+           file_path
+       else file_path)
+      |> keeper_observation_host_path_of_visible_path ~config ~meta
     in
     let partition, stored_file_path =
       Keeper_tool_filesystem_runtime.resolve_partition_for_write

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -13,7 +13,7 @@ open Keeper_tool_shared_runtime
 
 let handle_ide_annotate
       ~(config : Workspace.config)
-      ~(keeper_name : string)
+      ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   : string
   =
@@ -47,16 +47,31 @@ let handle_ide_annotate
       | Some k -> k
       | None -> Agent_observation.Comment
     in
-    let partition, _ =
+    (* #23469 (task-1733): the keeper hands us a path relative to its own
+       working root — the playground sandbox — so anchor it there before
+       partition resolution, exactly like the file tools resolve it. The
+       old join left the path for the resolver to anchor at the server
+       base path, which filed every keeper annotation under [_orphan/]
+       (or worse, under whichever repository the base path happened to
+       overlap), where repo-scoped IDE reads can never see it. *)
+    let anchored_file_path =
+      if Filename.is_relative file_path
+      then
+        Filename.concat
+          (keeper_observation_sandbox_root ~config ~meta)
+          file_path
+      else file_path
+    in
+    let partition, stored_file_path =
       Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir:base_dir ~kind:"annotation" ~file_path
+        ~base_dir:base_dir ~kind:"annotation" ~file_path:anchored_file_path
     in
     match
       Agent_observation.emit_annotation_request
         { base_path = base_dir
         ; partition
-        ; keeper_id = keeper_name
-        ; file_path
+        ; keeper_id = meta.name
+        ; file_path = stored_file_path
         ; line_start
         ; line_end
         ; kind

--- a/lib/keeper/keeper_tool_ide_runtime.mli
+++ b/lib/keeper/keeper_tool_ide_runtime.mli
@@ -4,9 +4,13 @@
 
 val handle_ide_annotate :
   config:Workspace.config ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
   args:Yojson.Safe.t ->
   string
 (** Handle [keeper_ide_annotate] tool call. Creates a line-bound
     annotation in the [.masc-ide/] store and returns the created
-    record's id and positions on success, or an error message. *)
+    record's id and positions on success, or an error message.
+    Relative [file_path] inputs are anchored at the keeper's playground
+    sandbox root before partition resolution (#23469), so annotations on
+    playground repo clones land in the repo's [By_url] bucket with a
+    repo-relative [file_path]. *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -266,10 +266,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
 ;;
 
 let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =
-  Keeper_tool_ide_runtime.handle_ide_annotate
-    ~config
-    ~keeper_name:meta.name
-    ~args
+  Keeper_tool_ide_runtime.handle_ide_annotate ~config ~meta ~args
 ;;
 
 let handle_voice ~config ~(meta : keeper_meta) ~name ~args () =

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -309,6 +309,25 @@ let keeper_default_read_root ~(config : Workspace.config) ~(meta : keeper_meta) 
   keeper_playground_root ~config ~meta
 ;;
 
+(* #23469 (task-1733): observation partitions must interpret keeper-relative
+   tool paths against the same root the file tools resolve against — the
+   keeper's playground sandbox — never the server base path. Unlike
+   [keeper_playground_root] this is a pure path computation: the observation
+   write path is fire-and-forget and must not run the
+   [ensure_sandbox_bundle] directory side effect. Anchored at the normalised
+   project root so a [.masc]-suffixed [config.base_path] cannot double up,
+   and stripped of the bundle-root trailing slash so downstream structural
+   parsers never see an empty path segment. *)
+let keeper_observation_sandbox_root
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+  =
+  Filename.concat
+    (Keeper_alerting_path.project_root_of_config config)
+    (Keeper_alerting_path.strip_trailing_slashes
+       (Keeper_sandbox.host_root_rel_of_meta ~meta))
+;;
+
 let safe_file_exists path =
   try Fs_compat.file_exists path with
   | Sys_error _ -> false

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -328,6 +328,34 @@ let keeper_observation_sandbox_root
        (Keeper_sandbox.host_root_rel_of_meta ~meta))
 ;;
 
+let keeper_observation_host_path_of_visible_path
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      raw_path
+  =
+  if Filename.is_relative raw_path
+     || meta.sandbox_profile <> Keeper_types_profile_sandbox.Docker
+  then raw_path
+  else (
+    let strip = Keeper_alerting_path.strip_trailing_slashes in
+    let normalize path = Keeper_alerting_path.normalize_path_for_check_stripped path in
+    let container_root = Keeper_sandbox.container_root meta.name |> normalize in
+    let raw_norm = normalize raw_path in
+    let host_root = keeper_observation_sandbox_root ~config ~meta |> strip in
+    if String.equal raw_norm container_root
+    then host_root
+    else if String.starts_with ~prefix:(container_root ^ "/") raw_norm
+    then (
+      let suffix =
+        String.sub
+          raw_norm
+          (String.length container_root + 1)
+          (String.length raw_norm - String.length container_root - 1)
+      in
+      Filename.concat host_root suffix)
+    else raw_path)
+;;
+
 let safe_file_exists path =
   try Fs_compat.file_exists path with
   | Sys_error _ -> false

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -88,6 +88,16 @@ val keeper_observation_sandbox_root
   -> meta:Keeper_meta_contract.keeper_meta
   -> string
 
+(** [keeper_observation_host_path_of_visible_path ~config ~meta path] maps a
+    Docker keeper's sandbox-visible absolute path to the corresponding host
+    playground path without creating the sandbox bundle. Local keepers, relative
+    paths, and unrelated absolute paths are returned unchanged. *)
+val keeper_observation_host_path_of_visible_path
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> string
+  -> string
+
 val project_relative_host_path : config:Workspace.config -> string -> string option
 
 val safe_file_exists : string -> bool

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -79,6 +79,15 @@ val keeper_default_read_root
   -> meta:Keeper_meta_contract.keeper_meta
   -> string
 
+(** [keeper_observation_sandbox_root ~config ~meta] is the keeper's
+    playground sandbox root anchored at the normalised project root.
+    Pure path computation for the observation write path — unlike
+    {!keeper_default_read_root} it never creates the sandbox bundle. *)
+val keeper_observation_sandbox_root
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> string
+
 val project_relative_host_path : config:Workspace.config -> string -> string option
 
 val safe_file_exists : string -> bool

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -37,9 +37,34 @@ let sample_repo =
   }
 ;;
 
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ; "goal", `String "hooks observation test"
+      ; "allowed_paths", `List [ `String "*" ]
+      ; ( "sandbox_profile"
+        , `String
+            (Keeper_types_profile_sandbox.sandbox_profile_to_string
+               Keeper_types_profile_sandbox.Local) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok m -> m
+  | Error e -> Alcotest.fail e
+;;
+
+(* #23469: relative tool paths anchor at the keeper's playground sandbox
+   root, mirroring the file tools' own resolution; absolute paths pass
+   through and pathless calls stay at [base_path]. *)
+let sandbox_root = "/sandbox/tester"
+
 let observed_path fields =
   Masc.Keeper_run_tools_hooks.observation_file_path_from_tool_input
     ~base_path:"/tmp/masc-base"
+    ~sandbox_root
     (`Assoc fields)
 ;;
 
@@ -47,7 +72,7 @@ let test_explicit_cwd_scopes_relative_file_path () =
   check
     string
     "cwd/file_path"
-    "repos/masc/lib/foo.ml"
+    "/sandbox/tester/repos/masc/lib/foo.ml"
     (observed_path
        [ "file_path", `String "lib/foo.ml"; "cwd", `String "repos/masc" ])
 ;;
@@ -56,7 +81,7 @@ let test_sandbox_rooted_file_path_ignores_cwd () =
   check
     string
     "sandbox-rooted"
-    "repos/masc/lib/foo.ml"
+    "/sandbox/tester/repos/masc/lib/foo.ml"
     (observed_path
        [ "file_path", `String "repos/masc/lib/foo.ml"
        ; "cwd", `String "repos/other"
@@ -74,11 +99,28 @@ let test_absolute_path_ignores_cwd () =
        ])
 ;;
 
+let test_absolute_cwd_scopes_relative_file_path () =
+  check
+    string
+    "absolute cwd"
+    "/abs/work/lib/foo.ml"
+    (observed_path
+       [ "file_path", `String "lib/foo.ml"; "cwd", `String "/abs/work" ])
+;;
+
+let test_bare_relative_path_anchors_at_sandbox_root () =
+  check
+    string
+    "bare relative"
+    "/sandbox/tester/lib/solo.ml"
+    (observed_path [ "file_path", `String "lib/solo.ml" ])
+;;
+
 let test_blank_path_falls_back_to_file_path () =
   check
     string
     "blank path fallback"
-    "repos/masc/lib/foo.ml"
+    "/sandbox/tester/repos/masc/lib/foo.ml"
     (observed_path
        [ "path", `String " "
        ; "file_path", `String "repos/masc/lib/foo.ml"
@@ -89,7 +131,7 @@ let test_path_priority_matches_ide_helper () =
   check
     string
     "path wins"
-    "repos/masc/lib/from-path.ml"
+    "/sandbox/tester/repos/masc/lib/from-path.ml"
     (observed_path
        [ "path", `String "repos/masc/lib/from-path.ml"
        ; "file_path", `String "repos/masc/lib/from-file-path.ml"
@@ -100,7 +142,7 @@ let test_nested_arguments_path_is_observed () =
   check
     string
     "nested arguments path"
-    "repos/masc/lib/nested.ml"
+    "/sandbox/tester/repos/masc/lib/nested.ml"
     (observed_path
        [ ( "arguments"
          , `Assoc [ "path", `String "repos/masc/lib/nested.ml" ] )
@@ -111,7 +153,7 @@ let test_nested_arguments_relative_path_uses_cwd () =
   check
     string
     "nested arguments cwd"
-    "repos/masc/lib/nested.ml"
+    "/sandbox/tester/repos/masc/lib/nested.ml"
     (observed_path
        [ ( "arguments"
          , `Assoc [ "file_path", `String "lib/nested.ml" ] )
@@ -123,7 +165,7 @@ let test_paths_list_uses_first_string_path () =
   check
     string
     "paths list"
-    "repos/masc/lib/a.ml"
+    "/sandbox/tester/repos/masc/lib/a.ml"
     (observed_path
        [ ( "paths"
          , `List
@@ -137,7 +179,7 @@ let test_files_list_uses_first_object_file_path () =
   check
     string
     "files object file_path"
-    "repos/masc/lib/from-file-object.ml"
+    "/sandbox/tester/repos/masc/lib/from-file-object.ml"
     (observed_path
        [ ( "files"
          , `List
@@ -153,18 +195,36 @@ let test_missing_path_falls_back_to_base_path () =
   check string "base fallback" "/tmp/masc-base" (observed_path [])
 ;;
 
-let test_partition_resolution_uses_project_root_for_masc_base_path () =
+let with_partition_fixture f =
   with_temp_base_path (fun base_path ->
     (match Repo_store.save_all ~base_path [ sample_repo ] with
      | Ok () -> ()
      | Error msg -> fail ("repo save failed: " ^ msg));
     let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
+    let meta = make_meta "tester" in
+    f ~config ~meta)
+;;
+
+let resolve_partition ~config ~meta fields =
+  Masc.Keeper_run_tools_hooks.observation_partition_for_tool_input
+    ~config
+    ~meta
+    ~kind:"tool_event"
+    (`Assoc fields)
+;;
+
+(* The keeper's playground clone of a registered repo resolves to the
+   repo's [By_url] bucket via the structural playground parse — the
+   #23469 regression this case pins: before the sandbox anchor, this
+   input re-anchored at the server base path and only matched because
+   the same repo happened to be registered at [repos/masc] there. *)
+let test_partition_resolution_uses_project_root_for_masc_base_path () =
+  with_partition_fixture (fun ~config ~meta ->
     let partition, rel_path =
-      Masc.Keeper_run_tools_hooks.observation_partition_for_tool_input
+      resolve_partition
         ~config
-        ~kind:"tool_event"
-        (`Assoc
-          [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ])
+        ~meta
+        [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ]
     in
     check string "repo-relative path" "lib/foo.ml" rel_path;
     match partition with
@@ -175,6 +235,41 @@ let test_partition_resolution_uses_project_root_for_masc_base_path () =
     | Agent_observation.Base_unresolved
     | Agent_observation.Legacy_default ->
       fail "expected By_url partition")
+;;
+
+let test_partition_unregistered_playground_repo_is_unmatched () =
+  with_partition_fixture (fun ~config ~meta ->
+    let partition, _ =
+      resolve_partition
+        ~config
+        ~meta
+        [ "path", `String "repos/ghost/lib/foo.ml" ]
+    in
+    match partition with
+    | Agent_observation.Unmatched -> ()
+    | Agent_observation.By_url _
+    | Agent_observation.No_canonical_url
+    | Agent_observation.Base_unresolved
+    | Agent_observation.Legacy_default ->
+      fail "expected Unmatched partition for unregistered playground repo")
+;;
+
+(* A bare relative path outside the [repos/<id>/] lane is a real
+   playground-local file, not a repo file — it must degrade to the typed
+   orphan partition instead of borrowing whichever repository overlaps
+   the server base path. *)
+let test_partition_bare_relative_outside_repos_is_base_unresolved () =
+  with_partition_fixture (fun ~config ~meta ->
+    let partition, _ =
+      resolve_partition ~config ~meta [ "path", `String "notes/todo.md" ]
+    in
+    match partition with
+    | Agent_observation.Base_unresolved -> ()
+    | Agent_observation.By_url _
+    | Agent_observation.No_canonical_url
+    | Agent_observation.Unmatched
+    | Agent_observation.Legacy_default ->
+      fail "expected Base_unresolved partition for playground-local file")
 ;;
 
 let () =
@@ -190,6 +285,14 @@ let () =
             `Quick
             test_sandbox_rooted_file_path_ignores_cwd
         ; test_case "absolute path ignores cwd" `Quick test_absolute_path_ignores_cwd
+        ; test_case
+            "absolute cwd scopes relative file_path"
+            `Quick
+            test_absolute_cwd_scopes_relative_file_path
+        ; test_case
+            "bare relative path anchors at sandbox root"
+            `Quick
+            test_bare_relative_path_anchors_at_sandbox_root
         ; test_case "blank path falls back to file_path" `Quick
             test_blank_path_falls_back_to_file_path
         ; test_case "path priority matches IDE helper" `Quick
@@ -210,6 +313,14 @@ let () =
             "uses project root when config base is .masc"
             `Quick
             test_partition_resolution_uses_project_root_for_masc_base_path
+        ; test_case
+            "unregistered playground repo is Unmatched"
+            `Quick
+            test_partition_unregistered_playground_repo_is_unmatched
+        ; test_case
+            "bare relative outside repos lane is Base_unresolved"
+            `Quick
+            test_partition_bare_relative_outside_repos_is_base_unresolved
         ] )
     ]
 ;;

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -37,7 +37,7 @@ let sample_repo =
   }
 ;;
 
-let make_meta name =
+let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
   let json =
     `Assoc
       [ "name", `String name
@@ -47,8 +47,8 @@ let make_meta name =
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile"
         , `String
-            (Keeper_types_profile_sandbox.sandbox_profile_to_string
-               Keeper_types_profile_sandbox.Local) )
+            (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
+        )
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -195,13 +195,17 @@ let test_missing_path_falls_back_to_base_path () =
   check string "base fallback" "/tmp/masc-base" (observed_path [])
 ;;
 
-let with_partition_fixture f =
+let with_partition_fixture ?sandbox_profile f =
   with_temp_base_path (fun base_path ->
     (match Repo_store.save_all ~base_path [ sample_repo ] with
      | Ok () -> ()
      | Error msg -> fail ("repo save failed: " ^ msg));
     let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
-    let meta = make_meta "tester" in
+    let meta =
+      match sandbox_profile with
+      | Some sandbox_profile -> make_meta ~sandbox_profile "tester"
+      | None -> make_meta "tester"
+    in
     f ~config ~meta)
 ;;
 
@@ -252,6 +256,29 @@ let test_partition_unregistered_playground_repo_is_unmatched () =
     | Agent_observation.Base_unresolved
     | Agent_observation.Legacy_default ->
       fail "expected Unmatched partition for unregistered playground repo")
+;;
+
+let test_partition_docker_visible_path_maps_to_playground_repo () =
+  with_partition_fixture
+    ~sandbox_profile:Keeper_types_profile_sandbox.Docker
+    (fun ~config ~meta ->
+       let container_repo_path =
+         Filename.concat
+           (Keeper_sandbox.container_root meta.name)
+           "repos/masc/lib/docker.ml"
+       in
+       let partition, rel_path =
+         resolve_partition ~config ~meta [ "path", `String container_repo_path ]
+       in
+       check string "repo-relative path" "lib/docker.ml" rel_path;
+       match partition with
+       | Agent_observation.By_url slug ->
+         check string "slug" "github.com_jeong-sik_masc" slug
+       | Agent_observation.No_canonical_url
+       | Agent_observation.Unmatched
+       | Agent_observation.Base_unresolved
+       | Agent_observation.Legacy_default ->
+         fail "expected Docker visible absolute path to resolve to By_url")
 ;;
 
 (* A bare relative path outside the [repos/<id>/] lane is a real
@@ -317,6 +344,10 @@ let () =
             "unregistered playground repo is Unmatched"
             `Quick
             test_partition_unregistered_playground_repo_is_unmatched
+        ; test_case
+            "Docker visible absolute path maps to playground repo"
+            `Quick
+            test_partition_docker_visible_path_maps_to_playground_repo
         ; test_case
             "bare relative outside repos lane is Base_unresolved"
             `Quick


### PR DESCRIPTION
## 무엇이 문제였나 (#23469 OBS-2 / OBS-4 / OBS-5, task-1733 완결)

keeper 파일 도구는 상대경로를 **keeper의 playground sandbox root**(`keeper_default_read_root`)에 대해 해석하는데, 관측(write) 경로만 **서버 base path**에 join했습니다. 도구가 실제로 만진 파일과 관측이 기록한 파일이 다른 파일이었습니다:

1. **OBS-2**: sandbox-rooted `repos/<id>/…` 편집이 base path에 재anchor → base path에 우연히 같은 이름으로 등록된 repo를 통해 귀속되거나(우연의 일치가 유일한 정답 경로), 등록이 없으면 orphan.
2. **OBS-4**: `keeper_ide_annotate`의 LLM-상대경로가 base path join → 모든 keeper annotation이 `_orphan/`행 → repo-scoped IDE read가 영원히 못 봄.
3. **OBS-5**: cursor 이벤트가 tool 이벤트의 잘못된 partition을 그대로 상속 — partition 값 수정으로 함께 해소.

## 무엇을 바꿨나

- `Keeper_tool_shared_runtime.keeper_observation_sandbox_root` 신설: 정규화된 project root에 anchor한 **순수 경로 계산** (`ensure_sandbox_bundle` 디렉토리 side effect 없음 — 관측 경로는 fire-and-forget이므로).
- `observation_file_path_from_tool_input`: 모든 상대경로 형태(sandbox-rooted / cwd-relative / bare)를 sandbox root에 anchor. 절대경로는 통과, 경로 없는 도구 호출은 기존대로 base_path(keeper-timeline fact, #23461의 keeper_lane 계약 유지).
- `handle_ide_annotate`: 동일 anchor + resolver가 돌려준 repo-relative 경로를 저장 — By_url partition의 저장 `file_path`가 read-side 계약(repo-relative)과 일치하게 됨.
- meta 스레딩: hook accumulator의 `acc.meta`, in_process 래퍼의 `meta`를 그대로 전달 (신규 상태 없음).

## 범위에서 제외한 것 (이슈에 명시된 분리)

- **OBS-7** (playground clone dirname ≠ repositories.toml id): clone-시점 repo_id 메타 기록이 필요 — repo provisioning 설계라 별도 진행.
- **OBS-6** (ide_ingest_queue drop-oldest silent): drop 카운터 노출만 하면 CLAUDE.md 워크어라운드 시그니처 1(텔레메트리-as-fix)에 해당 — 이슈 명시대로 backpressure RFC로.

## 검증

- 기존 테스트 12케이스를 sandbox-anchor 기대값으로 갱신 + 신규 5케이스:
  - absolute cwd는 sandbox 미적용 (통과 경로 고정)
  - bare relative → sandbox root anchor
  - playground clone(`repos/masc/…`) → **By_url** (registered id 경유 — 회귀 핀)
  - 미등록 playground repo → **Unmatched** (typed 강등, 조용한 By_url 차용 금지)
  - repos lane 밖 playground-local 파일 → **Base_unresolved**
- `ocamlformat --inplace` 7파일 통과(= full parse 통과). dune build/test는 CI에서 검증.

## RFC

RFC-0128 §4.5 (sandbox/working-tree 관측 join 계약) 하위 작업 — 코드 주석과 이슈 #23469가 인용하는 그 조항의 write-side 완결입니다. keeper_sandbox/containment 파일은 수정하지 않았고 `host_root_rel_of_meta`(기존 export)를 읽기만 합니다.

Closes 없음 — #23469는 OBS-7/OBS-6 잔여가 있어 열어둡니다 (부분 해소 코멘트 예정).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
