### PR TITLE
fix(test): reference board base path via public Board_core alias — unbreak main

### DIFF
--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2217,13 +2217,15 @@ let test_resolve_file_path_records_content_digest () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  (* Create a real artifact at the exact path [resolve_file_path] computes (via
-     [Board_paths.board_base_path]), so the test is robust to whatever the
-     harness sets as base_path. Before [digest_of_file], the Exists arm returned
-     [digest=None] — "evidence" meant only "any file under the base existed". *)
+  (* Create a real artifact at the exact path [resolve_file_path] computes.
+     [Board_core.board_base_path] is the public alias of the gate's internal
+     [Board_paths.board_base_path] (a wrapped-library module the test cannot
+     name), so the test is robust to whatever the harness sets as base_path.
+     Before [digest_of_file], the Exists arm returned [digest=None] —
+     "evidence" meant only "any file under the base existed". *)
   let artifact_rel = Filename.concat Common.masc_dirname "claim_gate_digest_fixture.ml" in
   let artifact_content = "let proof = \"digest-fixture-v1\"\n" in
-  let artifact_path = Filename.concat (Board_paths.board_base_path ()) artifact_rel in
+  let artifact_path = Filename.concat (Board_core.board_base_path ()) artifact_rel in
   (try Unix.mkdir (Filename.dirname artifact_path) 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
   Out_channel.with_open_bin artifact_path (fun oc -> output_string oc artifact_content);
   let expected = Some ("sha256:" ^ sha256_hex artifact_content) in
@@ -2239,7 +2241,7 @@ let test_resolve_file_path_rejects_digest_unavailable () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let artifact_rel = Filename.concat Common.masc_dirname "claim_gate_digest_dir" in
-  let artifact_path = Filename.concat (Board_paths.board_base_path ()) artifact_rel in
+  let artifact_path = Filename.concat (Board_core.board_base_path ()) artifact_rel in
   (try Unix.mkdir (Filename.dirname artifact_path) 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
   (try Unix.mkdir artifact_path 0o755 with Unix.Unix_error _ -> () | Sys_error _ -> ());
   match Board_claim_gate.resolve_file_path artifact_rel with


### PR DESCRIPTION
## 무엇

main `Build and Test` 잔여 컴파일 에러 수리 — `972f9304ab` 런의 2번째 에러:

```
File "test/test_tool_board_coverage.ml", line 2226, characters 39-50:
Error: Unbound module Board_paths
```

`Board_paths.board_base_path ()` (2사이트) → `Board_core.board_base_path ()`.

## 왜

#23525가 추가한 claim-gate digest 테스트 2건이 `Board_paths`를 직접 참조하는데, `Board_paths`는 wrapped library `masc_board_handlers` 내부 모듈이고 `lib/`에 facade가 없어 테스트 실행 파일에서 unbound. #23525의 PR 체크가 머지 시각에 취소(merge-before-green)되어 main에서 처음 발현 — 오늘 같은 패턴 4번째.

`Board_core.board_base_path`는 **같은 함수의 공개 별칭**입니다: `lib/board_core.{ml,mli}` facade → `Masc_board_handlers.Board_core` → `include Board_core_persist` → `let board_base_path = Board_paths.board_base_path` (board_core_persist.ml:406). gate(`board_claim_gate.ml:196`)가 계산하는 경로와 동일하다는 테스트 계약은 그대로 유지.

## 참고

- 같은 런의 1번째 에러(`keeper_pacing_shadow.ml:12` 타입 에러)는 #23536이 이미 수리 — 이 PR 머지 후에야 main 빌드가 처음으로 온전해집니다.
- 1파일 +8/−6, 테스트 참조 교체만. 로컬 dune 빌드는 CI 위임(운영 규칙), ocamlformat --check 통과.

RFC-WAIVED: test-only module reference fix; no subsystem code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
