### PR TITLE
fix: unbreak main — 3 merge-before-green compile reds (pacing_shadow + board test)

### DIFF
--- a/lib/board_tool_adapter/dune
+++ b/lib/board_tool_adapter/dune
@@ -12,9 +12,10 @@
  (name board_tool_adapter)
  (public_name masc.board_tool_adapter)
  (wrapped false)
+ ;; board_claim_gate is not private: test_tool_board_coverage exercises its
+ ;; resolve_file_path / artifact_resolution surface directly (#23525).
  (private_modules
   board_tool_cache
-  board_claim_gate
   board_tool_curation
   board_tool_handlers
   board_tool_post

--- a/lib/keeper/keeper_pacing_shadow.ml
+++ b/lib/keeper/keeper_pacing_shadow.ml
@@ -3,7 +3,10 @@
 let mu = Eio.Mutex.create ()
 let table : (string, Keeper_pacing.t) Hashtbl.t = Hashtbl.create 64
 
-let observed_runtime_ids state = List.map fst state
+(* [Keeper_pacing.t] is abstract; the observed runtime ids come from its
+   observability projection. #23524 landed this helper reading [state] as a
+   bare assoc list, which does not typecheck against the abstract [t]. *)
+let observed_runtime_ids state = List.map fst (Keeper_pacing.to_summary state)
 
 let next_due_remaining_of_state ~now state =
   match observed_runtime_ids state with

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1,5 +1,12 @@
 module Types = Masc_domain
 
+(* [Board_paths] lives in the wrapped [masc.board_handlers] library, so
+   [open Masc] does not bring it into scope. [Board_claim_gate] is in the
+   unwrapped [masc.board_tool_adapter] library (accessible bare once removed
+   from that library's private_modules — see its dune). #23525 added bare
+   references to both without this alias / visibility fix, breaking the build. *)
+module Board_paths = Masc_board_handlers.Board_paths
+
 open Masc
 
 (** {1 Test helpers} *)


### PR DESCRIPTION
## 목적

main(972f9304ab)의 3개 컴파일 red를 복구합니다. 전부 merge-before-green — PR 빌드가 머지 시 cancel돼 main에서 처음 발현됐습니다.

## 3개 red + fix

| # | 파일 | 원인 | fix |
|---|---|---|---|
| 1 | `lib/keeper/keeper_pacing_shadow.ml:6` | #23524(RFC-0313 W3)가 `observed_runtime_ids`를 추가하며 abstract `Keeper_pacing.t`를 assoc list처럼 `List.map fst` | `List.map fst (Keeper_pacing.to_summary state)` — 공개 projection 경유 |
| 2 | `test/test_tool_board_coverage.ml:2226,2242` | #23525가 `Board_paths.board_base_path` bare 참조 추가. `Board_paths`는 wrapped `masc.board_handlers` 소속이라 `open Masc`로 안 보임 | `module Board_paths = Masc_board_handlers.Board_paths` alias |
| 3 | `test/test_tool_board_coverage.ml:2231+` | #23525가 `Board_claim_gate`를 test에서 참조하나, 이 모듈이 `board_tool_adapter`의 `private_modules`라 외부 접근 불가 | dune `private_modules`에서 `board_claim_gate` 제거 (test가 검증 대상으로 삼는 public surface) |

## 검증

- `dune build @check` clean (세 red 모두 해소, 다른 red 없음).
- 순수 복구 — 기능 변경 0. #23524/#23525의 의도(pacing shadow telemetry, claim-gate digest test)를 살리는 방향.

## 근거

merge-before-green 누적. required check(CI Gate)가 aggregate라 개별 PR red여도 머지됨 (enforce_admins:false). 이번 세션 다수 관측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
