### PR TITLE
feat(ide): annotation popover delete control (#23471 FE follow-up)

### DIFF
--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -7,12 +7,14 @@ import {
   fetchIdeEvents,
   fetchIdeRegions,
 } from './ide'
+import { clearStoredToken, setStoredToken } from './core'
 
 const mockFetch = vi.fn()
 
 afterEach(() => {
   mockFetch.mockReset()
   vi.unstubAllGlobals()
+  clearStoredToken()
 })
 
 function stubFetch(response: unknown, ok = true, status?: number): void {
@@ -190,7 +192,8 @@ describe('ide API', () => {
     )
   })
 
-  it('deleteIdeAnnotation relies on token identity and appends repo_id param', async () => {
+  it('deleteIdeAnnotation sends the bearer token and appends repo_id param without keeper_id', async () => {
+    setStoredToken('delete-test-token', { source: 'manual', actor: 'dashboard-user' })
     stubFetch({}, true)
 
     await deleteIdeAnnotation('ann-1', { repoId: 'masc' })
@@ -199,6 +202,10 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/annotations/ann-1?')
     expect(url).toContain('repo_id=masc')
     expect(url).not.toContain('keeper_id=')
+    // The DELETE route is token-bound (CanBroadcast) — a header-less
+    // request is rejected 401 in every server configuration.
+    const init = mockFetch.mock.calls[0]![1] as RequestInit
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer delete-test-token' })
   })
 
   it('deleteIdeAnnotation maps success to deleted', async () => {
@@ -207,13 +214,29 @@ describe('ide API', () => {
     await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('deleted')
   })
 
-  it('deleteIdeAnnotation maps 403 ownership/scope rejection to forbidden', async () => {
-    stubFetch({}, false, 403)
+  it('deleteIdeAnnotation maps the coded 403 (ownership/not-found) to rejected', async () => {
+    stubFetch(
+      { ok: false, error: 'annotation delete rejected', code: 'annotation_delete_rejected' },
+      false,
+      403,
+    )
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('rejected')
+  })
+
+  it('deleteIdeAnnotation maps an uncoded 403 (auth tier) to forbidden', async () => {
+    stubFetch({ ok: false, error: 'permission denied' }, false, 403)
 
     await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('forbidden')
   })
 
-  it('deleteIdeAnnotation maps non-403 failures to error', async () => {
+  it('deleteIdeAnnotation maps 401 to unauthorized', async () => {
+    stubFetch({ ok: false, error: 'missing token' }, false, 401)
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('unauthorized')
+  })
+
+  it('deleteIdeAnnotation maps non-auth failures to error', async () => {
     stubFetch({}, false)
 
     await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('error')

--- a/dashboard/src/api/ide.test.ts
+++ b/dashboard/src/api/ide.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-function stubFetch(response: unknown, ok = true): void {
+function stubFetch(response: unknown, ok = true, status?: number): void {
   mockFetch.mockResolvedValue({
     ok,
-    status: ok ? 200 : 500,
+    status: status ?? (ok ? 200 : 500),
     statusText: ok ? 'OK' : 'Internal Server Error',
     headers: new Headers(),
     json: () => Promise.resolve(response),
@@ -199,6 +199,31 @@ describe('ide API', () => {
     expect(url).toContain('/api/v1/ide/annotations/ann-1?')
     expect(url).toContain('repo_id=masc')
     expect(url).not.toContain('keeper_id=')
+  })
+
+  it('deleteIdeAnnotation maps success to deleted', async () => {
+    stubFetch({}, true)
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('deleted')
+  })
+
+  it('deleteIdeAnnotation maps 403 ownership/scope rejection to forbidden', async () => {
+    stubFetch({}, false, 403)
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('forbidden')
+  })
+
+  it('deleteIdeAnnotation maps non-403 failures to error', async () => {
+    stubFetch({}, false)
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('error')
+  })
+
+  it('deleteIdeAnnotation maps network failure to error', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    await expect(deleteIdeAnnotation('ann-1', { repoId: 'masc' })).resolves.toBe('error')
   })
 
   it('fetchIdeEvents appends event filters and parses bridge events', async () => {

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -399,19 +399,26 @@ export async function createIdeAnnotation(
   return parseStrictRow('createIdeAnnotation', ideEnvelopeData(raw, 'createIdeAnnotation'), parseStrictIdeAnnotation)
 }
 
+// The DELETE route binds ownership to the token identity (task-1736 B3):
+// it answers 403 both for another identity's annotation and for a scope
+// the token may not mutate. Surface that apart from transport/server
+// failures so callers can explain the rejection instead of a generic error.
+export type IdeAnnotationDeleteOutcome = 'deleted' | 'forbidden' | 'error'
+
 export async function deleteIdeAnnotation(
   id: string,
   opts: IdeApiOptions = {},
-): Promise<boolean> {
+): Promise<IdeAnnotationDeleteOutcome> {
   const params = new URLSearchParams()
   appendWorkspaceParams(params, opts)
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const path = `/api/v1/ide/annotations/${encodeURIComponent(id)}${query}`
   try {
     const res = await fetchWithTimeout(path, { method: 'DELETE' }, 15_000)
-    return res.ok
+    if (res.ok) return 'deleted'
+    return res.status === 403 ? 'forbidden' : 'error'
   } catch {
-    return false
+    return 'error'
   }
 }
 

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -1,4 +1,4 @@
-import { get, post, fetchWithTimeout, type GetOptions } from './core'
+import { get, post, fetchWithTimeout, authHeaders, type GetOptions } from './core'
 import {
   type IdeAnnotation,
   type IdeCodeRegion,
@@ -399,11 +399,33 @@ export async function createIdeAnnotation(
   return parseStrictRow('createIdeAnnotation', ideEnvelopeData(raw, 'createIdeAnnotation'), parseStrictIdeAnnotation)
 }
 
-// The DELETE route binds ownership to the token identity (task-1736 B3):
-// it answers 403 both for another identity's annotation and for a scope
-// the token may not mutate. Surface that apart from transport/server
-// failures so callers can explain the rejection instead of a generic error.
-export type IdeAnnotationDeleteOutcome = 'deleted' | 'forbidden' | 'error'
+// Typed outcome of a DELETE (task-1736 B3 route, token-bound):
+// - 'rejected'     403 with the server's annotation_delete_rejected code —
+//                  the stored annotation is not owned by the token identity,
+//                  or it no longer exists (the server flattens the two).
+// - 'forbidden'    403 from the auth layer — the token's tier lacks the
+//                  write permission; ownership was never evaluated.
+// - 'unauthorized' 401 — missing/expired bearer token.
+// - 'error'        transport failure or any other server error.
+export type IdeAnnotationDeleteOutcome =
+  | 'deleted'
+  | 'rejected'
+  | 'forbidden'
+  | 'unauthorized'
+  | 'error'
+
+// Wire constant mirrored from server_ide_http.ml annotation_delete_rejected_code.
+const ANNOTATION_DELETE_REJECTED_CODE = 'annotation_delete_rejected'
+
+async function responseErrorCode(res: Response): Promise<string | null> {
+  try {
+    const body: unknown = await res.json()
+    if (isRecord(body) && typeof body.code === 'string') return body.code
+    return null
+  } catch {
+    return null
+  }
+}
 
 export async function deleteIdeAnnotation(
   id: string,
@@ -414,9 +436,18 @@ export async function deleteIdeAnnotation(
   const query = params.size > 0 ? `?${params.toString()}` : ''
   const path = `/api/v1/ide/annotations/${encodeURIComponent(id)}${query}`
   try {
-    const res = await fetchWithTimeout(path, { method: 'DELETE' }, 15_000)
+    const res = await fetchWithTimeout(
+      path,
+      { method: 'DELETE', headers: authHeaders() },
+      15_000,
+    )
     if (res.ok) return 'deleted'
-    return res.status === 403 ? 'forbidden' : 'error'
+    if (res.status === 401) return 'unauthorized'
+    if (res.status === 403) {
+      const code = await responseErrorCode(res)
+      return code === ANNOTATION_DELETE_REJECTED_CODE ? 'rejected' : 'forbidden'
+    }
+    return 'error'
   } catch {
     return 'error'
   }

--- a/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
+++ b/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
@@ -1,0 +1,152 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AnnotationDeleteControl } from './ide-editor-annotation-ui'
+import type { SelectedAnnotation } from './ide-lsp-client'
+import type { IdeAnnotationDeleteOutcome } from '../../api/ide'
+
+const annotation: SelectedAnnotation = {
+  id: 'ann-1',
+  keeper_id: 'sangsu',
+  kind: 'Comment',
+  content: '경계 조건 확인 필요',
+  goal_id: null,
+  task_id: null,
+  file_path: 'lib/foo.ml',
+  line_start: 12,
+  line_end: 34,
+}
+
+describe('AnnotationDeleteControl', () => {
+  let host: HTMLDivElement | null = null
+  const onDelete = vi.fn<(a: SelectedAnnotation) => Promise<IdeAnnotationDeleteOutcome>>()
+  const onDeleted = vi.fn()
+
+  beforeEach(() => {
+    onDelete.mockReset()
+    onDeleted.mockReset()
+  })
+
+  afterEach(() => {
+    if (host) {
+      render(null, host)
+      host.remove()
+      host = null
+    }
+  })
+
+  function mount(target: SelectedAnnotation = annotation): HTMLDivElement {
+    host = host ?? (() => {
+      const created = document.createElement('div')
+      document.body.appendChild(created)
+      return created
+    })()
+    render(
+      html`
+        <${AnnotationDeleteControl}
+          annotation=${target}
+          onDelete=${onDelete}
+          onDeleted=${onDeleted}
+        />
+      `,
+      host,
+    )
+    return host
+  }
+
+  function tick(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  function button(el: HTMLElement): HTMLButtonElement {
+    const found = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-delete"]')
+    expect(found).not.toBeNull()
+    return found!
+  }
+
+  it('arms on the first click without calling onDelete', async () => {
+    const el = mount()
+    expect(button(el).textContent?.trim()).toBe('삭제')
+
+    button(el).click()
+    await tick()
+
+    expect(onDelete).not.toHaveBeenCalled()
+    expect(button(el).textContent?.trim()).toBe('삭제 확인')
+  })
+
+  it('runs the delete on the second click and shows a pending state', async () => {
+    let resolveDelete: (outcome: IdeAnnotationDeleteOutcome) => void = () => {}
+    onDelete.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
+    const el = mount()
+
+    button(el).click()
+    await tick()
+    button(el).click()
+    await tick()
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onDelete).toHaveBeenCalledWith(annotation)
+    expect(button(el).textContent?.trim()).toBe('삭제 중…')
+    expect(button(el).disabled).toBe(true)
+
+    resolveDelete('deleted')
+    await tick()
+  })
+
+  it('notifies onDeleted when the outcome is deleted', async () => {
+    onDelete.mockResolvedValue('deleted')
+    const el = mount()
+
+    button(el).click()
+    await tick()
+    button(el).click()
+    await tick()
+
+    expect(onDeleted).toHaveBeenCalledTimes(1)
+  })
+
+  it('disarms without closing when the server rejects the deletion', async () => {
+    onDelete.mockResolvedValue('forbidden')
+    const el = mount()
+
+    button(el).click()
+    await tick()
+    button(el).click()
+    await tick()
+
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(button(el).textContent?.trim()).toBe('삭제')
+    expect(button(el).disabled).toBe(false)
+  })
+
+  it('disarms when the popover switches to a different annotation', async () => {
+    const el = mount()
+    button(el).click()
+    await tick()
+    expect(button(el).textContent?.trim()).toBe('삭제 확인')
+
+    mount({ ...annotation, id: 'ann-2' })
+    await tick()
+
+    expect(button(el).textContent?.trim()).toBe('삭제')
+    button(el).click()
+    await tick()
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  it('treats a rejected onDelete as an error and stays usable', async () => {
+    onDelete.mockRejectedValue(new Error('boom'))
+    const el = mount()
+
+    button(el).click()
+    await tick()
+    button(el).click()
+    await tick()
+
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(button(el).textContent?.trim()).toBe('삭제')
+    expect(button(el).disabled).toBe(false)
+  })
+})

--- a/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
+++ b/dashboard/src/components/ide/ide-editor-annotation-ui.test.ts
@@ -136,6 +136,46 @@ describe('AnnotationDeleteControl', () => {
     expect(onDelete).not.toHaveBeenCalled()
   })
 
+  it('does not stay armed after browsing away and back to the same annotation', async () => {
+    const el = mount()
+    button(el).click()
+    await tick()
+    expect(button(el).textContent?.trim()).toBe('삭제 확인')
+
+    mount({ ...annotation, id: 'ann-2' })
+    await tick()
+    mount(annotation)
+    await tick()
+
+    expect(button(el).textContent?.trim()).toBe('삭제')
+    button(el).click()
+    await tick()
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  it('does not close the popover when the target switched while the delete was in flight', async () => {
+    let resolveDelete: (outcome: IdeAnnotationDeleteOutcome) => void = () => {}
+    onDelete.mockReturnValue(new Promise(resolve => { resolveDelete = resolve }))
+    const el = mount()
+
+    button(el).click()
+    await tick()
+    button(el).click()
+    await tick()
+    expect(onDelete).toHaveBeenCalledWith(annotation)
+
+    mount({ ...annotation, id: 'ann-2' })
+    await tick()
+    expect(button(el).disabled).toBe(true)
+
+    resolveDelete('deleted')
+    await tick()
+
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(button(el).textContent?.trim()).toBe('삭제')
+    expect(button(el).disabled).toBe(false)
+  })
+
   it('treats a rejected onDelete as an error and stays usable', async () => {
     onDelete.mockRejectedValue(new Error('boom'))
     const el = mount()

--- a/dashboard/src/components/ide/ide-editor-annotation-ui.ts
+++ b/dashboard/src/components/ide/ide-editor-annotation-ui.ts
@@ -1,5 +1,7 @@
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import type { EditorView } from '@codemirror/view'
+import type { IdeAnnotationDeleteOutcome } from '../../api/ide'
 import type { SelectedAnnotation } from './ide-lsp-client'
 import {
   openIdeContextRouteLink,
@@ -54,14 +56,80 @@ export function EditorContextRouteCount({
   `
 }
 
+// Two-click destructive control: the first click arms, the second runs.
+// Deletability is not knowable up front — the dashboard has no whoami and
+// the DELETE route decides ownership from the token identity — so the
+// button is always offered and a 'forbidden' outcome (another identity's
+// annotation, or a scope the token may not mutate) simply disarms; the
+// delete handler owns the explanatory toast.
+export function AnnotationDeleteControl({
+  annotation,
+  onDelete,
+  onDeleted,
+}: {
+  readonly annotation: SelectedAnnotation
+  readonly onDelete: (annotation: SelectedAnnotation) => Promise<IdeAnnotationDeleteOutcome>
+  readonly onDeleted: () => void
+}) {
+  // Armed state is keyed to the annotation id: switching the popover to a
+  // different annotation reuses this component instance (same vDOM slot),
+  // and a plain boolean would carry the armed click over to the new
+  // target — one click would then delete an annotation the user never
+  // armed.
+  const [armedFor, setArmedFor] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+  const armed = armedFor === annotation.id
+
+  const run = async () => {
+    if (pending) return
+    if (!armed) {
+      setArmedFor(annotation.id)
+      return
+    }
+    setPending(true)
+    let outcome: IdeAnnotationDeleteOutcome
+    try {
+      outcome = await onDelete(annotation)
+    } catch {
+      outcome = 'error'
+    }
+    if (outcome === 'deleted') {
+      // The popover unmounts with the deleted annotation — skip state
+      // updates that would land on an unmounted component.
+      onDeleted()
+      return
+    }
+    setPending(false)
+    setArmedFor(null)
+  }
+
+  return html`
+    <button
+      type="button"
+      class="v2-ide-action"
+      data-testid="ide-annotation-delete"
+      disabled=${pending}
+      title=${armed
+        ? '한 번 더 누르면 삭제됩니다'
+        : '주석 삭제 (본인이 작성한 주석만 서버가 허용)'}
+      style=${{ color: armed ? 'var(--color-fg-warning)' : undefined, marginLeft: 'auto' }}
+      onClick=${() => void run()}
+    >
+      ${pending ? '삭제 중…' : armed ? '삭제 확인' : '삭제'}
+    </button>
+  `
+}
+
 export function AnnotationPopover({
   annotation,
   view,
   onClose,
+  onDelete,
 }: {
   readonly annotation: SelectedAnnotation
   readonly view: EditorView
   readonly onClose: () => void
+  readonly onDelete?: (annotation: SelectedAnnotation) => Promise<IdeAnnotationDeleteOutcome>
 }) {
   const line = annotation.line_start
   const lineInfo = line >= 1 && line <= view.state.doc.lines
@@ -159,6 +227,13 @@ export function AnnotationPopover({
           <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px' }}>
             task: ${annotation.task_id}
           </span>
+        ` : null}
+        ${onDelete ? html`
+          <${AnnotationDeleteControl}
+            annotation=${annotation}
+            onDelete=${onDelete}
+            onDeleted=${onClose}
+          />
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/ide/ide-editor-annotation-ui.ts
+++ b/dashboard/src/components/ide/ide-editor-annotation-ui.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import type { EditorView } from '@codemirror/view'
 import type { IdeAnnotationDeleteOutcome } from '../../api/ide'
 import type { SelectedAnnotation } from './ide-lsp-client'
@@ -71,35 +71,50 @@ export function AnnotationDeleteControl({
   readonly onDelete: (annotation: SelectedAnnotation) => Promise<IdeAnnotationDeleteOutcome>
   readonly onDeleted: () => void
 }) {
-  // Armed state is keyed to the annotation id: switching the popover to a
-  // different annotation reuses this component instance (same vDOM slot),
-  // and a plain boolean would carry the armed click over to the new
-  // target — one click would then delete an annotation the user never
-  // armed.
+  // Armed/pending state is keyed to the annotation id: switching the
+  // popover to a different annotation reuses this component instance
+  // (same vDOM slot), and a plain boolean would carry the armed click
+  // over to the new target — one click would then delete an annotation
+  // the user never armed.
   const [armedFor, setArmedFor] = useState<string | null>(null)
-  const [pending, setPending] = useState(false)
+  const [pendingFor, setPendingFor] = useState<string | null>(null)
+  const latestIdRef = useRef(annotation.id)
+  latestIdRef.current = annotation.id
+
+  // Disarm on target switch, not just mask: without this, arming ann-1,
+  // browsing to ann-2 and coming back would leave ann-1 pre-armed.
+  useEffect(() => {
+    setArmedFor(current =>
+      current !== null && current !== annotation.id ? null : current)
+  }, [annotation.id])
+
   const armed = armedFor === annotation.id
+  const pending = pendingFor === annotation.id
 
   const run = async () => {
-    if (pending) return
+    if (pendingFor !== null) return
     if (!armed) {
       setArmedFor(annotation.id)
       return
     }
-    setPending(true)
+    const target = annotation
+    setPendingFor(target.id)
     let outcome: IdeAnnotationDeleteOutcome
     try {
-      outcome = await onDelete(annotation)
+      outcome = await onDelete(target)
     } catch {
       outcome = 'error'
     }
-    if (outcome === 'deleted') {
+    if (outcome === 'deleted' && latestIdRef.current === target.id) {
       // The popover unmounts with the deleted annotation — skip state
       // updates that would land on an unmounted component.
       onDeleted()
       return
     }
-    setPending(false)
+    // Non-deleted outcome, or the popover moved to a different annotation
+    // while the delete was in flight — closing now would dismiss a target
+    // the user is looking at, so just settle the control.
+    setPendingFor(null)
     setArmedFor(null)
   }
 
@@ -108,7 +123,7 @@ export function AnnotationDeleteControl({
       type="button"
       class="v2-ide-action"
       data-testid="ide-annotation-delete"
-      disabled=${pending}
+      disabled=${pendingFor !== null}
       title=${armed
         ? '한 번 더 누르면 삭제됩니다'
         : '주석 삭제 (본인이 작성한 주석만 서버가 허용)'}

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -8,6 +8,7 @@ import type { KeeperLineOwnershipStore } from './keeper-line-ownership-store'
 import { ideEditorSelection } from './ide-editor-selection'
 import type { UnifiedDiffRow } from '../../api/workspace'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
+import type { IdeAnnotationDeleteOutcome } from '../../api/ide'
 import {
   readOnlyExt,
   themeExt,
@@ -69,6 +70,9 @@ interface IdeEditorProps {
   readonly onFindClose?: () => void
   readonly onKeeperLineSelect?: (keeperId: string, line: number) => void
   readonly annotations?: ReadonlyArray<IdeAnnotation>
+  readonly onAnnotationDelete?: (
+    annotation: SelectedAnnotation,
+  ) => Promise<IdeAnnotationDeleteOutcome>
 }
 
 const EMPTY_ACTIVE_LAYERS: ReadonlySet<string> = new Set()
@@ -94,6 +98,7 @@ export function IdeEditor({
   onFindClose,
   onKeeperLineSelect,
   annotations = [],
+  onAnnotationDelete,
 }: IdeEditorProps) {
   useStoreSubscription(documentStore.subscribe)
   useStoreSubscription(ownershipStore.subscribe)
@@ -267,6 +272,7 @@ export function IdeEditor({
               traceActive=${activeLayers.has('keeper-trace')}
               traceEvents=${replayTraceEvents}
               annotations=${annotations}
+              onAnnotationDelete=${onAnnotationDelete}
             />`
       }
     </div>
@@ -286,6 +292,7 @@ function CodeMirrorEditor({
   contextFocus,
   traceActive = false,
   traceEvents = EMPTY_TRACE_EVENTS,
+  onAnnotationDelete,
 }: {
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
@@ -296,6 +303,9 @@ function CodeMirrorEditor({
   readonly contextFocus?: IdeContextFocus | null
   readonly traceActive?: boolean
   readonly traceEvents?: ReadonlyArray<KeeperTraceEvent>
+  readonly onAnnotationDelete?: (
+    annotation: SelectedAnnotation,
+  ) => Promise<IdeAnnotationDeleteOutcome>
 }) {
   const containerRef = useRef<HTMLElement>(null)
   const editorRef = useRef<EditorView | null>(null)
@@ -501,6 +511,7 @@ function CodeMirrorEditor({
             setSelectedAnn(null)
           }
         },
+        onDelete: onAnnotationDelete,
       }) : null}
     </div>
   `

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -40,7 +40,9 @@ import {
   type KeeperCursorOverlay,
   type KeeperCursorStreamState,
 } from './keeper-cursor-overlay'
-import { lspStatusSnapshot, type LspStatusSnapshot } from './ide-lsp-client'
+import { lspStatusSnapshot, type LspStatusSnapshot, type SelectedAnnotation } from './ide-lsp-client'
+import { deleteIdeAnnotation, type IdeAnnotationDeleteOutcome } from '../../api/ide'
+import { showToast } from '../common/toast'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
 import { keepers } from '../../store'
@@ -1091,6 +1093,31 @@ export function IdeShell() {
     navigate('code', nextParams)
   }
 
+  // Annotation deletion (#23471 FE follow-up). Mirrors the composer's
+  // contract: mutations need a repo scope (keeper_lane is read-only) and
+  // ownership is decided server-side from the token identity, so the
+  // handler translates each outcome into a toast instead of pre-judging
+  // deletability in the FE.
+  const handleAnnotationDelete = async (
+    annotation: SelectedAnnotation,
+  ): Promise<IdeAnnotationDeleteOutcome> => {
+    const repoId = workspaceStore.activeRepositoryId()
+    if (repoId === null) {
+      showToast('주석 삭제에는 repo 선택이 필요합니다 (keeper_lane scope는 read-only)', 'error')
+      return 'error'
+    }
+    const outcome = await deleteIdeAnnotation(annotation.id, { repoId })
+    if (outcome === 'deleted') {
+      showToast(`주석 삭제됨: ${annotation.file_path}:${annotation.line_start}`, 'success')
+      workspaceStore.refresh()
+    } else if (outcome === 'forbidden') {
+      showToast('주석 삭제 거부 — 본인이 작성한 주석만 삭제할 수 있습니다', 'error')
+    } else {
+      showToast('주석 삭제 실패 — 서버/네트워크 오류', 'error')
+    }
+    return outcome
+  }
+
   const handleFindOpen = () => {
     navigate('code', {
       ...route.value.params,
@@ -1268,6 +1295,7 @@ export function IdeShell() {
             onFindClose=${handleFindClose}
             onKeeperLineSelect=${pinKeeper}
             annotations=${annotations}
+            onAnnotationDelete=${handleAnnotationDelete}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
         </div>

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1107,13 +1107,23 @@ export function IdeShell() {
       return 'error'
     }
     const outcome = await deleteIdeAnnotation(annotation.id, { repoId })
-    if (outcome === 'deleted') {
-      showToast(`주석 삭제됨: ${annotation.file_path}:${annotation.line_start}`, 'success')
-      workspaceStore.refresh()
-    } else if (outcome === 'forbidden') {
-      showToast('주석 삭제 거부 — 본인이 작성한 주석만 삭제할 수 있습니다', 'error')
-    } else {
-      showToast('주석 삭제 실패 — 서버/네트워크 오류', 'error')
+    switch (outcome) {
+      case 'deleted':
+        showToast(`주석 삭제됨: ${annotation.file_path}:${annotation.line_start}`, 'success')
+        workspaceStore.refresh()
+        break
+      case 'rejected':
+        showToast('주석 삭제 거부 — 본인이 작성한 주석이 아니거나 이미 삭제된 주석입니다', 'error')
+        break
+      case 'forbidden':
+        showToast('주석 삭제 권한 없음 — 토큰에 쓰기 권한(CanBroadcast tier)이 필요합니다', 'error')
+        break
+      case 'unauthorized':
+        showToast('인증 실패 — 대시보드 토큰이 없거나 만료되었습니다', 'error')
+        break
+      case 'error':
+        showToast('주석 삭제 실패 — 서버/네트워크 오류', 'error')
+        break
     }
     return outcome
   }

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -256,6 +256,13 @@ let keeper_id_not_accepted_error =
 
 let annotation_delete_rejected_error = "annotation delete rejected"
 
+(* Machine-readable code for the 403 above. [Ide_annotations.delete]
+   flattens not-found and keeper mismatch into one rejection, and the
+   auth layer also answers 403 when the token tier lacks the permission
+   — the code lets clients tell this rejection apart from a
+   credential-tier 403 without matching on the human message. *)
+let annotation_delete_rejected_code = "annotation_delete_rejected"
+
 let parse_json_body body_str =
   match Yojson.Safe.from_string body_str with
   | json -> Ok json
@@ -820,7 +827,9 @@ let add_routes router =
                    Http.Response.json_value
                      ~status:`Forbidden
                      ~request
-                     (json_error annotation_delete_rejected_error)
+                     (json_error
+                        ~code:annotation_delete_rejected_code
+                        annotation_delete_rejected_error)
                      reqd)))
            request
            reqd)


### PR DESCRIPTION
## 요약

`deleteIdeAnnotation`의 첫 UI 호출자를 배선합니다 (#23471 FE follow-up, #23531 후속 슬라이스로 선언됨). 사람이 IDE에서 주석을 만들 수는 있었지만(#23531) 지울 수는 없었습니다.

## 변경

| 파일 | 내용 |
|---|---|
| `api/ide.ts` | `deleteIdeAnnotation`에 **bearer token 부착**(적대 리뷰 P0 — 기존 코드는 header-less raw fetch라 토큰 필수 라우트에서 전 요청 401 DOA) + 반환을 boolean → typed outcome `'deleted' \| 'rejected' \| 'forbidden' \| 'unauthorized' \| 'error'` |
| `lib/server/server_ide_http.ml` | delete 거부 403에 machine-readable `code: annotation_delete_rejected` 1줄 추가 — auth-tier 403과 소유권/not-found 403을 클라이언트가 구분 (사람용 메시지 문자열 매칭 회피) |
| `ide-editor-annotation-ui.ts` | `AnnotationDeleteControl` 신규 — 2-click 무장(arm) 패턴, popover footer에 조건부 마운트 |
| `ide-editor.ts` | `onAnnotationDelete` prop을 `IdeEditor` → `CodeMirrorEditor` → popover로 스레딩 |
| `ide-shell.ts` | 핸들러 — repo scope 확인, API 호출, outcome별 toast(5-way), 성공 시 `workspaceStore.refresh()` |

## 서버 계약 미러링 (FE 재발명 없음)

- DELETE 라우트(task-1736 B3)는 소유권을 **토큰 identity에 바인딩**. FE에는 whoami가 없으므로 삭제 가능 여부를 예단하지 않고 서버 판정을 outcome별 toast로 번역:
  - `rejected` (403+code): "본인 주석이 아니거나 이미 삭제됨" — 서버가 not-found와 keeper mismatch를 flatten하므로 두 경우를 모두 명시
  - `forbidden` (403, code 없음): 토큰 tier가 `CanBroadcast` 미달 — 소유권 평가 전 단계
  - `unauthorized` (401): 토큰 부재/만료
- mutation은 repo scope 필수(`keeper_lane`은 read-only) — composer(#23531)와 동일 게이트.
- keeper_id는 전송하지 않음 (identity는 토큰 유래).

## 설계 노트

- **armed 상태를 annotation id에 키잉 + 전환 시 clear**: popover가 다른 주석으로 바뀌면 preact가 같은 vDOM 슬롯 인스턴스를 재사용 — plain boolean이면 무장 클릭이 새 타깃을 원클릭 삭제. 키잉만으로는 away-and-back 왕복 시 재무장이 남아 effect로 clear까지 수행. 회귀 테스트 2종.
- **in-flight 대상 전환**: ann-1 삭제가 진행 중일 때 popover가 ann-2로 이동하면, 완료 시 popover를 닫지 않고 컨트롤만 정리(사용자가 보고 있는 화면 보존).
- toast/refresh 책임은 shell 핸들러 한 곳 — 컨트롤은 outcome에 따라 닫힘/무장해제만 수행.

## 적대 리뷰 (fresh-context, 실도구 검증)

- **P0** header-less DELETE(전 요청 401) → `authHeaders()` 부착 + 요청 헤더 어서션 테스트
- **P1** 403 flatten으로 오도성 toast → 서버 code 1줄 + FE 5-way 매핑
- **P1** 테스트가 헤더 미검사 → Authorization 어서션 추가
- **P2×2** armed 재무장/in-flight 전환 → 상기 설계 노트, 회귀 테스트 포함
- (비고: 1차 디스패치한 adversarial-reviewer 에이전트는 tool 호출 0회로 환경-부재 서사를 날조해 폐기, 실도구 검증되는 에이전트로 재실행)

## 검증

- `vitest` 82 pass: `ide.test.ts` 23 (outcome 매핑 6케이스: 2xx/403+code/403/401/5xx/network + **Authorization 헤더 어서션**), `ide-editor-annotation-ui.test.ts` 8 (arm/pending/deleted/rejected-disarm/reject/switch-disarm/away-and-back/in-flight-switch), `ide-editor.test.ts`+`ide-shell.test.ts` 51
- `tsc --noEmit` clean, `eslint src` clean
- OCaml 1줄(`~code` 라벨 추가, `json_error`는 기존 `?code` 지원)은 dune CI Gate에서 검증

## 미검증

- 라이브 브라우저 e2e (서버 재기동 대기 — #23468 SSE 사망과 동일 조건)

RFC-WAIVED: dashboard IDE FE 슬라이스 + 서버 에러 바디 code 1줄 — RFC 게이트 대상 subsystem(credential/repo_manager/operator/hooks) 미접촉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
