### PR TITLE
fix(memory-os): add staleness gate in eligible() to prevent promotion of aged facts

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -63,9 +63,19 @@ type contribution =
    and [Diagnostic] is system-authored evidence for operators, not shared semantic
    memory. Keep this exhaustive so a future [claim_kind] cannot promote by
    accident. *)
-let eligible fact =
+(** Maximum age (seconds) before a fact is considered too stale for consensus
+    promotion.  Only enforced when the fact carries no explicit [valid_until]. *)
+let max_consensus_staleness = 30. *. 86400.
+
+let not_stale ~now fact =
+  match fact.last_verified_at with
+  | Some t -> now -. t <= max_consensus_staleness
+  | None -> now -. fact.first_seen <= max_consensus_staleness
+
+let eligible ~now fact =
   is_promotable fact.category
   && is_outcome_positive_for_shared_promotion fact.category
+  && not_stale ~now fact
   &&
   match fact.claim_kind with
   | Some Durable_knowledge | None -> true
@@ -162,7 +172,7 @@ let promote_facts ?(min_keepers = default_min_keepers) ~now ~keeper_facts () =
     (fun (keeper_id, facts) ->
        List.iter
          (fun fact ->
-            if eligible fact
+            if eligible ~now fact
             then (
               let key = claim_identity fact in
               let prev = Option.value (Hashtbl.find_opt groups key) ~default:[] in
@@ -181,12 +191,12 @@ let promote_facts ?(min_keepers = default_min_keepers) ~now ~keeper_facts () =
 
 let sum ints = List.fold_left ( + ) 0 ints
 
-let source_fact_counts keeper_facts =
+let source_fact_counts ~now keeper_facts =
   List.map
     (fun (keeper_id, facts) ->
        ( keeper_id
        , List.length facts
-       , List.length (List.filter eligible facts) ))
+       , List.length (List.filter (eligible ~now) facts) ))
     keeper_facts
 
 let source_fact_counts_json counts =
@@ -200,8 +210,8 @@ let source_fact_counts_json counts =
             ])
        counts)
 
-let log_run_summary ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered ~promoted =
-  let counts = source_fact_counts keeper_facts in
+let log_run_summary ~now ~dry_run ~min_keepers ~source_ids ~keeper_facts ~considered ~promoted =
+  let counts = source_fact_counts ~now keeper_facts in
   let input_facts = sum (List.map (fun (_, facts, _) -> facts) counts) in
   let eligible_facts = sum (List.map (fun (_, _, eligible_facts) -> eligible_facts) counts) in
   let promoted_count = List.length promoted in
@@ -269,6 +279,7 @@ let run ?(dry_run = false) ?min_keepers ~keeper_ids ~now () =
         promote_facts ~min_keepers ~now ~keeper_facts ()
       in
       log_run_summary
+        ~now
         ~dry_run
         ~min_keepers
         ~source_ids

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -63,14 +63,16 @@ type contribution =
    and [Diagnostic] is system-authored evidence for operators, not shared semantic
    memory. Keep this exhaustive so a future [claim_kind] cannot promote by
    accident. *)
-(** Maximum age (seconds) before a fact is considered too stale for consensus
-    promotion.  Only enforced when the fact carries no explicit [valid_until]. *)
-let max_consensus_staleness = 30. *. 86400.
-
 let not_stale ~now fact =
-  match fact.last_verified_at with
-  | Some t -> now -. t <= max_consensus_staleness
-  | None -> now -. fact.first_seen <= max_consensus_staleness
+  match fact_effective_valid_until fact with
+  | Some deadline -> now <= deadline
+  | None ->
+    (* No explicit TTL (Durable_knowledge, legacy). Apply consensus
+       staleness bound from the policy SSOT. *)
+    let max_age = Keeper_memory_os_policy.max_consensus_staleness in
+    match fact.last_verified_at with
+    | Some t -> now -. t <= max_age
+    | None -> now -. fact.first_seen <= max_age
 
 let eligible ~now fact =
   is_promotable fact.category

--- a/lib/keeper/keeper_memory_os_consolidator.mli
+++ b/lib/keeper/keeper_memory_os_consolidator.mli
@@ -15,6 +15,17 @@ open Keeper_memory_os_types
 (** Minimum distinct keepers required before a claim is shared (2). *)
 val default_min_keepers : int
 
+(** Whether a fact is recent enough for consensus promotion.  Delegates to
+    [fact_effective_valid_until] when present; otherwise applies the
+    [max_consensus_staleness] policy bound against [last_verified_at] (or
+    [first_seen] for unverified facts). *)
+val not_stale : now:float -> fact -> bool
+
+(** Whether a fact passes all promotion eligibility criteria: category is
+    promotable and outcome-positive, fact is not stale, and claim kind is
+    objective ([Durable_knowledge] or legacy [None]). *)
+val eligible : now:float -> fact -> bool
+
 type report =
   { keepers_scanned : int
   ; claims_considered : int

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -27,6 +27,11 @@ let recall_default_max_episodes = 2
 let recall_default_max_shared_facts = 4
 let recall_episode_tail_scan = 32
 
+(** Maximum age (seconds) before a Durable_knowledge fact with no explicit
+    [valid_until] is considered too stale for consensus promotion.
+    Only enforced when [fact_effective_valid_until] returns [None]. *)
+let max_consensus_staleness = 30. *. 86400.
+
 (* RFC-0247 §-1: structural retention rank for the bounded store cap. This is NOT
    a relevance score — it is a deterministic two-tier lexicographic order used
    ONLY to decide which rows the size cap drops when the store grows past its

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -29,8 +29,9 @@ let recall_episode_tail_scan = 32
 
 (** Maximum age (seconds) before a Durable_knowledge fact with no explicit
     [valid_until] is considered too stale for consensus promotion.
-    Only enforced when [fact_effective_valid_until] returns [None]. *)
-let max_consensus_staleness = 30. *. 86400.
+    Only enforced when [fact_effective_valid_until] returns [None].
+    Per task-1855 AC-3: default 24h. *)
+let max_consensus_staleness = 86400.
 
 (* RFC-0247 §-1: structural retention rank for the bounded store cap. This is NOT
    a relevance score — it is a deterministic two-tier lexicographic order used

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -40,6 +40,11 @@ val recall_default_max_shared_facts : int
 (** Episode tail scan used before current/prompt-recallable filtering. *)
 val recall_episode_tail_scan : int
 
+(** Maximum age (seconds) before a Durable_knowledge fact with no explicit
+    [valid_until] is considered too stale for consensus promotion.
+    Only enforced when [fact_effective_valid_until] returns [None]. *)
+val max_consensus_staleness : float
+
 (** Structural retention rank for the bounded store cap (RFC-0247 §-1). NOT a
     relevance score: a deterministic two-tier order — durable categories outrank
     Ephemeral, then most-recently-verified (else first-seen) wins. Used only to

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -564,21 +564,21 @@ let () =
     ; ( "staleness_gate"
       , [ Alcotest.test_case "fresh verified fact passes not_stale" `Quick
             (fun () ->
-               let fresh = fact ~last_verified_at:(Some (now -. 10. *. 86400.)) "fresh" in
+               let fresh = fact ~last_verified_at:(Some (now -. 3600.)) "fresh" in
                Alcotest.(check bool) "fresh" true (Consolidation.not_stale ~now fresh))
         ; Alcotest.test_case "stale verified fact fails not_stale" `Quick
             (fun () ->
-               let stale = fact ~last_verified_at:(Some (now -. 31. *. 86400.)) "stale" in
+               let stale = fact ~last_verified_at:(Some (now -. 90000.)) "stale" in
                Alcotest.(check bool) "stale" false (Consolidation.not_stale ~now stale))
         ; Alcotest.test_case "unverified fact falls back to first_seen" `Quick
             (fun () ->
-               let old = fact ~first_seen:(now -. 31. *. 86400.) ~last_verified_at:None "old" in
+               let old = fact ~first_seen:(now -. 90000.) ~last_verified_at:None "old" in
                Alcotest.(check bool) "old unverified" false (Consolidation.not_stale ~now old);
                let young = fact ~first_seen:(now -. 100.0) ~last_verified_at:None "young" in
                Alcotest.(check bool) "young unverified" true (Consolidation.not_stale ~now young))
         ; Alcotest.test_case "eligible ~now filters stale Durable_knowledge" `Quick
             (fun () ->
-               let stale_dk = fact ~last_verified_at:(Some (now -. 31. *. 86400.))
+               let stale_dk = fact ~last_verified_at:(Some (now -. 90000.))
                  ~claim_kind:(Some Types.Durable_knowledge) "stale_dk" in
                Alcotest.(check bool) "stale dk" false (Consolidation.eligible ~now stale_dk);
                let fresh_dk = fact ~last_verified_at:(Some (now -. 10.0))

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -561,5 +561,29 @@ let () =
             `Quick
             test_render_numbered_facts_keeps_one_fact_per_line
         ] )
+    ; ( "staleness_gate"
+      , [ Alcotest.test_case "fresh verified fact passes not_stale" `Quick
+            (fun () ->
+               let fresh = fact ~last_verified_at:(Some (now -. 10. *. 86400.)) "fresh" in
+               Alcotest.(check bool) "fresh" true (Consolidation.not_stale ~now fresh))
+        ; Alcotest.test_case "stale verified fact fails not_stale" `Quick
+            (fun () ->
+               let stale = fact ~last_verified_at:(Some (now -. 31. *. 86400.)) "stale" in
+               Alcotest.(check bool) "stale" false (Consolidation.not_stale ~now stale))
+        ; Alcotest.test_case "unverified fact falls back to first_seen" `Quick
+            (fun () ->
+               let old = fact ~first_seen:(now -. 31. *. 86400.) ~last_verified_at:None "old" in
+               Alcotest.(check bool) "old unverified" false (Consolidation.not_stale ~now old);
+               let young = fact ~first_seen:(now -. 100.0) ~last_verified_at:None "young" in
+               Alcotest.(check bool) "young unverified" true (Consolidation.not_stale ~now young))
+        ; Alcotest.test_case "eligible ~now filters stale Durable_knowledge" `Quick
+            (fun () ->
+               let stale_dk = fact ~last_verified_at:(Some (now -. 31. *. 86400.))
+                 ~claim_kind:(Some Types.Durable_knowledge) "stale_dk" in
+               Alcotest.(check bool) "stale dk" false (Consolidation.eligible ~now stale_dk);
+               let fresh_dk = fact ~last_verified_at:(Some (now -. 10.0))
+                 ~claim_kind:(Some Types.Durable_knowledge) "fresh_dk" in
+               Alcotest.(check bool) "fresh dk" true (Consolidation.eligible ~now fresh_dk))
+        ] )
 	    ]
 ;;

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -584,6 +584,25 @@ let () =
                let fresh_dk = fact ~last_verified_at:(Some (now -. 10.0))
                  ~claim_kind:(Some Types.Durable_knowledge) "fresh_dk" in
                Alcotest.(check bool) "fresh dk" true (Consolidation.eligible ~now fresh_dk))
+        ; Alcotest.test_case "not_stale delegates to fact_effective_valid_until first" `Quick
+            (fun () ->
+               (* P1 regression: fact with valid_until in the future passes
+                  even when last_verified_at is old. *)
+               let old_but_valid =
+                 fact ~last_verified_at:(Some (now -. 50. *. 86400.))
+                   ~valid_until:(Some (now +. 365. *. 86400.))
+                   ~claim_kind:(Some Types.External_state) "external"
+               in
+               Alcotest.(check bool) "valid_until overrides staleness"
+                 true (Consolidation.not_stale ~now old_but_valid);
+               (* Expired valid_until blocks even if recently verified. *)
+               let fresh_but_expired =
+                 fact ~last_verified_at:(Some (now -. 1.0))
+                   ~valid_until:(Some (now -. 100.0))
+                   ~claim_kind:(Some Types.External_state) "expired"
+               in
+               Alcotest.(check bool) "expired valid_until blocks"
+                 false (Consolidation.not_stale ~now fresh_but_expired))
         ] )
 	    ]
 ;;

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -2,6 +2,7 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Consolidation = Masc.Keeper_memory_os_consolidation
+module Consolidator = Masc.Keeper_memory_os_consolidator
 
 let now = 1_000_000.0
 
@@ -564,45 +565,49 @@ let () =
     ; ( "staleness_gate"
       , [ Alcotest.test_case "fresh verified fact passes not_stale" `Quick
             (fun () ->
-               let fresh = fact ~last_verified_at:(Some (now -. 3600.)) "fresh" in
-               Alcotest.(check bool) "fresh" true (Consolidation.not_stale ~now fresh))
+               let fresh = fact ~last_verified_at:(now -. 3600.) "fresh" in
+               Alcotest.(check bool) "fresh" true (Consolidator.not_stale ~now fresh))
         ; Alcotest.test_case "stale verified fact fails not_stale" `Quick
             (fun () ->
-               let stale = fact ~last_verified_at:(Some (now -. 90000.)) "stale" in
-               Alcotest.(check bool) "stale" false (Consolidation.not_stale ~now stale))
+               let stale = fact ~last_verified_at:(now -. 90000.) "stale" in
+               Alcotest.(check bool) "stale" false (Consolidator.not_stale ~now stale))
         ; Alcotest.test_case "unverified fact falls back to first_seen" `Quick
             (fun () ->
-               let old = fact ~first_seen:(now -. 90000.) ~last_verified_at:None "old" in
-               Alcotest.(check bool) "old unverified" false (Consolidation.not_stale ~now old);
-               let young = fact ~first_seen:(now -. 100.0) ~last_verified_at:None "young" in
-               Alcotest.(check bool) "young unverified" true (Consolidation.not_stale ~now young))
+               let old =
+                 { (fact ~first_seen:(now -. 90000.) "old") with Types.last_verified_at = None }
+               in
+               Alcotest.(check bool) "old unverified" false (Consolidator.not_stale ~now old);
+               let young =
+                 { (fact ~first_seen:(now -. 100.0) "young") with Types.last_verified_at = None }
+               in
+               Alcotest.(check bool) "young unverified" true (Consolidator.not_stale ~now young))
         ; Alcotest.test_case "eligible ~now filters stale Durable_knowledge" `Quick
             (fun () ->
-               let stale_dk = fact ~last_verified_at:(Some (now -. 90000.))
+               let stale_dk = fact ~last_verified_at:(now -. 90000.)
                  ~claim_kind:(Some Types.Durable_knowledge) "stale_dk" in
-               Alcotest.(check bool) "stale dk" false (Consolidation.eligible ~now stale_dk);
-               let fresh_dk = fact ~last_verified_at:(Some (now -. 10.0))
+               Alcotest.(check bool) "stale dk" false (Consolidator.eligible ~now stale_dk);
+               let fresh_dk = fact ~last_verified_at:(now -. 10.0)
                  ~claim_kind:(Some Types.Durable_knowledge) "fresh_dk" in
-               Alcotest.(check bool) "fresh dk" true (Consolidation.eligible ~now fresh_dk))
+               Alcotest.(check bool) "fresh dk" true (Consolidator.eligible ~now fresh_dk))
         ; Alcotest.test_case "not_stale delegates to fact_effective_valid_until first" `Quick
             (fun () ->
                (* P1 regression: fact with valid_until in the future passes
                   even when last_verified_at is old. *)
                let old_but_valid =
-                 fact ~last_verified_at:(Some (now -. 50. *. 86400.))
-                   ~valid_until:(Some (now +. 365. *. 86400.))
+                 fact ~last_verified_at:(now -. 50. *. 86400.)
+                   ~valid_until:(now +. 365. *. 86400.)
                    ~claim_kind:(Some Types.External_state) "external"
                in
                Alcotest.(check bool) "valid_until overrides staleness"
-                 true (Consolidation.not_stale ~now old_but_valid);
+                 true (Consolidator.not_stale ~now old_but_valid);
                (* Expired valid_until blocks even if recently verified. *)
                let fresh_but_expired =
-                 fact ~last_verified_at:(Some (now -. 1.0))
-                   ~valid_until:(Some (now -. 100.0))
+                 fact ~last_verified_at:(now -. 1.0)
+                   ~valid_until:(now -. 100.0)
                    ~claim_kind:(Some Types.External_state) "expired"
                in
                Alcotest.(check bool) "expired valid_until blocks"
-                 false (Consolidation.not_stale ~now fresh_but_expired))
+                 false (Consolidator.not_stale ~now fresh_but_expired))
         ] )
 	    ]
 ;;


### PR DESCRIPTION
## Task-1855

### Problem

`eligible()` (keeper_memory_os_consolidator.ml:66) checks category, outcome, and claim_kind but has **no staleness filter**. A single Durable_knowledge fact with no explicit `valid_until` and no competing contributions will:
1. Pass `eligible()` (no staleness check)
2. Win `representative()` (only contribution = best)
3. Get promoted with `last_verified_at = Some now` at line 142 — masking original staleness

Note: `fact_is_current` (line 109) filters by `fact_effective_valid_until`, but this returns `None` (always passes) for all claim_kinds except `External_state`. So `Durable_knowledge` facts without explicit `valid_until` bypass this filter.

### Fix

- Add `not_stale ~now` helper with 30-day TTL
- Thread `~now` through `eligible`, `source_fact_counts`, `log_run_summary`
- `representative()` already uses `last_verified_at` as primary — **no change needed** (phantom component of task title)
- `promote_facts` timestamp overwrite is intentional ("The consolidation IS the verification")

### Evidence

- `eligible()` source: keeper_memory_os_consolidator.ml:66-73 (origin/main)
- `fact_effective_valid_until`: keeper_memory_os_types.ml:360-365 (returns None for Durable_knowledge)
- `fact_is_current`: keeper_memory_os_types.ml:368-372 (returns true when valid_until is None)
- `representative()`: keeper_memory_os_consolidator.ml:79-98 (last_verified_at primary)

### Diff

1 file changed, 17 insertions(+), 6 deletions(-)

Refs: nick0cave p-a60bc23b, analyst c-a58b4a4