### PR TITLE
fix(test): qualify Keeper_sandbox with Masc (main-red from #23516)

### DIFF
--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -264,7 +264,7 @@ let test_partition_docker_visible_path_maps_to_playground_repo () =
     (fun ~config ~meta ->
        let container_repo_path =
          Filename.concat
-           (Keeper_sandbox.container_root meta.name)
+           (Masc.Keeper_sandbox.container_root meta.name)
            "repos/masc/lib/docker.ml"
        in
        let partition, rel_path =


### PR DESCRIPTION
## main-red fix (긴급)

`dune build .`가 실패합니다:
```
test/test_keeper_run_tools_hooks.ml:267
Error: Unbound module Keeper_sandbox
```

#23516(08:45 머지)이 line 267에 `Keeper_sandbox.container_root`를 **`Masc.` 접두사 없이** 추가했는데, 이 파일은 `open Masc`를 하지 않아 모듈이 안 보입니다. 파일의 나머지는 이미 `Masc.Workspace`, `Masc.Keeper_run_tools_hooks`로 qualify합니다.

**Fix**: line 267 → `Masc.Keeper_sandbox.container_root meta.name` (1줄, 파일 관례 + mli `val container_root : string -> string` 일치).

이 red가 모든 PR의 Build and Test를 막습니다(red main 위에서 빌드). 로컬 full build는 CI 위임(사용자 방침).

Refs #23516.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
