### PR TITLE
fix(board): rotate claim-evidence sidecar + bind artifact content digest (#23486 P1-2/P1-3)

### DIFF
--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -46,6 +46,14 @@ let has_prefix ~prefix s =
 
 let sha256_hex text = Digestif.SHA256.(digest_string text |> to_hex)
 
+let digest_of_file path =
+  (* Bind an artifact ref to the actual on-disk content: a sha256 of the file
+     body, so "evidence" is more than "any file under the base happened to
+     exist". [None] only if the file vanished between the [Sys.file_exists]
+     check and the read (TOCTOU) or is unreadable. *)
+  try Some ("sha256:" ^ sha256_hex (In_channel.with_open_text path In_channel.input_all))
+  with Sys_error _ -> None
+
 let normalize_sha256 raw =
   let trimmed = String.trim raw in
   if has_prefix ~prefix:"sha256:" trimmed
@@ -196,7 +204,7 @@ let resolve_file_path raw =
     | None -> Unknown { ref_; checked_at; reason = "artifact_ref_outside_base_path" }
     | Some path ->
       if Sys.file_exists path
-      then Exists { ref_; kind = "file_path"; checked_at; digest = None }
+      then Exists { ref_; kind = "file_path"; checked_at; digest = digest_of_file path }
       else Missing { ref_; checked_at; reason = "file_path_missing" })
 ;;
 
@@ -312,7 +320,13 @@ let append_record ~tool_name ~author ~target_post_id ~content ~claims ~snapshot 
        | Some s -> [ "source_post_snapshot", source_snapshot_to_yojson s ]
        | None -> [])
   in
-  Fs_compat.append_jsonl (Board_claim_evidence.sidecar_path ()) json
+  let path = Board_claim_evidence.sidecar_path () in
+  Fs_compat.append_jsonl path json;
+  (* Mirror sibling sidecars (board_posts/comments/reactions/sub_boards), which
+     rotate at [Board_paths.max_jsonl_bytes]. Without this the claim-evidence
+     ledger grew unbounded and the projection re-read the whole file on every
+     dashboard fetch. *)
+  Board_paths.rotate_if_needed path
 ;;
 
 let evaluate ~target_post_id ~claims ~snapshot ~artifact_refs ~resolutions =

--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -49,10 +49,9 @@ let sha256_hex text = Digestif.SHA256.(digest_string text |> to_hex)
 let digest_of_file path =
   (* Bind an artifact ref to the actual on-disk content: a sha256 of the file
      body, so "evidence" is more than "any file under the base happened to
-     exist". [None] only if the file vanished between the [Sys.file_exists]
-     check and the read (TOCTOU) or is unreadable. *)
-  try Some ("sha256:" ^ sha256_hex (In_channel.with_open_text path In_channel.input_all))
-  with Sys_error _ -> None
+     exist". *)
+  try Ok ("sha256:" ^ sha256_hex (In_channel.with_open_text path In_channel.input_all))
+  with Sys_error _ -> Error "file_path_digest_unavailable"
 
 let normalize_sha256 raw =
   let trimmed = String.trim raw in
@@ -204,7 +203,10 @@ let resolve_file_path raw =
     | None -> Unknown { ref_; checked_at; reason = "artifact_ref_outside_base_path" }
     | Some path ->
       if Sys.file_exists path
-      then Exists { ref_; kind = "file_path"; checked_at; digest = digest_of_file path }
+      then (
+        match digest_of_file path with
+        | Ok digest -> Exists { ref_; kind = "file_path"; checked_at; digest = Some digest }
+        | Error reason -> Unknown { ref_; checked_at; reason })
       else Missing { ref_; checked_at; reason = "file_path_missing" })
 ;;
 

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2230,6 +2230,25 @@ let test_resolve_file_path_records_content_digest () =
   in
   Alcotest.(check (option string)) "exists arm records content digest" expected got_digest
 
+let test_resolve_file_path_rejects_digest_unavailable () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let artifact_rel = Filename.concat Common.masc_dirname "claim_gate_digest_dir" in
+  let artifact_path = Filename.concat (Board_paths.board_base_path ()) artifact_rel in
+  (try Unix.mkdir (Filename.dirname artifact_path) 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
+  (try Unix.mkdir artifact_path 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
+  match Board_claim_gate.resolve_file_path artifact_rel with
+  | Board_claim_gate.Unknown { reason; _ } ->
+    Alcotest.(check string)
+      "digest unavailable is explicit"
+      "file_path_digest_unavailable"
+      reason
+  | Board_claim_gate.Exists _ ->
+    Alcotest.fail "digest-unavailable artifact must not resolve as existing evidence"
+  | Board_claim_gate.Missing _ ->
+    Alcotest.fail "digest-unavailable fixture should exist as a path"
+
 let test_comment_vote_missing () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2699,6 +2718,8 @@ let () =
             test_comment_claim_gate_rejects_unknown_claim_kind;
           Alcotest.test_case "claim gate resolves artifact content digest" `Quick
             test_resolve_file_path_records_content_digest;
+          Alcotest.test_case "claim gate rejects digest-unavailable artifact" `Quick
+            test_resolve_file_path_rejects_digest_unavailable;
           Alcotest.test_case "comment vote missing" `Quick test_comment_vote_missing;
           Alcotest.test_case "comment vote not found" `Quick
             test_comment_vote_not_found;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2209,6 +2209,27 @@ let test_comment_claim_gate_rejects_unknown_claim_kind () =
   Alcotest.(check bool) "unknown claim named" true
     (contains_substring (Tool_result.message result) "invalid_claim_kind")
 
+let test_resolve_file_path_records_content_digest () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  (* Create a real artifact at the exact path [resolve_file_path] computes (via
+     [Board_paths.board_base_path]), so the test is robust to whatever the
+     harness sets as base_path. Before [digest_of_file], the Exists arm returned
+     [digest=None] — "evidence" meant only "any file under the base existed". *)
+  let artifact_rel = Filename.concat Common.masc_dirname "claim_gate_digest_fixture.ml" in
+  let artifact_content = "let proof = \"digest-fixture-v1\"\n" in
+  let artifact_path = Filename.concat (Board_paths.board_base_path ()) artifact_rel in
+  (try Unix.mkdir (Filename.dirname artifact_path) 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
+  Out_channel.with_open_bin artifact_path (fun oc -> output_string oc artifact_content);
+  let expected = Some ("sha256:" ^ sha256_hex artifact_content) in
+  let got_digest =
+    match Board_claim_gate.resolve_file_path artifact_rel with
+    | Board_claim_gate.Exists { digest; _ } -> digest
+    | _ -> None
+  in
+  Alcotest.(check (option string)) "exists arm records content digest" expected got_digest
+
 let test_comment_vote_missing () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2676,6 +2697,8 @@ let () =
             test_board_dashboard_json_embeds_claim_evidence_projection;
           Alcotest.test_case "claim gate rejects unknown claim kind" `Quick
             test_comment_claim_gate_rejects_unknown_claim_kind;
+          Alcotest.test_case "claim gate resolves artifact content digest" `Quick
+            test_resolve_file_path_records_content_digest;
           Alcotest.test_case "comment vote missing" `Quick test_comment_vote_missing;
           Alcotest.test_case "comment vote not found" `Quick
             test_comment_vote_not_found;


### PR DESCRIPTION
## fix(board): claim-evidence sidecar rotation + artifact content digest

`#23486` 적대 리뷰(6-dimension workflow)에서 CONFIRMED된 두 P1의 mechanical fix. 둘 다 board claim gate의 typed 설계를 건드리지 않는 작고 정확한 변경입니다.

## P1-2 — sidecar rotation 없음 (무한 증가)

**문제**: `board_claim_evidence.jsonl`에 rotation 정책이 없었습니다. 모든 형제 sidecar(posts/comments/reactions/sub_boards)은 `Board_paths.rotate_if_needed`(10MB, `.1` 백업)로 rotate하지만, `append_record`는 `Fs_compat.append_jsonl`만 호출했습니다. 결과: ledger가 무한 증가하고, projection_lookup이 매 dashboard fetch마다 전 파일을 재독입.

**fix**: `append_record`에서 append 후 `Board_paths.rotate_if_needed path` 호출(sibling 패턴과 동일). sidecar_path를 bind해 중복 계산 제거.

## P1-3 — artifact_refs가 claim 의미와 미결합 + digest=None

**문제**: `resolve_file_path`가 `Sys.file_exists`만 보고 `Exists { digest = None; _ }`를 반환했습니다. 그래서 "evidence" = "MASC base 아래 어떤 파일이 존재한다"에 불과 — agent가 claim과 무관한 아무 파일 경로나 줘도 통과.

**fix**: `digest_of_file path`가 파일 본문의 sha256을 계산해 `Exists`의 digest에 넣습니다. 이제 evidence record가 실제 파일 내용에 bind됩니다. TOCTOU(exists check와 read 사이 파일 삭제)나 읽기 불가 시 `None`으로 degrade.

`test_resolve_file_path_records_content_digest`: 실제 파일을 `Board_paths.board_base_path ()` 하위에 만들고(어떤 base_path에도 robust), resolve 후 digest가 내용의 sha256과 일치하는지 단언.

## 범위 밖 (별도)

- **P1-1 (강제 snapshot / opt-in gate)**: 같은 워크플로우가 CONFIRMED했지만, fleet-safe 구현이 reader-identity plumbing을 필요로 합니다 — `masc_board_post_get` schema가 author 필드가 없어, "이 agent가 이 post를 읽었다"를 증명할 last-read snapshot 캐시를 (reader, post_id)로 keying할 수 없습니다. surgical + fleet-safe + 의미 있는 세 조건을 동시에 만족하는 설계가 없어(schema 변경 / post_id-only 캐시 / comment-time 계산 각각 한계), 별도 설계/RFC로 분리합니다.
- **artifact_ref ↔ claim subject binding**: digest는 "어떤 파일 내용"을 bind하지만, "이 ref가 이 claim에 대해 유효한지"는 여전히 agent 자발적 선언에 의존합니다. claim subject와 ref의 정적 binding은 별도 design.

## 검증

- `test/test_tool_board_coverage.ml`: artifact content digest 단위 테스트 추가. rotation은 이미 `Board_paths.rotate_if_needed` 자체 테스트가 cover(이 PR은 1-line call 추가).
- dune build/alcotest는 CI에서.

Co-Authored-By: Claude <noreply@anthropic.com>
