### PR TITLE
feat(dashboard): add GitHub App credentials configuration UI

### DIFF
--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -53,6 +53,7 @@ import { KeeperPromptAssemblyPanel } from './keeper-prompt-assembly-panel'
 import { KeeperRuntimeModelEditor } from './keeper-runtime-model-editor'
 import { KeeperConditionsDivergent } from './keeper-conditions-divergent'
 import { KeeperActivitySummary } from './keeper-detail-activity-summary'
+import { KeeperGithubAppConfigPanel } from './keeper-github-app-config'
 import { FsmHub } from './fsm-hub'
 import { currentDashboardActor } from '../api'
 import type { Keeper } from '../types'
@@ -194,6 +195,7 @@ export function KeeperDetailBody({
           <${KeeperRuntimeModelEditor} keeperName=${keeper.name} />
           <${KeeperToolTelemetry} keeperName=${keeper.name} />
           <${KeeperSecretProjectionPanel} keeperName=${keeper.name} projection=${compositeSnapshot?.secret_projection} />
+          <${KeeperGithubAppConfigPanel} keeperName=${keeper.name} projection=${compositeSnapshot?.secret_projection} />
           <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
           <${CollapsibleSection} title="Live Truth (composite/runtime 합성)" open=${false}>
             <${KeeperLiveTruthPanel}

--- a/dashboard/src/components/keeper-github-app-config.test.ts
+++ b/dashboard/src/components/keeper-github-app-config.test.ts
@@ -1,0 +1,152 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { KeeperGithubAppConfigPanel } from './keeper-github-app-config'
+import type { KeeperSecretProjection } from '../api/schemas/keeper-composite'
+
+describe('KeeperGithubAppConfigPanel', () => {
+  const mockProjectionEmpty: KeeperSecretProjection = {
+    status: 'ready',
+    configured: true,
+    root: '/mock/workspace/.masc/secrets/sangsu',
+    source: 'workspace_masc_secrets',
+    effective_roots: [],
+    env_count: 0,
+    file_count: 0,
+    env_names: [],
+    file_mounts: [],
+    values_validated: true,
+    error: null,
+    next_action: 'none',
+  }
+
+  const mockProjectionConfigured: KeeperSecretProjection = {
+    status: 'ready',
+    configured: true,
+    root: '/mock/workspace/.masc/secrets/sangsu',
+    source: 'workspace_masc_secrets',
+    effective_roots: [],
+    env_count: 2,
+    file_count: 1,
+    env_names: ['MASC_GITHUB_APP_ID', 'MASC_GITHUB_APP_INSTALLATION_ID'],
+    file_mounts: [
+      {
+        host_path: '/mock/workspace/.masc/secrets/sangsu/files/github-app/private-key.pem',
+        container_path: '/github-app/private-key.pem',
+      },
+    ],
+    values_validated: true,
+    error: null,
+    next_action: 'none',
+  }
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders correctly when credentials are not configured', () => {
+    render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionEmpty,
+      keeperName: 'sangsu',
+    }))
+
+    expect(screen.getByTestId('keeper-github-app-config-panel')).toBeInTheDocument()
+    expect(screen.getAllByText('Not Configured').length).toBe(2)
+    expect(screen.getByText('Not Uploaded')).toBeInTheDocument()
+  })
+
+  it('renders correctly when credentials are configured', () => {
+    render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionConfigured,
+      keeperName: 'sangsu',
+    }))
+
+    expect(screen.getAllByText('Configured').length).toBe(2)
+    expect(screen.getByText('Uploaded')).toBeInTheDocument()
+  })
+
+  it('calls setSecretEnv and setSecretFile when form is submitted', async () => {
+    const setSecretEnv = vi.fn().mockResolvedValue(mockProjectionConfigured)
+    const setSecretFile = vi.fn().mockResolvedValue(mockProjectionConfigured)
+    const onProjectionChange = vi.fn()
+
+    const { container } = render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionEmpty,
+      keeperName: 'sangsu',
+      setSecretEnv,
+      setSecretFile,
+      onProjectionChange,
+    }))
+
+    // Fill in App ID
+    const appIdInput = screen.getByLabelText('GitHub App ID')
+    fireEvent.input(appIdInput, { target: { value: '123456' } })
+
+    // Fill in Installation ID
+    const instIdInput = screen.getByLabelText('GitHub App Installation ID')
+    fireEvent.input(instIdInput, { target: { value: '7891011' } })
+
+    // Fill in PEM
+    const pemInput = screen.getByLabelText('GitHub App Private Key PEM')
+    fireEvent.input(pemInput, { target: { value: '-----BEGIN RSA PRIVATE KEY-----\npem-content\n-----END RSA PRIVATE KEY-----' } })
+
+    // Submit form directly to bypass happy-dom submit limitation
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    fireEvent.submit(form!)
+
+    await waitFor(() => {
+      expect(setSecretEnv).toHaveBeenCalledTimes(2)
+      expect(setSecretFile).toHaveBeenCalledTimes(1)
+      expect(onProjectionChange).toHaveBeenCalledWith(mockProjectionConfigured)
+    })
+
+    expect(setSecretEnv).toHaveBeenNthCalledWith(1, 'sangsu', {
+      scope: 'keeper',
+      name: 'MASC_GITHUB_APP_ID',
+      value: '123456',
+    })
+
+    expect(setSecretEnv).toHaveBeenNthCalledWith(2, 'sangsu', {
+      scope: 'keeper',
+      name: 'MASC_GITHUB_APP_INSTALLATION_ID',
+      value: '7891011',
+    })
+
+    expect(setSecretFile).toHaveBeenCalledWith('sangsu', {
+      scope: 'keeper',
+      path: '/github-app/private-key.pem',
+      value: '-----BEGIN RSA PRIVATE KEY-----\npem-content\n-----END RSA PRIVATE KEY-----',
+    })
+  })
+
+  it('calls deleteSecretEnv and deleteSecretFile when purge is clicked', async () => {
+    const deleteSecretEnv = vi.fn().mockResolvedValue(mockProjectionEmpty)
+    const deleteSecretFile = vi.fn().mockResolvedValue(mockProjectionEmpty)
+    const onProjectionChange = vi.fn()
+
+    // Mock confirm dialog globally using stubGlobal
+    const confirmMock = vi.fn().mockReturnValue(true)
+    vi.stubGlobal('confirm', confirmMock)
+
+    render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionConfigured,
+      keeperName: 'sangsu',
+      deleteSecretEnv,
+      deleteSecretFile,
+      onProjectionChange,
+    }))
+
+    const purgeBtn = screen.getByText('Purge Credentials')
+    fireEvent.click(purgeBtn)
+
+    await waitFor(() => {
+      expect(confirmMock).toHaveBeenCalled()
+      expect(deleteSecretEnv).toHaveBeenCalledTimes(2)
+      expect(deleteSecretFile).toHaveBeenCalledTimes(1)
+      expect(onProjectionChange).toHaveBeenCalledWith(mockProjectionEmpty)
+    })
+  })
+})

--- a/dashboard/src/components/keeper-github-app-config.test.ts
+++ b/dashboard/src/components/keeper-github-app-config.test.ts
@@ -63,6 +63,8 @@ describe('KeeperGithubAppConfigPanel', () => {
       keeperName: 'sangsu',
     }))
 
+    expect(screen.getByText('configured / unvalidated')).toBeInTheDocument()
+    expect(screen.queryByText('active')).not.toBeInTheDocument()
     expect(screen.getAllByText('Configured').length).toBe(2)
     expect(screen.getByText('Uploaded')).toBeInTheDocument()
   })
@@ -120,6 +122,81 @@ describe('KeeperGithubAppConfigPanel', () => {
       path: '/github-app/private-key.pem',
       value: '-----BEGIN RSA PRIVATE KEY-----\npem-content\n-----END RSA PRIVATE KEY-----',
     })
+  })
+
+  it('rejects partial bundle saves before mutating keeper secrets', async () => {
+    const setSecretEnv = vi.fn().mockResolvedValue(mockProjectionConfigured)
+    const setSecretFile = vi.fn().mockResolvedValue(mockProjectionConfigured)
+
+    const { container } = render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionEmpty,
+      keeperName: 'sangsu',
+      setSecretEnv,
+      setSecretFile,
+    }))
+
+    fireEvent.input(screen.getByLabelText('GitHub App ID'), { target: { value: '123456' } })
+
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    fireEvent.submit(form!)
+
+    await waitFor(() => {
+      expect(screen.getByText('GitHub App credentials must be saved as a complete bundle.')).toBeInTheDocument()
+    })
+    expect(setSecretEnv).not.toHaveBeenCalled()
+    expect(setSecretFile).not.toHaveBeenCalled()
+  })
+
+  it('rolls back applied bundle fields when a later save step fails', async () => {
+    const partialProjection: KeeperSecretProjection = {
+      ...mockProjectionEmpty,
+      env_count: 1,
+      env_names: ['MASC_GITHUB_APP_ID'],
+    }
+    const setSecretEnv = vi
+      .fn()
+      .mockResolvedValueOnce(partialProjection)
+      .mockRejectedValueOnce(new Error('installation write failed'))
+    const setSecretFile = vi.fn().mockResolvedValue(mockProjectionConfigured)
+    const deleteSecretEnv = vi.fn().mockResolvedValue(mockProjectionEmpty)
+    const deleteSecretFile = vi.fn().mockResolvedValue(mockProjectionEmpty)
+    const onProjectionChange = vi.fn()
+
+    const { container } = render(h(KeeperGithubAppConfigPanel, {
+      projection: mockProjectionEmpty,
+      keeperName: 'sangsu',
+      setSecretEnv,
+      setSecretFile,
+      deleteSecretEnv,
+      deleteSecretFile,
+      onProjectionChange,
+    }))
+
+    fireEvent.input(screen.getByLabelText('GitHub App ID'), { target: { value: '123456' } })
+    fireEvent.input(screen.getByLabelText('GitHub App Installation ID'), { target: { value: '7891011' } })
+    fireEvent.input(screen.getByLabelText('GitHub App Private Key PEM'), {
+      target: { value: '-----BEGIN RSA PRIVATE KEY-----\npem-content\n-----END RSA PRIVATE KEY-----' },
+    })
+
+    const form = container.querySelector('form')
+    expect(form).not.toBeNull()
+    fireEvent.submit(form!)
+
+    await waitFor(() => {
+      expect(screen.getByText(/installation write failed/)).toBeInTheDocument()
+      expect(screen.getByText(/Partially written GitHub App credentials were purged/)).toBeInTheDocument()
+    })
+
+    expect(setSecretEnv).toHaveBeenCalledTimes(2)
+    expect(setSecretFile).not.toHaveBeenCalled()
+    expect(deleteSecretEnv).toHaveBeenCalledTimes(1)
+    expect(deleteSecretEnv).toHaveBeenCalledWith('sangsu', {
+      scope: 'keeper',
+      name: 'MASC_GITHUB_APP_ID',
+    })
+    expect(deleteSecretFile).not.toHaveBeenCalled()
+    expect(onProjectionChange).toHaveBeenCalledWith(mockProjectionEmpty)
   })
 
   it('calls deleteSecretEnv and deleteSecretFile when purge is clicked', async () => {

--- a/dashboard/src/components/keeper-github-app-config.ts
+++ b/dashboard/src/components/keeper-github-app-config.ts
@@ -16,6 +16,14 @@ import { ActionButton } from './common/button'
 import { TextArea, TextInput } from './common/input'
 import { StatusChip } from './common/status-chip'
 
+const GITHUB_APP_ID_ENV = 'MASC_GITHUB_APP_ID'
+const GITHUB_APP_INSTALLATION_ID_ENV = 'MASC_GITHUB_APP_INSTALLATION_ID'
+const GITHUB_APP_PRIVATE_KEY_PATH = '/github-app/private-key.pem'
+
+type AppliedGithubAppSecret =
+  | { kind: 'env'; name: typeof GITHUB_APP_ID_ENV | typeof GITHUB_APP_INSTALLATION_ID_ENV }
+  | { kind: 'file'; path: typeof GITHUB_APP_PRIVATE_KEY_PATH }
+
 interface KeeperGithubAppConfigPanelProps {
   projection: KeeperSecretProjection | null | undefined
   keeperName?: string
@@ -24,6 +32,51 @@ interface KeeperGithubAppConfigPanelProps {
   deleteSecretEnv?: typeof deleteKeeperSecretEnv
   setSecretFile?: typeof setKeeperSecretFile
   deleteSecretFile?: typeof deleteKeeperSecretFile
+}
+
+function messageFromError(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback
+}
+
+function hasGithubAppPrivateKey(projection: KeeperSecretProjection | null | undefined): boolean {
+  return (projection?.file_mounts ?? []).some(
+    (mount: { container_path: string }) => mount.container_path === GITHUB_APP_PRIVATE_KEY_PATH,
+  )
+}
+
+async function rollbackAppliedGithubAppSecrets({
+  keeperName,
+  applied,
+  deleteSecretEnv,
+  deleteSecretFile,
+}: {
+  keeperName: string
+  applied: AppliedGithubAppSecret[]
+  deleteSecretEnv: typeof deleteKeeperSecretEnv
+  deleteSecretFile: typeof deleteKeeperSecretFile
+}): Promise<{ projection: KeeperSecretProjection | null; failures: string[] }> {
+  let projection: KeeperSecretProjection | null = null
+  const failures: string[] = []
+
+  for (const secret of [...applied].reverse()) {
+    try {
+      if (secret.kind === 'env') {
+        projection = await deleteSecretEnv(keeperName, {
+          scope: 'keeper',
+          name: secret.name,
+        })
+      } else {
+        projection = await deleteSecretFile(keeperName, {
+          scope: 'keeper',
+          path: secret.path,
+        })
+      }
+    } catch (error) {
+      failures.push(messageFromError(error, `failed to roll back ${secret.kind}`))
+    }
+  }
+
+  return { projection, failures }
 }
 
 export function KeeperGithubAppConfigPanel({
@@ -44,18 +97,25 @@ export function KeeperGithubAppConfigPanel({
 
   // Detect presence in the projection
   const envNames = projection?.env_names ?? []
-  const fileMounts = projection?.file_mounts ?? []
-  
-  const hasAppId = envNames.includes('MASC_GITHUB_APP_ID')
-  const hasInstallationId = envNames.includes('MASC_GITHUB_APP_INSTALLATION_ID')
-  const hasPrivateKey = fileMounts.some((m: { container_path: string }) => m.container_path === '/github-app/private-key.pem')
+  const hasAppId = envNames.includes(GITHUB_APP_ID_ENV)
+  const hasInstallationId = envNames.includes(GITHUB_APP_INSTALLATION_ID_ENV)
+  const hasPrivateKey = hasGithubAppPrivateKey(projection)
+  const hasCompleteConfig = hasAppId && hasInstallationId && hasPrivateKey
+  const appIdValue = appId.trim()
+  const installationIdValue = installationId.trim()
+  const privateKeyPemValue = privateKeyPem.trim()
+  const hasCompleteDraft = Boolean(appIdValue && installationIdValue && privateKeyPemValue)
 
-  const canSave = Boolean(keeperName) && pending === null && (appId.trim() || installationId.trim() || privateKeyPem.trim())
+  const canSave = Boolean(keeperName) && pending === null && hasCompleteDraft
   const canDelete = Boolean(keeperName) && pending === null && (hasAppId || hasInstallationId || hasPrivateKey)
 
   async function handleSave(event: Event) {
     event.preventDefault()
     if (!keeperName || pending !== null) return
+    if (!hasCompleteDraft) {
+      setError('GitHub App credentials must be saved as a complete bundle.')
+      return
+    }
 
     setPending('saving')
     setMessage(null)
@@ -64,38 +124,54 @@ export function KeeperGithubAppConfigPanel({
     try {
       let currentProjection = projection
       const steps: string[] = []
+      const applied: AppliedGithubAppSecret[] = []
 
-      // 1. App ID
-      if (appId.trim()) {
+      try {
         const mutation: KeeperSecretEnvSetMutation = {
           scope: 'keeper',
-          name: 'MASC_GITHUB_APP_ID',
-          value: appId.trim(),
+          name: GITHUB_APP_ID_ENV,
+          value: appIdValue,
         }
         currentProjection = await setSecretEnv(keeperName, mutation)
+        applied.push({ kind: 'env', name: GITHUB_APP_ID_ENV })
         steps.push('App ID')
-      }
 
-      // 2. Installation ID
-      if (installationId.trim()) {
-        const mutation: KeeperSecretEnvSetMutation = {
+        const installationMutation: KeeperSecretEnvSetMutation = {
           scope: 'keeper',
-          name: 'MASC_GITHUB_APP_INSTALLATION_ID',
-          value: installationId.trim(),
+          name: GITHUB_APP_INSTALLATION_ID_ENV,
+          value: installationIdValue,
         }
-        currentProjection = await setSecretEnv(keeperName, mutation)
+        currentProjection = await setSecretEnv(keeperName, installationMutation)
+        applied.push({ kind: 'env', name: GITHUB_APP_INSTALLATION_ID_ENV })
         steps.push('Installation ID')
-      }
 
-      // 3. Private Key PEM
-      if (privateKeyPem.trim()) {
-        const mutation: KeeperSecretFileSetMutation = {
+        const fileMutation: KeeperSecretFileSetMutation = {
           scope: 'keeper',
-          path: '/github-app/private-key.pem',
-          value: privateKeyPem.trim(),
+          path: GITHUB_APP_PRIVATE_KEY_PATH,
+          value: privateKeyPemValue,
         }
-        currentProjection = await setSecretFile(keeperName, mutation)
+        currentProjection = await setSecretFile(keeperName, fileMutation)
+        applied.push({ kind: 'file', path: GITHUB_APP_PRIVATE_KEY_PATH })
         steps.push('Private Key')
+      } catch (saveError) {
+        const rollback = await rollbackAppliedGithubAppSecrets({
+          keeperName,
+          applied,
+          deleteSecretEnv,
+          deleteSecretFile,
+        })
+        if (rollback.projection) {
+          currentProjection = rollback.projection
+          onProjectionChange?.(rollback.projection)
+        }
+        const saveMessage = messageFromError(saveError, 'Failed to save GitHub App configuration')
+        const rollbackMessage =
+          applied.length === 0
+            ? ''
+            : rollback.failures.length > 0
+            ? ` Rollback failed: ${rollback.failures.join('; ')}`
+            : ' Partially written GitHub App credentials were purged.'
+        throw new Error(`${saveMessage}.${rollbackMessage}`)
       }
 
       if (currentProjection) {
@@ -107,7 +183,7 @@ export function KeeperGithubAppConfigPanel({
       setPrivateKeyPem('')
       setMessage(`Successfully saved: ${steps.join(', ')}`)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save GitHub App configuration')
+      setError(messageFromError(e, 'Failed to save GitHub App configuration'))
     } finally {
       setPending(null)
     }
@@ -132,7 +208,7 @@ export function KeeperGithubAppConfigPanel({
       if (hasAppId) {
         const mutation: KeeperSecretEnvMutation = {
           scope: 'keeper',
-          name: 'MASC_GITHUB_APP_ID',
+          name: GITHUB_APP_ID_ENV,
         }
         currentProjection = await deleteSecretEnv(keeperName, mutation)
         steps.push('App ID')
@@ -142,7 +218,7 @@ export function KeeperGithubAppConfigPanel({
       if (hasInstallationId) {
         const mutation: KeeperSecretEnvMutation = {
           scope: 'keeper',
-          name: 'MASC_GITHUB_APP_INSTALLATION_ID',
+          name: GITHUB_APP_INSTALLATION_ID_ENV,
         }
         currentProjection = await deleteSecretEnv(keeperName, mutation)
         steps.push('Installation ID')
@@ -152,7 +228,7 @@ export function KeeperGithubAppConfigPanel({
       if (hasPrivateKey) {
         const mutation: KeeperSecretFileMutation = {
           scope: 'keeper',
-          path: '/github-app/private-key.pem',
+          path: GITHUB_APP_PRIVATE_KEY_PATH,
         }
         currentProjection = await deleteSecretFile(keeperName, mutation)
         steps.push('Private Key')
@@ -164,7 +240,7 @@ export function KeeperGithubAppConfigPanel({
 
       setMessage(`Successfully removed: ${steps.join(', ')}`)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to delete GitHub App configuration')
+      setError(messageFromError(e, 'Failed to delete GitHub App configuration'))
     } finally {
       setPending(null)
     }
@@ -185,8 +261,8 @@ export function KeeperGithubAppConfigPanel({
             <h4 class="text-sm font-bold text-[var(--color-fg-primary)]">GitHub App Installation (RFC-0236 §10)</h4>
           </div>
         </div>
-        <${StatusChip} tone=${(hasAppId && hasInstallationId && hasPrivateKey) ? 'success' : 'neutral'} uppercase=${false}>
-          ${(hasAppId && hasInstallationId && hasPrivateKey) ? 'active' : 'partial / inactive'}
+        <${StatusChip} tone=${hasCompleteConfig ? 'warn' : 'neutral'} uppercase=${false}>
+          ${hasCompleteConfig ? 'configured / unvalidated' : 'partial / inactive'}
         <//>
       </div>
 

--- a/dashboard/src/components/keeper-github-app-config.ts
+++ b/dashboard/src/components/keeper-github-app-config.ts
@@ -365,7 +365,7 @@ export function KeeperGithubAppConfigPanel({
             <${Trash2} size=${14} strokeWidth=${2.25} aria-hidden="true" />
             <span>${pending === 'deleting' ? 'Purging...' : 'Purge Credentials'}</span>
           <//>
-          
+
           <${ActionButton}
             type="submit"
             size="md"

--- a/dashboard/src/components/keeper-github-app-config.ts
+++ b/dashboard/src/components/keeper-github-app-config.ts
@@ -1,0 +1,307 @@
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { Save, Trash2, GitBranch, KeyRound, CheckCircle2, AlertCircle } from 'lucide-preact'
+import {
+  deleteKeeperSecretFile,
+  deleteKeeperSecretEnv,
+  setKeeperSecretFile,
+  setKeeperSecretEnv,
+  type KeeperSecretEnvSetMutation,
+  type KeeperSecretFileSetMutation,
+  type KeeperSecretEnvMutation,
+  type KeeperSecretFileMutation,
+} from '../api/dashboard-keeper-secrets'
+import type { KeeperSecretProjection } from '../api/schemas/keeper-composite'
+import { ActionButton } from './common/button'
+import { TextArea, TextInput } from './common/input'
+import { StatusChip } from './common/status-chip'
+
+interface KeeperGithubAppConfigPanelProps {
+  projection: KeeperSecretProjection | null | undefined
+  keeperName?: string
+  onProjectionChange?: (projection: KeeperSecretProjection) => void
+  setSecretEnv?: typeof setKeeperSecretEnv
+  deleteSecretEnv?: typeof deleteKeeperSecretEnv
+  setSecretFile?: typeof setKeeperSecretFile
+  deleteSecretFile?: typeof deleteKeeperSecretFile
+}
+
+export function KeeperGithubAppConfigPanel({
+  projection,
+  keeperName,
+  onProjectionChange,
+  setSecretEnv = setKeeperSecretEnv,
+  deleteSecretEnv = deleteKeeperSecretEnv,
+  setSecretFile = setKeeperSecretFile,
+  deleteSecretFile = deleteKeeperSecretFile,
+}: KeeperGithubAppConfigPanelProps) {
+  const [appId, setAppId] = useState('')
+  const [installationId, setInstallationId] = useState('')
+  const [privateKeyPem, setPrivateKeyPem] = useState('')
+  const [pending, setPending] = useState<'saving' | 'deleting' | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Detect presence in the projection
+  const envNames = projection?.env_names ?? []
+  const fileMounts = projection?.file_mounts ?? []
+  
+  const hasAppId = envNames.includes('MASC_GITHUB_APP_ID')
+  const hasInstallationId = envNames.includes('MASC_GITHUB_APP_INSTALLATION_ID')
+  const hasPrivateKey = fileMounts.some((m: { container_path: string }) => m.container_path === '/github-app/private-key.pem')
+
+  const canSave = Boolean(keeperName) && pending === null && (appId.trim() || installationId.trim() || privateKeyPem.trim())
+  const canDelete = Boolean(keeperName) && pending === null && (hasAppId || hasInstallationId || hasPrivateKey)
+
+  async function handleSave(event: Event) {
+    event.preventDefault()
+    if (!keeperName || pending !== null) return
+
+    setPending('saving')
+    setMessage(null)
+    setError(null)
+
+    try {
+      let currentProjection = projection
+      const steps: string[] = []
+
+      // 1. App ID
+      if (appId.trim()) {
+        const mutation: KeeperSecretEnvSetMutation = {
+          scope: 'keeper',
+          name: 'MASC_GITHUB_APP_ID',
+          value: appId.trim(),
+        }
+        currentProjection = await setSecretEnv(keeperName, mutation)
+        steps.push('App ID')
+      }
+
+      // 2. Installation ID
+      if (installationId.trim()) {
+        const mutation: KeeperSecretEnvSetMutation = {
+          scope: 'keeper',
+          name: 'MASC_GITHUB_APP_INSTALLATION_ID',
+          value: installationId.trim(),
+        }
+        currentProjection = await setSecretEnv(keeperName, mutation)
+        steps.push('Installation ID')
+      }
+
+      // 3. Private Key PEM
+      if (privateKeyPem.trim()) {
+        const mutation: KeeperSecretFileSetMutation = {
+          scope: 'keeper',
+          path: '/github-app/private-key.pem',
+          value: privateKeyPem.trim(),
+        }
+        currentProjection = await setSecretFile(keeperName, mutation)
+        steps.push('Private Key')
+      }
+
+      if (currentProjection) {
+        onProjectionChange?.(currentProjection)
+      }
+
+      setAppId('')
+      setInstallationId('')
+      setPrivateKeyPem('')
+      setMessage(`Successfully saved: ${steps.join(', ')}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save GitHub App configuration')
+    } finally {
+      setPending(null)
+    }
+  }
+
+  async function handleDelete() {
+    if (!keeperName || pending !== null) return
+
+    if (!confirm('Are you sure you want to delete the GitHub App configuration for this keeper?')) {
+      return
+    }
+
+    setPending('deleting')
+    setMessage(null)
+    setError(null)
+
+    try {
+      let currentProjection = projection
+      const steps: string[] = []
+
+      // 1. App ID
+      if (hasAppId) {
+        const mutation: KeeperSecretEnvMutation = {
+          scope: 'keeper',
+          name: 'MASC_GITHUB_APP_ID',
+        }
+        currentProjection = await deleteSecretEnv(keeperName, mutation)
+        steps.push('App ID')
+      }
+
+      // 2. Installation ID
+      if (hasInstallationId) {
+        const mutation: KeeperSecretEnvMutation = {
+          scope: 'keeper',
+          name: 'MASC_GITHUB_APP_INSTALLATION_ID',
+        }
+        currentProjection = await deleteSecretEnv(keeperName, mutation)
+        steps.push('Installation ID')
+      }
+
+      // 3. Private Key PEM
+      if (hasPrivateKey) {
+        const mutation: KeeperSecretFileMutation = {
+          scope: 'keeper',
+          path: '/github-app/private-key.pem',
+        }
+        currentProjection = await deleteSecretFile(keeperName, mutation)
+        steps.push('Private Key')
+      }
+
+      if (currentProjection) {
+        onProjectionChange?.(currentProjection)
+      }
+
+      setMessage(`Successfully removed: ${steps.join(', ')}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete GitHub App configuration')
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return html`
+    <div
+      class="mt-4 rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel)] p-5 shadow-sm transition-all hover:shadow"
+      data-testid="keeper-github-app-config-panel"
+    >
+      <div class="flex items-center justify-between border-b border-[var(--color-border-divider)] pb-3">
+        <div class="flex items-center gap-3">
+          <div class="rounded-full bg-[var(--color-bg-panel-alt)] p-2.5 text-[var(--color-fg-primary)]">
+            <${GitBranch} size=${20} strokeWidth=${2} aria-hidden="true" />
+          </div>
+          <div>
+            <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">OAuth / Git Credentials</div>
+            <h4 class="text-sm font-bold text-[var(--color-fg-primary)]">GitHub App Installation (RFC-0236 §10)</h4>
+          </div>
+        </div>
+        <${StatusChip} tone=${(hasAppId && hasInstallationId && hasPrivateKey) ? 'success' : 'neutral'} uppercase=${false}>
+          ${(hasAppId && hasInstallationId && hasPrivateKey) ? 'active' : 'partial / inactive'}
+        <//>
+      </div>
+
+      <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-panel-alt)] p-2.5">
+          <${KeyRound} size=${14} class=${hasAppId ? 'text-[var(--color-status-success-fg)]' : 'text-[var(--color-fg-muted)]'} />
+          <div class="min-w-0 flex-1">
+            <div class="text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">App ID</div>
+            <div class="truncate text-xs font-medium text-[var(--color-fg-primary)]">
+              ${hasAppId ? html`<span class="text-[var(--color-status-success-fg)] font-semibold">Configured</span>` : 'Not Configured'}
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-panel-alt)] p-2.5">
+          <${KeyRound} size=${14} class=${hasInstallationId ? 'text-[var(--color-status-success-fg)]' : 'text-[var(--color-fg-muted)]'} />
+          <div class="min-w-0 flex-1">
+            <div class="text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">Installation ID</div>
+            <div class="truncate text-xs font-medium text-[var(--color-fg-primary)]">
+              ${hasInstallationId ? html`<span class="text-[var(--color-status-success-fg)] font-semibold">Configured</span>` : 'Not Configured'}
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] bg-[var(--color-bg-panel-alt)] p-2.5">
+          <${GitBranch} size=${14} class=${hasPrivateKey ? 'text-[var(--color-status-success-fg)]' : 'text-[var(--color-fg-muted)]'} />
+          <div class="min-w-0 flex-1">
+            <div class="text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">Private Key PEM</div>
+            <div class="truncate text-xs font-medium text-[var(--color-fg-primary)]">
+              ${hasPrivateKey ? html`<span class="text-[var(--color-status-success-fg)] font-semibold">Uploaded</span>` : 'Not Uploaded'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <form class="mt-4 flex flex-col gap-4" onSubmit=${handleSave}>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <label class="flex flex-col gap-1.5 text-3xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+            GitHub App ID
+            <${TextInput}
+              value=${appId}
+              disabled=${pending !== null || !keeperName}
+              placeholder="e.g. 1024356"
+              ariaLabel="GitHub App ID"
+              autoComplete="off"
+              onInput=${(event: Event) => setAppId((event.currentTarget as HTMLInputElement).value)}
+            />
+          </label>
+
+          <label class="flex flex-col gap-1.5 text-3xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+            GitHub App Installation ID
+            <${TextInput}
+              value=${installationId}
+              disabled=${pending !== null || !keeperName}
+              placeholder="e.g. 89456123"
+              ariaLabel="GitHub App Installation ID"
+              autoComplete="off"
+              onInput=${(event: Event) => setInstallationId((event.currentTarget as HTMLInputElement).value)}
+            />
+          </label>
+        </div>
+
+        <label class="flex flex-col gap-1.5 text-3xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+          Private Key PEM Content
+          <${TextArea}
+            value=${privateKeyPem}
+            rows=${4}
+            disabled=${pending !== null || !keeperName}
+            placeholder="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+            ariaLabel="GitHub App Private Key PEM"
+            onInput=${(event: Event) => setPrivateKeyPem((event.currentTarget as HTMLTextAreaElement).value)}
+            class="font-mono text-xs"
+          />
+        </label>
+
+        ${message ? html`
+          <div class="flex items-center gap-2 rounded-[var(--r-1)] bg-[var(--color-status-success-bg)] p-3 text-xs text-[var(--color-status-success-fg)]">
+            <${CheckCircle2} size=${14} class="flex-shrink-0" />
+            <span>${message}</span>
+          </div>
+        ` : null}
+
+        ${error ? html`
+          <div class="flex items-center gap-2 rounded-[var(--r-1)] bg-[var(--color-status-error-bg)] p-3 text-xs text-[var(--color-status-error-fg)]">
+            <${AlertCircle} size=${14} class="flex-shrink-0" />
+            <span>${error}</span>
+          </div>
+        ` : null}
+
+        <div class="flex justify-end gap-3 border-t border-[var(--color-border-divider)] pt-4">
+          <${ActionButton}
+            type="button"
+            variant="danger"
+            size="md"
+            disabled=${!canDelete}
+            ariaBusy=${pending === 'deleting'}
+            class="inline-flex items-center gap-2"
+            onClick=${handleDelete}
+          >
+            <${Trash2} size=${14} strokeWidth=${2.25} aria-hidden="true" />
+            <span>${pending === 'deleting' ? 'Purging...' : 'Purge Credentials'}</span>
+          <//>
+          
+          <${ActionButton}
+            type="submit"
+            size="md"
+            disabled=${!canSave}
+            ariaBusy=${pending === 'saving'}
+            class="inline-flex items-center gap-2"
+          >
+            <${Save} size=${14} strokeWidth=${2.25} aria-hidden="true" />
+            <span>${pending === 'saving' ? 'Saving...' : 'Save Configuration'}</span>
+          <//>
+        </div>
+      </form>
+    </div>
+  `
+}


### PR DESCRIPTION
Implementation of the follow-up dashboard UI for GitHub App configuration per-keeper (RFC-0236 §10). Includes App ID, Installation ID, and Private Key PEM credentials inputs.