### PR TITLE
fix(test): repair two main quick-suite reds (curation identity #23489, W2 hard-quota fixture)

### DIFF
--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1201,7 +1201,11 @@ let test_board_curation_mcp_runtime_routes_read_and_submit () =
   in
   Alcotest.(check bool) "MCP runtime curation submit ok" true submit_ok;
   let submitted = Yojson.Safe.from_string submit_body in
-  Alcotest.(check string) "MCP runtime submitted_by persisted" "mcp-runtime-curator"
+  (* #23489 routes curation_submit through [enforce_caller_identity]:
+     a same-keeper surface form ("mcp-runtime-curator") is stored as the
+     canonical keeper name via [Server_utils.board_actor_author_for_write],
+     with the raw surface preserved in meta. *)
+  Alcotest.(check string) "MCP runtime submitted_by persisted" "curator"
     Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
   let read2_ok, read2_body =
     require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])


### PR DESCRIPTION
## 무엇

main `Build and Test` red 수리 2건 (둘 다 merge-before-green으로 main에서 처음 발현된 stale 테스트 기대값).

실패 런: 657af64717 https://github.com/jeong-sik/masc/actions/runs/28850381180/job/85564077949 · 95950e3890 head 런 동일+추가.

### 1. `test_tool_board_coverage.ml:1204` — "MCP runtime submitted_by persisted"

```
Expected: `"mcp-runtime-curator"'  /  Received: `"curator"'
```

#23489가 `masc_board_curation_submit`을 `enforce_caller_identity`로 라우팅하면서, 동일 키퍼의 surface form(`"mcp-runtime-curator"`)은 canonical keeper name(`"curator"`, `Server_utils.board_actor_author_for_write`)으로 저장되고 raw surface는 meta에 보존됩니다. 테스트가 #23489 이전 passthrough 값을 핀하고 있었음 → 강제 계약으로 기대값 갱신.

### 2. `test_keeper_runtime_failure_route.ml` — "hard-quota message must pace as hard quota, got retry_after_pacing:rate_limited"

W2(#23495) 테스트의 fixture 메시지 `"monthly quota reached"`는 `Retry.hard_quota_indicators`에 **없는** 문자열이라, OAS predicate가 낸 적 없는 분류를 단언하고 있었습니다(#23495 Build and Test가 머지 시각에 취소되어 main에서 처음 실행됨). pinned agent_sdk로 실증:

```
new_fixture_is_hard_quota=true old_fixture_is_hard_quota=false
```

fixture를 실제 indicator(`"exceeded your current quota"`)로 교체. 테스트 의도(predicate 소유권 가드)는 그대로.

## 남은 main red (이 PR 범위 밖)

head 런에는 #23486(board claim gate) 자체 테스트 실패 4건이 추가로 존재 — `test_comment_claim_gate_rejects_missing_artifact_endorsement`(gate가 reject 안 함, Expected false/Received true) + `board_claim_evidence.jsonl` Sys_error. 기능 소유 축 수리 필요 → 별도 이슈로 기록.

## 검증

- 리터럴 2건, 테스트 2파일만 수정. CI `Build and Test`가 두 exe를 실행.
- hard-quota 분류는 스크래치 바이너리로 pinned agent_sdk 대비 실행 검증(위 출력).

RFC-WAIVED: test-only literal alignment to already-merged behavior (#23489, #23495); no subsystem code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
