### PR TITLE
feat(dashboard): schedule 화면 cadence 축 + 캘린더 뷰 반영

### DIFF
--- a/dashboard/src/components/schedule/schedule-agenda.test.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.test.ts
@@ -1,0 +1,225 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { DashboardScheduledAutomationRequest } from '../../api'
+import {
+  Agenda,
+  CadenceSummary,
+  PollingStrip,
+  buildAgenda,
+  cadenceCounts,
+  cadenceOfRequest,
+  fireTimestampMs,
+  isTerminalRequest,
+  selectPollingSchedules,
+} from './schedule-agenda'
+
+// Anchor the deterministic "now" to 2026-07-07 12:00 *local* time. The agenda
+// splits days on the local midnight boundary (what an operator sees), so
+// fixtures are built with local Date components to stay timezone-independent.
+const NOW_MS = new Date(2026, 6, 7, 12, 0, 0).getTime()
+const HOUR_MS = 3_600_000
+const DAY_MS = 86_400_000
+/** Epoch *seconds* for a local wall-clock time (matches the backend due_at). */
+function localEpochSeconds(year: number, monthIndex: number, day: number, hour: number, minute = 0): number {
+  return new Date(year, monthIndex, day, hour, minute, 0).getTime() / 1000
+}
+
+function req(
+  overrides: Partial<DashboardScheduledAutomationRequest> & { schedule_id: string },
+): DashboardScheduledAutomationRequest {
+  return {
+    status: 'scheduled',
+    risk_class: 'read_only',
+    approval_required: false,
+    source: 'automated_request',
+    recurrence: { kind: 'one_shot' },
+    ...overrides,
+  }
+}
+
+describe('cadenceOfRequest', () => {
+  it('maps the closed backend recurrence set onto the operator cadence axis', () => {
+    expect(cadenceOfRequest(req({ schedule_id: 'a', recurrence: { kind: 'one_shot' } }))).toBe('oneshot')
+    expect(cadenceOfRequest(req({ schedule_id: 'b', recurrence: { kind: 'interval', interval_sec: 3600 } }))).toBe('interval')
+    expect(cadenceOfRequest(req({ schedule_id: 'c', recurrence: { kind: 'daily', hour: 2, minute: 0 } }))).toBe('scheduled')
+    // cron is a fixed time-scheduled job → 정기, not silently dropped to oneshot.
+    expect(cadenceOfRequest(req({ schedule_id: 'd', recurrence: { kind: 'cron', expression: '0 2 * * *' } }))).toBe('scheduled')
+  })
+
+  it('falls back to recurrence_kind when the structured recurrence is absent', () => {
+    expect(cadenceOfRequest(req({ schedule_id: 'e', recurrence: undefined, recurrence_kind: 'daily' }))).toBe('scheduled')
+  })
+
+  it('returns null for an unrecognized recurrence kind rather than a permissive default', () => {
+    expect(cadenceOfRequest(req({ schedule_id: 'f', recurrence: { kind: 'lunar' }, recurrence_kind: undefined }))).toBeNull()
+    expect(cadenceOfRequest(req({ schedule_id: 'g', recurrence: undefined, recurrence_kind: undefined }))).toBeNull()
+  })
+})
+
+describe('cadenceCounts', () => {
+  it('counts each cadence bucket and surfaces unknown kinds separately', () => {
+    const counts = cadenceCounts([
+      req({ schedule_id: 'a', recurrence: { kind: 'one_shot' } }),
+      req({ schedule_id: 'b', recurrence: { kind: 'one_shot' } }),
+      req({ schedule_id: 'c', recurrence: { kind: 'interval', interval_sec: 60 } }),
+      req({ schedule_id: 'd', recurrence: { kind: 'daily', hour: 9, minute: 0 } }),
+      req({ schedule_id: 'e', recurrence: { kind: 'cron', expression: '* * * * *' } }),
+      req({ schedule_id: 'f', recurrence: { kind: 'lunar' } }),
+    ])
+    expect(counts).toEqual({ scheduled: 2, interval: 1, oneshot: 2, unknown: 1 })
+  })
+})
+
+describe('isTerminalRequest', () => {
+  it('treats terminal statuses (case-insensitive, effective first) as terminal', () => {
+    expect(isTerminalRequest(req({ schedule_id: 'a', status: 'succeeded' }))).toBe(true)
+    expect(isTerminalRequest(req({ schedule_id: 'b', status: 'scheduled', effective_status: 'cancelled' }))).toBe(true)
+    expect(isTerminalRequest(req({ schedule_id: 'c', status: 'Expired' }))).toBe(true)
+    expect(isTerminalRequest(req({ schedule_id: 'd', status: 'scheduled' }))).toBe(false)
+    expect(isTerminalRequest(req({ schedule_id: 'e', status: 'due' }))).toBe(false)
+  })
+})
+
+describe('fireTimestampMs', () => {
+  it('prefers the ISO next-due field, then due ISO, then numeric epoch seconds', () => {
+    expect(fireTimestampMs(req({ schedule_id: 'a', next_due_at_iso: '2026-07-08T01:00:00Z' })))
+      .toBe(Date.parse('2026-07-08T01:00:00Z'))
+    expect(fireTimestampMs(req({ schedule_id: 'b', due_at_iso: '2026-07-08T02:00:00Z' })))
+      .toBe(Date.parse('2026-07-08T02:00:00Z'))
+    expect(fireTimestampMs(req({ schedule_id: 'c', next_due_at: 1_780_000_000, due_at: 1 })))
+      .toBe(1_780_000_000 * 1000)
+    expect(fireTimestampMs(req({ schedule_id: 'd', due_at: 1_780_000_500 })))
+      .toBe(1_780_000_500 * 1000)
+  })
+
+  it('returns null when the projection has no concrete wake time', () => {
+    expect(fireTimestampMs(req({ schedule_id: 'e' }))).toBeNull()
+  })
+})
+
+describe('selectPollingSchedules', () => {
+  it('keeps only non-terminal interval schedules, soonest next-tick first', () => {
+    const rows = selectPollingSchedules([
+      req({ schedule_id: 'later', recurrence: { kind: 'interval', interval_sec: 3600 }, due_at_iso: '2026-07-07T15:00:00Z' }),
+      req({ schedule_id: 'soon', recurrence: { kind: 'interval', interval_sec: 3600 }, due_at_iso: '2026-07-07T14:10:00Z' }),
+      req({ schedule_id: 'terminal', status: 'succeeded', recurrence: { kind: 'interval', interval_sec: 3600 }, due_at_iso: '2026-07-07T14:05:00Z' }),
+      req({ schedule_id: 'daily', recurrence: { kind: 'daily', hour: 2, minute: 0 }, due_at_iso: '2026-07-08T02:00:00Z' }),
+    ])
+    expect(rows.map(row => row.request.schedule_id)).toEqual(['soon', 'later'])
+  })
+})
+
+describe('buildAgenda', () => {
+  it('places scheduled/oneshot rows on the correct day column and excludes interval', () => {
+    const columns = buildAgenda(
+      [
+        req({ schedule_id: 'today', recurrence: { kind: 'one_shot' }, due_at: localEpochSeconds(2026, 6, 7, 18) }),
+        req({ schedule_id: 'tomorrow', recurrence: { kind: 'daily', hour: 2, minute: 0 }, next_due_at: localEpochSeconds(2026, 6, 8, 2) }),
+        req({ schedule_id: 'interval', recurrence: { kind: 'interval', interval_sec: 3600 }, due_at: localEpochSeconds(2026, 6, 7, 15) }),
+      ],
+      { nowMs: NOW_MS, days: 7 },
+    )
+    const idsByOffset = columns.map(column => column.events.map(event => event.request.schedule_id))
+    // 'today' lands on offset 0, 'tomorrow' on offset 1; interval is excluded.
+    expect(idsByOffset[0]).toContain('today')
+    expect(idsByOffset[1]).toContain('tomorrow')
+    expect(idsByOffset.flat()).not.toContain('interval')
+  })
+
+  it('drops terminal rows and rows without a concrete wake time', () => {
+    const columns = buildAgenda(
+      [
+        req({ schedule_id: 'terminal', status: 'succeeded', due_at_iso: '2026-07-07T18:00:00Z' }),
+        req({ schedule_id: 'no-time', recurrence: { kind: 'one_shot' } }),
+      ],
+      { nowMs: NOW_MS },
+    )
+    expect(columns.flatMap(column => column.events)).toHaveLength(0)
+  })
+
+  it('clamps an overdue wake onto today and drops rows beyond the window', () => {
+    const columns = buildAgenda(
+      [
+        req({ schedule_id: 'overdue', status: 'due', due_at: (NOW_MS - 2 * DAY_MS) / 1000 }),
+        req({ schedule_id: 'far', recurrence: { kind: 'daily', hour: 0, minute: 0 }, next_due_at: (NOW_MS + 30 * DAY_MS) / 1000 }),
+      ],
+      { nowMs: NOW_MS, days: 7 },
+    )
+    expect(columns[0]!.events.map(event => event.request.schedule_id)).toContain('overdue')
+    expect(columns.flatMap(column => column.events).map(event => event.request.schedule_id)).not.toContain('far')
+  })
+
+  it('sorts events within a day by wake time', () => {
+    const columns = buildAgenda(
+      [
+        req({ schedule_id: 'late', due_at: (NOW_MS + 5 * HOUR_MS) / 1000 }),
+        req({ schedule_id: 'early', due_at: (NOW_MS + 1 * HOUR_MS) / 1000 }),
+      ],
+      { nowMs: NOW_MS },
+    )
+    expect(columns[0]!.events.map(event => event.request.schedule_id)).toEqual(['early', 'late'])
+  })
+})
+
+describe('schedule calendar components', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders the cadence summary with counts and an unknown chip when present', () => {
+    const counts = { scheduled: 3, interval: 2, oneshot: 5, unknown: 1 }
+    render(html`<${CadenceSummary} counts=${counts} active=${null} onFilter=${() => {}} />`, container)
+    expect(container.querySelector('[data-testid="sch-cadsum-scheduled"]')?.textContent).toContain('3')
+    expect(container.querySelector('[data-testid="sch-cadsum-interval"]')?.textContent).toContain('2')
+    expect(container.querySelector('[data-testid="sch-cadsum-oneshot"]')?.textContent).toContain('5')
+    expect(container.querySelector('[data-testid="sch-cadsum-unknown"]')?.textContent).toContain('1')
+  })
+
+  it('omits the unknown chip when every recurrence kind is recognized', () => {
+    const counts = { scheduled: 1, interval: 0, oneshot: 0, unknown: 0 }
+    render(html`<${CadenceSummary} counts=${counts} active=${'scheduled'} onFilter=${() => {}} />`, container)
+    expect(container.querySelector('[data-testid="sch-cadsum-unknown"]')).toBeNull()
+  })
+
+  it('renders active interval schedules in the polling strip and shows empty state otherwise', () => {
+    render(
+      html`<${PollingStrip}
+        requests=${[req({ schedule_id: 'poll-1', recurrence: { kind: 'interval', interval_sec: 21600 }, due_at_iso: '2026-07-07T18:00:00Z' })]}
+        onOpen=${() => {}}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-schedule-id="poll-1"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="sch-polling-empty"]')).toBeNull()
+
+    render(
+      html`<${PollingStrip} requests=${[req({ schedule_id: 'one', recurrence: { kind: 'one_shot' } })]} onOpen=${() => {}} />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="sch-polling-empty"]')).not.toBeNull()
+  })
+
+  it('renders agenda events and the empty state when nothing is upcoming', () => {
+    render(
+      html`<${Agenda}
+        requests=${[req({ schedule_id: 'ev-1', due_at_iso: '2026-07-07T18:00:00Z' })]}
+        nowMs=${NOW_MS}
+        onOpen=${() => {}}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-schedule-id="ev-1"]')).not.toBeNull()
+
+    render(html`<${Agenda} requests=${[]} nowMs=${NOW_MS} onOpen=${() => {}} />`, container)
+    expect(container.querySelector('[data-testid="sch-agenda-empty"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/schedule/schedule-agenda.test.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.test.ts
@@ -138,6 +138,22 @@ describe('buildAgenda', () => {
     expect(columns.flatMap(column => column.events)).toHaveLength(0)
   })
 
+  it('keeps an unrecognized-cadence row on the agenda rather than dropping it', () => {
+    const columns = buildAgenda(
+      [
+        req({ schedule_id: 'unknown', recurrence: { kind: 'lunar' }, recurrence_kind: undefined, due_at: localEpochSeconds(2026, 6, 7, 18) }),
+        req({ schedule_id: 'interval', recurrence: { kind: 'interval', interval_sec: 3600 }, due_at: localEpochSeconds(2026, 6, 7, 15) }),
+      ],
+      { nowMs: NOW_MS, days: 7 },
+    )
+    const events = columns.flatMap(column => column.events)
+    // The unknown-cadence row is surfaced (cadence null); the interval row is not
+    // (it belongs in the polling strip).
+    expect(events.map(event => event.request.schedule_id)).toContain('unknown')
+    expect(events.map(event => event.request.schedule_id)).not.toContain('interval')
+    expect(events.find(event => event.request.schedule_id === 'unknown')?.cadence).toBeNull()
+  })
+
   it('clamps an overdue wake onto today and drops rows beyond the window', () => {
     const columns = buildAgenda(
       [

--- a/dashboard/src/components/schedule/schedule-agenda.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.ts
@@ -127,7 +127,9 @@ export function selectPollingSchedules(
 export interface AgendaEvent {
   readonly request: DashboardScheduledAutomationRequest
   readonly atMs: number
-  readonly cadence: Exclude<Cadence, 'interval'>
+  // scheduled | oneshot for a recognized recurrence kind; null when the kind is
+  // outside the closed backend set (surfaced, never silently dropped).
+  readonly cadence: Exclude<Cadence, 'interval'> | null
 }
 
 export interface AgendaColumn {
@@ -136,8 +138,10 @@ export interface AgendaColumn {
   readonly events: AgendaEvent[]
 }
 
-/** Project active scheduled/oneshot schedules onto `days` day columns starting
- * today. Interval schedules are excluded (they live in the polling strip). A row
+/** Project active, non-interval schedules onto `days` day columns starting
+ * today. Interval schedules are excluded (they live in the polling strip);
+ * scheduled, oneshot, AND unrecognized-cadence rows all belong here so an
+ * unknown recurrence kind is never silently dropped from the calendar. A row
  * whose next wake predates today is clamped onto today (overdue → visible now);
  * a row without a concrete wake time is dropped. */
 export function buildAgenda(
@@ -153,7 +157,9 @@ export function buildAgenda(
   for (const request of requests) {
     if (isTerminalRequest(request)) continue
     const cadence = cadenceOfRequest(request)
-    if (cadence !== 'scheduled' && cadence !== 'oneshot') continue
+    // interval → polling strip; everything else (scheduled, oneshot, unknown)
+    // belongs on the day agenda.
+    if (cadence === 'interval') continue
     const atMs = fireTimestampMs(request)
     if (atMs === null) continue
     const rawOffset = Math.round((startOfDayMs(atMs) - todayStart) / MS_PER_DAY)
@@ -350,7 +356,9 @@ function AgendaEventRow({
       onClick=${() => onOpen(request.schedule_id)}
     >
       <span class="sch-ev-time mono">${formatClock(event.atMs)}</span>
-      <${CadenceTag} cadence=${event.cadence} />
+      ${event.cadence === null
+        ? html`<span class="sch-cad dim" title="recurrence kind가 알려진 집합(one_shot·interval·daily·cron) 밖입니다 — projection/버전 불일치">⧗ 미상</span>`
+        : html`<${CadenceTag} cadence=${event.cadence} />`}
       <span class="sch-ev-body">
         <span class="sch-ev-title">${summaryText(request)}</span>
         <span class="sch-ev-meta">

--- a/dashboard/src/components/schedule/schedule-agenda.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.ts
@@ -1,0 +1,445 @@
+// Calendar (agenda) projection + presentation for the schedule surface.
+//
+// Ported from the keeper-v2 prototype (schedule.jsx: SchCadenceSummary /
+// SchPollingStrip / SchAgenda). The prototype worked off static data and a fixed
+// "now"; this module derives everything from the live schedule projection
+// (DashboardScheduledAutomationRequest[]) instead.
+//
+// Two honesty rules the prototype did not need but production does:
+//   1. Placement uses the backend-computed next wake (next_due_at ?? due_at). A
+//      row without a concrete wake time cannot be placed and is dropped — future
+//      occurrences are never fabricated on the client (no cron/DST guessing).
+//   2. `now` is injected, so the projection is a pure function of its inputs and
+//      the tests are deterministic.
+
+import { html } from 'htm/preact'
+import type { DashboardScheduledAutomationRequest } from '../../api'
+import { StatusChip } from '../common/status-chip'
+import {
+  automationTone,
+  recurrenceLabel,
+} from '../tools/scheduled-automation-panel'
+import {
+  SCHED_CADENCE,
+  SCHED_CADENCE_ORDER,
+  SCHED_TERMINAL_NORMALIZED,
+  cadenceOfRecurrenceKind,
+  parseRecurrenceKind,
+  schedPayloadSpec,
+  schedRiskSpec,
+  type Cadence,
+} from '../v2/schedule-constants'
+
+const MS_PER_DAY = 86_400_000
+const AGENDA_DAYS = 7
+const WEEKDAY_KO: readonly string[] = ['일', '월', '화', '수', '목', '금', '토']
+
+// ── derivations ────────────────────────────────────────────────────
+
+function normalizedStatus(request: DashboardScheduledAutomationRequest): string {
+  return (request.effective_status ?? request.status)?.trim().toLowerCase() ?? ''
+}
+
+export function isTerminalRequest(request: DashboardScheduledAutomationRequest): boolean {
+  return SCHED_TERMINAL_NORMALIZED.has(normalizedStatus(request))
+}
+
+/** Operator cadence for a request, or `null` when the recurrence kind is not one
+ * of the closed backend set (surfaced, never silently bucketed). */
+export function cadenceOfRequest(request: DashboardScheduledAutomationRequest): Cadence | null {
+  const kind = parseRecurrenceKind(request.recurrence?.kind ?? request.recurrence_kind)
+  return kind ? cadenceOfRecurrenceKind(kind) : null
+}
+
+export interface CadenceCounts {
+  readonly scheduled: number
+  readonly interval: number
+  readonly oneshot: number
+  /** Requests whose recurrence kind is outside the closed backend set. */
+  readonly unknown: number
+}
+
+export function cadenceCounts(
+  requests: readonly DashboardScheduledAutomationRequest[],
+): CadenceCounts {
+  let scheduled = 0
+  let interval = 0
+  let oneshot = 0
+  let unknown = 0
+  for (const request of requests) {
+    const cadence = cadenceOfRequest(request)
+    if (cadence === 'scheduled') scheduled += 1
+    else if (cadence === 'interval') interval += 1
+    else if (cadence === 'oneshot') oneshot += 1
+    else unknown += 1
+  }
+  return { scheduled, interval, oneshot, unknown }
+}
+
+/** Concrete next wake in epoch milliseconds, preferring the ISO field (matches
+ * the panel's `dueTimestamp`), then the numeric epoch-seconds field. `null` when
+ * the projection has no concrete wake time to place. */
+export function fireTimestampMs(request: DashboardScheduledAutomationRequest): number | null {
+  const iso = request.next_due_at_iso ?? request.due_at_iso ?? null
+  if (iso) {
+    const parsed = Date.parse(iso)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  const epochSeconds = request.next_due_at ?? request.due_at ?? null
+  if (typeof epochSeconds === 'number' && Number.isFinite(epochSeconds)) {
+    return epochSeconds * 1000
+  }
+  return null
+}
+
+function startOfDayMs(ms: number): number {
+  const date = new Date(ms)
+  date.setHours(0, 0, 0, 0)
+  return date.getTime()
+}
+
+// ── polling strip (interval schedules) ─────────────────────────────
+
+export interface PollingRow {
+  readonly request: DashboardScheduledAutomationRequest
+  readonly nextTickMs: number | null
+}
+
+/** Active (non-terminal) interval schedules — the always-on polling loops that
+ * do not belong on a specific calendar day. Sorted soonest-next-tick first;
+ * rows without a next tick sort last but are kept (they are still active). */
+export function selectPollingSchedules(
+  requests: readonly DashboardScheduledAutomationRequest[],
+): PollingRow[] {
+  const rows: PollingRow[] = []
+  for (const request of requests) {
+    if (isTerminalRequest(request)) continue
+    if (cadenceOfRequest(request) !== 'interval') continue
+    rows.push({ request, nextTickMs: fireTimestampMs(request) })
+  }
+  return rows.sort(
+    (a, b) => (a.nextTickMs ?? Number.MAX_SAFE_INTEGER) - (b.nextTickMs ?? Number.MAX_SAFE_INTEGER),
+  )
+}
+
+// ── day agenda (scheduled + oneshot schedules) ─────────────────────
+
+export interface AgendaEvent {
+  readonly request: DashboardScheduledAutomationRequest
+  readonly atMs: number
+  readonly cadence: Exclude<Cadence, 'interval'>
+}
+
+export interface AgendaColumn {
+  readonly offset: number
+  readonly dateMs: number
+  readonly events: AgendaEvent[]
+}
+
+/** Project active scheduled/oneshot schedules onto `days` day columns starting
+ * today. Interval schedules are excluded (they live in the polling strip). A row
+ * whose next wake predates today is clamped onto today (overdue → visible now);
+ * a row without a concrete wake time is dropped. */
+export function buildAgenda(
+  requests: readonly DashboardScheduledAutomationRequest[],
+  options: { nowMs: number; days?: number },
+): AgendaColumn[] {
+  const days = options.days ?? AGENDA_DAYS
+  const todayStart = startOfDayMs(options.nowMs)
+  const columns: AgendaColumn[] = []
+  for (let index = 0; index < days; index += 1) {
+    columns.push({ offset: index, dateMs: todayStart + index * MS_PER_DAY, events: [] })
+  }
+  for (const request of requests) {
+    if (isTerminalRequest(request)) continue
+    const cadence = cadenceOfRequest(request)
+    if (cadence !== 'scheduled' && cadence !== 'oneshot') continue
+    const atMs = fireTimestampMs(request)
+    if (atMs === null) continue
+    const rawOffset = Math.round((startOfDayMs(atMs) - todayStart) / MS_PER_DAY)
+    const offset = rawOffset < 0 ? 0 : rawOffset
+    if (offset >= days) continue
+    const column = columns[offset]
+    if (column) column.events.push({ request, atMs, cadence })
+  }
+  for (const column of columns) {
+    column.events.sort((a, b) => a.atMs - b.atMs)
+  }
+  return columns
+}
+
+// ── formatting ─────────────────────────────────────────────────────
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function formatClock(ms: number): string {
+  const date = new Date(ms)
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+}
+
+function formatDayDate(ms: number): string {
+  const date = new Date(ms)
+  return `${date.getMonth() + 1}/${date.getDate()} (${WEEKDAY_KO[date.getDay()]})`
+}
+
+function relativeDayLabel(offset: number): string {
+  if (offset === 0) return '오늘'
+  if (offset === 1) return '내일'
+  return `+${offset}일`
+}
+
+function scheduledBy(request: DashboardScheduledAutomationRequest): string {
+  return request.scheduled_by?.id ?? request.scheduled_by?.display_name ?? '—'
+}
+
+function summaryText(request: DashboardScheduledAutomationRequest): string {
+  return request.payload_summary?.trim() || schedPayloadSpec(request.payload_kind).lbl
+}
+
+function isPending(request: DashboardScheduledAutomationRequest): boolean {
+  return normalizedStatus(request) === 'pending_approval'
+}
+
+// ── presentation ───────────────────────────────────────────────────
+
+export function CadenceTag({ cadence, full }: { cadence: Cadence; full?: boolean }) {
+  const spec = SCHED_CADENCE[cadence]
+  return html`
+    <span class=${`sch-cad ${spec.cls}`} title=${spec.hint}>
+      ${spec.glyph} ${full ? spec.lbl : spec.short}
+    </span>
+  `
+}
+
+function RiskTag({ risk }: { risk: string }) {
+  const spec = schedRiskSpec(risk)
+  return html`<span class=${`sch-risk ${spec.cls}`} title=${`risk_class = ${risk}`}>${spec.lbl}</span>`
+}
+
+export function CadenceSummary({
+  counts,
+  active,
+  onFilter,
+}: {
+  counts: CadenceCounts
+  active: Cadence | null
+  onFilter: (cadence: Cadence | null) => void
+}) {
+  return html`
+    <div class="sch-cadsum" data-testid="sch-cadsum">
+      ${SCHED_CADENCE_ORDER.map(cadence => {
+        const spec = SCHED_CADENCE[cadence]
+        const on = active === cadence
+        const off = active !== null && !on
+        return html`
+          <button
+            key=${cadence}
+            class=${`sch-cadsum-i ${spec.cls} ${on ? 'on' : ''} ${off ? 'off' : ''}`}
+            title=${spec.hint}
+            aria-pressed=${on}
+            data-testid=${`sch-cadsum-${cadence}`}
+            onClick=${() => onFilter(on ? null : cadence)}
+          >
+            <span class="sch-cadsum-gl">${spec.glyph}</span>
+            <span class="sch-cadsum-n mono">${counts[cadence].toLocaleString()}</span>
+            <span class="sch-cadsum-l">${spec.lbl}</span>
+          </button>
+        `
+      })}
+      ${counts.unknown > 0
+        ? html`
+            <span
+              class="sch-cadsum-i dim"
+              title="recurrence kind가 알려진 집합(one_shot·interval·daily·cron) 밖입니다 — projection/버전 불일치"
+              data-testid="sch-cadsum-unknown"
+            >
+              <span class="sch-cadsum-gl">⧗</span>
+              <span class="sch-cadsum-n mono">${counts.unknown.toLocaleString()}</span>
+              <span class="sch-cadsum-l">미상</span>
+            </span>
+          `
+        : null}
+    </div>
+  `
+}
+
+function PollingCard({
+  request,
+  nextTickMs,
+  onOpen,
+}: {
+  request: DashboardScheduledAutomationRequest
+  nextTickMs: number | null
+  onOpen: (scheduleId: string) => void
+}) {
+  const tone = automationTone(request.effective_status ?? request.status)
+  return html`
+    <button
+      class=${`sch-poll-card st-${tone}`}
+      data-testid="sch-poll-card"
+      data-schedule-id=${request.schedule_id}
+      onClick=${() => onOpen(request.schedule_id)}
+    >
+      <div class="sch-poll-top">
+        <span class="sch-poll-int mono">↻ ${recurrenceLabel(request)}</span>
+        <${StatusChip} tone=${tone} uppercase=${false}>${request.effective_status ?? request.status}<//>
+      </div>
+      <div class="sch-poll-title">${summaryText(request)}</div>
+      <div class="sch-poll-foot">
+        <span class="mono sch-poll-by">${scheduledBy(request)}</span>
+        <${RiskTag} risk=${request.risk_class} />
+        <span class="sch-poll-next mono" title="다음 tick (next_due_at)">
+          ${nextTickMs === null ? '다음 tick 미상' : `다음 ~${formatClock(nextTickMs)}`}
+        </span>
+      </div>
+    </button>
+  `
+}
+
+export function PollingStrip({
+  requests,
+  onOpen,
+}: {
+  requests: readonly DashboardScheduledAutomationRequest[]
+  onOpen: (scheduleId: string) => void
+}) {
+  const rows = selectPollingSchedules(requests)
+  return html`
+    <section class="sch-poll" data-testid="sch-polling-strip">
+      <div class="sch-poll-h">
+        <span class="sch-cad volt">↻ 상시 폴링</span>
+        <span class="sch-poll-sub">고정 간격 반복 — 특정 시각이 아니라 계속 돎</span>
+      </div>
+      ${rows.length === 0
+        ? html`<div class="sch-day-empty mono" data-testid="sch-polling-empty">활성 폴링 없음</div>`
+        : html`
+            <div class="sch-poll-list">
+              ${rows.map(
+                row => html`
+                  <${PollingCard}
+                    key=${row.request.schedule_id}
+                    request=${row.request}
+                    nextTickMs=${row.nextTickMs}
+                    onOpen=${onOpen}
+                  />
+                `,
+              )}
+            </div>
+          `}
+    </section>
+  `
+}
+
+function AgendaEventRow({
+  event,
+  onOpen,
+}: {
+  event: AgendaEvent
+  onOpen: (scheduleId: string) => void
+}) {
+  const request = event.request
+  const tone = automationTone(request.effective_status ?? request.status)
+  const pending = isPending(request)
+  return html`
+    <button
+      class=${`sch-ev st-${tone} ${pending ? 'pending' : ''}`}
+      data-testid="sch-agenda-event"
+      data-schedule-id=${request.schedule_id}
+      onClick=${() => onOpen(request.schedule_id)}
+    >
+      <span class="sch-ev-time mono">${formatClock(event.atMs)}</span>
+      <${CadenceTag} cadence=${event.cadence} />
+      <span class="sch-ev-body">
+        <span class="sch-ev-title">${summaryText(request)}</span>
+        <span class="sch-ev-meta">
+          <span class="mono sch-ev-by">${scheduledBy(request)}</span>
+          <${RiskTag} risk=${request.risk_class} />
+          ${pending ? html`<span class="sch-ev-need mono">⊙ 승인 필요</span>` : null}
+        </span>
+      </span>
+      <${StatusChip} tone=${tone} uppercase=${false}>${request.effective_status ?? request.status}<//>
+    </button>
+  `
+}
+
+export function Agenda({
+  requests,
+  nowMs,
+  days,
+  onOpen,
+}: {
+  requests: readonly DashboardScheduledAutomationRequest[]
+  nowMs: number
+  days?: number
+  onOpen: (scheduleId: string) => void
+}) {
+  const columns = buildAgenda(requests, { nowMs, days })
+  // Keep today/tomorrow even when empty (anchors the timeline); drop later empty
+  // days so the agenda does not pad out with blank columns.
+  const visible = columns.filter(column => column.events.length > 0 || column.offset <= 1)
+  const hasAny = visible.some(column => column.events.length > 0)
+  return html`
+    <div class="sch-agenda" data-testid="sch-agenda">
+      ${!hasAny
+        ? html`<div class="sch-empty" data-testid="sch-agenda-empty">다가오는 ${(days ?? AGENDA_DAYS)}일에 예정된 예약이 없습니다.</div>`
+        : null}
+      ${visible.map(column => {
+        const isToday = column.offset === 0
+        return html`
+          <div key=${column.offset} class=${`sch-day ${isToday ? 'today' : ''}`}>
+            <div class="sch-day-h">
+              <span class="sch-day-rel">${relativeDayLabel(column.offset)}</span>
+              <span class="sch-day-date mono">${formatDayDate(column.dateMs)}</span>
+              ${isToday ? html`<span class="sch-day-now mono">지금 ${formatClock(nowMs)}</span>` : null}
+              <span class="sch-day-n mono">${column.events.length > 0 ? `${column.events.length}건` : ''}</span>
+            </div>
+            ${column.events.length === 0
+              ? html`<div class="sch-day-empty mono">예정 없음</div>`
+              : html`
+                  <div class="sch-day-evs">
+                    ${column.events.map(
+                      event => html`
+                        <${AgendaEventRow}
+                          key=${event.request.schedule_id}
+                          event=${event}
+                          onOpen=${onOpen}
+                        />
+                      `,
+                    )}
+                  </div>
+                `}
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+/** Calendar view: always-on polling strip (interval) above the day agenda
+ * (scheduled + oneshot). Cadence filter narrows both. */
+export function ScheduleCalendar({
+  requests,
+  nowMs,
+  cadenceFilter,
+  onOpen,
+}: {
+  requests: readonly DashboardScheduledAutomationRequest[]
+  nowMs: number
+  cadenceFilter: Cadence | null
+  onOpen: (scheduleId: string) => void
+}) {
+  const showPolling = cadenceFilter === null || cadenceFilter === 'interval'
+  const showAgenda = cadenceFilter === null || cadenceFilter !== 'interval'
+  const agendaRequests =
+    cadenceFilter === null
+      ? requests
+      : requests.filter(request => cadenceOfRequest(request) === cadenceFilter)
+  return html`
+    <div data-testid="sch-calendar">
+      ${showPolling ? html`<${PollingStrip} requests=${requests} onOpen=${onOpen} />` : null}
+      ${showAgenda ? html`<${Agenda} requests=${agendaRequests} nowMs=${nowMs} onOpen=${onOpen} />` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -324,4 +324,30 @@ describe('ScheduleSurface', () => {
     // No mutation controls leak onto either view (surface stays read-only).
     expect(container.querySelectorAll('[data-schedule-mutation]')).toHaveLength(0)
   })
+
+  it('narrows the list view rows when a cadence chip is active', async () => {
+    const automation = sampleAutomation()
+    automation.requests = [
+      { ...automation.requests[0]!, schedule_id: 'sched-oneshot', recurrence: { kind: 'one_shot' }, recurrence_kind: 'one_shot' },
+      { ...automation.requests[0]!, schedule_id: 'sched-interval', recurrence: { kind: 'interval', interval_sec: 3600 }, recurrence_kind: 'interval' },
+    ]
+    mocks.toolsData.value = {
+      generated_at: '2026-06-21T00:00:00Z',
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+      scheduled_automation: automation,
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    container.querySelector<HTMLButtonElement>('[data-testid="schedule-view-list"]')?.click()
+    await flush()
+    container.querySelector<HTMLButtonElement>('[data-testid="sch-cadsum-interval"]')?.click()
+    await flush()
+
+    // Only the interval schedule survives the 폴링 cadence filter in the list.
+    expect(container.querySelector('[data-schedule-id="sched-interval"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-oneshot"]')).toBeNull()
+  })
 })

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -158,8 +158,11 @@ describe('ScheduleSurface', () => {
       .toContain('관측 전용')
     expect(container.querySelector('[data-testid="schedule-reality-notice"]')?.textContent)
       .toContain('keeper turn을 자동 구동하지 않습니다')
-    expect(container.textContent).toContain('예약 자동화')
-    expect(container.textContent).toContain('예약 자동화 projection 없음')
+    // Calendar is the default view; with no projection it renders the empty
+    // agenda/polling states rather than the diagnostic panel's placeholder.
+    expect(container.querySelector('[data-testid="schedule-viewbar"]')).not.toBeNull()
+    expect(container.textContent).toContain('다가오는 7일에 예정된 예약이 없습니다')
+    expect(container.textContent).toContain('활성 폴링 없음')
   })
 
   it('renders backed schedule summary and reuses read-only schedule cards', async () => {
@@ -188,7 +191,10 @@ describe('ScheduleSurface', () => {
     expect(summary?.textContent).not.toContain('활성')
     expect(summary?.textContent).not.toContain('유효 도래')
     expect(summary?.textContent).not.toContain('승인 차단')
-    // The wake-signal feed header is renamed in v2.
+    // The diagnostic wake-signal feed lives in the 목록 (list) view; the surface
+    // now defaults to the 캘린더 view, so toggle before asserting the feed.
+    container.querySelector<HTMLButtonElement>('[data-testid="schedule-view-list"]')?.click()
+    await flush()
     expect(container.textContent).toContain('wake signal 피드 · schedule_runner.tick')
     expect(container.querySelector('[data-testid="schedule-waiting-inventory"]')?.textContent)
       .toContain('Keeper Waiting Inventory')
@@ -273,5 +279,49 @@ describe('ScheduleSurface', () => {
 
     expect(container.textContent).toContain('dashboard tools unavailable')
     expect(container.querySelector('[data-schedule-id="sched-1"]')).not.toBeNull()
+  })
+
+  it('defaults to the calendar view with a cadence filter strip', async () => {
+    mocks.toolsData.value = {
+      generated_at: '2026-06-21T00:00:00Z',
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+      scheduled_automation: sampleAutomation(),
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    // Calendar view is active by default (aria-selected), and the cadence strip
+    // renders a chip per operator cadence.
+    expect(container.querySelector('[data-testid="schedule-view-calendar"]')?.getAttribute('aria-selected'))
+      .toBe('true')
+    expect(container.querySelector('[data-testid="sch-cadsum"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="sch-cadsum-oneshot"]')).not.toBeNull()
+    // The sample request (one_shot, non-terminal) surfaces as an agenda event,
+    // not the diagnostic list; the wake-signal feed is list-only.
+    expect(container.querySelector('[data-testid="sch-agenda"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('wake signal 피드 · schedule_runner.tick')
+  })
+
+  it('toggles to the list view revealing the diagnostic wake-signal feed', async () => {
+    mocks.toolsData.value = {
+      generated_at: '2026-06-21T00:00:00Z',
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+      scheduled_automation: sampleAutomation(),
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    container.querySelector<HTMLButtonElement>('[data-testid="schedule-view-list"]')?.click()
+    await flush()
+
+    expect(container.querySelector('[data-testid="schedule-view-list"]')?.getAttribute('aria-selected'))
+      .toBe('true')
+    expect(container.textContent).toContain('wake signal 피드 · schedule_runner.tick')
+    // No mutation controls leak onto either view (surface stays read-only).
+    expect(container.querySelectorAll('[data-schedule-mutation]')).toHaveLength(0)
   })
 })

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -25,7 +25,7 @@ import {
   scheduledPendingApprovalCount,
 } from '../tools/scheduled-automation-panel'
 import type { Cadence } from '../v2/schedule-constants'
-import { CadenceSummary, ScheduleCalendar, cadenceCounts } from './schedule-agenda'
+import { CadenceSummary, ScheduleCalendar, cadenceCounts, cadenceOfRequest } from './schedule-agenda'
 import {
   loadTools,
   toolsData,
@@ -37,6 +37,20 @@ type ScheduleView = 'calendar' | 'list'
 
 function countLabel(count: number): string {
   return count.toLocaleString()
+}
+
+// Narrow the projection handed to the list view so the cadence chip filters
+// both views consistently. Requests and their durable signals are narrowed
+// together (a signal for a filtered-out schedule would otherwise dangle).
+function filterAutomationByCadence(
+  automation: DashboardScheduledAutomation,
+  cadence: Cadence | null,
+): DashboardScheduledAutomation {
+  if (cadence === null) return automation
+  const requests = (automation.requests ?? []).filter(request => cadenceOfRequest(request) === cadence)
+  const ids = new Set(requests.map(request => request.schedule_id))
+  const signals = automation.signals?.filter(signal => ids.has(signal.schedule_id))
+  return { ...automation, requests, signals }
 }
 
 function countByStatus(
@@ -171,7 +185,7 @@ export function ScheduleSurface() {
                 onOpen=${setSelectedScheduleId}
               />`
             : html`<${ScheduledAutomationPanel}
-                automation=${automation}
+                automation=${automation ? filterAutomationByCadence(automation, cadenceFilter) : automation}
                 variant="v2"
                 onResolved=${refresh}
                 selectedScheduleId=${selectedScheduleId}

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -1,9 +1,14 @@
 // Dedicated Schedule surface.
 //
-// The card/detail projection lives in tools/scheduled-automation-panel.ts and
-// is reused here so the route does not fork the backed schedule semantics.
-// Shell (header + KPI strip) ported to the keeper-v2 prototype (schedule.jsx):
-// `.ov.sch-surf` → `.ov-head` (eyebrow + title + sub) → `.ov-kpis` (4 KPIs).
+// Two views over one schedule projection (data.scheduled_automation):
+//   · 캘린더 — the always-on polling strip (interval) above a day agenda
+//     (scheduled + oneshot). Ported from the keeper-v2 prototype (schedule.jsx).
+//   · 목록   — the mature diagnostic list/cards/signal feed in
+//     tools/scheduled-automation-panel.ts (variant "v2"), reused verbatim so the
+//     route does not fork the backed schedule semantics.
+// A cadence filter (정기 · 폴링 · 1회) narrows both views. Both share one detail
+// overlay (SchDetail) and one selection state, so a row opens the same drawer
+// regardless of view.
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
@@ -12,13 +17,23 @@ import type { DashboardScheduledAutomation } from '../../api'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { StatusChip } from '../common/status-chip'
 import { KeeperWaitingInventoryPanel } from '../tools/keeper-waiting-inventory-panel'
-import { ScheduleAside, ScheduledAutomationPanel, normalizedScheduleStatus, scheduledPendingApprovalCount } from '../tools/scheduled-automation-panel'
+import {
+  ScheduleAside,
+  ScheduledAutomationPanel,
+  SchDetail,
+  normalizedScheduleStatus,
+  scheduledPendingApprovalCount,
+} from '../tools/scheduled-automation-panel'
+import type { Cadence } from '../v2/schedule-constants'
+import { CadenceSummary, ScheduleCalendar, cadenceCounts } from './schedule-agenda'
 import {
   loadTools,
   toolsData,
   toolsError,
   toolsLoading,
 } from '../tools/tool-state'
+
+type ScheduleView = 'calendar' | 'list'
 
 function countLabel(count: number): string {
   return count.toLocaleString()
@@ -49,10 +64,14 @@ export function ScheduleSurface() {
   const scheduledCount = countByStatus(automation, ['scheduled'])
   const runningCount = countByStatus(automation, ['running'])
   const dueRunning = dueEffective + runningCount
-  const totalCount = automation?.requests?.length ?? 0
+  const requests = automation?.requests ?? []
+  const totalCount = requests.length
+  const cadCounts = cadenceCounts(requests)
 
-  // Detail-overlay selection is lifted here so the read-only operations aside
-  // (right column) and the panel's cards/feed drive the same overlay.
+  const [view, setView] = useState<ScheduleView>('calendar')
+  const [cadenceFilter, setCadenceFilter] = useState<Cadence | null>(null)
+  // Detail-overlay selection is lifted here so the calendar view, the list
+  // panel, and the operations aside all drive the same overlay.
   const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
 
   useEffect(() => {
@@ -60,6 +79,21 @@ export function ScheduleSurface() {
       void loadTools()
     }
   }, [])
+
+  function switchView(next: ScheduleView) {
+    // Clear selection so a drawer opened in one view does not linger into the
+    // other (the list panel renders its own overlay from the same id).
+    setSelectedScheduleId(null)
+    setView(next)
+  }
+
+  const refresh = (): Promise<void> => loadTools()
+  // In the calendar view the list panel is unmounted, so the surface owns the
+  // overlay; the list panel renders its own overlay from the same selection.
+  const selectedRequest =
+    view === 'calendar' && selectedScheduleId
+      ? requests.find(request => request.schedule_id === selectedScheduleId) ?? null
+      : null
 
   return html`
     <main class="ov ov-2col sch-surf" data-screen-label="예약" data-testid="schedule-surface">
@@ -100,6 +134,28 @@ export function ScheduleSurface() {
           </div>
         </section>
 
+        <div class="sch-viewbar" data-testid="schedule-viewbar">
+          <div class="sch-viewseg" role="tablist" aria-label="예약 뷰">
+            <button
+              type="button"
+              role="tab"
+              aria-selected=${view === 'calendar' ? 'true' : 'false'}
+              class=${`sch-viewbtn ${view === 'calendar' ? 'on' : ''}`}
+              data-testid="schedule-view-calendar"
+              onClick=${() => switchView('calendar')}
+            >▦ 캘린더</button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected=${view === 'list' ? 'true' : 'false'}
+              class=${`sch-viewbtn ${view === 'list' ? 'on' : ''}`}
+              data-testid="schedule-view-list"
+              onClick=${() => switchView('list')}
+            >≡ 목록</button>
+          </div>
+          <${CadenceSummary} counts=${cadCounts} active=${cadenceFilter} onFilter=${setCadenceFilter} />
+        </div>
+
         <section class="ov-card mt-4" aria-label="Keeper waiting inventory" data-testid="schedule-waiting-inventory">
           <div class="ov-card-h"><h3>Keeper Waiting Inventory</h3></div>
           <${KeeperWaitingInventoryPanel} inventory=${waitingInventory} />
@@ -107,18 +163,33 @@ export function ScheduleSurface() {
 
         ${loading && !automation
           ? html`<${LoadingState}>예약 자동화 projection 불러오는 중...<//>`
-          : html`<${ScheduledAutomationPanel}
-              automation=${automation}
-              variant="v2"
-              selectedScheduleId=${selectedScheduleId}
-              onSelectSchedule=${setSelectedScheduleId}
-            />`}
+          : view === 'calendar'
+            ? html`<${ScheduleCalendar}
+                requests=${requests}
+                nowMs=${Date.now()}
+                cadenceFilter=${cadenceFilter}
+                onOpen=${setSelectedScheduleId}
+              />`
+            : html`<${ScheduledAutomationPanel}
+                automation=${automation}
+                variant="v2"
+                onResolved=${refresh}
+                selectedScheduleId=${selectedScheduleId}
+                onSelectSchedule=${setSelectedScheduleId}
+              />`}
       </div>
       ${automation
         ? html`<${ScheduleAside}
             requests=${automation.requests ?? []}
             sum=${{ scheduled: scheduledCount, dueRunning, pending: pendingCount, total: totalCount }}
             onOpen=${setSelectedScheduleId}
+          />`
+        : null}
+      ${selectedRequest
+        ? html`<${SchDetail}
+            request=${selectedRequest}
+            onClose=${() => setSelectedScheduleId(null)}
+            onResolved=${refresh}
           />`
         : null}
     </main>

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -77,7 +77,7 @@ export function scheduledPendingApprovalCount(
   return Math.max(fromCounts, fromRequests)
 }
 
-function automationTone(status: string | null | undefined): StatusChipTone {
+export function automationTone(status: string | null | undefined): StatusChipTone {
   switch (normalized(status)) {
     case 'running':
     case 'scheduled':
@@ -165,7 +165,7 @@ function CountChip({ name, count }: { name: string; count: number }) {
   `
 }
 
-function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
+export function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
   if (request.recurrence_summary?.trim()) return request.recurrence_summary
   const recurrence = request.recurrence
   const kind = recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
@@ -1672,7 +1672,7 @@ function SchCard({
 }
 
 /** Detail overlay `.turn-overlay > .turn-drawer.sch-drawer` (audit P0 #4). */
-function SchDetail({
+export function SchDetail({
   request,
   onClose,
   onResolved,

--- a/dashboard/src/components/v2/schedule-constants.test.ts
+++ b/dashboard/src/components/v2/schedule-constants.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SCHED_CADENCE,
+  SCHED_CADENCE_ORDER,
+  SCHED_TERMINAL,
+  SCHED_TERMINAL_NORMALIZED,
+  cadenceOfRecurrenceKind,
+  parseRecurrenceKind,
+  type Cadence,
+  type RecurrenceKind,
+} from './schedule-constants'
+
+describe('parseRecurrenceKind', () => {
+  it('accepts the closed backend recurrence set (case/space-insensitive)', () => {
+    expect(parseRecurrenceKind('one_shot')).toBe('one_shot')
+    expect(parseRecurrenceKind('Interval')).toBe('interval')
+    expect(parseRecurrenceKind('  daily ')).toBe('daily')
+    expect(parseRecurrenceKind('cron')).toBe('cron')
+  })
+
+  it('returns null for anything outside the set — never a permissive default', () => {
+    expect(parseRecurrenceKind('lunar')).toBeNull()
+    expect(parseRecurrenceKind('')).toBeNull()
+    expect(parseRecurrenceKind(null)).toBeNull()
+    expect(parseRecurrenceKind(undefined)).toBeNull()
+  })
+})
+
+describe('cadenceOfRecurrenceKind', () => {
+  it('is total over the closed recurrence set', () => {
+    const expected: Record<RecurrenceKind, Cadence> = {
+      one_shot: 'oneshot',
+      interval: 'interval',
+      daily: 'scheduled',
+      cron: 'scheduled',
+    }
+    for (const kind of Object.keys(expected) as RecurrenceKind[]) {
+      expect(cadenceOfRecurrenceKind(kind)).toBe(expected[kind])
+    }
+  })
+})
+
+describe('cadence display specs', () => {
+  it('defines a spec for every cadence in the filter strip order', () => {
+    for (const cadence of SCHED_CADENCE_ORDER) {
+      expect(SCHED_CADENCE[cadence]).toBeDefined()
+      expect(SCHED_CADENCE[cadence].key).toBe(cadence)
+    }
+    expect(new Set(SCHED_CADENCE_ORDER)).toEqual(new Set<Cadence>(['scheduled', 'interval', 'oneshot']))
+  })
+})
+
+describe('SCHED_TERMINAL_NORMALIZED', () => {
+  it('is the lowercased projection of SCHED_TERMINAL (one source, live casing)', () => {
+    expect(SCHED_TERMINAL_NORMALIZED).toEqual(new Set(SCHED_TERMINAL.map(status => status.toLowerCase())))
+    expect(SCHED_TERMINAL_NORMALIZED.has('cancelled')).toBe(true)
+    expect(SCHED_TERMINAL_NORMALIZED.has('scheduled')).toBe(false)
+  })
+})

--- a/dashboard/src/components/v2/schedule-constants.ts
+++ b/dashboard/src/components/v2/schedule-constants.ts
@@ -57,3 +57,89 @@ export function schedRiskSpec(risk: string | null | undefined): { lbl: string; c
 export function schedPayloadSpec(kind: string | null | undefined): { glyph: string; lbl: string } {
   return (kind && SCHED_PAYLOAD[kind]) || { glyph: '▢', lbl: kind || '작업' }
 }
+
+// ── cadence (예약 종류) ──────────────────────────────────────────────
+// The single axis operators reason about: is a schedule a one-off, a polling
+// loop, or a fixed time-scheduled job? Derived from the backend recurrence kind
+// (Schedule_domain.recurrence → one_shot | interval | daily | cron). The backend
+// set is closed, so an unrecognized wire value means projection/version skew and
+// is surfaced as `null` rather than silently bucketed into a permissive default.
+
+export type RecurrenceKind = 'one_shot' | 'interval' | 'daily' | 'cron'
+
+const RECURRENCE_KINDS: readonly RecurrenceKind[] = ['one_shot', 'interval', 'daily', 'cron']
+
+/** Parse a wire recurrence kind into the closed backend set, or `null` if it is
+ * not one of them (Unknown → explicit, never Unknown → permissive default). */
+export function parseRecurrenceKind(raw: string | null | undefined): RecurrenceKind | null {
+  const value = raw?.trim().toLowerCase() ?? ''
+  return (RECURRENCE_KINDS as readonly string[]).includes(value) ? (value as RecurrenceKind) : null
+}
+
+export type Cadence = 'scheduled' | 'interval' | 'oneshot'
+
+function assertNeverRecurrenceKind(value: never): never {
+  throw new Error(`unhandled recurrence kind: ${String(value)}`)
+}
+
+/** Total, exhaustive map from the closed recurrence set to the operator cadence
+ * axis. `daily` and `cron` are both fixed time-scheduled jobs → `scheduled`. A
+ * new RecurrenceKind fails to compile here rather than falling through. */
+export function cadenceOfRecurrenceKind(kind: RecurrenceKind): Cadence {
+  switch (kind) {
+    case 'one_shot':
+      return 'oneshot'
+    case 'interval':
+      return 'interval'
+    case 'daily':
+    case 'cron':
+      return 'scheduled'
+    default:
+      return assertNeverRecurrenceKind(kind)
+  }
+}
+
+export interface SchedCadenceSpec {
+  readonly key: Cadence
+  readonly lbl: string
+  readonly short: string
+  readonly glyph: string
+  readonly cls: string
+  readonly hint: string
+}
+
+export const SCHED_CADENCE: Readonly<Record<Cadence, SchedCadenceSpec>> = {
+  scheduled: {
+    key: 'scheduled',
+    lbl: '정기 · 시각',
+    short: '정기',
+    glyph: '◈',
+    cls: 'ok',
+    hint: '지정 시각에 반복되는 정기 잡 (daily · cron)',
+  },
+  interval: {
+    key: 'interval',
+    lbl: '폴링 · 주기',
+    short: '폴링',
+    glyph: '↻',
+    cls: 'volt',
+    hint: '고정 간격마다 반복 — 특정 시각이 아니라 계속 도는 상시 폴링 루프',
+  },
+  oneshot: {
+    key: 'oneshot',
+    lbl: '1회 · ad-hoc',
+    short: '1회',
+    glyph: '•',
+    cls: 'info',
+    hint: '한 번 실행하고 종료 — keeper가 상황에 맞춰 건 단발성 예약',
+  },
+}
+
+/** Display order for the cadence filter strip (정기 → 폴링 → 1회). */
+export const SCHED_CADENCE_ORDER: readonly Cadence[] = ['scheduled', 'interval', 'oneshot']
+
+/** Terminal statuses normalized to the lowercase form the live API emits, so
+ * non-terminal filters share one source with {@link SCHED_TERMINAL}. */
+export const SCHED_TERMINAL_NORMALIZED: ReadonlySet<string> = new Set(
+  SCHED_TERMINAL.map(status => status.toLowerCase()),
+)

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -140,3 +140,70 @@
 @media (max-width: 720px) {
   .sch-kv .k { width: 96px; }
 }
+
+/* ── cadence tag (예약 종류) — ported from prototype styles/schedule.css ── */
+.sch-cad { display: inline-flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.02em; padding: 1px 8px; border-radius: var(--radius-pill); white-space: nowrap; color: var(--tone, var(--text-dim)); border: 1px solid color-mix(in oklab, var(--tone, var(--text-dim)) 34%, transparent); background: color-mix(in oklab, var(--tone, var(--text-dim)) 9%, transparent); }
+.sch-cad.ok   { --tone: var(--status-ok); }
+.sch-cad.info { --tone: var(--info); }
+.sch-cad.volt { --tone: var(--volt-strong); }
+
+/* ── view toggle + cadence summary strip ── */
+.sch-viewbar { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin: 18px 0 14px; }
+.sch-viewseg { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-pill); overflow: hidden; flex: none; }
+.sch-viewbtn { font-family: var(--font-ui); font-size: var(--fs-12); padding: 6px 15px; background: transparent; border: 0; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.sch-viewbtn + .sch-viewbtn { border-left: 1px solid var(--border-main); }
+.sch-viewbtn:hover { color: var(--text-mid); }
+.sch-viewbtn.on { background: var(--volt-wash); color: var(--volt-strong); }
+.sch-cadsum { display: flex; gap: 8px; flex-wrap: wrap; margin-left: auto; }
+.sch-cadsum-i { display: inline-flex; align-items: center; gap: 7px; padding: 5px 12px 5px 10px; border-radius: var(--radius-sm); border: 1px solid color-mix(in oklab, var(--tone) 28%, transparent); background: color-mix(in oklab, var(--tone) 6%, transparent); color: var(--text-mid); cursor: pointer; transition: 0.14s; --tone: var(--text-dim); }
+.sch-cadsum-i.ok   { --tone: var(--status-ok); }
+.sch-cadsum-i.info { --tone: var(--info); }
+.sch-cadsum-i.volt { --tone: var(--volt-strong); }
+.sch-cadsum-i.dim  { --tone: var(--text-dim); cursor: default; }
+.sch-cadsum-i:hover { border-color: color-mix(in oklab, var(--tone) 55%, transparent); }
+.sch-cadsum-i.on { background: color-mix(in oklab, var(--tone) 15%, transparent); border-color: var(--tone); color: var(--text-bright); }
+.sch-cadsum-i.off { opacity: 0.5; }
+.sch-cadsum-gl { color: var(--tone); font-size: var(--fs-12); }
+.sch-cadsum-n { font-size: var(--fs-13); color: var(--tone); }
+.sch-cadsum-l { font-size: var(--fs-11); }
+
+/* ── 상시 폴링 strip (interval) ── */
+.sch-poll { margin-bottom: 16px; padding: 14px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: color-mix(in oklab, var(--volt-strong) 4%, var(--bg-card)); }
+.sch-poll-h { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; }
+.sch-poll-sub { font-size: var(--fs-11); color: var(--text-dim); }
+.sch-poll-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
+.sch-poll-card { text-align: left; display: flex; flex-direction: column; gap: 8px; padding: 11px 12px; border: 1px solid var(--border-main); border-left: 3px solid var(--tone, var(--volt-strong)); border-radius: var(--radius-sm); background: var(--bg-card); cursor: pointer; transition: 0.14s; --tone: var(--border-highlight); }
+.sch-poll-card.st-ok { --tone: var(--status-ok); } .sch-poll-card.st-warn { --tone: var(--status-warn); } .sch-poll-card.st-bad { --tone: var(--status-bad); } .sch-poll-card.st-info { --tone: var(--info); } .sch-poll-card.st-neutral { --tone: var(--border-highlight); }
+.sch-poll-card:hover { border-color: var(--border-highlight); border-left-color: var(--tone); }
+.sch-poll-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.sch-poll-int { font-size: var(--fs-11); color: var(--volt-strong); }
+.sch-poll-title { font-size: 12.5px; line-height: 1.45; color: var(--text-primary); text-wrap: pretty; }
+.sch-poll-foot { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.sch-poll-by { font-size: var(--fs-11); color: var(--text-mid); }
+.sch-poll-next { margin-left: auto; font-size: 10.5px; color: var(--text-dim); }
+
+/* ── 캘린더 아젠다 (daily · cron · oneshot) ── */
+.sch-agenda { display: flex; flex-direction: column; }
+.sch-day { border-top: 1px solid var(--border-soft); padding: 2px 0 12px; }
+.sch-day:first-child { border-top: 0; }
+.sch-day.today { border-top: 2px solid var(--volt-dim); }
+.sch-day-h { display: flex; align-items: baseline; gap: 10px; padding: 12px 2px 9px; }
+.sch-day-rel { font-family: var(--font-display); font-size: var(--fs-13); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-bright); }
+.sch-day.today .sch-day-rel { color: var(--volt-strong); }
+.sch-day-date { font-size: var(--fs-11); color: var(--text-dim); }
+.sch-day-now { margin-left: 4px; font-size: var(--fs-10); color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 8px; }
+.sch-day-n { margin-left: auto; font-size: var(--fs-11); color: var(--text-dim); }
+.sch-day-empty { font-size: var(--fs-11); color: var(--text-dim); padding: 2px 2px 4px; opacity: 0.6; }
+.sch-day-evs { display: flex; flex-direction: column; gap: 7px; }
+.sch-ev { display: flex; align-items: flex-start; gap: 11px; width: 100%; text-align: left; padding: 10px 12px; border: 1px solid var(--border-main); border-left: 3px solid var(--tone, var(--border-main)); border-radius: var(--radius-sm); background: var(--bg-card); cursor: pointer; transition: 0.14s; --tone: var(--border-highlight); }
+.sch-ev.st-ok { --tone: var(--status-ok); } .sch-ev.st-warn { --tone: var(--status-warn); } .sch-ev.st-bad { --tone: var(--status-bad); } .sch-ev.st-info { --tone: var(--info); } .sch-ev.st-neutral { --tone: var(--border-highlight); }
+.sch-ev:hover { border-color: var(--border-highlight); border-left-color: var(--tone); background: var(--bg-card-hover); }
+.sch-ev.pending { border-style: dashed; }
+.sch-ev-time { flex: none; width: 44px; font-size: 12.5px; color: var(--text-bright); padding-top: 1px; }
+.sch-ev-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.sch-ev-title { font-size: 12.5px; line-height: 1.45; color: var(--text-primary); text-wrap: pretty; }
+.sch-ev-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.sch-ev-by { font-size: var(--fs-11); color: var(--text-mid); }
+.sch-ev-need { font-size: var(--fs-10); color: var(--status-warn); }
+.sch-ev [data-status-chip] { flex: none; align-self: flex-start; }
+.sch-poll-top [data-status-chip] { flex: none; }

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -142,7 +142,7 @@
 }
 
 /* ── cadence tag (예약 종류) — ported from prototype styles/schedule.css ── */
-.sch-cad { display: inline-flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.02em; padding: 1px 8px; border-radius: var(--radius-pill); white-space: nowrap; color: var(--tone, var(--text-dim)); border: 1px solid color-mix(in oklab, var(--tone, var(--text-dim)) 34%, transparent); background: color-mix(in oklab, var(--tone, var(--text-dim)) 9%, transparent); }
+.sch-cad { display: inline-flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.02em; padding: 1px 8px; border-radius: var(--radius-pill); white-space: nowrap; color: var(--tone, var(--text-dim)); border: 1px solid color-mix(in oklab, var(--tone, var(--text-dim)) 34%, transparent); background: color-mix(in oklab, var(--tone, var(--text-dim)) 9%, transparent); }
 .sch-cad.ok   { --tone: var(--status-ok); }
 .sch-cad.info { --tone: var(--info); }
 .sch-cad.volt { --tone: var(--volt-strong); }


### PR DESCRIPTION
## 목표
keeper-v2 스케줄 시안(`schedule.jsx`)의 **나머지**를 실제 대시보드에 반영. 백엔드(`lib/schedule`)와 진단 목록/wake signal 피드는 이미 구현돼 있었고, 시안에는 있으나 라이브 라우트에 없던 두 축을 추가했습니다.

## 변경
- **Cadence 축 (정기 · 폴링 · 1회)**: 필터 strip. backend recurrence 닫힌 집합(`one_shot | interval | daily | cron`) 위 **exhaustive 매핑**. `daily`+`cron`은 `scheduled`(정기)로 접고, 알 수 없는 kind는 `미상`으로 노출 — permissive default로 조용히 삼키지 않음.
- **캘린더 뷰**: 상시 폴링 strip(interval) + 일자 아젠다(scheduled + oneshot). backend가 계산한 `next_due_at ?? due_at`으로 배치. 시각 없는 row는 미래 발생 날조 대신 drop. `now` 주입으로 순수·결정론.
- **목록 뷰**: 기존 `ScheduledAutomationPanel`(variant v2)을 그대로 재사용 — 스케줄 의미론을 fork하지 않음.
- 두 뷰가 하나의 상세 오버레이(`SchDetail`)와 선택 상태 공유. `recurrenceLabel`/`automationTone`/`SchDetail`은 패널에서 export해 재사용(SSOT, 중복 없음).

## 원칙 적용
- **No 하드코딩/휴리스틱**: cadence는 recurrence.kind에서 파생, 배치는 backend due 시각 사용(클라이언트 cron/DST 추정 없음).
- **No silent failure**: unknown recurrence kind는 별도 칩으로 노출. 시각 없는 row는 drop(parse, don't validate).
- **Immutable/결정론**: 순수 projection 함수, `now` 주입.

## 보류 (명시)
시안의 **Keeper 자율 백그라운드**(폴링 루프 + async in-flight 도구)는 라이브 projection 소스가 없습니다(시안은 static 데이터). static으로 배선하면 stub이라 no-stub 원칙상 미구현으로 남깁니다. 별도 백엔드 projection(keeper 자율 fiber 관측)이 선행돼야 합니다.

## 검증 (로컬)
- `tsc --noEmit`: schedule 관련 에러 0 (기존 main 2건 `agent-detail`/`keeper-detail-shell`은 무관).
- `eslint src/...schedule...`: clean.
- vitest: cadence 파생(parse/exhaustive/unknown) · agenda projection(배치/terminal·no-time drop/overdue clamp/window/sort) · polling 선택 · calendar↔list 토글 — 신규 포함 전부 green. 기존 `scheduled-automation-panel`(35) / `tools-main`(3) 회귀 없음.
- dune 빌드는 CI에서 수행.

RFC-WAIVED: dashboard schedule 표시 컴포넌트만 변경(credential/keeper-repo-mapping/operator/hooks 무관) — agent_delegation RFC 게이트 대상 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)