### PR TITLE
feat(memory-os): recall echo no longer refreshes the truth anchor (RFC-0285 §8)

### DIFF
--- a/docs/rfc/RFC-0285-memory-os-self-observation-claim-volatility.md
+++ b/docs/rfc/RFC-0285-memory-os-self-observation-claim-volatility.md
@@ -125,3 +125,62 @@ The first draft proposed `self_observation_horizon_of_claim : claim -> bool`, a 
 - **(Low) Horizon length**: set `self_observation_ttl_seconds` shorter than 86_400, or equal? Shorter quiets the echo faster but risks dropping a legitimate short-lived self-state.
 - **(Low) Legacy durable rows**: the code fix does not retrofit a horizon onto existing `valid_until = None` self-observation rows (reobserve inherits `existing` whole). Removal is via the §5 cleanup only. Alternative: have reobserve take `min(existing, incoming) valid_until` to self-heal legacy rows — but that complicates the "inherit anchor, no reset" invariant. Pure-inherit is recommended (cleanup is already separate).
 - **(Low) `Unknown of string` escape on `claim_kind`**: add only if a round-trip drift-guard requires it; if added, pin to durable routing by test.
+
+## 8. Addendum (2026-07-07): echo anchor suppression — closing §7's mistag gap structurally
+
+**Status**: implemented alongside this addendum (task-1857).
+
+§7 (High) accepted that a librarian mistag "degrades to pre-RFC status quo (safe)".
+Keeper albini falsified the "safe" half: the librarian *affirmatively* tagged
+self-referential inaction doctrine ("zero tool calls, one short line" and 80
+sibling rows, 81/316 of the store) as `durable_knowledge`, so the §3 layers never
+engaged. The flywheel that resulted is one line of policy: `reobserve_fact`
+advanced `last_verified_at` on every librarian re-extraction, recall ranks by
+that anchor, and recall had *injected the same claim into the very window the
+librarian summarized* — so injection → restatement → re-extraction → anchor
+refresh → re-injection. A fact could hold its recall slot indefinitely,
+independent of truth and immune to every claim_kind-keyed defense, because the
+mistagged kind routed it to the anchor-refreshing arm.
+
+The §8 fix is structural and content-blind — it does not read the claim, so no
+mistag can route around it:
+
+- **`reobservation_provenance`** (closed sum in `keeper_memory_os_policy.ml`):
+  `Independent_observation | Recalled_echo`. `reobserve_fact` takes it as a
+  required argument; a `Recalled_echo` inherits the row whole, for every
+  `claim_kind`. Not an optional flag: no call site can skip the judgment and
+  silently default to anchor refresh.
+- **`Keeper_recall_injection_window`** (new, in-memory): recall's
+  `render_if_enabled` notes the injected `claim_identity` keys per keeper per
+  turn (bounded to `window_turns = 32`, over-approximating the librarian slice
+  span). This is deliberately NOT the RFC-0264 ledger, whose contract is
+  telemetry-only/never-read-on-decision-paths; the window is the load-bearing
+  read model. Lost window (restart) degrades to the pre-§8 status quo, never to
+  wrong suppression.
+- **Write-boundary join** (`keeper_librarian_runtime.ml`): before folding each
+  incoming claim, join its `claim_identity` against the window; injected ⇒
+  `Recalled_echo` (+ `masc_keeper_memory_os_reobserve_echo_suppressed_total`
+  counter, labelled by keeper), else `Independent_observation`.
+
+Resulting dynamics: a fact that recall keeps injecting can no longer sustain its
+own recency — its anchor freezes, the staleness marker appears after the §"one
+day" horizon, fresher independently-observed facts outrank it, and it rotates
+out of the recall window. Once it has been out of the window for
+`window_turns`, a genuinely independent re-derivation (from real work, not from
+reading the prompt) refreshes the anchor again. Growth stays possible; only
+self-sustained doctrine decays.
+
+Known limits (stated, not hidden):
+- A *reworded* echo with no stable `claim_id` produces a different
+  `normalize_claim` identity and appends as a new row (fresh anchor) — the same
+  append-path residual as §3.2(b); L1(b)'s stable-id discipline is the
+  mitigation, and the observed albini rows were verbatim re-mints, which §8
+  does catch.
+- A legitimate re-verification that the keeper performs *while the fact is
+  still being injected* is also suppressed (indistinguishable from echo by
+  identity alone). The anchor then refreshes only after rotation — one
+  recall-cycle of delay, bounded by `window_turns`. Typed re-verification
+  evidence (tool-outcome-backed) would lift this; out of scope here.
+- Existing on-disk doctrine rows keep their current anchors; §8 stops the
+  *refresh*, so they age out from now rather than being retroactively decayed
+  (§5 cleanup posture unchanged).

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -638,17 +638,38 @@ let extract_and_append_with_provider_classified
        call applies the RFC-0239 Q4 retention cap (ranked by the structural
        [retention_rank]) in one atomic rewrite. Only after the facts are durable
        do we publish the episode file and append the event row; the event row is
-       the reader-visible commit marker for [read_episodes_tail]. *)
+       the reader-visible commit marker for [read_episodes_tail].
+
+       RFC-0285 §8: before folding, decide each claim's provenance. A claim
+       whose identity was recall-injected into this keeper's recent prompts is
+       an echo — the model restating what it just read — and must not advance
+       the truth anchor recall's recency ranking reads. The judgment (window
+       join + metric) lives here at the write boundary; the fold itself stays
+       a pure function of the decision. *)
     Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun () ->
       match
         try
           let window = Keeper_memory_os_io.fact_recall_window in
+          let merge ~existing ~incoming =
+            let provenance =
+              let key = Keeper_memory_os_types.claim_identity incoming in
+              if Keeper_recall_injection_window.recently_injected ~keeper_id ~key
+              then (
+                Otel_metric_store.inc_counter
+                  Keeper_metrics.(to_string MemoryOsReobserveEchoSuppressed)
+                  ~labels:[ "keeper", keeper_id ]
+                  ();
+                Keeper_memory_os_policy.Recalled_echo)
+              else Keeper_memory_os_policy.Independent_observation
+            in
+            Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
+          in
           let (_ : Keeper_memory_os_io.fact_merge_stats) =
             File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
               Keeper_memory_os_io.merge_and_cap_facts
                 ~now
                 ~keeper_id
-                ~merge:(Keeper_memory_os_policy.reobserve_fact ~now)
+                ~merge
                 ~incoming:episode.Keeper_memory_os_types.claims
                 ~keep:window
                 ~trigger:Keeper_memory_os_io.fact_store_max

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -48,6 +48,15 @@ let retention_rank ~now (f : fact) =
   tier +. recency
 ;;
 
+(* RFC-0285 §8: how the re-observed claim reached the librarian. The write
+   boundary decides this once (the production caller joins the incoming claim's
+   identity against [Keeper_recall_injection_window]); the policy below is a
+   pure function of the decision. A closed sum — not an optional flag — so no
+   call site can skip the judgment and silently default to anchor refresh. *)
+type reobservation_provenance =
+  | Independent_observation
+  | Recalled_echo
+
 (* RFC-0247 (purge): fold a re-observation of an existing fact into that fact.
    [existing] is the persisted row; [incoming] is the newly extracted claim with
    the same producer identity. Identity and first-seen provenance are preserved.
@@ -59,25 +68,37 @@ let retention_rank ~now (f : fact) =
    The prior merge also blended a confidence float and bumped an access counter;
    both fed the deleted composite score and are gone. There is no numeric
    strength to move — re-observation is a binary "seen again now". *)
-let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
-  match existing.claim_kind with
-  | Some Self_observation ->
-    (* RFC-0285 §3.3: inherit the prior row; do NOT advance
-       [last_verified_at]. The librarian re-extracting a recalled
-       self-observation is not re-verification; it is the same self-narrative
-       re-emitted from memory. *)
+let reobserve_fact ~now ~provenance ~existing ~incoming:(_ : fact) =
+  match provenance with
+  | Recalled_echo ->
+    (* RFC-0285 §8: the claim was recall-injected into the very window the
+       librarian summarized. Restating what the prompt just said is an echo of
+       stored memory, not re-verification — under the pre-§8 rule an echo
+       advanced [last_verified_at], which kept the fact at the top of the
+       recency-ranked recall window, which caused the next echo: a fact could
+       sustain its own recall slot indefinitely. Inherit the row whole; the
+       anchor advances only through independent re-observation after the fact
+       rotates out of the recall window. *)
     existing
-  | Some External_state ->
-    (* RFC-0259 P7: do not advance [last_verified_at] on mere re-assertion, but
-       do materialize the compatibility-derived horizon for legacy rows whose
-       on-disk [valid_until] was absent before P7. The anchor remains
-       [first_seen], not [now], so re-observation cannot extend stale external
-       state. *)
-    { existing with valid_until = fact_effective_valid_until existing }
-  | Some Durable_knowledge | Some Diagnostic | None ->
-    (* Durable/diagnostic re-observe: re-asserting a timeless claim from fresh
-       context is enough to advance the staleness marker. *)
-    { existing with last_verified_at = Some now }
+  | Independent_observation ->
+    (match existing.claim_kind with
+     | Some Self_observation ->
+       (* RFC-0285 §3.3: inherit the prior row; do NOT advance
+          [last_verified_at]. The librarian re-extracting a recalled
+          self-observation is not re-verification; it is the same self-narrative
+          re-emitted from memory. *)
+       existing
+     | Some External_state ->
+       (* RFC-0259 P7: do not advance [last_verified_at] on mere re-assertion, but
+          do materialize the compatibility-derived horizon for legacy rows whose
+          on-disk [valid_until] was absent before P7. The anchor remains
+          [first_seen], not [now], so re-observation cannot extend stale external
+          state. *)
+       { existing with valid_until = fact_effective_valid_until existing }
+     | Some Durable_knowledge | Some Diagnostic | None ->
+       (* Durable/diagnostic re-observe: re-asserting a timeless claim from fresh
+          context is enough to advance the staleness marker. *)
+       { existing with last_verified_at = Some now })
 ;;
 
 let events_to_facts_ratio_attention_threshold = 2.0

--- a/lib/keeper/keeper_memory_os_policy.mli
+++ b/lib/keeper/keeper_memory_os_policy.mli
@@ -46,12 +46,33 @@ val recall_episode_tail_scan : int
     decide which rows the size cap drops, never to rank recall. *)
 val retention_rank : now:float -> fact -> float
 
-(** Fold a re-observation of an existing fact into that fact: the only effect is
-    to refresh [last_verified_at] to [now] (re-extraction is fresh evidence the
-    claim still holds). Identity and first-seen provenance are preserved. The
-    prior confidence-blend and access-count bump fed the deleted score and are
-    gone — there is no numeric strength to move. *)
-val reobserve_fact : now:float -> existing:fact -> incoming:fact -> fact
+(** Provenance of a re-observation reaching {!reobserve_fact} (RFC-0285 §8).
+    [Recalled_echo] means the incoming claim's identity was recall-injected
+    into the conversation window the librarian summarized — the model restated
+    its own prompt, which is not fresh evidence. The write boundary decides
+    this once (the production caller joins against
+    {!Keeper_recall_injection_window.recently_injected}); tests exercising the
+    legacy semantics pass [Independent_observation]. A closed sum rather than
+    an optional flag so no call site can skip the judgment. *)
+type reobservation_provenance =
+  | Independent_observation
+  | Recalled_echo
+
+(** Fold a re-observation of an existing fact into that fact: for an
+    [Independent_observation] the only effect is to refresh [last_verified_at]
+    to [now] (re-extraction is fresh evidence the claim still holds). For a
+    [Recalled_echo] the row is inherited whole — an echo must never advance the
+    truth anchor that recall's recency ranking reads, or a fact can sustain its
+    own recall slot indefinitely (the RFC-0285 §8 flywheel). Identity and
+    first-seen provenance are preserved in both cases. The prior
+    confidence-blend and access-count bump fed the deleted score and are gone —
+    there is no numeric strength to move. *)
+val reobserve_fact
+  :  now:float
+  -> provenance:reobservation_provenance
+  -> existing:fact
+  -> incoming:fact
+  -> fact
 
 (** Diagnostic attention threshold for the dashboard's events:fact byte ratio.
     This is not a pruning or recall-ranking policy; it only marks stores whose

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -424,6 +424,14 @@ let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
     match String.trim result.block with
     | "" -> None
     | block ->
+      (* RFC-0285 §8: record what this turn's prompt actually contains so the
+         librarian write path can tell a recalled echo from an independent
+         re-observation. This in-memory window is the load-bearing counterpart
+         of the append-only ledger below (which stays telemetry-only). *)
+      Keeper_recall_injection_window.note
+        ~keeper_id
+        ~turn
+        ~keys:result.injected_fact_keys;
       Keeper_recall_injection_ledger.append
         ?failure_reason:(Option.map unavailable_reason_to_label result.failure_reason)
         ~masc_root

--- a/lib/keeper/keeper_recall_injection_window.ml
+++ b/lib/keeper/keeper_recall_injection_window.ml
@@ -1,0 +1,37 @@
+(** Keeper_recall_injection_window — see the interface for the contract. *)
+
+let window_turns = 32
+
+type entry =
+  { turn : int
+  ; keys : string list
+  }
+
+(* Guarded by [mu]. Keyed by keeper_id; each list is newest-first and bounded
+   by the prune in [note] (at most [window_turns] entries per keeper). *)
+let mu = Stdlib.Mutex.create ()
+let table : (string, entry list) Hashtbl.t = Hashtbl.create 16
+
+let note ~keeper_id ~turn ~keys =
+  match keys with
+  | [] -> ()
+  | _ ->
+    Stdlib.Mutex.protect mu (fun () ->
+      let prior =
+        Option.value (Hashtbl.find_opt table keeper_id) ~default:[]
+      in
+      let kept =
+        List.filter
+          (fun entry -> entry.turn < turn && turn - entry.turn < window_turns)
+          prior
+      in
+      Hashtbl.replace table keeper_id ({ turn; keys } :: kept))
+;;
+
+let recently_injected ~keeper_id ~key =
+  Stdlib.Mutex.protect mu (fun () ->
+    match Hashtbl.find_opt table keeper_id with
+    | None -> false
+    | Some entries ->
+      List.exists (fun entry -> List.exists (String.equal key) entry.keys) entries)
+;;

--- a/lib/keeper/keeper_recall_injection_window.ml
+++ b/lib/keeper/keeper_recall_injection_window.ml
@@ -17,7 +17,12 @@ let note ~keeper_id ~turn ~keys =
   | [] -> ()
   | _ ->
     Stdlib.Mutex.protect mu (fun () ->
+      (* Absence of a table entry IS the fact "no injections recorded for
+         this keeper yet" — the empty window — not an unknown input being
+         silently accepted. The .mli contract states unknown keepers and
+         lost (restarted) windows answer as empty. *)
       let prior =
+        (* DET-OK: empty window is the deterministic absence value. *)
         Option.value (Hashtbl.find_opt table keeper_id) ~default:[]
       in
       let kept =

--- a/lib/keeper/keeper_recall_injection_window.mli
+++ b/lib/keeper/keeper_recall_injection_window.mli
@@ -1,0 +1,39 @@
+(** Keeper_recall_injection_window — in-process record of which fact identities
+    Memory OS recall injected into a keeper's recent prompts.
+
+    Write side: {!Keeper_memory_os_recall.render_if_enabled} notes the injected
+    [claim_identity] keys after each non-empty render. Read side: the librarian
+    write path (RFC-0285 §8) asks {!recently_injected} before treating a
+    re-extracted claim as an independent re-observation — a claim the keeper
+    just re-read from its own recall block is an echo of stored memory, not
+    fresh evidence, so it must not advance the fact's truth anchor.
+
+    This is deliberately separate from {!Keeper_recall_injection_ledger}: the
+    ledger is an append-only telemetry artifact whose contract says it is never
+    read on any decision path; this window is the load-bearing read model, kept
+    in memory so a lost window degrades to the pre-RFC-0285-§8 status quo
+    (anchor refresh on echo) rather than to wrong suppression.
+
+    Properties:
+    - In-memory only. A server restart empties the window; the first librarian
+      run after a restart may refresh anchors it would otherwise suppress.
+    - Bounded per keeper: entries older than {!window_turns} turns (or from a
+      reset turn numbering) are dropped on the next {!note}.
+    - Tests isolate by [keeper_id]; there is no reset entry point. *)
+
+val window_turns : int
+(** How many turns an injection record stays visible to {!recently_injected}.
+    Chosen to over-approximate the librarian's episode slice span (cadence 3,
+    compaction slices somewhat longer): a claim injected anywhere in the window
+    the librarian may summarize counts as an echo. Over-approximation costs one
+    skipped anchor refresh; under-approximation re-opens the echo loop. *)
+
+val note : keeper_id:string -> turn:int -> keys:string list -> unit
+(** Record the [claim_identity] keys recall injected for [keeper_id] at [turn].
+    Re-noting the same turn replaces that turn's entry. [keys = []] is a no-op.
+    Entries from turns newer than [turn] (a reset turn numbering) and entries
+    older than {!window_turns} are pruned. *)
+
+val recently_injected : keeper_id:string -> key:string -> bool
+(** Whether [key] was injected into [keeper_id]'s prompt within the retained
+    window. Unknown keepers and lost (restarted) windows answer [false]. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -237,6 +237,7 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
+  | MemoryOsReobserveEchoSuppressed
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -518,6 +519,8 @@ let to_string = function
       "masc_keeper_memory_recall_read_errors_total"
   | MemoryOsRecallUnavailable ->
       "masc_keeper_memory_os_recall_unavailable_total"
+  | MemoryOsReobserveEchoSuppressed ->
+      "masc_keeper_memory_os_reobserve_echo_suppressed_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"
@@ -609,7 +612,7 @@ let all : t list =
     TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
     DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
-    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; RuntimeHttpProbeJsonParseFailures;
+    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; MemoryOsReobserveEchoSuppressed; RuntimeHttpProbeJsonParseFailures;
     VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
     KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;
     GhClassificationTotal; GatedGhLifecycleTotal; GatedGhBlockTimeSeconds;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -228,6 +228,7 @@ type t =
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
+  | MemoryOsReobserveEchoSuppressed
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/test/dune
+++ b/test/dune
@@ -32,6 +32,7 @@
   test_keeper_lifecycle_global_gate
   test_keeper_memory_os_io_fd
   test_keeper_memory_os_external_state_decay
+  test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane
@@ -383,6 +384,7 @@
   test_keeper_lifecycle_global_gate
   test_keeper_memory_os_io_fd
   test_keeper_memory_os_external_state_decay
+  test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -318,7 +318,7 @@ let scenario_truth_anchor_refresh () =
       Memory_io.merge_and_cap_facts
         ~now:later
         ~keeper_id:kid
-        ~merge:(Policy.reobserve_fact ~now:later)
+        ~merge:(Policy.reobserve_fact ~now:later ~provenance:Policy.Independent_observation)
         ~incoming
         ~keep:window
         ~trigger:(window + (window / 2))

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2340,7 +2340,7 @@ let test_gc_waits_for_fact_writer_lock () =
           Memory_io.merge_and_cap_facts
             ~now
             ~keeper_id
-            ~merge:(Policy.reobserve_fact ~now)
+            ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
             ~incoming:[ fresh ]
             ~keep:Policy.fact_recall_window
             ~trigger:fact_store_trigger
@@ -2658,7 +2658,7 @@ let test_recall_scans_whole_bounded_store () =
           Memory_io.merge_and_cap_facts
             ~now
             ~keeper_id
-            ~merge:(Policy.reobserve_fact ~now)
+            ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
             ~incoming:(head :: cap_fillers)
             ~keep:Policy.fact_recall_window
             ~trigger:Policy.fact_store_max
@@ -3165,7 +3165,7 @@ let test_merge_and_cap_drops_expired_no_incoming () =
       Memory_io.merge_and_cap_facts
         ~now
         ~keeper_id
-        ~merge:(Policy.reobserve_fact ~now)
+        ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
         ~incoming:[]
         ~keep:Policy.fact_recall_window
         ~trigger:Policy.fact_store_max
@@ -3489,7 +3489,7 @@ let test_reobserve_fact_refreshes_truth_anchor () =
     }
   in
   let incoming = { existing with Types.last_verified_at = Some now } in
-  let merged = Policy.reobserve_fact ~now ~existing ~incoming in
+  let merged = Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation ~existing ~incoming in
   Alcotest.(check (option (float 1e-9)))
     "last_verified_at refreshed to now"
     (Some now)
@@ -3525,7 +3525,7 @@ let test_merge_and_cap_upserts_reobserved_claim () =
       Memory_io.merge_and_cap_facts
         ~now
         ~keeper_id
-        ~merge:(Policy.reobserve_fact ~now)
+        ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
         ~incoming:[ reobserved ]
         ~keep:Policy.fact_recall_window
         ~trigger:Policy.fact_store_max
@@ -3562,7 +3562,7 @@ let test_merge_and_cap_appends_distinct_and_caps () =
       Memory_io.merge_and_cap_facts
         ~now
         ~keeper_id
-        ~merge:(Policy.reobserve_fact ~now)
+        ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
         ~incoming:[ mk 1; mk 2; mk 3 ]
         ~keep:2
         ~trigger:2
@@ -4481,7 +4481,7 @@ let test_self_observation_horizon_and_remint () =
      row entirely, so the horizon is not pushed past the original anchor. *)
   let later = now +. 1_800.0 in
   let incoming = mk_self ~first_seen:later () in
-  let merged = Policy.reobserve_fact ~now:later ~existing ~incoming in
+  let merged = Policy.reobserve_fact ~now:later ~provenance:Policy.Independent_observation ~existing ~incoming in
   Alcotest.(check (option (float 0.001)))
     "re-mint does not extend the self-observation horizon past the first anchor"
     existing.Types.valid_until
@@ -4888,7 +4888,7 @@ let test_merge_and_cap_upserts_same_claim_id () =
       Memory_io.merge_and_cap_facts
         ~now
         ~keeper_id
-        ~merge:(Policy.reobserve_fact ~now)
+        ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
         ~incoming:[ reworded ]
         ~keep:Policy.fact_recall_window
         ~trigger:Policy.fact_store_max
@@ -4938,7 +4938,7 @@ let test_merge_and_cap_no_over_merge_distinct_conclusions () =
       Memory_io.merge_and_cap_facts
         ~now
         ~keeper_id
-        ~merge:(Policy.reobserve_fact ~now)
+        ~merge:(Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation)
         ~incoming:[ merged ]
         ~keep:Policy.fact_recall_window
         ~trigger:Policy.fact_store_max
@@ -4963,7 +4963,7 @@ let test_reobserve_advances_durable_anchor () =
     }
   in
   let incoming = { existing with Types.last_verified_at = Some now } in
-  let reobserved = Policy.reobserve_fact ~now ~existing ~incoming in
+  let reobserved = Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation ~existing ~incoming in
   Alcotest.(check (option (float 1e-9)))
     "durable claim's last_verified_at advances to now"
     (Some now)
@@ -5004,7 +5004,7 @@ let test_reobserve_external_ref_refreshes_like_context () =
   in
   (* incoming is a reworded re-extraction of the same referent claim *)
   let incoming = { existing with Types.claim = "pull request #42 remains open" } in
-  let reobserved = Policy.reobserve_fact ~now ~existing ~incoming in
+  let reobserved = Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation ~existing ~incoming in
   Alcotest.(check (float 0.001))
     "first_seen inherited (not advanced to now)"
     older

--- a/test/test_keeper_memory_os_external_state_decay.ml
+++ b/test/test_keeper_memory_os_external_state_decay.ml
@@ -108,7 +108,7 @@ let test_reobserve_external_state_does_not_bump () =
       ~last_verified_at:stale_lv ()
   in
   let incoming = fact ~claim_kind:(Some Types.External_state) ~category:Types.Blocker () in
-  let merged = Policy.reobserve_fact ~now ~existing ~incoming in
+  let merged = Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation ~existing ~incoming in
   check (option (float 0.001))
     "External_state last_verified_at unchanged by re-observation" stale_lv
     merged.Types.last_verified_at;
@@ -120,7 +120,7 @@ let test_reobserve_external_state_does_not_bump () =
     fact ~claim_kind:(Some Types.Durable_knowledge) ~category:Types.Lesson
       ~last_verified_at:stale_lv ()
   in
-  let dk_merged = Policy.reobserve_fact ~now ~existing:dk ~incoming:dk in
+  let dk_merged = Policy.reobserve_fact ~now ~provenance:Policy.Independent_observation ~existing:dk ~incoming:dk in
   check (option (float 0.001))
     "Durable_knowledge last_verified_at advances to now" (Some now)
     dk_merged.Types.last_verified_at

--- a/test/test_keeper_memory_os_recall_echo.ml
+++ b/test/test_keeper_memory_os_recall_echo.ml
@@ -1,0 +1,206 @@
+(** RFC-0285 §8 — recall echo must not refresh the truth anchor.
+
+    The flywheel this closes: recall injects a fact into the prompt every turn
+    (top-N by truth-anchor recency); the model restates it; the librarian
+    re-extracts the restatement; [reobserve_fact] treated that as fresh
+    evidence and advanced [last_verified_at]; the advanced anchor kept the fact
+    at the top of the recency-ranked recall window — so a fact could sustain
+    its own recall slot indefinitely regardless of truth (observed: keeper
+    albini, 81/316 rows of self-referential inaction doctrine re-injected every
+    turn for days). §8 classifies each re-observation at the write boundary:
+    a claim whose identity was recall-injected into the summarized window is a
+    [Recalled_echo] and inherits the row whole. *)
+
+open Alcotest
+
+module Types = Masc.Keeper_memory_os_types
+module Policy = Masc.Keeper_memory_os_policy
+module Window = Masc.Keeper_recall_injection_window
+
+let now = 2_000_000.0
+
+let fact ?(claim = "keeper must do zero tool calls and emit one short line")
+    ?(claim_id = None) ?(claim_kind = None) ?(category = Types.Lesson)
+    ?(last_verified_at = Some (now -. 3_600.0)) () : Types.fact =
+  { Types.claim
+  ; Types.category
+  ; Types.external_ref = None
+  ; Types.claim_kind
+  ; Types.source = { Types.trace_id = "trace-echo"; Types.turn = 58; Types.tool_call_id = None }
+  ; Types.observed_by = []
+  ; Types.first_seen = now -. 86_400.0
+  ; Types.valid_until = None
+  ; Types.last_verified_at
+  ; Types.schema_version = Types.schema_version
+  ; Types.claim_id
+  }
+;;
+
+(* 1. The core anchor property: an echoed re-observation of a durable claim
+   inherits the row whole — [last_verified_at] does not advance — while an
+   independent re-observation of the same rows still advances it. *)
+let test_echo_does_not_advance_truth_anchor () =
+  let stale = Some (now -. 3_600.0) in
+  let existing = fact ~last_verified_at:stale () in
+  let incoming = fact () in
+  let echoed =
+    Policy.reobserve_fact ~now ~provenance:Policy.Recalled_echo ~existing ~incoming
+  in
+  check (option (float 0.001)) "echo: last_verified_at unchanged" stale
+    echoed.Types.last_verified_at;
+  check (option (float 0.001)) "echo: valid_until unchanged" None
+    echoed.Types.valid_until;
+  let independent =
+    Policy.reobserve_fact
+      ~now
+      ~provenance:Policy.Independent_observation
+      ~existing
+      ~incoming
+  in
+  check (option (float 0.001)) "independent: last_verified_at advances" (Some now)
+    independent.Types.last_verified_at
+;;
+
+(* 2. Echo inheritance is uniform across claim_kinds: the arms that already
+   preserved the anchor (Self_observation, External_state) keep doing so, and
+   Durable_knowledge — the arm the albini flywheel ran through, because the
+   librarian affirmatively mistagged inaction doctrine as durable — no longer
+   advances on echo. *)
+let test_echo_inherits_for_every_claim_kind () =
+  let stale = Some (now -. 3_600.0) in
+  List.iter
+    (fun claim_kind ->
+      let existing = fact ~claim_kind ~last_verified_at:stale () in
+      let incoming = fact ~claim_kind () in
+      let echoed =
+        Policy.reobserve_fact ~now ~provenance:Policy.Recalled_echo ~existing ~incoming
+      in
+      check (option (float 0.001)) "echo inherits anchor for every claim_kind" stale
+        echoed.Types.last_verified_at)
+    [ None
+    ; Some Types.Durable_knowledge
+    ; Some Types.Self_observation
+    ; Some Types.External_state
+    ; Some Types.Diagnostic
+    ]
+;;
+
+(* 3. Window membership: keys noted for a keeper are visible to that keeper
+   only, and only within [window_turns]. *)
+let test_window_membership_and_isolation () =
+  let keeper_id = "echo-test-membership" in
+  let other_id = "echo-test-membership-other" in
+  Window.note ~keeper_id ~turn:100 ~keys:[ "id:self-obs-idle-loop"; "claim:zero tool calls" ];
+  check bool "noted key is recently injected" true
+    (Window.recently_injected ~keeper_id ~key:"id:self-obs-idle-loop");
+  check bool "unknown key is not" false
+    (Window.recently_injected ~keeper_id ~key:"id:something-else");
+  check bool "other keeper does not see the key" false
+    (Window.recently_injected ~keeper_id:other_id ~key:"id:self-obs-idle-loop")
+;;
+
+(* 4. Pruning: an entry older than [window_turns] is dropped on the next note;
+   a turn-numbering reset (new turn lower than stored turns) also drops stale
+   entries instead of letting a dead numbering suppress forever. *)
+let test_window_prunes_old_and_reset_entries () =
+  let keeper_id = "echo-test-prune" in
+  Window.note ~keeper_id ~turn:10 ~keys:[ "claim:old entry" ];
+  Window.note ~keeper_id ~turn:(10 + Window.window_turns) ~keys:[ "claim:new entry" ];
+  check bool "entry beyond window_turns is pruned" false
+    (Window.recently_injected ~keeper_id ~key:"claim:old entry");
+  check bool "fresh entry survives" true
+    (Window.recently_injected ~keeper_id ~key:"claim:new entry");
+  let keeper_id = "echo-test-reset" in
+  Window.note ~keeper_id ~turn:500 ~keys:[ "claim:pre-reset" ];
+  Window.note ~keeper_id ~turn:3 ~keys:[ "claim:post-reset" ];
+  check bool "entries from a reset numbering are pruned" false
+    (Window.recently_injected ~keeper_id ~key:"claim:pre-reset");
+  check bool "post-reset entry visible" true
+    (Window.recently_injected ~keeper_id ~key:"claim:post-reset")
+;;
+
+(* 5. Empty keys are a no-op and re-noting a turn replaces that turn's entry. *)
+let test_window_empty_noop_and_same_turn_replace () =
+  let keeper_id = "echo-test-replace" in
+  Window.note ~keeper_id ~turn:7 ~keys:[];
+  check bool "empty note stores nothing" false
+    (Window.recently_injected ~keeper_id ~key:"claim:anything");
+  Window.note ~keeper_id ~turn:8 ~keys:[ "claim:first render" ];
+  Window.note ~keeper_id ~turn:8 ~keys:[ "claim:second render" ];
+  check bool "same-turn re-note replaces the entry" false
+    (Window.recently_injected ~keeper_id ~key:"claim:first render");
+  check bool "replacement entry visible" true
+    (Window.recently_injected ~keeper_id ~key:"claim:second render")
+;;
+
+(* 6. The write-boundary composition the librarian uses: joining the incoming
+   claim's identity against the window yields Recalled_echo exactly for
+   injected identities, and the [claim_identity] key matches whether the
+   identity comes from a producer claim_id or the normalized claim text. *)
+let test_write_boundary_join () =
+  let keeper_id = "echo-test-join" in
+  let with_id = fact ~claim_id:(Some "self-obs-idle-loop") () in
+  let by_text = fact ~claim:"board polling without new signals is waste" () in
+  Window.note
+    ~keeper_id
+    ~turn:42
+    ~keys:[ Types.claim_identity with_id; Types.claim_identity by_text ];
+  let provenance_of incoming =
+    if Window.recently_injected ~keeper_id ~key:(Types.claim_identity incoming)
+    then Policy.Recalled_echo
+    else Policy.Independent_observation
+  in
+  let is_echo p = match p with Policy.Recalled_echo -> true | _ -> false in
+  check bool "claim_id-keyed identity joins as echo" true (is_echo (provenance_of with_id));
+  check bool "text-keyed identity joins as echo" true (is_echo (provenance_of by_text));
+  let fresh = fact ~claim:"dune build failed on missing module alias" () in
+  check bool "un-injected claim stays independent" false (is_echo (provenance_of fresh))
+;;
+
+(* 7. Flywheel regression: simulate the inject -> restate -> re-extract loop.
+   Under the echo rule the anchor never advances across N cycles, so the fact
+   ages out of recency instead of self-sustaining. *)
+let test_flywheel_anchor_frozen_across_cycles () =
+  let keeper_id = "echo-test-flywheel" in
+  let anchor = Some (now -. 7_200.0) in
+  let existing = ref (fact ~claim_id:(Some "zero-tool-doctrine") ~last_verified_at:anchor ()) in
+  for cycle = 1 to 5 do
+    let turn = 200 + cycle in
+    Window.note ~keeper_id ~turn ~keys:[ Types.claim_identity !existing ];
+    let incoming = fact ~claim_id:(Some "zero-tool-doctrine") () in
+    let provenance =
+      if Window.recently_injected ~keeper_id ~key:(Types.claim_identity incoming)
+      then Policy.Recalled_echo
+      else Policy.Independent_observation
+    in
+    existing
+    := Policy.reobserve_fact
+         ~now:(now +. (60.0 *. float_of_int cycle))
+         ~provenance
+         ~existing:!existing
+         ~incoming
+  done;
+  check (option (float 0.001)) "anchor frozen across 5 echo cycles" anchor
+    !existing.Types.last_verified_at
+;;
+
+let () =
+  run
+    "keeper_memory_os_recall_echo"
+    [ ( "rfc-0285-s8"
+      , [ test_case "echo does not advance truth anchor" `Quick
+            test_echo_does_not_advance_truth_anchor
+        ; test_case "echo inherits for every claim_kind" `Quick
+            test_echo_inherits_for_every_claim_kind
+        ; test_case "window membership and isolation" `Quick
+            test_window_membership_and_isolation
+        ; test_case "window prunes old and reset entries" `Quick
+            test_window_prunes_old_and_reset_entries
+        ; test_case "window empty noop and same-turn replace" `Quick
+            test_window_empty_noop_and_same_turn_replace
+        ; test_case "write boundary join" `Quick test_write_boundary_join
+        ; test_case "flywheel anchor frozen across cycles" `Quick
+            test_flywheel_anchor_frozen_across_cycles
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What (task-1857)

Memory OS의 recall 메아리(echo)가 fact의 truth anchor를 갱신하지 못하게 만든다 — RFC-0285 §8 (본 PR에서 추가).

- `Keeper_memory_os_policy.reobservation_provenance` (closed sum): `Independent_observation | Recalled_echo`. `reobserve_fact`의 **필수 인자** — 어떤 호출자도 판단을 생략하고 anchor 갱신으로 조용히 기본값 탈 수 없음.
- 신규 `Keeper_recall_injection_window` (in-memory, keeper별 32턴 bounded): recall `render_if_enabled`가 주입한 `claim_identity` 키를 기록.
- librarian write boundary (`keeper_librarian_runtime.ml`): fold 전에 incoming claim의 identity를 윈도우와 조인 — 주입됐던 claim ⇒ `Recalled_echo`(행 전체 상속, anchor 동결) + `masc_keeper_memory_os_reobserve_echo_suppressed_total` counter, 아니면 `Independent_observation`(기존 동작).

## Why

keeper albini가 48시간 동안 사실상 무행동(173 turns → 8 artifacts, proactive chat 0건)이 된 근본원인 사슬:

1. recall이 truth-anchor recency 상위 8개 fact를 매 턴 프롬프트에 주입
2. 모델이 주입된 교리를 재진술 ("zero tool calls, one short line")
3. librarian이 재진술을 재추출 → `reobserve_fact`가 `last_verified_at = now`로 갱신 ("재진술 = 신선한 증거")
4. 갱신된 anchor가 그 fact를 recency 상위에 고정 → 1로 회귀

이 플라이휠은 claim_kind 기반 방어(RFC-0285 §3)를 전부 우회했다 — librarian이 교리를 `durable_knowledge`로 **적극 오태깅**했기 때문 (§7이 "safe degrade"로 수용한 리스크의 반증 실물: albini.facts.jsonl 316행 중 81행이 무행동 교리, 48h에 verbatim "0 tool calls" 한줄턴 36회). §8 fix는 **내용을 읽지 않는 구조적 규칙**이라 오태깅으로 우회 불가: "프롬프트에 주입된 claim의 재진술은 검증이 아니다".

RFC-0264 ledger를 재사용하지 않고 별도 in-memory 윈도우를 둔 이유: ledger 계약이 "decision path에서 절대 읽지 않는 telemetry 전용"이며, 윈도우 유실(재시작)은 §8 이전 status quo로만 강등되고 잘못된 억제로는 강등되지 않는 fail-degrade 방향이 필요해서다.

## Verification

- 신규 `test/test_keeper_memory_os_recall_echo.ml` 7 tests: anchor 동결(echo)/갱신(independent), claim_kind 전수 상속, 윈도우 membership·격리·prune(윈도우 초과+turn 리셋)·same-turn replace·empty noop, write-boundary 조인(claim_id 키/텍스트 키), 5-cycle 플라이휠 회귀(anchor 동결) — **7/7 OK**
- 기존 `test_keeper_memory_os_external_state_decay` **5/5 OK** (Self_observation/External_state arm 동작 불변)
- `dune build --root . lib/keeper_metrics lib/keeper test/...` exit 0
- 기존 `reobserve_fact` 호출부 14곳(테스트) 전부 `~provenance:Independent_observation`으로 명시 갱신

## Known limits (RFC-0285 §8에 명시)

- reworded echo + stable claim_id 부재 시 append 경로로 신규 행 생성 가능 (§3.2(b) 기존 잔여와 동일, albini 실측은 verbatim re-mint라 §8이 잡음)
- 주입 중인 fact의 정당한 재검증도 rotation 전까지 anchor 갱신이 지연됨 (typed re-verification evidence는 후속 과제)
- 기존 on-disk 교리 행은 소급 decay 없음 — 운영 정리는 별도 수행됨 (albini.facts.jsonl 57행 백업 후 제거, `.bak-echo-purge-20260707`)

## Notes

- CI: main red(#23524의 keeper_pacing_shadow 타입 에러)는 별도 PR #23536이 수정. 본 브랜치는 해당 fix 머지 후 rebase 예정.
- Related: RFC-0285 (§8 addendum 포함), RFC-0264 (ledger 경계), RFC-0247/0243 (upsert/anchor 의미론), task-1857.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
