### PR TITLE
fix(test): use a real hard-quota indicator in the W2 route fixture

### DIFF
--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -24,10 +24,14 @@ let test_api_rate_limited_threads_hint () =
           { retry_after = Some 30.0; message = "slow down" }))
 
 let test_api_hard_quota_message_wins () =
+  (* The message must be one [Retry.hard_quota_indicators] actually lists —
+     "monthly quota reached" is not an indicator, so the original fixture
+     asserted a classification the OAS predicate never made (surfaced on
+     main once #23495's cancelled PR run finally executed this exe). *)
   let err =
     Agent_sdk.Error.Api
       (Llm_provider.Retry.RateLimited
-         { retry_after = None; message = "monthly quota reached" })
+         { retry_after = None; message = "You have exceeded your current quota." })
   in
   match KFR.route_of_error err with
   | KFR.Retry_after_pacing { pacing = KFR.Hard_quota; _ } -> ()


### PR DESCRIPTION
## 무엇

main `Build and Test` red 잔여 1건 수리 — `test_keeper_runtime_failure_route`:

```
FAIL hard-quota message must pace as hard quota, got retry_after_pacing:rate_limited
```

## 왜

W2(#23495) 테스트 fixture 메시지 `"monthly quota reached"`는 `Retry.hard_quota_indicators`에 **없는** 문자열이라 OAS predicate가 낸 적 없는 분류를 단언하고 있었습니다 — #23495의 Build and Test 런이 머지 시각에 취소되어 main에서 처음 실행되며 발현. pinned agent_sdk 대비 스크래치 바이너리로 실증:

```
new_fixture_is_hard_quota=true old_fixture_is_hard_quota=false
```

indicator 목록에 문자열을 추가하는 방향(string 분류기 보강 = 워크어라운드 시그니처)이 아니라, fixture를 실제 indicator(`"exceeded your current quota"`)로 교체합니다. predicate 소유권 가드라는 테스트 의도는 유지.

## 경위

원래 #23520의 2번째 커밋(fe361bfa26)이었으나 머지(18:06 KST)가 push보다 빨라 squash에서 누락 — 병합된 브랜치에 얹힌 커밋은 main에 도달하지 않으므로(masc#5303 교훈) 새 PR로 재상정. 이 PR은 해당 커밋의 cherry-pick(1파일 +5/-1).

RFC-WAIVED: test-only fixture literal; no subsystem code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
