### PR TITLE
fix(dashboard): harden keeper lifecycle follow-up

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -797,6 +797,10 @@ export async function fetchKeeperTransitions(
 
 // --- Keeper lifecycle timeline (#12798) ---
 
+// Detail views need enough recent lifecycle entries to avoid silently truncating
+// active keepers, while compact surfaces can still pass an explicit lower limit.
+export const KEEPER_LIFECYCLE_DEFAULT_LIMIT = 200
+
 export interface KeeperLifecycleEvent {
   ts: number
   event: string
@@ -832,7 +836,7 @@ export function parseKeeperLifecycleResponse(raw: unknown): KeeperLifecycleTimel
 
 export async function fetchKeeperLifecycle(
   name: string,
-  limit = 200,
+  limit = KEEPER_LIFECYCLE_DEFAULT_LIMIT,
   opts?: { signal?: AbortSignal },
 ): Promise<KeeperLifecycleTimelineResponse> {
   const resp = await fetchWithTimeout(

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -252,10 +252,6 @@ export function AgentDetailOverlay() {
     >
       <div class="p-6 flex flex-col gap-5">
         <div class="flex justify-between items-start gap-4">
-          <div class="flex items-center gap-2">
-            <button class="btn btn-sm btn-ghost" onclick="${refreshAgentDetail}" title="Refresh">⟳</button>
-            <button class="btn btn-sm btn-ghost" onclick="${closeAgentDetail}" title="Close">✕</button>
-          </div>
           <div class="flex flex-col gap-3 flex-1">
             <div class="flex items-center gap-4">
               ${agentEmoji ? html`<div class="size-12 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] flex items-center justify-center text-3xl shadow-inset">${agentEmoji}</div>` : ''}
@@ -267,7 +263,7 @@ export function AgentDetailOverlay() {
                 </h2>
                 <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${unified.canonical} />
-                  <${KeeperPhaseBadge} phase=${keeper.phase} compact=${true} />
+                  ${keeper ? html`<${KeeperPhaseBadge} phase=${keeper.phase} compact=${true} />` : null}
                   ${unified.description !== unified.label ? html`<span class="text-2xs font-medium py-1 px-2 border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)] whitespace-nowrap rounded-[var(--r-1)]" title=${unified.description}>${unified.description}</span>` : null}
                   ${isArchivedParticipant ? html`<${IdPill}>이전 세션 참여자<//>` : null}
                   ${!agent && missionBrief?.archived_reason

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -1,4 +1,3 @@
-import { mentionText, sendingMention, submitMention } from './agent-detail-state'
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 import { signal } from '@preact/signals'


### PR DESCRIPTION
Follow-up to #23517. That PR merged with a dashboard compile break and with the lifecycle limit still encoded as an unnamed magic default.

P0: fixes the merged dashboard typecheck break by guarding the keeper phase badge and removing the unused keeper-detail import.

P1: replaces the hardcoded lifecycle default with `KEEPER_LIFECYCLE_DEFAULT_LIMIT` plus a local rationale.

P2: removes the duplicate raw refresh/close buttons; the existing header ActionButton controls remain.

P3: draft until CI completes.

Validation:
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-lifecycle-timeline.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`

No local Dune run; this is dashboard-only.