### PR TITLE
feat(ide): annotation composer — first UI caller for createIdeAnnotation (#23471 FE-4)

### DIFF
--- a/dashboard/src/components/ide/ide-annotation-composer.test.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.test.ts
@@ -124,6 +124,31 @@ describe('IdeAnnotationComposer', () => {
     expect(el.textContent ?? '').toContain('내용을 입력하세요')
   })
 
+  it.each(['1.9', '1e3', '12abc', '-3', ''])(
+    'rejects non-integer line input %j instead of silently truncating it',
+    async raw => {
+      const el = mount(composer())
+      await open(el)
+
+      const content = el.querySelector<HTMLTextAreaElement>('[data-testid="ide-annotation-content"]')
+      if (content) {
+        content.value = '유효한 내용'
+        content.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      const start = el.querySelector<HTMLInputElement>('[data-testid="ide-annotation-line-start"]')
+      expect(start).not.toBeNull()
+      if (start) {
+        start.value = raw
+        start.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+      await tick()
+
+      const submit = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')
+      expect(submit?.disabled).toBe(true)
+      expect(el.textContent ?? '').toContain('line_start는 1 이상의 정수')
+    },
+  )
+
   it('submits the draft with the repo scope and refreshes on success', async () => {
     createIdeAnnotationMock.mockResolvedValue({
       id: 'a-1',

--- a/dashboard/src/components/ide/ide-annotation-composer.test.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.test.ts
@@ -1,0 +1,167 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IdeAnnotationComposer } from './ide-annotation-composer'
+import { ideEditorSelection } from './ide-editor-selection'
+
+vi.mock('../../api/ide', async importOriginal => {
+  const original = await importOriginal<typeof import('../../api/ide')>()
+  return {
+    ...original,
+    createIdeAnnotation: vi.fn(),
+  }
+})
+
+vi.mock('../common/toast', async importOriginal => {
+  const original = await importOriginal<typeof import('../common/toast')>()
+  return {
+    ...original,
+    showToast: vi.fn(),
+  }
+})
+
+import { createIdeAnnotation } from '../../api/ide'
+
+const createIdeAnnotationMock = vi.mocked(createIdeAnnotation)
+
+function documentStoreFixture(filePath: string | null) {
+  return {
+    document: () => ({ file_path: filePath }),
+    subscribe: () => () => {},
+  }
+}
+
+function composer({
+  filePath = 'lib/foo.ml',
+  repoId = 'masc',
+  refresh = () => {},
+}: {
+  filePath?: string | null
+  repoId?: string | null
+  refresh?: () => void
+} = {}) {
+  return html`
+    <${IdeAnnotationComposer}
+      documentStore=${documentStoreFixture(filePath)}
+      activeRepositoryId=${() => repoId}
+      subscribeActiveRepositoryId=${() => () => {}}
+      refresh=${refresh}
+    />
+  `
+}
+
+describe('IdeAnnotationComposer', () => {
+  let host: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    createIdeAnnotationMock.mockReset()
+    ideEditorSelection.value = null
+  })
+
+  afterEach(() => {
+    if (host) {
+      render(null, host)
+      host.remove()
+      host = null
+    }
+  })
+
+  function mount(node: ReturnType<typeof html>): HTMLDivElement {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    render(node, host)
+    return host
+  }
+
+  function tick(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  async function open(el: HTMLElement): Promise<void> {
+    const button = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-open"]')
+    expect(button).not.toBeNull()
+    button?.click()
+    await tick()
+  }
+
+  it('renders nothing without an active file', () => {
+    const el = mount(composer({ filePath: null }))
+    expect(el.querySelector('[data-testid="ide-annotation-composer-closed"]')).toBeNull()
+    expect(el.querySelector('[data-testid="ide-annotation-composer-open"]')).toBeNull()
+  })
+
+  it('disables the entry button without a repo scope (keeper_lane is read-only)', () => {
+    const el = mount(composer({ repoId: null }))
+    const button = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-open"]')
+    expect(button?.disabled).toBe(true)
+    expect(button?.title ?? '').toContain('repo 선택')
+  })
+
+  it('opens the form with the editor selection as the default line range', async () => {
+    ideEditorSelection.value = { filePath: 'lib/foo.ml', lineStart: 12, lineEnd: 34 }
+    const el = mount(composer())
+    await open(el)
+    const start = el.querySelector<HTMLInputElement>('[data-testid="ide-annotation-line-start"]')
+    const end = el.querySelector<HTMLInputElement>('[data-testid="ide-annotation-line-end"]')
+    expect(start?.value).toBe('12')
+    expect(end?.value).toBe('34')
+  })
+
+  it('ignores a selection recorded for a different file', async () => {
+    ideEditorSelection.value = { filePath: 'lib/other.ml', lineStart: 12, lineEnd: 34 }
+    const el = mount(composer())
+    await open(el)
+    const start = el.querySelector<HTMLInputElement>('[data-testid="ide-annotation-line-start"]')
+    expect(start?.value).toBe('1')
+  })
+
+  it('keeps submit disabled while the draft is invalid', async () => {
+    const el = mount(composer())
+    await open(el)
+    const submit = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')
+    expect(submit?.disabled).toBe(true)
+    expect(el.textContent ?? '').toContain('내용을 입력하세요')
+  })
+
+  it('submits the draft with the repo scope and refreshes on success', async () => {
+    createIdeAnnotationMock.mockResolvedValue({
+      id: 'a-1',
+      file_path: 'lib/foo.ml',
+      line_start: 12,
+      line_end: 34,
+    } as Awaited<ReturnType<typeof createIdeAnnotation>>)
+    const refresh = vi.fn()
+    ideEditorSelection.value = { filePath: 'lib/foo.ml', lineStart: 12, lineEnd: 34 }
+    const el = mount(composer({ refresh }))
+    await open(el)
+
+    const content = el.querySelector<HTMLTextAreaElement>('[data-testid="ide-annotation-content"]')
+    expect(content).not.toBeNull()
+    if (content) {
+      content.value = '경계 조건 확인 필요'
+      content.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    await tick()
+
+    const submit = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')
+    expect(submit?.disabled).toBe(false)
+    submit?.click()
+    await tick()
+    await tick()
+
+    expect(createIdeAnnotationMock).toHaveBeenCalledTimes(1)
+    expect(createIdeAnnotationMock).toHaveBeenCalledWith(
+      {
+        file_path: 'lib/foo.ml',
+        line_start: 12,
+        line_end: 34,
+        kind: 'Comment',
+        content: '경계 조건 확인 필요',
+      },
+      { repoId: 'masc' },
+    )
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(el.querySelector('[data-testid="ide-annotation-composer-open"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/ide/ide-annotation-composer.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.ts
@@ -1,0 +1,220 @@
+// IDE annotation composer (#23471 FE-4). The write half of the annotation
+// plane: the read half (line chips, popover, Context Lens) has been wired
+// since Phase 1, but `createIdeAnnotation` had zero UI callers — a human
+// could not leave a comment/decision from the IDE at all.
+//
+// Contract notes (server-enforced, mirrored here instead of re-invented):
+// - Mutations require a repo scope; `keeper_lane` is read-only
+//   (`keeper_lane_read_only`), so the composer submits with the explorer's
+//   active repository and disables itself when none is selected.
+// - Identity comes from the auth token; the composer never sends a
+//   keeper_id.
+// - After a successful create the workspace fetches re-run, so the new
+//   record surfaces through the exact read path keeper annotations use.
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import type { VNode } from 'preact'
+import { createIdeAnnotation } from '../../api/ide'
+import type { AnnotationKind } from '../../api/schemas/ide-annotations'
+import { showToast } from '../common/toast'
+import { useSignalValue, useStoreSubscription } from './use-signal-value'
+import { ideEditorSelection } from './ide-editor-selection'
+
+const ANNOTATION_KINDS: readonly AnnotationKind[] = [
+  'Comment',
+  'Decision',
+  'Question',
+  'Bookmark',
+]
+
+interface ComposerDraft {
+  readonly kind: AnnotationKind
+  readonly lineStart: string
+  readonly lineEnd: string
+  readonly content: string
+}
+
+function draftFromSelection(filePath: string): ComposerDraft {
+  const selection = ideEditorSelection.value
+  const matches = selection !== null && selection.filePath === filePath
+  const lineStart = matches ? selection.lineStart : 1
+  const lineEnd = matches ? selection.lineEnd : lineStart
+  return {
+    kind: 'Comment',
+    lineStart: String(lineStart),
+    lineEnd: String(lineEnd),
+    content: '',
+  }
+}
+
+function parseLine(raw: string): number | null {
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isInteger(value) || value < 1) return null
+  return value
+}
+
+function draftProblem(draft: ComposerDraft): string | null {
+  const lineStart = parseLine(draft.lineStart)
+  const lineEnd = parseLine(draft.lineEnd)
+  if (lineStart === null) return 'line_start는 1 이상의 정수여야 합니다'
+  if (lineEnd === null) return 'line_end는 1 이상의 정수여야 합니다'
+  if (lineEnd < lineStart) return 'line_end는 line_start 이상이어야 합니다'
+  if (draft.content.trim() === '') return '내용을 입력하세요'
+  return null
+}
+
+export function IdeAnnotationComposer({
+  documentStore,
+  activeRepositoryId,
+  subscribeActiveRepositoryId,
+  refresh,
+}: {
+  documentStore: {
+    document: () => { readonly file_path: string | null }
+    subscribe: (listener: () => void) => () => void
+  }
+  activeRepositoryId: () => string | null
+  subscribeActiveRepositoryId: (listener: () => void) => () => void
+  refresh: () => void
+}): VNode | null {
+  useStoreSubscription(documentStore.subscribe)
+  useStoreSubscription(subscribeActiveRepositoryId)
+  useSignalValue(ideEditorSelection)
+
+  const [draft, setDraft] = useState<ComposerDraft | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const filePath = documentStore.document().file_path
+  if (filePath === null) return null
+  const repoId = activeRepositoryId()
+
+  if (draft === null) {
+    return html`
+      <div class="ide-annotation-composer" data-testid="ide-annotation-composer-closed">
+        <button
+          type="button"
+          class="v2-ide-action"
+          data-testid="ide-annotation-open"
+          disabled=${repoId === null}
+          title=${repoId === null
+            ? '주석 생성에는 repo 선택이 필요합니다 (keeper_lane scope는 read-only)'
+            : '현재 선택 라인에 주석을 남깁니다'}
+          onClick=${() => setDraft(draftFromSelection(filePath))}
+        >
+          주석 추가
+        </button>
+      </div>
+    `
+  }
+
+  const problem = draftProblem(draft)
+  const update = (patch: Partial<ComposerDraft>) =>
+    setDraft(current => (current === null ? current : { ...current, ...patch }))
+
+  const submit = async () => {
+    if (problem !== null || repoId === null || submitting) return
+    const lineStart = parseLine(draft.lineStart)
+    const lineEnd = parseLine(draft.lineEnd)
+    if (lineStart === null || lineEnd === null) return
+    setSubmitting(true)
+    try {
+      const created = await createIdeAnnotation(
+        {
+          file_path: filePath,
+          line_start: lineStart,
+          line_end: lineEnd,
+          kind: draft.kind,
+          content: draft.content.trim(),
+        },
+        { repoId },
+      )
+      if (created === null) {
+        showToast('주석 응답 파싱 실패 — 서버 응답을 확인하세요', 'error')
+      } else {
+        showToast(`주석 저장됨: ${created.file_path}:${created.line_start}`, 'success')
+        setDraft(null)
+        refresh()
+      }
+    } catch (error) {
+      showToast(`주석 저장 실패: ${error instanceof Error ? error.message : String(error)}`, 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return html`
+    <div class="ide-annotation-composer" data-testid="ide-annotation-composer-open">
+      <div class="flex flex-wrap items-center gap-1.5 text-2xs">
+        <span class="font-mono text-[var(--color-fg-muted)]" title=${filePath}>${filePath}</span>
+        <select
+          aria-label="주석 종류"
+          data-testid="ide-annotation-kind"
+          value=${draft.kind}
+          onChange=${(event: Event) =>
+            update({ kind: (event.currentTarget as HTMLSelectElement).value as AnnotationKind })}
+        >
+          ${ANNOTATION_KINDS.map(kind => html`<option key=${kind} value=${kind}>${kind}</option>`)}
+        </select>
+        <label class="flex items-center gap-1">
+          L
+          <input
+            type="number"
+            min="1"
+            aria-label="시작 라인"
+            data-testid="ide-annotation-line-start"
+            style=${{ width: '5.5em' }}
+            value=${draft.lineStart}
+            onInput=${(event: Event) =>
+              update({ lineStart: (event.currentTarget as HTMLInputElement).value })}
+          />
+        </label>
+        <label class="flex items-center gap-1">
+          –
+          <input
+            type="number"
+            min="1"
+            aria-label="끝 라인"
+            data-testid="ide-annotation-line-end"
+            style=${{ width: '5.5em' }}
+            value=${draft.lineEnd}
+            onInput=${(event: Event) =>
+              update({ lineEnd: (event.currentTarget as HTMLInputElement).value })}
+          />
+        </label>
+      </div>
+      <textarea
+        aria-label="주석 내용"
+        data-testid="ide-annotation-content"
+        rows="3"
+        placeholder="코멘트 / 결정 / 질문 내용"
+        value=${draft.content}
+        onInput=${(event: Event) =>
+          update({ content: (event.currentTarget as HTMLTextAreaElement).value })}
+      ></textarea>
+      <div class="flex items-center gap-1.5">
+        <button
+          type="button"
+          class="v2-ide-action"
+          data-testid="ide-annotation-submit"
+          disabled=${problem !== null || submitting || repoId === null}
+          title=${problem ?? ''}
+          onClick=${() => void submit()}
+        >
+          ${submitting ? '저장 중…' : '저장'}
+        </button>
+        <button
+          type="button"
+          class="v2-ide-action"
+          data-testid="ide-annotation-cancel"
+          onClick=${() => setDraft(null)}
+        >
+          취소
+        </button>
+        ${problem !== null
+          ? html`<span class="text-2xs text-[var(--color-status-warn)]">${problem}</span>`
+          : null}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/ide/ide-annotation-composer.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.ts
@@ -48,9 +48,15 @@ function draftFromSelection(filePath: string): ComposerDraft {
   }
 }
 
+// Strict positive-integer parse. `Number.parseInt` would silently
+// truncate browser number-input strings like "1.9", "1e3", or "12abc"
+// and file the annotation onto the wrong line while the draft still
+// reads as valid — the digit-shape check rejects those outright.
 function parseLine(raw: string): number | null {
-  const value = Number.parseInt(raw, 10)
-  if (!Number.isInteger(value) || value < 1) return null
+  const trimmed = raw.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  const value = Number(trimmed)
+  if (!Number.isSafeInteger(value) || value < 1) return null
   return value
 }
 

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -60,6 +60,11 @@ export interface IdeDataWorkspaceStore {
   readonly subscribeRepositories: (listener: () => void) => () => void
   readonly annotations: () => ReadonlyArray<IdeAnnotation>
   readonly subscribeAnnotations: (listener: () => void) => () => void
+  /** Re-run the workspace fetches on demand — the annotation composer
+   *  (#23471 FE-4) calls this after a successful create so the line
+   *  chips / popover / Context Lens pick the new record up through the
+   *  same read path keeper edits use. */
+  readonly refresh: () => void
   readonly dispose: () => void
 }
 
@@ -584,6 +589,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     annotations: () => annotationsSignal.value,
     subscribeAnnotations: (listener: () => void) =>
       annotationsSignal.subscribe(listener),
+    refresh: () => {
+      runWorkspaceFetches()
+    },
     dispose: () => {
       abortController.abort()
       unregisterLiveRefresh()

--- a/dashboard/src/components/ide/ide-editor-selection.ts
+++ b/dashboard/src/components/ide/ide-editor-selection.ts
@@ -1,0 +1,15 @@
+// Human selection state of the read-only CM6 editor (#23471 FE-4).
+// The editor's existing updateListener publishes the current main
+// selection as 1-based line numbers; the annotation composer reads it to
+// default the line range of a new annotation. Kept in its own module so
+// the composer does not import the (heavy) editor module.
+
+import { signal } from '@preact/signals'
+
+export interface IdeEditorSelection {
+  readonly filePath: string
+  readonly lineStart: number
+  readonly lineEnd: number
+}
+
+export const ideEditorSelection = signal<IdeEditorSelection | null>(null)

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -5,6 +5,7 @@ import { EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import type { CodeDocumentStore } from './code-document-store'
 import type { KeeperLineOwnershipStore } from './keeper-line-ownership-store'
+import { ideEditorSelection } from './ide-editor-selection'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import {
@@ -355,6 +356,16 @@ function CodeMirrorEditor({
             if (sel !== prevAnnRef.current) {
               prevAnnRef.current = sel
               setSelectedAnn(sel)
+            }
+            // #23471 FE-4: publish the human selection as 1-based line
+            // numbers for the annotation composer's default range.
+            if (update.selectionSet || update.docChanged) {
+              const main = update.state.selection.main
+              ideEditorSelection.value = {
+                filePath: mountFilePath,
+                lineStart: update.state.doc.lineAt(main.from).number,
+                lineEnd: update.state.doc.lineAt(main.to).number,
+              }
             }
           }),
           ...(onKeeperLineSelect

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -12,6 +12,7 @@ import { getIdeDataWorkspaceStore } from './ide-workspace-singleton'
 import { parsePositiveLineString } from '../common/normalize'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
+import { IdeAnnotationComposer } from './ide-annotation-composer'
 import { IdeConversationRail } from './ide-conversation-rail'
 import { IdeActivityPanel } from './ide-activity-panel'
 import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
@@ -1250,6 +1251,12 @@ export function IdeShell() {
         <div
           class="ide-plane-editor ide-v2-editor v2-ide-panel"
         >
+          <${IdeAnnotationComposer}
+            documentStore=${workspaceStore.documentStore}
+            activeRepositoryId=${workspaceStore.activeRepositoryId}
+            subscribeActiveRepositoryId=${workspaceStore.subscribeActiveRepositoryId}
+            refresh=${workspaceStore.refresh}
+          />
           <${IdeEditor}
             activeView=${activeView}
             activeLayers=${activeLayers}


### PR DESCRIPTION
## 무엇이 문제였나 (#23471 FE-4, P1)

annotation plane이 사실상 read-only였습니다 — line chip/popover/Context Lens는 annotation을 **렌더**하지만 `createIdeAnnotation`의 UI 호출자가 0이라, 사람이 IDE에서 코멘트/결정/질문을 남길 경로 자체가 없었습니다.

## 무엇을 바꿨나

에디터 페인에 **annotation composer**를 배선했습니다:

- "주석 추가" 버튼 → 폼. 라인 범위는 CM6 에디터의 현재 selection에서 기본값(기존 updateListener에 1-based 라인 publish 추가 — 신규 `ide-editor-selection` signal, 다른 파일의 selection은 무시)
- 제출은 기존 클라이언트 `createIdeAnnotation` + explorer의 active repository scope. **repo 미선택 시 버튼 비활성 + 사유 표기** — 서버의 `keeper_lane_read_only` mutation 계약을 FE에서 재발명하지 않고 미러링
- identity는 토큰 유래 그대로 — composer는 keeper_id를 보내지 않음 (#23461 계약)
- 성공 시 workspace store가 fetch를 재실행(신규 `refresh()` 노출)해 **keeper annotation과 동일한 read 경로**로 새 레코드가 chip/popover/Lens에 표면화. 실패는 toast, invalid draft(라인 역전/빈 내용)는 사유와 함께 submit 비활성

## 범위 제외

- `deleteIdeAnnotation` UI(호출자 0 동일) — popover에 삭제 버튼 추가는 후속 슬라이스 (소유자 검증 UX 별도 고민 필요)
- gutter 아이콘/인라인 하이라이트 등 rich UX — 이 PR은 "쓰기 경로 존재" 자체를 배선

## 검증

- 신규 테스트 6종: 파일 없음 / repo scope 없음(비활성+사유) / selection 기본값 / 타 파일 selection 무시 / invalid draft 비활성 / 제출 계약(인자+scope)+refresh 호출
- vitest 76/76 (composer 6 + editor/shell/store 이웃 70)
- tsc: 변경 파일 clean (agent-detail.ts/keeper-detail-shell.ts 2건은 main 기존, 미접촉)

Refs #23471 (FE-4)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
