### PR TITLE
feat(keeper): RFC-0313 W3 — flip failure-driven pauses to pacing + judgment stimuli

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1023,6 +1023,21 @@ recent_restart_count_threshold = 2
 tool_failure_count_threshold = 3
 tool_failure_ratio_threshold = 0.7
 
+# ── Pacing (RFC-0313 W3) ────────────────────────────────────────────
+# 실패는 존재(pause/crash/dead)가 아니라 per-runtime revisit 간격만 바꾼다.
+# - mode: "enforce"(기본) = failure-driven pause 경로 생략 + 스케줄러가
+#   revisit due를 소비. "shadow" = W3 이전 레거시 동작으로 되돌리는
+#   kill-switch (1 릴리즈 한정, W4에서 스위치 자체 제거).
+#   알 수 없는 값은 load 단계에서 config parse 실패 (fail-closed).
+# - base_sec / multiplier / cap_sec: 실패 시 revisit 지연 =
+#   min(cap_sec, base_sec * multiplier^(연속실패-1)); provider retry_after
+#   힌트가 있으면 그 값이 우선. 숫자 knob 누락/오타입은 warn + default.
+[pacing]
+mode = "enforce"
+base_sec = 30.0
+multiplier = 2.0
+cap_sec = 3600.0
+
 # ── Fusion 패널+심판 심의 (RFC-0252) ─────────────────────────────────
 # masc_fusion 도구의 out-of-band 심의 루프 설정. 개인 dev 카나리로 기본 ON.
 # harness(RFC-0252 §11) 미검증 — 카나리 출력(panel 답 + judge 종합)으로 사후 판단.

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -722,6 +722,7 @@ let degraded_reason_allows_candidate_cycle = function
 let degraded_rotation_after_recoverable_error
       ?(credential_pool_of_runtime_id = fun _ -> None)
       ?fallback_hint
+      ~(pacing_enforced : bool)
       ~(base_runtime : string)
       ~(effective_runtime : string)
     ~(attempted_runtimes : string list)
@@ -777,18 +778,25 @@ let degraded_rotation_after_recoverable_error
          Some { next_runtime; fallback_reason }
        | None
          when (not (is_completion_contract_violation err))
-              && degraded_reason_allows_candidate_cycle fallback_reason ->
+              && (pacing_enforced
+                  || degraded_reason_allows_candidate_cycle fallback_reason) ->
          (* Non-contract transient infrastructure errors (provider timeout,
             server error, capacity backpressure) may succeed on a later
             candidate pass. Quota/rate-limit classes cap after all candidates:
             retrying the same credential pool just amplifies an account-scoped
-            limit. #19930 *)
+            limit. #19930
+
+            RFC-0313 W3: under enforced pacing the class cap is bypassed —
+            in-turn cycling stays bounded by the turn cycle budget
+            (Candidates_filtered_after_cycles) and cross-turn retries are
+            spaced by revisit pacing, which is what the cap approximated. *)
          (match candidates with
           | [] -> None
           | first_candidate :: _ ->
             Some { next_runtime = first_candidate; fallback_reason })
        | None ->
-         (* Contract violation or quota/rate-limit exhaustion: cap rotation. *)
+         (* Contract violation, or (shadow mode) quota/rate-limit exhaustion:
+            cap rotation. *)
          None)
 
 (** [true] when a structured error indicates context overflow. *)

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -189,10 +189,18 @@ val degraded_retry_after_recoverable_error :
     futile and previously looped forever (2026-05-21, 2026-07-06, #23373).
     Contract violations, read-only no-progress accept rejections, and
     quota/rate-limit classes cap rotation after the candidate set is exhausted.
+
+    RFC-0313 W3: with [pacing_enforced:true] the class-based cycle cap is
+    bypassed — every recoverable class may re-cycle the (pool-filtered)
+    candidate set within the turn's cycle budget, because revisit pacing now
+    spaces the retries the cap used to suppress. [pacing_enforced:false]
+    keeps the legacy cap (kill-switch; the cap and this parameter go away in
+    W4). Contract violations never cycle in either mode.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?credential_pool_of_runtime_id:(string -> string option) ->
   ?fallback_hint:string ->
+  pacing_enforced:bool ->
   base_runtime:string ->
   effective_runtime:string ->
   attempted_runtimes:string list ->

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -81,6 +81,7 @@ type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;
   runtime_backpressure : runtime_backpressure_decision;
+  pacing_block : float option;
   should_run_turn : bool;
   verdict_reasons : string list;
   channel : string;
@@ -290,6 +291,20 @@ let run_keepalive_unified_turn
           ~keeper_resilience_of_name:(fun keeper_name ->
             if Health.is_healthy ~agent_name:keeper_name then None
             else Some "unhealthy")
+            (* RFC-0313 W3: with [pacing.mode = enforce] the scheduler
+               consumes failure revisit pacing — the next turn waits until
+               the earliest runtime revisit is eligible. Shadow mode keeps
+               the pre-W3 behavior (pacing observed, never consulted).
+               [next_due_remaining] (in-memory) is consulted first so the
+               per-tick hot path only pays the [Runtime.pacing] toml read
+               while a revisit is actually pending. *)
+          ~pacing_block_of_name:(fun keeper_name ->
+            match Keeper_pacing_shadow.next_due_remaining ~keeper_name with
+            | None -> None
+            | Some _ as remaining
+              when Keeper_pacing_shadow.pacing_enforced () ->
+              remaining
+            | Some _ -> None)
           ~stop
           ~meta:meta_after_triage
           obs

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -68,6 +68,7 @@ type keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;
   runtime_backpressure : Keeper_heartbeat_loop_observations.runtime_backpressure_decision;
+  pacing_block : float option;
   should_run_turn : bool;
   verdict_reasons : string list;
   channel : string;
@@ -77,6 +78,7 @@ val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
+  ?pacing_block_of_name:(string -> float option) ->
   ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -19,6 +19,7 @@ type keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;
   runtime_backpressure : runtime_backpressure_decision;
+  pacing_block : float option;
   should_run_turn : bool;
   verdict_reasons : string list;
   channel : string;
@@ -28,6 +29,7 @@ let decide_keepalive_scheduling
       ?(runtime_id_of_meta = Keeper_meta_contract.runtime_id_of_meta)
       ?(runtime_resilience_of_name = fun _ -> None)
       ?(keeper_resilience_of_name = fun _ -> None)
+      ?(pacing_block_of_name = fun (_ : string) -> None)
       ?(reactive_wake = false)
       ?(event_queue_triggers = [])
       ~stop
@@ -65,13 +67,28 @@ let decide_keepalive_scheduling
         ~should_run_turn:requested_should_run_turn
         ~runtime_id
   in
+  (* RFC-0313 W3: failure revisit pacing gates when the next turn runs.
+     Consulted only for a turn that would otherwise start — a keeper that is
+     stopped, unrequested, or runtime-backpressured is not additionally
+     stamped as pacing-blocked. *)
+  let pacing_block =
+    match runtime_backpressure with
+    | Runtime_backpressured _ -> None
+    | Runtime_admitted ->
+      if requested_should_run_turn then pacing_block_of_name meta.name else None
+  in
   let should_run_turn =
     match runtime_backpressure with
-    | Runtime_admitted -> requested_should_run_turn
+    | Runtime_admitted -> requested_should_run_turn && Option.is_none pacing_block
     | Runtime_backpressured _ -> false
   in
   let verdict_reasons =
     let base = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
+    let base =
+      match pacing_block with
+      | Some _ -> "pacing_pending" :: base
+      | None -> base
+    in
     match runtime_backpressure with
     | Runtime_backpressured _ -> "runtime_backpressure" :: base
     | Runtime_admitted -> base
@@ -80,6 +97,7 @@ let decide_keepalive_scheduling
   { turn_decision
   ; requested_should_run_turn
   ; runtime_backpressure
+  ; pacing_block
   ; should_run_turn
   ; verdict_reasons
   ; channel

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -4,6 +4,10 @@ type keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;
   runtime_backpressure : Keeper_heartbeat_loop_observations.runtime_backpressure_decision;
+  pacing_block : float option;
+      (** RFC-0313 W3: seconds until the earliest per-runtime revisit is
+          eligible when pacing blocked this turn; [None] when pacing admitted
+          it (or when the turn was already not requested / backpressured). *)
   should_run_turn : bool;
   verdict_reasons : string list;
   channel : string;
@@ -13,6 +17,7 @@ val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(Keeper_meta_contract.keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
+  ?pacing_block_of_name:(string -> float option) ->
   ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->
@@ -20,5 +25,9 @@ val decide_keepalive_scheduling :
   Keeper_world_observation.world_observation ->
   keepalive_scheduling_decision
 (** RFC-0303 Phase 3: the self-cadence wake-tombstone gate is retired;
-    [should_run_turn] is gated only by runtime backpressure on
-    [requested_should_run_turn]. *)
+    [should_run_turn] is gated by runtime backpressure and (RFC-0313 W3)
+    failure revisit pacing on [requested_should_run_turn].
+    [pacing_block_of_name] returns the seconds remaining until the keeper's
+    earliest runtime revisit is eligible ([None] = run now); the default
+    never blocks, callers wire {!Keeper_pacing_shadow.next_due_remaining}
+    when [pacing.mode = enforce]. *)

--- a/lib/keeper/keeper_pacing.ml
+++ b/lib/keeper/keeper_pacing.ml
@@ -6,7 +6,9 @@ type policy =
   ; cap_sec : float
   }
 
-let default_policy = { base_sec = 30.0; multiplier = 2.0; cap_sec = 3600.0 }
+(* Policy values live in config/runtime.toml [pacing]
+   (Runtime_schema.pacing_default when absent); callers build [policy]
+   through [Keeper_pacing_shadow.policy_of_runtime] (RFC-0313 W3). *)
 
 type revisit =
   { eligible_at : float

--- a/lib/keeper/keeper_pacing.mli
+++ b/lib/keeper/keeper_pacing.mli
@@ -20,14 +20,6 @@ type policy =
   ; cap_sec : float (** hard bound: no revisit exceeds now + cap_sec *)
   }
 
-val default_policy : policy
-(** base 30s, x2 per consecutive failure, cap 3600s. Single named
-    site for the shadow phase; RFC-0313 W3 moves the policy to
-    config/runtime.toml [pacing] when pacing becomes enforcing. With
-    these values the 2026-07-06 storm fixture window (300s) admits at
-    most ~7 attempts per runtime vs the 1,002 recorded
-    (test/fixtures/pacing_storm_20260706/). *)
-
 type revisit =
   { eligible_at : float (** unix seconds; runtime may be tried at/after this *)
   ; consecutive : int

--- a/lib/keeper/keeper_pacing_shadow.ml
+++ b/lib/keeper/keeper_pacing_shadow.ml
@@ -3,10 +3,15 @@
 let mu = Eio.Mutex.create ()
 let table : (string, Keeper_pacing.t) Hashtbl.t = Hashtbl.create 64
 
-let catalog_runtime_ids () =
-  match Runtime.get_runtime_ids () with
-  | [] -> []
-  | ids -> ids
+let observed_runtime_ids state = List.map fst state
+
+let next_due_remaining_of_state ~now state =
+  match observed_runtime_ids state with
+  | [] -> None
+  | catalog ->
+    let due = Keeper_pacing.next_turn_due ~catalog ~now state in
+    let remaining = due -. now in
+    if remaining > 0.0 then Some remaining else None
 
 let policy_of_runtime () =
   let p = Runtime.pacing () in
@@ -25,14 +30,17 @@ let emit_telemetry ~keeper_name ~runtime_id ~kind ~state ~now =
     Keeper_metrics.(to_string PacingShadowEvents)
     ~labels:[ "keeper", keeper_name; "runtime", runtime_id; "kind", kind ]
     ();
-  match catalog_runtime_ids () with
-  | [] -> ()
-  | catalog ->
-    let due = Keeper_pacing.next_turn_due ~catalog ~now state in
+  match next_due_remaining_of_state ~now state with
+  | None ->
     Otel_metric_store.set_gauge
       Keeper_metrics.(to_string PacingShadowNextDueSec)
       ~labels:[ "keeper", keeper_name ]
-      (Float.max 0.0 (due -. now))
+      0.0
+  | Some remaining ->
+    Otel_metric_store.set_gauge
+      Keeper_metrics.(to_string PacingShadowNextDueSec)
+      ~labels:[ "keeper", keeper_name ]
+      remaining
 
 let update ~keeper_name ~runtime_id ~kind f =
   let now = Time_compat.now () in
@@ -75,10 +83,4 @@ let next_due_remaining ~keeper_name =
   in
   match state with
   | None -> None
-  | Some state ->
-    (match catalog_runtime_ids () with
-     | [] -> None
-     | catalog ->
-       let due = Keeper_pacing.next_turn_due ~catalog ~now state in
-       let remaining = due -. now in
-       if remaining > 0.0 then Some remaining else None)
+  | Some state -> next_due_remaining_of_state ~now state

--- a/lib/keeper/keeper_pacing_shadow.ml
+++ b/lib/keeper/keeper_pacing_shadow.ml
@@ -1,4 +1,4 @@
-(* RFC-0313 W1 — observe-only pacing shadow. See keeper_pacing_shadow.mli. *)
+(* RFC-0313 W1/W3 — process-wide pacing state store. See keeper_pacing_shadow.mli. *)
 
 let mu = Eio.Mutex.create ()
 let table : (string, Keeper_pacing.t) Hashtbl.t = Hashtbl.create 64
@@ -7,6 +7,18 @@ let catalog_runtime_ids () =
   match Runtime.get_runtime_ids () with
   | [] -> []
   | ids -> ids
+
+let policy_of_runtime () =
+  let p = Runtime.pacing () in
+  { Keeper_pacing.base_sec = p.Runtime_schema.pacing_base_sec
+  ; multiplier = p.Runtime_schema.pacing_multiplier
+  ; cap_sec = p.Runtime_schema.pacing_cap_sec
+  }
+
+let pacing_enforced () =
+  match (Runtime.pacing ()).Runtime_schema.pacing_mode with
+  | Runtime_schema.Pacing_enforce -> true
+  | Runtime_schema.Pacing_shadow -> false
 
 let emit_telemetry ~keeper_name ~runtime_id ~kind ~state ~now =
   Otel_metric_store.inc_counter
@@ -40,7 +52,7 @@ let update ~keeper_name ~runtime_id ~kind f =
 let observe_failure ~keeper_name ~runtime_id ~retry_after =
   update ~keeper_name ~runtime_id ~kind:"failure" (fun ~now state ->
     Keeper_pacing.on_failure
-      ~policy:Keeper_pacing.default_policy
+      ~policy:(policy_of_runtime ())
       ~runtime_id
       ~retry_after
       ~now
@@ -55,3 +67,18 @@ let snapshot ~keeper_name =
     match Hashtbl.find_opt table keeper_name with
     | Some state -> Keeper_pacing.to_summary state
     | None -> [])
+
+let next_due_remaining ~keeper_name =
+  let now = Time_compat.now () in
+  let state =
+    Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.find_opt table keeper_name)
+  in
+  match state with
+  | None -> None
+  | Some state ->
+    (match catalog_runtime_ids () with
+     | [] -> None
+     | catalog ->
+       let due = Keeper_pacing.next_turn_due ~catalog ~now state in
+       let remaining = due -. now in
+       if remaining > 0.0 then Some remaining else None)

--- a/lib/keeper/keeper_pacing_shadow.mli
+++ b/lib/keeper/keeper_pacing_shadow.mli
@@ -14,9 +14,11 @@
     - counter [Keeper_metrics.PacingShadowEvents]
       labels keeper / runtime / kind (failure | success)
     - gauge [Keeper_metrics.PacingShadowNextDueSec]
-      labels keeper — seconds until the keeper's next turn is due under
-      pacing (0 when some runtime is eligible now), computed over the
-      live runtime catalog. *)
+      labels keeper — seconds until the keeper's next observed failure
+      revisit is due under pacing (0 when no observed failure is pending).
+      The scheduler consumes the same observed pacing state, not the global
+      runtime catalog, so unrelated configured runtimes cannot admit a
+      keeper whose failed runtime still has a revisit delay. *)
 
 val policy_of_runtime : unit -> Keeper_pacing.policy
 (** Pacing policy from runtime.toml [pacing] (defaults when absent). *)
@@ -42,7 +44,7 @@ val snapshot : keeper_name:string -> (string * Keeper_pacing.revisit) list
     is exposed. *)
 
 val next_due_remaining : keeper_name:string -> float option
-(** Seconds until the keeper's earliest runtime revisit becomes eligible,
-    over the live runtime catalog. [None] when the keeper may run now:
-    no failures observed, some runtime already eligible, or the runtime
-    catalog is empty (pacing cannot gate what it cannot enumerate). *)
+(** Seconds until the keeper's earliest observed runtime revisit becomes
+    eligible. [None] when no failure is pending or an observed revisit is
+    already eligible. The query intentionally ignores unrelated runtime
+    catalog entries with no pacing state. *)

--- a/lib/keeper/keeper_pacing_shadow.mli
+++ b/lib/keeper/keeper_pacing_shadow.mli
@@ -1,21 +1,31 @@
-(** RFC-0313 W1 — observe-only pacing shadow.
+(** RFC-0313 W1/W3 — process-wide pacing state store.
 
-    Computes what [Keeper_pacing] WOULD schedule for each keeper and
-    emits telemetry; changes no behavior. Consumers flip to reading
-    this state in RFC-0313 W3, after the storm-replay harness pins the
-    schedule against test/fixtures/pacing_storm_20260706/.
+    W1 introduced this module as an observe-only shadow; since the W3 flip
+    it is the live pacing state: the heartbeat scheduler reads
+    [next_due_remaining] when [pacing.mode = enforce] and delays the
+    keeper's next turn until the earliest per-runtime revisit is eligible.
+    The module name keeps its W1 form until the kill-switch is removed in
+    W4 (renaming while both modes exist would mislabel the shadow mode).
+
+    Policy comes from config/runtime.toml [pacing] via {!Runtime.pacing}
+    ({!Runtime_schema.pacing_default} when absent).
 
     Telemetry per observation:
     - counter [Keeper_metrics.PacingShadowEvents]
       labels keeper / runtime / kind (failure | success)
     - gauge [Keeper_metrics.PacingShadowNextDueSec]
-      labels keeper — seconds until the keeper's next turn would be due
-      under pacing (0 when some runtime is eligible now), computed over
-      the live runtime catalog.
+      labels keeper — seconds until the keeper's next turn is due under
+      pacing (0 when some runtime is eligible now), computed over the
+      live runtime catalog. *)
 
-    [retry_after] is the provider hint when the caller has one in hand;
-    W1 call sites pass [None] (the hint is threaded through routing in
-    RFC-0313 W2). *)
+val policy_of_runtime : unit -> Keeper_pacing.policy
+(** Pacing policy from runtime.toml [pacing] (defaults when absent). *)
+
+val pacing_enforced : unit -> bool
+(** [true] when runtime.toml [pacing].mode = "enforce" (the default):
+    failure-driven pause paths are skipped and the scheduler consumes
+    pacing. [false] restores the pre-W3 legacy behavior (kill-switch for
+    one release; removed in W4). *)
 
 val observe_failure
   :  keeper_name:string
@@ -26,7 +36,13 @@ val observe_failure
 val observe_success : keeper_name:string -> runtime_id:string -> unit
 
 val snapshot : keeper_name:string -> (string * Keeper_pacing.revisit) list
-(** Current shadow schedule for one keeper, sorted by runtime id.
+(** Current pacing schedule for one keeper, sorted by runtime id.
     Empty when nothing has been observed. State is keyed by keeper
     name, so tests isolate by using distinct names — no reset surface
     is exposed. *)
+
+val next_due_remaining : keeper_name:string -> float option
+(** Seconds until the keeper's earliest runtime revisit becomes eligible,
+    over the live runtime catalog. [None] when the keeper may run now:
+    no failures observed, some runtime already eligible, or the runtime
+    catalog is empty (pacing cannot gate what it cannot enumerate). *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -299,6 +299,16 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
     | Some
         { Keeper_failure_policy.lifecycle_effect = Keeper_failure_policy.Pause_keeper
         ; _
+        }
+      when Keeper_pacing_shadow.pacing_enforced () ->
+      (* RFC-0313 W3: failure policy verdicts no longer flip existence. A
+         crashed fiber is process reality; it relaunches on the standard
+         backoff path. The pause arms below stay reachable only in shadow
+         mode (kill-switch, removed in W4). *)
+      queue_standard_restart acc
+    | Some
+        { Keeper_failure_policy.lifecycle_effect = Keeper_failure_policy.Pause_keeper
+        ; _
         } ->
       (match entry.last_failure_reason with
        | Some (Keeper_registry.Stale_termination_storm { count }) ->
@@ -312,7 +322,12 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
             failure gate and let the reconcile loop relaunch a keeper whose
             disk meta still says [paused=false] while operators saw Paused. *)
          (match handle_stale_storm_pause ctx entry ~count with
-          | Ok () -> { acc with to_unregister = entry :: acc.to_unregister }
+          | Ok () ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string FailureDrivenPause)
+             ~labels:[ "keeper", entry.name; "site", "supervisor_stale_storm" ]
+             ();
+           { acc with to_unregister = entry :: acc.to_unregister }
           | Error err ->
             Log.Keeper.warn
               "%s: stale_storm pause not committed (%s); keeping registry entry \
@@ -326,7 +341,12 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
             keeper death. Same fail-closed unregister rule as the stale-storm
             branch above. *)
          (match handle_provider_timeout_pause ctx entry ~count with
-          | Ok () -> { acc with to_unregister = entry :: acc.to_unregister }
+          | Ok () ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string FailureDrivenPause)
+             ~labels:[ "keeper", entry.name; "site", "supervisor_provider_timeout" ]
+             ();
+           { acc with to_unregister = entry :: acc.to_unregister }
           | Error err ->
             Log.Keeper.warn
               "%s: provider_timeout_loop pause not committed (%s); keeping \
@@ -348,7 +368,12 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
             crash-auto-pause path, with the same fail-closed unregister rule as
             the stale-storm / provider-timeout arms above. *)
          (match handle_turn_failure_streak_pause ctx entry ~count with
-          | Ok () -> { acc with to_unregister = entry :: acc.to_unregister }
+          | Ok () ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string FailureDrivenPause)
+             ~labels:[ "keeper", entry.name; "site", "supervisor_turn_failure_streak" ]
+             ();
+           { acc with to_unregister = entry :: acc.to_unregister }
           | Error err ->
             Log.Keeper.warn
               "%s: turn_failure_streak pause not committed (%s); keeping \

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -655,6 +655,24 @@ let pause_keeper_for_overflow
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
     ~(reason : string) : keeper_meta =
+  if Keeper_pacing_shadow.pacing_enforced ()
+  then (
+    (* RFC-0313 W3: unresolved context overflow no longer pauses. The caller
+       fails the turn with the ContextOverflow error, so the routing site in
+       [Keeper_unified_turn] records pacing and enqueues a [Context_overflow]
+       judgment stimulus. Only the failure reason is latched here as
+       evidence. *)
+    Keeper_registry.set_failure_reason
+      ~base_path:config.base_path
+      meta.name
+      (Some Keeper_registry.Turn_overflow_pause);
+    Log.Keeper.warn
+      "%s: unresolved context overflow (%s) recorded without pause \
+       (RFC-0313 W3); judgment stimulus follows from turn failure routing"
+      meta.name
+      reason;
+    meta)
+  else (
   let resume_policy = overflow_pause_resume_policy () in
   match
     Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
@@ -668,6 +686,10 @@ let pause_keeper_for_overflow
       ()
   with
   | Ok paused_meta ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string FailureDrivenPause)
+      ~labels:[ "keeper", meta.name; "site", "turn_overflow" ]
+      ();
     (* Issue #8581: latch the retry-exhausted condition BEFORE the
        Operator_pause that drives the Paused phase.  The SSOT
        function already dispatched [Operator_pause]; we only need
@@ -710,7 +732,7 @@ let pause_keeper_for_overflow
       ~config
       ~keeper_name:meta.name
       Keeper_state_machine.Operator_pause;
-    paused_meta
+    paused_meta)
 
 let sync_keeper_paused_state_impl
     ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy option)
@@ -878,17 +900,32 @@ let make_post_turn_resilience_executor
             ; runtime_id = None
             ; reason = None
             }));
-    match
-      sync_keeper_paused_state_with_resume_policy
-        ~config
-        ~meta:latest_meta
-        ~paused:true
-        ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
-    with
-    | Ok paused_meta ->
-        on_paused paused_meta;
-        Ok ()
-    | Error err -> Error err
+    if Keeper_pacing_shadow.pacing_enforced ()
+    then (
+      (* RFC-0313 W3: post-turn resilience strategies latch the failure
+         reason as evidence but no longer pause. The failed turn already
+         went through failure routing (pacing + judgment stimulus). *)
+      Log.Keeper.warn ~keeper_name:meta.name
+        "%s: post-turn resilience strategy (code=%s) recorded without pause \
+         (RFC-0313 W3): %s"
+        meta.name code detail;
+      Ok ())
+    else
+      match
+        sync_keeper_paused_state_with_resume_policy
+          ~config
+          ~meta:latest_meta
+          ~paused:true
+          ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+      with
+      | Ok paused_meta ->
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string FailureDrivenPause)
+            ~labels:[ "keeper", meta.name; "site", "post_turn_resilience" ]
+            ();
+          on_paused paused_meta;
+          Ok ()
+      | Error err -> Error err
   in
   let fail_and_pause ~code ~detail =
     let detail = short_resilience_detail detail in

--- a/lib/keeper/keeper_turn_runtime_budget_routing.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_routing.ml
@@ -33,6 +33,7 @@ let next_fail_open_runtime_for_turn
   =
   EC.degraded_rotation_after_recoverable_error
     ~credential_pool_of_runtime_id
+    ~pacing_enforced:(Keeper_pacing_shadow.pacing_enforced ())
     ~base_runtime
     ~effective_runtime
     ~attempted_runtimes

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -72,13 +72,21 @@ let record_failure_and_maybe_escalate
       ~base_path:config.base_path
       meta.name
       (Some (Keeper_registry.Turn_consecutive_failures count));
+  (* RFC-0313 W3: with [pacing.mode = enforce] a turn failure never writes
+     [paused=true] — the failure was already recorded as pacing (revisit
+     widening) and, for judgment classes, as a [Failure_judgment] stimulus at
+     the routing site in [Keeper_unified_turn]. The three auto-pause flags
+     below stay reachable only in shadow mode (kill-switch, removed in W4). *)
+  let pacing_enforced = Keeper_pacing_shadow.pacing_enforced () in
   let runtime_auto_paused =
-    EC.is_runtime_exhausted_error err
+    (not pacing_enforced)
+    && EC.is_runtime_exhausted_error err
     && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
   let completion_contract_auto_paused =
-    EC.is_accept_no_usable_progress_error err
+    (not pacing_enforced)
+    && EC.is_accept_no_usable_progress_error err
     && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
@@ -86,7 +94,8 @@ let record_failure_and_maybe_escalate
     completion_contract_auto_paused && EC.is_read_only_no_progress_accept_rejection err
   in
   let idle_detected_auto_paused =
-    is_idle_detected_error err
+    (not pacing_enforced)
+    && is_idle_detected_error err
     && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
@@ -131,6 +140,10 @@ let record_failure_and_maybe_escalate
           ~resume_policy
       with
       | Ok _ ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string FailureDrivenPause)
+          ~labels:[ "keeper", meta.name; "site", "turn_failure_streak" ]
+          ();
         Keeper_registry.set_failure_reason
           ~base_path:config.base_path
           meta.name

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -70,19 +70,34 @@ let persist_turn_livelock_pause
       ~(detail : string)
   : unit
   =
-  match
-    Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
-      ~config
-      ~meta
-      ~reason_tag:"turn_livelock"
-      ~lifecycle_detail:detail
-      ~log_message:(Printf.sprintf "paused keeper after turn livelock block: %s" detail)
-      ~blocker_class:(Some Keeper_meta_contract.Turn_livelock_blocked)
-      ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
-      ()
-  with
-  | Ok _paused_meta -> ()
-  | Error _err -> ()
+  if Keeper_pacing_shadow.pacing_enforced ()
+  then
+    (* RFC-0313 W3: the livelock gate keeps blocking the repeated mutating
+       call in-turn (unchanged), but no longer flips keeper existence. The
+       blocked turn ends through the failure path, which records pacing and
+       routes the error. *)
+    Log.Keeper.warn
+      "%s: turn livelock block recorded without pause (RFC-0313 W3): %s"
+      meta.name
+      detail
+  else (
+    match
+      Keeper_supervisor_pause_policy.handle_auto_pause_from_meta
+        ~config
+        ~meta
+        ~reason_tag:"turn_livelock"
+        ~lifecycle_detail:detail
+        ~log_message:(Printf.sprintf "paused keeper after turn livelock block: %s" detail)
+        ~blocker_class:(Some Keeper_meta_contract.Turn_livelock_blocked)
+        ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+        ()
+    with
+    | Ok _paused_meta ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string FailureDrivenPause)
+        ~labels:[ "keeper", meta.name; "site", "turn_livelock" ]
+        ()
+    | Error _err -> ())
 ;;
 
 let handle

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -744,54 +744,89 @@ let record_completion_contract_attention_failure
     ~agent_name:updated_meta.name
     ~reason:(Keeper_types_profile.short_preview detail);
   let count = Keeper_registry.get_turn_failures ~base_path updated_meta.name in
-  let pause_threshold = Runtime.pause_threshold () in
-  let turn_fail_streak_threshold =
-    pause_threshold.Runtime_schema.turn_fail_streak_threshold
-  in
-  if count >= turn_fail_streak_threshold && not updated_meta.paused
+  if Keeper_pacing_shadow.pacing_enforced ()
   then (
-    let blocker =
-      Keeper_meta_contract.blocker_info_of_class
-        ~detail:(Keeper_types_profile.short_preview detail)
-        Keeper_meta_contract.Completion_contract_violation
-    in
-    let pause_meta =
-      { updated_meta with
-        runtime = { updated_meta.runtime with last_blocker = Some blocker }
+    (* RFC-0313 W3: contract attention after a runtime success is a judgment
+       stimulus, not a pause. The keeper keeps running; its own next turn
+       receives the typed [Failure_judgment] as input (identity-deduped in
+       the queue, no dedicated turn_reason, scheduling cadence unchanged). *)
+    let fj : Keeper_event_queue.failure_judgment =
+      { fj_runtime_id = Keeper_meta_contract.runtime_id_of_meta updated_meta
+      ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
+      ; fj_detail = detail
       }
     in
-    match
-      KCB.sync_keeper_paused_state_with_resume_policy
-        ~config
-        ~meta:pause_meta
-        ~paused:true
-        ~resume_policy:Keeper_supervisor_pause_policy.Manual_resume_required
-    with
-    | Ok paused_meta ->
-      Log.Keeper.warn
-        "%s: auto-paused after %d completion contract attention failures \
-         (pause_threshold=%d, reason=%s); operator must inspect provider/model \
-         reasoning/tool interleave before resuming"
-        updated_meta.name
-        count
-        turn_fail_streak_threshold
-        reason_code;
-      paused_meta
-    | Error sync_err ->
-      Log.Keeper.error
-        "%s: completion contract attention auto-pause sync failed: %s \
-         (persistent failure remains counted)"
-        updated_meta.name
-        sync_err;
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string RuntimeSyncFailures)
-        ~labels:
-          [ "keeper", updated_meta.name
-          ; "site", "completion_contract_attention_auto_pause"
-          ]
-        ();
-      pause_meta)
-  else updated_meta
+    Keeper_registry_event_queue.enqueue
+      ~base_path
+      updated_meta.name
+      { post_id = Keeper_event_queue.failure_judgment_post_id fj
+      ; urgency = Keeper_event_queue.Normal
+      ; arrived_at = Time_compat.now ()
+      ; payload = Keeper_event_queue.Failure_judgment fj
+      };
+    Log.Keeper.warn
+      "%s: completion contract attention (streak=%d, reason=%s) escalated as \
+       judgment stimulus; keeper keeps running (RFC-0313 W3)"
+      updated_meta.name
+      count
+      reason_code;
+    updated_meta)
+  else (
+    let pause_threshold = Runtime.pause_threshold () in
+    let turn_fail_streak_threshold =
+      pause_threshold.Runtime_schema.turn_fail_streak_threshold
+    in
+    if count >= turn_fail_streak_threshold && not updated_meta.paused
+    then (
+      let blocker =
+        Keeper_meta_contract.blocker_info_of_class
+          ~detail:(Keeper_types_profile.short_preview detail)
+          Keeper_meta_contract.Completion_contract_violation
+      in
+      let pause_meta =
+        { updated_meta with
+          runtime = { updated_meta.runtime with last_blocker = Some blocker }
+        }
+      in
+      match
+        KCB.sync_keeper_paused_state_with_resume_policy
+          ~config
+          ~meta:pause_meta
+          ~paused:true
+          ~resume_policy:Keeper_supervisor_pause_policy.Manual_resume_required
+      with
+      | Ok paused_meta ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string FailureDrivenPause)
+          ~labels:
+            [ "keeper", updated_meta.name
+            ; "site", "completion_contract_attention"
+            ]
+          ();
+        Log.Keeper.warn
+          "%s: auto-paused after %d completion contract attention failures \
+           (pause_threshold=%d, reason=%s); operator must inspect provider/model \
+           reasoning/tool interleave before resuming"
+          updated_meta.name
+          count
+          turn_fail_streak_threshold
+          reason_code;
+        paused_meta
+      | Error sync_err ->
+        Log.Keeper.error
+          "%s: completion contract attention auto-pause sync failed: %s \
+           (persistent failure remains counted)"
+          updated_meta.name
+          sync_err;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string RuntimeSyncFailures)
+          ~labels:
+            [ "keeper", updated_meta.name
+            ; "site", "completion_contract_attention_auto_pause"
+            ]
+          ();
+        pause_meta)
+    else updated_meta)
 ;;
 
 let emit_terminal_fsm

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -22,6 +22,7 @@ type t =
   | PacingShadowEvents
   | PacingShadowNextDueSec
   | FailureRoute
+  | FailureDrivenPause
   | IdleSeconds
   | ContractViolations
   | MetricEmitDropped
@@ -281,6 +282,7 @@ let to_string = function
   | PacingShadowEvents -> "masc_keeper_pacing_shadow_events_total"
   | PacingShadowNextDueSec -> "masc_keeper_pacing_shadow_next_due_sec"
   | FailureRoute -> "masc_keeper_failure_route_total"
+  | FailureDrivenPause -> "masc_keeper_failure_driven_pause_total"
   | IdleSeconds -> "masc_keeper_idle_seconds"
   | ContractViolations -> "masc_keeper_contract_violations_total"
   | MetricEmitDropped -> "masc_keeper_metric_emit_dropped_total"
@@ -556,7 +558,7 @@ let to_string = function
 let all : t list =
   [ Turns; InputTokens; OutputTokens; CacheCreationTokens;
     CacheReadTokens; UsageAnomalies; TotalCostUsd; TurnScheduled;
-    TurnCompleted; PacingShadowEvents; PacingShadowNextDueSec; FailureRoute; IdleSeconds; ContractViolations; MetricEmitDropped;
+    TurnCompleted; PacingShadowEvents; PacingShadowNextDueSec; FailureRoute; FailureDrivenPause; IdleSeconds; ContractViolations; MetricEmitDropped;
     ContextMaxObserved; TurnStarts; TurnReattempts; TurnRegressions;
     TurnLivelockBlocks; TurnLivelockBlocksRepeated; TurnLivelockBlocksThresholdPark; TurnLatencyBucket;
     TurnLatencyByModelBucket; ProviderCooldownSkip; ProviderCooldownRemainingSec; ProviderBlockDurationSec;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -13,6 +13,7 @@ type t =
   | PacingShadowEvents
   | PacingShadowNextDueSec
   | FailureRoute
+  | FailureDrivenPause
   | IdleSeconds
   | ContractViolations
   | MetricEmitDropped

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -157,6 +157,12 @@ let route_of_error (err : Agent_sdk.Error.sdk_error) : route =
      | Agent_sdk.Error.Provider p -> route_of_provider_error ~err p
      | Agent_sdk.Error.Mcp _ -> judge ~err Protocol_error
      | Agent_sdk.Error.Config _ -> judge ~err Config_mismatch
+     | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) ->
+       (* RFC-0313 W3: an idle loop (repeated no-usable-progress turns) was
+          a manual-resume pause class on the legacy ladder; under existence
+          invariance it escalates as a behavioral contract judgment, not as
+          an opaque internal error. *)
+       judge ~err Contract_violation
      | Agent_sdk.Error.Agent _
      | Agent_sdk.Error.Serialization _
      | Agent_sdk.Error.Io _

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1250,6 +1250,31 @@ let pause_threshold () =
        Runtime_schema.pause_threshold_default)
 ;;
 
+(* RFC-0313 W3. Same lookup shape as [pause_threshold] above. A config file
+   that fails to parse falls back to [pacing_default] (mode = enforce); the
+   fail-closed [pacing.mode] parse already rejected the file at boot via
+   [Runtime_toml.parse_file], so this fallback only covers a file that is
+   unreadable wholesale. *)
+let pacing () =
+  let runtime_config_path =
+    match (runtime_state ()).config_path with
+    | Some path -> Some path
+    | None -> config_path ()
+  in
+  match runtime_config_path with
+  | None -> Runtime_schema.pacing_default
+  | Some config_path ->
+    (match Runtime_toml.parse_file config_path with
+     | Ok cfg -> cfg.pacing
+     | Error errs ->
+       Log.Runtime.warn
+         "runtime: failed to parse [pacing] from %s (%d error(s)); using \
+          defaults"
+         config_path
+         (List.length errs);
+       Runtime_schema.pacing_default)
+;;
+
 let runtime_config_path_result ?runtime_config_path () =
   match runtime_config_path with
   | Some path -> Ok path

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -254,6 +254,12 @@ val pause_threshold : unit -> pause_threshold
     invalid. Operational pause decision paths use this accessor instead of the
     legacy top-level fallback constants. *)
 
+val pacing : unit -> pacing
+(** [\[pacing\]] policy from runtime.toml (RFC-0313 W3), or
+    {!Runtime_schema.pacing_default} when runtime.toml is unavailable.
+    An unknown [pacing.mode] value fails config parse at load (fail-closed)
+    rather than defaulting. *)
+
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id
     ["provider.model"] equals [id], or [None] if no such runtime is configured.

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -234,6 +234,40 @@ let pause_threshold_default =
   }
 ;;
 
+(** {1 Pacing (RFC-0313 W3)}
+
+    Typed record mirroring the [\[pacing\]] runtime.toml section. Failure
+    outcomes modulate per-runtime revisit pacing instead of keeper existence
+    (pause / crash / dead); this record carries the pacing policy knobs and
+    the W3 behavior switch. *)
+
+type pacing_mode =
+  | Pacing_shadow
+    (** Pacing is computed and logged but the legacy failure-driven pause
+        paths and the cycle-cap matrix stay live. Kill-switch position for
+        one release (RFC-0313 W3); the switch is removed in W4. *)
+  | Pacing_enforce
+    (** Failure-driven pause paths are skipped and the scheduler delays the
+        keeper's next turn until the earliest per-runtime revisit becomes
+        eligible. *)
+[@@deriving show, eq]
+
+type pacing =
+  { pacing_mode : pacing_mode
+  ; pacing_base_sec : float
+  ; pacing_multiplier : float
+  ; pacing_cap_sec : float
+  }
+[@@deriving show, eq]
+
+let pacing_default =
+  { pacing_mode = Pacing_enforce
+  ; pacing_base_sec = 30.0
+  ; pacing_multiplier = 2.0
+  ; pacing_cap_sec = 3600.0
+  }
+;;
+
 (** {1 Lanes}
 
     Lanes are ordered failover candidate lists declared in [runtime.lanes.<id>].
@@ -309,6 +343,14 @@ type config =
         [Pause_threshold.default]. Wrong-type value → load-time warn + fallback
         to default (fail-soft: wrong value is not catastrophic at boot).
         Operational callers read this through [Runtime.pause_threshold]. *)
+  ; pacing : pacing
+    (** [\[pacing\]] (RFC-0313 W3) — per-runtime failure revisit pacing policy
+        plus the shadow/enforce behavior switch. Missing section →
+        [pacing_default]. Numeric knobs fail soft like [\[pause\]]; [mode]
+        fails closed at load (an unknown value aborts config parse) because a
+        typo silently reverting the behavior flip is the permissive-default
+        failure the flip removes. Operational callers read this through
+        [Runtime.pacing]. *)
   ; lane_decls : lane_decl list
     (** [\[runtime.lanes.<id>\]] — ordered failover candidate lists.
         Declarations are resolved against materialized runtimes at load time;

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -158,6 +158,32 @@ type pause_threshold =
 
 val pause_threshold_default : pause_threshold
 
+(** {1 Pacing (RFC-0313 W3)}
+
+    Per-runtime failure revisit pacing: failure outcomes modulate {i when}
+    the next turn runs, never whether the keeper exists. *)
+
+type pacing_mode =
+  | Pacing_shadow
+    (** Pacing is computed and logged but the legacy failure-driven pause
+        paths and the cycle-cap matrix stay live. Kill-switch position for
+        one release (RFC-0313 W3); the switch is removed in W4. *)
+  | Pacing_enforce
+    (** Failure-driven pause paths are skipped and the scheduler delays the
+        keeper's next turn until the earliest per-runtime revisit becomes
+        eligible. *)
+[@@deriving show, eq]
+
+type pacing =
+  { pacing_mode : pacing_mode
+  ; pacing_base_sec : float
+  ; pacing_multiplier : float
+  ; pacing_cap_sec : float
+  }
+[@@deriving show, eq]
+
+val pacing_default : pacing
+
 (** {1 Lanes}
 
     Ordered failover candidate lists declared in [runtime.lanes.<id>].
@@ -225,6 +251,11 @@ type config =
   ; pause_threshold : pause_threshold
     (** [\[pause\]] — typed SSOT for keeper pause / regime threshold knobs.
         Missing or wrong-typed values fall back to [pause_threshold_default]. *)
+  ; pacing : pacing
+    (** [\[pacing\]] (RFC-0313 W3) — failure revisit pacing policy plus the
+        shadow/enforce switch. Missing section → [pacing_default]. Numeric
+        knobs fail soft like [\[pause\]]; an unknown [mode] value aborts
+        config parse (fail-closed). *)
   ; lane_decls : lane_decl list
     (** [\[runtime.lanes.<id>\]] — ordered failover candidate lists.
         Declarations are resolved against materialized runtimes at load time;

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1012,6 +1012,57 @@ let parse_pause_threshold (toml : Otoml.t) : Runtime_schema.pause_threshold =
   }
 ;;
 
+(* [\[pacing\]] section → typed [Runtime_schema.pacing] (RFC-0313 W3).
+
+   Numeric knobs fail soft like [\[pause\]] above (warn + default). [mode]
+   fails closed: an unknown value aborts config load instead of defaulting,
+   because a typo such as "enfoce" silently reverting the W3 behavior flip
+   to shadow is exactly the permissive-default failure the flip removes.
+   Operational callers read this through [Runtime.pacing]. *)
+let parse_pacing (toml : Otoml.t)
+  : (Runtime_schema.pacing, parse_error list) result
+  =
+  let d = Runtime_schema.pacing_default in
+  let read_field ~key ~getter =
+    try Ok (Otoml.find_opt toml getter [ "pacing"; key ]) with
+    | Otoml.Type_error msg -> Error (Printf.sprintf "[pacing].%s: %s" key msg)
+  in
+  let pick_float ~key ~default =
+    match read_field ~key ~getter:Otoml.get_float with
+    | Ok (Some v) -> v
+    | Ok None -> default
+    | Error msg ->
+      Log.Runtime.warn "runtime_toml: %s — using default %g" msg default;
+      default
+  in
+  let mode_result =
+    match read_field ~key:"mode" ~getter:Otoml.get_string with
+    | Ok None -> Ok d.Runtime_schema.pacing_mode
+    | Ok (Some "shadow") -> Ok Runtime_schema.Pacing_shadow
+    | Ok (Some "enforce") -> Ok Runtime_schema.Pacing_enforce
+    | Ok (Some other) ->
+      Error
+        (error
+           "pacing.mode"
+           (Printf.sprintf
+              "unknown pacing mode %S (expected \"shadow\" or \"enforce\")"
+              other))
+    | Error msg -> Error (error "pacing.mode" msg)
+  in
+  match mode_result with
+  | Error _ as e -> e
+  | Ok pacing_mode ->
+    Ok
+      { Runtime_schema.pacing_mode
+      ; pacing_base_sec =
+          pick_float ~key:"base_sec" ~default:d.Runtime_schema.pacing_base_sec
+      ; pacing_multiplier =
+          pick_float ~key:"multiplier" ~default:d.Runtime_schema.pacing_multiplier
+      ; pacing_cap_sec =
+          pick_float ~key:"cap_sec" ~default:d.Runtime_schema.pacing_cap_sec
+      }
+;;
+
 type runtime_section =
   { default_runtime_id : string option
   ; librarian_runtime_id : string option
@@ -1195,6 +1246,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let assignments_result = parse_keeper_assignments toml in
   let bindings_result = parse_bindings toml in
   let lanes_result = parse_lanes toml in
+  let pacing_result = parse_pacing toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs providers_result
@@ -1203,6 +1255,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     @ errs assignments_result
     @ errs bindings_result
     @ errs lanes_result
+    @ errs pacing_result
   in
   if all_errors <> []
   then Error all_errors
@@ -1223,6 +1276,9 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     let lane_decls =
       extract_after_all_errors_guard ~label:"lanes" lanes_result
     in
+    let pacing =
+      extract_after_all_errors_guard ~label:"pacing" pacing_result
+    in
     let pause_threshold = parse_pause_threshold toml in
     Ok
       { Runtime_schema.providers
@@ -1236,6 +1292,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; keeper_assignments
       ; media_failover = runtime_section.media_failover
       ; pause_threshold
+      ; pacing
       ; lane_decls
       })
 ;;

--- a/test/dune
+++ b/test/dune
@@ -2121,6 +2121,8 @@
 
 (include stanzas/test_runtime_pause_threshold_toml.inc)
 
+(include stanzas/test_runtime_pacing_toml.inc)
+
 (include stanzas/test_runtime_model_temperature_toml.inc)
 
 (include stanzas/test_keeper_response_feedback.inc)

--- a/test/stanzas/test_runtime_pacing_toml.inc
+++ b/test/stanzas/test_runtime_pacing_toml.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_pacing_toml)
+ (modules test_runtime_pacing_toml)
+ (libraries masc_test_deps))

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -909,6 +909,45 @@ let test_keeper_health_backpressure_uses_keeper_name () =
      check string "keeper health reason" "keeper_health_unhealthy" reason
    | Obs.Runtime_admitted -> fail "keeper health should reject turn")
 
+let test_pacing_block_delays_requested_turn () =
+  (* RFC-0313 W3: with pacing enforced, the caller wires
+     [Keeper_pacing_shadow.next_due_remaining] as [pacing_block_of_name];
+     a positive remaining delay gates the requested turn without touching
+     keeper existence. *)
+  let meta = make_meta "pacing-gate" in
+  let obs =
+    { base_observation with pending_mentions = [ "operator", "please run" ] }
+  in
+  let consulted = ref [] in
+  let decision =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~pacing_block_of_name:(fun keeper_name ->
+        consulted := keeper_name :: !consulted;
+        Some 42.0)
+      ~stop:(Atomic.make false)
+      ~meta
+      obs
+  in
+  check (list string) "pacing consulted by keeper name" [ meta.name ] !consulted;
+  check bool "world observation requested a turn" true
+    decision.requested_should_run_turn;
+  check bool "pacing block delays admission" false decision.should_run_turn;
+  (match decision.pacing_block with
+   | Some remaining ->
+     check (float 1e-6) "remaining seconds surfaced" 42.0 remaining
+   | None -> fail "pacing_block should carry the remaining delay");
+  check bool "verdict reasons include pacing_pending" true
+    (List.mem "pacing_pending" decision.verdict_reasons);
+  let admitted =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~stop:(Atomic.make false)
+      ~meta
+      obs
+  in
+  check bool "default pacing closure never blocks" true admitted.should_run_turn
+
 let test_crashed_cycle_records_health_failure () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -990,6 +1029,8 @@ let () =
         test_runtime_backpressure_blocks_requested_turn;
       test_case "keeper health blocks by keeper name" `Quick
         test_keeper_health_backpressure_uses_keeper_name;
+      test_case "pacing block delays requested turn (RFC-0313 W3)" `Quick
+        test_pacing_block_delays_requested_turn;
       test_case "crashed cycles feed agent health breaker" `Quick
         test_crashed_cycle_records_health_failure;
     ];

--- a/test/test_keeper_pacing.ml
+++ b/test/test_keeper_pacing.ml
@@ -9,7 +9,9 @@
 open Masc
 module KP = Keeper_pacing
 
-let policy = KP.default_policy
+(* Fixture pin: mirrors Runtime_schema.pacing_default (base 30s, x2, cap
+   3600s). The asserted schedules below are derived from these numbers. *)
+let policy = { KP.base_sec = 30.0; multiplier = 2.0; cap_sec = 3600.0 }
 let feq = Alcotest.(check (float 1e-6))
 
 let revisit_exn t runtime_id =

--- a/test/test_keeper_pacing.ml
+++ b/test/test_keeper_pacing.ml
@@ -88,6 +88,22 @@ let test_shadow_snapshot_isolated_by_keeper () =
     0
     (List.length (Keeper_pacing_shadow.snapshot ~keeper_name))
 
+let test_shadow_next_due_uses_observed_failures_only () =
+  Eio_main.run
+  @@ fun _env ->
+  let keeper_name = "test-keeper-pacing-shadow-observed-failures-only" in
+  Keeper_pacing_shadow.observe_failure
+    ~keeper_name
+    ~runtime_id:"observed-runtime"
+    ~retry_after:(Some 30.0);
+  match Keeper_pacing_shadow.next_due_remaining ~keeper_name with
+  | Some remaining ->
+    Alcotest.(check bool)
+      "observed failure blocks despite unrelated catalog entries"
+      true
+      (remaining > 0.0)
+  | None -> Alcotest.fail "observed pending failure should pace next turn"
+
 let () =
   Alcotest.run
     "keeper_pacing"
@@ -105,5 +121,10 @@ let () =
         ; Alcotest.test_case "always finite" `Quick test_next_turn_due_always_finite
         ] )
     ; ( "shadow"
-      , [ Alcotest.test_case "snapshot isolated by keeper" `Quick test_shadow_snapshot_isolated_by_keeper ] )
+      , [ Alcotest.test_case "snapshot isolated by keeper" `Quick test_shadow_snapshot_isolated_by_keeper
+        ; Alcotest.test_case
+            "next due uses observed failures only"
+            `Quick
+            test_shadow_next_due_uses_observed_failures_only
+        ] )
     ]

--- a/test/test_keeper_pacing_replay.ml
+++ b/test/test_keeper_pacing_replay.ml
@@ -18,6 +18,11 @@
 open Masc
 module KP = Keeper_pacing
 
+(* Fixture pin: mirrors Runtime_schema.pacing_default (base 30s, x2, cap
+   3600s). The asserted [0; 30; 90; 210] schedule is derived from these
+   numbers, so the policy is part of the fixture, not read from config. *)
+let fixture_policy = { KP.base_sec = 30.0; multiplier = 2.0; cap_sec = 3600.0 }
+
 let source_root () =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with
   | Some root when root <> "" -> root
@@ -122,7 +127,7 @@ let test_pacing_bounds_storm_window () =
   let events = load_events () in
   let catalog = distinct_runtimes events in
   let admitted =
-    simulate ~catalog ~policy:KP.default_policy ~window_sec:300.0
+    simulate ~catalog ~policy:fixture_policy ~window_sec:300.0
   in
   (* Deterministic schedule under base 30s x2: each runtime fails at
      t=0, 30, 90, 210; the next revisit (450) falls outside the window. *)
@@ -148,7 +153,7 @@ let test_provider_hint_spaces_revisit () =
      one attempt per hint interval and cannot go negative. *)
   let state =
     KP.on_failure
-      ~policy:KP.default_policy
+      ~policy:fixture_policy
       ~runtime_id:"glm-coding.glm-5-turbo"
       ~retry_after:(Some 120.0)
       ~now:0.0

--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -177,6 +177,18 @@ let test_non_provider_families_judge () =
    | KFR.Escalate_judgment { judgment = KFR.Internal_opaque; _ } -> ()
    | other ->
      Alcotest.failf "raw Internal should judge, got %s" (KFR.route_kind_label other));
+  (* RFC-0313 W3: an idle loop is a behavioral contract judgment, not an
+     opaque internal error (it was the legacy ladder's manual-resume pause
+     class). *)
+  (match
+     KFR.route_of_error
+       (Agent_sdk.Error.Agent
+          (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 3 }))
+   with
+   | KFR.Escalate_judgment { judgment = KFR.Contract_violation; _ } -> ()
+   | other ->
+     Alcotest.failf "idle loop should judge contract, got %s"
+       (KFR.route_kind_label other));
   match
     KFR.route_of_error
       (Agent_sdk.Error.Mcp (Agent_sdk.Error.InitializeFailed { detail = "handshake" }))

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -548,6 +548,7 @@ let test_soft_rate_limit_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"same.b"
       ~base_runtime:"same.a"
@@ -565,6 +566,7 @@ let test_soft_rate_limit_preserves_independent_pool_failover () =
   init_rate_limit_pool_runtime ();
   match
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"other.c"
       ~base_runtime:"same.a"
@@ -589,6 +591,7 @@ let test_hard_quota_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"same.b"
       ~base_runtime:"same.a"
@@ -606,6 +609,7 @@ let test_hard_quota_preserves_independent_pool_failover () =
   init_rate_limit_pool_runtime ();
   match
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
       ~fallback_hint:"other.c"
       ~base_runtime:"same.a"
@@ -924,6 +928,7 @@ let test_read_only_no_progress_rotates_to_default_runtime () =
    | None -> Alcotest.fail "expected read_only_no_progress recoverable reason");
   match
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~base_runtime:"same.b"
       ~effective_runtime:"same.b"
       ~attempted_runtimes:[ "same.b" ]
@@ -944,6 +949,7 @@ let test_read_only_no_progress_default_runtime_uses_tool_capable_candidate () =
   let err = read_only_no_progress_err ~scope:"same.a" in
   match
     EC.degraded_rotation_after_recoverable_error
+      ~pacing_enforced:false
       ~base_runtime:"same.a"
       ~effective_runtime:"same.a"
       ~attempted_runtimes:[ "same.a" ]
@@ -961,13 +967,65 @@ let test_read_only_no_progress_default_runtime_uses_tool_capable_candidate () =
 ;;
 
 let test_capacity_backpressure_does_not_cycle_candidates () =
-  (* Regression: capacity_backpressure must cap rotation rather than cycle.
-     When this reason allowed candidate cycling, two runtimes that were both
-     in capacity cooldown looped forever (2026-05-21, 2026-07-06, #23373). *)
+  (* Regression: in shadow mode capacity_backpressure must cap rotation
+     rather than cycle. When this reason allowed candidate cycling, two
+     runtimes that were both in capacity cooldown looped forever
+     (2026-05-21, 2026-07-06, #23373). RFC-0313 W3: enforced pacing
+     bypasses this matrix (spacing replaces the cap); the matrix and this
+     pin go away with the kill-switch in W4. *)
   Alcotest.(check bool)
     "capacity_backpressure does not allow candidate cycle"
     false
     (EC.degraded_reason_allows_candidate_cycle EC.Capacity_backpressure)
+;;
+
+let test_rate_limit_exhaustion_cycles_under_enforced_pacing () =
+  (* RFC-0313 W3: same exhausted-candidate input, both switch positions.
+     Shadow keeps the legacy cap (rotation gives up -> the failure walked
+     the pause ladder); enforce re-cycles the pool-filtered candidates
+     because cross-turn retries are now spaced by revisit pacing. *)
+  init_rate_limit_pool_runtime ();
+  let attempted = [ "same.a"; "same.b"; "other.c" ] in
+  (match
+     EC.degraded_rotation_after_recoverable_error
+       ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+       ~fallback_hint:"other.c"
+       ~pacing_enforced:false
+       ~base_runtime:"same.a"
+       ~effective_runtime:"same.a"
+       ~attempted_runtimes:attempted
+       soft_rate_limit_err
+   with
+   | None -> ()
+   | Some { EC.next_runtime; _ } ->
+     Alcotest.failf
+       "shadow mode must cap exhausted rate_limit rotation, got %s"
+       next_runtime);
+  match
+    EC.degraded_rotation_after_recoverable_error
+      ~credential_pool_of_runtime_id:rate_limit_pool_of_runtime_id
+      ~fallback_hint:"other.c"
+      ~pacing_enforced:true
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:attempted
+      soft_rate_limit_err
+  with
+  | Some { EC.fallback_reason = EC.Rate_limit; next_runtime } ->
+    Alcotest.(check bool)
+      (Printf.sprintf
+         "enforced pacing recycles a pool-filtered candidate (got %s)"
+         next_runtime)
+      true
+      (not (String.equal next_runtime ""))
+  | Some { fallback_reason; next_runtime } ->
+    Alcotest.failf
+      "expected rate_limit cycle under enforced pacing, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None ->
+    Alcotest.fail
+      "enforced pacing must re-cycle candidates instead of capping"
 ;;
 
 let () =
@@ -1078,6 +1136,10 @@ let () =
             "capacity_backpressure does not cycle candidates"
             `Quick
             test_capacity_backpressure_does_not_cycle_candidates
+        ; Alcotest.test_case
+            "rate_limit exhaustion cycles under enforced pacing (RFC-0313 W3)"
+            `Quick
+            test_rate_limit_exhaustion_cycles_under_enforced_pacing
         ] )
     ]
 ;;

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 250
+  check int "Keeper_metrics.all covers every constructor" 251
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_runtime_pacing_toml.ml
+++ b/test/test_runtime_pacing_toml.ml
@@ -1,0 +1,163 @@
+(** Tests for the [[pacing]] section parser in [Runtime_toml] (RFC-0313 W3).
+
+    Pinned invariants:
+
+    1. Missing [[pacing]] section → [Runtime_schema.pacing_default]
+       (mode = enforce, base 30s, x2, cap 3600s). The default IS the W3
+       behavior flip; shadow is the explicit kill-switch position.
+
+    2. mode = "shadow" / "enforce" parse to the corresponding variant;
+       numeric knobs parse verbatim.
+
+    3. An unknown [mode] value fails the whole config parse (fail-closed):
+       a typo like "enfoce" must not silently revert the flip to shadow.
+
+    4. A wrong-typed numeric knob falls back to its default field-by-field
+       (fail-soft, same contract as [[pause]]). *)
+
+open Alcotest
+
+module Schema = Runtime_schema
+module Toml = Runtime_toml
+
+let parse_string_or_fail s =
+  match Toml.parse_string s with
+  | Ok cfg -> cfg
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (e : Toml.parse_error) ->
+        Printf.sprintf "[%s] %s" e.path e.message)
+      |> String.concat "; "
+    in
+    failf "parse_string failed: %s" rendered
+;;
+
+let d = Schema.pacing_default
+
+let test_missing_pacing_section_uses_defaults () =
+  let cfg =
+    parse_string_or_fail
+      "[providers.local-ollama]\n\
+       protocol = \"ollama-http\"\n\
+       endpoint = \"http://127.0.0.1:11434\"\n"
+  in
+  check bool
+    "missing [pacing] defaults to enforce"
+    true
+    (Schema.equal_pacing_mode cfg.Schema.pacing.pacing_mode Schema.Pacing_enforce);
+  check (float 0.0001) "base_sec default" d.pacing_base_sec
+    cfg.pacing.pacing_base_sec;
+  check (float 0.0001) "multiplier default" d.pacing_multiplier
+    cfg.pacing.pacing_multiplier;
+  check (float 0.0001) "cap_sec default" d.pacing_cap_sec cfg.pacing.pacing_cap_sec
+;;
+
+let test_shadow_mode_and_knobs_parse_verbatim () =
+  let cfg =
+    parse_string_or_fail
+      "[pacing]\n\
+       mode = \"shadow\"\n\
+       base_sec = 12.5\n\
+       multiplier = 3.0\n\
+       cap_sec = 900.0\n"
+  in
+  check bool
+    "mode = shadow parses"
+    true
+    (Schema.equal_pacing_mode cfg.pacing.pacing_mode Schema.Pacing_shadow);
+  check (float 0.0001) "base_sec verbatim" 12.5 cfg.pacing.pacing_base_sec;
+  check (float 0.0001) "multiplier verbatim" 3.0 cfg.pacing.pacing_multiplier;
+  check (float 0.0001) "cap_sec verbatim" 900.0 cfg.pacing.pacing_cap_sec
+;;
+
+let test_enforce_mode_parses () =
+  let cfg = parse_string_or_fail "[pacing]\nmode = \"enforce\"\n" in
+  check bool
+    "mode = enforce parses"
+    true
+    (Schema.equal_pacing_mode cfg.pacing.pacing_mode Schema.Pacing_enforce)
+;;
+
+let test_unknown_mode_fails_config_parse () =
+  match Toml.parse_string "[pacing]\nmode = \"enfoce\"\n" with
+  | Ok _ ->
+    fail "unknown pacing mode must abort config parse, not default silently"
+  | Error errs ->
+    check bool
+      "error names pacing.mode"
+      true
+      (List.exists
+         (fun (e : Toml.parse_error) -> String.equal e.path "pacing.mode")
+         errs)
+;;
+
+let test_wrong_typed_mode_fails_config_parse () =
+  match Toml.parse_string "[pacing]\nmode = 3\n" with
+  | Ok _ -> fail "wrong-typed pacing mode must abort config parse"
+  | Error errs ->
+    check bool
+      "error names pacing.mode"
+      true
+      (List.exists
+         (fun (e : Toml.parse_error) -> String.equal e.path "pacing.mode")
+         errs)
+;;
+
+let test_wrong_typed_numeric_knob_falls_back () =
+  let cfg =
+    parse_string_or_fail
+      "[pacing]\n\
+       base_sec = \"thirty\"\n\
+       multiplier = 3.0\n"
+  in
+  check (float 0.0001)
+    "wrong-typed base_sec → default"
+    d.pacing_base_sec
+    cfg.pacing.pacing_base_sec;
+  check (float 0.0001)
+    "neighbor multiplier still parsed"
+    3.0
+    cfg.pacing.pacing_multiplier
+;;
+
+let test_pacing_default_is_pinned () =
+  (* Tripwire: these values are mirrored by the fixture policies in
+     test_keeper_pacing.ml / test_keeper_pacing_replay.ml, whose asserted
+     schedules ([0; 30; 90; 210]) derive from them. Change in lockstep. *)
+  check bool
+    "default mode = enforce"
+    true
+    (Schema.equal_pacing_mode d.pacing_mode Schema.Pacing_enforce);
+  check (float 0.0001) "default base_sec = 30" 30.0 d.pacing_base_sec;
+  check (float 0.0001) "default multiplier = 2" 2.0 d.pacing_multiplier;
+  check (float 0.0001) "default cap_sec = 3600" 3600.0 d.pacing_cap_sec
+;;
+
+let () =
+  run "runtime_pacing_toml"
+    [ ( "missing-section fallback"
+      , [ test_case "missing [pacing] uses enforce defaults" `Quick
+            test_missing_pacing_section_uses_defaults
+        ] )
+    ; ( "mode parse"
+      , [ test_case "shadow mode + knobs verbatim" `Quick
+            test_shadow_mode_and_knobs_parse_verbatim
+        ; test_case "enforce mode parses" `Quick test_enforce_mode_parses
+        ] )
+    ; ( "mode fails closed"
+      , [ test_case "unknown mode aborts config parse" `Quick
+            test_unknown_mode_fails_config_parse
+        ; test_case "wrong-typed mode aborts config parse" `Quick
+            test_wrong_typed_mode_fails_config_parse
+        ] )
+    ; ( "numeric knobs fail soft"
+      , [ test_case "wrong-typed base_sec falls back" `Quick
+            test_wrong_typed_numeric_knob_falls_back
+        ] )
+    ; ( "defaults pinned"
+      , [ test_case "pacing_default field values pinned" `Quick
+            test_pacing_default_is_pinned
+        ] )
+    ]
+;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -743,6 +743,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; pacing = Runtime_schema.pacing_default
     ; lane_decls = []
     }
   in
@@ -779,6 +780,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; pacing = Runtime_schema.pacing_default
     ; lane_decls = []
     }
   in
@@ -816,6 +818,7 @@ let provider_cfg () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; pacing = Runtime_schema.pacing_default
     ; lane_decls = []
     }
   in
@@ -898,6 +901,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; keeper_assignments = []
     ; media_failover = []
     ; pause_threshold = Runtime_schema.pause_threshold_default
+    ; pacing = Runtime_schema.pacing_default
     ; lane_decls = []
     }
   in


### PR DESCRIPTION
# RFC-0313 W3 — 실패는 pacing/routing만 바꾼다: failure-driven pause flip

RFC: `docs/rfc/RFC-0313-keeper-existence-invariance.md` §Migration **W3**.
스택: W0 #23481 → W1 #23487 → W2 #23495 (+ W2a dedup #23511) → 게이트 #23497 → **W3 (this PR)**.

## 무엇이 바뀌나

`runtime.toml [pacing] mode = "enforce"`(기본)에서:

1. **스케줄러가 pacing을 소비합니다.** `decide_keepalive_scheduling`에 `pacing_block_of_name` 게이트 추가 — 키퍼의 최단 per-runtime revisit이 미래면 턴 어드미션을 미루고 verdict reason `pacing_pending`을 남깁니다(기존 skip-reason counter/registry stamp 경로 재사용). hot path 주의: in-memory `next_due_remaining`을 먼저 보고, revisit이 실제로 걸려 있을 때만 `Runtime.pacing()`(toml 읽기)을 지불합니다.
2. **In-turn pause 5경로가 존재를 건드리지 않습니다** (RFC §Current-state의 6경로 중 ambiguous-partial-commit은 §4에 따라 **flip 제외** — HITL continue-gate는 operator intent acquisition):
   - turn-failure streak 3종(runtime_exhausted/completion-contract/idle): pause 생략. pacing + judgment stimulus는 W2 라우팅 사이트가 이미 기록. crash 사다리 백스톱(streak≥crash threshold)은 W4까지 유지(웨이브 슬라이스).
   - success-path contract-attention: `Manual_resume_required` pause → `Failure_judgment{Contract_violation}` stimulus(identity dedup, no-trigger — 스케줄링 cadence 불변).
   - livelock: in-turn 게이트는 그대로(반복 mutating 호출 차단), keeper pause만 생략.
   - context overflow: failure reason만 latch; 턴의 ContextOverflow 에러가 W2 라우트로 `Context_overflow` judgment stimulus가 됨. `Compact_retry_exhausted`/`Operator_pause` FSM 이벤트 미발행.
   - post-turn resilience 전략(pause_for_operator): failure reason latch만, pause 생략.
3. **Supervisor pause arm 3개가 relaunch로**: stale-storm / provider-timeout / turn-failure-streak(#23452) — crashed fiber는 process reality이므로 기존 backoff 재기동 경로(`queue_standard_restart`)로. (RFC 본문 "both supervisor auto arms"는 #23452 머지 전 표기 — 현행 3 arm 전부 적용.)
4. **Cycle-cap 매트릭스 우회**: `degraded_rotation_after_recoverable_error`에 필수 `~pacing_enforced` — enforce에서 클래스 기반 cap(`degraded_reason_allows_candidate_cycle`) 우회. in-turn 순환은 기존 turn cycle budget(`Candidates_filtered_after_cycles`)이 계속 bound하고, cross-turn 재시도는 pacing이 간격을 강제. contract violation은 양 모드 모두 순환 금지. quota/rate-limit credential-pool 필터는 유지(RFC: "quota keeps only the credential-pool filter").
5. **Route 정밀화**: `Agent(IdleDetected)` → `Escalate_judgment{Contract_violation}` (기존 Internal_opaque). RFC W3 "Manual-resume classes (idle, contract-attention) become Escalate_judgment stimuli"의 idle 절반.

## Kill-switch (1 릴리즈 한정, W4에서 제거)

- `[pacing] mode = "shadow"` = W3 이전 레거시 전체 복원(pause 사다리 + cycle-cap). `config/runtime.toml`에 `mode = "enforce"` 명시.
- **mode 파싱은 fail-closed**: `"enfoce"` 같은 오타는 config load 실패 — 조용히 shadow로 되돌아가는 permissive-default가 flip 자체를 무효화하는 것을 차단. 숫자 knob은 `[pause]`와 동일하게 fail-soft.
- RFC 텍스트는 "cycle-cap matrix deleted in this same PR"이지만, shadow 모드가 존재하는 동안 완전 삭제는 faithful shadow와 모순 → **enforce 경로에서 우회 + W4에서 스위치와 함께 물리 삭제**로 시행. (RFC rollback 절이 이 순서를 이미 명시: "the switch itself is removed in W4".)

## 관측

- 신규 counter `masc_keeper_failure_driven_pause_total`(keeper/site) — 실제 failure-driven pause 커밋 시에만 증가(6 사이트 라벨). **enforce에서 0 유지가 RFC Verification 항목** ("counter must exist and stay zero").
- 기존 `PacingShadowEvents`/`PacingShadowNextDueSec` 유지(대시보드 연속성). 모듈명 `Keeper_pacing_shadow`는 W4 스위치 제거와 함께 rename(양 모드 공존 중 rename은 shadow 모드를 오표기).
- policy SSOT: `Keeper_pacing.default_policy` 삭제 → `Runtime_schema.pacing_default`(30s/×2/3600s) + runtime.toml. 테스트 fixture는 스케줄 단언([0;30;90;210])의 유도 근거로 리터럴 pin.

## 테스트

- `test_runtime_pacing_toml`(신규): 기본값(enforce), shadow/enforce 파싱, unknown/wrong-typed mode fail-closed, 숫자 knob fail-soft, default pin.
- `test_heartbeat_integration`: pacing block이 어드미션을 막고 reason을 남김 + 기본 클로저는 절대 안 막음.
- `test_keeper_sdk_error_typed_bridge`: 동일 입력 shadow(None=cap) vs enforce(Some=cycle) 대조 테스트 + 기존 rotation 테스트 `~pacing_enforced:false` 명시.
- `test_keeper_runtime_failure_route`: IdleDetected → Contract_violation.
- 스톰 replay 게이트(`test_keeper_pacing_replay`, #23497)는 순수 모듈 불변으로 green 유지.
- `Keeper_metrics` 트립와이어 250→251.

## 검증 상태

- 변경 `.ml/.mli` 전체 ocamlformat 통과(구문), `keeper_runtime_failure_route.ml`은 실제 agent_sdk 대비 standalone ocamlc 타입체크 통과. 전체 빌드/테스트는 CI(dune-in-CI 정책).
- **의존**: main `Build and Test`는 현재 #23489발 stale literal로 red — 수리 PR **#23520** 선행 머지 필요(이 PR CI에도 같은 실패가 비침).

## 명시적 비변경 (RFC §What-this-does-NOT-change)

- Operator pause/resume UX, HITL 큐, ambiguous-partial continue-gate, return-to-base 라우팅, lease TTL.
- 크래시 threshold/restart budget/DEAD — **W4 숙청 범위** (이 PR은 pause 축만 flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
