### PR TITLE
feat(dashboard): keeper workspace lane state section from waiting inventory (#23507 PR-L1/L2)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -1,0 +1,156 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { DashboardKeeperWaitingInventory } from '../../api'
+import type { Keeper } from '../../types'
+import { KeeperLaneStrip } from './keeper-lane-strip'
+
+function keeperFixture(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'sangsu',
+    agent_name: 'agent-sangsu',
+    ...overrides,
+  } as Keeper
+}
+
+function inventoryFixture(): DashboardKeeperWaitingInventory {
+  return {
+    schema: 'masc.dashboard.keeper_waiting_inventory.v1',
+    source: 'server_keeper_waiting_inventory',
+    generated_at: '2026-07-07T09:00:00Z',
+    supported_states: ['idle', 'busy', 'waiting', 'deferred'],
+    keeper_count_known: true,
+    keeper_count: 2,
+    waiting_keeper_count: 1,
+    row_count: 2,
+    keepers: [
+      {
+        keeper_name: 'sangsu',
+        state: 'deferred',
+        waiting_count: 2,
+        next_action: 'keeper_drain_chat_queue',
+        waiting_on: [
+          {
+            keeper_name: 'sangsu',
+            source: 'chat_queue_pending',
+            waiting_on: 'dashboard_chat',
+            wake_producer: 'keeper_chat_queue',
+            since_iso: '2026-07-07T08:59:00Z',
+            next_action: 'keeper_drain_chat_queue',
+          },
+          {
+            keeper_name: 'sangsu',
+            source: 'turn_admission_waiting',
+            waiting_on: 'chat_lane',
+            wake_producer: 'keeper_turn_admission',
+            since_iso: '2026-07-07T08:58:00Z',
+            next_action: 'keeper_finish_in_flight_turn',
+          },
+        ],
+      },
+      {
+        keeper_name: 'idle-one',
+        state: 'idle',
+        waiting_count: 0,
+        waiting_on: [],
+      },
+    ],
+  }
+}
+
+describe('KeeperLaneStrip', () => {
+  let host: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (host) {
+      render(null, host)
+      host.remove()
+      host = null
+    }
+  })
+
+  function mount(node: ReturnType<typeof html>): HTMLDivElement {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    render(node, host)
+    return host
+  }
+
+  it('renders the matching keeper lane state and waiting rows verbatim', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const text = el.textContent ?? ''
+    expect(text).toContain('레인')
+    expect(text).toContain('deferred')
+    expect(text).toContain('dashboard_chat')
+    expect(text).toContain('chat_lane')
+    expect(text).toContain('keeper finish in flight turn')
+    expect(el.querySelector('[data-missing="keeper-lane"]')).toBeNull()
+  })
+
+  it('renders an explicit gap when the keeper is absent from the inventory', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture({ name: 'ghost', agent_name: 'agent-ghost' })}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const gap = el.querySelector('[data-missing="keeper-lane"]')
+    expect(gap).not.toBeNull()
+    expect(gap?.textContent ?? '').toContain('이 키퍼 항목이 없습니다')
+  })
+
+  it('renders an explicit gap when the response omits the inventory field', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${null}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    const gap = el.querySelector('[data-missing="keeper-lane"]')
+    expect(gap).not.toBeNull()
+    expect(gap?.textContent ?? '').toContain('keeper_waiting_inventory')
+  })
+
+  it('renders the fetch error instead of guessing a lane state', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${null}
+        ready=${false}
+        loading=${false}
+        error=${'boom'}
+      />
+    `)
+    const gap = el.querySelector('[data-missing="keeper-lane"]')
+    expect(gap?.textContent ?? '').toContain('boom')
+  })
+
+  it('shows the loading note before the first response arrives', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${null}
+        ready=${false}
+        loading=${true}
+        error=${null}
+      />
+    `)
+    expect(el.textContent ?? '').toContain('레인 상태 로딩')
+    expect(el.querySelector('[data-missing="keeper-lane"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -1,0 +1,145 @@
+// Keeper Workspace — lane state section (#23507 PR-L1/L2, slice 1).
+// Consume-only surface over the already-served `keeper_waiting_inventory`
+// (`GET /api/v1/dashboard/tools`, same shared resource the Tools/Schedule
+// surfaces read): per-keeper lane state (idle/busy/waiting/deferred) plus
+// the waiting rows behind it. State strings and rows render exactly as the
+// server sent them — no client-side judgement — and a keeper absent from
+// the inventory renders an explicit data gap instead of a guessed "idle".
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import type { VNode } from 'preact'
+import type { Keeper } from '../../types'
+import type {
+  DashboardKeeperWaitingInventory,
+  DashboardKeeperWaitingKeeper,
+  DashboardKeeperWaitingRow,
+} from '../../api'
+import { loadTools, toolsData, toolsError, toolsLoading } from '../tools/tool-state'
+import { StatusChip } from '../common/status-chip'
+import {
+  enumLabel,
+  sourceTone,
+  stateTone,
+} from '../tools/keeper-waiting-inventory-panel'
+import { formatDateTimeKo } from '../../lib/format-time'
+import { CountBadge } from '../v2/primitives-v2'
+
+const LANE_ROW_LIMIT = 3
+
+function inventoryEntry(
+  inventory: DashboardKeeperWaitingInventory | null | undefined,
+  keeper: Keeper,
+): DashboardKeeperWaitingKeeper | null {
+  if (!inventory) return null
+  const byName = inventory.keepers.find(k => k.keeper_name === keeper.name)
+  if (byName) return byName
+  if (keeper.agent_name != null && keeper.agent_name !== '') {
+    return inventory.keepers.find(k => k.keeper_name === keeper.agent_name) ?? null
+  }
+  return null
+}
+
+function LaneGap({ children }: { children: VNode | string }): VNode {
+  return html`
+    <div class="ctx-empty" data-missing="keeper-lane">
+      <strong>레인 상태 미수신</strong>
+      <span>${children}</span>
+    </div>
+  `
+}
+
+function LaneWaitingRow({ row }: { row: DashboardKeeperWaitingRow }): VNode {
+  return html`
+    <div class="grid gap-0.5 border-t border-[var(--color-border-subtle)] py-1.5 first:border-t-0">
+      <div class="flex min-w-0 flex-wrap items-center gap-1.5">
+        <${StatusChip} tone=${sourceTone(row.source)} uppercase=${false}>${enumLabel(row.source)}<//>
+        <span class="min-w-0 truncate font-mono text-2xs text-[var(--color-fg-primary)]">${row.waiting_on}</span>
+      </div>
+      <div class="flex flex-wrap gap-x-3 text-2xs text-[var(--color-fg-muted)]">
+        ${row.since_iso ? html`<span>since ${formatDateTimeKo(row.since_iso)}</span>` : null}
+        <span class="font-mono">${enumLabel(row.next_action)}</span>
+      </div>
+    </div>
+  `
+}
+
+/** Pure presentational part — container feeds it from the shared tools
+ *  resource; tests feed it fixtures. */
+export function KeeperLaneStrip({
+  keeper,
+  inventory,
+  ready,
+  loading,
+  error,
+}: {
+  keeper: Keeper
+  inventory: DashboardKeeperWaitingInventory | null | undefined
+  /** true once the shared tools resource has a response body — separates
+   *  "field absent from the response" from "response not fetched yet". */
+  ready: boolean
+  loading: boolean
+  error: string | null
+}): VNode {
+  const entry = inventoryEntry(inventory, keeper)
+  const rows = (entry?.waiting_on ?? []).slice(0, LANE_ROW_LIMIT)
+  const waitingCount = entry?.waiting_count ?? 0
+  return html`
+    <div class="ctx-sec" data-testid="keeper-lane-section">
+      <h4 style=${{ display: 'flex', alignItems: 'center', gap: '7px' }}>
+        레인
+        ${waitingCount > 0 ? html`<${CountBadge}>${waitingCount}<//>` : null}
+      </h4>
+      ${entry
+        ? html`
+            <div class="grid gap-1.5">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <${StatusChip} tone=${stateTone(entry.state)} uppercase=${false}>${enumLabel(entry.state)}<//>
+                ${entry.next_action
+                  ? html`<span class="font-mono text-2xs text-[var(--color-fg-muted)]">${enumLabel(entry.next_action)}</span>`
+                  : null}
+              </div>
+              ${rows.length > 0
+                ? html`
+                    <div>
+                      ${rows.map((row, index) => html`
+                        <${LaneWaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />
+                      `)}
+                      ${waitingCount > rows.length
+                        ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]">+${waitingCount - rows.length} more</div>`
+                        : null}
+                    </div>
+                  `
+                : null}
+              ${inventory?.generated_at
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">기준 ${formatDateTimeKo(inventory.generated_at)}</div>`
+                : null}
+            </div>
+          `
+        : inventory
+          ? html`<${LaneGap}>waiting inventory에 이 키퍼 항목이 없습니다.<//>`
+          : ready
+            ? html`<${LaneGap}>서버가 keeper_waiting_inventory를 보내지 않았습니다.<//>`
+            : error
+              ? html`<${LaneGap}>${`tools 응답 실패: ${error}`}<//>`
+              : html`<div class="text-2xs text-[var(--color-fg-muted)]">${loading ? '레인 상태 로딩…' : '레인 상태 로딩 대기…'}</div>`}
+    </div>
+  `
+}
+
+/** Container: reads the shared tools resource (loads it once if absent —
+ *  the same pattern schedule-surface uses) and renders the strip. */
+export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
+  useEffect(() => {
+    if (!toolsData.value && !toolsLoading.value) void loadTools()
+  }, [])
+  return html`
+    <${KeeperLaneStrip}
+      keeper=${keeper}
+      inventory=${toolsData.value?.keeper_waiting_inventory ?? null}
+      ready=${toolsData.value != null}
+      loading=${toolsLoading.value}
+      error=${toolsError.value}
+    />
+  `
+}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -44,6 +44,7 @@ import { persistentSignal } from '../../lib/persistent-signal'
 import { recordManualCompaction } from './compaction-snapshots'
 import type { MemoryKeeper } from '../memory-inspector'
 import { keepers } from '../../store'
+import { KeeperLaneSection } from './keeper-lane-strip'
 
 const LazyCompactionInspectorOverlay = lazy(async () => ({
   default: (await import('./compaction-inspector-overlay')).CompactionInspectorOverlay,
@@ -492,6 +493,7 @@ export function KeeperWorkspaceRail({
     <aside class="ctx" aria-label="키퍼 컨텍스트">
       <div class="ctx-scroll">
         <${AttentionSection} keeper=${keeper} />
+        <${KeeperLaneSection} keeper=${keeper} />
         <${RuntimeSection} keeper=${keeper} drift=${runtimeDrift} />
         <${ContextSection}
           keeper=${keeper}

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
@@ -7,12 +7,15 @@ import type {
 import { formatDateTimeKo } from '../../lib/format-time'
 import { StatusChip, type StatusChipTone } from '../common/status-chip'
 
-function enumLabel(value: string | null | undefined): string {
+// Exported for the keeper workspace lane strip (#23507): the lane
+// state/source palettes stay single-sourced here instead of growing a
+// second copy per consuming surface.
+export function enumLabel(value: string | null | undefined): string {
   if (!value) return '-'
   return value.replace(/_/g, ' ')
 }
 
-function stateTone(state: string | null | undefined): StatusChipTone {
+export function stateTone(state: string | null | undefined): StatusChipTone {
   switch (state) {
     case 'waiting':
       return 'warn'
@@ -27,7 +30,7 @@ function stateTone(state: string | null | undefined): StatusChipTone {
   }
 }
 
-function sourceTone(source: string | null | undefined): StatusChipTone {
+export function sourceTone(source: string | null | undefined): StatusChipTone {
   switch (source) {
     case 'read_error':
       return 'bad'


### PR DESCRIPTION
keeper workspace rail에 '레인' 섹션 추가 — 이미 서빙 중인 `keeper_waiting_inventory`(GET /api/v1/dashboard/tools, Tools/Schedule과 동일 공유 리소스)만 소비하는 consume-only 표면입니다. 신규 서버 코드/휴리스틱 0.

- state chip(idle/busy/waiting/deferred)+next_action을 서버 값 그대로 렌더
- waiting rows 상위 3건(source/waiting_on/since/next_action)+overflow 카운트
- 정직한 gap 3종 분리: inventory에 키퍼 부재 / 응답에 필드 부재 / fetch 실패 — 추측 idle 렌더 금지
- tone 팔레트는 keeper-waiting-inventory-panel에서 export로 승격해 재사용 (사본 금지)

검증: vitest 9/9 (신규 5 + 기존 panel 4), 변경 파일 tsc clean. (agent-detail.ts/keeper-detail-shell.ts의 tsc 오류 2건은 main 기존 — 미접촉.)

Refs #23507 — PR-L1 lane state strip + PR-L2 busy/deferral 표면의 slice 1. PR-L3(failure isolation 표면)은 후속.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
