### PR TITLE
fix(board): add board_claim_gate.mli — unbreak OCaml Structure Ratchet

### DIFF
--- a/lib/board_tool_adapter/board_claim_gate.mli
+++ b/lib/board_tool_adapter/board_claim_gate.mli
@@ -1,0 +1,93 @@
+(** Evidence-backed board claim gate (#23486).
+
+    Resolves the artifacts a board post claims about (exists / missing /
+    unknown, with content digests), classifies the claim kinds, and decides
+    whether a post/comment write may proceed. This interface exposes only the
+    surface consumed by {!Board_tool_post} (write gating) and the coverage
+    tests; the parsing/normalization helpers stay module-private.
+
+    Made a public module (mli required) in the fix that let
+    [test_tool_board_coverage] exercise [resolve_file_path] directly. *)
+
+type claim_kind =
+  | Artifact_exists
+  | Artifact_missing
+  | Artifact_created
+  | Artifact_endorsed
+  | Verification_endorsement
+  | Task_completion
+  | Pr_state
+  | Retraction_ack
+  | Opinion_or_routing
+
+type source_post_snapshot =
+  { post_id : string
+  ; post_updated_at : float
+  ; body_sha256 : string
+  ; body_excerpt : string
+  ; read_at : float
+  ; read_tool_call_id : string option
+  }
+
+(** Resolution of one claimed artifact reference. [Exists] carries the
+    content [digest] when the file is readable. *)
+type artifact_resolution =
+  | Exists of
+      { ref_ : string
+      ; kind : string
+      ; checked_at : float
+      ; digest : string option
+      }
+  | Missing of { ref_ : string; checked_at : float; reason : string }
+  | Unknown of { ref_ : string; checked_at : float; reason : string }
+
+type gate_decision =
+  | Allow
+  | Reject of string
+
+(** Outcome of a pre-write check: either nothing to record, or a resolved
+    claim bundle to persist alongside the write. *)
+type prechecked_write =
+  | No_record
+  | Record of
+      { claims : claim_kind list
+      ; snapshot : source_post_snapshot option
+      ; artifact_refs : string list
+      ; resolutions : artifact_resolution list
+      ; decision : gate_decision
+      }
+
+val claim_kind_to_string : claim_kind -> string
+
+(** [resolve_file_path raw] resolves a claimed artifact reference to its
+    existence/digest, rejecting parent-directory escapes. *)
+val resolve_file_path : string -> artifact_resolution
+
+(** Snapshot a source post's identity+body digest for claim provenance. *)
+val source_snapshot_of_post : Masc_board_handlers.Board.post -> Yojson.Safe.t
+
+(** Gate a comment write; [Error] rejects with a human-readable reason. *)
+val check_comment
+  :  tool_name:string
+  -> author:string
+  -> post_id:string
+  -> content:string
+  -> args:Yojson.Safe.t
+  -> (unit, string) result
+
+(** Gate a post-create write, returning the resolved claim bundle to record. *)
+val check_post_create
+  :  tool_name:string
+  -> author:string
+  -> content:string
+  -> args:Yojson.Safe.t
+  -> (prechecked_write, string) result
+
+(** Persist a [prechecked_write] produced by {!check_post_create}. *)
+val record_post_create
+  :  tool_name:string
+  -> author:string
+  -> target_post_id:string
+  -> content:string
+  -> prechecked_write
+  -> (unit, string) result

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1,12 +1,5 @@
 module Types = Masc_domain
 
-(* [Board_paths] lives in the wrapped [masc.board_handlers] library, so
-   [open Masc] does not bring it into scope. [Board_claim_gate] is in the
-   unwrapped [masc.board_tool_adapter] library (accessible bare once removed
-   from that library's private_modules — see its dune). #23525 added bare
-   references to both without this alias / visibility fix, breaking the build. *)
-module Board_paths = Masc_board_handlers.Board_paths
-
 open Masc
 
 (** {1 Test helpers} *)


### PR DESCRIPTION
## 목적

main ratchet(`OCaml Structure Ratchet`)의 `lib_other_mli_missing: 1 > baseline 0` FAIL을 복구합니다.

## 원인

#23544(제가 올린 main-red fix)가 `board_claim_gate`를 `board_tool_adapter`의 `private_modules`에서 제거해 public으로 만들었습니다 — `test_tool_board_coverage`가 `resolve_file_path`/`artifact_resolution`을 직접 검증하기 위해서였습니다. 그런데 이 모듈에 `.mli`가 없어, "public `lib/*/*.ml`은 `.mli` 필수" ratchet 규칙을 위반했습니다. private→public 전환의 필수 완성을 빠뜨린 회귀입니다.

## 변경

1. **`lib/board_tool_adapter/board_claim_gate.mli` 추가** — 외부 소비자(`Board_tool_post` 쓰기 게이팅 + coverage test)가 쓰는 표면만 노출: 타입 5종(`claim_kind`/`source_post_snapshot`/`artifact_resolution`/`gate_decision`/`prechecked_write`) + 함수 6종(`resolve_file_path`/`source_snapshot_of_post`/`check_comment`/`check_post_create`/`record_post_create`/`claim_kind_to_string`). 파싱/정규화 헬퍼(`has_prefix`/`sha256_hex`/`assoc_opt` 등)는 module-private로 캡슐화. 시그니처는 `ocaml-print-intf`로 추론해 정확성 보장.
2. **`test_tool_board_coverage.ml`: dead `Board_paths` alias 제거** — #23545가 사용처를 `Board_core.board_base_path`(public facade)로 이미 교체해, 제 #23544가 남긴 `module Board_paths = Masc_board_handlers.Board_paths` alias가 dead code가 됨. subtractive 정리.

## 검증

- `dune build lib/board_tool_adapter test/...exe` clean (mli가 .ml과 일치).
- `ocaml-structure-ratchet.sh` PASS (`mli_missing` FAIL 해소).
- `test_tool_board_coverage`: 로컬 11 failures는 **main HEAD와 동일**(`models.toml not found` + fs fixture 의존, 환경 전용). 내 변경 전후 실패 수/종류 불변 → mli는 동작 영향 0.

ratchet baseline을 regenerate(약화)하지 않고 근본(누락 mli 추가)으로 고침.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
