### PR TITLE
fix(keeper): migrate supervisor pause tests to RFC-0313 W3 pacing modes

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -802,8 +802,12 @@ let start_supervisor_sweep ctx =
         let should_act _beat = true
         let on_beat _beat =
           (try
+             (* RFC-0313 W3: pacing mode is read once per sweep at this
+                boundary and injected, so policy arms inside the sweep stay
+                free of hidden config reads. *)
              Keeper_supervisor.sweep_and_recover
                ~load_or_materialize_keeper_meta
+               ~pacing_enforced:(Keeper_pacing_shadow.pacing_enforced ())
                ctx
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -225,7 +225,8 @@ let pending_hitl_approval_keeper_names config =
        Keeper_approval_queue.has_pending_for_keeper ~keeper_name:name)
 ;;
 
-let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
+let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _ context)
+  =
   let now = Time_compat.now () in
   let max_restarts =
     Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
@@ -300,11 +301,13 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
         { Keeper_failure_policy.lifecycle_effect = Keeper_failure_policy.Pause_keeper
         ; _
         }
-      when Keeper_pacing_shadow.pacing_enforced () ->
+      when pacing_enforced ->
       (* RFC-0313 W3: failure policy verdicts no longer flip existence. A
          crashed fiber is process reality; it relaunches on the standard
          backoff path. The pause arms below stay reachable only in shadow
-         mode (kill-switch, removed in W4). *)
+         mode (kill-switch, removed in W4). [pacing_enforced] is injected by
+         the sweep caller so the mode is read once per sweep at the boundary,
+         not per entry inside policy code. *)
       queue_standard_restart acc
     | Some
         { Keeper_failure_policy.lifecycle_effect = Keeper_failure_policy.Pause_keeper

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -32,13 +32,20 @@ val pending_hitl_approval_keeper_names : Workspace.config -> string list
 val sweep_and_recover :
      load_or_materialize_keeper_meta:
        ('a context -> string -> (keeper_meta option, string) result)
+  -> pacing_enforced:bool
   -> 'a context
   -> unit
 (** Scan all supervised keepers in [Keeper_registry]. Detect zombies
     (resolved Promise), restart with exponential backoff if within
     budget, mark dead otherwise, and materialize configured keepalive
     keepers through the required callback. Called periodically by the
-    keeper supervisor loop. *)
+    keeper supervisor loop.
+
+    [pacing_enforced] is the RFC-0313 W3 mode, read once per sweep by the
+    caller (production wires [Keeper_pacing_shadow.pacing_enforced ()]).
+    When [true] (default runtime config), [Pause_keeper] policy verdicts
+    route to the standard restart/backoff path; when [false] (shadow
+    kill-switch, removed in W4), the legacy failure-driven pause arms run. *)
 
 (** {1 Pure Helpers (exposed for testing)} *)
 

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -509,9 +509,15 @@ let task_status_for_id config task_id =
 
 let noop_load_or_materialize_keeper_meta _ctx _name = Ok None
 
-let sweep_and_recover_no_materialize ctx =
+(* [pacing_enforced] defaults to [true] — the production runtime default
+   (RFC-0313 W3, [config/runtime.toml] [pacing] mode = "enforce").  The
+   legacy failure-driven pause tests pass [~pacing_enforced:false]
+   explicitly: they pin the shadow kill-switch semantics until W4 deletes
+   the pause arms and those tests with them. *)
+let sweep_and_recover_no_materialize ?(pacing_enforced = true) ctx =
   Sup.sweep_and_recover
     ~load_or_materialize_keeper_meta:noop_load_or_materialize_keeper_meta
+    ~pacing_enforced
     ctx
 
 let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
@@ -2000,7 +2006,7 @@ let test_stale_storm_pause_skips_restart () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       let after_pause =
         Masc.Otel_metric_store.metric_total "masc_keeper_stale_storm_paused_total"
       in
@@ -2099,7 +2105,7 @@ let test_stale_storm_pause_releases_owned_task () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       let task =
         Masc.Workspace.get_tasks_raw config
         |> List.find (fun (task : Masc_domain.task) ->
@@ -2219,7 +2225,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       let after_pause =
         Masc.Otel_metric_store.metric_total
           "masc_keeper_provider_timeout_loop_paused_total"
@@ -2305,7 +2311,7 @@ let test_turn_failure_streak_pause_skips_restart () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       let after_pause =
         Masc.Otel_metric_store.metric_total
           "masc_keeper_turn_failure_streak_paused_total"
@@ -2336,6 +2342,99 @@ let test_turn_failure_streak_pause_skips_restart () =
        | Error err -> fail ("read_meta failed: " ^ err));
       check bool "registry entry unregistered after turn failure streak pause"
         false (Reg.is_registered ~base_path:config.base_path name))
+
+(* RFC-0313 W3 enforce twins: under the production default ([pacing]
+   mode = "enforce" in config/runtime.toml), a [Pause_keeper] policy
+   verdict must not flip existence — the sweep routes the keeper to the
+   standard restart/backoff path instead.  The shadow tests above pass
+   [~pacing_enforced:false] to pin the legacy pause arms until W4 deletes
+   them (and those tests with them). *)
+let run_enforced_pacing_restart_twin ~keeper_name ~reason ~pause_counter =
+  with_restart_launch_noop @@ fun () ->
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _init_msg =
+        Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
+      in
+      write_keeper_toml config_dir ~name:keeper_name;
+      let meta = make_meta keeper_name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path keeper_name meta in
+      resolve_done_for_test reg (`Crashed "synthetic failure for enforce twin");
+      Reg.restore_supervisor_state ~base_path:config.base_path keeper_name
+        ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
+      Reg.set_failure_reason ~base_path:config.base_path keeper_name (Some reason);
+      let attempt_labels = [ ("keeper", keeper_name) ] in
+      let baseline_pause = Masc.Otel_metric_store.metric_total pause_counter in
+      let baseline_shadow =
+        Masc.Otel_metric_store.metric_total
+          Keeper_metrics.(to_string FailureDrivenPause)
+      in
+      let baseline_attempts =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string RestartAttempts)
+          ~labels:attempt_labels ()
+      in
+      let ctx : _ Keeper_types_profile.context =
+        {
+          config;
+          agent_name = supervisor_agent_name;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      sweep_and_recover_no_materialize ~pacing_enforced:true ctx;
+      check (float 0.001) "pause counter unchanged under enforce"
+        baseline_pause
+        (Masc.Otel_metric_store.metric_total pause_counter);
+      check (float 0.001)
+        "shadow FailureDrivenPause counter unchanged under enforce"
+        baseline_shadow
+        (Masc.Otel_metric_store.metric_total
+           Keeper_metrics.(to_string FailureDrivenPause));
+      check (float 0.001) "restart attempt queued instead of pause"
+        (baseline_attempts +. 1.0)
+        (Masc.Otel_metric_store.metric_value_or_zero
+           Keeper_metrics.(to_string RestartAttempts)
+           ~labels:attempt_labels ());
+      (match Keeper_meta_store.read_meta config keeper_name with
+       | Ok (Some m) ->
+           check bool "meta.paused stays false under enforce" false m.paused
+       | Ok None -> fail "meta missing after enforced sweep"
+       | Error err -> fail ("read_meta failed: " ^ err)))
+
+let test_enforced_pacing_routes_stale_storm_to_restart () =
+  run_enforced_pacing_restart_twin
+    ~keeper_name:"enforced-storm-restart-keeper"
+    ~reason:(Reg.Stale_termination_storm { count = 5 })
+    ~pause_counter:"masc_keeper_stale_storm_paused_total"
+
+let test_enforced_pacing_routes_provider_timeout_loop_to_restart () =
+  run_enforced_pacing_restart_twin
+    ~keeper_name:"enforced-provider-timeout-restart-keeper"
+    ~reason:(Reg.Provider_timeout_loop { count = 3 })
+    ~pause_counter:"masc_keeper_provider_timeout_loop_paused_total"
+
+let test_enforced_pacing_routes_turn_failure_streak_to_restart () =
+  run_enforced_pacing_restart_twin
+    ~keeper_name:"enforced-turn-streak-restart-keeper"
+    ~reason:(Reg.Turn_consecutive_failures 3)
+    ~pause_counter:"masc_keeper_turn_failure_streak_paused_total"
 
 (* Fail-closed pause commit: when [paused=true] cannot be persisted (here:
    meta missing on disk), the pause must not commit — no pause counter, no
@@ -2380,7 +2479,7 @@ let test_stale_storm_pause_persist_failure_keeps_entry_registered () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       let after_pause =
         Masc.Otel_metric_store.metric_total "masc_keeper_stale_storm_paused_total"
       in
@@ -2528,7 +2627,7 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       (match Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
            check bool "meta.paused = true after unresolved watchdog stop"
@@ -2736,7 +2835,7 @@ let test_storm_pause_requires_manual_resume () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       (* Stale storms are operator-owned pauses: no timer should re-enter
          the same failed runtime/tool loop automatically. *)
       (match Keeper_meta_store.read_meta config name with
@@ -2797,7 +2896,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      sweep_and_recover_no_materialize ctx;
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
       (* Back-off must double: 3600 -> 7200. *)
       (match Keeper_meta_store.read_meta config name with
        | Ok (Some m) ->
@@ -3679,6 +3778,12 @@ let () =
         test_provider_timeout_loop_pause_skips_restart;
       test_case "Turn failure streak honors Pause_keeper verdict, skips restart (#23439)" `Quick
         test_turn_failure_streak_pause_skips_restart;
+      test_case "enforced pacing routes stale storm to restart (RFC-0313 W3)" `Quick
+        test_enforced_pacing_routes_stale_storm_to_restart;
+      test_case "enforced pacing routes provider timeout loop to restart (RFC-0313 W3)"
+        `Quick test_enforced_pacing_routes_provider_timeout_loop_to_restart;
+      test_case "enforced pacing routes turn failure streak to restart (RFC-0313 W3)"
+        `Quick test_enforced_pacing_routes_turn_failure_streak_to_restart;
       test_case "storm pause persist failure keeps entry registered (fail-closed)" `Quick
         test_stale_storm_pause_persist_failure_keeps_entry_registered;
       test_case "terminal-state launch reject does not announce Running" `Quick


### PR DESCRIPTION
## 무엇

main `Build and Test` red 잔여 — quick suite 8건 실패 수리 (`5daeed7908` 런):

- `dead_state_alert #3`, `stale_storm_phase2 #0/#2/#3/#4/#7`, `self_healing_circuit_breaker #0/#1` — 전부 `test_keeper_supervisor.ml`의 **legacy failure-driven pause 단언**.

## 왜

RFC-0313 W3(#23524)가 supervisor의 `Pause_keeper` verdict를 enforce 모드(프로덕션 기본)에서 표준 restart 경로로 돌렸는데, `test_keeper_supervisor`는 마이그레이션되지 않았고 #23524의 CI 런은 머지 시각에 취소되어 main에서 처음 발현했습니다.

추가 발견: 테스트 fixture(`ensure_test_runtime`)가 init 직후 TOML을 삭제하는데 `Runtime.pacing ()`은 호출마다 파일을 재파싱하므로, 테스트에서 pacing 모드는 의도와 무관하게 **항상 enforce 기본으로 낙하**하고 있었습니다(로그의 `failed to parse [pacing] ...; using defaults` WARN).

## 어떻게 — 숨은 config read를 경계 주입으로

W3가 `degraded_rotation_after_recoverable_error`에 쓴 것과 같은 파라미터화 패턴:

1. `sweep_and_recover`에 **필수** `~pacing_enforced:bool` 추가. 프로덕션 호출자(keeper_runtime의 sweep consumer)가 `Keeper_pacing_shadow.pacing_enforced ()`를 **sweep당 1회** 경계에서 읽어 주입 — 기존에는 per-entry로 정책 코드 내부에서 TOML 재파싱이 일어날 수 있었음.
2. legacy pause 테스트 8건은 `~pacing_enforced:false` 명시 — shadow kill-switch 의미론을 결정론적으로 핀 (W4가 pause arm과 함께 일괄 삭제 예정).
3. **enforce 트윈 3건 신설** (`run_enforced_pacing_restart_twin` 파라미터화): stale storm / provider timeout loop / turn failure streak 각각에 대해 — pause counter 불변 + `FailureDrivenPause` 불변(RFC Verification 항목) + RestartAttempts +1 + `meta.paused = false` 단언. W3 핵심 불변식(실패는 존재를 못 바꾼다)을 supervisor 레벨에서 최초로 핀.

테스트 헬퍼 기본값은 `pacing_enforced = true`(프로덕션 기본과 일치) — 나머지 모드 무관 테스트 19곳은 이 CI 런에서 이미 enforce 하에 green이었음을 실측 확인.

## 검증

- ocamlformat --check 4파일 통과. dune 빌드는 CI 위임(운영 규칙).
- 참고: 같은 런의 `OCaml Structure Ratchet` fail(`lib_other_mli_missing: 1 > 0`)은 #23544가 `board_claim_gate`를 private에서 풀며 생긴 **별도 board 축** — 후속 PR에서 `board_claim_gate.mli` 작성으로 수리 예정.

RFC-0313 (docs/rfc/RFC-0313, W3 flip #23524의 테스트 마이그레이션 누락분).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
