### PR TITLE
fix(test): curation MCP runtime test expects canonical submitted_by (main red)

### DIFF
--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1201,7 +1201,12 @@ let test_board_curation_mcp_runtime_routes_read_and_submit () =
   in
   Alcotest.(check bool) "MCP runtime curation submit ok" true submit_ok;
   let submitted = Yojson.Safe.from_string submit_body in
-  Alcotest.(check string) "MCP runtime submitted_by persisted" "mcp-runtime-curator"
+  (* #23489 (#10297): [enforce_caller_identity] now runs on
+     [masc_board_curation_submit], so the stored [submitted_by] is the
+     canonical keeper name resolved from the caller's [agent_name]
+     ("mcp-runtime-curator" parses as a generated nickname whose agent
+     type is "curator"), not the raw surface form the caller supplied. *)
+  Alcotest.(check string) "MCP runtime submitted_by persisted" "curator"
     Yojson.Safe.Util.(submitted |> member "submitted_by" |> to_string);
   let read2_ok, read2_body =
     require_mcp_runtime_result ~sw ~clock "masc_board_curation_read" (make_args [])


### PR DESCRIPTION
main Build and Test red 수리: #23489가 masc_board_curation_submit에 enforce_caller_identity를 배선하면서 저장 submitted_by가 canonical keeper 이름("curator")이 됐는데, 테스트 리터럴은 raw surface("mcp-runtime-curator")를 고정하고 있었습니다. CI 실측: Expected mcp-runtime-curator / Received curator (run 28850381180). #23461 리터럴 미스(#23500이 수리)와 동일 클래스 — 계약 변경이 quick-suite 영수증 완료 전 머지. 테스트 기대값을 #10297/#23489 계약(canonical 저장, raw는 meta 보존)으로 갱신.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>