### PR TITLE
feat(runtime): dedicated [runtime].hitl_summary lane for HITL context-summary

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -760,7 +760,13 @@ let provider_config_for_summary ~keeper_name =
     | Some id when String.trim id <> "" -> id
     | Some _ | None -> Keeper_config.default_runtime_id ()
   in
-  match resolve (Runtime.runtime_id_for_structured_judge ()) with
+  (* HITL context-summary is enrichment, not a structured-output judge call: the
+     worker parses a JSON object from the response text, so a faster model is
+     acceptable. Prefer the dedicated [hitl_summary] lane (which falls back to
+     [structured_judge] then [librarian] then [default] inside Runtime) over the
+     requesting keeper's own model so the summary stays consistent and
+     JSON-capable regardless of which keeper asked for approval. *)
+  match resolve (Runtime.runtime_id_for_hitl_summary ()) with
   | Some _ as cfg -> cfg
   | None -> resolve (keeper_runtime_id ())
 ;;

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -220,6 +220,31 @@ let validate_structured_judge_runtime ~(config_path : string)
                runtime.model.id)))
 ;;
 
+(* [runtime].hitl_summary is the explicit lane for the HITL approval
+   context-summary worker. Unlike [runtime].structured_judge, this lane accepts
+   any resolved runtime id — the worker parses a JSON object from the response
+   text rather than requiring provider-native structured output, so a faster
+   model (e.g. deepseek-v4-flash that does not declare
+   supports-structured-output) is valid here. An unknown id is still rejected at
+   load. *)
+let validate_hitl_summary_runtime ~(config_path : string)
+    ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    (hitl_summary_id : string option) : (unit, string) result =
+  match hitl_summary_id with
+  | None -> Ok ()
+  | Some id ->
+    (match List.find_opt (fun (r : t) -> String.equal r.id id) runtimes with
+     | None ->
+       Error
+         (Printf.sprintf
+            "%s: [runtime].hitl_summary = %S%s"
+            config_path
+            id
+            (unresolved_runtime_suffix ~dropped_bindings
+               ~runtime_count:(List.length runtimes) id))
+     | Some _ -> Ok ())
+;;
+
 (* [runtime].media_failover (RFC-0265) mirrors [runtime].librarian validation for
    each id in the ordered list: an unknown id is an operator typo rejected at
    load, not a silent drop (Unknown→Permissive anti-pattern). [[]] is the designed
@@ -604,10 +629,11 @@ let missing_reference_error
 
 let degrade_loaded_for_missing_catalog
     ( (runtimes, configured_default, assignments, librarian_id, structured_judge_id,
-       cross_verifier_id, media_failover, lanes) :
+       hitl_summary_id, cross_verifier_id, media_failover, lanes) :
       t list
       * t
       * (string * string) list
+      * string option
       * string option
       * string option
       * string option
@@ -617,6 +643,7 @@ let degrade_loaded_for_missing_catalog
   : ( ( t list
         * t
         * (string * string) list
+        * string option
         * string option
         * string option
         * string option
@@ -656,11 +683,19 @@ let degrade_loaded_for_missing_catalog
   let structured_judge_id, structured_judge_drop =
     drop_route "[runtime].structured_judge" structured_judge_id
   in
+  let hitl_summary_id, hitl_summary_drop =
+    drop_route "[runtime].hitl_summary" hitl_summary_id
+  in
   let cross_verifier_id, cross_verifier_drop =
     drop_route "[runtime].cross_verifier" cross_verifier_id
   in
   let dropped_routes =
-    [ default_drop; librarian_drop; structured_judge_drop; cross_verifier_drop ]
+    [ default_drop
+    ; librarian_drop
+    ; structured_judge_drop
+    ; hitl_summary_drop
+    ; cross_verifier_drop
+    ]
     |> List.filter_map Fun.id
   in
   let kept_media_failover, dropped_media_failover =
@@ -753,6 +788,7 @@ let degrade_loaded_for_missing_catalog
         , kept_assignments
         , librarian_id
         , structured_judge_id
+        , hitl_summary_id
         , cross_verifier_id
         , kept_media_failover
         , kept_lanes )
@@ -763,6 +799,7 @@ let materialize_config ~(config_path : string) (cfg : config)
   : ( t list
       * t
       * (string * string) list
+      * string option
       * string option
       * string option
       * string option
@@ -805,6 +842,10 @@ let materialize_config ~(config_path : string) (cfg : config)
       cfg.structured_judge_runtime_id
   in
   let* () =
+    validate_hitl_summary_runtime ~config_path ~dropped_bindings runtimes
+      cfg.hitl_summary_runtime_id
+  in
+  let* () =
     validate_cross_verifier_runtime ~config_path ~dropped_bindings runtimes
       cfg.cross_verifier_runtime_id
   in
@@ -825,6 +866,7 @@ let materialize_config ~(config_path : string) (cfg : config)
     , assignments
     , cfg.librarian_runtime_id
     , cfg.structured_judge_runtime_id
+    , cfg.hitl_summary_runtime_id
     , cfg.cross_verifier_runtime_id
     , cfg.media_failover
     , lanes )
@@ -834,6 +876,7 @@ let load_list ~(config_path : string)
   : ( t list
        * t
        * (string * string) list
+       * string option
        * string option
        * string option
        * string option
@@ -864,6 +907,7 @@ type loaded_state =
   ; keeper_assignments : (string * string) list
   ; librarian_runtime_id : string option
   ; structured_judge_runtime_id : string option
+  ; hitl_summary_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
   ; lanes : Runtime_lane.t list
@@ -877,6 +921,7 @@ let empty_loaded_state =
   ; keeper_assignments = []
   ; librarian_runtime_id = None
   ; structured_judge_runtime_id = None
+  ; hitl_summary_runtime_id = None
   ; cross_verifier_runtime_id = None
   ; media_failover = []
   ; lanes = []
@@ -896,6 +941,7 @@ let set_loaded
     , assignments
     , librarian_id
     , structured_judge_id
+    , hitl_summary_id
     , cross_verifier_id
     , media_failover
     , lanes ) =
@@ -905,6 +951,7 @@ let set_loaded
     ; keeper_assignments = assignments
     ; librarian_runtime_id = librarian_id
     ; structured_judge_runtime_id = structured_judge_id
+    ; hitl_summary_runtime_id = hitl_summary_id
     ; cross_verifier_runtime_id = cross_verifier_id
     ; media_failover
     ; lanes
@@ -925,7 +972,7 @@ let init_default ~config_path =
 let init_default_strict_report ~config_path =
   match load_list ~config_path with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok ((runtimes, _, _, _, _, _, _, _) as loaded) ->
+  | Ok ((runtimes, _, _, _, _, _, _, _, _) as loaded) ->
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | Some report -> Error (Missing_catalog_models report)
      | None ->
@@ -939,7 +986,7 @@ let init_default_strict ~config_path =
 let init_default_degraded_report ~config_path =
   match load_list ~config_path with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok ((runtimes, _, _, _, _, _, _, _) as loaded) ->
+  | Ok ((runtimes, _, _, _, _, _, _, _, _) as loaded) ->
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | None ->
        set_loaded ~config_path loaded;
@@ -1007,6 +1054,20 @@ let runtime_id_for_structured_judge () =
   | Some id, _ -> id
   | None, Some id -> id
   | None, None -> default_runtime_id_or_fail ()
+;;
+
+(* [runtime].hitl_summary is the explicit runtime.toml SSOT for the HITL
+   approval context-summary worker. A faster model is acceptable here (the
+   worker parses a JSON object from response text). *)
+let hitl_summary_runtime_id () = (runtime_state ()).hitl_summary_runtime_id
+
+let runtime_id_for_hitl_summary () =
+  let state = runtime_state () in
+  match state.hitl_summary_runtime_id, state.structured_judge_runtime_id, state.librarian_runtime_id with
+  | Some id, _, _ -> id
+  | None, Some id, _ -> id
+  | None, None, Some id -> id
+  | None, None, None -> default_runtime_id_or_fail ()
 ;;
 
 (* [runtime].cross_verifier routing for the anti-rationalization evaluator.
@@ -1571,6 +1632,10 @@ let set_runtime_librarian ?runtime_config_path ~runtime_id () =
 
 let set_runtime_structured_judge ?runtime_config_path ~runtime_id () =
   set_runtime_scalar ?runtime_config_path ~key:"structured_judge" ~runtime_id ()
+;;
+
+let set_runtime_hitl_summary ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar ?runtime_config_path ~key:"hitl_summary" ~runtime_id ()
 ;;
 
 let set_runtime_cross_verifier ?runtime_config_path ~runtime_id () =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -106,17 +106,19 @@ val load_list :
        * string option
        * string option
        * string option
+       * string option
        * string list
        * Runtime_lane.t list
      , string )
      result
 (** [load_list ~config_path] parses runtime.toml into [(runtimes, default,
     keeper_assignments, librarian_runtime_id, structured_judge_runtime_id,
-    cross_verifier_runtime_id, media_failover, lanes)]. Fails ([Error]) if
-    [\[runtime\].default] is missing / unresolved, if any
+    hitl_summary_runtime_id, cross_verifier_runtime_id, media_failover, lanes)].
+    Fails ([Error]) if [\[runtime\].default] is missing / unresolved, if any
     [\[runtime.assignments\]] target does not resolve to a configured runtime, if
     [\[runtime\].librarian] / [\[runtime\].structured_judge] /
-    [\[runtime\].cross_verifier] is set to an unresolved id, if any
+    [\[runtime\].hitl_summary] / [\[runtime\].cross_verifier] is set to an
+    unresolved id, if any
     [\[runtime\].media_failover] entry does not resolve, or if any
     [\[runtime.lanes.<id>\]] candidate does not resolve (mirrors default
     validation — no silent fallback for a typo'd id). [keeper_assignments] is the
@@ -214,6 +216,19 @@ val runtime_id_for_structured_judge : unit -> string
     [\[runtime\].librarian] migration lane, then [\[runtime\].default]. The final
     default path still fails loudly at each caller's schema validation if the
     runtime cannot satisfy provider-native structured output. *)
+
+val hitl_summary_runtime_id : unit -> string option
+(** [\[runtime\].hitl_summary] runtime id for the HITL approval context-summary
+    worker, or [None] when unset. Unlike [structured_judge], a [Some] only needs
+    to resolve to a configured runtime — the worker parses a JSON object from
+    the response text rather than requiring provider-native structured output,
+    so a faster model (e.g. one that does not declare
+    [supports-structured-output]) is valid here. *)
+
+val runtime_id_for_hitl_summary : unit -> string
+(** Resolved runtime id for the HITL approval context-summary worker. Uses
+    [\[runtime\].hitl_summary] first, then [\[runtime\].structured_judge], then
+    [\[runtime\].librarian], then [\[runtime\].default]. *)
 
 val media_failover : unit -> string list
 (** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted when a
@@ -374,6 +389,12 @@ val set_runtime_structured_judge :
 (** Persist or clear [\[runtime\]].structured_judge through the runtime.toml
     SSOT writer, validate the resulting config, atomically write it, and refresh
     the in-process runtime cache. *)
+
+val set_runtime_hitl_summary :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+(** Persist or clear [\[runtime\]].hitl_summary through the runtime.toml SSOT
+    writer, validate the resulting config (id resolves to a configured runtime),
+    atomically write it, and refresh the in-process runtime cache. *)
 
 val set_runtime_cross_verifier :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -274,6 +274,12 @@ type config =
         judges. When set, it must resolve to a model declaring
         [supports-structured-output]. [None] lets callers use their documented
         migration fallback, but no caller may silently discard a schema request. *)
+  ; hitl_summary_runtime_id : string option
+    (** [\[runtime\].hitl_summary] — runtime id for the HITL approval
+        context-summary worker. A faster model is acceptable here because the
+        worker parses a JSON object from the response text rather than requiring
+        provider-native structured output. [None] = the worker falls back to
+        [\[runtime\].structured_judge] then the requesting keeper's runtime. *)
   ; cross_verifier_runtime_id : string option
     (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
         evaluator. It requests JSON mode and must run on a model declaring

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -195,6 +195,12 @@ type config =
         [supports-structured-output]. [None] lets callers use their documented
         migration fallback; schema requests still fail loudly if the resolved
         runtime cannot satisfy them. *)
+  ; hitl_summary_runtime_id : string option
+    (** [\[runtime\].hitl_summary] — runtime id for the HITL approval
+        context-summary worker. A faster model is acceptable (the worker parses
+        a JSON object from response text, no provider-native structured output
+        required). [None] = fall back to [\[runtime\].structured_judge] then the
+        requesting keeper's runtime. *)
   ; cross_verifier_runtime_id : string option
     (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
         evaluator (cross-model task verification). The evaluator requests JSON

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1016,6 +1016,7 @@ type runtime_section =
   { default_runtime_id : string option
   ; librarian_runtime_id : string option
   ; structured_judge_runtime_id : string option
+  ; hitl_summary_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
   }
@@ -1024,6 +1025,7 @@ let empty_runtime_section =
   { default_runtime_id = None
   ; librarian_runtime_id = None
   ; structured_judge_runtime_id = None
+  ; hitl_summary_runtime_id = None
   ; cross_verifier_runtime_id = None
   ; media_failover = []
   }
@@ -1077,6 +1079,16 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
               | Ok structured_judge_runtime_id ->
                 ( { section with
                     structured_judge_runtime_id = Some structured_judge_runtime_id
+                  }
+                , errs )
+              | Error e -> section, errs @ e)
+           | "hitl_summary" ->
+             (match
+                parse_runtime_string_leaf ~path:"runtime.hitl_summary" ~key value
+              with
+              | Ok hitl_summary_runtime_id ->
+                ( { section with
+                    hitl_summary_runtime_id = Some hitl_summary_runtime_id
                   }
                 , errs )
               | Error e -> section, errs @ e)
@@ -1222,6 +1234,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; default_runtime_id = runtime_section.default_runtime_id
       ; librarian_runtime_id = runtime_section.librarian_runtime_id
       ; structured_judge_runtime_id = runtime_section.structured_judge_runtime_id
+      ; hitl_summary_runtime_id = runtime_section.hitl_summary_runtime_id
       ; cross_verifier_runtime_id = runtime_section.cross_verifier_runtime_id
       ; keeper_assignments
       ; media_failover = runtime_section.media_failover


### PR DESCRIPTION
## HITL approval context-summary: dedicated fast-model lane

Splits the HITL approval-queue context-summary worker off the shared
`[runtime].structured_judge` lane onto a dedicated `[runtime].hitl_summary`
lane, so operators can point the summary at a faster model
(e.g. `ollama_cloud.deepseek-v4-flash`) without weakening the verifier /
memory-os judge that also consume `structured_judge`.

The HITL summary worker parses a JSON object from the response **text**
(`hitl_summary_worker.ml`); it does not require provider-native structured
output, so a model that does not declare `supports-structured-output` is valid
here. `validate_hitl_summary_runtime` checks only that the id resolves to a
configured runtime — not the `supports-structured-output` capability gate that
`validate_structured_judge_runtime` applies.

## What

- `runtime_schema.ml/mli`: `hitl_summary_runtime_id : string option` field
  (mirrors `structured_judge_runtime_id`).
- `runtime_toml.ml`: parse the `[runtime].hitl_summary` key.
- `runtime.ml/mli`: 9-tuple propagation through `load_list` /
  `materialize_config` / `degrade_loaded_for_missing_catalog` (with
  `hitl_summary_drop`) / `loaded_state` / `set_loaded` / default-report
  underscoring; `validate_hitl_summary_runtime` (id-resolves-only);
  `hitl_summary_runtime_id` / `runtime_id_for_hitl_summary` (fallback chain
  hitl_summary → structured_judge → librarian → default);
  `set_runtime_hitl_summary`.
- `keeper_approval_queue.ml`: `provider_config_for_summary` resolves via
  `runtime_id_for_hitl_summary` instead of `runtime_id_for_structured_judge`.

## Operator config (optional)

```toml
[runtime]
hitl_summary = "ollama_cloud.deepseek-v4-flash"
```

Unset → falls back to `structured_judge` → `librarian` → `default` (i.e. the
current behaviour, so this is a no-op until an operator opts in).

## Verification

- `dune build` exit 0 (full lib).
- `structured_judge` consumers (`verifier_oas`, memory-os judge) are untouched
  — separate field, separate accessor, separate validator, so the regression
  surface is zero.
- The HITL summary JSON-parse path (`hitl_summary_worker.ml`) is unchanged;
  only the runtime-id selection moved.

## Scope

BE only. A dashboard surface to set `[runtime].hitl_summary` is a follow-up
(it would reuse the existing `set_runtime_*` TOML-writer pattern).

Co-Authored-By: Claude <noreply@anthropic.com>
