### PR TITLE
fix(keeper): unbreak main — pacing shadow reads catalog via to_summary

### DIFF
--- a/lib/keeper/keeper_pacing_shadow.ml
+++ b/lib/keeper/keeper_pacing_shadow.ml
@@ -3,7 +3,10 @@
 let mu = Eio.Mutex.create ()
 let table : (string, Keeper_pacing.t) Hashtbl.t = Hashtbl.create 64
 
-let observed_runtime_ids state = List.map fst state
+(* [Keeper_pacing.t] is abstract; the observed runtime ids come from its
+   observability projection. #23524 landed this helper reading [state] as a
+   bare assoc list, which does not typecheck against the abstract [t]. *)
+let observed_runtime_ids state = List.map fst (Keeper_pacing.to_summary state)
 
 let next_due_remaining_of_state ~now state =
   match observed_runtime_ids state with


### PR DESCRIPTION
## What

`observed_runtime_ids`가 abstract `Keeper_pacing.t`를 bare assoc list로 읽어 `lib/keeper` 전체 빌드가 깨짐 (#23524, RFC-0313 W3 flip에서 유입). `Keeper_pacing.to_summary` observability projection 경유로 수정.

## Why

main red — `lib/keeper`에 의존하는 모든 타깃이 컴파일 불가:

```
File "lib/keeper/keeper_pacing_shadow.ml", line 12, characters 56-61:
Error: The value state has type (string * 'a) list
       but an expression was expected of type Keeper_pacing.t
```

## Verification

- `dune build --root . lib/keeper` exit 0 (was: type error above)
- 동작 변화 없음: `to_summary`는 `t`의 전체 runtime id를 정렬 반환하므로 `observed_runtime_ids`의 의도와 동일

RFC-WAIVED: one-line type fix to restore main build; no behavior/design change (RFC-0313 W3 소유)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
